### PR TITLE
New action for admin sitemap post types page

### DIFF
--- a/admin/views/tabs/sitemaps/post-types.php
+++ b/admin/views/tabs/sitemaps/post-types.php
@@ -22,6 +22,13 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 			$switch_values,
 			$pt->labels->name . ' (<code>' . $pt->name . '</code>)'
 		);
+		/**
+		 * Allow adding custom checkboxes to the admin sitemap page - Post Types tab
+		 *
+		 * @api  Yoast_Form  $yform  The Yoast_Form object
+		 * @api  Object  $pt  The post type
+		 */
+		do_action( 'wpseo_admin_page_sitemap_post_types', $yform, $pt );
 	}
 }
 

--- a/admin/views/tabs/sitemaps/post-types.php
+++ b/admin/views/tabs/sitemaps/post-types.php
@@ -26,7 +26,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 		 * Allow adding custom checkboxes to the admin sitemap page - Post Types tab
 		 *
 		 * @api  Yoast_Form  $yform  The Yoast_Form object
-		 * @api  Object  $pt  The post type
+		 * @api  Object      $pt     The post type
 		 */
 		do_action( 'wpseo_admin_page_sitemap_post_types', $yform, $pt );
 	}


### PR DESCRIPTION
This action is similar to "wpseo_admin_page_meta_post_types", which allows adding custom checkboxes to the "Admin meta page - Post Types tab"

Similarly, this action allows custom checkboxes to be adde to the "Admin sitemap page - Post Types tab"