### PR TITLE
Do not hide settings when API isn't available

### DIFF
--- a/inc/class-wpseo-installation.php
+++ b/inc/class-wpseo-installation.php
@@ -16,7 +16,7 @@ class WPSEO_Installation {
 	public function __construct() {
 		$is_first_install = $this->is_first_install();
 
-		if ( $is_first_install ) {
+		if ( $is_first_install && WPSEO_Utils::is_api_available() ) {
 			add_action( 'wpseo_activate', array( $this, 'set_first_install_options' ) );
 		}
 	}


### PR DESCRIPTION
When the API isn't available we shouldn't hide the settings and set a notice. 

Steps to test this: 
* With an older version of WP or change the version number in constant `REST_API_VERSION` ( file is `wp-includes/rest-api.php`)
* Remove all `wpseo` options.