### PR TITLE
Tools File Editor page add missing labels

### DIFF
--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -111,8 +111,8 @@ else {
 	else {
 		echo '<form action="', esc_url( $action_url ), '" method="post" id="robotstxtform">';
 		wp_nonce_field( 'wpseo-robotstxt', '_wpnonce', true, true );
-		echo '<p>', __( 'Edit the content of your robots.txt:', 'wordpress-seo' ), '</p>';
-		echo '<textarea class="large-text code" rows="15" name="robotsnew">', $robots_txt_content, '</textarea><br/>';
+		echo '<p><label for="robotsnew" class="yoast-inline-label">', __( 'Edit the content of your robots.txt:', 'wordpress-seo' ), '</label></p>';
+		echo '<textarea class="large-text code" rows="15" name="robotsnew" id="robotsnew">', $robots_txt_content, '</textarea><br/>';
 		echo '<div class="submit"><input class="button" type="submit" name="submitrobots" value="', __( 'Save changes to Robots.txt', 'wordpress-seo' ), '" /></div>';
 		echo '</form>';
 	}
@@ -137,8 +137,8 @@ if ( ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWAR
 		else {
 			echo '<form action="', esc_url( $action_url ), '" method="post" id="htaccessform">';
 			wp_nonce_field( 'wpseo-htaccess', '_wpnonce', true, true );
-			echo '<p>', __( 'Edit the content of your .htaccess:', 'wordpress-seo' ), '</p>';
-			echo '<textarea class="large-text code" rows="15" name="htaccessnew">', $contentht, '</textarea><br/>';
+			echo '<p><label for="htaccessnew" class="yoast-inline-label">', __( 'Edit the content of your .htaccess:', 'wordpress-seo' ), '</label></p>';
+			echo '<textarea class="large-text code" rows="15" name="htaccessnew" id="htaccessnew">', $contentht, '</textarea><br/>';
 			echo '<div class="submit"><input class="button" type="submit" name="submithtaccess" value="', __( 'Save changes to .htaccess', 'wordpress-seo' ), '" /></div>';
 			echo '</form>';
 		}

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -37,6 +37,11 @@ label {
 	margin-left: 6px;
 }
 
+.yoast-inline-label {
+	float: none;
+	margin: 0;
+}
+
 label.radio {
 	float: none;
 	margin-right: 20px;


### PR DESCRIPTION
Fixes #5748 

Adds missing labels for the robots.txt and .htaccess textarea elements.
Adds a CSS rule to reset the default labels style.