### PR TITLE
Add upgrade routine to rename the meta value.

### DIFF
--- a/admin/class-cornerstone.php
+++ b/admin/class-cornerstone.php
@@ -8,7 +8,7 @@
  */
 class WPSEO_Cornerstone {
 
-	const META_NAME = 'yst_is_cornerstone';
+	const META_NAME = '_yst_is_cornerstone';
 
 	/**
 	 * Registers the hooks.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -272,6 +272,10 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// The meta key has to be private, so prefix it.
-		$wpdb->query( 'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "' . WPSEO_Cornerstone::META_NAME . '"  WHERE meta_key = "yst_is_cornerstone"' );
-	}
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "s"  WHERE meta_key = "yst_is_cornerstone"',
+				WPSEO_Cornerstone::META_NAME
+			)
+		);	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -64,6 +64,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_44();
 		}
 
+		if ( version_compare( $this->options['version'], '4.7', '<' ) ) {
+			$this->upgrade_47();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -259,5 +263,15 @@ class WPSEO_Upgrade {
 			update_option( 'wpseo_titles', $option_titles );
 			update_option( 'wpseo', $option_wpseo );
 		}
+	}
+
+	/**
+	 * Renames the meta name for the cornerstone content. It was a public meta field and it has to be private.
+	 */
+	private function upgrade_47() {
+		global $wpdb;
+
+		// The meta key has to be private, so prefix it.
+		$wpdb->query( 'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "' . WPSEO_Cornerstone::META_NAME . '"  WHERE meta_key = "yst_is_cornerstone"' );
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -274,7 +274,7 @@ class WPSEO_Upgrade {
 		// The meta key has to be private, so prefix it.
 		$wpdb->query(
 			$wpdb->prepare(
-				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "s"  WHERE meta_key = "yst_is_cornerstone"',
+				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "%s"  WHERE meta_key = "yst_is_cornerstone"',
 				WPSEO_Cornerstone::META_NAME
 			)
 		);	}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -277,5 +277,6 @@ class WPSEO_Upgrade {
 				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "%s"  WHERE meta_key = "yst_is_cornerstone"',
 				WPSEO_Cornerstone::META_NAME
 			)
-		);	}
+		);
+	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -274,7 +274,7 @@ class WPSEO_Upgrade {
 		// The meta key has to be private, so prefix it.
 		$wpdb->query(
 			$wpdb->prepare(
-				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "%s"  WHERE meta_key = "yst_is_cornerstone"',
+				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "%s" WHERE meta_key = "yst_is_cornerstone"',
 				WPSEO_Cornerstone::META_NAME
 			)
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Test instructions

This PR can be tested by following these steps:

* Change `define( 'WPSEO_VERSION', '4.6' );` into `define( 'WPSEO_VERSION', '4.7' );` in the file: `wp-seo-main.php` to trigger the upgrade routine.
* In your database table `*_postmeta` the meta key should be changed. 

Fixes #6983
