### PR TITLE
Remove the noodp from the robots meta tag

### DIFF
--- a/admin/class-import-external.php
+++ b/admin/class-import-external.php
@@ -87,9 +87,6 @@ class WPSEO_Import_External {
 				if ( isset( $custom['_headspace_noarchive'] ) ) {
 					$robotsmeta_adv .= 'noarchive,';
 				}
-				if ( isset( $custom['_headspace_noodp'] ) ) {
-					$robotsmeta_adv .= 'noodp,';
-				}
 				$robotsmeta_adv = preg_replace( '`,$`', '', $robotsmeta_adv );
 				WPSEO_Meta::set_value( 'meta-robots-adv', $robotsmeta_adv, $post->ID );
 			}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -106,7 +106,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		self::$meta_fields['advanced']['meta-robots-adv']['description']             = __( 'Advanced <code>meta</code> robots settings for this page.', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-adv']['options']['-']            = __( 'Site-wide default: %s', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-adv']['options']['none']         = __( 'None', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-adv']['options']['noodp']        = __( 'NO ODP', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-adv']['options']['noimageindex'] = __( 'No Image Index', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-adv']['options']['noarchive']    = __( 'No Archive', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-adv']['options']['nosnippet']    = __( 'No Snippet', 'wordpress-seo' );

--- a/admin/views/tabs/metas/other.php
+++ b/admin/views/tabs/metas/other.php
@@ -16,8 +16,3 @@ echo '<p>', __( 'If you want to prevent /page/2/ and further of any archive to s
 
 $yform->light_switch( 'usemetakeywords', __( 'Use meta keywords tag?', 'wordpress-seo' ) );
 echo '<p>', __( 'I don\'t know why you\'d want to use meta keywords, but if you want to, enable this.', 'wordpress-seo' ), '</p>';
-
-/* translators: %s expands to <code>noodp</code> */
-$yform->light_switch( 'noodp', sprintf( __( 'Force %s meta robots tag sitewide', 'wordpress-seo' ), '<code>noodp</code>' ) );
-/* translators: %s expands to <code>noodp</code> */
-echo '<p>', sprintf( __( 'Prevents search engines from using the DMOZ description in the search results for all pages on this site. Note: If you set a custom description for a page or post, it will have the %s tag regardless of this setting.', 'wordpress-seo' ), '<code>noodp</code>' ), '</p>';

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -778,6 +778,7 @@ class WPSEO_Frontend {
 		}
 
 		$robotsstr = preg_replace( '`^index,follow,?`', '', $robotsstr );
+		$robotsstr = str_replace( array( 'noodp,', 'noodp' ), '', $robotsstr );
 
 		/**
 		 * Filter: 'wpseo_robots' - Allows filtering of the meta robots output of Yoast SEO

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -761,10 +761,6 @@ class WPSEO_Frontend {
 			if ( $is_paged && $noindex_subpages ) {
 				$robots['index'] = 'noindex';
 			}
-
-			if ( $this->options['noodp'] === true ) {
-				$robots['other'][] = 'noodp';
-			}
 			unset( $robot );
 		}
 
@@ -826,11 +822,6 @@ class WPSEO_Frontend {
 				$robots['other'][] = $robot;
 			}
 			unset( $robot );
-		}
-		elseif ( $meta_robots_adv === '' || $meta_robots_adv === '-' ) {
-			if ( $this->options['noodp'] === true ) {
-				$robots['other'][] = 'noodp';
-			}
 		}
 		unset( $meta_robots_adv );
 
@@ -1246,7 +1237,6 @@ class WPSEO_Frontend {
 		if ( $echo !== false ) {
 			if ( is_string( $this->metadesc ) && $this->metadesc !== '' ) {
 				echo '<meta name="description" content="', esc_attr( strip_tags( stripslashes( $this->metadesc ) ) ), '"/>', "\n";
-				$this->add_robot_content_noodp( $this->metadesc );
 			}
 			elseif ( current_user_can( 'manage_options' ) && is_singular() ) {
 				echo '<!-- ', __( 'Admin only notice: this page doesn\'t show a meta description because it doesn\'t have one, either write it for this page specifically or go into the SEO -> Titles menu and set up a template.', 'wordpress-seo' ), ' -->', "\n";
@@ -1883,17 +1873,6 @@ class WPSEO_Frontend {
 	 */
 	private function is_premium() {
 		return file_exists( WPSEO_PATH . 'premium/' );
-	}
-
-	/**
-	 * Checks whether the user has written a meta-description. If written,  makes sure meta robots content is noodp.
-	 *
-	 * @param String $description The content of the meta description.
-	 */
-	private function add_robot_content_noodp( $description ) {
-		if ( ! ( empty( $description ) ) && $this->options['noodp'] === false ) {
-			$this->options['noodp'] = true;
-		}
 	}
 
 	/**

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -188,7 +188,6 @@ class WPSEO_Meta {
 				'options'       => array(
 					'-'            => '', // Site-wide default - translation added later.
 					'none'         => '', // Translation added later.
-					'noodp'        => '', // Translation added later.
 					'noimageindex' => '', // Translation added later.
 					'noarchive'    => '', // Translation added later.
 					'nosnippet'    => '', // Translation added later.
@@ -404,17 +403,8 @@ class WPSEO_Meta {
 				$field_defs['meta-robots-noindex']['options']['0'] = sprintf( $field_defs['meta-robots-noindex']['options']['0'], ( ( isset( $options[ 'noindex-' . $post_type ] ) && $options[ 'noindex-' . $post_type ] === true ) ? 'noindex' : 'index' ) );
 
 				/* Adjust the robots advanced 'site-wide default' text string based on those settings */
-				if ( $options['noodp'] !== false ) {
-					$robots_adv = array();
-					if ( $options['noodp'] === true ) {
-						// Use translation from field def options - mind that $options and $field_def['options'] keys should be the same!
-						$robots_adv[] = $field_defs['meta-robots-adv']['options']['noodp'];
-					}
-					$robots_adv = implode( ', ', $robots_adv );
-				}
-				else {
-					$robots_adv = __( 'None', 'wordpress-seo' );
-				}
+				$robots_adv = __( 'None', 'wordpress-seo' );
+
 				$field_defs['meta-robots-adv']['options']['-'] = sprintf( $field_defs['meta-robots-adv']['options']['-'], $robots_adv );
 				unset( $robots_adv );
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -24,7 +24,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		// Form fields.
 		'forcerewritetitle'      => false,
 		'separator'              => 'sc-dash',
-		'noodp'                  => false,
 		'usemetakeywords'        => false,
 		'title-home-wpseo'       => '%%sitename%% %%page%% %%sep%% %%sitedesc%%', // Text field.
 		'title-author-wpseo'     => '', // Text field.

--- a/tests/test-class-wpseo-frontend-robots.php
+++ b/tests/test-class-wpseo-frontend-robots.php
@@ -45,7 +45,6 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::robots
 	 *
 	 * @todo   test post type archives
-	 * @todo   test with noodp and noydir option set
 	 * @todo   test with page_for_posts option
 	 * @todo   test date archives
 	 * @todo   test search results
@@ -286,14 +285,9 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$expected['follow'] = 'nofollow';
 		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
 
-		// test noodp with default meta-robots-adv
-		self::$class_instance->options['noodp'] = true;
-		$expected['other']                      = array( 'noodp' );
-		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
-
-		// test meta-robots adv noodp and nosnippet
-		WPSEO_Meta::set_value( 'meta-robots-adv', 'noodp,nosnippet', $post_id );
-		$expected['other'] = array( 'noodp', 'nosnippet' );
+		// test meta-robots adv nosnippet
+		WPSEO_Meta::set_value( 'meta-robots-adv', 'nosnippet', $post_id );
+		$expected['other'] = array( 'nosnippet' );
 		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
 
 		WPSEO_Meta::set_value( 'meta-robots-noindex', '2', $post_id );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Removed the noodp advanced robots meta value.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Test if the tag isn't set and used anymore.

Fixes #6843 
