### PR TITLE
facebook use featured image as fb first image. #1705

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -392,7 +392,7 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 		 *
 		 * @return bool
 		 */
-		function image_output( $img ) {
+		function image_output( $img, $og_meta='og:image:url' ) {
 			/**
 			 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph image
 			 *
@@ -421,7 +421,7 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 
 			array_push( $this->shown_images, $img );
 
-			$this->og_tag( 'og:image', esc_url( $img ) );
+			$this->og_tag( $og_meta, esc_url( $img ) );
 
 			return true;
 		}
@@ -456,7 +456,7 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 					 * @api string $unsigned Size string
 					 */
 					$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), apply_filters( 'wpseo_opengraph_image_size', 'original' ) );
-					$this->image_output( $thumb[0] );
+					$this->image_output( $thumb[0], 'og:image' );
 				}
 
 				/**


### PR DESCRIPTION
A minor modification to functions WPSEO_OpenGraph::image and WPSEO_OpenGraph::image_output. This mod causes facebook to prefer the featured image on the post over other images found within in the post.

How it works:
According to the Opengraph protocol a site could use "og:image:url"  or "og:image" to define images within the page. Currently wodpress-seo only makes use of one type "og:image". When facebook scrapes the page it only sees this one type, "og:image", on the page and uses some mystery algorithm (probably largest image, or random) to choose the best image to display.

However, facebook's algorithm currently prefer "og:image" over "og:image:url". 

By setting the featured image to "og:image" and the rest of the images to "og:image:url" we can guarantee facebook will choose the featured image over the other image. If there is no featured image, there is nothing to worry about as facebook will just act as normal and choose some mysterious "og:image:url"; 

In reference to ticket:
#1705, facebook use featured image as fb first image.

It may also address this ticket:
#1099, og:image property defaulting to 'first product in store page' rather than Featured Image or Yoast social Facebook default
