### PR TITLE
Update wp-seo-shortcode-plugin-305.js

### DIFF
--- a/js/dist/wp-seo-shortcode-plugin-305.js
+++ b/js/dist/wp-seo-shortcode-plugin-305.js
@@ -98,7 +98,7 @@
 	 */
 	YoastShortcodePlugin.prototype.bindElementEvents = function() {
 		var contentElement = document.getElementById( 'content' ) || false;
-		var callback =  _.debounce(	this.loadShortcodes.bind( this, this.declareReloaded.bind( this ) ), 500 );
+		var callback =  _.debounce(	this.loadShortcodes.bind( this, this.declareReloaded.bind( this ) ), 5000 );
 
 		if (contentElement) {
 			contentElement.addEventListener( 'keyup', callback );


### PR DESCRIPTION
Increase debounce from 500ms to 5s which is much more sane.

It would be even better to remove the keyup listener altogether.