### PR TITLE
When multisite, check if current page is not the network admin

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -502,7 +502,8 @@ function yoast_wpseo_self_deactivate() {
 function show_onboarding_wizard_notice() {
 	// When the site is not multisite and the options does not exists.
 	$is_multisite = is_multisite();
-	if ( ! $is_multisite || ( $is_multisite && ms_is_switched() ) ) {
+
+	if ( ! $is_multisite || ( $is_multisite && ms_is_switched() && ! is_network_admin()  ) ) {
 		return ( get_option( 'wpseo' ) === false );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Do the `is_network_admin` check to be sure the user is not on the network admin page.

## Test instructions

This PR can be tested by following these steps:

* Going to multisite and check if the notification appears on logic places.

Fixes #5609
