### PR TITLE
Improve incoming links detection functionality

### DIFF
--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -28,9 +28,9 @@ class WPSEO_Database_Proxy {
 	 * @param bool   $suppress_errors Should the errors be suppressed.
 	 */
 	public function __construct( $database, $table_name, $suppress_errors = true ) {
-		$this->table_name = $table_name;
+		$this->table_name      = $table_name;
 		$this->suppress_errors = (bool) $suppress_errors;
-		$this->database = $database;
+		$this->database        = $database;
 	}
 
 	/**
@@ -47,6 +47,48 @@ class WPSEO_Database_Proxy {
 		$result = $this->database->insert( $this->get_table_name(), $data, $format );
 
 		$this->post_execution();
+
+		return $result;
+	}
+
+	/**
+	 * Updates data in the database.
+	 *
+	 * @param array $data         Data to update on the table.
+	 * @param array $where        Where condition as key => value array.
+	 * @param null  $format       Optional. data prepare format.
+	 * @param null  $where_format Optional. Where prepare format.
+	 *
+	 * @return false|int False when the update request is invalid, int on number of rows changed.
+	 */
+	public function update( array $data, array $where, $format = null, $where_format = null ) {
+		$this->pre_execution();
+
+		$result = $this->database->update( $this->get_table_name(), $data, $where, $format, $where_format );
+
+		$this->post_execution();
+
+		return $result;
+	}
+
+	/**
+	 * Upserts data in the database.
+	 *
+	 * Tries to insert the data first, if this fails an update is attempted.
+	 *
+	 * @param array $data         Data to update on the table.
+	 * @param array $where        Where condition as key => value array.
+	 * @param null  $format       Optional. data prepare format.
+	 * @param null  $where_format Optional. Where prepare format.
+	 *
+	 * @return false|int False when the upsert request is invalid, int on number of rows changed.
+	 */
+	public function upsert( array $data, array $where, $format = null, $where_format = null ) {
+		$result = $this->insert( $data, $format );
+
+		if ( false === $result ) {
+			$result = $this->update( $data, $where, $format, $where_format );
+		}
 
 		return $result;
 	}

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -58,26 +58,6 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 	}
 
 	/**
-	 * Removes the record for given post_id.
-	 *
-	 * @param int $object_id The post_id to remove the record for.
-	 *
-	 * @return int|false The number of rows updated, or false on error.
-	 */
-	public function cleanup( $object_id ) {
-		$deleted = $this->database_proxy->delete(
-			array( 'object_id' => $object_id ),
-			array( '%d' )
-		);
-
-		if ( $deleted === false ) {
-			WPSEO_Meta_Table_Accessible::set_inaccessible();
-		}
-
-		return $deleted;
-	}
-
-	/**
 	 * Saves the link count to the database.
 	 *
 	 * @param int   $meta_id   The id to save the link count for.

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -48,7 +48,7 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 		return $this->database_proxy->create_table(
 			array(
 				'object_id bigint(20) UNSIGNED NOT NULL',
-				'internal_link_count int(10) UNSIGNED NOT NULL DEFAULT "0"',
+				'internal_link_count int(10) UNSIGNED NULL DEFAULT NULL',
 				'incoming_link_count int(10) UNSIGNED NULL DEFAULT NULL',
 			),
 			array(

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -64,15 +64,14 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 	 * @param array $meta_data The total amount of links.
 	 */
 	public function save_meta_data( $meta_id, array $meta_data ) {
-		$inserted = $this->database_proxy->insert(
-			array_merge(
-				array( 'object_id' => $meta_id ),
-				$meta_data
-			),
-			array( '%d', '%d' )
+		$where = array( 'object_id' => $meta_id );
+
+		$saved = $this->database_proxy->upsert(
+			array_merge( $where, $meta_data ),
+			$where
 		);
 
-		if ( $inserted === false ) {
+		if ( $saved === false ) {
 			WPSEO_Meta_Table_Accessible::set_inaccessible();
 		}
 	}

--- a/admin/links/class-link-column-count.php
+++ b/admin/links/class-link-column-count.php
@@ -34,7 +34,7 @@ class WPSEO_Link_Column_Count {
 	 */
 	public function get( $post_id, $target_field = 'internal_link_count' ) {
 		if ( array_key_exists( $post_id, $this->count ) && array_key_exists( $target_field, $this->count[ $post_id ] ) ) {
-			return (int) $this->count[ $post_id ][ $target_field ];
+			return $this->count[ $post_id ][ $target_field ];
 		}
 
 		return null;
@@ -66,7 +66,7 @@ class WPSEO_Link_Column_Count {
 		foreach ( $results as $result ) {
 			$output[ (int) $result['object_id'] ] = array(
 				'internal_link_count' => $result['internal_link_count'],
-				'incoming_link_count' => $result['incoming_link_count'],
+				'incoming_link_count' => (int) $result['incoming_link_count'],
 			);
 		}
 
@@ -74,7 +74,7 @@ class WPSEO_Link_Column_Count {
 		foreach ( $post_ids as $post_id ) {
 			if ( ! array_key_exists( $post_id, $output ) ) {
 				$output[ $post_id ] = array(
-					'internal_link_count' => 0,
+					'internal_link_count' => null,
 					'incoming_link_count' => 0,
 				);
 			}

--- a/admin/links/class-link-content-processor.php
+++ b/admin/links/class-link-content-processor.php
@@ -23,7 +23,7 @@ class WPSEO_Link_Content_Processor {
 	 *                                          counts.
 	 */
 	public function __construct( WPSEO_Link_Storage $storage, WPSEO_Meta_Storage $count_storage ) {
-		$this->storage = $storage;
+		$this->storage       = $storage;
 		$this->count_storage = $count_storage;
 	}
 
@@ -42,28 +42,28 @@ class WPSEO_Link_Content_Processor {
 		);
 
 		$extracted_links = $link_extractor->extract();
-		$links = $link_processor->build( $extracted_links );
-		$internal_links = array();
-		/** @var WPSEO_Link $link */
-		foreach ( $links as $link ) {
-			if ( $link->get_type() === WPSEO_Link::TYPE_INTERNAL ) {
-				$internal_links[] = $link;
-			}
-		}
+		$links           = $link_processor->build( $extracted_links );
 
-		$this->store_links( $post_id, $links );
+		$internal_links = array_filter( $links, array( $this, 'filter_internal_link' ) );
+
+		$stored_internal_links = $this->get_stored_internal_links( $post_id );
+
+		$this->storage->cleanup( $post_id );
+		$this->storage->save_links( $post_id, $links );
+
 		$this->store_internal_link_count( $post_id, count( $internal_links ) );
+		$this->update_incoming_links( $post_id, array_merge( $stored_internal_links, $internal_links ) );
 	}
 
 	/**
-	 * Stores the links.
+	 * Filters on INTERNAL links.
 	 *
-	 * @param int          $post_id The post id.
-	 * @param WPSEO_Link[] $links   The links to store.
+	 * @param WPSEO_Link $link Link to test type of.
+	 *
+	 * @return bool True for internal link, false for external link.
 	 */
-	protected function store_links( $post_id, array $links ) {
-		$this->storage->cleanup( $post_id );
-		$this->storage->save_links( $post_id, $links );
+	protected function filter_internal_link( WPSEO_Link $link ) {
+		return $link->get_type() === WPSEO_Link::TYPE_INTERNAL;
 	}
 
 	/**
@@ -71,14 +71,54 @@ class WPSEO_Link_Content_Processor {
 	 *
 	 * @param int $post_id             The post id.
 	 * @param int $internal_link_count Total amount of links in the post.
+	 *
+	 * @return void
 	 */
 	protected function store_internal_link_count( $post_id, $internal_link_count ) {
-		$this->count_storage->cleanup( $post_id );
 		$this->count_storage->save_meta_data( $post_id, array( 'internal_link_count' => $internal_link_count ) );
+	}
 
-		// When there are unprocess posts, just break out of this.
-		if ( ! WPSEO_Link_Query::has_unprocessed_posts( WPSEO_Link_Utils::get_public_post_types() ) ) {
-			$this->count_storage->update_incoming_link_counts( $this->storage );
+	/**
+	 * Updates the incoming link count.
+	 *
+	 * @param int          $post_id Post which is processed, this needs to be recalculated too.
+	 * @param WPSEO_Link[] $links   Links to update the incoming link count of.
+	 *
+	 * @return void
+	 */
+	protected function update_incoming_links( $post_id, $links ) {
+		$post_ids = $this->get_internal_post_ids( $links );
+		$post_ids = array_merge( array( $post_id ), $post_ids );
+		$this->count_storage->update_incoming_link_count( $post_ids, $this->storage );
+	}
+
+	/**
+	 * Extract the post IDs from the links.
+	 *
+	 * @param WPSEO_Link[] $links Links to update the incoming link count of.
+	 *
+	 * @return int[] List of post IDs.
+	 */
+	protected function get_internal_post_ids( $links ) {
+		$post_ids = array();
+		foreach ( $links as $link ) {
+			$post_ids[] = $link->get_target_post_id();
 		}
+
+		return array_filter( $post_ids );
+	}
+
+	/**
+	 * Retrieves the stored internal links for the supplied post.
+	 *
+	 * @param int $post_id The post to fetch links for.
+	 *
+	 * @return WPSEO_Link[] List of internal links connected to the post.
+	 */
+	protected function get_stored_internal_links( $post_id ) {
+		$links = $this->storage->get_links( $post_id );
+		$internal_link_objects = array_filter( $links, array( $this, 'filter_internal_link' ) );
+
+		return $internal_link_objects;
 	}
 }

--- a/admin/links/class-link-content-processor.php
+++ b/admin/links/class-link-content-processor.php
@@ -46,13 +46,13 @@ class WPSEO_Link_Content_Processor {
 
 		$internal_links = array_filter( $links, array( $this, 'filter_internal_link' ) );
 
-		$stored_internal_links = $this->get_stored_internal_links( $post_id );
+		$stored_links = $this->get_stored_internal_links( $post_id );
 
 		$this->storage->cleanup( $post_id );
 		$this->storage->save_links( $post_id, $links );
 
 		$this->store_internal_link_count( $post_id, count( $internal_links ) );
-		$this->update_incoming_links( $post_id, array_merge( $stored_internal_links, $internal_links ) );
+		$this->update_incoming_links( $post_id, array_merge( $stored_links, $internal_links ) );
 	}
 
 	/**
@@ -117,8 +117,6 @@ class WPSEO_Link_Content_Processor {
 	 */
 	protected function get_stored_internal_links( $post_id ) {
 		$links = $this->storage->get_links( $post_id );
-		$internal_link_objects = array_filter( $links, array( $this, 'filter_internal_link' ) );
-
-		return $internal_link_objects;
+		return array_filter( $links, array( $this, 'filter_internal_link' ) );
 	}
 }

--- a/admin/links/class-link-factory.php
+++ b/admin/links/class-link-factory.php
@@ -73,7 +73,7 @@ class WPSEO_Link_Factory {
 	 * @param int    $target_post_id The target post ID.
 	 * @param string $type           The link type.
 	 *
-	 * @return WPSEO_Link Generted link object.
+	 * @return WPSEO_Link Generated link object.
 	 */
 	public static function get_link( $url, $target_post_id, $type ) {
 		return new WPSEO_Link( $url, $target_post_id, $type );

--- a/admin/links/class-link-factory.php
+++ b/admin/links/class-link-factory.php
@@ -26,9 +26,9 @@ class WPSEO_Link_Factory {
 	 * @param WPSEO_Link_Filter          $filter          The link filter.
 	 */
 	public function __construct( WPSEO_Link_Type_Classifier $classifier, WPSEO_Link_Internal_Lookup $internal_lookup, WPSEO_Link_Filter $filter ) {
-		$this->classifier = $classifier;
+		$this->classifier      = $classifier;
 		$this->internal_lookup = $internal_lookup;
-		$this->filter = $filter;
+		$this->filter          = $filter;
 	}
 
 	/**
@@ -40,7 +40,10 @@ class WPSEO_Link_Factory {
 	 */
 	public function build( array $extracted_links ) {
 		$extracted_links = array_map( array( $this, 'build_link' ), $extracted_links );
-		$filtered_links = array_filter( $extracted_links, array( $this->filter, 'internal_link_with_fragment_filter' ) );
+		$filtered_links  = array_filter( $extracted_links, array(
+			$this->filter,
+			'internal_link_with_fragment_filter',
+		) );
 
 		return $filtered_links;
 	}
@@ -60,6 +63,19 @@ class WPSEO_Link_Factory {
 			$target_post_id = $this->internal_lookup->lookup( $link );
 		}
 
-		return new WPSEO_Link( $link, $target_post_id, $link_type );
+		return self::get_link( $link, $target_post_id, $link_type );
+	}
+
+	/**
+	 * Returns the link object.
+	 *
+	 * @param string $url            The URL of the link.
+	 * @param int    $target_post_id The target post ID.
+	 * @param string $type           The link type.
+	 *
+	 * @return WPSEO_Link Generted link object.
+	 */
+	public static function get_link( $url, $target_post_id, $type ) {
+		return new WPSEO_Link( $url, $target_post_id, $type );
 	}
 }

--- a/admin/links/class-link-query.php
+++ b/admin/links/class-link-query.php
@@ -127,8 +127,8 @@ class WPSEO_Link_Query {
 			  FROM ' . $wpdb->posts . ' AS posts
 		 LEFT JOIN ' . $count_table . ' AS yoast_meta
 				ON yoast_meta.object_id = posts.ID
-			 WHERE posts.post_status = "publish" 
-			   AND posts.post_type IN ( ' . $post_types . ' ) 
+			 WHERE posts.post_status = "publish"
+			   AND posts.post_type IN ( ' . $post_types . ' )
 			   AND yoast_meta.internal_link_count IS NULL';
 		// @codingStandardsIgnoreEnd
 

--- a/admin/links/class-link-query.php
+++ b/admin/links/class-link-query.php
@@ -27,10 +27,12 @@ class WPSEO_Link_Query {
 		// Get any object which has not got the processed meta key.
 		$query = '
 			SELECT ID
-			  FROM ' . $wpdb->posts . ' AS p
-			 WHERE p.post_type IN ( ' . $post_types . ' )
-			   AND p.post_status = "publish"
-			   AND ID NOT IN( SELECT object_id FROM ' . $count_table . ' ) 
+			  FROM ' . $wpdb->posts . ' AS posts
+		 LEFT JOIN ' . $count_table . ' AS yoast_meta
+				ON yoast_meta.object_id = posts.ID
+			 WHERE posts.post_status = "publish"
+			   AND posts.post_type IN ( ' . $post_types . ' )
+			   AND yoast_meta.internal_link_count IS NULL
 			 LIMIT 1';
 
 		// If anything is found, we have unprocessed posts.
@@ -85,11 +87,13 @@ class WPSEO_Link_Query {
 		// @codingStandardsIgnoreStart
 		$results = $wpdb->get_results(
 			$wpdb->prepare( '
-				SELECT ID, post_content
-				  FROM ' . $wpdb->posts . ' 
-				 WHERE post_status = "publish" 
-				   AND post_type IN ( ' . $post_types . ' )
-				   AND ID NOT IN( SELECT object_id FROM ' . $count_table . ' ) 
+				SELECT posts.ID, posts.post_content
+				  FROM ' . $wpdb->posts . ' AS posts
+			 LEFT JOIN ' . $count_table . ' AS yoast_meta
+			 		ON yoast_meta.object_id = posts.ID
+				 WHERE posts.post_status = "publish"
+				   AND posts.post_type IN ( ' . $post_types . ' )
+				   AND yoast_meta.internal_link_count IS NULL
 				 LIMIT %1$d
 				',
 				$limit
@@ -119,11 +123,13 @@ class WPSEO_Link_Query {
 
 		// @codingStandardsIgnoreStart
 		$query = '
-			SELECT COUNT( ID )
-			  FROM ' . $wpdb->posts . ' 
-			 WHERE post_status = "publish" 
-			   AND post_type IN ( ' . $post_types . ' ) 
-			   AND ID NOT IN ( SELECT object_id FROM ' . $count_table . ' )';
+			SELECT COUNT( posts.ID )
+			  FROM ' . $wpdb->posts . ' AS posts
+		 LEFT JOIN ' . $count_table . ' AS yoast_meta
+				ON yoast_meta.object_id = posts.ID
+			 WHERE posts.post_status = "publish" 
+			   AND posts.post_type IN ( ' . $post_types . ' ) 
+			   AND yoast_meta.internal_link_count IS NULL';
 		// @codingStandardsIgnoreEnd
 
 		return (int) $wpdb->get_var( $query );

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -60,12 +60,10 @@ class WPSEO_Link_Reindex_Dashboard {
 			$html .= '<p>' . $this->message_already_indexed() . '</p>';
 		}
 		else {
-			$height = 165 ;
-
 			$html .= '<p id="reindexLinks">';
 			$html .= sprintf(
 				'<a id="openLinkIndexing" href="#TB_inline?width=600&height=%1$s&inlineId=wpseo_index_links_wrapper" title="%2$s" class="btn button yoast-js-index-links yoast-js-calculate-index-links--all thickbox">%2$s</a>',
-				$height,
+				175,
 				esc_attr( __( 'Count links in your texts', 'wordpress-seo' ) )
 			);
 			$html .= '</p>';

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -59,7 +59,8 @@ class WPSEO_Link_Reindex_Dashboard {
 		if ( $this->unprocessed === 0 ) {
 			$html .= '<p>' . $this->message_already_indexed() . '</p>';
 		}
-		else {
+
+		if ( $this->unprocessed > 0 ) {
 			$html .= '<p id="reindexLinks">';
 			$html .= sprintf(
 				'<a id="openLinkIndexing" href="#TB_inline?width=600&height=%1$s&inlineId=wpseo_index_links_wrapper" title="%2$s" class="btn button yoast-js-index-links yoast-js-calculate-index-links--all thickbox">%2$s</a>',

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -92,7 +92,8 @@ class WPSEO_Link_Reindex_Dashboard {
 				esc_html( __( 'All your texts are already counted, there is no need to count them again.', 'wordpress-seo' ) )
 			);
 		}
-		else {
+
+		if ( $this->unprocessed > 0 ) {
 			$progress = sprintf(
 			/* translators: 1: expands to a <span> containing the number of items recalculated. 2: expands to a <strong> containing the total number of items. */
 				__( 'Text %1$s of %2$s processed.', 'wordpress-seo' ),

--- a/admin/links/class-link-storage.php
+++ b/admin/links/class-link-storage.php
@@ -26,7 +26,7 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 			$table_prefix = $GLOBALS['wpdb']->get_blog_prefix();
 		}
 
-		$this->table_prefix = $table_prefix;
+		$this->table_prefix   = $table_prefix;
 		$this->database_proxy = new WPSEO_Database_Proxy( $GLOBALS['wpdb'], $this->get_table_name(), true );
 	}
 
@@ -63,9 +63,9 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 	/**
 	 * Returns an array of links from the database.
 	 *
-	 * @param int $post_id The id to get the links for.
+	 * @param int $post_id The post to get the links for.
 	 *
-	 * @return array|null|object The resultset.
+	 * @return WPSEO_Link[] The links connected to the post.
 	 */
 	public function get_links( $post_id ) {
 		global $wpdb;
@@ -83,7 +83,12 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 			WPSEO_Link_Table_Accessible::set_inaccessible();
 		}
 
-		return $results;
+		$links = array();
+		foreach ( $results as $link ) {
+			$links[] = WPSEO_Link_Factory::get_link( $link->url, $link->target_post_id, $link->type );
+		}
+
+		return $links;
 	}
 
 	/**
@@ -130,10 +135,10 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 	protected function save_link( WPSEO_Link $link, $link_key, $post_id ) {
 		$inserted = $this->database_proxy->insert(
 			array(
-				'url' => $link->get_url(),
-				'post_id' => $post_id,
+				'url'            => $link->get_url(),
+				'post_id'        => $post_id,
 				'target_post_id' => $link->get_target_post_id(),
-				'type' => $link->get_type(),
+				'type'           => $link->get_type(),
 			),
 			array( '%s', '%d', '%d', '%s' )
 		);

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -76,6 +76,11 @@ class WPSEO_Upgrade {
 			$this->upgrade_50();
 		}
 
+		if ( version_compare( $this->options['version'], '5.0', '>=' )
+			 && version_compare( $this->options['version'], '5.1', '<' ) ) {
+			$this->upgrade_50_51();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -362,5 +367,15 @@ class WPSEO_Upgrade {
 
 		// Deletes the post meta value, which might created in the RC.
 		$wpdb->query( 'DELETE FROM ' . $wpdb->postmeta . ' WHERE meta_key = "_yst_content_links_processed"' );
+	}
+
+	/**
+	 * Updates the internal_link_count column to support improved functionality.
+	 */
+	private function upgrade_50_51() {
+		global $wpdb;
+
+		$count_storage = new WPSEO_Meta_Storage();
+		$wpdb->query( 'ALTER TABLE ' . $count_storage->get_table_name() . ' MODIFY internal_link_count int(10) UNSIGNED NULL DEFAULT NULL' );
 	}
 }

--- a/tests/admin/links/test-class-link-content-processor.php
+++ b/tests/admin/links/test-class-link-content-processor.php
@@ -1,4 +1,5 @@
 <?php
+
 class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 
 	/**
@@ -7,8 +8,8 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		$installer = new WPSEO_Link_Installer();
 		$installer->install();
-		parent::setUpBeforeClass();
 
+		parent::setUpBeforeClass();
 	}
 
 	/**
@@ -19,38 +20,14 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 
 		global $wpdb;
 
-		$storage = new WPSEO_Link_Storage();
+		$storage      = new WPSEO_Link_Storage();
 		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
 		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
 	}
-	
-	public function test_process() {
-		/** @var WPSEO_Link_Content_Processor $processor */
-		$processor = $this
-			->getMockBuilder( 'WPSEO_Link_Content_Processor' )
-			->setConstructorArgs( array( new WPSEO_Link_Storage(), new WPSEO_Meta_Storage() ) )
-			->setMethods( array( 'store_links' ) )
-			->getMock();
-
-		$processor
-			->expects( $this->once() )
-			->method( 'store_links' )
-			->with(
-				1,
-				array( new WPSEO_Link( 'http://example.org/post', 0, 'internal' ) )
-			);
-
-		$processor->process( 1, "<a href='http://example.org/post'>example post</a>" );
-	}
-
-	public function test_foo(  ) {
-		$this->assertTrue( true );
-	}
 
 	public function test_store_links() {
-
 		/** @var WPSEO_Link_Storage $storage */
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Link_Storage' )
@@ -70,9 +47,7 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 				array( new WPSEO_Link( 'http://example.org/post', 0, 'internal' ) )
 			);
 
-
 		$processor = new WPSEO_Link_Content_Processor( $storage, new WPSEO_Meta_Storage() );
 		$processor->process( 1, "<a href='http://example.org/post'>example post</a>" );
 	}
-
 }

--- a/tests/admin/links/test-class-link-utils.php
+++ b/tests/admin/links/test-class-link-utils.php
@@ -1,0 +1,28 @@
+<?php
+
+class WPSEO_Link_Utils_Test extends WPSEO_UnitTestCase {
+	/**
+	 * @covers WPSEO_Link_Utils::get_public_post_types
+	 */
+	public function test_get_public_post_types() {
+		$utils = new WPSEO_Link_Utils();
+
+		$expected = array(
+			'post' => 'post',
+			'page' => 'page',
+		);
+
+		$result = $utils->get_public_post_types();
+
+		$this->assertEquals( $result, $expected, 'Public post types do not match expected list.' );
+	}
+
+	/**
+	 * @covers WPSEO_Link_Utils::get_url_part
+	 */
+	public function test_get_url_part() {
+		$result = WPSEO_Link_Utils::get_url_part( 'http://www.example.com', 'host' );
+
+		$this->assertEquals( $result, 'www.example.com', 'URL Parsed Host does not match www.example.com' );
+	}
+}


### PR DESCRIPTION
## Summary

**Incoming links detection was done in the following way:**
After processing a post, it was determined if there were not unprocessed posts left.
No unprocessed posts was determined by matching the public posts to the entries in the `meta` table.
If there were none left, all incoming links where determined for all entries in the `meta` table.
Updating the `incoming column` in the `meta` table.

**Changes in this PR modify this functionality to the following:**
When a post is processed, the links that were in the post are listed and the links that are in the post after modifying are listed.
The incoming links are determined for the current post and all posts that were mentioned before and are present now. This will decrease and increase all numbers accordingly.

This PR can be summarized in the following changelog entry:

Fixes a problem saving posts and recalculating text link counts on sites with many posts which have many links to other posts.

## Relevant technical choices:

* Introduced an upgrade method to alter the column defaults on the meta table
* Introduced a static get_links method on the Link Factory
* Introduced an upsert method in the database proxy
  * It will attempt an `insert` before falling back on an `update` if the insert fails.
  * The insert will fail if a row already exists for the unique `object_id`
  * Trying an update first fails, because the `update` method on `wpdb` returns 0 when no data was update, but also when the record does not exist. It will only return `false` when the update request is malformed.

## Test instructions

This PR can be tested by following these steps:

* Removing all or any entries in the `wp_yoast_seo_meta` table
* Seeing that there are uncounted posts on the dashboard
* Recalculating posts again
* Saving a post should update the incoming links on relevant links and the current post

Please note that this PR has an upgrade script; which only runs for versions >= 5.0 and < 5.1 which fixes the column definition.

* Test this with a clean installation, to see the table gets created as expected
* Test this coming from 5.0, 5.0.1 or 5.0.2 to see the table being modified correctly

Fixes #7411