### PR TITLE
Improve the new SEO issues notifications popup

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -64,7 +64,7 @@ function wpseo_admin_bar_menu() {
 	}
 
 	// Never display notifications for network admin.
-	$counter = '';
+	$counter = $alert_popup = '';
 
 	// Set the top level menu item content for admins and network admins.
 	if ( $user_is_admin_or_networkadmin ) {
@@ -95,7 +95,7 @@ function wpseo_admin_bar_menu() {
 					_n( 'You have a new issue concerning your SEO!', 'You have %d new issues concerning your SEO!', $new_notifications_count, 'wordpress-seo' ),
 					$new_notifications_count
 				);
-				$counter .= '<div class="yoast-issue-added">' . $notification . '</div>';
+				$alert_popup = '<div class="yoast-issue-added">' . $notification . '</div>';
 			}
 		}
 	}
@@ -104,7 +104,7 @@ function wpseo_admin_bar_menu() {
 
 	$wp_admin_bar->add_menu( array(
 		'id'    => 'wpseo-menu',
-		'title' => $title . $score . $counter,
+		'title' => $title . $score . $counter . $alert_popup,
 		'href'  => $seo_url,
 		'meta'   => array( 'tabindex' => $top_level_link_tabindex ),
 	) );

--- a/js/src/wp-seo-admin-global.js
+++ b/js/src/wp-seo-admin-global.js
@@ -132,23 +132,44 @@
 	var $ = jQuery;
 
 	/**
-	 * Hide popup showing new alerts are present
+	 * Hide popup showing new alerts message.
 	 *
 	 * @returns {void}
 	 */
 	function hideAlertPopup() {
-		$( "#wp-admin-bar-root-default > li" ).off( "hover", hideAlertPopup );
+		// Remove the namespaced hover event from the menu top level list items.
+		$( "#wp-admin-bar-root-default > li" ).off( "hover.yoastalertpopup" );
+		// Hide the notification popup by fading it out.
 		$( ".yoast-issue-added" ).fadeOut( 200 );
 	}
 
 	/**
-	 * Show popup with new alerts message
+	 * Show popup with new alerts message.
 	 *
 	 * @returns {void}
 	 */
 	function showAlertPopup() {
-		$( ".yoast-issue-added" ).hover( hideAlertPopup ).fadeIn();
-		$( "#wp-admin-bar-root-default > li" ).on( "hover", hideAlertPopup );
+		// Attach an hover event and show the notification popup by fading it in.
+		$( ".yoast-issue-added" )
+			.on( "hover", function( evt ) {
+				// Avoid the hover event to propagate on the parent elements.
+				evt.stopPropagation();
+				// Hide the notification popup when hovering on it.
+				hideAlertPopup();
+			} )
+			.fadeIn();
+
+		// Attach a namespaced hover event on the menu top level list items.
+		$( "#wp-admin-bar-root-default > li" ).on( "hover.yoastalertpopup", function() {
+			/*
+			 * Hide the notification popup when hovering the menu top level list items.
+			 * Note: this will work just the first time the list items get hovered in the
+			 * first 3 seconds after DOM ready because this event is then removed.
+			 */
+			hideAlertPopup();
+		} );
+
+		// Hide the notification popup after 3 seconds from DOM ready.
 		setTimeout( hideAlertPopup, 3000 );
 	}
 

--- a/js/src/wp-seo-admin-global.js
+++ b/js/src/wp-seo-admin-global.js
@@ -159,15 +159,13 @@
 			} )
 			.fadeIn();
 
-		// Attach a namespaced hover event on the menu top level list items.
-		$( "#wp-admin-bar-root-default > li" ).on( "hover.yoastalertpopup", function() {
-			/*
-			 * Hide the notification popup when hovering the menu top level list items.
-			 * Note: this will work just the first time the list items get hovered in the
-			 * first 3 seconds after DOM ready because this event is then removed.
-			 */
-			hideAlertPopup();
-		} );
+		/*
+		 * Attach a namespaced hover event on the menu top level items to hide
+		 * the notification popup when hovering them.
+		 * Note: this will work just the first time the list items get hovered in the
+		 * first 3 seconds after DOM ready because this event is then removed.
+		 */
+		$( "#wp-admin-bar-root-default > li" ).on( "hover.yoastalertpopup", hideAlertPopup );
 
 		// Hide the notification popup after 3 seconds from DOM ready.
 		setTimeout( hideAlertPopup, 3000 );


### PR DESCRIPTION
Fixes #6283 

Please build the JS in order to test. What this PR does:
- on the PHP side, separate the "counter bubble" and the "alert popup" in order to print them out separately. The bubble needs to be printed out in two places while the alert should be printed out just on the menu top level item
- on the JS part:
  - prevents the `hover` event to propagate
  - use a namespaced event instead of passing the handler function name: functionally equivalent but maybe simpler to understand
  - adds comments