### PR TITLE
Remove separator & sitedesc when sitedesc isn't available

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -237,7 +237,12 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 					return '';
 				}
 			} else {
-				return wpseo_replace_vars( $this->options[ $index ], $var_source );
+				$format = $this->options[ $index ];
+				if (!get_bloginfo( 'description' )) {
+					$format = preg_replace('/ %%sep%% %%sitedesc%%$/', '', $format);
+				}
+
+				return wpseo_replace_vars( $format, $var_source );
 			}
 		}
 


### PR DESCRIPTION
When you don't have any description of your blog, the title is shown as: 'Your title -'.

As you can see, appears an extra "-" dash at the end, it must not be displayed when any blog description is available