### PR TITLE
Use 3 decimals for milliseconds on cache invalidator key generation

### DIFF
--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -42,8 +42,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 
 		try {
 			$type = self::truncate_type( $type, $prefix, $postfix );
-		}
-		catch ( OutOfBoundsException $exception ) {
+		} catch ( OutOfBoundsException $exception ) {
 			// Maybe do something with the exception, for now just mark as invalid.
 			return false;
 		}
@@ -240,7 +239,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 
 		// Transients are purged every 24h.
 		$seconds      = ( $seconds % DAY_IN_SECONDS );
-		$milliseconds = substr( $milliseconds, 2, 5 );
+		$milliseconds = intval( substr( $milliseconds, 2, 3 ), 10 );
 
 		// Combine seconds and milliseconds and convert to integer.
 		$validator = intval( $seconds . '' . $milliseconds, 10 );


### PR DESCRIPTION
On 32bit systems the PHP_INT_MAX poses a problem when using the full seconds + milliseconds values as integer.

By only using 3 decimals for the milliseconds this problem is avoided.

Fixes #4260