### PR TITLE
Restores the focus keyword on pageload

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -207,7 +207,7 @@ function wpseo_upsert_meta( $post_id, $new_meta_value, $orig_meta_value, $meta_k
 	$upsert_results = array(
 		'status'                 => 'success',
 		'post_id'                => $post_id,
-		"new_{$return_key}"      => $new_meta_value,
+		"new_{$return_key}"      => $sanitized_new_meta_value,
 		"original_{$return_key}" => $orig_meta_value,
 	);
 

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -9,7 +9,7 @@ module.exports = {
 			'js/dist/wp-seo-featured-image-330.js': ['js/src/wp-seo-featured-image.js'],
 			'js/dist/wp-seo-metabox-330.js': ['js/src/wp-seo-metabox.js'],
 			'js/dist/wp-seo-metabox-category-320.js': ['js/src/wp-seo-metabox-category.js'],
-			'js/dist/wp-seo-post-scraper-332.js': ['js/src/wp-seo-post-scraper.js'],
+			'js/dist/wp-seo-post-scraper-333.js': ['js/src/wp-seo-post-scraper.js'],
 			'js/dist/wp-seo-recalculate-324.js': ['js/src/wp-seo-recalculate.js'],
 			'js/dist/wp-seo-replacevar-plugin-330.js': ['js/src/wp-seo-replacevar-plugin.js'],
 			'js/dist/wp-seo-shortcode-plugin-320.js': ['js/src/wp-seo-shortcode-plugin.js'],

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -304,6 +304,9 @@ var updateAdminBar = require( './ui/adminBar' ).update;
 		$( '.wpseo-metabox-tabs' ).on( 'click', '.wpseo_tablink', function( ev ) {
 			ev.preventDefault();
 		});
+
+		var keyword = $( '#yoast_wpseo_focuskw' ).val();
+		$( '#yoast_wpseo_focuskw_text_input' ).val( keyword );
 	};
 
 	/**

--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -23,7 +23,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		);
 		$result = $class_instance->get_values();
 
-		$this->assertEquals( 'Content', $result['contentTab'] );
+		$this->assertEquals( 'Readability', $result['contentTab'] );
 		$this->assertTrue( array_key_exists( 'locale' , $result ) );
 		$this->assertTrue( array_key_exists( 'translations' , $result ) );
 		$this->assertTrue( is_array( $result['translations'] ) );


### PR DESCRIPTION
Fixes #4886 

This restores the focus keyword on pageload, so it can be used for analysis. 
Older posts don't have the `_yoast_wpseo_focuskw_text_input` field in the database which causes issues on old posts. 

For testing: 
Remove the `_yoast_wpseo_focuskw_text_input` from the wp_post_meta table for the post id you want to test. Without this field, it should still show the keyword in the keyword tab on pageload. 