### PR TITLE
Remove target=_blank from plugin conflict notification links

### DIFF
--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -132,7 +132,7 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 			/* translators: %1$s expands to Yoast SEO, %2%s: 'Facebook' plugin name of possibly conflicting plugin with regard to creating OpenGraph output*/
 			$plugin_sections['open_graph'] = __( 'Both %1$s and %2$s create OpenGraph output, which might make Facebook, Twitter, LinkedIn and other social networks use the wrong texts and images when your pages are being shared.', 'wordpress-seo' )
 			                                 . '<br/><br/>'
-			                                 . '<a target="_blank" class="button" href="' . admin_url( 'admin.php?page=wpseo_social#top#facebook' ) . '">'
+			                                 . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_social#top#facebook' ) . '">'
 			                                 /* translators: %1$s expands to Yoast SEO */
 			                                 . sprintf( __( 'Configure %1$s\'s OpenGraph settings', 'wordpress-seo' ), 'Yoast SEO' )
 			                                 . '</a>';
@@ -144,7 +144,7 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 			/* translators: %1$s expands to Yoast SEO, %2$s: 'Google XML Sitemaps' plugin name of possibly conflicting plugin with regard to the creation of sitemaps*/
 			$plugin_sections['xml_sitemaps'] = __( 'Both %1$s and %2$s can create XML sitemaps. Having two XML sitemaps is not beneficial for search engines, yet might slow down your site.', 'wordpress-seo' )
 			                  . '<br/><br/>'
-			                  . '<a target="_blank" class="button" href="' . admin_url( 'admin.php?page=wpseo_xml' ) . '">'
+			                  . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_xml' ) . '">'
 			                  /* translators: %1$s expands to Yoast SEO */
 			                  . sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
 			                  . '</a>';

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -199,7 +199,7 @@ class Yoast_Plugin_Conflict {
 			$error_message .= '<p>' . sprintf( $readable_plugin_section, 'Yoast SEO', $plugin_name ) . '</p>';
 
 			/* translators: %s: 'Facebook' plugin name of possibly conflicting plugin */
-			$error_message .= '<a target="_blank" class="button button-primary" href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin_file . '&amp;plugin_status=all', 'deactivate-plugin_' . $plugin_file ) . '">' . sprintf( __( 'Deactivate %s', 'wordpress-seo' ), WPSEO_Utils::get_plugin_name( $plugin_file ) ) . '</a> ';
+			$error_message .= '<a class="button button-primary" href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin_file . '&amp;plugin_status=all', 'deactivate-plugin_' . $plugin_file ) . '">' . sprintf( __( 'Deactivate %s', 'wordpress-seo' ), WPSEO_Utils::get_plugin_name( $plugin_file ) ) . '</a> ';
 
 			$identifier = $this->get_notification_identifier( $plugin_file );
 


### PR DESCRIPTION
I may be missing something but probably there are no good reasons to use `target="_blank"` on the links to change settings or disable a plugin when there are plugin conflicts, see screenshot below:

<img width="978" alt="incompatibility links target blank" src="https://cloud.githubusercontent.com/assets/1682452/16764137/bac4399a-482c-11e6-9085-50734b0102f0.png">

It may be confusing also for sighted users, consider this workflow:
- click on "Deactivate Header and Footer"
- a new tab opens with a notice "Plugin deactivated."
- close the tab or switch back to the previous tab
- you still see a notification about Header and Footer incompatibility so you may be in doubt about what just happened

Fixes #5359 