### PR TITLE
Removed unnecessary line in CSS 

### DIFF
--- a/css/snippet-307.css
+++ b/css/snippet-307.css
@@ -2,7 +2,6 @@
 	width: auto;
 	max-width: 512px;
 	margin: 0 0 10px;
-	padding: 0 5px;
 	font-family: Arial, Helvetica, sans-serif;
 	font-style: normal;
 }

--- a/css/snippet-307.min.css
+++ b/css/snippet-307.min.css
@@ -1,1 +1,1 @@
-#snippet_preview{width:auto;max-width:512px;margin:0 0 10px;padding:0 5px;font-family:Arial,Helvetica,sans-serif;font-style:normal}.form-table td .snippet-editor__label{font-size:1rem;line-height:2}.form-table td textarea{margin-top:0}.wp-core-ui .button.snippet-editor__submit{margin-top:1em}
+#snippet_preview{width:auto;max-width:512px;margin:0 0 10px;font-family:Arial,Helvetica,sans-serif;font-style:normal}.form-table td .snippet-editor__label{font-size:1rem;line-height:2}.form-table td textarea{margin-top:0}.wp-core-ui .button.snippet-editor__submit{margin-top:1em}


### PR DESCRIPTION
Removed unnecessary line in CSS which caused the snippet preview to look different for taxonomies.

Fixes: https://github.com/Yoast/wordpress-seo/issues/3744