### PR TITLE
No need to show Twitter image when OpenGraph is showing

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -42,12 +42,12 @@ class WPSEO_Twitter extends WPSEO_Frontend {
 		$this->site_twitter();
 		$this->site_domain();
 		$this->author_twitter();
-		// No need to show these when OpenGraph is also showing, as it'd be the same contents and Twitter
-		// would fallback to OpenGraph anyway.
-		$this->image();
-		$options = get_wpseo_options();
 
+		// No need to show these when OpenGraph is also showing, as it'd be the same contents and Twitter
+		// would fallback to OpenGraph anyway.	
+		$options = get_wpseo_options();
 		if ( !isset( $options['opengraph'] ) || !$options['opengraph'] ) {
+			$this->image();
 			$this->twitter_description();
 			$this->twitter_title();
 			$this->twitter_url();


### PR DESCRIPTION
Both the description within the PR, and that next to the `image()` method suggests that it doesn't need to be called when OpenGraph is also showing. Using the Twitter Card Validator confirms that when `twitter:image:src` isn't present, it falls back to using `og:image`.
