### PR TITLE
Added composer.json for composer support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     ],
     "type": "wordpress-plugin",
     "require": {
-        "composer/installers": "v1.0.6"
+        "composer/installers": "~1.0"
     }
 }


### PR DESCRIPTION
Would you be interested in supporting composer?

All you would have to do is add this composer.json.. Then next time your plugin is updated in the WordPress plugin directory http://wpackagist.org will mirror it across and allow people to install your plugin via composer (it already does this but a lack of composer.json makes updating to latest stable release tricky).

[Composer](http://getcomposer.org) is a package manager for php and is gaining a lot of traction. For developers like myself who work for an agency that host lots of WordPress sites composer could become an invaluable tool for managing plugins and WordPress core itself.

Rarst is leading the charge on possibly getting WordPress core to have support. http://core.trac.wordpress.org/ticket/23912

p.s thank you for the plugin, i use it on every site.
