### PR TITLE
Use validation in sitemap transient cache keys

### DIFF
--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -275,7 +275,7 @@ class WPSEO_Sitemaps {
 		if ( ! $this->sitemap || '' == $this->sitemap ) {
 			$this->build_sitemap( $type );
 
-			// 404 for invalid or emtpy sitemaps.
+			// 404 for invalid or empty sitemaps.
 			if ( $this->bad_sitemap ) {
 				$GLOBALS['wp_query']->set_404();
 				status_header( 404 );
@@ -284,7 +284,17 @@ class WPSEO_Sitemaps {
 			}
 
 			if ( $caching ) {
-				set_transient( $sitemap_cache_key, $this->sitemap );
+				/**
+				 * We need to set a timeout, otherwise the transient is loaded every request!
+				 *
+				 * See: https://codex.wordpress.org/Function_Reference/set_transient
+				 * NB: transients that never expire are autoloaded, whereas transients with an expiration time
+				 * are not autoloaded. Consider this when adding transients that may not be needed on every
+				 * page, and thus do not need to be autoloaded, impacting page performance.
+				 *
+				 * Using 24h in seconds: 60*60*24 = 86400
+				 */
+				set_transient( $sitemap_cache_key, $this->sitemap, 86400 );
 			}
 		}
 		else {

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -291,10 +291,8 @@ class WPSEO_Sitemaps {
 				 * NB: transients that never expire are autoloaded, whereas transients with an expiration time
 				 * are not autoloaded. Consider this when adding transients that may not be needed on every
 				 * page, and thus do not need to be autoloaded, impacting page performance.
-				 *
-				 * Using 24h in seconds: 60*60*24 = 86400
 				 */
-				set_transient( $sitemap_cache_key, $this->sitemap, 86400 );
+				set_transient( $sitemap_cache_key, $this->sitemap, DAY_IN_SECONDS );
 			}
 		}
 		else {

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -267,7 +267,9 @@ class WPSEO_Sitemaps {
 
 		if ( $caching ) {
 			do_action( 'wpseo_sitemap_stylesheet_cache_' . $type, $this );
-			$this->sitemap = get_transient( 'wpseo_sitemap_cache_' . $type . '_' . $this->n );
+
+			$sitemap_cache_key = WPSEO_Utils::get_sitemap_cache_key( $type, $this->n );
+			$this->sitemap = get_transient( $sitemap_cache_key );
 		}
 
 		if ( ! $this->sitemap || '' == $this->sitemap ) {
@@ -282,7 +284,7 @@ class WPSEO_Sitemaps {
 			}
 
 			if ( $caching ) {
-				set_transient( 'wpseo_sitemap_cache_' . $type . '_' . $this->n, $this->sitemap, DAY_IN_SECONDS );
+				set_transient( $sitemap_cache_key, $this->sitemap );
 			}
 		}
 		else {

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -721,7 +721,7 @@ class WPSEO_Utils {
 		list( $milliseconds, $seconds ) = explode( ' ', $microtime );
 
 		// Transients are purged every 24h.
-		$seconds      = ( $seconds % 86400 );
+		$seconds      = ( $seconds % DAY_IN_SECONDS );
 		$milliseconds = substr( $milliseconds, 2, 5 );
 
 		// Combine seconds and milliseconds and convert to integer.

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -563,7 +563,7 @@ class WPSEO_Utils {
 
 		// Clear only validator cache for type.
 		if ( ! is_null( $validator ) && ! is_null( $type ) ) {
-			// clear all cache.
+			// Clear all cache.
 			$where = sprintf( "option_name LIKE '_transient_%%_%s'", $validator );
 		}
 
@@ -577,9 +577,9 @@ class WPSEO_Utils {
 	 * Get the cache key for a certain type and page
 	 *
 	 * @param null|string $type The type to get the key for. Null or '1' for index cache.
-	 * @param int $page The page of cache to get the key for.
+	 * @param int         $page The page of cache to get the key for.
 	 *
-	 * @return string
+	 * @return string The key where the cache is stored on.
 	 */
 	public static function get_sitemap_cache_key( $type = null, $page = 1 ) {
 		// Using '1' for index "type".
@@ -613,16 +613,19 @@ class WPSEO_Utils {
 	private static function get_safe_sitemap_cache_type( $type, $prefix = '', $postfix = '' ) {
 		// Length of key should not be over 53.
 		$max_length = 53;
-		$max_length -= strlen($prefix);
-		$max_length -= strlen($postfix);
+		$max_length -= strlen( $prefix );
+		$max_length -= strlen( $postfix );
 
 		// If we go below 15 problems with overlap will surely occur.
 		$max_length = max( 15, $max_length );
 
 		if ( strlen( $type ) > $max_length ) {
-			$half = $max_length / 2;
+			$half = ( $max_length / 2 );
 
-			$type = substr( $type, 0, ceil( $half ) - 1 ) . '..' . substr( $type, 0 - ( floor( $half ) - 1 ) );
+			$first_part = substr( $type, 0, ( ceil( $half ) - 1 ) );
+			$last_part  = substr( $type, ( - 1 - floor( $half ) ) );
+
+			$type = $first_part . '..' . $last_part;
 		}
 
 		return $type;
@@ -688,7 +691,7 @@ class WPSEO_Utils {
 		list( $milliseconds, $seconds ) = explode( ' ', $microtime );
 
 		// Transients are purged every 24h.
-		$seconds      = $seconds % 86400;
+		$seconds      = ( $seconds % 86400 );
 		$milliseconds = substr( $milliseconds, 2, 5 );
 
 		// Combine seconds and milliseconds and convert to integer.
@@ -703,11 +706,13 @@ class WPSEO_Utils {
 	/**
 	 * Encode to base61 format.
 	 *
-	 * This is base64 (numeric + alhpa + alpha upper case) without the 0
+	 * This is base64 (numeric + alhpa + alpha upper case) without the 0.
 	 *
-	 * @param int $input The number that has to be converted to base 61
+	 * @param int $input The number that has to be converted to base 61.
 	 *
 	 * @return string Base 61 converted string.
+	 *
+	 * @throws InvalidArgumentException When the input is not an integer.
 	 */
 	public static function convert_base10_to_base61( $input ) {
 		if ( ! is_int( $input ) ) {
@@ -717,11 +722,11 @@ class WPSEO_Utils {
 		$characters = '123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 		$length     = strlen( $characters );
 
-		$index    = $input % $length;
+		$index    = ( $input % $length );
 		$output   = $characters[ $index ];
 		$position = floor( $input / $length );
 		while ( $position ) {
-			$index    = $position % $length;
+			$index    = ( $position % $length );
 			$output   = $characters[ $index ] . $output;
 			$position = floor( $position / $length );
 		}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -706,7 +706,7 @@ class WPSEO_Utils {
 	/**
 	 * Encode to base61 format.
 	 *
-	 * This is base64 (numeric + alhpa + alpha upper case) without the 0.
+	 * This is base64 (numeric + alpha + alpha upper case) without the 0.
 	 *
 	 * @param int $input The number that has to be converted to base 61.
 	 *

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -647,7 +647,12 @@ class WPSEO_Utils {
 				 * So this would not happen unintentionally..
 				 * Either by trying to cause a high server load, finding backdoors or misconfiguration.
 				 */
-				throw new OutOfRangeException( 'Trying to build a safe sitemap cache key, but the postfix and prefix combination leaves too little room to do this. You are probably requesting a page that is way out of expected range.' );
+				throw new OutOfRangeException(
+					__(
+						'Trying to build a safe sitemap cache key, but the postfix and prefix combination leaves too little room to do this. You are probably requesting a page that is way out of the expected range.',
+						'wordpress-seo'
+					)
+				);
 			}
 
 			$half = ( $max_length / 2 );
@@ -746,7 +751,7 @@ class WPSEO_Utils {
 	 */
 	public static function convert_base10_to_base61( $input ) {
 		if ( ! is_int( $input ) ) {
-			throw new InvalidArgumentException( 'Expected integer as input.' );
+			throw new InvalidArgumentException( __( 'Expected an integer as input.', 'wordpress-seo' ) );
 		}
 
 		$characters = '123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -754,10 +759,12 @@ class WPSEO_Utils {
 
 		$index    = ( $input % $length );
 		$output   = $characters[ $index ];
+
 		$position = floor( $input / $length );
 		while ( $position ) {
 			$index    = ( $position % $length );
 			$output   = $characters[ $index ] . $output;
+
 			$position = floor( $position / $length );
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -615,15 +615,28 @@ class WPSEO_Utils {
 	 * @param string $postfix The part after the type in the cache key. Only the length is used.
 	 *
 	 * @return string The type with a safe length to use
+	 *
+	 * @throws Exception
 	 */
 	private static function get_safe_sitemap_cache_type( $type, $prefix = '', $postfix = '' ) {
 		// Length of key should not be over 53.
-		$max_length = 53 - ( strlen( $prefix ) + strlen( $postfix ) );
-
-		// If we go below 15 problems with overlap will surely occur.
-		$max_length = max( 15, $max_length );
+		$max_length = 53;
+		$max_length -= strlen( $prefix );
+		$max_length -= strlen( $postfix );
 
 		if ( strlen( $type ) > $max_length ) {
+
+			if ( $max_length < 15 ) {
+				/**
+				 * If this happens the most likely cause is a 'page' that is too big.
+				 * "Normally" the max_length is 24 + strlen( page ), which is unlikely to go above 10 in the first place.
+				 *
+				 * So this would not happen unintentionally..
+				 * Either by trying to cause a high server load, finding backdoors or misconfiguration.
+				 */
+				throw new OutOfRangeException( 'Trying to build a safe sitemap cache key, but the postfix and prefix combination leaves too little room to do this. You are probably requesting a page that is way out of expected range.' );
+			}
+
 			$half = ( $max_length / 2 );
 
 			$first_part = substr( $type, 0, ( ceil( $half ) - 1 ) );

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -26,7 +26,7 @@ class WPSEO_Utils {
 	/**
 	 * @var string Sitemap Cache key prefix
 	 */
-	private static $sitemap_cache_key_prefix = 'wpseo_sitemap_';
+	private static $sitemap_cache_key_prefix = 'yst_sm_';
 
 	const SITEMAP_INDEX_TYPE = '1';
 
@@ -633,6 +633,7 @@ class WPSEO_Utils {
 	private static function get_safe_sitemap_cache_type( $type, $prefix = '', $postfix = '' ) {
 		// Length of key should not be over 53.
 		$max_length = 53;
+		$max_length -= strlen( 'timeout_' );
 		$max_length -= strlen( $prefix );
 		$max_length -= strlen( $postfix );
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -616,7 +616,7 @@ class WPSEO_Utils {
 	 *
 	 * @return string The type with a safe length to use
 	 *
-	 * @throws Exception
+	 * @throws OutOfRangeException When there is less than 15 characters of space for a key that is originally longer.
 	 */
 	private static function get_safe_sitemap_cache_type( $type, $prefix = '', $postfix = '' ) {
 		// Length of key should not be over 53.

--- a/tests/sitemap-cache/test-class-wpseo-sitemaps.php
+++ b/tests/sitemap-cache/test-class-wpseo-sitemaps.php
@@ -1,7 +1,0 @@
-<?php
-
-
-// test redirect fetching of cache
-/**
- * WPSEO_Sitemaps -> output todo
- */

--- a/tests/sitemap-cache/test-class-wpseo-sitemaps.php
+++ b/tests/sitemap-cache/test-class-wpseo-sitemaps.php
@@ -1,0 +1,7 @@
+<?php
+
+
+// test redirect fetching of cache
+/**
+ * WPSEO_Sitemaps -> output todo
+ */

--- a/tests/sitemap-cache/test-class-wpseo-utils.php
+++ b/tests/sitemap-cache/test-class-wpseo-utils.php
@@ -8,18 +8,18 @@
  *
  * Public
  *
- * ::register_cache_clear_option to-do
+ * ::register_cache_clear_option .done
  * ::clear_transient_cache - can't be done.
- * ::get_sitemap_cache_validator_key to do
- * ::get_sitemap_cache_key todo
- * ::clear_sitemap_cache todo
- * ::invalidate_sitemap_cache todo
+ * ::get_sitemap_cache_validator_key .done
+ * ::get_sitemap_cache_key .done
+ * ::clear_sitemap_cache .done
  *
  * Private (determine by coverage)
  *
- * ::new_sitemap_cache_validator
- * ::get_sitemap_cache_validator
- * ::get_safe_sitemap_cache_type
+ * ::invalidate_sitemap_cache .implied
+ * ::new_sitemap_cache_validator .implied
+ * ::get_sitemap_cache_validator .implied
+ * ::get_safe_sitemap_cache_type .implied
  */
 class WPSEO_Utils_Sitemap_Cache_Test extends WPSEO_UnitTestCase {
 

--- a/tests/sitemap-cache/test-class-wpseo-utils.php
+++ b/tests/sitemap-cache/test-class-wpseo-utils.php
@@ -8,16 +8,206 @@
  *
  * Public
  *
- * ::register_cache_clear_option todo
+ * ::register_cache_clear_option to-do
+ * ::clear_transient_cache - can't be done.
+ * ::get_sitemap_cache_validator_key to do
  * ::get_sitemap_cache_key todo
- * ::clear_transient_cache todo
  * ::clear_sitemap_cache todo
  * ::invalidate_sitemap_cache todo
  *
  * Private (determine by coverage)
  *
  * ::new_sitemap_cache_validator
- * ::get_sitemap_cache_validator_key
  * ::get_sitemap_cache_validator
  * ::get_safe_sitemap_cache_type
  */
+class WPSEO_Utils_Sitemap_Cache_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Test the building of cache keys
+	 */
+	public function test_get_sitemap_cache_validator_key_global() {
+		$result = WPSEO_Utils::get_sitemap_cache_validator_key();
+
+		$this->assertEquals( 'wpseo_sitemap_cache_validator_global', $result );
+	}
+
+	/**
+	 * Test the building of cache keys
+	 */
+	public function test_get_sitemap_cache_validator_key_type() {
+		$type     = 'blabla';
+		$expected = sprintf( 'wpseo_sitemap_%s_cache_validator', $type );
+
+		$result = WPSEO_Utils::get_sitemap_cache_validator_key( $type );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Normal cache key retrieval
+	 */
+	public function test_get_sitemap_cache_key() {
+		$n                = 1;
+		$type             = 'page';
+		$global_validator = 'global';
+		$type_validator   = 'type';
+
+		$global_validator_key = WPSEO_Utils::get_sitemap_cache_validator_key();
+		update_option( $global_validator_key, $global_validator );
+
+		$type_validator_key = WPSEO_Utils::get_sitemap_cache_validator_key( $type );
+		update_option( $type_validator_key, $type_validator );
+
+		$prefix  = WPSEO_Utils::get_sitemap_cache_key_prefix();
+		$postfix = sprintf( ':%d:%s:%s', $n, $global_validator, $type_validator );
+
+		$expected = $prefix . $type . $postfix;
+
+		// Act
+		$result = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+
+		// Assert
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Key length should never be over 53 characters
+	 */
+	public function test_get_sitemap_cache_key_very_long_type() {
+		$n    = 1;
+		$type = str_repeat( 'a', 60 );
+
+		// Act
+		$result = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+
+		// Assert
+		$this->assertEquals( 53, strlen( $result ) );
+	}
+
+	/**
+	 * Clearing all cache.
+	 */
+	public function test_clear_sitemap_cache() {
+		$type         = 'page';
+		$n            = 1;
+		$test_content = 'test_content';
+
+		$cache_key = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+		set_transient( $cache_key, $test_content );
+
+		// Clear all.
+		WPSEO_Utils::clear_sitemap_cache();
+
+		// Get the key again.
+		$cache_key = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+		$content   = get_transient( $cache_key );
+
+		$this->assertEmpty( $content );
+	}
+
+	/**
+	 * Clearing specific cache.
+	 */
+	public function test_clear_sitemap_cache_type() {
+		$type         = 'page';
+		$n            = 1;
+		$test_content = 'test_content';
+
+		$cache_key = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+		set_transient( $cache_key, $test_content );
+
+		// Clear specific cache.
+		WPSEO_Utils::clear_sitemap_cache( array( $type ) );
+
+		// Get the key again.
+		$cache_key = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+		$result    = get_transient( $cache_key );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Clearing specific cache should also clear index.
+	 */
+	public function test_clear_sitemap_cache_index_also_cleared() {
+		$test_index_content = 'test_content';
+
+		$index_cache_key = WPSEO_Utils::get_sitemap_cache_key();
+		set_transient( $index_cache_key, $test_index_content );
+
+		// Clear specific cache.
+		WPSEO_Utils::clear_sitemap_cache( array( 'page' ) );
+
+		// Get the key again.
+		$index_cache_key = WPSEO_Utils::get_sitemap_cache_key();
+		$result          = get_transient( $index_cache_key );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Clearing specific cache should not touch other type.
+	 */
+	public function test_clear_sitemap_cache_type_isolation() {
+		$type_a         = 'page';
+		$type_a_content = 'content_a';
+
+		$type_b         = 'post';
+		$type_b_content = 'content_b';
+
+		$type_a_key = WPSEO_Utils::get_sitemap_cache_key( $type_a );
+		set_transient( $type_a_key, $type_a_content );
+
+		$type_b_key = WPSEO_Utils::get_sitemap_cache_key( $type_b );
+		set_transient( $type_b_key, $type_b_content );
+
+		// Clear specific cache.
+		WPSEO_Utils::clear_sitemap_cache( array( $type_a ) );
+
+		// Get the key again.
+		$type_b_key = WPSEO_Utils::get_sitemap_cache_key( $type_b );
+		$result     = get_transient( $type_b_key );
+
+		$this->assertEquals( $type_b_content, $result );
+	}
+
+	/**
+	 * Make sure the hook is registered on registration
+	 */
+	public function test_register_cache_clear_option() {
+		$option = 'test_option';
+
+		$function = array( 'WPSEO_Utils', 'clear_transient_cache' );
+		$hook     = 'update_option';
+
+		WPSEO_Utils::register_cache_clear_option( $option );
+
+		// Hook will be added on default priority.
+		$this->assertEquals( 10, has_action( $hook, $function ) );
+	}
+
+	/**
+	 * Option update should clear cache for registered type.
+	 */
+	public function test_clear_transient_cache() {
+		$type         = 'page';
+		$n            = 1;
+		$test_content = 'test_content';
+		$option       = 'my_option';
+
+		WPSEO_Utils::register_cache_clear_option( $option, $type );
+
+		$cache_key = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+		set_transient( $cache_key, $test_content );
+
+		// Updating the option should clear cache for specified type.
+		do_action( 'update_option', $option );
+
+		// Get the key again.
+		$cache_key = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
+		$result    = get_transient( $cache_key );
+
+		$this->assertEmpty( $result );
+	}
+}

--- a/tests/sitemap-cache/test-class-wpseo-utils.php
+++ b/tests/sitemap-cache/test-class-wpseo-utils.php
@@ -1,0 +1,23 @@
+<?php
+
+// only test sitemap cache functions
+// these will be moved to the new structure in 3.2
+
+/**
+ * apply_filters( 'wpseo_enable_xml_sitemap_transient_caching', true ); -- only applicable for retrieval (awesome!)
+ *
+ * Public
+ *
+ * ::register_cache_clear_option todo
+ * ::get_sitemap_cache_key todo
+ * ::clear_transient_cache todo
+ * ::clear_sitemap_cache todo
+ * ::invalidate_sitemap_cache todo
+ *
+ * Private (determine by coverage)
+ *
+ * ::new_sitemap_cache_validator
+ * ::get_sitemap_cache_validator_key
+ * ::get_sitemap_cache_validator
+ * ::get_safe_sitemap_cache_type
+ */

--- a/tests/sitemap-cache/test-class-wpseo-utils.php
+++ b/tests/sitemap-cache/test-class-wpseo-utils.php
@@ -60,7 +60,7 @@ class WPSEO_Utils_Sitemap_Cache_Test extends WPSEO_UnitTestCase {
 		update_option( $type_validator_key, $type_validator );
 
 		$prefix  = WPSEO_Utils::get_sitemap_cache_key_prefix();
-		$postfix = sprintf( ':%d:%s:%s', $n, $global_validator, $type_validator );
+		$postfix = sprintf( '_%d:%s_%s', $n, $global_validator, $type_validator );
 
 		$expected = $prefix . $type . $postfix;
 
@@ -72,7 +72,9 @@ class WPSEO_Utils_Sitemap_Cache_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Key length should never be over 53 characters
+	 * Key length should never be over 45 characters
+	 *
+	 * This would be 53 if we don't use a timeout, but we can't because all sitemaps would be autoloaded every request.
 	 */
 	public function test_get_sitemap_cache_key_very_long_type() {
 		$n    = 1;
@@ -82,7 +84,7 @@ class WPSEO_Utils_Sitemap_Cache_Test extends WPSEO_UnitTestCase {
 		$result = WPSEO_Utils::get_sitemap_cache_key( $type, $n );
 
 		// Assert
-		$this->assertEquals( 53, strlen( $result ) );
+		$this->assertEquals( 45, strlen( $result ) );
 	}
 
 	/**

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -125,4 +125,12 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 			array( 100, false, 'Good' ),
 		);
 	}
+
+	/**
+	 * Test base 10 to base 61 converter
+	 *
+	 * @covers WPSEO_Utils::convert_base10_to_base61
+	 *
+	 * todo: make
+	 */
 }

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -131,6 +131,25 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Utils::convert_base10_to_base61
 	 *
-	 * todo: make
 	 */
+	public function test_base_10_to_base_61() {
+		// Because of not using 0, everything has an offset.
+		$this->assertEquals( '1', WPSEO_Utils::convert_base10_to_base61(0) );
+		$this->assertEquals( '2', WPSEO_Utils::convert_base10_to_base61(1) );
+		$this->assertEquals( 'Z', WPSEO_Utils::convert_base10_to_base61(60) );
+
+		// Not using 10, because 0 offsets all positions -> 1+1=2, 0+1=1, makes 21 (this is a string not a number!)
+		$this->assertEquals( '21', WPSEO_Utils::convert_base10_to_base61(61) );
+		$this->assertEquals( '22', WPSEO_Utils::convert_base10_to_base61(62) );
+		$this->assertEquals( '32', WPSEO_Utils::convert_base10_to_base61(123) );
+
+		$this->assertEquals( 'iINbb6W', WPSEO_Utils::convert_base10_to_base61(912830912830) );
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function test_base_10_to_base_61_non_integer() {
+		WPSEO_Utils::convert_base10_to_base61('ab');
+	}
 }


### PR DESCRIPTION
Instead of clearing Sitemap transient cache by removing specific keys, we now have validators added to the key. 
This way cache can be invalidated by just changing the validator.

For a full description and approach see https://github.com/Yoast/wordpress-seo/pull/3769#issuecomment-183657771
Originally from #3769
This moves the last bit out of that PR, the other fixes have already been moved to other PRs.

Fixes #3708