### PR TITLE
Added info about author archives links in theme to disable setting

### DIFF
--- a/admin/views/tabs/metas/archives.php
+++ b/admin/views/tabs/metas/archives.php
@@ -27,6 +27,8 @@ printf( __( 'If you\'re running a one author blog, the author archive will be ex
 echo ' ';
 /* translators: %s expands to <code>noindex, follow</code> */
 printf( __( 'If this is the case on your site, you can choose to either disable it (which makes it redirect to the homepage), or to add %s to it so it doesn\'t show up in the search results.', 'wordpress-seo' ), '<code>noindex,follow</code>' );
+echo ' ';
+echo __( 'Note that links to archives might be still output by your theme and you would need to remove them separately.', 'wordpress-seo' );
 echo '</p>';
 echo '</div>';
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Added info about author archives links in theme to disable setting

## Relevant technical choices:

* added additional localized string to setting descirption

## Test instructions

This PR can be tested by following these steps:

* visit SEO > Titles & Metas > Archives > Author Archives, observer added information in description

Fixes #3821

