### PR TITLE
Don't override changes to post metas made by other plugins

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -625,7 +625,7 @@ class WPSEO_Meta {
 			return true; // Stop saving the value.
 		}
 
-		return null; // Go on with the normal execution (update) in meta.php.
+		return $null; // Go on with the normal execution (update) in meta.php.
 	}
 
 
@@ -647,7 +647,7 @@ class WPSEO_Meta {
 			return true; // Stop saving the value.
 		}
 
-		return null; // Go on with the normal execution (add) in meta.php.
+		return $null; // Go on with the normal execution (add) in meta.php.
 	}
 
 


### PR DESCRIPTION
In functions hooked to 'update_post_metadata' and 'add_post_metadata', returning null instead of the current filtered value will override what's could have been done previously by another plugin.
