### PR TITLE
Conform Version About notification to Yoast Alert standards

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -56,33 +56,6 @@ class WPSEO_Admin_Init {
 		$this->load_admin_page_class();
 		$this->load_admin_user_class();
 		$this->load_xml_sitemaps_admin();
-
-		$this->sync_about_version_from_cookie();
-	}
-
-	/**
-	 * Get about version seen from cookie if set.
-	 */
-	protected function sync_about_version_from_cookie() {
-
-		$user_id                 = get_current_user_id();
-		$meta_seen_about_version = get_user_meta( $user_id, 'wpseo_seen_about_version', true );
-
-		$cookie_key = 'wpseo_seen_about_version_' . $user_id;
-
-		$cookie_seen_about_version = isset( $_COOKIE[ $cookie_key ] ) ? $_COOKIE[ $cookie_key ] : '';
-
-		if ( ! empty( $cookie_seen_about_version ) ) {
-
-			if ( version_compare( $cookie_seen_about_version, $meta_seen_about_version, '>' ) ) {
-				update_user_meta( $user_id, 'wpseo_seen_about_version', $cookie_seen_about_version );
-				$meta_seen_about_version = $cookie_seen_about_version;
-			}
-		}
-
-		if ( $cookie_seen_about_version !== $meta_seen_about_version ) {
-			setcookie( $cookie_key, $meta_seen_about_version, ( $_SERVER['REQUEST_TIME'] + YEAR_IN_SECONDS ) );
-		}
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -97,32 +97,26 @@ class WPSEO_Admin_Init {
 	 */
 	public function after_update_notice() {
 
-		$can_access = is_multisite() ? WPSEO_Utils::grant_access() : current_user_can( 'manage_options' );
-
-		if ( $can_access && $this->has_ignored_tour() && ! $this->seen_about() ) {
-
-			if ( filter_input( INPUT_GET, 'intro' ) === '1' || $this->dismiss_notice( 'wpseo-dismiss-about' ) ) {
-				update_user_meta( get_current_user_id(), 'wpseo_seen_about_version', WPSEO_VERSION );
-				return;
-			}
-
-			/* translators: %1$s expands to Yoast SEO, $2%s to the version number, %3$s and %4$s to anchor tags with link to intro page  */
-			$info_message = sprintf(
-				__( '%1$s has been updated to version %2$s. %3$sClick here%4$s to find out what\'s new!', 'wordpress-seo' ),
-				'Yoast SEO',
-				WPSEO_VERSION,
-				'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard&intro=1' ) . '">',
-				'</a>'
-			);
-
-			$notification_options = array(
-				'type'  => Yoast_Notification::UPDATED,
-				'id'    => 'wpseo-dismiss-about',
-				'nonce' => wp_create_nonce( 'wpseo-dismiss-about' ),
-			);
-
-			Yoast_Notification_Center::get()->add_notification( new Yoast_Notification( $info_message, $notification_options ) );
+		if ( ! $this->has_ignored_tour() || $this->seen_about() ) {
+			return;
 		}
+
+		/* translators: %1$s expands to Yoast SEO, $2%s to the version number, %3$s and %4$s to anchor tags with link to intro page  */
+		$info_message = sprintf(
+			__( '%1$s has been updated to version %2$s. %3$sClick here%4$s to find out what\'s new!', 'wordpress-seo' ),
+			'Yoast SEO',
+			WPSEO_VERSION,
+			'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard&intro=1' ) . '">',
+			'</a>'
+		);
+
+		$notification_options = array(
+			'type'         => Yoast_Notification::UPDATED,
+			'id'           => 'wpseo-dismiss-about',
+			'capabilities' => 'manage_options',
+		);
+
+		Yoast_Notification_Center::get()->add_notification( new Yoast_Notification( $info_message, $notification_options ) );
 	}
 
 	/**

--- a/admin/class-yoast-alerts.php
+++ b/admin/class-yoast-alerts.php
@@ -120,11 +120,13 @@ class Yoast_Alerts {
 
 		switch ( $type ) {
 			case 'error':
-			case 'warning':
-				$view = $type . 's';
+				$view = 'errors';
 				break;
+
+			case 'warning':
 			default:
-				return false;
+				$view = 'warnings';
+				break;
 		}
 
 		// Re-collect alerts.

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -115,13 +115,6 @@ class Yoast_Notification_Center {
 
 		$current_value = get_user_meta( $user_id, $dismissal_key, $single = true );
 
-		if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
-			$seen_about_version = substr( get_user_meta( $user_id, 'wpseo_seen_about_version', true ), 0, 3 );
-			$last_minor_version = substr( WPSEO_VERSION, 0, 3 );
-
-			return version_compare( $seen_about_version, $last_minor_version, '>=' );
-		}
-
 		return ! empty( $current_value );
 	}
 
@@ -519,21 +512,8 @@ class Yoast_Notification_Center {
 	 * @return bool
 	 */
 	private static function dismiss_notification( Yoast_Notification $notification, $meta_value = 'seen' ) {
-
-		$user_id = get_current_user_id();
-
-		// Set about version when dismissing about notification.
-		if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
-
-			// Update notification gets removed when dismissed.
-			$instance = self::get();
-			$instance->remove_notification(  $notification );
-			
-			return ( false !== update_user_meta( $user_id, 'wpseo_seen_about_version', WPSEO_VERSION ) );
-		}
-
 		// Dismiss notification.
-		return ( false !== update_user_meta( $user_id, $notification->get_dismissal_key(), $meta_value ) );
+		return ( false !== update_user_meta( get_current_user_id(), $notification->get_dismissal_key(), $meta_value ) );
 	}
 
 	/**

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -524,6 +524,11 @@ class Yoast_Notification_Center {
 
 		// Set about version when dismissing about notification.
 		if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
+
+			// Update notification gets removed when dismissed.
+			$instance = self::get();
+			$instance->remove_notification(  $notification );
+			
 			return ( false !== update_user_meta( $user_id, 'wpseo_seen_about_version', WPSEO_VERSION ) );
 		}
 

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -10,6 +10,8 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 if ( filter_input( INPUT_GET, 'intro' ) ) {
+
+	update_user_meta( get_current_user_id(), 'wpseo_seen_about_version', WPSEO_VERSION );
 	require WPSEO_PATH . 'admin/views/about.php';
 
 	return;


### PR DESCRIPTION
Removed the custom cookie sync from 3.2.5
Notification is no longer shown 'in full sight' so it can be dismissed without completely removing it

Make sure you don't have the `wpseo_seen_about_version` in your `wp_usermeta` table.
You need `wpseo_ignore_tour` set to `1` for your user otherwise the notification is not added.

You can now see the notification in the Alert Overview and dismiss it. Having it being put to the "ignored" list.
Resolving this issue is done by going to the about page (follow the link in the notification).

Fixes https://github.com/Yoast/wordpress-seo/issues/4669