### PR TITLE
Change onboarding wizard terminology to configuration wizard

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * @class WPSEO_Configuration_Wizard Loads the Yoast onboarding wizard.
+ * @class WPSEO_Configuration_Wizard Loads the Yoast configuration wizard.
  */
 class WPSEO_Configuration_Page {
 
@@ -98,7 +98,7 @@ class WPSEO_Configuration_Page {
 		<head>
 			<meta name="viewport" content="width=device-width"/>
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-			<title><?php _e( 'Yoast SEO &rsaquo; Setup Wizard', 'wordpress-seo' ); ?></title>
+			<title><?php _e( 'Yoast SEO &rsaquo; Configuration Wizard', 'wordpress-seo' ); ?></title>
 			<?php
 				do_action( 'admin_print_styles' );
 				do_action( 'admin_print_scripts' );
@@ -216,7 +216,7 @@ class WPSEO_Configuration_Page {
 	}
 
 	/**
-	 * Remove the options that triggers the notice for the onboarding wizard.
+	 * Remove the options that triggers the notice for the configuration wizard.
 	 */
 	private function remove_notification_option() {
 		$options = $this->get_options();

--- a/admin/config-ui/fields/class-field-upsell-configuration-service.php
+++ b/admin/config-ui/fields/class-field-upsell-configuration-service.php
@@ -14,7 +14,7 @@ class WPSEO_Config_Field_Upsell_Configuration_Service extends WPSEO_Config_Field
 	public function __construct() {
 		parent::__construct( 'upsellConfigurationService', 'HTML' );
 
-		$intro_text = __( 'Welcome to the Yoast SEO installation wizard. In a few simple steps we\'ll help you configure your SEO settings to match your website\'s needs!', 'wordpress-seo' );
+		$intro_text = __( 'Welcome to the Yoast SEO configuration wizard. In a few simple steps we\'ll help you configure your SEO settings to match your website\'s needs!', 'wordpress-seo' );
 
 		/* Translators: %1$s opens the link, %2$s closes the link. */
 		$upsell_text = sprintf(

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 if ( WPSEO_Utils::is_api_available() ) :
-	echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
+	echo '<h2>' . esc_html__( 'Configuration wizard', 'wordpress-seo' ) . '</h2>';
 	?>
 	<p>
 		<?php
@@ -20,7 +20,7 @@ if ( WPSEO_Utils::is_api_available() ) :
 	</p>
 <p>
 	<a class="button"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php _e( 'Open the installation wizard', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php _e( 'Open the configuration wizard', 'wordpress-seo' ); ?></a>
 </p>
 
 	<br/>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
All on boarding or installation wizard terms should be changed to configuration wizard, because that is what it is.

## Relevant technical choices:
none

## Test instructions

This PR can be tested by following these steps:
1. Go find the references to the wizard. Everything should now be configuration wizard and not something else.
2. Walk trough the wizard and the pages that point to it to check this.

Fixes #5690