### PR TITLE
Allow overriding `upload` metabox field setting CSS class

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -742,7 +742,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				break;
 
 			case 'upload':
-				$content .= '<input id="' . $esc_form_key . '" type="text" size="36" name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '" />';
+				$content .= '<input id="' . $esc_form_key . '" type="text" size="36" class="' . $class . '" name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '" />';
 				$content .= '<input id="' . $esc_form_key . '_button" class="wpseo_image_upload_button button" type="button" value="Upload Image" />';
 				break;
 		}


### PR DESCRIPTION
I'd love to be able to override the `upload` field's text input CSS class. `wpseo_image_upload_button` allows for customizing the button, but nothing is available for the upload text field.