### PR TITLE
Removes the babel polyfill import

### DIFF
--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -1,6 +1,3 @@
-// Required for browser compatibility.
-import "babel-polyfill";
-
 /* global yoastWizardConfig */
 import React from "react";
 import ReactDOM from "react-dom";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* n.a.

## Relevant technical choices:

* Remove the import of the polyfill for the configuration file, because it is loaded already

## Test instructions

This PR can be tested by following these steps:

* checkout `release/5.0` and do `grunt build:js` 
* open the configuration wizard and see an error in the console
* checkout this branch and do a `grunt build:js`
* the error should be gone!
* thank you

