### PR TITLE
Don't show promo block in premium

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -441,8 +441,10 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	private function register_premium_upsell_admin_block() {
-		$upsell_block = new Premium_Upsell_Admin_Block( 'wpseo_admin_promo_footer' );
-		$upsell_block->register_hooks();
+		if ( ! WPSEO_Utils::is_yoast_seo_premium() ) {
+			$upsell_block = new Premium_Upsell_Admin_Block( 'wpseo_admin_promo_footer' );
+			$upsell_block->register_hooks();
+		}
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -168,7 +168,7 @@ class WPSEO_Admin {
 
 		$admin_page_hooks[ self::PAGE_IDENTIFIER ] = 'seo'; // Wipe notification bits from hooks. R.
 
-		$license_page_title = defined( 'WPSEO_PREMIUM_PLUGIN_FILE' ) ? __( 'Premium', 'wordpress-seo' ) : __( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator();
+		$license_page_title = WPSEO_Utils::is_yoast_seo_premium() ? __( 'Premium', 'wordpress-seo' ) : __( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator();
 
 		// Sub menu pages.
 		$submenu_pages = array(

--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -26,7 +26,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 		$field = new WPSEO_Config_Field_Suggestions();
 
 		// Only show Premium upsell when we are not inside a Premium install.
-		if ( ! defined( 'WPSEO_PREMIUM_PLUGIN_FILE' ) ) {
+		if ( ! WPSEO_Utils::is_yoast_seo_premium() ) {
 			$field->add_suggestion(
 				/* translators: %s resolves to Yoast SEO Premium */
 				sprintf( __( 'Outrank the competition with %s', 'wordpress-seo' ), 'Yoast SEO Premium' ),
@@ -67,7 +67,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 		);
 
 		// When we are running in Yoast SEO Premium and don't have Local SEO installed, show Local SEO as suggestion.
-		if ( defined( 'WPSEO_PREMIUM_PLUGIN_FILE' ) && ! defined( 'WPSEO_LOCAL_FILE' ) ) {
+		if ( WPSEO_Utils::is_yoast_seo_premium() && ! defined( 'WPSEO_LOCAL_FILE' ) ) {
 			$field->add_suggestion(
 				sprintf( __( 'Attract more customers near you', 'wordpress-seo' ), 'Yoast SEO', 'Yoast SEO plugin training' ),
 				/* translators: %1$s resolves to Local SEO */

--- a/admin/views/partial-help-center-video.php
+++ b/admin/views/partial-help-center-video.php
@@ -21,7 +21,7 @@ if ( ! empty( $tab_video_url ) ) :
 		<?php
 
 		// Don't show for Premium.
-		if ( ! defined( 'WPSEO_PREMIUM_PLUGIN_FILE' ) ) :
+		if ( ! WPSEO_Utils::is_yoast_seo_premium() ) :
 			?>
 			<div class="wpseo-tab-video__panel__textarea">
 				<h3><?php _e( 'Need some help?', 'wordpress-seo' ); ?></h3>

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -839,6 +839,15 @@ class WPSEO_Utils {
 	}
 
 	/**
+	 * Checks if we are in the premium or free plugin.
+	 *
+	 * @return bool True when we are in the premium plugin.
+	 */
+	public static function is_yoast_seo_premium() {
+		return defined( 'WPSEO_PREMIUM_PLUGIN_FILE' );
+	}
+
+	/**
 	 * Determine if Yoast SEO is in development mode?
 	 *
 	 * Inspired by JetPack (https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1383-L1406).


### PR DESCRIPTION
In the 5.1 release process we have implemented a patch to hide the promo block on Premium installations.

This PR fixes the problem at the root.

See: https://github.com/Yoast/wordpress-seo-premium/blob/772dec17b665b80732c07aae33df11f47754e70f/premium/class-premium.php#L175

Testing instructions: 
Create a define for the constant in `wp-seo.php`:
`define( 'WPSEO_PREMIUM_PLUGIN_FILE', 1 );`