### PR TITLE
Hides stepper in IE9

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -89,7 +89,12 @@ class WPSEO_Configuration_Page {
 		$dashboard_url = admin_url( '/admin.php?page=wpseo_dashboard' );
 		?>
 		<!DOCTYPE html>
+		<!--[if IE 9]>
+		<html class="ie9" <?php language_attributes(); ?> >
+		<![endif]-->
+		<!--[if !(IE 9) ]><!-->
 		<html <?php language_attributes(); ?>>
+		<!--<![endif]-->
 		<head>
 			<meta name="viewport" content="width=device-width"/>
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -54,5 +54,5 @@
 
 }
 .ie9 .yoast-wizard--stepper {
-  display: none;/s
+  display: none;
 }

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -53,3 +53,6 @@
   }
 
 }
+.ie9 .yoast-wizard--stepper {
+  display: none;/s
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Hides the stepper in the onboarding wizard in IE9. 

## Relevant technical choices:
* Adds a conditional HTML tag on the page for the onboarding wizard. 

## Test instructions

This PR can be tested by following these steps:

* Open the onboarding wizard in IE and switch to IE9 compatibility mode (or open it in native IE9). The stepper should be hidden. 

Fixes #5683 

