### PR TITLE
Allow for WP bug #23268

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -234,12 +234,14 @@ if ( ! class_exists( 'WPSEO_Admin_Pages' ) ) {
 		/**
 		 * Deletes all post meta values with a given meta key from the database
 		 *
+		 * @todo [JRF => whomever] This method does not seem to be used anywhere. Double-check before removal.
+		 *
 		 * @param string $meta_key Key to delete all meta values for.
 		 */
-		function delete_meta( $meta_key ) {
+		/*function delete_meta( $meta_key ) {
 			global $wpdb;
 			$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->postmeta WHERE meta_key = %s", $meta_key ) );
-		}
+		}*/
 
 		/**
 		 * Exports the current site's WP SEO settings.

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -866,7 +866,7 @@ if ( ! class_exists( 'WPSEO_Sitemaps' ) ) {
 					'meta_query' => array(
 						array(
 							'key'     => '_yoast_wpseo_profile_updated',
-							'value'   => '', // This is ignored, but is necessary...
+							'value'   => 'needs-a-value-anyway', // This is ignored, but is necessary...
 							'compare' => 'NOT EXISTS',
 						),
 					)

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -681,7 +681,7 @@ function wpseo_sitemap_handler( $atts ) {
 						// include if this key doesn't exists
 						array(
 							'key'     => WPSEO_Meta::$meta_prefix . 'meta-robots-noindex',
-							'value'   => '', // This is ignored, but is necessary...
+							'value'   => 'needs-a-value-anyway', // This is ignored, but is necessary...
 							'compare' => 'NOT EXISTS',
 						),
 						// OR if key does exists include if it is not 1


### PR DESCRIPTION
Ref: http://codex.wordpress.org/Class_Reference/WP_Query#Custom_Field_Parameters
Ref: http://core.trac.wordpress.org/ticket/23268

Found these while doing a quick search round for any other queries on meta values which may or may not account for the defaults no longer being saved (inspired by issue #838). All those queries seemed to be fine at first glance.
Searched on `meta_query`, `meta_key` and `meta_value`.
