### PR TITLE
Implement website name markup

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -289,15 +289,24 @@ class Yoast_Form {
 	/**
 	 * Create a Text input field.
 	 *
-	 * @param string $var   The variable within the option to create the text input field for.
-	 * @param string $label The label to show for the variable.
-	 * @param string $class Extra class to add to the input field
+	 * @param string       $var   The variable within the option to create the text input field for.
+	 * @param string       $label The label to show for the variable.
+	 * @param array|string $attr  Extra class to add to the input field
 	 */
-	public function textinput( $var, $label, $class = '' ) {
-		$val = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+	public function textinput( $var, $label, $attr = array() ) {
+		if ( ! is_array( $attr ) ) {
+			$attr = array(
+				'class' => $attr,
+			);
+		}
+		$attr = wp_parse_args( $attr, array(
+			'placeholder' => '',
+			'class'       => '',
+		) );
+		$val  = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
 
 		$this->label( $label . ':', array( 'for' => $var ) );
-		echo '<input class="textinput ' . esc_attr( $class ) . ' " type="text" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"/>', '<br class="clear" />';
+		echo '<input class="textinput ' . esc_attr( $attr['class'] ) . ' " placeholder="' . esc_attr( $attr['placeholder'] ) . '" type="text" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"/>', '<br class="clear" />';
 	}
 
 	/**

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -182,6 +182,17 @@ if ( get_option( 'page_comments' ) && $options['ignore_page_comments'] === false
 		</p>
 	</div>
 	<div id="knowledge-graph" class="wpseotab">
+		<h3><?php _e( 'Website name', 'wordpress-seo' ); ?></h3>
+		<p>
+			<?php
+			_e( 'Google shows your website\'s name in the search results, we will default to your site name but you can adapt it here. You can also provide an alternate website name you want Google to consider.', 'wordpress-seo' );
+			?>
+		</p>
+		<?php
+		$yform->textinput( 'website_name', __( 'Website name', 'wordpress-seo' ), array( 'placeholder' => get_bloginfo( 'name' ) ) );
+		$yform->textinput( 'alternate_website_name', __( 'Alternate name', 'wordpress-seo' ) );
+		?>
+		<h3><?php _e( 'Company or person', 'wordpress-seo' ); ?></h3>
 		<p>
 			<?php
 			// @todo add KB link - JdV

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1916,10 +1916,9 @@ class WPSEO_JSON_LD {
 	/**
 	 * Returns JSON+LD schema for Organization
 	 *
-	 * @return string
+	 * @param boolean|array $output
 	 */
-	private function organization() {
-		$output = '';
+	private function organization( &$output ) {
 		if ( '' !== $this->options['company_name'] ) {
 			$output = array(
 				'@context' => 'http://schema.org',
@@ -1930,17 +1929,14 @@ class WPSEO_JSON_LD {
 				'sameAs'   => $this->profiles,
 			);
 		}
-
-		return $output;
 	}
 
 	/**
 	 * Returns JSON+LD schema for Person
 	 *
-	 * @return string
+	 * @param boolean|array $output
 	 */
-	private function person() {
-		$output = '';
+	private function person( &$output ) {
 		if ( '' !== $this->options['person_name'] ) {
 			$output = array(
 				'@context' => 'http://schema.org',
@@ -1950,8 +1946,6 @@ class WPSEO_JSON_LD {
 				'sameAs'   => $this->profiles,
 			);
 		}
-
-		return $output;
 	}
 
 	/**
@@ -1966,16 +1960,17 @@ class WPSEO_JSON_LD {
 
 		$this->fetch_social_profiles();
 
+		$output = false;
 		switch ( $this->options['company_or_person'] ) {
 			case 'company':
-				$output = $this->organization();
+				$this->organization( $output );
 				break;
 			case 'person':
-				$output = $this->person();
+				$this->person( $output );
 				break;
 		}
 
-		if ( isset( $output ) ) {
+		if ( $output ) {
 			$this->json_ld_output( $output, $this->options['company_or_person'] );
 		}
 	}

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1894,17 +1894,20 @@ class WPSEO_JSON_LD {
 	 *
 	 * @since 1.8
 	 *
-	 * @param string $output
+	 * @param string $output  The array to be encoded and output
+	 * @param string $context The context of the output, useful for filtering
 	 */
-	protected function json_ld_output( $output ) {
+	protected function json_ld_output( $output, $context ) {
 		echo "<script type='application/ld+json'>";
 
 		/**
 		 * Filter: 'wpseo_json_ld_output' - Allows filtering of the JSON+LD output
 		 *
 		 * @api array $output The output array, before its JSON encoded
+		 *
+		 * @param string $context The context of the output, useful to determine whether to filter or not
 		 */
-		$output = apply_filters( 'wpseo_json_ld_output', $output );
+		$output = apply_filters( 'wpseo_json_ld_output', $output, $context );
 
 		echo json_encode( $output );
 		echo '</script>' . "\n";
@@ -1973,7 +1976,7 @@ class WPSEO_JSON_LD {
 		}
 
 		if ( isset( $output ) ) {
-			$this->json_ld_output( $output );
+			$this->json_ld_output( $output, $this->options['company_or_person'] );
 		}
 	}
 
@@ -2019,7 +2022,7 @@ class WPSEO_JSON_LD {
 		$this->add_alternate_name( $output );
 		$this->internal_search_section( $output );
 
-		$this->json_ld_output( $output );
+		$this->json_ld_output( $output, 'website' );
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -2046,12 +2046,10 @@ class WPSEO_JSON_LD {
 	 * @link https://developers.google.com/structured-data/slsb-overview
 	 *
 	 * @param array $output
-	 *
-	 * @return string
 	 */
 	private function internal_search_section( &$output ) {
 		if ( ! is_front_page() ) {
-			return '';
+			return;
 		}
 
 		/**
@@ -2088,9 +2086,7 @@ class WPSEO_JSON_LD {
 		if ( '' !== $this->options['website_name'] ) {
 			return $this->options['website_name'];
 		}
-		else {
-			return get_bloginfo( 'name' );
-		}
+		return get_bloginfo( 'name' );
 	}
 
 	/**

--- a/inc/class-wpseo-options.php
+++ b/inc/class-wpseo-options.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package WPSEO\Internals
+ * @package    WPSEO\Internals
  * @since      1.5.0
  */
 
@@ -879,7 +879,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		// Non-form field, should only be set via validation routine
 		'version'                         => '', // leave default as empty to ensure activation/upgrade works
 		'seen_about'                      => false,
-
 		// Form fields:
 		'alexaverify'                     => '', // text field
 		'company_logo'                    => '',
@@ -889,6 +888,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'googleverify'                    => '', // text field
 		'msverify'                        => '', // text field
 		'person_name'                     => '',
+		'website_name'                    => '',
+		'alternate_website_name'          => '',
 		'yandexverify'                    => '',
 		'yoast_tracking'                  => false,
 	);
@@ -1015,6 +1016,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				/* text fields */
 				case 'company_name':
 				case 'person_name':
+				case 'website_name':
+				case 'alternate_website_name':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 						$clean[ $key ] = sanitize_text_field( $dirty[ $key ] );
 					}
@@ -1034,6 +1037,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 
 				/* boolean|null fields - if set a check was done, if null, it hasn't */
+				case 'seen_about':
 				case 'theme_has_description':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::validate_bool( $dirty[ $key ] );
@@ -1188,10 +1192,10 @@ class WPSEO_Option_Permalinks extends WPSEO_Option {
 		'cleanpermalink-googlesitesearch' => false,
 		'cleanreplytocom'                 => false,
 		'cleanslugs'                      => true,
-		'hide-feedlinks'   => false,
-		'hide-rsdlink'     => false,
-		'hide-shortlink'   => false,
-		'hide-wlwmanifest' => false,
+		'hide-feedlinks'                  => false,
+		'hide-rsdlink'                    => false,
+		'hide-shortlink'                  => false,
+		'hide-wlwmanifest'                => false,
 		'redirectattachment'              => false,
 		'stripcategorybase'               => false,
 		'trailingslash'                   => false,
@@ -2834,6 +2838,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 /**
  * Option: wpseo_ms
  */
+
 /**
  * Site option for Multisite installs only
  *
@@ -3019,7 +3024,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 					break;
 
 				default:
-						$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );
+					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );
 					break;
 			}
 		}
@@ -3028,22 +3033,22 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	}
 
 
-		/**
-		 * Clean a given option value
-		 *
-		 * @param  array  $option_value          Old (not merged with defaults or filtered) option value to
-		 *                                       clean according to the rules for this option
-		 * @param  string $current_version       (optional) Version from which to upgrade, if not set,
-		 *                                       version specific upgrades will be disregarded
-		 * @param  array  $all_old_option_values (optional) Only used when importing old options to have
-		 *                                       access to the real old values, in contrast to the saved ones
-		 *
-		 * @return  array            Cleaned option
-		 */
-		/*protected function clean_option( $option_value, $current_version = null, $all_old_option_values = null ) {
+	/**
+	 * Clean a given option value
+	 *
+	 * @param  array  $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                       clean according to the rules for this option
+	 * @param  string $current_version       (optional) Version from which to upgrade, if not set,
+	 *                                       version specific upgrades will be disregarded
+	 * @param  array  $all_old_option_values (optional) Only used when importing old options to have
+	 *                                       access to the real old values, in contrast to the saved ones
+	 *
+	 * @return  array            Cleaned option
+	 */
+	/*protected function clean_option( $option_value, $current_version = null, $all_old_option_values = null ) {
 
-			return $option_value;
-		}*/
+		return $option_value;
+	}*/
 } /* End of class WPSEO_Option_MS */
 
 /**

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -1,12 +1,21 @@
 <?php
+/**
+ * @package WPSEO\Unittests
+ */
 
+/**
+ * Class WPSEO_JSON_LD_Test
+ */
 class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var WPSEO_Frontend
+	 * @var WPSEO_JSON_LD
 	 */
 	private static $class_instance;
 
+	/**
+	 * Instantiate our class
+	 */
 	public static function setUpBeforeClass() {
 		self::$class_instance = new WPSEO_JSON_LD();
 	}
@@ -19,7 +28,18 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 
 		$home_url   = trailingslashit( home_url() );
 		$search_url = $home_url . '?s={search_term}';
-		$expected   = '<script type=\'application/ld+json\'>{ "@context": "http://schema.org","@type": "WebSite","url": "' . $home_url . '","name": "Test Blog","potentialAction": {"@type": "SearchAction","target": "' . $search_url . '","query-input": "required name=search_term"}}</script>' . "\n";
+		$json       = json_encode( array(
+			'@context'        => 'http://schema.org',
+			'@type'           => 'WebSite',
+			'url'             => $home_url,
+			'name'            => get_bloginfo( 'name' ),
+			'potentialAction' => array(
+				'@type'       => 'SearchAction',
+				'target'      => $search_url,
+				'query-input' => 'required name=search_term',
+			)
+		) );
+		$expected   = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 		$this->expectOutput( $expected, self::$class_instance->website() );
 	}
 
@@ -38,7 +58,14 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$this->go_to_home();
 
 		$home_url = home_url();
-		$expected = '<script type=\'application/ld+json\'>{ "@context": "http://schema.org","@type": "Person","name": "' . $name . '","url": "' . $home_url . '","sameAs": ["' . $instagram . '"]}</script>' . "\n";
+		$json     = json_encode( array(
+			'@context' => 'http://schema.org',
+			'@type'    => 'Person',
+			'name'     => $name,
+			'url'      => $home_url,
+			'sameAs'   => array( $instagram ),
+		) );
+		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 		$this->expectOutput( $expected, self::$class_instance->organization_or_person() );
 	}
 
@@ -59,7 +86,15 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$this->go_to_home();
 
 		$home_url = home_url();
-		$expected = '<script type=\'application/ld+json\'>{ "@context": "http://schema.org","@type": "Organization","name": "' . $name . '","url": "' . $home_url . '","logo": "","sameAs": ["' . $facebook . '","' . $instagram . '"]}</script>' . "\n";
+		$json     = json_encode( array(
+			'@context' => 'http://schema.org',
+			'@type'    => 'Organization',
+			'name'     => $name,
+			'url'      => $home_url,
+			'logo'     => '',
+			'sameAs'   => array( $instagram, $facebook, $instagram ),
+		) );
+		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 		$this->expectOutput( $expected, self::$class_instance->organization_or_person() );
 	}
 }

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -12,15 +12,15 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_JSON_LD::internal_search
+	 * @covers WPSEO_JSON_LD::website
 	 */
-	public function test_internal_search() {
+	public function test_website() {
 		$this->go_to_home();
 
 		$home_url   = trailingslashit( home_url() );
 		$search_url = $home_url . '?s={search_term}';
-		$expected   = '<script type=\'application/ld+json\'>{ "@context": "http://schema.org","@type": "WebSite","url": "' . $home_url . '","potentialAction": {"@type": "SearchAction","target": "' . $search_url . '","query-input": "required name=search_term"}}</script>' . "\n";
-		$this->expectOutput( $expected, self::$class_instance->internal_search() );
+		$expected   = '<script type=\'application/ld+json\'>{ "@context": "http://schema.org","@type": "WebSite","url": "' . $home_url . '","name": "Test Blog","potentialAction": {"@type": "SearchAction","target": "' . $search_url . '","query-input": "required name=search_term"}}</script>' . "\n";
+		$this->expectOutput( $expected, self::$class_instance->website() );
 	}
 
 	/**


### PR DESCRIPTION
This pull adds support for the new [website name JSON+LD markup](https://developers.google.com/structured-data/site-name).

This is the updated config screen:
![Updated config screen](http://uploads.yoast.nl/website-name_1AE0E639.png)

This is the output from [Google's structured data testing tool](https://developers.google.com/structured-data/testing-tool/):
![Output from Snippet test](http://uploads.yoast.nl/website-name_1AE0E6D3.png)

## Design decisions
To do this, the already present JSON+LD search markup functions had to be slightly altered. There's unfortunately no way to preserve the workings of the `wpseo_json_ld_search_output` filter. It was expecting the entire output, which included the Website context. If it was removed, that would now remove this markup too. As this markup seems to be pretty important, we're not going to allow that. All other filters around search output have been preserved but moved around.

To be able to add a placeholder this pull also slightly modifies the `Yoast_Form` class, adding support for a `placeholder` attribute in the `textinput` function. This is done in such a way that the third arg can now either be a string or an array. This makes the parameters the same for the `textarea` function and the `textinput` function. 

The filters per type of output (specifically `wpseo_json_ld_search_output`, `wpseo_json_ld_person`, `wpseo_json_ld_organization`) have all been removed in favor of one filter `wpseo_json_ld_output` which has a context parameter that allows you to see which type of output you're filtering.

## Other results
* This pull also fixes a bug where saving anything on the WP SEO dashboard page would redirect you to the intro screen.
* The `WPSEO_JSON_LD` class is now instantiated on every page.
* The `internal_search` public method in the `WPSEO_JSON_LD` class is now deprecated.