### PR TITLE
sensibly extend wpseo_use_page_analysis filter

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -594,10 +594,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		<div class="wpseo-metabox-tabs-div">
 		<ul class="wpseo-metabox-tabs" id="wpseo-metabox-tabs">
 			<li class="general">
-				<a class="wpseo_tablink" href="#wpseo_general"><?php _e( 'General', 'wordpress-seo' ); ?></a></li>
-			<li id="linkdex" class="linkdex">
-				<a class="wpseo_tablink" href="#wpseo_linkdex"><?php _e( 'Page Analysis', 'wordpress-seo' ); ?></a>
+				<a class="wpseo_tablink" href="#wpseo_general"><?php _e( 'General', 'wordpress-seo' ); ?></a>
 			</li>
+			<?php if ( apply_filters( 'wpseo_use_page_analysis', true ) === true ) : ?>
+				<li id="linkdex" class="linkdex">
+					<a class="wpseo_tablink" href="#wpseo_linkdex"><?php _e( 'Page Analysis', 'wordpress-seo' ); ?></a>
+				</li>
+			<?php endif; ?>
 			<?php if ( current_user_can( 'manage_options' ) || $options['disableadvanced_meta'] === false ) : ?>
 				<li class="advanced">
 					<a class="wpseo_tablink" href="#wpseo_advanced"><?php _e( 'Advanced', 'wordpress-seo' ); ?></a>
@@ -615,7 +618,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 		$this->do_tab( 'general', __( 'General', 'wordpress-seo' ), $content );
 
-		$this->do_tab( 'linkdex', __( 'Page Analysis', 'wordpress-seo' ), $this->linkdex_output( $post ) );
+		if ( apply_filters( 'wpseo_use_page_analysis', true ) === true ) {
+			$this->do_tab( 'linkdex', __( 'Page Analysis', 'wordpress-seo' ), $this->linkdex_output( $post ) );
+		}
 
 		if ( current_user_can( 'manage_options' ) || $options['disableadvanced_meta'] === false ) {
 			$content = '';


### PR DESCRIPTION
We should further extend the `wpseo_use_page_analysis` filter so that if set to `__return_false` we should not display the Page Analysis tab, or the content within, in the WPSEO_Metabox.

Fixes partial feature request in #869 and fixes what was mentioned in #2241 