### PR TITLE
Update travis build matrix for WP 4.7 release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,30 @@ branches:
     - trunk
 
 matrix:
-  allow_failures:
-    - php: hhvm
+  fast_finish: true
   include:
     - php: 7.0
-      env: WP_VERSION=master WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
+      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
       env: WP_VERSION=4.6 WP_MULTISITE=1 PHPLINT=1
-    - php: 5.6
-      env: WP_VERSION=4.6
     - php: 5.3
       env: WP_VERSION=4.5
+    - php: 5.6
+      env: WP_VERSION=4.4
+    # WP >= 4.7 is needed for PHP 7.1  
     - php: 7.1
-      env: WP_VERSION=master
+      env: WP_VERSION=4.7
     - php: hhvm
-      env: WP_VERSION=4.6
+      env: WP_VERSION=4.7
+    - php: 5.2
+      env: WP_VERSION=master
+    - php: nightly
+      env: WP_VERSION=master
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: nightly
+    - php: hhvm
+    - env: WP_VERSION=master
 
 cache:
   yarn: true


### PR DESCRIPTION
Also:
* Have at least one build run against WP 4.4 which is currently the minimum version for WPSEO according to the readme.txt file.
* Move WP master to allowed failures
* Include PHP nightly (allowed to fail)

This does raise the number of builds from 6 to 8, but the two new ones are both allowed to fail.
With the `fast_finish` addition, reporting should be just as fast or even faster.
