### PR TITLE
Change the usage of wp_parse_url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,18 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node CXX=g++-4.8
+      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node CXX=g++-4.8
     - php: 5.2
-      env: WP_VERSION=4.6 WP_MULTISITE=1 PHPLINT=1
+      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1
     - php: 5.3
-      env: WP_VERSION=4.5
+      env: WP_VERSION=4.6
     - php: 5.6
-      env: WP_VERSION=4.4
-    # WP >= 4.7 is needed for PHP 7.1  
+      env: WP_VERSION=4.6
+    # WP >= 4.8 is needed for PHP 7.1
     - php: 7.1
-      env: WP_VERSION=4.7
+      env: WP_VERSION=4.8
     - php: hhvm
-      env: WP_VERSION=4.7
+      env: WP_VERSION=4.8
     - php: 5.2
       env: WP_VERSION=master
     - php: nightly

--- a/admin/links/class-link-filter.php
+++ b/admin/links/class-link-filter.php
@@ -17,7 +17,7 @@ class WPSEO_Link_Filter {
 	 * @param string $current_page The current page.
 	 */
 	public function __construct( $current_page = '' ) {
-		$this->current_page_path = untrailingslashit( wp_parse_url( $current_page, PHP_URL_PATH ) );
+		$this->current_page_path = untrailingslashit( WPSEO_Link_Utils::get_url_part( $current_page, 'path' ) );
 	}
 
 	/**

--- a/admin/links/class-link-type-classifier.php
+++ b/admin/links/class-link-type-classifier.php
@@ -20,9 +20,10 @@ class WPSEO_Link_Type_Classifier {
 	 * @param string $base_url The base url to set.
 	 */
 	public function __construct( $base_url ) {
-		$this->base_host = wp_parse_url( $base_url, PHP_URL_HOST );
 
-		$base_path = wp_parse_url( $base_url, PHP_URL_PATH );
+		$this->base_host = WPSEO_Link_Utils::get_url_part( $base_url, 'host' );
+
+		$base_path = WPSEO_Link_Utils::get_url_part( $base_url, 'path' );
 		if ( $base_path ) {
 			$this->base_path = trailingslashit( $base_path );
 		}

--- a/admin/links/class-link-utils.php
+++ b/admin/links/class-link-utils.php
@@ -20,6 +20,24 @@ class WPSEO_Link_Utils {
 	}
 
 	/**
+	 * Returns the value that is part of the given url.
+	 *
+	 * @param string $url  The url to parse.
+	 * @param string $part The url part to use.
+	 *
+	 * @return string The value of the url part.
+	 */
+	public static function get_url_part( $url, $part ) {
+		$url_parts = wp_parse_url( $url );
+
+		if ( isset( $url_parts[ $part ] ) ) {
+			return $url_parts[ $part ];
+		}
+
+		return '';
+	}
+
+	/**
 	 * Filters the post types to remove unwanted items.
 	 *
 	 * @param string $public_post_type The post type to filter.

--- a/js/src/wp-seo-edit-page.js
+++ b/js/src/wp-seo-edit-page.js
@@ -6,11 +6,11 @@
 		parentLink
 			.addClass( "yoast-tooltip yoast-tooltip-n yoast-tooltip-multiline" )
 			.attr( "aria-label", $( this ).data( "label" ) );
-	})
+	} );
 
 	// Clean up the columns titles HTML for the Screen Options checkboxes labels.
 	$( ".yoast-column-header-has-tooltip, .yoast-tooltip", "#screen-meta" ).each( function() {
 		var text = $( this ).text();
 		$( this ).replaceWith( text );
-	});
+	} );
 }( jQuery ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Added a wrapper for the `wp_parse_url` to manually return a part.

## Relevant technical choices:

* Since WP 4.7 the second attribute for `wp_parse_url` is supported, this will results in errors, because we are supporting WP 4.6. I've added a wrapper for this functionality to get the required url part.

## Test instructions

This PR can be tested by following these steps:

* The build in travis should be passing.

Fixes #7421
