### PR TITLE
Include manual indexed tags into post tags sitemap

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -986,12 +986,13 @@ if ( ! class_exists( 'WPSEO_Sitemaps' ) ) {
 
 					$tax_noindex     = WPSEO_Taxonomy_Meta::get_term_meta( $c, $c->taxonomy, 'noindex' );
 					$tax_sitemap_inc = WPSEO_Taxonomy_Meta::get_term_meta( $c, $c->taxonomy, 'sitemap_include' );
-
-					if ( ( is_string( $tax_noindex ) && $tax_noindex === 'noindex' ) && ( ! is_string( $tax_sitemap_inc ) || $tax_sitemap_inc !== 'always' ) ) {
-						continue;
-					}
-
-					if ( $tax_sitemap_inc === 'never' ) {
+					
+					/**
+					 * Check noindex and include status per term
+					 * 
+					 * @todo check sitemap_include = default
+					 */
+					if ( $tax_noindex !== 'index' || $tax_sitemap_inc !== 'always' ) {
 						continue;
 					}
 


### PR DESCRIPTION
Checks noindex and include status for each term.
If _index_ and _always_ are selected for a term, this will include it in the _post_tag-sitemap.xml_.

The old validation double checked variable type with useless functions like _is_string()_ while _===_ does the same.
