### PR TITLE
Check capability for showing wizard

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -88,6 +88,7 @@ class WPSEO_Admin {
 
 		if ( WPSEO_Utils::is_api_available() ) {
 			$configuration = new WPSEO_Configuration_Page;
+			$configuration->set_hooks();
 			$configuration->catch_configuration_request();
 		}
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -11,16 +11,15 @@ class WPSEO_Configuration_Page {
 	const PAGE_IDENTIFIER = 'wpseo_configurator';
 
 	/**
-	 * WPSEO_Configuration_Wizard constructor.
+	 * Sets the hooks when the user has enought rights and is on the right page.
 	 */
-	public function __construct() {
+	public function set_hooks(  ) {
+		if ( ! ( $this->is_config_page() && ! current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE ) ) ) {
+			return;
+		}
 
 		if ( $this->should_add_notification() ) {
 			$this->add_notification();
-		}
-
-		if ( filter_input( INPUT_GET, 'page' ) !== self::PAGE_IDENTIFIER ) {
-			return;
 		}
 
 		// Register the page for the wizard.
@@ -177,6 +176,15 @@ class WPSEO_Configuration_Page {
 		);
 
 		return $config;
+	}
+
+	/**
+	 * Checks if the current page is the configuration page.
+	 *
+	 * @return bool
+	 */
+	protected function is_config_page(  ) {
+		return ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER );
 	}
 
 	/**

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -14,7 +14,7 @@ class WPSEO_Configuration_Page {
 	 * Sets the hooks when the user has enought rights and is on the right page.
 	 */
 	public function set_hooks() {
-		if ( ! ( $this->is_config_page() && ! current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE ) ) ) {
+		if ( ! ( $this->is_config_page() && current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE ) ) ) {
 			return;
 		}
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -13,7 +13,7 @@ class WPSEO_Configuration_Page {
 	/**
 	 * Sets the hooks when the user has enought rights and is on the right page.
 	 */
-	public function set_hooks(  ) {
+	public function set_hooks() {
 		if ( ! ( $this->is_config_page() && ! current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE ) ) ) {
 			return;
 		}
@@ -183,7 +183,7 @@ class WPSEO_Configuration_Page {
 	 *
 	 * @return bool
 	 */
-	protected function is_config_page(  ) {
+	protected function is_config_page() {
 		return ( filter_input( INPUT_GET, 'page' ) === self::PAGE_IDENTIFIER );
 	}
 

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -9,7 +9,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( WPSEO_Utils::is_api_available() ) :
+if ( WPSEO_Utils::is_api_available() && current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE )  ) :
 	echo '<h2>' . esc_html__( 'Configuration wizard', 'wordpress-seo' ) . '</h2>';
 	?>
 	<p>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* When the user hasn't enough rights to access the endpoint for the configuration wizard, we should hide the button to start the wizard.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and in class `WPSEO_Configuration_Page` change on line 17: 
```
if ( ! ( $this->is_config_page() && current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE ) ) ) {
``` 
in 
```
if ( ! ( $this->is_config_page() && ! current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE ) ) ) {
```
* Open the wizard and see an error page.