### PR TITLE
Exclude deprecated functions from test coverage

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -445,6 +445,7 @@ new Yoast_Dismissable_Notice_Ajax( 'recalculate', Yoast_Dismissable_Notice_Ajax:
  * Create an export and return the URL
  *
  * @deprecated 3.3.2
+ * @codeCoverageIgnore
  */
 function wpseo_get_export() {
 	_deprecated_function( __FUNCTION__, 'WPSEO 3.3.2', 'This method is deprecated.' );

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -520,6 +520,7 @@ class WPSEO_Admin_Init {
 	 * Returns whether or not the user has seen the tagline notice
 	 *
 	 * @deprecated 3.3
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool
 	 */
@@ -541,6 +542,7 @@ class WPSEO_Admin_Init {
 	 * Redirect first time or just upgraded users to the about screen.
 	 *
 	 * @deprecated 3.5
+	 * @codeCoverageIgnore
 	 */
 	public function after_update_notice() {
 		_deprecated_function( __METHOD__, 'WPSEO 3.5' );

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -517,6 +517,17 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
+	 * Check if the permalink uses %postname%
+	 *
+	 * @return bool
+	 */
+	private function has_postname_in_permalink() {
+		return ( false !== strpos( get_option( 'permalink_structure' ), '%postname%' ) );
+	}
+
+	/********************** DEPRECATED METHODS **********************/
+
+	/**
 	 * Returns whether or not the user has seen the tagline notice
 	 *
 	 * @deprecated 3.3
@@ -527,15 +538,6 @@ class WPSEO_Admin_Init {
 	public function seen_tagline_notice() {
 		_deprecated_function( __METHOD__, 'WPSEO 3.3.0' );
 		return false;
-	}
-
-	/**
-	 * Check if the permalink uses %postname%
-	 *
-	 * @return bool
-	 */
-	private function has_postname_in_permalink() {
-		return ( false !== strpos( get_option( 'permalink_structure' ), '%postname%' ) );
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -729,6 +729,7 @@ class WPSEO_Admin {
 
 	/********************** DEPRECATED METHODS **********************/
 
+	// @codeCoverageIgnoreStart
 	/**
 	 * Check whether the current user is allowed to access the configuration.
 	 *
@@ -810,4 +811,6 @@ class WPSEO_Admin {
 	function meta_description_warning() {
 		_deprecated_function( __FUNCTION__, 'WPSEO 3.3.0' );
 	}
+
+	// @codeCoverageIgnoreEnd
 }

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -596,56 +596,6 @@ class WPSEO_Admin {
 	}
 
 	/**
-	 * Returns the stopwords for the current language
-	 *
-	 * @since 1.1.7
-	 * @deprecated 3.1 Use WPSEO_Admin_Stop_Words::list_stop_words() instead.
-	 *
-	 * @return array $stopwords array of stop words to check and / or remove from slug
-	 */
-	function stopwords() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.1', 'WPSEO_Admin_Stop_Words::list_stop_words' );
-
-		$stop_words = new WPSEO_Admin_Stop_Words();
-		return $stop_words->list_stop_words();
-	}
-
-
-	/**
-	 * Check whether the stopword appears in the string
-	 *
-	 * @deprecated 3.1
-	 *
-	 * @param string $haystack    The string to be checked for the stopword.
-	 * @param bool   $checkingUrl Whether or not we're checking a URL.
-	 *
-	 * @return bool|mixed
-	 */
-	function stopwords_check( $haystack, $checkingUrl = false ) {
-		_deprecated_function( __METHOD__, 'WPSEO 3.1' );
-
-		$stopWords = $this->stopwords();
-
-		if ( is_array( $stopWords ) && $stopWords !== array() ) {
-			foreach ( $stopWords as $stopWord ) {
-				// If checking a URL remove the single quotes.
-				if ( $checkingUrl ) {
-					$stopWord = str_replace( "'", '', $stopWord );
-				}
-
-				// Check whether the stopword appears as a whole word.
-				// @todo [JRF => whomever] check whether the use of \b (=word boundary) would be more efficient ;-).
-				$res = preg_match( "`(^|[ \n\r\t\.,'\(\)\"\+;!?:])" . preg_quote( $stopWord, '`' ) . "($|[ \n\r\t\.,'\(\)\"\+;!?:])`iu", $haystack );
-				if ( $res > 0 ) {
-					return $stopWord;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Log the updated timestamp for user profiles when theme is changed
 	 */
 	function switch_theme() {
@@ -810,6 +760,56 @@ class WPSEO_Admin {
 	 */
 	function meta_description_warning() {
 		_deprecated_function( __FUNCTION__, 'WPSEO 3.3.0' );
+	}
+
+	/**
+	 * Returns the stopwords for the current language
+	 *
+	 * @since 1.1.7
+	 * @deprecated 3.1 Use WPSEO_Admin_Stop_Words::list_stop_words() instead.
+	 *
+	 * @return array $stopwords array of stop words to check and / or remove from slug
+	 */
+	function stopwords() {
+		_deprecated_function( __METHOD__, 'WPSEO 3.1', 'WPSEO_Admin_Stop_Words::list_stop_words' );
+
+		$stop_words = new WPSEO_Admin_Stop_Words();
+		return $stop_words->list_stop_words();
+	}
+
+
+	/**
+	 * Check whether the stopword appears in the string
+	 *
+	 * @deprecated 3.1
+	 *
+	 * @param string $haystack    The string to be checked for the stopword.
+	 * @param bool   $checkingUrl Whether or not we're checking a URL.
+	 *
+	 * @return bool|mixed
+	 */
+	function stopwords_check( $haystack, $checkingUrl = false ) {
+		_deprecated_function( __METHOD__, 'WPSEO 3.1' );
+
+		$stopWords = $this->stopwords();
+
+		if ( is_array( $stopWords ) && $stopWords !== array() ) {
+			foreach ( $stopWords as $stopWord ) {
+				// If checking a URL remove the single quotes.
+				if ( $checkingUrl ) {
+					$stopWord = str_replace( "'", '', $stopWord );
+				}
+
+				// Check whether the stopword appears as a whole word.
+				// @todo [JRF => whomever] check whether the use of \b (=word boundary) would be more efficient ;-).
+				$res = preg_match( "`(^|[ \n\r\t\.,'\(\)\"\+;!?:])" . preg_quote( $stopWord, '`' ) . "($|[ \n\r\t\.,'\(\)\"\+;!?:])`iu", $haystack );
+				if ( $res > 0 ) {
+					return $stopWord;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	// @codeCoverageIgnoreEnd

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -150,6 +150,7 @@ class WPSEO_Admin_Pages {
 
 	/********************** DEPRECATED METHODS **********************/
 
+	// @codeCoverageIgnoreStart
 	/**
 	 * Exports the current site's Yoast SEO settings.
 	 *
@@ -432,4 +433,5 @@ class WPSEO_Admin_Pages {
 		_deprecated_function( __METHOD__, 'WPSEO 1.5.0', 'WPSEO_Options::reset()' );
 		WPSEO_Options::reset();
 	}
+	// @codeCoverageIgnoreEnd
 } /* End of class */

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -154,6 +154,8 @@ class WPSEO_Admin_Pages {
 	/**
 	 * Exports the current site's Yoast SEO settings.
 	 *
+	 * @deprecated 2.0
+	 *
 	 * @param bool $include_taxonomy Whether to include the taxonomy metadata the plugin creates.
 	 *
 	 * @return bool|string $return False when failed, the URL to the export file when succeeded.

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -475,6 +475,7 @@ class WPSEO_Meta_Columns {
 	 * meta key clauses and not a combination - which is what we need.
 	 *
 	 * @deprecated 3.5 Unnecessary with nested meta queries in core.
+	 * @codeCoverageIgnore
 	 *
 	 * @param    string $where Where clause.
 	 *

--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -200,6 +200,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 
 	/********************** DEPRECATED METHODS **********************/
 
+	// @codeCoverageIgnoreStart
 	/**
 	 * Define the meta boxes for the Social tab
 	 *
@@ -238,4 +239,5 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 
 		return '';
 	}
+	// @codeCoverageIgnoreEnd
 } /* End of class */

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -562,6 +562,7 @@ class Yoast_Notification_Center {
 	 * Function renamed to 'update_storage'.
 	 *
 	 * @deprecated 3.2 remove in 3.5
+	 * @codeCoverageIgnore
 	 */
 	public function set_transient() {
 		_deprecated_function( __METHOD__, 'WPSEO 3.2' );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1185,6 +1185,7 @@ SVG;
 
 	/********************** DEPRECATED METHODS **********************/
 
+	// @codeCoverageIgnoreStart
 	/**
 	 * Adds the Yoast SEO box
 	 *
@@ -1678,4 +1679,5 @@ SVG;
 
 		return '';
 	}
+	// @codeCoverageIgnoreEnd
 }

--- a/admin/onpage/class-onpage-option.php
+++ b/admin/onpage/class-onpage-option.php
@@ -114,6 +114,7 @@ class WPSEO_OnPage_Option {
 
 	/**
 	 * @deprecated 3.0.2
+	 * @codeCoverageIgnore
 	 *
 	 * Returns the indexable status of the website.
 	 *

--- a/admin/onpage/class-onpage-request.php
+++ b/admin/onpage/class-onpage-request.php
@@ -66,6 +66,8 @@ class WPSEO_OnPage_Request {
 	 * Returns the fetched response
 	 *
 	 * @deprecated 3.1.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return array
 	 */
 	public function get_response() {

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -346,6 +346,7 @@ class WPSEO_Taxonomy {
 
 	/********************** DEPRECATED METHODS **********************/
 
+	// @codeCoverageIgnoreStart
 	/**
 	 * @deprecated 3.2
 	 *
@@ -387,4 +388,5 @@ class WPSEO_Taxonomy {
 	public function translate_meta_options() {
 		_deprecated_function( __METHOD__, 'WPSEO 3.2', 'WPSEO_Taxonomy_Settings_Fields::translate_meta_options' );
 	}
+	// @codeCoverageIgnoreEnd
 }

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -862,6 +862,7 @@ class WPSEO_Breadcrumbs {
 
 	/********************** DEPRECATED METHODS **********************/
 
+	// @codeCoverageIgnoreStart
 	/**
 	 * Wrapper function for the breadcrumb so it can be output for the supported themes.
 	 *
@@ -886,4 +887,5 @@ class WPSEO_Breadcrumbs {
 	public function create_breadcrumbs_string( $links, $wrapper = 'span', $element = 'span' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 1.5.2.3', 'yoast_breadcrumbs' );
 	}
+	// @codeCoverageIgnoreEnd
 }

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -259,6 +259,8 @@ class WPSEO_JSON_LD {
 	 *
 	 * @deprecated 2.1
 	 * @deprecated use WPSEO_JSON_LD::website()
+
+	 * @codeCoverageIgnore
 	 */
 	public function internal_search() {
 		_deprecated_function( __METHOD__, 'WPSEO 2.1', 'WPSEO_JSON_LD::website()' );

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -636,6 +636,8 @@ class WPSEO_Twitter {
 	 * Displays the domain tag for the site.
 	 *
 	 * @deprecated 3.0
+	 *
+	 * @codeCoverageIgnore
 	 */
 	protected function site_domain() {
 		_deprecated_function( __METHOD__, 'WPSEO 3.0' );

--- a/inc/class-wpseo-statistics.php
+++ b/inc/class-wpseo-statistics.php
@@ -58,6 +58,9 @@ class WPSEO_Statistics {
 		return $posts->found_posts;
 	}
 
+	/********************** DEPRECATED METHODS **********************/
+
+	// @codeCoverageIgnoreStart
 	/**
 	 * Returns the amount of posts that have no focus keyword
 	 *
@@ -135,4 +138,5 @@ class WPSEO_Statistics {
 
 		return $this->get_post_count( new WPSEO_Rank( WPSEO_Rank::NO_INDEX ) );
 	}
+	// @codeCoverageIgnoreEnd
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -977,6 +977,9 @@ class WPSEO_Utils {
 		         && version_compare( REST_API_VERSION, $minimum_version, '>=' ) );
 	}
 
+	/********************** DEPRECATED METHODS **********************/
+
+	// @codeCoverageIgnoreStart
 	/**
 	 * Wrapper for the PHP filter input function.
 	 *
@@ -1063,4 +1066,5 @@ class WPSEO_Utils {
 
 		return wp_json_encode( $array_to_encode, $options, $depth );
 	}
+	// @codeCoverageIgnoreEnd
 }

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -195,8 +195,6 @@ abstract class WPSEO_Option {
 	 */
 	// abstract public function enrich_defaults();
 
-// @codingStandardsIgnoreEnd
-
 	/* *********** METHODS INFLUENCING get_option() *********** */
 
 	/**
@@ -211,7 +209,7 @@ abstract class WPSEO_Option {
 		}
 	}
 
-
+	// @codingStandardsIgnoreStart
 	/**
 	 * Abusing a filter to re-add our default filters
 	 * WP 3.7 specific as update_option action hook was in the wrong place temporarily
@@ -715,6 +713,8 @@ abstract class WPSEO_Option {
 
 	/* *********** DEPRECATED METHODS *********** */
 
+	// @codeCoverageIgnoreStart
+
 	/**
 	 * Emulate the WP native sanitize_text_field function in a %%variable%% safe way
 	 *
@@ -849,4 +849,5 @@ abstract class WPSEO_Option {
 
 		return WPSEO_Utils::trim_recursive( $value );
 	}
+	// @codeCoverageIgnoreEnd
 }

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -421,6 +421,7 @@ class WPSEO_Options {
 
 	/********************** DEPRECATED FUNCTIONS **********************/
 
+	// @codeCoverageIgnoreStart
 	/**
 	 * Check whether the current user is allowed to access the configuration.
 	 *
@@ -473,4 +474,5 @@ class WPSEO_Options {
 		_deprecated_function( __METHOD__, 'WPSEO 1.5.6.1', 'WPSEO_Utils::clear_rewrites()' );
 		WPSEO_Utils::clear_rewrites();
 	}
+	// @codeCoverageIgnoreEnd
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,10 @@
 			<directory>./inc</directory>
 			<directory>./frontend</directory>
 			<directory>./admin</directory>
+			<exclude>
+				<directory suffix=".php">./deprecated</directory>
+				<file>./inc/wpseo-functions-deprecated.php</file>
+			</exclude>
 		</whitelist>
 	</filter>
 </phpunit>


### PR DESCRIPTION
Use `@codeCoverageIgnoreStart`, `@codeCoverageIgnoreEnd` and `@codeCoverageIgnore` to exclude functions and methods from the code coverage calculation.