### PR TITLE
Limited file check for assets to not development environment

### DIFF
--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -167,8 +167,7 @@ class WPSEO_Admin_Asset {
 			return '';
 		}
 
-		if ( ! $this->get_suffix() ) {
-
+		if ( 'development' !== YOAST_ENVIRONMENT && ! $this->get_suffix() ) {
 			$plugin_path = plugin_dir_path( $plugin_file );
 			if ( ! file_exists( $plugin_path . $relative_path ) ) {
 


### PR DESCRIPTION
(oops, I swallowed "not" in commit message :sweat: )

## Summary

This PR can be summarized in the following changelog entry:

Fixed slow performance when checking assets in development environment.

## Relevant technical choices:

* made check only fire in other cases, since in development environment files are there and we only care to make changes if they are not

## Test instructions

This PR can be tested by following these steps:

* no functional changes, reduces `file_exists()` calls by 60+ when in development context

Fixes #6028

