### PR TITLE
replace wpseo variables for social descriptions

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -484,8 +484,14 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 
 			if ( is_singular() ) {
 				$ogdesc = WPSEO_Meta::get_value( 'opengraph-description' );
+
+
+
 				if ( $ogdesc === '' ) {
 					$ogdesc = $this->metadesc( false );
+				} else {
+					// Replace WP SEO Variables
+					$ogdesc = wpseo_replace_vars( $ogdesc, get_post() );
 				}
 
 				// og:description is still blank so grab it from get_the_excerpt()


### PR DESCRIPTION
So users can use WPSEO variables in their Social meta. 

![image](https://cloud.githubusercontent.com/assets/885856/2613558/d3e2a250-bbd8-11e3-9e47-786885593650.png)
