### PR TITLE
Remove debug output (Supercache, Query monitor) for the Configuration Wizard

### DIFF
--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -110,13 +110,9 @@ class WPSEO_Configuration_Service {
 	 *
 	 * @return array List of settings.
 	 */
-	public function get_configuration() {
-		// disable debug output on this page
+	public function get_configuration() {	
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 			define( 'DONOTCACHEPAGE', true );
-		}
-		if ( ! defined( 'QM_DISABLED' ) ) {
-			define( 'QM_DISABLED' , true );
 		}
 
 		$this->populate_configuration();

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -110,11 +110,7 @@ class WPSEO_Configuration_Service {
 	 *
 	 * @return array List of settings.
 	 */
-	public function get_configuration() {	
-		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-			define( 'DONOTCACHEPAGE', true );
-		}
-
+	public function get_configuration() {
 		$this->populate_configuration();
 
 		$fields = $this->storage->retrieve();

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -110,9 +110,13 @@ class WPSEO_Configuration_Service {
 	 *
 	 * @return array List of settings.
 	 */
-	public function get_configuration() {	
+	public function get_configuration() {
+		// disable debug output on this page
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 			define( 'DONOTCACHEPAGE', true );
+		}
+		if ( ! defined( 'QM_DISABLED' ) ) {
+			define( 'QM_DISABLED' , true );
 		}
 
 		$this->populate_configuration();

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -110,7 +110,11 @@ class WPSEO_Configuration_Service {
 	 *
 	 * @return array List of settings.
 	 */
-	public function get_configuration() {
+	public function get_configuration() {	
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
+
 		$this->populate_configuration();
 
 		$fields = $this->storage->retrieve();

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -111,6 +111,14 @@ class WPSEO_Configuration_Service {
 	 * @return array List of settings.
 	 */
 	public function get_configuration() {
+		// Disable debug output on this page.
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
+		if ( ! defined( 'QM_DISABLED' ) ) {
+			define( 'QM_DISABLED' , true );
+		}
+
 		$this->populate_configuration();
 
 		$fields = $this->storage->retrieve();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Some cache plugins add debug output bellow content and wizard shows javascript errors.

## Test instructions

This PR can be tested by following these steps:

* Install WP Super Cache. Go to Settings > WP Super Cache > Debug. Enable debugging. Try to run Configuration Wizard (there were javascript errors)
* Install Query monitor. Try to run Configuration Wizard (it was shown QM debug output bellow configuration wizard)

Fixes #6025