### PR TITLE
Fixed incorrect timezone for zero offset

### DIFF
--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -74,7 +74,7 @@ class WPSEO_Sitemap_Timezone {
 		}
 
 		// Get UTC offset, if it isn't set then return UTC.
-		if ( 0 === ( $utc_offset = get_option( 'gmt_offset', 0 ) ) ) {
+		if ( 0 === ( $utc_offset = (int) get_option( 'gmt_offset', 0 ) ) ) {
 			return 'UTC';
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed incorrect timezone for zero offset case (Atlantic/Azores instead of UTC).

## Relevant technical choices:

* cast `gmt_offset` option return to int, could be string zero `"0"`

## Test instructions

This PR can be tested by following these steps:

* observer tests passing