### PR TITLE
Remove duplicated script handle

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -164,16 +164,6 @@ class WPSEO_Admin_Asset_Manager {
 				),
 			),
 			array(
-				'name' => 'metabox-taxonomypage',
-				'src'  => 'wp-seo-metabox-302',
-				'deps' => array(
-					'jquery',
-					'jquery-ui-core',
-					'jquery-ui-autocomplete',
-					self::PREFIX . 'jquery-qtip',
-				),
-			),
-			array(
 				'name'      => 'admin-gsc',
 				'src'       => 'wp-seo-admin-gsc-302',
 				'deps'      => array( 'jquery' ),

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -72,7 +72,7 @@ class WPSEO_Taxonomy {
 
 			wp_editor( '', 'description' );
 
-			$asset_manager->enqueue_script( 'metabox-taxonomypage' );
+			$asset_manager->enqueue_script( 'metabox' );
 			$asset_manager->enqueue_script( 'yoast-seo' );
 			$asset_manager->enqueue_script( 'term-scraper' );
 


### PR DESCRIPTION
The `metabox-taxonomypage` and `metabox` include the same script so they are functionally identical and this means one can be removed.