### PR TITLE
Change PUT to POST

### DIFF
--- a/admin/config-ui/class-configuration-endpoint.php
+++ b/admin/config-ui/class-configuration-endpoint.php
@@ -46,7 +46,7 @@ class WPSEO_Configuration_Endpoint {
 
 		// Register save changes.
 		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_STORE, array(
-			'methods'             => 'PUT',
+			'methods'             => 'POST',
 			'callback'            => array(
 				$this->service,
 				'set_configuration',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Using `POST` instead of `PUT`, because of some webservers having `PUT` requests disabled. :thinking: 

## Test instructions

This PR can be tested by following these steps:

* Open your console while proceeding through the installation wizard and check if there is a POST-request being executed. Run the wizard again to verify if all the values are saved correctly.

Fixes #5839 
Fixes #5898 
This issue might fix the issues: #5898, #5892, #5754 

Needs: https://github.com/Yoast/yoast-components/pull/102 
