### PR TITLE
Fixed shorthand date formats in Open Graph

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -670,10 +670,10 @@ class WPSEO_OpenGraph {
 			}
 		}
 
-		$pub = get_the_date( 'c' );
+		$pub = get_the_date( DATE_W3C );
 		$this->og_tag( 'article:published_time', $pub );
 
-		$mod = get_the_modified_date( 'c' );
+		$mod = get_the_modified_date( DATE_W3C );
 		if ( $mod != $pub ) {
 			$this->og_tag( 'article:modified_time', $mod );
 			$this->og_tag( 'og:updated_time', $mod );

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -604,7 +604,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 
 		// test published_time tags output
-		$published_time   = get_the_date( 'c' );
+		$published_time   = get_the_date( DATE_W3C );
 		$published_output = '<meta property="article:published_time" content="' . $published_time . '" />' . "\n";
 		$this->assertTrue( self::$class_instance->publish_date() );
 		$this->expectOutput( $published_output );
@@ -616,7 +616,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$post->post_modified_gmt = gmdate( 'Y-m-d H:i:s', ( time() + 1 + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) ) );
 
 		// test modified tags output
-		$modified_time   = get_the_modified_date( 'c' );
+		$modified_time   = get_the_modified_date( DATE_W3C );
 		$modified_output = '<meta property="article:modified_time" content="' . $modified_time . '" />' . "\n" . '<meta property="og:updated_time" content="' . $modified_time . '" />' . "\n";
 		$this->assertTrue( self::$class_instance->publish_date() );
 		$this->expectOutput( $published_output . $modified_output );


### PR DESCRIPTION
`c` is broken in WP and produced invalid time zone.