### PR TITLE
Optimize where textdomain is loaded

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -85,6 +85,8 @@ class WPSEO_Admin {
 		add_action( 'admin_init', array( $this, 'import_plugin_hooks' ) );
 
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
+
+		add_action( 'admin_init', 'wpseo_load_textdomain' );
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -21,6 +21,7 @@ class WPSEO_Sitemaps_Renderer {
 	 * Set up object properties.
 	 */
 	public function __construct() {
+		wpseo_load_textdomain();
 
 		$stylesheet_url   = preg_replace( '/(^http[s]?:)/', '', esc_url( home_url( 'main-sitemap.xsl' ) ) );
 		$this->stylesheet = '<?xml-stylesheet type="text/xsl" href="' . $stylesheet_url . '"?>';

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -290,3 +290,19 @@ function wpseo_split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id,
 }
 
 add_action( 'split_shared_term', 'wpseo_split_shared_term', 10, 4 );
+
+/**
+ * Load translations
+ */
+function wpseo_load_textdomain() {
+	$wpseo_path = str_replace( '\\', '/', WPSEO_PATH );
+	$mu_path    = str_replace( '\\', '/', WPMU_PLUGIN_DIR );
+
+	if ( false !== stripos( $wpseo_path, $mu_path ) ) {
+		load_muplugin_textdomain( 'wordpress-seo', dirname( WPSEO_BASENAME ) . '/languages/' );
+	}
+	else {
+		load_plugin_textdomain( 'wordpress-seo', false, dirname( WPSEO_BASENAME ) . '/languages/' );
+	}
+}
+

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -207,24 +207,6 @@ function wpseo_on_activate_blog( $blog_id ) {
 /* ***************************** PLUGIN LOADING *************************** */
 
 /**
- * Load translations
- */
-function wpseo_load_textdomain() {
-	$wpseo_path = str_replace( '\\', '/', WPSEO_PATH );
-	$mu_path    = str_replace( '\\', '/', WPMU_PLUGIN_DIR );
-
-	if ( false !== stripos( $wpseo_path, $mu_path ) ) {
-		load_muplugin_textdomain( 'wordpress-seo', dirname( WPSEO_BASENAME ) . '/languages/' );
-	}
-	else {
-		load_plugin_textdomain( 'wordpress-seo', false, dirname( WPSEO_BASENAME ) . '/languages/' );
-	}
-}
-
-add_action( 'plugins_loaded', 'wpseo_load_textdomain' );
-
-
-/**
  * On plugins_loaded: load the minimum amount of essential files for this plugin
  */
 function wpseo_init() {
@@ -277,6 +259,10 @@ function wpseo_frontend_init() {
 	}
 
 	add_action( 'template_redirect', 'wpseo_frontend_head_init', 999 );
+
+	if ( is_admin_bar_showing() ) {
+		wpseo_load_textdomain();
+	}
 }
 
 /**
@@ -470,5 +456,3 @@ function yoast_wpseo_self_deactivate() {
 		}
 	}
 }
-
-


### PR DESCRIPTION
Because we only need the textdomain when the adminbar is showing, and not for normal requests, I'm proposing this too optimize the loading...

On second thought. Don't merge this yet. class-frontend has textdomain calls too.