### PR TITLE
Dropped WP 4.2 from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
     - php: 7.0
       env: WP_VERSION=4.3
     - php: 5.6
-      env: WP_VERSION=4.2
-    - php: 5.6
       env: WP_VERSION=4.5
     - php: 5.5
       env: WP_VERSION=4.5


### PR DESCRIPTION
As plugin now requires 4.3+