### PR TITLE
Changes order of sitemap providers

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -79,8 +79,8 @@ class WPSEO_Sitemaps {
 		$this->cache       = new WPSEO_Sitemaps_Cache();
 		$this->providers   = array( // TODO API for add/remove. R.
 			new WPSEO_Post_Type_Sitemap_Provider(),
-			new WPSEO_Taxonomy_Sitemap_Provider(),
 			new WPSEO_Author_Sitemap_Provider(),
+			new WPSEO_Taxonomy_Sitemap_Provider(),
 		);
 
 		if ( ! empty( $_SERVER['SERVER_PROTOCOL'] ) ) {


### PR DESCRIPTION
## Summary
Changes order of sitemap providers.

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Fixes issues when exists taxonomy 'author', WPSEO_Author_Sitemap_Provider should have higher priority than WPSEO_Taxonomy_Sitemap_Provider

## Test instructions

This PR can be tested by following these steps:

* Install plugin **Co-Authors Plus**. Try to open author sitemap

Fixes #6343
