### PR TITLE
Fix missing heading icons and CSS classes consistency.

### DIFF
--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -85,26 +85,26 @@ class WPSEO_Taxonomy_Fields_Presenter {
 
 		switch ( $field_type ) {
 			case 'div' :
-				$field .= '<div id="' . $field_name . '"' . $aria_describedby . '></div>';
+				$field .= '<div id="' . $field_name . '"></div>';
 				break;
 
 			case 'snippetpreview':
 				$field .= '<div id="wpseo_snippet" class="wpseosnippet"></div>';
 				break;
 			case 'pageanalysis' :
-				$field .= '<div id="pageanalysis-section"' . $aria_describedby . '>';
-				$field .= '<section class="snippet-editor__preview yoast-section" id="wpseo-pageanalysis-section">';
-				$field .= '<h3 class="snippet-editor__heading snippet-editor__heading-icon snippet-editor__heading-icon-list">' . __( 'Analysis', 'wordpress-seo' ) .'</h3>';
+				$field .= '<div id="pageanalysis">';
+				$field .= '<section class="yoast-section" id="wpseo-pageanalysis-section">';
+				$field .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-list">' . __( 'Analysis', 'wordpress-seo' ) .'</h3>';
 				$field .= '<div id="wpseo_analysis"></div>';
 				$field .= '</section>';
 				$field .= '</div>';
 				break;
 			case 'focuskeyword':
-				$field .= '<div id="wpseofocuskeyword"' . $aria_describedby . '>';
-				$field .= '<section class="snippet-editor__preview yoast-section" id="wpseo-focuskeyword-section">';
-				$field .= '<h3 class="snippet-editor__heading snippet-editor__heading-icon snippet-editor__heading-icon-key">' . __( 'Focus keyword', 'wordpress-seo' ) . '</h3>';
+				$field .= '<div id="wpseofocuskeyword">';
+				$field .= '<section class="yoast-section" id="wpseo-focuskeyword-section">';
+				$field .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-key">' . __( 'Focus keyword', 'wordpress-seo' ) . '</h3>';
 				$field .= '<label for="' . $field_name . '" class="screen-reader-text">' . __( 'Enter a focus keyword', 'wordpress-seo' ) . '</label>';
-				$field .= '<input type="text" id="' . $field_name . '" autocomplete="off" name="' . $field_name . '" value="' . esc_attr( $field_value ) . '" class="large-text' . $class . '"' . $aria_describedby . '/><br />';
+				$field .= '<input type="text" id="' . $field_name . '" autocomplete="off" name="' . $field_name . '" value="' . esc_attr( $field_value ) . '" class="large-text' . $class . '"/><br />';
 				$field .= '</section>';
 				$field .= '</div>';
 				break;


### PR DESCRIPTION
Fixes #5823 

- tries to use the same CSS classes used in the post metabox
- thus, restores the missing heading icons
- removes some `aria-describedby` attributes set on not focusable elements 