### PR TITLE
WP Importing performance improvement (PR cleanup)

### DIFF
--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -176,6 +176,6 @@ class WPSEO_Sitemaps_Admin {
 			do_action( 'wpseo_hit_sitemap_index' );
 		}
 
-		wpseo_ping_search_engines();
+		WPSEO_Sitemaps::ping_search_engines();
 	}
 } /* End of class */

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -77,12 +77,19 @@ class WPSEO_Sitemaps_Admin {
 			return;
 		}
 
-		wp_cache_delete( 'lastpostmodified:gmt:' . $post->post_type, 'timeinfo' ); // #17455.
+		$post_type = get_post_type( $post );
+
+		wp_cache_delete( 'lastpostmodified:gmt:' . $post_type, 'timeinfo' ); // #17455.
+
+		// None of our interest..
+		if ( 'nav_menu_item' === $post_type ) {
+			return;
+		}
 
 		$options = WPSEO_Options::get_options( array( 'wpseo_xml', 'wpseo_titles' ) );
 
 		// If the post type is excluded in options, we can stop.
-		$option = sprintf( 'post_types-%s-not_in_sitemap', $post->post_type );
+		$option = sprintf( 'post_types-%s-not_in_sitemap', $post_type );
 		if ( isset( $options[ $option ] ) && $options[ $option ] === true ) {
 			return;
 		}
@@ -123,12 +130,7 @@ class WPSEO_Sitemaps_Admin {
 	 * @param \WP_Post $post       Post object.
 	 */
 	private function status_transition_bulk( $new_status, $old_status, $post ) {
-		// None of our interest..
-		if ( 'nav_menu_item' === $post->post_type ) {
-			return;
-		}
-
-		$this->importing_post_types[] = $post->post_type;
+		$this->importing_post_types[] = get_post_type( $post );
 		$this->importing_post_types   = array_unique( $this->importing_post_types );
 	}
 
@@ -150,6 +152,11 @@ class WPSEO_Sitemaps_Admin {
 
 		foreach ( $this->importing_post_types as $post_type ) {
 			wp_cache_delete( 'lastpostmodified:gmt:' . $post_type, 'timeinfo' ); // #17455.
+
+			// Just have the cache deleted for nav_menu_item.
+			if ( 'nav_menu_item' === $post_type ) {
+				continue;
+			}
 
 			$option = sprintf( 'post_types-%s-not_in_sitemap', $post_type );
 			if ( ! isset( $options[ $option ] ) || $options[ $option ] === false ) {

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -67,23 +67,23 @@ class WPSEO_Sitemaps_Admin {
 	 * @param \WP_Post $post       Post object.
 	 */
 	public function status_transition( $new_status, $old_status, $post ) {
+		if ( $new_status !== 'publish' ) {
+			return;
+		}
+
 		if ( defined( 'WP_IMPORTING' ) ) {
 			$this->status_transition_bulk( $new_status, $old_status, $post );
 
 			return;
 		}
 
-		if ( $new_status != 'publish' ) {
-			return;
-		}
-
 		wp_cache_delete( 'lastpostmodified:gmt:' . $post->post_type, 'timeinfo' ); // #17455.
 
 		$options = WPSEO_Options::get_options( array( 'wpseo_xml', 'wpseo_titles' ) );
-		if (
-			( isset( $options[ 'post_types-' . $post->post_type . '-not_in_sitemap' ] ) && $options[ 'post_types-' . $post->post_type . '-not_in_sitemap' ] === true )
-			|| ( $post->post_type === 'nav_menu_item' )
-		) {
+
+		// If the post type is excluded in options, we can stop.
+		$option = sprintf( 'post_types-%s-not_in_sitemap', $post->post_type );
+		if ( isset( $options[ $option ] ) && $options[ $option ] === true ) {
 			return;
 		}
 
@@ -123,14 +123,6 @@ class WPSEO_Sitemaps_Admin {
 	 * @param \WP_Post $post       Post object.
 	 */
 	private function status_transition_bulk( $new_status, $old_status, $post ) {
-		if ( ! defined( 'WP_IMPORTING' ) ) {
-			return;
-		}
-
-		if ( $new_status != 'publish' ) {
-			return;
-		}
-
 		// None of our interest..
 		if ( 'nav_menu_item' === $post->post_type ) {
 			return;

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -156,16 +156,14 @@ class WPSEO_Sitemaps_Admin {
 
 		$ping_search_engines = false;
 
-		do {
-			$post_type = array_shift( $this->importing_post_types );
-
+		foreach ( $this->importing_post_types as $post_type ) {
 			wp_cache_delete( 'lastpostmodified:gmt:' . $post_type, 'timeinfo' ); // #17455.
 
 			$option = sprintf( 'post_types-%s-not_in_sitemap', $post_type );
 			if ( ! isset( $options[ $option ] ) || $options[ $option ] === false ) {
 				$ping_search_engines = true;
 			}
-		} while ( ! empty( $this->importing_post_types ) );
+		}
 
 		// Nothing to do.
 		if ( false === $ping_search_engines ) {

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -8,17 +8,21 @@
  */
 class WPSEO_Sitemaps_Admin {
 
+	/**
+	 * @var array Post_types that are being imported.
+	 */
 	static $importing_post_types = array();
 
 	/**
 	 * Class constructor
 	 */
 	function __construct() {
-		if ( defined('WP_IMPORTING') && WP_IMPORTING === true ) {
+		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING === true ) {
 			add_action( 'transition_post_status', array( $this, 'status_transition' ), 10, 3 );
-		} else {
+		}
+		else {
 			add_action( 'transition_post_status', array( $this, 'status_transition_bulk' ), 10, 3 );
-			add_action( 'admin_footer', array( $this, 'status_transition_bulk_finished') );
+			add_action( 'admin_footer', array( $this, 'status_transition_bulk_finished' ) );
 		}
 
 		add_action( 'admin_init', array( $this, 'delete_sitemaps' ) );
@@ -148,7 +152,7 @@ class WPSEO_Sitemaps_Admin {
 
 			wp_cache_delete( 'lastpostmodified:gmt:' . $post_type, 'timeinfo' ); // #17455.
 
-			$option = sprintf('post_types-%s-not_in_sitemap', $post_type);
+			$option = sprintf( 'post_types-%s-not_in_sitemap', $post_type );
 			if ( ! isset( $options[ $option ] ) || $options[ $option ] !== true ) {
 				$ping_search_engines = true;
 			}

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -17,7 +17,7 @@ class WPSEO_Sitemaps_Admin {
 	 * Class constructor
 	 */
 	function __construct() {
-		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING === true ) {
+		if ( ! defined( 'WP_IMPORTING' ) ) {
 			add_action( 'transition_post_status', array( $this, 'status_transition' ), 10, 3 );
 		}
 		else {


### PR DESCRIPTION
Separated import and normal post_status changes.
Bulk handle changed post_types after bulk is completed.

This will speed up importing quite a bit without losing expected functionality.

Fixes #3937
Cleaned up version of https://github.com/Yoast/wordpress-seo/pull/3888