### PR TITLE
Filter wpseo_pre_analysis_post_content before suppressing domDocument::loadHTML errors

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -1151,10 +1151,12 @@ class WPSEO_Metabox {
 		$dom->strictErrorChecking = false;
 		$dom->preserveWhiteSpace  = false;
 		
-		$html = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
-		if ( !empty( $html ) )
-			@$dom->loadHTML( $html );
-		
+		$post_content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
+		if ( !empty( $post_content ) )
+			@$dom->loadHTML( $post_content );
+
+		unset( $post_content );
+
 		$xpath = new DOMXPath( $dom );
 
 		global $statistics;


### PR DESCRIPTION
wpseo_pre_analysis_post_content is a very handy filter, but not always used as securely. Themes may spit out errors (or worse, stop execution) while using this filter. Currently, it falls under the scope of the error suppressing '@' for the parsing of the HTML by domDocument. This is could potentially (and actually..) lead to hard-to-debug problems.
