### PR TITLE
Fixes red color not showing up in snippetPreview

### DIFF
--- a/css/snippet-307.css
+++ b/css/snippet-307.css
@@ -16,3 +16,7 @@
 .wp-core-ui .button.snippet-editor__submit {
 	margin-top: 1em;
 }
+
+input[type="text"].snippet-editor__field--invalid {
+	color: #f00;
+}

--- a/css/snippet-307.min.css
+++ b/css/snippet-307.min.css
@@ -1,1 +1,1 @@
-#snippet_preview{margin:0 0 10px;font-family:Arial,Helvetica,sans-serif;font-style:normal}.form-table td .snippet-editor__label{font-size:1rem;line-height:2}.form-table td textarea{margin-top:0}.wp-core-ui .button.snippet-editor__submit{margin-top:1em}
+#snippet_preview{margin:0 0 10px;font-family:Arial,Helvetica,sans-serif;font-style:normal}.form-table td .snippet-editor__label{font-size:1rem;line-height:2}.form-table td textarea{margin-top:0}.wp-core-ui .button.snippet-editor__submit{margin-top:1em}input[type=text].snippet-editor__field--invalid{color:red}


### PR DESCRIPTION
When the SEO title was too long, the text didn't turn red in the snippet editor. This CSS fixes that.