### PR TITLE
Incorect canonical tags when Wordpress is installed in a subdirectory

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -874,7 +874,7 @@ if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 			if ( is_string( $canonical ) && $canonical !== '' ) {
 				// Force canonical links to be absolute, relative is NOT an option.
 				if ( wpseo_is_url_relative( $canonical ) === true ) {
-					$canonical = home_url( $canonical );
+					$canonical = (is_ssl() ? 'https://' : 'http://') . parse_url(home_url(), PHP_URL_HOST) . $canonical;
 				}
 
 				if ( $echo !== false ) {


### PR DESCRIPTION
Fixed bug where plugin would generate invalid canonical urls.

I'm re-opening this pull request:
https://github.com/Yoast/wordpress-seo/pull/1711

I have now confirmed that this issue exists on a new Wordpress install with default theme and no other plugins.
I have done this on a new server and database and so I can confirm that this is genuinely an issue that should be fixed.

The easiest way to replicate this issue is to go on a Wordpress install which has been installed to a subdirectory such as "/blog".
Directly edit the canonical URL of a post using this plugin. ( image here: http://webenso.com/wbb/wp-content/uploads/2012/01/yoast-seo-wordpress.png )

Set the canonical URL to a url such as "/blog/post-name". This is a valid value and relates to www.example.com/blog/post-name. However, due to the change in 1.5.4 this plugin will now re-write the url in the canonical tag to www.example.com/blog/blog/post-name (which is of course incorrect!). The bug happens whenever Wordpress is installed to a subdirectory and a page has a permalink which starts with "/" (but not "//").

I have explained the technical details of why this happens in my previous comments so I will not repeat myself.

This is a legitimate problem and is not good for SEO. It is also a regression on previous versions of the plugin.
Many plugins and themes will set permalinks to strings which do not include the full domain name and so this is something that I consider very important.

If you could please merge this small change quickly I will be very happy.

Thank you.

Do not hesitate to contact me if you have any questions or queries.

Kind regards,
Shanee Vanstone.
