### PR TITLE
Explicitly hinted charset when loading post content into DOMDocument

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -20,6 +20,9 @@ class WPSEO_Sitemap_Image_Parser {
 	/** @var array $attachments Cached set of attachments for multiple posts. */
 	protected $attachments = array();
 
+	/** @var string $charset Holds blog charset value for use in DOM parsing.  */
+	protected $charset = 'UTF-8';
+
 	/**
 	 * Set up URL properties for reuse.
 	 */
@@ -35,6 +38,8 @@ class WPSEO_Sitemap_Image_Parser {
 		if ( ! empty( $parsed_home['scheme'] ) ) {
 			$this->scheme = $parsed_home['scheme'];
 		}
+
+		$this->charset = esc_attr( get_bloginfo( 'charset' ) );
 	}
 
 	/**
@@ -139,7 +144,7 @@ class WPSEO_Sitemap_Image_Parser {
 		libxml_use_internal_errors( true );
 
 		$post_dom = new DOMDocument();
-		$post_dom->loadHTML( $content );
+		$post_dom->loadHTML( '<?xml encoding="'. $this->charset .'">' . $content );
 
 		// Clear the errors, so they don't get kept in memory.
 		libxml_clear_errors();


### PR DESCRIPTION
Fixes non–ASCII symbols getting mangled in parsed image details.

Related #5110 