### PR TITLE
Putting filter input back, raising a notice if extensions is not there [Finishes #90489438]

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -70,7 +70,7 @@ class WPSEO_Admin_Init {
 	 * Determine if we should load our taxonomy edit class and if so, load it.
 	 */
 	private function load_taxonomy_class() {
-		if ( 'edit-tags.php' === $this->pagenow && WPSEO_Utils::filter_input( INPUT_GET, 'action' ) ) {
+		if ( 'edit-tags.php' === $this->pagenow && filter_input( INPUT_GET, 'action' ) ) {
 			new WPSEO_Taxonomy;
 		}
 	}
@@ -92,7 +92,7 @@ class WPSEO_Admin_Init {
 	 * Loads admin page class for all admin pages starting with `wpseo_`.
 	 */
 	private function load_admin_page_class() {
-		$page = WPSEO_Utils::filter_input( INPUT_GET, 'page' );
+		$page = filter_input( INPUT_GET, 'page' );
 		if ( 'admin.php' === $this->pagenow && strpos( $page, 'wpseo' ) === 0 ) {
 			// For backwards compatabilty, this still needs a global, for now...
 			$GLOBALS['wpseo_admin_pages'] = new WPSEO_Admin_Pages;
@@ -143,7 +143,7 @@ class WPSEO_Admin_Init {
 	 * See if we should start our tour.
 	 */
 	private function load_tour() {
-		$restart_tour = WPSEO_Utils::filter_input( INPUT_GET, 'wpseo_restart_tour' );
+		$restart_tour = filter_input( INPUT_GET, 'wpseo_restart_tour' );
 		if ( $restart_tour ) {
 			$this->options['ignore_tour'] = false;
 			update_option( 'wpseo', $this->options );

--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -27,7 +27,7 @@ class WPSEO_Admin_User_Profile {
 	 * @return mixed
 	 */
 	private function filter_input_post( $var_name ) {
-		$val = WPSEO_Utils::filter_input( INPUT_POST, $var_name );
+		$val = filter_input( INPUT_POST, $var_name );
 		if ( $val ) {
 			return WPSEO_Option::sanitize_text_field( $val );
 		}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -249,7 +249,7 @@ class WPSEO_Admin {
 	 * Load the form for a WPSEO admin page
 	 */
 	function load_page() {
-		$page = WPSEO_Utils::filter_input( INPUT_GET, 'page' );
+		$page = filter_input( INPUT_GET, 'page' );
 
 		switch ( $page ) {
 			case 'wpseo_advanced':
@@ -360,7 +360,7 @@ class WPSEO_Admin {
 		}
 
 		// No need to double display it on the dashboard
-		if ( 'wpseo_dashboard' === WPSEO_Utils::filter_input( INPUT_GET, 'page' ) ) {
+		if ( 'wpseo_dashboard' === filter_input( INPUT_GET, 'page' ) ) {
 			return;
 		}
 
@@ -461,17 +461,17 @@ class WPSEO_Admin {
 			return $slug;
 		}
 
-		if ( ! WPSEO_Utils::filter_input( INPUT_POST, 'post_title' ) ) {
+		if ( ! filter_input( INPUT_POST, 'post_title' ) ) {
 			return $slug;
 		}
 
 		// Don't change slug if the post is a draft, this conflicts with polylang
-		if ( 'draft' == WPSEO_Utils::filter_input( INPUT_POST, 'post_status' ) ) {
+		if ( 'draft' == filter_input( INPUT_POST, 'post_status' ) ) {
 			return $slug;
 		}
 
 		// Lowercase the slug and strip slashes
-		$clean_slug = sanitize_title( stripslashes( WPSEO_Utils::filter_input( INPUT_POST, 'post_title' ) ) );
+		$clean_slug = sanitize_title( stripslashes( filter_input( INPUT_POST, 'post_title' ) ) );
 
 		// Turn it to an array and strip stopwords by comparing against an array of stopwords
 		$clean_slug_array = array_diff( explode( '-', $clean_slug ), $this->stopwords() );

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -130,7 +130,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 * Shows an error notification if the nonce check fails.
 	 */
 	private function verify_nonce() {
-		if ( $this->should_verify_nonce() && ! wp_verify_nonce( WPSEO_Utils::filter_input( INPUT_GET, 'nonce' ), 'bulk-editor-table' ) ) {
+		if ( $this->should_verify_nonce() && ! wp_verify_nonce( filter_input( INPUT_GET, 'nonce' ), 'bulk-editor-table' ) ) {
 			Yoast_Notification_Center::get()->add_notification( new Yoast_Notification( __( 'You are not allowed to access this page.', 'wordpress-seo' ), 'error' ) );
 			Yoast_Notification_Center::get()->display_notifications();
 			die;
@@ -153,7 +153,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		);
 
 		foreach ( $possible_params as $param_name ) {
-			if ( WPSEO_Utils::filter_input( INPUT_GET, $param_name ) ) {
+			if ( filter_input( INPUT_GET, $param_name ) ) {
 				return true;
 			}
 		}
@@ -202,7 +202,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 * @param string $which
 	 */
 	function display_tablenav( $which ) {
-		$post_status = sanitize_text_field( WPSEO_Utils::filter_input( INPUT_GET, 'post_status' ) );
+		$post_status = sanitize_text_field( filter_input( INPUT_GET, 'post_status' ) );
 		?>
 		<div class="tablenav <?php echo esc_attr( $which ); ?>">
 
@@ -213,11 +213,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				<input type="hidden" name="tool" value="bulk-editor"/>
 				<input type="hidden" name="type" value="<?php echo esc_attr( $this->page_type ); ?>"/>
 				<input type="hidden" name="orderby"
-				       value="<?php echo esc_attr( WPSEO_Utils::filter_input( INPUT_GET, 'orderby' ) ); ?>"/>
+				       value="<?php echo esc_attr( filter_input( INPUT_GET, 'orderby' ) ); ?>"/>
 				<input type="hidden" name="order"
-				       value="<?php echo esc_attr( WPSEO_Utils::filter_input( INPUT_GET, 'order' ) ); ?>"/>
+				       value="<?php echo esc_attr( filter_input( INPUT_GET, 'order' ) ); ?>"/>
 				<input type="hidden" name="post_type_filter"
-				       value="<?php echo esc_attr( WPSEO_Utils::filter_input( INPUT_GET, 'post_type_filter' ) ); ?>"/>
+				       value="<?php echo esc_attr( filter_input( INPUT_GET, 'post_type_filter' ) ); ?>"/>
 				<?php if ( ! empty( $post_status ) ) { ?>
 					<input type="hidden" name="post_status" value="<?php echo esc_attr( $post_status ); ?>"/>
 				<?php } ?>
@@ -290,7 +290,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		);
 
 
-		$post_status         = WPSEO_Utils::filter_input( INPUT_GET, 'post_status' );
+		$post_status         = filter_input( INPUT_GET, 'post_status' );
 		$class               = empty( $post_status ) ? ' class="current"' : '';
 		$status_links['all'] = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=bulk-editor' . $this->page_url ) ) . '"' . $class . '>' . sprintf( _nx( 'All <span class="count">(%s)</span>', 'All <span class="count">(%s)</span>', $total_posts, 'posts', 'wordpress-seo' ), number_format_i18n( $total_posts ) ) . '</a>';
 
@@ -372,7 +372,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 						"
 				);
 
-				$post_type_filter = WPSEO_Utils::filter_input( INPUT_GET, 'post_type_filter' );
+				$post_type_filter = filter_input( INPUT_GET, 'post_type_filter' );
 				$selected         = ( ! empty( $post_type_filter ) ) ? sanitize_text_field( $post_type_filter ) : '-1';
 
 				$options = '<option value="-1">Show All Post Types</option>';
@@ -518,7 +518,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		// Filter Block
 		$post_types       = null;
 		$post_type_clause = '';
-		$post_type_filter = WPSEO_Utils::filter_input( INPUT_GET, 'post_type_filter' );
+		$post_type_filter = filter_input( INPUT_GET, 'post_type_filter' );
 
 		if ( ! empty( $post_type_filter ) && get_post_type_object( sanitize_text_field( $post_type_filter ) ) ) {
 			$post_types       = esc_sql( sanitize_text_field( $post_type_filter ) );
@@ -539,7 +539,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 		// Calculate items per page
 		$per_page = $this->get_items_per_page( 'wpseo_posts_per_page', 10 );
-		$paged    = esc_sql( sanitize_text_field( WPSEO_Utils::filter_input( INPUT_GET, 'paged' ) ) );
+		$paged    = esc_sql( sanitize_text_field( filter_input( INPUT_GET, 'paged' ) ) );
 
 		if ( empty( $paged ) || ! is_numeric( $paged ) || $paged <= 0 ) {
 			$paged = 1;
@@ -574,13 +574,13 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 */
 	protected function parse_item_query( $subquery, $all_states, $post_type_clause ) {
 		// Order By block
-		$orderby = WPSEO_Utils::filter_input( INPUT_GET, 'orderby' );
+		$orderby = filter_input( INPUT_GET, 'orderby' );
 
 		$orderby = ! empty( $orderby ) ? esc_sql( sanitize_text_field( $orderby ) ) : 'post_title';
 		$orderby = $this->sanitize_orderby( $orderby );
 
 		// Order clause
-		$order = WPSEO_Utils::filter_input( INPUT_GET, 'order' );
+		$order = filter_input( INPUT_GET, 'order' );
 		$order = ! empty( $order ) ? esc_sql( strtoupper( sanitize_text_field( $order ) ) ) : 'ASC';
 		$order = $this->sanitize_order( $order );
 

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -27,7 +27,7 @@ class WPSEO_Admin_Pages {
 	 * Make sure the needed scripts are loaded for admin pages
 	 */
 	function init() {
-		if ( WPSEO_Utils::filter_input( INPUT_GET, 'wpseo_reset_defaults' ) && wp_verify_nonce( WPSEO_Utils::filter_input( INPUT_GET, 'nonce' ), 'wpseo_reset_defaults' ) && current_user_can( 'manage_options' ) ) {
+		if ( filter_input( INPUT_GET, 'wpseo_reset_defaults' ) && wp_verify_nonce( filter_input( INPUT_GET, 'nonce' ), 'wpseo_reset_defaults' ) && current_user_can( 'manage_options' ) ) {
 			WPSEO_Options::reset();
 			wp_redirect( admin_url( 'admin.php?page=wpseo_dashboard' ) );
 		}
@@ -142,8 +142,8 @@ class WPSEO_Admin_Pages {
 		wp_enqueue_script( 'dashboard' );
 		wp_enqueue_script( 'thickbox' );
 
-		$page = WPSEO_Utils::filter_input( INPUT_GET, 'page' );
-		$tool = WPSEO_Utils::filter_input( INPUT_GET, 'tool' );
+		$page = filter_input( INPUT_GET, 'page' );
+		$tool = filter_input( INPUT_GET, 'tool' );
 
 		if ( in_array( $page, array( 'wpseo_social', 'wpseo_dashboard' ) ) ) {
 			wp_enqueue_media();

--- a/admin/class-pointers.php
+++ b/admin/class-pointers.php
@@ -143,7 +143,7 @@ class WPSEO_Pointers {
 			),
 		);
 
-		$page = WPSEO_Utils::filter_input( INPUT_GET, 'page' );
+		$page = filter_input( INPUT_GET, 'page' );
 		$page = str_replace( 'wpseo_', '', $page );
 
 		$button_array = array(

--- a/admin/pages/advanced.php
+++ b/admin/pages/advanced.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-$active_tab = WPSEO_Utils::filter_input( INPUT_GET, 'tab' );
+$active_tab = filter_input( INPUT_GET, 'tab' );
 
 $tabs = array(
 	'breadcrumbs' => array(

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( WPSEO_Utils::filter_input( INPUT_GET, 'intro' ) ) {
+if ( filter_input( INPUT_GET, 'intro' ) ) {
 	require WPSEO_PATH . 'admin/views/about.php';
 	return;
 }

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-$tool_page = (string) WPSEO_Utils::filter_input( INPUT_GET, 'tool' );
+$tool_page = (string) filter_input( INPUT_GET, 'tool' );
 
 $yform = Yoast_Form::get_instance();
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -700,45 +700,7 @@ class WPSEO_Utils {
 	 * @return mixed
 	 */
 	public static function filter_input( $type, $variable_name, $filter = FILTER_DEFAULT ) {
-		if ( function_exists( 'filter_input' ) ) {
-			return filter_input( $type, $variable_name, $filter );
-		}
-		else {
-			switch ( $type ) {
-				case INPUT_GET:
-					$type = $_GET;
-					break;
-				case INPUT_POST:
-					$type = $_POST;
-					break;
-				case INPUT_SERVER:
-					$type = $_SERVER;
-					break;
-				default:
-					return false;
-					break;
-			}
-
-			if ( isset( $type[ $variable_name ] ) ) {
-				$out = $type[ $variable_name ];
-			}
-			else {
-				return false;
-			}
-
-			switch ( $filter ) {
-				case FILTER_VALIDATE_INT:
-					$out = self::emulate_filter_int( $out );
-					break;
-				case FILTER_VALIDATE_BOOLEAN:
-					$out = self::emulate_filter_bool( $out );
-					break;
-				default:
-					$out = (string) $out;
-					break;
-			}
-			return $out;
-		}
+		return filter_input( $type, $variable_name, $filter );
 	}
 
 	/**

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -284,8 +284,8 @@ function wpseo_admin_init() {
 
 
 /* ***************************** BOOTSTRAP / HOOK INTO WP *************************** */
-$spl_autoload_exists = function_exists( 'spl_autoload_register' ) ;
-$filter_exists       = function_exists( 'filter_input' ) ;
+$spl_autoload_exists = function_exists( 'spl_autoload_register' );
+$filter_exists       = function_exists( 'filter_input' );
 
 if ( ! $spl_autoload_exists ) {
 	add_action( 'admin_init', 'yoast_wpseo_missing_spl', 1 );
@@ -295,7 +295,7 @@ if ( ! $filter_exists ) {
 	add_action( 'admin_init', 'yoast_wpseo_missing_filter', 1 );
 }
 
-if ( (! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) && ( $spl_autoload_exists && $filter_input_exists )  ) {
+if ( (! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) && ( $spl_autoload_exists && $filter_input_exists ) ) {
 	add_action( 'plugins_loaded', 'wpseo_init', 14 );
 
 	if ( is_admin() ) {
@@ -345,6 +345,9 @@ function yoast_wpseo_missing_spl() {
 	}
 }
 
+/**
+ * Returns the notice in case of missing spl extension
+ */
 function yoast_wpseo_missing_spl_notice() {
 	$message = esc_html__( 'The Standard PHP Library (SPL) extension seem to be unavailable. Please ask your web host to enable it.', 'wordpress-seo' );
 	echo '<div class="error"><p>' . __( 'Activation failed:', 'wordpress-seo' ) . ' ' . $message . '</p></div>';
@@ -366,18 +369,20 @@ function yoast_wpseo_missing_filter() {
 }
 
 /**
- * Returns the notice in case of missing filter extenstion
- * @return string
+ * Returns the notice in case of missing filter extension
  */
 function yoast_wpseo_missing_filter_notice() {
 	$message = esc_html__( 'The filter extension seem to be unavailable. Please ask your web host to enable it.', 'wordpress-seo' );
 	echo '<div class="error"><p>' . __( 'Activation failed:', 'wordpress-seo' ) . ' ' . $message . '</p></div>';
 }
 
+/**
+ * The method will deactivate the plugin, but only once, done by the static $is_deactivated
+ */
 function yoast_wpseo_self_deactivate() {
 	static $is_deactivated;
 
-	if( $is_deactivated === null ) {
+	if ( $is_deactivated === null ) {
 		$is_deactivated = true;
 		deactivate_plugins( plugin_basename( WPSEO_FILE ) );
 		if ( isset( $_GET['activate'] ) ) {

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -295,7 +295,7 @@ if ( ! $filter_exists ) {
 	add_action( 'admin_init', 'yoast_wpseo_missing_filter', 1 );
 }
 
-if ( (! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) && ( $spl_autoload_exists && $filter_input_exists ) ) {
+if ( ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) && ( $spl_autoload_exists && $filter_exists ) ) {
 	add_action( 'plugins_loaded', 'wpseo_init', 14 );
 
 	if ( is_admin() ) {


### PR DESCRIPTION
The filter extension is enabled by default in PHP 5.2. We don't want to rely on fallbacks, so we give the user a notice when extension is not home. 

The create function is giving errors, so it is replaced by existing methods to do the same trick.