### PR TITLE
Removes wp editor when custom taxonomy is private

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -35,10 +35,6 @@ class WPSEO_Taxonomy {
 		add_action( 'init', array( $this, 'custom_category_descriptions_allow_html' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-		$this->insert_description_field_editor();
-
-		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
-
 		if ( self::is_term_overview( $GLOBALS['pagenow'] ) ) {
 			new WPSEO_Taxonomy_Columns();
 		}
@@ -56,6 +52,10 @@ class WPSEO_Taxonomy {
 		if ( empty( $taxonomy ) || empty( $taxonomy->public ) || ! $this->show_metabox() ) {
 			return;
 		}
+
+		$this->insert_description_field_editor();
+
+		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
 
 		add_action( sanitize_text_field( $this->taxonomy ) . '_edit_form', array( $this, 'term_metabox' ), 90, 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
@@ -179,11 +179,6 @@ class WPSEO_Taxonomy {
 	 * Output the WordPress editor.
 	 */
 	public function custom_category_description_editor() {
-
-		if ( ! $this->show_metabox() ) {
-			return;
-		}
-
 		wp_editor( '', 'description' );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

Function `insert_description_field_editor` was calling from __construct (action plugins_loaded). It's too early and it isn't possible to detect kind of taxonomy. I moved this function and add_filter `category_description` later into function `admin_init`  (where is safe to call `get_taxonomy`).  Also, it's safe to move the code there because filters are triggering after action `admin_init` (I tested it on couple installations). 

Function custom_category_description_editor doesn't need more checking `! $this->show_metabox()` because it's already done in `admin_init`.

## Test instructions

This PR can be tested by following these steps:

Create private taxonomy (example is in #6452). Create a new custom taxonomy item called "test".
Edit the test custom taxonomy item. It should work without WP editor before field `Name`.

Fixes #6452, #6369, #6679 
