### PR TITLE
Major changes to Social network logic

### DIFF
--- a/admin/class-opengraph-admin.php
+++ b/admin/class-opengraph-admin.php
@@ -33,23 +33,35 @@ if ( ! class_exists( 'WPSEO_Social_Admin' ) ) {
 		 * the main meta box definition array in the class WPSEO_Meta() as well!!!!
 		 */
 		public static function translate_meta_boxes() {
-			self::$meta_fields['social']['opengraph-title']['title']       = __( 'Facebook Title', 'wordpress-seo' );
-			self::$meta_fields['social']['opengraph-title']['description'] = __( 'If you don\'t want to use the post title for sharing the post on Facebook but instead want another title there, write it here.', 'wordpress-seo' );
+			$title_text       = __( 'If you don\'t want to use the post title for sharing the post on %s but instead want another title there, write it here.', 'wordpress-seo' );
+			$description_text = __( 'If you don\'t want to use the meta description for sharing the post on %s but want another description there, write it here.', 'wordpress-seo' );
+			$image_text       = __( 'If you want to override the image used on %s for this post, upload / choose an image or add the URL here.', 'wordpress-seo' );
 
-			self::$meta_fields['social']['opengraph-description']['title']       = __( 'Facebook Description', 'wordpress-seo' );
-			self::$meta_fields['social']['opengraph-description']['description'] = __( 'If you don\'t want to use the meta description for sharing the post on Facebook but want another description there, write it here.', 'wordpress-seo' );
+			$options  = WPSEO_Options::get_all();
 
-			self::$meta_fields['social']['opengraph-image']['title']       = __( 'Facebook Image', 'wordpress-seo' );
-			self::$meta_fields['social']['opengraph-image']['description'] = __( 'If you want to override the Facebook image for this post, upload / choose an image or add the URL here.', 'wordpress-seo' );
+			foreach (
+				array(
+					'opengraph'   => __( 'Facebook', 'wordpress-seo' ),
+					'twitter'     => __( 'Twitter', 'wordpress-seo' ),
+					'googleplus'  => __( 'Google+', 'wordpress-seo' ),
+				) as $network => $label
+			) {
+				if ( true === $options[ $network ] ) {
+					if ( 'googleplus' == $network ) {
+						$network = 'google-plus'; // Yuck, I know.
+					}
 
-			self::$meta_fields['social']['google-plus-title']['title']       = __( 'Google+ Title', 'wordpress-seo' );
-			self::$meta_fields['social']['google-plus-title']['description'] = __( 'If you don\'t want to use the post title for sharing the post on Google+ but instead want another title there, write it here.', 'wordpress-seo' );
+					self::$meta_fields['social'][ $network . '-title' ]['title']       = sprintf( __( '%s Title', 'wordpress-seo' ), $label );
+					self::$meta_fields['social'][ $network . '-title' ]['description'] = sprintf( $title_text, $label );
 
-			self::$meta_fields['social']['google-plus-description']['title']       = __( 'Google+ Description', 'wordpress-seo' );
-			self::$meta_fields['social']['google-plus-description']['description'] = __( 'If you don\'t want to use the meta description for sharing the post on Google+ but want another description there, write it here.', 'wordpress-seo' );
+					self::$meta_fields['social'][ $network . '-description' ]['title']       = sprintf( __( '%s Description', 'wordpress-seo' ), $label );
+					self::$meta_fields['social'][ $network . '-description' ]['description'] = sprintf( $description_text, $label );
 
-			self::$meta_fields['social']['google-plus-image']['title']       = __( 'Google+ Image', 'wordpress-seo' );
-			self::$meta_fields['social']['google-plus-image']['description'] = __( 'If you want to override the image for this post that Google+ will use, upload / choose an image or add the URL here. Note that it will otherwise default to the Facebook one above.', 'wordpress-seo' );
+					self::$meta_fields['social'][ $network . '-image' ]['title']       = sprintf( __( '%s Image', 'wordpress-seo' ), $label );
+					self::$meta_fields['social'][ $network . '-image' ]['description'] = sprintf( $image_text, $label );
+				}
+			}
+
 		}
 
 		/**
@@ -104,7 +116,7 @@ if ( ! class_exists( 'WPSEO_Social_Admin' ) ) {
 
 				foreach ( $fields_to_compare AS $field_to_compare ) {
 					$old_value = self::get_value( $field_to_compare, $post->ID );
-					$new_value = $_POST[self::$form_prefix . $field_to_compare];
+					$new_value = $_POST[ self::$form_prefix . $field_to_compare ];
 
 					if ( $old_value !== $new_value ) {
 						$reset_facebook_cache = true;

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -457,6 +457,8 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 					 */
 					$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), apply_filters( 'wpseo_opengraph_image_size', 'original' ) );
 					$this->image_output( $thumb[0] );
+
+					return;
 				}
 
 				/**
@@ -480,8 +482,6 @@ if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 			if ( count( $this->shown_images ) == 0 && $this->options['og_default_image'] !== '' ) {
 				$this->image_output( $this->options['og_default_image'] );
 			}
-
-			// @TODO add G+ image stuff
 		}
 
 		/**

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'WPSEO_Meta' ) ) {
 	 * for get_post_meta(), get_post_custom() and the likes. That would have been the preferred solution.
 	 *
 	 * @internal all WP native get_meta() results get cached internally, so no need to cache locally.
-	 * @internal use $key when the key is the WPSEO internal name (without prefix), $meta_key when it 
+	 * @internal use $key when the key is the WPSEO internal name (without prefix), $meta_key when it
 	 *           includes the prefix
 	 */
 	class WPSEO_Meta {
@@ -232,45 +232,7 @@ if ( ! class_exists( 'WPSEO_Meta' ) ) {
 					'description'	=> '', // translation added later
 				),
 			),
-			'social'	=> array(
-				'opengraph-title'		=> array(
-					'type'			=> 'text',
-					'title' 		=> '', // translation added later
-					'default_value'	=> '',
-					'description'	=> '', // translation added later
-				),
-				'opengraph-description'		=> array(
-					'type'			=> 'textarea',
-					'title' 		=> '', // translation added later
-					'default_value'	=> '',
-					'description'	=> '', // translation added later
-				),
-				'opengraph-image'			=> array(
-					'type'			=> 'upload',
-					'title' 		=> '', // translation added later
-					'default_value'	=> '',
-					'description'	=> '', // translation added later
-				),
-				'google-plus-title'	=> array(
-					'type'			=> 'text',
-					'title' 		=> '', // translation added later
-					'default_value'	=> '',
-					'description'	=> '', // translation added later
-				),
-				'google-plus-description'	=> array(
-					'type'			=> 'textarea',
-					'title' 		=> '', // translation added later
-					'default_value'	=> '',
-					'description'	=> '', // translation added later
-				),
-				'google-plus-image'			=> array(
-					'type'			=> 'upload',
-					'title' 		=> '', // translation added later
-					'default_value'	=> '',
-					'description'	=> '', // translation added later
-				),
-
-			),
+			'social'	=> array(),
 
 			/* Fields we should validate & save, but not show on any form */
 			'non_form'	=> array(
@@ -307,6 +269,33 @@ if ( ! class_exists( 'WPSEO_Meta' ) ) {
 		 * @return void
 		 */
 		public static function init() {
+
+			$options = WPSEO_Options::get_all();
+
+			foreach (
+				array(
+					'opengraph'  => 'opengraph',
+					'twitter'    => 'twitter',
+					'googleplus' => 'google-plus',
+				) as $option => $network ) {
+				if ( true === $options[$option] ) {
+					foreach (
+						array(
+							'title'         => 'text',
+							'description'   => 'textarea',
+							'image'         => 'upload',
+						) as $box => $type
+					) {
+						self::$meta_fields['social'][$network.'-'.$box]	= array(
+							'type'			=> $type,
+							'title' 		=> '', // translation added later
+							'default_value'	=> '',
+							'description'	=> '', // translation added later
+						);
+					}
+				}
+			}
+
 			/**
 			 * Allow add-on plugins to register their meta fields for management by this class
 			 * add_filter() calls must be made before plugins_loaded prio 14


### PR DESCRIPTION
- **Functionality change**: when there's a featured image, output only that for both Twitter and FB, ignore other images in post.
- **UX change**: rework logic for showing networks on Social tab, social network no longer shows on social tabs if not enabled in admin.
- Adds Twitter inputs to the Social tab.
- Always output a specific Twitter title and description, as otherwise we can't overwrite them from metabox.

Props @tacoverdo for input :)
