### PR TITLE
small fixes to WPSEO_Admin::maybe_upgrade()

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -435,7 +435,7 @@ class WPSEO_Admin {
 
 		if ( version_compare( $current_version, '1.2.8', '<' ) ) {
 			$options = get_option( 'wpseo' );
-			if ( isset( $options['presstrends'] ) ) {
+			if ( is_array($options) and isset( $options['presstrends'] ) ) {
 				$options['yoast_tracking'] = 'on';
 				unset( $options['presstrends'] );
 				update_option( 'wpseo', $options );
@@ -444,11 +444,11 @@ class WPSEO_Admin {
 
 		if ( version_compare( $current_version, '1.2.8.2', '<' ) ) {
 			$options = get_option( 'wpseo' );
-			if ( isset( $options['presstrends'] ) ) {
+			if ( is_array($options) and isset( $options['presstrends'] ) ) {
 				$options['yoast_tracking'] = 'on';
 				unset( $options['presstrends'] );
 			}
-			if ( isset( $options['presstrends_popup'] ) ) {
+			if ( is_array($options) and isset( $options['presstrends_popup'] ) ) {
 				$options['tracking_popup'] = 'on';
 				unset( $options['presstrends_popup'] );
 			}


### PR DESCRIPTION
Hi, I've encountered a situation when Network activating the plugin on a multisite would throw "Cannot unset string offsets in /wp-content/plugins/wordpress-seo/admin/class-admin.php line 440".

I don't know if this is because a weird server configuration, but, in the snippet below, $options was a string, the isset would return true even if $options was not an array, and the unset line was throwing the error mentioned earlier.

``` php
$options = get_option( 'wpseo' );
if ( isset( $options['presstrends'] ) ) {
    ...
    unset( $options['presstrends'] );
}
```

I took the liberty to apply some is_array() checks to those lines, example:

``` php
if ( is_array($options) and isset( $options['presstrends'] ) ) {
    ...
    unset( $options['presstrends'] );
}
```
