### PR TITLE
Limited post type breadcrumb to single type in query

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -329,7 +329,7 @@ class WPSEO_Breadcrumbs {
 			if ( is_post_type_archive() ) {
 				$post_type = $wp_query->get( 'post_type' );
 
-				if ( $post_type ) {
+				if ( $post_type && is_string( $post_type ) ) {
 					$this->add_ptarchive_crumb( $post_type );
 				}
 			}


### PR DESCRIPTION
Skip post type breadcrumb for multiple types. Prevents error.

This isn't really a core case, so it's hard to come up with graceful handling for it. I assume if people are doing such customization its best for them to implement breadcrumb explicitly for it, as needed.

Fixes #2863 