### PR TITLE
Allow archive titles & meta to be set on non public post types 

### DIFF
--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -121,16 +121,12 @@ $wpseo_admin_pages->admin_header( true, WPSEO_Options::get_group_name( 'wpseo_ti
 	unset( $post_types );
 
 
-	$post_types = get_post_types( array( '_builtin' => false ), 'objects' );
+	$post_types = get_post_types( array( '_builtin' => false, 'has_archive' => true ), 'objects' );
 	if ( is_array( $post_types ) && $post_types !== array() ) {
 		echo '<h2>' . __( 'Custom Post Type Archives', 'wordpress-seo' ) . '</h2>';
 		echo '<p>' . __( 'Note: instead of templates these are the actual titles and meta descriptions for these custom post type archive pages.', 'wordpress-seo' ) . '</p>';
 
 		foreach ( $post_types as $pt ) {
-			if ( ! $pt->has_archive ) {
-				continue;
-			}
-
 			$name = $pt->name;
 
 			echo '<h4>' . esc_html( ucfirst( $pt->labels->name ) ) . '</h4>';

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -121,7 +121,7 @@ $wpseo_admin_pages->admin_header( true, WPSEO_Options::get_group_name( 'wpseo_ti
 	unset( $post_types );
 
 
-	$post_types = get_post_types( array( 'public' => true, '_builtin' => false ), 'objects' );
+	$post_types = get_post_types( array( '_builtin' => false ), 'objects' );
 	if ( is_array( $post_types ) && $post_types !== array() ) {
 		echo '<h2>' . __( 'Custom Post Type Archives', 'wordpress-seo' ) . '</h2>';
 		echo '<p>' . __( 'Note: instead of templates these are the actual titles and meta descriptions for these custom post type archive pages.', 'wordpress-seo' ) . '</p>';


### PR DESCRIPTION
Refers to  issue #1861

Removed the "public => true" requirement on the post types query on the meta & titles admin page for the custom post type archives section

A post type can be configured to have public set to false, but still have an active archive page. Setting public to false does not definitively remove the archive page from a post type: http://codex.wordpress.org/Function_Reference/register_post_type

Setting public to false but other properties to true is a common method of getting a post type with just an archive page, often ideal for "repository" style post types, eg: FAQ's etc...