### PR TITLE
Use number_format instead of strval for international bcmath calculations.

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -422,8 +422,8 @@ if ( ! function_exists( 'wpseo_calc' ) ) {
 		}
 
 		if ( $bc ) {
-			$number1 = strval( $number1 );
-			$number2 = strval( $number2 );
+			$number1 = number_format( $number1, 10, '.', '' );
+			$number2 = number_format( $number2, 10, '.', '' );
 		}
 
 		$result  = null;


### PR DESCRIPTION
Created my other pull-request (#1521) on the wrong branch, so recreating it here on the trunk branch.

This fixes bug #1505.