### PR TITLE
Make it possible to generate test coverage locally

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,12 @@
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+
+	<filter>
+		<whitelist>
+			<directory>./inc</directory>
+			<directory>./frontend</directory>
+			<directory>./admin</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -625,7 +625,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Testing with an Open Graph title for the taxonomy
 	 *
-	 * @covers WPSEO_OpenGraph::title
+	 * @covers WPSEO_OpenGraph::opengraph
 	 */
 	public function test_taxonomy_title() {
 		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -519,7 +519,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @covers WPSEO_Frontend::adjacent_rel_links
-	 * @covers WPSEO_Frontend::canonical for categories too
+	 * @covers WPSEO_Frontend::canonical
 	 */
 	public function test_adjacent_rel_links_canonical_category() {
 		// create a category, add 26 posts to it, go to page 2 of its archives

--- a/tests/test-class-wpseo-statistics.php
+++ b/tests/test-class-wpseo-statistics.php
@@ -27,7 +27,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Statistics::get_ok_seo_post_count
 	 * @covers WPSEO_Statistics::get_good_seo_post_count
 	 * @covers WPSEO_Statistics::get_no_focus_post_count
-	 * @covers WPSEO_Statistics::get_no_index_seo_post_count
+	 * @covers WPSEO_Statistics::get_no_index_post_count
 	 */
 	public function test_empty_statistics() {
 		$this->assertEquals( 0, $this->instance->get_bad_seo_post_count() );
@@ -94,7 +94,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the no index statistics function
 	 *
-	 * @covers WPSEO_Statistics::get_no_index_seo_post_count
+	 * @covers WPSEO_Statistics::get_no_index_post_count
 	 */
 	public function test_no_index_statistics() {
 		$posts = $this->factory->post->create_many( 7, array(

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -31,8 +31,8 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	* @covers wpseo_is_apache()
-	*/
+	 * @covers WPSEO_Utils::is_apache()
+	 */
 	public function test_wpseo_is_apache() {
 		$_SERVER['SERVER_SOFTWARE'] = 'Apache/2.2.22';
 		$this->assertTrue( WPSEO_Utils::is_apache() );
@@ -42,8 +42,8 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	* @covers test_wpseo_is_nginx()
-	*/
+	 * @covers WPSEO_Utils::is_nginx()
+	 */
 	public function test_wpseo_is_nginx() {
 		$_SERVER['SERVER_SOFTWARE'] = 'nginx/1.5.11';
 		$this->assertTrue( WPSEO_Utils::is_nginx() );


### PR DESCRIPTION
After this is merged given you have XDebug installed it is possible to generate coverage information with the following command:
```shell
phpunit --coverage-html=coverage
```

Fixes #3046 