### PR TITLE
Add EXCERPTLINK functionality to RSS

### DIFF
--- a/admin/pages/rss.php
+++ b/admin/pages/rss.php
@@ -37,6 +37,7 @@ $rows[] = array(
 		'<tr><th><strong>%%POSTLINK%%</strong></th><td>' . __( 'A link to the post, with the title as anchor text.', 'wordpress-seo' ) . '</td></tr>' .
 		'<tr><th><strong>%%BLOGLINK%%</strong></th><td>' . __( "A link to your site, with your site's name as anchor text.", 'wordpress-seo' ) . '</td></tr>' .
 		'<tr><th><strong>%%BLOGDESCLINK%%</strong></th><td>' . __( "A link to your site, with your site's name and description as anchor text.", 'wordpress-seo' ) . '</td></tr>' .
+		'<tr><th><strong>%%EXCERPTLINK%%</strong></th><td>' . __( "A link to the post, with the excerpt in 15 characters or less and ending at the end of the word.", 'wordpress-seo' ) . '</td></tr>' .
 		'</table>'
 );
 $wpseo_admin_pages->postbox( 'rssfootercontent', __( 'Content of your RSS Feed', 'wordpress-seo' ), $content . $wpseo_admin_pages->form_table( $rows ) );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1639,10 +1639,10 @@ class WPSEO_Frontend {
 		$blog_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . get_bloginfo( 'name' ) . '</a>';
 		$blog_desc_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . get_bloginfo( 'name' ) . ' - ' . strip_tags( get_bloginfo( 'description' ) ) . '</a>';
 		//reduce excerpt to 15 characters by using regex & end with whole word
-		$body= get_the_excerpt();
+		$body= wp_html_excerpt( $post->post_content);
 		$line= $body;
 		if (preg_match('/^.{1,15}\b/s', $body, $match)) {
-			$excerpt_link   = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . $line=$match[0] . ' ...Read more' . '</a>';
+			$excerpt_link   = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . $line=$match[0] . '...Read more' . '</a>';
 		}
 
 		$content = stripslashes( trim( $content ) );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1638,12 +1638,19 @@ class WPSEO_Frontend {
 		$post_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . get_the_title() . '</a>';
 		$blog_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . get_bloginfo( 'name' ) . '</a>';
 		$blog_desc_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . get_bloginfo( 'name' ) . ' - ' . strip_tags( get_bloginfo( 'description' ) ) . '</a>';
+		//reduce excerpt to 15 characters by using regex & end with whole word
+		$body= get_the_excerpt();
+		$line= $body;
+		if (preg_match('/^.{1,15}\b/s', $body, $match)) {
+			$excerpt_link   = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . $line=$match[0] . ' ...Read more' . '</a>';
+		}
 
 		$content = stripslashes( trim( $content ) );
 		$content = str_replace( '%%AUTHORLINK%%', $author_link, $content );
 		$content = str_replace( '%%POSTLINK%%', $post_link, $content );
 		$content = str_replace( '%%BLOGLINK%%', $blog_link, $content );
 		$content = str_replace( '%%BLOGDESCLINK%%', $blog_desc_link, $content );
+		$content = str_replace( '%%EXCERPTLINK%%', $excerpt_link, $content );
 
 		return $content;
 	}


### PR DESCRIPTION
Add %%EXCERPTLINK%% functionality to the RSS section.  I used a regular expression to reduce excerpt to 15 characters or less. This means it ends end with whole word instead of cutting off the word at the 15 character limit. I also added ...Read more at the end of excerpt to entice users to click on the link. 

I apologize ahead of time if I did not do something properly, this is my first merge pull request.