### PR TITLE
Fix a `Trying to get property of non-object` notice for non-post-type, non-taxonomy sitemaps.

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -604,6 +604,9 @@ class WPSEO_Replace_Vars {
 		if ( isset( $wp_query->query_vars['post_type'] ) && ( ( is_string( $wp_query->query_vars['post_type'] ) && $wp_query->query_vars['post_type'] !== '' ) || ( is_array( $wp_query->query_vars['post_type'] ) && $wp_query->query_vars['post_type'] !== array() ) ) ) {
 			$post_type = $wp_query->query_vars['post_type'];
 		}
+		elseif ( isset( $this->args->post_type ) && ( is_string( $this->args->post_type ) && $this->args->post_type !== '' ) ) {
+			$post_type = $this->args->post_type;
+		}
 		else {
 			// Make it work in preview mode.
 			$post_type = $wp_query->get_queried_object()->post_type;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
N/A

## Relevant technical choices:

While investigating https://github.com/Yoast/wpseo-video/issues/144, I ran into the following:

If a video sitemap - i.e. a non-post-type based, non-taxonomy based sitemap - was requested and the `%%pt_single%%` variable was used in a custom title/description, a `Trying to get property of non-object` notice would be thrown.

This PR fixes that as long as a post/term/other object with basic information is passed to the `wpseo_replace_vars()` function when called.

## Test instructions

This PR can be tested by following these steps:

Environment:
* WP + WPSEO + VideoSEO plugins installed & activated.
* Make sure your test environment has `error_reporting( -1);` (= show everything)

### Reproduce the issue
* Start by using the trunk branch of both WPSEO as well as VideoSEO
* Add a new post with a video. Edit the SEO snippet and change the `SEO title` to something like: `%%date%% %%sep%% %%pt_single%% %%sep%% %%title%%` & save the post.
(You can ignore that the `%%pt_single%%` will not be replaced in the snippet preview.)
* Open the last VideoSEO sitemap & see the error

### Confirm the fix
* Switch to this branch of WPSEO
* Clear the sitemap cache (change the max number of sitemap entries on the settings page & save)
* Open the last VideoSEO sitemap & the error is gone.
(You can ignore the fact that the replacements aren't done correctly yet as that will be fixed through a PR in VideoSEO)