### PR TITLE
Sets a notitication for the onboarding wizard on first install.

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -112,7 +112,7 @@ class WPSEO_Configuration_Page {
 		$message = sprintf(
 			__( 'Since you are new to %1$s you can configure the %2$splugin%3$s', 'wordpress-seo' ),
 			'Yoast SEO',
-			'<a href="' . admin_url( '?page=wpseo_configurator' ) . '">',
+			'<a href="' . admin_url( '?page=' . self::PAGE_IDENTIFIER ) . '">',
 			'</a>'
 		);
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -101,4 +101,30 @@ class WPSEO_Configuration_Page {
 
 		return $config;
 	}
+
+	/**
+	 * Adds a notification to the notification center.
+	 */
+	public static function add_notification() {
+
+		$message = sprintf(
+			__( 'Since you are new to %1$s you can configure the %2$splugin%3$s', 'wordpress-seo' ),
+			'Yoast SEO',
+			'<a href="' . admin_url( '?page=wpseo_configurator' ) . '">',
+			'</a>'
+		);
+
+		$notification = new Yoast_Notification(
+			$message,
+			array(
+				'type'         => Yoast_Notification::WARNING,
+				'id'           => 'wpseo-dismiss-onboarding-notice',
+				'capabilities' => 'manage_options',
+				'priority'     => 0.8,
+			)
+		);
+
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->add_notification( $notification );
+	}
 }

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -144,6 +144,11 @@ function _wpseo_activate() {
 	require_once( WPSEO_PATH . 'inc/wpseo-functions.php' );
 
 	wpseo_load_textdomain(); // Make sure we have our translations available for the defaults.
+
+	if ( show_onboarding_wizard_notice() ) {
+		WPSEO_Configuration_Page::add_notification();
+	}
+
 	WPSEO_Options::get_instance();
 	if ( ! is_multisite() ) {
 		WPSEO_Options::initialize();
@@ -483,4 +488,17 @@ function yoast_wpseo_self_deactivate() {
 	}
 }
 
+/**
+ * Checks if the onboarding wizard notice should be shown. This is the case when the WPSEO option doesn't exists.
+ *
+ * @return bool
+ */
+function show_onboarding_wizard_notice() {
+	// When the site is not multisite and the options does not exists.
+	$is_multisite = is_multisite();
+	if ( ! $is_multisite || ( $is_multisite && ms_is_switched() ) ) {
+		return ( get_option( 'wpseo' ) === false );
+	}
 
+	return false;
+}


### PR DESCRIPTION
## Summary
When the `wpseo` option isn't available, it might be the first install. In that case a notice, with a link to the wizard, will be added.

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Added a notifice on first install. 

## Test instructions

This PR can be tested by following these steps:

* Remove the `wpseo` option and run the plugin.

