### PR TITLE
Fixed plugin incompatibility

### DIFF
--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -105,7 +105,7 @@ class WPSEO_Primary_Term_Admin {
 	protected function get_primary_term_taxonomies( $post_ID = null ) {
 
 		if ( null === $post_ID ) {
-			$post_ID = (int) $_GET['post'];
+			$post_ID = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 		}
 
 		if ( false !== ( $taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_ID, 'wpseo' ) ) ) {

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -105,7 +105,7 @@ class WPSEO_Primary_Term_Admin {
 	protected function get_primary_term_taxonomies( $post_ID = null ) {
 
 		if ( null === $post_ID ) {
-			$post_ID = get_the_ID();
+			$post_ID = $_GET['post'];
 		}
 
 		if ( false !== ( $taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_ID, 'wpseo' ) ) ) {

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -105,7 +105,7 @@ class WPSEO_Primary_Term_Admin {
 	protected function get_primary_term_taxonomies( $post_ID = null ) {
 
 		if ( null === $post_ID ) {
-			$post_ID = $_GET['post'];
+			$post_ID = (int) $_GET['post'];
 		}
 
 		if ( false !== ( $taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_ID, 'wpseo' ) ) ) {

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -24,6 +24,7 @@ class WPSEO_Primary_Term_Admin {
 
 	/**
 	 * Get the current post ID.
+	 *
 	 * @return integer The post ID.
 	 */
 	protected function get_current_id() {

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -22,6 +22,10 @@ class WPSEO_Primary_Term_Admin {
 		$primary_term->register_hooks();
 	}
 
+	protected function get_current_id() {
+		return filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+	}
+
 	/**
 	 * Add primary term templates
 	 */
@@ -91,7 +95,7 @@ class WPSEO_Primary_Term_Admin {
 	 * @return int primary term id
 	 */
 	protected function get_primary_term( $taxonomy_name ) {
-		$primary_term = new WPSEO_Primary_Term( $taxonomy_name, get_the_ID() );
+		$primary_term = new WPSEO_Primary_Term( $taxonomy_name, $this->get_current_id() );
 
 		return $primary_term->get_primary_term();
 	}
@@ -105,7 +109,7 @@ class WPSEO_Primary_Term_Admin {
 	protected function get_primary_term_taxonomies( $post_ID = null ) {
 
 		if ( null === $post_ID ) {
-			$post_ID = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+			$post_ID = $this->get_current_id();
 		}
 
 		if ( false !== ( $taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_ID, 'wpseo' ) ) ) {

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -22,6 +22,10 @@ class WPSEO_Primary_Term_Admin {
 		$primary_term->register_hooks();
 	}
 
+	/**
+	 * Get the current post ID.
+	 * @return integer The post ID.
+	 */
 	protected function get_current_id() {
 		return filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 	}

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -10,7 +10,7 @@
 	 *
 	 * @param {Object} checkbox
 	 *
-	 * @return {bool}
+	 * @return {boolean}
 	 */
 	function hasPrimaryTermElements( checkbox ) {
 		return 1 === $( checkbox ).closest( 'li' ).children( '.wpseo-make-primary-term' ).length;


### PR DESCRIPTION
Due to get_the_ID() not being capable to getting the actual post ID, multiple plugins broke parts of Yoast SEO.

Fixes #4105
Possibly fixes #4100
Possibly fixes #4068
Possibly fixes #4221
Possibly fixes #4237