### PR TITLE
Removes the review banner from the sidebar

### DIFF
--- a/admin/banner/class-admin-banner-sidebar.php
+++ b/admin/banner/class-admin-banner-sidebar.php
@@ -130,16 +130,6 @@ class WPSEO_Admin_Banner_Sidebar {
 
 		$service_spot->add_banner(
 			new WPSEO_Admin_Banner(
-				'https://yoa.st/jl',
-				'website-review.png',
-				261,
-				152,
-				__( 'Order a Website Review and we will tell you what to improve to attract more visitors!', 'wordpress-seo' )
-			)
-		);
-
-		$service_spot->add_banner(
-			new WPSEO_Admin_Banner(
 				'https://yoa.st/jm',
 				'configuration-service.png',
 				261,


### PR DESCRIPTION
Based on https://github.com/Yoast/wordpress-seo/pull/6349

Removes the review banner since the reviews are replaced by SEOcare. 

When merging, please give props to https://github.com/abhinavkumar940 for creating this fix. 

Fixes #6331 