### PR TITLE
Fix the issue on missing/exceeding 'www.'

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -47,7 +47,8 @@ class WPSEO_Sitemaps {
 		add_action( 'wpseo_hit_sitemap_index', array( $this, 'hit_sitemap_index' ) );
 
 		// default stylesheet
-		$this->stylesheet = '<?xml-stylesheet type="text/xsl" href="' . home_url( 'main-sitemap.xsl' ) . '"?>';
+		$abs_main_sitemap_url = str_replace( get_option( 'home' ), $_SERVER['SERVER_NAME'], home_url( 'main-sitemap.xsl' ) );
+		$this->stylesheet = '<?xml-stylesheet type="text/xsl" href="' . $abs_main_sitemap_url . '"?>';
 
 		$this->options = get_wpseo_options();
 	}


### PR DESCRIPTION
in some host/wordpress configurations that falls in a 'Domains, protocols and ports must match' error.

If a domain is set to work with the www (i.e.: www.domain.com), if i call it without the www, it'll be placed automagically. But if i call the sitemap without the www it's loaded without the www, and the stylesheet is unreachable because of the reported bug.

That's the fixment.
