### PR TITLE
Removed legacy code, that was conditional to WP <4.4

### DIFF
--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -9,19 +9,6 @@
 class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 	/**
-	 * Set up filter for excluded authors.
-	 */
-	public function __construct() {
-
-		global $wp_version;
-
-		// TODO Remove after plugin requirements raised to WP 4.4. R.
-		if ( version_compare( $wp_version, '4.4', '<' ) ) {
-			add_filter( 'wpseo_sitemap_exclude_author', array( $this, 'user_sitemap_remove_excluded_authors' ), 8 );
-		}
-	}
-
-	/**
 	 * Check if provider supports given item type.
 	 *
 	 * @param string $type Type string to check for.
@@ -100,11 +87,12 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	protected function get_users( $arguments = array() ) {
 
-		global $wp_version, $wpdb;
+		global $wpdb;
 
 		$options = WPSEO_Options::get_all();
 
 		$defaults = array(
+			// TODO re-enable after plugin requirements raised to WP 4.6 with the fix.
 			// 'who'        => 'authors', Breaks meta keys, see https://core.trac.wordpress.org/ticket/36724#ticket R.
 			'meta_key'   => '_yoast_wpseo_profile_updated',
 			'orderby'    => 'meta_value_num',
@@ -112,7 +100,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			'meta_query' => array(
 				'relation' => 'AND',
 				array(
-					'key'     => $wpdb->get_blog_prefix() .'user_level',
+					'key'     => $wpdb->get_blog_prefix() . 'user_level',
 					'value'   => '0',
 					'compare' => '!=',
 				),
@@ -131,21 +119,16 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			),
 		);
 
-		// TODO Remove version condition after plugin requirements raised to WP 4.3. R.
-		if ( $options['disable_author_noposts'] === true && version_compare( $wp_version, '4.3', '>=' ) ) {
+		if ( $options['disable_author_noposts'] === true ) {
 			// $defaults['who']                 = ''; // Otherwise it cancels out next argument.
 			$defaults['has_published_posts'] = true;
 		}
 
-		// TODO Remove version condition after plugin requirements raised to WP 4.4. R.
-		if ( version_compare( $wp_version, '4.4', '>=' ) ) {
+		$excluded_roles = $this->get_excluded_roles();
 
-			$excluded_roles = $this->get_excluded_roles();
-
-			if ( ! empty( $excluded_roles ) ) {
-				// $defaults['who']          = ''; // Otherwise it cancels out next argument.
-				$defaults['role__not_in'] = $excluded_roles;
-			}
+		if ( ! empty( $excluded_roles ) ) {
+			// $defaults['who']          = ''; // Otherwise it cancels out next argument.
+			$defaults['role__not_in'] = $excluded_roles;
 		}
 
 		return get_users( array_merge( $defaults, $arguments ) );
@@ -259,7 +242,6 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			'meta_query' => array(
 				array(
 					'key'     => '_yoast_wpseo_profile_updated',
-					'value'   => 'needs-a-value-anyway', // This is ignored, but is necessary...
 					'compare' => 'NOT EXISTS',
 				),
 			),
@@ -289,65 +271,6 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 * @param array $users Array of user objects to filter.
 		 */
 		return apply_filters( 'wpseo_sitemap_exclude_author', $users );
-	}
-
-	/**
-	 * Filter users that should be excluded from the sitemap (by author metatag: wpseo_excludeauthorsitemap).
-	 *
-	 * Also filtering users that should be exclude by excluded role.
-	 *
-	 * @deprecated The checks are problematic legacy code and don't run on WP core above 4.4.
-	 * @TODO Remove after plugin requirements raised to WP 4.4. R.
-	 *
-	 * @param array $users Set of users to filter.
-	 *
-	 * @return array all the user that aren't excluded from the sitemap
-	 */
-	public function user_sitemap_remove_excluded_authors( $users ) {
-
-		if ( empty( $users ) ) {
-			return $users;
-		}
-
-		global $wp_version;
-
-		$options = get_option( 'wpseo_xml' );
-
-		foreach ( $users as $user_key => $user ) {
-
-			$exclude_user = false;
-
-			// Cheapest condition first; we have all information already.
-			if ( ! $exclude_user ) {
-				$user_role    = $user->roles[0];
-				$target_key   = "user_role-{$user_role}-not_in_sitemap";
-				$exclude_user = isset( $options[ $target_key ] ) && true === $options[ $target_key ];
-				unset( $user_role, $target_key );
-			}
-
-			// @TODO Remove after plugin requirements raised to WP 4.3. R.
-			if ( version_compare( $wp_version, '4.3', '<' ) ) {
-
-				// If the author has been excluded by preference on profile.
-				if ( ! $exclude_user ) {
-					$is_exclude_on = get_the_author_meta( 'wpseo_excludeauthorsitemap', $user->ID );
-					$exclude_user  = ( $is_exclude_on === 'on' );
-				}
-
-				// If the author has been excluded by general settings because there are no posts.
-				if ( ! $exclude_user && $options['disable_author_noposts'] === true ) {
-					$count_posts  = (int) count_user_posts( $user->ID );
-					$exclude_user = ( $count_posts === 0 );
-					unset( $count_posts );
-				}
-			}
-
-			if ( $exclude_user === true ) {
-				unset( $users[ $user_key ] );
-			}
-		}
-
-		return $users;
 	}
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -112,24 +112,6 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test if a user is -not- excluded from the sitemap when there are posts
-	 */
-	public function test_author_not_exclused_from_sitemap_by_zero_posts() {
-		$user = $this->get_user();
-
-		// Don't allow no posts.
-		add_filter( 'pre_option_wpseo_xml', array( $this, 'filter_exclude_author_by_no_posts' ) );
-
-		// Make the user -have- posts.
-		add_filter( 'get_usernumposts', array( $this, 'filter_user_has_posts' ) );
-
-		$result = self::$class_instance->user_sitemap_remove_excluded_authors( array( $user ) );
-
-		// User should not be removed.
-		$this->assertEquals( $result, array( $user ) );
-	}
-
-	/**
 	 * Get defaults
 	 *
 	 * @return array


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Removed legacy code in author sitemaps logic.

## Relevant technical choices:

* removed logic that was technically conditional/necessary to WP <4.4

## Test instructions

This PR can be tested by following these steps:

No functional changes on currently supported core versions (removed logic simply no longer ran on them).

* observe tests pass