### PR TITLE
Shorter category choosen in breadcrumb class

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -21,7 +21,7 @@ class WPSEO_Breadcrumbs {
 	/**
 	 * @var string    Last used 'after' string
 	 */
-	public static $after = '';
+	public static $after = '';p
 
 
 	/**
@@ -237,7 +237,7 @@ class WPSEO_Breadcrumbs {
 				unset( $parent );
 
 				// this will be true either if the current parents count is strictly bigger OR the current parent_order is lower
-				if ( count($parents) > $parents_count || $parent_order <= $term_order ) {
+				if ( count($parents) > $parents_count || $parent_order < $term_order ) {
 					$parents_count = count( $parents );
 					$term_order   = $parent_order;
 					$deepest_term = $term;

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -21,7 +21,7 @@ class WPSEO_Breadcrumbs {
 	/**
 	 * @var string    Last used 'after' string
 	 */
-	public static $after = '';p
+	public static $after = '';
 
 
 	/**


### PR DESCRIPTION
Hello there, 

i've found a bug where a post assigned to 2 categories one of them having 0 length and the other 4.

The generated breadcrumbs were using the first "shorter" category cause of "term_order" never being set in the categories.

Cheers,