### PR TITLE
Remove a tooltip CSS rule that should go in YoastSEO.js

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -638,11 +638,6 @@ ul.wpseo-metabox-premium-advantages {
 	padding: 0;
 }
 
-.yoast-tooltip.yoast-tooltip-hidden::before,
-.yoast-tooltip.yoast-tooltip-hidden::after {
-	display: none;
-}
-
 /* Workaround for VoiceOver bug see issue #5857 */
 .screen-reader-text.wpseo-generic-tab-textual-score,
 .screen-reader-text.wpseo-keyword-tab-textual-score {


### PR DESCRIPTION
See https://github.com/Yoast/YoastSEO.js/issues/1048

Fixes #6487 