### PR TITLE
Hide and show the sidebar with CSS.

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -134,15 +134,6 @@ table.wpseo th {
 	vertical-align: top;
 }
 
-.wpseo-remove-ads {
-	margin-top: 0;
-	padding: 12px;
-	border: 1px solid #0075b3;
-	border-radius: 20px;
-	border-bottom-right-radius: 0;
-	background-color: #fff;
-}
-
 #wpseo_content_top {
 	min-width: 800px;
 }
@@ -178,6 +169,10 @@ table.wpseo th {
 #sidebar-container {
 	width: 261px;
 	padding: 0 0 0 20px;
+}
+
+.yoast-help-center-open #sidebar-container {
+	display: none;
 }
 
 @media (max-width: 1020px) {

--- a/js/src/wp-seo-admin-global.js
+++ b/js/src/wp-seo-admin-global.js
@@ -390,11 +390,9 @@
 		var $slideout = $container.find( ".wpseo-tab-video-slideout" );
 		if ( $slideout.is( ":hidden" ) ) {
 			openVideoSlideout( $container );
-			$( "#sidebar-container" ).hide();
 		}
 		else {
 			closeVideoSlideout();
-			$( "#sidebar-container" ).show();
 		}
 	} );
 }() );


### PR DESCRIPTION
Fixes #6160 

Hides/shows the sidebar using a CSS class.
To check: build and please follow the steps described on the issue.

Also removes a CSS rule that is no more necessary with the new sidebar banners design.