### PR TITLE
A request for WPML plugin support

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -387,7 +387,15 @@ function wpseo_store_tracking_response() {
 }
 add_action('wp_ajax_wpseo_allow_tracking', 'wpseo_store_tracking_response');
 
-// WPML: Set titles for custom types / taxonomies as translatable
+/**
+ * WPML plugin support: Set titles for custom types / taxonomies as translatable.
+ * It adds new keys to a wpml-config.xml file for a custom post type title, metadesc, title-ptarchive and metadesc-ptarchive fields translation.
+ * Documentation: http://wpml.org/documentation/support/language-configuration-files/
+ * 
+ * @global $sitepress
+ * @param array $config
+ * @return array
+ */
 function wpseo_wpml_config( $config ) {
     global $sitepress;
 


### PR DESCRIPTION
Hi Joost,

Meta title and meta description can not be translated for a custom post type and custom taxonomy. That happens because they are not added automatically to a wpml-config.xml file. This fix is adding custom post types and custom taxonomies to a wpml-config.xml file on the fly.

Dominykas
