### PR TITLE
Improve the Search Console form. First pass.

### DIFF
--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -36,14 +36,14 @@ switch ( $platform_tabs->current_tab() ) {
 			// Print auth screen.
 			echo '<p>';
 			/* Translators: %1$s: expands to 'Yoast SEO', %2$s expands to Google Search Console. */
-			echo sprintf( __( 'To allow %1$s to fetch your %2$s information, please enter your Google Authorization Code.', 'wordpress-seo' ), 'Yoast SEO', 'Google Search Console' );
+			echo sprintf( __( 'To allow %1$s to fetch your %2$s information, please enter your Google Authorization Code. Clicking the button below will open a new window.', 'wordpress-seo' ), 'Yoast SEO', 'Google Search Console' );
 			echo "</p>\n";
 			echo '<input type="hidden" id="gsc_auth_url" value="', $this->service->get_client()->createAuthUrl() , '" />';
-			echo "<button id='gsc_auth_code' class='button-secondary'>" , __( 'Get Google Authorization Code', 'wordpress-seo' ) ,"</button>\n";
+			echo "<button type='button' id='gsc_auth_code' class='button-secondary'>" , __( 'Get Google Authorization Code', 'wordpress-seo' ) ,"</button>\n";
 
-			echo '<p>' . __( 'Please enter the Google Authorization Code in the field below and press the Authenticate button.', 'wordpress-seo' ) . "</p>\n";
+			echo '<p id="gsc-enter-code-label">' . __( 'Enter your Google Authorization Code and press the Authenticate button.', 'wordpress-seo' ) . "</p>\n";
 			echo "<form action='" . admin_url( 'admin.php?page=wpseo_search_console&tab=settings' ) . "' method='post'>\n";
-			echo "<input type='text' name='gsc[authorization_code]' value='' />";
+			echo "<input type='text' name='gsc[authorization_code]' value='' class='regular-text' aria-labelledby='gsc-enter-code-label' />";
 			echo "<input type='hidden' name='gsc[gsc_nonce]' value='" . wp_create_nonce( 'wpseo-gsc_nonce' ) . "' />";
 			echo "<input type='submit' name='gsc[Submit]' value='" . __( 'Authenticate', 'wordpress-seo' ) . "' class='button-primary' />";
 			echo "</form>\n";
@@ -53,12 +53,10 @@ switch ( $platform_tabs->current_tab() ) {
 			echo '<h3>',  __( 'Current profile', 'wordpress-seo' ), '</h3>';
 			if ( ($profile = WPSEO_GSC_Settings::get_profile() ) !== '' ) {
 				echo '<p>';
-				echo Yoast_Form::get_instance()->label( __( 'Current profile', 'wordpress-seo' ), array() );
 				echo $profile;
 				echo '</p>';
 
 				echo '<p>';
-				echo '<label class="select"></label>';
 				echo $reset_button;
 				echo '</p>';
 
@@ -76,16 +74,14 @@ switch ( $platform_tabs->current_tab() ) {
 				}
 				else {
 					$show_save = false;
-					echo '<label class="select" for="profile">', __( 'Profile', 'wordpress-seo' ), '</label>';
 					echo __( 'There were no profiles found', 'wordpress-seo' );
 				}
 				echo '</p>';
 
 				echo '<p>';
-				echo '<label class="select"></label>';
 
 				if ( $show_save ) {
-					echo '<input type="submit" name="submit" id="submit" class="button button-primary" value="' . __( 'Save Profile', 'wordpress-seo' ) . '" /> ' . __( 'or', 'wordpress-seo' ) , ' ';
+					echo '<input type="submit" name="submit" id="submit" class="button button-primary wpseo-gsc-save-profile" value="' . __( 'Save Profile', 'wordpress-seo' ) . '" /> ' . __( 'or', 'wordpress-seo' ) , ' ';
 				}
 				echo $reset_button;
 				echo '</p>';

--- a/css/yst_plugin_tools-320.css
+++ b/css/yst_plugin_tools-320.css
@@ -83,6 +83,10 @@ label.checkbox {
 	background-color: transparent;
 }
 
+.wp-core-ui .button.wpseo-gsc-save-profile {
+	margin-left: 200px;
+}
+
 table.wpseo th {
 	text-align: left;
 }


### PR DESCRIPTION
Thought to inform users that clicking the button a new window opens in the simplest way, just using plain text. Also:
- slightly changed a string so it can be used as text for `aria-labelledby`
- added `type='button'` to the auth code, maybe not required but maybe safer
- made the auth code field longer
- removed some redundant empty labels, seems they're used only for layout purposes

Side note: couldn't find a reason why VoiceOver announces the auth code field as "search field", probably a VoiceOver thing?

before:

![screen shot 2016-05-25 at 09 34 25](https://cloud.githubusercontent.com/assets/1682452/15537968/9747f700-2279-11e6-9119-e455c249fc05.png)

after:

![screen shot 2016-05-25 at 11 25 21](https://cloud.githubusercontent.com/assets/1682452/15537976/a3b9ddfa-2279-11e6-937c-ba72d65c8334.png)

<img width="482" alt="screen shot 2016-05-25 at 13 09 05" src="https://cloud.githubusercontent.com/assets/1682452/15538041/f8713ff0-2279-11e6-98f3-c8cd9e172b92.png">

<img width="707" alt="screen shot 2016-05-25 at 13 08 31" src="https://cloud.githubusercontent.com/assets/1682452/15538094/5c736a1e-227a-11e6-9dbd-568c21d7f59d.png">
<img width="499" alt="screen shot 2016-05-25 at 13 07 47" src="https://cloud.githubusercontent.com/assets/1682452/15538095/5c78ac18-227a-11e6-9556-c56df24ebca9.png">

Fixes #4642 