### PR TITLE
Added the wpseo_internal_linking action

### DIFF
--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -27,6 +27,11 @@ if ( WPSEO_Utils::is_api_available() ) :
 <?php
 endif;
 
+/**
+ * Action: 'wpseo_internal_linking' - Hook to add the internal linking analyze interface to the interface.
+ */
+do_action( 'wpseo_internal_linking' );
+
 echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 ?>
 <p>


### PR DESCRIPTION
This action is necessary for use to properly move the internal linking recalculation away from its own tab.

To test, create a dummy function in your theme's `functions.php` and hook it by calling `add_action( 'wpseo_internal_linking', [ $this, 'dummy_function' ] );`

Do something like a `var_dump( 'dummy function called!' );` in said dummy function.

Required for https://github.com/Yoast/wordpress-seo/issues/6577
