### PR TITLE
Use frontend singleton instead of wpseo_frontend global in wpseo_non_ajax_functions.php [Delivers #88599708]

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -866,11 +866,11 @@ class WPSEO_Frontend {
 			$canonical = $this->canonical_no_override;
 		}
 
-		if ( $echo !== false ) {
-			echo '<link rel="canonical" href="' . esc_url( $canonical, null, 'other' ) . '" />' . "\n";
-		} else {
+		if ( $echo === false ) {
 			return $canonical;
 		}
+
+		echo '<link rel="canonical" href="' . esc_url( $canonical, null, 'other' ) . '" />' . "\n";
 	}
 
 	/**

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -220,12 +220,9 @@ function wpseo_admin_bar_menu() {
 		return;
 	}
 
-	global $wp_admin_bar, $wpseo_front, $post;
+	global $wp_admin_bar, $post;
 
-	$url = '';
-	if ( is_object( $wpseo_front ) ) {
-		$url = $wpseo_front->canonical( false );
-	}
+	$url = WPSEO_Frontend::get_instance()->canonical( false );
 
 	$focuskw = '';
 	$score   = '';


### PR DESCRIPTION
Fixes a fatal error caused by the fact that the $wpseo_front global was still being referenced.

Should fix our end of the compatibility issues between Polylang and version 1.7.3 of WordPress SEO by Yoast, see #1997 