### PR TITLE
Fix for a warning that can appear on admin pages that do not have a valid screen object

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -56,7 +56,7 @@ class Yoast_Dashboard_Widget {
 	 * Enqueue's stylesheet for the dashboard if the current page is the dashboard
 	 */
 	public function enqueue_dashboard_stylesheet() {
-		if ( 'dashboard' === get_current_screen()->id ) {
+		if ( ! is_null( get_current_screen() ) && 'dashboard' === get_current_screen()->id ) {
 			wp_enqueue_style( 'wpseo-wp-dashboard', plugins_url( 'css/dashboard' . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_FILE ), array(), WPSEO_VERSION );
 		}
 	}

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -56,7 +56,9 @@ class Yoast_Dashboard_Widget {
 	 * Enqueue's stylesheet for the dashboard if the current page is the dashboard
 	 */
 	public function enqueue_dashboard_stylesheet() {
-		if ( get_current_screen() instanceof WP_Screen && 'dashboard' === get_current_screen()->id ) {
+		$current_screen = get_current_screen();
+
+		if ( $current_screen instanceof WP_Screen && 'dashboard' === $current_screen->id ) {
 			wp_enqueue_style( 'wpseo-wp-dashboard', plugins_url( 'css/dashboard' . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_FILE ), array(), WPSEO_VERSION );
 		}
 	}

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -56,7 +56,7 @@ class Yoast_Dashboard_Widget {
 	 * Enqueue's stylesheet for the dashboard if the current page is the dashboard
 	 */
 	public function enqueue_dashboard_stylesheet() {
-		if ( ! is_null( get_current_screen() ) && 'dashboard' === get_current_screen()->id ) {
+		if ( get_current_screen() instanceof WP_Screen && 'dashboard' === get_current_screen()->id ) {
 			wp_enqueue_style( 'wpseo-wp-dashboard', plugins_url( 'css/dashboard' . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_FILE ), array(), WPSEO_VERSION );
 		}
 	}


### PR DESCRIPTION
I found that some admin pages, typically those created by some plugins and themes, do not have a valid screen object. On such pages, the following warning is generated:

`Notice: Trying to get property of non-object in wordpress-seo/admin/class-yoast-dashboard-widget.php on line 59`

I added a check to ensure that get_current_screen() does not return null before checking get_current_screen()->id, thus preventing the warning.