### PR TITLE
Selectively show the `breadcrumbs-blog-remove` option

### DIFF
--- a/admin/pages/internal-links.php
+++ b/admin/pages/internal-links.php
@@ -21,7 +21,9 @@ $content .= $wpseo_admin_pages->textinput( 'breadcrumbs-prefix', __( 'Prefix for
 $content .= $wpseo_admin_pages->textinput( 'breadcrumbs-archiveprefix', __( 'Prefix for Archive breadcrumbs', 'wordpress-seo' ) );
 $content .= $wpseo_admin_pages->textinput( 'breadcrumbs-searchprefix', __( 'Prefix for Search Page breadcrumbs', 'wordpress-seo' ) );
 $content .= $wpseo_admin_pages->textinput( 'breadcrumbs-404crumb', __( 'Breadcrumb for 404 Page', 'wordpress-seo' ) );
-$content .= $wpseo_admin_pages->checkbox( 'breadcrumbs-blog-remove', __( 'Remove Blog page from Breadcrumbs', 'wordpress-seo' ) );
+if( get_option( 'page_for_posts' ) ) {
+	$content .= $wpseo_admin_pages->checkbox( 'breadcrumbs-blog-remove', __( 'Remove Blog page from Breadcrumbs', 'wordpress-seo' ) );
+}
 $content .= $wpseo_admin_pages->checkbox( 'breadcrumbs-boldlast', __( 'Bold the last page in the breadcrumb', 'wordpress-seo' ) );
 $content .= '<br/><br/>';
 


### PR DESCRIPTION
Only show the `breadcrumbs-blog-remove` option if user uses `page_for_posts` as it's not applicable otherwise and can cause confusion.

Ref: http://wordpress.org/support/topic/15-broke-catalyst-default-breadcrumbs-breadcrumbs-not-working?replies=1#post-5361404
