### PR TITLE
update react to ^15.3.1. in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "grunt-wp-css": "cedaro/grunt-wp-css#develop",
     "grunt-wp-i18n": "^0.5.4",
     "load-grunt-config": "^0.19.2",
-    "react": "15.3.0",
-    "react-dom": "15.3.0",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1",
     "sassdash": "^0.8.1",
     "time-grunt": "^1.0.0"
   },


### PR DESCRIPTION
React 15.3.0 was needed because of a bug in 15.3.1. We now have a workaround for this bug. yoast-components is already updated to 15.3.1

wordpress-seo should also be updated to prevent bugs for loading two different versions of React.

Testing:
1. Load the branch, also check if the yoast-components branch is set to develop in the package.json
2. Run npm update.
3. See if the wizard loads and works correctly