### PR TITLE
Partially fix issue #1428

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WPSEO_Replace_Vars' ) ) {
 			 *
 			 * @api bool $final
 			 */
-			if ( apply_filters( 'wpseo_replacements_final', true ) === true ) {
+			if ( apply_filters( 'wpseo_replacements_final', true ) === true && ( isset( $matches[1] ) && is_array( $matches[1] ) ) ) {
 				// Remove non-replaced variables
 				$remove = array_diff( $matches[1], $omit ); // Make sure the $omit variables do not get removed
 				$remove = array_map( array( __CLASS__, 'add_var_delimiter' ), $remove );


### PR DESCRIPTION
Get rid of two warnings for ridiculously rare cases where the PHP PCRE extension has been compiled without Unicode which would result in `$matches[1]` being empty or not set.
