### PR TITLE
Sitemap image parser fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"xrstf/composer-php52": "^1.0.20"
 	},
 	"require-dev": {
-		"yoast/yoastcs": "0.2",
+		"yoast/yoastcs": "0.3",
 		"codeclimate/php-test-reporter": "dev-master"
 	},
 	"minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3fc20e5eafa8ad35fef01a5e57322aa5",
-    "content-hash": "e1951d393a852b97e4d86f8a072928c7",
+    "hash": "4688d2a8cff02521f26d4b4526c7b0ac",
+    "content-hash": "bf77ea2e75c7a7b7f2114afc96a876e0",
     "packages": [
         {
             "name": "composer/installers",
@@ -266,7 +266,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/a026a4bc86867129e760b95dca44b8cd10819333",
+                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/3a2d3ebdc1df5acf372458c15041af240a6fc016",
                 "reference": "892163d67e3bd9c190d43655acb69657da765c7b",
                 "shasum": ""
             },
@@ -1095,16 +1095,16 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "0.2",
+            "version": "0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "ea0a13df8283af9d4af3db05bdd754e49ed0f298"
+                "reference": "f568cc6fc1194c5ef67ccc24b7cfd24259e92a16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/ea0a13df8283af9d4af3db05bdd754e49ed0f298",
-                "reference": "ea0a13df8283af9d4af3db05bdd754e49ed0f298",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f568cc6fc1194c5ef67ccc24b7cfd24259e92a16",
+                "reference": "f568cc6fc1194c5ef67ccc24b7cfd24259e92a16",
                 "shasum": ""
             },
             "require": {
@@ -1133,7 +1133,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-04-01 11:32:09"
+            "time": "2016-05-03 09:58:54"
         }
     ],
     "aliases": [],

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -145,9 +145,6 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				continue;
 			}
 
-			$post_ids = wp_list_pluck( $posts, 'ID' );
-			$this->image_parser->cache_attachments( $post_ids );
-
 			$posts_to_exclude = explode( ',', $this->options['excluded-posts'] );
 
 			foreach ( $posts as $post ) {

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -106,7 +106,11 @@ class WPSEO_Sitemap_Image_Parser {
 
 		$images = array();
 
-		$content      = $post->post_content;
+		if ( ! is_object( $post ) ) {
+			return $images;
+		}
+
+		$content      = get_post_field( 'post_content', $post );
 		$thumbnail_id = get_post_thumbnail_id( $post->ID );
 
 		if ( $thumbnail_id ) {

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -38,64 +38,6 @@ class WPSEO_Sitemap_Image_Parser {
 	}
 
 	/**
-	 * Cache attached images and thumbnails for a set of posts.
-	 *
-	 * @param array $post_ids Set of post IDs to cache attachments for.
-	 */
-	public function cache_attachments( $post_ids ) {
-
-		$imploded_post_ids = implode( $post_ids, ',' );
-		$this->attachments = $this->get_attachments( $imploded_post_ids );
-		$attachment_ids    = wp_list_pluck( $this->attachments, 'ID' );
-		$thumbnail_ids     = $this->get_thumbnails( $imploded_post_ids );
-		$attachment_ids    = array_unique( array_merge( $thumbnail_ids, $attachment_ids ) );
-
-		_prime_post_caches( $attachment_ids );
-		update_meta_cache( 'post', $attachment_ids );
-	}
-
-	/**
-	 * Getting the attachments from database.
-	 *
-	 * @param string $post_ids Set of post IDs.
-	 *
-	 * @return array
-	 */
-	private function get_attachments( $post_ids ) {
-
-		global $wpdb;
-
-		$sql = "
-			SELECT ID, post_title, post_parent
-			FROM {$wpdb->posts}
-			WHERE post_status = 'inherit'
-				AND post_type = 'attachment'
-				AND post_parent IN (" . $post_ids . ')';
-
-		return $wpdb->get_results( $sql );
-	}
-
-	/**
-	 * Get thumbnail IDs for a set of posts.
-	 *
-	 * @param array $post_ids Set of post IDs.
-	 *
-	 * @return array
-	 */
-	private function get_thumbnails( $post_ids ) {
-
-		global $wpdb;
-
-		$sql = "
-			SELECT meta_value
-			FROM {$wpdb->postmeta}
-			WHERE meta_key = '_thumbnail_id'
-				AND post_id IN (" . $post_ids . ')';
-
-		return $wpdb->get_col( $sql );
-	}
-
-	/**
 	 * Get set of image data sets for the given post.
 	 *
 	 * @param object $post Post object to get images for.
@@ -400,5 +342,17 @@ class WPSEO_Sitemap_Image_Parser {
 		}
 
 		return $src;
+	}
+
+	/**
+	 * Cache attached images and thumbnails for a set of posts.
+	 *
+	 * @deprecated 3.3 Blanket caching no longer makes sense with modern galleries. R.
+	 *
+	 * @param array $post_ids Set of post IDs to cache attachments for.
+	 */
+	public function cache_attachments( $post_ids ) {
+
+		_deprecated_function( __FUNCTION__, '3.3' );
 	}
 }

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -55,9 +55,11 @@ class WPSEO_Sitemap_Image_Parser {
 		$thumbnail_id = get_post_thumbnail_id( $post->ID );
 
 		if ( $thumbnail_id ) {
-			$src = $this->get_absolute_url( $this->image_url( $thumbnail_id ) );
-			// Content of title and alt is legacy from previous logic. R.
-			$images[] = $this->get_image_item( $post, $src, '', $post->post_title );
+
+			$src      = $this->get_absolute_url( $this->image_url( $thumbnail_id ) );
+			$alt      = get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true );
+			$title    = get_post_field( 'post_title', $thumbnail_id );
+			$images[] = $this->get_image_item( $post, $src, $title, $alt );
 		}
 
 		$images = array_merge( $images, $this->parse_html_images( $post ), $this->parse_galleries( $post ) );

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -217,6 +217,43 @@ class WPSEO_Sitemap_Image_Parser {
 	}
 
 	/**
+	 * Retrieves galleries from the passed post's content.
+	 *
+	 * Forked from core to skip executing shortcodes for performance.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return array A list of arrays, each containing gallery data.
+	 */
+	protected function get_post_galleries( $post ) {
+
+		if ( ! has_shortcode( $post->post_content, 'gallery' ) ) {
+			return array();
+		}
+
+		$galleries = array();
+
+		if ( ! preg_match_all( '/' . get_shortcode_regex() . '/s', $post->post_content, $matches, PREG_SET_ORDER ) ) {
+			return $galleries;
+		}
+
+		foreach ( $matches as $shortcode ) {
+			if ( 'gallery' === $shortcode[2] ) {
+
+				$attributes = shortcode_parse_atts( $shortcode[3] );
+
+				if ( '' === $attributes ) { // Valid shortcode without any attributes. R.
+					$attributes = array();
+				}
+
+				$galleries[] = $attributes;
+			}
+		}
+
+		return $galleries;
+	}
+
+	/**
 	 * Get image item array with filters applied.
 	 *
 	 * @param WP_Post $post  Post object for the context.

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -349,10 +349,8 @@ class WPSEO_Sitemap_Image_Parser {
 	 * Cache attached images and thumbnails for a set of posts.
 	 *
 	 * @deprecated 3.3 Blanket caching no longer makes sense with modern galleries. R.
-	 *
-	 * @param array $post_ids Set of post IDs to cache attachments for.
 	 */
-	public function cache_attachments( $post_ids ) {
+	public function cache_attachments() {
 
 		_deprecated_function( __FUNCTION__, '3.3' );
 	}

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -26,14 +26,13 @@ class WPSEO_Sitemap_Image_Parser {
 	public function __construct() {
 
 		$this->home_url = home_url();
+		$parsed_home    = parse_url( $this->home_url );
 
-		$parsed_home  = parse_url( $this->home_url );
-
-		if ( isset( $parsed_home['host'] ) && ! empty( $parsed_home['host'] ) ) {
+		if ( ! empty( $parsed_home['host'] ) ) {
 			$this->host = str_replace( 'www.', '', $parsed_home['host'] );
 		}
 
-		if ( isset( $parsed_home['scheme'] ) && ! empty( $parsed_home['scheme'] ) ) {
+		if ( ! empty( $parsed_home['scheme'] ) ) {
 			$this->scheme = $parsed_home['scheme'];
 		}
 	}

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -158,6 +158,10 @@ class WPSEO_Sitemap_Image_Parser {
 			}
 
 			// Forked from core gallery_shortcode() to have exact same logic. R.
+			if ( ! empty( $gallery['ids'] ) ) {
+				$gallery['include'] = $gallery['ids'];
+			}
+
 			if ( ! empty( $gallery['include'] ) ) {
 
 				$_attachments = get_posts( array(

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -296,19 +296,17 @@ class WPSEO_Sitemap_Image_Parser {
 			return '';
 		}
 
-		// TODO check all this logic, looks messy. R.
-		if ( 0 === strpos( $file, $uploads['basedir'] ) ) { // Check that the upload base exists in the file location.
-			$url = str_replace( $uploads['basedir'], $uploads['baseurl'], $file );
-		}
-		// Replace file location with url location.
-		elseif ( false !== strpos( $file, 'wp-content/uploads' ) ) {
-			$url = $uploads['baseurl'] . substr( $file, ( strpos( $file, 'wp-content/uploads' ) + 18 ) );
-		}
-		// It's a newly uploaded file, therefore $file is relative to the baseurl.
-		else {
-			$url = $uploads['baseurl'] . "/$file";
+		// Check that the upload base exists in the file location.
+		if ( 0 === strpos( $file, $uploads['basedir'] ) ) {
+			return str_replace( $uploads['basedir'], $uploads['baseurl'], $file );
 		}
 
-		return $url;
+		// Replace file location with url location.
+		if ( false !== strpos( $file, 'wp-content/uploads' ) ) {
+			return $uploads['baseurl'] . substr( $file, ( strpos( $file, 'wp-content/uploads' ) + 18 ) );
+		}
+
+		// It's a newly uploaded file, therefore $file is relative to the baseurl.
+		return $uploads['baseurl'] . "/$file";
 	}
 }

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -55,8 +55,9 @@ class WPSEO_Sitemap_Image_Parser {
 		$thumbnail_id = get_post_thumbnail_id( $post->ID );
 
 		if ( $thumbnail_id ) {
+			$src = $this->get_absolute_url( $this->image_url( $thumbnail_id ) );
 			// Content of title and alt is legacy from previous logic. R.
-			$images[] = $this->get_image_item( $post, $this->image_url( $thumbnail_id ), '', $post->post_title );
+			$images[] = $this->get_image_item( $post, $src, '', $post->post_title );
 		}
 
 		$images = array_merge( $images, $this->parse_html_images( $post ), $this->parse_galleries( $post ) );
@@ -186,7 +187,7 @@ class WPSEO_Sitemap_Image_Parser {
 
 		foreach ( $attachments as $attachment ) {
 
-			$src = $this->image_url( $attachment->ID );
+			$src = $this->get_absolute_url( $this->image_url( $attachment->ID ) );
 			$alt = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
 
 			$images[] = $this->get_image_item( $post, $src, $attachment->post_title, $alt );

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -108,8 +108,6 @@ class WPSEO_Sitemap_Image_Parser {
 				continue;
 			}
 
-			$title = $img->getAttribute( 'title' );
-			$alt   = $img->getAttribute( 'alt' );
 			$class = $img->getAttribute( 'class' );
 
 			if ( // This detects WP-inserted images, which we need to upsize. R.
@@ -131,7 +129,7 @@ class WPSEO_Sitemap_Image_Parser {
 				continue;
 			}
 
-			$image    = $this->get_image_item( $post, $src, $title, $alt );
+			$image    = $this->get_image_item( $post, $src, $img->getAttribute( 'title' ), $img->getAttribute( 'alt' ) );
 			$images[] = $image;
 		}
 

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -108,6 +108,19 @@ class WPSEO_Sitemap_Image_Parser {
 				continue;
 			}
 
+			$title = $img->getAttribute( 'title' );
+			$alt   = $img->getAttribute( 'alt' );
+			$class = $img->getAttribute( 'class' );
+
+			if ( // This detects WP-inserted images, which we need to upsize. R.
+				! empty( $class )
+				&& false === strpos( $class, 'size-full' )
+				&& preg_match( '|wp-image-(?P<id>\d+)|', $class, $matches )
+				&& get_post_status( $matches['id'] )
+			) {
+				$src = $this->image_url( $matches['id'] );
+			}
+
 			$src = $this->get_absolute_url( $src );
 
 			if ( strpos( $src, $this->host ) === false ) {
@@ -118,7 +131,7 @@ class WPSEO_Sitemap_Image_Parser {
 				continue;
 			}
 
-			$image    = $this->get_image_item( $post, $src, $img->getAttribute( 'title' ), $img->getAttribute( 'alt' ) );
+			$image    = $this->get_image_item( $post, $src, $title, $alt );
 			$images[] = $image;
 		}
 

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -106,12 +106,17 @@ class WPSEO_Sitemap_Image_Parser {
 
 		$images = array();
 
-		$content = $post->post_content;
-		$content = '<p><img src="' . $this->image_url( get_post_thumbnail_id( $post->ID ) ) . '" alt="' . $post->post_title . '" /></p>' . $content;
+		$content      = $post->post_content;
+		$thumbnail_id = get_post_thumbnail_id( $post->ID );
+
+		if ( $thumbnail_id ) {
+			// Content of title and alt is legacy from previous logic. R.
+			$images[] = $this->get_image_item( $post, $this->image_url( $thumbnail_id ), '', $post->post_title );
+		}
 
 		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
 
-			$images = $this->parse_matched_images( $matches[0], $post );
+			$images = array_merge( $images, $this->parse_matched_images( $matches[0], $post ) );
 		}
 
 		if ( strpos( $content, '[gallery' ) !== false ) {

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -165,19 +165,7 @@ class WPSEO_Sitemap_Image_Parser {
 				continue;
 			}
 
-			if ( WPSEO_Utils::is_url_relative( $src ) === true ) {
-
-				if ( $src[0] !== '/' ) {
-					continue;
-				}
-
-				// The URL is relative, we'll have to make it absolute.
-				$src = $this->home_url . $src;
-			}
-			elseif ( strpos( $src, 'http' ) !== 0 ) {
-				// Protocol relative url, we add the scheme as the standard requires a protocol.
-				$src = $this->scheme . ':' . $src;
-			}
+			$src = $this->get_absolute_url( $src );
 
 			if ( strpos( $src, $this->host ) === false ) {
 				continue;
@@ -307,5 +295,32 @@ class WPSEO_Sitemap_Image_Parser {
 
 		// It's a newly uploaded file, therefore $file is relative to the baseurl.
 		return $uploads['baseurl'] . "/$file";
+	}
+
+	/**
+	 * Make absolute URL for domain or protocol-relative one.
+	 *
+	 * @param string $src URL to process.
+	 *
+	 * @return string
+	 */
+	protected function get_absolute_url( $src ) {
+
+		if ( WPSEO_Utils::is_url_relative( $src ) === true ) {
+
+			if ( $src[0] !== '/' ) {
+				return $src;
+			}
+
+			// The URL is relative, we'll have to make it absolute.
+			return $this->home_url . $src;
+		}
+
+		if ( strpos( $src, 'http' ) !== 0 ) {
+			// Protocol relative url, we add the scheme as the standard requires a protocol.
+			return $this->scheme . ':' . $src;
+		}
+
+		return $src;
 	}
 }


### PR DESCRIPTION
Major refactoring of image parser:
- DOMDocument parser for HTML image tags
- handles all cases of gallery shortcodes
- deprecated legacy caching logic
 
Fixes #2165
Fixes #3010
Fixes #3041 
Fixes #3526 
Fixes #4466 