### PR TITLE
moving the loading of user notification from usermata from constructo…

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -42,9 +42,10 @@ class Yoast_Notification_Center {
 	 * Load the user notices on WP init
 	 */
 	public function init() {
+
 		$this->retrieve_notifications_from_storage();
 	}
-	
+
 	/**
 	 * Singleton getter
 	 *

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -39,9 +39,9 @@ class Yoast_Notification_Center {
 	}
 
 	/**
-	 * load the user notices on WP init
+	 * Load the user notices on WP init
 	 */
-	public function init(){
+	public function init() {
 		$this->retrieve_notifications_from_storage();
 	}
 	

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -28,7 +28,7 @@ class Yoast_Notification_Center {
 	 */
 	private function __construct() {
 
-		$this->retrieve_notifications_from_storage();
+		add_action( 'init', array( $this, 'init' ), 99 );
 
 		add_action( 'all_admin_notices', array( $this, 'display_notifications' ) );
 
@@ -38,6 +38,13 @@ class Yoast_Notification_Center {
 		add_action( 'shutdown', array( $this, 'update_storage' ) );
 	}
 
+	/**
+	 * load the user notices on WP init
+	 */
+	public function init(){
+		$this->retrieve_notifications_from_storage();
+	}
+	
 	/**
 	 * Singleton getter
 	 *


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: 

The pull request moves the contractor code from the class constructor to WordPress int action to that the BuddyPress user object is loaded
## Relevant technical choices:
-  justed pick a late init call to make it doesn't load before buddypress
## Test instructions

This PR can be tested by following these steps:
- load the plugin with buddypress active with degug

Fixes #5762

…r to INIT

this was causing error when call in constructor as buddypress is not loading at this point

You maybe able to load even later but I don't know the code to judge that
