### PR TITLE
Readability column width

### DIFF
--- a/css/edit-page-330.css
+++ b/css/edit-page-330.css
@@ -32,6 +32,10 @@ th#wpseo-score {
 	width: 63px;
 }
 
+th#wpseo-score {
+	width: 70px;
+}
+
 @media screen and (max-width: 782px) {
 	.column-wpseo-title,
 	.column-wpseo-score,

--- a/css/edit-page-330.css
+++ b/css/edit-page-330.css
@@ -32,8 +32,8 @@ th#wpseo-score {
 	width: 63px;
 }
 
-th#wpseo-score {
-	width: 70px;
+th#wpseo-score-readability {
+	width: 75px;
 }
 
 @media screen and (max-width: 782px) {

--- a/css/src/edit-page.scss
+++ b/css/src/edit-page.scss
@@ -32,6 +32,10 @@ th#wpseo-score {
 	width: 63px;
 }
 
+th#wpseo-score-readability {
+  width: 75px;
+}
+
 @media screen and ( max-width: 782px ) {
 	.column-wpseo-title,
 	.column-wpseo-score,


### PR DESCRIPTION
Based on https://github.com/Yoast/wordpress-seo/pull/6506

I've added this fix to the scss file, so it will work when we build the CSS files. Increased the width after discussion with @afercia, so it will look fine when the string is translated. 

Fixes #6498 