### PR TITLE
Update tool-import-export.php

### DIFF
--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -9,17 +9,10 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-/**
- * @todo [JRF => testers] Extensively test the export & import of the (new) settings!
- * If that all works fine, getting testers to export before and after upgrade will make testing easier.
- *
- * @todo [Yoast] The import for the RSS Footer plugin checks for data already entered via Yoast SEO,
- * the other import routines should do that too.
- */
-
 $yform = Yoast_Form::get_instance();
 
 $replace = false;
+$import  = false;
 
 /**
  * The import method is used to dermine if there should be something imported.
@@ -50,10 +43,6 @@ if ( filter_input( INPUT_POST, 'import' ) || filter_input( INPUT_GET, 'import' )
 	if ( ! empty( $post_wpseo['importwpseo'] ) || filter_input( INPUT_GET, 'importwpseo' ) ) {
 		$import = new WPSEO_Import_WPSEO( $replace );
 	}
-
-	// Allow custom import actions.
-	do_action( 'wpseo_handle_import' );
-
 }
 
 if ( isset( $_FILES['settings_import_file'] ) ) {
@@ -61,6 +50,13 @@ if ( isset( $_FILES['settings_import_file'] ) ) {
 
 	$import = new WPSEO_Import();
 }
+
+/**
+ * Allow custom import actions.
+ *
+ * @api bool|object $import Contains info about the handled import
+ */
+do_action( 'wpseo_handle_import', $import );
 
 if ( isset( $import ) || has_filter( 'wpseo_import_status' ) ) {
 	/**
@@ -76,8 +72,7 @@ if ( isset( $import ) || has_filter( 'wpseo_import_status' ) ) {
 			$msg .= ' ' . __( 'The old data of the imported plugin was deleted successfully.', 'wordpress-seo' );
 		}
 
-
-		$status = ( apply_filters( 'wpseo_import_status', isset( $import->success ) ? $import->success : 'error' ) ) ? 'updated' : 'error';
+		$status = ( $import->success ) ? 'updated' : 'error';
 
 		echo '<div id="message" class="message ', $status, '"><p>', $msg, '</p></div>';
 	}

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -58,7 +58,7 @@ if ( isset( $_FILES['settings_import_file'] ) ) {
  */
 $import = apply_filters( 'wpseo_handle_import', $import );
 
-if ( isset( $import ) || has_filter( 'wpseo_import_status' ) ) {
+if ( $import ) {
 	/**
 	 * Allow customization of import&export message
 	 *

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -62,7 +62,7 @@ if ( isset( $_FILES['settings_import_file'] ) ) {
 	$import = new WPSEO_Import();
 }
 
-if ( isset( $import ) ) {
+if ( isset( $import ) || has_filter( 'wpseo_import_status' ) ) {
 	/**
 	 * Allow customization of import&export message
 	 *
@@ -76,8 +76,12 @@ if ( isset( $import ) ) {
 	}
 
 	if ( $msg != '' ) {
-
-		$status = ( $import->success ) ? 'updated' : 'error';
+		/**
+		 * Allow customization of import&export status
+		 *
+		 * @api  bool  $success  The status.
+		 */
+		$status = ( apply_filters( 'wpseo_import_status', $import->success ) ) ? 'updated' : 'error';
 
 		echo '<div id="message" class="message ', $status, '"><p>', $msg, '</p></div>';
 	}

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -68,20 +68,16 @@ if ( isset( $import ) || has_filter( 'wpseo_import_status' ) ) {
 	 *
 	 * @api  string  $msg  The message.
 	 */
-	$msg = apply_filters( 'wpseo_import_message', $import->msg );
-
-	// Check if we've deleted old data and adjust message to match it.
-	if ( $replace ) {
-		$msg .= ' ' . __( 'The old data of the imported plugin was deleted successfully.', 'wordpress-seo' );
-	}
+	$msg = apply_filters( 'wpseo_import_message', isset( $import->msg ) ? $import->msg : '' );
 
 	if ( $msg != '' ) {
-		/**
-		 * Allow customization of import&export status
-		 *
-		 * @api  bool  $success  The status.
-		 */
-		$status = ( apply_filters( 'wpseo_import_status', $import->success ) ) ? 'updated' : 'error';
+		// Check if we've deleted old data and adjust message to match it.
+		if ( $replace ) {
+			$msg .= ' ' . __( 'The old data of the imported plugin was deleted successfully.', 'wordpress-seo' );
+		}
+
+
+		$status = ( apply_filters( 'wpseo_import_status', isset( $import->success ) ? $import->success : 'error' ) ) ? 'updated' : 'error';
 
 		echo '<div id="message" class="message ', $status, '"><p>', $msg, '</p></div>';
 	}
@@ -89,11 +85,11 @@ if ( isset( $import ) || has_filter( 'wpseo_import_status' ) ) {
 
 $tabs = array(
 	'wpseo-import' => array(
-		'label'                => __( 'Import', 'wordpress-seo' ),
+		'label'                => __( 'Import settings', 'wordpress-seo' ),
 		'screencast_video_url' => 'https://yoa.st/screencast-tools-import-export',
 	),
 	'wpseo-export' => array(
-		'label'                => __( 'Export', 'wordpress-seo' ),
+		'label'                => __( 'Export settings', 'wordpress-seo' ),
 		'screencast_video_url' => 'https://yoa.st/screencast-tools-import-export',
 	),
 	'import-seo'   => array(

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -56,7 +56,7 @@ if ( isset( $_FILES['settings_import_file'] ) ) {
  *
  * @api bool|object $import Contains info about the handled import
  */
-do_action( 'wpseo_handle_import', $import );
+$import = apply_filters( 'wpseo_handle_import', $import );
 
 if ( isset( $import ) || has_filter( 'wpseo_import_status' ) ) {
 	/**
@@ -98,7 +98,7 @@ $tabs = array(
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
 		<?php foreach ( $tabs as $identifier => $tab ) : ?>
-		<a class="nav-tab" id="<?php echo $identifier; ?>-tab" href="#top#<?php echo $identifier; ?>"><?php echo $tab['label']; ?></a>
+			<a class="nav-tab" id="<?php echo $identifier; ?>-tab" href="#top#<?php echo $identifier; ?>"><?php echo $tab['label']; ?></a>
 		<?php endforeach; ?>
 
 		<?php


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Allow filtering of the import success status, to allow showing import messages from within other plugins.

## Relevant technical choices:

* Old code assumes `$import` global exists, this adds a filter that allows bypassing that.

## Test instructions

This PR can be tested by following these steps:

* Best tested in conjunction with forthcoming WPSEO Premium pull requests about redirect imports.