### PR TITLE
Fix three not translatable strings.

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -847,7 +847,12 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				break;
 
 			case 'col_row_action':
-				$column_value = sprintf( '<a href="#" role="button" class="wpseo-save" data-id="%1$s">Save</a> <span aria-hidden="true">|</span> <a href="#" role="button" class="wpseo-save-all">Save All</a>', $rec->ID );
+				$column_value = sprintf(
+					'<a href="#" role="button" class="wpseo-save" data-id="%1$s">%2$s</a> <span aria-hidden="true">|</span> <a href="#" role="button" class="wpseo-save-all">%3$s</a>',
+					$rec->ID,
+					esc_html__( 'Save', 'wordpress-seo' ),
+					esc_html__( 'Save all', 'wordpress-seo' )
+				);
 				break;
 		}
 

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -37,7 +37,7 @@ $feature_toggles = array(
 $feature_toggles = apply_filters( 'wpseo_feature_toggles', $feature_toggles );
 
 ?>
-<h2>Features</h2>
+<h2><?php esc_html_e( 'Features', 'wordpress-seo' ); ?></h2>
 
 <?php echo esc_html( sprintf(
 	__( '%1$s comes with a lot of features. You can enable / disable some of them below.', 'wordpress-seo' ),


### PR DESCRIPTION
Make three strings translatable:

- the "Features" heading in the General > Features tab
- "Save" and "Save all" in the bulk editor table

Fixes #6589 
Fixes #6591 