### PR TITLE
The wpseo_internallinks option is required instead of wpseo_permalinks.

### DIFF
--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -63,7 +63,7 @@ class WPSEO_Customizer {
 	 * @return bool
 	 */
 	public function breadcrumbs_active_callback() {
-		$options = WPSEO_Options::get_option( 'wpseo_permalinks' );
+		$options = WPSEO_Options::get_option( 'wpseo_internallinks' );
 
 		return true === ( current_theme_supports( 'yoast-seo-breadcrumbs' ) || $options['breadcrumbs-enable'] );
 	}


### PR DESCRIPTION
Enable Yoast Breadcrumbs and head over to Appearance > customize. The old situation gave me a notice that `$options['breadcrumbs-enable']` did not exist.