### PR TITLE
special symbols in post name

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -573,7 +573,7 @@ if ( ! class_exists( 'WPSEO_Bulk_List_Table' ) ) {
 
 							case 'col_existing_yoast_seo_metadesc':
 								$cell_value = ( ( ! empty( $meta_data[WPSEO_Meta::$meta_prefix . 'metadesc'] ) ) ? $meta_data[WPSEO_Meta::$meta_prefix . 'metadesc'] : '' );
-								echo sprintf( '<td %2$s id="wpseo-existing-metadesc-%3$s">%1$s</td>', $cell_value, $attributes, $rec->ID );
+								echo sprintf( '<td %2$s id="wpseo-existing-metadesc-%3$s">%1$s</td>', htmlspecialchars($cell_value), $attributes, $rec->ID );
 								break;
 
 							case 'col_row_action':


### PR DESCRIPTION
if name/description of post contain special html symbol, like a &lt;title&gt; or &lt;div&gt;, browser process him, then table and js scripts may be broken. we need convert special symbols before showing list. thanks for great free plugin!
