### PR TITLE
Fixed performance when importing or migrating a large amount of posts

### DIFF
--- a/admin/class-sitemaps-admin.php
+++ b/admin/class-sitemaps-admin.php
@@ -60,6 +60,9 @@ class WPSEO_Sitemaps_Admin {
 	 * @param \WP_Post $post       Post object.
 	 */
 	function status_transition( $new_status, $old_status, $post ) {
+		if ( defined( 'WP_IMPORTING' ) ) {
+			return;
+		}
 		if ( $new_status != 'publish' ) {
 			return;
 		}


### PR DESCRIPTION
**Problem**

* When importing or migrating a large amount of posts (i.e. tens of thousands), the wordpress-seo plugin attempts to ping external sites for every single post, which substantially slows down the import/migration process.

**Details**

* Yes, there are filter hooks that allow to cancel the operation already, but they are specific to the wordpress-seo plugin, so they need to be implemented and maintained by all import/migration related plugins (and custom code).

**Proposed solution**

1. Respect the `WP_IMPORTING` flag.

  It is used by WordPress Core ([example](https://developer.wordpress.org/reference/functions/_publish_post_hook/)) and other plugins to mute/cancel very similar operations in case a post is created during an import/migration.
