### PR TITLE
Make closing comment marker unhookable.

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -43,6 +43,7 @@ class WPSEO_Frontend {
 		add_action( 'wpseo_head', array( $this, 'author' ), 22 );
 		add_action( 'wpseo_head', array( $this, 'publisher' ), 23 );
 		add_action( 'wpseo_head', array( $this, 'webmaster_tools_authentication' ), 90 );
+		add_action( 'wpseo_head', array( $this, 'debug_closing_marker' ), 999 );
 
 		// Remove actions that we will handle through our wpseo_head call, and probably change the output of
 		remove_action( 'wp_head', 'rel_canonical' );
@@ -457,6 +458,13 @@ class WPSEO_Frontend {
 	}
 
 	/**
+	 * Output the closing comment marker.
+	 */
+	public function debug_closing_marker() {
+		echo "<!-- / Yoast WordPress SEO plugin. -->\n\n";
+	}
+
+	/**
 	 * Output Webmaster Tools authentication strings
 	 */
 	public function webmaster_tools_authentication() {
@@ -499,8 +507,6 @@ class WPSEO_Frontend {
 		}
 
 		do_action( 'wpseo_head' );
-
-		echo "<!-- / Yoast WordPress SEO plugin. -->\n\n";
 
 		if ( !empty( $old_wp_query ) ) {
 			$GLOBALS['wp_query'] = $old_wp_query;
@@ -1215,7 +1221,7 @@ class WPSEO_Frontend {
 		}
 		return $content;
 	}
-	
+
 	/**
 	 * Adds the RSS footer and/or header to an RSS feed item.
 	 *


### PR DESCRIPTION
The opening and closing comment (debug) markers are unhookable via the following:

``` php
add_action( 'init', 'prefix_init', 15 );
/**
 * Remove WordPress SEO comment markers.
 */
function prefix_init() {
    global $wpseo_front;
    remove_action( 'wpseo_head', array( $wpseo_front, 'debug_marker' ), 2 ); // Remove opening WP SEO comment
    remove_action( 'wp_head', array( $wpseo_front, 'head' ), 1 ); // Remove closing WPSEO comment
    add_action( 'wp_head', 'gamajo_wpseo_head', 1 ); // Reinstate custom WPSEO head action
}

function prefix_wpseo_head() {
    global $wp_query;

    $old_wp_query = null;

    if ( ! $wp_query->is_main_query() ) {
        $old_wp_query = $wp_query;
        wp_reset_query();
    }

    do_action( 'wpseo_head' );

    // Closing comment marker removed from here

    if ( ! empty( $old_wp_query ) ) {
        $GLOBALS['wp_query'] = $old_wp_query;
        unset( $old_wp_query );
    }

    return;
}
```

If the `echo "<!-- / Yoast WordPress SEO plugin. -->\n\n";` line in `WPSEO_Frontend::head()` was hooked in to `wpseo_head` at a very late priority (it already immediately follows the hook), then it could be unhooked without having to define a clone of `head()` instead, with something like:

``` php
add_action( 'init', 'prefix_init', 15 );
/**
 * Remove WordPress SEO comment markers.
 */
function prefix_init() {
    global $wpseo_front;
    remove_action( 'wpseo_head', array( $wpseo_front, 'debug_marker' ), 2 ); // Remove opening WP SEO comment
    remove_action( 'wpseo_head', array( $wpseo_front, 'debug_closing_marker' ), 999 ); // Remove closing WPSEO comment
}
```
