### PR TITLE
Use helpcenter class for videos

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -30,8 +30,6 @@ class WPSEO_Admin_Pages {
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 	}
 
-
-
 	/**
 	 * Make sure the needed scripts are loaded for admin pages
 	 */

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -81,7 +81,7 @@ class WPSEO_Admin_Pages {
 	function config_page_scripts() {
 		$this->asset_manager->enqueue_script( 'admin-script' );
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoAdminL10n', $this->localize_admin_script() );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
 
 		wp_enqueue_script( 'dashboard' );
 		wp_enqueue_script( 'thickbox' );
@@ -110,35 +110,6 @@ class WPSEO_Admin_Pages {
 	public function localize_media_script() {
 		return array(
 			'choose_image' => __( 'Use Image', 'wordpress-seo' ),
-		);
-	}
-
-	/**
-	 * Pass some variables to js for the admin JS module.
-	 *
-	 * %s is replaced with <code>%s</code> and replaced again in the javascript with the actual variable.
-	 *
-	 * @return  array
-	 */
-	public function localize_admin_script() {
-		return array(
-			/* translators: %s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template */
-			'variable_warning' => sprintf( __( 'Warning: the variable %s cannot be used in this template.', 'wordpress-seo' ), '<code>%s</code>' ) . ' ' . __( 'See the help tab for more info.', 'wordpress-seo' ),
-			'locale' => get_locale(),
-			/* translators: %d: number of knowledge base search results found. */
-			'kb_found_results' => __( 'Number of search results: %d', 'wordpress-seo' ),
-			'kb_no_results' => __( 'No results found.', 'wordpress-seo' ),
-			'kb_heading' => __( 'Search the Yoast knowledge base', 'wordpress-seo' ),
-			'kb_search_button_text' => __( 'Search', 'wordpress-seo' ),
-			'kb_search_results_heading' => __( 'Search results', 'wordpress-seo' ),
-			'kb_error_message' => __( 'Something went wrong. Please try again later.', 'wordpress-seo' ),
-			'kb_loading_placeholder' => __( 'Loading...', 'wordpress-seo' ),
-			'kb_search' => __( 'search', 'wordpress-seo' ),
-			'kb_back' => __( 'Back', 'wordpress-seo' ),
-			'kb_back_label' => __( 'Back to search results' , 'wordpress-seo' ),
-			'kb_open' => __( 'Open', 'wordpress-seo' ),
-			'kb_open_label' => __( 'Open the knowledge base article in a new window or read it in the iframe below' , 'wordpress-seo' ),
-			'kb_iframe_title' => __( 'Knowledge base article', 'wordpress-seo' ),
 		);
 	}
 

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -180,4 +180,33 @@ class WPSEO_Help_Center {
 	private function is_a_help_center_item( $item ) {
 		return is_a( $item, 'WPSEO_Help_Center_Item' );
 	}
+
+	/**
+	 * Pass text variables to js for the help center JS module.
+	 *
+	 * %s is replaced with <code>%s</code> and replaced again in the javascript with the actual variable.
+	 *
+	 * @return  array Translated text strings for the help center.
+	 */
+	public static function get_translated_texts() {
+		return array(
+			/* translators: %s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template */
+			'variable_warning' => sprintf( __( 'Warning: the variable %s cannot be used in this template.', 'wordpress-seo' ), '<code>%s</code>' ) . ' ' . __( 'See the help tab for more info.', 'wordpress-seo' ),
+			'locale' => get_locale(),
+			/* translators: %d: number of knowledge base search results found. */
+			'kb_found_results' => __( 'Number of search results: %d', 'wordpress-seo' ),
+			'kb_no_results' => __( 'No results found.', 'wordpress-seo' ),
+			'kb_heading' => __( 'Search the Yoast knowledge base', 'wordpress-seo' ),
+			'kb_search_button_text' => __( 'Search', 'wordpress-seo' ),
+			'kb_search_results_heading' => __( 'Search results', 'wordpress-seo' ),
+			'kb_error_message' => __( 'Something went wrong. Please try again later.', 'wordpress-seo' ),
+			'kb_loading_placeholder' => __( 'Loading...', 'wordpress-seo' ),
+			'kb_search' => __( 'search', 'wordpress-seo' ),
+			'kb_back' => __( 'Back', 'wordpress-seo' ),
+			'kb_back_label' => __( 'Back to search results' , 'wordpress-seo' ),
+			'kb_open' => __( 'Open', 'wordpress-seo' ),
+			'kb_open_label' => __( 'Open the knowledge base article in a new window or read it in the iframe below' , 'wordpress-seo' ),
+			'kb_iframe_title' => __( 'Knowledge base article', 'wordpress-seo' ),
+		);
+	}
 }

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -23,13 +23,15 @@ if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== 
 
 // Video explains about the options when connected only.
 if ( null !== $this->service->get_client()->getAccessToken() ) {
-	$tab_video_url = 'https://yoa.st/screencast-search-console';
-	include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
+	$video_url = 'https://yoa.st/screencast-search-console';
 }
 else {
-	$tab_video_url = 'https://yoa.st/screencast-connect-search-console';
-	include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
+	$video_url = 'https://yoa.st/screencast-connect-search-console';
 }
+
+$tab = new WPSEO_Option_Tab( 'GSC', 'Google Search Console', array( 'video_url' => $video_url ) );
+$GSCHelpCenter = new WPSEO_Help_Center( 'google-search-console', $tab );
+$GSCHelpCenter->output_help_center();
 
 switch ( $platform_tabs->current_tab() ) {
 	case 'settings' :

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -29,7 +29,7 @@ else {
 	$video_url = 'https://yoa.st/screencast-connect-search-console';
 }
 
-$tab = new WPSEO_Option_Tab( 'GSC', 'Google Search Console', array( 'video_url' => $video_url ) );
+$tab = new WPSEO_Option_Tab( 'GSC', __( 'Google Search Console' ), array( 'video_url' => $video_url ) );
 $GSCHelpCenter = new WPSEO_Help_Center( 'google-search-console', $tab );
 $GSCHelpCenter->output_help_center();
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -289,9 +289,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	public function meta_box() {
 		$content_sections = $this->get_content_sections();
 
-		// Add Help Center to the metabox see #4701.
-		$tab_video_url = 'https://yoa.st/metabox-screencast';
-		include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
+		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', 'Meta box',
+			array( 'video_url' => 'https://yoa.st/metabox-screencast' ) );
+
+		$helpcenter = new WPSEO_Help_Center( 'metabox', $helpcenter_tab );
+		$helpcenter->output_help_center();
 
 		echo '<div class="wpseo-metabox-sidebar"><ul>';
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -266,35 +266,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
-	 * Pass some variables to js for the admin JS module.
-	 *
-	 * %s is replaced with <code>%s</code> and replaced again in the javascript with the actual variable.
-	 *
-	 * @return  array
-	 */
-	public function localize_admin_script() {
-		return array(
-			/* translators: %s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template */
-			'variable_warning' => sprintf( __( 'Warning: the variable %s cannot be used in this template.', 'wordpress-seo' ), '<code>%s</code>' ) . ' ' . __( 'See the help tab for more info.', 'wordpress-seo' ),
-			'locale' => get_locale(),
-			/* translators: %d: number of knowledge base search results found. */
-			'kb_found_results' => __( 'Number of search results: %d', 'wordpress-seo' ),
-			'kb_no_results' => __( 'No results found.', 'wordpress-seo' ),
-			'kb_heading' => __( 'Search the Yoast knowledge base', 'wordpress-seo' ),
-			'kb_search_button_text' => __( 'Search', 'wordpress-seo' ),
-			'kb_search_results_heading' => __( 'Search results', 'wordpress-seo' ),
-			'kb_error_message' => __( 'Something went wrong. Please try again later.', 'wordpress-seo' ),
-			'kb_loading_placeholder' => __( 'Loading...', 'wordpress-seo' ),
-			'kb_search' => __( 'search', 'wordpress-seo' ),
-			'kb_back' => __( 'Back', 'wordpress-seo' ),
-			'kb_back_label' => __( 'Back to search results' , 'wordpress-seo' ),
-			'kb_open' => __( 'Open', 'wordpress-seo' ),
-			'kb_open_label' => __( 'Open the knowledge base article in a new window or read it in the iframe below' , 'wordpress-seo' ),
-			'kb_iframe_title' => __( 'Knowledge base article', 'wordpress-seo' ),
-		);
-	}
-
-	/**
 	 * Output a tab in the Yoast SEO Metabox
 	 *
 	 * @param string $id      CSS ID of the tab.
@@ -822,7 +793,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'shortcode-plugin', 'wpseoShortcodePluginL10n', $this->localize_shortcode_plugin_script() );
 
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', $this->localize_admin_script() );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( get_locale() ) );
 
 			if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -266,6 +266,35 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
+	 * Pass some variables to js for the admin JS module.
+	 *
+	 * %s is replaced with <code>%s</code> and replaced again in the javascript with the actual variable.
+	 *
+	 * @return  array
+	 */
+	public function localize_admin_script() {
+		return array(
+			/* translators: %s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template */
+			'variable_warning' => sprintf( __( 'Warning: the variable %s cannot be used in this template.', 'wordpress-seo' ), '<code>%s</code>' ) . ' ' . __( 'See the help tab for more info.', 'wordpress-seo' ),
+			'locale' => get_locale(),
+			/* translators: %d: number of knowledge base search results found. */
+			'kb_found_results' => __( 'Number of search results: %d', 'wordpress-seo' ),
+			'kb_no_results' => __( 'No results found.', 'wordpress-seo' ),
+			'kb_heading' => __( 'Search the Yoast knowledge base', 'wordpress-seo' ),
+			'kb_search_button_text' => __( 'Search', 'wordpress-seo' ),
+			'kb_search_results_heading' => __( 'Search results', 'wordpress-seo' ),
+			'kb_error_message' => __( 'Something went wrong. Please try again later.', 'wordpress-seo' ),
+			'kb_loading_placeholder' => __( 'Loading...', 'wordpress-seo' ),
+			'kb_search' => __( 'search', 'wordpress-seo' ),
+			'kb_back' => __( 'Back', 'wordpress-seo' ),
+			'kb_back_label' => __( 'Back to search results' , 'wordpress-seo' ),
+			'kb_open' => __( 'Open', 'wordpress-seo' ),
+			'kb_open_label' => __( 'Open the knowledge base article in a new window or read it in the iframe below' , 'wordpress-seo' ),
+			'kb_iframe_title' => __( 'Knowledge base article', 'wordpress-seo' ),
+		);
+	}
+
+	/**
 	 * Output a tab in the Yoast SEO Metabox
 	 *
 	 * @param string $id      CSS ID of the tab.
@@ -777,6 +806,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$asset_manager->enqueue_style( 'scoring' );
 			$asset_manager->enqueue_style( 'snippet' );
 			$asset_manager->enqueue_style( 'select2' );
+			$asset_manager->enqueue_style( 'kb-search' );
 
 			$asset_manager->enqueue_script( 'metabox' );
 			$asset_manager->enqueue_script( 'admin-media' );
@@ -792,6 +822,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'shortcode-plugin', 'wpseoShortcodePluginL10n', $this->localize_shortcode_plugin_script() );
 
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', $this->localize_admin_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( get_locale() ) );
 
 			if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -50,7 +50,7 @@ class WPSEO_Taxonomy_Metabox {
 			$product_title .= ' Premium';
 		}
 
-		printf( '<div id="poststuff" class="postbox wpseo-taxonomy-metabox-postbox"><h2><span>%1$s</span></h2>', $product_title );
+		printf( '<div id="wpseo_meta" class="postbox wpseo-taxonomy-metabox-postbox"><h2><span>%1$s</span></h2>', $product_title );
 
 		echo '<div class="inside">';
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -52,14 +52,12 @@ class WPSEO_Taxonomy_Metabox {
 
 		printf( '<div id="poststuff" class="postbox wpseo-taxonomy-metabox-postbox"><h2><span>%1$s</span></h2>', $product_title );
 
-		// Add Help Center to the taxonomy metabox see #4701.
 		echo '<div class="inside">';
-		include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
 
-		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', 'Meta box',
+		$helpcenter_tab = new WPSEO_Option_Tab( 'tax-metabox', 'Meta box',
 			array( 'video_url' => 'https://yoa.st/metabox-taxonomy-screencast' ) );
 
-		$helpcenter = new WPSEO_Help_Center( 'metabox', $helpcenter_tab );
+		$helpcenter = new WPSEO_Help_Center( 'tax-metabox', $helpcenter_tab );
 		$helpcenter->output_help_center();
 
 		echo '<div id="taxonomy_overall"></div>';

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -54,9 +54,13 @@ class WPSEO_Taxonomy_Metabox {
 
 		// Add Help Center to the taxonomy metabox see #4701.
 		echo '<div class="inside">';
-		$tab_video_url = 'https://yoa.st/metabox-taxonomy-screencast';
 		include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
 
+		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', 'Meta box',
+			array( 'video_url' => 'https://yoa.st/metabox-taxonomy-screencast' ) );
+
+		$helpcenter = new WPSEO_Help_Center( 'metabox', $helpcenter_tab );
+		$helpcenter->output_help_center();
 
 		echo '<div id="taxonomy_overall"></div>';
 		echo '<div class="wpseo-metabox-sidebar"><ul>';

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -34,6 +34,7 @@ class WPSEO_Taxonomy {
 		add_action( 'edit_term', array( $this, 'update_term' ), 99, 3 );
 		add_action( 'init', array( $this, 'custom_category_descriptions_allow_html' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
+
 		// Needs a hook that runs before the description field.
 		add_action( "{$this->taxonomy}_term_edit_form_top", array( $this, 'custom_category_description_editor' ) );
 		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
@@ -41,7 +42,6 @@ class WPSEO_Taxonomy {
 		if ( self::is_term_overview( $GLOBALS['pagenow'] ) ) {
 			new WPSEO_Taxonomy_Columns();
 		}
-
 		$this->analysis_seo = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 	}
@@ -86,6 +86,7 @@ class WPSEO_Taxonomy {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_style( 'scoring' );
 
+
 		$tag_id = filter_input( INPUT_GET, 'tag_ID' );
 		if (
 			self::is_term_edit( $pagenow ) &&
@@ -98,10 +99,12 @@ class WPSEO_Taxonomy {
 			$asset_manager->enqueue_style( 'scoring' );
 			$asset_manager->enqueue_script( 'metabox' );
 			$asset_manager->enqueue_script( 'term-scraper' );
+			$asset_manager->enqueue_style( 'kb-search' );
 
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper', 'wpseoTermScraperL10n', $this->localize_term_scraper_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( get_locale() ) );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', $this->localize_admin_script() );
 
 			$asset_manager->enqueue_script( 'admin-media' );
 
@@ -225,6 +228,35 @@ class WPSEO_Taxonomy {
 			'no_parent_text' => __( '(no parent)', 'wordpress-seo' ),
 			'replace_vars'   => $this->get_replace_vars(),
 			'scope'          => $this->determine_scope(),
+		);
+	}
+
+	/**
+	 * Pass some variables to js for the admin JS module.
+	 *
+	 * %s is replaced with <code>%s</code> and replaced again in the javascript with the actual variable.
+	 *
+	 * @return  array
+	 */
+	public function localize_admin_script() {
+		return array(
+			/* translators: %s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template */
+			'variable_warning' => sprintf( __( 'Warning: the variable %s cannot be used in this template.', 'wordpress-seo' ), '<code>%s</code>' ) . ' ' . __( 'See the help tab for more info.', 'wordpress-seo' ),
+			'locale' => get_locale(),
+			/* translators: %d: number of knowledge base search results found. */
+			'kb_found_results' => __( 'Number of search results: %d', 'wordpress-seo' ),
+			'kb_no_results' => __( 'No results found.', 'wordpress-seo' ),
+			'kb_heading' => __( 'Search the Yoast knowledge base', 'wordpress-seo' ),
+			'kb_search_button_text' => __( 'Search', 'wordpress-seo' ),
+			'kb_search_results_heading' => __( 'Search results', 'wordpress-seo' ),
+			'kb_error_message' => __( 'Something went wrong. Please try again later.', 'wordpress-seo' ),
+			'kb_loading_placeholder' => __( 'Loading...', 'wordpress-seo' ),
+			'kb_search' => __( 'search', 'wordpress-seo' ),
+			'kb_back' => __( 'Back', 'wordpress-seo' ),
+			'kb_back_label' => __( 'Back to search results' , 'wordpress-seo' ),
+			'kb_open' => __( 'Open', 'wordpress-seo' ),
+			'kb_open_label' => __( 'Open the knowledge base article in a new window or read it in the iframe below' , 'wordpress-seo' ),
+			'kb_iframe_title' => __( 'Knowledge base article', 'wordpress-seo' ),
 		);
 	}
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -104,7 +104,7 @@ class WPSEO_Taxonomy {
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper', 'wpseoTermScraperL10n', $this->localize_term_scraper_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( get_locale() ) );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', $this->localize_admin_script() );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
 
 			$asset_manager->enqueue_script( 'admin-media' );
 
@@ -228,35 +228,6 @@ class WPSEO_Taxonomy {
 			'no_parent_text' => __( '(no parent)', 'wordpress-seo' ),
 			'replace_vars'   => $this->get_replace_vars(),
 			'scope'          => $this->determine_scope(),
-		);
-	}
-
-	/**
-	 * Pass some variables to js for the admin JS module.
-	 *
-	 * %s is replaced with <code>%s</code> and replaced again in the javascript with the actual variable.
-	 *
-	 * @return  array
-	 */
-	public function localize_admin_script() {
-		return array(
-			/* translators: %s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template */
-			'variable_warning' => sprintf( __( 'Warning: the variable %s cannot be used in this template.', 'wordpress-seo' ), '<code>%s</code>' ) . ' ' . __( 'See the help tab for more info.', 'wordpress-seo' ),
-			'locale' => get_locale(),
-			/* translators: %d: number of knowledge base search results found. */
-			'kb_found_results' => __( 'Number of search results: %d', 'wordpress-seo' ),
-			'kb_no_results' => __( 'No results found.', 'wordpress-seo' ),
-			'kb_heading' => __( 'Search the Yoast knowledge base', 'wordpress-seo' ),
-			'kb_search_button_text' => __( 'Search', 'wordpress-seo' ),
-			'kb_search_results_heading' => __( 'Search results', 'wordpress-seo' ),
-			'kb_error_message' => __( 'Something went wrong. Please try again later.', 'wordpress-seo' ),
-			'kb_loading_placeholder' => __( 'Loading...', 'wordpress-seo' ),
-			'kb_search' => __( 'search', 'wordpress-seo' ),
-			'kb_back' => __( 'Back', 'wordpress-seo' ),
-			'kb_back_label' => __( 'Back to search results' , 'wordpress-seo' ),
-			'kb_open' => __( 'Open', 'wordpress-seo' ),
-			'kb_open_label' => __( 'Open the knowledge base article in a new window or read it in the iframe below' , 'wordpress-seo' ),
-			'kb_iframe_title' => __( 'Knowledge base article', 'wordpress-seo' ),
 		);
 	}
 

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -32,11 +32,11 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 /**
  * Outputs a help center.
  */
-function render_help_center() {
-	$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', 'Bulk editor',
+function render_help_center( $id ) {
+	$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-' . $id, 'Bulk editor',
 		array( 'video_url' => 'https://yoa.st/screencast-tools-bulk-editor' ) );
 
-	$helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab );
+	$helpcenter = new WPSEO_Help_Center( 'bulk-editor' . $id, $helpcenter_tab );
 	$helpcenter->output_help_center();
 }
 
@@ -50,7 +50,7 @@ function get_rendered_tab( $table, $id ) {
 	?>
 	<div id="<?php echo $id ?>" class="wpseotab">
 		<?php
-		render_help_center();
+		render_help_center( $id );
 		$table->show_page();
 		?>
 	</div>

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -31,6 +31,8 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 
 /**
  * Outputs a help center.
+ *
+ * @param string $id The id for the tab.
  */
 function render_help_center( $id ) {
 	$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-' . $id, 'Bulk editor',

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -28,6 +28,35 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 	wp_redirect( remove_query_arg( array( '_wp_http_referer', '_wpnonce' ), stripslashes( $_SERVER['REQUEST_URI'] ) ) );
 	exit;
 }
+
+/**
+ * Outputs a help center.
+ */
+function render_help_center() {
+	$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', 'Bulk editor',
+		array( 'video_url' => 'https://yoa.st/screencast-tools-bulk-editor' ) );
+
+	$helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab );
+	$helpcenter->output_help_center();
+}
+
+/**
+ * Renders a bulk editor tab.
+ *
+ * @param WPSEO_Bulk_List_Table $table The table to render.
+ * @param string                $id    The id for the tab.
+ */
+function get_rendered_tab( $table, $id ) {
+	?>
+	<div id="<?php echo $id ?>" class="wpseotab">
+		<?php
+		render_help_center();
+		$table->show_page();
+		?>
+	</div>
+	<?php
+}
+
 ?>
 <script>
 	var wpseo_bulk_editor_nonce = '<?php echo wp_create_nonce( 'wpseo-bulk-editor' ); ?>';
@@ -42,26 +71,7 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 	</h2>
 
 	<div class="tabwrapper">
-		<div id="title" class="wpseotab">
-			<?php
-
-			$tab_video_url = 'https://yoa.st/screencast-tools-bulk-editor';
-			include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
-
-			$wpseo_bulk_titles_table->show_page();
-
-			?>
-		</div>
-		<div id="description" class="wpseotab">
-			<?php
-
-			$tab_video_url = 'https://yoa.st/screencast-tools-bulk-editor';
-			include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
-
-			$wpseo_bulk_description_table->show_page();
-
-			?>
-		</div>
-
+		<?php get_rendered_tab( $wpseo_bulk_titles_table, 'title' )?>
+		<?php get_rendered_tab( $wpseo_bulk_description_table, 'description' )?>
 	</div>
 </div>

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -75,10 +75,11 @@ else {
 }
 
 echo '<br><br>';
+$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', 'Bulk editor',
+	array( 'video_url' => 'https://yoa.st/screencast-tools-file-editor' ) );
 
-$tab_video_url = 'https://yoa.st/screencast-tools-file-editor';
-include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
-
+$helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab );
+$helpcenter->output_help_center();
 
 echo '<h2>', __( 'Robots.txt', 'wordpress-seo' ), '</h2>';
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -121,7 +121,12 @@ foreach ( $tabs as $identifier => $tab ) {
 
 	if ( ! empty( $tab['screencast_video_url'] ) ) {
 		$tab_video_url = $tab['screencast_video_url'];
-		include WPSEO_PATH . 'admin/views/partial-settings-tab-video.php';
+
+		$helpcenter_tab = new WPSEO_Option_Tab( $identifier, $tab['label'],
+			array( 'video_url' => $tab['screencast_video_url'] ) );
+
+		$helpcenter = new WPSEO_Help_Center( $identifier, $helpcenter_tab );
+		$helpcenter->output_help_center();
 	}
 
 	require_once WPSEO_PATH . 'admin/views/tabs/tool/' . $identifier . '.php';

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -188,6 +188,17 @@ ul.wpseo-metabox-tabs li {
 	font-size: 13px !important;
 }
 
+#wpseo_meta {
+	.wpseo-tab-video-container{
+		h2 {
+			font-size: 1.3em;
+			padding-left: 0px;
+			border: 0px;
+			margin-bottom: 20px;
+		}
+	}
+}
+
 .inside .wpseotab .form-table th {
 	width: 140px !important;
 	font-size: 13px;

--- a/js/src/kb-search/wp-seo-kb-search-init.js
+++ b/js/src/kb-search/wp-seo-kb-search-init.js
@@ -4,42 +4,67 @@ import React from "react";
 import ReactDom from "react-dom";
 import AlgoliaSearcher from "./wp-seo-kb-search.js";
 
-var intialiseAlgoliaSearch = () => {
+/**
+ * Gets the translations for the AlgoliaSearcher from the wpseoAdminL10n global and returns them in a properties array.
+ *
+ * @returns {{noResultsText: *, headingText: *, searchButtonText: *, searchResultsHeading: *, errorMessage: *,
+ *            loadingPlaceholder: *, search: *, open: *, openLabel: *, back: *, backLabel: *, iframeTitle: *}}
+ *            Object containing the translated text properties for the knowledge base component.
+ */
+var getTranslations = () => {
+	var translations = {
+		noResultsText: wpseoAdminL10n.kb_no_results,
+		headingText: wpseoAdminL10n.kb_heading,
+		searchButtonText: wpseoAdminL10n.kb_search_button_text,
+		searchResultsHeading: wpseoAdminL10n.kb_search_results_heading,
+		errorMessage: wpseoAdminL10n.kb_error_message,
+		loadingPlaceholder: wpseoAdminL10n.kb_loading_placeholder,
+		search: wpseoAdminL10n.kb_search,
+		open: wpseoAdminL10n.kb_open,
+		openLabel: wpseoAdminL10n.kb_open_label,
+		back: wpseoAdminL10n.kb_back,
+		backLabel: wpseoAdminL10n.kb_back_label,
+		iframeTitle: wpseoAdminL10n.kb_iframe_title,
+	};
+	return translations;
+};
+/**
+ * Renders the the AlgoliaSearchers into their containers.
+ *
+ * @returns {array} The rendered AlgoliaSearchers.
+ */
+var renderAlgoliaSearchers = () => {
 // Inject kb-search in divs with the classname of 'wpseo-kb-search'.
 	var mountingPoints = jQuery( ".wpseo-kb-search" );
 	var algoliaSearchers = [];
-	jQuery.each( mountingPoints, function( index, mountingPoint ) {
+	jQuery.each( mountingPoints, ( index, mountingPoint ) => {
 		var tabId = jQuery( mountingPoint ).closest( ".wpseotab" ).attr( "id" );
-		var translations = {
-			noResultsText: wpseoAdminL10n.kb_no_results,
-			headingText: wpseoAdminL10n.kb_heading,
-			searchButtonText: wpseoAdminL10n.kb_search_button_text,
-			searchResultsHeading: wpseoAdminL10n.kb_search_results_heading,
-			errorMessage: wpseoAdminL10n.kb_error_message,
-			loadingPlaceholder: wpseoAdminL10n.kb_loading_placeholder,
-			search: wpseoAdminL10n.kb_search,
-			open: wpseoAdminL10n.kb_open,
-			openLabel: wpseoAdminL10n.kb_open_label,
-			back: wpseoAdminL10n.kb_back,
-			backLabel: wpseoAdminL10n.kb_back_label,
-			iframeTitle: wpseoAdminL10n.kb_iframe_title,
-		};
+		var translations = getTranslations();
+
 		algoliaSearchers.push( {
-			/* jshint ignore:start */
 			tabName: tabId,
 			algoliaSearcher: ReactDom.render( React.createElement( AlgoliaSearcher, translations ), mountingPoint ),
-			/* jshint ignore:end */
 		} );
 	} );
+	return algoliaSearchers;
+};
 
-// Get the used search strings from the algoliaSearcher React component for the active tab and fire an event with this data.
-	jQuery( ".contact-support" ).on( "click", function() {
+/**
+ * Binds the event handlers to the AlgoliaSearchers.
+ *
+ * @param {array} algoliaSearchers The rendered Algolia searchers.
+ *
+ * @returns {void}
+ */
+var bindEventHandlers = ( algoliaSearchers )  => {
+	// Get the used search strings from the algoliaSearcher React component for the active tab and fire an event with this data.
+	jQuery( ".contact-support" ).on( "click", () => {
 		var activeTabName = jQuery( ".wpseotab.active" ).attr( "id" );
 
 		// 1st by default. (Used for the Advanced settings pages because of how the tabs were set up)
 		var activeAlgoliaSearcher = algoliaSearchers[ 0 ].algoliaSearcher;
 
-		jQuery.each( algoliaSearchers, function( key, searcher ) {
+		jQuery.each( algoliaSearchers, ( key, searcher ) => {
 			if ( searcher.tabName === activeTabName ) {
 				activeAlgoliaSearcher = searcher.algoliaSearcher;
 
@@ -52,4 +77,14 @@ var intialiseAlgoliaSearch = () => {
 	} );
 };
 
-export default intialiseAlgoliaSearch;
+/**
+ *  Initializes the AlgoliaSearchers (in the knowledge base tabs).
+ *
+ *  @returns {void}
+ */
+var initializeAlgoliaSearch = () => {
+	let algoliaSearchers = renderAlgoliaSearchers();
+	bindEventHandlers( algoliaSearchers );
+};
+
+export default initializeAlgoliaSearch;

--- a/js/src/kb-search/wp-seo-kb-search-init.js
+++ b/js/src/kb-search/wp-seo-kb-search-init.js
@@ -1,0 +1,55 @@
+/* global wpseoAdminL10n */
+
+import React from "react";
+import ReactDom from "react-dom";
+import AlgoliaSearcher from "./wp-seo-kb-search.js";
+
+var intialiseAlgoliaSearch = () => {
+// Inject kb-search in divs with the classname of 'wpseo-kb-search'.
+	var mountingPoints = jQuery( ".wpseo-kb-search" );
+	var algoliaSearchers = [];
+	jQuery.each( mountingPoints, function ( index, mountingPoint ) {
+		var tabId = jQuery( mountingPoint ).closest( ".wpseotab" ).attr( "id" );
+		var translations = {
+			noResultsText: wpseoAdminL10n.kb_no_results,
+			headingText: wpseoAdminL10n.kb_heading,
+			searchButtonText: wpseoAdminL10n.kb_search_button_text,
+			searchResultsHeading: wpseoAdminL10n.kb_search_results_heading,
+			errorMessage: wpseoAdminL10n.kb_error_message,
+			loadingPlaceholder: wpseoAdminL10n.kb_loading_placeholder,
+			search: wpseoAdminL10n.kb_search,
+			open: wpseoAdminL10n.kb_open,
+			openLabel: wpseoAdminL10n.kb_open_label,
+			back: wpseoAdminL10n.kb_back,
+			backLabel: wpseoAdminL10n.kb_back_label,
+			iframeTitle: wpseoAdminL10n.kb_iframe_title,
+		};
+		algoliaSearchers.push( {
+			/* jshint ignore:start */
+			tabName: tabId,
+			algoliaSearcher: ReactDom.render( React.createElement( AlgoliaSearcher, translations ), mountingPoint ),
+			/* jshint ignore:end */
+		} );
+	} );
+
+// Get the used search strings from the algoliaSearcher React component for the active tab and fire an event with this data.
+	jQuery( ".contact-support" ).on( "click", function () {
+		var activeTabName = jQuery( ".wpseotab.active" ).attr( "id" );
+
+		// 1st by default. (Used for the Advanced settings pages because of how the tabs were set up)
+		var activeAlgoliaSearcher = algoliaSearchers[ 0 ].algoliaSearcher;
+
+		jQuery.each( algoliaSearchers, function ( key, searcher ) {
+			if ( searcher.tabName === activeTabName ) {
+				activeAlgoliaSearcher = searcher.algoliaSearcher;
+
+				// returning false breaks the loop.
+				return false;
+			}
+		} );
+		var usedQueries = activeAlgoliaSearcher.state.usedQueries;
+		jQuery( window ).trigger( "YoastSEO:ContactSupport", { usedQueries: usedQueries } );
+	} );
+};
+
+export default intialiseAlgoliaSearch;

--- a/js/src/kb-search/wp-seo-kb-search-init.js
+++ b/js/src/kb-search/wp-seo-kb-search-init.js
@@ -8,7 +8,7 @@ var intialiseAlgoliaSearch = () => {
 // Inject kb-search in divs with the classname of 'wpseo-kb-search'.
 	var mountingPoints = jQuery( ".wpseo-kb-search" );
 	var algoliaSearchers = [];
-	jQuery.each( mountingPoints, function ( index, mountingPoint ) {
+	jQuery.each( mountingPoints, function( index, mountingPoint ) {
 		var tabId = jQuery( mountingPoint ).closest( ".wpseotab" ).attr( "id" );
 		var translations = {
 			noResultsText: wpseoAdminL10n.kb_no_results,
@@ -33,17 +33,17 @@ var intialiseAlgoliaSearch = () => {
 	} );
 
 // Get the used search strings from the algoliaSearcher React component for the active tab and fire an event with this data.
-	jQuery( ".contact-support" ).on( "click", function () {
+	jQuery( ".contact-support" ).on( "click", function() {
 		var activeTabName = jQuery( ".wpseotab.active" ).attr( "id" );
 
 		// 1st by default. (Used for the Advanced settings pages because of how the tabs were set up)
 		var activeAlgoliaSearcher = algoliaSearchers[ 0 ].algoliaSearcher;
 
-		jQuery.each( algoliaSearchers, function ( key, searcher ) {
+		jQuery.each( algoliaSearchers, function( key, searcher ) {
 			if ( searcher.tabName === activeTabName ) {
 				activeAlgoliaSearcher = searcher.algoliaSearcher;
 
-				// returning false breaks the loop.
+				// Returning false breaks the loop.
 				return false;
 			}
 		} );

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -4,7 +4,7 @@
 /* jshint unused:false */
 
 /* jshint ignore:start */
-import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
+import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 /* jshint ignore:end */
 
 ( function() {
@@ -245,7 +245,7 @@ import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 
 	jQuery( document ).ready( function() {
 
-		intialiseAlgoliaSearch();
+		intializeAlgoliaSearch();
 
 		// events
 		jQuery( "#enablexmlsitemap" ).change( function() {

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -1,11 +1,6 @@
 /* global wpseoAdminL10n, ajaxurl, tb_remove, wpseoSelect2Locale */
-/* jshint -W097 */
-/* jshint -W003 */
-/* jshint unused:false */
 
-/* jshint ignore:start */
-import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
-/* jshint ignore:end */
+import initializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 
 ( function() {
 	"use strict";
@@ -245,7 +240,7 @@ import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 
 	jQuery( document ).ready( function() {
 
-		intializeAlgoliaSearch();
+		initializeAlgoliaSearch();
 
 		// events
 		jQuery( "#enablexmlsitemap" ).change( function() {

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -4,9 +4,7 @@
 /* jshint unused:false */
 
 /* jshint ignore:start */
-import React from "react";
-import ReactDom from "react-dom";
-import AlgoliaSearcher from "./kb-search/wp-seo-kb-search.js";
+import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 /* jshint ignore:end */
 
 ( function() {
@@ -246,51 +244,8 @@ import AlgoliaSearcher from "./kb-search/wp-seo-kb-search.js";
 	window.wpseoSetTabHash = wpseoSetTabHash;
 
 	jQuery( document ).ready( function() {
-		// Inject kb-search in divs with the classname of 'wpseo-kb-search'.
-		var mountingPoints = jQuery( ".wpseo-kb-search" );
-		var algoliaSearchers = [];
-		jQuery.each( mountingPoints, function( index, mountingPoint ) {
-			var tabId = jQuery( mountingPoint ).closest( ".wpseotab" ).attr( "id" );
-			var translations = {
-				noResultsText: wpseoAdminL10n.kb_no_results,
-				headingText: wpseoAdminL10n.kb_heading,
-				searchButtonText: wpseoAdminL10n.kb_search_button_text,
-				searchResultsHeading: wpseoAdminL10n.kb_search_results_heading,
-				errorMessage: wpseoAdminL10n.kb_error_message,
-				loadingPlaceholder: wpseoAdminL10n.kb_loading_placeholder,
-				search: wpseoAdminL10n.kb_search,
-				open: wpseoAdminL10n.kb_open,
-				openLabel: wpseoAdminL10n.kb_open_label,
-				back: wpseoAdminL10n.kb_back,
-				backLabel: wpseoAdminL10n.kb_back_label,
-				iframeTitle: wpseoAdminL10n.kb_iframe_title,
-			};
-			algoliaSearchers.push( {
-				/* jshint ignore:start */
-				tabName: tabId,
-				algoliaSearcher: ReactDom.render( React.createElement( AlgoliaSearcher, translations ), mountingPoint ),
-				/* jshint ignore:end */
-			} );
-		} );
 
-		// Get the used search strings from the algoliaSearcher React component for the active tab and fire an event with this data.
-		jQuery( ".contact-support" ).on( "click", function() {
-			var activeTabName = jQuery( ".wpseotab.active" ).attr( "id" );
-
-			// 1st by default. (Used for the Advanced settings pages because of how the tabs were set up)
-			var activeAlgoliaSearcher = algoliaSearchers[ 0 ].algoliaSearcher;
-
-			jQuery.each( algoliaSearchers, function( key, searcher ) {
-				if ( searcher.tabName === activeTabName ) {
-					activeAlgoliaSearcher = searcher.algoliaSearcher;
-
-					// returning false breaks the loop.
-					return false;
-				}
-			} );
-			var usedQueries = activeAlgoliaSearcher.state.usedQueries;
-			jQuery( window ).trigger( "YoastSEO:ContactSupport", { usedQueries: usedQueries } );
-		} );
+		intialiseAlgoliaSearch();
 
 		// events
 		jQuery( "#enablexmlsitemap" ).change( function() {

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -1,8 +1,6 @@
-/* global wp, _, wpseoPrimaryCategoryL10n, wpseoAdminL10n */
+/* global wp, _, wpseoPrimaryCategoryL10n */
 
-/* jshint ignore:start */
 import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
-/* jshint ignore:end */
 
 ( function( $ ) {
 	"use strict";

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -1,6 +1,6 @@
 /* global wp, _, wpseoPrimaryCategoryL10n */
 
-import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
+import initializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 
 ( function( $ ) {
 	"use strict";
@@ -234,6 +234,6 @@ import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 		primaryTermScreenReaderTemplate = wp.template( "primary-term-screen-reader" );
 
 		$( _.values( taxonomies ) ).initYstSEOPrimaryCategory();
-		intializeAlgoliaSearch();
+		initializeAlgoliaSearch();
 	} );
 }( jQuery ) );

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -1,6 +1,6 @@
 /* global wp, _, wpseoPrimaryCategoryL10n */
 
-import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
+import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 
 ( function( $ ) {
 	"use strict";
@@ -234,6 +234,6 @@ import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 		primaryTermScreenReaderTemplate = wp.template( "primary-term-screen-reader" );
 
 		$( _.values( taxonomies ) ).initYstSEOPrimaryCategory();
-		intialiseAlgoliaSearch();
+		intializeAlgoliaSearch();
 	} );
 }( jQuery ) );

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -1,4 +1,9 @@
-/* global wp, _, wpseoPrimaryCategoryL10n */
+/* global wp, _, wpseoPrimaryCategoryL10n, wpseoAdminL10n */
+
+/* jshint ignore:start */
+import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
+/* jshint ignore:end */
+
 ( function( $ ) {
 	"use strict";
 
@@ -231,5 +236,6 @@
 		primaryTermScreenReaderTemplate = wp.template( "primary-term-screen-reader" );
 
 		$( _.values( taxonomies ) ).initYstSEOPrimaryCategory();
+		intialiseAlgoliaSearch();
 	} );
 }( jQuery ) );

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -1,7 +1,7 @@
 /* browser:true */
 /* global tb_show, wpseoSelect2Locale */
 
-import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
+import initializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 
 ( function( $ ) {
 	window.wpseo_init_tabs = function() {
@@ -50,7 +50,7 @@ import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 		jQuery( ".wpseo-metabox-tabs" ).show();
 		// End Tabs code
 
-		intializeAlgoliaSearch();
+		initializeAlgoliaSearch();
 	};
 
 	/**

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -1,13 +1,9 @@
 /* browser:true */
-/* global tb_show, wpseoSelect2Locale, wpseoAdminL10n, wpseoMediaL10n */
+/* global tb_show, wpseoSelect2Locale */
 
-/* jshint ignore:start */
 import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
-/* jshint ignore:end */
 
 ( function( $ ) {
-	"use strict";
-
 	window.wpseo_init_tabs = function() {
 		if ( jQuery( ".wpseo-metabox-tabs-div" ).length > 0 ) {
 			jQuery( ".wpseo-metabox-tabs" ).on( "click", "a.wpseo_tablink", function( ev ) {
@@ -58,7 +54,9 @@ import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 	};
 
 	/**
-	 * Adds select2 for selected fields.
+	 * @summary Adds select2 for selected fields.
+	 *
+	 * @returns {void}
 	 */
 	function initSelect2() {
 		// Select2 for Yoast SEO Metabox Advanced tab
@@ -67,7 +65,9 @@ import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 	}
 
 	/**
-	 * Shows a informational popup if someone click the add keyword button
+	 * @summary Shows a informational popup if someone click the add keyword button.
+	 *
+	 * @returns {void}
 	 */
 	function addKeywordPopup() {
 		var $buyButton = $( "#wpseo-add-keyword-popup-button" ),
@@ -115,7 +115,9 @@ import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 	}
 
 	/**
-	 * Adds keyword popup if the template for it is found
+	 * @summary Adds keyword popup if the template for it is found.
+	 *
+	 * @returns {void}
 	 */
 	function initAddKeywordPopup() {
 		// If add keyword popup exists bind it to the add keyword button
@@ -144,6 +146,7 @@ import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
  * @deprecated since version 3.0
  *
  * @param {string} str
+ *
  * @returns {string}
  */
 function ystClean( str ) {

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -1,5 +1,10 @@
 /* browser:true */
-/* global tb_show, wpseoSelect2Locale */
+/* global tb_show, wpseoSelect2Locale, wpseoAdminL10n, wpseoMediaL10n */
+
+/* jshint ignore:start */
+import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
+/* jshint ignore:end */
+
 ( function( $ ) {
 	"use strict";
 
@@ -48,6 +53,8 @@
 		jQuery( ".wpseo-heading" ).hide();
 		jQuery( ".wpseo-metabox-tabs" ).show();
 		// End Tabs code
+
+		intialiseAlgoliaSearch();
 	};
 
 	/**

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -1,7 +1,7 @@
 /* browser:true */
 /* global tb_show, wpseoSelect2Locale */
 
-import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
+import intializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 
 ( function( $ ) {
 	window.wpseo_init_tabs = function() {
@@ -50,7 +50,7 @@ import intialiseAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 		jQuery( ".wpseo-metabox-tabs" ).show();
 		// End Tabs code
 
-		intialiseAlgoliaSearch();
+		intializeAlgoliaSearch();
 	};
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
A new class was introduced for rendering the help center. This class is now used when possible for overall consistency with the help center.

## Test instructions

This PR can be tested by following these steps:

The following pages are edited:

- [x] google search console
- [x] metabox ( edit a post )
- [x] tax metabox ( edit a category ) 
- [x] tools: bulk editor
- [x] tools: file editor
- [x] tools: import/export

Open the help center and check if the following things are correct:

- Video
- Knowledge base search
- Go premium tab

They should all render.

Fixes #4753
