### PR TITLE
Prevented network admin load when not network active

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -23,6 +23,16 @@ if ( ! defined( 'WPSEO_BASENAME' ) ) {
 	define( 'WPSEO_BASENAME', plugin_basename( WPSEO_FILE ) );
 }
 
+if ( is_network_admin() ) {
+
+	require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+	// Not active on network, but getting loaded by main site.
+	if ( ! is_plugin_active_for_network( plugin_basename( WPSEO_FILE ) ) ) {
+		return;
+	}
+}
+
 /* ***************************** CLASS AUTOLOADING *************************** */
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Prevented network admin load when not network active

## Relevant technical choices:

* added `is_plugin_active_for_network()` check for load in network admin context.

## Test instructions

This PR can be tested by following these steps:

1. Network deactivate plugin
2. Activate plugin on main site
3. Visit network admin
4. Observe no plugin's menu or other elements

Fixes #2443

Could use second opinion on this. We do have some bits that run in network admin context, but it seems logical that they shouldn't fire either in this case.