### PR TITLE
Use https protocol for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "admin/license-manager"]
 	path = admin/license-manager
-	url = git://github.com/Yoast/License-Manager.git
+	url = https://github.com/Yoast/License-Manager.git
 [submodule "admin/includes/i18n-module"]
 	path = admin/includes/i18n-module
-	url = git://github.com/Yoast/i18n-module.git
+	url = https://github.com/Yoast/i18n-module.git
+	


### PR DESCRIPTION
SSH is an authenticated network protocol therefore if a user who does not have a GitHub.com account will not be able to pull these submodules. One such user is WP-Engine system user that does not authenticate with github for cloning the repository.

I am trying to use WP Engine git push service and using the wordpress-seo repository as submodule in my project. Unfortunately WP Engine system user does not authenticated when it clones the repositories.

This pull request makes its possible for anyone to clone this public repository without the need for authentication using a github.com user account.
