### PR TITLE
Updated parse_url() calls to wp_parse_url() where cleanly possible

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1011,7 +1011,7 @@ class WPSEO_Frontend {
 	private function base_url( $path = null ) {
 		$url = get_option( 'home' );
 
-		$parts = parse_url( $url );
+		$parts = wp_parse_url( $url );
 
 		$base_url = trailingslashit( $parts['scheme'] . '://' . $parts['host'] );
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -1070,7 +1070,7 @@ class WPSEO_OpenGraph_Image {
 
 		// If it's a relative URL, it's relative to the domain, not necessarily to the WordPress install, we
 		// want to preserve domain name and URL scheme (http / https) though.
-		$parsed_url = parse_url( home_url() );
+		$parsed_url = wp_parse_url( home_url() );
 		$img        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $img;
 
 		return $img;

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -474,7 +474,7 @@ class WPSEO_Twitter {
 		$img = apply_filters( 'wpseo_twitter_image', $img );
 
 		if ( WPSEO_Utils::is_url_relative( $img ) === true && $img[0] === '/' ) {
-			$parsed_url = parse_url( home_url() );
+			$parsed_url = wp_parse_url( home_url() );
 			$img        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $img;
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -661,7 +661,7 @@ class WPSEO_Utils {
 	 * @return mixed
 	 */
 	public static function format_url( $url ) {
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		$formatted_url = '';
 		if ( ! empty( $parsed_url['path'] ) ) {

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -29,7 +29,7 @@ class WPSEO_Sitemap_Image_Parser {
 	public function __construct() {
 
 		$this->home_url = home_url();
-		$parsed_home    = parse_url( $this->home_url );
+		$parsed_home    = wp_parse_url( $this->home_url );
 
 		if ( ! empty( $parsed_home['host'] ) ) {
 			$this->host = str_replace( 'www.', '', $parsed_home['host'] );

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -1028,7 +1028,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 				unset( $GLOBALS[ $v ] );
 			}
 		}
-		$parts = parse_url( $url );
+		$parts = wp_parse_url( $url );
 		if ( isset( $parts['scheme'] ) ) {
 			$req = isset( $parts['path'] ) ? $parts['path'] : '';
 			if ( isset( $parts['query'] ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Updated parse_url() calls to wp_parse_url()

## Relevant technical choices:

* parse_url() to wp_parse_url(), unless second argument is used, which will not be available until WP 4.7, see https://core.trac.wordpress.org/ticket/36356

## Test instructions

This PR can be tested by following these steps:

* PHPUnit tests pass

Fixes #6006

