### PR TITLE
Add new capability 'wpseo_metabox_advanced'

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -351,7 +351,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$content_sections[] = $this->social_admin->get_meta_section();
 		}
 
-		if ( current_user_can( 'manage_options' ) || $this->options['disableadvanced_meta'] === false ) {
+		if ( current_user_can( 'wpseo_metabox_advanced' ) || $this->options['disableadvanced_meta'] === false ) {
 			$content_sections[] = $this->get_advanced_meta_section();
 		}
 

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -388,7 +388,7 @@ class WPSEO_Meta {
 
 				$options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_titles', 'wpseo_internallinks' ) );
 
-				if ( ! current_user_can( 'manage_options' ) && $options['disableadvanced_meta'] ) {
+				if ( ! current_user_can( 'wpseo_metabox_advanced' ) && $options['disableadvanced_meta'] ) {
 					return array();
 				}
 

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -80,7 +80,7 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
 }
 
 /**
- * Add the bulk edit capability to the proper default roles, and setup a new capability to display the 'advanced' metabox tab
+ * Add the bulk edit capability to the proper default roles, and setup a new capability to display the 'advanced' metabox tab.
  */
 function wpseo_add_capabilities() {
 	$roles = array(
@@ -96,8 +96,8 @@ function wpseo_add_capabilities() {
 			$r->add_cap( 'wpseo_bulk_edit' );
 		}
 	}
-	
-	// Create a new cabaility to display the 'advanced' metabox tab
+
+	// Create a new cabaility to display the 'advanced' metabox tab.
 	$r = get_role( 'administrator' );
 	$r->add_cap( 'wpseo_metabox_advanced' );
 }

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -80,7 +80,7 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
 }
 
 /**
- * Add the bulk edit capability to the proper default roles.
+ * Add the bulk edit capability to the proper default roles, and setup a new capability to display the 'advanced' metabox tab
  */
 function wpseo_add_capabilities() {
 	$roles = array(
@@ -96,6 +96,10 @@ function wpseo_add_capabilities() {
 			$r->add_cap( 'wpseo_bulk_edit' );
 		}
 	}
+	
+	// Create a new cabaility to display the 'advanced' metabox tab
+	$r = get_role( 'administrator' );
+	$r->add_cap( 'wpseo_metabox_advanced' );
 }
 
 
@@ -118,6 +122,7 @@ function wpseo_remove_capabilities() {
 		$r = get_role( $role );
 		if ( $r ) {
 			$r->remove_cap( 'wpseo_bulk_edit' );
+			$r->remove_cap( 'wpseo_metabox_advanced' );
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add the new Wordpress capability 'wpseo_metabox_advanced' - this can be used to allow specific user roles to have access to the 'Advanced' tab in the Post Meta Box.

## Relevant technical choices:

* We have setup and removed the role using the existing capability activation/deactivation functions.
* We have used the same prefix 'wpseo' for the capability name
* By default, this new role is assigned to the 'Administrator' role (which should have access to the old capability 'manage_options' on all sites).

## Test instructions

This PR can be tested by following these steps:

1. Reactivate plugin (capability is only added on activation)
2. Check Administrator can still see 'Advanced' tab in the Metabox
3. Login as an Editor user
4. Check the Editor can't access the 'Advanced' tab in the Metabox
5. Login an an Administrator
6. Install a plugin such as User Role Editor
7. Assign the capability 'wpseo_metabox_advanced' to the Editor role
8. Login as an Editor user
9. The Editor should now have full access to the "Advanced" tab in the post metabox

## Fixes

There are no fixes in this pull request.