### PR TITLE
Change the coverage into an existing method.

### DIFF
--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -9,14 +9,6 @@
 class WPSEO_Configuration_Components_Mock extends WPSEO_Configuration_Components {
 
 	/**
-	 * WPSEO_Configuration_Components_Mock constructor.
-	 *
-	 * Removes default registrations
-	 */
-	public function __construct() {
-	}
-
-	/**
 	 * Retrieve all components
 	 *
 	 * @return array
@@ -54,7 +46,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Components::__construct()
+	 * @covers WPSEO_Configuration_Components::initialize()
 	 */
 	public function test_constructor() {
 		$components = new WPSEO_Configuration_Components_Mock();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Change the `@covers` for `__construct` to `initialize`. Because `__construct` has been removed.

## Test instructions

This PR can be tested by following these steps:

* Travis shouldn't give any coverage errors.

