### PR TITLE
Revert wptitle deprecation fix

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -35,7 +35,6 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dismissible' ) );
 		add_action( 'admin_init', array( $this, 'after_update_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'tagline_notice' ), 15 );
-		add_action( 'admin_init', array( $this, 'wp_title_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'ga_compatibility_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'ignore_tour' ) );
 		add_action( 'admin_init', array( $this, 'load_tour' ) );
@@ -97,29 +96,6 @@ class WPSEO_Admin_Init {
 	 */
 	private function seen_about() {
 		return get_user_meta( get_current_user_id(), 'wpseo_seen_about_version', true ) === WPSEO_VERSION;
-	}
-
-	/**
-	 * Setting a notice when the theme doesn't support the title-tag on WordPress 4.4
-	 */
-	public function wp_title_notice() {
-		$has_dismissed = WPSEO_Utils::grant_access() && '1' === get_user_meta( get_current_user_id(), 'wpseo_dismiss_wptitle', true );
-		if ( ! $has_dismissed &&  current_user_can( 'manage_options' ) && function_exists( 'wp_get_document_title' ) && ! current_theme_supports( 'title-tag' ) ) {
-			$info_message = sprintf(
-				/* translators: %1$s opens a link to a knowledge base article, $2%s closes the link  */
-				__( 'The way your theme handles titles is not compatible with the latest version of WordPress. %1$sRead more about this error on our knowledge base%2$s.' , 'wordpress-seo' ),
-				'<a href="http://yoa.st/wptitle" target="_blank">',
-				'</a>'
-			);
-
-			$notification_options = array(
-				'type'  => 'error yoast-dismissible',
-				'id'    => 'wpseo-dismiss-wptitle',
-				'nonce' => wp_create_nonce( 'wpseo-dismiss-wptitle' ),
-			);
-
-			Yoast_Notification_Center::get()->add_notification( new Yoast_Notification( $info_message, $notification_options ) );
-		}
 	}
 
 	/**

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -29,7 +29,7 @@ $yform->admin_header( true, 'wpseo_titles' );
 		<div id="general" class="wpseotab">
 			<table class="form-table">
 				<?php
-				if ( ! function_exists( 'wp_get_document_title' ) ) {
+				if ( ! current_theme_supports( 'title-tag' ) ) {
 					?>
 					<tr>
 						<th>

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -150,7 +150,7 @@ class WPSEO_Frontend {
 		add_filter( 'the_excerpt_rss', array( $this, 'embed_rssfooter_excerpt' ) );
 
 		// For WordPress functions below 4.4.
-		if ( ! function_exists( 'wp_get_document_title' ) && $this->options['forcerewritetitle'] === true ) {
+		if ( ! current_theme_supports( 'title-tag' ) && $this->options['forcerewritetitle'] === true ) {
 			add_action( 'template_redirect', array( $this, 'force_rewrite_output_buffer' ), 99999 );
 			add_action( 'wp_footer', array( $this, 'flush_cache' ), - 1 );
 		}

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -88,16 +88,8 @@ class WPSEO_Frontend {
 		remove_action( 'wp_head', 'noindex', 1 );
 
 		// When using WP 4.4, just use the new hook.
-		if ( function_exists( 'wp_get_document_title' ) ) {
-			add_filter( 'pre_get_document_title', array( $this, 'title' ), 15 );
-		}
-		// Otherwise, use the old way to hook into the title.
-		else {
-			if ( function_exists( 'wp_title' ) ) {
-				add_filter( 'wp_title', array( $this, 'title' ), 15, 3 );
-			}
-		}
-
+		add_filter( 'pre_get_document_title', array( $this, 'title' ), 15 );
+		add_filter( 'wp_title', array( $this, 'title' ), 15, 3 );
 
 		add_filter( 'thematic_doctitle', array( $this, 'title' ), 15 );
 


### PR DESCRIPTION
Fixes #3205 

This pull:
- Removes the `wp_title` notice.
- Sets the filters instead of wrapping them in `if`-statements
- Shows the enforce checkbox when `current_theme_supports` doesn't support the `title-tag`
- Executes the enforce titles only when `current_theme_supports` doesn't support the `title-tag`