### PR TITLE
Updated deprecated wp_get_sites() call to get_sites() on WP 4.6+

### DIFF
--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -47,7 +47,14 @@ if ( get_blog_count() > 100 ) {
 	$use_dropdown = false;
 }
 else {
-	$sites = wp_get_sites( array( 'deleted' => 0 ) );
+
+	if ( function_exists( 'get_sites' ) ) { // WP 4.6+.
+		$sites = array_map( 'get_object_vars', get_sites( array( 'deleted' => 0 ) ) );
+	}
+	else {
+		$sites = wp_get_sites( array( 'deleted' => 0 ) );
+	}
+
 	if ( is_array( $sites ) && $sites !== array() ) {
 		$dropdown_input = array(
 			'-' => __( 'None', 'wordpress-seo' ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed calls to deprecated wp_get_sites() in multisite settings.

## Relevant technical choices:

* added conditional call to current `get_sites()` if defined (WP 4.6+)

## Test instructions

This PR can be tested by following these steps:

1. Visit plugin settings in multisite network admin on WP 4.6
2. Observe dropdown with list of sites working
3. Observe no deprecated call message for `wp_get_sites()`

Fixes #5445