### PR TITLE
Avoids slow DELETE queries

### DIFF
--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -161,14 +161,8 @@ class WPSEO_Sitemaps_Cache_Validator {
 			$like = sprintf( '%s%%', self::STORAGE_KEY_PREFIX );
 		}
 		else {
-			if ( ! is_null( $validator ) ) {
-				// Clear all cache for provided type-validator.
-				$like = sprintf( '%%_%s', $validator );
-			}
-			else {
-				// Clear type cache for all type keys.
-				$like = sprintf( '%1$s%2$s_%%', self::STORAGE_KEY_PREFIX, $type );
-			}
+			// Clear type cache for all type keys.
+			$like = sprintf( '%1$s%2$s_%%', self::STORAGE_KEY_PREFIX, $type );
 		}
 
 		/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Fixes a bug where the sitemap invalidation uses an expensive query to clean up old validators.

## Relevant technical choices:

* Having a wildcard in the middle of a LIKE statement slows down the performance of the query a lot. This removes the wildcard in the middle and just uses the type to clean up everything related.

## Test instructions

This PR can be tested by following these steps:

* Modify a post
* Make sure the post sitemap was updated afterwards

Fixes #6313
