### PR TITLE
Add minimum version to is_api_version

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -867,15 +867,17 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Checks if the WP-REST-API with at least version 2.0 is available.
+	 * Checks if the WP-REST-API is available.
 	 *
 	 * @since 3.6
 	 *
-	 * @return bool
+	 * @param string $minimum_version The minimum version the API should be.
+	 *
+	 * @return bool Returns true if the API is available.
 	 */
-	public static function is_api_available() {
+	public static function is_api_available( $minimum_version = '2.0' ) {
 		return ( defined( 'REST_API_VERSION' )
-		         && version_compare( REST_API_VERSION, '2.0', '>=' ) );
+		         && version_compare( REST_API_VERSION, $minimum_version, '>=' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
We need to be able to check for a version of the REST API that is present. Currently version 2.0 is included in core, but new features will be implemented and the version will rise.

To make sure we only use the features that are available, we need to be able to specifically check for a version number before loading certain code.

This PR can be summarized in the following changelog entry:

## Relevant technical choices:
The function name is still is_api_available because the function is already shipped with a release. 

Changing the name to something more specific could break code for users that already use this function in their code.

## Test instructions

This PR can be tested by following these steps:
1. Provide another higher version number than 2.0 to the WPSEO_Utils::is_api_available function.
2. Check the function returns false.

Fixes #5736