### PR TITLE
Fixed option check for disabled post format archives in sitemaps.

### DIFF
--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -257,7 +257,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return false;
 		}
 
-		if ( 'post_format' === $taxonomy_name && ! empty( $this->options['disable-post_format'] ) ) {
+		if ( 'post_format' === $taxonomy_name && ! empty( $options['disable-post_format'] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed post format archives showing up in sitemap when disabled.

## Relevant technical choices:

* fixed broken options check, leftover from when properties got changed to static (?)

## Test instructions

This PR can be tested by following these steps:

* disable SEO > Titles & Metas > Taxonomies > Format > Format-based archive
* observe that post formats don't appear in sitemap index

Fixes #6044 

