### PR TITLE
Small interface improvement to metabox labels

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -50,7 +50,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		self::$meta_fields['general']['snippetpreview']['title'] = __( 'Snippet Editor', 'wordpress-seo' );
 		self::$meta_fields['general']['snippetpreview']['help']  = sprintf( __( 'This is a rendering of what this post might look like in Google\'s search results.<br/><br/>Read %sthis post%s for more info.', 'wordpress-seo' ), '<a href="https://yoast.com/snippet-preview/#utm_source=wordpress-seo-metabox&amp;utm_medium=inline-help&amp;utm_campaign=snippet-preview">', '</a>' );
 
-		self::$meta_fields['general']['pageanalysis']['title'] = __( 'Page Analysis', 'wordpress-seo' );
+		self::$meta_fields['general']['pageanalysis']['title'] = __( 'Content Analysis', 'wordpress-seo' );
 		self::$meta_fields['general']['pageanalysis']['help']  = sprintf( __( 'This is the content analysis, a collection of content checks that analyze the content of your page. Read %sthis post%s for more info.', 'wordpress-seo' ), '<a href="https://yoast.com/real-time-content-analysis/#utm_source=wordpress-seo-metabox&amp;utm_medium=inline-help&amp;utm_campaign=snippet-preview">', '</a>' );
 
 		self::$meta_fields['general']['focuskw_text_input']['title'] = __( 'Focus Keyword', 'wordpress-seo' );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -578,7 +578,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					'checkbox',
 				), true ) === false
 			) {
-				$label = '<label for="' . $esc_form_key . '">' . $label . ':</label>';
+				$label = '<label for="' . $esc_form_key . '">' . $label . '</label>';
 			}
 
 			$help = '';

--- a/admin/taxonomy/class-taxonomy-content-fields.php
+++ b/admin/taxonomy/class-taxonomy-content-fields.php
@@ -25,7 +25,7 @@ class WPSEO_Taxonomy_Content_Fields extends WPSEO_Taxonomy_Fields {
 				sprintf( __( 'Pick the main keyword or keyphrase that this post/page is about.<br/><br/>Read %sthis post%s for more info.', 'wordpress-seo' ), '<a href="https://yoast.com/focus-keyword/#utm_source=wordpress-seo-metabox&amp;utm_medium=inline-help&amp;utm_campaign=focus-keyword">', '</a>' )
 			),
 			'analysis' => $this->get_field_config(
-				__( 'Analysis', 'wordpress-seo' ),
+				__( 'Content Analysis', 'wordpress-seo' ),
 				sprintf( __( 'This is the content analysis, a collection of content checks that analyze the content of your page. Read %sthis post%s for more info.', 'wordpress-seo' ), '<a href="https://yoast.com/real-time-content-analysis/#utm_source=wordpress-seo-metabox&amp;utm_medium=inline-help&amp;utm_campaign=snippet-preview">', '</a>' ),
 				'div'
 			),


### PR DESCRIPTION
In the metabox, some labels are followed by a colon and some are not. This PR removes the colons from all labels and renames the "Page Analysis" label to "Content Analysis".

Old situation:

![screen shot 2015-11-17 at 12 28 35](https://cloud.githubusercontent.com/assets/1488816/11210394/2bcc82f2-8d28-11e5-832c-27811d9a97f4.png)

New:

![screen shot 2015-11-17 at 12 39 21](https://cloud.githubusercontent.com/assets/1488816/11210410/469385a4-8d28-11e5-86bf-dd8e618655c6.png)
