### PR TITLE
Switch i18n-module to translate.wordpress.org

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -440,18 +440,16 @@ class WPSEO_Admin_Init {
 	 * @link https://github.com/Yoast/i18n-module
 	 */
 	private function register_i18n_promo_class() {
-		new yoast_i18n(
-			array(
-				'textdomain'     => 'wordpress-seo',
-				'project_slug'   => 'wordpress-seo',
-				'plugin_name'    => 'Yoast SEO',
-				'hook'           => 'wpseo_admin_promo_footer',
-				'glotpress_url'  => 'http://translate.yoast.com/gp/',
-				'glotpress_name' => 'Yoast Translate',
-				'glotpress_logo' => 'https://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
-				'register_url'   => 'https://translate.yoast.com/gp/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-i18n-promo',
-			)
-		);
+		// BC, because an older version of the i18n-module didn't have this class.
+		if ( class_exists( 'Yoast_I18n_WordPressOrg' ) ) {
+			new Yoast_I18n_WordPressOrg(
+				array(
+					'textdomain'  => 'wordpress-seo',
+					'plugin_name' => 'Yoast SEO',
+					'hook'        => 'wpseo_admin_promo_footer',
+				)
+			);
+		}
 	}
 
 	/**

--- a/composer.lock
+++ b/composer.lock
@@ -172,22 +172,22 @@
         },
         {
             "name": "yoast/i18n-module",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/i18n-module.git",
-                "reference": "2c617396446eac6123f2df49ffe5cb7356bbd65a"
+                "reference": "f4c424ed3af9d89666b9ccb7aa8cfc21f42ed047"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/2c617396446eac6123f2df49ffe5cb7356bbd65a",
-                "reference": "2c617396446eac6123f2df49ffe5cb7356bbd65a",
+                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/f4c424ed3af9d89666b9ccb7aa8cfc21f42ed047",
+                "reference": "f4c424ed3af9d89666b9ccb7aa8cfc21f42ed047",
                 "shasum": ""
             },
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "i18n-module.php"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -206,7 +206,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2017-01-03T11:28:09+00:00"
+            "time": "2017-01-23T13:39:06+00:00"
         },
         {
             "name": "yoast/license-manager",
@@ -319,7 +319,7 @@
                 "codeclimate",
                 "coverage"
             ],
-            "time": "2016-08-15T17:21:16+00:00"
+            "time": "2016-08-15 17:21:16"
         },
         {
             "name": "guzzle/guzzle",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Move translations from translate.yoast.com to translate.wordpress.org

## Relevant technical choices:

* I updated the i18n-module to make sure we can use the wordpress.org class

## Test instructions

This PR can be tested by following these steps:

* Set your user language to something that hasn't been translated 100% yet on https://translate.wordpress.org/projects/wp-plugins/wordpress-seo
* Clear your transients.
* Go to an SEO page.
* Observe that the i18n-module is present and produces the correct percentage.