### PR TITLE
PHP Notice logged when site has capabilities created without 3rd value in args array

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -319,7 +319,7 @@ function allow_custom_field_edits( $allcaps, $cap, $args ) {
 	if ( in_array( $args[0], array( "edit_post_meta", "add_post_meta" ) ) ) {
 		// Only allow editing rights for users who have the rights to edit this post and make sure
 		// the meta value starts with _yoast_wpseo.
-		if ( current_user_can( 'edit_post', $args[2] ) && strpos( $args[3], "_yoast_wpseo_" ) === 0 )
+		if ( current_user_can( 'edit_post', $args[2] ) && ( ! empty( $args[3] ) && strpos( $args[3], "_yoast_wpseo_" ) === 0 ) )
 			$allcaps[$args[0]] = true;
 	}
 


### PR DESCRIPTION
Check if offset [3] exists in capabilitites array before confirming value of the 3rd arg.

This only seems to occur when using a client's custom capability manager plugin. I have edited that plugin too, but this seems like a good defensive fix w/ no negative outcome to checking if capability is specific to the SEO plugin
