### PR TITLE
Fixed issue #44 for resolution of OpenGraph image setting being ignored

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -242,13 +242,14 @@ class WPSEO_OpenGraph extends WPSEO_Frontend {
 	 * @return bool
 	 */
 	public function image() {
-		if ( is_singular() ) {
-			global $post;
+		global $post;
 
-			if ( is_front_page() ) {
-				if ( isset( $this->options['og_frontpage_image'] ) )
-					$this->image_output( $this->options['og_frontpage_image'] );
-			}
+		if ( is_front_page() ) {
+			if ( isset( $this->options['og_frontpage_image'] ) )
+				$this->image_output( $this->options['og_frontpage_image'] );
+		}
+
+		if ( is_singular() ) {
 
 			if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $post->ID ) ) {
 				$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), apply_filters( 'wpseo_opengraph_image_size', 'large' ) );


### PR DESCRIPTION
is_front_page will never be evaluated correctly if it's nested inside is_singular

moved the frontpage check to above is_singular check
