### PR TITLE
Set disable-author(archives) option based on multiple_authors

### DIFF
--- a/admin/config-ui/fields/class-field-multiple-authors.php
+++ b/admin/config-ui/fields/class-field-multiple-authors.php
@@ -68,14 +68,14 @@ class WPSEO_Config_Field_Multiple_Authors extends WPSEO_Config_Field_Choice {
 		$value = ( $data === 'yes' );
 
 		// Set multiple authors.
-		$resultMultipleAuthors = WPSEO_Options::save_option( 'wpseo', 'has_multiple_authors', $value );
+		$result_multiple_authors = WPSEO_Options::save_option( 'wpseo', 'has_multiple_authors', $value );
 
 		/*
 		 * Set disable author archives. Inverse the value for this, because the when multiple authors is true,
 		 * the disable author option has to be false.
 		 */
-		$resultAuthorArchives = WPSEO_Options::save_option( 'wpseo_titles', 'disable-author', ! $value );
+		$result_author_archives = WPSEO_Options::save_option( 'wpseo_titles', 'disable-author', ! $value );
 
-		return ( $resultMultipleAuthors === true && $resultAuthorArchives === true );
+		return ( $result_multiple_authors === true && $result_author_archives === true );
 	}
 }

--- a/admin/config-ui/fields/class-field-multiple-authors.php
+++ b/admin/config-ui/fields/class-field-multiple-authors.php
@@ -67,14 +67,15 @@ class WPSEO_Config_Field_Multiple_Authors extends WPSEO_Config_Field_Choice {
 	public function set_data( $data ) {
 		$value = ( $data === 'yes' );
 
-		$option                           = WPSEO_Options::get_option( 'wpseo' );
-		$option['has_multiple_authors'] = $value;
+		// Set multiple authors.
+		$resultMultipleAuthors = WPSEO_Options::save_option( 'wpseo', 'has_multiple_authors', $value );
 
-		update_option( 'wpseo', $option );
+		/*
+		 * Set disable author archives. Inverse the value for this, because the when multiple authors is true,
+		 * the disable author option has to be false.
+		 */
+		$resultAuthorArchives = WPSEO_Options::save_option( 'wpseo_titles', 'disable-author', ! $value );
 
-		// Check if everything got saved properly.
-		$saved_option = WPSEO_Options::get_option( 'wpseo' );
-
-		return ( $saved_option['has_multiple_authors'] === $option['has_multiple_authors'] );
+		return ( $resultMultipleAuthors === true && $resultAuthorArchives === true );
 	}
 }

--- a/admin/config-ui/fields/class-field-multiple-authors.php
+++ b/admin/config-ui/fields/class-field-multiple-authors.php
@@ -67,12 +67,12 @@ class WPSEO_Config_Field_Multiple_Authors extends WPSEO_Config_Field_Choice {
 	public function set_data( $data ) {
 		$value = ( $data === 'yes' );
 
-		// Set multiple authors.
+		// Set multiple authors option.
 		$result_multiple_authors = WPSEO_Options::save_option( 'wpseo', 'has_multiple_authors', $value );
 
 		/*
-		 * Set disable author archives. Inverse the value for this, because the when multiple authors is true,
-		 * the disable author option has to be false.
+		 * Set disable author archives option. When multiple authors is set to true,
+		 * the disable author option has to be false. Because of this the $value is inversed.
 		 */
 		$result_author_archives = WPSEO_Options::save_option( 'wpseo_titles', 'disable-author', ! $value );
 

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -386,7 +386,7 @@ class WPSEO_Options {
 	 * @param string $option_name              The name for the option to set.
 	 * @param *      $option_value             The value for the option.
 	 *
-	 * @return string Saving successful.
+	 * @return boolean Returns true if the options is successfully saved in the database.
 	 */
 	public static function save_option( $wpseo_options_group_name, $option_name, $option_value ) {
 		$options                           = WPSEO_Options::get_option( $wpseo_options_group_name );

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -379,6 +379,24 @@ class WPSEO_Options {
 		}
 	}
 
+	/**
+	 * Saves the option to the database.
+	 *
+	 * @param string $wpseo_options_group_name The name for the wpseo option group in the database.
+	 * @param string $option_name              The name for the option to set.
+	 * @param *      $option_value             The value for the option.
+	 *
+	 * @return string Saving successful.
+	 */
+	public static function save_option( $wpseo_options_group_name, $option_name, $option_value ) {
+		$options                           = WPSEO_Options::get_option( $wpseo_options_group_name );
+		$options[ $option_name ] = $option_value;
+		update_option( $wpseo_options_group_name, $options );
+
+		// Check if everything got saved properly.
+		$saved_option = self::get_option( $wpseo_options_group_name );
+		return $saved_option[ $option_name ] === $options[ $option_name ];
+	}
 
 	/********************** DEPRECATED FUNCTIONS **********************/
 

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -386,7 +386,7 @@ class WPSEO_Options {
 	 * @param string $option_name              The name for the option to set.
 	 * @param *      $option_value             The value for the option.
 	 *
-	 * @return boolean Returns true if the options is successfully saved in the database.
+	 * @return boolean Returns true if the option is successfully saved in the database.
 	 */
 	public static function save_option( $wpseo_options_group_name, $option_name, $option_value ) {
 		$options                           = WPSEO_Options::get_option( $wpseo_options_group_name );


### PR DESCRIPTION
## Summary
When selecting the site will be a single author site in the onboarding wizard. It should also disable the author archives.

This PR can be summarized in the following changelog entry:
- Disable author archives based on multiple authors option in the wizard.

## Relevant technical choices:
The disable-author(archives) option is now disabled when multiple_authors is set to true. I've also looked into the sitemaps for authors but they seem to be disabled when disable-author options is enabled. For this reason the sitemap options for authors are not specifically disabled when setting the multiple_authors option in the wizard.

## Test instructions

This PR can be tested by following these steps:

Start the wizard and go to step 7 'multiple authors'.

Select 'YES', check the following settings:
 - Titles & metas -> Archives -> Author archives: This should be enabled.
 - XML sitemap -> User sitemap tab: should be visible.

Select 'NO', check the following settings:
 - Titles & metas -> Archives -> Author archives: This should be disabled.
 - XML sitemap -> User sitemap tab: should be invisible.

Also switch between steps and refresh the wizard and see if the option is remembered.

Fixes #5695
