### PR TITLE
Decode the url path first.

### DIFF
--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -290,8 +290,11 @@ class WPSEO_Sitemaps_Renderer {
 		$path = parse_url( $url, PHP_URL_PATH );
 
 		if ( ! empty( $path ) && '/' !== $path ) {
-
 			$encoded_path = explode( '/', $path );
+
+			// First decode the path, to prevent double encoding.
+			$encoded_path = array_map( 'rawurldecode', $encoded_path );
+
 			$encoded_path = array_map( 'rawurlencode', $encoded_path );
 			$encoded_path = implode( '/', $encoded_path );
 			$encoded_path = str_replace( '%7E', '~', $encoded_path ); // PHP <5.3.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* [Bugfix] Fixes a bug where the url was encode twice.

## Relevant technical choices:

* Decode the url path first to prevent double encoding

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk
* Make a category with `לימודיסק-5-7-עוברים-לכיתה-א-מתנה-לילדי-הג` as a slug and attach a post to that category
* See it will be encoded twice in the sitemap
* Checkout this branch
* Add a new post and attach it to the sitemap to clear the cache
* Refresh the sitemap and see it is encoded once.


Fixes #7145 
