### PR TITLE
Add Support For Singular Post Types To The "noindex-subpages" Option

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -755,13 +755,13 @@ class WPSEO_Frontend {
 					$robots['index'] = 'noindex';
 				}
 			}
+		}
 
-			$is_paged         = isset( $wp_query->query_vars['paged'] ) && ( $wp_query->query_vars['paged'] && $wp_query->query_vars['paged'] > 1 );
-			$noindex_subpages = $this->options['noindex-subpages-wpseo'] === true;
-			if ( $is_paged && $noindex_subpages ) {
-				$robots['index'] = 'noindex';
-			}
-			unset( $robot );
+		$is_paged         = isset( $wp_query->query_vars['paged'] ) && ( $wp_query->query_vars['paged'] && $wp_query->query_vars['paged'] > 1 );
+		$noindex_subpages = true === $this->options['noindex-subpages-wpseo'];
+
+		if ( $is_paged && $noindex_subpages ) {
+			$robots['index'] = 'noindex';
 		}
 
 		// Force override to respect the WP settings.


### PR DESCRIPTION
## Summary
Make the noindex-subpages option apply to paged singular post types in addition to archives. This improves compatibility with custom page templates and/or page builder-built pages being used to display posts.

## Relevant technical choices:
* N/A

## Test instructions
1. Enable the noindex-subpages option.
2. Create a page using the Divi Builder that contains a Blog Module.
3. Check page 2 of the Blog Module output. 

Fixes #2906
Fixes #7246
Fixes elegantthemes/Divi#2952