### PR TITLE
Added check for relative Twitter image URL and made it absolute.

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -473,6 +473,11 @@ class WPSEO_Twitter {
 		 */
 		$img = apply_filters( 'wpseo_twitter_image', $img );
 
+		if ( WPSEO_Utils::is_url_relative( $img ) === true && $img[0] === '/' ) {
+			$parsed_url = parse_url( home_url() );
+			$img        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $img;
+		}
+
 		$escaped_img = esc_url( $img );
 
 		if ( in_array( $escaped_img, $this->shown_images ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed relative Twitter Card image URLs.

## Relevant technical choices:

* added a check for domain–relative URL in Twitter image output.

## Test instructions

This PR can be tested by following these steps:

1. Add a social Twitter image to a post, which is domain–relative (starts with `/`)
2. Observe that URL is converted to absolute in `twitter:image` meta output.

Fixes #3145