### PR TITLE
Twitter Card tags updated: Adds in-content images & new tag specs

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -147,12 +147,15 @@ class WPSEO_Twitter extends WPSEO_Frontend {
 				
 				if ( isset( $this->options['og_frontpage_image'] ) ) {
 					
-					$img = $this->options['og_frontpage_image'];
+					$escaped_img = esc_attr( $this->options['og_frontpage_image'] );
 					
-					echo '<meta name="twitter:image:src" content="' . esc_attr( $img ) . '"/>' . "\n";
+					if ( ! empty( $escaped_img ) ) {
+						echo '<meta name="twitter:image:src" content="' . $escaped_img . '"/>' . "\n";
+						
+						// No images yet, don't test
+						array_push( $shown_images, $escaped_img );
 					
-					// No images yet, don't test
-					array_push( $shown_images, $img );
+					}
 					
 				}
 				
@@ -164,13 +167,13 @@ class WPSEO_Twitter extends WPSEO_Frontend {
 	
 				if ( $featured_img ) {
 					
-					$img = apply_filters( 'wpseo_opengraph_image', $featured_img[0] );
+					$escaped_img = esc_attr( apply_filters( 'wpseo_opengraph_image', $featured_img[0] ) );
 					
-					if ( ! in_array( $img, $shown_images ) ) {
+					if ( ! empty( $escaped_img ) && ! in_array( $escaped_img, $shown_images ) ) {
 						
-						echo '<meta name="twitter:image:src" content="' . esc_attr( $img ) . '"/>' . "\n";
+						echo '<meta name="twitter:image:src" content="' . $escaped_img . '"/>' . "\n";
 						
-						array_push( $shown_images, $img );
+						array_push( $shown_images, $escaped_img );
 						
 					}
 					
@@ -183,12 +186,14 @@ class WPSEO_Twitter extends WPSEO_Frontend {
 				foreach ( $matches[0] as $img ) {
 					
 					if ( preg_match( '/src=("|\')(.*?)\1/', $img, $match ) ) {
+						
+						$escaped_match = esc_attr( $match[2] );
 					
-						if ( ! in_array( $match[2], $shown_images ) ) {
+						if ( ! empty( $escaped_match ) && ! in_array( $escaped_match, $shown_images ) ) {
 							
-							echo '<meta name="twitter:image:src" content="' . esc_attr( $match[2] ) . '"/>' . "\n";
+							echo '<meta name="twitter:image:src" content="' . $escaped_match . '"/>' . "\n";
 							
-							array_push( $shown_images, $match[2] );
+							array_push( $shown_images, $escaped_match );
 							
 						}
 					


### PR DESCRIPTION
Twitter Card tags have changed recently, plus we were seeing different images in Twitter Cards from what was in our Open Graph tags. This code fixes the 1st and makes the images 99% match what OG shows.

This code is tested & running on www.digitaltrends.com. Our Twitter Cards based on it have already been approved.

Changes:
- :image >> :image:src
- in-content images, w/ duplicate prevention
- meta tag format normalized
- required site domain tag added
