### PR TITLE
Remove PHP 5.4 & 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
       env: WP_VERSION=4.4
     - php: 5.6
       env: WP_VERSION=4.6
-    - php: 5.5
-      env: WP_VERSION=4.6
-    - php: 5.4
-      env: WP_VERSION=4.6
     - php: 5.3
       env: WP_VERSION=4.6
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,10 @@ matrix:
       env: WP_VERSION=master WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
       env: WP_VERSION=4.6 WP_MULTISITE=1 PHPLINT=1
-    - php: 7.0
-      env: WP_VERSION=4.6
-    - php: 7.0
-      env: WP_VERSION=4.5
-    - php: 7.0
-      env: WP_VERSION=4.4
     - php: 5.6
       env: WP_VERSION=4.6
     - php: 5.3
-      env: WP_VERSION=4.6
+      env: WP_VERSION=4.5
     - php: 7.1
       env: WP_VERSION=master
     - php: hhvm


### PR DESCRIPTION
Speeds up the build process. We only run these for the tiny, tiny, tiny chance that something works on both PHP 5.2, 5.3 and 5.6, but doesn't on 5.4 and 5.5...