### PR TITLE
Private pages/posts not linked in breadcrumbs for users who can't view them

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -664,10 +664,19 @@ class WPSEO_Breadcrumbs {
 	 * @return array Array of link text and url
 	 */
 	private function get_link_info_for_id( $id ) {
-		$link = array();
 
+		$link = array();
 		$link['url']  = get_permalink( $id );
+		$status = get_post_status( $id );
+
+		if ( 'private' == $status && ! current_user_can( 'read_private_pages' ) && ! current_user_can( 'read_private_posts' ) ) {
+
+			$link['url'] = '';
+
+		}
+
 		$link['text'] = WPSEO_Meta::get_value( 'bctitle', $id );
+
 		if ( $link['text'] === '' ) {
 			$link['text'] = strip_tags( get_the_title( $id ) );
 		}


### PR DESCRIPTION
Added page/post status check and user capability check to get_link_info_for_id(). If a page/post is private and the user does not have the capability to view private posts/pages, the breadcrumb to that page/post is not linked.

Closes #2580 