### PR TITLE
Fixing issue with parent overwriting child meta desc

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -643,7 +643,7 @@ if ( ! class_exists( 'WPSEO_Metabox' ) ) {
 		 * @return  bool|void   Boolean false if invalid save post request
 		 */
 		function save_postdata( $post_id ) {
-			if ( $post_id === null ) {
+			if ( $post_id === null || $post_id != get_the_ID() ) {
 				return false;
 			}
 


### PR DESCRIPTION
Changed `if ( $post_id === null )  {` to `if ( $post_id === null || $post_id != get_the_ID() ) {`
Fixes #1838