### PR TITLE
bbPress & BuddyPress compatibility fix

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -367,18 +367,18 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 			new Yoast_Plugin_Conflict_Ajax();
 
 			if ( filter_input( INPUT_POST, 'action' ) === 'inline-save' ) {
-				add_action( 'plugins_loaded', 'wpseo_admin_init', 15 );
+				add_action( 'admin_init', 'wpseo_admin_init', 15 );
 			}
 		}
 		else {
-			add_action( 'plugins_loaded', 'wpseo_admin_init', 15 );
+			add_action( 'admin_init', 'wpseo_admin_init', 15 );
 		}
 	}
 	else {
 		add_action( 'plugins_loaded', 'wpseo_frontend_init', 15 );
 	}
 
-	add_action( 'plugins_loaded', 'load_yoast_notifications' );
+	add_action( 'init', 'load_yoast_notifications' );
 }
 
 // Activation and deactivation hook.


### PR DESCRIPTION
Path to fix the warning "The current user is being initialized without
using $wp->init()" after installing bbPress or BuddyPress.