### PR TITLE
Use primary term in the breadcrumbs

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -505,20 +505,20 @@ class WPSEO_Breadcrumbs {
 
 					$primary_term = new WPSEO_Primary_Term( $main_tax, $this->post->ID );
 					if ( $primary_term->get_primary_term() ) {
-						$deepest_term = get_term( $primary_term->get_primary_term(), $main_tax );
+						$breadcrumb_term = get_term( $primary_term->get_primary_term(), $main_tax );
 					}
 					else {
-						$deepest_term = $this->find_deepest_term( $terms );
+						$breadcrumb_term = $this->find_deepest_term( $terms );
 					}
 
-					if ( is_taxonomy_hierarchical( $main_tax ) && $deepest_term->parent != 0 ) {
-						$parent_terms = $this->get_term_parents( $deepest_term );
+					if ( is_taxonomy_hierarchical( $main_tax ) && $breadcrumb_term->parent != 0 ) {
+						$parent_terms = $this->get_term_parents( $breadcrumb_term );
 						foreach ( $parent_terms as $parent_term ) {
 							$this->add_term_crumb( $parent_term );
 						}
 					}
 
-					$this->add_term_crumb( $deepest_term );
+					$this->add_term_crumb( $breadcrumb_term );
 				}
 			}
 		}

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -503,7 +503,13 @@ class WPSEO_Breadcrumbs {
 
 				if ( is_array( $terms ) && $terms !== array() ) {
 
-					$deepest_term = $this->find_deepest_term( $terms );
+					$primary_term = new WPSEO_Primary_Term( $main_tax, $this->post->ID );
+					if ( $primary_term->get_primary_term() ) {
+						$deepest_term = get_term( $primary_term->get_primary_term(), $main_tax );
+					}
+					else {
+						$deepest_term = $this->find_deepest_term( $terms );
+					}
 
 					if ( is_taxonomy_hierarchical( $main_tax ) && $deepest_term->parent != 0 ) {
 						$parent_terms = $this->get_term_parents( $deepest_term );


### PR DESCRIPTION
This should already have been included in the primary term PR, but was missed.

Fixes #3781 