### PR TITLE
Corrected hook for asset enqueue in admin

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -81,7 +81,7 @@ class WPSEO_Admin {
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
 
 		if ( WPSEO_Utils::is_yoast_seo_page() ) {
-			add_action( 'admin_head', array( $this, 'enqueue_assets' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		}
 
 		new WPSEO_Configuration_Page();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed admin stylesheets loading in footer instead of header.

## Relevant technical choices:

* moved timing of asset enqueue to appropriate `admin_enqueue_scripts` from late `admin_head`

## Test instructions

This PR can be tested by following these steps:

* observe that plugin's CSS stylesheets (such as help-center one) don't load in footer in admin area

Fixes #5489

