### PR TITLE
Fix un-dismissible notice on multisite: #3477, #3304 

### DIFF
--- a/admin/ajax/class-yoast-dismissable-notice.php
+++ b/admin/ajax/class-yoast-dismissable-notice.php
@@ -10,7 +10,8 @@
 class Yoast_Dismissable_Notice_Ajax {
 
 	const FOR_USER = 'user_meta';
-	const FOR_SITE = 'site_option';
+	const FOR_NETWORK = 'site_option';
+	const FOR_SITE = 'option';
 
 
 	/**
@@ -52,6 +53,12 @@ class Yoast_Dismissable_Notice_Ajax {
 	 */
 	private function save_dismissed() {
 		if ( $this->notice_type === self::FOR_SITE ) {
+			update_option( 'wpseo_dismiss_' . $this->notice_name, 1 );
+
+			return;
+		}
+
+		if ( $this->notice_type === self::FOR_NETWORK ) {
 			update_site_option( 'wpseo_dismiss_' . $this->notice_name, 1 );
 
 			return;

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -44,7 +44,7 @@ if ( '' === $tool_page ) {
 	);
 
 	if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
-		update_site_option( 'wpseo_dismiss_recalculate', 1 );
+		update_option( 'wpseo_dismiss_recalculate', 1 );
 		$tools['recalculate']['attr'] .= "data-open='open'";
 	}
 


### PR DESCRIPTION
When using `update_site_option` you should always read it in your mind as *update_**network**_option* on a multisite.

On a multisite `update_site_option` stores data in `_sitemeta` / `_siteid` not `_options` or `_*_options` as you would expect. This is not the case for a standalone site.

To factor for this an additional constant `FOR_NETWORK` has been added to the dismissible notice class. This is because `FOR_SITE` is misleading in a multisite setup. `FOR_SITE` has been modified accordingly along with it's conditional upon saving the dismissed message.

When the user dismissed the notice, this fired the ajax action which updated the option **network wide**.

This paired with the fact that the check to see if the notice was dismissed **site wide** in `admin_init` and not at a **network wide** level meant that the option was never dismissed

Fixes #3477, Fixes #3304