### PR TITLE
Show notice when links table cannot created

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -760,10 +760,16 @@ class WPSEO_Admin {
 
 		$storage = new WPSEO_Link_Storage( $wpdb->get_blog_prefix() );
 
+		$link_table_accessible = new WPSEO_Link_Table_Accessible_Notifier();
+
 		// When the table doesn't exists, just return early.
 		if ( $wpdb->get_var( 'SHOW TABLES LIKE "' . $storage->get_table_name() . '"' ) !== $storage->get_table_name() ) {
+			$link_table_accessible->add_notification();
+
 			return;
 		}
+
+		$link_table_accessible->remove_notification();
 
 		$seo_links = new WPSEO_Link_Watcher(
 			new WPSEO_Link_Content_Processor( $storage )

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -762,7 +762,7 @@ class WPSEO_Admin {
 
 		$link_table_accessible = new WPSEO_Link_Table_Accessible_Notifier();
 
-		// When the table doesn't exists, just return early.
+		// When the table doesn't exists, just add the notification and return early.
 		if ( $wpdb->get_var( 'SHOW TABLES LIKE "' . $storage->get_table_name() . '"' ) !== $storage->get_table_name() ) {
 			$link_table_accessible->add_notification();
 

--- a/admin/links/class-link-table-accessible-notifier.php
+++ b/admin/links/class-link-table-accessible-notifier.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package WPSEO\Admin\Links\Reindex
+ */
+
+/**
+ * Represents the notice when the table is not accessible.
+ */
+class WPSEO_Link_Table_Accessible_Notifier {
+
+	const NOTIFICATION_ID = 'wpseo-links-table-not-accessible';
+
+	/**
+	 * Adds the notification to the notification center.
+	 */
+	public function add_notification() {
+		Yoast_Notification_Center::get()->add_notification( $this->get_notification() );
+	}
+
+	/**
+	 * Removes the notification from the notification center.
+	 */
+	public function remove_notification() {
+		Yoast_Notification_Center::get()->remove_notification( $this->get_notification() );
+	}
+
+	/**
+	 * Returns the notification when table is not accessible.
+	 *
+	 * @return Yoast_Notification The notification.
+	 */
+	protected function get_notification(  ) {
+		return new Yoast_Notification(
+			sprintf(
+				/* translators: 1: Yoast SEO. 2: Version number of Yoast SEO 3: link to knowledge base article about solving table issue. 3: is anchor closing. */
+				__(
+					'The internal linking statistics feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.
+
+					Please read the following %3$sknowledge base article%4$s to find out how to resolve this problem.',
+					'wordpress-seo'
+				),
+				'Yoast SEO',
+				'5.0',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/' ) . '">',
+				'</a>'
+			),
+			array(
+				'type'         => Yoast_Notification::WARNING,
+				'id'           => self::NOTIFICATION_ID,
+				'capabilities' => 'manage_options',
+				'priority'     => 0.8,
+			)
+		);
+	}
+}

--- a/admin/links/class-link-table-accessible-notifier.php
+++ b/admin/links/class-link-table-accessible-notifier.php
@@ -25,14 +25,14 @@ class WPSEO_Link_Table_Accessible_Notifier {
 	}
 
 	/**
-	 * Returns the notification when table is not accessible.
+	 * Returns the notification when the table is not accessible.
 	 *
 	 * @return Yoast_Notification The notification.
 	 */
 	protected function get_notification(  ) {
 		return new Yoast_Notification(
 			sprintf(
-				/* translators: 1: Yoast SEO. 2: Version number of Yoast SEO 3: link to knowledge base article about solving table issue. 3: is anchor closing. */
+				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. %3$s: link to knowledge base article about solving table issue. %4$s: is anchor closing. */
 				__(
 					'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.
 					Please read the following %3$sknowledge base article%4$s to find out how to resolve this problem.',

--- a/admin/links/class-link-table-accessible-notifier.php
+++ b/admin/links/class-link-table-accessible-notifier.php
@@ -34,8 +34,7 @@ class WPSEO_Link_Table_Accessible_Notifier {
 			sprintf(
 				/* translators: 1: Yoast SEO. 2: Version number of Yoast SEO 3: link to knowledge base article about solving table issue. 3: is anchor closing. */
 				__(
-					'The internal linking statistics feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.
-
+					'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.
 					Please read the following %3$sknowledge base article%4$s to find out how to resolve this problem.',
 					'wordpress-seo'
 				),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Added a notification when the creation of new links table could not be done.

## Test instructions

This PR can be tested by following these steps:

* Remove the table and see a notice appear in the dashboard.

Fixes #7308 
