### PR TITLE
Add custom lookups for setting/getting environment type

### DIFF
--- a/admin/config-ui/fields/class-field-environment.php
+++ b/admin/config-ui/fields/class-field-environment.php
@@ -65,8 +65,7 @@ class WPSEO_Config_Field_Environment extends WPSEO_Config_Field_Choice {
 
 		$saved_environment_option = WPSEO_Options::get_option( 'wpseo' );
 
-		return ( $saved_environment_option['environment_type']
-		         === $option['environment_type'] );
+		return ( $saved_environment_option['environment_type'] === $option['environment_type'] );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-environment.php
+++ b/admin/config-ui/fields/class-field-environment.php
@@ -53,19 +53,20 @@ class WPSEO_Config_Field_Environment extends WPSEO_Config_Field_Choice {
 	 * @return bool Returns whether the value is successfully set.
 	 */
 	public function set_data( $environment_type ) {
-		$set_wp_indexation_successful = false;
-		$option                       = WPSEO_Options::get_option( 'wpseo' );
+		$option = WPSEO_Options::get_option( 'wpseo' );
 
 		if ( $option['environment_type'] !== $environment_type ) {
 			$option['environment_type'] = $environment_type;
 			update_option( 'wpseo', $option );
-			$set_wp_indexation_successful = $this->set_indexation( $environment_type );
+			if ( ! $this->set_indexation( $environment_type ) ) {
+				return false;
+			}
 		}
 
 		$saved_environment_option = WPSEO_Options::get_option( 'wpseo' );
 
-		return ( $saved_environment_option['environment_type'] === $option['environment_type']
-		         && $set_wp_indexation_successful );
+		return ( $saved_environment_option['environment_type']
+		         === $option['environment_type'] );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-environment.php
+++ b/admin/config-ui/fields/class-field-environment.php
@@ -27,6 +27,69 @@ class WPSEO_Config_Field_Environment extends WPSEO_Config_Field_Choice {
 	 * @param WPSEO_Configuration_Options_Adapter $adapter Adapter to register lookup on.
 	 */
 	public function set_adapter( WPSEO_Configuration_Options_Adapter $adapter ) {
-		$adapter->add_yoast_lookup( $this->get_identifier(), 'wpseo', 'environment_type' );
+		$adapter->add_custom_lookup(
+			$this->get_identifier(),
+			array( $this, 'get_data' ),
+			array( $this, 'set_data' )
+		);
+	}
+
+	/**
+	 * Gets the option that is set for this field.
+	 *
+	 * @return string The value for the environment_type wpseo option.
+	 */
+	public function get_data() {
+		$option = WPSEO_Options::get_option( 'wpseo' );
+
+		return $option['environment_type'];
+	}
+
+	/**
+	 * Set new data.
+	 *
+	 * @param string $environment_type The site's environment type.
+	 *
+	 * @return bool Returns whether the value is successfully set.
+	 */
+	public function set_data( $environment_type ) {
+		$set_wp_indexation_successful = false;
+		$option                       = WPSEO_Options::get_option( 'wpseo' );
+
+		if ( $option['environment_type'] !== $environment_type ) {
+			$option['environment_type'] = $environment_type;
+			update_option( 'wpseo', $option );
+			$set_wp_indexation_successful = $this->set_indexation( $environment_type );
+		}
+
+		$saved_environment_option = WPSEO_Options::get_option( 'wpseo' );
+
+		return ( $saved_environment_option['environment_type'] === $option['environment_type']
+		         && $set_wp_indexation_successful );
+	}
+
+	/**
+	 * Set the WordPress Search Engine Visibility option based on the environment type.
+	 *
+	 * @param string $environment_type The environment the site is running in.
+	 *
+	 * @return bool Returns if the options is set successfully.
+	 */
+	protected function set_indexation( $environment_type ) {
+		$new_blog_public_value     = 0;
+		$current_blog_public_value = get_option( 'blog_public' );
+
+		if ( $environment_type === 'production' ) {
+			$new_blog_public_value = 1;
+		}
+
+		if ( $current_blog_public_value !== $new_blog_public_value ) {
+			update_option( 'blog_public', $new_blog_public_value );
+
+			return true;
+		}
+		$saved_blog_public_value = get_option( 'blog_public' );
+
+		return ( $saved_blog_public_value === $new_blog_public_value );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
The environment_type was set in the wordpress-seo options but the indexation for the site was not set accordingly.

## Relevant technical choices:
- Set the WordPress blog_public value in WordPress to 1 for production and 0 for other values.

## Test instructions

This PR can be tested by following these steps:
1. Go to step 2 ‘environment’ in the wizard.
2. Change the value to production and see if the WordPress option ‘blog_public’ is set to 1. Also the wpseo option environment_type has to be set to ‘production’
3. Change the value to ‘staging’ or ‘development’ and check if the WordPress option ‘blog_public’ is set to 0. Also the environment_type has to be set accordingly again.

Fixes #5500