### PR TITLE
Change OnPage.org into Ryte

### DIFF
--- a/admin/ajax/class-yoast-onpage-ajax.php
+++ b/admin/ajax/class-yoast-onpage-ajax.php
@@ -6,7 +6,7 @@
 /**
  * Class Yoast_OnPage_Ajax
  *
- * This class will catch the request to dismiss the OnPage.org notice and will store the dismiss status as an user meta
+ * This class will catch the request to dismiss the Ryte notice and will store the dismiss status as an user meta
  * in the database
  */
 class Yoast_OnPage_Ajax {

--- a/admin/ajax/class-yoast-onpage-ajax.php
+++ b/admin/ajax/class-yoast-onpage-ajax.php
@@ -6,8 +6,8 @@
 /**
  * Class Yoast_OnPage_Ajax
  *
- * This class will catch the request to dismiss the Ryte notice and will store the dismiss status as an user meta
- * in the database
+ * This class will catch the request to dismiss the Ryte notice and will store
+ * the dismiss status as an user meta in the database.
  */
 class Yoast_OnPage_Ajax {
 

--- a/admin/onpage/class-onpage-option.php
+++ b/admin/onpage/class-onpage-option.php
@@ -104,7 +104,7 @@ class WPSEO_OnPage_Option {
 	}
 
 	/**
-	 * Getting the option with the Ryte data
+	 * Getting the option with the Ryte data.
 	 *
 	 * @return array
 	 */

--- a/admin/onpage/class-onpage-option.php
+++ b/admin/onpage/class-onpage-option.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * This class handles the data for the option where the OnPage.org data is stored.
+ * This class handles the data for the option where the Ryte data is stored.
  */
 class WPSEO_OnPage_Option {
 
@@ -34,7 +34,7 @@ class WPSEO_OnPage_Option {
 	const FETCH_LIMIT = 15;
 
 	/**
-	 * @var array The OnPage.org option stored in the database.
+	 * @var array The Ryte option stored in the database.
 	 */
 	private $onpage_option;
 
@@ -104,7 +104,7 @@ class WPSEO_OnPage_Option {
 	}
 
 	/**
-	 * Getting the option with the OnPage.org data
+	 * Getting the option with the Ryte data
 	 *
 	 * @return array
 	 */

--- a/admin/onpage/class-onpage-request.php
+++ b/admin/onpage/class-onpage-request.php
@@ -44,7 +44,7 @@ class WPSEO_OnPage_Request {
 	}
 
 	/**
-	 * Sending a request to OnPage to check if the $home_url is indexable
+	 * Sending a request to Ryte to check if the $home_url is indexable.
 	 *
 	 * @param string $target_url The URL that will be send to the API.
 	 * @param array  $parameters Array of extra parameters to send to Ryte.

--- a/admin/onpage/class-onpage-request.php
+++ b/admin/onpage/class-onpage-request.php
@@ -4,8 +4,9 @@
  */
 
 /**
- * This class will fetch a new status from Ryte and if it's necessary it will notify the site admin by email and
- * remove the current meta value for hidding the notice for all admin users
+ * This class will fetch a new status from Ryte and if it's necessary it will
+ * notify the site admin by email and remove the current meta value to hide the
+ * notice for all admin users.
  */
 class WPSEO_OnPage_Request {
 

--- a/admin/onpage/class-onpage-request.php
+++ b/admin/onpage/class-onpage-request.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * This class will fetch a new status from OnPage.org and if it's necessary it will notify the site admin by email and
+ * This class will fetch a new status from Ryte and if it's necessary it will notify the site admin by email and
  * remove the current meta value for hidding the notice for all admin users
  */
 class WPSEO_OnPage_Request {
@@ -18,7 +18,7 @@ class WPSEO_OnPage_Request {
 	 * Doing the remote get and returns the body
 	 *
 	 * @param string $target_url The home url.
-	 * @param array  $parameters Array of extra parameters to send to OnPage.
+	 * @param array  $parameters Array of extra parameters to send to Ryte.
 	 *
 	 * @return array
 	 * @throws Exception The error message that can be used to show to the user.
@@ -47,14 +47,14 @@ class WPSEO_OnPage_Request {
 	 * Sending a request to OnPage to check if the $home_url is indexable
 	 *
 	 * @param string $target_url The URL that will be send to the API.
-	 * @param array  $parameters Array of extra parameters to send to OnPage.
+	 * @param array  $parameters Array of extra parameters to send to Ryte.
 	 *
 	 * @return array
 	 */
 	public function do_request( $target_url, $parameters = array() ) {
 		$json_body = $this->get_remote( $target_url, $parameters );
 
-		// OnPage.org recognized a redirect, fetch the data of that URL by calling this method with the value from OnPage.org.
+		// Ryte recognized a redirect, fetch the data of that URL by calling this method with the value from Ryte.
 		if ( ! empty( $json_body['passes_juice_to'] ) ) {
 			return $this->do_request( $json_body['passes_juice_to'], $parameters );
 		}

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Handle the request for getting the onpage status
+ * Handle the request for getting the Ryte status.
  */
 class WPSEO_OnPage {
 
@@ -59,7 +59,7 @@ class WPSEO_OnPage {
 	}
 
 	/**
-	 * Fetching the data from onpage.
+	 * Fetching the data from Ryte.
 	 *
 	 * @return bool
 	 */
@@ -188,7 +188,7 @@ class WPSEO_OnPage {
 		// Adding admin notice if necessary.
 		add_filter( 'admin_init', array( $this, 'show_notice' ) );
 
-		// Setting the action for the OnPage fetch.
+		// Setting the action for the Ryte fetch.
 		add_action( 'wpseo_onpage_fetch', array( $this, 'fetch_from_onpage' ) );
 	}
 
@@ -202,7 +202,7 @@ class WPSEO_OnPage {
 	}
 
 	/**
-	 * Redo the fetch request for onpage
+	 * Redo the fetch request for Ryte.
 	 */
 	private function catch_redo_listener() {
 		if ( filter_input( INPUT_GET, 'wpseo-redo-onpage' ) === '1' ) {

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -130,7 +130,7 @@ class WPSEO_OnPage {
 	}
 
 	/**
-	 * Send a request to Ryte to get the indexability
+	 * Send a request to Ryte to get the indexability.
 	 *
 	 * @return int(0)|int(1)|false
 	 */

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -14,7 +14,7 @@ class WPSEO_OnPage {
 	const USER_META_KEY = 'wpseo_dismiss_onpage';
 
 	/**
-	 * @var WPSEO_OnPage_Option The OnPage.org option class.
+	 * @var WPSEO_OnPage_Option The Ryte option class.
 	 */
 	private $onpage_option;
 
@@ -99,10 +99,11 @@ class WPSEO_OnPage {
 
 		if ( $this->should_show_notice() ) {
 			$notification_center->add_notification( $notification );
+
+			return;
 		}
-		else {
-			$notification_center->remove_notification( $notification );
-		}
+
+		$notification_center->remove_notification( $notification );
 	}
 
 	/**
@@ -129,7 +130,7 @@ class WPSEO_OnPage {
 	}
 
 	/**
-	 * Send a request to OnPage.org to get the indexability
+	 * Send a request to Ryte to get the indexability
 	 *
 	 * @return int(0)|int(1)|false
 	 */

--- a/admin/views/dashboard-widget.php
+++ b/admin/views/dashboard-widget.php
@@ -73,7 +73,7 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 				echo '<span class="wpseo-score-icon na"></span>';
 				printf(
 					/* translators: %1$s opens a link to a related knowledge base article, %2$s expands to Yoast SEO, %3$s closes the link, %4$s expands to Ryte.  */
-					__( '%1$s%2$s has not been able to fetch your site\'s indexability status%3$s from Ryte', 'wordpress-seo' ),
+					__( '%1$s%2$s has not been able to fetch your site\'s indexability status%3$s from %4$s', 'wordpress-seo' ),
 					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpagerequestfailed' ) . '" target="_blank">',
 					'Yoast SEO',
 					'</a>',

--- a/admin/views/dashboard-widget.php
+++ b/admin/views/dashboard-widget.php
@@ -43,8 +43,8 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 <div class="onpage">
 	<h3><?php
 		printf(
-			/* translators: %s expands to Ryte */
-			__( 'Indexability check by %s', 'wordpress-seo' ),
+			/* translators: %1$s expands to Ryte. */
+			__( 'Indexability check by %1$s', 'wordpress-seo' ),
 			'Ryte'
 		);
 	?></h3>

--- a/admin/views/dashboard-widget.php
+++ b/admin/views/dashboard-widget.php
@@ -43,9 +43,9 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 <div class="onpage">
 	<h3><?php
 		printf(
-			/* translators: 1: expands to OnPage.org */
+			/* translators: 1: expands to Ryte */
 			__( 'Indexability check by %1$s', 'wordpress-seo' ),
-			'OnPage.org'
+			'Ryte'
 		);
 	?></h3>
 
@@ -72,19 +72,21 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 			case WPSEO_OnPage_Option::CANNOT_FETCH :
 				echo '<span class="wpseo-score-icon na"></span>';
 				printf(
-					/* translators: %1$s opens a link to a related knowledge base article, %2$s expands to Yoast SEO, %3$s closes the link. */
-					__( '%1$s%2$s has not been able to fetch your site\'s indexability status%3$s from OnPage.org', 'wordpress-seo' ),
+					/* translators: %1$s opens a link to a related knowledge base article, %2$s expands to Yoast SEO, %3$s closes the link, %4$s expands to Ryte.  */
+					__( '%1$s%2$s has not been able to fetch your site\'s indexability status%3$s from Ryte', 'wordpress-seo' ),
 					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpagerequestfailed' ) . '" target="_blank">',
 					'Yoast SEO',
-					'</a>'
+					'</a>',
+					'Ryte'
 				);
 				break;
 			case WPSEO_OnPage_Option::NOT_FETCHED :
 				echo '<span class="wpseo-score-icon na"></span>';
 				echo esc_html( sprintf(
-					/* translators: %s expands to Yoast SEO. */
-					__( '%s has not fetched your site\'s indexability status yet from OnPage.org', 'wordpress-seo' ),
-					'Yoast SEO'
+					/* translators: 1: expands to Yoast SEO, 2: expands to Ryte */
+					__( '%1$s has not fetched your site\'s indexability status yet from %2$s', 'wordpress-seo' ),
+					'Yoast SEO',
+					'Ryte'
 				) );
 				break;
 		endswitch;

--- a/admin/views/dashboard-widget.php
+++ b/admin/views/dashboard-widget.php
@@ -43,8 +43,8 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 <div class="onpage">
 	<h3><?php
 		printf(
-			/* translators: 1: expands to Ryte */
-			__( 'Indexability check by %1$s', 'wordpress-seo' ),
+			/* translators: %s expands to Ryte */
+			__( 'Indexability check by %s', 'wordpress-seo' ),
 			'Ryte'
 		);
 	?></h3>
@@ -63,7 +63,7 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 			case WPSEO_OnPage_Option::IS_NOT_INDEXABLE :
 				echo '<span class="wpseo-score-icon bad"></span>';
 				printf(
-					/* translators: 1: opens a link to a related knowledge base article. 2: closes the link */
+					/* translators: %1$s: opens a link to a related knowledge base article. %2$s: closes the link. */
 					__( '%1$sYour homepage cannot be indexed by search engines%2$s. This is very bad for SEO and should be fixed.', 'wordpress-seo' ),
 					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpageindexerror' ) . '" target="_blank">',
 					'</a>'
@@ -72,7 +72,7 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 			case WPSEO_OnPage_Option::CANNOT_FETCH :
 				echo '<span class="wpseo-score-icon na"></span>';
 				printf(
-					/* translators: %1$s opens a link to a related knowledge base article, %2$s expands to Yoast SEO, %3$s closes the link, %4$s expands to Ryte.  */
+					/* translators: %1$s: opens a link to a related knowledge base article, %2$s: expands to Yoast SEO, %3$s: closes the link, %4$s: expands to Ryte. */
 					__( '%1$s%2$s has not been able to fetch your site\'s indexability status%3$s from %4$s', 'wordpress-seo' ),
 					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpagerequestfailed' ) . '" target="_blank">',
 					'Yoast SEO',
@@ -83,7 +83,7 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 			case WPSEO_OnPage_Option::NOT_FETCHED :
 				echo '<span class="wpseo-score-icon na"></span>';
 				echo esc_html( sprintf(
-					/* translators: 1: expands to Yoast SEO, 2: expands to Ryte */
+					/* translators: %1$s: expands to Yoast SEO, %2$s: expands to Ryte. */
 					__( '%1$s has not fetched your site\'s indexability status yet from %2$s', 'wordpress-seo' ),
 					'Yoast SEO',
 					'Ryte'

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -28,8 +28,8 @@ $feature_toggles = array(
 	(object) array(
 		'name'    => 'Ryte',
 		'setting' => 'onpage_indexability',
-		/* translators: %s expands to Ryte. */
-		'label'   => sprintf( __( 'The %s integration checks daily if your site is still indexable by search engines and notifies you when this is not the case.', 'wordpress-seo' ), 'Ryte' ),
+		/* translators: %1$s expands to Ryte. */
+		'label'   => sprintf( __( 'The %1$s integration checks daily if your site is still indexable by search engines and notifies you when this is not the case.', 'wordpress-seo' ), 'Ryte' ),
 	),
 	(object) array(
 		'name'    => __( 'Admin bar menu', 'wordpress-seo' ),

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -28,8 +28,8 @@ $feature_toggles = array(
 	(object) array(
 		'name'    => 'Ryte',
 		'setting' => 'onpage_indexability',
-		/* translators: %1$s expands to Ryte */
-		'label'   => sprintf( __( 'The %1$s integration checks daily if your site is still indexable by search engines and notifies you when this is not the case.', 'wordpress-seo' ), 'Ryte' ),
+		/* translators: %s expands to Ryte. */
+		'label'   => sprintf( __( 'The %s integration checks daily if your site is still indexable by search engines and notifies you when this is not the case.', 'wordpress-seo' ), 'Ryte' ),
 	),
 	(object) array(
 		'name'    => __( 'Admin bar menu', 'wordpress-seo' ),

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -26,10 +26,10 @@ $feature_toggles = array(
 		'label'   => __( 'The advanced settings include site-wide settings for your titles and meta descriptions, social metadata, sitemaps and much more.', 'wordpress-seo' ),
 	),
 	(object) array(
-		'name'    => __( 'OnPage.org', 'wordpress-seo' ),
+		'name'    => 'Ryte',
 		'setting' => 'onpage_indexability',
-		/* translators: %1$s expands to OnPage.org */
-		'label'   => sprintf( __( 'The %1$s integration checks daily if your site is still indexable by search engines and notifies you when this is not the case.', 'wordpress-seo' ), 'OnPage.org' ),
+		/* translators: %1$s expands to Ryte */
+		'label'   => sprintf( __( 'The %1$s integration checks daily if your site is still indexable by search engines and notifies you when this is not the case.', 'wordpress-seo' ), 'Ryte' ),
 	),
 	(object) array(
 		'name'    => __( 'Admin bar menu', 'wordpress-seo' ),

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -397,7 +397,7 @@ register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
 add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );
 
-// Loading OnPage integration.
+// Loading Ryte integration.
 new WPSEO_OnPage();
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Renamed OnPage.org to Ryte
* Where possible pass Ryte to the `sprintf.

## Test instructions

This PR can be tested by following these steps:

* Check if the widget on the admin dashboard has been changed correctly
* Check if OnPage on the features tab is replaced correctly.

Fixes #7507
