### PR TITLE
Fix wrong variable usage

### DIFF
--- a/js/src/ui/adminBar.js
+++ b/js/src/ui/adminBar.js
@@ -1,12 +1,10 @@
-$ = jQuery;
-
 /**
  * Updates the traffic light present on the page
  *
  * @param {Object} indicator The indicator for the keyword score.
  */
 function updateAdminBar( indicator ) {
-	$( '.adminbar-seo-score' )
+	jQuery( '.adminbar-seo-score' )
 		.attr( 'class', 'wpseo-score-icon adminbar-seo-score ' + indicator.className )
 		.attr( 'alt', indicator.screenReaderText );
 }

--- a/js/src/ui/trafficLight.js
+++ b/js/src/ui/trafficLight.js
@@ -1,12 +1,10 @@
-$ = jQuery;
-
 /**
  * Updates the traffic light present on the page
  *
  * @param {Object} indicator The indicator for the keyword score.
  */
 function updateTrafficLight( indicator ) {
-	$( '.yst-traffic-light' )
+	jQuery( '.yst-traffic-light' )
 		.attr( 'class', 'yst-traffic-light ' + indicator.className )
 		.attr( 'alt', indicator.screenReaderText );
 }


### PR DESCRIPTION
We're overwriting `$` for no good reason at all. We shouldn't.

Fixes #4879