### PR TITLE
Fix deprecated usage of `is_a()`.

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -178,6 +178,6 @@ class WPSEO_Help_Center {
 	 * @return bool
 	 */
 	private function is_a_help_center_item( $item ) {
-		return is_a( $item, 'WPSEO_Help_Center_Item' );
+		return ( $item instanceof WPSEO_Help_Center_Item );
 	}
 }

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -49,7 +49,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 			'metaDescriptionDate' => '',
 		);
 
-		if ( is_a( $this->post, 'WP_Post' ) ) {
+		if ( $this->post instanceof WP_Post ) {
 			$values_to_set = array(
 				'keyword_usage'       => $this->get_focus_keyword_usage(),
 				'title_template'      => $this->get_title_template(),

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -315,7 +315,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$content_sections = array( $this->get_content_meta_section() );
 
 		// Check if social_admin is an instance of WPSEO_Social_Admin.
-		if ( is_a( $this->social_admin, 'WPSEO_Social_Admin' ) ) {
+		if ( $this->social_admin instanceof WPSEO_Social_Admin ) {
 			$content_sections[] = $this->social_admin->get_meta_section();
 		}
 


### PR DESCRIPTION
My error log is filling up with `PHP Strict standards:  is_a(): Deprecated. Please use the instanceof operator` notices.

This fixes that.