### PR TITLE
Fix early call of current_user_can()

### DIFF
--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -26,6 +26,10 @@ class WPSEO_Customizer {
 	 * @param WP_Customize_Manager $wp_customize
 	 */
 	public function wpseo_customize_register( $wp_customize ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		$this->wp_customize = $wp_customize;
 
 		$this->breadcrumbs_section();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -243,9 +243,7 @@ function wpseo_init() {
 	}
 
 	// Init it here because the filter must be present on the frontend as well or it won't work in the customizer.
-	if ( current_user_can( 'manage_options' ) ) {
-		new WPSEO_Customizer();
-	}
+	new WPSEO_Customizer();
 }
 
 /**


### PR DESCRIPTION
Call `current_user_can()` inside `plugins_load` is too early and this trigger some functions and hooks that can be used by another plugins.

I just saw a case where it forced the call of some hooks where the `$wp_rewrite` global variable does not exist yet.

On my side I can not correct in any way, only with hacks to avoid this. Then the best would be to move https://github.com/Yoast/wordpress-seo/blob/trunk/wp-seo-main.php#L246 into `WPSEO_Customizer` class.
