### PR TITLE
Change the working of the test.

### DIFF
--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -124,7 +124,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$result    = get_transient( $cache_key );
 
 		// Assert.
-		$this->assertEmpty( $result );
+		$this->assertTrue( empty( $result ) );
 	}
 
 	/**
@@ -146,7 +146,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$result          = get_transient( $index_cache_key );
 
 		// Assert.
-		$this->assertEmpty( $result );
+		$this->assertTrue( empty( $result ) );
 	}
 
 	/**
@@ -218,6 +218,6 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$result    = get_transient( $cache_key );
 
 		// Assert.
-		$this->assertEmpty( $result );
+		$this->assertTrue( empty( $result ) );
 	}
 }

--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -100,7 +100,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$content   = get_transient( $cache_key );
 
 		// Assert.
-		$this->assertEmpty( $content );
+		$this->assertTrue( empty( $content ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Use `assertTrue` with `empty($..)` as argument, to make it pass for PHP 7.1

## Test instructions

This PR can be tested by following these steps:

* Check if the tests are succeeding.

