### PR TITLE
Issue 571: fb:admins meta tag not added to the page

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -150,7 +150,7 @@ class WPSEO_OpenGraph extends WPSEO_Frontend {
 				if ( ! empty( $adminstr ) )
 					$adminstr .= ',' . $admin_id;
 				else
-					$adminstr = $admin_id;
+					$adminstr = is_int ( $admin_id ) ? (string) $admin_id : $admin_id;
 			}
 			$adminstr = apply_filters( 'wpseo_opengraph_admin', $adminstr );
 			if ( is_string( $adminstr ) && $adminstr !== '' )


### PR DESCRIPTION
fb:admins meta tag is not added to the page if we have a single fb
admin and the Facebook user id of the admin is string that looks
like a valid integer value.

Signed-off-by: Iñaki Arenaza iarenaza@mondragon.edu
