### PR TITLE
CSS: replace all occurrences of bold with 600

### DIFF
--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -8,7 +8,7 @@
 #TB_window .wpseo_content_wrapper label {
 	margin: 0 10px 0 0;
 	font-size: 14px;
-	font-weight: bold;
+	font-weight: 600;
 }
 
 .wpseo-premium-popup-title {

--- a/css/src/metabox-primary-category.scss
+++ b/css/src/metabox-primary-category.scss
@@ -1,6 +1,6 @@
 .wpseo-primary-term > label,
 .wpseo-is-primary-term {
-	font-weight: bold;
+	font-weight: 600;
 }
 
 .wpseo-primary-term > .wpseo-make-primary-term,

--- a/css/src/toggle-switch.scss
+++ b/css/src/toggle-switch.scss
@@ -264,7 +264,7 @@
 		min-width: 200px;
 		margin-top: 10px;
 		padding-right: 1em;
-		font-weight: bold;
+		font-weight: 600;
 		line-height: 2em;
 		vertical-align: middle;
 	}

--- a/css/xml-sitemap-xsl.php
+++ b/css/xml-sitemap-xsl.php
@@ -58,7 +58,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 				}
 				.expl a {
 					color: #da3114;
-					font-weight: bold;
+					font-weight: 600;
 				}
 				.expl a:visited {
 					color: #da3114;


### PR DESCRIPTION
## Summary

Make bold font weight standardize to `600` for consistency with WordPress.

[WordPress doesn't use `bold` as value for the font weight any longer](https://core.trac.wordpress.org/changeset/37740) and uses `600` instead. The difference is subtle and depends on many factors, including the platform font rendering engine.

## Test instructions

- build the CSS
- search in the codebase for `bold`
- the only occurrences left in the relevant files should come from select2 and `yoast-components`

Fixes #6422 
