### PR TITLE
Update the metabox email support heading level

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -63,7 +63,7 @@ class WPSEO_Help_Center {
 			'<a href="https://yoast.com/wordpress/plugins/seo-premium/#utm_source=wordpress-seo-metabox&utm_medium=popup&utm_campaign=multiple-keywords">Yoast SEO Premium</a>',
 			'yoast.com' );
 
-		$premium_popup                    = new WPSEO_Premium_Popup( 'contact-support', 'h2', $popup_title, $popup_content );
+		$premium_popup                    = new WPSEO_Premium_Popup( 'contact-support', 'h3', $popup_title, $popup_content );
 		$contact_support_help_center_item = new WPSEO_Help_Center_Item(
 			'contact-support',
 			__( 'Email support', 'wordpress-seo' ),


### PR DESCRIPTION
Fixes #5816 

Changes the heading level from h2 to h3. For visual purposes, it could be styled differently but the heading should stay as `<h3>`.

![screen shot 2016-10-07 at 10 58 44](https://cloud.githubusercontent.com/assets/1682452/19185123/857d9162-8c80-11e6-808f-1da78518e8c8.png)

![screen shot 2016-10-07 at 11 22 59](https://cloud.githubusercontent.com/assets/1682452/19185124/8584ab96-8c80-11e6-877b-98e3ae1f3d80.png)
