### PR TITLE
Make wp_redirect use a 301 when redirecting from sitemap.xml to sitemap_...

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -239,7 +239,7 @@ function wpseo_xml_redirect_sitemap() {
 
 	// must be 'sitemap.xml' and must be 404
 	if ( home_url( '/sitemap.xml' ) == $current_url && $wp_query->is_404 ) {
-		wp_redirect( home_url( '/sitemap_index.xml' ) );
+		wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
 		exit;
 	}
 }


### PR DESCRIPTION
By default WordPress's wp_redirect issues a 302 redirect, and considering the use of this I'm pretty sure it should be a 301 as this is a permanent not temporary redirect in terms of how Google would rank it? Correct me if I'm wrong though. Just not sure if there was reasoning behind this.

Thanks!
