### PR TITLE
Make the `WPSEO_OpenGraph::add_opengraph_namespace()` method more robust

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -23,7 +23,7 @@ class WPSEO_OpenGraph {
 			add_filter( 'fb_meta_tags', array( $this, 'facebook_filter' ), 10, 1 );
 		}
 		else {
-			add_filter( 'language_attributes', array( $this, 'add_opengraph_namespace' ) );
+			add_filter( 'language_attributes', array( $this, 'add_opengraph_namespace' ), 15 );
 
 			add_action( 'wpseo_opengraph', array( $this, 'locale' ), 1 );
 			add_action( 'wpseo_opengraph', array( $this, 'type' ), 5 );
@@ -114,7 +114,25 @@ class WPSEO_OpenGraph {
 	 * @return string
 	 */
 	public function add_opengraph_namespace( $input ) {
-		return $input . ' prefix="og: http://ogp.me/ns#' . ( ( $this->options['fbadminapp'] != 0 || ( is_array( $this->options['fb_admins'] ) && $this->options['fb_admins'] !== array() ) ) ? ' fb: http://ogp.me/ns/fb#' : '' ) . '"';
+		$namespaces = array(
+			'og: http://ogp.me/ns#',
+		);
+		if ( $this->options['fbadminapp'] != 0 || ( is_array( $this->options['fb_admins'] ) && $this->options['fb_admins'] !== array() ) ) {
+			$namespaces[] = 'fb: http://ogp.me/ns/fb#';
+		}
+
+		$namespace_string = implode( ' ', array_unique( apply_filters( 'wpseo_html_namespaces', $namespaces ) ) );
+
+		if ( strpos( $input, ' prefix=' ) !== false ) {
+			$regex   = '`prefix=([\'"])(.+?)\1`';
+			$replace = 'prefix="$2 ' . $namespace_string . '"';
+			$input   = preg_replace( $regex, $replace, $input );
+		}
+		else {
+			$input .= ' prefix="' . $namespace_string . '"';
+		}
+
+		return $input;
 	}
 
 	/**

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -121,7 +121,18 @@ class WPSEO_OpenGraph {
 			$namespaces[] = 'fb: http://ogp.me/ns/fb#';
 		}
 
-		$namespace_string = implode( ' ', array_unique( apply_filters( 'wpseo_html_namespaces', $namespaces ) ) );
+		/**
+		 * Allow for adding additional namespaces to the <html> prefix attributes.
+		 *
+		 * @since 3.9.0
+		 *
+		 * @param array $namespaces Currently registered namespaces which are to be
+		 *                          added to the prefix attribute.
+		 *                          Namespaces are strings and have the following syntax:
+		 *                          ns: http://url.to.namespace/definition
+		 */
+		$namespaces       = apply_filters( 'wpseo_html_namespaces', $namespaces );
+		$namespace_string = implode( ' ', array_unique( $namespaces ) );
 
 		if ( strpos( $input, ' prefix=' ) !== false ) {
 			$regex   = '`prefix=([\'"])(.+?)\1`';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _Allow for other plugins and themes to more easily add html namespaces through the new `wpseo_html_namespaces` filter._
* _Prevent conflicts with other plugins/themes which also add html namespaces._

## Relevant technical choices:

The previous implementation of the `WPSEO_OpenGraph::add_opengraph_namespace()` method was not very flexible and could easily cause conflicts with other plugins which would use the WP `language_attributes` filter to add the `prefix` attribute.

The renewed implementation allows for other plugins - like VideoSEO - and themes to hook into the `wpseo_html_namespaces` filter to add more namespaces.

The renewed implementation also prevents conflicts when other plugins/themes would have already added a `prefix` attribute and will merge the values (without removing doubles!).

This is better than having two attributes with the same name as in that case - generally speaking - the second attribute will override the first.

I've changed the prio on the hook-in as well to make sure this method runs a bit later - after most other plugins/themes which may hook into this function, so the chances of other plugins breaking things afterwards is smaller.

## Test instructions

This PR can be tested by following these steps:

Environment: WP + WPSEO active.

### Verify start situation
* Start with the `trunk` branch of WPSEO
* Make sure you have opengraph enabled in the options.
* Open a single post page on the web frontend and view the page source. Near the very top of the page you should see a tag which looks like:
```html
<html lang="en-US" prefix="og: http://ogp.me/ns#" class="no-js">
```

### Verify the potential for breakage
* Add the following code to a test code plugin or to the theme `functions.php` file:
```php
add_filter( 'language_attributes', 'prefix_add_fb_namespace' );
function prefix_add_fb_namespace( $output ) {
	return $output . ' prefix="fb: http://ogp.me/ns/fb#"';
}
```
* Reload the page & view the source again. You should now see something like: 
```html
<html lang="en-US" prefix="fb: http://ogp.me/ns/fb#" prefix="og: http://ogp.me/ns#" class="no-js">
```

### Verify the fix
* Switch to this branch of WPSEO
* Reload the page again and view the source again. The tag should now read:
```html
<html lang="en-US" prefix="fb: http://ogp.me/ns/fb# og: http://ogp.me/ns#" class="no-js">
```
* Go back to the test code plugin/function.php file and add the following code:
```php
add_filter( 'wpseo_html_namespaces', 'prefix_add_yandex_namespace' );
function prefix_add_yandex_namespace( $namespaces ) {
	$namespaces[] = 'ya: http://webmaster.yandex.ru/vocabularies/';
	return $namespaces;
}
```
* Reload the page again and view the source again. The tag should now read:
```html
<html lang="en-US" prefix="fb: http://ogp.me/ns/fb# og: http://ogp.me/ns# ya: http://webmaster.yandex.ru/vocabularies/" class="no-js">
```