### PR TITLE
Support breadcrumbs for queries with multiple post types

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -331,6 +331,8 @@ class WPSEO_Breadcrumbs {
 
 				if ( $post_type && is_string( $post_type ) ) {
 					$this->add_ptarchive_crumb( $post_type );
+				} elseif ( $post_type && is_array( $post_type ) ) {
+					$this->add_ptarchive_crumb( array_shift( $post_type ) );
 				}
 			}
 			elseif ( is_tax() || is_tag() || is_category() ) {


### PR DESCRIPTION
## Summary

Right now the WordPress SEO breadcrumbs don't support queries with multiple post types. If you have a query with multiple post type, you will end up with only the word "Home" in the breadcrumbs. This PR checks if the post types is an array, and if it is it will use the first post type from that array to display in the breadcrumbs.

## Relevant technical choices:

* The first post type in the array will be used for the breadcrumbs, because there is no way to know which post type is "primary".

## Test instructions

This PR can be tested by following these steps:

* Modify a query to support multiple post types via the `pre_get_posts` filter.
* Visit the post type archive and view the breadcrumbs
* You can use the code below to test this:

```
public function multiplePostTypes($query) {
    if ($query->is_post_type_archive('post')) {
        $query->set('post_type', ['post', 'page']);
    }
}

add_action('pre_get_posts', 'multiplePostTypes');
```

This PR is probably related: https://github.com/Yoast/wordpress-seo/pull/2988