### PR TITLE
Enhancement: Improved breadcrumbs and titles for 404 pages

### DIFF
--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -305,6 +305,10 @@ if ( ( isset( $_GET[ 'updated' ] ) && $_GET[ 'updated' ] == 'true' ) || ( isset(
 				<td>' . __( 'Replaced with the posts focus keyword', 'wordpress-seo' ) . '</td>
 			</tr>
 			<tr>
+				<th>%%term404%%</th>
+				<td>' . __( 'Replaced with the slug which caused the 404', 'wordpress-seo' ) . '</td>
+			</tr>
+			<tr>
 				<th>%%cf_&lt;custom-field-name&gt;%%</th>
 				<td>' . __( 'Replaced with a posts custom field value', 'wordpress-seo' ) . '</td>
 			</tr>

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -182,11 +182,45 @@ class WPSEO_Breadcrumbs {
 					$bc = __( 'You searched for', 'wordpress-seo' );
 				$links[] = array( 'text' => $bc . ' "' . esc_html( get_search_query() ) . '"' );
 			} elseif ( is_404() ) {
-				if ( isset( $options['breadcrumbs-404crumb'] ) && $options['breadcrumbs-404crumb'] != '' )
-					$crumb404 = $options['breadcrumbs-404crumb'];
-				else
-					$crumb404 = __( 'Error 404: Page not found', 'wordpress-seo' );
-				$links[] = array( 'text' => $crumb404 );
+
+				if ( 0 !== get_query_var( 'year' ) || ( 0 !== get_query_var( 'monthnum' ) || 0 !== get_query_var( 'day' ) ) ) {
+					
+					if ( 'page' == $on_front && !is_home() ) {
+						if ( $blog_page && ( !isset( $options['breadcrumbs-blog-remove'] ) || !$options['breadcrumbs-blog-remove'] ) )
+							$links[] = array( 'id' => $blog_page );
+					}
+
+					if ( isset( $options['breadcrumbs-archiveprefix'] ) )
+						$bc = $options['breadcrumbs-archiveprefix'];
+					else
+						$bc = __( 'Archives for', 'wordpress-seo' );
+
+
+					if ( 0 !== get_query_var( 'day' ) ) {
+						$links[] = array(
+							'url'  => get_month_link( get_query_var( 'year' ), get_query_var( 'monthnum' ) ),
+							'text' => $GLOBALS['wp_locale']->get_month( get_query_var( 'monthnum' ) ) . ' ' . get_query_var( 'year' )
+						);
+						global $post;
+						$original_p = $post;
+						$post->post_date = sprintf("%04d-%02d-%02d 00:00:00", get_query_var( 'year' ), get_query_var( 'monthnum' ), get_query_var( 'day' ) );
+						$links[] = array( 'text' => $bc . ' ' . get_the_date() );
+						$post = $original_p;
+
+					} else if ( 0 !== get_query_var( 'monthnum' ) ) {
+						$links[] = array( 'text' => $bc . ' ' . single_month_title( ' ', false ) );
+					} else if ( 0 !== get_query_var( 'year' ) ) {
+						$links[] = array( 'text' => $bc . ' ' . get_query_var( 'year' ) );
+					}
+				}
+				else {
+					if ( isset( $options['breadcrumbs-404crumb'] ) && '' != $options['breadcrumbs-404crumb'] )
+						$crumb404 = $options['breadcrumbs-404crumb'];
+					else
+						$crumb404 = __( 'Error 404: Page not found', 'wordpress-seo' );
+							
+					$links[] = array( 'text' => $crumb404 );
+				}
 			}
 		}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -377,10 +377,33 @@ class WPSEO_Frontend {
 					$title_part = __( 'Archives', 'wordpress-seo' );
 			}
 		} else if ( is_404() ) {
-			$title = $this->get_title_from_options( 'title-404' );
 
-			if ( empty( $title ) )
-				$title_part = __( 'Page not found', 'wordpress-seo' );
+			if ( 0 !== get_query_var( 'year' ) || ( 0 !== get_query_var( 'monthnum' ) || 0 !== get_query_var( 'day' ) ) ) {
+
+				if ( 0 !== get_query_var( 'day' ) ) {
+
+					global $post;
+					$original_p = $post;
+					$post->post_date = sprintf("%04d-%02d-%02d 00:00:00", get_query_var( 'year' ), get_query_var( 'monthnum' ), get_query_var( 'day' ) );
+					$title_part = sprintf( __( '%s Archives', 'wordpress-seo' ), get_the_date() );
+					$post = $original_p;
+				}
+				else if ( 0 !== get_query_var( 'monthnum' ) ) {
+					$title_part = sprintf( __( '%s Archives', 'wordpress-seo' ), single_month_title( ' ', false ) );
+				}
+				else if ( 0 !== get_query_var( 'year' ) ) {
+					$title_part = sprintf( __( '%s Archives', 'wordpress-seo' ), get_query_var( 'year' ) );
+				}
+				else {
+					$title_part = __( 'Archives', 'wordpress-seo' );
+				}
+			}
+			else {
+				$title = $this->get_title_from_options( 'title-404' );
+
+				if ( empty( $title ) )
+					$title_part = __( 'Page not found', 'wordpress-seo' );
+			}
 		} else {
 			// In case the page type is unknown, leave the title alone.
 			$modified_title = false;

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -120,6 +120,7 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
 		'post_title'    => '',
 		'taxonomy'      => '',
 		'term_id'       => '',
+		'term404'		=> '',
 	);
 
 	if ( isset( $args['post_content'] ) )
@@ -168,6 +169,7 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
 		'%%page%%'         => ( $max_num_pages > 1 && $pagenum > 1 ) ? sprintf( $sep . ' ' . __( 'Page %d of %d', 'wordpress-seo' ), $pagenum, $max_num_pages ) : '',
 		'%%pagetotal%%'    => $max_num_pages,
 		'%%pagenumber%%'   => $pagenum,
+		'%%term404%%'	   => sanitize_text_field ( str_replace( '-', ' ', $r->term404 ) ),
 	);
 
 	if ( isset( $r->ID ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,8 @@ You'll find the [FAQ on Yoast.com](http://yoast.com/wordpress/seo/faq/).
 
 * Bugfixes
 	* Fixed ampersand (&) in sitetitle in Title Templates loading as &amp;
+* Enhancements
+	* Improved breadcrumbs and titles for 404 pages - props [Jrf](http://profiles.wordpress.org/jrf).
 	
 = 1.4.12 =
 


### PR DESCRIPTION
### Breadcrumb and title for invalid day/month/year archive page and other 404 pages

**Enhancement as first reported in [this forum thread](http://wordpress.org/support/topic/plugin-wordpress-seo-by-yoast-bug-fix-for-title-and-breadcrumbs-of-404-pages)**
#### What I did/how to reproduce the issue:

I wanted to test the page users would be presented with when they visited a date-archive for a day/month/year in which no blogposts where published and for a non-existant category/article.

I tried both of the following as a 404 title template (for the non-date based pages):
You looked for: %%searchphrase%% %%sep%% %%sitename%%
You looked for: %%title%% %%sep%% %%sitename%%

On one of your own blogs, try for example:
- http://yoursite.com/1995/04/11/
- http://yoursite.com/1995/04/
- http://yoursite.com/1995/
- http://yoursite.com/test/
#### What I expected to happen:

That the title would say:
- 11 april 1995 - my blog name
- april 1995 - my blog name
- 1995 - my blog name
- You looked for: test - my blog name _OR_
- Page not found: test - my blog name

And that the breadcrumb would show:
- Home -> Blog -> 11 april 1995
- Home -> Blog -> april 1995
- Home -> Blog -> 1995
- Home -> Error 404: Page not Found => this is done as expected
#### What did happen:

For the date based pages:
The title came back as the 404-title
The breadcrumb, similarly, showed the 404 breadcrumb message

For the non-existant category/article pages:
The title came back as:
_You looked for: - my blog name_ - i.e. the phrase/slug/category/article name isn't there

**This commit fixes this.**
