### PR TITLE
Cache separate sitemap for HTTP(S)

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -327,8 +327,16 @@ class WPSEO_Sitemaps {
 		$caching = apply_filters( 'wpseo_enable_xml_sitemap_transient_caching', true );
 
 		if ( $caching ) {
+
+			if ( is_ssl() ) {
+				$cache_key = 'wpseo_sitemap_cache_https_' . $type . '_' . $this->n;
+			}
+			else {
+				$cache_key = 'wpseo_sitemap_cache_' . $type . '_' . $this->n;
+			}
+
 			do_action( 'wpseo_sitemap_stylesheet_cache_' . $type, $this );
-			$this->sitemap = get_transient( 'wpseo_sitemap_cache_' . $type . '_' . $this->n );
+			$this->sitemap = get_transient( $cache_key );
 		}
 
 		if ( ! $this->sitemap || '' == $this->sitemap ) {
@@ -343,7 +351,7 @@ class WPSEO_Sitemaps {
 			}
 
 			if ( $caching ) {
-				set_transient( 'wpseo_sitemap_cache_' . $type . '_' . $this->n, $this->sitemap, DAY_IN_SECONDS );
+				set_transient( $cache_key, $this->sitemap, DAY_IN_SECONDS );
 			}
 		}
 		else {

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -307,19 +307,24 @@ add_shortcode( 'wpseo_breadcrumb', 'wpseo_shortcode_yoast_breadcrumb' );
  * @param string $type
  */
 function wpseo_invalidate_sitemap_cache( $type ) {
-    // Delete at max 9 pages, just in case our object cache backend doesn't return false when nothing is deleted
-    for ( $n = 1; $n < 10; $n++ ) {
-        // Always delete the main index sitemaps cache, as that's always invalidated by any other change
-        if ( ! delete_transient( 'wpseo_sitemap_cache_1_' . $n ) ) {
-            break;
-        }
-    }
+	$cache_prefix = 'wpseo_sitemap_cache_';
 
-    for ( $n = 1; $n < 10; $n++ ) {
-        if ( ! delete_transient( 'wpseo_sitemap_cache_' . $type . '_' . $n ) ) {
-            break;
-        }
-    }
+	// Always delete the main index sitemaps cache, as that's always invalidated by any other change
+	$cache_keys = array(
+		'1',
+		'https_1',
+		$type,
+		'https_' . $type,
+	);
+
+	foreach ( $cache_keys as $cache_key ) {
+		// Delete at max 9 pages, just in case our object cache backend doesn't return false when nothing is deleted
+		for ( $n = 1; $n < 10; $n++ ) {
+			if ( ! delete_transient( $cache_prefix . $cache_key . '_' . $n ) ) {
+				break;
+			}
+		}
+	}
 }
 
 add_action( 'deleted_term_relationships', 'wpseo_invalidate_sitemap_cache' );

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -308,8 +308,8 @@ add_shortcode( 'wpseo_breadcrumb', 'wpseo_shortcode_yoast_breadcrumb' );
  */
 function wpseo_invalidate_sitemap_cache( $type ) {
 	// Always delete the main index sitemaps cache, as that's always invalidated by any other change
-	delete_transient( 'wpseo_sitemap_cache_1' );
-	delete_transient( 'wpseo_sitemap_cache_' . $type );
+	delete_transient( 'wpseo_sitemap_cache_1_1' );
+	delete_transient( 'wpseo_sitemap_cache_' . $type . '_1' );
 
 	WPSEO_Utils::clear_sitemap_cache( array( $type ) );
 }

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -307,11 +307,19 @@ add_shortcode( 'wpseo_breadcrumb', 'wpseo_shortcode_yoast_breadcrumb' );
  * @param string $type
  */
 function wpseo_invalidate_sitemap_cache( $type ) {
-	// Always delete the main index sitemaps cache, as that's always invalidated by any other change
-	delete_transient( 'wpseo_sitemap_cache_1_1' );
-	delete_transient( 'wpseo_sitemap_cache_' . $type . '_1' );
+    // Delete at max 9 pages, just in case our object cache backend doesn't return false when nothing is deleted
+    for ( $n = 1; $n < 10; $n++ ) {
+        // Always delete the main index sitemaps cache, as that's always invalidated by any other change
+        if ( ! delete_transient( 'wpseo_sitemap_cache_1_' . $n ) ) {
+            break;
+        }
+    }
 
-	WPSEO_Utils::clear_sitemap_cache( array( $type ) );
+    for ( $n = 1; $n < 10; $n++ ) {
+        if ( ! delete_transient( 'wpseo_sitemap_cache_' . $type . '_' . $n ) ) {
+            break;
+        }
+    }
 }
 
 add_action( 'deleted_term_relationships', 'wpseo_invalidate_sitemap_cache' );


### PR DESCRIPTION
When a site and its sitemap is accessible over both http and https, the `home_url` will reflect the protocol, and so will all links in the sitemap - all good. 

However, when the WP-SEO caches the sitemap in a transient, only 1 one of the two is cached and displayed for both protocols. Which of the two is decided by which one is hit first after the sitemap expires.

**This means that http sitemaps can contain https links (exclusively) and vice versa**. This would make all sitemap URLs [not allowed](https://support.google.com/webmasters/answer/35738?hl=en#u).

This PR adds `_https` to the transient key if the sitemap is loaded over HTTPS, so the http and https version will cache and display their own respective sitemaps.

Also, I found that the sitemap cache wasn't being invalidated correctly, because the page parameter (n) was missing from the cache key. I updated `wpseo_invalidate_sitemap_cache` to invalidate up to 9 pages of sitemap.

Regards,
Mike