### PR TITLE
Fixed conditional for displaying URL snippet

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -652,7 +652,7 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 			$desc  = self::get_value( 'metadesc' );
 
 			$slug = ( is_object( $post ) && isset( $post->post_name ) ) ? $post->post_name : '';
-			if ( $slug !== '' ) {
+			if ( $slug === '' ) {
 				$slug = sanitize_title( $title );
 			}
 


### PR DESCRIPTION
Fixed the conditional for displaying the URL snippet so that $slug is the post_name (if it exists), or else it is auto-generated by sanitizing the post's title (if post_name does not exist).
