### PR TITLE
Avoid x symbol and px abbreviations

### DIFF
--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -48,8 +48,10 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 
 		// Source: https://blog.bufferapp.com/ideal-image-sizes-social-media-posts.
 		$recommended_image_sizes = array(
-			'opengraph'   => __( '1200 by 630', 'wordpress-seo' ), // Source: https://developers.facebook.com/docs/sharing/best-practices#images.
-			'twitter'     => __( '1024 by 512', 'wordpress-seo' ),
+			/* translators: %1$s expands to the image recommended width, %2$s to its height. */
+			'opengraph'   => sprintf( __( '%1$s by %2$s', 'wordpress-seo' ), '1200', '630' ), // Source: https://developers.facebook.com/docs/sharing/best-practices#images.
+			/* translators: %1$s expands to the image recommended width, %2$s to its height. */
+			'twitter'     => sprintf( __( '%1$s by %2$s', 'wordpress-seo' ), '1024', '512' ),
 		);
 
 		foreach ( $social_networks as $network => $label ) {

--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -37,7 +37,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 		/* translators: %s expands to the social network's name */
 		$image_text       = __( 'If you want to override the image used on %s for this post, upload / choose an image or add the URL here.', 'wordpress-seo' );
 		/* translators: %1$s expands to the social network, %2$s to the recommended image size */
-		$image_size_text  = __( 'The recommended image size for %1$s is %2$spx.', 'wordpress-seo' );
+		$image_size_text  = __( 'The recommended image size for %1$s is %2$s pixels.', 'wordpress-seo' );
 
 		$options = WPSEO_Options::get_option( 'wpseo_social' );
 
@@ -48,8 +48,8 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 
 		// Source: https://blog.bufferapp.com/ideal-image-sizes-social-media-posts.
 		$recommended_image_sizes = array(
-			'opengraph'   => '1200 × 630', // Source: https://developers.facebook.com/docs/sharing/best-practices#images.
-			'twitter'     => '1024 × 512',
+			'opengraph'   => __( '1200 by 630', 'wordpress-seo' ), // Source: https://developers.facebook.com/docs/sharing/best-practices#images.
+			'twitter'     => __( '1024 by 512', 'wordpress-seo' ),
 		);
 
 		foreach ( $social_networks as $network => $label ) {

--- a/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/admin/taxonomy/class-taxonomy-social-fields.php
@@ -60,7 +60,7 @@ class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
 				/* translators: %1$s expands to the social network name */
 				sprintf( esc_html__( 'If you want to use an image for sharing on %1$s, you can upload / choose an image or add the image URL here.', 'wordpress-seo' ), $settings['label'] ) . '<br />' .
 				/* translators: %1$s expands to the social network name, %2$s expands to the image size */
-				sprintf( __( 'The recommended image size for %1$s is %2$spx.', 'wordpress-seo' ), $settings['label'], $settings['size'] ),
+				sprintf( __( 'The recommended image size for %1$s is %2$s pixels.', 'wordpress-seo' ), $settings['label'], $settings['size'] ),
 				'upload'
 			),
 		);
@@ -90,8 +90,8 @@ class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
 	private function get_social_networks() {
 		$social_networks = array(
 			// Source: https://developers.facebook.com/docs/sharing/best-practices#images.
-			'opengraph'  => $this->social_network( 'opengraph', __( 'Facebook', 'wordpress-seo' ), '1200 × 630' ),
-			'twitter'    => $this->social_network( 'twitter', __( 'Twitter', 'wordpress-seo' ), '1024 × 512' ),
+			'opengraph'  => $this->social_network( 'opengraph', __( 'Facebook', 'wordpress-seo' ), __( '1200 by 630', 'wordpress-seo' ) ),
+			'twitter'    => $this->social_network( 'twitter', __( 'Twitter', 'wordpress-seo' ), __( '1024 by 512', 'wordpress-seo' ) ),
 		);
 		$social_networks = $this->filter_social_networks( $social_networks );
 

--- a/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/admin/taxonomy/class-taxonomy-social-fields.php
@@ -90,8 +90,14 @@ class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
 	private function get_social_networks() {
 		$social_networks = array(
 			// Source: https://developers.facebook.com/docs/sharing/best-practices#images.
-			'opengraph'  => $this->social_network( 'opengraph', __( 'Facebook', 'wordpress-seo' ), __( '1200 by 630', 'wordpress-seo' ) ),
-			'twitter'    => $this->social_network( 'twitter', __( 'Twitter', 'wordpress-seo' ), __( '1024 by 512', 'wordpress-seo' ) ),
+			'opengraph' => $this->social_network( 'opengraph', __( 'Facebook', 'wordpress-seo' ), sprintf(
+				/* translators: %1$s expands to the image recommended width, %2$s to its height. */
+				__( '%1$s by %2$s', 'wordpress-seo' ), '1200', '630'
+			) ),
+			'twitter'   => $this->social_network( 'twitter', __( 'Twitter', 'wordpress-seo' ), sprintf(
+				/* translators: %1$s expands to the image recommended width, %2$s to its height. */
+				__( '%1$s by %2$s', 'wordpress-seo' ), '1024', '512'
+			) ),
 		);
 		$social_networks = $this->filter_social_networks( $social_networks );
 


### PR DESCRIPTION
Fixes #4573 

For accessibility, we should prefer natural language wherever possible and avoid symbols and abbreviations. Question: does this need translators comments or it is clear enough? /cc @tacoverdo 