### PR TITLE
RW/add gsc interaction feedback

### DIFF
--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -65,7 +65,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 			"toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=no, " +
 			"copyhistory=no, width=" + w + ", height=" + h + ", top=" + top + ", left=" + left
 		);
-	};
+	}
 
 	/**
 	 * Saves the authorization code.
@@ -96,22 +96,24 @@ class ConnectGoogleSearchConsole extends React.Component {
 	postJSON( url, config, callback ) {
 		this.startLoading();
 
-		jQuery.post( url, config, callback, "json" )
-		   .done( ( response ) => {
-		   	    this.endLoading();
+		jQuery
+			.post( url, config, callback, "json" )
+			.done( ( response ) => {
+				this.endLoading();
 
-			    return response;
-		     }
-		      )
-		      .fail( ( response ) => {
-		      	this.endLoading();
+				return response;
+			} )
+			.fail( ( response ) => {
+				this.endLoading();
 
-			    console.error( "There is an error with the request.", response );
-		     } );
+				console.error( "There is an error with the request.", response );
+			} );
 	}
 
 	/**
 	 * Sets the isLoading state to true.
+	 *
+	 * @returns {void}
 	 */
 	startLoading() {
 		this.setState( {
@@ -121,6 +123,8 @@ class ConnectGoogleSearchConsole extends React.Component {
 
 	/**
 	 * Sets the isLoading state to false.
+	 *
+	 * @returns {void}
 	 */
 	endLoading() {
 		this.setState( {
@@ -175,7 +179,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 			profileList: null,
 			profile: null,
 			error: null,
-			hasAccessToken: false
+			hasAccessToken: false,
 		} );
 	}
 
@@ -242,17 +246,14 @@ class ConnectGoogleSearchConsole extends React.Component {
 	}
 
 	/**
-	 * @summary Creates a select box for selecting a Google Analytics Profile
-	 * that is needed for the Google search console.
+	 * @summary Creates a select box for selecting a Google Search Console Profile.
 	 *
 	 * @returns {JSX.Element} Profile select box wrapped in a div element.
 	 */
 	getProfileSelectBox() {
-
 		if( ! this.hasProfiles() ) {
 			return ( <p>There were no profiles found</p> );
 		}
-
 
 		let profiles    = this.state.profileList;
 		let profileKeys = Object.keys( profiles );
@@ -286,7 +287,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 			</p>
 
 			<input type="text" id="gsc_authorization_code" name="gsc_authorization_code" defaultValue=""
-			       placeholder="Authorization code" aria-labelledby="gsc-enter-code-label" />
+				placeholder="Authorization code" aria-labelledby="gsc-enter-code-label" />
 			<RaisedButton label="Authenticate" onClick={this.saveAuthCode.bind( this )} />
 		</div> );
 	}
@@ -330,11 +331,11 @@ class ConnectGoogleSearchConsole extends React.Component {
 	/**
 	 * Gets the loading indicator.
 	 *
-	 * @returns {null|JSX.Element}
+	 * @returns {null|JSX.Element} The loading indicator.
 	 */
 	getLoadingIndicator() {
 		if ( ! this.state.isLoading ) {
-			return null
+			return null;
 		}
 
 		return ( <div className="yoast-wizard-overlay"><LoadingIndicator/></div> );
@@ -348,7 +349,7 @@ ConnectGoogleSearchConsole.propTypes = {
 	value: React.PropTypes.shape( {
 		profileList: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
-			React.PropTypes.array
+			React.PropTypes.array,
 		] ),
 
 		profile: React.PropTypes.string,

--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -85,9 +85,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 			this.setProfileList.bind( this ),
 			"json"
 		).done( (response) => {
-				console.log( 'Response done..',response );
 				newState = this.getLoadingState( false );
-				console.log( newState );
 				this.setState(
 					newState
 				)
@@ -278,7 +276,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 	/**
 	 * @summary Renders the Google Search Console component.
 	 *
-	 * @returns {XML} The HTML of the rendered component.
+	 * @returns {JSX.Element} The rendered Google Search Console component.
 	 */
 	render() {
 		this.onChange = this.props.onChange;
@@ -286,9 +284,6 @@ class ConnectGoogleSearchConsole extends React.Component {
 		let profiles = (this.hasProfiles())
 			? this.getProfileSelectBox()
 			: <p>There were no profiles found</p>;
-
-
-		console.log("rendering gsc.. ", this.state);
 
 		if( this.state.hasAccessToken ) {
 			return (
@@ -307,7 +302,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 					Authorization Code. Clicking the button below will open a new window.
 				</p>
 				<RaisedButton label="Get Google Authorization Code" primary={true} onClick={this.openGoogleAuthDialog.bind( this )} />
-				{this.getGoogleAuthCodeInput}
+				{this.getGoogleAuthCodeInput()}
 				{(this.state.isLoading) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : null}
 			</div>
 		);

--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -23,6 +23,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 		super( props );
 
 		this.state = {
+			isLoading: false,
 			profileList: props.value.profileList,
 			profile: props.value.profile,
 			error: null,
@@ -72,68 +73,59 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 * @returns {void}
 	 */
 	saveAuthCode() {
-		let url = yoastWizardConfig.ajaxurl;
-		let config = {
-			action: "wpseo_save_auth_code",
-			ajax_nonce: yoastWizardConfig.gscNonce,
-			authorization: jQuery( "#gsc_authorization_code" ).val(),
-		};
-		let callback = this.setProfileList.bind( this );
-		let dataType = "json";
-
-		this.sendJQueryAJAXrequest( url, config, callback, dataType );
+		this.postJSON(
+			yoastWizardConfig.ajaxurl,
+			{
+				action: "wpseo_save_auth_code",
+				ajax_nonce: yoastWizardConfig.gscNonce,
+				authorization: jQuery( "#gsc_authorization_code" ).val(),
+			},
+			this.setProfileList.bind( this )
+		);
 	}
 
 	/**
 	 * @summary Sends a jQuery AJAX post request.
 	 *
-	 * @param {string} url The URL to post to.
-	 * @param {object} config The parameters to send with the request.
+	 * @param {string}   url      The URL to post to.
+	 * @param {object}   config   The parameters to send with the request.
 	 * @param {function} callback The function to call after executing the request.
-	 * @param {string} dataType The dataType for the params.
 	 *
 	 * @returns {void}
 	 */
-	sendJQueryAJAXrequest( url, config, callback, dataType ) {
-		let newState = this.getLoadingState( true );
-		this.setState( newState );
+	postJSON( url, config, callback ) {
+		this.startLoading();
 
-		jQuery.post( url, config, callback, dataType )
+		jQuery.post( url, config, callback, "json" )
 		   .done( ( response ) => {
-			    newState = this.getLoadingState( false );
-			    this.setState(
-				    newState
-			    );
+		   	    this.endLoading();
+
 			    return response;
 		     }
 		      )
 		      .fail( ( response ) => {
-			    console.log( response );
+		      	this.endLoading();
+
+			    console.error( "There is an error with the request.", response );
 		     } );
 	}
 
+	/**
+	 * Sets the isLoading state to true.
+	 */
+	startLoading() {
+		this.setState( {
+			isLoading: true,
+		} );
+	}
 
 	/**
-	 * Gets a new state object with the loading state added to it.
-	 *
-	 * @param {bool} isLoading Is the google search console loading.
-	 *
-	 * @returns {object} Returns the current state object with the isLoading variable added.
+	 * Sets the isLoading state to false.
 	 */
-	getLoadingState( isLoading ) {
-		let currentState = this.state;
-
-		if( currentState.isLoading === true && isLoading === false ) {
-			currentState.isLoading = false;
-			return currentState;
-		}
-
-		let newState = {
-			isLoading
-		};
-
-		Object.assign( newState, currentState );
-		return newState;
+	endLoading() {
+		this.setState( {
+			isLoading: false,
+		} );
 	}
 
 	/**
@@ -142,15 +134,14 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 * @returns {void}
 	 */
 	clearAuthCode() {
-		let url = yoastWizardConfig.ajaxurl;
-		let config = {
-			action: "wpseo_clear_auth_code",
-			ajax_nonce: yoastWizardConfig.gscNonce,
-		};
-		let callback = this.clear.bind( this );
-		let dataType = "json";
-
-		this.sendJQueryAJAXrequest( url, config, callback, dataType );
+		this.postJSON(
+			yoastWizardConfig.ajaxurl,
+			{
+				action: "wpseo_clear_auth_code",
+				ajax_nonce: yoastWizardConfig.gscNonce,
+			},
+			this.clear.bind( this )
+		);
 	}
 
 	/**
@@ -257,10 +248,16 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 * @returns {JSX.Element} Profile select box wrapped in a div element.
 	 */
 	getProfileSelectBox() {
+
+		if( ! this.hasProfiles() ) {
+			return ( <p>There were no profiles found</p> );
+		}
+
+
 		let profiles    = this.state.profileList;
 		let profileKeys = Object.keys( profiles );
 
-		return <div>
+		return ( <div>
 			<select onChange={this.setProfile.bind( this )} name={this.name} value={this.state.profile}>
 				<option value="">Choose a profile</option>
 				{ profileKeys.map(
@@ -273,7 +270,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 					}
 				) }
 			</select>
-		</div>;
+		</div> );
 	}
 
 	/**
@@ -283,7 +280,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 *                        input field and submit button.
 	 */
 	getGoogleAuthCodeInput() {
-		return <div>
+		return ( <div>
 			<p>
 				Enter your Google Authorization Code and press the Authenticate button.
 			</p>
@@ -291,7 +288,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 			<input type="text" id="gsc_authorization_code" name="gsc_authorization_code" defaultValue=""
 			       placeholder="Authorization code" aria-labelledby="gsc-enter-code-label" />
 			<RaisedButton label="Authenticate" onClick={this.saveAuthCode.bind( this )} />
-		</div>;
+		</div> );
 	}
 
 	/**
@@ -302,16 +299,15 @@ class ConnectGoogleSearchConsole extends React.Component {
 	render() {
 		this.onChange = this.props.onChange;
 		this.name = this.props.name;
-		let profiles = ( this.hasProfiles() )
-			? this.getProfileSelectBox()
-			: <p>There were no profiles found</p>;
-		let loader = ( this.state.isLoading ) ? <div className="yoast-wizard-overlay">
-			<LoadingIndicator/></div> : null;
+
+		let loader = this.getLoadingIndicator();
 
 		if( this.state.hasAccessToken ) {
+			let profileSelectBox = this.getProfileSelectBox();
+
 			return (
 				<div>
-					{profiles}
+					{profileSelectBox}
 					<RaisedButton label="Reauthenticate with Google" onClick={this.clearAuthCode.bind( this )} />
 					{loader}
 				</div>
@@ -329,6 +325,19 @@ class ConnectGoogleSearchConsole extends React.Component {
 				{loader}
 			</div>
 		);
+	}
+
+	/**
+	 * Gets the loading indicator.
+	 *
+	 * @returns {null|JSX.Element}
+	 */
+	getLoadingIndicator() {
+		if ( ! this.state.isLoading ) {
+			return null
+		}
+
+		return ( <div className="yoast-wizard-overlay"><LoadingIndicator/></div> );
 	}
 
 }

--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -51,7 +51,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 *
 	 * @returns {Window} Returns instance of the created window.
 	 */
-	openGoogleAuthDialog() {
+	openGoogleAuthDialog = () => {
 		var authUrl = yoastWizardConfig.gscAuthURL,
 			w = 600,
 			h = 500,
@@ -64,7 +64,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 			"toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=no, " +
 			"copyhistory=no, width=" + w + ", height=" + h + ", top=" + top + ", left=" + left
 		);
-	}
+	};
 
 	/**
 	 * Saves the authorization code.
@@ -84,6 +84,16 @@ class ConnectGoogleSearchConsole extends React.Component {
 		this.sendJQueryAJAXrequest( url, config, callback, dataType );
 	}
 
+	/**
+	 * @summary Sends a jQuery AJAX post request.
+	 *
+	 * @param {string} url The URL to post to.
+	 * @param {object} config The parameters to send with the request.
+	 * @param {function} callback The function to call after executing the request.
+	 * @param {string} dataType The dataType for the params.
+	 *
+	 * @returns {void}
+	 */
 	sendJQueryAJAXrequest( url, config, callback, dataType ) {
 		let newState = this.getLoadingState( true );
 		this.setState( newState );
@@ -266,6 +276,12 @@ class ConnectGoogleSearchConsole extends React.Component {
 		</div>;
 	}
 
+	/**
+	 * Gets the input field option for the google authentication code.
+	 *
+	 * @returns {JSX.Element} Div element containing a description,
+	 *                        input field and submit button.
+	 */
 	getGoogleAuthCodeInput() {
 		return <div>
 			<p>

--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -72,30 +72,36 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 * @returns {void}
 	 */
 	saveAuthCode() {
-		let newState = this.getLoadingState(true);
-		this.setState(newState);
+		let url = yoastWizardConfig.ajaxurl;
+		let config = {
+			action: "wpseo_save_auth_code",
+			ajax_nonce: yoastWizardConfig.gscNonce,
+			authorization: jQuery( "#gsc_authorization_code" ).val(),
+		};
+		let callback = this.setProfileList.bind( this );
+		let dataType = "json";
 
-		jQuery.post(
-			yoastWizardConfig.ajaxurl,
-			{
-				action: "wpseo_save_auth_code",
-				ajax_nonce: yoastWizardConfig.gscNonce,
-				authorization: jQuery( "#gsc_authorization_code" ).val(),
-			},
-			this.setProfileList.bind( this ),
-			"json"
-		).done( (response) => {
-				newState = this.getLoadingState( false );
-				this.setState(
-					newState
-				)
-			}
-		)
-        .fail( (response) => {
-        	console.log( response )
-	      }
-        );
+		this.sendJQueryAJAXrequest( url, config, callback, dataType );
 	}
+
+	sendJQueryAJAXrequest( url, config, callback, dataType ) {
+		let newState = this.getLoadingState( true );
+		this.setState( newState );
+
+		jQuery.post( url, config, callback, dataType )
+		   .done( ( response ) => {
+			    newState = this.getLoadingState( false );
+			    this.setState(
+				    newState
+			    );
+			    return response;
+		     }
+		      )
+		      .fail( ( response ) => {
+			    console.log( response );
+		     } );
+	}
+
 
 	/**
 	 * Gets a new state object with the loading state added to it.
@@ -104,10 +110,10 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 *
 	 * @returns {object} Returns the current state object with the isLoading variable added.
 	 */
-	getLoadingState(isLoading) {
+	getLoadingState( isLoading ) {
 		let currentState = this.state;
 
-		if( currentState.isLoading === true && isLoading === false){
+		if( currentState.isLoading === true && isLoading === false ) {
 			currentState.isLoading = false;
 			return currentState;
 		}
@@ -126,15 +132,15 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 * @returns {void}
 	 */
 	clearAuthCode() {
-		return jQuery.post(
-			yoastWizardConfig.ajaxurl,
-			{
-				action: "wpseo_clear_auth_code",
-				ajax_nonce: yoastWizardConfig.gscNonce,
-			},
-			this.clear.bind( this ),
-			"json"
-		);
+		let url = yoastWizardConfig.ajaxurl;
+		let config = {
+			action: "wpseo_clear_auth_code",
+			ajax_nonce: yoastWizardConfig.gscNonce,
+		};
+		let callback = this.clear.bind( this );
+		let dataType = "json";
+
+		this.sendJQueryAJAXrequest( url, config, callback, dataType );
 	}
 
 	/**
@@ -240,7 +246,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 *
 	 * @returns {JSX.Element} Profile select box wrapped in a div element.
 	 */
-	getProfileSelectBox(){
+	getProfileSelectBox() {
 		let profiles    = this.state.profileList;
 		let profileKeys = Object.keys( profiles );
 
@@ -257,11 +263,10 @@ class ConnectGoogleSearchConsole extends React.Component {
 					}
 				) }
 			</select>
-		</div>
-
+		</div>;
 	}
 
-	getGoogleAuthCodeInput(){
+	getGoogleAuthCodeInput() {
 		return <div>
 			<p>
 				Enter your Google Authorization Code and press the Authenticate button.
@@ -270,7 +275,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 			<input type="text" id="gsc_authorization_code" name="gsc_authorization_code" defaultValue=""
 			       placeholder="Authorization code" aria-labelledby="gsc-enter-code-label" />
 			<RaisedButton label="Authenticate" onClick={this.saveAuthCode.bind( this )} />
-		</div>
+		</div>;
 	}
 
 	/**
@@ -281,7 +286,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 	render() {
 		this.onChange = this.props.onChange;
 		this.name = this.props.name;
-		let profiles = (this.hasProfiles())
+		let profiles = ( this.hasProfiles() )
 			? this.getProfileSelectBox()
 			: <p>There were no profiles found</p>;
 
@@ -290,7 +295,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 				<div>
 					{profiles}
 					<RaisedButton label="Reauthenticate with Google" onClick={this.clearAuthCode.bind( this )} />
-					{(this.state.isLoading) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : null}
+					{( this.state.isLoading ) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : null}
 				</div>
 			);
 		}
@@ -303,7 +308,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 				</p>
 				<RaisedButton label="Get Google Authorization Code" primary={true} onClick={this.openGoogleAuthDialog.bind( this )} />
 				{this.getGoogleAuthCodeInput()}
-				{(this.state.isLoading) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : null}
+				{( this.state.isLoading ) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : null}
 			</div>
 		);
 	}

--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -51,8 +51,8 @@ class ConnectGoogleSearchConsole extends React.Component {
 	 *
 	 * @returns {Window} Returns instance of the created window.
 	 */
-	openGoogleAuthDialog = () => {
-		var authUrl = yoastWizardConfig.gscAuthURL,
+	openGoogleAuthDialog() {
+		let authUrl = yoastWizardConfig.gscAuthURL,
 			w = 600,
 			h = 500,
 			left = ( screen.width / 2 ) - ( w / 2 ),
@@ -305,13 +305,15 @@ class ConnectGoogleSearchConsole extends React.Component {
 		let profiles = ( this.hasProfiles() )
 			? this.getProfileSelectBox()
 			: <p>There were no profiles found</p>;
+		let loader = ( this.state.isLoading ) ? <div className="yoast-wizard-overlay">
+			<LoadingIndicator/></div> : null;
 
 		if( this.state.hasAccessToken ) {
 			return (
 				<div>
 					{profiles}
 					<RaisedButton label="Reauthenticate with Google" onClick={this.clearAuthCode.bind( this )} />
-					{( this.state.isLoading ) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : null}
+					{loader}
 				</div>
 			);
 		}
@@ -324,7 +326,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 				</p>
 				<RaisedButton label="Get Google Authorization Code" primary={true} onClick={this.openGoogleAuthDialog.bind( this )} />
 				{this.getGoogleAuthCodeInput()}
-				{( this.state.isLoading ) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : null}
+				{loader}
 			</div>
 		);
 	}


### PR DESCRIPTION
## Summary
The Google Search Console element performed requests in the background but did not provide any feedback. A loader should be shown when waiting for the request to complete.

## Relevant technical choices:
Used jQuery for now but to make the GSC component usable for cross-platform, a more generic solution is suitable.

Created https://github.com/Yoast/wordpress-seo/issues/5617
*

## Test instructions
1. Go to step 8 'Google Search Console.'
2. Get a authentication code and paste this in the input field. When pressing authenticate a loader should be shown until the request is done.
3. The same should happen when pressing re-authenticate.
*

Fixes https://github.com/Yoast/wordpress-seo/issues/5575
Fixes https://github.com/Yoast/wordpress-seo/issues/5547
