### PR TITLE
Fix the eslint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ matrix:
     - php: 5.2
       env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1
     - php: 5.3
-      env: WP_VERSION=4.7
+      env: WP_VERSION=4.6
     - php: 5.6
-      env: WP_VERSION=4.7
+      env: WP_VERSION=4.6
     # WP >= 4.7 is needed for PHP 7.1
     - php: 7.1
       env: WP_VERSION=4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env: WP_VERSION=4.6
     - php: 5.6
       env: WP_VERSION=4.6
-    # WP >= 4.7 is needed for PHP 7.1
+    # WP >= 4.8 is needed for PHP 7.1
     - php: 7.1
       env: WP_VERSION=4.8
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,18 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node CXX=g++-4.8
+      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node CXX=g++-4.8
     - php: 5.2
-      env: WP_VERSION=4.6 WP_MULTISITE=1 PHPLINT=1
+      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1
     - php: 5.3
-      env: WP_VERSION=4.5
+      env: WP_VERSION=4.7
     - php: 5.6
-      env: WP_VERSION=4.4
-    # WP >= 4.7 is needed for PHP 7.1  
+      env: WP_VERSION=4.7
+    # WP >= 4.7 is needed for PHP 7.1
     - php: 7.1
-      env: WP_VERSION=4.7
+      env: WP_VERSION=4.8
     - php: hhvm
-      env: WP_VERSION=4.7
+      env: WP_VERSION=4.8
     - php: 5.2
       env: WP_VERSION=master
     - php: nightly

--- a/js/src/wp-seo-edit-page.js
+++ b/js/src/wp-seo-edit-page.js
@@ -6,11 +6,11 @@
 		parentLink
 			.addClass( "yoast-tooltip yoast-tooltip-n yoast-tooltip-multiline" )
 			.attr( "aria-label", $( this ).data( "label" ) );
-	})
+	} );
 
 	// Clean up the columns titles HTML for the Screen Options checkboxes labels.
 	$( ".yoast-column-header-has-tooltip, .yoast-tooltip", "#screen-meta" ).each( function() {
 		var text = $( this ).text();
 		$( this ).replaceWith( text );
-	});
+	} );
 }( jQuery ) );


### PR DESCRIPTION
* Some eslint errors were introduced, these should be fixed now. 
* I've also updated the travis config because of we only support WP 4.7 and 4.8.

Look in travis, to see the build being passed.
