### PR TITLE
Set new transient data directly to $transient

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -108,12 +108,12 @@ class Yoast_Dashboard_Widget {
 			$transient = array();
 		}
 
-		$user_id                  = get_current_user_id();
-		$filtered_items[ $user_id ] = array_filter( $this->get_seo_scores_with_post_count(), array( $this, 'filter_items' ) );
+		$user_id               = get_current_user_id();
+		$transient[ $user_id ] = array_filter( $this->get_seo_scores_with_post_count(), array( $this, 'filter_items' ) );
 
-		set_transient( self::CACHE_TRANSIENT_KEY, array_merge( $filtered_items, $transient ), DAY_IN_SECONDS );
+		set_transient( self::CACHE_TRANSIENT_KEY, $transient, DAY_IN_SECONDS );
 
-		return $filtered_items[ $user_id ];
+		return $transient[ $user_id ];
 	}
 
 	/**


### PR DESCRIPTION
Removes $filtered_items and array_merge() usage. So now keys are keep intact. This prevents the transient being set on every page load.