### PR TITLE
Checks if post_name element exists

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -267,8 +267,9 @@ var snippetPreviewHelpers = require( './analysis/snippetPreview' );
 					leavePostNameUntouched = false;
 					return;
 				}
-
-				document.getElementById( 'post_name' ).value = value;
+				if( document.getElementById( 'post_name' ) !== null ) {
+					document.getElementById( 'post_name' ).value = value;
+				}
 				if (
 					document.getElementById( 'editable-post-name' ) !== null &&
 					document.getElementById( 'editable-post-name-full' ) !== null ) {


### PR DESCRIPTION
Fixes #5117 
We didn't check if the post_name field exists before setting the value. To prevent this from erroring, add a simple check before seetting the value. 