### PR TITLE
Remove hardcoded "blog" prefix for categories permalinks

### DIFF
--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -121,9 +121,10 @@ class WPSEO_Rewrite {
 		$category_rewrite = array();
 
 		$taxonomy = get_taxonomy( 'category' );
+		$permalink_structure = get_option( 'permalink_structure' );
 
 		$blog_prefix = '';
-		if ( is_multisite() && ! is_subdomain_install() && is_main_site() ) {
+		if ( is_multisite() && ! is_subdomain_install() && is_main_site() && 0 === strpos( $permalink_structure, '/blog/' ) ) {
 			$blog_prefix = 'blog/';
 		}
 

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -89,8 +89,9 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 		$c = self::$class_instance;
 
 		$categories = get_categories( array( 'hide_empty' => false ) );
+		$permalink_structure = get_option( 'permalink_structure' );
 
-		if ( false == is_multisite() ) {
+		if ( ! (is_multisite() && 0 === strpos( $permalink_structure, '/blog/' ) ) ) {
 			$expected = array(
 				'(uncategorized)/(?:feed/)?(feed|rdf|rss|rss2|atom)/?$' => 'index.php?category_name=$matches[1]&feed=$matches[2]',
 				'(uncategorized)/page/?([0-9]{1,})/?$' => 'index.php?category_name=$matches[1]&paged=$matches[2]',


### PR DESCRIPTION
"blog" prefix can be removed from permalinks: https://wordpress.org/support/topic/why-wp-multisite-force-blog-slug-how-to-remove-it so it should not be hardcoded for categories.