### PR TITLE
Author Sitemap Cache Clearing

### DIFF
--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -31,7 +31,7 @@ class WPSEO_Admin_User_Profile {
 	 */
 	public function clear_author_sitemap_cache( $meta_id, $object_id, $meta_key ) {
 		if ( '_yoast_wpseo_profile_updated' === $meta_key ) {
-			WPSEO_Utils::clear_sitemap_cache( array( 'author' ) );
+			WPSEO_Sitemaps_Cache::clear( array( 'author' ) );
 		}
 	}
 


### PR DESCRIPTION
## Summary

Replacing the deprecated `WPSEO_Utils::clear_sitemap_cache()` with `WPSEO_Sitemaps_Cache::clear()` to remove deprecation warnings.


## Test instructions

This PR can be tested by following these steps:

* Update an existing author

Fixes #6586

Replaced the deprecated `WPSEO_Utils::clear_sitemap_cache()` with `WPSEO_Sitemaps_Cache::clear()`.