### PR TITLE
wrong nesting breadcrumbs on archive paginations

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -770,7 +770,7 @@ class WPSEO_Breadcrumbs {
 			}
 
 			if ( ( isset( $link['url'] ) && ( is_string( $link['url'] ) && $link['url'] !== '' ) ) &&
-			     ( $i < ( $this->crumb_count - 1 ) || $GLOBALS['paged'] )
+			     ( $i < ( $this->crumb_count - 1 ) )
 			) {
 				if ( $i === 0 ) {
 					$link_output .= '<' . $this->element . ' typeof="v:Breadcrumb">';


### PR DESCRIPTION
In the case of archive page (post or custom post type) with paging, the
nesting of breadcrumbs was wrong: closing tags were not printed.

An example online: https://yoast.com/cat/seo/page/2/

This page is missing the closing of two span tags