### PR TITLE
I18n: Fix useless translation function.

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -375,7 +375,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$tabs[] = new WPSEO_Metabox_Form_Tab(
 			'content',
 			$content,
-			__( '', 'wordpress-seo' ),
+			'',
 			array(
 				'tab_class' => 'yoast-seo__remove-tab',
 			)

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -115,7 +115,7 @@ class WPSEO_Taxonomy_Metabox {
 		$tab = new WPSEO_Metabox_Form_Tab(
 			'content',
 			$content,
-			__( '', 'wordpress-seo' ),
+			'',
 			array(
 				'tab_class' => 'yoast-seo__remove-tab',
 			)


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
Fixes _"Strings should have translatable content"_ errors.

No functional changes. Compliance with the WP I18n guidelines.

## Test instructions

_N/A_
