### PR TITLE
Always use https for the mailchimp signup.

### DIFF
--- a/admin/config-ui/fields/class-field-mailchimp-signup.php
+++ b/admin/config-ui/fields/class-field-mailchimp-signup.php
@@ -20,7 +20,7 @@ class WPSEO_Config_Field_Mailchimp_Signup extends WPSEO_Config_Field {
 		$this->set_property( 'title' , __( 'Newsletter signup', 'wordpress-seo' ) );
 		$this->set_property( 'label', __( 'If you would like us to keep you up-to-date regarding Yoast SEO, other plugins by Yoast and major news in the world of SEO, subscribe to our newsletter:', 'wordpress-seo' ) );
 
-		$this->set_property( 'mailchimpActionUrl', 'http://yoast.us1.list-manage1.com/subscribe/post-json?u=ffa93edfe21752c921f860358&id=972f1c9122' );
+		$this->set_property( 'mailchimpActionUrl', 'https://yoast.us1.list-manage.com/subscribe/post-json?u=ffa93edfe21752c921f860358&id=972f1c9122' );
 		$this->set_property( 'currentUserEmail', $user_email );
 		$this->set_property( 'userName', trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ) );
 	}


### PR DESCRIPTION
When request is done on a http website, it is aborted because of mixed content. This pull request forces the request to be done on https always.

I used https://www.ostraining.com/blog/coding/mailchimp-forms-ssl/ for inspiration.

