### PR TITLE
Fix issue #1073 date localization

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -581,9 +581,9 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 		 */
 		function get_post_date( $post ) {
 			if ( isset( $post->post_date ) && $post->post_status == 'publish' ) {
-				$date = date( 'j M Y', strtotime( $post->post_date ) );
+				$date = date_i18n( 'j M Y', strtotime( $post->post_date ) );
 			} else {
-				$date = date( 'j M Y' );
+				$date = date_i18n( 'j M Y' );
 			}
 
 			return $date;

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -589,7 +589,7 @@ if ( ! class_exists( 'WPSEO_Breadcrumbs' ) ) {
 				$date = get_the_date();
 			}
 			else {
-				$date = mysql2date( get_option( 'date_format' ), $date );
+				$date = mysql2date( get_option( 'date_format' ), $date, true );
 				$date = apply_filters( 'get_the_date', $date, '' );
 			}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -428,7 +428,7 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 					// @todo [JRF => Yoast] Should these not use the archive default if no title found ?
 					if ( 0 !== get_query_var( 'day' ) ) {
 						$date = sprintf( '%04d-%02d-%02d 00:00:00', get_query_var( 'year' ), get_query_var( 'monthnum' ), get_query_var( 'day' ) );
-						$date = mysql2date( get_option( 'date_format' ), $date );
+						$date = mysql2date( get_option( 'date_format' ), $date, true );
 						$date = apply_filters( 'get_the_date', $date, '' );
 						$title_part      = sprintf( __( '%s Archives', 'wordpress-seo' ), $date );
 					} elseif ( 0 !== get_query_var( 'monthnum' ) ) {

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -993,7 +993,7 @@ if ( ! class_exists( 'WPSEO_Sitemaps' ) ) {
 		 */
 		function sitemap_url( $url ) {
 			if ( isset( $url['mod'] ) ) {
-				$date = mysql2date( 'Y-m-d\TH:i:s+00:00', $url['mod'] );
+				$date = mysql2date( 'Y-m-d\TH:i:s+00:00', $url['mod'], false );
 			} else {
 				$date = date( 'c' );
 			}

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -172,16 +172,15 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
 		'%%sep%%'          => $sep,
 		'%%sitename%%'     => get_bloginfo( 'name' ),
 		'%%sitedesc%%'     => get_bloginfo( 'description' ),
-		'%%currenttime%%'  => date( get_option( 'time_format' ) ),
-		'%%currentdate%%'  => date( get_option( 'date_format' ) ),
-		'%%currentday%%'   => date( 'j' ),
-		'%%currentmonth%%' => date( 'F' ),
-		'%%currentyear%%'  => date( 'Y' ),
+		'%%currenttime%%'  => date_i18n( get_option( 'time_format' ) ),
+		'%%currentdate%%'  => date_i18n( get_option( 'date_format' ) ),
+		'%%currentday%%'   => date_i18n( 'j' ),
+		'%%currentmonth%%' => date_i18n( 'F' ),
+		'%%currentyear%%'  => date_i18n( 'Y' ),
 	);
 
-	foreach ( $simple_replacements as $var => $repl ) {
-		$string = str_replace( $var, $repl, $string );
-	}
+	$string = str_replace( array_keys( $simple_replacements ), array_values( $simple_replacements ), $string );
+
 
 	// Let's see if we can bail early.
 	if ( strpos( $string, '%%' ) === false ) {
@@ -235,7 +234,7 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
 
 	// Let's do date first as it's a bit more work to get right.
 	if ( $r->post_date != '' ) {
-		$date = mysql2date( get_option( 'date_format' ), $r->post_date );
+		$date = mysql2date( get_option( 'date_format' ), $r->post_date, true );
 	}
 	else {
 		if ( get_query_var( 'day' ) && get_query_var( 'day' ) != '' ) {
@@ -272,7 +271,7 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
 				'%%excerpt_only%%' => strip_tags( $r->post_excerpt ),
 				'%%focuskw%%'      => WPSEO_Meta::get_value( 'focuskw', $r->ID ),
 				'%%id%%'           => $r->ID,
-				'%%modified%%'     => mysql2date( get_option( 'date_format' ), $r->post_modified ),
+				'%%modified%%'     => mysql2date( get_option( 'date_format' ), $r->post_modified, true ),
 				'%%name%%'         => get_the_author_meta( 'display_name', ! empty( $r->post_author ) ? $r->post_author : get_query_var( 'author' ) ),
 				'%%tag%%'          => wpseo_get_terms( $r->ID, 'post_tag' ),
 				'%%title%%'        => stripslashes( $r->post_title ),

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ You'll find the [FAQ on Yoast.com](https://yoast.com/wordpress/plugins/seo/faq/)
 
 * Bugfixes
 	* Don't ping search engines if the blog is set to 'discourage search engines from indexing this site' - props [Jrf](http://profiles.wordpress.org/jrf).
+	* Localize dates where appropriate as suggested by [allankronmark](https://github.com/allankronmark) in [issue #1073](https://github.com/Yoast/wordpress-seo/issues/1073). 
 
 = 1.5.2.8 =
 


### PR DESCRIPTION
Fixes dates not always being localized in the `wpseo_replace_vars()` function.

Also:
- similar date localization in metabox preview snippet (after all Google is localized too)
- minor efficiency tweak in `wpseo_replace_vars()`
- ensure that dates in sitemap are _not_ localized - this might fix some invalid date format issues people are having when validation the sitemap in GWT
