### PR TITLE
Moved bootstrapping of plugin to plugins_loaded hook

### DIFF
--- a/wp-seo.php
+++ b/wp-seo.php
@@ -33,9 +33,24 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
-if ( ! defined( 'WPSEO_FILE' ) ) {
-	define( 'WPSEO_FILE', __FILE__ );
+/**
+* Bootstraps the WordPress SEO Plugin
+*
+* Checks if WordPress SEO Premium is activated
+*/ 
+function wpseo_bootstrap() {
+
+	if( defined( "WPSEO_VERSION" ) ) {
+		return false;
+	}
+
+	if ( ! defined( 'WPSEO_FILE' ) ) {
+		define( 'WPSEO_FILE', __FILE__ );
+	}
+
+	// Load the WordPress SEO plugin
+	require_once( 'wp-seo-main.php' );
 }
 
-// Load the WordPress SEO plugin
-require_once( 'wp-seo-main.php' );
+add_action( 'plugins_loaded', 'wpseo_bootstrap', 2 );
+


### PR DESCRIPTION
This allows for checking if WordPress SEO Premium is running and if it is, not loading WordPress SEO files. Prevents a fatal error when activating premium while still running WP SEO.

This needs https://github.com/Yoast/wordpress-seo-premium/pull/95 to prevent the fatal error upon plugin activation of Premium.

**Note**
WordPress SEO hooks into `plugins_loaded` a couple of times more so the hook priority should not be set any higher than 14. WP SEO Premium can use the same hook for bootstrapping but with a hook priority of 1, to ensure it is loaded first.
