### PR TITLE
use underscore as a string literal in query to avoid unneccessary wil…

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -511,13 +511,13 @@ class WPSEO_Utils {
 					$query .= ' OR ';
 				}
 
-				$query .= " option_name LIKE '_transient_wpseo_sitemap_cache_" . $sitemap_type . "_%' OR option_name LIKE '_transient_timeout_wpseo_sitemap_cache_" . $sitemap_type . "_%'";
+				$query .= " option_name LIKE '\_transient_wpseo_sitemap_cache_" . $sitemap_type . "_%' OR option_name LIKE '\_transient_timeout_wpseo_sitemap_cache_" . $sitemap_type . "_%'";
 
 				$first = false;
 			}
 		}
 		else {
-			$query .= " option_name LIKE '_transient_wpseo_sitemap_%' OR option_name LIKE '_transient_timeout_wpseo_sitemap_%'";
+			$query .= " option_name LIKE '\_transient_wpseo_sitemap_%' OR option_name LIKE '\_transient_timeout_wpseo_sitemap_%'";
 		}
 
 		$wpdb->query( $query );


### PR DESCRIPTION
…dcard matches.  this also ensures we use the option_name index as per https://dev.mysql.com/doc/refman/5.5/en/index-btree-hash.html when doing a LIKE match with the first character being a wildcard (_ or %) the indexes arent used causing full table scans.. this can be verified with explain.