### PR TITLE
Hide recalculate tool

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -175,7 +175,7 @@ class WPSEO_Admin_Init {
 	 * Shows the notice for recalculating the post. the Notice will only be shown if the user hasn't dismissed it before.
 	 */
 	public function recalculate_notice() {
-		// Just a return, because we want to temporary disable this notice (#3998).
+		// Just a return, because we want to temporary disable this notice (#3998 and #4532).
 		return;
 
 		if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -33,16 +33,20 @@ if ( '' === $tool_page ) {
 		);
 	}
 
-	$tools['recalculate'] = array(
-		'href'    => '#TB_inline?width=300&height=150&inlineId=wpseo_recalculate',
-		'attr'    => "id='wpseo_recalculate_link' class='thickbox'",
-		'title'   => __( 'Recalculate SEO scores', 'wordpress-seo' ),
-		'desc'    => __( 'Recalculate SEO scores for all pieces of content with a focus keyword.', 'wordpress-seo' ),
-	);
+	/*
+		Temporary disabled. See: https://github.com/Yoast/wordpress-seo/issues/4532
 
-	if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
-		$tools['recalculate']['attr'] .= "data-open='open'";
-	}
+		$tools['recalculate'] = array(
+			'href'    => '#TB_inline?width=300&height=150&inlineId=wpseo_recalculate',
+			'attr'    => "id='wpseo_recalculate_link' class='thickbox'",
+			'title'   => __( 'Recalculate SEO scores', 'wordpress-seo' ),
+			'desc'    => __( 'Recalculate SEO scores for all pieces of content with a focus keyword.', 'wordpress-seo' ),
+		);
+
+		if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
+			$tools['recalculate']['attr'] .= "data-open='open'";
+		}
+	*/
 
 	/* translators: %1$s expands to Yoast SEO */
 	echo '<p>', sprintf( __( '%1$s comes with some very powerful built-in tools:', 'wordpress-seo' ), 'Yoast SEO' ), '</p>';


### PR DESCRIPTION
Fixes #4532 

Testing:
Under the menu tools the recalculate anchor should be removed.