### PR TITLE
Add bottom margin to the title separator controls.

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -294,7 +294,7 @@ textarea.wpseo-new-metadesc {
 
 /* Titles & Metas: title separator. */
 #separator {
-	margin: 1.5em 0 1em;
+	margin: 1.5em 0 0.5em;
 }
 
 #separator input.radio {
@@ -308,7 +308,7 @@ textarea.wpseo-new-metadesc {
 #separator input.radio + label {
 	float: left;
 	width: 30px !important;
-	margin: 0 5px 0 0 !important;
+	margin: 0 5px 0.5em 0 !important;
 	padding: 9px 6px;
 	border: 1px solid #ccc;
 	/* Don't change: these mimic Google's font and font size for titles */


### PR DESCRIPTION
## Summary

On small screens, the title separator controls go in multiple lines and need some bottom margin.

## Test instructions

Build the CSS then check at various viewport widths.

Screenshot before:

<img width="424" alt="screen shot 2017-01-23 at 11 23 53" src="https://cloud.githubusercontent.com/assets/1682452/22430506/cd6c81a2-e70e-11e6-93c8-b2d1506fabc1.png">

Screenshot after:

<img width="412" alt="screen shot 2017-02-02 at 15 58 26" src="https://cloud.githubusercontent.com/assets/1682452/22554632/19bae432-e961-11e6-93ac-0d6129f4f652.png">

Fixes #6557 
