### PR TITLE
Avoid using <code> in translation strings

### DIFF
--- a/admin/views/tab-permalinks.php
+++ b/admin/views/tab-permalinks.php
@@ -13,7 +13,9 @@ $yform = Yoast_Form::get_instance();
 $yform->currentoption = 'wpseo_permalinks';
 
 echo '<h3>', __( 'Change URLs', 'wordpress-seo' ), '</h3>';
-$yform->checkbox( 'stripcategorybase', __( 'Strip the category base (usually <code>/category/</code>) from the category URL.', 'wordpress-seo' ) );
+
+/* translators %s expands to <code>/category/</code> */
+$yform->checkbox( 'stripcategorybase', sprintf( __( 'Strip the category base (usually %s) from the category URL.', 'wordpress-seo' ), '<code>/category/</code>' ) );
 
 echo '<p>' . __( 'Attachments to posts are stored in the database as posts, this means they\'re accessible under their own URL\'s if you do not redirect them, enabling this will redirect them to the post they were attached to.', 'wordpress-seo' ) . '</p>';
 $yform->checkbox( 'redirectattachment', __( 'Redirect attachment URL\'s to parent post URL.', 'wordpress-seo' ) );
@@ -23,7 +25,9 @@ echo '<p>' . __( 'This helps you to create cleaner URLs by automatically removin
 $yform->checkbox( 'cleanslugs', __( 'Remove stop words from slugs.', 'wordpress-seo' ) );
 
 echo '<p>' . __( 'This prevents threaded replies from working when the user has JavaScript disabled, but on a large site can mean a <em>huge</em> improvement in crawl efficiency for search engines when you have a lot of comments.', 'wordpress-seo' ) . '</p>';
-$yform->checkbox( 'cleanreplytocom', __( 'Remove the <code>?replytocom</code> variables.', 'wordpress-seo' ) );
+
+/* translators %s expands to <code>?replytocom</code> */
+$yform->checkbox( 'cleanreplytocom', sprintf( __( 'Remove the %s variables.', 'wordpress-seo' ), '<code>?replytocom</code>' ) );
 
 /* translators %s expands to <code>.html</code> */
 echo '<p>' . sprintf( __( 'If you choose a permalink for your posts with %1$s, or anything else but a %2$s at the end, this will force WordPress to add a trailing slash to non-post pages nonetheless.', 'wordpress-seo' ), '<code>.html</code>', '<code>/</code>' ) . '</p>';

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1096,7 +1096,11 @@ class WPSEO_Replace_Vars {
 			'term_description'     => __( 'Replaced with the term description', 'wordpress-seo' ),
 			'term_title'           => __( 'Replaced with the term name', 'wordpress-seo' ),
 			'searchphrase'         => __( 'Replaced with the current search phrase', 'wordpress-seo' ),
-			'sep'                  => __( 'The separator defined in your theme\'s <code>wp_title()</code> tag.', 'wordpress-seo' ),
+			'sep'                  => sprintf(
+										/* translators: %s: wp_title() function */
+										__( 'The separator defined in your theme\'s %s tag.', 'wordpress-seo' ),
+										'<code>wp_title()</code>'
+									),
 		);
 	}
 


### PR DESCRIPTION
In the next version of WordPress (4.4), we fixed translation strings that use html tags inside the strings. We moved them out using sprintf().

See: https://core.trac.wordpress.org/query?milestone=4.4&component=I18N&reporter=ramiy&group=milestone&col=id&col=summary&col=milestone&col=type&col=priority&col=component&col=severity&col=resolution&order=priority

The same thing should be done in Yoast SEO.