### PR TITLE
Make the Save Changes button use sentence case.

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -118,7 +118,7 @@ class Yoast_Form {
 	 */
 	public function admin_footer( $submit = true, $show_sidebar = true ) {
 		if ( $submit ) {
-			submit_button();
+			submit_button( __( 'Save changes', 'wordpress-seo' ) );
 
 			echo '
 			</form>';


### PR DESCRIPTION
## Summary

Change the "Save Changes" button text to  "Save changes". See #6570.

Fixes #6738 
