### PR TITLE
Disable the notices.

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -118,6 +118,10 @@ class WPSEO_Admin_Init {
 	 * Notify about the default tagline if the user hasn't changed it
 	 */
 	public function tagline_notice() {
+
+		// Just a return, because we want to temporary disable this notice (#3998).
+		return;
+
 		if ( current_user_can( 'manage_options' ) && $this->has_default_tagline() && ! $this->seen_tagline_notice() ) {
 
 			// Only add the notice on GET requests, not in the customizer, and not in "action" type submits to prevent faulty return url.
@@ -197,6 +201,9 @@ class WPSEO_Admin_Init {
 	 * Shows the notice for recalculating the post. the Notice will only be shown if the user hasn't dismissed it before.
 	 */
 	public function recalculate_notice() {
+		// Just a return, because we want to temporary disable this notice (#3998).
+		return;
+
 		if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
 			update_option( 'wpseo_dismiss_recalculate', '1' );
 			return;

--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -114,6 +114,9 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 	 * @param string|bool $plugin Optional plugin basename to check.
 	 */
 	public static function hook_check_for_plugin_conflicts( $plugin = false ) {
+		// Just a return, because we want to temporary disable this notice (#3998).
+		return;
+
 		// The instance of itself.
 		$instance = self::get_instance();
 

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -93,6 +93,9 @@ class WPSEO_OnPage {
 	 * Show a notice when the website is not indexable
 	 */
 	public function show_notice() {
+		// Just a return, because we want to temporary disable this notice (#3998).
+		return;
+
 		if ( $this->should_show_notice() ) {
 			$notice = sprintf(
 				/* translators: 1: opens a link to a related knowledge base article. 2: closes the link */


### PR DESCRIPTION
Fixes #3998 

Because using comments to disable hooks will result in CS errors and strange ways to fix those, I've chosen for the a return in the method that will be set the notices. 
When the notices have to be enabled, just search for #3398 in PhpStorm or the editor that is being used at that moment.

