### PR TITLE
Yoast Form fieldset methods. First pass.

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -289,6 +289,42 @@ class Yoast_Form {
 	}
 
 	/**
+	 * Output a fieldset element start tag.
+	 *
+	 * Starts catching output buffering to get the wrapped form elements.
+	 *
+	 * @param array  $attr        HTML attributes set for the fieldset.
+	 * @param string $legend      Optional. The legend text to show for the field set, if any.
+	 * @param array  $legend_attr Optional. The attributes for the legend, if any.
+	 */
+	 public function fieldset_start( $attr = array(), $legend = '', $legend_attr = array() ) {
+		$attr = wp_parse_args( $attr, array(
+				'id' => '',
+				'class' => '',
+			)
+		);
+
+		$id = ( '' === $attr['id'] ) ? '' : ' id="' . esc_attr( $attr['id'] ) . '"';
+		echo '<fieldset class="yoast-form-fieldset ' . $attr['class'] . '"' . $id . '>';
+
+		if ( '' !== $legend ) {
+			$this->legend( $legend, $legend_attr );
+		}
+
+		ob_start();
+	 }
+
+	/**
+	 * Output a fieldset element closing tag.
+	 *
+	 * Gets, outputs, and cleans output buffering.
+	 */
+	 public function fieldset_end() {
+		 $fields = ob_get_clean();
+		 echo $fields . '</fieldset>';
+	 }
+
+	/**
 	 * Output a legend element.
 	 *
 	 * @param string $text Legend text string.

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -19,10 +19,13 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	method="post" accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php
 	wp_nonce_field( 'wpseo-import', '_wpnonce', true, true );
+
+	$yform->fieldset_start( array(), __( 'Import data from:', 'wordpress-seo' ), array( 'class' => 'screen-reader-text' ) );
 	$yform->checkbox( 'importheadspace', __( 'Import from HeadSpace2?', 'wordpress-seo' ) );
 	$yform->checkbox( 'importaioseo', __( 'Import from All-in-One SEO?', 'wordpress-seo' ) );
 	$yform->checkbox( 'importwoo', __( 'Import from WooThemes SEO framework?', 'wordpress-seo' ) );
 	$yform->checkbox( 'importwpseo', __( 'Import from wpSEO', 'wordpress-seo' ) );
+	$yform->fieldset_end();
 
 	do_action( 'wpseo_import_other_plugins' );
 	?>


### PR DESCRIPTION
Fixes #4593 

First pass for an alternate approach, as suggested by @moorscode: no new class but two `Yoast_Form` new methods using output buffering.

However, I'm not sure this can help in the context of the metabox where form elements are typically returned and not printed out.