### PR TITLE
Use get_the_terms in breadcrums

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -480,8 +480,7 @@ class WPSEO_Breadcrumbs {
 		if ( isset( $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ] ) && $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ] != '0' ) {
 			$main_tax = $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ];
 			if ( isset( $this->post->ID ) ) {
-				// TODO Flagged about being uncached, consider get_the_terms(). Update phpcs.xml if changed. R.
-				$terms = wp_get_object_terms( $this->post->ID, $main_tax );
+				$terms = get_the_terms( $this->post, $main_tax );
 
 				if ( is_array( $terms ) && $terms !== array() ) {
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,7 +15,6 @@
     <rule ref="Yoast">
         <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" /><!-- TODO audit and fix nonces -->
         <exclude name="WordPress.WP.PreparedSQL.NotPrepared" /><!-- TODO audit raw queries -->
-        <exclude name="WordPress.VIP.RestrictedFunctions.wp_get_post_terms" /><!-- TODO audit and possibly update to get_the_terms() -->
     </rule>
 
     <rule ref="WordPress.WP.EnqueuedResources.NonEnqueuedScript">


### PR DESCRIPTION
wp_get_object_terms is an uncached. Use get_the_terms instead.