### PR TITLE
Fixed canonical tags when Wordpress is installed in a sub-folder

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -877,7 +877,7 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 			if ( is_string( $canonical ) && $canonical !== '' ) {
 				// Force canonical links to be absolute, relative is NOT an option.
 				if ( wpseo_is_url_relative( $canonical ) === true ) {
-					$canonical = home_url( $canonical );
+					$canonical = (is_ssl() ? 'https://' : 'http://') . parse_url(home_url(), PHP_URL_HOST) . $canonical;
 				}
 
 				if ( $echo !== false ) {


### PR DESCRIPTION
Fixed bug where plugin would generate invalid canonical urls.

If you set up a Wordpress site at "example.com/blog" then both site_url() and home_url() will be "http://example.com/blog". The previous code assumed that home_url() would instead return "http://example.com". Therefore the previous code when converting href="/blog/page1" would convert it into "http://example.com/blog/blog/page1" for the canonical tag. This is obviously incorrect.

Sometimes other logic is triggered hiding this bug. To replicate install Wordpress to a subfolder so that home_url() and site_url() give a domain name with a path at the end (such as "example.com/blog"). Then view a blog archive or tag page. (Other pages are also affected but not all pages are).

This bug was introduced in 1.5.4 when all canonical urls were converted to be absolute.

I would be very happy if you could merge this small change quickly as it is likely very bad for SEO that many pages on my websites now have a incorrect canonical url set.

Thank you.

Do not hesitate to contact me if you have any questions or queries.

Kind regards,
Shanee Vanstone.
