### PR TITLE
Update register_meta usage for WP 4.6

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -295,6 +295,7 @@ class WPSEO_Meta {
 		unset( $extra_fields );
 
 		$register = function_exists( 'register_meta' );
+		$installed_version = get_bloginfo( 'version' );
 
 		foreach ( self::$meta_fields as $subset => $field_group ) {
 			foreach ( $field_group as $key => $field_def ) {
@@ -304,7 +305,13 @@ class WPSEO_Meta {
 					 * function_exists as a precaution in case they remove it.
 					 */
 					if ( $register === true ) {
-						register_meta( 'post', self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ) );
+						if ( version_compare( $installed_version, '4.6', '>=' ) ) {
+							register_meta( 'post', self::$meta_prefix . $key, array(
+								'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
+							) );
+						} else {
+							register_meta( 'post', self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ) );
+						}
 					}
 					else {
 						add_filter( 'sanitize_post_meta_' . self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ), 10, 2 );

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -295,7 +295,6 @@ class WPSEO_Meta {
 		unset( $extra_fields );
 
 		$register = function_exists( 'register_meta' );
-		$installed_version = get_bloginfo( 'version' );
 
 		foreach ( self::$meta_fields as $subset => $field_group ) {
 			foreach ( $field_group as $key => $field_def ) {
@@ -305,14 +304,9 @@ class WPSEO_Meta {
 					 * function_exists as a precaution in case they remove it.
 					 */
 					if ( $register === true ) {
-						if ( version_compare( $installed_version, '4.6', '>=' ) ) {
-							register_meta( 'post', self::$meta_prefix . $key, array(
-								'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
-							) );
-						}
-						else {
-							register_meta( 'post', self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ) );
-						}
+						register_meta( 'post', self::$meta_prefix . $key, array(
+							'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
+						) );
 					}
 					else {
 						add_filter( 'sanitize_post_meta_' . self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ), 10, 2 );

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -309,7 +309,8 @@ class WPSEO_Meta {
 							register_meta( 'post', self::$meta_prefix . $key, array(
 								'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
 							) );
-						} else {
+						}
+						else {
 							register_meta( 'post', self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ) );
 						}
 					}


### PR DESCRIPTION
## Summary

Register meta to be compatible with WordPress 4.6
Towards #5152

## Relevant technical choices:

* Provides BC via a check for the installed version

## Test instructions

This PR can be tested by following these steps:

* Verify that all registered meta is present in the global `$wp_meta_keys` array.

Fixes #

Brings `register_meta` usage up to date with WP 4.6. Without this change, registered meta is not "considered completely registered. The callbacks will be registered, but the key will not be added to the global registry and register_meta() will return false." [source](https://make.wordpress.org/core/2016/07/20/additional-register_meta-changes-in-4-6/)