### PR TITLE
Update travis script to start testing on PHP 7.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 matrix:
   allow_failures:
     - php: hhvm
+    - php: 7.1
   include:
     - php: 7.0
       env: WP_VERSION=master WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
@@ -25,6 +26,8 @@ matrix:
     - php: 5.4
       env: WP_VERSION=4.6
     - php: 5.3
+      env: WP_VERSION=4.6
+    - php: 7.1
       env: WP_VERSION=4.6
     - php: hhvm
       env: WP_VERSION=4.6


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Tested for PHP 7.1 compatibility_ (currently failing)

## Relevant technical choices:

PHP 7.1 is expected soonish and build testing on PHP 7.1 is already supported on travis, so let's take advantage of that ;-)

## Test instructions

N/A

## To do

Fix unit tests -> opened issue #5662 to address this.7.1

