### PR TITLE
Remove unused headings from the meta box

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -295,7 +295,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	public function do_tab( $id, $heading, $content ) {
 		?>
 		<div id="wpseo_<?php echo esc_attr( $id ) ?>" class="wpseotab <?php echo esc_attr( $id ) ?>">
-			<h3 class="wpseo-heading"><?php echo esc_html( $heading ); ?></h3>
 			<?php echo $content ?>
 		</div>
 	<?php

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -206,10 +206,6 @@ ul.wpseo-metabox-tabs li {
 	border: 1px solid;
 }
 
-.wpseo-heading {
-	padding-left: 10px;
-}
-
 #wpseo_meta {
 	.inside {
 		margin: 6px 0 0 0;

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -67,7 +67,6 @@ import initializeAlgoliaSearch from "./kb-search/wp-seo-kb-search-init";
 				} );
 		}
 
-		jQuery( ".wpseo-heading" ).hide();
 		jQuery( ".wpseo-metabox-tabs" ).show();
 		// End Tabs code.
 


### PR DESCRIPTION
## Summary

Remove an unused heading from `WPSEO_Metabox->do_tab()` 

About the method `do_tab()`, seems it's currently used only by the add-ons (e.g. Video and News) and the heading output by this method is then hidden via JavaScript.

## Test instructions

- activate the News and/or Video add-ons
- edit a post and go in the meta box Add-ons section
- check in the News or Video tab that no hidden headings are present in the source at the beginning of the tab content

Fixes #6419