### PR TITLE
Update edit-page.css

### DIFF
--- a/css/edit-page.css
+++ b/css/edit-page.css
@@ -33,7 +33,7 @@
 }
 
 th#wpseo-score {
-	width: 60px;
+	width: 61px;
 }
 
 @media screen and ( max-width: 782px ) {


### PR DESCRIPTION
The WP SEO-score heading made the table row jump on hover because there wasn't enough place left for the down arrow. 1px makes a difference.
