### PR TITLE
Changed options used on user profile to new database

### DIFF
--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -80,7 +80,8 @@ class WPSEO_Admin_User_Profile {
 	 * @param WP_User $user User instance to output for.
 	 */
 	public function user_profile( $user ) {
-		$options = WPSEO_Options::get_option( 'wpseo_titles' );
+		$options = WPSEO_Options::get_option( 'wpseo' );
+		$options_titles = WPSEO_Options::get_option( 'wpseo_titles' );
 
 		wp_nonce_field( 'wpseo_user_profile_update', 'wpseo_nonce' );
 

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -30,6 +30,7 @@
 			name="wpseo_author_exclude"
 			value="on" <?php echo ( get_the_author_meta( 'wpseo_excludeauthorsitemap', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
 		<label class="yoast-label-strong" for="wpseo_author_exclude"><?php _e( 'Exclude user from Author-sitemap', 'wordpress-seo' ); ?></label><br>
+
 	<?php if ( $options['keyword_analysis_active'] === true ) { ?>
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_keyword_analysis_disable"
 			name="wpseo_keyword_analysis_disable" aria-describedby="wpseo_keyword_analysis_disable_desc"

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -20,7 +20,7 @@
 	<textarea rows="5" cols="30" id="wpseo_author_metadesc" class="yoast-settings__textarea yoast-settings__textarea--medium"
 		name="wpseo_author_metadesc"><?php echo esc_textarea( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea><br>
 
-	<?php if ( $options['usemetakeywords'] === true ) { ?>
+	<?php if ( $options_titles['usemetakeywords'] === true ) { ?>
 		<label for="wpseo_author_metakey"><?php _e( 'Meta keywords to use for Author page', 'wordpress-seo' ); ?></label>
 		<input class="yoast-settings__text regular-text" type="text" id="wpseo_author_metakey"
 			name="wpseo_author_metakey"
@@ -30,8 +30,7 @@
 			name="wpseo_author_exclude"
 			value="on" <?php echo ( get_the_author_meta( 'wpseo_excludeauthorsitemap', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
 		<label class="yoast-label-strong" for="wpseo_author_exclude"><?php _e( 'Exclude user from Author-sitemap', 'wordpress-seo' ); ?></label><br>
-
-	<?php if ( $options['keyword-analysis-active'] === true ) { ?>
+	<?php if ( $options['keyword_analysis_active'] === true ) { ?>
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_keyword_analysis_disable"
 			name="wpseo_keyword_analysis_disable" aria-describedby="wpseo_keyword_analysis_disable_desc"
 			value="on" <?php echo ( get_the_author_meta( 'wpseo_keyword_analysis_disable', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
@@ -41,7 +40,7 @@
 		</p>
 	<?php } ?>
 
-	<?php if ( $options['content-analysis-active'] === true ) { ?>
+	<?php if ( $options['content_analysis_active'] === true ) { ?>
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_content_analysis_disable"
 			name="wpseo_content_analysis_disable" aria-describedby="wpseo_content_analysis_disable_desc"
 			value="on" <?php echo ( get_the_author_meta( 'wpseo_content_analysis_disable', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Changed options on user-profile to use new database location.

## Relevant technical choices:

Changed database location and option name. Renamed option variable for the titles options to keep it intuitive.

## Test instructions

This PR can be tested by following these steps:

*on the release branch, check user-profile.php and see if the checkboxes to disable keyword/content analysis work, and if the meta keywords input field appears and disappears when the associated option is enabled/disabled.

Fixes #6684
