### PR TITLE
Instead of hiding all tabs, pick the right ones

### DIFF
--- a/js/src/analysis/snippetPreview.js
+++ b/js/src/analysis/snippetPreview.js
@@ -22,7 +22,7 @@ function isolate( snippetContainer ) {
 	tr.siblings().hide();
 
 	// Remove the tab navigation.
-	jQuery( ".wpseo-metabox-tabs" ).hide();
+	snippetContainer.closest( ".wpseo-metabox-tabs" ).hide();
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Fixes a bug where the tabs in the social and advanced metabox section are gone when keyword analysis has been disabled.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk and do a `grunt build:js`
* Disable keyword analysis 
* See the tabs on social are gone.
* Checkout this branch and do a `grunt build:js`
* Make sure keyword analysis is still disabled
* The tabs on social are visible.

The same applies for the advanced section in the metabox.

Fixes #6240
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1095
