### PR TITLE
Fix broken rel prev / next

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -900,7 +900,9 @@ class WPSEO_Frontend {
 			return $canonical;
 		}
 
-		echo '<link rel="canonical" href="' . esc_url( $canonical, null, 'other' ) . '" />' . "\n";
+		if ( is_string( $canonical ) && '' !== $canonical ) {
+			echo '<link rel="canonical" href="' . esc_url( $canonical, null, 'other' ) . '" />' . "\n";
+		}
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -892,8 +892,7 @@ class WPSEO_Frontend {
 		if ( $un_paged ) {
 			$canonical = $this->canonical_unpaged;
 		}
-
-		if ( $no_override ) {
+		elseif ( $no_override ) {
 			$canonical = $this->canonical_no_override;
 		}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -981,6 +981,9 @@ class WPSEO_Frontend {
 			if ( $canonical && get_query_var( 'paged' ) > 1 ) {
 				global $wp_rewrite;
 				if ( ! $wp_rewrite->using_permalinks() ) {
+					if ( is_front_page() ) {
+						$canonical = trailingslashit( $canonical );
+					}
 					$canonical = add_query_arg( 'paged', get_query_var( 'paged' ), $canonical );
 				}
 				else {

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -530,8 +530,10 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$this->factory->post->create_many( 26, array( 'post_category' => array( $category_id ) ) );
 
 		$category_link = get_category_link( $category_id );
-		$this->go_to( $category_link . '&paged=2' );
+		$this->go_to( $category_link );
+		$next_link = get_pagenum_link( 2 );
 
+		$this->go_to( $next_link );
 		$next_link = get_pagenum_link( 3 );
 
 		self::$class_instance->adjacent_rel_links();

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -533,18 +533,17 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 		$category_link = get_category_link( $category_id );
 
-		// Test page 1 of the category
-		self::$class_instance->reset();
+		// Test page 1 of the category, should have just next
 		$this->go_to( $category_link );
 
 		$page_2_link = get_pagenum_link( 2, false );
 		$expected    = '<link rel="next" href="' . esc_url( $page_2_link ) . '" />' . "\n";
 
 		self::$class_instance->adjacent_rel_links();
-		$this->expectOutput( $expected );
 		$this->assertEquals( $category_link, self::$class_instance->canonical( false ) );
+		$this->expectOutput( $expected );
 
-		// Test page 2 of the category
+		// Test page 2 of the category, should have prev and next
 		self::$class_instance->reset();
 		$this->go_to( $page_2_link );
 
@@ -552,10 +551,10 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$expected    = '<link rel="prev" href="' . $category_link . '" />' . "\n" . '<link rel="next" href="' . esc_url( $page_3_link ) . '" />' . "\n";
 
 		self::$class_instance->adjacent_rel_links();
-		$this->expectOutput( $expected );
 		$this->assertEquals( $page_2_link, self::$class_instance->canonical( false ) );
+		$this->expectOutput( $expected );
 
-		// Test page 3 of the category
+		// Test page 3 of the category, should have just prev
 		self::$class_instance->reset();
 		$this->go_to( $page_3_link );
 

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -525,11 +525,9 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::adjacent_rel_links
 	 */
 	public function test_adjacent_rel_links() {
-		update_site_option( 'posts_per_page', 5 );
-
 		// create a category, add 26 posts to it, go to page 2 of its archives
 		$category_id = wp_create_category( 'boom' );
-		$this->factory->post->create_many( 12, array( 'post_category' => array( $category_id ) ) );
+		$this->factory->post->create_many( 22, array( 'post_category' => array( $category_id ) ) );
 
 		$category_link = get_category_link( $category_id );
 

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -961,6 +961,8 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Override the go_to function in core as its broken when path isn't set.
 	 *
+	 * Can be removed when https://core.trac.wordpress.org/ticket/31417 is fixed.
+	 *
 	 * @param $url
 	 */
 	function go_to( $url ) {

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -550,6 +550,30 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * @covers WPSEO_Frontend::canonical
+	 */
+	public function test_canonical_filter() {
+		add_filter( 'wpseo_canonical', '__return_false' );
+		self::$class_instance->canonical();
+		$this->expectOutput( '' );
+
+		self::$class_instance->reset();
+		remove_filter( 'wpseo_canonical', '__return_false' );
+		add_filter( 'wpseo_canonical', array( $this, 'filter_canonical_test' ) );
+		$this->go_to( home_url() );
+		$this->assertEquals( 'http://canonic.al', self::$class_instance->canonical( false ) );
+	}
+
+	/**
+	 * Used to test the workings of canonical
+	 *
+	 * @return string
+	 */
+	public function filter_canonical_test() {
+		return 'http://canonic.al';
+	}
+
+	/**
 	 * @covers WPSEO_Frontend::publisher
 	 */
 	public function test_publisher() {

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -498,7 +498,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$this->factory->post->create_many( 22, array( 'post_author' => $user_id ) );
 
 		$user     = new WP_User( $user_id );
-		$user_url = get_author_posts_url( $user_id, $user->user_login );
+		$user_url = get_author_posts_url( $user_id, $user->user_nicename );
 
 		// Test page 1 of the author archives, should have just a rel=next and a canonical
 		$this->go_to( $user_url );

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -525,7 +525,14 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::adjacent_rel_links
 	 */
 	public function test_adjacent_rel_links() {
-		// @todo
+		// create a category, add 26 posts to it, go to page 2 of its archives
+		$category_id = wp_create_category( 'boom' );
+		$this->factory->post->create_many( 26, array( 'post_category' => array( $category_id ) ) );
+
+		$category_link = get_category_link( $category_id );
+		$this->go_to( $category_link . '&paged=2' );
+		self::$class_instance->adjacent_rel_links();
+		$this->expectOutput( '<link rel="prev" href="' . $category_link . '" />' . "\n" . '<link rel="next" href="' . $category_link . '&#038;paged=3" />' . "\n" );
 	}
 
 	/**

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -536,8 +536,10 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$this->go_to( $next_link );
 		$next_link = get_pagenum_link( 3 );
 
+		$expected = '<link rel="prev" href="' . $category_link . '" />' . "\n" . '<link rel="next" href="' . $next_link . '" />' . "\n";
+
 		self::$class_instance->adjacent_rel_links();
-		$this->expectOutput( '<link rel="prev" href="' . $category_link . '" />' . "\n" . '<link rel="next" href="' . $next_link . '" />' . "\n" );
+		$this->expectOutput( $expected );
 	}
 
 	/**

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -531,8 +531,11 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 		$category_link = get_category_link( $category_id );
 		$this->go_to( $category_link . '&paged=2' );
+
+		$next_link = get_pagenum_link( 3 );
+
 		self::$class_instance->adjacent_rel_links();
-		$this->expectOutput( '<link rel="prev" href="' . $category_link . '" />' . "\n" . '<link rel="next" href="' . $category_link . '&#038;paged=3" />' . "\n" );
+		$this->expectOutput( '<link rel="prev" href="' . $category_link . '" />' . "\n" . '<link rel="next" href="' . $next_link . '" />' . "\n" );
 	}
 
 	/**

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -958,4 +958,44 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$this->expectOutput( $expected, self::$class_instance->internal_search_json_ld() );
 	}
 
+	/**
+	 * Override the go_to function in core as its broken when path isn't set.
+	 *
+	 * @param $url
+	 */
+	function go_to( $url ) {
+		// note: the WP and WP_Query classes like to silently fetch parameters
+		// from all over the place (globals, GET, etc), which makes it tricky
+		// to run them more than once without very carefully clearing everything
+		$_GET = $_POST = array();
+		foreach (array('query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow') as $v) {
+			if ( isset( $GLOBALS[$v] ) ) unset( $GLOBALS[$v] );
+		}
+		$parts = parse_url($url);
+		if (isset($parts['scheme'])) {
+			$req = isset( $parts['path'] ) ? $parts['path'] : '';
+			if (isset($parts['query'])) {
+				$req .= '?' . $parts['query'];
+				// parse the url query vars into $_GET
+				parse_str($parts['query'], $_GET);
+			}
+		} else {
+			$req = $url;
+		}
+		if ( ! isset( $parts['query'] ) ) {
+			$parts['query'] = '';
+		}
+
+		$_SERVER['REQUEST_URI'] = $req;
+		unset($_SERVER['PATH_INFO']);
+
+		$this->flush_cache();
+		unset($GLOBALS['wp_query'], $GLOBALS['wp_the_query']);
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
+		$GLOBALS['wp'] = new WP();
+		_cleanup_query_vars();
+
+		$GLOBALS['wp']->main($parts['query']);
+	}
 }

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -519,9 +519,17 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$user_url = get_author_posts_url( $user_id, $user->user_nicename );
 
 		$this->run_test_on_consecutive_pages( $user_url );
+	}
 
-		// @todo test date archives
-		// @todo test force_transport
+	/**
+	 * @covers WPSEO_Frontend::adjacent_rel_links
+	 * @covers WPSEO_Frontend::canonical
+	 */
+	public function test_adjacent_rel_links_canonical_date_archive() {
+		$this->factory->post->create_many( 22 );
+
+		$date_link = get_day_link( false, false, false );  // Having three times false generates a link for today, which is what we need
+		$this->run_test_on_consecutive_pages( $date_link );
 	}
 
 	/**
@@ -539,13 +547,6 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$category_link = get_category_link( $category_id );
 
 		$this->run_test_on_consecutive_pages( $category_link );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::adjacent_rel_link
-	 */
-	public function test_adjacent_rel_link() {
-		// @todo
 	}
 
 	/**
@@ -961,9 +962,9 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Override the go_to function in core as its broken when path isn't set.
 	 *
-	 * Can be removed when https://core.trac.wordpress.org/ticket/31417 is fixed.
+	 * Can be removed when https://core.trac.wordpress.org/ticket/31417 is fixed and in all releases we're testing (so when 4.2 is the lowest common denominator).
 	 *
-	 * @param $url
+	 * @param string $url
 	 */
 	function go_to( $url ) {
 		// note: the WP and WP_Query classes like to silently fetch parameters

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -134,7 +134,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	public function test_get_author_title() {
 
 		// create and go to author
-		$user_id = $this->factory->user->create( );
+		$user_id = $this->factory->user->create();
 		$this->go_to( get_author_posts_url( $user_id ) );
 
 		// test general author title
@@ -260,9 +260,9 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	public function test_json_ld() {
 		$this->go_to_home();
 
-		$home_url = trailingslashit( home_url() );
+		$home_url   = trailingslashit( home_url() );
 		$search_url = $home_url . '?s={search_term}';
-		$this->run_json_ld_test( '<script type="application/ld+json">{ "@context": "http://schema.org", "@type": "WebSite", "url": "' . $home_url . '", "potentialAction": { "@type": "SearchAction", "target": "' . $search_url .'", "query-input": "required name=search_term" } }</script>' . "\n" );
+		$this->run_json_ld_test( '<script type="application/ld+json">{ "@context": "http://schema.org", "@type": "WebSite", "url": "' . $home_url . '", "potentialAction": { "@type": "SearchAction", "target": "' . $search_url . '", "query-input": "required name=search_term" } }</script>' . "\n" );
 	}
 
 	/**
@@ -277,11 +277,11 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @covers WPSEO_Frontend::robots
 	 *
-	 * @todo test post type archives
-	 * @todo test with noodp and noydir option set
-	 * @todo test with page_for_posts option
-	 * @todo test date archives
-	 * @todo test search results
+	 * @todo   test post type archives
+	 * @todo   test with noodp and noydir option set
+	 * @todo   test with page_for_posts option
+	 * @todo   test date archives
+	 * @todo   test search results
 	 */
 	public function test_robots() {
 		// go to home
@@ -402,10 +402,10 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
 
-		$robots = array(
-			'index' => 'index',
+		$robots   = array(
+			'index'  => 'index',
 			'follow' => 'follow',
-			'other' => array(),
+			'other'  => array(),
 		);
 		$expected = $robots;
 
@@ -421,12 +421,12 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 		// test noodp with default meta-robots-adv
 		self::$class_instance->options['noodp'] = true;
-		$expected['other'] = array( 'noodp' );
+		$expected['other']                      = array( 'noodp' );
 		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
 
 		// test noydir with default meta-robots-adv
 		self::$class_instance->options['noydir'] = true;
-		$expected['other'] = array( 'noodp', 'noydir' );
+		$expected['other']                       = array( 'noodp', 'noydir' );
 		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
 
 		// test meta-robots adv noodp and nosnippet
@@ -506,7 +506,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		if ( is_multisite() ) {
 			return;
 		}
-				// test taxonomy pages, category pages and tag pages
+		// test taxonomy pages, category pages and tag pages
 		$category_id   = wp_create_category( 'Category Name' );
 		$category_link = get_category_link( $category_id );
 		$this->go_to( $category_link );
@@ -625,7 +625,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_noindex_page() {
 		$expected = '<meta name="robots" content="noindex" />' . "\n";
-		$this->expectOutput( $expected, self::$class_instance->noindex_page( ) );
+		$this->expectOutput( $expected, self::$class_instance->noindex_page() );
 
 	}
 
@@ -655,22 +655,22 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$c = self::$class_instance;
 
 		// test on author, authors enabled -> false
-		$wp_query->is_author = true;
+		$wp_query->is_author          = true;
 		$c->options['disable-author'] = false;
 		$this->assertFalse( $c->archive_redirect() );
 
 		// test not on author, authors disabled -> false
-		$wp_query->is_author = false;
+		$wp_query->is_author          = false;
 		$c->options['disable-author'] = true;
 		$this->assertFalse( $c->archive_redirect() );
 
 		// test on date, dates enabled -> false
-		$wp_query->is_date = true;
+		$wp_query->is_date          = true;
 		$c->options['disable-date'] = false;
 		$this->assertFalse( $c->archive_redirect() );
 
 		// test not on date, dates disabled -> false
-		$wp_query->is_date = false;
+		$wp_query->is_date          = false;
 		$c->options['disable-date'] = true;
 		$this->assertFalse( $c->archive_redirect() );
 	}
@@ -864,7 +864,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		// test if input was changed
 		self::$class_instance->options['rssbefore'] = 'Some RSS before text';
 		self::$class_instance->options['rssafter']  = '';
-		$expected = wpautop( self::$class_instance->options['rssbefore'] ) . $input;
+		$expected                                   = wpautop( self::$class_instance->options['rssbefore'] ) . $input;
 		$this->assertEquals( $expected, self::$class_instance->embed_rss( $input, 'full' ) );
 	}
 
@@ -915,30 +915,33 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	* @param string $name
-	* @return string
-	*/
+	 * @param string $name
+	 *
+	 * @return string
+	 */
 	private function get_option( $name ) {
-		return self::$class_instance->options[$name];
+		return self::$class_instance->options[ $name ];
 	}
 
 	/**
 	 * @param string $option_name
 	 * @param string $expected
+	 *
 	 * @return void
 	 */
 	private function run_webmaster_tools_authentication_option_test( $option_name, $expected ) {
-		self::$class_instance->options[$option_name] = $option_name;
-		$this->expectOutput( $expected, self::$class_instance->webmaster_tools_authentication( ) );
-		self::$class_instance->options[$option_name] = '';
+		self::$class_instance->options[ $option_name ] = $option_name;
+		$this->expectOutput( $expected, self::$class_instance->webmaster_tools_authentication() );
+		self::$class_instance->options[ $option_name ] = '';
 	}
 
 	/**
 	 * @param string $expected
+	 *
 	 * @return void
 	 */
 	private function run_json_ld_test( $expected ) {
-		$this->expectOutput( $expected, self::$class_instance->internal_search_json_ld( ) );
+		$this->expectOutput( $expected, self::$class_instance->internal_search_json_ld() );
 	}
 
 }

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -529,6 +529,8 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$category_id = wp_create_category( 'boom' );
 		$this->factory->post->create_many( 22, array( 'post_category' => array( $category_id ) ) );
 
+		flush_rewrite_rules();
+
 		$category_link = get_category_link( $category_id );
 
 		// Test page 1 of the category, should have just next

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -531,7 +531,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 		$category_link = get_category_link( $category_id );
 		$this->go_to( $category_link );
-		$next_link = get_pagenum_link( 2 );
+		$next_link = get_pagenum_link( 2, false );
 
 		$this->go_to( $next_link );
 		$next_link = get_pagenum_link( 3 );

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -525,7 +525,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::adjacent_rel_links
 	 */
 	public function test_adjacent_rel_links() {
-		update_option( 'posts_per_page', 5 );
+		update_site_option( 'posts_per_page', 5 );
 
 		// create a category, add 26 posts to it, go to page 2 of its archives
 		$category_id = wp_create_category( 'boom' );


### PR DESCRIPTION
Fixes #2000 ; funky behavior in retrieving canonical caused wrong rel=next / rel=prev links on paginated pages, leading to all sorts of crawl errors.

Fixes #2024 where you could no longer filter a canonical to false to remove it.

This pull also adds lots of test cases around this issue.

