### PR TITLE
Fix build error because of and old gcc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ branches:
     - master
     - trunk
 
-env:
-  - CXX=g++-4.8
 addons:
   apt:
     sources:
@@ -20,7 +18,7 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
+      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node CXX=g++-4.8
     - php: 5.2
       env: WP_VERSION=4.6 WP_MULTISITE=1 PHPLINT=1
     - php: 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ branches:
     - master
     - trunk
 
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/4771
And see https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements

It is not really nice, but the only solution for now.