### PR TITLE
CS compliance: variable names should be lowercase [10]

### DIFF
--- a/admin/config-ui/components/class-component-connect-google-search-console.php
+++ b/admin/config-ui/components/class-component-connect-google-search-console.php
@@ -131,8 +131,8 @@ class WPSEO_Config_Component_Connect_Google_Search_Console implements WPSEO_Conf
 	protected function get_profilelist() {
 		$profiles = array();
 		$sites    = $this->gsc_service->get_sites();
-		foreach ( $sites as $siteKey => $siteValue ) {
-			$profiles[ untrailingslashit( $siteKey )  ] = untrailingslashit( $siteValue );
+		foreach ( $sites as $site_key => $site_value ) {
+			$profiles[ untrailingslashit( $site_key )  ] = untrailingslashit( $site_value );
 		}
 
 		return $profiles;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* Code style compliance

Local variable names can be safely changed to comply with this lowercase variable names rule without breaking anything.

## Test instructions

_N/A_