### PR TITLE
Added a filter for single breadcrumb link_info. This fixes #3622

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -652,6 +652,15 @@ class WPSEO_Breadcrumbs {
 				$link_info = $this->get_link_info_for_ptarchive( $crumb['ptarchive'] );
 			}
 
+			/**
+			 * Filter: 'wpseo_breadcrumb_single_link_info' - Allow developer to filter the Yoast SEO Breadcrumb link information.
+			 *
+			 * @api array $link_info The Breadcrumb link information
+			 *
+			 * @param array $crumb The crumb
+			 */
+			$link_info = apply_filters( 'wpseo_breadcrumb_single_link_info', $link_info, $crumb );
+
 			$this->links[] = $this->crumb_to_link( $link_info, $i );
 		}
 	}


### PR DESCRIPTION
I added a new filter based on `wp_seo_get_bc_title`, but on the whole link_info element which allows developers greater freedom in that they will be able to alter both the link text and the URL. It will also keep the `$id` parameter for the `wp_seo_get_bc_title` filter intact to avoid breaking existing filters.