### PR TITLE
Fix: error when there are no elements with class 'yoast_help'

### DIFF
--- a/js/wp-seo-metabox-302.js
+++ b/js/wp-seo-metabox-302.js
@@ -65,29 +65,31 @@
 		jQuery( '.wpseo-metabox-tabs' ).show();
 		// End Tabs code
 
-		if(jQuery( '.yoast_help' ).length) jQuery( '.yoast_help' ).qtip(
-			{
-				content: {
-					attr: 'alt'
-				},
-				position: {
-					my: 'bottom left',
-					at: 'top center'
-				},
-				style: {
-					tip: {
-						corner: true
+		if(jQuery( '.yoast_help' ).length) {
+			jQuery( '.yoast_help' ).qtip(
+				{
+					content: {
+						attr: 'alt'
 					},
-					classes: 'yoast-qtip qtip-rounded qtip-blue'
-				},
-				show: 'click',
-				hide: {
-					fixed: true,
-					delay: 500
+					position: {
+						my: 'bottom left',
+						at: 'top center'
+					},
+					style: {
+						tip: {
+							corner: true
+						},
+						classes: 'yoast-qtip qtip-rounded qtip-blue'
+					},
+					show: 'click',
+					hide: {
+						fixed: true,
+						delay: 500
+					}
+	
 				}
-
-			}
-		);
+			);
+		}
 	};
 
 	/**

--- a/js/wp-seo-metabox-302.js
+++ b/js/wp-seo-metabox-302.js
@@ -65,7 +65,7 @@
 		jQuery( '.wpseo-metabox-tabs' ).show();
 		// End Tabs code
 
-		jQuery( '.yoast_help' ).qtip(
+		if(jQuery( '.yoast_help' ).length) jQuery( '.yoast_help' ).qtip(
 			{
 				content: {
 					attr: 'alt'

--- a/js/wp-seo-metabox-302.js
+++ b/js/wp-seo-metabox-302.js
@@ -86,7 +86,6 @@
 						fixed: true,
 						delay: 500
 					}
-	
 				}
 			);
 		}


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/uncaught-typeerror-jqueryqtip-is-not-a-function , https://wordpress.org/support/topic/yoast-seo-update-301-not-working , https://wordpress.org/support/topic/seo-yoast-stopped-working-js-error-qtip-is-not-a-function-1

Other plugins may cause jQuery('.yoast_help') to return a 0-length set, causing the script to bomb out