### PR TITLE
Make some "Yoast SEO/Premium" not translatable and Improve strings and translators comments

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -64,9 +64,18 @@ class WPSEO_Help_Center {
 		/* translators: %1$s: expands to 'Yoast SEO Premium'. */
 		$popup_content .= '<p>' . sprintf( __( 'Other benefits of %1$s for you:', 'wordpress-seo' ), 'Yoast SEO Premium' ) . '</p>';
 		$popup_content .= '<ul>';
-		$popup_content .= '<li>' . __( 'No more dead links: easy redirect manager', 'wordpress-seo' ) . '</li>';
-		$popup_content .= '<li>' . __( 'Superfast internal link suggestions', 'wordpress-seo' ) . '</li>';
-		$popup_content .= '<li>' . __( 'Social media preview: Facebook & Twitter', 'wordpress-seo' ) . '</li>';
+		$popup_content .= '<li>' . sprintf(
+			// We don't use strong text here, but we do use it in the "Add keyword" popup, this is just to have the same translatable strings.
+			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+			__( '%1$sNo more dead links%2$s: easy redirect manager', 'wordpress-seo' ), '', ''
+		) . '</li>';
+		$popup_content .= '<li>' . __( 'Superfast internal links suggestions', 'wordpress-seo' ) . '</li>';
+		$popup_content .= '<li>' . sprintf(
+			// We don't use strong text here, but we do use it in the "Add keyword" popup, this is just to have the same translatable strings.
+			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+			__( '%1$sSocial media preview%2$s: Facebook &amp; Twitter', 'wordpress-seo' ), '', ''
+		) . '</li>';
+		$popup_content .= '<li>' . __( '24/7 support', 'wordpress-seo' ) . '</li>';
 		$popup_content .= '<li>' . __( 'No ads!', 'wordpress-seo' ) . '</li>';
 		$popup_content .= '</ul>';
 

--- a/admin/config-ui/components/class-component-configuration-choices.php
+++ b/admin/config-ui/components/class-component-configuration-choices.php
@@ -25,29 +25,46 @@ class WPSEO_Config_Component_Configuration_Choices implements WPSEO_Config_Compo
 	public function get_field() {
 		$field = new WPSEO_Config_Field_Configuration_Choices();
 
-		/* translators: %s resolves to Yoast SEO */
-		$field->set_property( 'label', sprintf( __( 'Please choose the %s configuration of your liking:', 'wordpress-seo' ), 'Yoast SEO' ) );
+		$field->set_property( 'label', sprintf(
+			/* translators: %s expands to 'Yoast SEO'. */
+			__( 'Please choose the %s configuration of your liking:', 'wordpress-seo' ), 'Yoast SEO' )
+		);
 
 		$field->add_choice(
-			__( 'Configure Yoast SEO in a few steps', 'wordpress-seo' ),
-			sprintf( __( 'Welcome to the %1$s configuration wizard. In a few simple steps we\'ll help you configure your SEO settings to match your website\'s needs! %1$s will take care of all the technical optimizations your site needs.', 'wordpress-seo' ), 'Yoast SEO' ),
+			sprintf(
+				/* translators: %s expands to 'Yoast SEO'. */
+				__( 'Configure %s in a few steps', 'wordpress-seo' ),
+				'Yoast SEO'
+			),
+			sprintf(
+				/* translators: %1$s expands to 'Yoast SEO'. */
+				__( 'Welcome to the %1$s configuration wizard. In a few simple steps we\'ll help you configure your SEO settings to match your website\'s needs! %1$s will take care of all the technical optimizations your site needs.', 'wordpress-seo' ),
+				'Yoast SEO'
+			),
 			array(
-				'type'   => 'primary',
-				'label'   => sprintf( __( 'Configure %s', 'wordpress-seo' ), 'Yoast SEO' ),
+				'type'  => 'primary',
+				'label' => sprintf(
+					/* translators: %s expands to 'Yoast SEO'. */
+					__( 'Configure %s', 'wordpress-seo' ), 'Yoast SEO'
+				),
 				'action' => 'nextStep',
 			),
 			plugin_dir_url( WPSEO_FILE ) . '/images/Yoast_SEO_Icon.svg'
 		);
 		$field->add_choice(
-			__( 'Let us set up Yoast SEO for you', 'wordpress-seo' ),
 			sprintf(
+				/* translators: %s expands to 'Yoast SEO'. */
+				__( 'Let us set up %s for you', 'wordpress-seo' ), 'Yoast SEO'
+			),
+			sprintf(
+				/* translators: %1$s expands to 'Yoast SEO', %2$s expands to 'Yoast SEO Premium'. */
 				__( 'While we strive to make setting up %1$s as easy as possible, we understand it can still be daunting. If you would rather have us set up %1$s for you (and get a copy of %2$s in the process), order a %1$s configuration service and sit back while we configure your site.', 'wordpress-seo' ),
 				'Yoast SEO',
 				'Yoast SEO Premium'
 			),
 			array(
 				'type'   => 'secondary',
-				'label'   => __( 'Configuration service', 'wordpress-seo' ),
+				'label'  => __( 'Configuration service', 'wordpress-seo' ),
 				'action' => 'followURL',
 				'url'    => 'https://yoa.st/wizard-configuration-upsell',
 			),

--- a/admin/metabox/class-metabox-add-keyword-tab.php
+++ b/admin/metabox/class-metabox-add-keyword-tab.php
@@ -26,15 +26,24 @@ class Metabox_Add_Keyword_Tab implements WPSEO_Metabox_Tab {
 
 		<?php
 		$popup_title = __( 'Want to add more than one keyword?', 'wordpress-seo' );
-		/* translators: %1$s: expands to 'Yoast SEO Premium', %2$s: links to Yoast SEO Premium plugin page. */
+		/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
 		$popup_content = '<p>' . sprintf( __( 'Great news: you can, with %1$s!', 'wordpress-seo' ),
-				'<a href="https://yoa.st/pe-premium-page">Yoast SEO Premium</a>',
-				'yoast.com' ) . '</p>';
-		$popup_content .= '<p>' . __( 'Other benefits of Yoast SEO Premium for you:', 'wordpress-seo' ) . '</p>';
+				'<a href="https://yoa.st/pe-premium-page">Yoast SEO Premium</a>'
+				) . '</p>';
+		$popup_content .= '<p>' . sprintf(
+			/* translators: %s expands to 'Yoast SEO Premium'. */
+			__( 'Other benefits of %s for you:', 'wordpress-seo' ), 'Yoast SEO Premium'
+			) . '</p>';
 		$popup_content .= '<ul>';
-		$popup_content .= '<li>' . __( '<strong>No more dead links</strong>: easy redirect manager', 'wordpress-seo' ) . '</li>';
-		$popup_content .= '<li><strong>' . __( 'Superfast internal linking suggestions', 'wordpress-seo' ) . '</strong></li>';
-		$popup_content .= '<li>' . __( '<strong>Social media preview</strong>: Facebook &amp; Twitter', 'wordpress-seo' ) . '</li>';
+		$popup_content .= '<li>' . sprintf(
+			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+			__( '%1$sNo more dead links%2$s: easy redirect manager', 'wordpress-seo' ), '<strong>', '</strong>'
+		) . '</li>';
+		$popup_content .= '<li><strong>' . __( 'Superfast internal links suggestions', 'wordpress-seo' ) . '</strong></li>';
+		$popup_content .= '<li>' . sprintf(
+			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+			__( '%1$sSocial media preview%2$s: Facebook &amp; Twitter', 'wordpress-seo' ), '<strong>', '</strong>'
+		) . '</li>';
 		$popup_content .= '<li><strong>' . __( '24/7 support', 'wordpress-seo' ) . '</strong></li>';
 		$popup_content .= '<li><strong>' . __( 'No ads!', 'wordpress-seo' ) . '</strong></li>';
 		$popup_content .= '</ul>';


### PR DESCRIPTION
- makes some `Yoast SEO` and  `Yoast SEO Premium` not translatable
- unifies some strings for easier translations
- adds '24/7 support' in the Help Center "Email support" tab
- adds/fixes translators comments
- minor: fixes a few spaces for better code alignment

See screenshot of the "before" state:

<img width="1248" alt="screen shot 2017-04-12 at 10 28 34" src="https://cloud.githubusercontent.com/assets/1682452/24951489/dce293ee-1f74-11e7-8cb0-00223d38ee37.png">

Fixes #6973 