### PR TITLE
Check WP version compatibility on term edit pages. 

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -184,6 +184,7 @@ class WPSEO_Taxonomy {
 	 * Output the WordPress editor.
 	 */
 	public function custom_category_description_editor() {
+
 		if ( ! $this->show_metabox() ) {
 			return;
 		}

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -35,14 +35,8 @@ class WPSEO_Taxonomy {
 		add_action( 'init', array( $this, 'custom_category_descriptions_allow_html' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-		// Needs a hook that runs before the description field. Prior to WP version 4.5 we need to use edit_form as
-		// term_edit_form_top was introduced in WP 4.5. This can be removed after <4.5 is no longer supported.
-		if ( version_compare( $GLOBALS['wp_version'], '4.5', '<' ) ) {
-			add_action( "{$this->taxonomy}_edit_form", array( $this, 'custom_category_description_editor' ) );
-		}
-		else {
-			add_action( "{$this->taxonomy}_term_edit_form_top", array( $this, 'custom_category_description_editor' ) );
-		}
+		$this->insert_description_field_editor();
+
 		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
 
 		if ( self::is_term_overview( $GLOBALS['pagenow'] ) ) {
@@ -332,6 +326,23 @@ class WPSEO_Taxonomy {
 		}
 
 		return $cached_replacement_vars;
+	}
+
+	/**
+	 * Adds custom category description editor.
+	 * Needs a hook that runs before the description field. Prior to WP version 4.5 we need to use edit_form as
+	 * term_edit_form_top was introduced in WP 4.5. This can be removed after <4.5 is no longer supported.
+	 *
+	 * @return {void}
+	 */
+	private function insert_description_field_editor() {
+		if ( version_compare( $GLOBALS['wp_version'], '4.5', '<' ) ) {
+
+			add_action( "{$this->taxonomy}_edit_form", array( $this, 'custom_category_description_editor' ) );
+			return;
+		}
+
+		add_action( "{$this->taxonomy}_term_edit_form_top", array( $this, 'custom_category_description_editor' ) );
 	}
 
 	/********************** DEPRECATED METHODS **********************/

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -39,7 +39,8 @@ class WPSEO_Taxonomy {
 		// term_edit_form_top was introduced in WP 4.5. This can be removed after <4.5 is no longer supported.
 		if ( version_compare( $GLOBALS['wp_version'], '4.5', '<' ) ) {
 			add_action( "{$this->taxonomy}_edit_form", array( $this, 'custom_category_description_editor' ) );
-		} else {
+		}
+		else {
 			add_action( "{$this->taxonomy}_term_edit_form_top", array( $this, 'custom_category_description_editor' ) );
 		}
 		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -337,7 +337,6 @@ class WPSEO_Taxonomy {
 	 */
 	private function insert_description_field_editor() {
 		if ( version_compare( $GLOBALS['wp_version'], '4.5', '<' ) ) {
-
 			add_action( "{$this->taxonomy}_edit_form", array( $this, 'custom_category_description_editor' ) );
 			return;
 		}

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -35,8 +35,13 @@ class WPSEO_Taxonomy {
 		add_action( 'init', array( $this, 'custom_category_descriptions_allow_html' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-		// Needs a hook that runs before the description field.
-		add_action( "{$this->taxonomy}_term_edit_form_top", array( $this, 'custom_category_description_editor' ) );
+		// Needs a hook that runs before the description field. Prior to WP version 4.5 we need to use edit_form as
+		// term_edit_form_top was introduced in WP 4.5. This can be removed after <4.5 is no longer supported.
+		if ( version_compare( $GLOBALS['wp_version'], '4.5', '<' ) ) {
+			add_action( "{$this->taxonomy}_edit_form", array( $this, 'custom_category_description_editor' ) );
+		} else {
+			add_action( "{$this->taxonomy}_term_edit_form_top", array( $this, 'custom_category_description_editor' ) );
+		}
 		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
 
 		if ( self::is_term_overview( $GLOBALS['pagenow'] ) ) {
@@ -179,7 +184,6 @@ class WPSEO_Taxonomy {
 	 * Output the WordPress editor.
 	 */
 	public function custom_category_description_editor() {
-
 		if ( ! $this->show_metabox() ) {
 			return;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Fixes a bug where the description field was gone on category pages. 

## Relevant technical choices:

* Added a check to class-taxonomy to check the WP version

## Test instructions

This PR can be tested by following these steps:

* Use an older WP version ( must be lower than 4.5 )
* Go to a term edit page (ie category). 
* You should see an editor for the description field. 

Fixes #5725 
