### PR TITLE
Add contributor fix for slow categorypicker if it has 1000+ categories

### DIFF
--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -10,7 +10,7 @@
 	 *
 	 * @param {Object} checkbox
 	 *
-	 * @return {boolean}
+	 * @returns {boolean}
 	 */
 	function hasPrimaryTermElements( checkbox ) {
 		return 1 === $( checkbox ).closest( "li" ).children( ".wpseo-make-primary-term" ).length;
@@ -20,7 +20,7 @@
 	 * Retrieves the primary term for a taxonomy
 	 *
 	 * @param {string} taxonomyName
-	 * @return {string}
+	 * @returns {string}
 	 */
 	function getPrimaryTerm( taxonomyName ) {
 		var primaryTermInput;
@@ -34,6 +34,8 @@
 	 *
 	 * @param {string} taxonomyName
 	 * @param {string} termId
+	 *
+	 * @returns {void}
 	 */
 	function setPrimaryTerm( taxonomyName, termId ) {
 		var primaryTermInput;
@@ -47,6 +49,8 @@
 	 *
 	 * @param {string} taxonomyName
 	 * @param {Object} checkbox
+	 *
+	 * @returns {void}
 	 */
 	function createPrimaryTermElements( taxonomyName, checkbox ) {
 		var label, html;
@@ -65,6 +69,8 @@
 	 * Updates the primary term selectors/indicators for a certain taxonomy
 	 *
 	 * @param {string} taxonomyName
+	 *
+	 * @returns {void}
 	 */
 	function updatePrimaryTermSelectors( taxonomyName ) {
 		var checkedTerms, uncheckedTerms;
@@ -72,22 +78,24 @@
 
 		checkedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked' );
 		uncheckedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:not(:checked)' );
-        $( "#" + taxonomyName + 'checklist li').removeClass("wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term");
+
+		// Remove all classes for a consistent experience
+		checkedTerms.add( uncheckedTerms ).closest( "li" )
+			.removeClass( "wpseo-term-unchecked" )
+			.removeClass( "wpseo-primary-term" )
+			.removeClass( "wpseo-non-primary-term" );
 
 		$( ".wpseo-primary-category-label" ).remove();
 
 		// If there is only one term selected we don't want to show our interface.
 		if ( checkedTerms.length <= 1 ) {
-            $( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
+			checkedTerms.add( uncheckedTerms ).closest( "li" ).addClass( "wpseo-term-unchecked" );
 			return;
-		} else {
-            $( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
-        }
+		}
 
 		checkedTerms.each( function( i, term ) {
 			term = $( term );
 			listItem = term.closest( "li" );
-            listItem.removeClass("wpseo-term-unchecked");
 
 			// Create our interface elements if they don't exist.
 			if ( ! hasPrimaryTermElements( term ) ) {
@@ -107,12 +115,17 @@
 				listItem.addClass( "wpseo-non-primary-term" );
 			}
 		} );
+
+		// Hide our interface elements on all unchecked checkboxes.
+		uncheckedTerms.closest( "li" ).addClass( "wpseo-term-unchecked" );
 	}
 
 	/**
 	 * Makes the first term primary for a certain taxonomy
 	 *
 	 * @param {string} taxonomyName
+	 *
+	 * @returns {void}
 	 */
 	function makeFirstTermPrimary( taxonomyName ) {
 		var firstTerm = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked:first' );
@@ -125,6 +138,8 @@
 	 * If we check a term while there is no primary term we make that one the primary term.
 	 *
 	 * @param {string} taxonomyName
+	 *
+	 * @returns {void}
 	 */
 	function ensurePrimaryTerm( taxonomyName ) {
 		if ( "" === getPrimaryTerm( taxonomyName ) ) {
@@ -136,7 +151,7 @@
 	 * Returns the term checkbox handler for a certain taxonomy name
 	 *
 	 * @param {string} taxonomyName
-	 * @return {Function}
+	 * @returns {Function}
 	 */
 	function termCheckboxHandler( taxonomyName ) {
 		return function() {

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -73,10 +73,10 @@
 		var listItem, label;
 
 		checkedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked' );
-        $( "#" + taxonomyName + "checklist li" ).removeClass("wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term");
+        $( "#" + taxonomyName + "checklist li" ).removeClass( "wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term" );
 
 		$( ".wpseo-primary-category-label" ).remove();
-		$( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
+		$( "#" + taxonomyName + "checklist li" ).addClass("wpseo-term-unchecked");
 
 		// If there is only one term selected we don't want to show our interface.
 		if ( checkedTerms.length <= 1 ) {

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -6,21 +6,21 @@
 	var taxonomies = wpseoPrimaryCategoryL10n.taxonomies;
 
 	/**
-	 * Checks if the elements to make a term the primary term and the display for a primary term exist
+	 * Checks if the elements to make a term the primary term and the display for a primary term exist.
 	 *
 	 * @param {Object} checkbox
 	 *
-	 * @return {boolean}
+	 * @returns {boolean}
 	 */
 	function hasPrimaryTermElements( checkbox ) {
 		return 1 === $( checkbox ).closest( "li" ).children( ".wpseo-make-primary-term" ).length;
 	}
 
 	/**
-	 * Retrieves the primary term for a taxonomy
+	 * Retrieves the primary term for a taxonomy.
 	 *
 	 * @param {string} taxonomyName
-	 * @return {string}
+	 * @returns {string}
 	 */
 	function getPrimaryTerm( taxonomyName ) {
 		var primaryTermInput;
@@ -30,10 +30,12 @@
 	}
 
 	/**
-	 * Sets the primary term for a taxonomy
+	 * Sets the primary term for a taxonomy.
 	 *
 	 * @param {string} taxonomyName
 	 * @param {string} termId
+	 *
+	 * @returns {void}
 	 */
 	function setPrimaryTerm( taxonomyName, termId ) {
 		var primaryTermInput;
@@ -43,7 +45,7 @@
 	}
 
 	/**
-	 * Creates the elements necessary to show something is a primary term or to make it the primary term
+	 * Creates the elements necessary to show something is a primary term or to make it the primary term.
 	 *
 	 * @param {string} taxonomyName
 	 * @param {Object} checkbox
@@ -62,27 +64,24 @@
 	}
 
 	/**
-	 * Updates the primary term selectors/indicators for a certain taxonomy
+	 * Updates the primary term selectors/indicators for a certain taxonomy.
 	 *
 	 * @param {string} taxonomyName
 	 */
 	function updatePrimaryTermSelectors( taxonomyName ) {
-		var checkedTerms, uncheckedTerms;
+		var checkedTerms;
 		var listItem, label;
 
 		checkedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked' );
-		uncheckedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:not(:checked)' );
-        $( "#" + taxonomyName + 'checklist li').removeClass("wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term");
+        $( "#" + taxonomyName + "checklist li" ).removeClass("wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term");
 
 		$( ".wpseo-primary-category-label" ).remove();
+		$( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
 
 		// If there is only one term selected we don't want to show our interface.
 		if ( checkedTerms.length <= 1 ) {
-            $( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
 			return;
-		} else {
-            $( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
-        }
+		}
 
 		checkedTerms.each( function( i, term ) {
 			term = $( term );
@@ -110,7 +109,7 @@
 	}
 
 	/**
-	 * Makes the first term primary for a certain taxonomy
+	 * Makes the first term primary for a certain taxonomy.
 	 *
 	 * @param {string} taxonomyName
 	 */
@@ -133,10 +132,10 @@
 	}
 
 	/**
-	 * Returns the term checkbox handler for a certain taxonomy name
+	 * Returns the term checkbox handler for a certain taxonomy name.
 	 *
 	 * @param {string} taxonomyName
-	 * @return {Function}
+	 * @returns {Function}
 	 */
 	function termCheckboxHandler( taxonomyName ) {
 		return function() {
@@ -152,7 +151,7 @@
 	}
 
 	/**
-	 * Returns the term list add handler for a certain taxonomy name
+	 * Returns the term list add handler for a certain taxonomy name.
 	 *
 	 * @param {string} taxonomyName
 	 * @returns {Function}
@@ -165,7 +164,7 @@
 	}
 
 	/**
-	 * Returns the make primary event handler for a certain taxonomy name
+	 * Returns the make primary event handler for a certain taxonomy name.
 	 *
 	 * @param {string} taxonomyName
 	 * @returns {Function}

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -73,10 +73,12 @@
 		var listItem, label;
 
 		checkedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked' );
-        $( "#" + taxonomyName + "checklist li" ).removeClass( "wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term" );
+
+		var taxonomyListItem = $( "#" + taxonomyName + "checklist li" );
+		taxonomyListItem.removeClass( "wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term" );
 
 		$( ".wpseo-primary-category-label" ).remove();
-		$( "#" + taxonomyName + "checklist li" ).addClass("wpseo-term-unchecked");
+		taxonomyListItem.addClass( "wpseo-term-unchecked" );
 
 		// If there is only one term selected we don't want to show our interface.
 		if ( checkedTerms.length <= 1 ) {
@@ -86,7 +88,7 @@
 		checkedTerms.each( function( i, term ) {
 			term = $( term );
 			listItem = term.closest( "li" );
-            listItem.removeClass("wpseo-term-unchecked");
+			listItem.removeClass( "wpseo-term-unchecked" );
 
 			// Create our interface elements if they don't exist.
 			if ( ! hasPrimaryTermElements( term ) ) {

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -10,7 +10,7 @@
 	 *
 	 * @param {Object} checkbox
 	 *
-	 * @returns {boolean}
+	 * @return {boolean}
 	 */
 	function hasPrimaryTermElements( checkbox ) {
 		return 1 === $( checkbox ).closest( "li" ).children( ".wpseo-make-primary-term" ).length;
@@ -20,7 +20,7 @@
 	 * Retrieves the primary term for a taxonomy
 	 *
 	 * @param {string} taxonomyName
-	 * @returns {string}
+	 * @return {string}
 	 */
 	function getPrimaryTerm( taxonomyName ) {
 		var primaryTermInput;
@@ -34,8 +34,6 @@
 	 *
 	 * @param {string} taxonomyName
 	 * @param {string} termId
-	 *
-	 * @returns {void}
 	 */
 	function setPrimaryTerm( taxonomyName, termId ) {
 		var primaryTermInput;
@@ -49,8 +47,6 @@
 	 *
 	 * @param {string} taxonomyName
 	 * @param {Object} checkbox
-	 *
-	 * @returns {void}
 	 */
 	function createPrimaryTermElements( taxonomyName, checkbox ) {
 		var label, html;
@@ -69,8 +65,6 @@
 	 * Updates the primary term selectors/indicators for a certain taxonomy
 	 *
 	 * @param {string} taxonomyName
-	 *
-	 * @returns {void}
 	 */
 	function updatePrimaryTermSelectors( taxonomyName ) {
 		var checkedTerms, uncheckedTerms;
@@ -78,24 +72,22 @@
 
 		checkedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked' );
 		uncheckedTerms = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:not(:checked)' );
-
-		// Remove all classes for a consistent experience
-		checkedTerms.add( uncheckedTerms ).closest( "li" )
-			.removeClass( "wpseo-term-unchecked" )
-			.removeClass( "wpseo-primary-term" )
-			.removeClass( "wpseo-non-primary-term" );
+        $( "#" + taxonomyName + 'checklist li').removeClass("wpseo-term-unchecked wpseo-primary-term wpseo-non-primary-term");
 
 		$( ".wpseo-primary-category-label" ).remove();
 
 		// If there is only one term selected we don't want to show our interface.
 		if ( checkedTerms.length <= 1 ) {
-			checkedTerms.add( uncheckedTerms ).closest( "li" ).addClass( "wpseo-term-unchecked" );
+            $( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
 			return;
-		}
+		} else {
+            $( "#" + taxonomyName + 'checklist li').addClass("wpseo-term-unchecked");
+        }
 
 		checkedTerms.each( function( i, term ) {
 			term = $( term );
 			listItem = term.closest( "li" );
+            listItem.removeClass("wpseo-term-unchecked");
 
 			// Create our interface elements if they don't exist.
 			if ( ! hasPrimaryTermElements( term ) ) {
@@ -115,17 +107,12 @@
 				listItem.addClass( "wpseo-non-primary-term" );
 			}
 		} );
-
-		// Hide our interface elements on all unchecked checkboxes.
-		uncheckedTerms.closest( "li" ).addClass( "wpseo-term-unchecked" );
 	}
 
 	/**
 	 * Makes the first term primary for a certain taxonomy
 	 *
 	 * @param {string} taxonomyName
-	 *
-	 * @returns {void}
 	 */
 	function makeFirstTermPrimary( taxonomyName ) {
 		var firstTerm = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked:first' );
@@ -138,8 +125,6 @@
 	 * If we check a term while there is no primary term we make that one the primary term.
 	 *
 	 * @param {string} taxonomyName
-	 *
-	 * @returns {void}
 	 */
 	function ensurePrimaryTerm( taxonomyName ) {
 		if ( "" === getPrimaryTerm( taxonomyName ) ) {
@@ -151,7 +136,7 @@
 	 * Returns the term checkbox handler for a certain taxonomy name
 	 *
 	 * @param {string} taxonomyName
-	 * @returns {Function}
+	 * @return {Function}
 	 */
 	function termCheckboxHandler( taxonomyName ) {
 		return function() {

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -49,6 +49,8 @@
 	 *
 	 * @param {string} taxonomyName
 	 * @param {Object} checkbox
+	 *
+	 * @returns {void}
 	 */
 	function createPrimaryTermElements( taxonomyName, checkbox ) {
 		var label, html;
@@ -67,6 +69,8 @@
 	 * Updates the primary term selectors/indicators for a certain taxonomy.
 	 *
 	 * @param {string} taxonomyName
+	 *
+	 * @returns {void}
 	 */
 	function updatePrimaryTermSelectors( taxonomyName ) {
 		var checkedTerms;
@@ -114,6 +118,8 @@
 	 * Makes the first term primary for a certain taxonomy.
 	 *
 	 * @param {string} taxonomyName
+	 *
+	 * @returns {void}
 	 */
 	function makeFirstTermPrimary( taxonomyName ) {
 		var firstTerm = $( "#" + taxonomyName + 'checklist input[type="checkbox"]:checked:first' );
@@ -126,6 +132,8 @@
 	 * If we check a term while there is no primary term we make that one the primary term.
 	 *
 	 * @param {string} taxonomyName
+	 *
+	 * @returns {void}
 	 */
 	function ensurePrimaryTerm( taxonomyName ) {
 		if ( "" === getPrimaryTerm( taxonomyName ) ) {


### PR DESCRIPTION
## Summary

Original issue: #5569

This PR can be summarized in the following changelog entry:

## Relevant technical choices:
Not applicable.

## Test instructions

This PR can be tested by following these steps:
1. Use wp term generate to generate 2000+ categories.
2. Create a new post and select a category for the post. See how much time it takes. Also take note of how selecting the categories behave.
3. Now switch to the branch from this PR. Build the JS and see if the correct JS is loaded(and not one from the cache)
3. Now create a new post and add some categories. It should be quicker now.
4. Play around with electing different categories and see if everything behaves like it should.

Fixes #5569
Replaces #5801