### PR TITLE
Fix PHP 7.1 build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 matrix:
   allow_failures:
     - php: hhvm
-    - php: 7.1
   include:
     - php: 7.0
       env: WP_VERSION=master WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - php: 5.3
       env: WP_VERSION=4.6
     - php: 7.1
-      env: WP_VERSION=trunk
+      env: WP_VERSION=master
     - php: hhvm
       env: WP_VERSION=4.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - php: 5.3
       env: WP_VERSION=4.6
     - php: 7.1
-      env: WP_VERSION=4.6
+      env: WP_VERSION=trunk
     - php: hhvm
       env: WP_VERSION=4.6
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Changed to the master branch of WP in Git (master=svn trunk), to make sure WP is compatible with PHP 7.1. Also removed 7.1 from allowed failures. At this moment trunk will become WP 4.7 which should be compatible with 7.1

## Test instructions

This PR can be tested by following these steps:

* Check if the travis build will past.

Fixes #5662 
