### PR TITLE
Flush rules on activate plugin

### DIFF
--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -14,7 +14,6 @@ class WPSEO_Sitemaps_Router {
 	public function __construct() {
 
 		add_action( 'init', array( $this, 'init' ), 1 );
-		add_action( 'wpseo_activate', array( $this, 'init' ), 1 );
 
 		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
 		add_action( 'template_redirect', array( $this, 'template_redirect' ), 0 );

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -14,6 +14,8 @@ class WPSEO_Sitemaps_Router {
 	public function __construct() {
 
 		add_action( 'init', array( $this, 'init' ), 1 );
+		add_action( 'wpseo_activate', array( $this, 'init' ), 1 );
+
 		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
 		add_action( 'template_redirect', array( $this, 'template_redirect' ), 0 );
 	}

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -14,7 +14,6 @@ class WPSEO_Sitemaps_Router {
 	public function __construct() {
 
 		add_action( 'init', array( $this, 'init' ), 1 );
-
 		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
 		add_action( 'template_redirect', array( $this, 'template_redirect' ), 0 );
 	}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -147,7 +147,7 @@ function _wpseo_activate() {
 		delete_option( 'rewrite_rules' );
 	}
 	else {
-		add_action( 'shutdown', 'flush_rewrite_rules' );
+		add_action( 'activated_plugin', 'flush_rewrite_rules' );
 	}
 
 	wpseo_add_capabilities();
@@ -168,7 +168,7 @@ function _wpseo_deactivate() {
 		delete_option( 'rewrite_rules' );
 	}
 	else {
-		add_action( 'shutdown', 'flush_rewrite_rules' );
+		add_action( 'deactivated_plugin', 'flush_rewrite_rules' );
 	}
 
 	wpseo_remove_capabilities();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -147,16 +147,14 @@ function _wpseo_activate() {
 		delete_option( 'rewrite_rules' );
 	}
 	else {
-		add_action( 'activated_plugin', 'flush_rewrite_rules' );
+		$wpseo_rewrite = new WPSEO_Rewrite();
+		$wpseo_rewrite->schedule_flush();
 	}
 
 	wpseo_add_capabilities();
 
 	// Clear cache so the changes are obvious.
 	WPSEO_Utils::clear_cache();
-
-	// Add rewrite rules so they can be flushed.
-	new WPSEO_Sitemaps_Router();
 
 	do_action( 'wpseo_activate' );
 }

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -155,6 +155,9 @@ function _wpseo_activate() {
 	// Clear cache so the changes are obvious.
 	WPSEO_Utils::clear_cache();
 
+	// Add rewrite rules so they can be flushed.
+	new WPSEO_Sitemaps_Router();
+
 	do_action( 'wpseo_activate' );
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -167,7 +167,7 @@ function _wpseo_deactivate() {
 
 	if ( is_multisite() && ms_is_switched() ) {
 		delete_option( 'rewrite_rules' );
- 	}
+	}
 	else {
 		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -168,9 +168,6 @@ function _wpseo_deactivate() {
 	if ( is_multisite() && ms_is_switched() ) {
 		delete_option( 'rewrite_rules' );
 	}
-	else {
-		add_action( 'deactivated_plugin', 'flush_rewrite_rules' );
-	}
 
 	wpseo_remove_capabilities();
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -167,6 +167,9 @@ function _wpseo_deactivate() {
 
 	if ( is_multisite() && ms_is_switched() ) {
 		delete_option( 'rewrite_rules' );
+ 	}
+	else {
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
 	wpseo_remove_capabilities();


### PR DESCRIPTION
When the plugin is activated hook on the proper hooks that get called on plugin activation.
Also register the Sitemap Router initialisation on `wpseo_activate` which registers the rewrite rules on activation so the flush actually contains the sitemap indices.

Fixes #3088