### PR TITLE
Fixed the issue where some posts were included in the sitemap while they...

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -775,6 +775,10 @@ class WPSEO_Sitemaps {
 					if ( WPSEO_Meta::get_value( 'meta-robots-noindex', $p->ID ) === '1' && WPSEO_Meta::get_value( 'sitemap-include', $p->ID ) !== 'always' ) {
 						continue;
 					}
+					if ( isset( $this->options[ 'noindex-' . $post_type ] ) && $this->options[ 'noindex-' . $post_type ] === true &&
+					     WPSEO_Meta::get_value( 'meta-robots-noindex', $p->ID ) === '0' && WPSEO_Meta::get_value( 'sitemap-include', $p->ID ) !== 'always' ) {
+					     	continue;
+					}
 					if ( WPSEO_Meta::get_value( 'sitemap-include', $p->ID ) === 'never' ) {
 						continue;
 					}


### PR DESCRIPTION
... shouldn't have been

If a post type globally was set as noindex by default but not excluded from the sitemap (so as to allow individual posts of that type to be included), all the individual posts of that type were getting included, even those whose individual flags were set as noindex --> auto and include in site map --> auto. I.e. the global noindex flag for the post type was ignored.