### PR TITLE
Prevent marking a page as a gallery card when there are less than 4 images.

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -19,7 +19,7 @@ class WPSEO_Twitter {
 	/**
 	 * @var array Images
 	 */
-	public $images = array();
+	private $images = array();
 
 	/**
 	 * @var array Images

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -19,6 +19,11 @@ class WPSEO_Twitter {
 	/**
 	 * @var array Images
 	 */
+	public $images = array();
+
+	/**
+	 * @var array Images
+	 */
 	public $shown_images = array();
 
 	/**
@@ -91,7 +96,10 @@ class WPSEO_Twitter {
 		if ( is_singular() ) {
 			// If the current post has a gallery, output a gallery card
 			if ( has_shortcode( $GLOBALS['post']->post_content, 'gallery' ) ) {
-				$this->type = 'gallery';
+				$this->images = get_post_gallery_images();
+				if ( count( $this->images ) > 3 ) {
+					$this->type = 'gallery';
+				}
 			}
 		}
 
@@ -305,7 +313,6 @@ class WPSEO_Twitter {
 	 * Only used when OpenGraph is inactive or Summary Large Image card is chosen.
 	 */
 	protected function image() {
-
 		if ( 'gallery' === $this->type ) {
 			$this->gallery_images_output();
 		}
@@ -322,17 +329,8 @@ class WPSEO_Twitter {
 	 * Outputs the first 4 images of a gallery as the posts gallery images
 	 */
 	private function gallery_images_output() {
-		$images = get_post_gallery_images();
-
-		// If there are no images attached, use the standard single image output
-		if ( count( $images ) === 0 ) {
-			$this->single_image_output();
-
-			return;
-		}
-
 		$image_counter = 0;
-		foreach ( $images as $image ) {
+		foreach ( $this->images as $image ) {
 			if ( $image_counter > 3 ) {
 				return;
 			}

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -332,7 +332,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		$expected = $this->metatag( 'card', 'gallery' );
 
 		// Insert images into DB so we have something to test against
-		foreach ( range( 0, 2 ) as $i ) {
+		foreach ( range( 0, 3 ) as $i ) {
 			$filename = "image$i.jpg";
 			$ids[] = $this->factory->attachment->create_object( $filename, 0, array(
 				'post_mime_type' => 'image/jpeg',


### PR DESCRIPTION
Fixes #2129