### PR TITLE
Optimise retain_variable_keys function.

### DIFF
--- a/inc/class-wpseo-options.php
+++ b/inc/class-wpseo-options.php
@@ -576,7 +576,7 @@ if ( ! class_exists( 'WPSEO_Option' ) ) {
 				foreach ( $dirty as $key => $value ) {
 
 					// do nothing if already in filtered options
-					if( isset( $clean[ $key ] ) ) {
+					if ( isset( $clean[ $key ] ) ) {
 						continue;
 					}
 
@@ -1923,8 +1923,8 @@ if ( ! class_exists( 'WPSEO_Option_Titles' ) ) {
 
 				foreach ( $dirty as $key => $value ) {
 
-					// do nothing if already in filtered options
-					if( isset( $clean[ $key ] ) ) {
+					// do nothing if already in filtered option array
+					if ( isset( $clean[ $key ] ) ) {
 						continue;
 					}
 


### PR DESCRIPTION
Playing around with XHProf I noticed `WPSEO_Option_Titles::retain_variable_keys` was responsible for close to 4% of the execution time of the rendered page.

Looking at the function, I noticed a check could be done to prevent even going into the second loop which would have no consequences, AFAIK.

**Current situation**
![image](https://cloud.githubusercontent.com/assets/885856/4427210/cc298560-45bc-11e4-90e1-fab9e594ff0f.png)

**New situation (with this PR)**
![image](https://cloud.githubusercontent.com/assets/885856/4427214/d6265a20-45bc-11e4-98d3-917a5000775e.png)

Pinging @jrfnl as she probably knows best what the consequences are for this seemingly simple change.
