### PR TITLE
Added zip type hint to settings upload form

### DIFF
--- a/admin/pages/import.php
+++ b/admin/pages/import.php
@@ -428,7 +428,7 @@ if ( ! isset( $_FILES['settings_import_file'] ) || empty( $_FILES['settings_impo
 	// @todo [JRF => whomever] add action for form tag
 	$content .= '<form action="" method="post" enctype="multipart/form-data" accept-charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
 	$content .= wp_nonce_field( 'wpseo-import-file', '_wpnonce', true, false );
-	$content .= '<input type="file" name="settings_import_file"/>';
+	$content .= '<input type="file" name="settings_import_file" accept="application/x-zip,application/x-zip-compressed,application/zip" />';
 	$content .= '<input type="hidden" name="action" value="wp_handle_upload"/>';
 	$content .= '<input type="submit" class="button" value="' . __( 'Import settings', 'wordpress-seo' ) . '"/>';
 	$content .= '</form><br/>';


### PR DESCRIPTION
Narrows down file picker to ZIP archives on supporting browsers. Should get old behavior on others (that would be Safari I think).

Makes it simpler to select `settings.zip` file and reduces user errors in the process.

Prompted by #1963, though not the exact issue.