### PR TITLE
Remove two U+2028 invisible characters

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -60,7 +60,7 @@ class WPSEO_Help_Center {
 		/* translators: %s: expands to 'Yoast SEO Premium'. */
 		$popup_title = sprintf( __( 'Email support is a %s feature', 'wordpress-seo' ), 'Yoast SEO Premium' );
 
-		$popup_content = '<p>' . __( 'Go Premium and our experts will be there for you to answer any questions you might have about the set-up and use of the plug-in!  ', 'wordpress-seo' ) . '</p>';
+		$popup_content = '<p>' . __( 'Go Premium and our experts will be there for you to answer any questions you might have about the set-up and use of the plug-in!', 'wordpress-seo' ) . '</p>';
 		/* translators: %1$s: expands to 'Yoast SEO Premium'. */
 		$popup_content .= '<p>' . sprintf( __( 'Other benefits of %1$s for you:', 'wordpress-seo' ), 'Yoast SEO Premium' ) . '</p>';
 		$popup_content .= '<ul>';


### PR DESCRIPTION
In `admin/class-help-center.php` there is something after the exclamation mark in `plug-in!  `. I think there are two invisible line separator U+2028. Displaying this kind of characters with editors commonly used for development can be hard.

To double check: open the vile with VIM, it will display two spaces.

<img width="1440" alt="screen shot 2017-04-13 at 10 42 30" src="https://cloud.githubusercontent.com/assets/1682452/24998816/b12f6340-203b-11e7-9721-a11d53b76c31.png">

Or just drag the file inside a Chrome tab:

<img width="1018" alt="screen shot 2017-04-13 at 11 02 39" src="https://cloud.githubusercontent.com/assets/1682452/24998823/b6dd6f80-203b-11e7-830f-7d6d00a9232f.png">

Or, better, delete the last part of the string `the plug-in!',` in your editor and rewrite it. Then display a diff in your terminal:

![screen shot 2017-04-13 at 11 16 41](https://cloud.githubusercontent.com/assets/1682452/24998831/bfa1f230-203b-11e7-8cee-c007626754a5.png)

Xcode (and also TextEdit!) displays two line breaks.

Other IDEs/Editors like Phpstorm and Atom don't display anything but when moving the cursor along the line using the right arrow key, you will need to press it twice after the exclamation mark.


Fixes #6845 