### PR TITLE
Only show adminbar CSS when a user is logged in

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -273,6 +273,10 @@ add_action( 'admin_bar_menu', 'wpseo_admin_bar_menu', 95 );
  * Enqueue CSS to format the Yoast SEO adminbar item.
  */
 function wpseo_admin_bar_style() {
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
 	$asset_manager = new WPSEO_Admin_Asset_Manager();
 	$asset_manager->register_assets();
 	$asset_manager->enqueue_style( 'adminbar' );


### PR DESCRIPTION
**Testing**
Open browser without logging in into your WordPress installation
View source of the home-page (or any other page on the front end) and confirm the adminbar css is not present in the styles loaded.

Fixes https://github.com/Yoast/wordpress-seo/issues/4728