### PR TITLE
Specify post ID when using wp_enqueue_media() to set up correctly for the post being edited.

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -709,7 +709,7 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 			if ( $pagenow == 'edit.php' ) {
 				wp_enqueue_style( 'edit-page', plugins_url( 'css/edit-page' . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_FILE ), array(), WPSEO_VERSION );
 			} else {
-				wp_enqueue_media(); // enqueue files needed for upload functionality
+				wp_enqueue_media( array( 'post' => get_queried_object_id() ) ); // enqueue files needed for upload functionality
 				wp_enqueue_style( 'metabox-tabs', plugins_url( 'css/metabox-tabs' . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_FILE ), array(), WPSEO_VERSION );
 				wp_enqueue_style( "metabox-$color", plugins_url( 'css/metabox-' . esc_attr( $color ) . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_FILE ), array(), WPSEO_VERSION );
 


### PR DESCRIPTION
wp_enqueue_media() requires the Post ID to be passed as a parameter.

Without this the 'Uploaded to this post' option was not working in the media modal for my custom post type.

This fixes the issue.
