### PR TITLE
Fix pagination redirect

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -63,7 +63,7 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 			add_filter( 'thematic_doctitle', array( $this, 'title' ), 15 );
 
 			add_action( 'wp', array( $this, 'page_redirect' ), 99 );
-			add_action( 'wp', array( $this, 'pagination_overflow_redirect' ), 99 );
+			add_action( 'get_header', array( $this, 'pagination_overflow_redirect' ), 99 );
 
 			add_action( 'template_redirect', array( $this, 'noindex_feed' ) );
 


### PR DESCRIPTION
This line (fixed in this commit) is causing pagination to break in some cases. With bbPress installed, pagination won't work on forum search pages. With Buddypress also installed, all pagination on group forums won't work.

The function pagination_overflow_redirect is running on the action 'wp', which is too early. At that time, those paginated pages still return a 404, causing a redirect so you can never leave the first page of results. By calling the function on the action 'get_header', those pages do not return a 404, but actual 404s still do, so the function works as intended.

I testing this on a clean install of Wordpress. I tried using the action 'template_redirect', but that's still too early.
