### PR TITLE
Adds fix for undefined parentId.options.

### DIFF
--- a/js/wp-seo-replacevar-plugin.js
+++ b/js/wp-seo-replacevar-plugin.js
@@ -70,7 +70,7 @@
 	YoastReplaceVarPlugin.prototype.parentReplace = function( data ) {
 		var parentId = document.getElementById( 'parent_id' );
 
-		if ( parentId !== null && parentId.options[ parentId.selectedIndex ].text !== wpseoReplaceVarsL10n.no_parent_text ) {
+		if ( parentId !== null && typeof parentId.options !== 'undefined' && parentId.options[ parentId.selectedIndex ].text !== wpseoReplaceVarsL10n.no_parent_text ) {
 			data = data.replace( /%%parent_title%%/, parentId.options[ parentId.selectedIndex ].text );
 		}
 		return data;


### PR DESCRIPTION
Fixes error when parendId.options was undefined in the replaceVars plugins. This happened in the woocommerceplugin.