### PR TITLE
fixes #6338 - Stray </span> tag in Breadcrumbs

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -302,7 +302,7 @@ class WPSEO_Breadcrumbs {
 		/** @var WP_Query $wp_query */
 		global $wp_query;
 
-		$this->add_home_crumb();
+		$this->maybe_add_home_crumb();
 		$this->maybe_add_blog_crumb();
 
 		if ( ( $this->show_on_front === 'page' && is_front_page() ) || ( $this->show_on_front === 'posts' && is_home() ) ) {
@@ -434,12 +434,14 @@ class WPSEO_Breadcrumbs {
 	/**
 	 * Add Homepage crumb to the crumbs property
 	 */
-	private function add_home_crumb() {
-		$this->add_predefined_crumb(
-			$this->options['breadcrumbs-home'],
-			WPSEO_Utils::home_url(),
-			true
-		);
+	private function maybe_add_home_crumb() {
+		if ($this->options['breadcrumbs-home'] !== '') {
+			$this->add_predefined_crumb(
+				$this->options['breadcrumbs-home'],
+				WPSEO_Utils::home_url(),
+				true
+			);
+		}
 	}
 
 	/**

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -435,7 +435,7 @@ class WPSEO_Breadcrumbs {
 	 * Add Homepage crumb to the crumbs property
 	 */
 	private function maybe_add_home_crumb() {
-		if ($this->options['breadcrumbs-home'] !== '') {
+		if ( $this->options['breadcrumbs-home'] !== '' ) {
 			$this->add_predefined_crumb(
 				$this->options['breadcrumbs-home'],
 				WPSEO_Utils::home_url(),


### PR DESCRIPTION
https://github.com/Yoast/wordpress-seo/issues/6338#issuecomment-274399182

## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

add a check 'breadcrumbs-home' option to prevent blank entry being added to crumbs array

rename the add_home_crumb function to maybe_add_home_crumb to be consistent with other function names in the plugin

as per issue comment, the empty item was being pushed to the array increading the count of closing span's by 1 incorrectly, since the (blank) array item is not added to the opening elements

## Test instructions

This PR can be tested by following these steps:

(* create a hierarchical custom post type)
* remove home anchor option in Yoast breadcrumb settings
* output usual yoast_breadcrumb in template

Fixes #6338
