### PR TITLE
Replaced references to the snippet-editor CSS class with yoast-section.

### DIFF
--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -93,16 +93,16 @@ class WPSEO_Taxonomy_Fields_Presenter {
 				break;
 			case 'pageanalysis' :
 				$field .= '<div id="pageanalysis-section"' . $aria_describedby . '>';
-				$field .= '<section class="snippet-editor__preview yoast-section" id="wpseo-pageanalysis-section">';
-				$field .= '<h3 class="snippet-editor__heading snippet-editor__heading-icon snippet-editor__heading-icon-list">' . __( 'Analysis', 'wordpress-seo' ) .'</h3>';
+				$field .= '<section class="yoast-section" id="wpseo-pageanalysis-section">';
+				$field .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-list">' . __( 'Analysis', 'wordpress-seo' ) .'</h3>';
 				$field .= '<div id="wpseo_analysis"></div>';
 				$field .= '</section>';
 				$field .= '</div>';
 				break;
 			case 'focuskeyword':
 				$field .= '<div id="wpseofocuskeyword"' . $aria_describedby . '>';
-				$field .= '<section class="snippet-editor__preview yoast-section" id="wpseo-focuskeyword-section">';
-				$field .= '<h3 class="snippet-editor__heading snippet-editor__heading-icon snippet-editor__heading-icon-key">' . __( 'Focus keyword', 'wordpress-seo' ) . '</h3>';
+				$field .= '<section class="yoast-section" id="wpseo-focuskeyword-section">';
+				$field .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-key">' . __( 'Focus keyword', 'wordpress-seo' ) . '</h3>';
 				$field .= '<label for="' . $field_name . '" class="screen-reader-text">' . __( 'Enter a focus keyword', 'wordpress-seo' ) . '</label>';
 				$field .= '<input type="text" id="' . $field_name . '" autocomplete="off" name="' . $field_name . '" value="' . esc_attr( $field_value ) . '" class="large-text' . $class . '"' . $aria_describedby . '/><br />';
 				$field .= '</section>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Replaces the old references to `snippet-editor` CSS classes with references to `yoast-section`.

## Test instructions

This PR can be tested by following these steps:

* Open a taxonomy edit page.
* Observe that the icons are now visible for both keyword and analysis sections.

Fixes #5823 

