### PR TITLE
Improve PHPCS grunt task to use vendor phpcs

### DIFF
--- a/grunt/config/phpcs.js
+++ b/grunt/config/phpcs.js
@@ -7,7 +7,6 @@ module.exports = {
 		options: {
 			bin: "vendor/bin/phpcs",
 			standard: "phpcs.xml",
-			reportFile: "<%= paths.logs %>phpcs.log",
 			extensions: "php",
 		},
 		dir: [

--- a/grunt/config/phpcs.js
+++ b/grunt/config/phpcs.js
@@ -5,6 +5,7 @@ module.exports = {
 	},
 	plugin: {
 		options: {
+			bin: 'vendor/bin/phpcs',
 			standard: "phpcs.xml",
 			reportFile: "<%= paths.logs %>phpcs.log",
 			extensions: "php",

--- a/grunt/config/phpcs.js
+++ b/grunt/config/phpcs.js
@@ -5,7 +5,7 @@ module.exports = {
 	},
 	plugin: {
 		options: {
-			bin: 'vendor/bin/phpcs',
+			bin: "vendor/bin/phpcs",
 			standard: "phpcs.xml",
 			reportFile: "<%= paths.logs %>phpcs.log",
 			extensions: "php",


### PR DESCRIPTION
Noticed that the PHPCS task was not using the proper `phpcs` by default. Easy fix, it seems, is this.