### PR TITLE
Implemented a premium tab for upsell reasons

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -422,19 +422,19 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			
 			<p><a class='wpseo-metabox-go-to' href='%s'>%s</a></p>
 		</div>",
-			__( "You're not getting the benefits of Yoast SEO Premium yet. If you had Yoast SEO Premium, you could use its awesome features:", "wordpress-seo" ),
-			__( "Redirect manager", "wordpress-seo" ),
-			__( "Create and manage redirects within your WordPress install.", "wordpress-seo" ),
-			__( "Multiple focus keywords", "wordpress-seo" ),
-			__( "Optimize a single post for up to 5 keywords.", "wordpress-seo" ),
-			__( "Social Previews", "wordpress-seo" ),
-			__( "Check what your Facebook or Twitter post will look like.", "wordpress-seo" ),
-			__( "Premium support", "wordpress-seo" ),
-			__( "Gain access to our 24/7 support team.", "wordpress-seo" ),
+			__( 'You\'re not getting the benefits of Yoast SEO Premium yet. If you had Yoast SEO Premium, you could use its awesome features:', 'wordpress-seo' ),
+			__( 'Redirect manager', 'wordpress-seo' ),
+			__( 'Create and manage redirects within your WordPress install.', 'wordpress-seo' ),
+			__( 'Multiple focus keywords', 'wordpress-seo' ),
+			__( 'Optimize a single post for up to 5 keywords.', 'wordpress-seo' ),
+			__( 'Social Previews', 'wordpress-seo' ),
+			__( 'Check what your Facebook or Twitter post will look like.', 'wordpress-seo' ),
+			__( 'Premium support', 'wordpress-seo' ),
+			__( 'Gain access to our 24/7 support team.', 'wordpress-seo' ),
 			$upsell_url,
-			__( "Get Yoast SEO Premium now!", "wordpress-seo" ),
+			__( 'Get Yoast SEO Premium now!', 'wordpress-seo' ),
 			$more_information_url,
-			__( "More info", "wordpress-seo" )
+			__( 'More info', 'wordpress-seo' )
 			);
 
 		$tab = new WPSEO_Metabox_Form_Tab(

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -390,7 +390,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
-	 * Returns the metabox section for the advanced settings.
+	 * Returns the metabox section for the Premium section.
 	 *
 	 * @return WPSEO_Metabox_Section
 	 */

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -323,9 +323,12 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$content_sections[] = $this->get_advanced_meta_section();
 		}
 
+		$content_sections[] = $this->get_buy_premium_section();
+
 		if ( has_action( 'wpseo_tab_header' ) || has_action( 'wpseo_tab_content' ) ) {
 			$content_sections[] = $this->get_addons_meta_section();
 		}
+
 		return $content_sections;
 	}
 
@@ -380,6 +383,70 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			array( $tab ),
 			array(
 				'link_title' => __( 'Advanced', 'wordpress-seo' ),
+			)
+		);
+	}
+
+	/**
+	 * Returns the metabox section for the advanced settings.
+	 *
+	 * @return WPSEO_Metabox_Section
+	 */
+	private function get_buy_premium_section() {
+
+		$upsell_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=metabox-upsell-button&utm_campaign=metabox-upsell-section';
+		$more_information_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=link-info&utm_campaign=metabox-upsell-section';
+
+		$content = sprintf( "<div class='wpseo-metabox-premium-description'>
+			%s
+			<ul class='wpseo-metabox-premium-advantages'>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+			</ul>
+			
+			<a id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
+				%s
+			</a>
+			
+			<p><a class='wpseo-metabox-go-to' href='%s'>%s</a></p>
+		</div>",
+			__( "You're not getting the benefits of Yoast SEO Premium yet. If you had Yoast SEO Premium, you could use its awesome features:", "wordpress-seo" ),
+			__( "Redirect manager", "wordpress-seo" ),
+			__( "Create and manage redirects within your WordPress install.", "wordpress-seo" ),
+			__( "Multiple focus keywords", "wordpress-seo" ),
+			__( "Optimize a single post for up to 5 keywords.", "wordpress-seo" ),
+			__( "Social Previews", "wordpress-seo" ),
+			__( "Check what your Facebook or Twitter post will look like.", "wordpress-seo" ),
+			__( "Premium support", "wordpress-seo" ),
+			__( "Gain access to our 24/7 support team.", "wordpress-seo" ),
+			$upsell_url,
+			__( "Get Yoast SEO Premium now!", "wordpress-seo" ),
+			$more_information_url,
+			__( "More info", "wordpress-seo" )
+			);
+
+		$tab = new WPSEO_Metabox_Form_Tab(
+			'premium',
+			$content,
+			__( 'Yoast SEO Premium', 'wordpress-seo' )
+		);
+
+		return new WPSEO_Metabox_Tab_Section(
+			'premium',
+			'<span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>',
+			array( $tab ),
+			array(
+				'link_title' => __( 'Yoast SEO Premium', 'wordpress-seo' ),
 			)
 		);
 	}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -323,7 +323,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$content_sections[] = $this->get_advanced_meta_section();
 		}
 
-		$content_sections[] = $this->get_buy_premium_section();
+		if ( ! file_exists( WPSEO_PATH . 'premium/' ) ) {
+			$content_sections[] = $this->get_buy_premium_section();
+		}
 
 		if ( has_action( 'wpseo_tab_header' ) || has_action( 'wpseo_tab_content' ) ) {
 			$content_sections[] = $this->get_addons_meta_section();

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -412,11 +412,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				</li>
 			</ul>
 			
-			<a id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
+			<a target='_blank' id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
 				%s
 			</a>
 			
-			<p><a class='wpseo-metabox-go-to' href='%s'>%s</a></p>
+			<p><a target='_blank' class='wpseo-metabox-go-to' href='%s'>%s</a></p>
 		</div>",
 			__( 'You\'re not getting the benefits of Yoast SEO Premium yet. If you had Yoast SEO Premium, you could use its awesome features:', 'wordpress-seo' ),
 			__( 'Redirect manager', 'wordpress-seo' ),

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -323,7 +323,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$content_sections[] = $this->get_advanced_meta_section();
 		}
 
-		if ( ! file_exists( WPSEO_PATH . 'premium/' ) ) {
+		if ( ! defined( 'WPSEO_PREMIUM_FILE' ) ) {
 			$content_sections[] = $this->get_buy_premium_section();
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -395,10 +395,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return WPSEO_Metabox_Section
 	 */
 	private function get_buy_premium_section() {
-
-		$upsell_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=metabox-upsell-button&utm_campaign=metabox-upsell-section';
-		$more_information_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=link-info&utm_campaign=metabox-upsell-section';
-
 		$content = sprintf( "<div class='wpseo-metabox-premium-description'>
 			%s
 			<ul class='wpseo-metabox-premium-advantages'>
@@ -431,9 +427,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			__( 'Check what your Facebook or Twitter post will look like.', 'wordpress-seo' ),
 			__( 'Premium support', 'wordpress-seo' ),
 			__( 'Gain access to our 24/7 support team.', 'wordpress-seo' ),
-			$upsell_url,
+			'https://yoa.st/pe-buy-premium',
 			__( 'Get Yoast SEO Premium now!', 'wordpress-seo' ),
-			$more_information_url,
+			'https://yoa.st/pe-premium-page',
 			__( 'More info', 'wordpress-seo' )
 			);
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -214,11 +214,11 @@ class WPSEO_Taxonomy_Metabox {
 				</li>
 			</ul>
 			
-			<a id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
+			<a target='_blank' id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
 				%s
 			</a>
 			
-			<p><a class='wpseo-metabox-go-to' href='%s'>%s</a></p>
+			<p><a target='_blank' class='wpseo-metabox-go-to' href='%s'>%s</a></p>
 		</div>",
 			__( 'You\'re not getting the benefits of Yoast SEO Premium yet. If you had Yoast SEO Premium, you could use its awesome features:', 'wordpress-seo' ),
 			__( 'Redirect manager', 'wordpress-seo' ),

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -197,10 +197,6 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return WPSEO_Metabox_Section
 	 */
 	private function get_buy_premium_section() {
-
-		$upsell_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=metabox-upsell-button&utm_campaign=metabox-upsell-section';
-		$more_information_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=link-info&utm_campaign=metabox-upsell-section';
-
 		$content = sprintf( "<div class='wpseo-metabox-premium-description'>
 			%s
 			<ul class='wpseo-metabox-premium-advantages'>
@@ -233,9 +229,9 @@ class WPSEO_Taxonomy_Metabox {
 			__( 'Check what your Facebook or Twitter post will look like.', 'wordpress-seo' ),
 			__( 'Premium support', 'wordpress-seo' ),
 			__( 'Gain access to our 24/7 support team.', 'wordpress-seo' ),
-			$upsell_url,
+			'https://yoa.st/pe-buy-premium',
 			__( 'Get Yoast SEO Premium now!', 'wordpress-seo' ),
-			$more_information_url,
+			'https://yoa.st/pe-premium-page',
 			__( 'More info', 'wordpress-seo' )
 		);
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -85,6 +85,10 @@ class WPSEO_Taxonomy_Metabox {
 			$this->get_settings_meta_section(),
 		);
 
+		if ( ! file_exists( WPSEO_PATH . 'premium/' ) ) {
+			$content_sections[] = $this->get_buy_premium_section();
+		}
+
 		return $content_sections;
 	}
 
@@ -183,6 +187,70 @@ class WPSEO_Taxonomy_Metabox {
 			$tabs,
 			array(
 				'link_title' => __( 'Social', 'wordpress-seo' ),
+			)
+		);
+	}
+
+	/**
+	 * Returns the metabox section for the Premium section.
+	 *
+	 * @return WPSEO_Metabox_Section
+	 */
+	private function get_buy_premium_section() {
+
+		$upsell_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=metabox-upsell-button&utm_campaign=metabox-upsell-section';
+		$more_information_url = 'https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=link-info&utm_campaign=metabox-upsell-section';
+
+		$content = sprintf( "<div class='wpseo-metabox-premium-description'>
+			%s
+			<ul class='wpseo-metabox-premium-advantages'>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+				<li>
+					<strong>%s</strong> - %s
+				</li>
+			</ul>
+			
+			<a id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
+				%s
+			</a>
+			
+			<p><a class='wpseo-metabox-go-to' href='%s'>%s</a></p>
+		</div>",
+			__( 'You\'re not getting the benefits of Yoast SEO Premium yet. If you had Yoast SEO Premium, you could use its awesome features:', 'wordpress-seo' ),
+			__( 'Redirect manager', 'wordpress-seo' ),
+			__( 'Create and manage redirects within your WordPress install.', 'wordpress-seo' ),
+			__( 'Multiple focus keywords', 'wordpress-seo' ),
+			__( 'Optimize a single post for up to 5 keywords.', 'wordpress-seo' ),
+			__( 'Social Previews', 'wordpress-seo' ),
+			__( 'Check what your Facebook or Twitter post will look like.', 'wordpress-seo' ),
+			__( 'Premium support', 'wordpress-seo' ),
+			__( 'Gain access to our 24/7 support team.', 'wordpress-seo' ),
+			$upsell_url,
+			__( 'Get Yoast SEO Premium now!', 'wordpress-seo' ),
+			$more_information_url,
+			__( 'More info', 'wordpress-seo' )
+		);
+
+		$tab = new WPSEO_Metabox_Form_Tab(
+			'premium',
+			$content,
+			__( 'Yoast SEO Premium', 'wordpress-seo' )
+		);
+
+		return new WPSEO_Metabox_Tab_Section(
+			'premium',
+			'<span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>',
+			array( $tab ),
+			array(
+				'link_title' => __( 'Yoast SEO Premium', 'wordpress-seo' ),
 			)
 		);
 	}

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -85,7 +85,7 @@ class WPSEO_Taxonomy_Metabox {
 			$this->get_settings_meta_section(),
 		);
 
-		if ( ! file_exists( WPSEO_PATH . 'premium/' ) ) {
+		if ( ! defined( 'WPSEO_PREMIUM_FILE' ) ) {
 			$content_sections[] = $this->get_buy_premium_section();
 		}
 

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -62,15 +62,23 @@ ul.wpseo-metabox-tabs li.active {
 .wpseo-metabox-sidebar li span {
 	margin: 3px 0 0 -5px;
 	padding: 0 2px 0 5px;
-	border-width: 0 0 0 3px;
-	border-style: solid;
-	border-color: transparent;
+	border: 0 solid transparent;
+	border-left-width: 3px;
 	border-radius: 3px;
+
+	&.wpseo-buy-premium {
+		color: #FCA701;
+	}
 }
 
 .wpseo-metabox-sidebar li.active span {
 	border-color: #333;
 	color: #333;
+
+	&.wpseo-buy-premium {
+		color: #FCA701;
+		border-color: #FCA701;
+	}
 }
 
 /* Floated to reset white space between list items */
@@ -79,9 +87,8 @@ ul.wpseo-metabox-tabs li {
 	margin-right: 5px;
 	margin-bottom: -1px;
 	padding: 0;
-	border-width: 1px 1px 0;
-	border-style: solid solid none;
-	border-color: #dfdfdf;
+	border: 1px solid #dfdfdf;
+	border-bottom: 0 none;
 
 	.wpseo-keyword {
 		display: inline-block;
@@ -464,8 +471,7 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 	width: 18px;
 	margin-right: 5px;
 	height: 18px;
-	background-image: url(svg-icon-yoast(#999));
-	background-repeat: no-repeat;
+	background: url(svg-icon-yoast(#999)) no-repeat;
 	background-size: 18px;
 }
 
@@ -496,4 +502,31 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 
 .term-php .wpseo-taxonomy-metabox-postbox h2 {
 	border-bottom: 1px solid #eee;
+}
+
+.wpseo-metabox-go-to {
+	&::after {
+		content: " \00BB";
+		position: static;
+		top: auto;
+		right: auto;
+		width: auto;
+		height: auto;
+		border: none;
+	}
+}
+
+#wpseo-buy-premium-popup-button.button-buy-premium {
+	background: #A4286A;
+	border-color: #A4286A;
+	color: #fff;
+}
+
+.wpseo-metabox-premium-description {
+	margin-top: 0.5em;
+}
+
+ul.wpseo-metabox-premium-advantages {
+  	list-style: disc;
+	padding-left: 1.5em;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Adds an extra tab to Yoast SEO to highlight the advantages of buying Yoast SEO Premium.

## Test instructions

This PR can be tested by following these steps:

* Create a new post.
* Click the star-shaped icon in the metabox section.
* The new tab with information and external links should be available.

Fixes #5543 

