### PR TITLE
Fix issue #1045 - 'breadcrumb_last' class was missing on homepage

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -297,7 +297,7 @@ if ( ! class_exists( 'WPSEO_Breadcrumbs' ) ) {
 			$this->maybe_add_blog_crumb();
 
 			if ( ( $this->show_on_front === 'page' && is_front_page() ) || ( $this->show_on_front === 'posts' && is_home() ) ) {
-				return;
+				// do nothing
 			}
 			elseif ( $this->show_on_front == 'page' && is_home() ) {
 				$this->add_blog_crumb();

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ You'll find the [FAQ on Yoast.com](https://yoast.com/wordpress/plugins/seo/faq/)
 
 * Bugfixes
 	* Don't ping search engines if the blog is set to 'discourage search engines from indexing this site' - props [Jrf](http://profiles.wordpress.org/jrf).
+	* Fixed: 'breadcrumb_last' class was missing on homepage, as reported by [uprise10](https://github.com/uprise10) in [issue #1045](https://github.com/Yoast/wordpress-seo/issues/1045) - props [Jrf](http://profiles.wordpress.org/jrf).
 
 = 1.5.2.8 =
 


### PR DESCRIPTION
... as the function was returning without updating the crumb counter property nor running the filter
