### PR TITLE
Pass $post_id in all WPSEO_Meta::get_value calls in metabox - fixes #1519

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -198,21 +198,21 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 			return $this->statistics;
 		}
 
-        /**
-         * Returns post in metabox context
-         *
-         * @returns WP_Post
-         */
-        private function get_metabox_post() {
-            if ( isset( $_GET['post'] ) ) {
+		/**
+		 * Returns post in metabox context
+		 *
+		 * @returns WP_Post
+		 */
+		private function get_metabox_post() {
+			if ( isset( $_GET['post'] ) ) {
 				$post_id = (int) WPSEO_Option::validate_int( $_GET['post'] );
 				$post    = get_post( $post_id );
 			} else {
 				global $post;
 			}
 
-            return $post;
-        }
+			return $post;
+		}
 
 		/**
 		 * Lowercase a sentence while preserving "weird" characters.
@@ -257,9 +257,9 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 
 			echo '<div class="misc-pub-section misc-yoast misc-pub-section-last">';
 
-            $post = $this->get_metabox_post();
+			$post = $this->get_metabox_post();
 
-			if ( self::get_value( 'meta-robots-noindex' ) === '1' ) {
+			if ( self::get_value( 'meta-robots-noindex', $post->ID ) === '1' ) {
 				$score_label = 'noindex';
 				$title       = __( 'Post is set to noindex.', 'wordpress-seo' );
 				$score_title = $title;
@@ -472,7 +472,8 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 		function do_meta_box( $meta_field_def, $key = '' ) {
 			$content      = '';
 			$esc_form_key = esc_attr( self::$form_prefix . $key );
-			$meta_value   = self::get_value( $key );
+			$post         = $this->get_metabox_post();
+			$meta_value   = self::get_value( $key, $post->ID );
 
 			$class = '';
 			if ( isset( $meta_field_def['class'] ) && $meta_field_def['class'] !== '' ) {
@@ -644,8 +645,8 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 				$date = $this->get_post_date( $post );
 			}
 
-			$title = self::get_value( 'title' );
-			$desc  = self::get_value( 'metadesc' );
+			$title = self::get_value( 'title', $post->ID );
+			$desc  = self::get_value( 'metadesc', $post->ID );
 
 			$slug = ( is_object( $post ) && isset( $post->post_name ) ) ? $post->post_name : '';
 			if ( $slug !== '' ) {
@@ -1176,7 +1177,7 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 			$sampleurl             = $this->get_sample_permalink( $post );
 			$job['pageUrl']        = preg_replace( '`%(?:post|page)name%`', $sampleurl[1], $sampleurl[0] );
 			$job['pageSlug']       = urldecode( $post->post_name );
-			$job['keyword']        = self::get_value( 'focuskw' );
+			$job['keyword']        = self::get_value( 'focuskw', $post->ID );
 			$job['keyword_folded'] = $this->strip_separators_and_fold( $job['keyword'] );
 			$job['post_id']        = $post->ID;
 			$job['post_type']      = $post->post_type;
@@ -1210,7 +1211,7 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 			$this->score_keyword( $job['keyword'], $results );
 
 			// Title
-			$title = self::get_value( 'title' );
+			$title = self::get_value( 'title', $post->ID );
 			if ( $title !== '' ) {
 				$job['title'] = $title;
 			} else {
@@ -1226,7 +1227,7 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 
 			// Meta description
 			$description = '';
-			$desc_meta   = self::get_value( 'metadesc' );
+			$desc_meta   = self::get_value( 'metadesc', $post->ID );
 			if ( $desc_meta !== '' ) {
 				$description = $desc_meta;
 			} elseif ( isset( $options[ 'metadesc-' . $post->post_type ] ) && $options[ 'metadesc-' . $post->post_type ] !== '' ) {


### PR DESCRIPTION
If another plugin overwrites the global $post in `post.php`, the SEO metabox displays the metadata from the wrong post, and consequently saves the wrong data to the right post, leading to the strange behaviour of #1519.

WP SEO already fetched the correct post by checking for `$_GET['post']` first, but didn't pass this post on in `WPSEO_Meta::get_value` calls. All `get_value` calls in the metabox now get the post ID as well. The check for `$_GET['post']` was happening quite often in the class, so I also abstracted that into the private method `WPSEO_Metabox::get_metabox_post()`.
