### PR TITLE
Added check to buffer clean, prevents notice on no buffer

### DIFF
--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -249,7 +249,9 @@ class WPSEO_Export {
 	 */
 	private function serve_settings_export() {
 		// Clean any content that has been already output. For example by other plugins or faulty PHP files.
-		ob_clean();
+		if ( ob_get_contents() ) {
+			ob_clean();
+		}
 		header( 'Content-Type: application/octet-stream; charset=utf-8' );
 		header( 'Content-Transfer-Encoding: Binary' );
 		header( 'Content-Disposition: attachment; filename=' . self::ZIP_FILENAME );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

- Added check to buffer clean, prevents notice on no buffer, which can break export process.

## Relevant technical choices:

* added `ob_get_content()` check, which is only truthy for buffering enabled and buffer containing something.

## Test instructions

This PR can be tested by following these steps:

* perform export without any buffering in code running and errors displayed, observe process completing without error notice.

See https://github.com/Yoast/wordpress-seo/issues/5272#issuecomment-237441681

Fixes #5314
