### PR TITLE
Improve the wpseo columns content in the list tables

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -40,10 +40,10 @@ class WPSEO_Meta_Columns {
 		}
 
 		return array_merge( $columns, array(
-			'wpseo-score'    => sprintf( '<span aria-label="%s">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) ),
+			'wpseo-score'    => sprintf( '<span class="screen-reader-text">%s</span></span><span aria-hidden="true">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) ),
 			'wpseo-title'    => __( 'SEO Title', 'wordpress-seo' ),
-			'wpseo-metadesc' => sprintf( '<span aria-label="%s">%s</span>', __( 'Meta Description', 'wordpress-seo' ), __( 'Meta Desc.', 'wordpress-seo' ) ),
-			'wpseo-focuskw'  => sprintf( '<span aria-label="%s">%s</span>', __( 'Focus Keyword', 'wordpress-seo' ), __( 'Focus KW', 'wordpress-seo' ) ),
+			'wpseo-metadesc' => sprintf( '<span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span>', __( 'Meta Description', 'wordpress-seo' ), __( 'Meta Desc.', 'wordpress-seo' ) ),
+			'wpseo-focuskw'  => sprintf( '<span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span>', __( 'Focus Keyword', 'wordpress-seo' ), __( 'Focus KW', 'wordpress-seo' ) ),
 		) );
 	}
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -67,12 +67,12 @@ class WPSEO_Meta_Columns {
 				break;
 			case 'wpseo-metadesc' :
 				$metadesc_val = apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) );
-				$metadesc = '' === $metadesc_val ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
+				$metadesc = ( '' === $metadesc_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
 				echo $metadesc;
 				break;
 			case 'wpseo-focuskw' :
 				$focuskw_val = WPSEO_Meta::get_value( 'focuskw', $post_id );
-				$focuskw = '' === $focuskw_val ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
+				$focuskw = ( '' === $focuskw_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
 				echo $focuskw;
 				break;
 		}

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -40,10 +40,10 @@ class WPSEO_Meta_Columns {
 		}
 
 		return array_merge( $columns, array(
-			'wpseo-score'    => __( 'SEO', 'wordpress-seo' ),
+			'wpseo-score'    => sprintf( '<span aria-label="%s">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) ),
 			'wpseo-title'    => __( 'SEO Title', 'wordpress-seo' ),
-			'wpseo-metadesc' => __( 'Meta Desc.', 'wordpress-seo' ),
-			'wpseo-focuskw'  => __( 'Focus KW', 'wordpress-seo' ),
+			'wpseo-metadesc' => sprintf( '<span aria-label="%s">%s</span>', __( 'Meta Description', 'wordpress-seo' ), __( 'Meta Desc.', 'wordpress-seo' ) ),
+			'wpseo-focuskw'  => sprintf( '<span aria-label="%s">%s</span>', __( 'Focus Keyword', 'wordpress-seo' ), __( 'Focus KW', 'wordpress-seo' ) ),
 		) );
 	}
 
@@ -66,11 +66,14 @@ class WPSEO_Meta_Columns {
 				echo esc_html( apply_filters( 'wpseo_title', wpseo_replace_vars( $this->page_title( $post_id ), get_post( $post_id, ARRAY_A ) ) ) );
 				break;
 			case 'wpseo-metadesc' :
-				echo esc_html( apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) ) );
+				$metadesc_val = apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) );
+				$metadesc = '' === $metadesc_val ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
+				echo $metadesc;
 				break;
 			case 'wpseo-focuskw' :
-				$focuskw = WPSEO_Meta::get_value( 'focuskw', $post_id );
-				echo esc_html( $focuskw );
+				$focuskw_val = WPSEO_Meta::get_value( 'focuskw', $post_id );
+				$focuskw = '' === $focuskw_val ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
+				echo $focuskw;
 				break;
 		}
 	}
@@ -338,7 +341,7 @@ class WPSEO_Meta_Columns {
 			$title = $rank->get_label();
 		}
 
-		return '<div title="' . esc_attr( $title ) . '" class="wpseo-score-icon ' . esc_attr( $rank->get_css_class() ) . '"></div>';
+		return '<div aria-hidden="true" title="' . esc_attr( $title ) . '" class="wpseo-score-icon ' . esc_attr( $rank->get_css_class() ) . '"></div><span class="screen-reader-text">' . $title . '</span>';
 
 	}
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -40,10 +40,10 @@ class WPSEO_Meta_Columns {
 		}
 
 		return array_merge( $columns, array(
-			'wpseo-score'    => sprintf( '<span class="screen-reader-text">%s</span></span><span aria-hidden="true">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) ),
+			'wpseo-score'    => __( 'SEO', 'wordpress-seo' ),
 			'wpseo-title'    => __( 'SEO Title', 'wordpress-seo' ),
-			'wpseo-metadesc' => sprintf( '<span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span>', __( 'Meta Description', 'wordpress-seo' ), __( 'Meta Desc.', 'wordpress-seo' ) ),
-			'wpseo-focuskw'  => sprintf( '<span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span>', __( 'Focus Keyword', 'wordpress-seo' ), __( 'Focus KW', 'wordpress-seo' ) ),
+			'wpseo-metadesc' => __( 'Meta Desc.', 'wordpress-seo' ),
+			'wpseo-focuskw'  => __( 'Focus KW', 'wordpress-seo' ),
 		) );
 	}
 

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -40,7 +40,7 @@ class WPSEO_Taxonomy_Columns {
 			$new_columns[ $column_name ] = $column_value;
 
 			if ( $column_name === 'description' ) {
-				$new_columns['wpseo_score'] = sprintf( '<span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) );
+				$new_columns['wpseo_score'] = __( 'SEO', 'wordpress-seo' );
 			}
 		}
 

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -40,7 +40,7 @@ class WPSEO_Taxonomy_Columns {
 			$new_columns[ $column_name ] = $column_value;
 
 			if ( $column_name === 'description' ) {
-				$new_columns['wpseo_score'] = sprintf( '<span aria-label="%s">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) );
+				$new_columns['wpseo_score'] = sprintf( '<span class="screen-reader-text">%s</span><span aria-hidden="true">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) );
 			}
 		}
 

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -40,7 +40,7 @@ class WPSEO_Taxonomy_Columns {
 			$new_columns[ $column_name ] = $column_value;
 
 			if ( $column_name === 'description' ) {
-				$new_columns['wpseo_score'] = __( 'SEO', 'wordpress-seo' );
+				$new_columns['wpseo_score'] = sprintf( '<span aria-label="%s">%s</span>', __( 'SEO Score', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) );
 			}
 		}
 
@@ -124,7 +124,7 @@ class WPSEO_Taxonomy_Columns {
 	 * @return string
 	 */
 	private function create_score_icon( WPSEO_Rank $rank, $title ) {
-		return '<div title="' . esc_attr( $title ) . '" class="wpseo-score-icon ' . esc_attr( $rank->get_css_class() ) . '"></div>';
+		return '<div aria-hidden="true" title="' . esc_attr( $title ) . '" class="wpseo-score-icon ' . esc_attr( $rank->get_css_class() ) . '"></div><span class="screen-reader-text">' . $title . '</span>';
 	}
 
 	/**

--- a/inc/class-wpseo-rank.php
+++ b/inc/class-wpseo-rank.php
@@ -98,7 +98,7 @@ class WPSEO_Rank {
 	 */
 	public function get_label() {
 		$labels = array(
-			self::NO_FOCUS => __( 'N/A', 'wordpress-seo' ),
+			self::NO_FOCUS => __( 'Not available', 'wordpress-seo' ),
 			self::NO_INDEX => __( 'No index', 'wordpress-seo' ),
 			self::BAD      => __( 'Bad', 'wordpress-seo' ),
 			self::OK       => __( 'OK', 'wordpress-seo' ),

--- a/tests/test-class-wpseo-rank.php
+++ b/tests/test-class-wpseo-rank.php
@@ -56,7 +56,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	public function provider_get_label() {
 		return array(
-			array( WPSEO_Rank::NO_FOCUS, 'N/A' ),
+			array( WPSEO_Rank::NO_FOCUS, 'Not available' ),
 			array( WPSEO_Rank::NO_INDEX, 'No index' ),
 			array( WPSEO_Rank::BAD, 'Bad' ),
 			array( WPSEO_Rank::OK, 'OK' ),

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -113,7 +113,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 			array( 71, true, 'good' ),
 			array( 83, true, 'good' ),
 			array( 100, true, 'good' ),
-			array( 0, false, 'N/A' ),
+			array( 0, false, 'Not available' ),
 			array( 1, false, 'Bad' ),
 			array( 23, false, 'Bad' ),
 			array( 40, false, 'Bad' ),


### PR DESCRIPTION
Fixes #4507.

I'd say to skip the Column headers for now and focus on the table cells content.

The proposed changes introduce some `screen-reader-text` to be used when the cells are empty, in the same way WordPress already does, using an "em dash" for the visual part and hidden text for the accessibility part. Also, ensure the score text is always announced by screen readers.

![wpseo list table 01](https://cloud.githubusercontent.com/assets/1682452/15216841/1ec01648-1859-11e6-9070-4a2c99a46c70.png)

![wpseo list table 02](https://cloud.githubusercontent.com/assets/1682452/15216848/24e10bae-1859-11e6-8c12-34c39ebdecbb.png)

About the 'N/A' string now changed in 'Not available', I've seen it's used for example in the Terms screens, when a category or tag has not been edited yet. Not sure if it's used also in other places. Would greatly appreciate any feedback and thoughts.

<img width="833" alt="not available was na" src="https://cloud.githubusercontent.com/assets/1682452/15216857/2dc50e46-1859-11e6-80e7-cafd3990069a.png">
