### PR TITLE
Use the latest node version in the travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ cache:
     - vendor
     - $HOME/.composer/cache
 
+before_install:
+- nvm install $TRAVIS_NODE_VERSION
+
 before_script:
 - phpenv local 5.6
 - composer selfupdate 1.0.0 --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - php: hhvm
   include:
     - php: 7.0
-      env: WP_VERSION=master WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1
+      env: WP_VERSION=master WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
       env: WP_VERSION=4.5 WP_MULTISITE=1 PHPLINT=1
     - php: 7.0


### PR DESCRIPTION
This is required to make ESLint work because they are using newer syntax
that older node versions don't support.