### PR TITLE
Improve function yst_clean

### DIFF
--- a/js/wp-seo-metabox.js
+++ b/js/wp-seo-metabox.js
@@ -5,7 +5,7 @@ function yst_clean(str) {
 	try {
 		str = jQuery('<div/>').html(str).text();
 		str = str.replace(/<\/?[^>]+>/gi, '');
-		str = str.replace(/\[(.+?)\](.+?\[\/\\1\])?/g, '');
+		str = str.replace(/\[([^:].*?)\](.+?\[\/\\1\])?/g, '');
 	} catch (e) {
 	}
 


### PR DESCRIPTION
qTranslate-X, https://wordpress.org/plugins/qtranslate-x/, uses combination '[:' to encode multilingual content, which should survive application of function 'yst_clean'. Wordpress shortcodes will still be removed by this version of 'yst_clean', as it should be.