### PR TITLE
Hotfix for `max` warning in Sitemaps

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -453,7 +453,11 @@ class WPSEO_Sitemaps {
 
 		$dates = array_intersect_key( $post_type_dates, array_flip( $post_types ) );
 
-		return max( $dates );
+		if ( count( $dates ) > 0 ) {
+			return max( $dates );
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -90,4 +90,29 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 			'Served from transient cache',
 		) );
 	}
+
+	/**
+	 * Test for last modified date
+	 *
+	 * @covers WPSEO_Sitemaps::get_last_modified_gmt
+	 */
+	public function test_last_modified_post_type() {
+
+		$older_date  = '2015-01-01 12:00:00';
+		$newest_date = '2016-01-01 12:00:00';
+
+		$this->factory->post->create( array( 'post_status' => 'publish', 'post_date' => $newest_date ) );
+		$this->factory->post->create( array( 'post_status' => 'publish', 'post_date' => $older_date ) );
+
+		$this->assertEquals( $newest_date, WPSEO_Sitemaps::get_last_modified_gmt( array( 'post' ) ) );
+	}
+
+	/**
+	 * Test for last modified date with invalid post types
+	 *
+	 * @covers WPSEO_Sitemaps::get_last_modified_gmt
+	 */
+	public function test_last_modified_with_invalid_post_type() {
+		$this->assertFalse( WPSEO_Sitemaps::get_last_modified_gmt( array( 'invalid_post_type' ) ) );
+	}
 }

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -91,7 +91,7 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 		) );
 	}
 
-	/**
+	/**d
 	 * Test for last modified date
 	 *
 	 * @covers WPSEO_Sitemaps::get_last_modified_gmt


### PR DESCRIPTION
https://github.com/Yoast/wordpress-seo/pull/4474 on the correct branch.
Fixes https://github.com/Yoast/wordpress-seo/issues/4473