### PR TITLE
Fix the Yoast icon on the Credits page responsive view

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -344,9 +344,8 @@ textarea.wpseo-new-metadesc {
 
 /* Yoast SEO credits page. */
 body.toplevel_page_wpseo_dashboard .wp-badge {
-	border: none;
-	background: url(../images/Yoast_SEO_Icon.svg);
-	background-size: 150px 160px;
+	background: transparent url(../images/Yoast_SEO_Icon.svg) no-repeat 50% 10px;
+	background-size: 140px 140px;
 	box-shadow: none;
 }
 
@@ -522,5 +521,14 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 			margin: 0 auto;
 			border-bottom: 1px solid #ddd;
 		}
+	}
+}
+
+@media screen and ( max-width: 500px ) {
+	body.toplevel_page_wpseo_dashboard .wp-badge {
+		padding-top: 80px;
+		background-size: 100px 100px;
+		background-color: #a4286a;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 	}
 }


### PR DESCRIPTION
## Summary

Currently, the Yoast icon on the Credits page is a background image and, in the responsive view, the background is repeated:

![screen shot 2017-02-02 at 16 29 12](https://cloud.githubusercontent.com/assets/1682452/22556604/09249abc-e968-11e6-8bc2-7a25c9094696.png)

To fix it, we could mimic what WordPress does under a viewport of 500 pixels, displaying a background color and centering the image:

![screen shot 2017-02-06 at 12 33 27](https://cloud.githubusercontent.com/assets/1682452/22646086/d314ffa6-ec6a-11e6-9180-27ffcbddf973.png)

or, maybe, completely hide the image? /cc @moorscode 

## Test instructions
- build the CSS
- check the Credits page at different viewport widths

Fixes #6584 
