### PR TITLE
Use select2.full instead of select2

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -250,7 +250,7 @@ class WPSEO_Admin_Asset_Manager {
 			),
 			array(
 				'name'   => 'select2',
-				'src'    => 'select2/select2',
+				'src'    => 'select2/select2.full',
 				'suffix' => '.min',
 				'deps'   => array(
 					'jquery',

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -5,7 +5,7 @@ module.exports = {
 			{
 				expand: true,
 				cwd: "node_modules/select2/dist/js/",
-				src: [ "select2.min.js", "i18n/*", "!i18n/build.txt" ],
+				src: [ "select2.full.min.js", "i18n/*", "!i18n/build.txt" ],
 				dest: "js/dist/select2/",
 			},
 			{


### PR DESCRIPTION
Currently we're loading select2.min.js for our select2 components,
this can cause JavaScript errors in combination with WooCommerce and
certain themes/plugins. This PR changes the usage of select2.min.js to
select2.full.min.js

fixes #6942