### PR TITLE
Bulk editor table: remove title attributes and use aria-label.

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -379,7 +379,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				$post_type_filter = filter_input( INPUT_GET, 'post_type_filter' );
 				$selected         = ( ! empty( $post_type_filter ) ) ? sanitize_text_field( $post_type_filter ) : '-1';
 
-				$options = '<option value="-1">Show All Post Types</option>';
+				$options = '<option value="-1">' . __( 'Show All Post Types', 'wordpress-seo' ) . '</option>';
 
 				if ( is_array( $post_types ) && $post_types !== array() ) {
 					foreach ( $post_types as $post_type ) {
@@ -388,7 +388,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 					}
 				}
 
-				echo sprintf( '<select name="post_type_filter">%1$s</select>', $options );
+				printf( '<select name="post_type_filter">%1$s</select>', $options );
 				submit_button( __( 'Filter', 'wordpress-seo' ), 'button', false, false, array( 'id' => 'post-query-submit' ) );
 				echo '</div>';
 			}
@@ -750,17 +750,35 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$actions = array();
 
 		if ( $can_edit_post && 'trash' !== $rec->post_status ) {
-			$actions['edit'] = '<a href="' . esc_url( get_edit_post_link( $rec->ID, true ) ) . '" title="' . esc_attr( __( 'Edit this item', 'wordpress-seo' ) ) . '">' . __( 'Edit', 'wordpress-seo' ) . '</a>';
+			$actions['edit'] = sprintf(
+				'<a href="%s" aria-label="%s">%s</a>',
+				esc_url( get_edit_post_link( $rec->ID, true ) ),
+				/* translators: %s: post title */
+				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;', 'wordpress-seo' ), $rec->post_title ) ),
+				__( 'Edit', 'wordpress-seo' )
+			);
 		}
 
 		if ( $post_type_object->public ) {
 			if ( in_array( $rec->post_status, array( 'pending', 'draft', 'future' ) ) ) {
 				if ( $can_edit_post ) {
-					$actions['view'] = '<a href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $rec->ID ) ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'wordpress-seo' ), $rec->post_title ) ) . '">' . __( 'Preview', 'wordpress-seo' ) . '</a>';
+					$actions['view'] = sprintf(
+						'<a href="%s" aria-label="%s">%s</a>',
+						esc_url( add_query_arg( 'preview', 'true', get_permalink( $rec->ID ) ) ),
+						/* translators: %s: post title */
+						esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'wordpress-seo' ), $rec->post_title ) ),
+						__( 'Preview', 'wordpress-seo' )
+					);
 				}
 			}
 			elseif ( 'trash' !== $rec->post_status ) {
-				$actions['view'] = '<a href="' . esc_url( get_permalink( $rec->ID ) ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'wordpress-seo' ), $rec->post_title ) ) . '" rel="bookmark">' . __( 'View', 'wordpress-seo' ) . '</a>';
+				$actions['view'] = sprintf(
+					'<a href="%s" aria-label="%s" rel="bookmark">%s</a>',
+					esc_url( get_permalink( $rec->ID ) ),
+					/* translators: %s: post title */
+					esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'wordpress-seo' ), $rec->post_title ) ),
+					__( 'View', 'wordpress-seo' )
+				);
 			}
 		}
 


### PR DESCRIPTION
Fixes #5365 

In the Bulk editor table, improve the accessibility of the "Edit | Preview | View" row actions links, removing the title attribute and using an `aria-label` attribute instead. Always refer to the post title so the links make sense even when read out of context. Also changes a couple more things:
- the filter select default option `Show All Post Types` was not translatable
- changes one `echo sprintf()` in `printf()`


![screen shot 2016-08-10 at 11 10 59](https://cloud.githubusercontent.com/assets/1682452/17548916/4445d868-5eee-11e6-8182-993e1e8e79c2.png)

![screen shot 2016-08-10 at 11 11 10](https://cloud.githubusercontent.com/assets/1682452/17548917/444b2322-5eee-11e6-9a0c-12587c8ed1e0.png)


About other tables (Search console and Redirects) I doubt that expanding the link with aria-label to include the URL (which can be very long) or the redirect type (e.g. "301") could help users. For example, links would be announced as:
`link, View /toplevelpage/subpage/my-beautiful-page` or
`link, Edit 301`

There's room for more accessibility improvements on this table, will open a separate issue.