### PR TITLE
Keyword density preg_quote fix

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -1764,7 +1764,7 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 				// Keyword Density check
 				$keywordDensity = 0;
 				if ( $wordCount > 100 ) {
-					$keywordCount = preg_match_all( '`\b' . preg_quote( $job['keyword'], '`' ) . '\b`miu', utf8_encode ( $body ), $res );
+					$keywordCount = preg_match_all( '`\b' . preg_quote( $job['keyword'], '`' ) . '\b`miu', utf8_encode( $body ), $res );
 					if ( ( $keywordCount > 0 && $keywordWordCount > 0 ) && $wordCount > $keywordCount ) {
 						$keywordDensity = wpseo_calc( wpseo_calc( $keywordCount, '/', wpseo_calc( $wordCount, '-', ( wpseo_calc( wpseo_calc( $keywordWordCount, '-', 1 ), '*', $keywordCount ) ) ) ), '*', 100, true, 2 );
 					}


### PR DESCRIPTION
Fix misplaced character in `preg_quote()`. This will probably fix the keyword density issue without the `utf8_encode()`, but I'll leave it up to @barrykooij to test this and remove the `utf8_encode()` if he agrees.
