### PR TITLE
Deprecate upgrade hook

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -53,6 +53,8 @@ class WPSEO_Upgrade {
 		/**
 		 * Filter: 'wpseo_run_upgrade' - Runs the upgrade hook which are dependent on Yoast SEO
 		 *
+		 * @deprecated Since 3.1
+		 *
 		 * @api string - The current version of Yoast SEO
 		 */
 		do_action( 'wpseo_run_upgrade', $this->options['version'] );


### PR DESCRIPTION
Because it is not needed anymore in premium.