### PR TITLE
Fix taxonomy meta box title styling

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -195,6 +195,7 @@ ul.wpseo-metabox-tabs li {
 
 #wpseo_meta {
 	.inside {
+		margin: 6px 0 0 0;
 		overflow: auto;
 	}
 }
@@ -543,12 +544,12 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 	background-image: url(svg-icon-yoast($color));
 }
 
-#poststuff.wpseo-taxonomy-metabox-postbox {
-	padding-top: 0;
-}
-
 .term-php .wpseo-taxonomy-metabox-postbox h2 {
+	margin: 0;
+	padding: 8px 12px;
 	border-bottom: 1px solid #eee;
+	font-size: 14px;
+	line-height: 1.4;
 }
 
 .wpseo-buy-premium {


### PR DESCRIPTION
Fixes #5805 

How to test:
Build CSS, edit a term and check the taxonomy meta box title looks OK.