### PR TITLE
Fix post type visibility radio boxes

### DIFF
--- a/admin/config-ui/fields/class-field-choice-post-type.php
+++ b/admin/config-ui/fields/class-field-choice-post-type.php
@@ -58,7 +58,13 @@ class WPSEO_Config_Field_Choice_Post_Type extends WPSEO_Config_Field_Choice {
 
 		$key = 'post_types-' . $this->get_post_type() . '-not_in_sitemap';
 
-		return ( ! isset( $option[ $key ] ) || false === $option[ $key ] );
+		$storedData = ! isset( $option[ $key ] ) || false === $option[ $key ];
+
+		if ( $storedData ) {
+			return 'true';
+		}
+
+		return 'false';
 	}
 
 	/**
@@ -73,13 +79,13 @@ class WPSEO_Config_Field_Choice_Post_Type extends WPSEO_Config_Field_Choice {
 
 		$option = WPSEO_Options::get_option( 'wpseo_xml' );
 
-		$option[ 'post_types-' . $post_type . '-not_in_sitemap' ] = ( $visible !== 'false' );
+		$option[ 'post_types-' . $post_type . '-not_in_sitemap' ] = ( $visible === 'false' );
 
 		update_option( 'wpseo_xml', $option );
 
 		// Check if everything got saved properly.
 		$saved_option = WPSEO_Options::get_option( 'wpseo_xml' );
 
-		return ( ( $visible !== 'false' ) && $saved_option[ 'post_types-' . $post_type . '-not_in_sitemap' ] === true );
+		return ( ( $visible === 'false' ) && $saved_option[ 'post_types-' . $post_type . '-not_in_sitemap' ] === true );
 	}
 }

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -63,7 +63,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 		$components = new WPSEO_Configuration_Components_Mock( true );
 		$list       = $components->get_components();
 
-		$this->assertEquals( 1, count( $list ) );
+		$this->assertEquals( 2, count( $list ) );
 	}
 
 	/**


### PR DESCRIPTION
The post type visibility fields did not work. The data from the WP-options was not correctly handled.

This PR fixes that. To test this:
1. Go to post type visibility.
2. See if the default values for radio buttons are selected. 
3. See if the default values are the same as the values in /wp-admin/admin.php?page=wpseo_xml#top#post-types
4. Change the values and see if the values update in the settings.

