### PR TITLE
Better dismiss notifications

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -78,7 +78,10 @@ class WPSEO_Admin_Init {
 		if ( $can_access && $this->has_ignored_tour() && ! $this->seen_about() ) {
 
 			if ( filter_input( INPUT_GET, 'intro' ) === '1' || $this->dismiss_notice( 'wpseo-dismiss-about' ) ) {
-				update_user_meta( get_current_user_id(), 'wpseo_seen_about_version' , WPSEO_VERSION );
+
+				$user_id = get_current_user_id();
+				update_user_meta( $user_id, 'wpseo_seen_about_version', WPSEO_VERSION );
+				update_user_meta( $user_id, 'wpseo-dismiss-about', 'seen' );
 
 				return;
 			}
@@ -182,7 +185,7 @@ class WPSEO_Admin_Init {
 		if ( defined( 'GAWP_VERSION' ) && '5.4.3' === GAWP_VERSION ) {
 
 			$info_message = sprintf(
-				/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
+			/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
 				__( '%1$s detected you are using version %2$s of %3$s, please update to the latest version to prevent compatibility issues.', 'wordpress-seo' ),
 				'Yoast SEO',
 				'5.4.3',
@@ -206,6 +209,7 @@ class WPSEO_Admin_Init {
 
 		if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
 			update_option( 'wpseo_dismiss_recalculate', '1' );
+
 			return;
 		}
 
@@ -213,7 +217,7 @@ class WPSEO_Admin_Init {
 		if ( $can_access && ! $this->is_site_notice_dismissed( 'wpseo_dismiss_recalculate' ) ) {
 			Yoast_Notification_Center::get()->add_notification(
 				new Yoast_Notification(
-					/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
+				/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
 					sprintf(
 						__( 'We\'ve updated our SEO score algorithm. %1$sClick here to recalculate the SEO scores%2$s for all posts and pages.', 'wordpress-seo' ),
 						'<a href="' . admin_url( 'admin.php?page=wpseo_tools&recalculate=1' ) . '">',
@@ -402,7 +406,7 @@ class WPSEO_Admin_Init {
 
 		foreach ( $deprecated_notices as $deprecated_filter ) {
 			_deprecated_function(
-				/* %s expands to the actual filter/action that has been used. */
+			/* %s expands to the actual filter/action that has been used. */
 				sprintf( __( '%s filter/action', 'wordpress-seo' ), $deprecated_filter ),
 				'WPSEO 3.0',
 				'javascript'

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -185,7 +185,7 @@ class WPSEO_Admin_Init {
 		if ( defined( 'GAWP_VERSION' ) && '5.4.3' === GAWP_VERSION ) {
 
 			$info_message = sprintf(
-			/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
+				/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
 				__( '%1$s detected you are using version %2$s of %3$s, please update to the latest version to prevent compatibility issues.', 'wordpress-seo' ),
 				'Yoast SEO',
 				'5.4.3',
@@ -217,7 +217,7 @@ class WPSEO_Admin_Init {
 		if ( $can_access && ! $this->is_site_notice_dismissed( 'wpseo_dismiss_recalculate' ) ) {
 			Yoast_Notification_Center::get()->add_notification(
 				new Yoast_Notification(
-				/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
+					/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
 					sprintf(
 						__( 'We\'ve updated our SEO score algorithm. %1$sClick here to recalculate the SEO scores%2$s for all posts and pages.', 'wordpress-seo' ),
 						'<a href="' . admin_url( 'admin.php?page=wpseo_tools&recalculate=1' ) . '">',
@@ -406,7 +406,7 @@ class WPSEO_Admin_Init {
 
 		foreach ( $deprecated_notices as $deprecated_filter ) {
 			_deprecated_function(
-			/* %s expands to the actual filter/action that has been used. */
+				/* %s expands to the actual filter/action that has been used. */
 				sprintf( __( '%s filter/action', 'wordpress-seo' ), $deprecated_filter ),
 				'WPSEO 3.0',
 				'javascript'

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -56,6 +56,33 @@ class WPSEO_Admin_Init {
 		$this->load_admin_page_class();
 		$this->load_admin_user_class();
 		$this->load_xml_sitemaps_admin();
+
+		$this->sync_about_version_from_cookie();
+	}
+
+	/**
+	 * Get about version seen from cookie if set.
+	 */
+	protected function sync_about_version_from_cookie() {
+
+		$user_id                   = get_current_user_id();
+		$meta_seen_about_version   = get_user_meta( $user_id, 'wpseo_seen_about_version', true );
+		
+		$cookie_key = 'wpseo_seen_about_version_' . $user_id;
+
+		$cookie_seen_about_version = isset($_COOKIE[$cookie_key]) ? $_COOKIE[$cookie_key] : '';
+
+		if ( ! empty( $cookie_seen_about_version ) ) {
+
+			if ( version_compare( $cookie_seen_about_version, $meta_seen_about_version, '>' ) ) {
+				update_user_meta( $user_id, 'wpseo_seen_about_version', $cookie_seen_about_version );
+				$meta_seen_about_version = $cookie_seen_about_version;
+			}
+		}
+
+		if ( $cookie_seen_about_version !== $meta_seen_about_version ) {
+			setcookie( $cookie_key, $meta_seen_about_version, $_SERVER['REQUEST_TIME'] + YEAR_IN_SECONDS );
+		}
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -81,7 +81,7 @@ class WPSEO_Admin_Init {
 		}
 
 		if ( $cookie_seen_about_version !== $meta_seen_about_version ) {
-			setcookie( $cookie_key, $meta_seen_about_version, $_SERVER['REQUEST_TIME'] + YEAR_IN_SECONDS );
+			setcookie( $cookie_key, $meta_seen_about_version, ( $_SERVER['REQUEST_TIME'] + YEAR_IN_SECONDS ) );
 		}
 	}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -78,11 +78,8 @@ class WPSEO_Admin_Init {
 		if ( $can_access && $this->has_ignored_tour() && ! $this->seen_about() ) {
 
 			if ( filter_input( INPUT_GET, 'intro' ) === '1' || $this->dismiss_notice( 'wpseo-dismiss-about' ) ) {
-
-				$user_id = get_current_user_id();
-				update_user_meta( $user_id, 'wpseo_seen_about_version', WPSEO_VERSION );
-				update_user_meta( $user_id, 'wpseo-dismiss-about', 'seen' );
-
+				update_user_meta( get_current_user_id(), 'wpseo_seen_about_version', WPSEO_VERSION );
+				
 				return;
 			}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -65,12 +65,12 @@ class WPSEO_Admin_Init {
 	 */
 	protected function sync_about_version_from_cookie() {
 
-		$user_id                   = get_current_user_id();
-		$meta_seen_about_version   = get_user_meta( $user_id, 'wpseo_seen_about_version', true );
-		
+		$user_id                 = get_current_user_id();
+		$meta_seen_about_version = get_user_meta( $user_id, 'wpseo_seen_about_version', true );
+
 		$cookie_key = 'wpseo_seen_about_version_' . $user_id;
 
-		$cookie_seen_about_version = isset($_COOKIE[$cookie_key]) ? $_COOKIE[$cookie_key] : '';
+		$cookie_seen_about_version = isset( $_COOKIE[ $cookie_key ] ) ? $_COOKIE[ $cookie_key ] : '';
 
 		if ( ! empty( $cookie_seen_about_version ) ) {
 
@@ -106,7 +106,6 @@ class WPSEO_Admin_Init {
 
 			if ( filter_input( INPUT_GET, 'intro' ) === '1' || $this->dismiss_notice( 'wpseo-dismiss-about' ) ) {
 				update_user_meta( get_current_user_id(), 'wpseo_seen_about_version', WPSEO_VERSION );
-				
 				return;
 			}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -209,7 +209,6 @@ class WPSEO_Admin_Init {
 
 		if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
 			update_option( 'wpseo_dismiss_recalculate', '1' );
-
 			return;
 		}
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -182,7 +182,7 @@ class Yoast_Notification_Center {
 
 		// Fallback to ?dismissal_key=1&nonce=bla when JavaScript fails.
 		if ( ! $is_dismissing ) {
-			$is_dismissing = ( 1 === intval( self::get_user_input( $dismissal_key ) ) );
+			$is_dismissing = ( '1' === self::get_user_input( $dismissal_key ) );
 		}
 
 		if ( ! $is_dismissing ) {

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -496,9 +496,14 @@ class Yoast_Notification_Center {
 	 */
 	private static function dismiss_notification( Yoast_Notification $notification, $meta_value = 'seen' ) {
 
+		$user_id = get_current_user_id();
+
 		// Set about version when dismissing about notification.
 		if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
-			return ( false !== update_user_meta( get_current_user_id(), 'wpseo_seen_about_version', WPSEO_VERSION ) );
+
+			setcookie( 'wpseo_seen_about_version_' . $user_id, WPSEO_VERSION, $_SERVER['REQUEST_TIME'] + YEAR_IN_SECONDS );
+
+			return ( false !== update_user_meta( $user_id, 'wpseo_seen_about_version', WPSEO_VERSION ) );
 		}
 
 		// Dismiss notification.

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -501,7 +501,7 @@ class Yoast_Notification_Center {
 		// Set about version when dismissing about notification.
 		if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
 
-			setcookie( 'wpseo_seen_about_version_' . $user_id, WPSEO_VERSION, $_SERVER['REQUEST_TIME'] + YEAR_IN_SECONDS );
+			setcookie( 'wpseo_seen_about_version_' . $user_id, WPSEO_VERSION, ( $_SERVER['REQUEST_TIME'] + YEAR_IN_SECONDS ) );
 
 			return ( false !== update_user_meta( $user_id, 'wpseo_seen_about_version', WPSEO_VERSION ) );
 		}

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -169,11 +169,16 @@ class Yoast_Notification_Center {
 		$notification_id = $notification->get_id();
 
 		$is_dismissing = ( $dismissal_key === self::get_user_input( 'notification' ) );
+
 		if ( ! $is_dismissing ) {
 			$is_dismissing = ( $notification_id === self::get_user_input( 'notification' ) );
 		}
 
-		// Can be dismissed by dismissal_key or notification_id.
+		// Fallback to ?dismissal_key=1&nonce=bla when JavaScript fails.
+		if ( ! $is_dismissing ) {
+			$is_dismissing = ( 1 === intval( self::get_user_input( $dismissal_key ) ) );
+		}
+
 		if ( ! $is_dismissing ) {
 			return false;
 		}
@@ -483,7 +488,7 @@ class Yoast_Notification_Center {
 	 *
 	 * @return bool
 	 */
-	private static function dismiss_notification( Yoast_Notification $notification, $meta_value = 'seen' ) {
+	public static function dismiss_notification( Yoast_Notification $notification, $meta_value = 'seen' ) {
 
 		// Dismiss notification.
 		return ( false !== update_user_meta( get_current_user_id(), $notification->get_dismissal_key(), $meta_value ) );

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -169,7 +169,6 @@ class Yoast_Notification_Center {
 		$notification_id = $notification->get_id();
 
 		$is_dismissing = ( $dismissal_key === self::get_user_input( 'notification' ) );
-
 		if ( ! $is_dismissing ) {
 			$is_dismissing = ( $notification_id === self::get_user_input( 'notification' ) );
 		}

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -488,7 +488,7 @@ class Yoast_Notification_Center {
 	 *
 	 * @return bool
 	 */
-	public static function dismiss_notification( Yoast_Notification $notification, $meta_value = 'seen' ) {
+	private static function dismiss_notification( Yoast_Notification $notification, $meta_value = 'seen' ) {
 
 		// Dismiss notification.
 		return ( false !== update_user_meta( get_current_user_id(), $notification->get_dismissal_key(), $meta_value ) );

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -147,6 +147,13 @@ class Yoast_Notification_Center {
 
 		$current_value = get_user_meta( $user_id, $dismissal_key, $single = true );
 
+		if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
+			$seen_about_version = substr( get_user_meta( $user_id, 'wpseo_seen_about_version', true ), 0, 3 );
+			$last_minor_version = substr( WPSEO_VERSION, 0, 3 );
+
+			return version_compare( $seen_about_version, $last_minor_version, '>=' );
+		}
+
 		return ! empty( $current_value );
 	}
 
@@ -488,6 +495,11 @@ class Yoast_Notification_Center {
 	 * @return bool
 	 */
 	private static function dismiss_notification( Yoast_Notification $notification, $meta_value = 'seen' ) {
+
+		// Set about version when dismissing about notification.
+		if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
+			return ( false !== update_user_meta( get_current_user_id(), 'wpseo_seen_about_version', WPSEO_VERSION ) );
+		}
 
 		// Dismiss notification.
 		return ( false !== update_user_meta( get_current_user_id(), $notification->get_dismissal_key(), $meta_value ) );


### PR DESCRIPTION
Added explicit dismissal meta data when dismissal data is detected inside the URL.
Added missing dismissal detection inside the Notification Center for non-ajax fallback request on the update notification.