### PR TITLE
Fix split term action in WP 4.3

### DIFF
--- a/admin/class-taxonomy.php
+++ b/admin/class-taxonomy.php
@@ -33,7 +33,6 @@ class WPSEO_Taxonomy {
 			), 90, 1 );
 		}
 
-		add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
 		add_action( 'edit_term', array( $this, 'update_term' ), 99, 3 );
 
 		add_action( 'init', array( $this, 'custom_category_descriptions_allow_html' ) );
@@ -41,26 +40,6 @@ class WPSEO_Taxonomy {
 		add_action( 'admin_init', array( $this, 'translate_meta_options' ) );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-	}
-
-	/**
-	 * Makes sure the taxonomy meta is updated when a taxonomy term is split.
-	 *
-	 * @link https://make.wordpress.org/core/2015/02/16/taxonomy-term-splitting-in-4-2-a-developer-guide/ Article explaining the taxonomy term splitting in WP 4.2.
-	 *
-	 * @param string $old_term_id      Old term id of the taxonomy term that was splitted.
-	 * @param string $new_term_id      New term id of the taxonomy term that was splitted.
-	 * @param string $term_taxonomy_id Term taxonomy id for the taxonomy that was affected.
-	 * @param string $taxonomy         The taxonomy that the taxonomy term was splitted for.
-	 */
-	public function split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
-		$tax_meta = get_option( 'wpseo_taxonomy_meta', array() );
-
-		if ( ! empty( $tax_meta[ $taxonomy ][ $old_term_id ] ) ) {
-			$tax_meta[ $taxonomy ][ $new_term_id ] = $tax_meta[ $taxonomy ][ $old_term_id ];
-			unset( $tax_meta[ $taxonomy ][ $old_term_id ] );
-			update_option( 'wpseo_taxonomy_meta', $tax_meta );
-		}
 	}
 
 	/**

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -385,7 +385,7 @@ function wpseo_split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id,
 	}
 }
 
-add_action( 'split_shared_term', array( $this, 'wpseo_split_shared_term' ), 10, 4 );
+add_action( 'split_shared_term', 'wpseo_split_shared_term', 10, 4 );
 
 
 /********************** DEPRECATED FUNCTIONS **********************/

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -365,6 +365,28 @@ if ( ! extension_loaded( 'ctype' ) || ! function_exists( 'ctype_digit' ) ) {
 	}
 }
 
+/**
+ * Makes sure the taxonomy meta is updated when a taxonomy term is split.
+ *
+ * @link https://make.wordpress.org/core/2015/02/16/taxonomy-term-splitting-in-4-2-a-developer-guide/ Article explaining the taxonomy term splitting in WP 4.2.
+ *
+ * @param string $old_term_id      Old term id of the taxonomy term that was splitted.
+ * @param string $new_term_id      New term id of the taxonomy term that was splitted.
+ * @param string $term_taxonomy_id Term taxonomy id for the taxonomy that was affected.
+ * @param string $taxonomy         The taxonomy that the taxonomy term was splitted for.
+ */
+function wpseo_split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
+	$tax_meta = get_option( 'wpseo_taxonomy_meta', array() );
+
+	if ( ! empty( $tax_meta[ $taxonomy ][ $old_term_id ] ) ) {
+		$tax_meta[ $taxonomy ][ $new_term_id ] = $tax_meta[ $taxonomy ][ $old_term_id ];
+		unset( $tax_meta[ $taxonomy ][ $old_term_id ] );
+		update_option( 'wpseo_taxonomy_meta', $tax_meta );
+	}
+}
+
+add_action( 'split_shared_term', array( $this, 'wpseo_split_shared_term' ), 10, 4 );
+
 
 /********************** DEPRECATED FUNCTIONS **********************/
 


### PR DESCRIPTION
In the current implementation, the split_shared_term action isn't registered unless the current page is 'edit-tags.php' (see https://github.com/Yoast/wordpress-seo/blob/trunk/admin/class-admin-init.php#L208-L210). 

As the term splitting is handled via a cron job in 4.3, the action will never be registered and the term meta won't be migrated to the new term IDs. 

This patch moves the split term logic into the wpseo-functions.php file, so the action is registered on plugin load.