### PR TITLE
Keyword density calculation not working when special character in focus keyword

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -1663,6 +1663,7 @@ class WPSEO_Metabox {
 			$this->save_score_result( $results, 9, sprintf( $scoreBodyGoodLength, $wordCount ), 'body_length', $wordCount );
 
 		$body = $this->strtolower_utf8( $body );
+		$job["keyword"] = $this->strtolower_utf8( $job["keyword"] );
 
 		$keywordWordCount = str_word_count( $job["keyword"] );
 		if ( $keywordWordCount > 10 ) {


### PR DESCRIPTION
When special characters are in focus keyword (ä,ö,ü etc.) it doesn't calculate the keyword density correctly (always 0%) ... this fixes the encoding error.
