### PR TITLE
Fix permalink generation for new posts.

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -24,7 +24,7 @@ var publishBox = require( './ui/publishBox' );
 
 	var titleElement;
 
-	var leavePostNameEmpty = false;
+	var leavePostNameUntouched = false;
 
 	var app, snippetPreview;
 
@@ -158,11 +158,11 @@ var publishBox = require( './ui/publishBox' );
 
 				/*
 				 * WordPress leaves the post name empty to signify that it should be generated from the title once the
-				 * post is saved. So in some cases when we receive an auto generated slug from WordPress we should be
+				 * post is saved. So when we receive an auto generated slug from WordPress we should be
 				 * able to not save this to the UI. This conditional makes that possible.
 				 */
-				if ( leavePostNameEmpty ) {
-					leavePostNameEmpty = false;
+				if ( leavePostNameUntouched ) {
+					leavePostNameUntouched = false;
 					return;
 				}
 
@@ -309,15 +309,6 @@ var publishBox = require( './ui/publishBox' );
 	};
 
 	/**
-	 * Returns whether or not the current post has a title.
-	 *
-	 * @returns {boolean}
-	 */
-	function postHasTitle() {
-		return '' !== titleElement.val();
-	}
-
-	/**
 	 * Retrieves either a generated slug or the page title as slug for the preview.
 	 *
 	 * @param {Object} response The AJAX response object.
@@ -345,12 +336,10 @@ var publishBox = require( './ui/publishBox' );
 
 		if ( 'string' === typeof ajaxOptions.data && -1 !== ajaxOptions.data.indexOf( 'action=sample-permalink' ) ) {
 			/*
-			 * If the post has no title, WordPress wants to auto generate the slug once the title is set, so we need to
-			 * keep the post name empty.
+			 * WordPress do not update post name for auto-generated slug, so we should leave this field untouched.
 			 */
-			if ( ! postHasTitle() ) {
-				leavePostNameEmpty = true;
-			}
+			leavePostNameUntouched = true;
+
 			app.snippetPreview.setUrlPath( getUrlPathFromResponse( response ) );
 		}
 	} );


### PR DESCRIPTION
Case:

1. Go to  create new post form.
2. Type post title.
3. Click on editor (post was saved as draft, sample permalink was generated).
4. Change title (permalink sample preview was not changed).
5. Click Publish.

By default in this case WordPress ignore value from permalink sample and generate new slug from title. With Yoast SEO enabled this works differently - WP use permalink sample and ignore further changes of post title. 

This is related to #3418, but #3418 fix this bug only partially. Sample permalink generated by WP should never modify `post_name` field, because it is only default slug, and it is generated on post publishing anyway.