### PR TITLE
Make the metabox premium tab star icon purple

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -67,7 +67,11 @@ ul.wpseo-metabox-tabs li.active {
 	border-radius: 3px;
 
 	&.wpseo-buy-premium {
-		color: #FCA701;
+		color: #a4286a;
+
+		&:hover {
+			color: #832055;
+		}
 	}
 }
 
@@ -76,8 +80,13 @@ ul.wpseo-metabox-tabs li.active {
 	color: #333;
 
 	&.wpseo-buy-premium {
-		color: #FCA701;
-		border-color: #FCA701;
+		color: #a4286a;
+		border-color: #a4286a;
+
+		&:hover {
+			color: #832055;
+			border-color: #832055;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #5671 

For better color contrast, makes the meta box Premium tab star icon purple, also adds hover style with a slightly darker purple (same darker purple used on https://github.com/Yoast/yoast-components/pull/70/files ).