### PR TITLE
Add better styling for Mailchimp component fields

### DIFF
--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -164,6 +164,7 @@ class MailchimpSignup extends React.Component {
 		this.onChange = this.props.onChange;
 
 		let input = <input id="mailchimpEmail"
+		                   className="yoast-wizard-text-input-field"
 		                   ref="emailInput"
 		                   type="text"
 		                   name={this.props.name}
@@ -183,6 +184,7 @@ class MailchimpSignup extends React.Component {
 						Name
 					</label>
 					<input id="mailchimpName"
+					       className="yoast-wizard-text-input-field"
 					       ref="nameInput"
 					       type="text"
 					       name="name"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
- Add better styling to the input fields and labels in the MailChimp component.

## Relevant technical choices:
- Used the same CSS classes as the other text input fields in the wizard. This way they have the same look as the other fields and labels.

## Test instructions

This PR can be tested by following these steps:
1. Start the wizard and go to step 1
2. See if the labels and input fields for the name and email are shown correctly.


Fixes https://github.com/Yoast/wordpress-seo/issues/5565
