### PR TITLE
Add dashboard page only when current page is the wizard.

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -14,12 +14,14 @@ class WPSEO_Configuration_Page {
 	 * WPSEO_Configuration_Wizard constructor.
 	 */
 	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'add_wizard_page' ) );
+
+
 		if ( filter_input( INPUT_GET, 'page' ) !== self::PAGE_IDENTIFIER ) {
 			return;
 		}
 
 		// Register the page for the wizard.
+		add_action( 'admin_menu', array( $this, 'add_wizard_page' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'admin_init', array( $this, 'render_wizard_page' ) );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Added submenu page for dashboard only when current page is the wizard.

## Test instructions

This PR can be tested by following these steps:

* Open the wp-admin
* Hover over dashboard item and look if there is an empty menu item.

Fixes #5589

