### PR TITLE
Add new filter: `wpseo_sitemap_content_before_parse_html` 

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -68,11 +68,12 @@ class WPSEO_Sitemap_Image_Parser {
 		}
 
 		/**
-		 * Filters the post content before it is parsed for images.
+		 * Filter: 'wpseo_sitemap_content_before_parse_html_images' - Filters the post content
+		 * before it is parsed for images.
 		 *
-		 * @param string $content
+		 * @param string $content The raw/unprocessed post content.
 		 */
-		$content = apply_filters( 'wpseo_sitemap_content_before_parse_html', $post->post_content );
+		$content = apply_filters( 'wpseo_sitemap_content_before_parse_html_images', $post->post_content );
 
 		$unfiltered_images = $this->parse_html_images( $content );
 

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -67,7 +67,14 @@ class WPSEO_Sitemap_Image_Parser {
 			$images[] = $this->get_image_item( $post, $src, $title, $alt );
 		}
 
-		$unfiltered_images = $this->parse_html_images( $post->post_content );
+		/**
+		 * Filters the post content before it is parsed for images.
+		 *
+		 * @param string $content
+		 */
+		$content = apply_filters( 'wpseo_sitemap_content_before_parse_html', $post->post_content );
+
+		$unfiltered_images = $this->parse_html_images( $content );
 
 		foreach ( $unfiltered_images as $image ) {
 			$images[] = $this->get_image_item( $post, $image['src'], $image['title'], $image['alt'] );


### PR DESCRIPTION
## Summary
Add new filter: `wpseo_sitemap_content_before_parse_html` to allow the post content to be filtered before it is parsed for images (for the xml sitemap). This will allow themes and plugins to process their own shortcodes if they wish to have the images properly included in the sitemap.

## Relevant technical choices:
* N/A

## Test instructions
* Once hook is implemented in Divi, images in page content of pages created with the Divi Builder will show up in the sitemap.

Fixes #4808
Fixes elegantthemes/Divi#2369
Related #6040
