### PR TITLE
Update react-tap-event-plugin version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jed": "^1.1.1",
     "lodash": "^4.7.0",
     "material-ui": "^0.15.4",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "select2": "^4.0.3",
     "yoast-components": "git+https://github.com/Yoast/yoast-components#master",
     "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#master"


### PR DESCRIPTION
Updated the react-tap-event-plugin, because it gave an error in the beta release script.

Fixes #6139

To test this fix, run create_beta script with this branch.