### PR TITLE
Fixed Composer version to 1.0.0 in Travis to fix autoload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ cache:
 
 before_script:
 - phpenv local 5.6
-- composer selfupdate --no-interaction
+- composer selfupdate 1.0.0 --no-interaction
 - composer install --no-interaction
 - composer config-yoastcs
 - phpenv local --unset


### PR DESCRIPTION
Related https://bitbucket.org/xrstf/composer-php52/issues/9/getautoloadrealfile-strikes-again