### PR TITLE
Add phplinting for two versions of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - php: "5.5"
       env: WP_VERSION=3.9 WP_MULTISITE=1
     - php: "5.4"
-      env: WP_VERSION=3.8 WP_MULTISITE=1
-    - php: "5.3"
       env: WP_VERSION=3.8 WP_MULTISITE=0
+    - php: "5.3"
+      env: WP_VERSION=3.8 WP_MULTISITE=1
     - php: "5.3"
       env: WP_VERSION=3.9 WP_MULTISITE=0
     - php: "5.2"


### PR DESCRIPTION
Run PHP lint on all files for the lowest and highest PHP version tested on/supported so any parse errors which may accidentally still exist are caught.

Suggestion: we could also add a switch like this to phpcs as that doesn't need to be run for all versions either.
Code style either complies or doesn't.

**[Update]**
Added selective running of phpcs as well.
