### PR TITLE
Remove keyword & SEO score column when disabled

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -9,12 +9,19 @@
 class WPSEO_Meta_Columns {
 
 	/**
+	 * @var WPSEO_Metabox_Analysis_SEO
+	 */
+	private $analysis_seo;
+
+	/**
 	 * When page analysis is enabled, just initialize the hooks
 	 */
 	public function __construct() {
 		if ( apply_filters( 'wpseo_use_page_analysis', true ) === true ) {
 			add_action( 'admin_init', array( $this, 'setup_hooks' ) );
 		}
+
+		$this->analysis_seo = new WPSEO_Metabox_Analysis_SEO();
 	}
 
 	/**
@@ -39,11 +46,16 @@ class WPSEO_Meta_Columns {
 			return $columns;
 		}
 
+		if ( $this->analysis_seo->is_enabled() ) {
+			$columns = array_merge( $columns, array(
+				'wpseo-score'    => __( 'SEO', 'wordpress-seo' ),
+				'wpseo-focuskw'  => __( 'Focus KW', 'wordpress-seo' ),
+			) );
+		}
+
 		return array_merge( $columns, array(
-			'wpseo-score'    => __( 'SEO', 'wordpress-seo' ),
 			'wpseo-title'    => __( 'SEO Title', 'wordpress-seo' ),
 			'wpseo-metadesc' => __( 'Meta Desc.', 'wordpress-seo' ),
-			'wpseo-focuskw'  => __( 'Focus KW', 'wordpress-seo' ),
 		) );
 	}
 
@@ -91,7 +103,10 @@ class WPSEO_Meta_Columns {
 		}
 
 		$columns['wpseo-metadesc'] = 'wpseo-metadesc';
-		$columns['wpseo-focuskw']  = 'wpseo-focuskw';
+
+		if ( $this->analysis_seo->is_enabled() ) {
+			$columns['wpseo-focuskw'] = 'wpseo-focuskw';
+		}
 
 		return $columns;
 	}
@@ -115,7 +130,11 @@ class WPSEO_Meta_Columns {
 				$result = array();
 			}
 
-			array_push( $result, 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
+			array_push( $result, 'wpseo-title', 'wpseo-metadesc' );
+
+			if ( $this->analysis_seo->is_enabled() ) {
+				array_push( $result, 'wpseo-focuskw' );
+			}
 		}
 
 		return $result;

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -40,6 +40,9 @@ class WPSEO_Metabox_Formatter {
 	 * @return array
 	 */
 	private function get_defaults() {
+		$analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
+
 		return array(
 			'search_url'        => '',
 			'post_edit_url'     => '',
@@ -52,8 +55,8 @@ class WPSEO_Metabox_Formatter {
 			'keyword_usage'     => array(),
 			'title_template'    => '',
 			'metadesc_template' => '',
-			'contentAnalysisActive' => $this->is_content_analysis_active(),
-			'keywordAnalysisActive' => $this->is_keyword_analysis_active(),
+			'contentAnalysisActive' => $analysis_readability->is_enabled() ? 1 : 0,
+			'keywordAnalysisActive' => $analysis_seo->is_enabled() ? 1 : 0,
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.
@@ -89,35 +92,5 @@ class WPSEO_Metabox_Formatter {
 		}
 
 		return array();
-	}
-
-	/**
-	 * Determines if the content analysis is active or not.
-	 *
-	 * @return bool Whether or not the content analysis is active.
-	 */
-	private function is_content_analysis_active() {
-		$options = WPSEO_Options::get_option( 'wpseo_titles' );
-
-		if ( ! $options['content-analysis-active'] ) {
-			return 0;
-		}
-
-		return ( ! get_the_author_meta( 'wpseo_content_analysis_disable', get_current_user_id() ) ) ? 1 : 0;
-	}
-
-	/**
-	 * Determines if the keyword analysis is active or not.
-	 *
-	 * @return bool Whether or not the keyword analysis is active.
-	 */
-	private function is_keyword_analysis_active() {
-		$options = WPSEO_Options::get_option( 'wpseo_titles' );
-
-		if ( ! $options['keyword-analysis-active'] ) {
-			return 0;
-		}
-
-		return ( ! get_the_author_meta( 'wpseo_keyword_analysis_disable', get_current_user_id() ) ) ? 1 : 0;
 	}
 }

--- a/admin/metabox/class-metabox-analysis-readability.php
+++ b/admin/metabox/class-metabox-analysis-readability.php
@@ -1,6 +1,11 @@
 <?php
+/**
+ * @package WPSEO\Admin\Metabox
+ */
 
-
+/**
+ * Represents the readability analysis
+ */
 class WPSEO_Metabox_Analysis_Readability implements WPSEO_Metabox_Analysis {
 
 	/**

--- a/admin/metabox/class-metabox-analysis-readability.php
+++ b/admin/metabox/class-metabox-analysis-readability.php
@@ -1,0 +1,34 @@
+<?php
+
+
+class WPSEO_Metabox_Analysis_Readability implements WPSEO_Metabox_Analysis {
+
+	/**
+	 * Whether this analysis is enabled.
+	 *
+	 * @return bool Whether or not this analysis is enabled.
+	 */
+	public function is_enabled() {
+		return $this->is_globally_enabled() && $this->is_user_enabled();
+	}
+
+	/**
+	 * Whether or not this analysis is enabled by the user.
+	 *
+	 * @return bool Whether or not this analysis is enabled by the user.
+	 */
+	public function is_user_enabled() {
+		return ! get_the_author_meta( 'wpseo_content_analysis_disable', get_current_user_id() );
+	}
+
+	/**
+	 * Whether or not this analysis is enabled globally.
+	 *
+	 * @return bool Whether or not this analysis is enabled globally.
+	 */
+	public function is_globally_enabled() {
+		$options = WPSEO_Options::get_option( 'wpseo_titles' );
+
+		return (bool) $options['content-analysis-active'];
+	}
+}

--- a/admin/metabox/class-metabox-analysis-seo.php
+++ b/admin/metabox/class-metabox-analysis-seo.php
@@ -1,0 +1,34 @@
+<?php
+
+
+class WPSEO_Metabox_Analysis_SEO implements WPSEO_Metabox_Analysis{
+
+	/**
+	 * Whether this analysis is enabled.
+	 *
+	 * @return bool Whether or not this analysis is enabled.
+	 */
+	public function is_enabled() {
+		return $this->is_globally_enabled() && $this->is_user_enabled();
+	}
+
+	/**
+	 * Whether or not this analysis is enabled by the user.
+	 *
+	 * @return bool Whether or not this analysis is enabled by the user.
+	 */
+	public function is_user_enabled() {
+		return ! get_the_author_meta( 'wpseo_keyword_analysis_disable', get_current_user_id() );
+	}
+
+	/**
+	 * Whether or not this analysis is enabled globally.
+	 *
+	 * @return bool Whether or not this analysis is enabled globally.
+	 */
+	public function is_globally_enabled() {
+		$options = WPSEO_Options::get_option( 'wpseo_titles' );
+
+		return (bool) $options['keyword-analysis-active'];
+	}
+}

--- a/admin/metabox/class-metabox-analysis-seo.php
+++ b/admin/metabox/class-metabox-analysis-seo.php
@@ -1,6 +1,11 @@
 <?php
+/**
+ * @package WPSEO\Admin\Metabox
+ */
 
-
+/**
+ * Represents the SEO analysis
+ */
 class WPSEO_Metabox_Analysis_SEO implements WPSEO_Metabox_Analysis{
 
 	/**

--- a/admin/metabox/interface-metabox-analysis.php
+++ b/admin/metabox/interface-metabox-analysis.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Describes an interface for an analysis that can either be enabled or disabled
+ */
+interface WPSEO_Metabox_Analysis {
+
+	/**
+	 * Whether this analysis is enabled.
+	 *
+	 * @return bool Whether or not this analysis is enabled.
+	 */
+	public function is_enabled();
+
+	/**
+	 * Whether or not this analysis is enabled by the user.
+	 *
+	 * @return bool Whether or not this analysis is enabled by the user.
+	 */
+	public function is_user_enabled();
+
+	/**
+	 * Whether or not this analysis is enabled globally.
+	 *
+	 * @return bool Whether or not this analysis is enabled globally.
+	 */
+	public function is_globally_enabled();
+}

--- a/admin/metabox/interface-metabox-analysis.php
+++ b/admin/metabox/interface-metabox-analysis.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Metabox
+ */
 
 /**
  * Describes an interface for an analysis that can either be enabled or disabled

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -10,36 +10,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 /**
- * Returns whether or not the readability analysis is enabled. A 1 if it is, a 0 if it isn't.
- *
- * @return int Whether or not the readability analysis is enabled.
- */
-function wpseo_content_analysis_is_enabled() {
-	$options = WPSEO_Options::get_option( 'wpseo_titles' );
-
-	if ( ! $options['content-analysis-active'] ) {
-		return 0;
-	}
-
-	return ( ! get_the_author_meta( 'wpseo_content_analysis_disable', get_current_user_id() ) ) ? 1 : 0;
-}
-
-/**
- * Returns whether or not the SEO analysis is enabled. A 1 if it is, 1 0 if it isn't.
- *
- * @return int Whether or not the SEO analysis is enabled.
- */
-function wpseo_keyword_analysis_is_enabled() {
-	$options = WPSEO_Options::get_option( 'wpseo_titles' );
-
-	if ( ! $options['keyword-analysis-active'] ) {
-		return 0;
-	}
-
-	return ( ! get_the_author_meta( 'wpseo_keyword_analysis_disable', get_current_user_id() ) ) ? 1 : 0;
-}
-
-/**
  * Adds an SEO admin bar menu with several options. If the current user is an admin he can also go straight to several settings menu's from here.
  */
 function wpseo_admin_bar_menu() {
@@ -60,6 +30,9 @@ function wpseo_admin_bar_menu() {
 	$score   = '';
 	$seo_url = '';
 
+	$analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+	$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
+
 	if ( ( is_singular() || ( is_admin() && in_array( $GLOBALS['pagenow'], array(
 					'post.php',
 					'post-new.php',
@@ -67,7 +40,7 @@ function wpseo_admin_bar_menu() {
 	) {
 		$focuskw    = WPSEO_Meta::get_value( 'focuskw', $post->ID );
 
-		if ( wpseo_content_analysis_is_enabled() || wpseo_keyword_analysis_is_enabled() ) {
+		if ( $analysis_readability->is_enabled() || $analysis_seo->is_enabled() ) {
 			$score = '<div class="wpseo-score-icon adminbar-seo-score"><span class="adminbar-seo-score-text screen-reader-text"></span></div>';
 		}
 
@@ -75,7 +48,7 @@ function wpseo_admin_bar_menu() {
 	}
 
 	if ( WPSEO_Taxonomy::is_term_edit( $GLOBALS['pagenow'] ) ) {
-		if ( wpseo_content_analysis_is_enabled() || wpseo_keyword_analysis_is_enabled() ) {
+		if ( $analysis_readability->is_enabled() || $analysis_seo->is_enabled() ) {
 			$score = '<div class="wpseo-score-icon adminbar-seo-score"><span class="adminbar-seo-score-text screen-reader-text"></span></div>';
 		}
 


### PR DESCRIPTION
If the SEO analysis is disabled there is no point in showing the SEO score
column or the focus keyword column.

Also abstracted the retrieval of the options if the analyses are enabled
or disabled.

Fixes #5093