### PR TITLE
Hide the snippet preview in the taxonomy meta box readability tab.

### DIFF
--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -89,7 +89,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 				break;
 
 			case 'snippetpreview':
-				$field .= '<div id="wpseo_snippet" class="wpseosnippet"></div>';
+				$field .= '<div id="wpseosnippet" class="wpseosnippet"></div>';
 				break;
 			case 'pageanalysis' :
 				$field .= '<div id="pageanalysis">';

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -162,10 +162,8 @@ import initializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 		);
 
 		var snippetHelp = jQuery( "#help-yoast-snippetpreview" ).detach().removeClass( "wpseo_hidden" );
-		// Post/media meta box.
+		// Post/taxonomy/media meta box.
 		jQuery( "#wpseosnippet" ).find( "h3" ).after( snippetHelp );
-		// Taxonomy meta box.
-		jQuery( "#wpseo_snippet" ).find( "h3" ).after( snippetHelp );
 	}
 
 	jQuery( document ).ready( function() {

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -163,7 +163,7 @@ window.yoastHideMarkers = true;
 	jQuery( document ).ready( function() {
 		var args, termScraper, translations;
 
-		snippetContainer = $( "#wpseo_snippet" );
+		snippetContainer = $( "#wpseosnippet" );
 
 		insertTinyMCE();
 


### PR DESCRIPTION
## Summary

Taxonomy meta box: hide the snippet preview when switching to the readability tab.

## Test instructions

- build the JS
- edit a category or tag
- on the meta box "Keyword" tab observe the snippet preview correctly displayed
- switch to the "Readability" tab: the snippet preview should be hidden

Fixes #6373 
