### PR TITLE
Sidebar banners better focus style

### DIFF
--- a/admin/banner/class-admin-banner-renderer.php
+++ b/admin/banner/class-admin-banner-renderer.php
@@ -19,8 +19,8 @@ class WPSEO_Admin_Banner_Renderer {
 	 * @return string
 	 */
 	public function render( WPSEO_Admin_Banner $banner ) {
-		$output  = '<a target="_blank" href="' . esc_url( $banner->get_url() ) . '">';
-		$output .= '<img width="' . esc_attr( $banner->get_width() ) . '" height="' . esc_attr( $banner->get_height() ) . '" src="' . esc_attr( $this->get_image_path( $banner->get_image() ) ) . '" alt="' . esc_attr( $banner->get_alt() ) . '"/>';
+		$output  = '<a class="wpseo-banner__link" target="_blank" href="' . esc_url( $banner->get_url() ) . '">';
+		$output .= '<img class="wpseo-banner__image" width="' . esc_attr( $banner->get_width() ) . '" height="' . esc_attr( $banner->get_height() ) . '" src="' . esc_attr( $this->get_image_path( $banner->get_image() ) ) . '" alt="' . esc_attr( $banner->get_alt() ) . '"/>';
 		$output .= '</a>';
 
 		return $output;

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -520,17 +520,25 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 		text-align: left;
 		box-sizing: border-box;
 		line-height: 19px;
-		border-bottom: 1px solid #a4286a
+		border-bottom: 1px solid #a4286a;
 	}
 
 	&__spot {
 		padding: 10px 0;
-		border-bottom: 1px solid #DDD;
+		border-bottom: 1px solid #ddd;
 
 		a {
 			color: #a4286a;
 		}
 	}
+}
 
+.wpseo-banner {
+	&__link {
+	   display: inline-block;
+	}
 
+	&__image {
+	   vertical-align: top;
+	}
 }

--- a/tests/admin/banner/test-class-admin-banner-renderer.php
+++ b/tests/admin/banner/test-class-admin-banner-renderer.php
@@ -11,7 +11,7 @@ class WPSEO_Admin_Banner_Renderer_Test extends WPSEO_UnitTestCase {
 
 		$admin_banner_renderer = new WPSEO_Admin_Banner_Renderer;
 
-		$expected_output = '<a target="_blank" href="http://url"><img width="200" height="300" src="/image.png" alt="alt"/></a>';
+		$expected_output = '<a class="wpseo-banner__link" target="_blank" href="http://url"><img class="wpseo-banner__image" width="200" height="300" src="/image.png" alt="alt"/></a>';
 		$actual_output   = $admin_banner_renderer->render( new WPSEO_Admin_Banner( 'url', 'image.png', 200, 300, 'alt' ) );
 
 		$this->assertEquals( $expected_output, $actual_output );
@@ -30,7 +30,7 @@ class WPSEO_Admin_Banner_Renderer_Test extends WPSEO_UnitTestCase {
 		$admin_banner_renderer = new WPSEO_Admin_Banner_Renderer;
 		$admin_banner_renderer->set_base_path( 'test_path' );
 
-		$expected_output = '<a target="_blank" href="http://url"><img width="200" height="300" src="test_path/image.png" alt="alt"/></a>';
+		$expected_output = '<a class="wpseo-banner__link" target="_blank" href="http://url"><img class="wpseo-banner__image" width="200" height="300" src="test_path/image.png" alt="alt"/></a>';
 		$actual_output   = $admin_banner_renderer->render( new WPSEO_Admin_Banner( 'url', 'image.png', 200, 300, 'alt' ) );
 
 		$this->assertEquals( $expected_output, $actual_output );

--- a/tests/admin/banner/test-class-admin-banner-spot-renderer.php
+++ b/tests/admin/banner/test-class-admin-banner-spot-renderer.php
@@ -49,7 +49,7 @@ class WPSEO_Admin_Banner_Spot_Renderer_Test extends WPSEO_UnitTestCase {
 		$banner_spot->set_description( 'This is a test spot' );
 		$banner_spot->add_banner( new WPSEO_Admin_Banner( 'url', 'image', 100, 100, 'alt' ) );
 
-		$expected_output = '<div class="yoast-sidebar__spot"><strong>Test spot</strong><p>This is a test spot</p><a target="_blank" href=';
+		$expected_output = '<div class="yoast-sidebar__spot"><strong>Test spot</strong><p>This is a test spot</p><a class="wpseo-banner__link" target="_blank" href=';
 		$actual_output   = $this->admin_banner_spot_renderer->render( $banner_spot );
 
 		$this->assertStringStartsWith( $expected_output, $actual_output );
@@ -64,7 +64,7 @@ class WPSEO_Admin_Banner_Spot_Renderer_Test extends WPSEO_UnitTestCase {
 		$banner_spot = new WPSEO_Admin_Banner_Spot( 'Test spot' );
 		$banner_spot->add_banner( new WPSEO_Admin_Banner( 'url', 'image', 100, 100, 'alt' ) );
 
-		$expected_output = '<div class="yoast-sidebar__spot"><strong>Test spot</strong><a target="_blank" href=';
+		$expected_output = '<div class="yoast-sidebar__spot"><strong>Test spot</strong><a class="wpseo-banner__link" target="_blank" href=';
 		$actual_output   = $this->admin_banner_spot_renderer->render( $banner_spot );
 
 		$this->assertStringStartsWith( $expected_output, $actual_output );


### PR DESCRIPTION
Fixes #6163 

To review, check focus style on the sidebar banners. See also screenshots on the issue.

Fixes also a couple minor CSS syntax things.
Tested also with IE11 and Edge.