### PR TITLE
Changed stats meta query to focus keyword field

### DIFF
--- a/inc/class-wpseo-statistics.php
+++ b/inc/class-wpseo-statistics.php
@@ -23,7 +23,7 @@ class WPSEO_Statistics {
 				'meta_query' => array(
 					'relation' => 'OR',
 					array(
-						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
+						'key'     => WPSEO_Meta::$meta_prefix . 'focuskw',
 						'value'   => 'needs-a-value-anyway',
 						'compare' => 'NOT EXISTS',
 					)

--- a/tests/test-class-wpseo-statistics.php
+++ b/tests/test-class-wpseo-statistics.php
@@ -42,8 +42,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 			'post_status' => 'publish'
 		) );
 
-		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 );
-		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 1 );
+		add_post_meta( $posts[1], '_yoast_wpseo_focuskw', 'focus keyword' );
 
 		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::NO_FOCUS ) ) );
 	}
@@ -114,8 +113,14 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // no-focus
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 1 ); // bad
+
 		add_post_meta( $posts[1], '_yoast_wpseo_linkdex', 41 ); // ok
+		add_post_meta( $posts[1], '_yoast_wpseo_focuskw', 'focus keyword' );
+
 		add_post_meta( $posts[2], '_yoast_wpseo_linkdex', 71 ); // good
+		add_post_meta( $posts[2], '_yoast_wpseo_focuskw', 'focus keyword' );
+
+		add_post_meta( $posts[3], '_yoast_wpseo_focuskw', 'focus keyword' );
 
 		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::BAD ) ) );
 		$this->assertEquals( 1, $this->instance->get_post_count( new WPSEO_Rank( WPSEO_Rank::OK ) ) );


### PR DESCRIPTION
The current implementation queries for presence of _score_ value, rather than _focus keyword_ instead. This leads to unexpected results when posts with keyword, but without value (such as recently created) are counted as missing focus keyword.

Fixes #3173