### PR TITLE
Disable link count with a toggle

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -772,14 +772,13 @@ class WPSEO_Admin {
 		$link_table_compatibility_notifier = new WPSEO_Link_Compatibility_Notifier();
 		$link_table_accessible_notifier    = new WPSEO_Link_Table_Accessible_Notifier();
 
-		if ( $this->options['enable_text_link_counter'] ) {
-			$integrations[] = new WPSEO_Link_Cleanup_Transient();
-		}
-
 		if ( ! $this->options['enable_text_link_counter'] ) {
 			$link_table_compatibility_notifier->remove_notification();
-			return array();
+
+			return $integrations;
 		}
+
+		$integrations[] = new WPSEO_Link_Cleanup_Transient();
 
 		// Only use the link module for PHP 5.3 and higher and show a notice when version is wrong.
 		if ( version_compare( phpversion(), '5.3', '<' ) ) {
@@ -797,10 +796,9 @@ class WPSEO_Admin {
 			return $integrations;
 		}
 
-
 		$link_table_accessible_notifier->remove_notification();
 
-		$storage = new WPSEO_Link_Storage();
+		$storage       = new WPSEO_Link_Storage();
 		$count_storage = new WPSEO_Meta_Storage();
 
 		$integrations[] = new WPSEO_Link_Watcher(
@@ -808,9 +806,7 @@ class WPSEO_Admin {
 		);
 
 		$integrations[] = new WPSEO_Link_Columns( $count_storage );
-
 		$integrations[] = new WPSEO_Link_Reindex_Dashboard();
-
 		$integrations[] = new WPSEO_Link_Notifier();
 
 		return $integrations;

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -767,12 +767,15 @@ class WPSEO_Admin {
 	 * @returns WPSEO_WordPress_Integration[]
 	 */
 	protected function initialize_seo_links() {
-		// Always make sure all possible notices are removed.
+		$integrations = array();
 		$link_table_compatibility_notifier = new WPSEO_Link_Compatibility_Notifier();
 		$link_table_compatibility_notifier->remove_notification();
 
 		$link_table_accessible_notifier = new WPSEO_Link_Table_Accessible_Notifier();
 		$link_table_accessible_notifier->remove_notification();
+		if ( $this->options['enable_text_link_counter'] ) {
+			$integrations[] = new WPSEO_Link_Cleanup_Transient();
+		}
 
 		if ( ! $this->options['enable_text_link_counter'] ) {
 			return array();
@@ -782,35 +785,30 @@ class WPSEO_Admin {
 		if ( version_compare( phpversion(), '5.3', '<' ) ) {
 			$link_table_compatibility_notifier->add_notification();
 
-			return array();
+			return $integrations;
 		}
 
 		// When the table doesn't exists, just add the notification and return early.
 		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			$link_table_accessible_notifier->add_notification();
 
-			return array();
+			return $integrations;
 		}
 
 		$storage = new WPSEO_Link_Storage();
 		$count_storage = new WPSEO_Meta_Storage();
 
-		$seo_links = new WPSEO_Link_Watcher(
+		$integrations[] = new WPSEO_Link_Watcher(
 			new WPSEO_Link_Content_Processor( $storage, $count_storage )
 		);
 
-		$seo_link_columns = new WPSEO_Link_Columns( $count_storage );
+		$integrations[] = new WPSEO_Link_Columns( $count_storage );
 
-		$link_reindex_interface = new WPSEO_Link_Reindex_Dashboard();
+		$integrations[] = new WPSEO_Link_Reindex_Dashboard();
 
-		$link_notifier = new WPSEO_Link_Notifier();
+		$integrations[] = new WPSEO_Link_Notifier();
 
-		return array(
-			$seo_links,
-			$seo_link_columns,
-			$link_reindex_interface,
-			$link_notifier,
-		);
+		return $integrations;
 	}
 
 	/********************** DEPRECATED METHODS **********************/

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -767,7 +767,12 @@ class WPSEO_Admin {
 	 * @returns WPSEO_WordPress_Integration[]
 	 */
 	protected function initialize_seo_links() {
+		// Always make sure all possible notices are removed.
 		$link_table_compatibility_notifier = new WPSEO_Link_Compatibility_Notifier();
+		$link_table_compatibility_notifier->remove_notification();
+
+		$link_table_accessible_notifier = new WPSEO_Link_Table_Accessible_Notifier();
+		$link_table_accessible_notifier->remove_notification();
 
 		// Only use the link module for PHP 5.3 and higher and show a notice when version is wrong.
 		if ( version_compare( phpversion(), '5.3', '<' ) ) {
@@ -776,18 +781,12 @@ class WPSEO_Admin {
 			return array();
 		}
 
-		$link_table_compatibility_notifier->remove_notification();
-
-		$link_table_accessible_notifier = new WPSEO_Link_Table_Accessible_Notifier();
-
 		// When the table doesn't exists, just add the notification and return early.
 		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			$link_table_accessible_notifier->add_notification();
 
 			return array();
 		}
-
-		$link_table_accessible_notifier->remove_notification();
 
 		$storage = new WPSEO_Link_Storage();
 		$count_storage = new WPSEO_Meta_Storage();

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -768,16 +768,16 @@ class WPSEO_Admin {
 	 */
 	protected function initialize_seo_links() {
 		$integrations = array();
-		$link_table_compatibility_notifier = new WPSEO_Link_Compatibility_Notifier();
-		$link_table_compatibility_notifier->remove_notification();
 
-		$link_table_accessible_notifier = new WPSEO_Link_Table_Accessible_Notifier();
-		$link_table_accessible_notifier->remove_notification();
+		$link_table_compatibility_notifier = new WPSEO_Link_Compatibility_Notifier();
+		$link_table_accessible_notifier    = new WPSEO_Link_Table_Accessible_Notifier();
+
 		if ( $this->options['enable_text_link_counter'] ) {
 			$integrations[] = new WPSEO_Link_Cleanup_Transient();
 		}
 
 		if ( ! $this->options['enable_text_link_counter'] ) {
+			$link_table_compatibility_notifier->remove_notification();
 			return array();
 		}
 
@@ -788,12 +788,17 @@ class WPSEO_Admin {
 			return $integrations;
 		}
 
+		$link_table_compatibility_notifier->remove_notification();
+
 		// When the table doesn't exists, just add the notification and return early.
 		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			$link_table_accessible_notifier->add_notification();
 
 			return $integrations;
 		}
+
+
+		$link_table_accessible_notifier->remove_notification();
 
 		$storage = new WPSEO_Link_Storage();
 		$count_storage = new WPSEO_Meta_Storage();

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -774,6 +774,10 @@ class WPSEO_Admin {
 		$link_table_accessible_notifier = new WPSEO_Link_Table_Accessible_Notifier();
 		$link_table_accessible_notifier->remove_notification();
 
+		if ( ! $this->options['enable_text_link_counter'] ) {
+			return array();
+		}
+
 		// Only use the link module for PHP 5.3 and higher and show a notice when version is wrong.
 		if ( version_compare( phpversion(), '5.3', '<' ) ) {
 			$link_table_compatibility_notifier->add_notification();

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -42,6 +42,15 @@ class WPSEO_Meta_Table_Accessible {
 	}
 
 	/**
+	 * Removes the transient.
+	 *
+	 * @return void
+	 */
+	public static function cleanup() {
+		delete_transient( self::transient_name() );
+	}
+
+	/**
 	 * Returns the name of the transient.
 	 *
 	 * @return string The name of the transient to use.

--- a/admin/links/class-link-cleanup-transient.php
+++ b/admin/links/class-link-cleanup-transient.php
@@ -24,9 +24,8 @@ class WPSEO_Link_Cleanup_Transient implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function remove_transients_on_updated_option( $old_value, $value ) {
-
 		$option_name = 'enable_text_link_counter';
-		if ( $old_value[ $option_name ] !== $value[ $option_name ] && empty( $value[ $option_name ] ) ) {
+		if ( $value[ $option_name ] === false && $old_value[ $option_name ] !== $value[ $option_name ] ) {
 			WPSEO_Link_Table_Accessible::cleanup();
 			WPSEO_Meta_Table_Accessible::cleanup();
 		}

--- a/admin/links/class-link-cleanup-transient.php
+++ b/admin/links/class-link-cleanup-transient.php
@@ -18,7 +18,7 @@ class WPSEO_Link_Cleanup_Transient implements WPSEO_WordPress_Integration {
 	/**
 	 * Removes the transient when the option is updated.
 	 *
-	 * @param mixed $old_value The old value
+	 * @param mixed $old_value The old value.
 	 * @param mixed $value     The new value.
 	 *
 	 * @return void

--- a/admin/links/class-link-cleanup-transient.php
+++ b/admin/links/class-link-cleanup-transient.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package WPSEO\Admin\Links
+ */
+
+/**
+ * Represents the cleanup logic when the text link counter features has been disabled.
+ */
+class WPSEO_Link_Cleanup_Transient implements WPSEO_WordPress_Integration {
+
+	/**
+	 * Registers the hooks.
+	 */
+	public function register_hooks() {
+		add_action( 'update_option_wpseo', array( $this, 'remove_transients_on_updated_option' ), 10, 2 );
+	}
+
+	/**
+	 * Removes the transient when the option is updated.
+	 *
+	 * @param mixed $old_value The old value
+	 * @param mixed $value     The new value.
+	 *
+	 * @return void
+	 */
+	public function remove_transients_on_updated_option( $old_value, $value ) {
+
+		$option_name = 'enable_text_link_counter';
+		if ( $old_value[ $option_name ] !== $value[ $option_name ] && empty( $value[ $option_name ] ) ) {
+			WPSEO_Link_Table_Accessible::cleanup();
+			WPSEO_Meta_Table_Accessible::cleanup();
+		}
+	}
+}

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -42,6 +42,15 @@ class WPSEO_Link_Table_Accessible {
 	}
 
 	/**
+	 * Removes the transient.
+	 *
+	 * @return void
+	 */
+	public static function cleanup() {
+		delete_transient( self::transient_name() );
+	}
+
+	/**
 	 * Returns the name of the transient.
 	 *
 	 * @return string The name of the transient to use.

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -51,7 +51,7 @@ $feature_toggles = array(
 		'name'    => __( 'Text link counter', 'wordpress-seo' ),
 		'setting' => 'enable_text_link_counter',
 		'label'   => sprintf(
-			__( 'This feature plays a crucial part in helping you with improving the internal linking of your site. If you want to know more about the why and how of internal linking, check out the %1$sarticle about internal linking on Yoast.com%2$s.', 'wordpress-seo' ),
+			__( 'This feature plays a crucial part in helping you with improving the internal linking within your site. If you want to know more about the why and how of internal linking, check out the %1$sarticle about internal linking on Yoast.com%2$s.', 'wordpress-seo' ),
 			'<a href="' .  WPSEO_Shortlinker::get( 'https://yoa.st/17g' ) . '" target="_blank">',
 			'</a>'
 		),

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -47,6 +47,11 @@ $feature_toggles = array(
 			'</a>'
 		),
 	),
+	(object) array(
+		'name'    => __( 'Text link counter', 'wordpress-seo' ),
+		'setting' => 'enable_text_link_counter',
+		'label'   => __( 'The text link counter functionality ...', 'wordpress-seo' ),
+	),
 );
 
 /**

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -43,14 +43,18 @@ $feature_toggles = array(
 		/* translators: 1: open link tag 2: close link tag */
 		'label'   => sprintf(
 			__( 'The Cornerstone content functionality enables you to mark and filter cornerstone content on your website. %1$sRead more about how cornerstone content can help you improve your site structure.%2$s', 'wordpress-seo' ),
-			'<a href="' .  WPSEO_Shortlinker::get( 'https://yoa.st/dashboard-help-cornerstone' ) . '">',
+			'<a href="' .  WPSEO_Shortlinker::get( 'https://yoa.st/dashboard-help-cornerstone' ) . '" target="_blank">',
 			'</a>'
 		),
 	),
 	(object) array(
 		'name'    => __( 'Text link counter', 'wordpress-seo' ),
 		'setting' => 'enable_text_link_counter',
-		'label'   => __( 'The text link counter functionality ...', 'wordpress-seo' ),
+		'label'   => sprintf(
+			__( 'This feature plays a crucial part in helping you with improving the internal linking of your site. If you want to know more about the why and how of internal linking, check out the %1$sarticle about internal linking on Yoast.com%2$s.', 'wordpress-seo' ),
+			'<a href="' .  WPSEO_Shortlinker::get( 'https://yoa.st/17g' ) . '" target="_blank">',
+			'</a>'
+		),
 	),
 );
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -44,6 +44,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'enable_setting_pages'            => true,
 		'enable_admin_bar_menu'			  => true,
 		'enable_cornerstone_content'      => true,
+		'enable_text_link_counter'        => true,
 		'show_onboarding_notice'          => false,
 		'first_activated_on'              => false,
 	);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Added the option to disabled the text links counter.

## Relevant technical choices:

* Added a toggle for disabling the text links counter.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch
* See the feature is enabled by default
* Go to dashboard -> features and disable the Text links count
* Go to the post overview and see the columns being removed
* Enable the features and see the columns being added in the post overview.

👷  Before merging 
* [x] Before merging the copy should be changed with some real stuff. @moorscode can you add this???


Fixes #7404 
