### PR TITLE
Init sitemap providers after theme setup

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -66,6 +66,7 @@ class WPSEO_Sitemaps {
 	 */
 	public function __construct() {
 
+		add_action( 'after_setup_theme', array( $this, 'init_sitemaps_providers' ) );
 		add_action( 'after_setup_theme', array( $this, 'reduce_query_load' ), 99 );
 		add_action( 'pre_get_posts', array( $this, 'redirect' ), 1 );
 		add_action( 'wpseo_hit_sitemap_index', array( $this, 'hit_sitemap_index' ) );
@@ -77,6 +78,19 @@ class WPSEO_Sitemaps {
 		$this->router      = new WPSEO_Sitemaps_Router();
 		$this->renderer    = new WPSEO_Sitemaps_Renderer();
 		$this->cache       = new WPSEO_Sitemaps_Cache();
+
+		if ( ! empty( $_SERVER['SERVER_PROTOCOL'] ) ) {
+			$this->http_protocol = sanitize_text_field( $_SERVER['SERVER_PROTOCOL'] );
+		}
+	}
+
+	/**
+	 * Initialize sitemap providers classes.
+	 *
+	 * @since 5.1
+	 */
+	public function init_sitemaps_providers() {
+
 		$this->providers   = array(
 			new WPSEO_Post_Type_Sitemap_Provider(),
 			new WPSEO_Taxonomy_Sitemap_Provider(),
@@ -89,10 +103,6 @@ class WPSEO_Sitemaps {
 			if ( is_object( $provider ) && $provider instanceof WPSEO_Sitemap_Provider ) {
 				$this->providers[] = $provider;
 			}
-		}
-
-		if ( ! empty( $_SERVER['SERVER_PROTOCOL'] ) ) {
-			$this->http_protocol = sanitize_text_field( $_SERVER['SERVER_PROTOCOL'] );
 		}
 	}
 

--- a/tests/sitemaps/class-wpseo-sitemaps-double.php
+++ b/tests/sitemaps/class-wpseo-sitemaps-double.php
@@ -4,9 +4,18 @@
  */
 
 /**
- * Exposes the protected functions of the WPSEO Twitter class for testing
+ * Overwrite couple functions of the WPSEO Sitemaps class for testing
  */
 class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->init_sitemaps_providers();
+	}
 
 	/**
 	 * Overwrite sitemap_close() so we don't die on outputting the sitemap


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Moving initialization of sitemap providers after theme setup.

## Test instructions

This PR can be tested by following these steps:

* Add filter `wpseo_sitemaps_providers` (introduced into #7274) to `functions.php`. This filter will be triggered.

Fixes #7561
