### PR TITLE
Remove component creation to initialize function

### DIFF
--- a/admin/config-ui/class-configuration-components.php
+++ b/admin/config-ui/class-configuration-components.php
@@ -15,9 +15,9 @@ class WPSEO_Configuration_Components {
 	protected $adapter;
 
 	/**
-	 * WPSEO_Configuration_Components constructor.
+	 * Add default components.
 	 */
-	public function __construct() {
+	public function initialize() {
 		$this->add_component( new WPSEO_Config_Component_Connect_Google_Search_Console() );
 		$this->add_component( new WPSEO_Config_Component_Mailchimp_Signup() );
 	}

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -105,6 +105,8 @@ class WPSEO_Configuration_Service {
 	 * @return array List of settings.
 	 */
 	public function get_configuration() {
+		$this->components->initialize();
+
 		$fields = $this->storage->retrieve();
 		$steps  = $this->structure->retrieve();
 
@@ -122,6 +124,8 @@ class WPSEO_Configuration_Service {
 	 * @return array List of feedback per option if saving succeeded.
 	 */
 	public function set_configuration( WP_REST_Request $request ) {
+		$this->components->initialize();
+
 		return $this->storage->store( $request->get_json_params() );
 	}
 }

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -34,11 +34,6 @@ class WPSEO_Configuration_Service {
 	 * Register the service and boot handlers
 	 */
 	public function initialize() {
-		$this->storage->set_adapter( $this->adapter );
-		$this->storage->add_default_fields();
-
-		$this->components->set_storage( $this->storage );
-
 		$this->endpoint->register();
 	}
 
@@ -100,12 +95,23 @@ class WPSEO_Configuration_Service {
 	}
 
 	/**
+	 * Populate the configuration
+	 */
+	protected function populate_configuration() {
+		$this->storage->set_adapter( $this->adapter );
+		$this->storage->add_default_fields();
+
+		$this->components->initialize();
+		$this->components->set_storage( $this->storage );
+	}
+
+	/**
 	 * Used by endpoint to retrieve configuration
 	 *
 	 * @return array List of settings.
 	 */
 	public function get_configuration() {
-		$this->components->initialize();
+		$this->populate_configuration();
 
 		$fields = $this->storage->retrieve();
 		$steps  = $this->structure->retrieve();
@@ -124,7 +130,7 @@ class WPSEO_Configuration_Service {
 	 * @return array List of feedback per option if saving succeeded.
 	 */
 	public function set_configuration( WP_REST_Request $request ) {
-		$this->components->initialize();
+		$this->populate_configuration();
 
 		return $this->storage->store( $request->get_json_params() );
 	}

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -13,10 +13,7 @@ class WPSEO_Configuration_Components_Mock extends WPSEO_Configuration_Components
 	 *
 	 * Removes default registrations
 	 */
-	public function __construct( $execute_default_constructor = false ) {
-		if ( $execute_default_constructor ) {
-			parent::__construct();
-		}
+	public function __construct() {
 	}
 
 	/**
@@ -60,7 +57,8 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Components::__construct()
 	 */
 	public function test_constructor() {
-		$components = new WPSEO_Configuration_Components_Mock( true );
+		$components = new WPSEO_Configuration_Components_Mock();
+		$components->initialize();
 		$list       = $components->get_components();
 
 		$this->assertEquals( 2, count( $list ) );

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -133,10 +133,6 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Service::initialize()
 	 */
 	public function test_initialize_functions() {
-		$adapter = $this
-			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->getMock();
-
 		$endpoint = $this
 			->getMockBuilder( 'WPSEO_Configuration_Endpoint' )
 			->setMethods( array( 'register' ) )
@@ -146,35 +142,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 			->expects( $this->once() )
 			->method( 'register' );
 
-		$storage = $this
-			->getMockBuilder( 'WPSEO_Configuration_Storage' )
-			->setMethods( array( 'add_default_fields', 'set_adapter' ) )
-			->getMock();
-
-		$storage
-			->expects( $this->once() )
-			->method( 'add_default_fields' );
-
-		$storage
-			->expects( $this->once() )
-			->method( 'set_adapter' )
-			->with( $adapter );
-
-		$components = $this
-			->getMockBuilder( 'WPSEO_Configuration_Components' )
-			->setMethods( array( 'set_storage' ) )
-			->getMock();
-
-		$components
-			->expects( $this->once() )
-			->method( 'set_storage' )
-			->with( $storage );
-
-		$this->configuration_service->set_storage( $storage );
 		$this->configuration_service->set_endpoint( $endpoint );
-		$this->configuration_service->set_options_adapter( $adapter );
-		$this->configuration_service->set_components( $components );
-
 		$this->configuration_service->initialize();
 
 	}
@@ -187,6 +155,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	public function test_get_configuration() {
 		$storage   = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->setMethods( array( 'retrieve' ) )->getMock();
 		$structure = $this->getMockBuilder( 'WPSEO_Configuration_Structure' )->setMethods( array( 'retrieve' ) )->getMock();
+		$adapter = new WPSEO_Configuration_Options_Adapter();
 
 		$storage
 			->expects( $this->once() )
@@ -199,7 +168,9 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( array() ) );
 
 		$this->configuration_service->set_storage( $storage );
+		$this->configuration_service->set_options_adapter( $adapter );
 		$this->configuration_service->set_structure( $structure );
+		$this->configuration_service->set_components( new WPSEO_Configuration_Components() );
 
 		$result = $this->configuration_service->get_configuration();
 
@@ -243,6 +214,8 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 			->with( $expected );
 
 		$this->configuration_service->set_storage( $storage );
+		$this->configuration_service->set_options_adapter( new WPSEO_Configuration_Options_Adapter() );
+		$this->configuration_service->set_components( new WPSEO_Configuration_Components() );
 		$this->configuration_service->set_configuration( $data );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Fixes a bug where the Google API is loaded on every page request

## Test instructions

This PR can be tested by following these steps:

* Loading a page that is not the configuration wizard page and determining that the include path has not been altered to match to Google API vendor folder.

Fixes #5735

Register the components only on retrieval or saving of config