### PR TITLE
remove next scripts from the conflicts list.

### DIFF
--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -44,8 +44,6 @@ if ( ! class_exists( 'WPSEO_Plugin_Conflict' ) ) {
 				'header-footer/plugin.php',                              // Header and Footer
 				'network-publisher/networkpub.php',                      // Network Publisher
 				'nextgen-facebook/nextgen-facebook.php',                 // NextGEN Facebook OG
-				'social-networks-auto-poster-facebook-twitter-g/NextScripts_SNAP.php',
-				// NextScripts SNAP
 				'opengraph/opengraph.php',                               // Open Graph
 				'open-graph-protocol-framework/open-graph-protocol-framework.php',
 				// Open Graph Protocol Framework


### PR DESCRIPTION
Following up on #1796. Investigated next scripts and removed them from the conflict list.

Their plugin checks if the og tags are already outputted before adding them to the head.
