### PR TITLE
Support multiple domains - add domain to cache prefix

### DIFF
--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -38,6 +38,11 @@ class WPSEO_Sitemaps_Cache_Validator {
 		$type_cache_validator   = self::get_validator( $type );
 
 		$prefix  = self::STORAGE_KEY_PREFIX;
+		
+		$host = parse_url(home_url(), PHP_URL_HOST);
+		$host = convert_base10_to_base61($host);
+		$prefix .= $host . '_';
+		
 		$postfix = sprintf( '_%d:%s_%s', $page, $global_cache_validator, $type_cache_validator );
 
 		try {


### PR DESCRIPTION
When using one single Wordpress instance (no network installation) for multiple domains, e.g. by adding dynamic SITEURL, the sitemaps would not differ. This change adds the domain to the cache prefix.

The following is an example to deliver a single Wordpress with multiple domains/names/titles... 

```
define('WP_SITEURL', 'http://' . $_SERVER['SERVER_NAME']);
define('WP_HOME', 'http://' . $_SERVER['SERVER_NAME']);

add_filter( 'pre_option_blogdescription', array($this, 'modify_blogdescription'),10,2);
add_filter( 'pre_option_blogname', array($this, 'modify_blogname') );
```
