### PR TITLE
Explicitely remove Notification when resolved

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -70,6 +70,23 @@ class WPSEO_Admin_Init {
 	 */
 	public function after_update_notice() {
 
+		$notification        = $this->get_update_notification();
+		$notification_center = Yoast_Notification_Center::get();
+		
+		if ( $this->has_ignored_tour() && ! $this->seen_about() ) {
+			$notification_center->add_notification( $notification );
+		}
+		else {
+			$notification_center->remove_notification( $notification );
+		}
+	}
+
+	/**
+	 * Build the update notification
+	 * 
+	 * @return Yoast_Notification
+	 */
+	private function get_update_notification() {
 		/* translators: %1$s expands to Yoast SEO, $2%s to the version number, %3$s and %4$s to anchor tags with link to intro page  */
 		$info_message = sprintf(
 			__( '%1$s has been updated to version %2$s. %3$sClick here%4$s to find out what\'s new!', 'wordpress-seo' ),
@@ -85,15 +102,7 @@ class WPSEO_Admin_Init {
 			'capabilities' => 'manage_options',
 		);
 
-		$after_update_notification = new Yoast_Notification( $info_message, $notification_options );
-
-		$notification_center = Yoast_Notification_Center::get();
-		if ( $this->has_ignored_tour() && ! $this->seen_about() ) {
-			$notification_center->add_notification( $after_update_notification );
-		}
-		else {
-			$notification_center->remove_notification( $after_update_notification );
-		}
+		return new Yoast_Notification( $info_message, $notification_options );
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -159,28 +159,38 @@ class WPSEO_Admin_Init {
 	 */
 	public function ga_compatibility_notice() {
 
+		$notification        = $this->get_compatibility_notification();
+		$notification_center = Yoast_Notification_Center::get();
+
+		if ( defined( 'GAWP_VERSION' ) && '5.4.3' === GAWP_VERSION ) {
+			$notification_center->add_notification( $notification );
+		}
+		else {
+			$notification_center->remove_notification( $notification );
+		}
+	}
+
+	/**
+	 * Build compatibility problem notification
+	 *
+	 * @return Yoast_Notification
+	 */
+	private function get_compatibility_notification() {
 		$info_message = sprintf(
-		/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
+			/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
 			__( '%1$s detected you are using version %2$s of %3$s, please update to the latest version to prevent compatibility issues.', 'wordpress-seo' ),
 			'Yoast SEO',
 			'5.4.3',
 			'Google Analytics by Yoast'
 		);
 
-		$notification_options = array(
-			'id'   => 'gawp-compatibility-notice',
-			'type' => Yoast_Notification::ERROR,
+		return new Yoast_Notification(
+			$info_message,
+			array(
+				'id'   => 'gawp-compatibility-notice',
+				'type' => Yoast_Notification::ERROR,
+			)
 		);
-
-		$ga_compatibility_notification = new Yoast_Notification( $info_message, $notification_options );
-
-		$notification_center = Yoast_Notification_Center::get();
-		if ( defined( 'GAWP_VERSION' ) && '5.4.3' === GAWP_VERSION ) {
-			$notification_center->add_notification( $ga_compatibility_notification );
-		}
-		else {
-			$notification_center->remove_notification( $ga_compatibility_notification );
-		}
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -72,7 +72,7 @@ class WPSEO_Admin_Init {
 
 		$notification        = $this->get_update_notification();
 		$notification_center = Yoast_Notification_Center::get();
-		
+
 		if ( $this->has_ignored_tour() && ! $this->seen_about() ) {
 			$notification_center->add_notification( $notification );
 		}
@@ -83,7 +83,7 @@ class WPSEO_Admin_Init {
 
 	/**
 	 * Build the update notification
-	 * 
+	 *
 	 * @return Yoast_Notification
 	 */
 	private function get_update_notification() {

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -70,10 +70,6 @@ class WPSEO_Admin_Init {
 	 */
 	public function after_update_notice() {
 
-		if ( ! $this->has_ignored_tour() || $this->seen_about() ) {
-			return;
-		}
-
 		/* translators: %1$s expands to Yoast SEO, $2%s to the version number, %3$s and %4$s to anchor tags with link to intro page  */
 		$info_message = sprintf(
 			__( '%1$s has been updated to version %2$s. %3$sClick here%4$s to find out what\'s new!', 'wordpress-seo' ),
@@ -89,7 +85,15 @@ class WPSEO_Admin_Init {
 			'capabilities' => 'manage_options',
 		);
 
-		Yoast_Notification_Center::get()->add_notification( new Yoast_Notification( $info_message, $notification_options ) );
+		$after_update_notification = new Yoast_Notification( $info_message, $notification_options );
+
+		$notification_center = Yoast_Notification_Center::get();
+		if ( $this->has_ignored_tour() && ! $this->seen_about() ) {
+			$notification_center->add_notification( $after_update_notification );
+		}
+		else {
+			$notification_center->remove_notification( $after_update_notification );
+		}
 	}
 
 	/**
@@ -109,11 +113,6 @@ class WPSEO_Admin_Init {
 	 */
 	public function tagline_notice() {
 
-		// Just a return, because we want to temporary disable this notice (#3998).
-		if ( ! $this->has_default_tagline() ) {
-			return;
-		}
-
 		$current_url = ( is_ssl() ? 'https://' : 'http://' );
 		$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 		$customize_url = add_query_arg( array(
@@ -132,7 +131,15 @@ class WPSEO_Admin_Init {
 			'capabilities' => 'manage_options',
 		);
 
-		Yoast_Notification_Center::get()->add_notification( new Yoast_Notification( $info_message, $notification_options ) );
+		$tagline_notification = new Yoast_Notification( $info_message, $notification_options );
+
+		$notification_center = Yoast_Notification_Center::get();
+		if ( $this->has_default_tagline() ) {
+			$notification_center->add_notification( $tagline_notification );
+		}
+		else {
+			$notification_center->remove_notification( $tagline_notification );
+		}
 	}
 
 	/**
@@ -151,12 +158,9 @@ class WPSEO_Admin_Init {
 	 * on the google search console page.
 	 */
 	public function ga_compatibility_notice() {
-		if ( ! defined( 'GAWP_VERSION' ) || '5.4.3' !== GAWP_VERSION ) {
-			return;
-		}
 
 		$info_message = sprintf(
-			/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
+		/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.4.3, %3$s expands to Google Analytics by Yoast */
 			__( '%1$s detected you are using version %2$s of %3$s, please update to the latest version to prevent compatibility issues.', 'wordpress-seo' ),
 			'Yoast SEO',
 			'5.4.3',
@@ -168,7 +172,15 @@ class WPSEO_Admin_Init {
 			'type' => Yoast_Notification::ERROR,
 		);
 
-		Yoast_Notification_Center::get()->add_notification( new Yoast_Notification( $info_message, $notification_options ) );
+		$ga_compatibility_notification = new Yoast_Notification( $info_message, $notification_options );
+
+		$notification_center = Yoast_Notification_Center::get();
+		if ( defined( 'GAWP_VERSION' ) && '5.4.3' === GAWP_VERSION ) {
+			$notification_center->add_notification( $ga_compatibility_notification );
+		}
+		else {
+			$notification_center->remove_notification( $ga_compatibility_notification );
+		}
 	}
 
 	/**

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -20,11 +20,8 @@ class Yoast_Notification_Center {
 	/** @var array Notifications there are newly added */
 	private $new = array();
 
-	/** @var array Notifications that were added this execution */
-	private $touched = array();
-
-	/** @var bool Remove untouched notification if we have never reached admin_init */
-	private $remove_untouched = false;
+	/** @var array Notifications that were resolved this execution */
+	private $resolved = 0;
 
 	/**
 	 * Construct
@@ -33,14 +30,12 @@ class Yoast_Notification_Center {
 
 		$this->retrieve_notifications_from_storage();
 
-		add_action( 'admin_init', array( $this, 'enable_remove_untouched' ) );
 		add_action( 'all_admin_notices', array( $this, 'display_notifications' ) );
 
 		add_action( 'wp_ajax_yoast_get_notifications', array( $this, 'ajax_get_notifications' ) );
 
 		add_action( 'wpseo_deactivate', array( $this, 'deactivate_hook' ) );
 		add_action( 'shutdown', array( $this, 'update_storage' ) );
-		add_action( 'shutdown', array( $this, 'clear_dismissals' ) );
 	}
 
 	/**
@@ -55,20 +50,6 @@ class Yoast_Notification_Center {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * After admin_init all notification that are not added again should be removed
-	 *
-	 * We have pages that redirect after adding a notification
-	 * which means that we can't have all notifications added to the stack
-	 * so they aren't "touched".
-	 *
-	 * If we remove untouched these will be seen as new, which isn't true.
-	 */
-	public function enable_remove_untouched() {
-
-		$this->remove_untouched = true;
 	}
 
 	/**
@@ -194,26 +175,6 @@ class Yoast_Notification_Center {
 	}
 
 	/**
-	 * Clear dismissals of resolved notifications
-	 */
-	public function clear_dismissals() {
-
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			return;
-		}
-
-		$notifications = array_filter(
-			$this->notifications,
-			array( $this, 'filter_untouched_notifications' )
-		);
-
-		$resolved_notifications = array_diff( $this->notifications, $notifications );
-
-		// Remove dismissal so it will be shown next time the condition is met.
-		array_map( array( $this, 'clear_dismissal' ), $resolved_notifications );
-	}
-
-	/**
 	 * Add notification to the cookie
 	 *
 	 * @param Yoast_Notification $notification Notification object instance.
@@ -229,8 +190,6 @@ class Yoast_Notification_Center {
 
 		// Empty notifications are always added.
 		if ( $notification_id !== '' ) {
-
-			$this->touched[ $notification_id ] = true;
 
 			// If notification ID exists in notifications, don't add again.
 			$present_notification = $this->get_notification_by_id( $notification_id );
@@ -289,11 +248,30 @@ class Yoast_Notification_Center {
 	 *
 	 * @param Yoast_Notification $notification Notification to remove.
 	 */
-	private function remove_notification( Yoast_Notification $notification ) {
+	public function remove_notification( Yoast_Notification $notification ) {
 
-		$index = array_search( $notification, $this->notifications, true );
+		$index = false;
+
+		// Match persistent Notifications by ID, non persistent by item in the array.
+		if ( $notification->is_persistent() ) {
+			foreach ( $this->notifications as $current_index => $present_notification ) {
+				if ( $present_notification->get_id() === $notification->get_id() ) {
+					$index = $current_index;
+					break;
+				}
+			}
+		}
+		else {
+			$index = array_search( $notification, $this->notifications, true );
+		}
+
 		if ( false === $index ) {
 			return;
+		}
+
+		if ( $notification->is_persistent() ) {
+			$this->resolved++;
+			$this->clear_dismissal( $notification );
 		}
 
 		unset( $this->notifications[ $index ] );
@@ -320,7 +298,7 @@ class Yoast_Notification_Center {
 	}
 
 	/**
-	 * Get the number of notifications not touched this execution
+	 * Get the number of notifications resolved this execution
 	 *
 	 * These notifications have been resolved and should be counted when active again.
 	 *
@@ -328,7 +306,7 @@ class Yoast_Notification_Center {
 	 */
 	public function get_resolved_notification_count() {
 
-		return ( count( $this->notifications ) - count( $this->touched ) );
+		return $this->resolved;
 	}
 
 	/**
@@ -402,13 +380,7 @@ class Yoast_Notification_Center {
 	 */
 	public function get_notifications() {
 
-		$notifications = $this->notifications;
-
-		if ( ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) && $this->remove_untouched ) {
-			$notifications = array_filter( $notifications, array( $this, 'filter_untouched_notifications' ) );
-		}
-
-		return $notifications;
+		return $this->notifications;
 	}
 
 	/**
@@ -419,24 +391,6 @@ class Yoast_Notification_Center {
 	public function get_new_notifications() {
 
 		return array_map( array( $this, 'get_notification_by_id' ), $this->new );
-	}
-
-	/**
-	 * Only get touched notifications
-	 *
-	 * @param Yoast_Notification $notification Notification to test.
-	 *
-	 * @return bool
-	 */
-	private function filter_untouched_notifications( Yoast_Notification $notification ) {
-
-		$notification_id = $notification->get_id();
-
-		if ( empty( $notification_id ) ) {
-			return true;
-		}
-
-		return array_key_exists( $notification_id, $this->touched ) && $this->touched[ $notification_id ];
 	}
 
 	/**

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -72,24 +72,26 @@ class WPSEO_GSC {
 	 */
 	public function register_gsc_notification() {
 
-		if ( WPSEO_GSC_Settings::get_profile() !== '' ) {
-			return;
-		}
-
-		Yoast_Notification_Center::get()->add_notification(
-			new Yoast_Notification(
-				sprintf(
-					__( 'Don\'t miss your crawl errors: %1$sconnect with Google Search Console here%2$s.', 'wordpress-seo' ),
-					'<a href="' . admin_url( 'admin.php?page=wpseo_search_console&tab=settings' ) . '">',
-					'</a>'
-				),
-				array(
-					'type'         => Yoast_Notification::WARNING,
-					'id'           => 'wpseo-dismiss-gsc',
-					'capabilities' => 'manage_options',
-				)
+		$gsc_notification = new Yoast_Notification(
+			sprintf(
+				__( 'Don\'t miss your crawl errors: %1$sconnect with Google Search Console here%2$s.', 'wordpress-seo' ),
+				'<a href="' . admin_url( 'admin.php?page=wpseo_search_console&tab=settings' ) . '">',
+				'</a>'
+			),
+			array(
+				'type'         => Yoast_Notification::WARNING,
+				'id'           => 'wpseo-dismiss-gsc',
+				'capabilities' => 'manage_options',
 			)
 		);
+
+		$notification_center = Yoast_Notification_Center::get();
+		if ( WPSEO_GSC_Settings::get_profile() === '' ) {
+			$notification_center->add_notification( $gsc_notification );
+		}
+		else {
+			$notification_center->remove_notification( $gsc_notification );
+		}
 	}
 
 	/**

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -72,7 +72,24 @@ class WPSEO_GSC {
 	 */
 	public function register_gsc_notification() {
 
-		$gsc_notification = new Yoast_Notification(
+		$notification        = $this->get_profile_notification();
+		$notification_center = Yoast_Notification_Center::get();
+
+		if ( WPSEO_GSC_Settings::get_profile() === '' ) {
+			$notification_center->add_notification( $notification );
+		}
+		else {
+			$notification_center->remove_notification( $notification );
+		}
+	}
+
+	/**
+	 * Builds the notification used when GSC is not connected to a profile
+	 *
+	 * @return Yoast_Notification
+	 */
+	private function get_profile_notification() {
+		return new Yoast_Notification(
 			sprintf(
 				__( 'Don\'t miss your crawl errors: %1$sconnect with Google Search Console here%2$s.', 'wordpress-seo' ),
 				'<a href="' . admin_url( 'admin.php?page=wpseo_search_console&tab=settings' ) . '">',
@@ -84,14 +101,6 @@ class WPSEO_GSC {
 				'capabilities' => 'manage_options',
 			)
 		);
-
-		$notification_center = Yoast_Notification_Center::get();
-		if ( WPSEO_GSC_Settings::get_profile() === '' ) {
-			$notification_center->add_notification( $gsc_notification );
-		}
-		else {
-			$notification_center->remove_notification( $gsc_notification );
-		}
 	}
 
 	/**

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -107,7 +107,7 @@ class WPSEO_OnPage {
 
 	/**
 	 * Builds the indexability notification
-	 * 
+	 *
 	 * @return Yoast_Notification
 	 */
 	private function get_indexability_notification() {

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -94,14 +94,31 @@ class WPSEO_OnPage {
 	 */
 	public function show_notice() {
 
+		$notification        = $this->get_indexability_notification();
+		$notification_center = Yoast_Notification_Center::get();
+
+		if ( $this->should_show_notice() ) {
+			$notification_center->add_notification( $notification );
+		}
+		else {
+			$notification_center->remove_notification( $notification );
+		}
+	}
+
+	/**
+	 * Builds the indexability notification
+	 * 
+	 * @return Yoast_Notification
+	 */
+	private function get_indexability_notification() {
 		$notice = sprintf(
-		/* translators: 1: opens a link to a related knowledge base article. 2: closes the link */
+			/* translators: 1: opens a link to a related knowledge base article. 2: closes the link */
 			__( '%1$sYour homepage cannot be indexed by search engines%2$s. This is very bad for SEO and should be fixed.', 'wordpress-seo' ),
 			'<a href="https://yoa.st/onpageindexerror" target="_blank">',
 			'</a>'
 		);
 
-		$onpage_notification = new Yoast_Notification(
+		return new Yoast_Notification(
 			$notice,
 			array(
 				'type'  => Yoast_Notification::ERROR,
@@ -109,14 +126,6 @@ class WPSEO_OnPage {
 				'capabilities' => 'manage_options',
 			)
 		);
-
-		$notification_center = Yoast_Notification_Center::get();
-		if ( $this->should_show_notice() ) {
-			$notification_center->add_notification( $onpage_notification );
-		}
-		else {
-			$notification_center->remove_notification( $onpage_notification );
-		}
 	}
 
 	/**

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -94,25 +94,28 @@ class WPSEO_OnPage {
 	 */
 	public function show_notice() {
 
+		$notice = sprintf(
+		/* translators: 1: opens a link to a related knowledge base article. 2: closes the link */
+			__( '%1$sYour homepage cannot be indexed by search engines%2$s. This is very bad for SEO and should be fixed.', 'wordpress-seo' ),
+			'<a href="https://yoa.st/onpageindexerror" target="_blank">',
+			'</a>'
+		);
+
+		$onpage_notification = new Yoast_Notification(
+			$notice,
+			array(
+				'type'  => Yoast_Notification::ERROR,
+				'id'    => 'wpseo-dismiss-onpageorg',
+				'capabilities' => 'manage_options',
+			)
+		);
+
+		$notification_center = Yoast_Notification_Center::get();
 		if ( $this->should_show_notice() ) {
-
-			$notice = sprintf(
-				/* translators: 1: opens a link to a related knowledge base article. 2: closes the link */
-				__( '%1$sYour homepage cannot be indexed by search engines%2$s. This is very bad for SEO and should be fixed.', 'wordpress-seo' ),
-				'<a href="https://yoa.st/onpageindexerror" target="_blank">',
-				'</a>'
-			);
-
-			Yoast_Notification_Center::get()->add_notification(
-				new Yoast_Notification(
-					$notice,
-					array(
-						'type'  => Yoast_Notification::ERROR,
-						'id'    => 'wpseo-dismiss-onpageorg',
-						'capabilities' => 'manage_options',
-					)
-				)
-			);
+			$notification_center->add_notification( $onpage_notification );
+		}
+		else {
+			$notification_center->remove_notification( $onpage_notification );
 		}
 	}
 


### PR DESCRIPTION
Instead of checking if a notification was 'touched' (aka re-added) we now keep all notifications in storage until they have been explicitly removed by the remove_notification function.

This is only applicable to 'persistent' notifications.

**Testing**
1. Set the default tagline inside your installation.
2. Check if you have the notification in the overview
3. Remove the `$notification_center->add_notification( $tagline_notification );` in file `class-admin-init.php` on line `147`
4. Check if the notification is still present
5. Change the tagline to something else (add a '.')
6. Check if the notification is removed