### PR TITLE
Do not block the use of buffer in wp_footer hooks for other plugins

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -99,7 +99,7 @@ class WPSEO_Frontend {
 
 		if ( isset( $this->options['forcerewritetitle'] ) && $this->options['forcerewritetitle'] ) {
 			add_action( 'get_header', array( $this, 'force_rewrite_output_buffer' ) );
-			add_action( 'wp_footer', array( $this, 'flush_cache' ) );
+			add_action( 'wp_footer', array( $this, 'flush_cache' ), -1 );
 		}
 
 		if ( isset( $this->options['title_test'] ) && $this->options['title_test'] )


### PR DESCRIPTION
So be free to use on wp_footer actions. Otherwise buffer are blocked by the SEO WordPress itself.
