### PR TITLE
Fixed sorting of taxonomies in breadcrumbs to go for term_order instead of name

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -116,14 +116,14 @@ class WPSEO_Breadcrumbs {
 
                                 $parent_order = 9999; //set default order
                                 foreach ( $parents as $parent ) {
-                                    if ( $parent->parent == 0 ) {
+                                    if ( $parent->parent == 0 && isset( $parent->term_order ) ) {
                                         $parent_order = $parent->term_order;
                                     }
                                 }
 
                                 //check if parent has lowest order
                                 if ( $parent_order < $term_order ) {
-                                    $term_order = $term->term_order;
+                                    $term_order = $parent_order;
 
                                     $deepest_term = $term;
                                 }


### PR DESCRIPTION
It will order by oldest ancestor instead of its own name.
