### PR TITLE
Rename "Snippet" to "Snippet Editor" 

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -48,7 +48,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * the main meta box definition array in the class WPSEO_Meta() as well!!!!
 	 */
 	public static function translate_meta_boxes() {
-		self::$meta_fields['general']['snippetpreview']['title'] = __( 'Snippet', 'wordpress-seo' );
+		self::$meta_fields['general']['snippetpreview']['title'] = __( 'Snippet Editor', 'wordpress-seo' );
 		self::$meta_fields['general']['snippetpreview']['help']  = sprintf( __( 'This is a rendering of what this post might look like in Google\'s search results.<br/><br/>Read %sthis post%s for more info.', 'wordpress-seo' ), '<a href="https://yoast.com/snippet-preview/#utm_source=wordpress-seo-metabox&amp;utm_medium=inline-help&amp;utm_campaign=snippet-preview">', '</a>' );
 
 		self::$meta_fields['general']['pageanalysis']['title'] = __( 'Page Analysis', 'wordpress-seo' );

--- a/admin/taxonomy/class-taxonomy-content-fields.php
+++ b/admin/taxonomy/class-taxonomy-content-fields.php
@@ -16,7 +16,7 @@ class WPSEO_Taxonomy_Content_Fields extends WPSEO_Taxonomy_Fields {
 	public function get() {
 		$fields = array(
 			'snippet' => $this->get_field_config(
-				__( 'Snippet', 'wordpress-seo' ),
+				__( 'Snippet Editor', 'wordpress-seo' ),
 				sprintf( __( 'This is a rendering of what this post might look like in Google\'s search results.<br/><br/>Read %sthis post%s for more info.', 'wordpress-seo' ), '<a href="https://yoast.com/snippet-preview/#utm_source=wordpress-seo-metabox&amp;utm_medium=inline-help&amp;utm_campaign=snippet-preview">', '</a>' ),
 				'div'
 			),

--- a/tests/taxonomy/test-class-taxonomy-content-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-content-fields.php
@@ -52,6 +52,6 @@ class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( is_array( $fields ) );
 
 		$this->assertTrue( array_key_exists( 'title', $fields ) );
-		$this->assertEquals( __( 'Snippet', 'wordpress-seo' ), $fields['snippet']['label'] );
+		$this->assertEquals( __( 'Snippet Editor', 'wordpress-seo' ), $fields['snippet']['label'] );
 	}
 }


### PR DESCRIPTION
Small UX improvement to clarify that the snippet is editable.