### PR TITLE
Cherry pick - Better styling for GSC component

### DIFF
--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -25,9 +25,17 @@
     }
   }
 
+  &-input {
+    padding-bottom: 0.5em;
+
+    &__select {
+      font-size: 14px;
+    }
+  }
+
   &-image-upload-container {
 
-    &__image{
+    &__image {
       max-width: 151px;
     }
 
@@ -42,4 +50,5 @@
       display: block;
     }
   }
+
 }

--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -2,6 +2,8 @@
 
 import React from "react";
 import RaisedButton from "material-ui/RaisedButton";
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
 
 /**
  * Represents a Google search console interface.
@@ -215,18 +217,22 @@ class ConnectGoogleSearchConsole extends React.Component {
 				return (
 					<div>
 						<div>
-							<select onChange={this.setProfile.bind( this )} name={this.name} value={this.state.profile}>
-								<option value="">Choose a profile</option>
+							<SelectField onChange={this.setProfile.bind( this )}
+							             name={this.name}
+							             value={this.state.profile}>
+								<MenuItem value=""
+								          primaryText="Choose a profile"/>
 								{ profileKeys.map(
 									( profileKey, index ) => {
 										return (
-											<option value={profileKey} key={index}>
-												{ profiles[ profileKey ] }
-											</option>
+											<MenuItem value={profileKey}
+											          key={index}
+											          primaryText={ profiles[ profileKey ] }
+											/>
 										);
 									}
 								) }
-							</select>
+							</SelectField>
 						</div>
 
 						<RaisedButton label="Reauthenticate with Google" onClick={this.clearAuthCode.bind( this )} />
@@ -236,7 +242,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 
 			return (
 				<div>
-					<div>There were no profiles found</div>
+					<p>There were no profiles found</p>
 
 					<RaisedButton label="Reauthenticate with Google" onClick={this.clearAuthCode.bind( this )} />
 				</div>

--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -2,8 +2,6 @@
 
 import React from "react";
 import RaisedButton from "material-ui/RaisedButton";
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
 
 /**
  * Represents a Google search console interface.
@@ -216,23 +214,20 @@ class ConnectGoogleSearchConsole extends React.Component {
 
 				return (
 					<div>
-						<div>
-							<SelectField onChange={this.setProfile.bind( this )}
-							             name={this.name}
-							             value={this.state.profile}>
-								<MenuItem value=""
-								          primaryText="Choose a profile"/>
+						<div className="yoast-wizard-input">
+							<label className="yoast-wizard-text-input-label" htmlFor="yoast-wizard-gsc-select-profile"> Select profile</label>
+							<select className="yoast-wizard-input__select" id="yoast-wizard-gsc-select-profile" onChange={this.setProfile.bind( this )} name={this.name} value={this.state.profile}>
+								<option value="">Choose a profile</option>
 								{ profileKeys.map(
 									( profileKey, index ) => {
 										return (
-											<MenuItem value={profileKey}
-											          key={index}
-											          primaryText={ profiles[ profileKey ] }
-											/>
+											<option value={profileKey} key={index}>
+												{ profiles[ profileKey ] }
+											</option>
 										);
 									}
 								) }
-							</SelectField>
+							</select>
 						</div>
 
 						<RaisedButton label="Reauthenticate with Google" onClick={this.clearAuthCode.bind( this )} />


### PR DESCRIPTION
This is a cherry pick from a branch already merged on trunk. This needs a quick CR and acceptance to see if everything works ok.

## Summary
The google search component had no styling. The select box now uses a styled select box from Material-UI.

This PR can be summarized in the following changelog entry:
- Add styling for the Google Search Console in the onboarding wizard.

## Relevant technical choices:
Material-UI is not used for styling. Using this made the select boxes look really nice, but made them unaccessible. Now the default styling for select boxes is used. In chrome the select box looks a bit small, but this is a concession that has to be made in terms of accessibility.
*

## Test instructions

This PR can be tested by following these steps:
1. Go to step 8 'Google Search Console'
2. Setup the google search console.
3. Test if the values are remembered after switching steps and refreshing the page.

*

Fixes #5574 
