### PR TITLE
[PR] Improved handling of rewrites on (de)activation in multisite

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -143,7 +143,9 @@ function _wpseo_activate() {
 	}
 	WPSEO_Options::ensure_options_exist();
 
-	add_action( 'shutdown', 'flush_rewrite_rules' );
+	if ( ! ms_is_switched() ) {
+		add_action( 'shutdown', 'flush_rewrite_rules' );
+	}
 
 	wpseo_add_capabilities();
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -143,8 +143,12 @@ function _wpseo_activate() {
 	}
 	WPSEO_Options::ensure_options_exist();
 
-	if ( ! ms_is_switched() ) {
-		add_action( 'shutdown', 'flush_rewrite_rules' );
+	if ( is_multisite() ) {
+		if ( ! ms_is_switched() ) {
+			add_action( 'shutdown', 'flush_rewrite_rules' );
+		} else {
+			delete_option( 'rewrite_rules' );
+		}
 	}
 
 	wpseo_add_capabilities();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -164,7 +164,13 @@ function _wpseo_activate() {
 function _wpseo_deactivate() {
 	require_once( WPSEO_PATH . 'inc/wpseo-functions.php' );
 
-	add_action( 'shutdown', 'flush_rewrite_rules' );
+	if ( is_multisite() ) {
+		if ( ! ms_is_switched() ) {
+			add_action( 'shutdown', 'flush_rewrite_rules' );
+		} else {
+			delete_option( 'rewrite_rules' );
+		}
+	}
 
 	wpseo_remove_capabilities();
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -108,7 +108,6 @@ function wpseo_deactivate( $networkwide = false ) {
 function wpseo_network_activate_deactivate( $activate = true ) {
 	global $wpdb;
 
-	$original_blog_id = get_current_blog_id(); // Alternatively use: $wpdb->blogid.
 	$all_blogs        = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
 
 	if ( is_array( $all_blogs ) && $all_blogs !== array() ) {
@@ -121,9 +120,9 @@ function wpseo_network_activate_deactivate( $activate = true ) {
 			else {
 				_wpseo_deactivate();
 			}
+
+			restore_current_blog();
 		}
-		// Restore back to original blog.
-		switch_to_blog( $original_blog_id );
 	}
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -142,12 +142,11 @@ function _wpseo_activate() {
 	}
 	WPSEO_Options::ensure_options_exist();
 
-	if ( is_multisite() ) {
-		if ( ! ms_is_switched() ) {
-			add_action( 'shutdown', 'flush_rewrite_rules' );
-		} else {
-			delete_option( 'rewrite_rules' );
-		}
+	if ( is_multisite() && ms_is_switched() ) {
+		delete_option( 'rewrite_rules' );
+	}
+	else {
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
 	wpseo_add_capabilities();
@@ -164,12 +163,11 @@ function _wpseo_activate() {
 function _wpseo_deactivate() {
 	require_once( WPSEO_PATH . 'inc/wpseo-functions.php' );
 
-	if ( is_multisite() ) {
-		if ( ! ms_is_switched() ) {
-			add_action( 'shutdown', 'flush_rewrite_rules' );
-		} else {
-			delete_option( 'rewrite_rules' );
-		}
+	if ( is_multisite() && ms_is_switched() ) {
+		delete_option( 'rewrite_rules' );
+	}
+	else {
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
 	wpseo_remove_capabilities();


### PR DESCRIPTION
This handles rewrites differently depending on the context the plugin is being activated or deactivated in. If in a switched context because we're activating a new site, we need to delete the rewrite rules option rather than relying on WP_Rewrite to generate proper rules. If we're in a standard context, flushing the rewrite rules is fine.

This appears to resolve #2239.