### PR TITLE
Adds check if tinyMCE is loaded

### DIFF
--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -144,10 +144,12 @@ var editorRemoveMarks = require( './decorator/tinyMCE' ).editorRemoveMarks;
 			if ( ! isUndefined( YoastSEO.app.seoAssessorPresenter ) ) {
 				YoastSEO.app.seoAssessorPresenter._disableMarkerButtons = true;
 			}
+			if( isTinyMCELoaded() ) {
+				tinyMCE.on( 'AddEditor' , function( ) {
+					enableMarkerButtons( );
+				} );
+			}
 
-			tinyMCE.on( 'AddEditor' , function( ) {
-				enableMarkerButtons( );
-			} );
 		}
 	}
 

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -149,7 +149,6 @@ var editorRemoveMarks = require( './decorator/tinyMCE' ).editorRemoveMarks;
 					enableMarkerButtons( );
 				} );
 			}
-
 		}
 	}
 


### PR DESCRIPTION
Fixes #5118 

Before calling an AddEditor on tinyMCe, check if it exists. 

To test: Disable the visual editor in your user profile. If it is disabled it triggers an error, that is fixed in this branch. 