### PR TITLE
User profile settings a11y improvements

### DIFF
--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -11,27 +11,28 @@
 	?></h2>
 <table class="form-table">
 	<tr>
-		<th>
+		<th scope="row">
 			<label
 				for="wpseo_author_title"><?php _e( 'Title to use for Author page', 'wordpress-seo' ); ?></label>
 		</th>
-		<td><input class="regular-text" type="text" id="wpseo_author_title" name="wpseo_author_title"
+		<td>
+			<input class="regular-text" type="text" id="wpseo_author_title" name="wpseo_author_title"
 		           value="<?php echo esc_attr( get_the_author_meta( 'wpseo_title', $user->ID ) ); ?>"/>
 		</td>
 	</tr>
 	<tr>
-		<th>
+		<th scope="row">
 			<label
 				for="wpseo_author_metadesc"><?php _e( 'Meta description to use for Author page', 'wordpress-seo' ); ?></label>
 		</th>
 		<td>
-						<textarea rows="3" cols="30" id="wpseo_author_metadesc"
-						          name="wpseo_author_metadesc"><?php echo esc_textarea( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea>
+			<textarea rows="3" cols="30" id="wpseo_author_metadesc"
+			          name="wpseo_author_metadesc"><?php echo esc_textarea( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea>
 		</td>
 	</tr>
 	<?php if ( $options['usemetakeywords'] === true ) { ?>
 		<tr>
-			<th>
+			<th scope="row">
 				<label
 					for="wpseo_author_metakey"><?php _e( 'Meta keywords to use for Author page', 'wordpress-seo' ); ?></label>
 			</th>
@@ -43,28 +44,28 @@
 		</tr>
 	<?php } ?>
 	<tr>
-		<th>
-			<label
-				for="wpseo_author_exclude"><?php _e( 'Exclude user from Author-sitemap', 'wordpress-seo' ); ?></label>
-		</th>
+		<td></td>
 		<td>
 			<input class="checkbox double" type="checkbox" id="wpseo_author_exclude"
 			       name="wpseo_author_exclude"
 			       value="on" <?php echo ( get_the_author_meta( 'wpseo_excludeauthorsitemap', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
+			<label class="yoast-label-strong"
+				for="wpseo_author_exclude"><?php _e( 'Exclude user from Author-sitemap', 'wordpress-seo' ); ?></label>
 		</td>
 	</tr>
 
 	<?php if ( $options['keyword-analysis-active'] === true ) { ?>
 		<tr>
-			<th>
-				<label
-					for="wpseo_keyword_analysis_disable"><?php _e( 'Disable SEO analysis', 'wordpress-seo' ); ?></label>
-			</th>
+			<td></td>
 			<td>
 				<input class="checkbox double" type="checkbox" id="wpseo_keyword_analysis_disable"
-				       name="wpseo_keyword_analysis_disable"
+				       name="wpseo_keyword_analysis_disable" aria-describedby="wpseo_keyword_analysis_disable_desc"
 				       value="on" <?php echo ( get_the_author_meta( 'wpseo_keyword_analysis_disable', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
-				<p class="description"><label for="wpseo_keyword_analysis_disable"><?php _e( 'Removes the keyword tab from the metabox and disables all SEO-related suggestions.', 'wordpress-seo' ); ?></label></p>
+				<label class="yoast-label-strong"
+					for="wpseo_keyword_analysis_disable"><?php _e( 'Disable SEO analysis', 'wordpress-seo' ); ?></label>
+				<p class="description" id="wpseo_keyword_analysis_disable_desc">
+					<?php _e( 'Removes the keyword tab from the metabox and disables all SEO-related suggestions.', 'wordpress-seo' ); ?>
+				</p>
 			</td>
 		</tr>
 
@@ -72,15 +73,16 @@
 
 	<?php if ( $options['content-analysis-active'] === true ) { ?>
 		<tr>
-			<th>
-				<label
-					for="wpseo_content_analysis_disable"><?php _e( 'Disable readability analysis', 'wordpress-seo' ); ?></label>
-			</th>
+			<td></td>
 			<td>
 				<input class="checkbox double" type="checkbox" id="wpseo_content_analysis_disable"
-				       name="wpseo_content_analysis_disable"
+				       name="wpseo_content_analysis_disable" aria-describedby="wpseo_content_analysis_disable_desc"
 				       value="on" <?php echo ( get_the_author_meta( 'wpseo_content_analysis_disable', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
-				<p class="description"><label for="wpseo_content_analysis_disable"><?php _e( 'Removes the readability tab from the metabox and disables all readability-related suggestions.', 'wordpress-seo' ); ?></label></p>
+				<label class="yoast-label-strong"
+					for="wpseo_content_analysis_disable"><?php _e( 'Disable readability analysis', 'wordpress-seo' ); ?></label>
+				<p class="description" id="wpseo_content_analysis_disable_desc">
+					<?php _e( 'Removes the readability tab from the metabox and disables all readability-related suggestions.', 'wordpress-seo' ); ?>
+				</p>
 			</td>
 		</tr>
 	<?php } ?>

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -36,3 +36,7 @@
 	margin-top: 6px !important;
 	line-height: inherit;
 }
+
+.yoast-label-strong {
+	font-weight: 600;
+}


### PR DESCRIPTION
Fixes #5716 

- for the inputs fields and textarea, keeps the `<th>` elements and associate them using `scope="row"`
- for the checkboxes, changes the `<th>` in `<td>` and move the labels on the right
- associates the descriptions using `aria-describedby`
- introduces a CSS class `.yoast-label-strong` to make labels strong when necessary

Visually, it would look like this:

![screen shot 2016-09-26 at 12 11 57](https://cloud.githubusercontent.com/assets/1682452/18831561/a57531fc-83e6-11e6-86f8-d297d4009466.png)
