### PR TITLE
Moved export bootstrap to admin init

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -42,8 +42,23 @@ class WPSEO_Admin_Pages {
 		}
 
 		if ( WPSEO_Utils::grant_access() ) {
+			add_action( 'admin_init', array( $this, 'admin_init' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'config_page_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'config_page_styles' ) );
+		}
+	}
+
+	/**
+	 * Run admin-specific actions.
+	 */
+	public function admin_init() {
+
+		$page         = filter_input( INPUT_GET, 'page' );
+		$tool         = filter_input( INPUT_GET, 'tool' );
+		$export_nonce = filter_input( INPUT_POST, WPSEO_Export::NONCE_NAME );
+
+		if ( 'wpseo_tools' === $page && 'import-export' === $tool && $export_nonce !== null ) {
+			$this->do_yoast_export();
 		}
 	}
 
@@ -143,10 +158,6 @@ class WPSEO_Admin_Pages {
 
 		if ( 'bulk-editor' === $tool ) {
 			$this->asset_manager->enqueue_script( 'bulk-editor' );
-		}
-
-		if ( 'import-export' === $tool && filter_input( INPUT_POST, WPSEO_Export::NONCE_NAME ) !== null ) {
-			$this->do_yoast_export();
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed settings export broken by error notices in some cases.

## Relevant technical choices:

* moved export logic to `admin_init` from late `admin_enqueue_scripts`.

## Test instructions

Hard to test since I couldn't exactly reproduce the message reported, but enqueue hook is _definitely_ too late to be doing any downloads output.

Fixes #5272 