### PR TITLE
added 'wpseo_pre_analysis_post_content' to WPSEO_Twitter class

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -460,6 +460,13 @@ class WPSEO_Twitter {
 	 * @return bool
 	 */
 	private function image_from_content_output() {
+		/**
+		 * Filter: 'wpseo_pre_analysis_post_content' - Allow filtering the content before analysis
+		 *
+		 * @api string $post_content The Post content string
+		 *
+		 * @param object $post - The post object.
+		 */
 		global $post;
 		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -460,7 +460,10 @@ class WPSEO_Twitter {
 	 * @return bool
 	 */
 	private function image_from_content_output() {
-		if ( preg_match_all( '`<img [^>]+>`', $GLOBALS['post']->post_content, $matches ) ) {
+		global $post;
+		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
+
+		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
 			foreach ( $matches[0] as $img ) {
 				if ( preg_match( '`src=(["\'])(.*?)\1`', $img, $match ) ) {
 					$this->image_output( $match[2] );


### PR DESCRIPTION
Updated the image_from_content_output() function

This was done to match the same functionality in the WPSEO_OpenGraph class, get_content_images() function.  Right now, there is no way to filter the content in the Twitter class prior to searching for images. I have some customizations on an attachment page and was able to tap into the filter to add the image to an opengraph tag, but am not able to do so for a Twitter card.  Example: https://github.com/petenelson/pn-stock-theme-customization/blob/master/index.php#L16