### PR TITLE
Wrap remaining shortlink urls with WPSEO_Shortlinker

### DIFF
--- a/admin/config-ui/components/class-component-configuration-choices.php
+++ b/admin/config-ui/components/class-component-configuration-choices.php
@@ -66,7 +66,7 @@ class WPSEO_Config_Component_Configuration_Choices implements WPSEO_Config_Compo
 				'type'   => 'secondary',
 				'label'  => __( 'Configuration service', 'wordpress-seo' ),
 				'action' => 'followURL',
-				'url'    => 'https://yoa.st/wizard-configuration-upsell',
+				'url'    => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-configuration-upsell' ),
 			),
 			plugin_dir_url( WPSEO_FILE ) . 'images/yoast-configuration-icon.svg'
 		);

--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -35,9 +35,9 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 				array(
 					'label' => __( 'Upgrade to Premium', 'wordpress-seo' ),
 					'type' => 'primary',
-					'url'  => 'https://yoa.st/wizard-suggestion-premium',
+					'url'  => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-premium' ),
 				),
-				'https://yoa.st/video-yoast-seo-premium'
+				WPSEO_Shortlinker::get( 'https://yoa.st/video-yoast-seo-premium' )
 			);
 		}
 
@@ -48,9 +48,9 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 			array(
 				'label' => 'SEO copywriting training',
 				'type' => 'link',
-				'url'  => 'https://yoa.st/configuration-wizard-copywrite-course-link',
+				'url'  => WPSEO_Shortlinker::get( 'https://yoa.st/configuration-wizard-copywrite-course-link' ),
 			),
-			'https://yoa.st/video-course-copywriting'
+			WPSEO_Shortlinker::get( 'https://yoa.st/video-course-copywriting' )
 		);
 
 		$field->add_suggestion(
@@ -61,9 +61,9 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 			array(
 				'label' => 'Yoast SEO plugin training',
 				'type' => 'link',
-				'url' => 'https://yoa.st/wizard-suggestion-plugin-course',
+				'url' => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-plugin-course' ),
 			),
-			'https://yoa.st/video-plugin-course'
+			WPSEO_Shortlinker::get( 'https://yoa.st/video-plugin-course' )
 		);
 
 		// When we are running in Yoast SEO Premium and don't have Local SEO installed, show Local SEO as suggestion.
@@ -75,9 +75,9 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 				array(
 					'label' => 'Local SEO',
 					'type' => 'link',
-					'url' => 'https://yoa.st/wizard-suggestion-localseo',
+					'url' => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-localseo' ),
 				),
-				'https://yoa.st/video-localseo'
+				WPSEO_Shortlinker::get( 'https://yoa.st/video-localseo' )
 			);
 		}
 

--- a/admin/config-ui/fields/class-field-success-message.php
+++ b/admin/config-ui/fields/class-field-success-message.php
@@ -23,7 +23,7 @@ class WPSEO_Config_Field_Success_Message extends WPSEO_Config_Field {
 		$this->set_property( 'title', 'You\'ve done it!' );
 		$this->set_property( 'message', $success_message );
 		$this->set_property( 'video', array(
-				'url'   => 'https://yoa.st/metabox-screencast',
+				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ),
 				'title' => sprintf(
 				/* translators: %1$s expands to Yoast SEO. */
 					__( '%1$s video tutorial', 'wordpress-seo' ),

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -22,10 +22,10 @@ if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== 
 
 // Video explains about the options when connected only.
 if ( null !== $this->service->get_client()->getAccessToken() ) {
-	$video_url = 'https://yoa.st/screencast-search-console';
+	$video_url = WPSEO_Shortlinker::get( 'https://yoa.st/screencast-search-console' );
 }
 else {
-	$video_url = 'https://yoa.st/screencast-connect-search-console';
+	$video_url = WPSEO_Shortlinker::get( 'https://yoa.st/screencast-connect-search-console' );
 }
 
 $tab = new WPSEO_Option_Tab( 'GSC', __( 'Google Search Console', 'wordpress-seo' ), array( 'video_url' => $video_url ) );

--- a/admin/metabox/class-metabox-add-keyword-tab.php
+++ b/admin/metabox/class-metabox-add-keyword-tab.php
@@ -31,7 +31,7 @@ class Metabox_Add_Keyword_Tab implements WPSEO_Metabox_Tab {
 		$popup_title = __( 'Want to add more than one keyword?', 'wordpress-seo' );
 		/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
 		$popup_content = '<p>' . sprintf( __( 'Great news: you can, with %1$s!', 'wordpress-seo' ),
-				'<a href="https://yoa.st/pe-premium-page">Yoast SEO Premium</a>'
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ) . '">Yoast SEO Premium</a>'
 				) . '</p>';
 		$popup_content .= '<p>' . sprintf(
 			/* translators: %s expands to 'Yoast SEO Premium'. */

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -311,7 +311,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$content_sections = $this->get_content_sections();
 
 		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', 'Meta box',
-			array( 'video_url' => 'https://yoa.st/metabox-screencast' ) );
+			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ) ) );
 
 		$helpcenter = new WPSEO_Help_Center( 'metabox', $helpcenter_tab );
 		$helpcenter->output_help_center();

--- a/admin/pages/advanced.php
+++ b/admin/pages/advanced.php
@@ -17,7 +17,7 @@ $tabs->add_tab(
 		'breadcrumbs',
 		__( 'Breadcrumbs', 'wordpress-seo' ),
 		array(
-			'video_url' => 'https://yoa.st/screencast-breadcrumbs',
+			'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-breadcrumbs' ),
 			'opt_group' => 'wpseo_internallinks',
 		)
 	)
@@ -27,7 +27,7 @@ $tabs->add_tab(
 		'permalinks',
 		__( 'Permalinks', 'wordpress-seo' ),
 		array(
-			'video_url' => 'https://yoa.st/screencast-permalinks',
+			'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-permalinks' ),
 			'opt_group' => 'wpseo_permalinks',
 		)
 	)
@@ -37,7 +37,7 @@ $tabs->add_tab(
 		'rss',
 		__( 'RSS', 'wordpress-seo' ),
 		array(
-			'video_url' => 'https://yoa.st/screencast-rss',
+			'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-rss' ),
 			'opt_group' => 'wpseo_rss',
 		)
 	)

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -55,13 +55,13 @@ if ( is_array( $options['blocking_files'] ) && count( $options['blocking_files']
 }
 
 $tabs = new WPSEO_Option_Tabs( 'dashboard' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'dashboard', __( 'Dashboard', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-notification-center' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'dashboard', __( 'Dashboard', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-notification-center' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-general' ) ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
 $knowledge_graph_label = ( 'company' === $options['company_or_person'] ) ? __( 'Company info', 'wordpress-seo' ) : __( 'Your info', 'wordpress-seo' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'knowledge-graph', $knowledge_graph_label, array( 'video_url' => 'https://yoa.st/screencast-knowledge-graph' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'webmaster-tools', __( 'Webmaster tools', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-general-search-console' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'security', __( 'Security', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-security' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'knowledge-graph', $knowledge_graph_label, array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-knowledge-graph' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'webmaster-tools', __( 'Webmaster tools', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-general-search-console' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'security', __( 'Security', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-security' ) ) ) );
 
 do_action( 'wpseo_settings_tabs_dashboard', $tabs );
 

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -17,12 +17,12 @@ $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_titles' );
 
 $tabs = new WPSEO_Option_Tabs( 'metas' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-metas' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'home', __( 'Homepage', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-metas-homepage' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'post-types', __( 'Post Types', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-metas-post-types' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'taxonomies', __( 'Taxonomies', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-metas-taxonomies' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'archives', __( 'Archives', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-metas-archives' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'other', __( 'Other', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-metas-other' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-metas' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'home', __( 'Homepage', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-metas-homepage' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'post-types', __( 'Post Types', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-metas-post-types' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'taxonomies', __( 'Taxonomies', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-metas-taxonomies' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'archives', __( 'Archives', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-metas-archives' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'other', __( 'Other', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-metas-other' ) ) ) );
 $tabs->display( $yform, $options );
 
 $yform->admin_footer();

--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -13,11 +13,11 @@ $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_social' );
 
 $tabs = new WPSEO_Option_Tabs( 'social' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-social-accounts' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'facebook', __( 'Facebook', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-social-facebook' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'twitterbox', __( 'Twitter', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-social-twitter' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'pinterest', __( 'Pinterest', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-social-pinterest' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'google', __( 'Google+', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-social-google' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-social-accounts' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'facebook', __( 'Facebook', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-social-facebook' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'twitterbox', __( 'Twitter', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-social-twitter' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'pinterest', __( 'Pinterest', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-social-pinterest' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'google', __( 'Google+', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-social-google' ) ) ) );
 $tabs->display( $yform );
 
 $yform->admin_footer();

--- a/admin/pages/xml-sitemaps.php
+++ b/admin/pages/xml-sitemaps.php
@@ -27,17 +27,17 @@ echo '<br/>';
 $yform->light_switch( 'enablexmlsitemap', __( 'XML sitemap functionality', 'wordpress-seo' ) );
 
 $tabs = new WPSEO_Option_Tabs( 'sitemaps' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-sitemaps' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-sitemaps' ) ) ) );
 
 $title_options = WPSEO_Options::get_option( 'wpseo_titles' );
 
 if ( empty( $title_options['disable-author'] ) ) {
-	$tabs->add_tab( new WPSEO_Option_Tab( 'user-sitemap', __( 'User sitemap', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-sitemaps-user-sitemap' ) ) );
+	$tabs->add_tab( new WPSEO_Option_Tab( 'user-sitemap', __( 'User sitemap', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-sitemaps-user-sitemap' ) ) ) );
 }
 
-$tabs->add_tab( new WPSEO_Option_Tab( 'post-types', __( 'Post Types', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-sitemaps-post-types' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'exclude-post', __( 'Excluded Posts', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-sitemaps-exclude-post' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'taxonomies', __( 'Taxonomies', 'wordpress-seo' ), array( 'video_url' => 'https://yoa.st/screencast-sitemaps-taxonomies' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'post-types', __( 'Post Types', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-sitemaps-post-types' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'exclude-post', __( 'Excluded Posts', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-sitemaps-exclude-post' ) ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'taxonomies', __( 'Taxonomies', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-sitemaps-taxonomies' ) ) ) );
 
 echo '<div id="sitemapinfo">';
 $tabs->display( $yform, $options );

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -55,7 +55,7 @@ class WPSEO_Taxonomy_Metabox {
 		echo '<div class="inside">';
 
 		$helpcenter_tab = new WPSEO_Option_Tab( 'tax-metabox', 'Meta box',
-			array( 'video_url' => 'https://yoa.st/metabox-taxonomy-screencast' ) );
+			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-taxonomy-screencast' ) ) );
 
 		$helpcenter = new WPSEO_Help_Center( 'tax-metabox', $helpcenter_tab );
 		$helpcenter->output_help_center();

--- a/admin/views/about.php
+++ b/admin/views/about.php
@@ -39,7 +39,7 @@ function wpseo_display_contributors( $contributors ) {
 		printf( __( 'While most of the development team is at %1$sYoast%2$s in the Netherlands, %3$s is created by a worldwide team.', 'wordpress-seo' ), '<a target="_blank" href="https://yoast.com/">', '</a>', 'Yoast SEO' );
 		echo ' ';
 		/* translators: 1: link open tag; 2: link close tag. */
-		printf( __( 'Want to help us develop? Read our %1$scontribution guidelines%2$s!', 'wordpress-seo' ), '<a target="_blank" href="https://yoa.st/wpseocontributionguidelines">', '</a>' );
+		printf( __( 'Want to help us develop? Read our %1$scontribution guidelines%2$s!', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/wpseocontributionguidelines' ) . '">', '</a>' );
 		?>
 	</p>
 

--- a/admin/views/dashboard-widget.php
+++ b/admin/views/dashboard-widget.php
@@ -99,7 +99,7 @@ if ( ! empty( $onpage ) && $can_access ) : ?>
 			echo '<a class="fetch-status button" href="' . esc_attr( add_query_arg( 'wpseo-redo-onpage', '1' ) ) . '#wpseo-dashboard-overview">' . __( 'Fetch the current status', 'wordpress-seo' ) . ' </a> ';
 		endif;
 
-		echo '<a class="landing-page button" href="https://yoa.st/rytelp" target="_blank">' . __( 'Analyze entire site', 'wordpress-seo' ) . ' </a>';
+		echo '<a class="landing-page button" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/rytelp' ) . '" target="_blank">' . __( 'Analyze entire site', 'wordpress-seo' ) . ' </a>';
 		?>
 	</p>
 </div>

--- a/admin/views/partial-help-center-video.php
+++ b/admin/views/partial-help-center-video.php
@@ -26,7 +26,7 @@ if ( ! empty( $tab_video_url ) ) :
 			<div class="wpseo-tab-video__panel__textarea">
 				<h3><?php _e( 'Need some help?', 'wordpress-seo' ); ?></h3>
 				<p><?php _e( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ) ?></p>
-				<p><a href="<?php  WPSEO_Shortlinker::show( 'https://yoa.st/seo-premium-vt' ); ?>" target="_blank"><?php
+				<p><a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/seo-premium-vt' ); ?>" target="_blank"><?php
 				/* translators: %s expands to Yoast SEO Premium */
 				printf( __( 'Get %s now &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );
 				?></a>

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -36,7 +36,7 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
  */
 function render_help_center( $id ) {
 	$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-' . $id, __( 'Bulk editor', 'wordpress-seo' ),
-		array( 'video_url' => 'https://yoa.st/screencast-tools-bulk-editor' ) );
+		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) );
 
 	$helpcenter = new WPSEO_Help_Center( 'bulk-editor' . $id, $helpcenter_tab );
 	$helpcenter->output_help_center();

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -76,7 +76,7 @@ else {
 
 echo '<br><br>';
 $helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', 'Bulk editor',
-	array( 'video_url' => 'https://yoa.st/screencast-tools-file-editor' ) );
+	array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-file-editor' ) ) );
 
 $helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab );
 $helpcenter->output_help_center();

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -85,15 +85,15 @@ if ( $import ) {
 $tabs = array(
 	'wpseo-import' => array(
 		'label'                => __( 'Import settings', 'wordpress-seo' ),
-		'screencast_video_url' => 'https://yoa.st/screencast-tools-import-export',
+		'screencast_video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-import-export' ),
 	),
 	'wpseo-export' => array(
 		'label'                => __( 'Export settings', 'wordpress-seo' ),
-		'screencast_video_url' => 'https://yoa.st/screencast-tools-import-export',
+		'screencast_video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-import-export' ),
 	),
 	'import-seo'   => array(
 		'label'                => __( 'Import from other SEO plugins', 'wordpress-seo' ),
-		'screencast_video_url' => 'https://yoa.st/screencast-tools-import-export',
+		'screencast_video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-import-export' ),
 	),
 );
 


### PR DESCRIPTION
Wraps all unwrapped shortlink calls with the `WPSEO_Shortlinker`, which will add the UTM tag to them.

Partially fixes https://github.com/Yoast/wordpress-seo/issues/7104