### PR TITLE
Catch the output buffer to prevent any output being rendered

### DIFF
--- a/admin/links/class-link-reindex-post-service.php
+++ b/admin/links/class-link-reindex-post-service.php
@@ -18,9 +18,18 @@ class WPSEO_Link_Reindex_Post_Service {
 
 		$posts = WPSEO_Link_Query::get_unprocessed_posts( WPSEO_Link_Utils::get_public_post_types() );
 		foreach ( $posts as $post ) {
+			/*
+			 * Make sure plugins that echo in shortcodes do not echo during this execution.
+			 * See https://github.com/Yoast/wordpress-seo/issues/7405.
+			 */
+			ob_start();
+
 			// Apply the filters to have the same content as shown on the frontend.
 			$content = apply_filters( 'the_content', $post->post_content );
 			$content = str_replace( ']]>', ']]&gt;', $content );
+
+			// Clear the output buffering without using it.
+			ob_end_clean();
 
 			$content_processor->process( $post->ID, $content );
 		}

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -41,9 +41,18 @@ class WPSEO_Link_Watcher {
 
 		$content = $post->post_content;
 
+		/*
+		 * Make sure plugins that echo in shortcodes do not echo during this execution.
+		 * See https://github.com/Yoast/wordpress-seo/issues/7405.
+		 */
+		ob_start();
+
 		// Apply the filters to have the same content as shown on the frontend.
 		$content = apply_filters( 'the_content', $content );
 		$content = str_replace( ']]>', ']]&gt;', $content );
+
+		// Clear the output buffering without using it.
+		ob_end_clean();
 
 		$this->content_processor->process( $post_id, $content );
 	}


### PR DESCRIPTION
Some plugins tend to output stuff when shortcodes are executed.
This prevents any unwanted data to be outputted and causing `headers already sent` problems.

## Summary

This PR can be summarized in the following changelog entry:
- Fixes plugin conflicts where plugins or themes write output while applying `the_content` filter

## Relevant technical choices:

* Wrapped `the_content` filter with output buffer capturing

## Test instructions

This PR can be tested by following these steps:

* Enable a plugin or theme that outputs something in `the_content` filter or during a `shortcode` parse which is present in the content.

Fixes #7468
