### PR TITLE
Metabox: remove redundant title and alt attributes

### DIFF
--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -87,7 +87,6 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 				$this->get_social_tab_content( 'opengraph', $social_meta_fields ),
 				'<span class="dashicons dashicons-facebook-alt"></span>',
 				array(
-					'link_alt' => __( 'Facebook / Open Graph metadata', 'wordpress-seo' ),
 					'link_title' => __( 'Facebook / Open Graph metadata', 'wordpress-seo' ),
 				)
 			);
@@ -99,7 +98,6 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 				$this->get_social_tab_content( 'twitter', $social_meta_fields ),
 				'<span class="dashicons dashicons-twitter"></span>',
 				array(
-					'link_alt' => __( 'Twitter metadata', 'wordpress-seo' ),
 					'link_title' => __( 'Twitter metadata', 'wordpress-seo' ),
 				)
 			);
@@ -111,7 +109,6 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 				$this->get_social_tab_content( 'google-plus', $social_meta_fields ),
 				'<span class="dashicons dashicons-googleplus"></span>',
 				array(
-					'link_alt' => __( 'Google+ metadata', 'wordpress-seo' ),
 					'link_title' => __( 'Google+ metadata', 'wordpress-seo' ),
 				)
 			);
@@ -122,7 +119,6 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 			'<span class="dashicons dashicons-share"></span>',
 			$tabs,
 			array(
-				'link_alt' => __( 'Social', 'wordpress-seo' ),
 				'link_title' => __( 'Social', 'wordpress-seo' ),
 			)
 		);

--- a/admin/metabox/class-metabox-form-tab.php
+++ b/admin/metabox/class-metabox-form-tab.php
@@ -59,7 +59,7 @@ class WPSEO_Metabox_Form_Tab implements WPSEO_Metabox_Tab {
 			'<li class="%1$s %2$s"><a class="wpseo_tablink" href="#wpseo_%1$s"%3$s>%4$s</a></li>',
 			esc_attr( $this->name ),
 			esc_attr( $this->link_class ),
-			'' !== $this->link_title ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
+			( '' !== $this->link_title ) ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
 			$this->link_content
 		);
 	}

--- a/admin/metabox/class-metabox-form-tab.php
+++ b/admin/metabox/class-metabox-form-tab.php
@@ -31,11 +31,6 @@ class WPSEO_Metabox_Form_Tab implements WPSEO_Metabox_Tab {
 	/**
 	 * @var string
 	 */
-	private $link_alt;
-
-	/**
-	 * @var string
-	 */
 	private $link_title;
 
 	/**
@@ -51,7 +46,6 @@ class WPSEO_Metabox_Form_Tab implements WPSEO_Metabox_Tab {
 		$this->content      = $content;
 		$this->link_content = $link_content;
 		$this->link_class	= isset( $options['link_class'] ) ? $options['link_class'] : '';
-		$this->link_alt     = isset( $options['link_alt'] ) ? $options['link_alt'] : '';
 		$this->link_title   = isset( $options['link_title'] ) ? $options['link_title'] : '';
 	}
 
@@ -62,11 +56,10 @@ class WPSEO_Metabox_Form_Tab implements WPSEO_Metabox_Tab {
 	 */
 	public function link() {
 		return sprintf(
-			'<li class="%1$s %2$s"><a class="wpseo_tablink" href="#wpseo_%1$s" alt="%3$s" title="%4$s">%5$s</a></li>',
+			'<li class="%1$s %2$s"><a class="wpseo_tablink" href="#wpseo_%1$s"%3$s>%4$s</a></li>',
 			esc_attr( $this->name ),
 			esc_attr( $this->link_class ),
-			esc_attr( $this->link_alt ),
-			esc_attr( $this->link_title ),
+			'' !== $this->link_title ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
 			$this->link_content
 		);
 	}

--- a/admin/metabox/class-metabox-tab-section.php
+++ b/admin/metabox/class-metabox-tab-section.php
@@ -26,11 +26,6 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 	/**
 	 * @var string
 	 */
-	private $link_alt;
-
-	/**
-	 * @var string
-	 */
 	private $link_title;
 
 	/**
@@ -47,7 +42,6 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 			$this->add_tab( $tab );
 		}
 		$this->link_content = $link_content;
-		$this->link_alt     = isset( $options['link_alt'] ) ? $options['link_alt'] : '';
 		$this->link_title   = isset( $options['link_title'] ) ? $options['link_title'] : '';
 	}
 
@@ -57,10 +51,9 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 	public function display_link() {
 		if ( $this->has_tabs() ) {
 			printf(
-				'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link" alt="%2$s" title="%3$s">%4$s</a></li>',
+				'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link"%2$s>%3$s</a></li>',
 				esc_attr( $this->name ),
-				esc_attr( $this->link_alt ),
-				esc_attr( $this->link_title ),
+				'' !== $this->link_title ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
 				$this->link_content
 			);
 		}

--- a/admin/metabox/class-metabox-tab-section.php
+++ b/admin/metabox/class-metabox-tab-section.php
@@ -53,7 +53,7 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 			printf(
 				'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link"%2$s>%3$s</a></li>',
 				esc_attr( $this->name ),
-				'' !== $this->link_title ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
+				( '' !== $this->link_title ) ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
 				$this->link_content
 			);
 		}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -315,7 +315,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			__( 'Content', 'wordpress-seo' ),
 			array(
 				'link_class' => 'wpseo_keyword_tab',
-				'link_title' => __( 'Content', 'wordpress-seo' ),
 			)
 		);
 
@@ -326,7 +325,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'<span class="yst-traffic-light-container">' . $this->traffic_light_svg() . '</span>',
 			$tabs,
 			array(
-				'link_alt' => __( 'Content', 'wordpress-seo' ),
 				'link_title' => __( 'Content', 'wordpress-seo' ),
 			)
 		);
@@ -343,10 +341,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$tab = new WPSEO_Metabox_Form_Tab(
 			'advanced',
 			$content,
-			__( 'Advanced', 'wordpress-seo' ),
-			array(
-				'link_title' => __( 'Advanced', 'wordpress-seo' ),
-			)
+			__( 'Advanced', 'wordpress-seo' )
 		);
 
 		return new WPSEO_Metabox_Tab_Section(
@@ -354,7 +349,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'<span class="dashicons dashicons-admin-generic"></span>',
 			array( $tab ),
 			array(
-				'link_alt' => __( 'Advanced', 'wordpress-seo' ),
 				'link_title' => __( 'Advanced', 'wordpress-seo' ),
 			)
 		);
@@ -372,7 +366,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'<span class="dashicons dashicons-admin-plugins"></span>',
 			array(),
 			array(
-				'link_alt' => __( 'Add-ons', 'wordpress-seo' ),
 				'link_title' => __( 'Add-ons', 'wordpress-seo' ),
 			)
 		);

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -99,7 +99,6 @@ class WPSEO_Taxonomy_Metabox {
 			__( 'Content', 'wordpress-seo' ),
 			array(
 				'link_class' => 'wpseo_keyword_tab',
-				'link_title' => __( 'Content', 'wordpress-seo' ),
 			)
 		);
 
@@ -108,7 +107,6 @@ class WPSEO_Taxonomy_Metabox {
 			'<span class="yst-traffic-light-container">' . $this->traffic_light_svg() . '</span>',
 			array( $tab ),
 			array(
-				'link_alt'   => __( 'Content', 'wordpress-seo' ),
 				'link_title' => __( 'Content', 'wordpress-seo' ),
 			)
 		);
@@ -126,10 +124,7 @@ class WPSEO_Taxonomy_Metabox {
 		$tab = new WPSEO_Metabox_Form_Tab(
 			'settings',
 			$content,
-			__( 'Settings', 'wordpress-seo' ),
-			array(
-				'link_title' => __( 'Settings', 'wordpress-seo' ),
-			)
+			__( 'Settings', 'wordpress-seo' )
 		);
 
 		return new WPSEO_Metabox_Tab_Section(
@@ -137,7 +132,6 @@ class WPSEO_Taxonomy_Metabox {
 			'<span class="dashicons dashicons-admin-generic"></span>',
 			array( $tab ),
 			array(
-				'link_alt'   => __( 'Settings', 'wordpress-seo' ),
 				'link_title' => __( 'Settings', 'wordpress-seo' ),
 			)
 		);
@@ -161,7 +155,6 @@ class WPSEO_Taxonomy_Metabox {
 				$this->taxonomy_tab_content->html( $facebook_meta_fields ),
 				'<span class="dashicons dashicons-facebook-alt"></span>',
 				array(
-					'link_alt'   => __( 'Facebook / Opengraph metadata', 'wordpress-seo' ),
 					'link_title' => __( 'Facebook / Opengraph metadata', 'wordpress-seo' ),
 				)
 			);
@@ -175,7 +168,6 @@ class WPSEO_Taxonomy_Metabox {
 				$this->taxonomy_tab_content->html( $twitter_meta_fields ),
 				'<span class="dashicons dashicons-twitter"></span>',
 				array(
-					'link_alt'   => __( 'Twitter metadata', 'wordpress-seo' ),
 					'link_title' => __( 'Twitter metadata', 'wordpress-seo' ),
 				)
 			);
@@ -189,7 +181,6 @@ class WPSEO_Taxonomy_Metabox {
 				$this->taxonomy_tab_content->html( $googleplus_meta_fields ),
 				'<span class="dashicons dashicons-googleplus"></span>',
 				array(
-					'link_alt'   => __( 'Google+ metadata', 'wordpress-seo' ),
 					'link_title' => __( 'Google+ metadata', 'wordpress-seo' ),
 				)
 			);
@@ -200,7 +191,6 @@ class WPSEO_Taxonomy_Metabox {
 			'<span class="dashicons dashicons-share"></span>',
 			$tabs,
 			array(
-				'link_alt'   => __( 'Social', 'wordpress-seo' ),
 				'link_title' => __( 'Social', 'wordpress-seo' ),
 			)
 		);


### PR DESCRIPTION
Also, avoids to print out empty title attributes.

Fixes #4049