### PR TITLE
Cherry pick - Get WP sitename by default for onboading wizard

### DIFF
--- a/admin/config-ui/fields/class-field-site-name.php
+++ b/admin/config-ui/fields/class-field-site-name.php
@@ -24,7 +24,6 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	 * @param WPSEO_Configuration_Options_Adapter $adapter Adapter to register lookup on.
 	 */
 	public function set_adapter( WPSEO_Configuration_Options_Adapter $adapter ) {
-//		$adapter->add_yoast_lookup( $this->get_identifier(), 'wpseo', 'website_name' );
 		$adapter->add_custom_lookup(
 			$this->get_identifier(),
 			array( $this, 'get_data' ),
@@ -53,6 +52,16 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	 * @return bool Returns true or false for successful storing the data.
 	 */
 	public function set_data( $data ) {
+		$value = $data;
 
+		$option                   = WPSEO_Options::get_option( 'wpseo' );
+		$option['website_name'] = $value;
+
+		update_option( 'wpseo', $option );
+
+		// Check if everything got saved properly.
+		$saved_option = WPSEO_Options::get_option( 'wpseo' );
+
+		return ( $saved_option['website_name'] === $option['website_name'] );
 	}
 }

--- a/admin/config-ui/fields/class-field-site-name.php
+++ b/admin/config-ui/fields/class-field-site-name.php
@@ -25,8 +25,11 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	 */
 	public function set_adapter( WPSEO_Configuration_Options_Adapter $adapter ) {
 //		$adapter->add_yoast_lookup( $this->get_identifier(), 'wpseo', 'website_name' );
-		$adapter->add_custom_lookup( $this, 'get_data', 'set_data' );
-	}
+		$adapter->add_custom_lookup(
+			$this->get_identifier(),
+			array( $this, 'get_data' ),
+			array( $this, 'set_data' )
+		);	}
 
 	/**
 	 * Get the data from the stored options.
@@ -34,8 +37,22 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	 * @return null|string
 	 */
 	public function get_data() {
-		return array(
-			'sitename' => get_bloginfo( 'name' ),
-		);
+		$option = WPSEO_Options::get_option( 'wpseo' );
+		if ( ! empty( $option['website_name'] ) ) {
+			return $option['website_name'];
+		}
+
+		return get_bloginfo( 'name' );
+	}
+
+	/**
+	 * Set the data in the options.
+	 *
+	 * @param {string} $data The data to set for the field.
+	 *
+	 * @return bool Returns true or false for successful storing the data.
+	 */
+	public function set_data( $data ) {
+
 	}
 }

--- a/admin/config-ui/fields/class-field-site-name.php
+++ b/admin/config-ui/fields/class-field-site-name.php
@@ -24,6 +24,18 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	 * @param WPSEO_Configuration_Options_Adapter $adapter Adapter to register lookup on.
 	 */
 	public function set_adapter( WPSEO_Configuration_Options_Adapter $adapter ) {
-		$adapter->add_yoast_lookup( $this->get_identifier(), 'wpseo', 'website_name' );
+//		$adapter->add_yoast_lookup( $this->get_identifier(), 'wpseo', 'website_name' );
+		$adapter->add_custom_lookup( $this, 'get_data', 'set_data' );
+	}
+
+	/**
+	 * Get the data from the stored options.
+	 *
+	 * @return null|string
+	 */
+	public function get_data() {
+		return array(
+			'sitename' => get_bloginfo( 'name' ),
+		);
 	}
 }


### PR DESCRIPTION
This is a cherry pick from trunk. This PR was already merged but also has to be merged into the release/3.6 branch.

## Summary
The site name was left empty if it was not set in the Yoast SEO settings while there was a site name set in the WP settings.

This PR can be summarized in the following changelog entry:
- Get WP site name if Yoast SEO sitename is not set or empty.

## Relevant technical choices:
None.

## Test instructions
1. Go to the onboarding wizard step 9 'title settings'
2. See if the website name contains the WP site name.
3. If you've set a site name in the Yoast SEO settings, the site name should display that site name.
4. Check if the site name is stored correctly by changing it, go to the next step and check the site name in the settings.


Fixes https://github.com/Yoast/wordpress-seo/issues/5616