### PR TITLE
Support term.php in WordPress 4.5

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -269,7 +269,10 @@ class WPSEO_Admin_Init {
 	 * Determine if we should load our taxonomy edit class and if so, load it.
 	 */
 	private function load_taxonomy_class() {
-		if ( 'edit-tags.php' === $this->pagenow ) {
+		if (
+			WPSEO_Taxonomy::is_term_edit( $this->pagenow )
+			|| WPSEO_Taxonomy::is_term_overview( $this->pagenow )
+		) {
 			new WPSEO_Taxonomy;
 		}
 	}

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -274,8 +274,7 @@ SVG;
 	 * Keyword tab for enabling analysis of multiple keywords.
 	 */
 	public function template_keyword_tab() {
-		// Only do this on the taxonomy pages.
-		if ( 'edit-tags' !== get_current_screen()->base ) {
+		if ( ! WPSEO_Taxonomy::is_term_edit( $GLOBALS['pagenow'] ) ) {
 			return;
 		}
 

--- a/tests/taxonomy/test-class-taxonomy.php
+++ b/tests/taxonomy/test-class-taxonomy.php
@@ -1,6 +1,10 @@
 <?php
 
-class WPSEO_Taxonomy_Test extends \PHPUnit_Framework_TestCase {
+class WPSEO_Taxonomy_Test extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Make sure certain pages are marked as term edit
+	 */
 	public function test_is_term_edit() {
 		$this->assertTrue( WPSEO_Taxonomy::is_term_edit( 'term.php' ) );
 		$this->assertTrue( WPSEO_Taxonomy::is_term_edit( 'edit-tags.php' ) );
@@ -8,6 +12,9 @@ class WPSEO_Taxonomy_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( WPSEO_Taxonomy::is_term_edit( 'random' ) );
 	}
 
+	/**
+	 * Make sure certain pages are marked as term overview
+	 */
 	public function test_is_term_overview() {
 		$this->assertFalse( WPSEO_Taxonomy::is_term_overview( 'term.php' ) );
 		$this->assertTrue( WPSEO_Taxonomy::is_term_overview( 'edit-tags.php' ) );

--- a/tests/taxonomy/test-class-taxonomy.php
+++ b/tests/taxonomy/test-class-taxonomy.php
@@ -1,0 +1,17 @@
+<?php
+
+class WPSEO_Taxonomy_Test extends \PHPUnit_Framework_TestCase {
+	public function test_is_term_edit() {
+		$this->assertTrue( WPSEO_Taxonomy::is_term_edit( 'term.php' ) );
+		$this->assertTrue( WPSEO_Taxonomy::is_term_edit( 'edit-tags.php' ) );
+		$this->assertFalse( WPSEO_Taxonomy::is_term_edit( '' ) );
+		$this->assertFalse( WPSEO_Taxonomy::is_term_edit( 'random' ) );
+	}
+
+	public function test_is_term_overview() {
+		$this->assertFalse( WPSEO_Taxonomy::is_term_overview( 'term.php' ) );
+		$this->assertTrue( WPSEO_Taxonomy::is_term_overview( 'edit-tags.php' ) );
+		$this->assertFalse( WPSEO_Taxonomy::is_term_overview( '' ) );
+		$this->assertFalse( WPSEO_Taxonomy::is_term_overview( 'random' ) );
+	}
+}


### PR DESCRIPTION
WordPress changed the term edit page from edit-tags.php to term.php.
Change our code to be able to deal with this.

Certain parts are only present to support WordPress 4.4 and lower, these
can be removed once we don't support WordPress 4.4.

Fixes #3944