### PR TITLE
Metabox needs to ignore accents on keywords

### DIFF
--- a/js/wp-seo-metabox.js
+++ b/js/wp-seo-metabox.js
@@ -12,14 +12,17 @@ function yst_clean(str) {
 	return str;
 }
 
-function ptest(str, p) {
-	str = yst_clean(str);
+function ptest( str, p ) {
+	str = yst_clean( str );
 	str = str.toLowerCase();
-	var r = str.match(p);
-	if (r != null)
+	str = removeLowerCaseDiacritics( str );
+	p = removeLowerCaseDiacritics( str );
+	var r = str.match( p );
+	if ( r != null ){
 		return '<span class="good">Yes (' + r.length + ')</span>';
-	else
+	} else {
 		return '<span class="wrong">No</span>';
+	}
 }
 
 function removeLowerCaseDiacritics(str) {


### PR DESCRIPTION
I was doing an Article to my own blog and the main keyword had an accented character and as most of the Search Engines consider accents on edge cases only the plugin should ignore the accent when checking for the keyword.