### PR TITLE
Move the configuration page check

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -87,11 +87,8 @@ class WPSEO_Admin {
 		}
 
 		if ( WPSEO_Utils::is_api_available() ) {
-			$configuration = new WPSEO_Configuration_Page();
-
-			if ( filter_input( INPUT_GET, 'page' ) === WPSEO_Configuration_Page::PAGE_IDENTIFIER ) {
-				$configuration->catch_configuration_request();
-			}
+			$configuration = new WPSEO_Configuration_Page;
+			$configuration->catch_configuration_request();
 		}
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -89,7 +89,7 @@ class WPSEO_Admin {
 		if ( WPSEO_Utils::is_api_available() ) {
 			$configuration = new WPSEO_Configuration_Page();
 
-			if ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER ) {
+			if ( filter_input( INPUT_GET, 'page' ) === WPSEO_Configuration_Page::PAGE_IDENTIFIER ) {
 				$configuration->catch_configuration_request();
 			}
 		}

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -33,8 +33,10 @@ class WPSEO_Configuration_Page {
 	 * Check if the configuration is finished. If so, just remove the notification.
 	 */
 	public function catch_configuration_request() {
-		if ( filter_input( INPUT_GET, 'configuration' ) !== 'finished'
-		     || ( ! filter_input( INPUT_GET, 'page' ) === WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ) {
+		$configuration_page = filter_input( INPUT_GET, 'configuration' );
+		$page          = filter_input( INPUT_GET, 'page' );
+
+		if ( ! ( $configuration_page === 'finished' && ( $page === WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ) ) {
 			return;
 		}
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -33,7 +33,8 @@ class WPSEO_Configuration_Page {
 	 * Check if the configuration is finished. If so, just remove the notification.
 	 */
 	public function catch_configuration_request() {
-		if ( filter_input( INPUT_GET, 'configuration' ) !== 'finished' ) {
+		if ( filter_input( INPUT_GET, 'configuration' ) !== 'finished'
+		     && ( ! filter_input( INPUT_GET, 'page' ) === self::get_configuration_page_identifier() ) ) {
 			return;
 		}
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -34,7 +34,7 @@ class WPSEO_Configuration_Page {
 	 */
 	public function catch_configuration_request() {
 		if ( filter_input( INPUT_GET, 'configuration' ) !== 'finished'
-		     && ( ! filter_input( INPUT_GET, 'page' ) === self::get_configuration_page_identifier() ) ) {
+		     || ( ! filter_input( INPUT_GET, 'page' ) === WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ) {
 			return;
 		}
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -36,7 +36,7 @@ class WPSEO_Configuration_Page {
 		$configuration_page = filter_input( INPUT_GET, 'configuration' );
 		$page          = filter_input( INPUT_GET, 'page' );
 
-		if ( ! ( $configuration_page === 'finished' && ( $page === WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ) ) {
+		if ( ! ( $configuration_page === 'finished' && ( $page === WPSEO_Admin::PAGE_IDENTIFIER ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
Currently the admin/class-admin.php has functionality that belongs inside the Configuration Page itself. This is moved to the class-configuration-page class.

This PR can be summarized in the following changelog entry:
- Move the configuration page check to configuration page class.

## Relevant technical choices:
Did not remove the $configuration variable to prevent doing to much in the constructor.

## Test instructions

This PR can be tested by following these steps:
1. Test if you can still go to the wizard via the notification and general settings tab.
2. Test if the wizard redirects after closing in the last step.

Fixes #5741