### PR TITLE
Resolve conflict with W3TC plugin and New Relic extension

### DIFF
--- a/css/xml-sitemap-xsl.php
+++ b/css/xml-sitemap-xsl.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 // This is to prevent issues with New Relics stupid auto injection of code. It's ugly but I don't want
 // to deal with support requests for other people's wrong code...
 if ( extension_loaded( 'newrelic' ) && function_exists( 'newrelic_disable_autorum' ) ) {
-	define('DONOTAUTORUM', TRUE); // Resolves conflict with W3TC's NR extension.
+	define( 'DONOTAUTORUM', true ); // Resolves conflict with W3TC's NR extension.
 	newrelic_disable_autorum();
 }
 

--- a/css/xml-sitemap-xsl.php
+++ b/css/xml-sitemap-xsl.php
@@ -12,6 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 // This is to prevent issues with New Relics stupid auto injection of code. It's ugly but I don't want
 // to deal with support requests for other people's wrong code...
 if ( extension_loaded( 'newrelic' ) && function_exists( 'newrelic_disable_autorum' ) ) {
+	define('DONOTAUTORUM', TRUE); // Resolves conflict with W3TC's NR extension.
 	newrelic_disable_autorum();
 }
 


### PR DESCRIPTION
When using the New Relic extension for the popular W3 Total Cache plugin, javascript is injected into the XML stylesheet, causing the stylesheet to break. 

This is already resolved if not using W3TC's NR extension (just using NR's PHP daemon, for example) but this one change makes the solution work for W3TC users too.

See https://github.com/Yoast/wordpress-seo/issues/603
Also see usage of the DONOTAUTORUM constant in the w3-total-cache plugin.

## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
