### PR TITLE
Allow 3rd party sitemaps providers

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -77,11 +77,12 @@ class WPSEO_Sitemaps {
 		$this->router      = new WPSEO_Sitemaps_Router();
 		$this->renderer    = new WPSEO_Sitemaps_Renderer();
 		$this->cache       = new WPSEO_Sitemaps_Cache();
-		$this->providers   = array( // TODO API for add/remove. R.
+		$providers = array(
 			new WPSEO_Post_Type_Sitemap_Provider(),
 			new WPSEO_Taxonomy_Sitemap_Provider(),
-			new WPSEO_Author_Sitemap_Provider(),
+			new WPSEO_Author_Sitemap_Provider()
 		);
+		$this->providers   = apply_filters( 'wpseo_sitmaps_providers', $providers );
 
 		if ( ! empty( $_SERVER['SERVER_PROTOCOL'] ) ) {
 			$this->http_protocol = sanitize_text_field( $_SERVER['SERVER_PROTOCOL'] );

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -80,7 +80,7 @@ class WPSEO_Sitemaps {
 		$providers = array(
 			new WPSEO_Post_Type_Sitemap_Provider(),
 			new WPSEO_Taxonomy_Sitemap_Provider(),
-			new WPSEO_Author_Sitemap_Provider()
+			new WPSEO_Author_Sitemap_Provider(),
 		);
 		$this->providers   = apply_filters( 'wpseo_sitmaps_providers', $providers );
 

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -83,7 +83,7 @@ class WPSEO_Sitemaps {
 			new WPSEO_Author_Sitemap_Provider(),
 		);
 
-		$external_providers = apply_filters( 'wpseo_sitmaps_providers', array() );
+		$external_providers = apply_filters( 'wpseo_sitemaps_providers', array() );
 
 		foreach ( $external_providers as $provider ) {
 			if ( is_object( $provider ) && $provider instanceof WPSEO_Sitemap_Provider ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -77,12 +77,19 @@ class WPSEO_Sitemaps {
 		$this->router      = new WPSEO_Sitemaps_Router();
 		$this->renderer    = new WPSEO_Sitemaps_Renderer();
 		$this->cache       = new WPSEO_Sitemaps_Cache();
-		$providers = array(
+		$this->providers   = array(
 			new WPSEO_Post_Type_Sitemap_Provider(),
 			new WPSEO_Taxonomy_Sitemap_Provider(),
 			new WPSEO_Author_Sitemap_Provider(),
 		);
-		$this->providers   = apply_filters( 'wpseo_sitmaps_providers', $providers );
+
+		$external_providers = apply_filters( 'wpseo_sitmaps_providers', array() );
+
+		foreach ( $external_providers as $provider ) {
+			if ( is_object( $provider ) && $provider instanceof WPSEO_Sitemap_Provider ) {
+				$this->providers[] = $provider;
+			}
+		}
 
 		if ( ! empty( $_SERVER['SERVER_PROTOCOL'] ) ) {
 			$this->http_protocol = sanitize_text_field( $_SERVER['SERVER_PROTOCOL'] );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: Allow 3rd party sitemaps providers

## Relevant technical choices:

* fragment marked as a TODO
* now other developers can add own sitemap providers
* this is only a filter on a class property