### PR TITLE
I18n: Fix placement of /* translators: */ comments.

### DIFF
--- a/admin/banner/class-admin-banner-sidebar.php
+++ b/admin/banner/class-admin-banner-sidebar.php
@@ -291,8 +291,8 @@ class WPSEO_Admin_Banner_Sidebar {
 				'yoast-seo-for-wordpress-training.png',
 				261,
 				152,
-				/* translators: %1$s expands to Yoast SEO for WordPress Training, %2$s to Yoast SEO for WordPress. */
 				sprintf(
+					/* translators: %1$s expands to Yoast SEO for WordPress Training, %2$s to Yoast SEO for WordPress. */
 					__( 'Take the %s course and become a certified %2$s expert!', 'wordpress-seo' ),
 					'Yoast SEO for WordPress Training',
 					'Yoast SEO for WordPress'

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -152,8 +152,8 @@ class WPSEO_Admin_Init {
 		$info_message = __( 'Paging comments is enabled, this is not needed in 999 out of 1000 cases, we recommend to disable it.', 'wordpress-seo' );
 		$info_message .= '<br/>';
 
-		/* translators: %1$s resolves to the opening tag of the link to the comment setting page, %2$s resolves to the closing tag of the link */
 		$info_message .= sprintf(
+			/* translators: %1$s resolves to the opening tag of the link to the comment setting page, %2$s resolves to the closing tag of the link */
 			__( 'Simply uncheck the box before "Break comments into pages..." on the %1$sComment settings page%2$s.', 'wordpress-seo' ),
 			'<a href="' . esc_url( admin_url( 'options-discussion.php' ) ) . '">',
 			'</a>'
@@ -333,8 +333,8 @@ class WPSEO_Admin_Init {
 		if ( $can_access && ! $this->is_site_notice_dismissed( 'wpseo_dismiss_recalculate' ) ) {
 			Yoast_Notification_Center::get()->add_notification(
 				new Yoast_Notification(
-					/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
 					sprintf(
+						/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
 						__( 'We\'ve updated our SEO score algorithm. %1$sRecalculate the SEO scores%2$s for all posts and pages.', 'wordpress-seo' ),
 						'<a href="' . admin_url( 'admin.php?page=wpseo_tools&recalculate=1' ) . '">',
 						'</a>'

--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -113,8 +113,8 @@ class WPSEO_Product_Upsell_Notice {
 	protected function get_premium_upsell_section() {
 		$features = new WPSEO_Features();
 		if ( $features->is_free() ) {
-			/* translators: %1$s expands anchor to premium plugin page, %2$s expands to </a> */
 			return sprintf(
+				/* translators: %1$s expands anchor to premium plugin page, %2$s expands to </a> */
 				__( 'By the way, did you know we also have a %1$sPremium plugin%2$s? It offers advanced features, like a redirect manager and support for multiple keywords. It also comes with 24/7 personal support.' , 'wordpress-seo' ),
 				"<a href='https://yoa.st/premium-notification'>",
 				'</a>'
@@ -130,8 +130,8 @@ class WPSEO_Product_Upsell_Notice {
 	 * @return Yoast_Notification
 	 */
 	protected function get_notification() {
-		/* translators: %1$s expands to Yoast SEO, %2$s is a link start tag to the plugin page on WordPress.org, %3$s is the link closing tag. */
 		$message = sprintf(
+			/* translators: %1$s expands to Yoast SEO, %2$s is a link start tag to the plugin page on WordPress.org, %3$s is the link closing tag. */
 			__( 'We\'ve noticed you\'ve been using %1$s for some time now; we hope you love it! We\'d be thrilled if you could %2$sgive us a 5 stars rating on WordPress.org%3$s!', 'wordpress-seo' ),
 			'Yoast SEO',
 			'<a href="https://yoa.st/rate-yoast-seo">',

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -614,8 +614,8 @@ class Yoast_Form {
 				'banner-yoast-seo-for-wordpress-training.png',
 				261,
 				190,
-				/* translators: %1$s expands to Yoast SEO for WordPress Training, %2$s to Yoast SEO for WordPress. */
 				sprintf(
+					/* translators: %1$s expands to Yoast SEO for WordPress Training, %2$s to Yoast SEO for WordPress. */
 					__( 'Take the %s course and become a certified %2$s expert!', 'wordpress-seo' ),
 					'Yoast SEO for WordPress Training',
 					'Yoast SEO for WordPress'

--- a/admin/config-ui/fields/class-field-upsell-configuration-service.php
+++ b/admin/config-ui/fields/class-field-upsell-configuration-service.php
@@ -20,8 +20,8 @@ class WPSEO_Config_Field_Upsell_Configuration_Service extends WPSEO_Config_Field
 			'Yoast SEO'
 		);
 
-		/* Translators: %1$s expands to Yoast SEO, %2$s expands to Yoast SEO Premium, %3$s opens the link, %4$s closes the link. */
 		$upsell_text = sprintf(
+			/* Translators: %1$s expands to Yoast SEO, %2$s expands to Yoast SEO Premium, %3$s opens the link, %4$s closes the link. */
 			__( 'While we strive to make setting up %1$s as easy as possible, we understand it can be daunting. If you’d rather have us set up %1$s for you (and get a copy of %2$s in the process), order our %3$s%1$s configuration service%4$s here!', 'wordpress-seo' ),
 			'Yoast SEO',
 			'Yoast SEO Premium',

--- a/admin/config-ui/fields/class-field-upsell-site-review.php
+++ b/admin/config-ui/fields/class-field-upsell-site-review.php
@@ -14,8 +14,8 @@ class WPSEO_Config_Field_Upsell_Site_Review extends WPSEO_Config_Field {
 	public function __construct() {
 		parent::__construct( 'upsellSiteReview', 'HTML' );
 
-		/* translators: Text between %1$s and %2$s will be a link to a review explanation page. Text between %3$s and %4$s will be a link to an SEO copywriting course page. */
 		$upsell_text = sprintf(
+			/* translators: Text between %1$s and %2$s will be a link to a review explanation page. Text between %3$s and %4$s will be a link to an SEO copywriting course page. */
 			__( 'If you want more help creating awesome content, check out our %3$sSEO copywriting course%4$s. We can also %1$sreview your site%2$s if you’d like some more in-depth help!', 'wordpress-seo' ),
 			'<a href="https://yoa.st/1a" target="_blank">',
 			'</a>',

--- a/admin/google_search_console/class-gsc-service.php
+++ b/admin/google_search_console/class-gsc-service.php
@@ -141,8 +141,8 @@ class WPSEO_GSC_Service {
 
 		if ( class_exists( 'Yoast_Api_Google_Client' ) === false ) {
 			$this->incompatible_api_libs(
-				/* translators: %1$s expands to Yoast SEO, %2$s expands to Google Analytics by Yoast */
 				sprintf(
+					/* translators: %1$s expands to Yoast SEO, %2$s expands to Google Analytics by Yoast */
 					__(
 						'%1$s detected you’re using a version of %2$s which is not compatible with %1$s. Please update %2$s to the latest version to use this feature.',
 						'wordpress-seo'

--- a/admin/google_search_console/views/gsc-create-redirect.php
+++ b/admin/google_search_console/views/gsc-create-redirect.php
@@ -47,8 +47,8 @@ $unique_id = md5( $url );
 			echo '<h1 class="wpseo-redirect-url-title">', __( 'Error: a redirect for this URL already exists', 'wordpress-seo' ), '</h1>';
 			echo '<p>';
 
-			/* Translators: %1$s: expands to the current URL and %2$s expands to URL the redirects points to. */
 			echo sprintf(
+				/* Translators: %1$s: expands to the current URL and %2$s expands to URL the redirects points to. */
 				__( 'You do not have to create a redirect for URL %1$s because a redirect already exists. The existing redirect points to %2$s. If this is fine you can mark this issue as fixed. If not, please go to the redirects page and change the target URL.', 'wordpress-seo' ),
 				$url,
 				$current_redirect
@@ -61,8 +61,8 @@ $unique_id = md5( $url );
 			/* Translators: %s: expands to Yoast SEO Premium */
 			echo '<h1 class="wpseo-redirect-url-title">', sprintf( __( 'Creating redirects is a %s feature', 'wordpress-seo' ), 'Yoast SEO Premium' ), '</h1>';
 			echo '<p>';
-			/* Translators: %1$s: expands to 'Yoast SEO Premium', %2$s: links to Yoast SEO Premium plugin page. */
 			echo sprintf(
+				/* Translators: %1$s: expands to 'Yoast SEO Premium', %2$s: links to Yoast SEO Premium plugin page. */
 				__( 'To be able to create a redirect and fix this issue, you need %1$s. You can buy the plugin, including one year of support and updates, on %2$s.', 'wordpress-seo' ),
 				'Yoast SEO Premium',
 				'<a href="https://yoa.st/redirects" target="_blank">yoast.com</a>'

--- a/admin/pages/licenses.php
+++ b/admin/pages/licenses.php
@@ -154,8 +154,8 @@ $utm_info = '#utm_source=wordpress-seo-config&utm_medium=button-info&utm_campaig
 				<?php endif; ?>
 
 				<a target="_blank" href="<?php echo esc_url( $url . $utm_info ); ?>" class="yoast-link--more-info"><?php
-					/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 					printf(
+						/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 						__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 						'<span class="screen-reader-text">',
 						'</span>',
@@ -206,8 +206,8 @@ $utm_info = '#utm_source=wordpress-seo-config&utm_medium=button-info&utm_campaig
 						<?php endif; ?>
 
 						<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $url . $utm_info ); ?>"><?php
-							/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 							printf(
+								/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 								__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 								'<span class="screen-reader-text">',
 								'</span>',

--- a/admin/views/partial-help-center-video.php
+++ b/admin/views/partial-help-center-video.php
@@ -27,9 +27,10 @@ if ( ! empty( $tab_video_url ) ) :
 				<h3><?php _e( 'Need more help?', 'wordpress-seo' ); ?></h3>
 				<?php /* translators: %s expands to Yoast SEO Premium */ ?>
 				<p><?php printf( __( 'If you buy %s you\'ll get access to our support team and bonus features!', 'wordpress-seo' ), 'Yoast SEO Premium' ); ?></p>
-				<?php /* translators: %s expands to Yoast SEO Premium */ ?>
-				<p><a href="https://yoa.st/seo-premium-vt"
-				      target="_blank"><?php printf( __( 'Get %s &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' ); ?></a>
+				<p><a href="https://yoa.st/seo-premium-vt" target="_blank"><?php
+				/* translators: %s expands to Yoast SEO Premium */
+				printf( __( 'Get %s &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );
+				?></a>
 				</p>
 			</div>
 			<?php
@@ -40,9 +41,10 @@ if ( ! empty( $tab_video_url ) ) :
 			<h3><?php printf( __( 'Want to be a %s Expert?', 'wordpress-seo' ), 'Yoast SEO' ); ?></h3>
 			<?php /* translators: %$1s expands to Yoast SEO */ ?>
 			<p><?php printf( __( 'Follow our %1$s for WordPress training and become a certified %1$s Expert!', 'wordpress-seo' ), 'Yoast SEO' ); ?></p>
-			<?php /* translators: %s expands to Yoast SEO for WordPress */ ?>
-			<p><a href="https://yoa.st/wordpress-training-vt"
-			      target="_blank"><?php printf( __( 'Enroll in the %s training &raquo;', 'wordpress-seo' ), 'Yoast SEO for WordPress' ); ?></a>
+			<p><a href="https://yoa.st/wordpress-training-vt" target="_blank"><?php
+			/* translators: %s expands to Yoast SEO for WordPress */
+			printf( __( 'Enroll in the %s training &raquo;', 'wordpress-seo' ), 'Yoast SEO for WordPress' );
+			?></a>
 			</p>
 		</div>
 	</div>

--- a/admin/views/tabs/advanced/permalinks.php
+++ b/admin/views/tabs/advanced/permalinks.php
@@ -15,9 +15,9 @@ $yform->currentoption = 'wpseo_permalinks';
 echo '<h2>', __( 'Change URLs', 'wordpress-seo' ), '</h2>';
 
 $remove_buttons = array( __( 'Keep', 'wordpress-seo' ), __( 'Remove', 'wordpress-seo' ) );
-/* translators: %s expands to <code>/category/</code> */
 $yform->light_switch(
 	'stripcategorybase',
+	/* translators: %s expands to <code>/category/</code> */
 	sprintf( __( 'Strip the category base (usually %s) from the category URL.', 'wordpress-seo' ), '<code>/category/</code>' ),
 	$remove_buttons,
 	false

--- a/admin/views/tabs/sitemaps/general.php
+++ b/admin/views/tabs/sitemaps/general.php
@@ -13,8 +13,8 @@ echo '<h2>' . esc_html__( 'Your XML Sitemap', 'wordpress-seo' ) . '</h2>';
 
 if ( $options['enablexmlsitemap'] === true ) {
 	echo '<p>';
-	/* translators: %1$s opening tag of the link to the Sitemap, %2$s closing tag for the link. */
 	printf(
+		/* translators: %1$s opening tag of the link to the Sitemap, %2$s closing tag for the link. */
 		esc_html__( 'You can find your XML Sitemap here: %1$sXML Sitemap%2$s', 'wordpress-seo' ),
 		'<a target="_blank" href="' . esc_url( WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ) ) . '">',
 		'</a>'


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
Translators comments must be on the line *directly* above the gettext call for them to be recognized by both makepot as well as xgettext.

No functional changes. Compliance with the WP I18n guidelines.

## Test instructions

_N/A_
