### PR TITLE
Permalink containing %postname% notification moved to Alert Center

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -172,6 +172,7 @@ class WPSEO_Admin_Init {
 		$info_message = __( 'You do not have your postname in the URL of your posts and pages, it is highly recommended that you do. Consider setting your permalink structure to <strong>/%postname%/</strong>.', 'wordpress-seo' );
 		$info_message .= '<br/>';
 		$info_message .= sprintf(
+			/* translators: %1$s resolves to the starting tag of the link to the permalink settings page, %2$s resolves to the closing tag of the link */
 			__( 'You can fix this on the %1$sPermalink settings page%2$s.', 'wordpress-seo' ),
 			'<a href="' . admin_url( 'options-permalink.php' ) . '">',
 			'</a>'

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -44,6 +44,7 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dismissible' ) );
 		add_action( 'admin_init', array( $this, 'after_update_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'tagline_notice' ), 15 );
+		add_action( 'admin_init', array( $this, 'permalink_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'ga_compatibility_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'recalculate_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'ignore_tour' ) );
@@ -161,6 +162,37 @@ class WPSEO_Admin_Init {
 		$blog_description = get_bloginfo( 'description' );
 		$default_blog_description = 'Just another WordPress site';
 		return __( $default_blog_description ) === $blog_description || $default_blog_description === $blog_description;
+	}
+
+	/**
+	 * Show alert when the permalink doesn't contain %postname%
+	 */
+	public function permalink_notice() {
+
+		$info_message = __( 'You do not have your postname in the URL of your posts and pages, it is highly recommended that you do. Consider setting your permalink structure to <strong>/%postname%/</strong>.', 'wordpress-seo' );
+		$info_message .= '<br/>';
+		$info_message .= sprintf(
+			__( 'You can fix this on the %1$sPermalink settings page%2$s.', 'wordpress-seo' ),
+			'<a href="' . admin_url( 'options-permalink.php' ) . '">',
+			'</a>'
+		);
+
+		$notification_options = array(
+			'type'         => Yoast_Notification::WARNING,
+			'id'           => 'wpseo-dismiss-permalink-notice',
+			'capabilities' => 'manage_options',
+			'priority'     => 0.8,
+		);
+
+		$notification = new Yoast_Notification( $info_message, $notification_options );
+
+		$notification_center = Yoast_Notification_Center::get();
+		if ( ! $this->has_postname_in_permalink() ) {
+			$notification_center->add_notification( $notification );
+		}
+		else {
+			$notification_center->remove_notification( $notification );
+		}
 	}
 
 	/**
@@ -440,5 +472,14 @@ class WPSEO_Admin_Init {
 	 */
 	public function seen_tagline_notice() {
 		return false;
+	}
+
+	/**
+	 * Check if the permalink uses %postname%
+	 *
+	 * @return bool
+	 */
+	private function has_postname_in_permalink() {
+		return ( false !== strpos( get_option( 'permalink_structure' ), '%postname%' ) );
 	}
 }

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -132,14 +132,6 @@ if ( $options['theme_description_found'] !== '' ) {
 	echo '</p>';
 }
 
-
-if ( strpos( get_option( 'permalink_structure' ), '%postname%' ) === false && $options['ignore_permalink'] === false ) {
-	echo '<p id="wrong_permalink" class="wrong">';
-	echo '<a href="', esc_url( admin_url( 'options-permalink.php' ) ), '" class="button fixit">', __( 'Fix it.', 'wordpress-seo' ), '</a>';
-	echo '<a href="javascript:wpseoSetIgnore(\'permalink\',\'wrong_permalink\',\'', esc_js( wp_create_nonce( 'wpseo-ignore' ) ), '\');" class="button fixit">', __( 'Ignore.', 'wordpress-seo' ), '</a>';
-	echo __( 'You do not have your postname in the URL of your posts and pages, it is highly recommended that you do. Consider setting your permalink structure to <strong>/%postname%/</strong>.', 'wordpress-seo' ), '</p>';
-}
-
 if ( get_option( 'page_comments' ) && $options['ignore_page_comments'] === false ) {
 	echo '<p id="wrong_page_comments" class="wrong">';
 	echo '<a href="javascript:setWPOption(\'page_comments\',\'0\',\'wrong_page_comments\',\'', esc_js( wp_create_nonce( 'wpseo-setoption' ) ), '\');" class="button fixit">', __( 'Fix it.', 'wordpress-seo' ), '</a>';

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -23,7 +23,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'ignore_blog_public_warning'      => false,
 		'ignore_meta_description_warning' => null, // Overwrite in __construct().
 		'ignore_page_comments'            => false,
-		'ignore_permalink'                => false,
 		'ms_defaults_set'                 => false,
 		'theme_description_found'         => null, // Overwrite in __construct().
 		'theme_has_description'           => null, // Overwrite in __construct().
@@ -60,7 +59,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'ignore_blog_public_warning',
 		'ignore_meta_description_warning',
 		'ignore_page_comments',
-		'ignore_permalink',
 		/* theme dependent */
 		'theme_description_found',
 		'theme_has_description',
@@ -201,7 +199,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'ignore_blog_public_warning':
 				case 'ignore_meta_description_warning':
 				case 'ignore_page_comments':
-				case 'ignore_permalink':
 				case 'ms_defaults_set':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::validate_bool( $dirty[ $key ] );
@@ -272,7 +269,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'ignore_blog_public_warning',
 			'ignore_meta_description_warning',
 			'ignore_page_comments',
-			'ignore_permalink',
 			// 'disableadvanced_meta', => not needed as is 'on' which will auto-convert to true.
 		);
 		foreach ( $value_change as $key ) {


### PR DESCRIPTION
When the permalink does not contain %postname% a SEO warning is issued.
This used to be a custom notification on the dashboard/"General" page.

**Testing**
1. Select a custom permalink on the `/wp-admin/options-permalink.php` page
2. Change %postname% to something else
3. Alert should be added to the alert center
4. Changing the value back so it contains %postname% again removes the alert

See #4650 