### PR TITLE
Added post_status check for attachments.

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -365,8 +365,10 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				SELECT ID
 				FROM {$wpdb->posts}
 				{$join_filter}
+				t
 				WHERE post_status = '%s'
 					AND post_password = ''
+					AND 'publish' = ALL(SELECT post_status FROM $wpdb->posts m WHERE m.ID = t.post_parent)
 					AND post_type = '%s'
 					AND post_date != '0000-00-00 00:00:00'
 					{$where_filter}


### PR DESCRIPTION
Hi!

### The bug:
When creating the attachment-sitemap wordpress-seo will **publish links to attachments of unpublished posts** resulting in 404 errors. This is because you only check the post_status of the current item (which is inherit for all attachments).

### The solution:
Therefore I modified the query so that it will also check whether the post_parent's post_status is 'publish'.

Note, that the ALL-Modifier is needed because with it the equality check will return true if the subquery returns no result (which is the case if the post has no parent).