### PR TITLE
Fixed get_plugin_name() to use WP_PLUGIN_DIR constant

### DIFF
--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -108,7 +108,7 @@ class Yoast_Plugin_Conflict {
 	 * @return bool
 	 */
 	private function get_plugin_name( $plugin ) {
-		$plugin_details = get_plugin_data( ABSPATH . '/wp-content/plugins/' . $plugin );
+		$plugin_details = get_plugin_data( WP_PLUGIN_DIR .'/'. $plugin );
 
 		if ( $plugin_details['Name'] != '' ) {
 			return $plugin_details['Name'];


### PR DESCRIPTION
The `get_plugin_name()` function was using a hardcoded path to the plugins directory which may or may not be the correct one, particularly if you are using something like Bedrock.

Changed it to use the WP_PLUGIN_DIR constant, which is the correct way to access the directory regardless.