### PR TITLE
Disable settings on new install

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -86,9 +86,12 @@ class WPSEO_Admin {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		}
 
-		new WPSEO_Configuration_Page();
+		$configuration = new WPSEO_Configuration_Page();
 
-		$this->catch_configuration_request();
+		if( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {
+			$configuration->catch_configuration_request();
+		}
+
 	}
 
 	/**
@@ -392,28 +395,6 @@ class WPSEO_Admin {
 			default:
 				require_once( WPSEO_PATH . 'admin/pages/dashboard.php' );
 				break;
-		}
-	}
-
-	/**
-	 * Check if the configuration is finished and store this to hide the admin settings pages.
-	 */
-	private function catch_configuration_request() {
-
-		$is_dashboard_page = ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER );
-		$is_configuration_finished = ( filter_input( INPUT_GET, 'configuration' ) === 'finished' );
-		if ( $is_dashboard_page && $is_configuration_finished ) {
-			// Remove the notification, because the wizard has been completed.
-			WPSEO_Configuration_Page::remove_notification();
-
-			$options = get_option( 'wpseo' );
-
-			$options['enable_setting_pages'] = false;
-
-			update_option( 'wpseo', $options );
-
-			wp_redirect( admin_url( 'admin.php?page=' . self::PAGE_IDENTIFIER ) );
-			exit;
 		}
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -88,10 +88,9 @@ class WPSEO_Admin {
 
 		$configuration = new WPSEO_Configuration_Page();
 
-		if( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {
+		if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {
 			$configuration->catch_configuration_request();
 		}
-
 	}
 
 	/**

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -30,6 +30,21 @@ class WPSEO_Configuration_Page {
 	}
 
 	/**
+	 * Check if the configuration is finished. If so, just remove the notification.
+	 */
+	public function catch_configuration_request() {
+		if ( ! filter_input( INPUT_GET, 'configuration' ) === 'finished' ) {
+			return;
+		}
+
+		$this->remove_notification();
+
+		wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) );
+		exit;
+	}
+
+
+	/**
 	 *  Registers the page for the wizard.
 	 */
 	public function add_wizard_page() {
@@ -139,7 +154,7 @@ class WPSEO_Configuration_Page {
 	/**
 	 * Adds a notification to the notification center.
 	 */
-	public static function add_notification() {
+	private function add_notification() {
 		$notification_center = Yoast_Notification_Center::get();
 		$notification_center->add_notification( self::get_notification() );
 	}
@@ -147,7 +162,7 @@ class WPSEO_Configuration_Page {
 	/**
 	 * Removes the notification from the notification center.
 	 */
-	public static function remove_notification() {
+	private function remove_notification() {
 		$notification_center = Yoast_Notification_Center::get();
 		$notification_center->remove_notification( self::get_notification() );
 	}
@@ -157,7 +172,7 @@ class WPSEO_Configuration_Page {
 	 *
 	 * @return Yoast_Notification
 	 */
-	private static function get_notification() {
+	private function get_notification() {
 		$message = sprintf(
 			__( 'Since you are new to %1$s you can configure the %2$splugin%3$s', 'wordpress-seo' ),
 			'Yoast SEO',

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -15,7 +15,7 @@ class WPSEO_Configuration_Page {
 	 */
 	public function __construct() {
 
-		if ( WPSEO_Installation::get_first_install() ) {
+		if ( $this->should_add_notification() ) {
 			$this->add_notification();
 		}
 
@@ -38,6 +38,7 @@ class WPSEO_Configuration_Page {
 		}
 
 		$this->remove_notification();
+		$this->remove_notification_option();
 
 		wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) );
 		exit;
@@ -192,4 +193,35 @@ class WPSEO_Configuration_Page {
 
 		return $notification;
 	}
+
+	/**
+	 * When the notice should be shown.
+	 *
+	 * @return bool
+	 */
+	private function should_add_notification() {
+		$options = $this->get_options();
+
+		return $options['show_onboarding_notice'] === true;
+	}
+
+	/**
+	 * Remove the options that triggers the notice for the onboarding wizard.
+	 */
+	private function remove_notification_option() {
+		$options = $this->get_options();
+
+		$options[ 'show_onboarding_notice' ] = false;
+
+		update_option( 'wpseo', $options );
+	}
+
+	/**
+	 * Returns the set options
+	 * @return mixed|void
+	 */
+	private function get_options() {
+		return get_option( 'wpseo' );
+	}
+
 }

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -33,7 +33,7 @@ class WPSEO_Configuration_Page {
 	 * Check if the configuration is finished. If so, just remove the notification.
 	 */
 	public function catch_configuration_request() {
-		if ( ! filter_input( INPUT_GET, 'configuration' ) === 'finished' ) {
+		if ( filter_input( INPUT_GET, 'configuration' ) !== 'finished' ) {
 			return;
 		}
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -211,17 +211,17 @@ class WPSEO_Configuration_Page {
 	private function remove_notification_option() {
 		$options = $this->get_options();
 
-		$options[ 'show_onboarding_notice' ] = false;
+		$options['show_onboarding_notice'] = false;
 
 		update_option( 'wpseo', $options );
 	}
 
 	/**
 	 * Returns the set options
+	 *
 	 * @return mixed|void
 	 */
 	private function get_options() {
 		return get_option( 'wpseo' );
 	}
-
 }

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -15,6 +15,9 @@ class WPSEO_Configuration_Page {
 	 */
 	public function __construct() {
 
+		if ( WPSEO_Installation::get_first_install() ) {
+			$this->add_notification();
+		}
 
 		if ( filter_input( INPUT_GET, 'page' ) !== self::PAGE_IDENTIFIER ) {
 			return;

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -50,6 +50,7 @@ echo '<h2>' . esc_html__( 'Enable settings pages', 'wordpress-seo' ) . '</h2>';
 		array( 'on' => __( 'Yes', 'wordpress-seo' ), 'off' => __( 'No', 'wordpress-seo' ) ),
 		__( 'Enable the settings pages', 'wordpress-seo' )
 	);
+	$yform->hidden( 'show_onboarding_notice', 'wpseo_show_onboarding_notice' );
 	?>
 </p>
 

--- a/inc/class-wpseo-installation.php
+++ b/inc/class-wpseo-installation.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This class checks if the wpseo option doesn't exists. In the case it doesn't it will set a property that is
+ * accessible via a method to check if the installation is fresh.
+ */
+class WPSEO_Installation {
+
+	/** @var bool */
+	private static $is_first_install = false;
+
+	/**
+	 * Checks if Yoast SEO is installed for the first time.
+	 */
+	public function __construct() {
+		self::$is_first_install = $this->is_first_install();
+	}
+
+	/**
+	 * Returns the value of $is_first_install.
+	 *
+	 * @return bool
+	 */
+	public static function get_first_install(  ) {
+		return self::$is_first_install;
+	}
+
+	/**
+	 * When the option doesn't exists, it should be a new install.
+	 *
+	 * @return bool
+	 */
+	private function is_first_install() {
+		// When the site is not multisite and the options does not exists.
+		$is_multisite = is_multisite();
+		if ( ! $is_multisite || ( $is_multisite && ms_is_switched() ) ) {
+			return ( get_option( 'wpseo' ) === false );
+		}
+
+		return false;
+	}
+
+}

--- a/inc/class-wpseo-installation.php
+++ b/inc/class-wpseo-installation.php
@@ -22,18 +22,12 @@ class WPSEO_Installation {
 	}
 
 	/**
-	 * When the option doesn't exists, it should be a new install.
+	 * When the option doesn't exist, it should be a new install.
 	 *
 	 * @return bool
 	 */
 	private function is_first_install() {
-		// When the site is not multisite and the options does not exists.
-		$is_multisite = is_multisite();
-		if ( ! $is_multisite || ( $is_multisite && ms_is_switched() ) ) {
-			return ( get_option( 'wpseo' ) === false );
-		}
-
-		return false;
+		return ( get_option( 'wpseo' ) === false );
 	}
 
 	/**

--- a/inc/class-wpseo-installation.php
+++ b/inc/class-wpseo-installation.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @package WPSEO\Internals
+ * @since   3.6
+ */
 
 /**
  * This class checks if the wpseo option doesn't exists. In the case it doesn't it will set a property that is
@@ -43,5 +47,4 @@ class WPSEO_Installation {
 
 		update_option( 'wpseo', $options );
 	}
-
 }

--- a/inc/class-wpseo-installation.php
+++ b/inc/class-wpseo-installation.php
@@ -6,28 +6,15 @@
  */
 class WPSEO_Installation {
 
-	/** @var bool */
-	private static $is_first_install = false;
-
 	/**
 	 * Checks if Yoast SEO is installed for the first time.
 	 */
 	public function __construct() {
-		self::$is_first_install = $this->is_first_install();
+		$is_first_install = $this->is_first_install();
 
-		if ( self::$is_first_install ) {
-			add_action( 'wpseo_activate', array( $this, 'disable_settings_pages' ) );
+		if ( $is_first_install ) {
+			add_action( 'wpseo_activate', array( $this, 'set_first_install_options' ) );
 		}
-
-	}
-
-	/**
-	 * Returns the value of $is_first_install.
-	 *
-	 * @return bool
-	 */
-	public static function get_first_install(  ) {
-		return self::$is_first_install;
 	}
 
 	/**
@@ -46,12 +33,13 @@ class WPSEO_Installation {
 	}
 
 	/**
-	 * Disables the settings pages.
+	 * Sets the options on first install for showing the installation notice and disabling of the settings pages.
 	 */
-	public function disable_settings_pages() {
+	public function set_first_install_options() {
 		$options = get_option( 'wpseo' );
 
-		$options['enable_setting_pages'] = false;
+		$options['enable_setting_pages']   = false;
+		$options['show_onboarding_notice'] = true;
 
 		update_option( 'wpseo', $options );
 	}

--- a/inc/class-wpseo-installation.php
+++ b/inc/class-wpseo-installation.php
@@ -14,6 +14,11 @@ class WPSEO_Installation {
 	 */
 	public function __construct() {
 		self::$is_first_install = $this->is_first_install();
+
+		if ( self::$is_first_install ) {
+			add_action( 'wpseo_activate', array( $this, 'disable_settings_pages' ) );
+		}
+
 	}
 
 	/**
@@ -38,6 +43,17 @@ class WPSEO_Installation {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Disables the settings pages.
+	 */
+	public function disable_settings_pages() {
+		$options = get_option( 'wpseo' );
+
+		$options['enable_setting_pages'] = false;
+
+		update_option( 'wpseo', $options );
 	}
 
 }

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -40,6 +40,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'has_multiple_authors'            => '',
 		'environment_type'                => '',
 		'enable_setting_pages'            => true,
+		'show_onboarding_notice'          => false,
 	);
 
 	/**

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -142,12 +142,11 @@ function wpseo_network_activate_deactivate( $activate = true ) {
  */
 function _wpseo_activate() {
 	require_once( WPSEO_PATH . 'inc/wpseo-functions.php' );
+	require_once( WPSEO_PATH . 'inc/class-wpseo-installation.php' );
 
 	wpseo_load_textdomain(); // Make sure we have our translations available for the defaults.
 
-	if ( show_onboarding_wizard_notice() ) {
-		WPSEO_Configuration_Page::add_notification();
-	}
+	new WPSEO_Installation();
 
 	WPSEO_Options::get_instance();
 	if ( ! is_multisite() ) {
@@ -492,19 +491,4 @@ function yoast_wpseo_self_deactivate() {
 			unset( $_GET['activate'] );
 		}
 	}
-}
-
-/**
- * Checks if the onboarding wizard notice should be shown. This is the case when the WPSEO option doesn't exists.
- *
- * @return bool
- */
-function show_onboarding_wizard_notice() {
-	// When the site is not multisite and the options does not exists.
-	$is_multisite = is_multisite();
-	if ( ! $is_multisite || ( $is_multisite && ms_is_switched() ) ) {
-		return ( get_option( 'wpseo' ) === false );
-	}
-
-	return false;
 }


### PR DESCRIPTION
Disable the settings pages on first install instead on wizard completion.

Added a class for checking if the install is the first one.

Fixes #5623
Fixes #5611