### PR TITLE
Corrected priority of gallery images in twitter cards

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -339,10 +339,8 @@ class WPSEO_Twitter {
 	 * Only used when OpenGraph is inactive or Summary Large Image card is chosen.
 	 */
 	protected function image() {
-		if ( count( $this->images ) > 0 ) {
-			$this->gallery_images_output();
-		}
-		elseif ( is_category() || is_tax() || is_tag() ) {
+
+		if ( is_category() || is_tax() || is_tag() ) {
 			$this->taxonomy_image_output();
 		}
 		else {
@@ -390,6 +388,10 @@ class WPSEO_Twitter {
 				return;
 			}
 			if ( $this->image_thumbnail_output() ) {
+				return;
+			}
+			if ( count( $this->images ) > 0 ) {
+				$this->gallery_images_output();
 				return;
 			}
 			if ( $this->image_from_content_output() ) {

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -86,6 +86,7 @@ class WPSEO_Twitter {
 	private function determine_card_type() {
 		$this->type = $this->options['twitter_card_type'];
 
+		// TODO this should be reworked to use summary_large_image for any fitting image R.
 		if ( is_singular() && has_shortcode( $GLOBALS['post']->post_content, 'gallery' ) ) {
 
 			$this->images = get_post_gallery_images();


### PR DESCRIPTION
Leftover logic from when galleries had separate Twitter Card type was causing gallery to beat all other images in priority.

See https://github.com/Yoast/wordpress-seo/issues/3651#issuecomment-169341542

Fixes #3384