### PR TITLE
Cleanup taxonomy page

### DIFF
--- a/admin/class-taxonomy.php
+++ b/admin/class-taxonomy.php
@@ -152,7 +152,7 @@ if ( ! class_exists( 'WPSEO_Taxonomy' ) ) {
 
 			echo '
 		<tr class="form-field">
-			<th scope="row">' . ( '' !== $label ? '<label for="' . $esc_var . '">' . esc_html( $label ) . ':</label>' : '' ) . '</th>
+			<th scope="row">' . ( '' !== $label ? '<label for="' . $esc_var . '">' . esc_html( $label ) . '</label>' : '' ) . '</th>
 			<td>' . $field . '</td>
 		</tr>';
 		}
@@ -171,7 +171,7 @@ if ( ! class_exists( 'WPSEO_Taxonomy' ) ) {
 			$options  = WPSEO_Options::get_all();
 
 
-			echo '<h2>' . __( 'Yoast WordPress SEO Settings', 'wordpress-seo' ) . '</h2>';
+			echo '<h3>' . __( 'Yoast WordPress SEO Settings', 'wordpress-seo' ) . '</h3>';
 			echo '<table class="form-table wpseo-taxonomy-form">';
 
 			$this->form_row( 'wpseo_title', __( 'SEO Title', 'wordpress-seo' ), esc_html__( 'The SEO title is used on the archive page for this term.', 'wordpress-seo' ), $tax_meta );


### PR DESCRIPTION
This removes the colons from the labels on the taxonomy pages to be consistent with WordPress core.

It also uses a h3 instead of a h2 for the heading as all subheading on this page should be a level lower than h2 which is used for the main 'Edit ___' heading.