### PR TITLE
Add sourcemaps to compiled JavaScript files

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -4,6 +4,9 @@ module.exports = {
 			transform: [
 				[ "babelify", { presets: [ "es2015" ] } ],
 			],
+			browserifyOptions: {
+				debug: true,
+			},
 		},
 		files: {
 			"js/dist/wp-seo-admin-340.js": [ "js/src/wp-seo-admin.js" ],


### PR DESCRIPTION
## Relevant technical choices:

* Inline sourcemaps are easiest.

## Test instructions

This PR can be tested by following these steps:

* Testing if the sourcemaps for JavaScript work in your browser if choice.