### PR TITLE
Wrong caps usage on General and Company info tabs

### DIFF
--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -60,7 +60,7 @@ $tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' 
 $tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
 $knowledge_graph_label = ( 'company' === $options['company_or_person'] ) ? __( 'Company info', 'wordpress-seo' ) : __( 'Your info', 'wordpress-seo' );
 $tabs->add_tab( new WPSEO_Option_Tab( 'knowledge-graph', $knowledge_graph_label, array( 'video_url' => 'https://yoa.st/screencast-knowledge-graph' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'webmaster-tools', __( 'Webmaster Tools', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general-search-console' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'webmaster-tools', __( 'Webmaster tools', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general-search-console' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'security', __( 'Security', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-security' ) ) );
 
 do_action( 'wpseo_settings_tabs_dashboard', $tabs );

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -58,7 +58,7 @@ $tabs = new WPSEO_Option_Tabs( 'dashboard' );
 $tabs->add_tab( new WPSEO_Option_Tab( 'dashboard', __( 'Dashboard', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-notification-center' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
-$knowledge_graph_label = ( 'company' === $options['company_or_person'] ) ? __( 'Company Info', 'wordpress-seo' ) : __( 'Your Info', 'wordpress-seo' );
+$knowledge_graph_label = ( 'company' === $options['company_or_person'] ) ? __( 'Company info', 'wordpress-seo' ) : __( 'Your info', 'wordpress-seo' );
 $tabs->add_tab( new WPSEO_Option_Tab( 'knowledge-graph', $knowledge_graph_label, array( 'video_url' => 'https://yoa.st/screencast-knowledge-graph' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'webmaster-tools', __( 'Webmaster Tools', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general-search-console' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'security', __( 'Security', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-security' ) ) );

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -20,7 +20,7 @@ if ( WPSEO_Utils::is_api_available() ) :
 	</p>
 <p>
 	<a class="button"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php _e( 'Open the configuration wizard', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php esc_html_e( 'Open the configuration wizard', 'wordpress-seo' ); ?></a>
 </p>
 
 	<br/>
@@ -43,7 +43,7 @@ echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 
 <p>
 	<a class="button"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php _e( 'View credits', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php esc_html_e( 'View credits', 'wordpress-seo' ); ?></a>
 </p>
 <br/>
 <?php
@@ -57,7 +57,7 @@ echo '<h2>' . esc_html__( 'Restore default settings', 'wordpress-seo' ) . '</h2>
 </p>
 
 <p>
-	<a onclick="if ( !confirm( '<?php _e( 'Are you sure you want to reset your SEO settings?', 'wordpress-seo' ); ?>' ) ) return false;"
+	<a onclick="if ( !confirm( '<?php esc_html_e( 'Are you sure you want to reset your SEO settings?', 'wordpress-seo' ); ?>' ) ) return false;"
 	   class="button"
-	   href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php _e( 'Restore default settings', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php esc_html_e( 'Restore default settings', 'wordpress-seo' ); ?></a>
 </p>

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -43,7 +43,7 @@ echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 
 <p>
 	<a class="button"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php _e( 'View Credits', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php _e( 'View credits', 'wordpress-seo' ); ?></a>
 </p>
 <br/>
 <?php
@@ -59,5 +59,5 @@ echo '<h2>' . esc_html__( 'Restore default settings', 'wordpress-seo' ) . '</h2>
 <p>
 	<a onclick="if ( !confirm( '<?php _e( 'Are you sure you want to reset your SEO settings?', 'wordpress-seo' ); ?>' ) ) return false;"
 	   class="button"
-	   href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php _e( 'Restore Default Settings', 'wordpress-seo' ); ?></a>
+	   href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php _e( 'Restore default settings', 'wordpress-seo' ); ?></a>
 </p>

--- a/admin/views/tabs/dashboard/knowledge-graph.php
+++ b/admin/views/tabs/dashboard/knowledge-graph.php
@@ -39,8 +39,8 @@ $yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ),
 <div id="knowledge-graph-company">
 	<h3><?php esc_html_e( 'Company', 'wordpress-seo' ); ?></h3>
 	<?php
-	$yform->textinput( 'company_name', __( 'Company Name', 'wordpress-seo' ) );
-	$yform->media_input( 'company_logo', __( 'Company Logo', 'wordpress-seo' ) );
+	$yform->textinput( 'company_name', __( 'Company name', 'wordpress-seo' ) );
+	$yform->media_input( 'company_logo', __( 'Company logo', 'wordpress-seo' ) );
 	?>
 </div>
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
 - Fixes wrong capitalization on Dashboard -> General and Dashboard -> Company Info

Changing "Save Changes" to "Save changes", as suggested in #6570 isn't possible because the Save Changes button is part of WordPress Core. 

Fixes #6570
