### PR TITLE
User language for the Configuration wizard

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -185,7 +185,7 @@ class WPSEO_Configuration_Page {
 	 * @returns array The translations for the configuration wizard.
 	 */
 	public function get_translations() {
-		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/yoast-components-' . get_locale() . '.json';
+		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/yoast-components-' . WPSEO_Utils::get_user_locale() . '.json';
 		if ( file_exists( $file ) && $file = file_get_contents( $file ) ) {
 			return json_decode( $file, true );
 		}

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -24,17 +24,25 @@ class WPSEO_Configuration_Service {
 	protected $adapter;
 
 	/**
-	 * Hook into the REST API
-	 */
-	public function register_hooks() {
-		add_action( 'rest_api_init', array( $this, 'initialize' ) );
-	}
-
-	/**
-	 * Register the service and boot handlers
+	 * Hook into the REST API and switch language.
 	 */
 	public function initialize() {
+		// Switch to the user locale with fallback to the site locale.
+		if ( function_exists( 'switch_to_locale' ) ) {
+			switch_to_locale( WPSEO_Utils::get_user_locale() );
+		}
+
+		// Make sure we have our translations available.
+		wpseo_load_textdomain();
+
+		$this->set_default_providers();
+		$this->populate_configuration();
 		$this->endpoint->register();
+
+		// @todo: check if this is really needed, since the switch happens only in the API.
+		if ( function_exists( 'restore_current_locale' ) ) {
+			restore_current_locale();
+		}
 	}
 
 	/**
@@ -111,8 +119,6 @@ class WPSEO_Configuration_Service {
 	 * @return array List of settings.
 	 */
 	public function get_configuration() {
-		$this->populate_configuration();
-
 		$fields = $this->storage->retrieve();
 		$steps  = $this->structure->retrieve();
 

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -56,12 +56,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Service::register_hooks()
 	 */
 	public function test_rest_api_init_hooked() {
-		$this->configuration_service->register_hooks();
-
-		$this->assertEquals( 10, has_action( 'rest_api_init', array(
-			$this->configuration_service,
-			'initialize',
-		) ) );
+		$this->assertEquals( 10, has_action( 'rest_api_init', 'wpseo_init_rest_api' ) );
 	}
 
 	/**
@@ -127,24 +122,6 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 
 		$this->assertNull( $service->set_structure( $structure ) );
 		$this->assertEquals( $structure, $service->get( 'structure' ) );
-	}
-
-	/**
-	 * @covers WPSEO_Configuration_Service::initialize()
-	 */
-	public function test_initialize_functions() {
-		$endpoint = $this
-			->getMockBuilder( 'WPSEO_Configuration_Endpoint' )
-			->setMethods( array( 'register' ) )
-			->getMock();
-
-		$endpoint
-			->expects( $this->once() )
-			->method( 'register' );
-
-		$this->configuration_service->set_endpoint( $endpoint );
-		$this->configuration_service->initialize();
-
 	}
 
 	/**

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -278,10 +278,30 @@ function wpseo_init() {
 function wpseo_init_rest_api() {
 	// We can't do anything when requirements are not met.
 	if ( WPSEO_Utils::is_api_available() ) {
+		// Display the Configuration Wizard in the user's locale in WordPress 4.7+.
+		if ( function_exists( 'switch_to_locale' ) ) {
+			// Switch to the user locale with fallback to the site locale.
+			switch_to_locale( WPSEO_Utils::get_user_locale() );
+			// Make sure we have our translations available.
+			wpseo_load_textdomain();
+		}
 		// Boot up REST API endpoints.
 		$configuration_service = new WPSEO_Configuration_Service();
 		$configuration_service->set_default_providers();
 		$configuration_service->register_hooks();
+	}
+}
+
+/**
+ * Restore the frontend to the correct locale.
+ */
+if ( function_exists( 'restore_previous_locale' ) ) {
+	add_action( 'wp', 'wpseo_restore_locale' );
+
+	function wpseo_restore_locale() {
+		if ( is_locale_switched() ) {
+			restore_previous_locale();
+		}
 	}
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -278,30 +278,9 @@ function wpseo_init() {
 function wpseo_init_rest_api() {
 	// We can't do anything when requirements are not met.
 	if ( WPSEO_Utils::is_api_available() ) {
-		// Display the Configuration Wizard in the user's locale in WordPress 4.7+.
-		if ( function_exists( 'switch_to_locale' ) ) {
-			// Switch to the user locale with fallback to the site locale.
-			switch_to_locale( WPSEO_Utils::get_user_locale() );
-			// Make sure we have our translations available.
-			wpseo_load_textdomain();
-		}
-		// Boot up REST API endpoints.
+		// Boot up REST API.
 		$configuration_service = new WPSEO_Configuration_Service();
-		$configuration_service->set_default_providers();
-		$configuration_service->register_hooks();
-	}
-}
-
-/**
- * Restore the frontend to the correct locale.
- */
-if ( function_exists( 'restore_previous_locale' ) ) {
-	add_action( 'wp', 'wpseo_restore_locale' );
-
-	function wpseo_restore_locale() {
-		if ( is_locale_switched() ) {
-			restore_previous_locale();
-		}
+		$configuration_service->initialize();
 	}
 }
 
@@ -374,7 +353,7 @@ if ( ! function_exists( 'wp_installing' ) ) {
 
 if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 	add_action( 'plugins_loaded', 'wpseo_init', 14 );
-	add_action( 'init', 'wpseo_init_rest_api' );
+	add_action( 'rest_api_init', 'wpseo_init_rest_api' );
 
 	if ( is_admin() ) {
 


### PR DESCRIPTION
Fixes #6188 

This fixes just a first part of the issue. The REST API part still needs to be addressed.

In the screenshot below:
user language: Italian
site language: Dutch

Notice that some strings were recently changed so some translations are not updated yet and they fallback to English, but you can see Dutch in the step 4 tooltip

![screen shot 2016-12-08 at 12 55 42](https://cloud.githubusercontent.com/assets/1682452/21009253/f78a4930-bd45-11e6-940e-f2a23b9a95de.png)



