### PR TITLE
Fixes the global problems of sitemap cache not being cleared.

### DIFF
--- a/admin/class-sitemaps-admin.php
+++ b/admin/class-sitemaps-admin.php
@@ -14,6 +14,8 @@ class WPSEO_Sitemaps_Admin {
 	function __construct() {
 		add_action( 'transition_post_status', array( $this, 'status_transition' ), 10, 3 );
 		add_action( 'admin_init', array( $this, 'delete_sitemaps' ) );
+
+		WPSEO_Utils::register_cache_clear_option( 'wpseo_xml', '' );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -494,26 +494,14 @@ class WPSEO_Utils {
 			return;
 		}
 
-		// Not sure about efficiency, but that's what code elsewhere does R.
-		$options = WPSEO_Options::get_option( 'wpseo_xml' );
-
-		if ( true !== $options['enablexmlsitemap'] ) {
-			return;
-		}
-
 		$query = "DELETE FROM $wpdb->options WHERE";
 
 		if ( ! empty( $types ) ) {
-			$first = true;
+			$query .= " option_name LIKE '_transient_wpseo_sitemap_cache_1_%' OR option_name LIKE '_transient_timeout_wpseo_sitemap_cache_1_%'";
 
 			foreach ( $types as $sitemap_type ) {
-				if ( ! $first ) {
-					$query .= ' OR ';
-				}
-
+				$query .= ' OR ';
 				$query .= " option_name LIKE '_transient_wpseo_sitemap_cache_" . $sitemap_type . "_%' OR option_name LIKE '_transient_timeout_wpseo_sitemap_cache_" . $sitemap_type . "_%'";
-
-				$first = false;
 			}
 		}
 		else {

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -311,8 +311,8 @@ add_shortcode( 'wpseo_breadcrumb', 'wpseo_shortcode_yoast_breadcrumb' );
  */
 function wpseo_invalidate_sitemap_cache( $type ) {
 	// Always delete the main index sitemaps cache, as that's always invalidated by any other change.
-	delete_transient( 'wpseo_sitemap_cache_1' );
-	delete_transient( 'wpseo_sitemap_cache_' . $type );
+	delete_transient( 'wpseo_sitemap_cache_1_1' );
+	delete_transient( 'wpseo_sitemap_cache_' . $type . '_1' );
 
 	WPSEO_Utils::clear_sitemap_cache( array( $type ) );
 }


### PR DESCRIPTION
Using the correct transient keys
Removing the `index` for `type` cache clears.
Removing cache on `wpseo_xml` option value changes.

This is a preface to #3769 where the sitemap cache will be cleared for all pages in all situations.