### PR TITLE
Empty value for unchecked checkbox.

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -752,7 +752,7 @@ class WPSEO_Metabox {
 				if ( isset( $_POST['yoast_wpseo_' . $meta_box['name']] ) )
 					$data = 'on';
 				else
-					$data = 'off';
+					$data = '';
 			}
 			else if ( 'multiselect' == $meta_box['type'] ) {
 				if ( isset( $_POST['yoast_wpseo_' . $meta_box['name']] ) ) {


### PR DESCRIPTION
Note the logic for displaying checkbox fields [here](https://github.com/Yoast/wordpress-seo/blob/master/admin/class-metabox.php#L566)

In order for checkbox metabox fields to work, the unchecked state should be saved as a value that evaluates to `false`.
