### PR TITLE
Add functions for retrieving page identifiers

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -40,7 +40,7 @@ class WPSEO_Configuration_Page {
 		$this->remove_notification();
 		$this->remove_notification_option();
 
-		wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) );
+		wp_redirect( admin_url( 'admin.php?page=' . self::get_configuration_page_identifier() ) );
 		exit;
 	}
 
@@ -49,7 +49,7 @@ class WPSEO_Configuration_Page {
 	 *  Registers the page for the wizard.
 	 */
 	public function add_wizard_page() {
-		add_dashboard_page( '', '', 'manage_options', self::PAGE_IDENTIFIER, '' );
+		add_dashboard_page( '', '', 'manage_options', self::get_configuration_page_identifier(), '' );
 	}
 
 	/**
@@ -86,7 +86,7 @@ class WPSEO_Configuration_Page {
 	 */
 	public function show_wizard() {
 		$this->enqueue_assets();
-		$dashboard_url = admin_url( '/admin.php?page=wpseo_dashboard' );
+		$dashboard_url = admin_url( '/admin.php?page='. self::get_wpseo_dashboard_page() );
 		?>
 		<!DOCTYPE html>
 		<!--[if IE 9]>
@@ -138,7 +138,7 @@ class WPSEO_Configuration_Page {
 			'nonce'             => wp_create_nonce( 'wp_rest' ),
 			'root'              => esc_url_raw( rest_url() ),
 			'ajaxurl'           => admin_url( 'admin-ajax.php' ),
-			'finishUrl'         => admin_url( 'admin.php?page=wpseo_dashboard&configuration=finished' ),
+			'finishUrl'         => admin_url( 'admin.php?page=' . self::get_wpseo_dashboard_page() . '&configuration=finished' ),
 			'gscAuthURL'        => $service->get_client()->createAuthUrl(),
 			'gscProfiles'       => $service->get_sites(),
 			'gscNonce'          => wp_create_nonce( 'wpseo-gsc-ajax-security' ),
@@ -187,7 +187,7 @@ class WPSEO_Configuration_Page {
 		$message = sprintf(
 			__( 'Since you are new to %1$s you can configure the %2$splugin%3$s', 'wordpress-seo' ),
 			'Yoast SEO',
-			'<a href="' . admin_url( '?page=' . self::PAGE_IDENTIFIER ) . '">',
+			'<a href="' . admin_url( '?page=' . self::get_configuration_page_identifier() ) . '">',
 			'</a>'
 		);
 
@@ -233,5 +233,23 @@ class WPSEO_Configuration_Page {
 	 */
 	private function get_options() {
 		return get_option( 'wpseo' );
+	}
+
+	/**
+	 * Returns the page identifier for the configuration UI.
+	 *
+	 * @return string The configuration page identifier.
+	 */
+	public static function get_configuration_page_identifier() {
+		return self::PAGE_IDENTIFIER;
+	}
+
+	/**
+	 * Returns the page identifier for the wpseo dashboard.
+	 *
+	 * @return string The dashboard page identifier.
+	 */
+	public static function get_wpseo_dashboard_page() {
+		return WPSEO_Admin::PAGE_IDENTIFIER;
 	}
 }

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -7,8 +7,10 @@
  * @class WPSEO_Configuration_Wizard Loads the Yoast onboarding wizard.
  */
 class WPSEO_Configuration_Page {
-
-	const PAGE_IDENTIFIER = 'wpseo_configurator';
+	/**
+	 * @var string The identifier for the configuration page.
+	 */
+	private $page_identifier = 'wpseo_configurator';
 
 	/**
 	 * WPSEO_Configuration_Wizard constructor.
@@ -19,7 +21,7 @@ class WPSEO_Configuration_Page {
 			$this->add_notification();
 		}
 
-		if ( filter_input( INPUT_GET, 'page' ) !== self::PAGE_IDENTIFIER ) {
+		if ( filter_input( INPUT_GET, 'page' ) !== $this->get_page_identifier() ) {
 			return;
 		}
 
@@ -40,7 +42,7 @@ class WPSEO_Configuration_Page {
 		$this->remove_notification();
 		$this->remove_notification_option();
 
-		wp_redirect( admin_url( 'admin.php?page=' . self::get_configuration_page_identifier() ) );
+		wp_redirect( admin_url( 'admin.php?page=' . $this->get_page_identifier() ) );
 		exit;
 	}
 
@@ -49,7 +51,7 @@ class WPSEO_Configuration_Page {
 	 *  Registers the page for the wizard.
 	 */
 	public function add_wizard_page() {
-		add_dashboard_page( '', '', 'manage_options', self::get_configuration_page_identifier(), '' );
+		add_dashboard_page( '', '', 'manage_options', $this->get_page_identifier(), '' );
 	}
 
 	/**
@@ -86,7 +88,7 @@ class WPSEO_Configuration_Page {
 	 */
 	public function show_wizard() {
 		$this->enqueue_assets();
-		$dashboard_url = admin_url( '/admin.php?page='. self::get_wpseo_dashboard_page() );
+		$dashboard_url = admin_url( '/admin.php?page='. WPSEO_Admin::PAGE_IDENTIFIER );
 		?>
 		<!DOCTYPE html>
 		<!--[if IE 9]>
@@ -138,7 +140,7 @@ class WPSEO_Configuration_Page {
 			'nonce'             => wp_create_nonce( 'wp_rest' ),
 			'root'              => esc_url_raw( rest_url() ),
 			'ajaxurl'           => admin_url( 'admin-ajax.php' ),
-			'finishUrl'         => admin_url( 'admin.php?page=' . self::get_wpseo_dashboard_page() . '&configuration=finished' ),
+			'finishUrl'         => admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&configuration=finished' ),
 			'gscAuthURL'        => $service->get_client()->createAuthUrl(),
 			'gscProfiles'       => $service->get_sites(),
 			'gscNonce'          => wp_create_nonce( 'wpseo-gsc-ajax-security' ),
@@ -167,7 +169,7 @@ class WPSEO_Configuration_Page {
 	 */
 	private function add_notification() {
 		$notification_center = Yoast_Notification_Center::get();
-		$notification_center->add_notification( self::get_notification() );
+		$notification_center->add_notification( $this->get_notification() );
 	}
 
 	/**
@@ -175,7 +177,7 @@ class WPSEO_Configuration_Page {
 	 */
 	private function remove_notification() {
 		$notification_center = Yoast_Notification_Center::get();
-		$notification_center->remove_notification( self::get_notification() );
+		$notification_center->remove_notification( $this->get_notification() );
 	}
 
 	/**
@@ -183,11 +185,11 @@ class WPSEO_Configuration_Page {
 	 *
 	 * @return Yoast_Notification
 	 */
-	private static function get_notification() {
+	private function get_notification() {
 		$message = sprintf(
 			__( 'Since you are new to %1$s you can configure the %2$splugin%3$s', 'wordpress-seo' ),
 			'Yoast SEO',
-			'<a href="' . admin_url( '?page=' . self::get_configuration_page_identifier() ) . '">',
+			'<a href="' . admin_url( '?page=' . $this->get_page_identifier() ) . '">',
 			'</a>'
 		);
 
@@ -240,16 +242,7 @@ class WPSEO_Configuration_Page {
 	 *
 	 * @return string The configuration page identifier.
 	 */
-	public static function get_configuration_page_identifier() {
-		return self::PAGE_IDENTIFIER;
-	}
-
-	/**
-	 * Returns the page identifier for the wpseo dashboard.
-	 *
-	 * @return string The dashboard page identifier.
-	 */
-	public static function get_wpseo_dashboard_page() {
-		return WPSEO_Admin::PAGE_IDENTIFIER;
+	public function get_page_identifier() {
+		return $this->page_identifier;
 	}
 }

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -10,6 +10,8 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 if ( WPSEO_Utils::is_api_available() ) :
+	$wpseo_configuration_page = new WPSEO_Configuration_Page();
+
 	echo '<h2>' . esc_html__( 'Installation wizard', 'wordpress-seo' ) . '</h2>';
 	?>
 	<p>
@@ -20,7 +22,7 @@ if ( WPSEO_Utils::is_api_available() ) :
 	</p>
 <p>
 	<a class="button"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php _e( 'Open the installation wizard', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . $wpseo_configuration_page->get_page_identifier() ) ); ?>"><?php _e( 'Open the installation wizard', 'wordpress-seo' ); ?></a>
 </p>
 
 	<br/>


### PR DESCRIPTION
## Summary

Retrieving the dashboard page should be a method call, this way it will be easier to override in implementations.

This PR can be summarized in the following changelog entry:
## Relevant technical choices:

Also used WPSEO_Admin constant for retrieving the dashboard page.
## Test instructions

This PR can be tested by following these steps:

Test all links to the configuration wizard and all links from the configuration wizard back to the dashboard. Links to test:
- Onboarding notification
- General settings
  Links in the wizard:
- The link: Go back to the Yoast SEO dashboard.
- The link behind the close button in step 10 of the wizard.

Fixes #5739
Fixes #5740 
