### PR TITLE
Use get_the_author_meta() to get a translated name when WPML translat…

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -350,8 +350,9 @@ class WPSEO_Breadcrumbs {
 			}
 			elseif ( is_author() ) {
 				$user = $wp_query->get_queried_object();
+				$display_name = get_the_author_meta( 'display_name', $user->ID );
 				$this->add_predefined_crumb(
-					$this->options['breadcrumbs-archiveprefix'] . ' ' . $user->display_name,
+					$this->options['breadcrumbs-archiveprefix'] . ' ' . $display_name,
 					null,
 					true
 				);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
- Translate display_name in author archive breadcrumb.
## Relevant technical choices:
- WPML only returns translated usermeta when we use get_the_author_meta() function. 
## Test instructions

This PR can be tested by following these steps:
- Setup this plugin with WPML and String Translation.
- Enable author meta translation in String Translation settings.
- Translate first name and last name.
- Visit an author archive.
- You should see the translated display_name

The issue was reported initially over here:
https://wpml.org/forums/topic/author-name-isnt-showing-translation-in-yoast-breadcrumbs-author-archive/
