### PR TITLE
Added check for error in sitemap blocking files detection

### DIFF
--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -54,6 +54,10 @@ class WPSEO_Sitemaps_Admin {
 		// Find all files and directories containing 'sitemap' and are post-fixed .xml.
 		$blocking_files = glob( ABSPATH . '*sitemap*.xml', ( GLOB_NOSORT | GLOB_MARK ) );
 
+		if ( false === $blocking_files ) { // Some systems might return error on no matches.
+			$blocking_files = array();
+		}
+
 		// Save if we have changes.
 		$wpseo_options = WPSEO_Options::get_option( 'wpseo' );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed blocking sitemap file removal message not going away on some systems.

## Relevant technical choices:

* added explicit check for `false` return from `glob()` and normalized to empty array.

## Test instructions

I cannot reproduce this on my system, since I think it's down to differences in `glob()` behavior on different systems. Just foolproofing against that.

Fixes #5078 (I think)

