### PR TITLE
Implemented premium package install logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 		"yoast/yoastcs": "dev-master"
 	},
 	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"autoload": {
 		"classmap": [
 			"admin/",

--- a/composer.json
+++ b/composer.json
@@ -56,5 +56,25 @@
 		"post-autoload-dump": [
 			"xrstf\\Composer52\\Generator::onPostInstallCmd"
 		]
-	}
+	},
+	"repositories": [
+		{
+			"type"   : "package",
+			"package": {
+				"name"    : "yoast/wordpress-seo-premium",
+				"version" : "dev-composer-package",
+				"source"  : {
+					"url"      : "https://github.com/Yoast/wordpress-seo-premium/",
+					"type"     : "git",
+					"reference": "composer-package"
+				},
+				"autoload": {
+					"classmap": [
+						"class-premium.php",
+						"classes/"
+					]
+				}
+			}
+		}
+	]
 }

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
 			"\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
 		],
+		"config-premium": [
+			"composer require yoast/wordpress-seo-premium"
+		],
 		"post-install-cmd": [
 			"xrstf\\Composer52\\Generator::onPostInstallCmd"
 		],

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -45,3 +45,23 @@ if ( ! defined( 'WPSEO_FILE' ) ) {
 
 // Load the WordPress SEO plugin
 require_once( dirname( __FILE__ ) . '/wp-seo-main.php' );
+
+/**
+ * Premium init
+ */
+function wpseo_premium_init() {
+	$premium = new WPSEO_Premium();
+
+	if ( basename( dirname( __FILE__ ) ) === 'wordpress-seo' ) { // if we had built premium in free's folder
+		remove_action( 'admin_init', array( $premium, 'disable_wordpress_seo' ), 1 );
+	}
+}
+
+if ( class_exists( 'WPSEO_Premium' ) ) {
+
+	add_action( 'plugins_loaded', 'wpseo_premium_init', 14 );
+
+	if ( is_admin() ) {
+		register_activation_hook( __FILE__, array( 'WPSEO_Premium', 'install' ) );
+	}
+}


### PR DESCRIPTION
:warning: Work in progress.

## Usage

To build premium:
```
composer create-project yoast/wordpress-seo wordpress-seo-premium dev-issues/rarst/premium-installer --no-install --no-interaction
cd wordpress-seo-premium
composer config-premium
```
Note that the actual premium codepulled in will be tad stale, from older branch. It's too hard to keep major changes required in sync with trunk.

## Tasks

 - [x] initial installer command
 - [x] conditional premium boot logic
 - [ ] automate plugin header update
 - [ ] code freeze premium
 - [ ] truncate premium to its own code (again)
 - [ ] remove custom autoload from premium
 - [ ] audit path changes and asset loading for errors
 - [ ] safeguard against committing premium built state into free repository