### PR TITLE
Massively improve travis JS checks performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
 script:
 - if [[ "$PHPLINT" == "1" ]]; then find -L .  -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
 - if [[ "$PHPLINT" == "1" ]]; then vendor/bin/phpcs -v; fi
-- if [[ "$CHECKS" == "1" ]]; then npm install -g grunt-cli && npm install && grunt check:js; fi
+- if [[ "$CHECKS" == "1" ]]; then npm install -g grunt-cli && npm install --no-optional && grunt check:js; fi
 - phpunit -c phpunit.xml
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "grunt-checktextdomain": "^1.0.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-cssmin": "^0.10.0",
-    "grunt-contrib-imagemin": "^0.9.2",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
@@ -38,5 +37,8 @@
     "grunt-wp-i18n": "^0.4.8",
     "load-grunt-config": "^0.16.0",
     "time-grunt": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "grunt-contrib-imagemin": "^0.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/Yoast/wordpress-seo"
   },
   "devDependencies": {
-    "assemble-less": "~0.7.0",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^1.0.1",
     "grunt-checktextdomain": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-glotpress": "^0.1.1",
-    "grunt-jsbeautifier": "~0.2.7",
     "grunt-jscs": "^0.8.1",
     "grunt-jsonlint": "^1.0.4",
     "grunt-jsvalidate": "^0.2.2",


### PR DESCRIPTION
This moves `grunt-contrib-imagemin` to the optional dependencies (they are still installed when using `npm install`) and let travis not install them. We are never going to optimise the images in a travis installation so it is wasteful to install the image min native C bindings.

See #2942 