### PR TITLE
Fix the go premium svg for Safari and use valid code.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -717,7 +717,7 @@ class WPSEO_Admin {
 		$text = apply_filters( 'wpseo_premium_indicator_text', __( 'Disabled', 'wordpress-seo' ) );
 
 		$premium_indicator = sprintf(
-			"<span class='%s'><svg alt=\"\" width=\"1792\" height=\"1792\" viewBox=\"0 0 1792 1792\" xmlns=\"http://www.w3.org/2000/svg\"><path fill=\"currentColor\" d=\"M1728 647q0 22-26 48l-363 354 86 500q1 7 1 20 0 21-10.5 35.5t-30.5 14.5q-19 0-40-12l-449-236-449 236q-22 12-40 12-21 0-31.5-14.5t-10.5-35.5q0-6 2-20l86-500-364-354q-25-27-25-48 0-37 56-46l502-73 225-455q19-41 49-41t49 41l225 455 502 73q56 9 56 46z\"/></svg><span class='screen-reader-text'>%s</span></span>",
+			"<span class='%s' aria-hidden='true'><svg width=\"20\" height=\"20\" viewBox=\"0 0 1792 1792\" xmlns=\"http://www.w3.org/2000/svg\"><path fill=\"currentColor\" d=\"M1728 647q0 22-26 48l-363 354 86 500q1 7 1 20 0 21-10.5 35.5t-30.5 14.5q-19 0-40-12l-449-236-449 236q-22 12-40 12-21 0-31.5-14.5t-10.5-35.5q0-6 2-20l86-500-364-354q-25-27-25-48 0-37 56-46l502-73 225-455q19-41 49-41t49 41l225 455 502 73q56 9 56 46z\"/></svg></span><span class='screen-reader-text'>%s</span>",
 			esc_attr( implode( ' ', $classes ) ),
 			esc_html( $text )
 		);


### PR DESCRIPTION
Fixes #5713 

Tested also on IE 11 and Edge. The svg icon looks OK in all browsers, including Safari. Also, removes the invalid `alt` attribute and uses `aria-hidden="true"` instead.

![screen shot 2016-09-26 at 10 32 13](https://cloud.githubusercontent.com/assets/1682452/18829249/b9d96920-83db-11e6-9978-f771bd43366a.png)
