### PR TITLE
Extend the search post to search get method.

### DIFF
--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -223,7 +223,7 @@ class WPSEO_GSC {
 		}
 
 		// When there is nothing being search and there is no search param in the url, break this method.
-		if( $search_string === '' && filter_input( INPUT_GET, 's' ) === null ) {
+		if ( $search_string === '' && filter_input( INPUT_GET, 's' ) === null ) {
 			return;
 		}
 

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -216,13 +216,23 @@ class WPSEO_GSC {
 	 * Catch the redirects search post and redirect it to a search get
 	 */
 	private function list_table_search_post_to_get() {
-		if ( ( $search_string = filter_input( INPUT_POST, 's' ) ) !== null ) {
-			$url = ( $search_string !== '' ) ? add_query_arg( 's', $search_string ) : remove_query_arg( 's' );
+		$search_string = filter_input( INPUT_POST, 's' );
 
-			// Do the redirect.
-			wp_redirect( $url );
-			exit;
+		if ( $search_string === null ) {
+			return;
 		}
+
+		// When there is nothing being search and there is no search param in the url, break this method.
+		if( $search_string === '' && filter_input( INPUT_GET, 's' ) === null ) {
+			return;
+		}
+
+		$url = ( $search_string !== '' ) ? add_query_arg( 's', $search_string ) : remove_query_arg( 's' );
+
+		// Do the redirect.
+		wp_redirect( $url );
+		exit;
+
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Check if there is a `get` attribute representing a searchstring before converting the post to a request string. 
In the current situation we are removing a searchstring from the request uri in cases when there is no searchstring being posted, resulting in a permanent redirect on doing the bulk actions

## Test instructions

This PR can be tested by following these steps:

* check some GSC issues and perform the bulk action `mark as fixed`

Fixes #3412 

