### PR TITLE
Adds babel polyfill for compatibility

### DIFF
--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -1,5 +1,5 @@
 // Required for browser compatibility.
-import "babel-polyfill"
+import "babel-polyfill";
 
 /* global yoastWizardConfig */
 import React from "react";

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -1,3 +1,6 @@
+// Required for browser compatibility.
+import "babel-polyfill"
+
 /* global yoastWizardConfig */
 import React from "react";
 import ReactDOM from "react-dom";

--- a/package.json
+++ b/package.json
@@ -58,12 +58,13 @@
   },
   "dependencies": {
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
+    "babel-polyfill": "^6.13.0",
     "jed": "^1.1.1",
     "lodash": "^4.7.0",
     "material-ui": "^0.15.4",
     "react-tap-event-plugin": "^1.0.0",
     "select2": "^4.0.3",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components#release/1.0",
+    "yoast-components": "git+https://github.com/Yoast/yoast-components#DT/IE-compatibility",
     "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release/1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "material-ui": "^0.15.4",
     "react-tap-event-plugin": "^1.0.0",
     "select2": "^4.0.3",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components#DT/IE-compatibility",
+    "yoast-components": "git+https://github.com/Yoast/yoast-components#release/1.0",
     "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release/1.6"
   }
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Adds IE compatibility to the onboarding wizard. 

## Relevant technical choices:

* Adds babel polyfill to the package.json and included this in the configuration wizard. 

## Test instructions

This PR can be tested by following these steps:
* Use this in combination with https://github.com/Yoast/yoast-components/pull/91 and test the onboarding wizard in IE9, 10 or 11

Fixes #5660

