### PR TITLE
Add missing data-colname attribute in the bulk editor table

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -705,7 +705,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 						$classes .= ' has-row-actions column-primary';
 					}
 
-					$attributes = $this->column_attributes( $column_name, $hidden, $classes );
+					$attributes = $this->column_attributes( $column_name, $hidden, $classes, $column_display_name );
 
 					$column_value = $this->parse_column( $column_name, $rec );
 
@@ -726,13 +726,14 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * Getting the attributes for each table cell.
 	 *
-	 * @param string $column_name Column name string.
-	 * @param array  $hidden      Set of hidden columns.
-	 * @param string $classes     Additional CSS classes.
+	 * @param string $column_name         Column name string.
+	 * @param array  $hidden              Set of hidden columns.
+	 * @param string $classes             Additional CSS classes.
+	 * @param string $column_display_name Column display name string.
 	 *
 	 * @return string
 	 */
-	protected function column_attributes( $column_name, $hidden, $classes ) {
+	protected function column_attributes( $column_name, $hidden, $classes, $column_display_name ) {
 
 		$attributes = '';
 		$class = array( $column_name, "column-$column_name$classes" );
@@ -741,8 +742,10 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			$class[] = 'hidden';
 		}
 
+		$data_colname = ' data-colname="' . esc_attr( $column_display_name ) . '"';
+
 		if ( ! empty( $class ) ) {
-			$attributes = 'class="' . implode( ' ', $class ) . '"';
+			$attributes = 'class="' . implode( ' ', $class ) . '"' . $data_colname;
 		}
 
 		return $attributes;

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -742,11 +742,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			$class[] = 'hidden';
 		}
 
-		$data_colname = ' data-colname="' . esc_attr( $column_display_name ) . '"';
-
 		if ( ! empty( $class ) ) {
-			$attributes = 'class="' . implode( ' ', $class ) . '"' . $data_colname;
+			$attributes = 'class="' . implode( ' ', $class ) . '"';
 		}
+
+		$attributes .= ' data-colname="' . esc_attr( $column_display_name ) . '"';
 
 		return $attributes;
 	}


### PR DESCRIPTION
## Summary

Adds a `data-colname` attribute to show the column names on the left of each table cell in the responsive view.

WordPress uses some CSS generated content to show "titles" for each table cell in the responsive view. The CSS generated content targets a `data-colname` attribute that is missing ont he Bulk Editor tables.


## Test instructions
- go to Tools > Bulk editor
- trigger the responsive view in your browser
- expand one of the items in the table
- check the column names appear on the left of each cell (see screenshot below)

Note about accessibility: not all screen readers announce CSS generated content. VoiceOver does it, others don't. [This is likely going to change in the future](https://www.w3.org/TR/css-content-3/#accessibility) since the CSS3 specs states that "generated content must be rendered for speech output".

Note: we may consider to use shorter column names.

Screenshots before and after:

![blabla](https://cloud.githubusercontent.com/assets/1682452/22781470/ecf8f6a2-eec2-11e6-8c45-e9f461561eb7.png)

Fixes #6628 