### PR TITLE
Allow users to prevent redirects to the about page

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -111,14 +111,14 @@ class WPSEO_Upgrade {
 	 * Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
 	 */
 	private function finish_up() {
-		$this->options = get_option( 'wpseo' );                             // re-get to make sure we have the latest version
-		$this->options['seen_about'] = false;                               // make sure user is redirected to the about screen
-		update_option( 'wpseo', $this->options );                           // this also ensures the DB version is equal to WPSEO_VERSION
+		$this->options = get_option( 'wpseo' );                                                        // re-get to make sure we have the latest version
+		$this->options['seen_about'] = apply_filters( 'wpseo_prevent_redirect_after_upgrade', false ); // optionally make sure user is redirected to the about screen
+		update_option( 'wpseo', $this->options );                                                      // this also ensures the DB version is equal to WPSEO_VERSION
 
-		add_action( 'shutdown', 'flush_rewrite_rules' );                    // Just flush rewrites, always, to at least make them work after an upgrade.
-		WPSEO_Utils::clear_sitemap_cache();                                 // Flush the sitemap cache
+		add_action( 'shutdown', 'flush_rewrite_rules' );                                               // Just flush rewrites, always, to at least make them work after an upgrade.
+		WPSEO_Utils::clear_sitemap_cache();                                                            // Flush the sitemap cache
 
-		WPSEO_Options::ensure_options_exist();                              // Make sure all our options always exist - issue #1245
+		WPSEO_Options::ensure_options_exist();                                                         // Make sure all our options always exist - issue #1245
 	}
 
 }


### PR DESCRIPTION
This PR makes the redirect to the about page after an upgrade optional, through a new filter, `wpseo_prevent_redirect_after_upgrade`. (I'm open to a less verbose filter name!)

By default, this value is `false`, so the redirect is not prevented.

Optionally, users can filter this to `true`, which effectively prevents the redirect by setting `seen_about` to true:

```php
add_filter( 'wpseo_prevent_redirect_after_upgrade', '__return_true' );
```