### PR TITLE
Check if tab hash is correct after being redirected from Facebook API.

### DIFF
--- a/js/wp-seo-admin.js
+++ b/js/wp-seo-admin.js
@@ -1,38 +1,36 @@
-(function($) {
+jQuery(document).ready(function() {
 
-	$(document).ready(function() {
+	// events
+	jQuery("#enablexmlsitemap").change(function() {
+		jQuery("#sitemapinfo").toggle(jQuery(this).is(':checked'));
+	}).change();
 
-		// events
-		$("#enablexmlsitemap").change(function() {
-			$("#sitemapinfo").toggle($(this).is(':checked'));
-		}).change();
+	jQuery("#cleanpermalinks").change(function() {
+		jQuery("#cleanpermalinksdiv").toggle(jQuery(this).is(':checked'));
+	}).change();
 
-		$("#cleanpermalinks").change(function() {
-			$("#cleanpermalinksdiv").toggle($(this).is(':checked'));
-		}).change();
-
-		$('#wpseo-tabs a').click(function() {
-			$('#wpseo-tabs a').removeClass('nav-tab-active');
-			$('.wpseotab').removeClass('active');
-		
-			var id = $(this).attr('id').replace('-tab','');
-			$('#' + id).addClass('active');
-			$(this).addClass('nav-tab-active');
-		});
-
-		// init
-		var active_tab = window.location.hash.replace('#top#','');
-
-		if ( active_tab == '' || active_tab == '#_=_') {
-			active_tab = $('.wpseotab').attr('id');
-		}
-
-		$('#' + active_tab).addClass('active');
-		$('#' + active_tab + '-tab').addClass('nav-tab-active');
-		
+	jQuery('#wpseo-tabs a').click(function() {
+		jQuery('#wpseo-tabs a').removeClass('nav-tab-active');
+		jQuery('.wpseotab').removeClass('active');
+	
+		var id = jQuery(this).attr('id').replace('-tab','');
+		jQuery('#' + id).addClass('active');
+		jQuery(this).addClass('nav-tab-active');
 	});
 
-})(jQuery);
+	// init
+	var active_tab = window.location.hash.replace('#top#','');
+
+	// default to first tab
+	if ( active_tab == '' || active_tab == '#_=_') {
+		active_tab = jQuery('.wpseotab').attr('id');
+	}
+
+	jQuery('#' + active_tab).addClass('active');
+	jQuery('#' + active_tab + '-tab').addClass('nav-tab-active');
+		
+});
+
 
 // global functions
 function setWPOption( option, newval, hide, nonce ) {


### PR DESCRIPTION
After being redirected from the Facebook API, FB adds a weird `#_=_` hash ([see here](https://developers.facebook.com/blog/post/552/)) which breaks the WP SEO tabs. 

This adds a simple conditional to the active tab and falls back to the default tab + cleans up the JS file.

Fixes #505 .
