### PR TITLE
Open Graph Meta tags: automatically disable Jetpack's OG tags

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 
 				add_action( 'wpseo_opengraph', array( $this, 'image' ), 30 );
 			}
-			remove_action( 'wp_head', 'jetpack_og_tags' );
+			add_filter( 'jetpack_enable_open_graph', '__return_false' );
 			add_action( 'wpseo_head', array( $this, 'opengraph' ), 30 );
 		}
 


### PR DESCRIPTION
In [14eb4e7f710fd83fe89d856f94fecdfdb44cdaad](https://github.com/Automattic/jetpack/commit/14eb4e7f710fd83fe89d856f94fecdfdb44cdaad), Jetpack stopped automatically deactivating its Open Graph meta tags when WP SEO or WP SEO Premium were activated. We thought that wasn't necessary anymore, since WP SEO already removed the tags here:
https://github.com/Yoast/wordpress-seo/blob/1.5.4.2/frontend/class-opengraph.php#L60

Unfortunately that doesn't work, and since Jetpack 3.1 was released users using both Jetpack and WP SEO get a duplicate set of Open Graph tags. We'll get this fixed in Jetpack 3.1.1 (see Automattic/jetpack#929), but I think it'd be nice to update WP SEO as well to use the correct filter, and thus avoid duplicate sets of tags.
