### PR TITLE
Fix stop words filtering

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -360,6 +360,39 @@ function ajax_get_term_keyword_usage() {
 
 add_action( 'wp_ajax_get_term_keyword_usage',  'ajax_get_term_keyword_usage' );
 
+/**
+ * Removes stopword from the sample permalink that is generated in an AJAX request
+ *
+ * @param array  $permalink The permalink generated for this post by WordPress.
+ * @param int    $post_ID The ID of the post.
+ * @param string $title The title for the post that the user used.
+ * @param string $name The name for the post that the user used.
+ *
+ * @return array
+ */
+function wpseo_remove_stopwords_sample_permalink( $permalink, $post_ID, $title, $name ) {
+	WPSEO_Options::get_instance();
+	$options = WPSEO_Options::get_options( array( 'wpseo_permalinks' ) );
+	if ( $options['cleanslugs'] !== true ) {
+		return $permalink;
+	}
+
+	/*
+	 * If the name is empty and the title is not, WordPress will generate a slug. In that case we want to remove stop
+	 * words from the slug.
+	 */
+	if ( empty( $name ) && ! empty( $title ) ) {
+		$stop_words = new WPSEO_Admin_Stop_Words();
+
+		// The second element is the slug.
+		$permalink[1] = $stop_words->remove_in( $permalink[1] );
+	}
+
+	return $permalink;
+}
+
+add_action( 'get_sample_permalink', 'wpseo_remove_stopwords_sample_permalink', 10, 4 );
+
 // Crawl Issue Manager AJAX hooks.
 new WPSEO_GSC_Ajax;
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -562,47 +562,30 @@ class WPSEO_Admin {
 		}
 
 		// Lowercase the slug and strip slashes.
-		$clean_slug = sanitize_title( stripslashes( $post_title ) );
+		$new_slug = sanitize_title( stripslashes( $post_title ) );
 
-		// Turn it to an array and strip stopwords by comparing against an array of stopwords.
-		$clean_slug_array = array_diff( explode( '-', $clean_slug ), $this->stopwords() );
-
-		// Don't change the slug if there are less than 3 words left.
-		if ( count( $clean_slug_array ) < 3 ) {
-			return $clean_slug;
-		}
-
-		// Turn the sanitized array into a string.
-		$clean_slug = join( '-', $clean_slug_array );
-
-		return $clean_slug;
+		$stop_words = new WPSEO_Admin_Stop_Words();
+		return $stop_words->remove_in( $new_slug );
 	}
 
 	/**
 	 * Returns the stopwords for the current language
 	 *
 	 * @since 1.1.7
+	 * @deprecated 3.1 Use WPSEO_Admin_Stop_Words::list_stop_words() instead.
 	 *
 	 * @return array $stopwords array of stop words to check and / or remove from slug
 	 */
 	function stopwords() {
-		/* translators: this should be an array of stopwords for your language, separated by comma's. */
-		$stopwords = explode( ',', __( "a,about,above,after,again,against,all,am,an,and,any,are,as,at,be,because,been,before,being,below,between,both,but,by,could,did,do,does,doing,down,during,each,few,for,from,further,had,has,have,having,he,he'd,he'll,he's,her,here,here's,hers,herself,him,himself,his,how,how's,i,i'd,i'll,i'm,i've,if,in,into,is,it,it's,its,itself,let's,me,more,most,my,myself,nor,of,on,once,only,or,other,ought,our,ours,ourselves,out,over,own,same,she,she'd,she'll,she's,should,so,some,such,than,that,that's,the,their,theirs,them,themselves,then,there,there's,these,they,they'd,they'll,they're,they've,this,those,through,to,too,under,until,up,very,was,we,we'd,we'll,we're,we've,were,what,what's,when,when's,where,where's,which,while,who,who's,whom,why,why's,with,would,you,you'd,you'll,you're,you've,your,yours,yourself,yourselves", 'wordpress-seo' ) );
-
-		/**
-		 * Allows filtering of the stop words list
-		 * Especially useful for users on a language in which WPSEO is not available yet
-		 * and/or users who want to turn off stop word filtering
-		 * @api  array  $stopwords  Array of all lowercase stopwords to check and/or remove from slug
-		 */
-		$stopwords = apply_filters( 'wpseo_stopwords', $stopwords );
-
-		return $stopwords;
+		$stop_words = new WPSEO_Admin_Stop_Words();
+		return $stop_words->list_stop_words();
 	}
 
 
 	/**
 	 * Check whether the stopword appears in the string
+	 *
+	 * @deprecated 3.1
 	 *
 	 * @param string $haystack    The string to be checked for the stopword.
 	 * @param bool   $checkingUrl Whether or not we're checking a URL.

--- a/admin/class-stop-words.php
+++ b/admin/class-stop-words.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Manages stop words and filtering stop words from slugs
+ */
+class WPSEO_Admin_Stop_Words {
+	/**
+	 * Removes stop words in a slug
+	 *
+	 * @param string $original_slug The slug to remove stop words in.
+	 *
+	 * @return string
+	 */
+	public function remove_in( $original_slug ) {
+		// Turn it to an array and strip stop words by comparing against an array of stopwords.
+		$new_slug_parts = array_diff( explode( '-', $original_slug ), $this->list_stop_words() );
+
+		// Don't change the slug if there are less than 3 words left.
+		if ( count( $new_slug_parts ) < 3 ) {
+			return $original_slug;
+		}
+
+		// Turn the sanitized array into a string.
+		$new_slug = join( '-', $new_slug_parts );
+
+		return $new_slug;
+	}
+
+	/**
+	 * Returns a translated, filtered list of stop words
+	 *
+	 * @return array An array of stop words.
+	 */
+	public function list_stop_words() {
+		/* translators: this should be an array of stop words for your language, separated by comma's. */
+		$stopwords = explode( ',', __( "a,about,above,after,again,against,all,am,an,and,any,are,as,at,be,because,been,before,being,below,between,both,but,by,could,did,do,does,doing,down,during,each,few,for,from,further,had,has,have,having,he,he'd,he'll,he's,her,here,here's,hers,herself,him,himself,his,how,how's,i,i'd,i'll,i'm,i've,if,in,into,is,it,it's,its,itself,let's,me,more,most,my,myself,nor,of,on,once,only,or,other,ought,our,ours,ourselves,out,over,own,same,she,she'd,she'll,she's,should,so,some,such,than,that,that's,the,their,theirs,them,themselves,then,there,there's,these,they,they'd,they'll,they're,they've,this,those,through,to,too,under,until,up,very,was,we,we'd,we'll,we're,we've,were,what,what's,when,when's,where,where's,which,while,who,who's,whom,why,why's,with,would,you,you'd,you'll,you're,you've,your,yours,yourself,yourselves", 'wordpress-seo' ) );
+
+		/**
+		 * Allows filtering of the stop words list
+		 * Especially useful for users on a language in which WPSEO is not available yet
+		 * and/or users who want to turn off stop word filtering
+		 * @api  array  $stopwords  Array of all lowercase stop words to check and/or remove from slug
+		 */
+		$stopwords = apply_filters( 'wpseo_stopwords', $stopwords );
+
+		return $stopwords;
+	}
+}

--- a/tests/admin/test-class-stop-words.php
+++ b/tests/admin/test-class-stop-words.php
@@ -16,7 +16,7 @@ class WPSEO_Admin_Stop_WordsTest extends PHPUnit_Framework_TestCase {
 	public function test_remove_stop_words() {
 		$original = 'and-without-about-stop-blaat-words';
 		$expected = 'without-stop-words';
-		$subject = $this->getMock( WPSEO_Admin_Stop_Words::class, array( 'list_stop_words' ) );
+		$subject = $this->getMock( 'WPSEO_Admin_Stop_Words', array( 'list_stop_words' ) );
 
 		$subject->method( 'list_stop_words' )
 			->willReturn( array( 'and', 'about', 'blaat' ) );

--- a/tests/admin/test-class-stop-words.php
+++ b/tests/admin/test-class-stop-words.php
@@ -1,0 +1,46 @@
+<?php
+
+class WPSEO_Admin_Stop_WordsTest extends PHPUnit_Framework_TestCase {
+	/**
+	 * @var WPSEO_Admin_Stop_Words
+	 */
+	protected $subject;
+
+	public function setUp() {
+		$this->subject = new WPSEO_Admin_Stop_Words();
+	}
+
+	/**
+	 * @cover WPSEO_Admin_Stop_Words:remove_in
+	 */
+	public function test_remove_stop_words() {
+		$original = 'and-without-about-stop-blaat-words';
+		$expected = 'without-stop-words';
+		$subject = $this->getMock( WPSEO_Admin_Stop_Words::class, array( 'list_stop_words' ) );
+
+		$subject->method( 'list_stop_words' )
+			->willReturn( array( 'and', 'about', 'blaat' ) );
+
+		/* @type WPSEO_Admin_Stop_Words $subject */
+		$this->assertEquals( $expected, $subject->remove_in( $original ) );
+	}
+
+	/**
+	 * @cover WPSEO_Admin_Stop_Words:remove_in
+	 */
+	public function test_remove_stop_words_EMPTY() {
+		$original = '';
+		$expected = '';
+
+		$this->assertEquals( $expected, $this->subject->remove_in( $original ) );
+	}
+
+	/**
+	 * Check if list_stop_words works and throws no errors
+	 */
+	public function test_stop_words() {
+		$stopwords = $this->subject->list_stop_words();
+
+		$this->assertTrue( is_array( $stopwords ) );
+	}
+}

--- a/tests/admin/test-class-stop-words.php
+++ b/tests/admin/test-class-stop-words.php
@@ -21,7 +21,7 @@ class WPSEO_Admin_Stop_WordsTest extends PHPUnit_Framework_TestCase {
 		$subject
 			->expects( $this->once() )
 			->method( 'list_stop_words' )
-			->willReturn( array( 'and', 'about', 'blaat' ) );
+			->will( $this->returnValue( array( 'and', 'about', 'blaat' ) ) );
 
 		/* @type WPSEO_Admin_Stop_Words $subject */
 		$this->assertEquals( $expected, $subject->remove_in( $original ) );

--- a/tests/admin/test-class-stop-words.php
+++ b/tests/admin/test-class-stop-words.php
@@ -18,7 +18,9 @@ class WPSEO_Admin_Stop_WordsTest extends PHPUnit_Framework_TestCase {
 		$expected = 'without-stop-words';
 		$subject = $this->getMock( 'WPSEO_Admin_Stop_Words', array( 'list_stop_words' ) );
 
-		$subject->method( 'list_stop_words' )
+		$subject
+			->expects( $this->once() )
+			->method( 'list_stop_words' )
 			->willReturn( array( 'and', 'about', 'blaat' ) );
 
 		/* @type WPSEO_Admin_Stop_Words $subject */


### PR DESCRIPTION
Stop words filtering was broken because it assumes the post name is
empty before it will filter stop words. Because of the slug
synchronisation we do on changing the slug anywhere the post name is
always set. This meant that the stop words would never be filtered.

Fix this by filtering the stop words on the "get sample permalink" ajax
request. This also makes it much more clear towards the users what is
happening.

Fixes #3559