### PR TITLE
avoid duplicate json-ld on empty context

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1901,6 +1901,11 @@ class WPSEO_JSON_LD {
 	 * @param string $context The context of the output, useful for filtering
 	 */
 	protected function output( $context ) {
+		// avoid output if context is empty (like when no organisation or person was set)
+		if ( '' === $context ) {
+			return ;
+		}
+
 		/**
 		 * Filter: 'wpseo_json_ld_output' - Allows filtering of the JSON+LD output
 		 *


### PR DESCRIPTION
Implement a sanity test on `output()` in favour of a more complex data preparation on `organisation_or_person()`.

The issue occurs when neither organisation nor person data is provided and the corresponding method fails to pass a context (`''` is used). This causes the output of the last defined `$this->data` which was provided by the `website()` method.

A rather minor issue as it causes only minimal traffic overhead.
