### PR TITLE
Introduce a utility method to get the new WordPress user locale

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -117,7 +117,7 @@ class WPSEO_Admin_Asset_Manager {
 	private function scripts_to_be_registered() {
 
 		$select2_language = 'en';
-		$locale           = get_locale();
+		$locale           = WPSEO_Utils::get_user_locale();
 		$language         = WPSEO_Utils::get_language( $locale );
 
 		if ( file_exists( WPSEO_PATH . "js/dist/select2/i18n/{$locale}.js" ) ) {

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -88,7 +88,7 @@ class WPSEO_Admin_Pages {
 
 		$page = filter_input( INPUT_GET, 'page' );
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoSelect2Locale', WPSEO_Utils::get_language( get_locale() ) );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
 
 		if ( in_array( $page, array( 'wpseo_social', WPSEO_Admin::PAGE_IDENTIFIER ) ) ) {
 			wp_enqueue_media();

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -51,7 +51,7 @@ class WPSEO_Metabox_Formatter {
 			'keywordTab'        => __( 'Keyword:', 'wordpress-seo' ),
 			'enterFocusKeyword' => __( 'Enter your focus keyword', 'wordpress-seo' ),
 			'removeKeyword'     => __( 'Remove keyword', 'wordpress-seo' ),
-			'locale'            => get_locale(),
+			'locale'            => WPSEO_Utils::get_user_locale(),
 			'translations'      => $this->get_translations(),
 			'keyword_usage'     => array(),
 			'title_template'    => '',
@@ -82,24 +82,12 @@ class WPSEO_Metabox_Formatter {
 	}
 
 	/**
-	 * Gets the locale used for translations.
-	 *
-	 * @return string
-	 */
-	private function get_translation_locale() {
-		if ( function_exists( 'get_user_locale' ) ) {
-			return get_user_locale();
-		}
-		return get_locale();
-	}
-
-	/**
 	 * Returns Jed compatible YoastSEO.js translations.
 	 *
 	 * @return array
 	 */
 	private function get_translations() {
-		$locale = $this->get_translation_locale();
+		$locale = WPSEO_Utils::get_user_locale();
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . $locale . '.json';
 		if ( file_exists( $file ) && $file = file_get_contents( $file ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -898,7 +898,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'shortcode-plugin', 'wpseoShortcodePluginL10n', $this->localize_shortcode_plugin_script() );
 
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( get_locale() ) );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
 
 			if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
 				$asset_manager->enqueue_style( 'featured-image' );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -103,7 +103,7 @@ class WPSEO_Taxonomy {
 
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper', 'wpseoTermScraperL10n', $this->localize_term_scraper_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( get_locale() ) );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
 
 			$asset_manager->enqueue_script( 'admin-media' );

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -867,6 +867,24 @@ class WPSEO_Utils {
 	}
 
 	/**
+	 * Returns the user locale for the language to be used in the admin.
+	 *
+	 * WordPress 4.7 introduced the ability for users to specify an Admin language
+	 * different from the language used on the front end. This checks if the feature
+	 * is available and returns the user's language, with a fallback to the site's language.
+	 * Can be removed when support for WordPress 4.6 will be dropped, in favor
+	 * of WordPress get_user_locale() that already fallbacks to the site’s locale.
+	 *
+	 * @returns string The locale.
+	 */
+	public static function get_user_locale() {
+		if ( function_exists( 'get_user_locale' ) ) {
+			return get_user_locale();
+		}
+		return get_locale();
+	}
+
+	/**
 	 * Checks if the WP-REST-API is available.
 	 *
 	 * @since 3.6

--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -38,7 +38,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Metabox_Formatter::get_translations
 	 */
 	public function test_with_fake_language_file() {
-		$file_name = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . get_locale() . '.json';
+		$file_name = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . WPSEO_Utils::get_user_locale() . '.json';
 		file_put_contents(
 			$file_name,
 			json_encode( array( 'key' => 'value' ) )


### PR DESCRIPTION
Fixes #6187 

Abstracts the work done on https://github.com/Yoast/wordpress-seo/pull/6172/files in a new utility method: `WPSEO_Utils::get_user_locale()` and uses it for Select2 i18n files and in the meta box related things. First pass.

Other uses of Wordpress `get_locale()` should be checked in the related open issues.

Please notice the new method is used also in a test, not sure if that's correct.

How to test:
- set the site language in a language other than English or Dutch
- set the user language in Dutch
- go for example in SEO > General > Company Info
- use the "Company or person:" select2 and type a non-sense string
- observe the "no results found" message is in the wrong language
- go in the post meta box > advanced tab
- use the "Meta robots advanced" select2 typing a non-sense string
- observe the "no results found" message is in the wrong language
- switch to this branch, repeat the tests and check the correct language is used
- check the analysis results are still in the correct language