### PR TITLE
Fix all failing tests

### DIFF
--- a/tests/admin/banner/test-class-admin-banner-sidebar-renderer.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar-renderer.php
@@ -6,6 +6,7 @@ class WPSEO_Admin_Banner_Sidebar_Renderer_Test extends WPSEO_UnitTestCase {
 	protected $sidebar;
 
 	public function setUp(  ) {
+		parent::setUp();
 		$this->sidebar = new WPSEO_Admin_Banner_Sidebar( 'test_title', new WPSEO_Admin_Banner_Renderer() );
 		$this->sidebar->initialize( new WPSEO_Features() );
 	}
@@ -41,7 +42,7 @@ class WPSEO_Admin_Banner_Sidebar_Renderer_Test extends WPSEO_UnitTestCase {
 			->setConstructorArgs( array( new WPSEO_Admin_Banner_Spot_Renderer() ) )
 			->setMethods( array( 'render_banner_spots' ) )
 			->getMock();
-		
+
 
 		$mock
 			->expects( $this->once() )

--- a/tests/admin/test-class-stop-words.php
+++ b/tests/admin/test-class-stop-words.php
@@ -7,6 +7,7 @@ class WPSEO_Admin_Stop_WordsTest extends PHPUnit_Framework_TestCase {
 	protected $subject;
 
 	public function setUp() {
+		parent::setUp();
 		$this->subject = new WPSEO_Admin_Stop_Words();
 	}
 

--- a/tests/metabox/test-class-metabox-editor.php
+++ b/tests/metabox/test-class-metabox-editor.php
@@ -9,6 +9,7 @@ class WPSEO_Metabox_Editor_Test extends PHPUnit_Framework_TestCase {
 	protected $subject;
 
 	public function setUp() {
+		parent::setUp();
 		$this->subject = new WPSEO_Metabox_Editor();
 	}
 

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -24,6 +24,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 * Set up our double class
 	 */
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::$class_instance = new WPSEO_Author_Sitemap_Provider;
 	}
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -15,6 +15,7 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 	 * Set up our class.
 	 */
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::$class_instance = new WPSEO_Sitemaps_Router();
 	}
 

--- a/tests/test-class-admin-asset-manager.php
+++ b/tests/test-class-admin-asset-manager.php
@@ -7,6 +7,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	private $asset_manager;
 
 	public function setUp() {
+		parent::setUp();
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 	}
 

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -15,6 +15,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Set up class instance
 	 */
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		self::$class_instance = new WPSEO_OpenGraph;
 	}
 
@@ -34,6 +36,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Clean output buffer after each test
 	 */
 	public function tearDown() {
+		parent::tearDown();
+
 		ob_clean();
 	}
 

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -16,6 +16,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 	private static $class_instance;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::$class_instance = new WPSEO_Rewrite;
 	}
 

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -11,6 +11,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	private static $class_instance;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		ob_start();
 
 		// create instance of WPSEO_Twitter class
@@ -23,6 +24,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 
 
 	public function tearDown() {
+		parent::tearDown();
 		ob_clean();
 		WPSEO_Frontend::get_instance()->reset();
 

--- a/tests/test-class-wpseo-frontend-robots.php
+++ b/tests/test-class-wpseo-frontend-robots.php
@@ -1,0 +1,320 @@
+<?php
+
+/**
+ * @package WPSEO\Unittests
+ */
+class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * @var WPSEO_Frontend
+	 */
+	private static $class_instance;
+
+	/**
+	 * Setting up
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$class_instance = WPSEO_Frontend::get_instance();
+	}
+
+	/**
+	 * Provision tests
+	 */
+	public function setUp() {
+		parent::setUp();
+		WPSEO_Frontend::get_instance()->reset();
+
+		// start each test on the home page
+		$this->go_to_home();
+	}
+
+	/**
+	 * Reset after running a test
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		ob_clean();
+
+
+	}
+
+	/**
+	 * @covers WPSEO_Frontend::robots
+	 *
+	 * @todo   test post type archives
+	 * @todo   test with noodp and noydir option set
+	 * @todo   test with page_for_posts option
+	 * @todo   test date archives
+	 * @todo   test search results
+	 */
+	public function test_robots() {
+		// go to home
+		$this->go_to( get_home_url() );
+
+		// test home page with no special options
+		$this->assertEquals( '', self::$class_instance->robots() );
+	}
+
+	public function _test_robots_on_private_blog(  ) {
+		// go to home
+		$this->go_to_home();
+
+		// test WP visibility setting
+		update_option( 'blog_public', '0' );
+		$this->assertEquals( 'noindex,follow', self::$class_instance->robots() );
+
+		// clean-up
+		update_option( 'blog_public', '1' );
+	}
+
+
+	public function _test_with_replytocom_attribute(  ) {
+		// go to home
+		$this->go_to_home();
+
+		$expected = 'noindex,follow';
+		// test replytocom
+		$_GET['replytocom'] = '1';
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+
+		// clean-up
+		unset( $_GET['replytocom'] );
+	}
+
+
+	public function test_subpages_with_robots_using_default_state() {
+
+		// go to home
+		$this->go_to_home();
+
+		// test 'paged' query var
+		set_query_var( 'paged', 2 );
+		$this->assertEquals( '', self::$class_instance->robots() );
+		set_query_var( 'paged', 0 );
+	}
+
+	public function test_subpages_robots_noindex(  ) {
+		// go to home
+		$this->go_to_home();
+
+		set_query_var( 'paged', 2 );
+
+		self::$class_instance->options['noindex-subpages-wpseo'] = true;
+		$this->assertEquals( 'noindex,follow', self::$class_instance->robots() );
+
+		// clean-up
+		self::$class_instance->options['noindex-subpages-wpseo'] = false;
+		set_query_var( 'paged', 0 );
+
+	}
+
+
+	public function test_post_robots_default_state() {
+		// create and go to post
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		// test regular post with no special options
+		$expected = '';
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+
+	}
+
+
+
+	public function test_post_noindex(  ) {
+		// create and go to post
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		// test noindex-post option
+		self::$class_instance->options['noindex-post'] = true;
+		$this->assertEquals( 'noindex,follow', self::$class_instance->robots() );
+
+		// clean-up
+//		self::$class_instance->options['noindex-post'] = false;
+
+	}
+
+
+	public function test_private_post() {
+		// create and go to post
+		$post_id = $this->factory->post->create( [ 'post_status' => 'private' ] );
+		$this->go_to( get_permalink( $post_id ) );
+
+		// test private posts
+		$this->assertEquals( 'noindex,follow', self::$class_instance->robots() );
+	}
+
+
+	public function test_category() {
+
+		// go to category page
+		$category_id = wp_create_category( 'Category Name' );
+		flush_rewrite_rules();
+
+		// add posts to category
+		$this->factory->post->create_many( 6, array( 'post_category' => array( $category_id ) ) );
+
+		$category_link = get_category_link( $category_id );
+		$this->go_to( $category_link );
+
+		// test regular category with no special options
+		$expected = '';
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+	}
+
+	public function test_category_noindex(  ) {
+		// go to category page
+		$category_id = wp_create_category( 'Category Name' );
+		flush_rewrite_rules();
+
+		// add posts to category
+		$this->factory->post->create_many( 6, array( 'post_category' => array( $category_id ) ) );
+
+		$category_link = get_category_link( $category_id );
+		$this->go_to( $category_link );
+
+		// test category with noindex-tax-category option
+		$expected                                              = 'noindex,follow';
+		self::$class_instance->options['noindex-tax-category'] = true;
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+
+		// clean-up
+		self::$class_instance->options['noindex-tax-category'] = false;
+	}
+
+	public function test_subpages_category_archives(  ) {
+
+		// go to category page
+		$category_id = wp_create_category( 'Category Name' );
+		flush_rewrite_rules();
+
+		// add posts to category
+		$this->factory->post->create_many( 6, array( 'post_category' => array( $category_id ) ) );
+
+		$category_link = get_category_link( $category_id );
+		$this->go_to( $category_link );
+
+
+		// test subpages of category archives
+		update_site_option( 'posts_per_page', 1 );
+		self::$class_instance->options['noindex-subpages-wpseo'] = true;
+		$this->go_to( add_query_arg( array( 'paged' => 2 ), $category_link ) );
+
+		$expected = 'noindex,follow';
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+
+	}
+
+
+	public function test_author_archive() {
+
+		// go to author page
+		$user_id = $this->factory->user->create();
+		$this->go_to( get_author_posts_url( $user_id ) );
+
+		// test author archive with no special options
+		$expected = '';
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+
+	}
+
+	public function test_author_archive_noindex(  ) {
+
+		// go to author page
+		$user_id = $this->factory->user->create();
+		$this->go_to( get_author_posts_url( $user_id ) );
+
+
+		// test author archive with 'noindex-author-wpseo'
+		$expected                                              = 'noindex,follow';
+		self::$class_instance->options['noindex-author-wpseo'] = true;
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+
+		// clean-up
+		self::$class_instance->options['noindex-author-wpseo'] = false;
+
+	}
+
+
+	/**
+	 * This test was broken when it was located in test-class-wpseo-frontend.php
+	 *
+	 * @covers WPSEO_Frontend::robots
+	 */
+	public function test_robots_for_404() {
+		// Save 404 state.
+		global $wp_query;
+		$original_404_state = is_404();
+
+		// Assertion.
+		$wp_query->is_404 = true;
+		$expected         = 'noindex,follow';
+		$this->assertEquals( $expected, self::$class_instance->robots() );
+
+		// Clean-up.
+		$wp_query->is_404 = false;
+	}
+
+	/**
+	 * @covers WPSEO_Frontend::robots_for_single_post
+	 */
+	public function test_robots_for_single_post() {
+
+		// create and go to post
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$robots   = array(
+			'index'  => 'index',
+			'follow' => 'follow',
+			'other'  => array(),
+		);
+		$expected = $robots;
+
+		// test noindex
+		WPSEO_Meta::set_value( 'meta-robots-noindex', '1', $post_id );
+		$expected['index'] = 'noindex';
+		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
+
+		// test nofollow
+		WPSEO_Meta::set_value( 'meta-robots-nofollow', 1, $post_id );
+		$expected['follow'] = 'nofollow';
+		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
+
+		// test noodp with default meta-robots-adv
+		self::$class_instance->options['noodp'] = true;
+		$expected['other']                      = array( 'noodp' );
+		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
+
+		// test meta-robots adv noodp and nosnippet
+		WPSEO_Meta::set_value( 'meta-robots-adv', 'noodp,nosnippet', $post_id );
+		$expected['other'] = array( 'noodp', 'nosnippet' );
+		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
+
+		WPSEO_Meta::set_value( 'meta-robots-noindex', '2', $post_id );
+		$expected['index'] = 'index';
+		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
+	}
+
+	/**
+	 * @covers WPSEO_Frontend::noindex_page
+	 */
+	public function test_noindex_page() {
+		$expected = '<meta name="robots" content="noindex" />' . "\n";
+		$this->expectOutput( $expected, self::$class_instance->noindex_page() );
+
+	}
+
+	/**
+	 * @covers WPSEO_Frontend::noindex_feed
+	 */
+	public function test_noindex_feed() {
+		// @todo
+	}
+
+}

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -17,6 +17,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 	 * Instantiate our class
 	 */
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::$class_instance = new WPSEO_JSON_LD();
 	}
 

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -11,6 +11,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	private static $class_instance;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::$class_instance = new WPSEO_Meta_Columns;
 	}
 

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -11,6 +11,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	private static $class_instance;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::$class_instance = new WPSEO_Metabox;
 	}
 


### PR DESCRIPTION
Because of some changes in the [WordPress](https://github.com/WordPress/wordpress-develop/commit/f593d8532aa65b405556d884ae60bc13f97cd1cbl) we have to call the parent methods of `setUpBeforeClass` and `tearDown` to make sure the test is handled correctly.