### PR TITLE
Add support for html entities

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -81,7 +81,7 @@ class WPSEO_Metabox {
 	public function strtolower_utf8( $string ) {
 		
 		// Prevent comparison between utf8 characters and html entities (é vs &eacute;)
-        $string = html_entity_decode( $string );
+		$string = html_entity_decode( $string );
 		
 		$convert_to   = array(
 			"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u",

--- a/js/wp-seo-metabox.js
+++ b/js/wp-seo-metabox.js
@@ -3,7 +3,7 @@ function yst_clean(str) {
 		return '';
 
 	try {
-        str = jQuery('<div/>').html(str).text();
+		str = jQuery('<div/>').html(str).text();
 		str = str.replace(/<\/?[^>]+>/gi, '');
 		str = str.replace(/\[(.+?)\](.+?\[\/\\1\])?/g, '');
 	} catch (e) {
@@ -13,7 +13,7 @@ function yst_clean(str) {
 }
 
 function ptest(str, p) {
-    str = yst_clean(str);
+	str = yst_clean(str);
 	str = str.toLowerCase();
 	var r = str.match(p);
 	if (r != null)


### PR DESCRIPTION
Decode html entities in post content to support french special characters (some themes store html entity in post table). See Issue : https://github.com/Yoast/wordpress-seo/issues/613
