### PR TITLE
Refactored plugin status check for performance

### DIFF
--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -74,13 +74,17 @@ class WPSEO_Plugin_Availability {
 	 * Sets certain plugin properties based on WordPress' status.
 	 */
 	protected function register_yoast_plugins_status() {
-		$installed_plugins = get_plugins();
 
 		foreach ( $this->plugins as $name => $plugin ) {
-			if ( isset( $installed_plugins[ $plugin['slug'] ] ) ) {
+
+			$plugin_slug = $plugin['slug'];
+			$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_slug;
+
+			if ( file_exists( $plugin_path ) ) {
+				$plugin_data                         = get_plugin_data( $plugin_path, false, false );
 				$this->plugins[ $name ]['installed'] = true;
-				$this->plugins[ $name ]['version'] = $installed_plugins[ $plugin['slug'] ]['Version'];
-				$this->plugins[ $name ]['active'] = is_plugin_active( $plugin['slug'] );
+				$this->plugins[ $name ]['version']   = $plugin_data['Version'];
+				$this->plugins[ $name ]['active']    = is_plugin_active( $plugin_slug );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Improved performance of plugin status check.

## Relevant technical choices:

* inverted logic from retrieving full plugin list with `get_plugins()` to checking for known plugins and retrieving their data selectively.

## Test instructions

This PR can be tested by following these steps:

* observe no slowdown of `admin_init` hook execution

Fixes #5486