### PR TITLE
Make the Yoast SEO menu visible in the responsive admin bar

### DIFF
--- a/css/src/adminbar.scss
+++ b/css/src/adminbar.scss
@@ -72,3 +72,34 @@
 #wpadminbar #wp-admin-bar-wpseo-licenses .ab-item {
 	color: #f18500;
 }
+
+@media screen and ( max-width: 782px ) {
+	#wpadminbar #wp-admin-bar-wpseo-menu {
+		display: block;
+		position: static;
+	}
+
+	#wpadminbar .yoast-logo.svg {
+		width: 52px;
+		height: 46px;
+		background-position: 50% 8px;
+		background-size: 30px;
+	}
+
+	// Target just the first counter in the top level.
+	#wpadminbar .yoast-logo + .yoast-issue-counter {
+		margin-left: -10px;
+	}
+
+	// Target just the second counter in the sub-menu.
+	#wpadminbar .ab-sub-wrapper .yoast-issue-counter {
+		vertical-align: text-top;
+		position: relative;
+		top: -5px;
+	}
+
+	#wp-admin-bar-wpseo-menu.menupop .ab-sub-wrapper #wp-admin-bar-wpseo-kwresearch,
+	#wp-admin-bar-wpseo-menu.menupop .ab-sub-wrapper #wp-admin-bar-wpseo-settings {
+		display: none;
+	}
+}

--- a/css/src/adminbar.scss
+++ b/css/src/adminbar.scss
@@ -102,4 +102,8 @@
 	#wp-admin-bar-wpseo-menu.menupop .ab-sub-wrapper #wp-admin-bar-wpseo-settings {
 		display: none;
 	}
+
+	#wpadminbar .yoast-issue-added {
+		top: 46px;
+	}
 }


### PR DESCRIPTION
## Summary

Make the Yoast SEO menu top and first item visible in the responsive view. 

While under a viewport width of 600 pixels WordPress takes care to transform the menu sub-levels and displays them full width:

![screen shot 2017-02-06 at 10 44 03](https://cloud.githubusercontent.com/assets/1682452/22643979/02dd2da8-ec61-11e6-8d23-898ec143b29a.png)

between 600 and 782 pixels instead, they're are still "fly-out" menus and there's not enough space to display them:

![screen shot 2017-02-06 at 10 43 48](https://cloud.githubusercontent.com/assets/1682452/22644024/3587bf02-ec61-11e6-9e85-351742a2a79e.png)

Instead of trying to do complicated things (reverse the fly-outs, change the icons, etc.), I'd propose to keep it simple and display just the top and first items to give access to the notification center:

![screen shot 2017-02-06 at 11 20 54](https://cloud.githubusercontent.com/assets/1682452/22644082/83523c80-ec61-11e6-9014-34f981107118.png)

This would look consistent with what WP does:

![screen shot 2017-02-06 at 11 13 52](https://cloud.githubusercontent.com/assets/1682452/22644192/ceea8d00-ec61-11e6-9beb-d59927a38af0.png)

Under 600 pixels:

![screen shot 2017-02-06 at 11 23 21](https://cloud.githubusercontent.com/assets/1682452/22644223/ecfc06ac-ec61-11e6-9473-4daff6d786ec.png)

![screen shot 2017-02-06 at 11 23 29](https://cloud.githubusercontent.com/assets/1682452/22644224/ed01b96c-ec61-11e6-8c9c-9f084ad394e3.png)


## Test instructions
- build the CSS
- test at different viewport widths

Fixes #6366 
