### PR TITLE
Fix notice on 404 page

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -247,7 +247,7 @@ class WPSEO_Frontend {
 		if ( is_null( $object ) ) {
 			$object = $GLOBALS['wp_query']->get_queried_object();
 		}
-		if( is_object($object) ) {
+		if ( is_object($object) ) {
 			$title = WPSEO_Meta::get_value( 'title', $object->ID );
 
 			if ( $title !== '' ) {
@@ -257,8 +257,8 @@ class WPSEO_Frontend {
 			$post_type = ( isset( $object->post_type ) ? $object->post_type : $object->query_var );
 
 			return $this->get_title_from_options( 'title-' . $post_type, $object );
-        }
-        return $this->get_title_from_options('title-404-wpseo');
+		}
+		return $this->get_title_from_options( 'title-404-wpseo' );
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -247,7 +247,7 @@ class WPSEO_Frontend {
 		if ( is_null( $object ) ) {
 			$object = $GLOBALS['wp_query']->get_queried_object();
 		}
-		
+
 		if ( is_object( $object ) ) {
 			$title = WPSEO_Meta::get_value( 'title', $object->ID );
 
@@ -259,7 +259,7 @@ class WPSEO_Frontend {
 
 			return $this->get_title_from_options( 'title-' . $post_type, $object );
 		}
-		
+
 		return $this->get_title_from_options( 'title-404-wpseo' );
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -247,7 +247,7 @@ class WPSEO_Frontend {
 		if ( is_null( $object ) ) {
 			$object = $GLOBALS['wp_query']->get_queried_object();
 		}
-		if ( is_object($object) ) {
+		if ( is_object( $object ) ) {
 			$title = WPSEO_Meta::get_value( 'title', $object->ID );
 
 			if ( $title !== '' ) {

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -247,6 +247,7 @@ class WPSEO_Frontend {
 		if ( is_null( $object ) ) {
 			$object = $GLOBALS['wp_query']->get_queried_object();
 		}
+		
 		if ( is_object( $object ) ) {
 			$title = WPSEO_Meta::get_value( 'title', $object->ID );
 
@@ -258,6 +259,7 @@ class WPSEO_Frontend {
 
 			return $this->get_title_from_options( 'title-' . $post_type, $object );
 		}
+		
 		return $this->get_title_from_options( 'title-404-wpseo' );
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -247,7 +247,7 @@ class WPSEO_Frontend {
 		if ( is_null( $object ) ) {
 			$object = $GLOBALS['wp_query']->get_queried_object();
 		}
-        if( is_object($object) ) {
+		if( is_object($object) ) {
 			$title = WPSEO_Meta::get_value( 'title', $object->ID );
 
 			if ( $title !== '' ) {

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -247,16 +247,18 @@ class WPSEO_Frontend {
 		if ( is_null( $object ) ) {
 			$object = $GLOBALS['wp_query']->get_queried_object();
 		}
+        if( is_object($object) ) {
+			$title = WPSEO_Meta::get_value( 'title', $object->ID );
 
-		$title = WPSEO_Meta::get_value( 'title', $object->ID );
+			if ( $title !== '' ) {
+				return wpseo_replace_vars( $title, $object );
+			}
 
-		if ( $title !== '' ) {
-			return wpseo_replace_vars( $title, $object );
-		}
+			$post_type = ( isset( $object->post_type ) ? $object->post_type : $object->query_var );
 
-		$post_type = ( isset( $object->post_type ) ? $object->post_type : $object->query_var );
-
-		return $this->get_title_from_options( 'title-' . $post_type, $object );
+			return $this->get_title_from_options( 'title-' . $post_type, $object );
+        }
+        return $this->get_title_from_options('title-404-wpseo');
 	}
 
 	/**


### PR DESCRIPTION
$object can be null on 404 page when permalink option is set to "simple" (no rewrite)
and trigger php notice:
Notice: Trying to get property of non-object in /...../wp-content/plugins/wordpress-seo/frontend/class-frontend.php on line 267

About the fix:
Verify $object is an object, get 404 title otherwise.