### PR TITLE
Don't change the snippet preview width

### DIFF
--- a/css/snippet-307.css
+++ b/css/snippet-307.css
@@ -1,6 +1,4 @@
 #snippet_preview {
-	width: auto;
-	max-width: 512px;
 	margin: 0 0 10px;
 	font-family: Arial, Helvetica, sans-serif;
 	font-style: normal;

--- a/css/snippet-307.min.css
+++ b/css/snippet-307.min.css
@@ -1,1 +1,1 @@
-#snippet_preview{width:auto;max-width:512px;margin:0 0 10px;font-family:Arial,Helvetica,sans-serif;font-style:normal}.form-table td .snippet-editor__label{font-size:1rem;line-height:2}.form-table td textarea{margin-top:0}.wp-core-ui .button.snippet-editor__submit{margin-top:1em}
+#snippet_preview{margin:0 0 10px;font-family:Arial,Helvetica,sans-serif;font-style:normal}.form-table td .snippet-editor__label{font-size:1rem;line-height:2}.form-table td textarea{margin-top:0}.wp-core-ui .button.snippet-editor__submit{margin-top:1em}


### PR DESCRIPTION
YoastSEO.js knows how wide it should be.

Needs to be applied in conjunction with: https://github.com/Yoast/YoastSEO.js/pull/244

Fixes https://github.com/Yoast/YoastSEO.js/issues/238