### PR TITLE
Fix two default tagline issues

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -99,17 +99,10 @@ class WPSEO_Admin_Init {
 	public function tagline_notice() {
 		if ( current_user_can( 'manage_options' ) && $this->has_default_tagline() && ! $this->seen_tagline_notice() ) {
 
-			if ( filter_input( INPUT_GET, 'dismiss_tagline_notice' ) === '1' ) {
-				update_user_meta( get_current_user_id(), 'wpseo_seen_tagline_notice', 'seen' );
-
-				return;
-			}
-
 			$current_url = ( is_ssl() ? 'https://' : 'http://' );
 			$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 			$customize_url = add_query_arg( array(
 				'url' => urlencode( $current_url ),
-				'dismiss_tagline_notice' => '1',
 			), wp_customize_url() );
 
 			$info_message = sprintf(

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -99,6 +99,11 @@ class WPSEO_Admin_Init {
 	public function tagline_notice() {
 		if ( current_user_can( 'manage_options' ) && $this->has_default_tagline() && ! $this->seen_tagline_notice() ) {
 
+			// Only add the notice on GET requests and not in the customizer to prevent faulty return url.
+			if ( 'GET' !== filter_input( INPUT_SERVER, 'REQUEST_METHOD' ) || is_customize_preview() ) {
+				return;
+			}
+
 			$current_url = ( is_ssl() ? 'https://' : 'http://' );
 			$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 			$customize_url = add_query_arg( array(

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -38,6 +38,7 @@ class Yoast_Notification_Center {
 		add_action( 'all_admin_notices', array( $this, 'display_notifications' ) );
 		add_action( 'shutdown', array( $this, 'set_transient' ) );
 		add_action( 'wp_ajax_yoast_get_notifications', array( $this, 'ajax_get_notifications' ) );
+		add_action( 'wpseo_deactivate', array( $this, 'deactivate_hook' ) );
 	}
 
 	/**
@@ -95,6 +96,13 @@ class Yoast_Notification_Center {
 	 */
 	private function clear_notifications() {
 		$this->notifications = array();
+	}
+
+	/**
+	 * Remove transient when the plugin is deactivated
+	 */
+	public function deactivate_hook() {
+		$this->clear_notifications();
 	}
 
 	/**


### PR DESCRIPTION
* Keep showing the notice if you go to the customizer to fix it, because the problem still persists if you do.
* Prevent duplicate notices.