### PR TITLE
Fix output of author for Google+ when using a static front page.

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -752,7 +752,11 @@ class WPSEO_Frontend {
 	public function author() {
 		$gplus   = false;
 
-		if ( is_singular() ) {
+		if ( is_home() || is_front_page()) {
+			if ( isset( $this->options['plus-author'] ) && $this->options['plus-author'] != -1 )
+				$gplus = get_the_author_meta( 'googleplus', $this->options['plus-author'] );
+
+		} else if ( is_singular() ) {
 			global $post;
 			$gplus = get_the_author_meta( 'googleplus', $post->post_author );
 
@@ -760,10 +764,6 @@ class WPSEO_Frontend {
 			if ( isset( $this->options['noauthorship-' . $post->post_type] ) && $this->options['noauthorship-' . $post->post_type] ) {
 				$gplus = false;
 			}
-
-		} else if ( is_home() ) {
-			if ( isset( $this->options['plus-author'] ) )
-				$gplus = get_the_author_meta( 'googleplus', $this->options['plus-author'] );
 		}
 
 		$gplus = apply_filters( 'wpseo_author_link', $gplus );


### PR DESCRIPTION
When the front page is set to static and a page or post, the author is displayed even when it is set to not display.

The first check should be if it's the home page. Both is_home and is_front_page need to be used. is_home doesn't return true when the front page is static and set to a post.

The next step is to check if the option plus-author is set and it's doesn't have the value of -1, which is the value given when you select not to show an author on the home page.

Signed-off-by: Peter van der Does github@avirtualhome.com
