### PR TITLE
Change the way of initialization of the i18n promo

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -350,7 +350,7 @@ class WPSEO_Admin_Init {
 				'textdomain'     => 'wordpress-seo',
 				'project_slug'   => 'wordpress-seo',
 				'plugin_name'    => 'Yoast SEO',
-				'hook'           => 'wpseo_admin_footer',
+				'hook'           => 'wpseo_admin_promo-footer',
 				'glotpress_url'  => 'http://translate.yoast.com/gp/',
 				'glotpress_name' => 'Yoast Translate',
 				'glotpress_logo' => 'https://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -350,7 +350,7 @@ class WPSEO_Admin_Init {
 				'textdomain'     => 'wordpress-seo',
 				'project_slug'   => 'wordpress-seo',
 				'plugin_name'    => 'Yoast SEO',
-				'hook'           => 'wpseo_admin_promo-footer',
+				'hook'           => 'wpseo_admin_promo_footer',
 				'glotpress_url'  => 'http://translate.yoast.com/gp/',
 				'glotpress_name' => 'Yoast Translate',
 				'glotpress_logo' => 'https://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -331,7 +331,11 @@ class WPSEO_Admin_Init {
 		if ( $this->on_wpseo_admin_page() ) {
 			// For backwards compatabilty, this still needs a global, for now...
 			$GLOBALS['wpseo_admin_pages'] = new WPSEO_Admin_Pages;
-			$this->register_i18n_promo_class();
+
+			// Only register the yoast i18n when the page is a Yoast SEO page.
+			if ( WPSEO_Utils::is_yoast_seo_free_page( filter_input( INPUT_GET, 'page' ) ) ) {
+				$this->register_i18n_promo_class();
+			}
 		}
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -118,7 +118,7 @@ class Yoast_Form {
 		/**
 		 * Run possibly set actions to add for example an i18n box
 		 */
-		do_action( 'wpseo_admin_promo-footer' );
+		do_action( 'wpseo_admin_promo_footer' );
 
 		echo '
 			</div><!-- end of div wpseo_content_top -->';

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -110,9 +110,15 @@ class Yoast_Form {
 			</form>';
 		}
 
-		if ( WPSEO_Utils::is_yoast_seo_free_page( filter_input( INPUT_GET, 'page' ) ) ) {
-			do_action( 'wpseo_admin_footer' );
-		}
+		/**
+		 * Apply general admin_footer hooks
+		 */
+		do_action( 'wpseo_admin_footer' );
+
+		/**
+		 * Run possibly set actions to add for example an i18n box
+		 */
+		do_action( 'wpseo_admin_promo-footer' );
 
 		echo '
 			</div><!-- end of div wpseo_content_top -->';


### PR DESCRIPTION
I've change the way how we are loading the i18n promo class. I am check if the current page is a Yoast SEO page before initiating a the promo class. The check around the `do_action` is removed now.