### PR TITLE
Enforce wpseo_opengraph_image filters

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -399,6 +399,7 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 				// If it's a relative URL, it's relative to the domain, not necessarily to the WordPress install, we
 				// want to preserve domain name and URL scheme (http / https) though.
 				$parsed_url = parse_url( home_url() );
+				$parsed_url = apply_filters( 'wpseo_opengraph_image', $parsed_url );
 				$img        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $img;
 			}
 


### PR DESCRIPTION
Applies any wpseo_opengraph_image filters to the $parsed_url. Helpful for ensuring image links are served over CDN with the right filter setup.
