### PR TITLE
changed the check against direct access to php files

### DIFF
--- a/admin/TextStatistics.php
+++ b/admin/TextStatistics.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( ! defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**
@@ -362,27 +363,27 @@ class WPSEO_Admin {
 
 		wp_nonce_field( 'wpseo_user_profile_update', 'wpseo_nonce' );
 		?>
-		<h3 id="wordpress-seo"><?php _e( "WordPress SEO settings", 'wordpress-seo' ); ?></h3>
-		<table class="form-table">
-			<tr>
-				<th><?php _e( "Title to use for Author page", 'wordpress-seo' ); ?></th>
-				<td><input class="regular-text" type="text" name="wpseo_author_title"
+    <h3 id="wordpress-seo"><?php _e( "WordPress SEO settings", 'wordpress-seo' ); ?></h3>
+    <table class="form-table">
+        <tr>
+            <th><?php _e( "Title to use for Author page", 'wordpress-seo' ); ?></th>
+            <td><input class="regular-text" type="text" name="wpseo_author_title"
 									 value="<?php echo esc_attr( get_the_author_meta( 'wpseo_title', $user->ID ) ); ?>" /></td>
-			</tr>
-			<tr>
-				<th><?php _e( "Meta description to use for Author page", 'wordpress-seo' ); ?></th>
-				<td><textarea rows="3" cols="30"
-											name="wpseo_author_metadesc"><?php echo esc_html( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea>
-				</td>
-			</tr>
-			<?php if ( isset( $options['usemetakeywords'] ) && $options['usemetakeywords'] ) { ?>
-				<tr>
-					<th><?php _e( "Meta keywords to use for Author page", 'wordpress-seo' ); ?></th>
-					<td><input class="regular-text" type="text" name="wpseo_author_metakey"
+        </tr>
+        <tr>
+            <th><?php _e( "Meta description to use for Author page", 'wordpress-seo' ); ?></th>
+            <td><textarea rows="3" cols="30"
+                          name="wpseo_author_metadesc"><?php echo esc_html( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea>
+            </td>
+        </tr>
+		<?php     if ( isset( $options['usemetakeywords'] ) && $options['usemetakeywords'] ) { ?>
+        <tr>
+            <th><?php _e( "Meta keywords to use for Author page", 'wordpress-seo' ); ?></th>
+            <td><input class="regular-text" type="text" name="wpseo_author_metakey"
 										 value="<?php echo esc_attr( get_the_author_meta( 'wpseo_metakey', $user->ID ) ); ?>" /></td>
-				</tr>
-			<?php } ?>
-		</table>
+        </tr>
+		<?php } ?>
+    </table>
 		<br /><br />
 	<?php
 	}
@@ -594,7 +595,7 @@ class WPSEO_Admin {
 		 * Allows filtering of the stop words list
 		 * Especially useful for users on a language in which WPSEO is not available yet
 		 * and/or users who want to turn off stop word filtering
-		 * @api  array  $stopwords  Array of all lowercase stopwords to check and/or remove from slug
+		 * @api	array	$stopwords	Array of all lowercase stopwords to check and/or remove from slug
 		 */
 		$stopwords = apply_filters( 'wpseo_stopwords', $stopwords );
 
@@ -619,8 +620,8 @@ class WPSEO_Admin {
 					$stopWord = str_replace( "'", '', $stopWord );
 
 				// Check whether the stopword appears as a whole word
-				// @todo check whether the use of \b (=word boundary) would be more efficient ;-)
-				$res = preg_match( "`(^|[ \n\r\t\.,'\(\)\"\+;!?:])" . preg_quote( $stopWord, '`' ) . "($|[ \n\r\t\.,'\(\)\"\+;!?:])`iu", $haystack, $match );
+	        		// @todo check whether the use of \b (=word boundary) would be more efficient ;-)
+		        	$res = preg_match( "`(^|[ \n\r\t\.,'\(\)\"\+;!?:])" . preg_quote( $stopWord, '`' ) . "($|[ \n\r\t\.,'\(\)\"\+;!?:])`iu", $haystack, $match );
 				if ( $res > 0 )
 					return $stopWord;
 			}

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -5,9 +5,10 @@
  * This code generates the metabox on the edit post / page as well as contains all page analysis functionality.
  */
 
-if ( ! defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**
@@ -106,7 +107,7 @@ class WPSEO_Metabox {
 
 		if ( wpseo_get_value( 'meta-robots-noindex' ) == 1 ) {
 			$score_label = 'noindex';
-			$title       = __( 'Post is set to noindex.', 'wordpress-seo' );
+			$title = __( 'Post is set to noindex.', 'wordpress-seo' );
 		}
 		else {
 			$score = wpseo_get_value( 'linkdex' );
@@ -129,7 +130,7 @@ class WPSEO_Metabox {
 				$score = wpseo_get_value( 'linkdex' );
 				if ( ! $score || empty( $score ) ) {
 					$score_label = 'na';
-					$title       = __( 'No focus keyword set.', 'wordpress-seo' );
+					$title = __( 'No focus keyword set.', 'wordpress-seo' );
 				}
 				else {
 					$score_label = wpseo_translate_score( $score );
@@ -454,14 +455,14 @@ class WPSEO_Metabox {
 		<div class="wpseo-metabox-tabs-div">
 		<ul class="wpseo-metabox-tabs" id="wpseo-metabox-tabs">
 			<li class="general"><a class="wpseo_tablink"
-														 href="#wpseo_general"><?php _e( "General", 'wordpress-seo' ); ?></a></li>
+								   href="#wpseo_general"><?php _e( "General", 'wordpress-seo' ); ?></a></li>
 			<li id="linkdex" class="linkdex"><a class="wpseo_tablink"
-																					href="#wpseo_linkdex"><?php _e( "Page Analysis", 'wordpress-seo' ); ?></a>
+												href="#wpseo_linkdex"><?php _e( "Page Analysis", 'wordpress-seo' ); ?></a>
 			</li>
 			<?php if ( current_user_can( 'manage_options' ) || ! isset( $options['disableadvanced_meta'] ) || ! $options['disableadvanced_meta'] ): ?>
-				<li class="advanced"><a class="wpseo_tablink"
-																href="#wpseo_advanced"><?php _e( "Advanced", 'wordpress-seo' ); ?></a></li>
-			<?php endif; ?>
+			<li class="advanced"><a class="wpseo_tablink"
+									href="#wpseo_advanced"><?php _e( "Advanced", 'wordpress-seo' ); ?></a></li>
+		<?php endif; ?>
 			<?php do_action( 'wpseo_tab_header' ); ?>
 		</ul>
 		<?php
@@ -818,13 +819,13 @@ class WPSEO_Metabox {
 		echo '<select name="seo_filter">';
 		echo '<option value="">' . __( "All SEO Scores", 'wordpress-seo' ) . '</option>';
 		foreach ( array(
-								'na'      => __( 'SEO: No Focus Keyword', 'wordpress-seo' ),
-								'bad'     => __( 'SEO: Bad', 'wordpress-seo' ),
-								'poor'    => __( 'SEO: Poor', 'wordpress-seo' ),
-								'ok'      => __( 'SEO: OK', 'wordpress-seo' ),
-								'good'    => __( 'SEO: Good', 'wordpress-seo' ),
-								'noindex' => __( 'SEO: Post Noindexed', 'wordpress-seo' )
-							) as $val => $text ) {
+					  'na'      => __( 'SEO: No Focus Keyword', 'wordpress-seo' ),
+					  'bad'     => __( 'SEO: Bad', 'wordpress-seo' ),
+					  'poor'    => __( 'SEO: Poor', 'wordpress-seo' ),
+					  'ok'      => __( 'SEO: OK', 'wordpress-seo' ),
+					  'good'    => __( 'SEO: Good', 'wordpress-seo' ),
+					  'noindex' => __( 'SEO: Post Noindexed', 'wordpress-seo' )
+				  ) as $val => $text ) {
 			$sel = '';
 			if ( isset( $_GET['seo_filter'] ) && $_GET['seo_filter'] == $val )
 				$sel = 'selected ';
@@ -854,24 +855,24 @@ class WPSEO_Metabox {
 		if ( $column_name == 'wpseo-score' ) {
 			if ( wpseo_get_value( 'meta-robots-noindex', $post_id ) == 1 ) {
 				$score_label = 'noindex';
-				$title       = __( 'Post is set to noindex.', 'wordpress-seo' );
+				$title = __( 'Post is set to noindex.', 'wordpress-seo' );
 				if ( wpseo_get_value( 'meta-robots-noindex', $post_id ) !== 0 )
 					wpseo_set_value( 'linkdex', 0, $post_id );
 			}
 			else if ( $score = wpseo_get_value( 'linkdex', $post_id ) ) {
 				$score_label = wpseo_translate_score( round( $score / 10 ) );
-				$title       = wpseo_translate_score( round( $score / 10 ), $css = false );
+				$title = wpseo_translate_score( round( $score / 10 ), $css = false );
 			}
 			else {
 				$this->calculate_results( get_post( $post_id ) );
 				$score = wpseo_get_value( 'linkdex', $post_id );
 				if ( ! $score || empty( $score ) ) {
 					$score_label = 'na';
-					$title       = __( 'Focus keyword not set.', 'wordpress-seo' );
+					$title = __( 'Focus keyword not set.', 'wordpress-seo' );
 				}
 				else {
 					$score_label = wpseo_translate_score( $score );
-					$title       = wpseo_translate_score( $score, $css = false );
+					$title = wpseo_translate_score( $score, $css = false );
 				}
 			}
 
@@ -1118,8 +1119,8 @@ class WPSEO_Metabox {
 		elseif ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
 			$result = new WP_Error( 'page-analysis-disabled', sprintf( __( 'Page Analysis has been disabled.', 'wordpress-seo' ), $post->post_type ) );
 
-			return $result;
-		}
+   			return $result;
+  		}
 
 		$results = array();
 		$job     = array();
@@ -1501,8 +1502,8 @@ class WPSEO_Metabox {
 				}
 				else {
 					$count[$type]['dofollow'] ++;
-				}
 			}
+		}
 		}
 		return $count;
 	}
@@ -1549,7 +1550,7 @@ class WPSEO_Metabox {
 	 *
 	 * @param int    $post_id The post to find images in.
 	 * @param string $body    The post content to find images in.
-	 * @param array  $imgs    The array holding the image information.
+	 * @param array  $imgs The array holding the image information.
 	 *
 	 * @return array The updated images array.
 	 */
@@ -1622,8 +1623,8 @@ class WPSEO_Metabox {
 		preg_match_all( '`<h([1-6])(?:[^>]+)?>(.*?)</h\\1>`i', $postcontent, $matches );
 		if( isset( $matches ) && isset( $matches[2] ) ) {
 			foreach ( $matches[2] as $heading ) {
-				$headings[] = $this->strtolower_utf8( $heading );
-			}
+			$headings[] = $this->strtolower_utf8( $heading );
+		}
 		}
 
 		return $headings;
@@ -1722,7 +1723,7 @@ class WPSEO_Metabox {
 		else
 			$this->save_score_result( $results, 9, sprintf( $scoreBodyGoodLength, $wordCount ), 'body_length', $wordCount );
 
-		$body           = $this->strtolower_utf8( $body );
+		$body = $this->strtolower_utf8( $body );
 		$job["keyword"] = $this->strtolower_utf8( $job["keyword"] );
 
 		$keywordWordCount = str_word_count( $job["keyword"] );

--- a/admin/class-opengraph-admin.php
+++ b/admin/class-opengraph-admin.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/class-pointers.php
+++ b/admin/class-pointers.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/class-sitemaps-admin.php
+++ b/admin/class-sitemaps-admin.php
@@ -3,9 +3,10 @@
  * @package XML_Sitemaps
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/class-taxonomy.php
+++ b/admin/class-taxonomy.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/class-tracking.php
+++ b/admin/class-tracking.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -5,10 +5,12 @@
  * @package Admin
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
+
 global $wpseo_admin_pages;
 
 $options = get_option( 'wpseo' );

--- a/admin/pages/files.php
+++ b/admin/pages/files.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/import.php
+++ b/admin/pages/import.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/internal-links.php
+++ b/admin/pages/internal-links.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/permalinks.php
+++ b/admin/pages/permalinks.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/rss.php
+++ b/admin/pages/rss.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/admin/pages/xml-sitemaps.php
+++ b/admin/pages/xml-sitemaps.php
@@ -3,9 +3,10 @@
  * @package Admin
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 global $wpseo_admin_pages;

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -3,9 +3,10 @@
  * @package Frontend
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -5,9 +5,10 @@
  * Main frontend code.
  */
 
-if ( ! defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**
@@ -77,8 +78,8 @@ class WPSEO_Frontend {
 		}
 
 		if ( ( isset( $this->options['disable-date'] ) && $this->options['disable-date'] ) ||
-				( isset( $this->options['disable-author'] ) && $this->options['disable-author'] ) ||
-				( isset( $this->options['disable-post_formats'] ) && $this->options['disable-post_formats'] )
+			( isset( $this->options['disable-author'] ) && $this->options['disable-author'] ) ||
+			( isset( $this->options['disable-post_formats'] ) && $this->options['disable-post_formats'] )
 		)
 			add_action( 'wp', array( $this, 'archive_redirect' ) );
 
@@ -577,9 +578,9 @@ class WPSEO_Frontend {
 					$robots['index'] = 'index';
 			}
 			else if (
-					( is_author() && isset( $this->options['noindex-author'] ) && $this->options['noindex-author'] ) ||
-					( is_date() && isset( $this->options['noindex-archive'] ) && $this->options['noindex-archive'] ) ||
-					( is_home() && get_query_var( 'paged' ) > 1 )
+				( is_author() && isset( $this->options['noindex-author'] ) && $this->options['noindex-author'] ) ||
+				( is_date() && isset( $this->options['noindex-archive'] ) && $this->options['noindex-archive'] ) ||
+				( is_home() && get_query_var( 'paged' ) > 1 )
 			) {
 				$robots['index'] = 'noindex';
 			}
@@ -968,7 +969,7 @@ class WPSEO_Frontend {
 			else if ( is_archive() ) {
 				if ( isset( $this->options['metadesc-archive'] ) && '' != $this->options['metadesc-archive'] ) {
 					$metadesc = wpseo_replace_vars( $this->options['metadesc-archive'], (array) $wp_query->get_queried_object() );
-				}
+		}
 			}
 		}
 
@@ -1039,9 +1040,9 @@ class WPSEO_Frontend {
 		global $wp_query;
 
 		if (
-				( isset( $this->options['disable-date'] ) && $this->options['disable-date'] && $wp_query->is_date ) ||
-				( isset( $this->options['disable-author'] ) && $this->options['disable-author'] && $wp_query->is_author ) ||
-				( isset( $this->options['disable-post_formats'] ) && $this->options['disable-post_formats'] && $wp_query->is_tax( 'post_format' ) )
+			( isset( $this->options['disable-date'] ) && $this->options['disable-date'] && $wp_query->is_date ) ||
+			( isset( $this->options['disable-author'] ) && $this->options['disable-author'] && $wp_query->is_author ) ||
+			( isset( $this->options['disable-post_formats'] ) && $this->options['disable-post_formats'] && $wp_query->is_tax( 'post_format' ) )
 		) {
 			wp_safe_redirect( get_bloginfo( 'url' ), 301 );
 			exit;

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -5,9 +5,10 @@
  * This code handles the OpenGraph output.
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -3,9 +3,10 @@
  * @package Frontend
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -3,9 +3,10 @@
  * @package Frontend
  */
 
-if ( !defined('WPSEO_VERSION') ) {
-	header('HTTP/1.0 403 Forbidden');
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/inc/class-sitemap-walker.php
+++ b/inc/class-sitemap-walker.php
@@ -3,9 +3,10 @@
  * @package ?
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -3,9 +3,10 @@
  * @package XML_Sitemaps
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -3,9 +3,10 @@
  * @package Internals
  */
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -5,9 +5,10 @@
 
 include 'class-sitemap-walker.php';
 
-if ( !defined( 'WPSEO_VERSION' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 /**

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -28,9 +28,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * @package Main
  */
 
-if ( !defined( 'DB_NAME' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
+if ( ! function_exists( 'add_filter' ) ) {
+	header('Status: 403 Forbidden');
+	header('HTTP/1.1 403 Forbidden');
+	exit();
 }
 
 if ( !defined( 'WPSEO_URL' ) )


### PR DESCRIPTION
These changes implement best practice for the check against direct access to the php files of the wp plugin. It returns proper 403 headers in most (nothing is perfect) environments.
It also reduces the usage of PHP globals. Usage of PHP globals where not absolutely necessary is considered bad practice.
