### PR TITLE
Add filter for overriding checks.

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -808,7 +808,7 @@ SVG;
 	 */
 	public function template_keyword_tab() {
 		// Only do this on the edit post pages.
-		if ( 'post' !== get_current_screen()->base && 'post-new' !== get_current_screen()->base ) {
+		if ( 'post' !== get_current_screen()->base && 'post-new' !== get_current_screen()->base && ! apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This is consistent with the same filter that is added in `WPSEO_Admin_Init::load_meta_boxes` and is necessary to prevent javascript errors like this on non native wp editor routes including WPSEO:

```
Uncaught TypeError: Cannot read property 'replace' of undefined
```

