### PR TITLE
Make sure both the transient and the transient_timeout are cleared

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -551,13 +551,13 @@ class WPSEO_Utils {
 					$query .= ' OR ';
 				}
 
-				$query .= " option_name LIKE '_transient_timeout_wpseo_sitemap_cache_" . $sitemap_type . "_%'";
+				$query .= " option_name LIKE '_transient_wpseo_sitemap_cache_" . $sitemap_type . "_%' OR option_name LIKE '_transient_timeout_wpseo_sitemap_cache_" . $sitemap_type . "_%'";
 
 				$first = false;
 			}
 		}
 		else {
-			$query .= " option_name LIKE '_transient_timeout_wpseo_sitemap_%'";
+			$query .= " option_name LIKE '_transient_wpseo_sitemap_%' OR option_name LIKE '_transient_timeout_wpseo_sitemap_%'";
 		}
 
 		$wpdb->query( $query );


### PR DESCRIPTION
While testing with WP 4.3, we found out sitemap caches were no longer being cleared.

It turned out that after a previous refactoring(#1900), we only cleared the transient_timeouts and not the actual transients anymore. With get_transient becoming more strict in WP 4.3, this became an issue.

Also see: https://core.trac.wordpress.org/changeset/33110

@atimmer please review
@tacoverdo please test