### PR TITLE
Clear the dashboard widget cache on quickedit

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -373,3 +373,5 @@ add_action( 'wp_ajax_wpseo_add_fb_admin', 'wpseo_add_fb_admin' );
 
 // Crawl Issue Manager AJAX hooks.
 new WPSEO_GSC_Ajax;
+
+new Yoast_Dashboard_Widget();


### PR DESCRIPTION
To do this load the dashboard class on AJAX so it can register it's
hooks to flush the cache.

Fixes #2663 