### PR TITLE
Implemented Open Graph dimensions for thumbnails

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -691,7 +691,6 @@ class WPSEO_OpenGraph {
 
 		return true;
 	}
-
 } /* End of class */
 
 /**
@@ -939,5 +938,4 @@ class WPSEO_OpenGraph_Image {
 
 		return $img;
 	}
-
 }

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -841,6 +841,10 @@ class WPSEO_OpenGraph_Image {
 			$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), apply_filters( 'wpseo_opengraph_image_size', 'original' ) );
 
 			if ( $this->check_featured_image_size( $thumb ) ) {
+
+				$this->dimensions['width']  = $thumb[1];
+				$this->dimensions['height'] = $thumb[2];
+
 				return $this->add_image( $thumb[0] );
 			}
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -499,6 +499,16 @@ class WPSEO_OpenGraph {
 		foreach ( $opengraph_images->get_images() as $img ) {
 			$this->og_tag( 'og:image', esc_url( $img ) );
 		}
+
+		$dimensions = $opengraph_images->get_dimensions();
+
+		if ( ! empty( $dimensions['width'] ) ) {
+			$this->og_tag( 'og:image:width', absint( $dimensions['width'] ) );
+		}
+
+		if ( ! empty( $dimensions['height'] ) ) {
+			$this->og_tag( 'og:image:height', absint( $dimensions['height'] ) );
+		}
 	}
 
 	/**
@@ -699,6 +709,9 @@ class WPSEO_OpenGraph_Image {
 	 */
 	private $images = array();
 
+	/** @var array $dimensions Holds image dimensions, if determined. */
+	protected $dimensions = array();
+
 	/**
 	 * Constructor
 	 *
@@ -721,6 +734,15 @@ class WPSEO_OpenGraph_Image {
 	 */
 	public function get_images() {
 		return $this->images;
+	}
+
+	/**
+	 * Return the dimensions array.
+	 *
+	 * @return array
+	 */
+	public function get_dimensions() {
+		return $this->dimensions;
 	}
 
 	/**

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -832,7 +832,8 @@ class WPSEO_OpenGraph_Image {
 	 * @return bool
 	 */
 	private function get_featured_image( $post_id ) {
-		if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $post_id ) ) {
+
+		if ( has_post_thumbnail( $post_id ) ) {
 			/**
 			 * Filter: 'wpseo_opengraph_image_size' - Allow changing the image size used for OpenGraph sharing
 			 *


### PR DESCRIPTION
This introduces Open Graph image dimensions in general and fills the data in for the case of featured image.

Other cases not handled yet due to complexity of reliably reverse engineering dimensions from URLs.

See #2151