### PR TITLE
Filter links with hashtags

### DIFF
--- a/admin/links/class-link-content-processor.php
+++ b/admin/links/class-link-content-processor.php
@@ -35,7 +35,11 @@ class WPSEO_Link_Content_Processor {
 	 */
 	public function process( $post_id, $content ) {
 		$link_extractor = new WPSEO_Link_Extractor( $content );
-		$link_processor = new WPSEO_Link_Factory( new WPSEO_Link_Type_Classifier( site_url() ), new WPSEO_Link_Internal_Lookup() );
+		$link_processor = new WPSEO_Link_Factory(
+			new WPSEO_Link_Type_Classifier( site_url() ),
+			new WPSEO_Link_Internal_Lookup(),
+			new WPSEO_Link_Filter( get_permalink( $post_id ) )
+		);
 
 		$extracted_links = $link_extractor->extract();
 		$links = $link_processor->build( $extracted_links );

--- a/admin/links/class-link-factory.php
+++ b/admin/links/class-link-factory.php
@@ -33,7 +33,10 @@ class WPSEO_Link_Factory {
 	 * @return WPSEO_Link[] The formatted links.
 	 */
 	public function build( array $extracted_links ) {
-		return array_map( array( $this, 'build_link' ), $extracted_links );
+		$extracted_links = array_map( array( $this, 'build_link' ), $extracted_links );
+		$filtered_links = array_filter( $extracted_links, array( $this, 'internal_link_with_fragment_filter' ) );
+
+		return $filtered_links;
 	}
 
 	/**
@@ -52,5 +55,22 @@ class WPSEO_Link_Factory {
 		}
 
 		return new WPSEO_Link( $link, $target_post_id, $link_type );
+	}
+
+	/**
+	 * Filters all internal links that contains an fragment in the URL.
+	 *
+	 * @param WPSEO_Link $link The link that might be filtered.
+	 *
+	 * @return bool False when url contains a fragment.
+	 */
+	protected function internal_link_with_fragment_filter( WPSEO_Link $link ) {
+		if ( $link->get_type() !== WPSEO_Link::TYPE_INTERNAL ) {
+			return true;
+		}
+
+		$url_parts = parse_url( $link->get_url() );
+
+		return empty( $url_parts['fragment'] );
 	}
 }

--- a/admin/links/class-link-factory.php
+++ b/admin/links/class-link-factory.php
@@ -12,17 +12,23 @@ class WPSEO_Link_Factory {
 	protected $classifier;
 
 	/** @var WPSEO_Link_Internal_Lookup */
+
 	protected $internal_lookup;
+
+	/** @var WPSEO_Link_Filter */
+	protected $filter;
 
 	/**
 	 * Sets the dependencies for this object.
 	 *
 	 * @param WPSEO_Link_Type_Classifier $classifier      The classifier to use.
 	 * @param WPSEO_Link_Internal_Lookup $internal_lookup The internal lookup to use.
+	 * @param WPSEO_Link_Filter          $filter          The link filter.
 	 */
-	public function __construct( WPSEO_Link_Type_Classifier $classifier, WPSEO_Link_Internal_Lookup $internal_lookup ) {
+	public function __construct( WPSEO_Link_Type_Classifier $classifier, WPSEO_Link_Internal_Lookup $internal_lookup, WPSEO_Link_Filter $filter ) {
 		$this->classifier = $classifier;
 		$this->internal_lookup = $internal_lookup;
+		$this->filter = $filter;
 	}
 
 	/**
@@ -34,7 +40,7 @@ class WPSEO_Link_Factory {
 	 */
 	public function build( array $extracted_links ) {
 		$extracted_links = array_map( array( $this, 'build_link' ), $extracted_links );
-		$filtered_links = array_filter( $extracted_links, array( $this, 'internal_link_with_fragment_filter' ) );
+		$filtered_links = array_filter( $extracted_links, array( $this->filter, 'internal_link_with_fragment_filter' ) );
 
 		return $filtered_links;
 	}
@@ -55,22 +61,5 @@ class WPSEO_Link_Factory {
 		}
 
 		return new WPSEO_Link( $link, $target_post_id, $link_type );
-	}
-
-	/**
-	 * Filters all internal links that contains an fragment in the URL.
-	 *
-	 * @param WPSEO_Link $link The link that might be filtered.
-	 *
-	 * @return bool False when url contains a fragment.
-	 */
-	protected function internal_link_with_fragment_filter( WPSEO_Link $link ) {
-		if ( $link->get_type() !== WPSEO_Link::TYPE_INTERNAL ) {
-			return true;
-		}
-
-		$url_parts = parse_url( $link->get_url() );
-
-		return empty( $url_parts['fragment'] );
 	}
 }

--- a/admin/links/class-link-filter.php
+++ b/admin/links/class-link-filter.php
@@ -39,7 +39,7 @@ class WPSEO_Link_Filter {
 			return true;
 		}
 
-		return empty( $url_parts['fragment'] );
+		return false;
 	}
 
 	/**

--- a/admin/links/class-link-filter.php
+++ b/admin/links/class-link-filter.php
@@ -35,11 +35,7 @@ class WPSEO_Link_Filter {
 
 		$url_path = untrailingslashit( parse_url( $link->get_url(), PHP_URL_PATH ) );
 
-		if ( ! $this->is_current_page( $url_path ) ) {
-			return true;
-		}
-
-		return false;
+		return ( ! $this->is_current_page( $url_path ) );
 	}
 
 	/**

--- a/admin/links/class-link-filter.php
+++ b/admin/links/class-link-filter.php
@@ -33,9 +33,13 @@ class WPSEO_Link_Filter {
 			return true;
 		}
 
-		$url_path = untrailingslashit( parse_url( $link->get_url(), PHP_URL_PATH ) );
+		$url_parts = parse_url( $link->get_url() );
 
-		return ( ! $this->is_current_page( $url_path ) );
+		if ( isset( $url_parts['path'] ) ) {
+			return ! $this->is_current_page( untrailingslashit( $url_parts['path'] ) );
+		}
+
+		return ( ! isset( $url_parts['fragment'] ) && ! isset( $url_parts['query'] ) );
 	}
 
 	/**

--- a/admin/links/class-link-filter.php
+++ b/admin/links/class-link-filter.php
@@ -17,7 +17,7 @@ class WPSEO_Link_Filter {
 	 * @param string $current_page The current page.
 	 */
 	public function __construct( $current_page = '' ) {
-		$this->current_page_path = parse_url( $current_page, PHP_URL_PATH );
+		$this->current_page_path = untrailingslashit( parse_url( $current_page, PHP_URL_PATH ) );
 	}
 
 	/**
@@ -33,7 +33,7 @@ class WPSEO_Link_Filter {
 			return true;
 		}
 
-		$url_path = parse_url( $link->get_url(), PHP_URL_PATH );
+		$url_path = untrailingslashit( parse_url( $link->get_url(), PHP_URL_PATH ) );
 
 		if ( ! $this->is_current_page( $url_path ) ) {
 			return true;

--- a/admin/links/class-link-filter.php
+++ b/admin/links/class-link-filter.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package WPSEO\Admin\Links
+ */
+
+/**
+ * Represents the filter for filtering links
+ */
+class WPSEO_Link_Filter {
+
+	/** @var string|null */
+	protected $current_page_path;
+
+	/**
+	 * Sets the current page path
+	 *
+	 * @param string $current_page The current page.
+	 */
+	public function __construct( $current_page = '' ) {
+		$this->current_page_path = parse_url( $current_page, PHP_URL_PATH );
+	}
+
+	/**
+	 * Filters all internal links that contains an fragment in the URL.
+	 *
+	 * @param WPSEO_Link $link The link that might be filtered.
+	 *
+	 * @return bool False when url contains a fragment.
+	 */
+	public function internal_link_with_fragment_filter( WPSEO_Link $link ) {
+		// When the type is external.
+		if ( $link->get_type() === WPSEO_Link::TYPE_EXTERNAL ) {
+			return true;
+		}
+
+		$url_path = parse_url( $link->get_url(), PHP_URL_PATH );
+
+		if ( ! $this->is_current_page( $url_path ) ) {
+			return true;
+		}
+
+		return empty( $url_parts['fragment'] );
+	}
+
+	/**
+	 * Is the url path the same as the current page path.
+	 *
+	 * @param string $url_path The url path.
+	 *
+	 * @return bool True when path is equal to the current page path.
+	 */
+	protected function is_current_page( $url_path ) {
+		return ( ! empty( $url_path ) && $url_path === $this->current_page_path );
+	}
+}

--- a/tests/admin/links/test-class-link-columns-count.php
+++ b/tests/admin/links/test-class-link-columns-count.php
@@ -5,8 +5,8 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Creates the table to make sure the tests for this class can be executed.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 
 		$installer = new WPSEO_Link_Installer();
 		$installer->install();
@@ -15,14 +15,16 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Drops the table when all tests for this class are executed.
 	 */
-	public function tearDown() {
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
 		global $wpdb;
 
-		parent::tearDown();
-
 		$storage = new WPSEO_Link_Storage();
+		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
+		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
 	}
 
 	/**
@@ -77,8 +79,8 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 				$this->returnValue(
 					array(
 						1 => array(
-							'link_count' => 10,
-							'internal_link_count' => 0,
+							'incoming_link_count' => 0,
+							'internal_link_count' => 10,
 						),
 					)
 				)
@@ -120,7 +122,7 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 		$column_count = new WPSEO_Link_Column_Count();
 		$column_count->set( array( 100 ) );
 
-		$this->assertEquals( 1, $column_count->get( 100, 'internal_link_count' ) );
+		$this->assertEquals( 0, $column_count->get( 100, 'incoming_link_count' ) );
 	}
 
 	/**

--- a/tests/admin/links/test-class-link-columns.php
+++ b/tests/admin/links/test-class-link-columns.php
@@ -1,6 +1,31 @@
 <?php
-/** @group test */
+
 class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Creates the table to make sure the tests for this class can be executed.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		$installer = new WPSEO_Link_Installer();
+		$installer->install();
+	}
+
+	/**
+	 * Drops the table when all tests for this class are executed.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		global $wpdb;
+
+		$storage = new WPSEO_Link_Storage();
+		$meta_storage = new WPSEO_Meta_Storage();
+
+		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
+		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
+	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/admin/links/test-class-link-content-processor.php
+++ b/tests/admin/links/test-class-link-content-processor.php
@@ -1,12 +1,36 @@
 <?php
-
 class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 
+	/**
+	 * Creates the table to make sure the tests for this class can be executed.
+	 */
+	public static function setUpBeforeClass() {
+		$installer = new WPSEO_Link_Installer();
+		$installer->install();
+		parent::setUpBeforeClass();
+
+	}
+
+	/**
+	 * Drops the table when all tests for this class are executed.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		global $wpdb;
+
+		$storage = new WPSEO_Link_Storage();
+		$meta_storage = new WPSEO_Meta_Storage();
+
+		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
+		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
+	}
+	
 	public function test_process() {
 		/** @var WPSEO_Link_Content_Processor $processor */
 		$processor = $this
 			->getMockBuilder( 'WPSEO_Link_Content_Processor' )
-			->setConstructorArgs( array( new WPSEO_Link_Storage( 'test_' ), new WPSEO_Meta_Storage() ) )
+			->setConstructorArgs( array( new WPSEO_Link_Storage(), new WPSEO_Meta_Storage() ) )
 			->setMethods( array( 'store_links' ) )
 			->getMock();
 
@@ -21,7 +45,12 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 		$processor->process( 1, "<a href='http://example.org/post'>example post</a>" );
 	}
 
+	public function test_foo(  ) {
+		$this->assertTrue( true );
+	}
+
 	public function test_store_links() {
+
 		/** @var WPSEO_Link_Storage $storage */
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Link_Storage' )
@@ -40,6 +69,7 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 				1,
 				array( new WPSEO_Link( 'http://example.org/post', 0, 'internal' ) )
 			);
+
 
 		$processor = new WPSEO_Link_Content_Processor( $storage, new WPSEO_Meta_Storage() );
 		$processor->process( 1, "<a href='http://example.org/post'>example post</a>" );

--- a/tests/admin/links/test-class-link-factory.php
+++ b/tests/admin/links/test-class-link-factory.php
@@ -67,4 +67,32 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 		);
 	}
 
+	public function test_filter_internal_link_with_fragment() {
+		/** @var WPSEO_Link_Type_Classifier $stub */
+		$classifier = $this
+			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$classifier
+			->expects( $this->once() )
+			->method( 'classify' )
+			->will( $this->returnValue( 'internal' ) );
+
+		/** @var WPSEO_Link_Internal_Lookup $populator */
+		$populator = $this
+			->getMockBuilder( 'WPSEO_Link_Internal_Lookup' )
+			->getMock();
+		$populator
+			->expects( $this->once() )
+			->method( 'lookup' )
+			->will( $this->returnValue( 2 ) );
+
+		$processor = new WPSEO_Link_Factory( $classifier, $populator );
+		$this->assertEquals(
+			array(),
+			$processor->build( array( 'test.html#hashtag' ) )
+		);
+	}
+
 }

--- a/tests/admin/links/test-class-link-factory.php
+++ b/tests/admin/links/test-class-link-factory.php
@@ -6,28 +6,15 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	 * Tests the processing of an external link.
 	 */
 	public function test_process_external_link(  ) {
-
-		/** @var WPSEO_Link_Type_Classifier $stub */
-		$classifier = $this
-			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$classifier
-			->expects( $this->once() )
-			->method( 'classify' )
-			->will( $this->returnValue( 'external' ) );
-
 		$populator = $this
 			->getMockBuilder( 'WPSEO_Link_Internal_Lookup' )
 			->getMock();
 
 		$populator
 			->expects( $this->never() )
-			->method( 'lookup' )
-			->will( $this->returnValue( 0 ) );
+			->method( 'lookup' );
 
-		$processor = new WPSEO_Link_Factory( $classifier, $populator );
+		$processor = new WPSEO_Link_Factory( $this->getClassifierMock( 'external' ), $populator, $this->getFilterMock( 'page', true ) );
 
 		$this->assertEquals(
 			array( new WPSEO_Link( 'test', 0,'external'  ) ),
@@ -36,39 +23,58 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests the processing of an internal link.
+	 * @dataProvider link_provider
+	 *
+	 * @param WPSEO_Link_Type_Classifier $classifier The classifier mock
+	 * @param WPSEO_Link_Internal_Lookup $lookup     The lookup mock
+	 * @param WPSEO_Link_Filter          $filter     The link filter.
+	 * @param string                     $linkURL    The link url to test.
+	 * @param mixed                      $expected   The expected result
 	 */
-	public function test_process_internal_link(  ) {
+	public function test_process_internal_link( $classifier, $lookup, $filter, $linkURL, $expected ) {
+		$processor = new WPSEO_Link_Factory( $classifier, $lookup, $filter );
+		$actual    = $processor->build( array( $linkURL ) );
 
-		/** @var WPSEO_Link_Type_Classifier $stub */
-		$classifier = $this
-			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->assertEquals( $expected, $actual );
+	}
 
-		$classifier
-			->expects( $this->once() )
-			->method( 'classify' )
-			->will( $this->returnValue( 'internal' ) );
+	/**
+	 * Provides a couple of internal links
+	 *
+	 * @return array
+	 */
+	public function link_provider() {
 
-		$populator = $this
-			->getMockBuilder( 'WPSEO_Link_Internal_Lookup' )
-			->getMock();
-		$populator
-			->expects( $this->once() )
-			->method( 'lookup' )
-			->will( $this->returnValue( 2 ) );
-
-		$processor = new WPSEO_Link_Factory( $classifier, $populator );
-
-		$this->assertEquals(
-			array( new WPSEO_Link( 'test',  2,'internal'  ) ),
-			$processor->build( array( 'test' ) )
+		return array(
+			array(
+				$this->getClassifierMock( 'internal' ),
+				$this->getLookUpMock( 2 ),
+				$this->getFilterMock( 'currentpage', true ),
+				'test',
+				array( new WPSEO_Link( 'test',  2,'internal'  )  )
+			),
+			array(
+				$this->getClassifierMock( 'internal' ),
+				$this->getLookUpMock( 2 ),
+				$this->getFilterMock( 'test.html', false ),
+				'test.html#hastag',
+				array()
+			),
+			array(
+				$this->getClassifierMock( 'internal' ),
+				$this->getLookUpMock( 2 ),
+				$this->getFilterMock( 'test.html', false ),
+				'test.html?foo=bar',
+				array()
+			),
 		);
 	}
 
-	public function test_filter_internal_link_with_fragment() {
-		/** @var WPSEO_Link_Type_Classifier $stub */
+	/**
+	 *
+	 */
+	protected function getClassifierMock( $classifyResult ) {
+		/** @var WPSEO_Link_Type_Classifier $classifier */
 		$classifier = $this
 			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
 			->disableOriginalConstructor()
@@ -77,22 +83,36 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 		$classifier
 			->expects( $this->once() )
 			->method( 'classify' )
-			->will( $this->returnValue( 'internal' ) );
+			->will( $this->returnValue( $classifyResult ) );
 
-		/** @var WPSEO_Link_Internal_Lookup $populator */
-		$populator = $this
+		return $classifier;
+	}
+
+	protected function getLookUpMock( $lookupResult ) {
+		$lookup = $this
 			->getMockBuilder( 'WPSEO_Link_Internal_Lookup' )
 			->getMock();
-		$populator
+
+		$lookup
 			->expects( $this->once() )
 			->method( 'lookup' )
-			->will( $this->returnValue( 2 ) );
+			->will( $this->returnValue( $lookupResult ) );
 
-		$processor = new WPSEO_Link_Factory( $classifier, $populator );
-		$this->assertEquals(
-			array(),
-			$processor->build( array( 'test.html#hashtag' ) )
-		);
+		return $lookup;
+	}
+
+	protected function getFilterMock( $currentPage, $filterResult ) {
+		$filter = $this
+			->getMockBuilder( 'WPSEO_Link_Filter' )
+			->setConstructorArgs( array( $currentPage ) )
+			->getMock();
+
+		$filter
+			->expects( $this->once() )
+			->method( 'internal_link_with_fragment_filter' )
+			->will( $this->returnValue( $filterResult ) );
+
+		return $filter;
 	}
 
 }

--- a/tests/admin/links/test-class-link-filter.php
+++ b/tests/admin/links/test-class-link-filter.php
@@ -58,6 +58,26 @@ class WPSEO_Link_Filter_Test extends WPSEO_UnitTestCase {
 				new WPSEO_Link( 'http://extern.al/page?param=foo', 0, 'external' ),
 				true,
 			),
+			array(
+				'page',
+				new WPSEO_Link( '/', 0, 'internal' ),
+				true,
+			),
+			array(
+				'/',
+				new WPSEO_Link( '/', 0, 'internal' ),
+				true,
+			),
+			array(
+				'page',
+				new WPSEO_Link( '?param=foo', 0, 'internal' ),
+				false,
+			),
+			array(
+				'page',
+				new WPSEO_Link( '#fragment', 0, 'internal' ),
+				false,
+			),
 		);
 	}
 }

--- a/tests/admin/links/test-class-link-filter.php
+++ b/tests/admin/links/test-class-link-filter.php
@@ -1,0 +1,58 @@
+<?php
+
+class WPSEO_Link_Filter_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * @dataProvider link_provider
+	 *
+	 * @param string     $currentPage
+	 * @param WPSEO_Link $link
+	 * @param bool       $expected
+	 */
+	public function test_internal_link_with_fragment_filter( $currentPage, WPSEO_Link $link, $expected ) {
+		$filter = new WPSEO_Link_Filter( $currentPage );
+
+		$this->assertEquals( $expected, $filter->internal_link_with_fragment_filter( $link ) );
+	}
+
+	/**
+	 * Provides a couple of internal links
+	 *
+	 * @return array
+	 */
+	public function link_provider() {
+
+		return array(
+			array(
+				'page',
+				new WPSEO_Link( 'testpage', 0, 'internal' ),
+				true,
+			),
+			array(
+				'testpage',
+				new WPSEO_Link( 'testpage', 0, 'internal' ),
+				false,
+			),
+			array(
+				'page',
+				new WPSEO_Link( 'page#fragment', 0, 'internal' ),
+				false,
+			),
+			array(
+				'page',
+				new WPSEO_Link( 'testpage#fragment', 0, 'internal' ),
+				true,
+			),
+			array(
+				'page',
+				new WPSEO_Link( 'page?param=foo', 0, 'internal' ),
+				false,
+			),
+			array(
+				'page',
+				new WPSEO_Link( 'testpage?param=foo', 0, 'internal' ),
+				true,
+			),
+		);
+	}
+}

--- a/tests/admin/links/test-class-link-filter.php
+++ b/tests/admin/links/test-class-link-filter.php
@@ -53,6 +53,11 @@ class WPSEO_Link_Filter_Test extends WPSEO_UnitTestCase {
 				new WPSEO_Link( 'testpage?param=foo', 0, 'internal' ),
 				true,
 			),
+			array(
+				'page',
+				new WPSEO_Link( 'http://extern.al/page?param=foo', 0, 'external' ),
+				true,
+			),
 		);
 	}
 }

--- a/tests/admin/links/test-class-link-storage.php
+++ b/tests/admin/links/test-class-link-storage.php
@@ -21,8 +21,10 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 		global $wpdb;
 
 		$storage = new WPSEO_Link_Storage();
+		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
+		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
 	}
 
 	/**

--- a/tests/admin/links/test-class-link-type-classifier.php
+++ b/tests/admin/links/test-class-link-type-classifier.php
@@ -1,6 +1,5 @@
 <?php
 
-/** @group test */
 class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 
 	/** @var WPSEO_Link_Type_Classifier */

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -11,6 +11,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 		$installer = new WPSEO_Link_Installer();
 		$installer->install();
 	}
+
 	/**
 	 * Drops the table when all tests for this class are executed.
 	 */
@@ -20,8 +21,10 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 		global $wpdb;
 
 		$storage = new WPSEO_Link_Storage();
+		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
+		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Added a filter in the factory.

## Test instructions

This PR can be tested by following these steps:

* Have a post with a link containing a fragment (example.html#hashtag)
* It won't be counted, thus the column in the post overview will say 0
* Happiness 😄 

Fixes #7374 
