### PR TITLE
Remove redundant build step

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -67,7 +67,6 @@ release:
   - 'cssmin'
 'release:js':
   - 'copy'
-  - 'browserify:build'
   - 'browserify:release-es6'
   - 'uglify'
 'release:clean':


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
n/a

## Relevant technical choices:

* `browserify:release-es6` is now compiling all the files so the `browserify:build` is no longer necessary.

## Test instructions

This PR can be tested by following these steps:

* Make sure you can still create a valid beta using the beta script.