### PR TITLE
Added PHP MD ruleset for CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,6 +12,8 @@ engines:
     enabled: true
   phpmd:
     enabled: true
+    config:
+      rulesets: "phpmd.xml"
 ratings:
   paths:
   - "**.css"

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ Gruntfile.js export-ignore
 package.json export-ignore
 phpunit.xml export-ignore
 phpcs.xml export-ignore
+phpmd.xml export-ignore
 CONTRIBUTING.md export-ignore
 README.md export-ignore
 ISSUE_TEMPLATE.md export-ignore

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Yoast"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+	<description>Yoast Standards</description>
+
+	<rule ref="rulesets/cleancode.xml">
+
+		<!-- used all over -->
+		<exclude name="BooleanArgumentFlag" />
+
+		<!-- in lack of real namespacing -->
+		<exclude name="StaticAccess" />
+	</rule>
+
+	<rule ref="rulesets/codesize.xml" />
+
+	<rule ref="rulesets/design.xml">
+
+		<!-- normal in WP for redirects, etc -->
+		<exclude name="ExitExpression" />
+	</rule>
+
+	<rule ref="rulesets/naming.xml/ShortVariable">
+		<properties>
+
+			<!-- common in WP -->
+			<property name="exceptions" value="id,wp" />
+		</properties>
+	</rule>
+
+	<rule ref="rulesets/naming.xml/LongVariable" />
+	<rule ref="rulesets/naming.xml/ShortMethodName" />
+	<rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass" />
+	<rule ref="rulesets/naming.xml/ConstantNamingConventions" />
+	<rule ref="rulesets/naming.xml/BooleanGetMethodName" />
+
+</ruleset>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Added PHP MD ruleset for CodeClimate

## Relevant technical choices:

* added our custom `phpmd.xml` ruleset to root and to Code Climate config.

## Test instructions

This PR can be tested by following these steps:

* observe Code Climate not exploding and not complaining about things we don't want.

