### PR TITLE
Change ConditionalInput to Input components

### DIFF
--- a/admin/config-ui/fields/class-field-company-logo.php
+++ b/admin/config-ui/fields/class-field-company-logo.php
@@ -12,7 +12,7 @@ class WPSEO_Config_Field_Company_Logo extends WPSEO_Config_Field {
 	 * WPSEO_Config_Field_Company_Logo constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'publishingEntityCompanyLogo', 'ConditionalInput' );
+		parent::__construct( 'publishingEntityCompanyLogo', 'Input' );
 
 		$this->set_property( 'label', __( 'Provide an image of the company logo', 'wordpress-seo' ) );
 

--- a/admin/config-ui/fields/class-field-company-name.php
+++ b/admin/config-ui/fields/class-field-company-name.php
@@ -12,7 +12,7 @@ class WPSEO_Config_Field_Company_Name extends WPSEO_Config_Field {
 	 * WPSEO_Config_Field_Company_Name constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'publishingEntityCompanyName', 'ConditionalInput' );
+		parent::__construct( 'publishingEntityCompanyName', 'Input' );
 
 		$this->set_property( 'label', __( 'The name of the company', 'wordpress-seo' ) );
 

--- a/admin/config-ui/fields/class-field-person-name.php
+++ b/admin/config-ui/fields/class-field-person-name.php
@@ -12,7 +12,7 @@ class WPSEO_Config_Field_Person_Name extends WPSEO_Config_Field {
 	 * WPSEO_Config_Field_Company_Or_Person constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'publishingEntityPersonName', 'ConditionalInput' );
+		parent::__construct( 'publishingEntityPersonName', 'Input' );
 
 		$this->set_property( 'label', __( 'The name of the person', 'wordpress-seo' ) );
 


### PR DESCRIPTION
The ConditionalInput fields are changed to Input field. The every field can now be conditional in the wizard by adding a requires property.

Testing:
0 - Make sure you use the develop branch for yoast-components and have run and npm update grunt build:js.
1 - Go to the wizard page and click step 4 ‘company or person’.
2 - Select the different options and see if the input fields change accordingly.
