### PR TITLE
Convert &#39; to apostrophe symbol in post types

### DIFF
--- a/admin/config-ui/factories/class-factory-post-type.php
+++ b/admin/config-ui/factories/class-factory-post-type.php
@@ -23,7 +23,7 @@ class WPSEO_Config_Factory_Post_Type {
 			$post_types = get_post_types( array( 'public' => true ), 'objects' );
 			if ( ! empty( $post_types ) ) {
 				foreach ( $post_types as $post_type => $post_type_object ) {
-					$label = str_replace( '&#39;', '’', $post_type_object->label );
+					$label = WPSEO_Utils::decode_html_entities( $post_type_object->label );
 					$field = new WPSEO_Config_Field_Choice_Post_Type( $post_type, $label );
 
 					$this->add_custom_properties( $post_type, $field );
@@ -33,7 +33,6 @@ class WPSEO_Config_Factory_Post_Type {
 			}
 
 			self::$fields = $fields;
-
 		}
 
 		return self::$fields;

--- a/admin/config-ui/factories/class-factory-post-type.php
+++ b/admin/config-ui/factories/class-factory-post-type.php
@@ -23,7 +23,8 @@ class WPSEO_Config_Factory_Post_Type {
 			$post_types = get_post_types( array( 'public' => true ), 'objects' );
 			if ( ! empty( $post_types ) ) {
 				foreach ( $post_types as $post_type => $post_type_object ) {
-					$field = new WPSEO_Config_Field_Choice_Post_Type( $post_type, $post_type_object->label );
+					$label = str_replace( '&#39;', '’', $post_type_object->label );
+					$field = new WPSEO_Config_Field_Choice_Post_Type( $post_type, $label );
 
 					$this->add_custom_properties( $post_type, $field );
 

--- a/admin/config-ui/factories/class-factory-post-type.php
+++ b/admin/config-ui/factories/class-factory-post-type.php
@@ -23,7 +23,7 @@ class WPSEO_Config_Factory_Post_Type {
 			$post_types = get_post_types( array( 'public' => true ), 'objects' );
 			if ( ! empty( $post_types ) ) {
 				foreach ( $post_types as $post_type => $post_type_object ) {
-					$label = WPSEO_Utils::decode_html_entities( $post_type_object->label );
+					$label = $this->decode_html_entities( $post_type_object->label );
 					$field = new WPSEO_Config_Field_Choice_Post_Type( $post_type, $label );
 
 					$this->add_custom_properties( $post_type, $field );
@@ -48,5 +48,19 @@ class WPSEO_Config_Factory_Post_Type {
 		if ( 'attachment' === $post_type ) {
 			$field->set_property( 'explanation', __( 'WordPress automatically generates an URL for each media item in the library. Enabling this will allow for google to index the generated URL.', 'wordpress-seo' ) );
 		}
+	}
+
+	/**
+	 * Replaces the HTML entity with it's actual symbol.
+	 *
+	 * Because we do not not know what consequences it will have if we convert every HTML entity,
+	 * we will only replace the characters that we have known problems with in text's.
+	 *
+	 * @param string $text The text to decode.
+	 *
+	 * @return string String with decoded HTML entities.
+	 */
+	private function decode_html_entities( $text ) {
+		return str_replace( '&#39;', '’', $text );
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -867,20 +867,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Replaces the HTML entity with it's actual symbol.
-	 *
-	 * Because we do not not know what consequences it will have if we convert every HTML entity,
-	 * we will only replace the characters that we have known problems with in text's.
-	 *
-	 * @param string $text The text to decode.
-	 *
-	 * @return string String with decoded HTML entities.
-	 */
-	public static function decode_html_entities( $text ) {
-		return str_replace( '&#39;', '’', $text );
-	}
-
-	/**
 	 * Wrapper for the PHP filter input function.
 	 *
 	 * This is used because stupidly enough, the `filter_input` function is not available on all hosts...

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -867,6 +867,20 @@ class WPSEO_Utils {
 	}
 
 	/**
+	 * Replaces the HTML entity with it's actual symbol.
+	 *
+	 * Because we do not not know what consequences it will have if we convert every HTML entity,
+	 * we will only replace the characters that we have known problems with in text's.
+	 *
+	 * @param string $text The text to decode.
+	 *
+	 * @return string String with decoded HTML entities.
+	 */
+	public static function decode_html_entities( $text ) {
+		return str_replace( '&#39;', '’', $text );
+	}
+
+	/**
 	 * Wrapper for the PHP filter input function.
 	 *
 	 * This is used because stupidly enough, the `filter_input` function is not available on all hosts...


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
The #39; HTML entities was not converted to the apostrophe symbol.

## Relevant technical choices:
- Converted the apostrophe symbol in the back-end when the labels for the post-types are set. This prevents the use of dangerously set HTML in the wizard.

## Test instructions

This PR can be tested by following these steps:
1. Create a custom post type with an `&#39;` in the name. (https://generatewp.com/post-type/)
2. Go to step 6 in the wizard and see if it is converted to an apostrophe symbol.

Fixes #5613
Replaces https://github.com/Yoast/yoast-components/pull/95
