### PR TITLE
Updated graph.facebook.com API node

### DIFF
--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -179,7 +179,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 
 			if ( $reset_facebook_cache ) {
 				wp_remote_get(
-					'https://graph.facebook.com/?id=' . get_permalink( $post->ID ) . '&scrape=true&method=post'
+					'https://graph.facebook.com/v2.6/?id=' . get_permalink( $post->ID ) . '&scrape=true&method=post'
 				);
 			}
 		}


### PR DESCRIPTION
Fixes #4988.

Code in ```admin/class-social-admin.php``` was using old Facebook API 2.0 call. This has been now updated to latest version.

Old: 'https://graph.facebook.com/?id=' . get_permalink( $post->ID ) . '&scrape=true&method=post'
New: https://graph.facebook.com/v2.6/?id=' . get_permalink( $post->ID ) . '&scrape=true&method=post'

Thank you.