### PR TITLE
Account for a WP_Error result from Google Suggest request

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -93,13 +93,15 @@ function wpseo_get_suggest() {
 	$term   = urlencode( $_GET['term'] );
 	$result = wp_remote_get( 'https://www.google.com/complete/search?output=toolbar&q=' . $term );
 
-	preg_match_all( '`suggestion data="([^"]+)"/>`u', $result['body'], $matches );
-
 	$return_arr = array();
 
-	if ( isset( $matches[1] ) && ( is_array( $matches[1] ) && $matches[1] !== array() ) ) {
-		foreach ( $matches[1] as $match ) {
-			$return_arr[] = html_entity_decode( $match, ENT_COMPAT, 'UTF-8' );
+	if ( ! is_wp_error( $result ) ) {
+		preg_match_all( '`suggestion data="([^"]+)"/>`u', $result['body'], $matches );
+
+		if ( isset( $matches[1] ) && ( is_array( $matches[1] ) && $matches[1] !== array() ) ) {
+			foreach ( $matches[1] as $match ) {
+				$return_arr[] = html_entity_decode( $match, ENT_COMPAT, 'UTF-8' );
+			}
 		}
 	}
 	echo json_encode( $return_arr );


### PR DESCRIPTION
`PHP message: PHP Fatal error: Cannot use object of type WP_Error as array in /var/www/wp-content/plugins/wordpress-seo/admin/ajax.php on line 96`

If a request fails and the result is a WP_Error object, a fatal error is thrown when attempting to access the result as an array.

This wraps the processing of the response in a check for the error and results in an empty return array if one is found.

It may be beneficial to provide some sort of error message on the front end.
