### PR TITLE
Made check for cached dashboard widget stats more broad.

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -92,7 +92,7 @@ class Yoast_Dashboard_Widget {
 		$transient = get_transient( self::CACHE_TRANSIENT_KEY );
 		$user_id   = get_current_user_id();
 
-		if ( isset( $transient[ $user_id ][1] ) ) {
+		if ( isset( $transient[ $user_id ] ) ) {
 			return $transient[ $user_id ];
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: fixed cache check in dashboard widget, which could cause unnecessary queries.

## Relevant technical choices:

* changed check to higher level of array, if data for user ID was processed and set in principle, not if there is _any_ data (which there might not be).

## Test instructions

This PR can be tested by following these steps:

1. load dashboard with widget and user without any posts
2. make sure queries aren't firing repeatedly after first load

Fixes #4540

