### PR TITLE
Snippet CSS cleaning

### DIFF
--- a/css/src/snippet.scss
+++ b/css/src/snippet.scss
@@ -3,22 +3,10 @@
 	font-style: normal;
 }
 
-.form-table td .snippet-editor__label {
+.wpseosnippet .snippet-editor__label {
 	font-size: 1rem;
 	line-height: 1;
-}
-
-.form-table td textarea {
-	margin-top: 5px;
-}
-
-.wp-core-ui .button.snippet-editor__submit {
-	margin-top: 1em;
-}
-
-/* In the snippet editor reset the margin that throws of the layout */
-.inside .wpseotab .form-table td input.snippet-editor__input {
-	margin-top: 5px;
+	font-weight: 400;
 }
 
 input[type="text"].snippet-editor__field--invalid {


### PR DESCRIPTION
## Summary

Removes conflicting CSS rules that are not needed any longer. Additionally, fixes the Snippet Editor labels and fields styling after #6418 

## Test instructions

- on trunk: see the Snippet Editor labels are now bold and smaller and also the fields content is bold, see screenshot 1
- switch to this branch and build the CSS
- check the Snippet Editor looks like it should, see screenshot 2

Screenshot 1: bad

<img width="673" alt="screen shot 2017-01-13 at 12 04 31" src="https://cloud.githubusercontent.com/assets/1682452/21928111/37bfd0c4-d989-11e6-8b65-c6482f7acce7.png">

Screenshot 2: good

<img width="679" alt="screen shot 2017-01-13 at 12 05 07" src="https://cloud.githubusercontent.com/assets/1682452/21928116/43b717ca-d989-11e6-852f-0d908d29b243.png">

Fixes #6421 
