### PR TITLE
Yoast form: introduce a method to output a legend element.

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -272,6 +272,22 @@ class Yoast_Form {
 	}
 
 	/**
+	 * Output a legend element.
+	 *
+	 * @param string $text Legend text string.
+	 * @param array  $attr HTML attributes set.
+	 */
+	public function legend( $text, $attr ) {
+		$attr = wp_parse_args( $attr, array(
+				'id' => '',
+				'class' => ''
+			)
+		);
+		$id = ( '' === $attr['id'] ) ? '' : ' id="' . esc_attr( $attr['id'] ) . '"';
+		echo '<legend class="yoast-form-legend ' . $attr['class'] . '"' . $id . '>' . $text . '</legend>';
+	}
+
+	/**
 	 * Create a Checkbox input field.
 	 *
 	 * @param string $var        The variable within the option to create the checkbox for.

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -280,7 +280,7 @@ class Yoast_Form {
 	public function legend( $text, $attr ) {
 		$attr = wp_parse_args( $attr, array(
 				'id' => '',
-				'class' => ''
+				'class' => '',
 			)
 		);
 		$id = ( '' === $attr['id'] ) ? '' : ' id="' . esc_attr( $attr['id'] ) . '"';


### PR DESCRIPTION
First pass to introduce a `legend()` method in Yoast Form.
Fixes #4680 