### PR TITLE
Implement fix for slow categorypicker if it has 1000+ categories

### DIFF
--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -66,9 +66,9 @@
 	}
 
 	/**
-	 * Updates the primary term selectors/indicators for a certain taxonomy
+	 * Updates the primary term selectors/indicators for a certain taxonomy.
 	 *
-	 * @param {string} taxonomyName
+	 * @param {string} taxonomyName The name for the taxonomy.
 	 *
 	 * @returns {void}
 	 */
@@ -80,13 +80,14 @@
 		uncheckedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:not(:checked)' );
 
 		// Remove all classes for a consistent experience
-		checkedTerms.add( uncheckedTerms )
-		            .closest( "li" )
-		            .removeClass( "wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term" );
+		checkedTerms
+			.add( uncheckedTerms )
+			.closest( "li" )
+			.removeClass( "wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term" );
 
 		$( ".wpseo-primary-category-label" ).remove();
 
-		$( "#" + taxonomyName + 'checklist li' ).addClass( "wpseo-term-unchecked" );
+		$( "#" + taxonomyName + "checklist li" ).addClass( "wpseo-term-unchecked" );
 
 		// If there is only one term selected we don't want to show our interface.
 		if ( checkedTerms.length <= 1 ) {

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -80,22 +80,23 @@
 		uncheckedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:not(:checked)' );
 
 		// Remove all classes for a consistent experience
-		checkedTerms.add( uncheckedTerms ).closest( "li" )
-			.removeClass( "wpseo-term-unchecked" )
-			.removeClass( "wpseo-primary-term" )
-			.removeClass( "wpseo-non-primary-term" );
+		checkedTerms.add( uncheckedTerms )
+		            .closest( "li" )
+		            .removeClass( "wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term" );
 
 		$( ".wpseo-primary-category-label" ).remove();
 
+		$( "#" + taxonomyName + 'checklist li' ).addClass( "wpseo-term-unchecked" );
+
 		// If there is only one term selected we don't want to show our interface.
 		if ( checkedTerms.length <= 1 ) {
-			checkedTerms.add( uncheckedTerms ).closest( "li" ).addClass( "wpseo-term-unchecked" );
 			return;
 		}
 
 		checkedTerms.each( function( i, term ) {
 			term = $( term );
 			listItem = term.closest( "li" );
+			listItem.removeClass( "wpseo-term-unchecked" );
 
 			// Create our interface elements if they don't exist.
 			if ( ! hasPrimaryTermElements( term ) ) {
@@ -115,9 +116,6 @@
 				listItem.addClass( "wpseo-non-primary-term" );
 			}
 		} );
-
-		// Hide our interface elements on all unchecked checkboxes.
-		uncheckedTerms.closest( "li" ).addClass( "wpseo-term-unchecked" );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Original issue: #5569

This PR can be summarized in the following changelog entry:

## Relevant technical choices:
Not applicable.

## Test instructions

This PR can be tested by following these steps:
1. Use wp term generate to generate 2000+ categories.
2. Create a new post and select a category for the post. See how much time it takes. Also take note of how selecting the categories behave.
3. Now switch to the branch from this PR. Build the JS and see if the correct JS is loaded(and not one from the cache)
3. Now create a new post and add some categories. It should be quicker now.
4. Play around with electing different categories and see if everything behaves like it should.


Fixes #5569