### PR TITLE
Fixed condition to enqueue CSS for toolbar

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -365,7 +365,8 @@ add_action( 'admin_bar_menu', 'wpseo_admin_bar_menu', 95 );
  * Enqueue CSS to format the Yoast SEO adminbar item.
  */
 function wpseo_admin_bar_style() {
-	if ( ! is_user_logged_in() ) {
+
+	if ( ! is_admin_bar_showing() ) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed Toolbar CSS loading when Toolbar is disabled.

## Relevant technical choices:

* changed `is_user_logged_in()` check to a more comprehensive `is_admin_bar_showing()`

## Test instructions

This PR can be tested by following these steps:

* disable toolbar via code or user setting, observe `wordpress-seo/css/adminbar-340.min.css` not loading when Toolbar is not appearing.

Fixes #5201