### PR TITLE
Allowed Local SEO access to the Premium e-mail functionality.

### DIFF
--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -59,7 +59,7 @@ class WPSEO_Premium_Popup {
 	 */
 	public function get_premium_message( $popup = true ) {
 		// Don't show in Premium.
-		if ( defined( 'WPSEO_PREMIUM_FILE' ) ) {
+		if ( defined( 'WPSEO_PREMIUM_FILE' ) ||  defined( 'WPSEO_LOCAL_FILE' ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Suppresses the message to purchase Yoast SEO Premium if the user has Local SEO installed. This is done because people with a license for Local SEO are allowed to contact support from within the plugin. 

## Test instructions

This PR can be tested by following these steps:

* Install Local SEO.
* Go to the Local SEO settings page, click on Help center.
* Click E-mail Support
* There shouldn't be any message regarding purchasing Yoast SEO Premium.