### PR TITLE
Replaced usages of deprecated getMock() in tests

### DIFF
--- a/tests/admin/test-class-stop-words.php
+++ b/tests/admin/test-class-stop-words.php
@@ -16,7 +16,11 @@ class WPSEO_Admin_Stop_WordsTest extends PHPUnit_Framework_TestCase {
 	public function test_remove_stop_words() {
 		$original = 'and-without-about-stop-blaat-words';
 		$expected = 'without-stop-words';
-		$subject = $this->getMock( 'WPSEO_Admin_Stop_Words', array( 'list_stop_words' ) );
+		$subject  =
+			$this
+				->getMockBuilder( 'WPSEO_Admin_Stop_Words' )
+				->setMethods( array( 'list_stop_words' ) )
+				->getMock();
 
 		$subject
 			->expects( $this->once() )

--- a/tests/frontend/test-class-primary-category.php
+++ b/tests/frontend/test-class-primary-category.php
@@ -13,10 +13,11 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->subject = $this->getMock( 'WPSEO_Frontend_Primary_Category', array(
-			'get_category',
-			'get_primary_category',
-		) );
+		$this->subject =
+			$this
+				->getMockBuilder( 'WPSEO_Frontend_Primary_Category' )
+				->setMethods( array( 'get_category', 'get_primary_category', ) )
+				->getMock();
 	}
 
 	/**

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -118,7 +118,9 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 
 		$class_instance =
 			$this
-				->getMock( 'WPSEO_OnPage_Double', array( 'notify_admins' ) );
+				->getMockBuilder( 'WPSEO_OnPage_Double' )
+				->setMethods( array( 'notify_admins' ) )
+				->getMock();
 
 		$class_instance
 			->expects( $this->once() )

--- a/tests/test-class-admin-asset-manager.php
+++ b/tests/test-class-admin-asset-manager.php
@@ -156,9 +156,12 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_scripts
 	 */
 	public function test_register_scripts() {
+
 		$class_instance =
 			$this
-				->getMock( 'WPSEO_Admin_Asset_Manager', array( 'register_script' ) );
+				->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
+				->setMethods( array( 'register_script' ) )
+				->getMock();
 
 		$class_instance
 			->expects( $this->at( 0 ) )
@@ -204,9 +207,12 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_styles
 	 */
 	public function test_register_styles() {
+
 		$class_instance =
 			$this
-				->getMock( 'WPSEO_Admin_Asset_Manager', array( 'register_style' ) );
+				->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
+				->setMethods( array( 'register_style' ) )
+				->getMock();
 
 		$class_instance
 			->expects( $this->at( 0 ) )
@@ -252,9 +258,12 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_assets
 	 */
 	public function test_register_assets() {
+
 		$class_instance =
 			$this
-				->getMock( 'WPSEO_Admin_Asset_Manager', array( 'register_scripts', 'register_styles' ) );
+				->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
+				->setMethods( array( 'register_scripts', 'register_styles' ) )
+				->getMock();
 
 		$class_instance
 			->expects( $this->once() )

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -235,7 +235,12 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_OpenGraph::image
 	 */
 	public function test_image_HAS_front_page_image() {
-		$stub = $this->getMock( 'WPSEO_OpenGraph', array( 'og_tag') );
+
+		$stub =
+			$this
+				->getMockBuilder( 'WPSEO_OpenGraph' )
+				->setMethods( array( 'og_tag' ) )
+				->getMock();
 
 		$stub->options = array(
 			'og_frontpage_image' => get_site_url() . '/wp-content/uploads/2015/01/iphone5_ios7-300x198.jpg',
@@ -254,7 +259,12 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_OpenGraph::image
 	 */
 	public function test_image_HAS_NO_image() {
-		$stub = $this->getMock( 'WPSEO_OpenGraph', array( 'og_tag') );
+
+		$stub =
+			$this
+				->getMockBuilder( 'WPSEO_OpenGraph' )
+				->setMethods( array( 'og_tag' ) )
+				->getMock();
 
 		$stub
 			->expects( $this->never() )

--- a/tests/test-class-primary-term-admin.php
+++ b/tests/test-class-primary-term-admin.php
@@ -7,7 +7,11 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
     public function setUp() {
         parent::setUp();
 
-        $this->class_instance = $this->getMock( 'WPSEO_Primary_Term_Admin', array( 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ) );
+	    $this->class_instance =
+		    $this
+			    ->getMockBuilder( 'WPSEO_Primary_Term_Admin' )
+			    ->setMethods( array( 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ) )
+			    ->getMock();
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Replaced usages of deprecated getMock() in tests

## Relevant technical choices:

* replaced with more verbose `getMockBuilder()` calls, which should still be available in older PHPUnit 3.6 on PHP 5.2

## Test instructions

This PR can be tested by following these steps:

* observe tests not throwing warning about `getMock()` on PHPUnit 5.4+

Fixes #5405
