### PR TITLE
Don't load adminbar css when not loggedin

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -24,8 +24,6 @@ class WPSEO_Upgrade {
 
 		WPSEO_Options::maybe_set_multisite_defaults( false );
 
-		$this->init();
-
 		if ( version_compare( $this->options['version'], '1.5.0', '<' ) ) {
 			$this->upgrade_15( $this->options['version'] );
 		}
@@ -50,8 +48,8 @@ class WPSEO_Upgrade {
 			$this->upgrade_30();
 		}
 
-		if ( version_compare( $this->options['version'], '3.4', '<' ) ) {
-			$this->upgrade_34();
+		if ( version_compare( $this->options['version'], '3.3', '<' ) ) {
+			$this->upgrade_33();
 		}
 
 		/**
@@ -64,19 +62,6 @@ class WPSEO_Upgrade {
 		do_action( 'wpseo_run_upgrade', $this->options['version'] );
 
 		$this->finish_up();
-	}
-
-	/**
-	 * Run some functions that run when we first run or when we upgrade Yoast SEO from < 1.4.13
-	 */
-	private function init() {
-		if ( $this->options['version'] === '' || version_compare( $this->options['version'], '1.4.13', '<' ) ) {
-			/* Make sure title_test and description_test functions are available */
-			require_once( WPSEO_PATH . 'inc/wpseo-non-ajax-functions.php' );
-
-			// Run description test once theme has loaded.
-			add_action( 'init', 'wpseo_description_test' );
-		}
 	}
 
 	/**
@@ -187,9 +172,9 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs upgrade functions to Yoast SEO 3.4
+	 * Performs upgrade functions to Yoast SEO 3.3
 	 */
-	private function upgrade_34() {
+	private function upgrade_33() {
 		// Notification dismissals have been moved to User Meta instead of global option.
 		delete_option( Yoast_Notification_Center::STORAGE_KEY );
 	}

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -273,6 +273,10 @@ add_action( 'admin_bar_menu', 'wpseo_admin_bar_menu', 95 );
  * Enqueue CSS to format the Yoast SEO adminbar item.
  */
 function wpseo_admin_bar_style() {
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
 	$asset_manager = new WPSEO_Admin_Asset_Manager();
 	$asset_manager->register_assets();
 	$asset_manager->enqueue_style( 'adminbar' );


### PR DESCRIPTION
Adminbar CSS was loaded always, instead of when the user is logged in.

**Testing**
Use incognito to view source of your WordPress install.
Look for adminbar css.

Fixes https://github.com/Yoast/wordpress-seo/issues/4728