### PR TITLE
Fix PHP warnings when post_type is an array

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -382,7 +382,12 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 				}
 			} elseif ( is_post_type_archive() ) {
 				$post_type = get_query_var( 'post_type' );
-				$title     = $this->get_title_from_options( 'title-ptarchive-' . $post_type );
+
+				if ( is_array( $post_type ) ) {
+					$post_type = reset( $post_type );
+				}
+
+				$title = $this->get_title_from_options( 'title-ptarchive-' . $post_type );
 
 				if ( ! is_string( $title ) || '' === $title ) {
 					$post_type_obj = get_post_type_object( $post_type );
@@ -619,6 +624,11 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 
 				} elseif ( is_post_type_archive() ) {
 					$post_type = get_query_var( 'post_type' );
+
+					if ( is_array( $post_type ) ) {
+						$post_type = reset( $post_type );
+					}
+
 					if ( isset( $this->options['noindex-ptarchive-' . $post_type] ) && $this->options['noindex-ptarchive-' . $post_type] === true )
 						$robots['index'] = 'noindex';
 				}
@@ -761,7 +771,11 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 						$canonical = get_term_link( $term, $term->taxonomy );
 					}
 				} elseif ( is_post_type_archive() ) {
-					$canonical = get_post_type_archive_link( get_query_var( 'post_type' ) );
+					$post_type = get_query_var( 'post_type' );
+					if ( is_array( $post_type ) ) {
+						$post_type = reset( $post_type );
+					}
+					$canonical = get_post_type_archive_link( $post_type );
 				} elseif ( is_author() ) {
 					$canonical = get_author_posts_url( get_query_var( 'author' ), get_query_var( 'author_name' ) );
 				} elseif ( is_archive() ) {
@@ -1013,6 +1027,9 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 					}
 				} elseif ( is_post_type_archive() ) {
 					$post_type = get_query_var( 'post_type' );
+					if ( is_array( $post_type ) ) {
+						$post_type = reset( $post_type );
+					}
 					if ( isset( $this->options['metakey-ptarchive-' . $post_type] ) && $this->options['metakey-ptarchive-' . $post_type] !== '' ) {
 						$keywords = wpseo_replace_vars( $this->options['metakey-ptarchive-' . $post_type], (array) $wp_query->get_queried_object() );
 					}
@@ -1088,6 +1105,9 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 					}
 				} elseif ( is_post_type_archive() ) {
 					$post_type = get_query_var( 'post_type' );
+					if ( is_array( $post_type ) ) {
+						$post_type = reset( $post_type );
+					}
 					if ( isset( $this->options['metadesc-ptarchive-' . $post_type] ) && $this->options['metadesc-ptarchive-' . $post_type] !== '' ) {
 						$metadesc = wpseo_replace_vars( $this->options['metadesc-ptarchive-' . $post_type], (array) $wp_query->get_queried_object() );
 					}


### PR DESCRIPTION
WordPress SEO expects `get_query_var( 'post_type' )` to be a string, but it can also be an array. This leads to a PHP warning when viewing a post type archive:

```
Warning: Illegal offset type in isset or empty in wp-includes/post.php on line 1060
```

The warning comes from `WPSEO_Frontend::canonical()`, where `get_query_var( 'post_type' )` is passed directly to `get_post_type_archive_link()`, which only accepts a string.

Sample code to reproduce the issue:

```
function query_multiple_post_types( $query ) {
    if ( ! is_admin() && $query->is_main_query() ) {
        $query->set( 'post_type', array( 'post', 'page' ) );
    }
}
add_action( 'pre_get_posts', 'query_multiple_post_types' );
```
