### PR TITLE
Focus keyword field: use input event instead of keyup

### DIFF
--- a/js/src/analysis/usedKeywords.js
+++ b/js/src/analysis/usedKeywords.js
@@ -45,7 +45,7 @@ UsedKeywords.prototype.init = function() {
 	var eventHandler = _debounce( this.keywordChangeHandler.bind( this ), 500 );
 
 	this._plugin.registerPlugin();
-	this._focusKeywordElement.on( "keyup", eventHandler );
+	this._focusKeywordElement.on( "input", eventHandler );
 };
 
 /**


### PR DESCRIPTION
Fixes #4184 