### PR TITLE
Remove the notice when installation has been completed.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -403,6 +403,9 @@ class WPSEO_Admin {
 		$is_dashboard_page = ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER );
 		$is_configuration_finished = ( filter_input( INPUT_GET, 'configuration' ) === 'finished' );
 		if ( $is_dashboard_page && $is_configuration_finished ) {
+			// Remove the notification, because the wizard has been completed.
+			WPSEO_Configuration_Page::remove_notification();
+			
 			$options = get_option( 'wpseo' );
 
 			$options['enable_setting_pages'] = false;

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -405,7 +405,7 @@ class WPSEO_Admin {
 		if ( $is_dashboard_page && $is_configuration_finished ) {
 			// Remove the notification, because the wizard has been completed.
 			WPSEO_Configuration_Page::remove_notification();
-			
+
 			$options = get_option( 'wpseo' );
 
 			$options['enable_setting_pages'] = false;

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -69,9 +69,9 @@ class WPSEO_Configuration_Page {
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 			<title><?php _e( 'Yoast SEO &rsaquo; Setup Wizard', 'wordpress-seo' ); ?></title>
 			<?php
-			do_action( 'admin_print_styles' );
-			do_action( 'admin_print_scripts' );
-			do_action( 'admin_head' );
+				do_action( 'admin_print_styles' );
+				do_action( 'admin_print_scripts' );
+				do_action( 'admin_head' );
 			?>
 		</head>
 		<body>

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -69,9 +69,9 @@ class WPSEO_Configuration_Page {
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 			<title><?php _e( 'Yoast SEO &rsaquo; Setup Wizard', 'wordpress-seo' ); ?></title>
 			<?php
-				do_action( 'admin_print_styles' );
-				do_action( 'admin_print_scripts' );
-				do_action( 'admin_head' );
+			do_action( 'admin_print_styles' );
+			do_action( 'admin_print_scripts' );
+			do_action( 'admin_head' );
 			?>
 		</head>
 		<body>
@@ -135,7 +135,24 @@ class WPSEO_Configuration_Page {
 	 * Adds a notification to the notification center.
 	 */
 	public static function add_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->add_notification( self::get_notification() );
+	}
 
+	/**
+	 * Removes the notification from the notification center.
+	 */
+	public static function remove_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->remove_notification( self::get_notification() );
+	}
+
+	/**
+	 * Gets the notification.
+	 *
+	 * @return Yoast_Notification
+	 */
+	private static function get_notification() {
 		$message = sprintf(
 			__( 'Since you are new to %1$s you can configure the %2$splugin%3$s', 'wordpress-seo' ),
 			'Yoast SEO',
@@ -153,7 +170,6 @@ class WPSEO_Configuration_Page {
 			)
 		);
 
-		$notification_center = Yoast_Notification_Center::get();
-		$notification_center->add_notification( $notification );
+		return $notification;
 	}
 }


### PR DESCRIPTION
## Summary

We are adding a notice to let the user know he can do the installation wizard, but this one isn't removed when installation has been completed. This pull is removing that notice.

## Test instructions

This PR can be tested by following these steps:

* Be sure the notification has been set (by remove the `WPSEO` option)
* Do the installation wizard ( page dashboard, tab general )
* Complete the wizard
* Check if the notification has been removed. 

Fixes #5620 0

