### PR TITLE
Fix generated PHP language files that we use for translate.wordpress.org

### DIFF
--- a/grunt/custom/convert-pot-to-wp.js
+++ b/grunt/custom/convert-pot-to-wp.js
@@ -17,13 +17,13 @@ let fileFooter = NEWLINE + [
 ].join( NEWLINE ) + NEWLINE;
 
 /**
- * Escapes double quotes.
+ * Escapes single quotes.
  *
  * @param {string} input The string to be escaped.
  * @returns {string} The escaped string.
  */
-function escapeDoubleQuotes( input ) {
-	return input.replace( /"/g, '\\"' );
+function escapeSingleQuotes( input ) {
+	return input.replace( /'/g, "\\'" );
 }
 
 /**
@@ -61,14 +61,14 @@ function convertTranslationToPHP( translation, textdomain ) {
 	}
 
 	if ( "" !== original ) {
-		original = escapeDoubleQuotes( original );
+		original = escapeSingleQuotes( original );
 
 		if ( _isEmpty( translation.msgid_plural ) ) {
-			php += TAB + `__( "${original}", "${textdomain}" )`;
+			php += TAB + `__( '${original}', '${textdomain}' )`;
 		} else {
-			let plural = escapeDoubleQuotes( translation.msgid_plural );
+			let plural = escapeSingleQuotes( translation.msgid_plural );
 
-			php += TAB + `_n( "${original}", "${plural}", 1, "${textdomain}" )`;
+			php += TAB + `_n( '${original}', '${plural}', 1, '${textdomain}' )`;
 		}
 	}
 

--- a/grunt/custom/convert-pot-to-wp.js
+++ b/grunt/custom/convert-pot-to-wp.js
@@ -68,7 +68,7 @@ function convertTranslationToPHP( translation, textdomain ) {
 		} else {
 			let plural = escapeSingleQuotes( translation.msgid_plural );
 
-			php += TAB + `_n( '${original}', '${plural}', 1, '${textdomain}' )`;
+			php += TAB + `_n_noop( '${original}', '${plural}', '${textdomain}' )`;
 		}
 	}
 

--- a/languages/yoast-components.php
+++ b/languages/yoast-components.php
@@ -2,125 +2,125 @@
 /* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
 $generated_i18n_strings = array(
 	// Reference: yoast-components/composites/OnboardingWizard/OnboardingWizard.js:275
-	__( "Next step", "wordpress-seo" ),
+	__( 'Next step', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/OnboardingWizard/OnboardingWizard.js:274
-	__( "Next", "wordpress-seo" ),
+	__( 'Next', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/OnboardingWizard/OnboardingWizard.js:266
-	__( "Previous step", "wordpress-seo" ),
+	__( 'Previous step', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/OnboardingWizard/OnboardingWizard.js:265
-	__( "Previous", "wordpress-seo" ),
+	__( 'Previous', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/OnboardingWizard/OnboardingWizard.js:238
-	__( "Close the Wizard", "wordpress-seo" ),
+	__( 'Close the Wizard', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/OnboardingWizard/OnboardingWizard.js:237
-	__( "Close", "wordpress-seo" ),
+	__( 'Close', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/OnboardingWizard/OnboardingWizard.js:163
-	__( "A problem occurred when saving the current step, {{link}}please file a bug report{{/link}} describing what step you are on and which changes you want to make (if any).", "wordpress-seo" ),
+	__( 'A problem occurred when saving the current step, {{link}}please file a bug report{{/link}} describing what step you are on and which changes you want to make (if any).', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/OnboardingWizard/StepIndicator.js:48
-	__( "Step %1$d: %2$s", "wordpress-seo" ),
+	__( 'Step %1$d: %2$s', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:67
-	__( "Close search result form", "wordpress-seo" ),
+	__( 'Close search result form', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:46
-	__( "Please provide a meta description by editing it here.", "wordpress-seo" ),
+	__( 'Please provide a meta description by editing it here.', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:45
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:44
-	__( "Meta description preview: ", "wordpress-seo" ),
+	__( 'Meta description preview: ', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:44
-	__( "Slug preview: ", "wordpress-seo" ),
+	__( 'Slug preview: ', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:43
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:42
-	__( "This is an example title - edit by clicking here", "wordpress-seo" ),
+	__( 'This is an example title - edit by clicking here', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:42
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:41
-	__( "SEO title preview: ", "wordpress-seo" ),
+	__( 'SEO title preview: ', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:41
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:40
-	__( "You can click on each element in the preview to jump to the Snippet Editor.", "wordpress-seo" ),
+	__( 'You can click on each element in the preview to jump to the Snippet Editor.', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultForm/SearchResultForm.js:40
-	__( "Search Result Form", "wordpress-seo" ),
+	__( 'Search Result Form', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:72
-	__( "Edit snippet", "wordpress-seo" ),
+	__( 'Edit snippet', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:45
-	__( "Please provide a meta description by editing the snippet below.", "wordpress-seo" ),
+	__( 'Please provide a meta description by editing the snippet below.', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:43
-	__( "URL preview: ", "wordpress-seo" ),
+	__( 'URL preview: ', 'wordpress-seo' ),
 
 	// Reference: yoast-components/composites/SearchResultPreview/SearchResultPreview.js:39
-	__( "Search Result Preview", "wordpress-seo" ),
+	__( 'Search Result Preview', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:352
-	__( "Get Google Authorization Code", "wordpress-seo" ),
+	__( 'Get Google Authorization Code', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:345
-	__( "To allow %s to fetch your Google Search Console information, please enter your Google Authorization Code. Clicking the button below will open a new window.", "wordpress-seo" ),
+	__( 'To allow %s to fetch your Google Search Console information, please enter your Google Authorization Code. Clicking the button below will open a new window.', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:334
-	__( "Reauthenticate with Google", "wordpress-seo" ),
+	__( 'Reauthenticate with Google', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:311
-	__( "Authenticate", "wordpress-seo" ),
+	__( 'Authenticate', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:308
-	__( "Authorization code", "wordpress-seo" ),
+	__( 'Authorization code', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:297
-	__( "Enter your Google Authorization Code and press the Authenticate button.", "wordpress-seo" ),
+	__( 'Enter your Google Authorization Code and press the Authenticate button.', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:273
-	__( "Choose a profile", "wordpress-seo" ),
+	__( 'Choose a profile', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:267
-	__( "Select profile", "wordpress-seo" ),
+	__( 'Select profile', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:256
-	__( "There were no profiles found", "wordpress-seo" ),
+	__( 'There were no profiles found', 'wordpress-seo' ),
 
 	// Reference: js/src/components/ConnectGoogleSearchConsole.js:110
-	__( "There is an error with the request.", "wordpress-seo" ),
+	__( 'There is an error with the request.', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MailchimpSignup.js:220
-	__( "Email", "wordpress-seo" ),
+	__( 'Email', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MailchimpSignup.js:206
-	__( "Name", "wordpress-seo" ),
+	__( 'Name', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MailchimpSignup.js:193
-	__( "Sign Up!", "wordpress-seo" ),
+	__( 'Sign Up!', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MailchimpSignup.js:111
-	__( "MailChimp signup failed:", "wordpress-seo" ),
+	__( 'MailChimp signup failed:', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MailchimpSignup.js:23
-	__( "Sign up for our newsletter!", "wordpress-seo" ),
+	__( 'Sign up for our newsletter!', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MediaUpload.js:106
-	__( "Choose image", "wordpress-seo" ),
+	__( 'Choose image', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MediaUpload.js:96
-	__( "company logo image preview", "wordpress-seo" ),
+	__( 'company logo image preview', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MediaUpload.js:89
-	__( "Remove the image", "wordpress-seo" ),
+	__( 'Remove the image', 'wordpress-seo' ),
 
 	// Reference: js/src/components/MediaUpload.js:19
 	// Reference: js/src/components/MediaUpload.js:18
-	__( "Choose an image", "wordpress-seo" )
+	__( 'Choose an image', 'wordpress-seo' )
 );
 /* THIS IS THE END OF THE GENERATED FILE */

--- a/languages/yoast-seo-js.php
+++ b/languages/yoast-seo-js.php
@@ -2,160 +2,160 @@
 /* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
 $generated_i18n_strings = array(
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:18
-	__( "very easy", "wordpress-seo" ),
+	__( 'very easy', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:26
-	__( "easy", "wordpress-seo" ),
+	__( 'easy', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:34
-	__( "fairly easy", "wordpress-seo" ),
+	__( 'fairly easy', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:42
-	__( "ok", "wordpress-seo" ),
+	__( 'ok', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:50
-	__( "fairly difficult", "wordpress-seo" ),
+	__( 'fairly difficult', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:51
-	__( "Try to make shorter sentences to improve readability.", "wordpress-seo" ),
+	__( 'Try to make shorter sentences to improve readability.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:58
-	__( "difficult", "wordpress-seo" ),
+	__( 'difficult', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:59
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:67
-	__( "Try to make shorter sentences, using less difficult words to improve readability.", "wordpress-seo" ),
+	__( 'Try to make shorter sentences, using less difficult words to improve readability.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:66
-	__( "very difficult", "wordpress-seo" ),
+	__( 'very difficult', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/fleschReadingEaseAssessment.js:85
 	/* Translators: %1$s expands to the numeric flesch reading ease score, %2$s to a link to a Yoast.com article about Flesch ease reading score,
 	   %3$s to the easyness of reading, %4$s expands to a note about the flesch reading score. */
-	__( "The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s", "wordpress-seo" ),
+	__( 'The copy scores %1$s in the %2$s test, which is considered %3$s to read. %4$s', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/introductionKeywordAssessment.js:14
-	__( "The focus keyword appears in the first paragraph of the copy.", "wordpress-seo" ),
+	__( 'The focus keyword appears in the first paragraph of the copy.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/introductionKeywordAssessment.js:20
-	__( "The focus keyword doesn't appear in the first paragraph of the copy. Make sure the topic is clear immediately.", "wordpress-seo" ),
+	__( 'The focus keyword doesn\'t appear in the first paragraph of the copy. Make sure the topic is clear immediately.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/keyphraseLengthAssessment.js:18
-	__( "No focus keyword was set for this page. If you do not set a focus keyword, no score can be calculated.", "wordpress-seo" ),
+	__( 'No focus keyword was set for this page. If you do not set a focus keyword, no score can be calculated.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/keyphraseLengthAssessment.js:22
-	__( "The keyphrase is over 10 words, a keyphrase should be shorter.", "wordpress-seo" ),
+	__( 'The keyphrase is over 10 words, a keyphrase should be shorter.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/keywordDensityAssessment.js:29
 	/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
 	   %3$s expands to the maximum keyword density percentage. */
-	__( "The keyword density is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d times.", "wordpress-seo" ),
+	__( 'The keyword density is %1$s, which is way over the advised %3$s maximum; the focus keyword was found %2$d times.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/keywordDensityAssessment.js:43
 	/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count,
 	   %3$s expands to the maximum keyword density percentage. */
-	__( "The keyword density is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d times.", "wordpress-seo" ),
+	__( 'The keyword density is %1$s, which is over the advised %3$s maximum; the focus keyword was found %2$d times.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/keywordDensityAssessment.js:56
 	/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
-	__( "The keyword density is %1$s, which is great; the focus keyword was found %2$d times.", "wordpress-seo" ),
+	__( 'The keyword density is %1$s, which is great; the focus keyword was found %2$d times.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/keywordDensityAssessment.js:66
 	/* Translators: %1$s expands to the keyword density percentage, %2$d expands to the keyword count. */
-	__( "The keyword density is %1$s, which is too low; the focus keyword was found %2$d times.", "wordpress-seo" ),
+	__( 'The keyword density is %1$s, which is too low; the focus keyword was found %2$d times.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/keywordStopWordsAssessment.js:20
 	/* Translators: %1$s opens a link to a Yoast article about stop words, %2$s closes the link */
-	_n( "The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.", "The focus keyword contains %3$d stop words. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.", 1, "wordpress-seo" ),
+	_n( 'The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.', 'The focus keyword contains %3$d stop words. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/metaDescriptionKeywordAssessment.js:13
-	__( "The meta description contains the focus keyword.", "wordpress-seo" ),
+	__( 'The meta description contains the focus keyword.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/metaDescriptionKeywordAssessment.js:19
-	__( "A meta description has been specified, but it does not contain the focus keyword.", "wordpress-seo" ),
+	__( 'A meta description has been specified, but it does not contain the focus keyword.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/metaDescriptionLengthAssessment.js:15
-	__( "No meta description has been specified. Search engines will display copy from the page instead.", "wordpress-seo" ),
+	__( 'No meta description has been specified. Search engines will display copy from the page instead.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/metaDescriptionLengthAssessment.js:22
-	__( "The meta description is under %1$d characters long. However, up to %2$d characters are available.", "wordpress-seo" ),
+	__( 'The meta description is under %1$d characters long. However, up to %2$d characters are available.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/metaDescriptionLengthAssessment.js:29
-	__( "The meta description is over %1$d characters. Reducing the length will ensure the entire description will be visible.", "wordpress-seo" ),
+	__( 'The meta description is over %1$d characters. Reducing the length will ensure the entire description will be visible.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/metaDescriptionLengthAssessment.js:36
-	__( "The length of the meta description is sufficient.", "wordpress-seo" ),
+	__( 'The length of the meta description is sufficient.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/pageTitleWidthAssessment.js:19
-	__( "The page title is too short. Use the space to add keyword variations or create compelling call-to-action copy.", "wordpress-seo" ),
+	__( 'The page title is too short. Use the space to add keyword variations or create compelling call-to-action copy.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/pageTitleWidthAssessment.js:29
-	__( "The page title has a nice length.", "wordpress-seo" ),
+	__( 'The page title has a nice length.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/pageTitleWidthAssessment.js:39
-	__( "The page title is wider than the viewable limit.", "wordpress-seo" ),
+	__( 'The page title is wider than the viewable limit.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/pageTitleWidthAssessment.js:46
-	__( "Please create a page title.", "wordpress-seo" ),
+	__( 'Please create a page title.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/paragraphTooLongAssessment.js:60
-	__( "None of the paragraphs are too long, which is great.", "wordpress-seo" ),
+	__( 'None of the paragraphs are too long, which is great.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/paragraphTooLongAssessment.js:68
 	/* Translators: %1$d expands to the number of paragraphs, %2$d expands to the recommended value */
-	_n( "%1$d of the paragraphs contains more than the recommended maximum of %2$d words. Are you sure all information is about the same topic, and therefore belongs in one single paragraph?", "%1$d of the paragraphs contain more than the recommended maximum of %2$d words. Are you sure all information within each of these paragraphs is about the same topic, and therefore belongs in a single paragraph?", 1, "wordpress-seo" ),
+	_n( '%1$d of the paragraphs contains more than the recommended maximum of %2$d words. Are you sure all information is about the same topic, and therefore belongs in one single paragraph?', '%1$d of the paragraphs contain more than the recommended maximum of %2$d words. Are you sure all information within each of these paragraphs is about the same topic, and therefore belongs in a single paragraph?', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/passiveVoiceAssessment.js:54
 	/* Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
 	   %3$s expands to the anchor end tag, %4$s expands to the recommended value. */
-	__( "%1$s of the sentences contain %2$spassive voice%3$s, which is less than or equal to the recommended maximum of %4$s.", "wordpress-seo" ),
+	__( '%1$s of the sentences contain %2$spassive voice%3$s, which is less than or equal to the recommended maximum of %4$s.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/passiveVoiceAssessment.js:72
 	/* Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
 	   %3$s expands to the anchor end tag, %4$s expands to the recommended value. */
-	__( "%1$s of the sentences contain %2$spassive voice%3$s, which is more than the recommended maximum of %4$s. Try to use their active counterparts.", "wordpress-seo" ),
+	__( '%1$s of the sentences contain %2$spassive voice%3$s, which is more than the recommended maximum of %4$s. Try to use their active counterparts.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/sentenceBeginningsAssessment.js:56
 	/* Translators: %1$d expands to the number of instances where 3 or more consecutive sentences start with the same word.
 	   %2$d expands to the number of consecutive sentences starting with the same word. */
-	_n( "The text contains %2$d consecutive sentences starting with the same word. Try to mix things up!", "The text contains %1$d instances where %2$d or more consecutive sentences start with the same word. Try to mix things up!", 1, "wordpress-seo" ),
+	_n( 'The text contains %2$d consecutive sentences starting with the same word. Try to mix things up!', 'The text contains %1$d instances where %2$d or more consecutive sentences start with the same word. Try to mix things up!', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/sentenceLengthInDescriptionAssessment.js:45
 	/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the recommended maximum sentence length,
 	   %3$s expands to the anchor end tag. */
-	__( "The meta description contains no sentences %1$sover %2$s words%3$s.", "wordpress-seo" ),
+	__( 'The meta description contains no sentences %1$sover %2$s words%3$s.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/sentenceLengthInDescriptionAssessment.js:56
 	/* Translators: %1$d expands to number of sentences, %2$s expands to a link on yoast.com,
 	   %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag. */
-	_n( "The meta description contains %1$d sentence %2$sover %3$s words%4$s. Try to shorten this sentence.", "The meta description contains %1$d sentences %2$sover %3$s words%4$s. Try to shorten these sentences.", 1, "wordpress-seo" ),
+	_n( 'The meta description contains %1$d sentence %2$sover %3$s words%4$s. Try to shorten this sentence.', 'The meta description contains %1$d sentences %2$sover %3$s words%4$s. Try to shorten these sentences.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/sentenceLengthInTextAssessment.js:79
 	/* Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
 	   %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag,
 	   %5$s expands to the recommended maximum percentage. */
-	__( "%1$s of the sentences contain %2$smore than %3$s words%4$s, which is less than or equal to the recommended maximum of %5$s.", "wordpress-seo" ),
+	__( '%1$s of the sentences contain %2$smore than %3$s words%4$s, which is less than or equal to the recommended maximum of %5$s.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/sentenceLengthInTextAssessment.js:96
 	/* Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
 	   %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag,
 	   %5$s expands to the recommended maximum percentage. */
-	__( "%1$s of the sentences contain %2$smore than %3$s words%4$s, which is more than the recommended maximum of %5$s. Try to shorten the sentences.", "wordpress-seo" ),
+	__( '%1$s of the sentences contain %2$smore than %3$s words%4$s, which is more than the recommended maximum of %5$s. Try to shorten the sentences.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/subheadingDistributionTooLongAssessment.js:40
-	__( "The text does not contain any subheadings. Add at least one subheading.", "wordpress-seo" ),
+	__( 'The text does not contain any subheadings. Add at least one subheading.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/subheadingDistributionTooLongAssessment.js:68
-	__( "The amount of words following each of the subheadings doesn't exceed the recommended maximum of %1$d words, which is great.", "wordpress-seo" ),
+	__( 'The amount of words following each of the subheadings doesn\'t exceed the recommended maximum of %1$d words, which is great.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/subheadingDistributionTooLongAssessment.js:81
-	_n( "%1$d of the subheadings is followed by more than the recommended maximum of %2$d words. Try to insert another subheading.", "%1$d of the subheadings are followed by more than the recommended maximum of %2$d words. Try to insert additional subheadings.", 1, "wordpress-seo" ),
+	_n( '%1$d of the subheadings is followed by more than the recommended maximum of %2$d words. Try to insert another subheading.', '%1$d of the subheadings are followed by more than the recommended maximum of %2$d words. Try to insert additional subheadings.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/subheadingsKeywordAssessment.js:14
-	__( "You have not used the focus keyword in any subheading (such as an H2) in your copy.", "wordpress-seo" ),
+	__( 'You have not used the focus keyword in any subheading (such as an H2) in your copy.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/subheadingsKeywordAssessment.js:20
-	__( "The focus keyword appears in %2$d (out of %1$d) subheadings in the copy. While not a major ranking factor, this is beneficial.", "wordpress-seo" ),
+	__( 'The focus keyword appears in %2$d (out of %1$d) subheadings in the copy. While not a major ranking factor, this is beneficial.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:20
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:39
@@ -169,18 +169,18 @@ $generated_i18n_strings = array(
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:94
 	/* Translators: %1$d expands to the number of words in the text.
 	   Translators: %1$d expands to the number of words in the text */
-	_n( "The text contains %1$d word.", "The text contains %1$d words.", 1, "wordpress-seo" ),
+	_n( 'The text contains %1$d word.', 'The text contains %1$d words.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:26
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:24
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-	_n( "This is more than or equal to the recommended minimum of %2$d word.", "This is more than or equal to the recommended minimum of %2$d words.", 1, "wordpress-seo" ),
+	_n( 'This is more than or equal to the recommended minimum of %2$d word.', 'This is more than or equal to the recommended minimum of %2$d words.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:45
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:43
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words.
 	   Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-	_n( "This is slightly below the recommended minimum of %2$d word. Add a bit more copy.", "This is slightly below the recommended minimum of %2$d words. Add a bit more copy.", 1, "wordpress-seo" ),
+	_n( 'This is slightly below the recommended minimum of %2$d word. Add a bit more copy.', 'This is slightly below the recommended minimum of %2$d words. Add a bit more copy.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:64
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:83
@@ -188,196 +188,196 @@ $generated_i18n_strings = array(
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:81
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words.
 	   Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-	_n( "This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.", "This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.", 1, "wordpress-seo" ),
+	_n( 'This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.', 'This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:102
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:100
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words.
 	   Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-	_n( "This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.", "This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.", 1, "wordpress-seo" ),
+	_n( 'This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.', 'This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textCompetingLinksAssessment.js:20
-	__( "You're linking to another page with the focus keyword you want this page to rank for. Consider changing that if you truly want this page to rank.", "wordpress-seo" ),
+	__( 'You\'re linking to another page with the focus keyword you want this page to rank for. Consider changing that if you truly want this page to rank.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textImagesAssessment.js:14
-	__( "No images appear in this page, consider adding some as appropriate.", "wordpress-seo" ),
+	__( 'No images appear in this page, consider adding some as appropriate.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textImagesAssessment.js:32
-	__( "The images on this page contain alt attributes with the focus keyword.", "wordpress-seo" ),
+	__( 'The images on this page contain alt attributes with the focus keyword.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textImagesAssessment.js:40
-	__( "The images on this page do not have alt attributes containing the focus keyword.", "wordpress-seo" ),
+	__( 'The images on this page do not have alt attributes containing the focus keyword.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textImagesAssessment.js:48
-	__( "The images on this page contain alt attributes.", "wordpress-seo" ),
+	__( 'The images on this page contain alt attributes.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textImagesAssessment.js:56
-	__( "The images on this page are missing alt attributes.", "wordpress-seo" ),
+	__( 'The images on this page are missing alt attributes.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textLinksAssessment.js:15
-	__( "No links appear in this page, consider adding some as appropriate.", "wordpress-seo" ),
+	__( 'No links appear in this page, consider adding some as appropriate.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textLinksAssessment.js:23
 	/* Translators: %1$s expands the number of outbound links */
-	__( "This page has %1$s outbound link(s), all nofollowed.", "wordpress-seo" ),
+	__( 'This page has %1$s outbound link(s), all nofollowed.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textLinksAssessment.js:32
 	/* Translators: %1$s expands to the number of nofollow links, %2$s to the number of outbound links */
-	__( "This page has %1$s nofollowed link(s) and %2$s normal outbound link(s).", "wordpress-seo" ),
+	__( 'This page has %1$s nofollowed link(s) and %2$s normal outbound link(s).', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textLinksAssessment.js:41
 	/* Translators: %1$s expands to the number of outbound links */
-	__( "This page has %1$s outbound link(s).", "wordpress-seo" ),
+	__( 'This page has %1$s outbound link(s).', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textPresenceAssessment.js:18
-	__( "You have far too little content, please add some content to enable a good analysis.", "wordpress-seo" ),
+	__( 'You have far too little content, please add some content to enable a good analysis.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/titleKeywordAssessment.js:17
-	__( "The focus keyword '%1$s' does not appear in the SEO title.", "wordpress-seo" ),
+	__( 'The focus keyword \'%1$s\' does not appear in the SEO title.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/titleKeywordAssessment.js:23
-	__( "The SEO title contains the focus keyword, at the beginning which is considered to improve rankings.", "wordpress-seo" ),
+	__( 'The SEO title contains the focus keyword, at the beginning which is considered to improve rankings.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/titleKeywordAssessment.js:29
-	__( "The SEO title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning.", "wordpress-seo" ),
+	__( 'The SEO title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/transitionWordsAssessment.js:66
 	/* Translators: %1$s expands to the number of sentences containing transition words, %2$s expands to a link on yoast.com,
 	   %3$s expands to the anchor end tag, %4$s expands to the recommended value. */
-	__( "%1$s of the sentences contain a %2$stransition word%3$s or phrase, which is less than the recommended minimum of %4$s.", "wordpress-seo" ),
+	__( '%1$s of the sentences contain a %2$stransition word%3$s or phrase, which is less than the recommended minimum of %4$s.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/transitionWordsAssessment.js:79
 	/* Translators: %1$s expands to the number of sentences containing transition words, %2$s expands to a link on yoast.com,
 	   %3$s expands to the anchor end tag. */
-	__( "%1$s of the sentences contain a %2$stransition word%3$s or phrase, which is great.", "wordpress-seo" ),
+	__( '%1$s of the sentences contain a %2$stransition word%3$s or phrase, which is great.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/urlKeywordAssessment.js:13
-	__( "The focus keyword appears in the URL for this page.", "wordpress-seo" ),
+	__( 'The focus keyword appears in the URL for this page.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/urlKeywordAssessment.js:19
-	__( "The focus keyword does not appear in the URL for this page. If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!", "wordpress-seo" ),
+	__( 'The focus keyword does not appear in the URL for this page. If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/urlLengthAssessment.js:16
-	__( "The slug for this page is a bit long, consider shortening it.", "wordpress-seo" ),
+	__( 'The slug for this page is a bit long, consider shortening it.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/urlStopWordsAssessment.js:20
 	/* Translators: %1$s opens a link to a wikipedia article about stop words, %2$s closes the link */
-	_n( "The slug for this page contains a %1$sstop word%2$s, consider removing it.", "The slug for this page contains %1$sstop words%2$s, consider removing them.", 1, "wordpress-seo" ),
+	_n( 'The slug for this page contains a %1$sstop word%2$s, consider removing it.', 'The slug for this page contains %1$sstop words%2$s, consider removing them.', 1, 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/urlStopWordsAssessment.js:46
 	/* Translators: this link is referred to in the content analysis when a slug contains one or more stop words */
-	__( "http://en.wikipedia.org/wiki/Stop_words", "wordpress-seo" ),
+	__( 'http://en.wikipedia.org/wiki/Stop_words', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/wordComplexityAssessment.js:64
 	/* Translators: %1$s expands to the percentage of complex words, %2$s expands to a link on yoast.com,
 	   %3$d expands to the recommended maximum number of syllables,
 	   %4$s expands to the anchor end tag, %5$s expands to the recommended maximum number of syllables. */
-	__( "%1$s of the words contain %2$sover %3$s syllables%4$s, which is less than or equal to the recommended maximum of %5$s.", "wordpress-seo" ),
+	__( '%1$s of the words contain %2$sover %3$s syllables%4$s, which is less than or equal to the recommended maximum of %5$s.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/wordComplexityAssessment.js:80
 	/* Translators: %1$s expands to the percentage of complex words, %2$s expands to a link on yoast.com,
 	   %3$d expands to the recommended maximum number of syllables,
 	   %4$s expands to the anchor end tag, %5$s expands to the recommended maximum number of syllables. */
-	__( "%1$s of the words contain %2$sover %3$s syllables%4$s, which is more than the recommended maximum of %5$s.", "wordpress-seo" ),
+	__( '%1$s of the words contain %2$sover %3$s syllables%4$s, which is more than the recommended maximum of %5$s.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessor.js:191
 	/* Translators: %1$s expands to the name of the assessment. */
-	__( "An error occurred in the '%1$s' assessment", "wordpress-seo" ),
+	__( 'An error occurred in the \'%1$s\' assessment', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/bundledPlugins/previouslyUsedKeywords.js:69
-	__( "You've never used this focus keyword before, very good.", "wordpress-seo" ),
+	__( 'You\'ve never used this focus keyword before, very good.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/bundledPlugins/previouslyUsedKeywords.js:77
 	/* Translators: %1$s and %2$s expand to an admin link where the focus keyword is already used */
-	__( "You've used this focus keyword %1$sonce before%2$s, be sure to make very clear which URL on your site is the most important for this keyword.", "wordpress-seo" ),
+	__( 'You\'ve used this focus keyword %1$sonce before%2$s, be sure to make very clear which URL on your site is the most important for this keyword.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/bundledPlugins/previouslyUsedKeywords.js:87
 	/* Translators: %1$s and $3$s expand to the admin search page for the focus keyword, %2$d expands to the number of times this focus
 	   keyword has been used before, %4$s and %5$s expand to a link to an article on yoast.com about cornerstone content */
-	__( "You've used this focus keyword %1$s%2$d times before%3$s, it's probably a good idea to read %4$sthis post on cornerstone content%5$s and improve your keyword strategy.", "wordpress-seo" ),
+	__( 'You\'ve used this focus keyword %1$s%2$d times before%3$s, it\'s probably a good idea to read %4$sthis post on cornerstone content%5$s and improve your keyword strategy.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:10
-	__( "Feedback", "wordpress-seo" ),
+	__( 'Feedback', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:11
-	__( "Content optimization: Has feedback", "wordpress-seo" ),
+	__( 'Content optimization: Has feedback', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:16
-	__( "Bad SEO score", "wordpress-seo" ),
+	__( 'Bad SEO score', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:17
-	__( "Content optimization: Bad SEO score", "wordpress-seo" ),
+	__( 'Content optimization: Bad SEO score', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:18
-	__( "Needs improvement", "wordpress-seo" ),
+	__( 'Needs improvement', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:22
-	__( "OK SEO score", "wordpress-seo" ),
+	__( 'OK SEO score', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:23
-	__( "Content optimization: OK SEO score", "wordpress-seo" ),
+	__( 'Content optimization: OK SEO score', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:24
-	__( "OK", "wordpress-seo" ),
+	__( 'OK', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:28
-	__( "Good SEO score", "wordpress-seo" ),
+	__( 'Good SEO score', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:29
-	__( "Content optimization: Good SEO score", "wordpress-seo" ),
+	__( 'Content optimization: Good SEO score', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/config/presenter.js:30
-	__( "Good", "wordpress-seo" ),
+	__( 'Good', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/renderers/AssessorPresenter.js:350
-	__( "Marks are disabled in current view", "wordpress-seo" ),
+	__( 'Marks are disabled in current view', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/renderers/AssessorPresenter.js:351
-	__( "Mark this result in the text", "wordpress-seo" ),
+	__( 'Mark this result in the text', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/renderers/AssessorPresenter.js:352
-	__( "Remove marks in the text", "wordpress-seo" ),
+	__( 'Remove marks in the text', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:371
-	__( "Edit snippet", "wordpress-seo" ),
+	__( 'Edit snippet', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:372
-	__( "SEO title", "wordpress-seo" ),
+	__( 'SEO title', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:373
-	__( "Slug", "wordpress-seo" ),
+	__( 'Slug', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:374
-	__( "Meta description", "wordpress-seo" ),
+	__( 'Meta description', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:375
-	__( "Close snippet editor", "wordpress-seo" ),
+	__( 'Close snippet editor', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:376
-	__( "Snippet preview", "wordpress-seo" ),
+	__( 'Snippet preview', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:377
-	__( "SEO title preview:", "wordpress-seo" ),
+	__( 'SEO title preview:', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:378
-	__( "Slug preview:", "wordpress-seo" ),
+	__( 'Slug preview:', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:379
-	__( "Meta description preview:", "wordpress-seo" ),
+	__( 'Meta description preview:', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:382
-	__( "You can click on each element in the preview to jump to the Snippet Editor.", "wordpress-seo" ),
+	__( 'You can click on each element in the preview to jump to the Snippet Editor.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:384
-	__( "Desktop preview", "wordpress-seo" ),
+	__( 'Desktop preview', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:385
-	__( "Mobile preview", "wordpress-seo" ),
+	__( 'Mobile preview', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:597
-	__( "Please provide an SEO title by editing the snippet below.", "wordpress-seo" ),
+	__( 'Please provide an SEO title by editing the snippet below.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/snippetPreview.js:673
-	__( "Please provide a meta description by editing the snippet below.", "wordpress-seo" )
+	__( 'Please provide a meta description by editing the snippet below.', 'wordpress-seo' )
 );
 /* THIS IS THE END OF THE GENERATED FILE */

--- a/languages/yoast-seo-js.php
+++ b/languages/yoast-seo-js.php
@@ -66,7 +66,7 @@ $generated_i18n_strings = array(
 
 	// Reference: node_modules/yoastseo/js/assessments/keywordStopWordsAssessment.js:20
 	/* Translators: %1$s opens a link to a Yoast article about stop words, %2$s closes the link */
-	_n( 'The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.', 'The focus keyword contains %3$d stop words. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.', 1, 'wordpress-seo' ),
+	_n_noop( 'The focus keyword contains a stop word. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.', 'The focus keyword contains %3$d stop words. This may or may not be wise depending on the circumstances. Read %1$sthis article%2$s for more info.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/metaDescriptionKeywordAssessment.js:13
 	__( 'The meta description contains the focus keyword.', 'wordpress-seo' ),
@@ -103,7 +103,7 @@ $generated_i18n_strings = array(
 
 	// Reference: node_modules/yoastseo/js/assessments/paragraphTooLongAssessment.js:68
 	/* Translators: %1$d expands to the number of paragraphs, %2$d expands to the recommended value */
-	_n( '%1$d of the paragraphs contains more than the recommended maximum of %2$d words. Are you sure all information is about the same topic, and therefore belongs in one single paragraph?', '%1$d of the paragraphs contain more than the recommended maximum of %2$d words. Are you sure all information within each of these paragraphs is about the same topic, and therefore belongs in a single paragraph?', 1, 'wordpress-seo' ),
+	_n_noop( '%1$d of the paragraphs contains more than the recommended maximum of %2$d words. Are you sure all information is about the same topic, and therefore belongs in one single paragraph?', '%1$d of the paragraphs contain more than the recommended maximum of %2$d words. Are you sure all information within each of these paragraphs is about the same topic, and therefore belongs in a single paragraph?', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/passiveVoiceAssessment.js:54
 	/* Translators: %1$s expands to the number of sentences in passive voice, %2$s expands to a link on yoast.com,
@@ -118,7 +118,7 @@ $generated_i18n_strings = array(
 	// Reference: node_modules/yoastseo/js/assessments/sentenceBeginningsAssessment.js:56
 	/* Translators: %1$d expands to the number of instances where 3 or more consecutive sentences start with the same word.
 	   %2$d expands to the number of consecutive sentences starting with the same word. */
-	_n( 'The text contains %2$d consecutive sentences starting with the same word. Try to mix things up!', 'The text contains %1$d instances where %2$d or more consecutive sentences start with the same word. Try to mix things up!', 1, 'wordpress-seo' ),
+	_n_noop( 'The text contains %2$d consecutive sentences starting with the same word. Try to mix things up!', 'The text contains %1$d instances where %2$d or more consecutive sentences start with the same word. Try to mix things up!', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/sentenceLengthInDescriptionAssessment.js:45
 	/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the recommended maximum sentence length,
@@ -128,7 +128,7 @@ $generated_i18n_strings = array(
 	// Reference: node_modules/yoastseo/js/assessments/sentenceLengthInDescriptionAssessment.js:56
 	/* Translators: %1$d expands to number of sentences, %2$s expands to a link on yoast.com,
 	   %3$s expands to the recommended maximum sentence length, %4$s expands to the anchor end tag. */
-	_n( 'The meta description contains %1$d sentence %2$sover %3$s words%4$s. Try to shorten this sentence.', 'The meta description contains %1$d sentences %2$sover %3$s words%4$s. Try to shorten these sentences.', 1, 'wordpress-seo' ),
+	_n_noop( 'The meta description contains %1$d sentence %2$sover %3$s words%4$s. Try to shorten this sentence.', 'The meta description contains %1$d sentences %2$sover %3$s words%4$s. Try to shorten these sentences.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/sentenceLengthInTextAssessment.js:79
 	/* Translators: %1$d expands to percentage of sentences, %2$s expands to a link on yoast.com,
@@ -149,7 +149,7 @@ $generated_i18n_strings = array(
 	__( 'The amount of words following each of the subheadings doesn\'t exceed the recommended maximum of %1$d words, which is great.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/subheadingDistributionTooLongAssessment.js:81
-	_n( '%1$d of the subheadings is followed by more than the recommended maximum of %2$d words. Try to insert another subheading.', '%1$d of the subheadings are followed by more than the recommended maximum of %2$d words. Try to insert additional subheadings.', 1, 'wordpress-seo' ),
+	_n_noop( '%1$d of the subheadings is followed by more than the recommended maximum of %2$d words. Try to insert another subheading.', '%1$d of the subheadings are followed by more than the recommended maximum of %2$d words. Try to insert additional subheadings.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/subheadingsKeywordAssessment.js:14
 	__( 'You have not used the focus keyword in any subheading (such as an H2) in your copy.', 'wordpress-seo' ),
@@ -169,18 +169,18 @@ $generated_i18n_strings = array(
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:94
 	/* Translators: %1$d expands to the number of words in the text.
 	   Translators: %1$d expands to the number of words in the text */
-	_n( 'The text contains %1$d word.', 'The text contains %1$d words.', 1, 'wordpress-seo' ),
+	_n_noop( 'The text contains %1$d word.', 'The text contains %1$d words.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:26
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:24
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words. */
-	_n( 'This is more than or equal to the recommended minimum of %2$d word.', 'This is more than or equal to the recommended minimum of %2$d words.', 1, 'wordpress-seo' ),
+	_n_noop( 'This is more than or equal to the recommended minimum of %2$d word.', 'This is more than or equal to the recommended minimum of %2$d words.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:45
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:43
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words.
 	   Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-	_n( 'This is slightly below the recommended minimum of %2$d word. Add a bit more copy.', 'This is slightly below the recommended minimum of %2$d words. Add a bit more copy.', 1, 'wordpress-seo' ),
+	_n_noop( 'This is slightly below the recommended minimum of %2$d word. Add a bit more copy.', 'This is slightly below the recommended minimum of %2$d words. Add a bit more copy.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:64
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:83
@@ -188,13 +188,13 @@ $generated_i18n_strings = array(
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:81
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words.
 	   Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-	_n( 'This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.', 'This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.', 1, 'wordpress-seo' ),
+	_n_noop( 'This is below the recommended minimum of %2$d word. Add more content that is relevant for the topic.', 'This is below the recommended minimum of %2$d words. Add more content that is relevant for the topic.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/taxonomyTextLengthAssessment.js:102
 	// Reference: node_modules/yoastseo/js/assessments/textLengthAssessment.js:100
 	/* Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words.
 	   Translators: The preceding sentence is "The text contains x words.", %2$s expands to the recommended minimum of words */
-	_n( 'This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.', 'This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.', 1, 'wordpress-seo' ),
+	_n_noop( 'This is far below the recommended minimum of %2$d word. Add more content that is relevant for the topic.', 'This is far below the recommended minimum of %2$d words. Add more content that is relevant for the topic.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/textCompetingLinksAssessment.js:20
 	__( 'You\'re linking to another page with the focus keyword you want this page to rank for. Consider changing that if you truly want this page to rank.', 'wordpress-seo' ),
@@ -262,7 +262,7 @@ $generated_i18n_strings = array(
 
 	// Reference: node_modules/yoastseo/js/assessments/urlStopWordsAssessment.js:20
 	/* Translators: %1$s opens a link to a wikipedia article about stop words, %2$s closes the link */
-	_n( 'The slug for this page contains a %1$sstop word%2$s, consider removing it.', 'The slug for this page contains %1$sstop words%2$s, consider removing them.', 1, 'wordpress-seo' ),
+	_n_noop( 'The slug for this page contains a %1$sstop word%2$s, consider removing it.', 'The slug for this page contains %1$sstop words%2$s, consider removing them.', 'wordpress-seo' ),
 
 	// Reference: node_modules/yoastseo/js/assessments/urlStopWordsAssessment.js:46
 	/* Translators: this link is referred to in the content analysis when a slug contains one or more stop words */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where some strings wouldn't be translated.

## Relevant technical choices:

* Switch from double to single quotes because PHP tries to interpret the dollar signs as variables when using double quotes.
* Switch from _n to _n_noop because that function returns instead of echo'ing. This is more appropriate for our use case.