### PR TITLE
Add  "Hide Emoji script and style" to  "Advanced > Permalinks > Clean up the <head>" section

### DIFF
--- a/admin/views/tab-permalinks.php
+++ b/admin/views/tab-permalinks.php
@@ -54,3 +54,4 @@ $yform->checkbox( 'hide-rsdlink', __( 'Hide RSD Links', 'wordpress-seo' ) );
 $yform->checkbox( 'hide-wlwmanifest', __( 'Hide WLW Manifest Links', 'wordpress-seo' ) );
 $yform->checkbox( 'hide-shortlink', __( 'Hide Shortlink for posts', 'wordpress-seo' ) );
 $yform->checkbox( 'hide-feedlinks', __( 'Hide RSS Links', 'wordpress-seo' ) );
+$yform->checkbox( 'hide-emoji', __( 'Hide Emoji script and style', 'wordpress-seo' ) );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -115,6 +115,10 @@ class WPSEO_Frontend {
 			remove_action( 'wp_head', 'feed_links', 2 );
 			remove_action( 'wp_head', 'feed_links_extra', 3 );
 		}
+		if ( $this->options['hide-emoji'] === true ) {
+			remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		}
 
 		if ( ( $this->options['disable-date'] === true ||
 		       $this->options['disable-author'] === true ) ||

--- a/inc/options/class-wpseo-option-permalinks.php
+++ b/inc/options/class-wpseo-option-permalinks.php
@@ -29,6 +29,7 @@ class WPSEO_Option_Permalinks extends WPSEO_Option {
 		'hide-rsdlink'                    => false,
 		'hide-shortlink'                  => false,
 		'hide-wlwmanifest'                => false,
+		'hide-emoji'                      => false,
 		'redirectattachment'              => false,
 		'stripcategorybase'               => false,
 		'trailingslash'                   => false,
@@ -99,6 +100,7 @@ class WPSEO_Option_Permalinks extends WPSEO_Option {
 				 *		'hide-wlwmanifest'
 				 *		'hide-shortlink'
 				 *		'hide-feedlinks'
+				 *		'hide-emoji'
 				 *		'redirectattachment'
 				 *		'stripcategorybase'
 				 *		'trailingslash'


### PR DESCRIPTION
Since WordPress 4.2, the <**head**> has an emoji JS and a CSS style. I usually remove those using dedicated filters. But since Yoast SEO already has a **Clean up the head** section, we can add a new option to remove this code from the plugin.

This is my first patch to **Yoast WordPress SEO**. Please test the code.