### PR TITLE
Optimisation in Unit Tests

### DIFF
--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -10,13 +10,20 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 */
 	private static $class_instance;
 
+	/**
+	 * Setting up
+	 */
 	public static function setUpBeforeClass() {
 		self::$class_instance = WPSEO_Frontend::get_instance();
 	}
 
+	/**
+	 * Reset after running a test
+	 */
 	public function tearDown() {
 		ob_clean();
 		self::$class_instance->reset();
+		update_option( 'posts_per_page', 10 );
 	}
 
 	/**
@@ -30,7 +37,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		update_option( 'show_on_front', 'page' );
 		$this->assertFalse( self::$class_instance->is_home_posts_page() );
 
-		// create and go to post
+		// Create and go to post.
 		update_option( 'show_on_front', 'notapage' );
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
@@ -454,7 +461,9 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::canonical
 	 */
 	public function test_canonical_home() {
-		$this->factory->post->create_many( 22 );
+		update_option( 'posts_per_page', 1 );
+
+		$this->factory->post->create_many( 3 );
 
 		$url = home_url();
 
@@ -465,8 +474,9 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::canonical
 	 */
 	public function test_canonical_search() {
+		update_option( 'posts_per_page', 1 );
 
-		$this->factory->post->create_many( 22, array( 'post_title' => 'sample post %d' ) );
+		$this->factory->post->create_many( 3, array( 'post_title' => 'sample post %d' ) );
 
 		// test search
 		$search_link = get_search_link( 'sample post' );
@@ -479,9 +489,11 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::canonical
 	 */
 	public function test_adjacent_rel_links_canonical_post_type() {
+		update_option( 'posts_per_page', 1 );
+
 		register_post_type( 'yoast', array( 'public' => true, 'has_archive' => true ) );
 
-		$this->factory->post->create_many( 22, array( 'post_type' => 'yoast' ) );
+		$this->factory->post->create_many( 3, array( 'post_type' => 'yoast' ) );
 
 		flush_rewrite_rules();
 
@@ -495,10 +507,11 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::canonical
 	 */
 	public function test_adjacent_rel_links_canonical_author() {
+		update_option( 'posts_per_page', 1 );
 
 		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 
-		$this->factory->post->create_many( 22, array( 'post_author' => $user_id ) );
+		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
 
 		$user     = new WP_User( $user_id );
 		$user_url = get_author_posts_url( $user_id, $user->user_nicename );
@@ -511,7 +524,9 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::canonical
 	 */
 	public function test_adjacent_rel_links_canonical_date_archive() {
-		$this->factory->post->create_many( 22 );
+		update_option( 'posts_per_page', 1 );
+
+		$this->factory->post->create_many( 3 );
 
 		$date_link = get_day_link( false, false, false );  // Having three times false generates a link for today, which is what we need
 		$this->run_test_on_consecutive_pages( $date_link );
@@ -522,9 +537,11 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::canonical
 	 */
 	public function test_adjacent_rel_links_canonical_category() {
+		update_option( 'posts_per_page', 1 );
+
 		// create a category, add 26 posts to it, go to page 2 of its archives
 		$category_id = wp_create_category( 'Yoast SEO Plugins' );
-		$this->factory->post->create_many( 22, array( 'post_category' => array( $category_id ) ) );
+		$this->factory->post->create_many( 3, array( 'post_category' => array( $category_id ) ) );
 
 		// This shouldn't be necessary but apparently multisite's rewrites are borked when you create a category and you don't flush (on 4.0 only).
 		flush_rewrite_rules();

--- a/tests/test-class-wpseo-statistics.php
+++ b/tests/test-class-wpseo-statistics.php
@@ -32,25 +32,94 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 0, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::NO_INDEX ) ) );
 	}
 
+	/**
+	 * Tests if the statistics functions can correctly count the amount of posts in the database
+	 *
+	 * @covers WPSEO_Statistics::get_post_count
+	 */
+	public function test_filled_statistics_no_focus() {
+		$posts = $this->factory->post->create_many( 2, array(
+			'post_status' => 'publish'
+		) );
+
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 );
+		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 1 );
+
+		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::NO_FOCUS ) ) );
+	}
 
 	/**
 	 * Tests if the statistics functions can correctly count the amount of posts in the database
 	 *
 	 * @covers WPSEO_Statistics::get_post_count
 	 */
-	public function test_filled_statistics() {
-		$posts = $this->factory->post->create_many( 100, array(
+	public function test_filled_statistics_bad() {
+		$posts = $this->factory->post->create_many( 4, array(
 			'post_status' => 'publish'
 		) );
 
-		$i = 0;
-		foreach ( $posts as $post_id ) {
-			add_post_meta( $post_id, '_yoast_wpseo_linkdex', $i++ );
-		}
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // not bad
+		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 1 ); // bad
+		add_post_meta( $posts[2], '_yoast_wpseo_linkdex', 40 ); // bad
+		add_post_meta( $posts[3], '_yoast_wpseo_linkdex', 41 ); // not bad
 
-		$this->assertEquals( 40, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::BAD ) ) );
-		$this->assertEquals( 30, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::OK ) ) );
-		$this->assertEquals( 29, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::GOOD ) ) );
+		$this->assertEquals( 2, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::BAD ) ) );
+	}
+
+	/**
+	 * Tests if the statistics functions can correctly count the amount of posts in the database
+	 *
+	 * @covers WPSEO_Statistics::get_post_count
+	 */
+	public function test_filled_statistics_ok() {
+		$posts = $this->factory->post->create_many( 4, array(
+			'post_status' => 'publish'
+		) );
+
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 40 ); // not ok
+		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 41 ); // ok
+		add_post_meta( $posts[2], '_yoast_wpseo_linkdex', 70 ); // ok
+		add_post_meta( $posts[3], '_yoast_wpseo_linkdex', 71 ); // not ok
+
+		$this->assertEquals( 2, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::OK ) ) );
+	}
+
+	/**
+	 * Tests if the statistics functions can correctly count the amount of posts in the database
+	 *
+	 * @covers WPSEO_Statistics::get_post_count
+	 */
+	public function test_filled_statistics_good() {
+		$posts = $this->factory->post->create_many( 4, array(
+			'post_status' => 'publish'
+		) );
+
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 70 ); // not good
+		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 71 ); // good
+		add_post_meta( $posts[2], '_yoast_wpseo_linkdex', 100 ); // good
+		add_post_meta( $posts[3], '_yoast_wpseo_linkdex', 101 ); // not good
+
+		$this->assertEquals( 2, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::GOOD ) ) );
+	}
+
+	/**
+	 * Tests if the functions only count published posts
+	 *
+	 * @covers WPSEO_Statistics::get_post_count
+	 */
+	public function test_all_statistics_published_posts() {
+		$posts = $this->factory->post->create_many( 4, array(
+			'post_status' => 'publish'
+		) );
+
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // no-focus
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 1 ); // bad
+		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 41 ); // ok
+		add_post_meta( $posts[2], '_yoast_wpseo_linkdex', 71 ); // good
+
+		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::BAD ) ) );
+		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::OK ) ) );
+		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::GOOD ) ) );
 		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::NO_FOCUS ) ) );
 	}
 
@@ -60,14 +129,14 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Statistics::get_post_count
 	 */
 	public function test_only_published_posts() {
-		$posts = $this->factory->post->create_many( 100, array(
+		$posts = $this->factory->post->create_many( 4, array(
 			'post_status' => 'draft'
 		) );
 
-		$i = 0;
-		foreach ( $posts as $post_id ) {
-			add_post_meta( $post_id, '_yoast_wpseo_linkdex', $i++ );
-		}
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // no-focus
+		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 1 ); // bad
+		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 41 ); // ok
+		add_post_meta( $posts[2], '_yoast_wpseo_linkdex', 71 ); // good
 
 		$this->assertEquals( 0, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::BAD ) ) );
 		$this->assertEquals( 0, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::OK ) ) );


### PR DESCRIPTION
Because of the waiting time in Travis I decided to take a look at the unit test execution times and see if I could improve anything.

**Statistics:**
Instead of testing for the full range, just testing the boundaries. This means that only 4 items need to be created instead of 100.

**Frontend:**
Instead of creating 22 items to test for 3 pages (with 10 items per page) just set items per page to 1 and test with 3 items.
Resetting post per page to the default in tearDown.