### PR TITLE
Added filter to modify entire output of JSON+LD function

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -584,7 +584,7 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 			 *
 			 * @api string $output The output of the function.
 			 */
-			echo apply_filters( 'wpseo_json_ld_search_output', '<script type="application/ld+json">{ "@context": "http://schema.org", "@type": "WebSite", "url": "' . $home_url . '", "potentialAction": { "@type": "SearchAction", "target": "' . $search_url .'", "query-input": "required name=search_term" } }</script>' . "\n");
+			echo apply_filters( 'wpseo_json_ld_search_output', '<script type="application/ld+json">{ "@context": "http://schema.org", "@type": "WebSite", "url": "' . $home_url . '", "potentialAction": { "@type": "SearchAction", "target": "' . $search_url .'", "query-input": "required name=search_term" } }</script>' . "\n" );
 		}
 
 		/**


### PR DESCRIPTION
Added 'wpseo_json_ld_search_output' filter to allow changes to the entire output of the 'internal_search_json_ld' function. This allows user to add code before or after the output, or modify the existing output.

The JSON+LD code currently breaks any site that optimises Javascript with the Autopimize plugin. This new filter allows user to add 'no optimise' tags around the JSON+LD code.
