### PR TITLE
Efficiency: don't use `count()` in the condition of a looping structure.

### DIFF
--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -146,7 +146,8 @@ class WPSEO_Export {
 
 		foreach ( $options as $key => $elem ) {
 			if ( is_array( $elem ) ) {
-				for ( $i = 0; $i < count( $elem ); $i ++ ) {
+				$count = count( $elem );
+				for ( $i = 0; $i < $count; $i ++ ) {
 					$this->write_setting( $key . '[]', $elem[ $i ] );
 				}
 			}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* Code style compliance

## Test instructions

_N/A_