### PR TITLE
Huge performance gain for enrich_defaults()

### DIFF
--- a/inc/class-wpseo-options.php
+++ b/inc/class-wpseo-options.php
@@ -1576,12 +1576,13 @@ if ( ! class_exists( 'WPSEO_Option_Titles' ) ) {
 			}
 
 			if ( $post_type_objects_custom !== array() ) {
+				$archive = sprintf( __( '%s Archive', 'wordpress-seo' ), '%%pt_plural%%' );
 				foreach ( $post_type_objects_custom as $pt ) {
 					if ( ! $pt->has_archive ) {
 						continue;
 					}
 
-					$this->defaults[ 'title-ptarchive-' . $pt->name ]    = sprintf( __( '%s Archive', 'wordpress-seo' ), '%%pt_plural%%' ) . ' %%page%% %%sep%% %%sitename%%'; // text field
+					$this->defaults[ 'title-ptarchive-' . $pt->name ]    = $archive . ' %%page%% %%sep%% %%sitename%%'; // text field
 					$this->defaults[ 'metadesc-ptarchive-' . $pt->name ] = ''; // text area
 					$this->defaults[ 'metakey-ptarchive-' . $pt->name ]  = ''; // text field
 					$this->defaults[ 'bctitle-ptarchive-' . $pt->name ]  = ''; // text field
@@ -1591,8 +1592,9 @@ if ( ! class_exists( 'WPSEO_Option_Titles' ) ) {
 			}
 
 			if ( $taxonomy_names !== array() ) {
+				$archives = sprintf( __( '%s Archives', 'wordpress-seo' ), '%%term_title%%' );
 				foreach ( $taxonomy_names as $tax ) {
-					$this->defaults[ 'title-tax-' . $tax ]       = sprintf( __( '%s Archives', 'wordpress-seo' ), '%%term_title%%' ) . ' %%page%% %%sep%% %%sitename%%'; // text field
+					$this->defaults[ 'title-tax-' . $tax ]       = $archives . ' %%page%% %%sep%% %%sitename%%'; // text field
 					$this->defaults[ 'metadesc-tax-' . $tax ]    = ''; // text area
 					$this->defaults[ 'metakey-tax-' . $tax ]     = ''; // text field
 					$this->defaults[ 'hideeditbox-tax-' . $tax ] = false;


### PR DESCRIPTION
When working with around 50 taxonomies, which is not that uncommon, I experienced an abnormal performance loss coming from the WPSEO title functionality. I narrowed it down all the way to `WPSEO_Option_Titles::enrich_defaults()`, in my particular setup it was being fired by the plugin around 25 times, to enrich the defaults for the `wpseo_titles` option (I'm still shaking from going through all that code!). 

Looking into it a bit further, I discovered that the foreach loop going over my taxonomies (53) took between 0.1 and 0.2 sec to complete, each time the function was being called (see http://pastebin.com/hx4qM1ke). I noticed the translation function. Although it has the same outcome, it is being executed each and every iteration. So it can also be done only once outside of the loop. That is what I did and I got some [astonishing results](http://pastebin.com/KzUyDLxS).

I know the underlying problem probably lies with the handling of the translation (I have WPML installed), but when you have the choice to choose between executing a function 25 times in stead of 1325 times, the choice is fairly easy to make, I think.

Thanks!

Koen

*PS: I did the same for the post type archives, because.. what's the harm in some extra performance, right? :)*