### PR TITLE
Ignore files in `git archive` that are only important for development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,20 @@
 
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
+
+grunt export-ignore
+tests export-ignore
+.csscomb.json export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.gruntjshintrc export-ignore
+.jscsrc export-ignore
+.jshintrc export-ignore
+.travis.yml export-ignore
+codesniffer.xml export-ignore
+CONTRIBUTING.md export-ignore
+Gruntfile.js export-ignore
+package.json export-ignore
+phpunit.xml export-ignore
+README.md export-ignore


### PR DESCRIPTION
Great work on implementing composer natively 👍, I look forward to including WordPress SEO using packagist instead of wppackagist. @Rarst Awesome job.

I have an improvement though, now you get all development files as well and that is not really useful on production environments. [In this reddit thread](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production) someones explains a way to ignore some files from a `git archive` (which github uses). It is also something that [The League of Extraordinary Packages](https://thephpleague.com) recommends.

This pull requests adds the most obvious files with an `export-ignore` to `.gitattributes`