### PR TITLE
Fix issue #1248 - breadcrumb on search

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -452,7 +452,7 @@ if ( ! class_exists( 'WPSEO_Breadcrumbs' ) ) {
 		 * Add Blog crumb to the crumbs property for single posts where Home != blogpage
 		 */
 		private function maybe_add_blog_crumb() {
-			if ( 'page' === $this->show_on_front && 'post' === get_post_type() && ! is_home() ) {
+			if ( ( 'page' === $this->show_on_front && 'post' === get_post_type() ) && ( ! is_home() && ! is_search() ) ) {
 				if ( $this->page_for_posts && $this->options['breadcrumbs-blog-remove'] === false ) {
 					$this->add_blog_crumb();
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,7 @@ You'll find the [FAQ on Yoast.com](https://yoast.com/wordpress/plugins/seo/faq/)
 	* Fixed: `%%pt_single%%` and `%%pt_plural%%` didn't work in preview mode.
 	* Fixed: `%%page_total%%` would sometimes be one short.
 	* Fixed: `%%term404%%` would sometimes be empty while the pagename causing the 404 was known.
+	* Fixed: if first result of a search is a post, the blog page was incorrectly added to the breadcrumb, as reported in [issue #1248](https://github.com/Yoast/wordpress-seo/issues/1248) by [Nikoya](https://github.com/Nikoya) - props [Jrf](http://profiles.wordpress.org/jrf).
 
 * Enhancements
 	* New `wpseo_register_extra_replacements` action hook which lets plugin/theme builders add new `%%...%%` replacement variables - including relevant help texts -. See [function documentation](https://github.com/Yoast/wordpress-seo/blob/master/inc/wpseo-functions.php) for an example of how to use this new functionality.


### PR DESCRIPTION
If first result of a search is a post, the blog page was incorrectly added to the breadcrumb
