### PR TITLE
Removed WP 4.3 from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       env: WP_VERSION=4.5
     - php: 7.0
       env: WP_VERSION=4.4
-    - php: 7.0
-      env: WP_VERSION=4.3
     - php: 5.6
       env: WP_VERSION=4.6
     - php: 5.5


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Removed WP 4.3 from Travis matrix

## Relevant technical choices:

* WP 4.3 no longer in supported versions.

## Test instructions

This PR can be tested by following these steps:

* Travis tests pass

See #6057

