### PR TITLE
Add upgrade routing for removing the upgrade notice.

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -361,6 +361,8 @@ class Yoast_Notification_Center {
 
 		$notifications = $this->get_notifications();
 
+		$notifications = apply_filters( 'yoast_notifications_before_storage', $notifications );
+
 		// No notifications to store, clear storage.
 		if ( empty( $notifications ) ) {
 			$this->remove_storage();

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -361,6 +361,11 @@ class Yoast_Notification_Center {
 
 		$notifications = $this->get_notifications();
 
+		/**
+		 * Filter: 'yoast_notifications_before_storage' - Allows developer to filter notifications before saving them.
+		 *
+		 * @api Yoast_Notification[] $notifications
+		 */
 		$notifications = apply_filters( 'yoast_notifications_before_storage', $notifications );
 
 		// No notifications to store, clear storage.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -328,9 +328,11 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * @param Yoast_Notification[] $notifications
+	 * Filters the wpseo-dismiss-about notice from all the notification current user has.
 	 *
-	 * @return mixed
+	 * @param Yoast_Notification[] $notifications The notifications to filter.
+	 *
+	 * @return Yoast_Notification[]
 	 */
 	public function remove_about_notice( $notifications ) {
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -335,8 +335,7 @@ class WPSEO_Upgrade {
 	 * @return Yoast_Notification[]
 	 */
 	public function remove_about_notice( $notifications ) {
-
-		foreach( $notifications as $notification_key => $notification ) {
+		foreach ( $notifications as $notification_key => $notification ) {
 			if ( $notification->get_id() === 'wpseo-dismiss-about' ) {
 				unset( $notifications[ $notification_key ] );
 			}
@@ -344,5 +343,4 @@ class WPSEO_Upgrade {
 
 		return $notifications;
 	}
-
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -291,17 +291,17 @@ class WPSEO_Upgrade {
 	private function upgrade_49() {
 		global $wpdb;
 
-		$usermetas = $wpdb->get_results( "
+		$usermetas = $wpdb->get_results( '
 			SELECT user_id, meta_value 
-			FROM " . $wpdb->usermeta . " 
-			WHERE meta_key = 'wp_yoast_notifications' && meta_value LIKE '%wpseo-dismiss-about%'
-			", ARRAY_A
+			FROM ' . $wpdb->usermeta . ' 
+			WHERE meta_key = "wp_yoast_notifications" && meta_value LIKE "%wpseo-dismiss-about%"
+			', ARRAY_A
 		);
 
-		foreach( $usermetas as $usermeta ) {
+		foreach ( $usermetas as $usermeta ) {
 			$notifications = unserialize( $usermeta['meta_value'] );
 
-			foreach( $notifications as $notification_key => $notification ) {
+			foreach ( $notifications as $notification_key => $notification ) {
 				if ( ! empty( $notification['options']['id'] ) && $notification['options']['id'] === 'wpseo-dismiss-about' ) {
 					unset( $notifications[ $notification_key ] );
 				}
@@ -309,11 +309,11 @@ class WPSEO_Upgrade {
 
 			// Using a hard query, because WordPress is caching the user meta.
 			$wpdb->query(
-				$wpdb->prepare("
-					UPDATE " . $wpdb->usermeta . " 
-					SET meta_value = '%s' 
-					WHERE meta_key = 'wp_yoast_notifications' && user_id = '%s' 	
-					",
+				$wpdb->prepare('
+					UPDATE ' . $wpdb->usermeta . '
+					SET meta_value = "%s"
+					WHERE meta_key = "wp_yoast_notifications" && user_id = "%s"
+					',
 					serialize( $notifications ),
 					$usermeta['user_id']
 				)

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -328,11 +328,11 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Filters the wpseo-dismiss-about notice from all the notification current user has.
+	 * Removes the wpseo-dismiss-about notice from a list of notifications.
 	 *
 	 * @param Yoast_Notification[] $notifications The notifications to filter.
 	 *
-	 * @return Yoast_Notification[]
+	 * @return Yoast_Notification[] The filtered list of notifications. Excluding the wpseo-dismiss-about notification.
 	 */
 	public function remove_about_notice( $notifications ) {
 		foreach ( $notifications as $notification_key => $notification ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Remove the upgrade notice for each user. 

## Relevant technical choices:

* Do a hard query to get the user meta for each user that has the notice being set.
* The previous routine was wrong, because it only removed the notice for the user that executed the upgrade routing

## Test instructions

This PR can be tested by following these steps:

* Have the notice present for multiple users.
* Change the version number in the options table for option name `wpseo` to a value below 4.8
* Refresh the WordPress backend.
* The upgrade notice should be removed.

Fixes #5862
