### PR TITLE
Updates required WordPress version in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://yoast.com/
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: SEO, XML sitemap, Google Search Console, Content analysis, Readability
-Requires at least: 4.4
+Requires at least: 4.7
 Tested up to: 4.7
 Stable tag: 4.3
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://yoast.com/
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: SEO, XML sitemap, Google Search Console, Content analysis, Readability
-Requires at least: 4.7
+Requires at least: 4.6
 Tested up to: 4.7
 Stable tag: 4.3
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Updated the required WordPress version in readme.txt

## Relevant technical choices:

* In a blog post we state that we no longer support anything but the latest and the prior to last version, so readme.txt should show that the prior-to-latest WordPress version is required. 

## Test instructions

This PR can be tested by following these steps:

* Open readme.txt and check line 7. 

Fixes #6391 
Fixes #828