### PR TITLE
added 'wpseo_twitter_card' filter for easier disabling of Twitter card

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -49,6 +49,16 @@ class WPSEO_Twitter {
 	 * Outputs the Twitter Card code on singular pages.
 	 */
 	public function twitter() {
+
+		/**
+		 * Filter: 'wpseo_twitter_card' - Allow disabling of the Twitter card
+		 *
+		 * @api bool $enabled Enabled/disabled flag
+		 */
+		if ( false === apply_filters( 'wpseo_twitter_card', true ) ) {
+			return;
+		}
+
 		wp_reset_query();
 
 		$this->type();


### PR DESCRIPTION
## Summary

Offers a cleaner solution for disabling a Twitter card in specific instances.

## Relevant technical choices:

While working on a site for a client, we needed to disabled Twitter card meta for specific post types since they were being created by [Akamai Edge Side Includes](https://www.akamai.com/us/en/support/esi.jsp).  While we were able to use filters to disable most of the Twitter card meta tags, the summary tag was still being output.

Currently, the only way to completely disable a Twitter card in specific instances is to remove the action added during the `template_redirect` action.  Example:
```
// Remove all the Twitter card meta tags.
add_action( 'wpseo_head', function() {
	remove_action( 'wpseo_head', array( 'WPSEO_Twitter', 'get_instance' ), 40 );
}, 10 );
```

A cleaner solution would be to offer a filter to disable the Twitter card via a filter, similar to `wpseo_canonical`, `wpseo_metadesc`, etc.
```
add_filter( 'wpseo_twitter_card', '__return_false' );
```

## Test instructions

This PR can be tested by following these steps:

* Create the following snippet in a theme or plugin to disable Twitter cards for a singular 'post':
```
add_filter( 'wpseo_twitter_card', function( $enabled ) {
	return is_singular( 'post' ) ? false : $enabled;
} );
```

