### PR TITLE
Move primary category permalink hook to frontend

### DIFF
--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -17,7 +17,9 @@ class WPSEO_Primary_Term_Admin {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		add_action( 'save_post', array( $this, 'save_primary_terms' ) );
-		add_filter( 'post_link_category', array( $this, 'post_link_category' ) );
+
+		$primary_term = new WPSEO_Frontend_Primary_Category();
+		$primary_term->register_hooks();
 	}
 
 	/**
@@ -73,23 +75,6 @@ class WPSEO_Primary_Term_Admin {
 		foreach ( $taxonomies as $taxonomy ) {
 			$this->save_primary_term( $post_ID, $taxonomy );
 		}
-	}
-
-	/**
-	 * Filters post_link_category to change the category to the chosen category by the user
-	 *
-	 * @param stdClass $category The category that is now used for the post link.
-	 *
-	 * @return array|null|object|WP_Error The category we want to use for the post link.
-	 */
-	public function post_link_category( $category ) {
-		$primary_category = $this->get_primary_term( 'category' );
-
-		if ( false !== $primary_category && $primary_category !== $category->cat_ID ) {
-			$category = $this->get_category( $primary_category );
-		}
-
-		return $category;
 	}
 
 	/**
@@ -150,19 +135,6 @@ class WPSEO_Primary_Term_Admin {
 			$primary_term_object = new WPSEO_Primary_Term( $taxonomy->name, $post_ID );
 			$primary_term_object->set_primary_term( $primary_term );
 		}
-	}
-
-	/**
-	 * Wrapper for get category to make mocking easier
-	 *
-	 * @param int $primary_category id of primary category.
-	 *
-	 * @return array|null|object|WP_Error
-	 */
-	protected function get_category( $primary_category ) {
-		$category = get_category( $primary_category );
-
-		return $category;
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -66,6 +66,10 @@ class WPSEO_Frontend {
 	 */
 	private $required_options = array( 'wpseo', 'wpseo_rss', 'wpseo_social', 'wpseo_permalinks', 'wpseo_titles' );
 
+	/**
+	 * @var array
+	 */
+	private $hooks;
 
 	/**
 	 * Class constructor
@@ -163,6 +167,11 @@ class WPSEO_Frontend {
 		if ( $this->options['title_test'] > 0 ) {
 			add_filter( 'wpseo_title', array( $this, 'title_test_helper' ) );
 		}
+
+		$primary_category = new WPSEO_Frontend_Primary_Category();
+		$primary_category->register_hooks();
+
+		$this->hooks = array( $primary_category );
 	}
 
 	/**

--- a/frontend/class-primary-category.php
+++ b/frontend/class-primary-category.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @package WPSEO\Frontend
+ */
+
+/**
+ * Adds customizations to the front end for the primary category
+ */
+class WPSEO_Frontend_Primary_Category {
+
+	/**
+	 * Registers the hooks necessary for correct primary category behaviour.
+	 */
+	public function register_hooks() {
+		add_filter( 'post_link_category', array( $this, 'post_link_category' ) );
+	}
+
+	/**
+	 * Filters post_link_category to change the category to the chosen category by the user
+	 *
+	 * @param stdClass $category The category that is now used for the post link.
+	 *
+	 * @return array|null|object|WP_Error The category we want to use for the post link.
+	 */
+	public function post_link_category( $category ) {
+		$primary_category = $this->get_primary_category();
+
+		if ( false !== $primary_category && $primary_category !== $category->cat_ID ) {
+			$category = $this->get_category( $primary_category );
+		}
+
+		return $category;
+	}
+
+	/**
+	 * /**
+	 * Get the id of the primary category
+	 *
+	 * @return int primary category id
+	 */
+	protected function get_primary_category() {
+		$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+
+		return $primary_term->get_primary_term();
+	}
+
+	/**
+	 * Wrapper for get category to make mocking easier
+	 *
+	 * @param int $primary_category id of primary category.
+	 *
+	 * @return array|null|object|WP_Error
+	 */
+	protected function get_category( $primary_category ) {
+		$category = get_category( $primary_category );
+
+		return $category;
+	}
+}

--- a/tests/frontend/test-class-primary-category.php
+++ b/tests/frontend/test-class-primary-category.php
@@ -1,0 +1,69 @@
+<?php
+
+
+class WPSEO_Frontend_Primary_Category_Test extends PHPUnit_Framework_TestCase {
+	/**
+	 * @type WPSEO_Frontend_Primary_Category
+	 */
+	protected $subject;
+
+	public function setUp() {
+		$this->subject = $this->getMock( 'WPSEO_Frontend_Primary_Category', array(
+			'get_category',
+			'get_primary_category',
+		) );
+	}
+
+	/**
+	 * When the primary term id is not equal to the category id, the id should get updated.
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::post_link_category
+	 */
+	public function test_post_link_category_primary_term_IS_NOT_category_id() {
+		$this->subject
+			->expects ( $this->once() )
+			->method( 'get_primary_category' )
+			->will ( $this->returnValue( '54' ) );
+
+		$expect = ( object ) array(
+			'term_id' => 54
+		);
+
+		$this->subject
+			->expects( $this->once() )
+			->method( 'get_category' )
+			->will( $this->returnValue( $expect ) );
+
+		$category = ( object ) array(
+			'cat_ID' => 52,
+		);
+
+		$this->assertEquals( $expect, $this->subject->post_link_category( $category ) );
+	}
+
+	/**
+	 * When the primary term is equal to the category id, return the category
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::post_link_category
+	 */
+	public function test_post_link_category_primary_term_IS_category_id() {
+		$this->subject
+			->expects ( $this->once() )
+			->method( 'get_primary_category' )
+			->will ( $this->returnValue( 1 ) );
+
+		$this->subject
+			->expects( $this->never() )
+			->method( 'get_category' );
+
+		$category = ( object ) array(
+			'term_id' => 1,
+			'name' => 'test',
+			'term_taxonomy_id' => 1,
+			'cat_ID' => 1,
+		);
+
+		$this->assertEquals( $category, $this->subject->post_link_category( $category ) );
+	}
+
+}

--- a/tests/test-class-primary-term-admin.php
+++ b/tests/test-class-primary-term-admin.php
@@ -7,7 +7,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
     public function setUp() {
         parent::setUp();
 
-        $this->class_instance = $this->getMock( 'WPSEO_Primary_Term_Admin', array( 'get_category', 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ) );
+        $this->class_instance = $this->getMock( 'WPSEO_Primary_Term_Admin', array( 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ) );
     }
 
     /**
@@ -179,60 +179,4 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 
         $this->class_instance->save_primary_terms( 1 );
     }
-
-    /**
-     * When the primary term id is not equal to the category id, the id should get updated.
-     *
-     * @covers WPSEO_Primary_Term_Admin::post_link_category
-     */
-    public function test_post_link_category_primary_term_IS_NOT_category_id() {
-        $this->class_instance
-            ->expects ( $this->once() )
-            ->method( 'get_primary_term' )
-            ->will ( $this->returnValue( '54' ) );
-
-        $get_category = ( object ) array(
-            'term_id' => 54
-        );
-
-        $this->class_instance
-            ->expects( $this->once() )
-            ->method( 'get_category' )
-            ->will( $this->returnValue( $get_category ) );
-
-        $category = ( object ) array(
-            'term_id' => 52,
-            'name' => 'test',
-            'term_taxonomy_id' => 52,
-            'cat_ID' => 52,
-        );
-
-        $this->assertEquals( $get_category, $this->class_instance->post_link_category( $category ) );
-    }
-
-    /**
-     * When the primary term is equal to the category id, return the category
-     *
-     * @covers WPSEO_Primary_Term_Admin::post_link_category
-     */
-    public function test_post_link_category_primary_term_IS_category_id() {
-        $this->class_instance
-            ->expects ( $this->once() )
-            ->method( 'get_primary_term' )
-            ->will ( $this->returnValue( 1 ) );
-
-        $this->class_instance
-            ->expects( $this->never() )
-            ->method( 'get_category' );
-
-        $category = ( object ) array(
-            'term_id' => 1,
-            'name' => 'test',
-            'term_taxonomy_id' => 1,
-            'cat_ID' => 1,
-        );
-
-        $this->assertEquals( $category, $this->class_instance->post_link_category( $category ) );
-    }
-
 }


### PR DESCRIPTION
This makes sure get_permalink called on the frontend returns the correct
permalink if the user has chosen a primary category for a post.

Fixes #4098