### PR TITLE
Allow users to always enable/disable breadcrumbs

### DIFF
--- a/admin/views/tabs/advanced/breadcrumbs.php
+++ b/admin/views/tabs/advanced/breadcrumbs.php
@@ -14,10 +14,8 @@ $yform->currentoption = 'wpseo_internallinks';
 
 echo '<h2>' . __( 'Breadcrumbs settings', 'wordpress-seo' ) . '</h2>';
 
-if ( ! current_theme_supports( 'yoast-seo-breadcrumbs' ) ) {
-	$yform->light_switch( 'breadcrumbs-enable', __( 'Enable Breadcrumbs', 'wordpress-seo' ) );
-	echo '<br/>';
-}
+$yform->light_switch( 'breadcrumbs-enable', __( 'Enable Breadcrumbs', 'wordpress-seo' ) );
+echo '<br/>';
 echo '<div id="breadcrumbsinfo">';
 $yform->textinput( 'breadcrumbs-sep', __( 'Separator between breadcrumbs', 'wordpress-seo' ) );
 $yform->textinput( 'breadcrumbs-home', __( 'Anchor text for the Homepage', 'wordpress-seo' ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Users should also be able to disable the breadcrumbs when their theme supports the Yoast breadcrumbs.

## Context

If a theme includes 'yoast-seo-breadcrumbs' theme support by default, the user can no longer disable breadcrumbs via the admin. Even with theme support enabled the end user should still be able to enable/disable it, otherwise the theme will have to add a new setting to disable Yoast Breadcrumbs theme_support or the end user will have to use a child theme to disable it. Since there already is a setting available lets make it usable for everyone. Thanks!