### PR TITLE
Removed WP versions below 4.2 from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
     - php: 5.6
       env: WP_VERSION=4.2
     - php: 5.6
-      env: WP_VERSION=4.1
-    - php: 5.6
-      env: WP_VERSION=4.0
-    - php: 5.6
       env: WP_VERSION=4.4
     - php: 5.5
       env: WP_VERSION=4.4


### PR DESCRIPTION
No longer supported.