### PR TITLE
Added check for facebook_image post meta as primary Facebook thumbnail

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -224,7 +224,12 @@ class WPSEO_OpenGraph extends WPSEO_Frontend {
 				}
 			}
 
-			if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $post->ID ) ) {
+			if ($img = get_post_meta($post->ID, "facebook_image", 1)  ) {
+                $img = apply_filters( 'wpseo_opengraph_image', $img );
+                echo "<meta property='og:image' content='" . esc_attr( $img ) . "'/>\n";
+                $shown_imgs[] = $img;
+                return true;
+			} else if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $post->ID ) ) {
 				$featured_img = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), apply_filters( 'wpseo_opengraph_image_size', 'medium' ) );
 
 				if ( $featured_img ) {


### PR DESCRIPTION
On some sites, maintainers may desire to retain more control of what image is used for Facebook OpenGraph thumbnails.

My site, for example, uses a wide landscape format for site images. When Facebook pulls these images, it often crops them in an unfavorable way. I prefer to manually select the image I want promoted for the site content.

This change checks for a facebook_image post_meta value, and if it exists, returns it as the SOLE thumbnail for opengraph. Removing the return true would allow it to be returned as one of many if there are other thumbnails available.

Ideally, this would probably be an option that can be chosen in the setting.
