### PR TITLE
Changes references from wpseo_titles to wpseo

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -38,7 +38,7 @@ class WPSEO_Meta_Columns {
 
 		$options = WPSEO_Options::get_option( 'wpseo' );
 
-		if ( ! empty( $options['keyword_analysis_active'] ) ) {
+		if ( $this->analysis_seo->is_enabled() ) {
 			add_action( 'restrict_manage_posts', array( $this, 'posts_filter_dropdown' ) );
 		}
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -36,9 +36,9 @@ class WPSEO_Meta_Columns {
 	public function setup_hooks() {
 		$this->set_post_type_hooks();
 
-		$options = WPSEO_Options::get_option( 'wpseo_titles' );
+		$options = WPSEO_Options::get_option( 'wpseo' );
 
-		if ( ! empty( $options['keyword-analysis-active'] ) ) {
+		if ( ! empty( $options['keyword_analysis_active'] ) ) {
 			add_action( 'restrict_manage_posts', array( $this, 'posts_filter_dropdown' ) );
 		}
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -36,8 +36,6 @@ class WPSEO_Meta_Columns {
 	public function setup_hooks() {
 		$this->set_post_type_hooks();
 
-		$options = WPSEO_Options::get_option( 'wpseo' );
-
 		if ( $this->analysis_seo->is_enabled() ) {
 			add_action( 'restrict_manage_posts', array( $this, 'posts_filter_dropdown' ) );
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Changed references from wpseo_titles to wpseo to fix the disappeared SEO scores dropdown on the post overview page.


Fixes #6722
