### PR TITLE
Enhancement: New [yoast_breadcrumb] shortcode

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -542,3 +542,42 @@ function create_type_sitemap_template( $post_type ) {
 	$output .= '<br />';
 	return $output;
 }
+
+
+/**
+ * Handler for the [yoast_breadcrumb] shortcode, which displays the breadcrumb using a shortcode.
+ *
+ * If the breadcrumb feature is disabled, then this shortcode outputs nothing.
+ *
+ * Supported arguments, both of which are optional:
+ *
+ * before: The prefix for the breadcrumb, usually something like "You're here". Can also be HTML such as <p>.
+ * after:  The suffix for the breadcrumb. Can also be HTML such as </p>.
+ *
+ * Examples:
+ *
+ * [yoast_breadcrumb]
+ * [yoast_breadcrumb before='<p class="breadcrumb">You are here: ' after='</p>']
+ *
+ * @since 1.4.14
+ *
+ * @param array $atts shortcode attributes/arguments
+ *
+ * @return string Shortcode output
+ */
+function yoast_breadcrumb_shortcode_handler( $atts = array() ) {
+	$defaults = array(
+		'before' => '',
+		'after'  => ''
+	);
+
+	if ( function_exists( 'yoast_breadcrumb' ) ) {
+		$atts = shortcode_atts( $defaults, $atts );
+		return yoast_breadcrumb( $atts['before'], $atts['after'], false );
+	} else {
+		// Breadcrumb feature disabled
+		return '';
+	}
+}
+
+add_shortcode( 'yoast_breadcrumb', 'yoast_breadcrumb_shortcode_handler' );

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,11 @@ You'll find the [FAQ on Yoast.com](http://yoast.com/wordpress/seo/faq/).
 
 == Changelog ==
 
+= 1.4.14 =
+
+* Enhancements
+	* New [yoast_breadcrumb] shortcode, for displaying the breadcrumb without needing to add a function call to your theme.
+
 = 1.4.13 =
 
 * Bugfixes


### PR DESCRIPTION
Currently to display the breadcrumb, the user's theme must be edited to include a function call to yoast_breadcrumb() (as per http://yoast.com/wordpress/breadcrumbs/).

This enhancements adds a new `[yoast_breadcrumb]` shortcode, which can be used for displaying the breadcrumb without needing to add a function call to your theme.

This is particularly useful in themes such as WooThemes Canvas, where the hook manager allows you to add a shortcode to the header without having to edit the theme.

There are two shortcode arguments, both of which are optional:
- `before:` The prefix for the breadcrumb, usually something like `You're here`. Can also be HTML such as `<p>`.
- `after`:  The suffix for the breadcrumb. Can also be HTML such as `</p>`.

Examples:
- `[yoast_breadcrumb]`
- `[yoast_breadcrumb before='<p class="breadcrumb">You are here: ' after='</p>']`

Note: If the breadcrumb feature is disabled, then this shortcode outputs nothing.
