### PR TITLE
New hook for admin page meta taxonomies

### DIFF
--- a/admin/views/tabs/metas/taxonomies.php
+++ b/admin/views/tabs/metas/taxonomies.php
@@ -42,6 +42,13 @@ if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 					/* translators: %1$s expands to Yoast SEO */
 				), sprintf( __( '%1$s Meta Box', 'wordpress-seo' ), 'Yoast SEO' ) );
 		}
+		/**
+		 * Allow adding a custom checkboxes to the admin meta page - Taxonomies tab
+		 *
+		 * @api  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
+		 * @api  Object  $tax  The taxonomy
+		 */
+		do_action( 'wpseo_admin_page_meta_taxonomies', $yform, $tax );
 		echo '<br/><br/>';
 		echo '</div>';
 	}

--- a/admin/views/tabs/metas/taxonomies.php
+++ b/admin/views/tabs/metas/taxonomies.php
@@ -43,10 +43,10 @@ if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 				), sprintf( __( '%1$s Meta Box', 'wordpress-seo' ), 'Yoast SEO' ) );
 		}
 		/**
-		 * Allow adding a custom checkboxes to the admin meta page - Taxonomies tab
+		 * Allow adding custom checkboxes to the admin meta page - Taxonomies tab
 		 *
 		 * @api  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
-		 * @api  Object  $tax  The taxonomy
+		 * @api  Object             $tax    The taxonomy
 		 */
 		do_action( 'wpseo_admin_page_meta_taxonomies', $yform, $tax );
 		echo '<br/><br/>';


### PR DESCRIPTION
This adds a new hook "**wpseo_admin_page_meta_taxonomies**", which allows adding custom options to each taxonomy. This is similar to the existing hook "wpseo_admin_page_meta_post_types".

This will be useful when trying to build options to turn taxonomies indexing on or off for multilingual plugins.

@moorscode This is similar to [https://github.com/Yoast/wordpress-seo/pull/4608](https://github.com/Yoast/wordpress-seo/pull/4608)