### PR TITLE
Fix premium detection

### DIFF
--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -26,9 +26,7 @@ class WPSEO_Product_Upsell_Notice {
 	 * Checks if the notice should be added or removed.
 	 */
 	public function initialize() {
-
-		$features = new WPSEO_Features();
-		if ( $features->is_premium() || $this->is_notice_dismissed() ) {
+		if ( $this->is_notice_dismissed() ) {
 			$this->remove_notification();
 
 			return;

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -57,11 +57,8 @@ class WPSEO_Upgrade {
 		}
 
 		// Since 3.7.
-		$features = new WPSEO_Features();
-		if ( ! $features->is_premium() ) {
-			$upsell_notice = new WPSEO_Product_Upsell_Notice();
-			$upsell_notice->set_upgrade_notice();
-		}
+		$upsell_notice = new WPSEO_Product_Upsell_Notice();
+		$upsell_notice->set_upgrade_notice();
 
 		/**
 		 * Filter: 'wpseo_run_upgrade' - Runs the upgrade hook which are dependent on Yoast SEO

--- a/inc/class-wpseo-features.php
+++ b/inc/class-wpseo-features.php
@@ -15,7 +15,7 @@ class WPSEO_Features {
 	 * @return bool
 	 */
 	public function is_premium() {
-		return ( defined( 'WPSEO_Premium_File' ) );
+		return ( defined( 'WPSEO_PREMIUM_FILE' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
n/a

## Test instructions

This PR can be tested by following these steps:

* Merge this into a branch on premium, make sure that you are not seing the premium upsell in the 5star question. But you are still seeing the notification
* In free, make sure you get the question and also the premium upsell

PS. This is already present in premium, because we found it just before release.