### PR TITLE
Allow other taxonomies in yoast_get_primary_term

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -45,15 +45,16 @@ if ( ! function_exists( 'yoast_get_primary_term_id' ) ) {
 	/**
 	 * Get the primary term ID
 	 *
+	 * @param string           $taxonomy Optional. The taxonomy to get the primary term ID for. Defaults to category.
 	 * @param null|int|WP_Post $post Optional. Post to get the primary term ID for.
 	 *
 	 * @return bool|int
 	 */
-	function yoast_get_primary_term_id( $post = null ) {
+	function yoast_get_primary_term_id( $taxonomy = 'category', $post = null ) {
 		$post = get_post( $post );
 
-		$wpseo_primary_term = new WPSEO_Primary_Term( 'category', $post->ID );
-		return $wpseo_primary_term->get_primary_term();
+		$primary_term = new WPSEO_Primary_Term( $taxonomy, $post->ID );
+		return $primary_term->get_primary_term();
 	}
 }
 
@@ -61,14 +62,15 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
 	/**
 	 * Get the primary term name
 	 *
+	 * @param string           $taxonomy Optional. The taxonomy to get the primary term for. Defaults to category.
 	 * @param null|int|WP_Post $post Optional. Post to get the primary term for.
 	 *
 	 * @return string Name of the primary term.
 	 */
-	function yoast_get_primary_term( $post ) {
-		$wpseo_primary_term_id = yoast_get_primary_term_id( $post );
+	function yoast_get_primary_term( $taxonomy = 'category', $post = null ) {
+		$primary_term_id = yoast_get_primary_term_id( $taxonomy, $post );
 
-		$term = get_term( $wpseo_primary_term_id );
+		$term = get_term( $primary_term_id );
 		if ( ! is_wp_error( $term ) && ! empty( $term ) ) {
 			return $term->name;
 		}


### PR DESCRIPTION
`yoast_get_primary_term` was essentially `yoast_get_primary_category`, this PR fixes that.