### PR TITLE
Better OG locale

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -312,9 +312,13 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 			);
 
 			// check to see if the locale is a valid FB one, if not, use en_US as a fallback
-			if ( ! in_array( $locale, $fb_valid_fb_locales ) ) {
-				$locale = 'en_US';
-			}
+			// check to see if the locale is a valid FB one, if not, use en_US as a fallback
+            if ( ! in_array( $locale, $fb_valid_fb_locales ) ) {
+                $locale = strtolower( substr($locale, 0, 2) ) . '_' . strtoupper( substr($locale, 0, 2) );
+                if ( ! in_array( $locale, $fb_valid_fb_locales ) ) {
+                    $locale = 'en_US';
+                }
+            }
 
 			if ( $echo !== false ) {
 				$this->og_tag( 'og:locale', $locale );


### PR DESCRIPTION
I ran into a case for a client using the locale es_PE in wordpress, and as it's not recognized by facebook, the OG meta was set to en_US.

With the fix it's now setting es_ES which looks more appropriate. Correct me if i'm wrong.
The best one would be es_LA, but it's corner case i guess.
