### PR TITLE
Included both material UI and react tap plugin in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,12 @@
     "grunt-contrib-imagemin": "^1.0.0"
   },
   "dependencies": {
-    "lodash": "^4.7.0",
-    "select2": "^4.0.3",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#master",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components#master"
+    "lodash": "^4.7.0",
+    "material-ui": "^0.15.4",
+    "react-tap-event-plugin": "^1.0.0",
+    "select2": "^4.0.3",
+    "yoast-components": "git+https://github.com/Yoast/yoast-components#master",
+    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#master"
   }
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Currently every time we want to work with the `trunk` version of the plugin, we need to manually install multiple node modules. This PR ensures we don't have to anymore.

## Test instructions

This PR can be tested by following these steps:

* Clear out the `node_modules` directory
* Run `npm install`.
* All the relevant modules should now be installed, including both `react-tap-event-plugin` and `material-ui`.
* Rejoice!


