### PR TITLE
Added "wpseo_sitemap_index_url" filter to $url['loc'] variable within…

### DIFF
--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -186,7 +186,7 @@ class WPSEO_Sitemaps_Renderer {
 			$date = $this->timezone->format_date( $url['lastmod'] );
 		}
 
-		$url['loc'] = htmlspecialchars( $url['loc'] );
+		$url['loc'] = apply_filters( 'wpseo_sitemap_index_url', htmlspecialchars( $url['loc'] ) );
 
 		$output = "\t<sitemap>\n";
 		$output .= "\t\t<loc>" . $url['loc'] . "</loc>\n";


### PR DESCRIPTION
… the sitemap_index_url function. Line 189

I would like to add a filter to the sitemap_index_url. We are using WP Multisite with domain mapping and want to keep the Dashboard rendering as the full multisite url so we can navigate easily between sites. But, keeping this option makes our sitemaps render the multisite urls as opposed to the mapped domain urls. I am able to filter individual post urls using the "wpseo_sitemap_entry" filter, but there currently isn't a filter to modify the urls contained in the "sitemap_index.xml" file. This merge would resolve that issue.

Thanks!