### PR TITLE
Mailchimp fixes and styling

### DIFF
--- a/admin/config-ui/fields/class-field-mailchimp-signup.php
+++ b/admin/config-ui/fields/class-field-mailchimp-signup.php
@@ -17,6 +17,7 @@ class WPSEO_Config_Field_Mailchimp_Signup extends WPSEO_Config_Field {
 		$current_user = wp_get_current_user();
 		$user_email = ( $current_user->ID > 0 ) ? $current_user->user_email : '';
 
+		$this->set_property( 'title' , __( 'Newsletter signup', 'wordpress-seo' ) );
 		$this->set_property( 'label', __( 'If you would like us to keep you up-to-date regarding Yoast SEO and other plugins by Yoast, subscribe to our newsletter:', 'wordpress-seo' ) );
 		$this->set_property( 'mailchimpActionUrl', 'http://yoast.us1.list-manage1.com/subscribe/post-json?u=ffa93edfe21752c921f860358&id=972f1c9122' );
 		$this->set_property( 'currentUserEmail', $user_email );

--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -87,15 +87,15 @@ class MailchimpSignup extends React.Component {
 			.then(
 				( response ) => {
 					if ( response.result === "error" ) {
+
 						this.setState( {
 							isLoading: false,
 							successfulSignup: false,
-							message: this.stripMessage( response.msg ),
+							message: this.stripMessage( this.stripLinkFromMessage(response.msg) ),
 						} );
 
 						return;
 					}
-
 					this.setState( {
 						isLoading: false,
 						successfulSignup: true,
@@ -105,6 +105,17 @@ class MailchimpSignup extends React.Component {
 			.catch( ( response )=> {
 				console.error( "MailChimp signup failed:", response );
 			} );
+	}
+
+	/**
+	 * Strips an HTML link element from the message string.
+	 *
+	 * @param {string} message The message string.
+	 *
+	 * @returns {string} The message string without a link element.
+	 */
+	stripLinkFromMessage(message) {
+		return message.replace( /<a.*?<\/a>/, "" );
 	}
 
 	/**

--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -91,7 +91,7 @@ class MailchimpSignup extends React.Component {
 						this.setState( {
 							isLoading: false,
 							successfulSignup: false,
-							message: this.stripMessage( this.stripLinkFromMessage(response.msg) ),
+							message: this.stripMessage( this.stripLinkFromMessage( response.msg ) ),
 						} );
 
 						return;
@@ -114,7 +114,7 @@ class MailchimpSignup extends React.Component {
 	 *
 	 * @returns {string} The message string without a link element.
 	 */
-	stripLinkFromMessage(message) {
+	stripLinkFromMessage( message ) {
 		return message.replace( /<a.*?<\/a>/, "" );
 	}
 

--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -19,7 +19,6 @@ class MailchimpSignup extends React.Component {
 		super( props );
 
 		this.state = {
-			message: "",
 			successfulSignup: this.props.value,
 		};
 	}
@@ -60,7 +59,6 @@ class MailchimpSignup extends React.Component {
 		let name = this.refs.nameInput.value.trim();
 
 		if ( name !== "" ) {
-			// MERGE7 = the name field in the Yoast newsletter signup form.
 			data = data + `&NAME=${encodeURIComponent( name )}`;
 		}
 
@@ -94,8 +92,6 @@ class MailchimpSignup extends React.Component {
 							successfulSignup: false,
 							message: this.stripMessage( response.msg ),
 						} );
-
-						this.setSubscription();
 
 						return;
 					}
@@ -211,7 +207,7 @@ class MailchimpSignup extends React.Component {
 	 * @returns {XML}
 	 */
 	getSignupMessage() {
-		if( !this.state.successfulSignup ) {
+		if( this.state.successfulSignup ) {
 			return <p className="yoast-wizard-mailchimp-message-success">{this.state.message}</p>;
 		}
 

--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -19,7 +19,7 @@ class MailchimpSignup extends React.Component {
 		super( props );
 
 		this.state = {
-			message: this.getMessage(),
+			message: "",
 			successfulSignup: this.props.value,
 		};
 	}
@@ -38,20 +38,6 @@ class MailchimpSignup extends React.Component {
 		if( successfulSignup ) {
 			this.sendChangeEvent();
 		}
-	}
-
-	/**
-	 * Gets a message when the user has subscribed to the newsletter before.
-	 *
-	 * @returns {string} The message if applicable otherwise an empty string.
-	 */
-	getMessage() {
-		if( this.hasSubscription() ) {
-			return "You've already signed up for our newsletter, thank you! If you'd like you can sign up with " +
-				"another email address.";
-		}
-
-		return "";
 	}
 
 	/**
@@ -75,7 +61,7 @@ class MailchimpSignup extends React.Component {
 
 		if ( name !== "" ) {
 			// MERGE7 = the name field in the Yoast newsletter signup form.
-			data = data + `&MERGE7=${encodeURIComponent( name )}`;
+			data = data + `&NAME=${encodeURIComponent( name )}`;
 		}
 
 		let result = sendRequest(
@@ -182,7 +168,8 @@ class MailchimpSignup extends React.Component {
 
 		return (
 			<div>
-				<h4>{this.props.properties.label}</h4>
+				<h2>{this.props.properties.title}</h2>
+				<p>{this.props.properties.label}</p>
 				<div className="yoast-wizard-text-input">
 					<label htmlFor="mailchimpName"
 					       className="yoast-wizard-text-input-label">
@@ -224,7 +211,7 @@ class MailchimpSignup extends React.Component {
 	 * @returns {XML}
 	 */
 	getSignupMessage() {
-		if( this.state.successfulSignup ) {
+		if( !this.state.successfulSignup ) {
 			return <p className="yoast-wizard-mailchimp-message-success">{this.state.message}</p>;
 		}
 
@@ -233,6 +220,7 @@ class MailchimpSignup extends React.Component {
 }
 
 MailchimpSignup.propTypes = {
+	title: React.PropTypes.string,
 	component: React.PropTypes.string,
 	name: React.PropTypes.string.isRequired,
 	properties: React.PropTypes.object,
@@ -240,13 +228,14 @@ MailchimpSignup.propTypes = {
 	onChange: React.PropTypes.func,
 	value: React.PropTypes.shape(
 		{
-			hasSignup : React.PropTypes.bool
+			hasSignup : React.PropTypes.bool,
 		}
 	),
 	stepState: React.PropTypes.object
 };
 
 MailchimpSignup.defaultProps = {
+	title: "Mailchimp signup",
 	component: "",
 	properties: {},
 	data: "",


### PR DESCRIPTION
- The Mailchimp component should now has a header like: 'Sign up for our newsletter'.
- If you've already signed up for the newsletter a red message has to be shown which does not contain a HTML link element.
- The request to the server should now contain 'NAME=' instead of 'MERGE7='
- The green message showing that you've already signed up for the newsletter is removed.

Fixes #5566 
Fixes #5519 
Fixes #5600 