### PR TITLE
Add XML schema for image sitemap

### DIFF
--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -79,7 +79,8 @@ class WPSEO_Sitemaps_Renderer {
 	public function get_sitemap( $links, $type, $current_page ) {
 
 		$urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" '
-			. 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" '
+			. 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd '
+			.                     'http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" '
 			. 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 
 		/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

In order to validate sitemaps, we need to add image schema into  xsi:schemaLocation
http://www.google.com/schemas/sitemap-image/1.1/

## Test instructions

This PR can be tested by following these steps:

- Open XML validator (eg. http://www.xmlvalidation.com/) and try to validate sitemap

Fixes #6144 

