### PR TITLE
Send charset utf-8 with Content-Type HTTP header

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -1113,7 +1113,7 @@ class WPSEO_Sitemaps {
 			header( $this->http_protocol() . ' 200 OK', true, 200 );
 			// Prevent the search engines from indexing the XML Sitemap.
 			header( 'X-Robots-Tag: noindex, follow', true );
-			header( 'Content-Type: text/xml' );
+			header( 'Content-Type: text/xml; charset=utf-8' );
 
 			// Make the browser cache this file properly.
 			$expires = YEAR_IN_SECONDS;
@@ -1134,7 +1134,7 @@ class WPSEO_Sitemaps {
 		header( $this->http_protocol() . ' 200 OK', true, 200 );
 		// Prevent the search engines from indexing the XML Sitemap.
 		header( 'X-Robots-Tag: noindex,follow', true );
-		header( 'Content-Type: text/xml' );
+		header( 'Content-Type: text/xml; charset=utf-8' );
 		echo '<?xml version="1.0" encoding="' . esc_attr( $this->charset ) . '"?>';
 		if ( $this->stylesheet ) {
 			echo apply_filters( 'wpseo_stylesheet_url', $this->stylesheet ) . "\n";


### PR DESCRIPTION
For sitemaps which contain characters from an extended set, sitemaps are invalidated in case the charset is not specified.

For example, the presence of such an URL in the sitemap would mark the sitemap invalid in Google Webmaster Tools: http://www.example.com/wp-content/uploads/2015/02/A-file-with-a-©-character-in-its-name.jpg