### PR TITLE
Move home_url call from constructor to get_* function

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -9,7 +9,7 @@
 class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 	/** @var string $home_url Holds the home_url() value to speed up loops. */
-	protected $home_url = '';
+	protected $home_url = null;
 
 	/** @var array $options All of plugin options. */
 	protected $options = array();
@@ -22,11 +22,26 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	public function __construct() {
 
-		$this->home_url     = WPSEO_Utils::home_url();
 		$this->options      = WPSEO_Options::get_all();
 		$this->image_parser = new WPSEO_Sitemap_Image_Parser();
 
 		add_filter( 'save_post', array( $this, 'save_post' ) );
+	}
+
+	/**
+	 * Get Home URL
+	 *
+	 * This has been moved from the constructor because wp_rewrite is not available on plugins_loaded in multisite.
+	 * It will now be requested on need and not on initialization.
+	 *
+	 * @return string
+	 */
+	protected function get_home_url() {
+		if ( ! isset( $this->home_url ) ) {
+			$this->home_url = WPSEO_Utils::home_url();
+		}
+
+		return $this->home_url;
 	}
 
 	/**
@@ -282,9 +297,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		if ( ! $front_id && ( $post_type == 'post' || $post_type == 'page' ) ) {
 
 			$links[] = array(
-				'loc' => $this->home_url,
+				'loc' => $this->get_home_url(),
 				'pri' => 1,
-				'chf' => WPSEO_Sitemaps::filter_frequency( 'homepage', 'daily', $this->home_url ),
+				'chf' => WPSEO_Sitemaps::filter_frequency( 'homepage', 'daily', $this->get_home_url() ),
 			);
 		}
 		elseif ( $front_id && $post_type === 'post' && $page_for_posts ) {
@@ -451,7 +466,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 *
 		 * @see https://wordpress.org/plugins/page-links-to/ can rewrite permalinks to external URLs.
 		 */
-		if ( false === strpos( $url['loc'], $this->home_url ) ) {
+		if ( false === strpos( $url['loc'], $this->get_home_url() ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
wp_rewrite is not available on `plugins_loaded` where sitemaps is being constructed
this is needed by `user_trailingslashit` which is being used by `WPSEO_Utils::home_url`

The `home_url` is now requested when needed and initialized when it has not been set.
This also improves performance because it is not requested on every pageload, only when needed.

**Testing**
Make sure you have WP_DEBUG set to `true` otherwise the notice is not displayed.
This will be shown on any subsite of a multisite installation but not on the network admin site.

Fixes https://github.com/Yoast/wordpress-seo/issues/4822