### PR TITLE
Use a finish url to navigate to when wizard is completed.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -400,18 +400,18 @@ class WPSEO_Admin {
 	 */
 	private function catch_configuration_request() {
 
-		if ( filter_input( INPUT_GET, 'page' ) !== self::PAGE_IDENTIFIER && filter_input( INPUT_GET, 'configuration' ) !== 'finished' ) {
-			return;
+		$is_dashboard_page = ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER );
+		$is_configuration_finished = ( filter_input( INPUT_GET, 'configuration' ) === 'finished' );
+		if ( $is_dashboard_page && $is_configuration_finished ) {
+			$options = get_option( 'wpseo' );
+
+			$options['enable_setting_pages'] = false;
+
+			update_option( 'wpseo', $options );
+
+			wp_redirect( admin_url( 'admin.php?page=' . self::PAGE_IDENTIFIER ) );
+			exit;
 		}
-
-		$options = get_option( 'wpseo' );
-
-		$options['enable_setting_pages'] = false;
-
-		update_option( 'wpseo', $options );
-
-		wp_redirect( admin_url( 'admin.php?page=' . self::PAGE_IDENTIFIER ) );
-		exit;
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -400,7 +400,7 @@ class WPSEO_Admin {
 	 */
 	private function catch_configuration_request() {
 
-		if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER && filter_input( INPUT_GET, 'configuration' ) !== 'finished' ) {
+		if ( filter_input( INPUT_GET, 'page' ) !== self::PAGE_IDENTIFIER && filter_input( INPUT_GET, 'configuration' ) !== 'finished' ) {
 			return;
 		}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -87,6 +87,8 @@ class WPSEO_Admin {
 		}
 
 		new WPSEO_Configuration_Page();
+
+		$this->catch_configuration_request();
 	}
 
 	/**
@@ -393,6 +395,24 @@ class WPSEO_Admin {
 		}
 	}
 
+	/**
+	 * Check if the configuration is finished and store this to hide the admin settings pages.
+	 */
+	private function catch_configuration_request() {
+
+		if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER && filter_input( INPUT_GET, 'configuration' ) !== 'finished' ) {
+			return;
+		}
+
+		$options = get_option( 'wpseo' );
+
+		$options['enable_setting_pages'] = false;
+
+		update_option( 'wpseo', $options );
+
+		wp_redirect( admin_url( 'admin.php?page=' . self::PAGE_IDENTIFIER ) );
+		exit;
+	}
 
 	/**
 	 * Loads the form for the network configuration page.

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -106,6 +106,7 @@ class WPSEO_Configuration_Page {
 			'nonce'             => wp_create_nonce( 'wp_rest' ),
 			'root'              => esc_url_raw( rest_url() ),
 			'ajaxurl'           => admin_url( 'admin-ajax.php' ),
+			'finishUrl'         => admin_url( 'admin.php?page=wpseo_dashboard&configuration=finished' ),
 			'gscAuthURL'        => $service->get_client()->createAuthUrl(),
 			'gscProfiles'       => $service->get_sites(),
 			'gscNonce'          => wp_create_nonce( 'wpseo-gsc-ajax-security' ),

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -41,6 +41,7 @@ class App extends React.Component {
 			config = response;
 		} );
 
+		config.finishUrl = yoastWizardConfig.finishUrl;
 		config.endpoint = endpoint;
 		config.customComponents = { MailchimpSignup, MediaUpload, ConnectGoogleSearchConsole };
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Add url parameter for `wpseo_dashboard` to check if option should be stored

## Test instructions

This PR can be tested by following these steps:

* Open the admin and be sure all admin pages for yoast seo are visible. If not, make them visible by going to page dashboard -> tab general.
* Walk through the yoast wizard
* Hit the close button
* All admin settings pages except `dashboard`, `google search console` and `go premium` should be hidden.

