### PR TITLE
Breadcrumb customizer fixes

### DIFF
--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -45,12 +45,23 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_section(
 			'wpseo_breadcrumbs_customizer_section', array(
 				/* translators: %s is the name of the plugin */
-				'title'          => sprintf( __( '%s Breadcrumbs', 'wordpress-seo' ), 'Yoast SEO' ),
-				'priority'       => 999,
-				'theme_supports' => 'yoast-seo-breadcrumbs',
+				'title'           => sprintf( __( '%s Breadcrumbs', 'wordpress-seo' ), 'Yoast SEO' ),
+				'priority'        => 999,
+				'active_callback' => array( $this, 'breadcrumbs_active_callback' )
 			)
 		);
 
+	}
+
+	/**
+	 * Returns whether or not the breadcrumbs are active
+	 *
+	 * @return bool
+	 */
+	public function breadcrumbs_active_callback() {
+		$options = WPSEO_Options::get_all();
+
+		return true === ( current_theme_supports( 'yoast-seo-breadcrumbs' ) || $options['breadcrumbs-enable'] );
 	}
 
 	/**
@@ -103,11 +114,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-separator', array(
-					'label'           => __( 'Breadcrumbs separator:', 'wordpress-seo' ),
-					'type'            => 'text',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_internallinks[breadcrumbs-sep]',
-					'context'         => '',
+					'label'    => __( 'Breadcrumbs separator:', 'wordpress-seo' ),
+					'type'     => 'text',
+					'section'  => 'wpseo_breadcrumbs_customizer_section',
+					'settings' => 'wpseo_internallinks[breadcrumbs-sep]',
+					'context'  => '',
 				)
 			)
 		);
@@ -128,11 +139,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-home', array(
-					'label'           => __( 'Anchor text for the homepage:', 'wordpress-seo' ),
-					'type'            => 'text',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_internallinks[breadcrumbs-home]',
-					'context'         => '',
+					'label'    => __( 'Anchor text for the homepage:', 'wordpress-seo' ),
+					'type'     => 'text',
+					'section'  => 'wpseo_breadcrumbs_customizer_section',
+					'settings' => 'wpseo_internallinks[breadcrumbs-home]',
+					'context'  => '',
 				)
 			)
 		);
@@ -153,11 +164,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-prefix', array(
-					'label'           => __( 'Prefix for breadcrumbs:', 'wordpress-seo' ),
-					'type'            => 'text',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_internallinks[breadcrumbs-prefix]',
-					'context'         => '',
+					'label'    => __( 'Prefix for breadcrumbs:', 'wordpress-seo' ),
+					'type'     => 'text',
+					'section'  => 'wpseo_breadcrumbs_customizer_section',
+					'settings' => 'wpseo_internallinks[breadcrumbs-prefix]',
+					'context'  => '',
 				)
 			)
 		);
@@ -178,11 +189,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-archiveprefix', array(
-					'label'           => __( 'Prefix for archive pages:', 'wordpress-seo' ),
-					'type'            => 'text',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_internallinks[breadcrumbs-archiveprefix]',
-					'context'         => '',
+					'label'    => __( 'Prefix for archive pages:', 'wordpress-seo' ),
+					'type'     => 'text',
+					'section'  => 'wpseo_breadcrumbs_customizer_section',
+					'settings' => 'wpseo_internallinks[breadcrumbs-archiveprefix]',
+					'context'  => '',
 				)
 			)
 		);
@@ -203,11 +214,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-searchprefix', array(
-					'label'           => __( 'Prefix for search result pages:', 'wordpress-seo' ),
-					'type'            => 'text',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_internallinks[breadcrumbs-searchprefix]',
-					'context'         => '',
+					'label'    => __( 'Prefix for search result pages:', 'wordpress-seo' ),
+					'type'     => 'text',
+					'section'  => 'wpseo_breadcrumbs_customizer_section',
+					'settings' => 'wpseo_internallinks[breadcrumbs-searchprefix]',
+					'context'  => '',
 				)
 			)
 		);
@@ -228,11 +239,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-404crumb', array(
-					'label'           => __( 'Breadcrumb for 404 pages:', 'wordpress-seo' ),
-					'type'            => 'text',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_internallinks[breadcrumbs-404crumb]',
-					'context'         => '',
+					'label'    => __( 'Breadcrumb for 404 pages:', 'wordpress-seo' ),
+					'type'     => 'text',
+					'section'  => 'wpseo_breadcrumbs_customizer_section',
+					'settings' => 'wpseo_internallinks[breadcrumbs-404crumb]',
+					'context'  => '',
 				)
 			)
 		);

--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -29,9 +29,6 @@ class WPSEO_Customizer {
 		$this->wp_customize = $wp_customize;
 
 		$this->breadcrumbs_section();
-		$this->breadcrumbs_enable_setting();
-		$this->breadcrumbs_enable_setting();
-		$this->breadcrumbs_boldlast_setting();
 		$this->breadcrumbs_blog_remove_setting();
 		$this->breadcrumbs_separator_setting();
 		$this->breadcrumbs_home_setting();
@@ -57,68 +54,6 @@ class WPSEO_Customizer {
 	}
 
 	/**
-	 * Adds the enable breadcrumbs checkbox
-	 */
-	private function breadcrumbs_enable_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_internallinks[breadcrumbs-enable]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
-		);
-
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-enable', array(
-					'label'    => __( 'Enable Breadcrumbs', 'wordpress-seo' ),
-					'type'     => 'checkbox',
-					'section'  => 'wpseo_breadcrumbs_customizer_section',
-					'settings' => 'wpseo_internallinks[breadcrumbs-enable]',
-					'context'  => '',
-				)
-			)
-		);
-	}
-
-	/**
-	 * Returns whether or not the breadcrumbs are active
-	 *
-	 * @return bool
-	 */
-	public function breadcrumbs_active_callback() {
-		$options = WPSEO_Options::get_all();
-
-		return true === $options['breadcrumbs-enable'];
-	}
-
-	/**
-	 * Adds the breadcrumbs bold last checkbox
-	 */
-	private function breadcrumbs_boldlast_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_internallinks[breadcrumbs-boldlast]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
-		);
-
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-boldlast', array(
-					'label'           => __( 'Bold the last page in the breadcrumb', 'wordpress-seo' ),
-					'type'            => 'checkbox',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_internallinks[breadcrumbs-boldlast]',
-					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
-				)
-			)
-		);
-	}
-
-	/**
 	 * Adds the breadcrumbs remove blog checkbox
 	 */
 	private function breadcrumbs_blog_remove_setting() {
@@ -133,7 +68,7 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-blog-remove', array(
-					'label'           => __( 'Remove Blog page from Breadcrumbs', 'wordpress-seo' ),
+					'label'           => __( 'Remove blog page from breadcrumbs', 'wordpress-seo' ),
 					'type'            => 'checkbox',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
 					'settings'        => 'wpseo_internallinks[breadcrumbs-blog-remove]',
@@ -150,7 +85,7 @@ class WPSEO_Customizer {
 	 * @return bool
 	 */
 	public function breadcrumbs_blog_remove_active_cb() {
-		return $this->breadcrumbs_active_callback() && 'page' === get_option( 'show_on_front' );
+		return 'page' === get_option( 'show_on_front' );
 	}
 
 	/**
@@ -168,12 +103,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-separator', array(
-					'label'           => __( 'Breadcrumbs Separator:', 'wordpress-seo' ),
+					'label'           => __( 'Breadcrumbs separator:', 'wordpress-seo' ),
 					'type'            => 'text',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
 					'settings'        => 'wpseo_internallinks[breadcrumbs-sep]',
 					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 				)
 			)
 		);
@@ -194,12 +128,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-home', array(
-					'label'           => __( 'Anchor Text for Homepage:', 'wordpress-seo' ),
+					'label'           => __( 'Anchor text for the homepage:', 'wordpress-seo' ),
 					'type'            => 'text',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
 					'settings'        => 'wpseo_internallinks[breadcrumbs-home]',
 					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 				)
 			)
 		);
@@ -220,12 +153,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-prefix', array(
-					'label'           => __( 'Prefix for the breadcrumb path:', 'wordpress-seo' ),
+					'label'           => __( 'Prefix for breadcrumbs:', 'wordpress-seo' ),
 					'type'            => 'text',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
 					'settings'        => 'wpseo_internallinks[breadcrumbs-prefix]',
 					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 				)
 			)
 		);
@@ -246,12 +178,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-archiveprefix', array(
-					'label'           => __( 'Prefix for Archive breadcrumbs:', 'wordpress-seo' ),
+					'label'           => __( 'Prefix for archive pages:', 'wordpress-seo' ),
 					'type'            => 'text',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
 					'settings'        => 'wpseo_internallinks[breadcrumbs-archiveprefix]',
 					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 				)
 			)
 		);
@@ -272,12 +203,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-searchprefix', array(
-					'label'           => __( 'Prefix for Search Page breadcrumbs:', 'wordpress-seo' ),
+					'label'           => __( 'Prefix for search result pages:', 'wordpress-seo' ),
 					'type'            => 'text',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
 					'settings'        => 'wpseo_internallinks[breadcrumbs-searchprefix]',
 					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 				)
 			)
 		);
@@ -298,12 +228,11 @@ class WPSEO_Customizer {
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
 				$this->wp_customize, 'wpseo-breadcrumbs-404crumb', array(
-					'label'           => __( 'Breadcrumb for 404 Page:', 'wordpress-seo' ),
+					'label'           => __( 'Breadcrumb for 404 pages:', 'wordpress-seo' ),
 					'type'            => 'text',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
 					'settings'        => 'wpseo_internallinks[breadcrumbs-404crumb]',
 					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 				)
 			)
 		);

--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -47,7 +47,7 @@ class WPSEO_Customizer {
 				/* translators: %s is the name of the plugin */
 				'title'           => sprintf( __( '%s Breadcrumbs', 'wordpress-seo' ), 'Yoast SEO' ),
 				'priority'        => 999,
-				'active_callback' => array( $this, 'breadcrumbs_active_callback' )
+				'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 			)
 		);
 

--- a/admin/views/tab-breadcrumbs.php
+++ b/admin/views/tab-breadcrumbs.php
@@ -13,8 +13,10 @@ $yform = Yoast_Form::get_instance();
 
 $yform->currentoption = 'wpseo_internallinks';
 
-$yform->checkbox( 'breadcrumbs-enable', __( 'Enable Breadcrumbs', 'wordpress-seo' ) );
-echo '<br/>';
+if ( ! current_theme_supports( 'yoast-seo-breadcrumbs' ) ) {
+	$yform->checkbox( 'breadcrumbs-enable', __( 'Enable Breadcrumbs', 'wordpress-seo' ) );
+	echo '<br/>';
+}
 echo '<div id="breadcrumbsinfo">';
 $yform->textinput( 'breadcrumbs-sep', __( 'Separator between breadcrumbs', 'wordpress-seo' ) );
 $yform->textinput( 'breadcrumbs-home', __( 'Anchor text for the Homepage', 'wordpress-seo' ) );

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -23,17 +23,6 @@ if ( ! function_exists( 'yoast_breadcrumb' ) ) {
 	/**
 	 * Template tag for breadcrumbs.
 	 *
-	 * @todo [JRF => Yoast/whomever] We could probably get rid of the 'breadcrumbs-enable' option key
-	 * as the file is now only loaded when the template tag is encountered anyway.
-	 * Only issue with that would be the removal of the bbPress crumb from within wpseo_frontend_init()
-	 * in wpseo.php which is also based on this setting.
-	 * Whether or not to show the bctitle field within meta boxes is also based on this setting, but
-	 * showing these when someone hasn't implemented the template tag shouldn't really give cause for concern.
-	 * Other than that, leaving the setting is an easy way to enable/disable the bc without having to
-	 * edit the template files again, but having to manually enable when you've added the template tag
-	 * in your theme is kind of double, so I'm undecided about what to do.
-	 * I guess I'm leaning towards removing the option key.
-	 *
 	 * @param string $before  What to show before the breadcrumb.
 	 * @param string $after   What to show after the breadcrumb.
 	 * @param bool   $display Whether to display the breadcrumb (true) or return it (false).
@@ -41,9 +30,13 @@ if ( ! function_exists( 'yoast_breadcrumb' ) ) {
 	 * @return string
 	 */
 	function yoast_breadcrumb( $before = '', $after = '', $display = true ) {
-		$options = get_option( 'wpseo_internallinks' );
+		$breadcrumbs_enabled = current_theme_supports( 'yoast-seo-breadcrumbs' );
+		if ( ! $breadcrumbs_enabled ) {
+			$options             = get_option( 'wpseo_internallinks' );
+			$breadcrumbs_enabled = ( $options['breadcrumbs-enable'] === true );
+		}
 
-		if ( $options['breadcrumbs-enable'] === true ) {
+		if ( $breadcrumbs_enabled ) {
 			return WPSEO_Breadcrumbs::breadcrumb( $before, $after, $display );
 		}
 	}


### PR DESCRIPTION
* Automatically enable breadcrumbs when theme support is declared, fixes #2656
* Remove bold option from customizer, fixes #2658
* Change strings in customizer to be better language (introduces new translatable strings, sorry)