### PR TITLE
Gplus meta bugfix

### DIFF
--- a/frontend/class-googleplus.php
+++ b/frontend/class-googleplus.php
@@ -60,13 +60,29 @@ if ( ! class_exists( 'WPSEO_GooglePlus' ) ) {
 			if ( is_singular() ) {
 				$desc = WPSEO_Meta::get_value( 'google-plus-description' );
 
+				// Replace WP SEO Variables
+				$desc = wpseo_replace_vars( $desc, get_post() );
+				
+				// Use metadesc if $desc is empty
+				if ( $desc === '' ) {
+					$desc = $this->metadesc( false );
+				}
+				
+				// google meta description is still blank so grab it from get_the_excerpt()
+				if ( ! is_string( $desc ) || ( is_string( $desc ) && $desc === '' ) ) {
+					$desc = str_replace( '[&hellip;]', '&hellip;', strip_tags( get_the_excerpt() ) );
+				}
+				
+				// Strip shortcodes if any
+				$desc = strip_shortcodes( $desc );
+				
 				/**
 				 * Filter: 'wpseo_googleplus_desc' - Allow developers to change the Google+ specific description output
 				 *
 				 * @api string $desc The description string
 				 */
 				$desc = trim( apply_filters( 'wpseo_googleplus_desc', $desc ) );
-
+				
 				if ( is_string( $desc ) && '' !== $desc ) {
 					echo '<meta itemprop="description" content="' . esc_attr( $desc ) . '">' . "\n";
 				}
@@ -79,6 +95,12 @@ if ( ! class_exists( 'WPSEO_GooglePlus' ) ) {
 		public function google_plus_title() {
 			if ( is_singular() ) {
 				$title = WPSEO_Meta::get_value( 'google-plus-title' );
+                                if ( $title === '' ) {
+                                        $title = $this->title( '' );
+                                } else {
+                                        // Replace WP SEO Variables
+                                        $title = wpseo_replace_vars( $title, get_post() );
+                                }
 
 				/**
 				 * Filter: 'wpseo_googleplus_title' - Allow developers to change the Google+ specific title
@@ -99,16 +121,48 @@ if ( ! class_exists( 'WPSEO_GooglePlus' ) ) {
 		 * Output the Google+ specific image
 		 */
 		public function google_plus_image() {
+
+			global $post;
+			
 			if ( is_singular() ) {
 				$image = WPSEO_Meta::get_value( 'google-plus-image' );
-
+		
+				if ( (!is_string( $image ) || $image === '' ) && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $post->ID ) ) {
+					/**
+					 * Filter: 'wpseo_google_plus_image_size' - Allow changing the image size used for Google plus sharing
+					 *
+					 * @api string $unsigned Size string
+					 */
+					$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), apply_filters( 'wpseo_google_plus_image_size', 'original' ) );
+					$image = $image[0];
+				}
+		
+				if (!is_string( $image ) || $image === '' ) {
+					/**
+					 * Filter: 'wpseo_pre_analysis_post_content' - Allow filtering the content before analysis
+					 *
+					 * @api string $post_content The Post content string
+					 *
+					 * @param object $post The post object.
+					 */
+					$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
+			
+					if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
+						foreach ( $matches[0] as $img ) {
+							if ( preg_match( '`src=(["\'])(.*?)\1`', $img, $match ) ) {
+								$image = $match[2];
+							}
+						}
+					}
+				}
+				
 				/**
 				 * Filter: 'wpseo_googleplus_image' - Allow changing the Google+ image
 				 *
 				 * @api string $img Image URL string
 				 */
 				$image = trim( apply_filters( 'wpseo_googleplus_image', $image ) );
-
+				
 				if ( is_string( $image ) && $image !== '' ) {
 					echo '<meta itemprop="image" content="' . esc_url( $image ) . '">' . "\n";
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License URI: http://www.gnu.org/licenses/gpl.html
 Tags: seo, SEO, Yoast SEO, google, meta, meta description, search engine optimization, xml sitemap, xml sitemaps, google sitemap, sitemap, sitemaps, robots meta, rss, rss footer, yahoo, bing, news sitemaps, XML News Sitemaps, WordPress SEO, WordPress SEO by Yoast, yoast, multisite, canonical, nofollow, noindex, keywords, meta keywords, description, webmaster tools, google webmaster tools, seo pack
 Requires at least: 3.8
 Tested up to: 4.0
-Stable tag: 1.7
+Stable tag: 1.7.1
 
 Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using Yoast's WordPress SEO plugin.
 
@@ -115,6 +115,12 @@ You'll find the [FAQ on Yoast.com](https://yoast.com/wordpress/plugins/seo/faq/)
 7. The advanced section of the WordPress SEO meta box.
 
 == Changelog ==
+
+= 1.7.1 =
+
+* Bugfixes
+	* Fixes a bug where "undefined index" notice was triggered when saving Advanced Custom fields.
+	* Fixes a bug where the translation box didn't link to the Yoast translations site correctly.
 
 = 1.7 =
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -14,7 +14,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * @internal Nobody should be able to overrule the real version number as this can cause serious issues
  * with the options, so no if ( ! defined() )
  */
-define( 'WPSEO_VERSION', '1.7' );
+define( 'WPSEO_VERSION', '1.7.1' );
 
 if ( ! defined( 'WPSEO_PATH' ) ) {
 	define( 'WPSEO_PATH', plugin_dir_path( WPSEO_FILE ) );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WordPress SEO
-Version: 1.7
+Version: 1.7.1
 Plugin URI: https://yoast.com/wordpress/plugins/seo/#utm_source=wpadmin&utm_medium=plugin&utm_campaign=wpseoplugin
 Description: The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.
 Author: Team Yoast


### PR DESCRIPTION
If opengraph meta data were enabled and no fb title was written, SEO plugin filled og:title with post title, same logic for og:description and og:image.
Google plus meta tags didn't work like that, they simply were not displayed if not specified.
I think a refactor of class WPSEO_GooglePlus should be planned to enhance consinstency with WPSEO_OpenGraph and WPSEO_Twitter.
Meanwhile itemprop=name, itemprop=description and itemprop=image work like opengraph ones for post view.