### PR TITLE
Show Breadcrumb Title in advanced tab on theme support

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -382,7 +382,7 @@ class WPSEO_Meta {
 				global $post;
 
 				$options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_titles', 'wpseo_internallinks' ) );
-
+				
 				if ( ! current_user_can( 'manage_options' ) && $options['disableadvanced_meta'] ) {
 					return array();
 				}
@@ -415,7 +415,7 @@ class WPSEO_Meta {
 
 
 				/* Don't show the breadcrumb title field if breadcrumbs aren't enabled */
-				if ( $options['breadcrumbs-enable'] !== true ) {
+				if ( $options['breadcrumbs-enable'] !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ) ) {
 					unset( $field_defs['bctitle'] );
 				}
 

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -382,7 +382,7 @@ class WPSEO_Meta {
 				global $post;
 
 				$options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_titles', 'wpseo_internallinks' ) );
-				
+
 				if ( ! current_user_can( 'manage_options' ) && $options['disableadvanced_meta'] ) {
 					return array();
 				}


### PR DESCRIPTION
When the theme supports Breadcrumbs (thus enables them) the Breadcrumb Title option should be displayed on the advanced tab in the widget.

Fixes #2817