### PR TITLE
Fix issue #864 - work-around wrong verification key input

### DIFF
--- a/inc/class-wpseo-options.php
+++ b/inc/class-wpseo-options.php
@@ -900,7 +900,7 @@ if ( ! class_exists( 'WPSEO_Option_Wpseo' ) ) {
 							$meta = $dirty[$key];
 							if ( strpos( $meta, 'content=' ) ) {
 								// Make sure we only have the real key, not a complete meta tag
-								preg_match( '`content=([\'"])([^\'"]+)\1`', $meta, $match );
+								preg_match( '`content=([\'"])?([^\'"> ]+)(?:\1|[ />])`', $meta, $match );
 								if ( isset( $match[2] ) ) {
 									$meta = $match[2];
 								}

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,11 @@ You'll find the [FAQ on Yoast.com](https://yoast.com/wordpress/plugins/seo/faq/)
 
 == Changelog ==
 
+= Trunk =
+
+* Enhancement
+	* Enhanced validation of webmaster verification keys to prevent invalidating incorrect input which does contain a key as reported by [TheZoker](https://github.com/TheZoker) in [issue #864](https://github.com/Yoast/wordpress-seo/issues/864) - props [Jrf](http://profiles.wordpress.org/jrf).
+
 = 1.5.2.3 =
 
 ** Note: if you already upgraded to v1.5+, you will need to retrieve your Facebook Apps again and please also check your Google+ URL. We had some bugs with both being escaped too aggressively. Sorry about that. **


### PR DESCRIPTION
The conversation could already deal with a complete meta tag being given as input while it needs only the verification ID.
Now it will also be able to deal with the complete meta tag if the html is invalid.... _sigh_
