### PR TITLE
Fix profile update issue

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -216,7 +216,7 @@ class WPSEO_Admin_Init {
 	 * Loads admin page class for all admin pages starting with `wpseo_`.
 	 */
 	private function load_admin_user_class() {
-		if ( in_array( $this->pagenow, array( 'user-edit.php', 'profile.php' ) ) ) {
+		if ( in_array( $this->pagenow, array( 'user-edit.php', 'profile.php' ) ) && current_user_can( 'edit_users' ) ) {
 			new WPSEO_Admin_User_Profile;
 		}
 	}

--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -40,21 +40,19 @@ class WPSEO_Admin_User_Profile {
 	 */
 	public function process_user_option_update( $user_id ) {
 
-		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+		if ( ! current_user_can( 'edit_users' ) ) {
 			return;
 		}
 
 		update_user_meta( $user_id, '_yoast_wpseo_profile_updated', time() );
 
-		if ( $this->filter_input_post( 'wpseo_author_title' ) || $this->filter_input_post( 'wpseo_author_metadesc' ) || $this->filter_input_post( 'wpseo_author_metakey' ) || $this->filter_input_post( 'wpseo_author_exclude' ) ) {
-			check_admin_referer( 'wpseo_user_profile_update', 'wpseo_nonce' );
+		check_admin_referer( 'wpseo_user_profile_update', 'wpseo_nonce' );
 
-			update_user_meta( $user_id, 'wpseo_title', $this->filter_input_post( 'wpseo_author_title' ) );
-			update_user_meta( $user_id, 'wpseo_metadesc', $this->filter_input_post( 'wpseo_author_metadesc' ) );
-			update_user_meta( $user_id, 'wpseo_metakey', $this->filter_input_post( 'wpseo_author_metakey' ) );
-			update_user_meta( $user_id, 'wpseo_excludeauthorsitemap', $this->filter_input_post( 'wpseo_author_exclude' ) );
-		}
-	}
+		update_user_meta( $user_id, 'wpseo_title', $this->filter_input_post( 'wpseo_author_title' ) );
+		update_user_meta( $user_id, 'wpseo_metadesc', $this->filter_input_post( 'wpseo_author_metadesc' ) );
+		update_user_meta( $user_id, 'wpseo_metakey', $this->filter_input_post( 'wpseo_author_metakey' ) );
+		update_user_meta( $user_id, 'wpseo_excludeauthorsitemap', $this->filter_input_post( 'wpseo_author_exclude' ) );
+}
 
 	/**
 	 * Add the inputs needed for SEO values to the User Profile page

--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -46,12 +46,14 @@ class WPSEO_Admin_User_Profile {
 
 		update_user_meta( $user_id, '_yoast_wpseo_profile_updated', time() );
 
-		check_admin_referer( 'wpseo_user_profile_update', 'wpseo_nonce' );
+		if ( $this->filter_input_post( 'wpseo_author_title' ) || $this->filter_input_post( 'wpseo_author_metadesc' ) || $this->filter_input_post( 'wpseo_author_metakey' ) || $this->filter_input_post( 'wpseo_author_exclude' ) ) {
+			check_admin_referer( 'wpseo_user_profile_update', 'wpseo_nonce' );
 
-		update_user_meta( $user_id, 'wpseo_title', $this->filter_input_post( 'wpseo_author_title' ) );
-		update_user_meta( $user_id, 'wpseo_metadesc', $this->filter_input_post( 'wpseo_author_metadesc' ) );
-		update_user_meta( $user_id, 'wpseo_metakey', $this->filter_input_post( 'wpseo_author_metakey' ) );
-		update_user_meta( $user_id, 'wpseo_excludeauthorsitemap', $this->filter_input_post( 'wpseo_author_exclude' ) );
+			update_user_meta( $user_id, 'wpseo_title', $this->filter_input_post( 'wpseo_author_title' ) );
+			update_user_meta( $user_id, 'wpseo_metadesc', $this->filter_input_post( 'wpseo_author_metadesc' ) );
+			update_user_meta( $user_id, 'wpseo_metakey', $this->filter_input_post( 'wpseo_author_metakey' ) );
+			update_user_meta( $user_id, 'wpseo_excludeauthorsitemap', $this->filter_input_post( 'wpseo_author_exclude' ) );
+		}
 	}
 
 	/**

--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -39,11 +39,6 @@ class WPSEO_Admin_User_Profile {
 	 * @param    int $user_id of the updated user.
 	 */
 	public function process_user_option_update( $user_id ) {
-
-		if ( ! current_user_can( 'edit_users' ) ) {
-			return;
-		}
-
 		update_user_meta( $user_id, '_yoast_wpseo_profile_updated', time() );
 
 		check_admin_referer( 'wpseo_user_profile_update', 'wpseo_nonce' );
@@ -60,11 +55,6 @@ class WPSEO_Admin_User_Profile {
 	 * @param    object $user
 	 */
 	public function user_profile( $user ) {
-
-		if ( ! current_user_can( 'edit_users' ) ) {
-			return;
-		}
-
 		$options = WPSEO_Options::get_all();
 
 		wp_nonce_field( 'wpseo_user_profile_update', 'wpseo_nonce' );

--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -52,7 +52,7 @@ class WPSEO_Admin_User_Profile {
 		update_user_meta( $user_id, 'wpseo_metadesc', $this->filter_input_post( 'wpseo_author_metadesc' ) );
 		update_user_meta( $user_id, 'wpseo_metakey', $this->filter_input_post( 'wpseo_author_metakey' ) );
 		update_user_meta( $user_id, 'wpseo_excludeauthorsitemap', $this->filter_input_post( 'wpseo_author_exclude' ) );
-}
+	}
 
 	/**
 	 * Add the inputs needed for SEO values to the User Profile page


### PR DESCRIPTION
Fixes #2711

In [PR#2524](https://github.com/Yoast/wordpress-seo/pull/2524/files#diff-89d200c4cf17edbc19be793df00ea911L47) a check was removed to see if wpseo user meta fields were actually posted, causing an issue where users fail the nonce check when updating their profile and the wpseo meta fields are not present (which can be the case for non-admin users).

The original check only checked for wpseo_author_title being present. This is what actually caused #2323. I've simply extended the check to include all wpseo user meta's

@Rarst please take notice.
@jdevalk please review.