### PR TITLE
removed the unused option 'disable-post_formats'

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -120,8 +120,7 @@ class WPSEO_Frontend {
 		}
 
 		if ( ( $this->options['disable-date'] === true ||
-		       $this->options['disable-author'] === true ) ||
-		     ( isset( $this->options['disable-post_formats'] ) && $this->options['disable-post_formats'] )
+		       $this->options['disable-author'] === true )
 		) {
 			add_action( 'wp', array( $this, 'archive_redirect' ) );
 		}
@@ -1431,9 +1430,9 @@ class WPSEO_Frontend {
 		global $wp_query;
 
 		if (
-			( $this->options['disable-date'] === true && $wp_query->is_date ) ||
-			( $this->options['disable-author'] === true && $wp_query->is_author ) ||
-			( isset( $this->options['disable-post_formats'] ) && $this->options['disable-post_formats'] && $wp_query->is_tax( 'post_format' ) )
+			$this->options['disable-date'] === true && $wp_query->is_date ||
+			$this->options['disable-author'] === true && $wp_query->is_author ||
+			$wp_query->is_tax( 'post_format' )
 		) {
 			wp_safe_redirect( get_bloginfo( 'url' ), 301 );
 			exit;
@@ -1887,7 +1886,7 @@ class WPSEO_Frontend {
 	 * @param String $description The content of the meta description.
 	 */
 	private function add_robot_content_noodp( $description ) {
-		if ( ! ( empty( $description )  ) && $this->options['noodp'] === false ) {
+		if ( ! ( empty( $description ) ) && $this->options['noodp'] === false ) {
 			$this->options['noodp'] = true;
 		}
 	}


### PR DESCRIPTION
The option `disable-post_formats` is never set and it seems like it has always been this way. Svn shows that the lines I deleted in this PR, were added in v1.2. However, there was no setting field (or anything else at all) related to this option in this release.

So, the option was _used_ as of 1.2, but I still don't think that _writing_ the option was ever possible within the plugin.
I checked a few old releases for any occurrences of the option (or parts of it).
- 0.3.3
- 1.0
- 1.1.5
- 1.1.8
- 1.1.9
- 1.2
- 1.2.1
- 1.2.2
- 3.0.6
I searched for: `disable`, `disable-post`, `post_formats`, `formats`.

Also no sign of the option in the most recent versions of Local, Woo, News and video.
