### PR TITLE
Fixes sitemap transient caching.

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -277,7 +277,9 @@ class WPSEO_Sitemaps {
 	 */
 	function sitemap_close() {
 		remove_all_actions( 'wp_footer' );
-		die();
+		if ( ! defined( 'WPSEO_UNIT_TEST' ) || ! WPSEO_UNIT_TEST ) {
+			die();
+		}
 	}
 
 	/**
@@ -1186,10 +1188,12 @@ class WPSEO_Sitemaps {
 	 * Spit out the generated sitemap and relevant headers and encoding information.
 	 */
 	function output() {
-		header( $this->http_protocol() . ' 200 OK', true, 200 );
-		// Prevent the search engines from indexing the XML Sitemap.
-		header( 'X-Robots-Tag: noindex,follow', true );
-		header( 'Content-Type: text/xml' );
+		if ( ! headers_sent() ) {
+			header( $this->http_protocol() . ' 200 OK', true, 200 );
+			// Prevent the search engines from indexing the XML Sitemap.
+			header( 'X-Robots-Tag: noindex,follow', true );
+			header( 'Content-Type: text/xml' );
+		}
 		echo '<?xml version="1.0" encoding="', esc_attr( $this->charset ), '"?>';
 		if ( $this->stylesheet ) {
 			echo apply_filters( 'wpseo_stylesheet_url', $this->stylesheet ), "\n";

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -1227,8 +1227,10 @@ class WPSEO_Sitemaps {
 	 */
 	function sitemap_url( $url ) {
 
-		// Create a DateTime object date in the correct timezone
-		$date = $this->get_datetime_with_timezone( $url['mod'] );
+		if ( isset( $url['mod'] ) ) {
+			// Create a DateTime object date in the correct timezone
+			$date = $this->get_datetime_with_timezone( $url['mod'] );
+		}
 
 		$url['loc'] = htmlspecialchars( $url['loc'] );
 

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -16,7 +16,7 @@ class WPSEO_Sitemaps {
 	 *
 	 * @var string $sitemap
 	 */
-	private $sitemap = '';
+	protected $sitemap = '';
 
 	/**
 	 * XSL stylesheet for styling a sitemap for web browsers
@@ -277,9 +277,7 @@ class WPSEO_Sitemaps {
 	 */
 	function sitemap_close() {
 		remove_all_actions( 'wp_footer' );
-		if ( ! defined( 'WPSEO_UNIT_TEST' ) || ! WPSEO_UNIT_TEST ) {
-			die();
-		}
+		die();
 	}
 
 	/**
@@ -1277,7 +1275,7 @@ class WPSEO_Sitemaps {
 	 *
 	 * @return bool|string $redirect
 	 */
-	function canonical( $redirect ) {
+	public function canonical( $redirect ) {
 		$sitemap = get_query_var( 'sitemap' );
 		if ( ! empty( $sitemap ) ) {
 			return false;

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -306,6 +306,7 @@ class WPSEO_Sitemaps {
 		if ( is_scalar( $n ) && intval( $n ) > 0 ) {
 			$this->n = intval( $n );
 		}
+		unset( $n );
 
 		/**
 		 * Filter: 'wpseo_enable_xml_sitemap_transient_caching' - Allow disabling the transient cache
@@ -331,7 +332,7 @@ class WPSEO_Sitemaps {
 			}
 
 			if ( $caching ) {
-				set_transient( 'wpseo_sitemap_cache_' . $type . '_' . $n, $this->sitemap, DAY_IN_SECONDS );
+				set_transient( 'wpseo_sitemap_cache_' . $type . '_' . $this->n, $this->sitemap, DAY_IN_SECONDS );
 			}
 		}
 		else {

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -402,7 +402,7 @@ class WPSEO_Sitemaps {
 				$where_filter = apply_filters( 'wpseo_typecount_where', '', $post_type );
 
 				// using the same query with build_post_type_map($post_type) function to count number of posts.
-				$query = $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts {$join_filter} WHERE post_status IN ('publish','inherit') AND post_password = '' AND post_author != 0 AND post_date != '0000-00-00 00:00:00' AND post_type = %s " . $where_filter, $post_type );
+				$query = $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts {$join_filter} WHERE post_status IN ('publish','inherit') AND post_password = '' AND post_date != '0000-00-00 00:00:00' AND post_type = %s " . $where_filter, $post_type );
 
 				$count = $wpdb->get_var( $query );
 				if ( $count == 0  ) {
@@ -643,7 +643,7 @@ class WPSEO_Sitemaps {
 		$join_filter  = apply_filters( 'wpseo_typecount_join', '', $post_type );
 		$where_filter = apply_filters( 'wpseo_typecount_where', '', $post_type );
 
-		$query = $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts {$join_filter} WHERE post_status IN ('publish','inherit') AND post_password = '' AND post_author != 0 AND post_date != '0000-00-00 00:00:00' AND post_type = %s " . $where_filter, $post_type );
+		$query = $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts {$join_filter} WHERE post_status IN ('publish','inherit') AND post_password = '' AND post_date != '0000-00-00 00:00:00' AND post_type = %s " . $where_filter, $post_type );
 
 		$typecount = $wpdb->get_var( $query );
 
@@ -732,14 +732,14 @@ class WPSEO_Sitemaps {
 
 
 		/**
-		 * We grab post_date, post_name, post_author and post_status too so we can throw these objects
+		 * We grab post_date, post_name and post_status too so we can throw these objects
 		 * into get_permalink, which saves a get_post call for each permalink.
 		 */
 		while ( $total > $offset ) {
 
 			// Optimized query per this thread: http://wordpress.org/support/topic/plugin-wordpress-seo-by-yoast-performance-suggestion
 			// Also see http://explainextended.com/2009/10/23/mysql-order-by-limit-performance-late-row-lookups/
-			$query = $wpdb->prepare( "SELECT l.ID, post_title, post_content, post_name, post_author, post_parent, post_modified_gmt, post_date, post_date_gmt FROM ( SELECT ID FROM $wpdb->posts {$join_filter} WHERE post_status = '%s' AND post_password = '' AND post_type = '%s' AND post_author != 0 AND post_date != '0000-00-00 00:00:00' {$where_filter} ORDER BY post_modified ASC LIMIT %d OFFSET %d ) o JOIN $wpdb->posts l ON l.ID = o.ID ORDER BY l.ID",
+			$query = $wpdb->prepare( "SELECT l.ID, post_title, post_content, post_name, post_parent, post_modified_gmt, post_date, post_date_gmt FROM ( SELECT ID FROM $wpdb->posts {$join_filter} WHERE post_status = '%s' AND post_password = '' AND post_type = '%s' AND post_date != '0000-00-00 00:00:00' {$where_filter} ORDER BY post_modified ASC LIMIT %d OFFSET %d ) o JOIN $wpdb->posts l ON l.ID = o.ID ORDER BY l.ID",
 				$status, $post_type, $steps, $offset
 			);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,8 +12,6 @@ if ( function_exists( 'xdebug_disable' ) ) {
 echo 'Welcome to the WordPress SEO Test Suite' . PHP_EOL;
 echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 
-define( 'WPSEO_UNIT_TEST', true );
-
 if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,12 @@ if ( function_exists( 'xdebug_disable' ) ) {
 echo 'Welcome to the WordPress SEO Test Suite' . PHP_EOL;
 echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 
+define( 'WPSEO_UNIT_TEST', true );
+
+if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
+	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
+}
+
 $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'wordpress-seo/wp-seo.php' ),
 );

--- a/tests/framework/class-wpseo-unit-test-case.php
+++ b/tests/framework/class-wpseo-unit-test-case.php
@@ -41,4 +41,15 @@ class WPSEO_UnitTestCase extends WP_UnitTestCase {
 		$expected = preg_replace( '|\R|', "\r\n", $expected );
 		$this->assertEquals( $expected, $output );
 	}
+
+	/**
+	 * @param string $expected
+	 */
+	protected function expectOutputContains( $expected ) {
+		$output = preg_replace( '|\R|', "\r\n", ob_get_contents() );
+		ob_clean();
+
+		$found = strpos( $output, $expected );
+		$this->assertEquals( true, ( $found !== false ) );
+	}
 }

--- a/tests/framework/class-wpseo-unit-test-case.php
+++ b/tests/framework/class-wpseo-unit-test-case.php
@@ -43,13 +43,19 @@ class WPSEO_UnitTestCase extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @param string $expected
+	 * @param string|array $expected
 	 */
 	protected function expectOutputContains( $expected ) {
 		$output = preg_replace( '|\R|', "\r\n", ob_get_contents() );
 		ob_clean();
 
-		$found = strpos( $output, $expected );
-		$this->assertEquals( true, ( $found !== false ) );
+		if ( ! is_array( $expected ) ) {
+			$expected = array( $expected );
+		}
+
+		foreach ( $expected as $needle ) {
+			$found = strpos( $output, $needle );
+			$this->assertTrue( $found !== false );
+		}
 	}
 }

--- a/tests/test-class-wpseo-sitemaps.php
+++ b/tests/test-class-wpseo-sitemaps.php
@@ -78,7 +78,7 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	public function test_post_sitemap() {
 		self::$class_instance->reset();
 
-		$post_id   = $this->factory->post->create( array( 'post_author' => 1 ) );
+		$post_id   = $this->factory->post->create();
 		$permalink = get_permalink( $post_id );
 
 		set_query_var( 'sitemap', 'post' );
@@ -93,6 +93,8 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the main sitemap and also tests the transient cache
+	 *
 	 * @covers WPSEO_Sitemaps::redirect
 	 */
 	public function test_main_sitemap() {
@@ -102,26 +104,12 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 		// Go to the XML sitemap twice, see if transient cache is set
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
-
 		$this->expectOutputContains( array(
 			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
 			'<sitemap>',
 			'<lastmod>',
 			'</sitemapindex>',
 		) );
-	}
-
-	/**
-	 * @covers WPSEO_Sitemaps::redirect
-	 */
-	public function test_main_sitemap_transient_cache() {
-		self::$class_instance->reset();
-
-		set_query_var( 'sitemap', 1 );
-
-		// Go to the XML sitemap twice, see if transient cache is set
-		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
-		ob_clean();
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
 

--- a/tests/test-class-wpseo-sitemaps.php
+++ b/tests/test-class-wpseo-sitemaps.php
@@ -10,9 +10,7 @@
 class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
 
 	/**
-	 * Prevent stupid plugins from running shutdown scripts when we're obviously not outputting HTML.
-	 *
-	 * @since 1.4.16
+	 * Overwrite sitemap_close() so we don't die on outputting the sitemap
 	 */
 	function sitemap_close() {
 		remove_all_actions( 'wp_footer' );
@@ -38,6 +36,9 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	 */
 	private static $class_instance;
 
+	/**
+	 * Set up our double class
+	 */
 	public static function setUpBeforeClass() {
 		self::$class_instance = new WPSEO_Sitemaps_Double;
 	}

--- a/tests/test-class-wpseo-sitemaps.php
+++ b/tests/test-class-wpseo-sitemaps.php
@@ -125,6 +125,12 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
 
-		$this->expectOutputContains( 'Served from transient cache' );
+		$this->expectOutputContains( array(
+			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+			'<sitemap>',
+			'<lastmod>',
+			'</sitemapindex>',
+			'Served from transient cache',
+		) );
 	}
 }

--- a/tests/test-class-wpseo-sitemaps.php
+++ b/tests/test-class-wpseo-sitemaps.php
@@ -43,4 +43,19 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( $date, date( 'c', strtotime( $post->post_modified_gmt ) ) );
 	}
+
+	/**
+	 * @covers WPSEO_Sitemaps::redirect
+	 */
+	public function test_main_sitemap_transient_cache() {
+		set_query_var( 'sitemap', 1 );
+
+		// Go to the XML sitemap twice, see if transient cache is set
+		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
+		ob_clean();
+
+		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
+
+		$this->expectOutputContains( 'Served from transient cache' );
+	}
 }


### PR DESCRIPTION
* Fixes wrongly used local var `$n` in favour of class var `$this->n`.
* Fixes a notice for the homepage URL in post type sitemaps (because that has no modification date/time).
* Fixes a possible "headers already sent" error (which occurred in testing a lot too).
* Removed `post_author` from queries as it's not in use anywhere (it used to be, long ago).
* Makes XML sitemaps properly testable and adds some initial tests.

@andizer please review.

@tacoverdo feel free to use this branch with client for testing.