### PR TITLE
Upgrade route cleanup sitemap autoloaded options

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -190,7 +190,7 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// Between 3.2 and 3.4 the sitemap options were saved with autoloading enabled.
-		$wpdb->query( 'DELETE FROM ' . $wpdb->prefix . 'options WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"' );
+		$wpdb->query( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"' );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -52,8 +52,8 @@ class WPSEO_Upgrade {
 			$this->upgrade_33();
 		}
 
-		if ( version_compare( $this->options['version'], '3.4', '<' ) ) {
-			$this->upgrade_34();
+		if ( version_compare( $this->options['version'], '3.6', '<' ) ) {
+			$this->upgrade_36();
 		}
 
 		/**
@@ -184,9 +184,9 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs upgrade functions to Yoast SEO 3.4
+	 * Performs upgrade functions to Yoast SEO 3.6
 	 */
-	private function upgrade_34() {
+	private function upgrade_36() {
 		global $wpdb;
 
 		// Between 3.2 and 3.4 the sitemap options were saved with autoloading enabled.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -190,7 +190,7 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// Between 3.2 and 3.4 the sitemap options were saved with autoloading enabled.
-		$wpdb->query( 'DELETE FROM ' . $wpdb->prefix . '_options WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"' );
+		$wpdb->query( 'DELETE FROM ' . $wpdb->prefix . 'options WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"' );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -52,6 +52,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_33();
 		}
 
+		if ( version_compare( $this->options['version'], '3.4', '<' ) ) {
+			$this->upgrade_34();
+		}
+
 		/**
 		 * Filter: 'wpseo_run_upgrade' - Runs the upgrade hook which are dependent on Yoast SEO
 		 *
@@ -177,6 +181,16 @@ class WPSEO_Upgrade {
 	private function upgrade_33() {
 		// Notification dismissals have been moved to User Meta instead of global option.
 		delete_option( Yoast_Notification_Center::STORAGE_KEY );
+	}
+
+	/**
+	 * Performs upgrade functions to Yoast SEO 3.4
+	 */
+	private function upgrade_34() {
+		global $wpdb;
+
+		// Between 3.2 and 3.4 the sitemap options were saved with autoloading enabled.
+		$wpdb->query( 'DELETE FROM ' . $wpdb->prefix . '_options WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
- Clean up potentially existing autoloaded sitemap options

## Test instructions

This PR can be tested by following these steps:

* Have Yoast SEO version < 3.4 installed
* Have sitemaps enabled
* Have sitemap entries in the database (results for `SELECT FROM wp_options WHERE option_name LIKE "wpseo_sitemap_%" AND autoload = "yes"`)
* Activate branch which will trigger the upgrade routine
* See all autoloaded sitemap options removed from the database

Fixes https://github.com/Yoast/wordpress-seo/issues/5418
