### PR TITLE
Fixing assumption that there are no other ajaxComplete events on the document

### DIFF
--- a/js/wp-seo-post-scraper-305.js
+++ b/js/wp-seo-post-scraper-305.js
@@ -444,7 +444,7 @@
 	 * If the response matches with permalinkstring, the snippet can be rerendered.
 	 */
 	jQuery( document ).on( 'ajaxComplete', function( ev, response ) {
-		if ( response.responseText.match( 'Permalink:' ) !== null ) {
+		if ( response.responseText && response.responseText.match( 'Permalink:' ) !== null ) {
 			YoastSEO.app.callbacks.getData();
 			YoastSEO.app.runAnalyzer();
 			YoastSEO.app.snippetPreview.reRender();


### PR DESCRIPTION
No one was patching https://github.com/Yoast/wordpress-seo/issues/3605 so I added a patch for you. Not sure of your process for minification so I only modified the unminified file.

Fixes #3605