### PR TITLE
Custom post type date issue on sitemap

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -754,7 +754,7 @@ if ( ! class_exists( 'WPSEO_Sitemaps' ) ) {
 
 						$url = array();
 
-						if ( isset( $p->post_modified_gmt ) && $p->post_modified_gmt != '0000-00-00 00:00:00' && $p->post_modified_gmt > $p->post_date_gmt ) {
+						if ( isset( $p->post_modified_gmt ) && $p->post_modified_gmt != '0000-00-00 00:00:00' && $p->post_date_gmt != '1970-01-01 00:00:00' && $p->post_modified_gmt > $p->post_date_gmt ) {
 							$url['mod'] = $p->post_modified_gmt;
 						} else {
 							if ( '0000-00-00 00:00:00' != $p->post_date_gmt ) {


### PR DESCRIPTION
It seems that the plugin I'm using its adding as default post_date_gmt the date `1970-01-01 00:00:00` and its causing issues with sitemap since its only checking for `0000-00-00 00:00:00``
and thus showing the wrong date. 

Not sure if this will really need fixed in this sitemap plugin, but at the very least, it will not hurt either. Other plugins may by doing this also so its best to check it just in case.
