### PR TITLE
Update class-rewrite.php

### DIFF
--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -126,7 +126,7 @@ class WPSEO_Rewrite {
 				$category_nicename = get_category_parents( $category->parent, false, '/', true ) . $category_nicename;
 
 			$category_rewrite[$blog_prefix . '(' . $category_nicename . ')/(?:feed/)?(feed|rdf|rss|rss2|atom)/?$'] = 'index.php?category_name=$matches[1]&feed=$matches[2]';
-			$category_rewrite[$blog_prefix . '(' . $category_nicename . ')/page/?([0-9]{1,})/?$']                  = 'index.php?category_name=$matches[1]&paged=$matches[2]';
+			$category_rewrite[$blog_prefix . '(' . $category_nicename . ')/'.$wp_rewrite->pagination_base.'/?([0-9]{1,})/?$']                  = 'index.php?category_name=$matches[1]&paged=$matches[2]';
 			$category_rewrite[$blog_prefix . '(' . $category_nicename . ')/?$']                                    = 'index.php?category_name=$matches[1]';
 		}
 


### PR DESCRIPTION
FIXES 404 error for pagination with custom 'page' query var

See: http://wordpress.org/support/topic/plugin-wp-no-category-base-wpml-compatible-solution-to-fix-category-pagination-404-error

I am having pagination issues (404) using a theme that changes the 'pagination_base' field of 'wp_rewrite' together with Yoast SEO configured to suppress the base category. This patch solves the issue.
