### PR TITLE
Return early from clean permalink logic if there are not GET vars to consider

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1516,7 +1516,7 @@ class WPSEO_Frontend {
 	 * @return boolean
 	 */
 	public function clean_permalink() {
-		if ( is_robots() || get_query_var( 'sitemap' ) ) {
+		if ( is_robots() || get_query_var( 'sitemap' ) || empty( $_GET ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Improved compatibility of redirect ugly URLs to clean permalinks feature.

## Relevant technical choices:

* added early return if `$_GET` is empty and there can be no vars to clean

## Test instructions

This PR can be tested by following these steps:

* broken case described in https://github.com/Yoast/wordpress-seo/issues/5299#issuecomment-237160307

Fixes #5299