### PR TITLE
Onboarding wizard CSS adjustments for form elements

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -47,6 +47,11 @@ class WPSEO_Configuration_Page {
 	public function enqueue_assets() {
 		wp_enqueue_media();
 
+		/*
+		 * Print the `forms.css` WP stylesheet before any Yoast style, this way
+		 * it's easier to override selectors with the same specificity later.
+		 */
+		wp_enqueue_style( 'forms' );
 		$assetManager = new WPSEO_Admin_Asset_Manager();
 		$assetManager->register_assets();
 		$assetManager->enqueue_script( 'configuration-wizard' );
@@ -76,7 +81,7 @@ class WPSEO_Configuration_Page {
 				do_action( 'admin_head' );
 			?>
 		</head>
-		<body>
+		<body class="wp-admin">
 		<div id="wizard"></div>
 		<a class="yoast-wizard-return-link" href="<?php echo $dashboard_url ?>">
 			<?php _e( 'Go back to the Yoast SEO dashboard.', 'wordpress-seo' ); ?>

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -29,7 +29,8 @@
     padding-bottom: 0.5em;
 
     &__select {
-      font-size: 14px;
+	  margin: 1em 0;
+	  font-size: 14px;
     }
   }
 


### PR DESCRIPTION
Fixes #5560 

- enqueue the WordPress `forms.css` stylesheet
- makes a few CSS adjustments

Some notes:
- material-ui uses a font stack `Roboto, sans-serif` I've tried to change it but then the step buttons and other things look differently so better to don't touch that
- further adjustments should go on the yoast-component side including the font-stack for the Onboarding wizard page