### PR TITLE
Readability Column on Post Listings

### DIFF
--- a/css/edit-page-330.css
+++ b/css/edit-page-330.css
@@ -32,6 +32,10 @@ th#wpseo-score {
 	width: 63px;
 }
 
+th#wpseo-score {
+	width: 70px;
+}
+
 @media screen and (max-width: 782px) {
 	.column-wpseo-title,
 	.column-wpseo-score,


### PR DESCRIPTION
Fix the Readability column width on the post listings page. Incidentally, this is my first time on Github, so I'm hoping I'm doing things correctly.

## Summary

This PR can be summarized in the following changelog entry:
Just doing what was suggested in [this thread](https://github.com/Yoast/wordpress-seo/issues/6498). 

## Relevant technical choices:

* It was suggested that the width be set as 63px for consistency, but the word "readability" is too long for 63px, so I randomly set it as 70px.