### PR TITLE
Hidden SEO score filter in post list views when keyword analysis disabled

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -36,7 +36,12 @@ class WPSEO_Meta_Columns {
 	public function setup_hooks() {
 		$this->set_post_type_hooks();
 
-		add_action( 'restrict_manage_posts', array( $this, 'posts_filter_dropdown' ) );
+		$options = WPSEO_Options::get_option( 'wpseo_titles' );
+
+		if ( $options['keyword-analysis-active'] ) {
+			add_action( 'restrict_manage_posts', array( $this, 'posts_filter_dropdown' ) );
+		}
+
 		add_filter( 'request', array( $this, 'column_sort_orderby' ) );
 	}
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -38,7 +38,7 @@ class WPSEO_Meta_Columns {
 
 		$options = WPSEO_Options::get_option( 'wpseo_titles' );
 
-		if ( $options['keyword-analysis-active'] ) {
+		if ( ! empty( $options['keyword-analysis-active'] ) ) {
 			add_action( 'restrict_manage_posts', array( $this, 'posts_filter_dropdown' ) );
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Hidden SEO score filter in post list views when keyword analysis disabled

## Relevant technical choices:

* made hooking post filter dropdown callback conditional on `keyword-analysis-active` option

## Test instructions

This PR can be tested by following these steps:

1. Disable SEO > Titles and Metas > Keyword analysis
2. Go to posts list view, observe All SEO Scores filter **not** appearing

Fixes #5307