### PR TITLE
Add Filters to customise sitemaps

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -930,7 +930,7 @@ class WPSEO_Sitemaps {
 
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
 		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
-		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		$sitemap_urlset .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
 		$this->sitemap .= $output;
 
@@ -1047,9 +1047,9 @@ class WPSEO_Sitemaps {
 		}
 
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ';
-  		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
-  		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-  		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
+		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
+		$sitemap_urlset .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
 		if ( is_string( $output ) && trim( $output ) !== '' ) {
 			$this->sitemap .= $output;
 		}
@@ -1147,9 +1147,9 @@ class WPSEO_Sitemaps {
 		}
 
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
-  		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
-  		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-  		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
+		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
+		$sitemap_urlset .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
 		$this->sitemap .= $output;
 
 		// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -928,9 +928,10 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
-		$this->sitemap = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
-		$this->sitemap .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
-		$this->sitemap .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
+  		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
+  		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+  		$this->sitemap = apply_filters("sm_urlset_header", $sitemap_urlset);
 		$this->sitemap .= $output;
 
 		// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.
@@ -1045,9 +1046,10 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
-		$this->sitemap = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ';
-		$this->sitemap .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
-		$this->sitemap .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ';
+  		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
+  		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+  		$this->sitemap = apply_filters("sm_urlset_header", $sitemap_urlset);
 		if ( is_string( $output ) && trim( $output ) !== '' ) {
 			$this->sitemap .= $output;
 		}
@@ -1144,9 +1146,10 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
-		$this->sitemap = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
-		$this->sitemap .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
-		$this->sitemap .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
+  		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
+  		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+  		$this->sitemap = apply_filters("sm_urlset_header", $sitemap_urlset);
 		$this->sitemap .= $output;
 
 		// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.
@@ -1259,6 +1262,7 @@ class WPSEO_Sitemaps {
 			}
 			unset( $img );
 		}
+		$output = apply_filters("sm_render_xml", $output, $url['loc']);
 		$output .= "\t</url>\n";
 
 		return $output;

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -929,9 +929,9 @@ class WPSEO_Sitemaps {
 		}
 
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
-  		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
-  		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-  		$this->sitemap = apply_filters("sm_urlset_header", $sitemap_urlset);
+		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
+		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
 		$this->sitemap .= $output;
 
 		// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.
@@ -1049,7 +1049,7 @@ class WPSEO_Sitemaps {
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ';
   		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
   		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-  		$this->sitemap = apply_filters("sm_urlset_header", $sitemap_urlset);
+  		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
 		if ( is_string( $output ) && trim( $output ) !== '' ) {
 			$this->sitemap .= $output;
 		}
@@ -1149,7 +1149,7 @@ class WPSEO_Sitemaps {
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
   		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
   		$sitemap_urlset.= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-  		$this->sitemap = apply_filters("sm_urlset_header", $sitemap_urlset);
+  		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
 		$this->sitemap .= $output;
 
 		// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.
@@ -1262,7 +1262,7 @@ class WPSEO_Sitemaps {
 			}
 			unset( $img );
 		}
-		$output = apply_filters("sm_render_xml", $output, $url['loc']);
+		$output = apply_filters( 'sm_render_xml', $output, $url['loc'] );
 		$output .= "\t</url>\n";
 
 		return $output;

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -931,7 +931,7 @@ class WPSEO_Sitemaps {
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
 		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
 		$sitemap_urlset .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
+		$this->sitemap = apply_filters( 'wpseo_sitemap_' . $post_type . '_urlset', $sitemap_urlset );
 		$this->sitemap .= $output;
 
 		// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.
@@ -1049,7 +1049,7 @@ class WPSEO_Sitemaps {
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ';
 		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
 		$sitemap_urlset .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
+		$this->sitemap = apply_filters( 'wpseo_sitemap_taxonomy_urlset', $sitemap_urlset );
 		if ( is_string( $output ) && trim( $output ) !== '' ) {
 			$this->sitemap .= $output;
 		}
@@ -1149,7 +1149,7 @@ class WPSEO_Sitemaps {
 		$sitemap_urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ';
 		$sitemap_urlset .= 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" ';
 		$sitemap_urlset .= 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
-		$this->sitemap = apply_filters( 'sm_urlset_header', $sitemap_urlset );
+		$this->sitemap = apply_filters( 'wpseo_sitemap_author_urlset', $sitemap_urlset );
 		$this->sitemap .= $output;
 
 		// Filter to allow adding extra URLs, only do this on the first XML sitemap, not on all.
@@ -1262,7 +1262,7 @@ class WPSEO_Sitemaps {
 			}
 			unset( $img );
 		}
-		$output = apply_filters( 'sm_render_xml', $output, $url['loc'] );
+		$output = apply_filters( 'wpseo_sitemap_url', $output, $url['loc'] );
 		$output .= "\t</url>\n";
 
 		return $output;


### PR DESCRIPTION
I have a plugin which needs to be able to modify the output of the sitemap and would prefer not to have to create and maintain the whole sitemap functionality when existing solutions such as yours already do a great job at it.

In my particular case it is adding translation pages to each url as below.
<xhtml:link rel="alternate" hreflang="de" href="http://www.example.com/deutsch/"  />

To achieve this I have simply added a filter when creating the entry for a URL along with the parent <urlset> tag since my code required a different schema.

These changes achieve my required outcome, are flexible enough to be used for many other things and will have no adverse effects on sites which don't use the filters.