### PR TITLE
Differentiated message depending on if import it was success or fail

### DIFF
--- a/admin/class-import.php
+++ b/admin/class-import.php
@@ -17,6 +17,9 @@ class WPSEO_Import {
 	 */
 	public $msg = '';
 
+	/** @var bool $success If import was a success flag. */
+	public $success = false;
+
 	/**
 	 * @var array
 	 */
@@ -145,7 +148,8 @@ class WPSEO_Import {
 			foreach ( $options as $name => $opt_group ) {
 				$this->parse_option_group( $name, $opt_group, $options );
 			}
-			$this->msg = __( 'Settings successfully imported.', 'wordpress-seo' );
+			$this->msg     = __( 'Settings successfully imported.', 'wordpress-seo' );
+			$this->success = true;
 		}
 		else {
 			$this->msg = __( 'Settings could not be imported:', 'wordpress-seo' ) . ' ' . __( 'No settings found in file.', 'wordpress-seo' );

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -76,7 +76,10 @@ if ( isset( $import ) ) {
 	}
 
 	if ( $msg != '' ) {
-		echo '<div id="message" class="message updated" style="width:94%;"><p>', $msg, '</p></div>';
+
+		$status = ( $import->success ) ? 'updated' : 'error';
+
+		echo '<div id="message" class="message ', $status, '" style="width:94%;"><p>', $msg, '</p></div>';
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

- fixed notification types for settings import result

## Relevant technical choices:

* added success flag to an import class and made import result notification's type conditional on it

## Test instructions

This PR can be tested by following these steps:

* perform successful settings import, observe result message is `.updated`/green
* perform unsuccessful settings import, observer result message is `.error`/red

Fixes #3859

