### PR TITLE
I18n: Fix jumbled up (un)translatable strings.

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -183,8 +183,9 @@ class WPSEO_Admin_Init {
 	 */
 	public function has_default_tagline() {
 		$blog_description = get_bloginfo( 'description' );
-		$default_blog_description = 'Just another WordPress site';
-		return __( $default_blog_description ) === $blog_description || $default_blog_description === $blog_description;
+		$default_blog_description    = 'Just another WordPress site';
+		$translated_blog_description = __( 'Just another WordPress site' );
+		return $translated_blog_description === $blog_description || $default_blog_description === $blog_description;
 	}
 
 	/**

--- a/admin/class-import-aioseo.php
+++ b/admin/class-import-aioseo.php
@@ -50,16 +50,21 @@ class WPSEO_Import_AIOSEO extends WPSEO_Import_External {
 
 			$plugin_install_nonce = wp_create_nonce( 'install-plugin_google-analytics-for-wordpress' ); // Use the old name because that's the WordPress.org repo.
 
-			$this->set_msg( __( sprintf(
-				'All in One SEO data successfully imported. Would you like to %sdisable the All in One SEO plugin%s. You\'ve had Google Analytics enabled in All in One SEO, would you like to install our %sGoogle Analytics plugin%s?',
+			$this->set_msg( sprintf(
+				/* translators: 1,2: link open tag; 3: link close tag. */
+				__( 'All in One SEO data successfully imported. Would you like to %1$sdisable the All in One SEO plugin%3$s. You\'ve had Google Analytics enabled in All in One SEO, would you like to install our %2$sGoogle Analytics plugin%3$s?', 'wordpress-seo' ),
 				'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export&deactivate_aioseo=1#top#import-seo' ) ) . '">',
-				'</a>',
 				'<a href="' . esc_url( admin_url( 'update.php?action=install-plugin&plugin=google-analytics-for-wordpress&_wpnonce=' . $plugin_install_nonce ) ) . '">',
 				'</a>'
-			), 'wordpress-seo' ) );
+			) );
 		}
 		else {
-			$this->set_msg( __( sprintf( 'All in One SEO data successfully imported. Would you like to %sdisable the All in One SEO plugin%s.', '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export&deactivate_aioseo=1#top#import-seo' ) ) . '">', '</a>' ), 'wordpress-seo' ) );
+			$this->set_msg( sprintf(
+				/* translators: 1: link open tag; 2: link close tag. */
+				__( 'All in One SEO data successfully imported. Would you like to %1$sdisable the All in One SEO plugin%2$s.', 'wordpress-seo' ),
+				'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export&deactivate_aioseo=1#top#import-seo' ) ) . '">',
+				'</a>'
+			) );
 		}
 	}
 

--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -20,13 +20,11 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 		$this->import_taxonomy_metas();
 
 		$this->set_msg(
-			__(
-				sprintf(
-					'wpSEO data successfully imported. Would you like to %sdisable the wpSEO plugin%s?',
-					'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export&deactivate_wpseo=1#top#import-seo' ) ) . '">',
-					'</a>'
-				),
-				'wordpress-seo'
+			sprintf(
+				/* translators: 1: link open tag; 2: link close tag. */
+				__( 'wpSEO data successfully imported. Would you like to %1$sdisable the wpSEO plugin%2$s?', 'wordpress-seo' ),
+				'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export&deactivate_wpseo=1#top#import-seo' ) ) . '">',
+				'</a>'
 			)
 		);
 

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -59,7 +59,7 @@ $tabs->add_tab( new WPSEO_Option_Tab( 'dashboard', __( 'Dashboard', 'wordpress-s
 $tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
 $knowledge_graph_label = ( 'company' === $options['company_or_person'] ) ? __( 'Company Info', 'wordpress-seo' ) : __( 'Your Info', 'wordpress-seo' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'knowledge-graph', __( $knowledge_graph_label, 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-knowledge-graph' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'knowledge-graph', $knowledge_graph_label, array( 'video_url' => 'https://yoa.st/screencast-knowledge-graph' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'webmaster-tools', __( 'Webmaster Tools', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general-search-console' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'security', __( 'Security', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-security' ) ) );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
Fixes _"The $text arg should be a single string literal, not ..."_ errors.

Includes adding of missing `translators:` comments for these strings when relevant.

No functional changes, but should allow for better translatability of three of the phrases. Compliance with the WP I18n guidelines.

## Test instructions

_N/A_