### PR TITLE
Fix Fatal error: Call to undefined function bccomp()

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -461,7 +461,7 @@ class Yoast_Notification_Center {
 		$b_type = $b->get_type();
 
 		if ( $a_type === $b_type ) {
-			return bccomp( $b->get_priority(), $a->get_priority() );
+			return WPSEO_Utils::calc( $b->get_priority(), 'compare', $a->get_priority() );
 		}
 
 		if ( 'error' === $a_type ) {


### PR DESCRIPTION
Use WPSEO_Utils in replace of bccomp.

In the rare case that the bcmath extension would not be loaded, bccomp will fatal error due to an undefined function call. Using the WPSEO_Utils calc function  it will return the normal calculation results using the compare action.