### PR TITLE
Check if the REST-API is defined and hide the wizards buttons/page if not

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -86,7 +86,7 @@ class WPSEO_Admin {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		}
 
-		if ( defined( 'REST_API_VERSION' ) && version_compare( REST_API_VERSION, '2.0', '>=' ) ) {
+		if ( wp_rest_api_available() ) {
 			$configuration = new WPSEO_Configuration_Page();
 
 			if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -86,7 +86,7 @@ class WPSEO_Admin {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		}
 
-		if ( wpseo_api_available() ) {
+		if ( WPSEO_Utils::is_api_available() ) {
 			$configuration = new WPSEO_Configuration_Page();
 
 			if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -86,10 +86,12 @@ class WPSEO_Admin {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		}
 
-		$configuration = new WPSEO_Configuration_Page();
+		if ( defined( 'REST_API_VERSION' ) && version_compare( REST_API_VERSION, '2.0', '>=' ) ) {
+			$configuration = new WPSEO_Configuration_Page();
 
-		if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {
-			$configuration->catch_configuration_request();
+			if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {
+				$configuration->catch_configuration_request();
+			}
 		}
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -86,7 +86,7 @@ class WPSEO_Admin {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		}
 
-		if ( wp_rest_api_available() ) {
+		if ( wpseo_api_available() ) {
 			$configuration = new WPSEO_Configuration_Page();
 
 			if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -9,9 +9,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( defined( 'REST_API_VERSION' ) && version_compare( REST_API_VERSION, '2.0', '>=' ) ) :
-echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
-?>
+if ( wp_rest_api_available() ) :
+	echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
+	?>
 	<p>
 		<?php
 			/* translators: %1$s expands to Yoast SEO */

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -9,7 +9,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( wp_rest_api_available() ) :
+if ( wpseo_api_available() ) :
 	echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
 	?>
 	<p>

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -9,7 +9,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( wpseo_api_available() ) :
+if ( WPSEO_Utils::is_api_available() ) :
 	echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
 	?>
 	<p>

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -9,6 +9,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
+if ( defined( 'REST_API_VERSION' ) && version_compare( REST_API_VERSION, '2.0', '>=' ) ) :
 echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
 ?>
 	<p>
@@ -24,6 +25,7 @@ echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
 
 	<br/>
 <?php
+endif;
 
 echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 ?>

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -946,5 +946,4 @@ class WPSEO_Utils {
 	public static function json_encode( array $array_to_encode, $options = 0, $depth = 512 ) {
 		return wp_json_encode( $array_to_encode, $options, $depth );
 	}
-
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -867,6 +867,18 @@ class WPSEO_Utils {
 	}
 
 	/**
+	 * Checks if the WP-REST-API with at least version 2.0 is available.
+	 *
+	 * @since 3.6
+	 *
+	 * @return bool
+	 */
+	public static function is_api_available() {
+		return ( defined( 'REST_API_VERSION' )
+		         && version_compare( REST_API_VERSION, '2.0', '>=' ) );
+	}
+
+	/**
 	 * Wrapper for the PHP filter input function.
 	 *
 	 * This is used because stupidly enough, the `filter_input` function is not available on all hosts...
@@ -934,4 +946,5 @@ class WPSEO_Utils {
 	public static function json_encode( array $array_to_encode, $options = 0, $depth = 512 ) {
 		return wp_json_encode( $array_to_encode, $options, $depth );
 	}
+
 }

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -9,20 +9,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( ! function_exists( 'wp_rest_api_available' ) ) {
-	/**
-	 * Checks if the WP-REST-API with at least version 2.0 is available.
-	 *
-	 * @return bool
-	 */
-	function wp_rest_api_available() {
-		if ( defined( 'REST_API_VERSION' ) && version_compare( REST_API_VERSION, '2.0', '>=' ) ) {
-			return true;
-		}
-		return false;
-	}
-}
-
 if ( ! function_exists( 'initialize_wpseo_front' ) ) {
 	/**
 	 * Wraps frontend class.

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -9,6 +9,20 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
+if ( ! function_exists( 'wp_rest_api_available' ) ) {
+	/**
+	 * Checks if the WP-REST-API with at least version 2.0 is available.
+	 *
+	 * @return bool
+	 */
+	function wp_rest_api_available() {
+		if ( defined( 'REST_API_VERSION' ) && version_compare( REST_API_VERSION, '2.0', '>=' ) ) {
+			return true;
+		}
+		return false;
+	}
+}
+
 if ( ! function_exists( 'initialize_wpseo_front' ) ) {
 	/**
 	 * Wraps frontend class.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -277,7 +277,7 @@ function wpseo_init() {
  */
 function wpseo_init_rest_api() {
 	// We can't do anything when requirements are not met.
-	if ( defined( 'REST_API_VERSION' ) && version_compare( REST_API_VERSION, '2.0', '>=' ) ) {
+	if ( wp_rest_api_available() ) {
 		// Boot up REST API endpoints.
 		$configuration_service = new WPSEO_Configuration_Service();
 		$configuration_service->set_default_providers();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -277,7 +277,7 @@ function wpseo_init() {
  */
 function wpseo_init_rest_api() {
 	// We can't do anything when requirements are not met.
-	if ( wp_rest_api_available() ) {
+	if ( wpseo_api_available() ) {
 		// Boot up REST API endpoints.
 		$configuration_service = new WPSEO_Configuration_Service();
 		$configuration_service->set_default_providers();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -277,7 +277,7 @@ function wpseo_init() {
  */
 function wpseo_init_rest_api() {
 	// We can't do anything when requirements are not met.
-	if ( wpseo_api_available() ) {
+	if ( WPSEO_Utils::is_api_available() ) {
 		// Boot up REST API endpoints.
 		$configuration_service = new WPSEO_Configuration_Service();
 		$configuration_service->set_default_providers();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
The plugin shows the links to the configuration wizard even if the REST-API is not available and the wizard can not work. 

This PR removes the references to the configuration wizard if the REST-API is not available.

## Relevant technical choices:
- Check if REST_API_VERSION global is defined to determine if the REST-API is available

## Test instructions

This PR can be tested by following these steps:
1. Go to rest-api.php and remove define( 'REST_API_VERSION', '2.0' );
2. Go to the Yoast SEO settings, general tab check if you do not see the button to go to the wizard anymore.
3. Check if the notification for the wizard does not come back if you de-activate the plugin (and it’s options) and reactivate. 


Fixes #5522