### PR TITLE
Prevent a fatal error if `wp_remote_get()` fails ...

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -41,7 +41,10 @@ function wpseo_title_test() {
 			$options['forcerewritetitle'] = true;
 
 			$resp = wp_remote_get( get_bloginfo( 'url' ), $args );
-			$res  = preg_match( '`/<title>([^>]+)</title>`im', $resp['body'], $matches );
+			$res  = false;
+			if ( ( $resp && ! is_wp_error( $resp ) ) && ( 200 == $resp['response']['code'] && isset( $resp['body'] ) ) ) {
+				$res  = preg_match( '`/<title>([^>]+)</title>`im', $resp['body'], $matches );
+			}
 		}
 
 		if ( ! $res || $matches[1] != $expected_title ) {

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ You'll find the [FAQ on Yoast.com](https://yoast.com/wordpress/plugins/seo/faq/)
 	* Fixed some PHP 'undefined index' notices.
 	* Fix banner images overlapping text in help tabs.
 	* Fixed meta description tag not showing for taxonomy (category/tag/etc) pages as reported in [issue #737](https://github.com/Yoast/wordpress-seo/issues/737) and [#780](https://github.com/Yoast/wordpress-seo/issues/780) - props [Jrf](http://profiles.wordpress.org/jrf).
+	* Prevent a fatal error if `wp_remote_get()` fails while testing whether the title needs to be force rewritten as reported by [homeispv](http://wordpress.org/support/profile/homeispv) - props [Jrf](http://profiles.wordpress.org/jrf).
 
 * Enhancements
 	* Added composer support - props [codekipple](https://github.com/codekipple) and [Rarst](https://github.com/Rarst).


### PR DESCRIPTION
... while testing whether the title needs to be force rewritten

Ref: http://wordpress.org/support/topic/yoast-1521-will-not-install
