### PR TITLE
Make the metabox left sidebar responsive

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -72,6 +72,25 @@ ul.wpseo-metabox-tabs li.active {
 	vertical-align: top;
 }
 
+.wpseo-metabox-sidebar ul {
+	margin: 0;
+}
+
+.wpseo-metabox-sidebar li {
+	display: inline-block; /* Microsoft Edge 38. */
+	margin-bottom: 0;
+	padding: 5px;
+}
+
+.wpseo-metabox-sidebar a {
+	display: inline-block;
+	width: 35px;
+	height: 35px;
+	font-size: 20px;
+	line-height: 30px;
+	text-decoration: none;
+}
+
 .wpseo-metabox-sidebar li span {
 	margin: 3px 0 0 -5px;
 	padding: 0 2px 0 5px;
@@ -180,24 +199,6 @@ ul.wpseo-metabox-tabs li {
 	width: 30px;
 	height: 30px;
 	font-size: 30px;
-}
-
-.wpseo-metabox-sidebar a {
-	display: inline-block;
-	width: 35px;
-	height: 35px;
-	font-size: 20px;
-	line-height: 30px;
-	text-decoration: none;
-}
-
-.wpseo-metabox-sidebar ul {
-	margin: 0;
-}
-
-.wpseo-metabox-sidebar li {
-	margin-bottom: 0;
-	padding: 5px;
 }
 
 .wpseo-metabox-tabs-div div.wpseo-tabs-panel {
@@ -665,6 +666,10 @@ ul.wpseo-metabox-premium-advantages {
 		clear: both;
 	}
 
+	.wpseo-metabox-sidebar ul {
+		display: inline-block; /* Contain floated children. */
+	}
+
 	.wpseo-metabox-sidebar li {
 		float: left;
 		text-align: center;
@@ -678,10 +683,10 @@ ul.wpseo-metabox-premium-advantages {
 	.wpseo-meta-section-link .dashicons,
 	.wpseo-meta-section-link .yst-traffic-light-container {
 		display: block;
-		width: auto;
-		height: 37px; /* 37 + 3 bottom border = 40. */
+		width: 40px;
+		height: 35px; /* 35+5+2+3=45 must be 5px taller than the container to show the border outside of the contaiiner. */
 		margin: 0;
-		padding: 0;
+		padding: 5px 0 2px;
 		border-left-width: 0;
 		border-bottom-width: 3px;
 	}
@@ -690,7 +695,6 @@ ul.wpseo-metabox-premium-advantages {
 	.wpseo-meta-section-link .yst-traffic-light,
 	.wpseo-meta-section-link .dashicons:before {
 		margin: 0;
-		vertical-align: middle;
 	}
 
 	/* The "advanced" dashicon (the gear) is not perfectly centered and needs to be adjusted. */

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -653,6 +653,63 @@ ul.wpseo-metabox-premium-advantages {
 }
 
 @media screen and ( max-width: 782px ) {
+	.wpseo-metabox-sidebar {
+		display: inline-block; /* Contain floated children, don't use overflow hidden to avoid cutting-off content. */
+		width: auto;
+		margin: 0 0 10px -5px;
+		padding: 0;
+	}
+
+	.wpseo-meta-section.active {
+		display: block;
+		clear: both;
+	}
+
+	.wpseo-metabox-sidebar li {
+		float: left;
+		text-align: center;
+	}
+
+	.wpseo-metabox-sidebar .wpseo-meta-section-link {
+		width: 40px;
+		height: 40px;
+	}
+
+	.wpseo-meta-section-link .dashicons,
+	.wpseo-meta-section-link .yst-traffic-light-container {
+		display: block;
+		width: auto;
+		height: 37px; /* 37 + 3 bottom border = 40. */
+		margin: 0;
+		padding: 0;
+		border-left-width: 0;
+		border-bottom-width: 3px;
+	}
+
+	/* Traffic light svg and CSS generated dashicons. */
+	.wpseo-meta-section-link .yst-traffic-light,
+	.wpseo-meta-section-link .dashicons:before {
+		margin: 0;
+		vertical-align: middle;
+	}
+
+	/* The "advanced" dashicon (the gear) is not perfectly centered and needs to be adjusted. */
+	.wpseo-meta-section-link .dashicons-admin-generic:before {
+		position: relative;
+		left: 1px;
+	}
+
+	/* Go Premium dashicon. */
+	.wpseo-metabox-buy-premium .wpseo-buy-premium {
+		display: inline-block;
+		height: auto;
+		padding-right: 5px;
+	}
+
+	.wpseo-metabox-buy-premium .dashicons:before {
+		vertical-align: top;
+	}
+
 	.yoast-help-panel {
 		max-width: none !important;
 	}


### PR DESCRIPTION
## Summary

Make the meta box left sidebar change to a horizontal layout at a viewport width of 782 pixels and less.

In order to reserve all the available viewport width to the meta box content on small screens, we need to move the left sidebar above the content and display the icons horizontally. See screenshots below.

## Test instructions

Build the CSS and test emulating a viewport width of 782 pixels and less or, better, test on real mobile devices. I've tested emulating various devices in Chrome and also emulating a Windows 10 mobile device on Edge.

Fixes #6453 

Screenshots:

On small screens (detail: the icons dark border emulates the behavior of the desktop view and it's displayed outside of the clickable area):

<img width="352" alt="screen shot 2017-01-17 at 16 19 36" src="https://cloud.githubusercontent.com/assets/1682452/22027244/828137b8-dcd3-11e6-9992-71c1583c42d9.png">

For comparison, the dark border on the desktop view:

<img width="393" alt="screen shot 2017-01-17 at 16 17 30" src="https://cloud.githubusercontent.com/assets/1682452/22027285/a8145ece-dcd3-11e6-94ac-f7154af22886.png">
