### PR TITLE
Seperate user language from site language for translations.

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -87,7 +87,13 @@ class WPSEO_Metabox_Formatter {
 	 * @return array
 	 */
 	private function get_translations() {
-		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . get_user_locale() . '.json';
+		$locale = get_locale();
+
+		if ( function_exists ( get_user_locale ) ) {
+			$locale = get_user_locale();
+		}
+
+		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . $locale . '.json';
 		if ( file_exists( $file ) && $file = file_get_contents( $file ) ) {
 			return json_decode( $file, true );
 		}

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -87,7 +87,7 @@ class WPSEO_Metabox_Formatter {
 	 * @return array
 	 */
 	private function get_translations() {
-		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . get_locale() . '.json';
+		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . get_user_locale() . '.json';
 		if ( file_exists( $file ) && $file = file_get_contents( $file ) ) {
 			return json_decode( $file, true );
 		}

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -82,17 +82,15 @@ class WPSEO_Metabox_Formatter {
 	}
 
 	/**
-	 * Gets the locale used for translations. 
+	 * Gets the locale used for translations.
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	private function get_translation_locale() {
-		$locale = get_locale();
-
 		if ( function_exists ( 'get_user_locale' ) ) {
-			$locale = get_user_locale();
+			return  get_user_locale();
 		}
-		return $locale;
+		return get_locale();
 	}
 
 	/**

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -82,16 +82,26 @@ class WPSEO_Metabox_Formatter {
 	}
 
 	/**
-	 * Returns Jed compatible YoastSEO.js translations.
+	 * Gets the locale used for translations. 
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	private function get_translations() {
+	private function get_translation_locale() {
 		$locale = get_locale();
 
 		if ( function_exists ( 'get_user_locale' ) ) {
 			$locale = get_user_locale();
 		}
+		return $locale;
+	}
+
+	/**
+	 * Returns Jed compatible YoastSEO.js translations.
+	 *
+	 * @return array
+	 */
+	private function get_translations() {
+		$locale = $this->get_translation_locale();
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . $locale . '.json';
 		if ( file_exists( $file ) && $file = file_get_contents( $file ) ) {

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -87,7 +87,7 @@ class WPSEO_Metabox_Formatter {
 	 * @return string
 	 */
 	private function get_translation_locale() {
-		if ( function_exists ( 'get_user_locale' ) ) {
+		if ( function_exists( 'get_user_locale' ) ) {
 			return  get_user_locale();
 		}
 		return get_locale();

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -89,7 +89,7 @@ class WPSEO_Metabox_Formatter {
 	private function get_translations() {
 		$locale = get_locale();
 
-		if ( function_exists ( get_user_locale ) ) {
+		if ( function_exists ( 'get_user_locale' ) ) {
 			$locale = get_user_locale();
 		}
 

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -88,7 +88,7 @@ class WPSEO_Metabox_Formatter {
 	 */
 	private function get_translation_locale() {
 		if ( function_exists( 'get_user_locale' ) ) {
-			return  get_user_locale();
+			return get_user_locale();
 		}
 		return get_locale();
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses the user settings to render to correct language. 

## Relevant technical choices:

* use the `get_user_locale()`  for the user language. 

## Test instructions

This PR can be tested by following these steps:

Please check 4.6 AND 4.7
4.6:
* Set the site language to English. 
* Open a post and make sure the feedback is in English. 
* Set the site language to something else (NL or DE). 
* Open a post and make sure the feedback is in the selected language.

4.7:
* Set the site language to German.
* Set the user language to English.
* Open a post and make sure the feedback is in English.
* Set the site language to English.
* Set the user language to German.
* Open a post and make sure the feedback is in German.

Fixes #6053 

