### PR TITLE
I18n: Fix mixed ordered and unordered placeholders in translatable strings

### DIFF
--- a/admin/banner/class-admin-banner-sidebar.php
+++ b/admin/banner/class-admin-banner-sidebar.php
@@ -293,7 +293,7 @@ class WPSEO_Admin_Banner_Sidebar {
 				152,
 				sprintf(
 					/* translators: %1$s expands to Yoast SEO for WordPress Training, %2$s to Yoast SEO for WordPress. */
-					__( 'Take the %s course and become a certified %2$s expert!', 'wordpress-seo' ),
+					__( 'Take the %1$s course and become a certified %2$s expert!', 'wordpress-seo' ),
 					'Yoast SEO for WordPress Training',
 					'Yoast SEO for WordPress'
 				)

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -616,7 +616,7 @@ class Yoast_Form {
 				190,
 				sprintf(
 					/* translators: %1$s expands to Yoast SEO for WordPress Training, %2$s to Yoast SEO for WordPress. */
-					__( 'Take the %s course and become a certified %2$s expert!', 'wordpress-seo' ),
+					__( 'Take the %1$s course and become a certified %2$s expert!', 'wordpress-seo' ),
 					'Yoast SEO for WordPress Training',
 					'Yoast SEO for WordPress'
 				)


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
Fixes _"Multiple placeholders should be ordered. Mix of ordered and non-ordered placeholders found"_ errors.

Includes adding of missing `translators:` comments for these strings.

No functional changes. Compliance with the WP I18n guidelines.

## Test instructions

_N/A_