### PR TITLE
Opengraph image filters

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -561,14 +561,26 @@ class WPSEO_OpenGraph {
 	 *
 	 * @param string|boolean $image Optional image URL.
 	 */
+
 	public function image( $image = false ) {
 		$opengraph_images = new WPSEO_OpenGraph_Image( $this->options, $image );
 
-		foreach ( $opengraph_images->get_images() as $img ) {
+		/**
+		 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph images of the page
+		 *
+		 */
+		$images = apply_filters( 'wpseo_opengraph_image', $opengraph_images->get_images() );
+
+		foreach ( $images as $img ) {
 			$this->og_tag( 'og:image', esc_url( $img ) );
 		}
 
 		$dimensions = $opengraph_images->get_dimensions();
+		/**
+		 * Filter: 'wpseo_opengraph_dimensions' - Allow changing the OpenGraph page images dimensions.
+		 *
+		 */
+		$dimensions = apply_filters( 'wpseo_opengraph_dimensions', $dimensions );
 
 		if ( ! empty( $dimensions['width'] ) ) {
 			$this->og_tag( 'og:image:width', absint( $dimensions['width'] ) );

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -21,8 +21,7 @@ class WPSEO_OpenGraph {
 
 		if ( isset( $GLOBALS['fb_ver'] ) || class_exists( 'Facebook_Loader', false ) ) {
 			add_filter( 'fb_meta_tags', array( $this, 'facebook_filter' ), 10, 1 );
-		}
-		else {
+		} else {
 			add_filter( 'language_attributes', array( $this, 'add_opengraph_namespace' ), 15 );
 
 			add_action( 'wpseo_opengraph', array( $this, 'locale' ), 1 );
@@ -138,8 +137,7 @@ class WPSEO_OpenGraph {
 			$regex   = '`prefix=([\'"])(.+?)\1`';
 			$replace = 'prefix="$2 ' . $namespace_string . '"';
 			$input   = preg_replace( $regex, $replace, $input );
-		}
-		else {
+		} else {
 			$input .= ' prefix="' . $namespace_string . '"';
 		}
 
@@ -204,8 +202,7 @@ class WPSEO_OpenGraph {
 			$this->og_tag( 'fb:app_id', $this->options['fbadminapp'] );
 
 			return true;
-		}
-		else if ( isset( $this->options['fb_admins'] ) && is_array( $this->options['fb_admins'] ) && $this->options['fb_admins'] !== array() ) {
+		} else if ( isset( $this->options['fb_admins'] ) && is_array( $this->options['fb_admins'] ) && $this->options['fb_admins'] !== array() ) {
 			$adminstr = implode( ',', array_keys( $this->options['fb_admins'] ) );
 			/**
 			 * Filter: 'wpseo_opengraph_admin' - Allow developer to filter the fb:admins string put out by Yoast SEO
@@ -250,26 +247,21 @@ class WPSEO_OpenGraph {
 
 			if ( $title === '' ) {
 				$title = $frontend->title( '' );
-			}
-			else {
+			} else {
 				// Replace Yoast SEO Variables.
 				$title = wpseo_replace_vars( $title, $post );
 			}
-		}
-		else if ( is_front_page() ) {
+		} else if ( is_front_page() ) {
 			$title = ( isset( $this->options['og_frontpage_title'] ) && $this->options['og_frontpage_title'] !== '' ) ? $this->options['og_frontpage_title'] : $frontend->title( '' );
-		}
-		elseif ( is_category() || is_tax() || is_tag() ) {
+		} elseif ( is_category() || is_tax() || is_tag() ) {
 			$title = WPSEO_Taxonomy_Meta::get_meta_without_term( 'opengraph-title' );
 			if ( $title === '' ) {
 				$title = $frontend->title( '' );
-			}
-			else {
+			} else {
 				// Replace Yoast SEO Variables.
 				$title = wpseo_replace_vars( $title, $GLOBALS['wp_query']->get_queried_object() );
 			}
-		}
-		else {
+		} else {
 			$title = $frontend->title( '' );
 		}
 
@@ -533,8 +525,7 @@ class WPSEO_OpenGraph {
 
 		if ( is_front_page() || is_home() ) {
 			$type = 'website';
-		}
-		elseif ( is_singular() ) {
+		} elseif ( is_singular() ) {
 
 			// This'll usually only be changed by plugins right now.
 			$type = WPSEO_Meta::get_value( 'og_type' );
@@ -542,8 +533,7 @@ class WPSEO_OpenGraph {
 			if ( $type === '' ) {
 				$type = 'article';
 			}
-		}
-		else {
+		} else {
 			// We use "object" for archives etc. as article doesn't apply there.
 			$type = 'object';
 		}
@@ -558,8 +548,7 @@ class WPSEO_OpenGraph {
 		if ( is_string( $type ) && $type !== '' ) {
 			if ( $echo !== false ) {
 				$this->og_tag( 'og:type', $type );
-			}
-			else {
+			} else {
 				return $type;
 			}
 		}
@@ -613,8 +602,7 @@ class WPSEO_OpenGraph {
 		if ( is_front_page() ) {
 			if ( isset( $this->options['og_frontpage_desc'] ) && $this->options['og_frontpage_desc'] !== '' ) {
 				$ogdesc = wpseo_replace_vars( $this->options['og_frontpage_desc'], null );
-			}
-			else {
+			} else {
 				$ogdesc = $frontend->metadesc( false );
 			}
 		}
@@ -804,8 +792,7 @@ class WPSEO_OpenGraph_Image {
 
 		if ( ! empty( $image ) && $this->add_image( $image ) ) {
 			// Safely assume an image was added so we don't need to automatically determine it anymore.
-		}
-		else {
+		} else {
 			$this->set_images();
 		}
 	}
@@ -834,8 +821,7 @@ class WPSEO_OpenGraph_Image {
 	private function set_images() {
 		if ( is_front_page() ) {
 			$this->get_front_page_image();
-		}
-		elseif ( is_home() ) { // Posts page, which won't be caught by is_singular() below.
+		} elseif ( is_home() ) { // Posts page, which won't be caught by is_singular() below.
 			$this->get_posts_page_image();
 		}
 


### PR DESCRIPTION
## Summary

I found that there is not any specific filter to change opengraph image meta tag like we have for type , url ,sitename ,description etc

I was facing first-time image share issue of not picking image Url with Yoast SEO plugin. which we can solve by adding image dimension (i.e height, width).

adding two filters one to change image URL and one to edit image dimension array.

## Relevant technical choices:

* Done some changes in image function of WPSEO_OpenGraph

```
public function image( $image = false ) {
		$opengraph_images = new WPSEO_OpenGraph_Image( $this->options, $image );

		/**
		 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph images of the page
		 *
		 */
		$images = apply_filters( 'wpseo_opengraph_image', $opengraph_images->get_images() );

		foreach ( $images as $img ) {
			$this->og_tag( 'og:image', esc_url( $img ) );
		}

		$dimensions = $opengraph_images->get_dimensions();
		/**
		 * Filter: 'wpseo_opengraph_dimensions' - Allow changing the OpenGraph page images dimensions.
		 *
		 */
		$dimensions = apply_filters( 'wpseo_opengraph_dimensions', $dimensions );

		if ( ! empty( $dimensions['width'] ) ) {
			$this->og_tag( 'og:image:width', absint( $dimensions['width'] ) );
		}

		if ( ! empty( $dimensions['height'] ) ) {
			$this->og_tag( 'og:image:height', absint( $dimensions['height'] ) );
		}
	}

```

## Test instructions

Download file till PR and just check it with any simple facebook share code.
