### PR TITLE
Update wp-seo-metabox.js

### DIFF
--- a/js/wp-seo-metabox.js
+++ b/js/wp-seo-metabox.js
@@ -282,12 +282,12 @@ function yst_updateDesc() {
 		snippet.find('.desc span.content').html('');
 		yst_testFocusKw();
 
-		if (tinyMCE.get('excerpt') !== null) {
+		if ( tinyMCE && tinyMCE.get('excerpt') !== null) {
 			desc = tinyMCE.get('excerpt').getContent();
 			desc = yst_clean(desc);
 		}
 
-		if ( tinyMCE.get('content') !== null && desc.length === 0) {
+		if ( tinyMCE && tinyMCE.get('content') !== null && desc.length === 0) {
 			desc = tinyMCE.get('content').getContent();
 
 			desc = yst_clean(desc);
@@ -465,11 +465,11 @@ jQuery(document).ready(function () {
 			yst_updateSnippet();
 
 			// Adding events to content and excerpt
-			if( tinyMCE.get( 'content' ) !== null ) {
+			if( tinyMCE && tinyMCE.get( 'content' ) !== null ) {
 				tinyMCE.get( 'content' ).on( 'blur', yst_updateDesc );
 			}
 
-			if( tinyMCE.get( 'excerpt' ) !== null ) {
+			if( tinyMCE && tinyMCE.get( 'excerpt' ) !== null ) {
 				tinyMCE.get( 'excerpt' ).on( 'blur', yst_updateDesc );
 			}
 		},


### PR DESCRIPTION
Add a check to see if tinyMCE is active.  When creating a custom post type without editor support, tinyMCE is not present and this script will throw errors.