### PR TITLE
Wrong conditions for the multisite robots and htaccess edition panel since last UI update

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -254,7 +254,7 @@ class WPSEO_Admin {
 			), $icon_svg );
 
 			if ( WPSEO_Utils::allow_system_file_edit() === true ) {
-				add_submenu_page( 'wpseo_dashboard', 'Yoast SEO: ' . __( 'Edit Files', 'wordpress-seo' ), __( 'Edit Files', 'wordpress-seo' ), 'delete_users', 'wpseo_files', array(
+				add_submenu_page( 'wpseo_dashboard', 'Yoast SEO: ' . __( 'Edit Files', 'wordpress-seo' ), __( 'Edit Files', 'wordpress-seo' ), 'delete_users', 'wpseo_tools', array(
 					$this,
 					'load_page',
 				) );

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -26,7 +26,7 @@ if ( '' === $tool_page ) {
 			'desc' => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) blog.', 'wordpress-seo' ),
 		),
 	);
-	if ( WPSEO_Utils::allow_system_file_edit() === true && ! is_multisite() ) {
+	if ( WPSEO_Utils::allow_system_file_edit() === true && ( ! is_multisite() || is_multisite() && is_network_admin() ) ) {
 		$tools['file-editor'] = array(
 			'title' => __( 'File editor', 'wordpress-seo' ),
 			'desc' => __( 'This tool allows you to quickly change important files for your SEO, like your robots.txt and, if you have one, your .htaccess file.', 'wordpress-seo' ),
@@ -34,7 +34,7 @@ if ( '' === $tool_page ) {
 	}
 
 	/* translators: %1$s expands to Yoast SEO */
-	echo '<p>', sprintf( __( '%1$s comes with some very powerful built-in tools:', 'wordpress-seo' ), 'Yoast SEO' ), '</p>';
+	echo '<p>', __( 'WordPress SEO by Yoast comes with some very powerful built-in tools:', 'wordpress-seo' ), '</p>';
 
 	asort( $tools );
 

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -34,7 +34,7 @@ if ( '' === $tool_page ) {
 	}
 
 	/* translators: %1$s expands to Yoast SEO */
-	echo '<p>', __( 'WordPress SEO by Yoast comes with some very powerful built-in tools:', 'wordpress-seo' ), '</p>';
+	echo '<p>', sprintf( __( '%1$s comes with some very powerful built-in tools:', 'wordpress-seo' ), 'Yoast SEO' ), '</p>';
 
 	asort( $tools );
 

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -26,7 +26,7 @@ if ( '' === $tool_page ) {
 			'desc' => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) blog.', 'wordpress-seo' ),
 		),
 	);
-	if ( WPSEO_Utils::allow_system_file_edit() === true && ( ! is_multisite() || is_multisite() && is_network_admin() ) ) {
+	if ( WPSEO_Utils::allow_system_file_edit() === true && ( ! is_multisite() || is_network_admin() ) ) {
 		$tools['file-editor'] = array(
 			'title' => __( 'File editor', 'wordpress-seo' ),
 			'desc' => __( 'This tool allows you to quickly change important files for your SEO, like your robots.txt and, if you have one, your .htaccess file.', 'wordpress-seo' ),


### PR DESCRIPTION
A customer alarmed me yesterday, he wasn't able to edit the robots.txt on a multisite version.
This request fixes the display condition on the "File editor" link and only displays it on the network pages, and changes the target page for the admin sidebar link, to match the switch in load_page().