### PR TITLE
Only save the value when the checkbox is checked.

### DIFF
--- a/admin/class-cornerstone.php
+++ b/admin/class-cornerstone.php
@@ -25,6 +25,12 @@ class WPSEO_Cornerstone {
 	public function save_meta_value( $post_id ) {
 		$is_cornerstone = ( filter_input( INPUT_POST, self::META_NAME ) === '1' );
 
-		update_post_meta( $post_id, self::META_NAME, $is_cornerstone );
+		if ( $is_cornerstone ) {
+			update_post_meta( $post_id, self::META_NAME, $is_cornerstone );
+
+			return;
+		}
+
+		delete_post_meta( $post_id, self::META_NAME );
 	}
 }


### PR DESCRIPTION
This is a small optimization. The cornerstone flag only will be saved when the checkbox is checked. If this is not the case, the value will be removed. We only need the cornerstone = 1 values, this makes the non cornerstone meta values not being used.
