### PR TITLE
Added an extra check to ensure we're not updating the wrong post

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -619,7 +619,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		 * Determine we're not accidentally updating a different post.
 		 * We can't use filter_input here as the ID isn't available at this point, other than in the $_POST data.
 		 */
-		if ( ! isset( $_POST['ID'] ) || $post_id !== $_POST['ID'] ) {
+		if ( ! isset( $_POST['ID'] ) || $post_id !== (int) $_POST['ID'] ) {
 			return false;
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -619,7 +619,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		 * Determine we're not accidentally updating a different post.
 		 * We can't use filter_input here as the ID isn't available at this point, other than in the $_POST data.
 		 */
-		if ($post_id !== $_POST['ID'] ) {
+		if ( $post_id !== $_POST['ID'] ) {
 			return false;
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -619,7 +619,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		 * Determine we're not accidentally updating a different post.
 		 * We can't use filter_input here as the ID isn't available at this point, other than in the $_POST data.
 		 */
-		if ( $post_id !== $_POST['ID'] ) {
+		if ( ! isset( $_POST['ID'] ) || $post_id !== $_POST['ID'] ) {
 			return false;
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -615,6 +615,14 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$post_id = wp_is_post_revision( $post_id );
 		}
 
+		/**
+		 * Determine we're not accidentally updating a different post.
+		 * We can't use filter_input here as the ID isn't available at this point, other than in the $_POST data.
+		 */
+		if ($post_id !== $_POST['ID'] ) {
+			return false;
+		}
+
 		clean_post_cache( $post_id );
 		$post = get_post( $post_id );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Checks whether the post ID that is being passed is the same as the one currently available in the `$_POST` data. If not, it doesn't save the post data.


## Test instructions

This PR can be tested by following these steps:

* Add a post with a title, description and keyword.
* Check the Attribution page and ensure the keyword isn't the same as the saved post.

Fixes #5389

