### PR TITLE
Added @id fields to JSON LD output

### DIFF
--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -82,6 +82,7 @@ class WPSEO_JSON_LD {
 		$this->data = array(
 			'@context' => 'http://schema.org',
 			'@type'    => 'WebSite',
+			'@id'      => '#website',
 			'url'      => $this->get_home_url(),
 			'name'     => $this->get_website_name(),
 		);
@@ -125,6 +126,7 @@ class WPSEO_JSON_LD {
 	private function organization() {
 		if ( '' !== $this->options['company_name'] ) {
 			$this->data['@type'] = 'Organization';
+			$this->data['@id']   = '#organization';
 			$this->data['name']  = $this->options['company_name'];
 			$this->data['logo']  = $this->options['company_logo'];
 			return;
@@ -138,6 +140,7 @@ class WPSEO_JSON_LD {
 	private function person() {
 		if ( '' !== $this->options['person_name'] ) {
 			$this->data['@type'] = 'Person';
+			$this->data['@id']   = '#person';
 			$this->data['name']  = $this->options['person_name'];
 			return;
 		}

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -31,6 +31,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$json       = wp_json_encode( array(
 			'@context'        => 'http://schema.org',
 			'@type'           => 'WebSite',
+			'@id'             => '#website',
 			'url'             => $home_url,
 			'name'            => get_bloginfo( 'name' ),
 			'potentialAction' => array(
@@ -63,6 +64,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 			'@type'    => 'Person',
 			'url'      => $home_url,
 			'sameAs'   => array( $instagram ),
+			'@id'      => '#person',
 			'name'     => $name,
 		) );
 		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
@@ -91,6 +93,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 			'@type'    => 'Organization',
 			'url'      => $home_url,
 			'sameAs'   => array( $instagram, $facebook, $instagram ),
+			'@id'      => '#organization',
 			'name'     => $name,
 			'logo'     => '',
 		) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Added @id fields to JSON LD output

## Relevant technical choices:

* added `@id` fields in relative `#name` format.

## Test instructions

This PR can be tested by following these steps:

* configure JSON LD
* observe JSON LD output in page source having `@id` fields

Implementing on suggestion from user, need someone familiar with JSON LD to go over if this makes proper sense.

Fixes #5362

