### PR TITLE
Bugfix primary term function for a switched site.

### DIFF
--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -68,6 +68,11 @@ class WPSEO_Primary_Term_Admin {
 	 * @param int $post_ID Post ID to save primary terms for.
 	 */
 	public function save_primary_terms( $post_ID ) {
+		// Bail if this is a multisite installation and the site has been switched.
+		if ( is_multisite() && ms_is_switched() ) {
+			return;
+		}
+
 		$taxonomies = $this->get_primary_term_taxonomies( $post_ID );
 
 		foreach ( $taxonomies as $taxonomy ) {


### PR DESCRIPTION
Hello Yoast folks,

similar to #3531, your new _Primary Term_ feature doesn't take a switched site in a multisite installation into account. The problem here is that you run `check_admin_referer()` (later in `WPSEO_Primary_Term_Admin::save_primary_term()`) which fails, producing an _Are you sure_ error screen.

The fix is simple, and follows what I did earlier this year. However, I'm pretty sure there are several other functions that you apply while implicitly assuming you're located in the _current_ (default) site in a multisite - which is just not true per se. Please be nice to multisite (and plugins that depend on multisite). :)

Thanks,
Thorsten