### PR TITLE
Add support for Jetpack SEO import

### DIFF
--- a/admin/class-import-jetpack.php
+++ b/admin/class-import-jetpack.php
@@ -25,5 +25,4 @@ class WPSEO_Import_Jetpack_SEO extends WPSEO_Import_External {
 	private function import_metas() {
 		WPSEO_Meta::replace_meta( 'advanced_seo_description', WPSEO_Meta::$meta_prefix . 'metadesc', $this->replace );
 	}
-
 }

--- a/admin/class-import-jetpack.php
+++ b/admin/class-import-jetpack.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package WPSEO\Admin\Import\External
+ */
+
+/**
+ * Class WPSEO_Import_Jetpack_SEO
+ *
+ * Class with functionality to import Yoast SEO settings from Jetpack Advanced SEO
+ */
+class WPSEO_Import_Jetpack_SEO extends WPSEO_Import_External {
+
+	/**
+	 * Import Jetpack Advanced SEO settings
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->import_metas();
+	}
+
+	/**
+	 * Import All In One SEO meta values
+	 */
+	private function import_metas() {
+		WPSEO_Meta::replace_meta( 'advanced_seo_description', WPSEO_Meta::$meta_prefix . 'metadesc', $this->replace );
+	}
+
+}

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -22,9 +22,10 @@ printf( __( 'If you\'ve used another SEO plugin, try the %1$sSEO Data Transporte
 	method="post" accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php
 	wp_nonce_field( 'wpseo-import', '_wpnonce', true, true );
-	$yform->checkbox( 'importheadspace', __( 'Import from HeadSpace2?', 'wordpress-seo' ) );
-	$yform->checkbox( 'importaioseo', __( 'Import from All-in-One SEO?', 'wordpress-seo' ) );
-	$yform->checkbox( 'importwoo', __( 'Import from WooThemes SEO framework?', 'wordpress-seo' ) );
+	$yform->checkbox( 'importheadspace', __( 'Import from HeadSpace2', 'wordpress-seo' ) );
+	$yform->checkbox( 'importaioseo', __( 'Import from All-in-One SEO', 'wordpress-seo' ) );
+	$yform->checkbox( 'importjetpackseo', __( 'Import from Jetpack SEO', 'wordpress-seo' ) );
+	$yform->checkbox( 'importwoo', __( 'Import from WooThemes SEO framework', 'wordpress-seo' ) );
 	$yform->checkbox( 'importwpseo', __( 'Import from wpSEO', 'wordpress-seo' ) );
 
 	do_action( 'wpseo_import_other_plugins' );

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -40,6 +40,10 @@ if ( filter_input( INPUT_POST, 'import' ) || filter_input( INPUT_GET, 'import' )
 		$import->import_headspace();
 	}
 
+	if ( ! empty( $post_wpseo['importjetpackseo'] ) || filter_input( INPUT_GET, 'importjetpackseo' ) ) {
+		$import = new WPSEO_Import_Jetpack_SEO( $replace );
+	}
+
 	if ( ! empty( $post_wpseo['importwpseo'] ) || filter_input( INPUT_GET, 'importwpseo' ) ) {
 		$import = new WPSEO_Import_WPSEO( $replace );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Added support for import of Jetpack SEO.

## Relevant technical choices:

* Jetpack only stores descriptions, so that's the only thing we're importing for now.

## Test instructions

This PR can be tested by following these steps:

* Have a couple posts with description coming from Jetpack (stored in `advanced_seo_description` custom fields).