### PR TITLE
Fix Google Search Console in multisite subdirectory

### DIFF
--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -206,7 +206,7 @@ class WPSEO_GSC_Table extends WP_List_Table {
 			$actions['create_redirect'] = '<a href="#TB_inline?width=600&height=' . $this->modal_heights[ $modal_height ] . '&inlineId=redirect-' . md5( $item['url'] ) . '" class="thickbox wpseo-open-gsc-redirect-modal aria-button-if-js">' . __( 'Create redirect', 'wordpress-seo' ) . '</a>';
 		}
 
-		$actions['view']        = '<a href="' . $item['url'] . '" target="_blank">' . __( 'View', 'wordpress-seo' ) . '</a>';
+		$actions['view']        = '<a href="' . home_url( $item['url'] ) . '" target="_blank">' . __( 'View', 'wordpress-seo' ) . '</a>';
 		$actions['markasfixed'] = '<a href="javascript:wpseo_mark_as_fixed(\'' . urlencode( $item['url'] ) . '\');">' . __( 'Mark as fixed', 'wordpress-seo' ) . '</a>';
 
 		return sprintf(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
The Google Search Console 'view' and 'mark as resolved' did not work on a multisite subdirectory setup. 

## Relevant technical choices:

Used the 'home_url' function for determining the site base url.

## Test instructions

This PR can be tested by following these steps:
1. Create a multisite subdirectory test environment.
2. Set a valid GSC profile for the site in the subdirectory as well as in the main site.
3. Check the rows with crawl issues. The url's in the 'view' buttons have to point to the url for the site in the subdir appended by the path from the URL column for that issue.

Fixes #4498

