### PR TITLE
Removed usages of INPUT_SERVER as unreliable in some PHP configurations

### DIFF
--- a/admin/class-social-facebook.php
+++ b/admin/class-social-facebook.php
@@ -160,7 +160,7 @@ class Yoast_Social_Facebook {
 		unset( $admin_id );
 
 		// Clean up the referrer url for later use.
-		if ( filter_input( INPUT_SERVER, 'REQUEST_URI' ) ) {
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
 			$this->cleanup_referrer_url( 'nonce', 'delfbadmin' );
 		}
 	}
@@ -178,7 +178,7 @@ class Yoast_Social_Facebook {
 		$this->success_notice( __( 'Successfully cleared all Facebook Data', 'wordpress-seo' ) );
 
 		// Clean up the referrer url for later use.
-		if ( filter_input( INPUT_SERVER, 'REQUEST_URI' ) ) {
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
 			$this->cleanup_referrer_url( 'nonce', 'fbclearall' );
 		}
 	}
@@ -189,9 +189,7 @@ class Yoast_Social_Facebook {
 	private function cleanup_referrer_url() {
 		$_SERVER['REQUEST_URI'] = remove_query_arg(
 			func_get_args(),
-			filter_input(
-				INPUT_SERVER, 'REQUEST_URI', FILTER_CALLBACK, array( 'options' => 'sanitize_text_field' )
-			)
+			sanitize_text_field( $_SERVER['REQUEST_URI'] )
 		);
 	}
 

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -212,9 +212,8 @@ class WPSEO_Taxonomy_Columns {
 	 * @return int
 	 */
 	private function get_taxonomy_input_type() {
-		$request_type = filter_input( INPUT_SERVER, 'REQUEST_METHOD' );
 
-		if ( $request_type === 'POST' ) {
+		if ( ! empty( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST' ) {
 			return INPUT_POST;
 		}
 

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -57,9 +57,14 @@ class WPSEO_Sitemaps_Router {
 
 		global $wp_query;
 
-		$current_url = ( filter_input( INPUT_SERVER, 'HTTPS' ) === 'on' ) ? 'https://' : 'http://';
-		$current_url .= sanitize_text_field( filter_input( INPUT_SERVER, 'SERVER_NAME' ) );
-		$current_url .= sanitize_text_field( filter_input( INPUT_SERVER, 'REQUEST_URI' ) );
+		$current_url = 'http://';
+
+		if ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ) {
+			$current_url = 'https://';
+		}
+
+		$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] );
+		$current_url .= sanitize_text_field( $_SERVER['REQUEST_URI'] );
 
 		if ( home_url( '/sitemap.xml' ) === $current_url && $wp_query->is_404 ) {
 			wp_redirect( home_url( '/sitemap_index.xml' ), 301 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

- removed usages of INPUT_SERVER as unreliable in some PHP configurations

## Relevant technical choices:

* changed usages of INPUT_SERVER filter to `$_SERVER` superglobal

## Test instructions

No functional changes, problematic environment is server–dependent and there is no clear way to reproduce.

Fixes #5296

