### PR TITLE
Prevent manipulation of remote posts's metadata

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -572,6 +572,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return  bool|void   Boolean false if invalid save post request
 	 */
 	function save_postdata( $post_id ) {
+		// Bail if this is a multisite installation and the site has been switched.
+		if ( is_multisite() && ms_is_switched() ) {
+			return false;
+		}
+
 		if ( $post_id === null ) {
 			return false;
 		}


### PR DESCRIPTION
This PR fixes #4556.

---

Hi, it's me, again.

Similar to #3531 and #4087 your meta box doesn't take a switched site in a multisite installation into account. The problem here is that you run `save_postdata()`, which overwrites all remote posts's metadata.

The fix is simple, and follows what I did earlier this year, twice.

As I assumed before, I'm pretty sure there are several other functions that you apply while implicitly assuming you're located in the _current_ (default) site in a multisite - which is just not true per se. Please be nice to multisite (and plugins that depend on multisite). :)

Thanks,
Thorsten