### PR TITLE
Show 'premium' for menu item when premium is installed

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -157,6 +157,8 @@ class WPSEO_Admin {
 
 		$admin_page_hooks[ self::PAGE_IDENTIFIER ] = 'seo'; // Wipe notification bits from hooks. R.
 
+		$license_page_title = defined( 'WPSEO_PREMIUM_PLUGIN_FILE' ) ? __( 'Premium', 'wordpress-seo' ) : __( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator();
+
 		// Sub menu pages.
 		$submenu_pages = array(
 			array(
@@ -224,7 +226,7 @@ class WPSEO_Admin {
 			array(
 				self::PAGE_IDENTIFIER,
 				'',
-				__( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator(),
+				$license_page_title,
 				$manage_options_cap,
 				'wpseo_licenses',
 				array( $this, 'load_page' ),


### PR DESCRIPTION
Otherwise so 'Go Premium' with the added Star icon; as is always shown before this PR.

## Summary

This PR can be summarized in the following changelog entry:

## Test instructions

This PR can be tested by following these steps:

* Look at the SEO menu in WordPress
* Without this PR the `extensions` page-title will always show as `Go Premium *` even when premium is installed.
* Define the constant `WPSEO_PREMIUM_PLUGIN_FILE`
* See that the menu item is now displayed as `Premium`

Fixes #
