### PR TITLE
Hotfix twitter image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
       env: WP_VERSION=4.0 WP_MULTISITE=1
     - php: '5.3'
       env: WP_VERSION=4.0 WP_MULTISITE=0
-    - php: '5.4'
-      env: WP_VERSION=3.9 WP_MULTISITE=0
     - php: 'hhvm'
       env: WP_VERSION=4.1 WP_MULTISITE=0
     - php: 'hhvm'

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -384,11 +384,13 @@ class WPSEO_Twitter {
 	 * Outputs a Twitter image tag for a given image
 	 *
 	 * @param string $img The source URL to the image.
-	 * @param string $tag The tag to output, defaults to <code>image:src</code> but can be altered for use in galleries.
+	 * @param string $tag The tag to output, defaults to <code>image</code>.
+	 *
+	 * TODO deprecate tag argument altogether later with gallery card type. R.
 	 *
 	 * @return bool
 	 */
-	protected function image_output( $img, $tag = 'image:src' ) {
+	protected function image_output( $img, $tag = 'image' ) {
 		/**
 		 * Filter: 'wpseo_twitter_image' - Allow changing the Twitter Card image
 		 *

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://yoast.com/
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: seo, SEO, Yoast SEO, google, meta, meta description, search engine optimization, xml sitemap, xml sitemaps, google sitemap, sitemap, sitemaps, robots meta, rss, rss footer, yahoo, bing, news sitemaps, XML News Sitemaps, WordPress SEO, WordPress SEO by Yoast, yoast, multisite, canonical, nofollow, noindex, keywords, meta keywords, description, webmaster tools, google webmaster tools, seo pack
-Requires at least: 3.9
+Requires at least: 4.0
 Tested up to: 4.3
 Stable tag: 2.3.4
 


### PR DESCRIPTION
Quick adjustment to Twitter image markup (old tag went from deprecated to semi-broken).

Also bumped core compat requirement, which is hard break on 3.9 now.

Fixes #2857
Fixes #2831 