### PR TITLE
Fix #6593 

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -365,7 +365,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 			// Plugin conflict ajax hooks.
 			new Yoast_Plugin_Conflict_Ajax();
 
-			if ( filter_input( INPUT_POST, 'action' ) === 'inline-save' ) {
+			if ( filter_input( INPUT_POST, 'action' ) === 'inline-save' || apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) ) {
 				add_action( 'plugins_loaded', 'wpseo_admin_init', 15 );
 			}
 		}


### PR DESCRIPTION
## Summary

* make filter `wpseo_always_register_metaboxes_on_admin` work

## Test instructions

* install polylang
* include PHP Code `add_filter( 'wpseo_always_register_metaboxes_on_admin', '__return_true' );` somewhere in theme or mu-plugin
* QuickEdit a post or page. SEO-Columns won't disappear any more.

Fixes #6593 
