### PR TITLE
Fix output buffer when forcing title rewrites

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1785,8 +1785,7 @@ class WPSEO_Frontend {
 			return false;
 		}
 
-		$content = ob_get_contents();
-		ob_end_clean();
+		$content = ob_get_clean();
 
 		$old_wp_query = $wp_query;
 


### PR DESCRIPTION
Using ob_end_clean on an empty output buffer creates a notice. We can avoid this by using ob_get_clean instead.

Fixes #470