### PR TITLE
Stop translating the options values and keys.

### DIFF
--- a/admin/views/form/select.php
+++ b/admin/views/form/select.php
@@ -19,6 +19,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 ?>
 <select <?php echo $attributes; ?>name="<?php esc_attr_e( $name ); ?>" id="<?php esc_attr_e( $id ); ?>">
 	<?php foreach ( $options as $option_attribute_value => $option_html_value ) : ?>
-	<option value="<?php esc_attr_e( $option_attribute_value ); ?>"<?php echo selected( $selected, $option_attribute_value, false ); ?>><?php esc_html_e( $option_html_value ); ?></option>
+	<option value="<?php echo esc_attr( $option_attribute_value ); ?>"<?php echo selected( $selected, $option_attribute_value, false ); ?>><?php echo esc_html( $option_html_value ); ?></option>
 	<?php endforeach; ?>
 </select>


### PR DESCRIPTION
In commit https://github.com/Yoast/wordpress-seo/commit/4859d8583e1d326ef6ef02eec6303bdb2117d57d I introduced a view for generating a dropdown. But I used `esc_attr_e` to escape and echo the keys/values. I didn't see that this function was ment for translating and escaping the given value. 

I guess I thought the `esc_attr_e` should be used to escape and echo the given value and not translate.

Fixes https://github.com/Yoast/wpseo-news/issues/211