### PR TITLE
Conform "connect search console" notification to new Yoast Alert standards

### DIFF
--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -72,7 +72,7 @@ class WPSEO_GSC {
 	 */
 	public function register_gsc_notification() {
 
-		if ( ! current_user_can( 'manage_options' ) || WPSEO_GSC_Settings::get_profile() !== '' || get_user_option( 'wpseo_dismissed_gsc_notice', get_current_user_id() ) == '1' ) {
+		if ( WPSEO_GSC_Settings::get_profile() !== '' ) {
 			return;
 		}
 
@@ -84,8 +84,9 @@ class WPSEO_GSC {
 					'</a>'
 				),
 				array(
-					'type'      => Yoast_Notification::WARNING,
-					'id'        => 'wpseo-dismiss-gsc',
+					'type'         => Yoast_Notification::WARNING,
+					'id'           => 'wpseo-dismiss-gsc',
+					'capabilities' => 'manage_options'
 				)
 			)
 		);

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -86,7 +86,7 @@ class WPSEO_GSC {
 				array(
 					'type'         => Yoast_Notification::WARNING,
 					'id'           => 'wpseo-dismiss-gsc',
-					'capabilities' => 'manage_options'
+					'capabilities' => 'manage_options',
 				)
 			)
 		);


### PR DESCRIPTION
Removed the checks to not spawn the notification.
Moved the capability check inside the notification instead of in the condition.

**Testing**
Do not connect to Search Console to have this notification active.
Connect to Search Console to have it removed completely.

Having dismissed this in a previous version will have a user option with `wpseo_dismissed_gsc_notice` set to `1` which will refrain from showing this notification before this change.

See https://github.com/Yoast/wordpress-seo/issues/4650
Fixes https://github.com/Yoast/wordpress-seo/issues/4646