### PR TITLE
Updated CSS for the overallscore on term scraper pages.

### DIFF
--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -55,8 +55,7 @@ class WPSEO_Taxonomy_Metabox {
 		/* translators: %1$s expands to Yoast SEO */
 		$metabox_heading = sprintf( __( '%1$s Settings', 'wordpress-seo' ), $product_title );
 
-		printf( '<div id="poststuff" class="postbox"><h3><span>%1$s</span></h3><div class="inside">' , $metabox_heading );
-
+		printf( '<div id="poststuff" class="postbox"><h3><span>%1$s</span></h3><div id="taxonomy_overall"></div><div class="inside">' , $metabox_heading );
 		echo '<div class="wpseo-metabox-sidebar"><ul>';
 
 		foreach ( $content_sections as $content_section ) {
@@ -68,7 +67,7 @@ class WPSEO_Taxonomy_Metabox {
 		foreach ( $content_sections as $content_section ) {
 			$content_section->display_content();
 		}
-		echo '<div id="taxonomy_overall"></div></div></div>';
+		echo '</div></div>';
 	}
 
 	/**

--- a/css/yst_seo_score.css
+++ b/css/yst_seo_score.css
@@ -47,7 +47,7 @@
 }
 
 #taxonomy_overall {
-	float: right;
-	position: relative;
-	margin-top: -75px;
+	position: absolute;
+	top: 0;
+	margin-left: 87.5%;
 }


### PR DESCRIPTION
fixes #3105. 
Updated the CSS for the overallscore icon on the termscraper pages so it aligns in the top corner of the metabox.