### PR TITLE
Fix for #3022 - Don't initiate search engine pings for menu items

### DIFF
--- a/admin/class-sitemaps-admin.php
+++ b/admin/class-sitemaps-admin.php
@@ -67,7 +67,10 @@ class WPSEO_Sitemaps_Admin {
 		wp_cache_delete( 'lastpostmodified:gmt:' . $post->post_type, 'timeinfo' ); // #17455.
 
 		$options = WPSEO_Options::get_options( array( 'wpseo_xml', 'wpseo_titles' ) );
-		if ( isset( $options[ 'post_types-' . $post->post_type . '-not_in_sitemap' ] ) && $options[ 'post_types-' . $post->post_type . '-not_in_sitemap' ] === true ) {
+		if (
+			( isset( $options[ 'post_types-' . $post->post_type . '-not_in_sitemap' ] ) && $options[ 'post_types-' . $post->post_type . '-not_in_sitemap' ] === true )
+			|| ( $post->post_type === 'nav_menu_item' )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
**Fixes #3022**

This Pull Request updates the action for the `transition_post_status` hook that's used to initiate search engine pings, such that posts of type `nav_menu_item` (i.e menu items) don't schedule unnecessary tasks. `nav_menu_item` posts are never included in sitemaps, so this functionality isn't needed for them.

This helps to prevent performance issues when saving large menus in the Wordpress Admin, as detailed in issue #3022.