### PR TITLE
Remove advanced settings from adminbar

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -248,7 +248,7 @@ function wpseo_admin_bar_menu() {
 	// @todo: add links to bulk title and bulk description edit pages.
 	if ( $user_is_admin_or_networkadmin ) {
 
-		$advanced_settings = advanced_settings_enabled( $options );
+		$advanced_settings = wpseo_advanced_settings_enabled( $options );
 
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-menu',
@@ -424,12 +424,13 @@ function allow_custom_field_edits( $allcaps, $cap, $args ) {
 add_filter( 'user_has_cap', 'allow_custom_field_edits', 0, 3 );
 
 /**
- * @summary Detects if the advanced settings are enabled.
- * @param {array} $wpseo_options The wpseo settings.
+ * Detects if the advanced settings are enabled.
  *
- * @returns True if the advanced settings are enabled, false if not.
+ * @param array $wpseo_options The wpseo settings.
+ *
+ * @returns boolean True if the advanced settings are enabled, false if not.
  */
-function advanced_settings_enabled( $wpseo_options ) {
+function wpseo_advanced_settings_enabled( $wpseo_options ) {
 	return ( $wpseo_options['enable_setting_pages'] === true );
 }
 

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -311,7 +311,7 @@ function wpseo_admin_bar_menu() {
 }
 
 /**
- * Returns the SEO score element for the adminbar.
+ * Returns the SEO score element for the admin bar.
  *
  * @return string
  */
@@ -425,6 +425,9 @@ add_filter( 'user_has_cap', 'allow_custom_field_edits', 0, 3 );
 
 /**
  * @summary Detects if the advanced settings are enabled.
+ * @param {array} $wpseo_options The wpseo settings.
+ *
+ * @returns True if the advanced settings are enabled, false if not.
  */
 function advanced_settings_enabled( $wpseo_options ) {
 	return ( $wpseo_options['enable_setting_pages'] === true );

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -247,6 +247,9 @@ function wpseo_admin_bar_menu() {
 
 	// @todo: add links to bulk title and bulk description edit pages.
 	if ( $user_is_admin_or_networkadmin ) {
+
+		$advanced_settings = advanced_settings_enabled( $options );
+
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-menu',
 			'id'     => 'wpseo-settings',
@@ -259,36 +262,38 @@ function wpseo_admin_bar_menu() {
 			'title'  => __( 'Dashboard', 'wordpress-seo' ),
 			'href'   => admin_url( 'admin.php?page=wpseo_dashboard' ),
 		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => 'wpseo-settings',
-			'id'     => 'wpseo-titles',
-			'title'  => __( 'Titles &amp; Metas', 'wordpress-seo' ),
-			'href'   => admin_url( 'admin.php?page=wpseo_titles' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => 'wpseo-settings',
-			'id'     => 'wpseo-social',
-			'title'  => __( 'Social', 'wordpress-seo' ),
-			'href'   => admin_url( 'admin.php?page=wpseo_social' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => 'wpseo-settings',
-			'id'     => 'wpseo-xml',
-			'title'  => __( 'XML Sitemaps', 'wordpress-seo' ),
-			'href'   => admin_url( 'admin.php?page=wpseo_xml' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => 'wpseo-settings',
-			'id'     => 'wpseo-wpseo-advanced',
-			'title'  => __( 'Advanced', 'wordpress-seo' ),
-			'href'   => admin_url( 'admin.php?page=wpseo_advanced' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => 'wpseo-settings',
-			'id'     => 'wpseo-tools',
-			'title'  => __( 'Tools', 'wordpress-seo' ),
-			'href'   => admin_url( 'admin.php?page=wpseo_tools' ),
-		) );
+		if ( $advanced_settings ) {
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'wpseo-settings',
+				'id'     => 'wpseo-titles',
+				'title'  => __( 'Titles &amp; Metas', 'wordpress-seo' ),
+				'href'   => admin_url( 'admin.php?page=wpseo_titles' ),
+			) );
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'wpseo-settings',
+				'id'     => 'wpseo-social',
+				'title'  => __( 'Social', 'wordpress-seo' ),
+				'href'   => admin_url( 'admin.php?page=wpseo_social' ),
+			) );
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'wpseo-settings',
+				'id'     => 'wpseo-xml',
+				'title'  => __( 'XML Sitemaps', 'wordpress-seo' ),
+				'href'   => admin_url( 'admin.php?page=wpseo_xml' ),
+			) );
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'wpseo-settings',
+				'id'     => 'wpseo-wpseo-advanced',
+				'title'  => __( 'Advanced', 'wordpress-seo' ),
+				'href'   => admin_url( 'admin.php?page=wpseo_advanced' ),
+			) );
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'wpseo-settings',
+				'id'     => 'wpseo-tools',
+				'title'  => __( 'Tools', 'wordpress-seo' ),
+				'href'   => admin_url( 'admin.php?page=wpseo_tools' ),
+			) );
+		}
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-settings',
 			'id'     => 'wpseo-search-console',
@@ -298,7 +303,7 @@ function wpseo_admin_bar_menu() {
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-settings',
 			'id'     => 'wpseo-licenses',
-			'title'  => '<span style="color:#f18500">' . __( 'Extensions', 'wordpress-seo' ) . '</span>',
+			'title' => '<span style="color:#f18500">' . __( 'Go Premium', 'wordpress-seo' ) . '</span>',
 			'href'   => admin_url( 'admin.php?page=wpseo_licenses' ),
 		) );
 	}
@@ -418,6 +423,12 @@ function allow_custom_field_edits( $allcaps, $cap, $args ) {
 
 add_filter( 'user_has_cap', 'allow_custom_field_edits', 0, 3 );
 
+/**
+ * @summary Detects if the advanced settings are enabled.
+ */
+function advanced_settings_enabled( $wpseo_options ) {
+	return ( $wpseo_options['enable_setting_pages'] === true );
+}
 
 /********************** DEPRECATED FUNCTIONS **********************/
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
The advanced settings still showed in the admin bar when they were disabled.

When users clicked on it the got redirected to a page where they did not have permissions for.

The advanced options should not show in the admin bar when they are disabled.

## Relevant technical choices:
- Checked for the option ‘enable_setting_pages’ if this is false the advanced settings are not added to the admin bar.
- Changed the orange text 'extensions' to Go Premium like in the other menu's

## Test instructions

This PR can be tested by following these steps:
1. Go to the Yoast SEO settings - Features tab. 
2. When you disable the advanced settings pages, the SEO settings under the Yoast logo in the admin bar should show this:

- Dashboard
- Search console
- Go Premium

3. When the advanced settings are enabled it should show this:

![general_-_yoast_seo_ _test_ _wordpress](https://cloud.githubusercontent.com/assets/7293908/19032537/98a70e9a-895a-11e6-8cfd-4fe018c8bca0.jpg)


Fixes #5733
