### PR TITLE
Remove about page

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -42,7 +42,6 @@ class WPSEO_Admin_Init {
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dismissible' ) );
-		add_action( 'admin_init', array( $this, 'after_update_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'tagline_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'blog_public_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'permalink_notice' ), 15 );
@@ -68,46 +67,6 @@ class WPSEO_Admin_Init {
 	 */
 	public function enqueue_dismissible() {
 		$this->asset_manager->enqueue_style( 'dismissible' );
-	}
-
-	/**
-	 * Redirect first time or just upgraded users to the about screen.
-	 */
-	public function after_update_notice() {
-
-		$notification        = $this->get_update_notification();
-		$notification_center = Yoast_Notification_Center::get();
-
-		if ( $this->has_ignored_tour() && ! $this->seen_about() ) {
-			$notification_center->add_notification( $notification );
-		}
-		else {
-			$notification_center->remove_notification( $notification );
-		}
-	}
-
-	/**
-	 * Build the update notification
-	 *
-	 * @return Yoast_Notification
-	 */
-	private function get_update_notification() {
-		/* translators: %1$s expands to Yoast SEO, $2%s to the version number, %3$s and %4$s to anchor tags with link to intro page */
-		$info_message = sprintf(
-			__( '%1$s has been updated to version %2$s. %3$sFind out what\'s new!%4$s', 'wordpress-seo' ),
-			'Yoast SEO',
-			WPSEO_VERSION,
-			'<a href="' . admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) . '">',
-			'</a>'
-		);
-
-		$notification_options = array(
-			'type'         => Yoast_Notification::UPDATED,
-			'id'           => 'wpseo-dismiss-about',
-			'capabilities' => 'manage_options',
-		);
-
-		return new Yoast_Notification( $info_message, $notification_options );
 	}
 
 	/**
@@ -611,5 +570,14 @@ class WPSEO_Admin_Init {
 	 */
 	private function has_postname_in_permalink() {
 		return ( false !== strpos( get_option( 'permalink_structure' ), '%postname%' ) );
+	}
+
+	/**
+	 * Redirect first time or just upgraded users to the about screen.
+	 *
+	 * @deprecated 3.5
+	 */
+	public function after_update_notice() {
+		_deprecated_function( 'WPSEO_Admin_Init::after_update_notice', 'WPSEO 3.5' );
 	}
 }

--- a/admin/views/about.php
+++ b/admin/views/about.php
@@ -34,142 +34,23 @@ function wpseo_display_contributors( $contributors ) {
 		?></h1>
 
 	<p class="about-text">
-		Yoast SEO 3.4 mostly brings a lot of accessibility improvements. After Yoast SEO 3.3 brought a new content tab,
-		we brought functionality to you in 3.4 that allows you to disable both the content
-		analysis and the SEO analysis, should you be so inclined.
+		<?php
+		/* translators: %1$s and %2$s expands to anchor tags, %3$s expands to Yoast SEO */
+		printf( __( 'While most of the development team is at %1$sYoast%2$s in the Netherlands, %3$s is created by a worldwide team.', 'wordpress-seo' ), '<a target="_blank" href="https://yoast.com/">', '</a>', 'Yoast SEO' );
+		echo ' ';
+		printf( __( 'Want to help us develop? Read our %1$scontribution guidelines%2$s!', 'wordpress-seo' ), '<a target="_blank" href="https://yoa.st/wpseocontributionguidelines">', '</a>' );
+		?>
 	</p>
 
 	<div class="wp-badge"></div>
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<a class="nav-tab" href="#top#new" id="new-tab">
-			<?php
-			/* translators: %s: '3.2' version number */
-			echo sprintf( __( 'What’s new in %s', 'wordpress-seo' ), $version );
-			?>
-		</a>
-		<a class="nav-tab" href="#top#integrations"
-		   id="integrations-tab"><?php _e( 'Integrations', 'wordpress-seo' ); ?></a>
 		<a class="nav-tab" href="#top#credits" id="credits-tab"><?php _e( 'Credits', 'wordpress-seo' ); ?></a>
+		<a class="nav-tab" href="#top#integrations" id="integrations-tab"><?php _e( 'Integrations', 'wordpress-seo' ); ?></a>
 	</h2>
-
-	<div id="new" class="wpseotab">
-
-		<h2 class="screen-reader-text"><?php esc_html_e( 'Main new features', 'wordpress-seo' ); ?></h2>
-
-		<div class="feature-section two-col">
-			<div class="col">
-				<h3>Disable SEO &amp; Content analysis</h3>
-
-				<p>If green bullets aren't your thing, you can now disable the SEO analysis, both site wide and per
-					user. The same is true for the readability analysis.</p>
-			</div>
-			<div class="col">
-				<h3>New readability check</h3>
-
-				<p>We now warn you if you start 3 or more consecutive sentences with the same word. Works for English,
-					German, French and Spanish.</p>
-			</div>
-		</div>
-		<div class="feature-section two-col">
-			<div class="col">
-				<h3>Accessibility changes</h3>
-
-				<p>A ton of work has been put into improving the accessibility of Yoast SEO. Some of the changes:</p>
-				<ul>
-					<li>Improved the headings hierarchy on several pages.</li>
-					<li>Improved the knowledge base search and admin menu by making it focusable and operable with a
-						keyboard.
-					</li>
-					<li>Adding labels and titles to several fields.</li>
-				</ul>
-			</div>
-			<div class="col">
-				<h3>Transliterations</h3>
-
-				<p>Transliteration is the conversion of non-standard latin characters and non-latin characters to
-					standard latin characters. It's used, for instance, to convert characters with diacritics to
-					characters
-					that can be used safely in URLs and analyses.</p>
-				<p>On top of the 24 languages we already supported, this release adds support for: Breton, Chamorro,
-					Corsican, Kashubian, Welsh,
-					Ewe, Estonian, Basque, Fulah, Fijian, Arpitan, Friulian, Frisian, Irish, Scottish Gaelic, Galician,
-					Guarani, Swiss German, Haitian Creole, Hawaiian, Croatian, Georgian, Greenlandic, Kinyarwanda,
-					Luxembourgish, Limburgish, Lingala, Lithuanian, Malagasy, Macedonian, Maori, Mirandese, Occitan,
-					Oromo, Portuguese, Romansh Vallader,Aromanian, Romanian, Slovak, Slovenian, Albanian, Klingon (in
-					Latin characters, not KLI PlqaD script, yet), Hungarian, Sardinian, Silesian, Tahitian, Venetian,
-					Walloon.</p>
-			</div>
-		</div>
-
-		<hr/>
-
-		<div class="changelog">
-			<h2>Under the hood</h2>
-			<div class="under-the-hood two-col">
-				<div class="col">
-					<h3>Analysis markers</h3>
-					<p>We now disable the analysis marker buttons when switching from visual to text view in the editor. Simply because we can't highlight in the text view.</p>
-				</div>
-				<div class="col">
-					<h3>Readability score everywhere</h3>
-					<p>We've added the readability score to the post and term overview.</p>
-				</div>
-			</div>
-		</div>
-
-		<div class="return-to-dashboard">
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) ); ?>"><?php _e( 'Go to the General settings page →', 'wordpress-seo' ); ?></a>
-		</div>
-
-	</div>
-
-	<div id="integrations" class="wpseotab">
-		<h2>Yoast SEO Integrations</h2>
-		<p class="about-description">
-			Yoast SEO 3.0 brought a way for theme builders and custom field plugins to integrate with Yoast SEO. These
-			integrations make sure that <em>all</em> the data on your page is used for the content analysis. On this
-			page, we highlight the frameworks that have nicely working integrations.
-		</p>
-
-		<ol>
-			<li><a target="_blank" href="https://wordpress.org/plugins/yoast-seo-acf-analysis/">Yoast ACF
-					Integration</a> - an integration built by <a href="https://forsberg.ax">Marcus Forsberg</a> and Team
-				Yoast
-			</li>
-			<li><a target="_blank" href="https://www.elegantthemes.com/plugins/divi-builder/">Divi Builder</a></li>
-			<li><a target="_blank" href="https://vc.wpbakery.com/">Visual Composer</a></li>
-		</ol>
-
-		<h3>Other integrations</h3>
-		<p class="about-description">
-			We've got another integration we'd like to tell you about:
-		</p>
-
-		<ol>
-			<li><a target="_blank" href="https://wordpress.org/plugins/glue-for-yoast-seo-amp/">Glue for Yoast SEO &amp;
-					AMP</a> - an integration between <a href="https://wordpress.org/plugins/amp/">the WordPress AMP
-					plugin</a> and Yoast SEO.
-			</li>
-			<li>
-				<a target="_blank" href="https://wordpress.org/plugins/fb-instant-articles/">Instant Articles for WP</a>
-				- Enable Instant Articles for Facebook on your WordPress site and integrates with Yoast SEO.
-			</li>
-		</ol>
-
-
-	</div>
 
 	<div id="credits" class="wpseotab">
 		<h2 class="screen-reader-text"><?php esc_html_e( 'Team and contributors', 'wordpress-seo' ); ?></h2>
-		<p class="about-description">
-			<?php
-			/* translators: %1$s and %2$s expands to anchor tags, %3$s expands to Yoast SEO */
-			printf( __( 'While most of the development team is at %1$sYoast%2$s in the Netherlands, %3$s is created by a worldwide team.', 'wordpress-seo' ), '<a target="_blank" href="https://yoast.com/">', '</a>', 'Yoast SEO' );
-			echo ' ';
-			printf( __( 'Want to help us develop? Read our %1$scontribution guidelines%2$s!', 'wordpress-seo' ), '<a target="_blank" href="https://yoa.st/wpseocontributionguidelines">', '</a>' );
-			?>
-		</p>
 
 		<h3 class="wp-people-group"><?php _e( 'Product Management', 'wordpress-seo' ); ?></h3>
 		<ul class="wp-people-group " id="wp-people-group-project-leaders">
@@ -318,5 +199,39 @@ function wpseo_display_contributors( $contributors ) {
 			}
 			?>
 		</ul>
+	</div>
+
+	<div id="integrations" class="wpseotab">
+		<h2>Yoast SEO Integrations</h2>
+		<p class="about-description">
+			Yoast SEO 3.0 brought a way for theme builders and custom field plugins to integrate with Yoast SEO. These
+			integrations make sure that <em>all</em> the data on your page is used for the content analysis. On this
+			page, we highlight the frameworks that have nicely working integrations.
+		</p>
+
+		<ol>
+			<li><a target="_blank" href="https://wordpress.org/plugins/yoast-seo-acf-analysis/">Yoast ACF
+					Integration</a> - an integration built by <a href="https://forsberg.ax">Marcus Forsberg</a> and Team
+				Yoast
+			</li>
+			<li><a target="_blank" href="https://www.elegantthemes.com/plugins/divi-builder/">Divi Builder</a></li>
+			<li><a target="_blank" href="https://vc.wpbakery.com/">Visual Composer</a></li>
+		</ol>
+
+		<h3>Other integrations</h3>
+		<p class="about-description">
+			We've got another integration we'd like to tell you about:
+		</p>
+
+		<ol>
+			<li><a target="_blank" href="https://wordpress.org/plugins/glue-for-yoast-seo-amp/">Glue for Yoast SEO &amp;
+					AMP</a> - an integration between <a href="https://wordpress.org/plugins/amp/">the WordPress AMP
+					plugin</a> and Yoast SEO.
+			</li>
+			<li>
+				<a target="_blank" href="https://wordpress.org/plugins/fb-instant-articles/">Instant Articles for WP</a>
+				- Enable Instant Articles for Facebook on your WordPress site and integrates with Yoast SEO.
+			</li>
+		</ol>
 	</div>
 </div>

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -27,6 +27,12 @@ endif;
 
 echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 ?>
+<p>
+	<?php
+		/* translators: %1$s expands to Yoast SEO */
+		printf( __( 'Take a look at the people that create %1$s.', 'wordpress-seo' ), 'Yoast SEO' );
+	?>
+</p>
 
 <p>
 	<a class="button button-secondary"

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -25,18 +25,12 @@ if ( get_user_meta( get_current_user_id(), 'wpseo_ignore_tour' ) ) :
 <?php
 endif;
 
-echo '<h2>' . esc_html__( 'Latest changes', 'wordpress-seo' ) . '</h2>';
+echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 ?>
-<p>
-	<?php
-	/* translators: %s expands to Yoast SEO */
-	printf( __( 'We\'ve summarized the most recent changes in %s.', 'wordpress-seo' ), 'Yoast SEO' );
-	?>
-</p>
 
 <p>
 	<a class="button button-secondary"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php _e( 'View Changes', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php _e( 'View Credits', 'wordpress-seo' ); ?></a>
 </p>
 
 <br/>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Remove about page

## Relevant technical choices:

* Move credits to the first tab and change the copy on the general page to make it clear that it is now a credits page.

## Test instructions

This PR can be tested by following these steps:

* Check out the general page and click through to the credits page.

Fixes #