### PR TITLE
Fixed unreachable filter wpseo_sitemap_[post_type]_content

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -734,7 +734,7 @@ if ( ! class_exists( 'WPSEO_Sitemaps' ) ) {
 			$this->sitemap .= $output;
 
 			// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.
-			if ( $n == 0 ) {
+			if ( $n == 1 ) {
 				$this->sitemap .= apply_filters( 'wpseo_sitemap_' . $post_type . '_content', '' );
 			}
 


### PR DESCRIPTION
There was condition, which would run the filter only on first page on sitemap. This condition would never be true in old code.
I'm referencing issues https://github.com/Yoast/wordpress-seo/issues/1156 and https://github.com/Yoast/wordpress-seo/issues/963
