### PR TITLE
Fixed dashboard widget permissions

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -186,6 +186,6 @@ class Yoast_Dashboard_Widget {
 	private function show_widget() {
 		$analysis_seo = new WPSEO_Metabox_Analysis_SEO();
 
-		return $analysis_seo->is_enabled();
+		return $analysis_seo->is_enabled() && current_user_can( 'edit_posts' );
 	}
 }

--- a/admin/views/dashboard-widget.php
+++ b/admin/views/dashboard-widget.php
@@ -37,7 +37,8 @@
 		</tr>
 	<?php endforeach; ?>
 </table>
-<?php if ( ! empty( $onpage ) && WPSEO_Utils::grant_access() ) : ?>
+<?php $can_access = is_multisite() ? WPSEO_Utils::grant_access() : current_user_can( 'manage_options' );
+if ( ! empty( $onpage ) && $can_access ) : ?>
 <div class="onpage">
 	<h3 class="hide-if-no-js"><?php
 		printf(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed dashboard widget permissions.

## Relevant technical choices:

* added `edit_posts` cap check to show widget
* added `manage_options` cap check to show OnPage status on non-multisite

## Test instructions

This PR can be tested by following these steps:

* switch to Subscriber level user, observe dasboard widget not appearing
* switch to Contributor level user, observe OnPage status not showing in dashboard widget

Fixes #5348
