### PR TITLE
Don't perform a strict type check on 'blog_public'

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -548,7 +548,7 @@ class WPSEO_Admin_Init {
 	 * @return bool
 	 */
 	private function is_blog_public() {
-		return '1' === get_option( 'blog_public' );
+		return '1' == get_option( 'blog_public' );
 	}
 
 	/**


### PR DESCRIPTION
Plugins can return truthy or falsy values, so we need to accommodate those cases.

Core doesn't perform a strict check, so plugins shouldn't either: https://github.com/WordPress/WordPress/blob/25e66e4f1e5ab91235c2de2fe7d218d0a2f2997d/wp-admin/options-writing.php#L169