### PR TITLE
Hide certain post overview columns by default

### DIFF
--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -1226,7 +1226,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @return array|false $result
 	 */
-	function column_hidden( $result, $option, $user ) {
+	public function column_hidden( $result, $option, $user ) {
 		global $wpdb;
 
 		$prefix = $wpdb->get_blog_prefix();

--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -1224,7 +1224,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
-	 * Hide certain columns if the user hasn't chosen which columns to hide
+	 * Hide the SEO Title, Meta Desc and Focus KW columns if the user hasn't chosen which columns to hide
 	 *
 	 * @param array|false $result
 	 * @param string      $option

--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -152,13 +152,19 @@ class WPSEO_Metabox extends WPSEO_Meta {
 							'column_sort',
 						), 10, 2 );
 
-						add_filter( sprintf(
+						/*
+						 * Use the `get_user_option_{$option}` filter to change the output of the get_user_option
+						 * function for the `manage{$screen}columnshidden` option, which is based on the current
+						 * admin screen. The admin screen we want to target is the `edit-{$post_type}` screen.
+						 */
+						$filter = sprintf(
 							'get_user_option_%s',
 							sprintf(
 								'manage%scolumnshidden',
 								'edit-' . $pt
 							)
-						), array( $this, 'column_hidden' ), 10, 3 );
+						);
+						add_filter( $filter, array( $this, 'column_hidden' ), 10, 3 );
 					}
 				}
 				unset( $pt );

--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -151,6 +151,14 @@ class WPSEO_Metabox extends WPSEO_Meta {
 							$this,
 							'column_sort',
 						), 10, 2 );
+
+						add_filter( sprintf(
+							'get_user_option_%s',
+							sprintf(
+								'manage%scolumnshidden',
+								'edit-' . $pt
+							)
+						), array( $this, 'column_hidden' ), 10, 3 );
 					}
 				}
 				unset( $pt );
@@ -1207,6 +1215,34 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		return $vars;
+	}
+
+	/**
+	 * Hide certain columns if the user hasn't chosen which columns to hide
+	 *
+	 * @param array|false $result
+	 * @param string      $option
+	 * @param WP_User     $user
+	 *
+	 * @return array|false $result
+	 */
+	function column_hidden( $result, $option, $user ) {
+		global $wpdb;
+
+		$prefix = $wpdb->get_blog_prefix();
+		var_dump( $user->has_prop( $prefix . $option ) );
+		if ( ! $user->has_prop( $prefix . $option ) && ! $user->has_prop( $option ) ) {
+
+			if ( ! is_array( $result ) ) {
+				$result = array();
+			}
+
+			$result[] = 'wpseo-title';
+			$result[] = 'wpseo-metadesc';
+			$result[] = 'wpseo-focuskw';
+		}
+
+		return $result;
 	}
 
 	/**

--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -1242,9 +1242,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				$result = array();
 			}
 
-			$result[] = 'wpseo-title';
-			$result[] = 'wpseo-metadesc';
-			$result[] = 'wpseo-focuskw';
+			array_push( $result, 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
 		}
 
 		return $result;

--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -1230,7 +1230,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		global $wpdb;
 
 		$prefix = $wpdb->get_blog_prefix();
-		var_dump( $user->has_prop( $prefix . $option ) );
 		if ( ! $user->has_prop( $prefix . $option ) && ! $user->has_prop( $option ) ) {
 
 			if ( ! is_array( $result ) ) {

--- a/admin/class-metabox.php
+++ b/admin/class-metabox.php
@@ -157,13 +157,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 						 * function for the `manage{$screen}columnshidden` option, which is based on the current
 						 * admin screen. The admin screen we want to target is the `edit-{$post_type}` screen.
 						 */
-						$filter = sprintf(
-							'get_user_option_%s',
-							sprintf(
-								'manage%scolumnshidden',
-								'edit-' . $pt
-							)
-						);
+						$filter = sprintf( 'get_user_option_%s', sprintf( 'manage%scolumnshidden', 'edit-' . $pt ) );
 						add_filter( $filter, array( $this, 'column_hidden' ), 10, 3 );
 					}
 				}

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -95,8 +95,9 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_column_hidden() {
 
-		// Option shouldn't be touched if the user has set it already
-		$user = $this->getMockBuilder('WP_User')
+		// Option shouldn't be touched if the user has set it already.
+		$user = $this->getMockBuilder( 'WP_User' )
+					 ->setMethods( array( 'has_prop' ) )
 					 ->getMock();
 
 		$user->method( 'has_prop' )
@@ -107,10 +108,11 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( $expected, $received );
 
-		$user2 = $this->getMockBuilder('WP_User')
+		$user2 = $this->getMockBuilder( 'WP_User' )
+					  ->setMethods( array( 'has_prop' ) )
 					  ->getMock();
 
-		// Option may be filled if the user has not set it
+		// Option may be filled if the user has not set it.
 		$user2->method( 'has_prop' )
 			 ->willReturn( false );
 

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -102,7 +102,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 
 		$user->expects( $this->any() )
 			 ->method( 'has_prop' )
-			 ->willReturn( true );
+			 ->will( $this->returnValue( true ) );
 
 		$expected = array( 'column1', 'column2' );
 		$received = self::$class_instance->column_hidden( $expected, 'option-name', $user );
@@ -116,7 +116,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		// Option may be filled if the user has not set it.
 		$user2->expects( $this->any() )
 			  ->method( 'has_prop' )
-			  ->willReturn( false );
+			  ->will( $this->returnValue( false ) );
 
 		$expected = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
 		$received = self::$class_instance->column_hidden( array(), 'option-name', $user2 );

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -91,36 +91,65 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Metabox::column_hidden
+	 * Tests that column_hidden returns the columns if the option isn't set
+	 *
+	 * @covers WPSEO_Metabox::column_hidden()
 	 */
-	public function test_column_hidden() {
+	public function test_column_hidden_HIDE_COLUMNS() {
+		$user = $this->getMockBuilder( 'WP_User' )
+		             ->getMock();
+
+		// Option may be filled if the user has not set it.
+		$user->expects( $this->any() )
+		     ->method( 'has_prop' )
+		     ->will( $this->returnValue( false ) );
+
+		$expected = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
+		$received = self::$class_instance->column_hidden( array(), 'option-name', $user );
+
+		$this->assertEquals( $expected, $received );
+	}
+
+	/**
+	 * Tests that column_hidden returns the option if the option is set
+	 *
+	 * @covers WPSEO_Metabox::column_hidden()
+	 */
+	public function test_column_hidden_KEEP_OPTION() {
 
 		// Option shouldn't be touched if the user has set it already.
 		$user = $this->getMockBuilder( 'WP_User' )
-					 ->setMethods( array( 'has_prop' ) )
 					 ->getMock();
 
 		$user->expects( $this->any() )
 			 ->method( 'has_prop' )
 			 ->will( $this->returnValue( true ) );
 
-		$expected = array( 'column1', 'column2' );
+		$expected = array( 'wpseo-title' );
 		$received = self::$class_instance->column_hidden( $expected, 'option-name', $user );
 
 		$this->assertEquals( $expected, $received );
+	}
 
-		$user2 = $this->getMockBuilder( 'WP_User' )
-					  ->setMethods( array( 'has_prop' ) )
-					  ->getMock();
+	/**
+	 * Tests if column_hidden can deal with bad option values
+	 *
+	 * @covers WPSEO_Metabox::column_hidden()
+	 */
+	public function test_column_hidden_BAD_VALUE() {
+		$user = $this->getMockBuilder( 'WP_User' )
+					 ->getMock();
 
-		// Option may be filled if the user has not set it.
-		$user2->expects( $this->any() )
-			  ->method( 'has_prop' )
-			  ->will( $this->returnValue( false ) );
+		$user->expects( $this->any() )
+			 ->method( 'has_prop' )
+			 ->will( $this->returnValue( false ) );
 
 		$expected = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
-		$received = self::$class_instance->column_hidden( array(), 'option-name', $user2 );
 
+		$received = self::$class_instance->column_hidden( false, 'option-name', $user );
+		$this->assertEquals( $expected, $received );
+
+		$received = self::$class_instance->column_hidden( 'bad-value', 'option-name', $user );
 		$this->assertEquals( $expected, $received );
 	}
 

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -100,7 +100,8 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 					 ->setMethods( array( 'has_prop' ) )
 					 ->getMock();
 
-		$user->method( 'has_prop' )
+		$user->expects( $this->any() )
+			 ->method( 'has_prop' )
 			 ->willReturn( true );
 
 		$expected = array( 'column1', 'column2' );
@@ -113,8 +114,9 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 					  ->getMock();
 
 		// Option may be filled if the user has not set it.
-		$user2->method( 'has_prop' )
-			 ->willReturn( false );
+		$user2->expects( $this->any() )
+			  ->method( 'has_prop' )
+			  ->willReturn( false );
 
 		$expected = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
 		$received = self::$class_instance->column_hidden( array(), 'option-name', $user2 );

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -91,6 +91,36 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * @covers WPSEO_Metabox::column_hidden
+	 */
+	public function test_column_hidden() {
+
+		// Option shouldn't be touched if the user has set it already
+		$user = $this->getMockBuilder('WP_User')
+					 ->getMock();
+
+		$user->method( 'has_prop' )
+			 ->willReturn( true );
+
+		$expected = array( 'column1', 'column2' );
+		$received = self::$class_instance->column_hidden( $expected, 'option-name', $user );
+
+		$this->assertEquals( $expected, $received );
+
+		$user2 = $this->getMockBuilder('WP_User')
+					  ->getMock();
+
+		// Option may be filled if the user has not set it
+		$user2->method( 'has_prop' )
+			 ->willReturn( false );
+
+		$expected = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
+		$received = self::$class_instance->column_hidden( array(), 'option-name', $user2 );
+
+		$this->assertEquals( $expected, $received );
+	}
+
+	/**
 	 * @covers WPSEO_Metabox::strtolower_utf8()
 	 */
 	public function test_strtolower_utf8() {

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -91,7 +91,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that column_hidden returns the columns if the option isn't set
+	 * Tests that column_hidden returns the columns to hide so that WordPress hides them
 	 *
 	 * @covers WPSEO_Metabox::column_hidden()
 	 */
@@ -111,7 +111,9 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that column_hidden returns the option if the option is set
+	 * Tests that column_hidden returns the value WordPress has saved in the database
+	 *
+	 * This is so the user can still set the columns they want to hide.
 	 *
 	 * @covers WPSEO_Metabox::column_hidden()
 	 */
@@ -132,11 +134,11 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests if column_hidden can deal with bad option values
+	 * Tests if column_hidden can deal with non array values returned from WordPress
 	 *
 	 * @covers WPSEO_Metabox::column_hidden()
 	 */
-	public function test_column_hidden_BAD_VALUE() {
+	public function test_column_hidden_UNEXPECTED_VALUE() {
 		$user = $this->getMockBuilder( 'WP_User' )
 					 ->getMock();
 


### PR DESCRIPTION
The only way to do this is using the user option's filter. This means we
check if the user has chosen a setting and if they didn't we add the
columns we want to hide.

fixes #2502 