### PR TITLE
Adds check for tinyMCE required iframe

### DIFF
--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -45,6 +45,18 @@ var termsTmceId = "description";
 	}
 
 	/**
+	 * Checks if the content_ifr iframe is available. TinyMCE needs this for getContent to be working.
+	 * If this element isn't loaded yet, it will let tinyMCE crash when calling getContent. Since tinyMCE
+	 * itself doesn't have a check for this and simply assumes the element is always there, we need
+	 * to do this check ourselves.
+	 *
+	 * @returns {boolean} Whether the element is found or not.
+	 */
+	function isTinyMCEBodyAvailable() {
+		return document.getElementById( "content_ifr" ) !== null;
+	}
+
+	/**
 	 * Returns whether or not a tinyMCE editor with the given ID is available.
 	 *
 	 * @param {string} editorID The ID of the tinyMCE editor.
@@ -83,7 +95,7 @@ var termsTmceId = "description";
 	function getContentTinyMce( content_id ) {
 		// if no TinyMce object available
 		var content = "";
-		if ( isTinyMCEAvailable( content_id ) === false ) {
+		if ( isTinyMCEAvailable( content_id ) === false || isTinyMCEBodyAvailable === false ) {
 			content = tinyMCEElementContent( content_id );
 		}
 		else {
@@ -93,7 +105,7 @@ var termsTmceId = "description";
 		return convertHtmlEntities( content );
 	}
 	/**
-	 * Adds an event handler to certain tinyMCE events
+	 * Adds an event handler to certain tinyMCE events.
 	 *
 	 * @param {string} editorId The ID for the tinyMCE editor.
 	 * @param {Array<string>} events The events to bind to.

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -95,7 +95,7 @@ var termsTmceId = "description";
 	function getContentTinyMce( content_id ) {
 		// if no TinyMce object available
 		var content = "";
-		if ( isTinyMCEAvailable( content_id ) === false || isTinyMCEBodyAvailable === false ) {
+		if ( isTinyMCEAvailable( content_id ) === false || isTinyMCEBodyAvailable() === false ) {
 			content = tinyMCEElementContent( content_id );
 		}
 		else {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Fixes a bug where tinyMCE would return an error when calling getContent().

## Relevant technical choices:
* Includes a check if the iframe tinyMCE uses exists. If it doesn't exist, we rely on the fallback to the original textarea element. 

## Test instructions

This PR can be tested by following these steps:

* Install visual composer
* Install the atelier theme
* Open a post, preferably one with some content. And see the tinyMCE error. If you don't see the error refresh a couple of times. The error doesn't show up on every load. 
* Switch to this branch and build the JS files.
* Refresh again and again and again and again, the error should not be present. 

Fixes #5742 
Fixes #5673
Fixes #5640
Fixes #5971