### PR TITLE
Introduce post/term content filters for recalculation

### DIFF
--- a/admin/ajax/class-recalculate-scores-ajax.php
+++ b/admin/ajax/class-recalculate-scores-ajax.php
@@ -41,8 +41,14 @@ class WPSEO_Recalculate_Scores_Ajax {
 	public function recalculate_scores() {
 		check_ajax_referer( 'wpseo_recalculate', 'nonce' );
 
-		if ( $response = $this->get_fetch_object()->get_items_to_recalculate( filter_input( INPUT_POST, 'paged', FILTER_VALIDATE_INT ) ) ) {
-			wp_die( WPSEO_Utils::json_encode( $response ) );
+		$fetch_object = $this->get_fetch_object();
+		if ( ! empty( $fetch_object ) ) {
+			$paged    = filter_input( INPUT_POST, 'paged', FILTER_VALIDATE_INT );
+			$response = $fetch_object->get_items_to_recalculate( $paged );
+
+			if ( ! empty( $response ) ) {
+				wp_die( WPSEO_Utils::json_encode( $response ) );
+			}
 		}
 
 		wp_die( '' );
@@ -54,7 +60,11 @@ class WPSEO_Recalculate_Scores_Ajax {
 	public function save_score() {
 		check_ajax_referer( 'wpseo_recalculate', 'nonce' );
 
-		$this->get_fetch_object()->save_scores( $scores = filter_input( INPUT_POST, 'scores', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ) );
+		$fetch_object = $this->get_fetch_object();
+		if ( ! empty( $fetch_object ) ) {
+			$scores = filter_input( INPUT_POST, 'scores', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+			$fetch_object->save_scores( $scores );
+		}
 
 		wp_die();
 	}
@@ -68,11 +78,11 @@ class WPSEO_Recalculate_Scores_Ajax {
 		switch ( filter_input( INPUT_POST, 'type' ) ) {
 			case 'post':
 				return new WPSEO_Recalculate_Posts();
-				break;
-			default:
+			case 'term':
 				return new WPSEO_Recalculate_Terms();
-				break;
 		}
+
+		return null;
 	}
 
 	/**
@@ -85,7 +95,8 @@ class WPSEO_Recalculate_Scores_Ajax {
 			array(
 				'post_type'      => 'any',
 				'meta_key'       => '_yoast_wpseo_focuskw',
-				'posts_per_page' => -1,
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
 			)
 		);
 

--- a/admin/recalculate/class-recalculate-posts.php
+++ b/admin/recalculate/class-recalculate-posts.php
@@ -60,6 +60,7 @@ class WPSEO_Recalculate_Posts extends WPSEO_Recalculate {
 		$focus_keyword = WPSEO_Meta::get_value( 'focuskw', $item->ID );
 
 		$content = $item->post_content;
+
 		/**
 		 * Filter the post content for use in the SEO score recalculation.
 		 *

--- a/admin/recalculate/class-recalculate.php
+++ b/admin/recalculate/class-recalculate.php
@@ -16,7 +16,7 @@ abstract class WPSEO_Recalculate {
 	/**
 	 * @var int
 	 */
-	protected $items_per_page = 10;
+	protected $items_per_page = 20;
 
 	/**
 	 * Saves the array with scores to the database.

--- a/admin/recalculate/class-recalculate.php
+++ b/admin/recalculate/class-recalculate.php
@@ -49,7 +49,7 @@ abstract class WPSEO_Recalculate {
 	 *
 	 * @param int $paged The current page number.
 	 *
-	 * @return string
+	 * @return array Items that can be recalculated.
 	 */
 	public function get_items_to_recalculate( $paged ) {
 		$return = array();

--- a/admin/recalculate/class-recalculate.php
+++ b/admin/recalculate/class-recalculate.php
@@ -16,7 +16,7 @@ abstract class WPSEO_Recalculate {
 	/**
 	 * @var int
 	 */
-	protected $items_per_page = 20;
+	protected $items_per_page = 10;
 
 	/**
 	 * Saves the array with scores to the database.
@@ -52,24 +52,21 @@ abstract class WPSEO_Recalculate {
 	 * @return string
 	 */
 	public function get_items_to_recalculate( $paged ) {
+		$return = array();
+
 		$paged = abs( $paged );
+		$this->options = WPSEO_Options::get_all();
 
-		if ( $items = $this->get_items( $paged ) ) {
-			$this->options = WPSEO_Options::get_all();
+		$items = $this->get_items( $paged );
 
-			$return = array(
-				'items'       => $this->parse_items( $items ),
-				'total_items' => count( $items ),
-			);
+		$return['items']       = $this->parse_items( $items );
+		$return['total_items'] = count( $items );
 
-			if ( $return['total_items'] >= $this->items_per_page ) {
-				$return['next_page'] = ( $paged + 1 );
-			}
-
-			return $return;
+		if ( $return['total_items'] >= $this->items_per_page ) {
+			$return['next_page'] = ( $paged + 1 );
 		}
 
-		return false;
+		return $return;
 	}
 
 	/**
@@ -82,7 +79,10 @@ abstract class WPSEO_Recalculate {
 	protected function parse_items( array $items ) {
 		$return = array();
 		foreach ( $items as $item ) {
-			$return[] = $this->item_to_response( $item );
+			$response = $this->item_to_response( $item );
+			if ( ! empty( $response ) ) {
+				$return[] = $response;
+			}
 		}
 
 		return $return;

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -27,6 +27,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 			1 => $this->factory->post->create( array( 'post_title' => 'Post with focus keyword' ) ),
 			2 => $this->factory->post->create( array( 'post_title' => 'Test Post 2' ) ),
 			3 => $this->factory->post->create( array( 'post_title' => 'Test Post 3' ) ),
+			4 => $this->factory->post->create( array( 'post_title' => 'Test Post 4' ) ),
 		);
 	}
 
@@ -57,7 +58,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_get_items_to_recalculate_no_focus_keywords() {
 		$response = $this->instance->get_items_to_recalculate(1);
 
-		$this->assertEquals(  "", $response );
+		$this->assertEquals( array( 'items' => array(), 'total_items' => 0 ), $response );
 	}
 
 	/**
@@ -75,6 +76,66 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 2, $response['total_items'] );
 		$this->assertTrue( is_array( $response['items'] ) );
 
+	}
+
+	/**
+	 * Test adding content to the post
+	 */
+	public function test_add_content() {
+		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
+
+		$post = get_post($this->posts[1]);
+		$expected = $this->add_dummy_content( $post->post_content );
+
+		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content' ), 10, 2 );
+
+		$response = $this->instance->get_items_to_recalculate(1);
+
+		remove_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content' ) );
+
+		$this->assertEquals( $expected, $response['items'][0]['text'] );
+	}
+
+	/**
+	 * Test adding content to the post with a shortcode
+	 */
+	public function test_add_content_with_shortcode() {
+		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
+
+		$post = get_post($this->posts[1]);
+		$expected = do_shortcode( $this->add_dummy_content_with_shortcode( $post->post_content ) );
+
+		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content_with_shortcode' ), 10, 2 );
+
+		$response = $this->instance->get_items_to_recalculate(1);
+
+		remove_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content_with_shortcode' ) );
+
+		$this->assertEquals( $expected, $response['items'][0]['text'] );
+	}
+
+	/**
+	 * Provide filter dummy data
+	 *
+	 * @param string $content
+	 * @param WP_Post|null $post
+	 *
+	 * @return string
+	 */
+	public function add_dummy_content( $content, WP_Post $post = null ) {
+		return $content . ' _extra_dummy_content_';
+	}
+
+	/**
+	 * Provide filer dummy data with shortcode
+	 *
+	 * @param $content
+	 * @param WP_Post|null $post
+	 *
+	 * @return string
+	 */
+	public function add_dummy_content_with_shortcode( $content, WP_Post $post = null ) {
+		return $content . ' [caption]My Caption[/caption]';
 	}
 
 }

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -80,6 +80,8 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test adding content to the post
+	 *
+	 * @covers WPSEO_Recalculate_Posts::get_items_to_recalculate
 	 */
 	public function test_add_content() {
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
@@ -98,6 +100,8 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test adding content to the post with a shortcode
+	 *
+	 * @covers WPSEO_Recalculate_Posts::get_items_to_recalculate
 	 */
 	public function test_add_content_with_shortcode() {
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );

--- a/tests/recalculate/test-class-recalculate-scores-ajax.php
+++ b/tests/recalculate/test-class-recalculate-scores-ajax.php
@@ -1,8 +1,8 @@
 <?php
+
 /**
  * @package WPSEO\Unittests
  */
-
 class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 
 	private $instance;
@@ -25,12 +25,14 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Get the total of posts to be recalculated with no applicable posts
 	 *
+	 * @covers WPSEO_Recalculate_Scores_Ajax::get_total
 	 */
 	public function test_get_total() {
 		add_filter( 'wp_die_handler', array( $this, 'set_total_response_no_posts' ) );
 
-		$ajax_nonce = wp_create_nonce( "wpseo_recalculate" );
+		$ajax_nonce        = wp_create_nonce( "wpseo_recalculate" );
 		$_REQUEST['nonce'] = $ajax_nonce;
 
 		$this->instance->get_total();
@@ -38,22 +40,36 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 		remove_filter( 'wp_die_handler', array( $this, 'set_total_response_no_posts' ) );
 	}
 
+	/**
+	 * Override die handler for test_get_total()
+	 *
+	 * @param $response
+	 *
+	 * @return array Callable handler for wp_die
+	 */
 	public function set_total_response_no_posts( $response ) {
-		return array($this, 'get_total_response_no_posts');
+		return array( $this, 'get_total_response_no_posts' );
 	}
 
+	/**
+	 * Custom die handler which performs the actual assertion for test_get_total()
+	 *
+	 * @param string $response The result of the execution.
+	 */
 	public function get_total_response_no_posts( $response ) {
-		$object = json_decode($response);
+		$object = json_decode( $response );
 		$this->assertEquals( 0, $object->posts );
 	}
 
 	/**
+	 * Get the total of recalculation posts with posts applicable
 	 *
+	 * @covers WPSEO_Recalculate_Scores_Ajax::get_total
 	 */
 	public function test_get_total_with_posts() {
 		add_filter( 'wp_die_handler', array( $this, 'set_total_response_two_posts' ) );
 
-		$ajax_nonce = wp_create_nonce( "wpseo_recalculate" );
+		$ajax_nonce        = wp_create_nonce( "wpseo_recalculate" );
 		$_REQUEST['nonce'] = $ajax_nonce;
 
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
@@ -64,52 +80,24 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 		remove_filter( 'wp_die_handler', array( $this, 'set_total_response_two_posts' ) );
 	}
 
+	/**
+	 * Override die handler for test_get_total_with_posts()
+	 *
+	 * @param $response
+	 *
+	 * @return array Callable handler for wp_die
+	 */
 	public function set_total_response_two_posts( $response ) {
-		return array($this, 'get_total_response_two_posts');
+		return array( $this, 'get_total_response_two_posts' );
 	}
 
+	/**
+	 * Custom die handler which performs the actual assertion for test_get_total_with_posts()
+	 *
+	 * @param string $response The result of the execution.
+	 */
 	public function get_total_response_two_posts( $response ) {
-		$object = json_decode($response);
+		$object = json_decode( $response );
 		$this->assertEquals( 2, $object->posts );
 	}
-
-	/**
-	 * Recalculate scores
-	 */
-	public function test_recalculate_scores() {
-
-		/**
-		 * We cannot test this, because filter_input is not mockable/overrideable at this moment.
-		 */
-//		$ajax_nonce = wp_create_nonce( "wpseo_recalculate" );
-//		$_REQUEST['nonce'] = $ajax_nonce;
-//
-//		$_POST['paged'] = 1;
-//		$_POST['type'] = 'post';
-//
-//		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
-//		WPSEO_Meta::set_value( 'focuskw', 'testable', $this->posts[3] );
-//
-//		add_filter( 'wp_die_handler', array( $this, 'set_recalculate_post_ajax_catcher' ) );
-//
-//		$this->instance->recalculate_scores();
-//
-//		remove_filter( 'wp_die_handler', array( $this, 'set_recalculate_post_ajax_catcher' ) );
-	}
-
-	/*
-	public function set_recalculate_post_ajax_catcher( $response ) {
-		return array($this, 'get_recalculate_post_ajax_catcher');
-	}
-
-	public function get_recalculate_post_ajax_catcher( $response ) {
-		$object = json_decode( $response );
-		print_r($object);
-	}
-	*/
-
-
-	/**
-	 * Save scores
-	 */
 }

--- a/tests/recalculate/test-class-recalculate-scores-ajax.php
+++ b/tests/recalculate/test-class-recalculate-scores-ajax.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @package WPSEO\Unittests
+ */
+
+class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
+
+	private $instance;
+
+	private $posts = array();
+
+	/**
+	 * Setup the class instance and create some posts
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new WPSEO_Recalculate_Scores_Ajax();
+
+		$this->posts = array(
+			1 => $this->factory->post->create( array( 'post_title' => 'Post with focus keyword' ) ),
+			2 => $this->factory->post->create( array( 'post_title' => 'Test Post 2' ) ),
+			3 => $this->factory->post->create( array( 'post_title' => 'Test Post 3' ) ),
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_total() {
+		add_filter( 'wp_die_handler', array( $this, 'set_total_response_no_posts' ) );
+
+		$ajax_nonce = wp_create_nonce( "wpseo_recalculate" );
+		$_REQUEST['nonce'] = $ajax_nonce;
+
+		$this->instance->get_total();
+
+		remove_filter( 'wp_die_handler', array( $this, 'set_total_response_no_posts' ) );
+	}
+
+	public function set_total_response_no_posts( $response ) {
+		return array($this, 'get_total_response_no_posts');
+	}
+
+	public function get_total_response_no_posts( $response ) {
+		$object = json_decode($response);
+		$this->assertEquals( 0, $object->posts );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_total_with_posts() {
+		add_filter( 'wp_die_handler', array( $this, 'set_total_response_two_posts' ) );
+
+		$ajax_nonce = wp_create_nonce( "wpseo_recalculate" );
+		$_REQUEST['nonce'] = $ajax_nonce;
+
+		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
+		WPSEO_Meta::set_value( 'focuskw', 'testable', $this->posts[3] );
+
+		$this->instance->get_total();
+
+		remove_filter( 'wp_die_handler', array( $this, 'set_total_response_two_posts' ) );
+	}
+
+	public function set_total_response_two_posts( $response ) {
+		return array($this, 'get_total_response_two_posts');
+	}
+
+	public function get_total_response_two_posts( $response ) {
+		$object = json_decode($response);
+		$this->assertEquals( 2, $object->posts );
+	}
+
+	/**
+	 * Recalculate scores
+	 */
+
+	/**
+	 * Save scores
+	 */
+}

--- a/tests/recalculate/test-class-recalculate-scores-ajax.php
+++ b/tests/recalculate/test-class-recalculate-scores-ajax.php
@@ -76,6 +76,38 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Recalculate scores
 	 */
+	public function test_recalculate_scores() {
+
+		/**
+		 * We cannot test this, because filter_input is not mockable/overrideable at this moment.
+		 */
+//		$ajax_nonce = wp_create_nonce( "wpseo_recalculate" );
+//		$_REQUEST['nonce'] = $ajax_nonce;
+//
+//		$_POST['paged'] = 1;
+//		$_POST['type'] = 'post';
+//
+//		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
+//		WPSEO_Meta::set_value( 'focuskw', 'testable', $this->posts[3] );
+//
+//		add_filter( 'wp_die_handler', array( $this, 'set_recalculate_post_ajax_catcher' ) );
+//
+//		$this->instance->recalculate_scores();
+//
+//		remove_filter( 'wp_die_handler', array( $this, 'set_recalculate_post_ajax_catcher' ) );
+	}
+
+	/*
+	public function set_recalculate_post_ajax_catcher( $response ) {
+		return array($this, 'get_recalculate_post_ajax_catcher');
+	}
+
+	public function get_recalculate_post_ajax_catcher( $response ) {
+		$object = json_decode( $response );
+		print_r($object);
+	}
+	*/
+
 
 	/**
 	 * Save scores


### PR DESCRIPTION
Introducing the filters:
`wpseo_post_content_for_recalculation`
`wpseo_term_description_for_recalculation`

Which provide the content of the post/term and allow for modifications and additions.

Added `do_shortcode` to the collected post content to parse all shortcodes.

Added unittests for the changed files.
Some unittests cannot be written because of the `filter_input` being unmockable.

Fixes #3933, #3503