### PR TITLE
Changed get_post_custom to get_post_meta for performance reasons

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -24,9 +24,9 @@ function wpseo_get_value( $val, $postid = 0 ) {
 		else
 			return false;
 	}
-	$custom = get_post_custom( $postid );
-	if ( !empty( $custom['_yoast_wpseo_' . $val][0] ) )
-		return maybe_unserialize( $custom['_yoast_wpseo_' . $val][0] );
+	$post_meta = get_post_meta( $postid, '_yoast_wpseo_' . $val, true );
+	if ( !empty( $post_meta ) )
+		return $post_meta;
 	else
 		return false;
 }


### PR DESCRIPTION
get_post_custom retrieves all the meta data and creates a lot of overhead depending on the number of meta keys available. I think that get_post_meta is better suited in this case and very beneficial for larger sites.

For further information, please see pods-framework/pods#2007 
