### PR TITLE
On the attachment page for an image, use the image itself for shares

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -832,6 +832,10 @@ class WPSEO_OpenGraph_Image {
 			return;
 		}
 
+		if ( $this->get_attachment_page_image( $post->ID ) ) {
+			return;
+		}
+
 		if ( $this->get_featured_image( $post->ID ) ) {
 			return;
 		}
@@ -896,6 +900,27 @@ class WPSEO_OpenGraph_Image {
 				$this->dimensions['height'] = $thumb[2];
 
 				return $this->add_image( $thumb[0] );
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * If this is an attachment page, call add_image with the attachment and return true
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return bool
+	 */
+	private function get_attachment_page_image( $post_id ) {
+		if ( get_post_type( $post->ID ) === 'attachment' ) {
+			$mime_type = get_post_mime_type( $post->ID );
+			switch ($mime_type) {
+				case 'image/jpeg':
+				case 'image/png':
+				case 'image/gif':
+					return $this->add_image( wp_get_attachment_url( $post_id ) );
 			}
 		}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -916,7 +916,7 @@ class WPSEO_OpenGraph_Image {
 	private function get_attachment_page_image( $post_id ) {
 		if ( get_post_type( $post_id ) === 'attachment' ) {
 			$mime_type = get_post_mime_type( $post_id );
-			switch ($mime_type) {
+			switch ( $mime_type ) {
 				case 'image/jpeg':
 				case 'image/png':
 				case 'image/gif':

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -914,8 +914,8 @@ class WPSEO_OpenGraph_Image {
 	 * @return bool
 	 */
 	private function get_attachment_page_image( $post_id ) {
-		if ( get_post_type( $post->ID ) === 'attachment' ) {
-			$mime_type = get_post_mime_type( $post->ID );
+		if ( get_post_type( $post_id ) === 'attachment' ) {
+			$mime_type = get_post_mime_type( $post_id );
 			switch ($mime_type) {
 				case 'image/jpeg':
 				case 'image/png':

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -389,6 +389,9 @@ class WPSEO_Twitter {
 			if ( $this->image_from_meta_values_output() ) {
 				return;
 			}
+			if ( $this->image_of_attachment_page_output() ) {
+				return;
+			}
 			if ( $this->image_thumbnail_output() ) {
 				return;
 			}
@@ -464,6 +467,26 @@ class WPSEO_Twitter {
 				$this->image_output( $img );
 
 				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	* Retrieve an attachment page's attachment
+	*
+	* @return bool
+	*/
+	private function image_of_attachment_page_output() {
+		if ( get_post_type( get_the_ID() ) === 'attachment' ) {
+			$mime_type = get_post_mime_type( $post->ID );
+			switch ($mime_type) {
+				case 'image/jpeg':
+				case 'image/png':
+				case 'image/gif':
+					$this->image_output( wp_get_attachment_url( get_the_ID() ) );
+					return true;
 			}
 		}
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -474,14 +474,14 @@ class WPSEO_Twitter {
 	}
 
 	/**
-	* Retrieve an attachment page's attachment
-	*
-	* @return bool
-	*/
+	 * Retrieve an attachment page's attachment
+	 *
+	 * @return bool
+	 */
 	private function image_of_attachment_page_output() {
 		if ( get_post_type( get_the_ID() ) === 'attachment' ) {
 			$mime_type = get_post_mime_type( $post->ID );
-			switch ($mime_type) {
+			switch ( $mime_type ) {
 				case 'image/jpeg':
 				case 'image/png':
 				case 'image/gif':


### PR DESCRIPTION
On image attachment pages, if a custom variable is not used to set the page's Open Graph image, use the image itself as the value for the ````og:image```` and ````twitter:image```` meta tags.

See the page source for [http://collectpostmarks.com/american-kestrel-maximum-card](http://collectpostmarks.com/american-kestrel-maximum-card/) for a demonstration.