### PR TITLE
Campaign URL cleanup

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -436,7 +436,7 @@ class WPSEO_Admin {
 		}
 
 		// Add link to premium support landing page.
-		$premium_link = '<a href="https://yoast.com/wordpress/plugins/seo-premium/support/#utm_source=wordpress-seo-settings-link&utm_medium=text-link&utm_campaign=support-link">' . __( 'Premium Support', 'wordpress-seo' ) . '</a>';
+		$premium_link = '<a href="https://yoast.com/wordpress/plugins/seo-premium/support/#utm_source=wordpress-seo-settings-link&amp;utm_medium=textlink&amp;utm_campaign=support-link">' . __( 'Premium Support', 'wordpress-seo' ) . '</a>';
 		array_unshift( $links, $premium_link );
 
 		// Add link to docs.

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -225,7 +225,7 @@ class Yoast_Form {
 		}
 		?>
 				<strong><?php _e( 'Remove these ads?', 'wordpress-seo' ); ?></strong><br/>
-				<a target="_blank" href="https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-config&utm_medium=textlink&utm_campaign=remove-ads-link"><?php
+				<a target="_blank" href="https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-config&amp;utm_medium=textlink&amp;utm_campaign=remove-ads-link"><?php
 				 /* translators: %1$s expands to Yoast SEO Premium */
 				printf( __( 'Upgrade to %1$s &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' ); ?></a><br/><br/>
 			</div>

--- a/admin/google_search_console/views/gsc-create-redirect.php
+++ b/admin/google_search_console/views/gsc-create-redirect.php
@@ -62,7 +62,7 @@
 					echo sprintf(
 						__( 'To be able to create a redirect and fix this issue, you need %1$s. You can buy the plugin, including one year support and updates, on %2$s.', 'wordpress-seo' ),
 						'Yoast SEO Premium',
-						'<a href="https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-config&utm_medium=textlink&utm_campaign=redirect-popup" target="_blank">yoast.com</a>'
+						'<a href="https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-config&amp;utm_medium=textlink&amp;utm_campaign=redirect-popup" target="_blank">yoast.com</a>'
 					);
 					echo '</p>';
 					break;


### PR DESCRIPTION
Make sure all campaign links are properly using `&amp;` and standardise on `textlink` instead of `text-link`.