### PR TITLE
Change method visibility

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -294,7 +294,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @return string
 	 */
-	public function get_metadesc_date( $post ) {
+	private function get_metadesc_date( $post ) {
 		$date = '';
 
 		if ( is_a( $post, 'WP_Post' ) && $this->is_show_date_enabled( $post ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -972,7 +972,7 @@ SVG;
 	 * @param WP_Post $post The post to retrieve this for.
 	 * @return bool
 	 */
-	private static function is_show_date_enabled( $post ) {
+	private function is_show_date_enabled( $post ) {
 		$post_type = $post->post_type;
 
 		$options = WPSEO_Options::get_option( 'wpseo_titles' );


### PR DESCRIPTION
`get_metadesc_date ` does not have to be public and `is_show_date_enabled` doesn't have to be static, because it's called the non-static way.