### PR TITLE
Show schema org on every page

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -155,7 +155,10 @@ class WPSEO_Frontend {
 		$primary_category = new WPSEO_Frontend_Primary_Category();
 		$primary_category->register_hooks();
 
-		$this->hooks = array( $primary_category );
+		$json_ld = new WPSEO_JSON_LD();
+		$json_ld->register_hooks();
+
+		$this->hooks = array( $primary_category, $json_ld );
 	}
 
 	/**
@@ -166,7 +169,6 @@ class WPSEO_Frontend {
 			return;
 		}
 
-		new WPSEO_JSON_LD;
 		add_action( 'wpseo_head', array( $this, 'webmaster_tools_authentication' ), 90 );
 	}
 

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -10,7 +10,7 @@
  *
  * @since 1.8
  */
-class WPSEO_JSON_LD {
+class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 
 	/**
 	 * @var array Holds the plugins options.
@@ -32,7 +32,12 @@ class WPSEO_JSON_LD {
 	 */
 	public function __construct() {
 		$this->options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_social' ) );
+	}
 
+	/**
+	 * Registers the hooks.
+	 */
+	public function register_hooks() {
 		add_action( 'wpseo_head', array( $this, 'json_ld' ), 90 );
 		add_action( 'wpseo_json_ld', array( $this, 'website' ), 10 );
 		add_action( 'wpseo_json_ld', array( $this, 'organization_or_person' ), 20 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Show the schema.org data on every page.

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk and see the schema.org data only being visible on the frontpage.
* Checkout this branch and see it being visible on every page.
* Thank you!

Fixes #6953