### PR TITLE
Improved wording on Pinterest social tab

### DIFF
--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -99,13 +99,16 @@ $yform->admin_header( true, 'wpseo_social' );
 			<?php _e( 'Pinterest uses Open Graph metadata just like Facebook, so be sure to keep the Open Graph checkbox on the Facebook tab checked if you want to optimize your site for Pinterest.', 'wordpress-seo' ); ?>
 		</p>
 		<p>
+			<?php _e( 'If you have already confirmed your website with Pinterest, you can skip the step below.', 'wordpress-seo' ); ?>
+		</p>
+		<p>
 			<?php
 				/* translators: %1$s / %2$s expands to a link to pinterest.com's help page. */
-				printf( __( 'To %1$sverify your site with Pinterest%2$s, add the meta tag here:', 'wordpress-seo' ), '<a target="_blank" href="https://help.pinterest.com/en/articles/verify-your-website#meta_tag">', '</a>' );
+				printf( __( 'To %1$sconfirm your site with Pinterest%2$s, add the meta tag here:', 'wordpress-seo' ), '<a target="_blank" href="https://help.pinterest.com/en/articles/confirm-your-website#meta_tag">', '</a>' );
 			?>
 		</p>
 
-		<?php $yform->textinput( 'pinterestverify', __( 'Pinterest verification', 'wordpress-seo' ) ); ?>
+		<?php $yform->textinput( 'pinterestverify', __( 'Pinterest confirmation', 'wordpress-seo' ) ); ?>
 
 		<?php
 		do_action( 'wpseo_admin_pinterest_section' );


### PR DESCRIPTION
Fixes #2805 

Changed the following things:
* The URL to 'verify your site with Pinterest' is changed to the correct Pinterest article.
* The label for 'Pinterest verification' is changed to 'Pinterest confirmation'.
* Added an extra line to explain this step can be skipped if the site is already confirmed with Pinterest.

![schermafbeelding_2016-04-04_om_10_32_29](https://cloud.githubusercontent.com/assets/8614579/14242145/01e6d8da-fa50-11e5-8557-2fa5beca4562.png)