### PR TITLE
Reinstate WPSEO_URL constant.

### DIFF
--- a/wp-seo.php
+++ b/wp-seo.php
@@ -35,6 +35,8 @@ if ( !defined( 'DB_NAME' ) ) {
 	die;
 }
 
+if ( !defined( 'WPSEO_URL' ) )
+	define( 'WPSEO_URL', plugin_dir_url( __FILE__ ) );
 if ( !defined( 'WPSEO_PATH' ) )
 	define( 'WPSEO_PATH', plugin_dir_path( __FILE__ ) );
 if ( !defined( 'WPSEO_BASENAME' ) )


### PR DESCRIPTION
Although WordPress SEO itself doesn't use this constant, a number of Yoast's premium add-on plugins do (WPSEO Local for example). Without this constant in place, stylesheets are not loaded. The result is broken looking option screens for the add-on plugins. I've attached a screenshot of the WPSEO Local options screen below to demonstrate the effects...

![wpseo-local](https://f.cloud.github.com/assets/148775/1582657/531c59fe-51f2-11e3-8817-7f2922c9936f.png)
