### PR TITLE
Add a per-entry setting to exclude Google Authorship.

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -423,6 +423,17 @@ class WPSEO_Metabox {
 			"title"       => __( "301 Redirect", 'wordpress-seo' ),
 			"description" => __( "The URL that this page should redirect to.", 'wordpress-seo' )
 		);
+		$mbs['authorship']             = array(
+			'name'    => 'authorship',
+			'std'     => 'include',
+			'title'   => __( 'Authorship:', 'wordpress-seo' ),
+			'type'    => 'radio',
+			"options" => array(
+				"0" => __( "Include", 'wordpress-seo' ),
+				"1" => __( "Exclude", 'wordpress-seo' ),
+			),
+			'description' => __( 'Include <code>rel="author"</code> on this page?', 'wordpress-seo' ),
+		);
 
 		// Apply filters for in advanced section
 		$mbs = apply_filters( 'wpseo_metabox_entries_advanced', $mbs );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -802,6 +802,11 @@ class WPSEO_Frontend {
 			}
 		}
 
+		// Unset gplus when authorship is disabled for this entry
+		if ( wpseo_get_value( 'authorship' ) ) {
+			$gplus = false;
+		}
+
 		$gplus = apply_filters( 'wpseo_author_link', $gplus );
 
 		if ( $gplus )


### PR DESCRIPTION
Pages like a Home or About page have an author assigned, but may not be ideal for having Google authorship assigned since it may be off-topic from what the typical content is. Authors may want to exclude authorship for other reasons as well. This new setting is tucked away on the Advanced tab of the Edit entry meta box, and is set to Include by default.

Related: #38 
