### PR TITLE
move toggles keyword and content analysis from general tab to features tab

### DIFF
--- a/admin/metabox/class-metabox-analysis-readability.php
+++ b/admin/metabox/class-metabox-analysis-readability.php
@@ -32,8 +32,8 @@ class WPSEO_Metabox_Analysis_Readability implements WPSEO_Metabox_Analysis {
 	 * @return bool Whether or not this analysis is enabled globally.
 	 */
 	public function is_globally_enabled() {
-		$options = WPSEO_Options::get_option( 'wpseo_titles' );
+		$options = WPSEO_Options::get_option( 'wpseo' );
 
-		return (bool) $options['content-analysis-active'];
+		return (bool) $options['content_analysis_active'];
 	}
 }

--- a/admin/metabox/class-metabox-analysis-seo.php
+++ b/admin/metabox/class-metabox-analysis-seo.php
@@ -32,8 +32,8 @@ class WPSEO_Metabox_Analysis_SEO implements WPSEO_Metabox_Analysis {
 	 * @return bool Whether or not this analysis is enabled globally.
 	 */
 	public function is_globally_enabled() {
-		$options = WPSEO_Options::get_option( 'wpseo_titles' );
+		$options = WPSEO_Options::get_option( 'wpseo' );
 
-		return (bool) $options['keyword-analysis-active'];
+		return (bool) $options['keyword_analysis_active'];
 	}
 }

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -11,6 +11,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 $feature_toggles = array(
 	(object) array(
+		'name'    => __( 'Readability analysis', 'wordpress-seo' ),
+		'setting' => 'content_analysis_active',
+		'label'   => __( 'Removes the readability tab from the metabox and disables all readability-related suggestions.', 'wordpress-seo' ),
+	),
+	(object) array(
+		'name'    => __( 'Keyword analysis', 'wordpress-seo' ),
+		'setting' => 'keyword_analysis_active',
+		'label'   => __( 'Removes the keyword tab from the metabox and disables all keyword-related suggestions.', 'wordpress-seo' ),
+	),
+	(object) array(
 		'name'    => __( 'Advanced settings pages', 'wordpress-seo' ),
 		'setting' => 'enable_setting_pages',
 		'label'   => __( 'The advanced settings include site-wide settings for your titles and meta descriptions, social metadata, sitemaps and much more.', 'wordpress-seo' ),

--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -21,6 +21,7 @@ $legend_attr = array( 'class' => 'radiogroup screen-reader-text' );
 $yform->radio( 'separator', WPSEO_Option_Titles::get_instance()->get_separator_options(), $legend, $legend_attr );
 echo '<p class="description">', __( 'Choose the symbol to use as your title separator. This will display, for instance, between your post title and site name.', 'wordpress-seo' ), ' ', __( 'Symbols are shown in the size they\'ll appear in the search results.', 'wordpress-seo' ), '</p>';
 
+// To remove in this branch.
 echo '<h2>' . __( 'Enabled analysis', 'wordpress-seo' ) . '</h2>';
 
 $yform->light_switch( 'content-analysis-active', __( 'Readability analysis', 'wordpress-seo' ) );

--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -20,12 +20,3 @@ $legend      = __( 'Title separator symbol', 'wordpress-seo' );
 $legend_attr = array( 'class' => 'radiogroup screen-reader-text' );
 $yform->radio( 'separator', WPSEO_Option_Titles::get_instance()->get_separator_options(), $legend, $legend_attr );
 echo '<p class="description">', __( 'Choose the symbol to use as your title separator. This will display, for instance, between your post title and site name.', 'wordpress-seo' ), ' ', __( 'Symbols are shown in the size they\'ll appear in the search results.', 'wordpress-seo' ), '</p>';
-
-// To remove in this branch.
-echo '<h2>' . __( 'Enabled analysis', 'wordpress-seo' ) . '</h2>';
-
-$yform->light_switch( 'content-analysis-active', __( 'Readability analysis', 'wordpress-seo' ) );
-echo '<p class="description">', __( 'Removes the readability tab from the metabox and disables all readability-related suggestions.', 'wordpress-seo' ) . '</p>';
-
-$yform->light_switch( 'keyword-analysis-active', __( 'Keyword analysis', 'wordpress-seo' ) );
-echo '<p class="description">', __( 'Removes the keyword tab from the metabox and disables all keyword-related suggestions.', 'wordpress-seo' ) . '</p>';

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -248,10 +248,6 @@ class WPSEO_Upgrade {
 	private function upgrade_44() {
 		$option_titles = WPSEO_Options::get_option( 'wpseo_titles' );
 		$option_wpseo = WPSEO_Options::get_option( 'wpseo' );
-		echo $option_titles;
-		echo "<br><br>------------------------------------<br><br>";
-		echo $option_wpseo;
-		exit;
 
 		if ( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {
 			$option_wpseo['content_analysis_active'] = $option_titles['content-analysis-active'];

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -247,6 +247,7 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_44() {
 		$option_titles = get_option( 'wpseo_titles' );
+		$option_wpseo = get_option( 'wpseo' );
 
 		if( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {
 			$option_wpseo['content_analysis_active'] = $option_titles['content-analysis-active'];

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -60,6 +60,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_40();
 		}
 
+		if ( version_compare( $this->options['version'], '4.3', '<' ) ) {
+			$this->upgrade_43();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -235,6 +239,24 @@ class WPSEO_Upgrade {
 
 		if ( $notification ) {
 			$center->remove_notification( $notification );
+		}
+	}
+
+	/**
+	 * Moves the content-analysis-active and keyword-analysis-acive options from wpseo-titles to wpseo.
+	 */
+	private function upgrade_43() {
+		$option_titles = get_option( 'wpseo_titles' );
+
+		if( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {
+			$option_wpseo['content_analysis_active'] = $option_titles['content-analysis-active'];
+			unset( $option_titles['content-analysis-active'] );
+
+			$option_wpseo['keyword_analysis_active'] = $option_titles['keyword-analysis-active'];
+			unset( $option_titles['keyword-analysis-active'] );
+
+			update_option( 'wpseo_titles', $option_titles );
+			update_option( 'wpseo', $option_wpseo );
 		}
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -249,7 +249,7 @@ class WPSEO_Upgrade {
 		$option_titles = get_option( 'wpseo_titles' );
 		$option_wpseo = get_option( 'wpseo' );
 
-		if( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {
+		if ( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {
 			$option_wpseo['content_analysis_active'] = $option_titles['content-analysis-active'];
 			unset( $option_titles['content-analysis-active'] );
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -246,8 +246,12 @@ class WPSEO_Upgrade {
 	 * Moves the content-analysis-active and keyword-analysis-acive options from wpseo-titles to wpseo.
 	 */
 	private function upgrade_44() {
-		$option_titles = get_option( 'wpseo_titles' );
-		$option_wpseo = get_option( 'wpseo' );
+		$option_titles = WPSEO_Options::get_option( 'wpseo_titles' );
+		$option_wpseo = WPSEO_Options::get_option( 'wpseo' );
+		echo $option_titles;
+		echo "<br><br>------------------------------------<br><br>";
+		echo $option_wpseo;
+		exit;
 
 		if ( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {
 			$option_wpseo['content_analysis_active'] = $option_titles['content-analysis-active'];

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -60,8 +60,8 @@ class WPSEO_Upgrade {
 			$this->upgrade_40();
 		}
 
-		if ( version_compare( $this->options['version'], '4.3', '<' ) ) {
-			$this->upgrade_43();
+		if ( version_compare( $this->options['version'], '4.4', '<' ) ) {
+			$this->upgrade_44();
 		}
 
 		// Since 3.7.
@@ -245,7 +245,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Moves the content-analysis-active and keyword-analysis-acive options from wpseo-titles to wpseo.
 	 */
-	private function upgrade_43() {
+	private function upgrade_44() {
 		$option_titles = get_option( 'wpseo_titles' );
 
 		if( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -23,8 +23,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'title_test'             => 0,
 		// Form fields.
 		'forcerewritetitle'      => false,
-		'content-analysis-active' => true,
-		'keyword-analysis-active' => true,
 		'separator'              => 'sc-dash',
 		'noodp'                  => false,
 		'usemetakeywords'        => false,

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -39,6 +39,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'site_type'                       => '', // List of options.
 		'has_multiple_authors'            => '',
 		'environment_type'                => '',
+		'content_analysis_active'         => true,
+		'keyword_analysis_active'         => true,
 		'enable_setting_pages'            => true,
 		'enable_admin_bar_menu'			  => true,
 		'show_onboarding_notice'          => false,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Moved the options allowing users to disable keyword and content analysis from the general tab to the features tab. 

I'm not super satisfied with the user interace of the 'features'-tab, but I'm also not sure how to improve this, If you have any suggestions here, feel free to comment.

## Relevant technical choices:

*Involves moving the database value from the wpseo_titles option to the wpseo option. 
*All places where the option values are checked now have to look for it at the new location.
*removed old options from the database, and created an upgrade routine that should give the new options the old value.

## Test instructions

This PR can be tested by following these steps:
1. Check if the options are removed in the titles&metas -> general tab.
2. Check if the options are added in the dashboard -> features tab.
3. Check if the options are functional. 
4. Ideally, the upgrade routine should be tested as well. There's no easy way to do this, unfortunately. What I tried is isolating the upgrade routine code, running this seperately after changing from the old situation to my branch, then see if the options in the branch get the old values of the old situation and if the old options are removed in the database. If there's an easier way to do this, i'd like to know :).

Fixes #6571
