### PR TITLE
Adds plugin conflict warning for RS Head Cleaner

### DIFF
--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -156,7 +156,7 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 			                  . '</a>';
 		}
 
-		/* translators: %1$s expands to Yoast SEO, %2$s: 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to differentiating output between search engines and normal users. */
+		/* translators: %2$s expands to 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to differentiating output between search engines and normal users. */
 		$plugin_sections['cloaking'] = __( 'The plugin %2$s changes your site\'s output and in doing that differentiates between search engines and normal users, a process that\'s called cloaking. We highly recommend that you disable it.', 'wordpress-seo' );
 
 		$instance->check_plugin_conflicts( $plugin_sections );

--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -157,7 +157,7 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		}
 
 		/* translators: %1$s expands to Yoast SEO, %2$s: 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to differentiating output between search engines and normal users. */
-		$plugins_sections['cloaking'] = __( 'The plugin %2$s changes your site\'s output and in doing that differentiates between search engines and normal users, a process that\'s called cloaking. We highly recommend that you disable it.', 'wordpress-seo' );
+		$plugin_sections['cloaking'] = __( 'The plugin %2$s changes your site\'s output and in doing that differentiates between search engines and normal users, a process that\'s called cloaking. We highly recommend that you disable it.', 'wordpress-seo' );
 
 		$instance->check_plugin_conflicts( $plugin_sections );
 	}

--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -96,6 +96,8 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		'cloaking' => array(
 			'rs-head-cleaner/rs-head-cleaner.php',
 			// RS Head Cleaner Plus https://wordpress.org/plugins/rs-head-cleaner/.
+			'rs-head-cleaner-lite/rs-head-cleaner-lite.php',
+			// RS Head Cleaner Lite https://wordpress.org/plugins/rs-head-cleaner-lite/.
 		),
 	);
 
@@ -133,11 +135,11 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		// Only check for open graph problems when they are enabled.
 		$social_options = WPSEO_Options::get_option( 'wpseo_social' );
 		if ( $social_options['opengraph'] ) {
-			/* translators: %1$s expands to Yoast SEO, %2%s: 'Facebook' plugin name of possibly conflicting plugin with regard to creating OpenGraph output*/
+			/* translators: %1$s expands to Yoast SEO, %2%s: 'Facebook' plugin name of possibly conflicting plugin with regard to creating OpenGraph output. */
 			$plugin_sections['open_graph'] = __( 'Both %1$s and %2$s create OpenGraph output, which might make Facebook, Twitter, LinkedIn and other social networks use the wrong texts and images when your pages are being shared.', 'wordpress-seo' )
 			                                 . '<br/><br/>'
 			                                 . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_social#top#facebook' ) . '">'
-			                                 /* translators: %1$s expands to Yoast SEO */
+			                                 /* translators: %1$s expands to Yoast SEO. */
 			                                 . sprintf( __( 'Configure %1$s\'s OpenGraph settings', 'wordpress-seo' ), 'Yoast SEO' )
 			                                 . '</a>';
 		}
@@ -145,16 +147,16 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		// Only check for XML conflicts if sitemaps are enabled.
 		$xml_sitemap_options = WPSEO_Options::get_option( 'wpseo_xml' );
 		if ( $xml_sitemap_options['enablexmlsitemap'] ) {
-			/* translators: %1$s expands to Yoast SEO, %2$s: 'Google XML Sitemaps' plugin name of possibly conflicting plugin with regard to the creation of sitemaps*/
+			/* translators: %1$s expands to Yoast SEO, %2$s: 'Google XML Sitemaps' plugin name of possibly conflicting plugin with regard to the creation of sitemaps. */
 			$plugin_sections['xml_sitemaps'] = __( 'Both %1$s and %2$s can create XML sitemaps. Having two XML sitemaps is not beneficial for search engines, yet might slow down your site.', 'wordpress-seo' )
 			                  . '<br/><br/>'
 			                  . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_xml' ) . '">'
-			                  /* translators: %1$s expands to Yoast SEO */
+			                  /* translators: %1$s expands to Yoast SEO. */
 			                  . sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
 			                  . '</a>';
 		}
 
-		/* translators: %1$s expands to Yoast SEO, %2$s: 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to the creation of sitemaps*/
+		/* translators: %1$s expands to Yoast SEO, %2$s: 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to differentiating output between search engines and normal users. */
 		$plugins_sections['cloaking'] = __( 'The plugin %2$s changes your site\'s output and in doing that differentiates between search engines and normal users, a process that\'s called cloaking. We highly recommend that you disable it.', 'wordpress-seo' );
 
 		$instance->check_plugin_conflicts( $plugin_sections );

--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -93,6 +93,10 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 			'rps-sitemap-generator/rps-sitemap-generator.php',
 			// RPS Sitemap Generator (redpixelstudios).
 		),
+		'cloaking' => array(
+			'rs-head-cleaner/rs-head-cleaner.php',
+			// RS Head Cleaner Plus https://wordpress.org/plugins/rs-head-cleaner/
+		),	
 	);
 
 	/**
@@ -149,6 +153,9 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 			                  . sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
 			                  . '</a>';
 		}
+		
+		/* translators: %1$s expands to Yoast SEO, %2$s: 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to the creation of sitemaps*/
+		$plugins_sections['cloaking'] = __( 'The plugin %2$s changes your site\'s output and in doing that differentiates between search engines and normal users, a process that\'s called cloaking. We highly recommend that you disable it.', 'wordpress-seo' );
 
 		$instance->check_plugin_conflicts( $plugin_sections );
 	}

--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -95,8 +95,8 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		),
 		'cloaking' => array(
 			'rs-head-cleaner/rs-head-cleaner.php',
-			// RS Head Cleaner Plus https://wordpress.org/plugins/rs-head-cleaner/
-		),	
+			// RS Head Cleaner Plus https://wordpress.org/plugins/rs-head-cleaner/.
+		),
 	);
 
 	/**
@@ -153,7 +153,7 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 			                  . sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
 			                  . '</a>';
 		}
-		
+
 		/* translators: %1$s expands to Yoast SEO, %2$s: 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to the creation of sitemaps*/
 		$plugins_sections['cloaking'] = __( 'The plugin %2$s changes your site\'s output and in doing that differentiates between search engines and normal users, a process that\'s called cloaking. We highly recommend that you disable it.', 'wordpress-seo' );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Throws a warning in the admin for RS Head Cleaner because it cloaks. 

## Test instructions

This PR can be tested by following these steps:

* Enable RS Head Cleaner, see warning.

Fixes #6685
