### PR TITLE
Conform OnPage notification to Yoast Alert standards

### DIFF
--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -94,10 +94,8 @@ class WPSEO_OnPage {
 	 */
 	public function show_notice() {
 
-		// Just a return, because we want to temporary disable this notice (#3998).
-		return;
-
 		if ( $this->should_show_notice() ) {
+
 			$notice = sprintf(
 				/* translators: 1: opens a link to a related knowledge base article. 2: closes the link */
 				__( '%1$sYour homepage cannot be indexed by search engines%2$s. This is very bad for SEO and should be fixed.', 'wordpress-seo' ),
@@ -109,8 +107,9 @@ class WPSEO_OnPage {
 				new Yoast_Notification(
 					$notice,
 					array(
-						'type'  => 'error yoast-dismissible',
+						'type'  => Yoast_Notification::ERROR,
 						'id'    => 'wpseo-dismiss-onpageorg',
+						'capabilities' => 'manage_options',
 					)
 				)
 			);
@@ -144,12 +143,12 @@ class WPSEO_OnPage {
 	 * @return bool
 	 */
 	protected function should_show_notice() {
-		// If development note is on or the tagline notice is shown, just don't show this notice.
+		// If development note is on or the blog is not public, just don't show this notice.
 		if ( WPSEO_Utils::is_development_mode() || ( '0' === get_option( 'blog_public' ) ) ) {
 			return false;
 		}
 
-		return WPSEO_Utils::grant_access() && ! $this->user_has_dismissed() && $this->onpage_option->get_status() === WPSEO_OnPage_Option::IS_NOT_INDEXABLE;
+		return $this->onpage_option->get_status() === WPSEO_OnPage_Option::IS_NOT_INDEXABLE;
 	}
 
 	/**

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -143,7 +143,7 @@ class WPSEO_OnPage {
 	 * @return bool
 	 */
 	protected function should_show_notice() {
-		// If development note is on or the blog is not public, just don't show this notice.
+		// If development mode is on or the blog is not public, just don't show this notice.
 		if ( WPSEO_Utils::is_development_mode() || ( '0' === get_option( 'blog_public' ) ) ) {
 			return false;
 		}

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -189,15 +189,6 @@ class WPSEO_OnPage {
 	}
 
 	/**
-	 * Get the state from the user to check if the current user has dismissed
-	 *
-	 * @return mixed
-	 */
-	private function user_has_dismissed() {
-		return '1' === get_user_meta( get_current_user_id(), WPSEO_OnPage::USER_META_KEY, true );
-	}
-
-	/**
 	 * Redo the fetch request for onpage
 	 */
 	private function catch_redo_listener() {


### PR DESCRIPTION
Removed the `grant_access` because this is done inside the `Yoast_Notification`.
Removed dismissal because that is now handled inside the `Yoast_Notification_Center`.

Test this by faking OnPage results.

Add the following code to `wp-seo-main.php` above 
```php
// Loading OnPage integration.
new WPSEO_OnPage();
```

Add:
```php
add_filter( 'pre_option_' . WPSEO_OnPage_Option::OPTION_NAME, function( $value ) {
	return array( WPSEO_OnPage_Option::STATUS => WPSEO_OnPage_Option::IS_NOT_INDEXABLE, WPSEO_OnPage_Option::LAST_FETCH => time() );
});
```

Fixes #4664 