### PR TITLE
Get timezone with daylight save mode

### DIFF
--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -81,8 +81,13 @@ class WPSEO_Sitemap_Timezone {
 		// Adjust UTC offset from hours to seconds.
 		$utc_offset *= HOUR_IN_SECONDS;
 
-		// Attempt to guess the timezone string from the UTC offset.
-		$timezone = timezone_name_from_abbr( '', $utc_offset );
+		// Attempt to guess the timezone string from the UTC offset and daylight save mode.
+		$timezone = timezone_name_from_abbr('', $utc_offset, 1 );
+
+		if ( false === $timezone ) {
+			// Attempt to guess the timezone string from the UTC offset.
+			$timezone = timezone_name_from_abbr( '', $utc_offset, 0 );
+		}
 
 		if ( false !== $timezone ) {
 			return $timezone;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Try to use daylight save mode when a UTC value has been set

## Test instructions

This PR can be tested by following these steps:

* Check if the sitemap works as expected. If it works we should redo the pull https://github.com/Yoast/wpseo-news/pull/295

If this pull doesn't work, please close it or ping me for a pairing session, because I am not entirely sure how to solve it.

Fixes #7193
