### PR TITLE
Default to no primary term if none is set

### DIFF
--- a/inc/class-wpseo-primary-term.php
+++ b/inc/class-wpseo-primary-term.php
@@ -43,16 +43,6 @@ class WPSEO_Primary_Term {
 			$primary_term = false;
 		}
 
-		// By default the first term (sorted by ID) is the primary term.
-		if ( ! $primary_term ) {
-
-			if ( ! empty( $terms ) ) {
-				usort( $terms, '_usort_terms_by_ID' );
-				$primary_term = array_shift( $terms );
-				$primary_term = $primary_term->term_id;
-			}
-		}
-
 		$primary_term = (int) $primary_term;
 		return ( $primary_term ) ? ( $primary_term ) : false;
 	}

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -40,6 +40,7 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
      */
     public function test_get_primary_term_WHERE_primary_term_EXISTS() {
         $class_instance = new WPSEO_Primary_Term_Double( $this->taxonomy_name, $this->post_id );
+        $class_instance->set_primary_term( $this->primary_term_id );
 
         $this->assertEquals( $this->primary_term_id, $class_instance->get_primary_term() );
 
@@ -66,9 +67,7 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 
         $class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $post_id );
 
-        $terms = wp_get_post_terms( $post_id, $this->taxonomy_name );
-
-        $this->assertEquals( $terms[0]->term_id, $class_instance->get_primary_term() );
+        $this->assertFalse( $class_instance->get_primary_term() );
     }
 
     /**
@@ -87,7 +86,7 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 
         $class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $post_id );
 
-        $this->assertEquals( $term_first->term_id, $class_instance->get_primary_term() );
+        $this->assertFalse( $class_instance->get_primary_term() );
     }
 
     /**


### PR DESCRIPTION
The default primary term prevented the breadcrumbs from using the
deepest category in the breadcrumbs. With this fix the deepest category
will be shown in the breadcrumbs.

Fixes #4060