### PR TITLE
Revert "Show 'premium' for menu item when premium is installed"

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -158,8 +158,6 @@ class WPSEO_Admin {
 
 		$admin_page_hooks[ self::PAGE_IDENTIFIER ] = 'seo'; // Wipe notification bits from hooks. R.
 
-		$license_page_title = defined( 'WPSEO_PREMIUM_PLUGIN_FILE' ) ? __( 'Premium', 'wordpress-seo' ) : __( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator();
-
 		// Sub menu pages.
 		$submenu_pages = array(
 			array(
@@ -227,7 +225,7 @@ class WPSEO_Admin {
 			array(
 				self::PAGE_IDENTIFIER,
 				'',
-				$license_page_title,
+				__( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator(),
 				$manage_options_cap,
 				'wpseo_licenses',
 				array( $this, 'load_page' ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
```
Renames admin bar menu item 'Go Premium' to 'Premium'.
```

See https://github.com/Yoast/wordpress-seo-premium/issues/900#issuecomment-313026547