### PR TITLE
Wiped notification info from generated admin page hook

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -123,6 +123,8 @@ class WPSEO_Admin {
 			return;
 		}
 
+		global $admin_page_hooks;
+
 		// Base 64 encoded SVG image.
 		$icon_svg = WPSEO_Utils::get_icon_svg();
 
@@ -140,6 +142,8 @@ class WPSEO_Admin {
 			$this,
 			'load_page',
 		), $icon_svg, '99.31337' );
+
+		$admin_page_hooks[ self::PAGE_IDENTIFIER ] = 'seo'; // Wipe notification bits from hooks. R.
 
 		// Sub menu pages.
 		$submenu_pages = array(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Removed errant notification output from admin page hooks.

## Relevant technical choices:

* replaced generated page hook base with unwanted plugin it `$admin_page_hooks` global after top page registration.

## Test instructions

This PR can be tested by following these steps:

* check that admin context globals (`$hook_suffix`, `$page_hook`) don't contain unwanted text output, such as `seo-11-notification_page_wpseo_titles`

Fixes #5353, replaces #5372 

@afercia please take a look, I think this will be less code/trouble.

