### PR TITLE
Add param and return docs for JS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,3 +7,4 @@ rules:
   brace-style: 1
   max-len: 1
   max-statements: 1
+  valid-jsdoc: 2

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 425,
+			maxWarnings: 275,
 		},
 	},
 	grunt: {

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -214,8 +214,8 @@ PostDataCollector.prototype.getPermalink = function() {
 
 /**
  * Get the category name from the list item.
- * @param {jQuery Object} li Item which contains the category
- * @returns {String} Name of the category
+ * @param {Object} li Item which contains the category.
+ * @returns {String} Name of the category.
  */
 PostDataCollector.prototype.getCategoryName = function( li ) {
 	var clone = li.clone();
@@ -225,8 +225,9 @@ PostDataCollector.prototype.getCategoryName = function( li ) {
 
 /**
  * When the snippet is updated, update the (hidden) fields on the page.
- * @param {Object} value
- * @param {String} type
+ *
+ * @param {Object} value The value to set.
+ * @param {String} type  The type to set the value for.
  *
  * @returns {void}
  */
@@ -267,10 +268,10 @@ PostDataCollector.prototype.setDataFromSnippet = function( value, type ) {
 /**
  * The data passed from the snippet editor.
  *
- * @param {Object} data
- * @param {string} data.title
- * @param {string} data.urlPath
- * @param {string} data.metaDesc
+ * @param {Object} data          Object with data value.
+ * @param {string} data.title    The title.
+ * @param {string} data.urlPath  The url.
+ * @param {string} data.metaDesc The meta description.
  *
  * @returns {void}
  */
@@ -283,6 +284,8 @@ PostDataCollector.prototype.saveSnippetData = function( data ) {
 /**
  * Calls the event binders.
  *
+ * @param {app} app The app object.
+ *
  * @returns {void}
  */
 PostDataCollector.prototype.bindElementEvents = function( app ) {
@@ -292,6 +295,8 @@ PostDataCollector.prototype.bindElementEvents = function( app ) {
 
 /**
  * Binds the reanalyze timer on change of dom element.
+ *
+ * @param {app} app The app object.
  *
  * @returns {void}
  */
@@ -304,6 +309,8 @@ PostDataCollector.prototype.changeElementEventBinder = function( app ) {
 
 /**
  * Binds the renewData function on the change of input elements.
+ *
+ * @param {app} app The app object.
  *
  * @returns {void}
  */

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -214,8 +214,10 @@ PostDataCollector.prototype.getPermalink = function() {
 
 /**
  * Get the category name from the list item.
+ *
  * @param {Object} li Item which contains the category.
- * @returns {String} Name of the category.
+ *
+ * @returns {String}  Name of the category.
  */
 PostDataCollector.prototype.getCategoryName = function( li ) {
 	var clone = li.clone();

--- a/js/src/analysis/TermDataCollector.js
+++ b/js/src/analysis/TermDataCollector.js
@@ -28,7 +28,7 @@ var TermDataCollector = function( args ) {
 /**
  * Returns data fetched from input fields.
  *
- * @returns {{keyword: *, meta: *, text: *, pageTitle: *, title: *, url: *, baseUrl: *, snippetTitle: *, snippetMeta: *, snippetCite: *}}
+ * @returns {{keyword: *, meta: *, text: *, pageTitle: *, title: *, url: *, baseUrl: *, snippetTitle: *, snippetMeta: *, snippetCite: *}} The object with data.
  */
 TermDataCollector.prototype.getData = function() {
 	return {
@@ -207,10 +207,10 @@ TermDataCollector.prototype.setDataFromSnippet = function( value, type ) {
 /**
  * The data passed from the snippet editor.
  *
- * @param {Object} data
- * @param {string} data.title
- * @param {string} data.urlPath
- * @param {string} data.metaDesc
+ * @param {Object} data          Object with data value.
+ * @param {string} data.title    The title.
+ * @param {string} data.urlPath  The url.
+ * @param {string} data.metaDesc The meta description.
  *
  * @returns {void}
  */
@@ -223,6 +223,8 @@ TermDataCollector.prototype.saveSnippetData = function( data ) {
 /**
  * Binds TermDataCollector events to elements.
  *
+ * @param {app} app The app object.
+ *
  * @returns {void}
  */
 TermDataCollector.prototype.bindElementEvents = function( app ) {
@@ -231,6 +233,8 @@ TermDataCollector.prototype.bindElementEvents = function( app ) {
 
 /**
  * Binds the renewData function on the change of inputelements.
+ *
+ * @param {app} app The app object.
  *
  * @returns {void}
  */

--- a/js/src/analysis/keywordTab.js
+++ b/js/src/analysis/keywordTab.js
@@ -26,7 +26,7 @@ module.exports = ( function() {
 
 	/**
 	 * Constructor for a keyword tab object
-	 * @param {Object} args
+	 * @param {Object} args The arguments.
 	 * @constructor
 	 */
 	function KeywordTab( args ) {
@@ -45,9 +45,8 @@ module.exports = ( function() {
 	/**
 	 * Updates the keyword tabs with new values.
 	 *
-	 * @param {string} scoreClass
-	 * @param {string} scoreText
-	 * @param {string} [keyword]
+	 * @param {string} score   The score to set.
+	 * @param {string} keyword The keyword to set the score for.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/wp-seo-admin-global.js
+++ b/js/src/wp-seo-admin-global.js
@@ -28,7 +28,7 @@
 	/**
 	 * Used to dismiss the tagline notice for a specific user.
 	 *
-	 * @param {string} nonce
+	 * @param {string} nonce Nonce for verification.
 	 *
 	 * @returns {void}
 	 */
@@ -43,9 +43,9 @@
 	/**
 	 * Used to remove the admin notices for several purposes, dies on exit.
 	 *
-	 * @param {string} option
-	 * @param {string} hide
-	 * @param {string} nonce
+	 * @param {string} option The option to ignnore
+	 * @param {string} hide   The target element to hide.
+	 * @param {string} nonce  Nonce for verification.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/wp-seo-admin-global.js
+++ b/js/src/wp-seo-admin-global.js
@@ -43,7 +43,7 @@
 	/**
 	 * Used to remove the admin notices for several purposes, dies on exit.
 	 *
-	 * @param {string} option The option to ignnore
+	 * @param {string} option The option to ignore.
 	 * @param {string} hide   The target element to hide.
 	 * @param {string} nonce  Nonce for verification.
 	 *

--- a/js/src/wp-seo-admin-gsc.js
+++ b/js/src/wp-seo-admin-gsc.js
@@ -86,6 +86,9 @@ jQuery( function() {
  * Decrement current category count by one.
  *
  * @param {string} category The category count to update.
+ *
+ * @returns {void}
+ *
  */
 function wpseo_update_category_count( category ) {
 	"use strict";
@@ -106,6 +109,8 @@ function wpseo_update_category_count( category ) {
  * @param {string} platform The platform to mark the issue for.
  * @param {string} category The category to mark the issue for.
  * @param {string} url      The url to mark as fixed.
+ *
+ * @returns {void}
  */
 function wpseo_send_mark_as_fixed( nonce, platform, category, url ) {
 	jQuery.post(

--- a/js/src/wp-seo-admin-gsc.js
+++ b/js/src/wp-seo-admin-gsc.js
@@ -88,7 +88,6 @@ jQuery( function() {
  * @param {string} category The category count to update.
  *
  * @returns {void}
- *
  */
 function wpseo_update_category_count( category ) {
 	"use strict";

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -9,7 +9,9 @@ import a11ySpeak from "a11y-speak";
 	/**
 	 * Detects the wrong use of variables in title and description templates
 	 *
-	 * @param {element} e
+	 * @param {element} e The element to verify.
+	 *
+	 * @returns {void}
 	 */
 	function wpseoDetectWrongVariables( e ) {
 		var warn = false;
@@ -73,10 +75,12 @@ import a11ySpeak from "a11y-speak";
 	/**
 	 * Sets a specific WP option
 	 *
-	 * @param {string} option The option to update
-	 * @param {string} newval The new value for the option
-	 * @param {string} hide The ID of the element to hide on success
-	 * @param {string} nonce The nonce for the action
+	 * @param {string} option The option to update.
+	 * @param {string} newval The new value for the option.
+	 * @param {string} hide   The ID of the element to hide on success.
+	 * @param {string} nonce  The nonce for the action.
+	 *
+	 * @returns {void}
 	 */
 	function setWPOption( option, newval, hide, nonce ) {
 		jQuery.post( ajaxurl, {
@@ -95,7 +99,9 @@ import a11ySpeak from "a11y-speak";
 	/**
 	 * Do the kill blocking files action
 	 *
-	 * @param {string} nonce
+	 * @param {string} nonce Nonce to validate request.
+	 *
+	 * @returns {void}
 	 */
 	function wpseoKillBlockingFiles( nonce ) {
 		jQuery.post( ajaxurl, {
@@ -119,6 +125,8 @@ import a11ySpeak from "a11y-speak";
 
 	/**
 	 * Copies the meta description for the homepage
+	 *
+	 * @returns {void}
 	 */
 	function wpseoCopyHomeMeta() {
 		jQuery( "#og_frontpage_desc" ).val( jQuery( "#meta_description" ).val() );
@@ -126,6 +134,8 @@ import a11ySpeak from "a11y-speak";
 
 	/**
 	 * Makes sure we store the action hash so we can return to the right hash
+	 *
+	 * @returns {void}
 	 */
 	function wpseoSetTabHash() {
 		var conf = jQuery( "#wpseo-conf" );
@@ -142,6 +152,8 @@ import a11ySpeak from "a11y-speak";
 
 	/**
 	 * Add a Facebook admin for via AJAX.
+	 *
+	 * @returns {void}
 	 */
 	function wpseo_add_fb_admin() {
 		var target_form = jQuery( "#TB_ajaxContent" );
@@ -178,6 +190,8 @@ import a11ySpeak from "a11y-speak";
 
 	/**
 	 * Adds select2 for selected fields.
+	 *
+	 * @returns {void}
 	 */
 	function initSelect2() {
 		var select2Width = "400px";
@@ -209,6 +223,8 @@ import a11ySpeak from "a11y-speak";
 
 	/**
 	 * Set the initial active tab in the settings pages.
+	 *
+	 * @returns {void}
 	 */
 	function setInitialActiveTab() {
 		var activeTabId = window.location.hash.replace( "#top#", "" );

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -23,9 +23,9 @@ import a11ySpeak from "a11y-speak";
 	};
 
 	/**
-	 * Set's the featured image to use in the analysis
+	 * Sets the featured image to use in the analysis
 	 *
-	 * @param {String} featuredImage
+	 * @param {String} featuredImage The featured image to use.
 	 *
 	 * @returns {void}
 	 */
@@ -65,8 +65,8 @@ import a11ySpeak from "a11y-speak";
 	/**
 	 * Adds featured image to sort so it can be analyzed
 	 *
-	 * @param {String} content
-	 * @returns {String}
+	 * @param {String} content The content to alter.
+	 * @returns {String} Returns the possible altered content.
 	 */
 	FeaturedImagePlugin.prototype.addImageToContent = function( content ) {
 		if ( null !== this.featuredImage ) {
@@ -88,7 +88,7 @@ import a11ySpeak from "a11y-speak";
 
 	/**
 	 * Check if image is smaller than 200x200 pixels. If this is the case, show a warning
-	 * @param {object} featuredImage
+	 * @param {object} featuredImage The featured image object.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -66,6 +66,7 @@ import a11ySpeak from "a11y-speak";
 	 * Adds featured image to sort so it can be analyzed
 	 *
 	 * @param {String} content The content to alter.
+	 *
 	 * @returns {String} Returns the possible altered content.
 	 */
 	FeaturedImagePlugin.prototype.addImageToContent = function( content ) {
@@ -88,6 +89,7 @@ import a11ySpeak from "a11y-speak";
 
 	/**
 	 * Check if image is smaller than 200x200 pixels. If this is the case, show a warning
+	 *
 	 * @param {object} featuredImage The featured image object.
 	 *
 	 * @returns {void}

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -20,6 +20,7 @@
 	 * Retrieves the primary term for a taxonomy.
 	 *
 	 * @param {string} taxonomyName The taxonomy name.
+	 *
 	 * @returns {string} The value of the primary term.
 	 */
 	function getPrimaryTerm( taxonomyName ) {
@@ -145,6 +146,7 @@
 	 * Returns the term checkbox handler for a certain taxonomy name.
 	 *
 	 * @param {string} taxonomyName The taxonomy name.
+	 *
 	 * @returns {Function} Event handler for the checkbox.
 	 */
 	function termCheckboxHandler( taxonomyName ) {
@@ -164,6 +166,7 @@
 	 * Returns the term list add handler for a certain taxonomy name.
 	 *
 	 * @param {string} taxonomyName The taxonomy name.
+	 *
 	 * @returns {Function} The term list add handler.
 	 */
 	function termListAddHandler( taxonomyName ) {
@@ -177,6 +180,7 @@
 	 * Returns the make primary event handler for a certain taxonomy name.
 	 *
 	 * @param {string} taxonomyName The taxonomy name.
+	 *
 	 * @returns {Function} The event handler.
 	 */
 	function makePrimaryHandler( taxonomyName ) {

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -8,9 +8,9 @@
 	/**
 	 * Checks if the elements to make a term the primary term and the display for a primary term exist.
 	 *
-	 * @param {Object} checkbox
+	 * @param {Object} checkbox The checkbox to get the closest required fields for.
 	 *
-	 * @returns {boolean}
+	 * @returns {boolean} True when there are primary elements.
 	 */
 	function hasPrimaryTermElements( checkbox ) {
 		return 1 === $( checkbox ).closest( "li" ).children( ".wpseo-make-primary-term" ).length;
@@ -19,8 +19,8 @@
 	/**
 	 * Retrieves the primary term for a taxonomy.
 	 *
-	 * @param {string} taxonomyName
-	 * @returns {string}
+	 * @param {string} taxonomyName The taxonomy name.
+	 * @returns {string} The value of the primary term.
 	 */
 	function getPrimaryTerm( taxonomyName ) {
 		var primaryTermInput;
@@ -32,8 +32,8 @@
 	/**
 	 * Sets the primary term for a taxonomy.
 	 *
-	 * @param {string} taxonomyName
-	 * @param {string} termId
+	 * @param {string} taxonomyName The taxonomy name.
+	 * @param {string} termId       The term id.
 	 *
 	 * @returns {void}
 	 */
@@ -47,8 +47,8 @@
 	/**
 	 * Creates the elements necessary to show something is a primary term or to make it the primary term.
 	 *
-	 * @param {string} taxonomyName
-	 * @param {Object} checkbox
+	 * @param {string} taxonomyName The taxonomy name.
+	 * @param {Object} checkbox     The checkbox to get label for.
 	 *
 	 * @returns {void}
 	 */
@@ -68,7 +68,7 @@
 	/**
 	 * Updates the primary term selectors/indicators for a certain taxonomy.
 	 *
-	 * @param {string} taxonomyName
+	 * @param {string} taxonomyName The taxonomy name.
 	 *
 	 * @returns {void}
 	 */
@@ -117,7 +117,7 @@
 	/**
 	 * Makes the first term primary for a certain taxonomy.
 	 *
-	 * @param {string} taxonomyName
+	 * @param {string} taxonomyName The taxonomy name.
 	 *
 	 * @returns {void}
 	 */
@@ -131,7 +131,7 @@
 	/**
 	 * If we check a term while there is no primary term we make that one the primary term.
 	 *
-	 * @param {string} taxonomyName
+	 * @param {string} taxonomyName The taxonomy name.
 	 *
 	 * @returns {void}
 	 */
@@ -144,8 +144,8 @@
 	/**
 	 * Returns the term checkbox handler for a certain taxonomy name.
 	 *
-	 * @param {string} taxonomyName
-	 * @returns {Function}
+	 * @param {string} taxonomyName The taxonomy name.
+	 * @returns {Function} Event handler for the checkbox.
 	 */
 	function termCheckboxHandler( taxonomyName ) {
 		return function() {
@@ -163,8 +163,8 @@
 	/**
 	 * Returns the term list add handler for a certain taxonomy name.
 	 *
-	 * @param {string} taxonomyName
-	 * @returns {Function}
+	 * @param {string} taxonomyName The taxonomy name.
+	 * @returns {Function} The term list add handler.
 	 */
 	function termListAddHandler( taxonomyName ) {
 		return function() {
@@ -176,8 +176,8 @@
 	/**
 	 * Returns the make primary event handler for a certain taxonomy name.
 	 *
-	 * @param {string} taxonomyName
-	 * @returns {Function}
+	 * @param {string} taxonomyName The taxonomy name.
+	 * @returns {Function} The event handler.
 	 */
 	function makePrimaryHandler( taxonomyName ) {
 		return function( e ) {

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -41,7 +41,7 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 	/**
 	 * Retrieves either a generated slug or the page title as slug for the preview.
 	 * @param {Object} response The AJAX response object.
-	 * @returns {String}
+	 * @returns {String} The url path.
 	 */
 	function getUrlPathFromResponse( response ) {
 		if ( response.responseText === "" ) {
@@ -76,8 +76,8 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 	/**
 	 * Initializes the snippet preview.
 	 *
-	 * @param {PostDataCollector} postScraper
-	 * @returns {SnippetPreview}
+	 * @param {PostDataCollector} postScraper Object for getting post data.
+	 * @returns {SnippetPreview} The created snippetpreview element.
 	 */
 	function initSnippetPreview( postScraper ) {
 		return snippetPreviewHelpers.create( snippetContainer, {
@@ -89,7 +89,7 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 	/**
 	 * Determines if markers should be shown.
 	 *
-	 * @returns {boolean}
+	 * @returns {boolean} True when markers should be shown.
 	 */
 	function displayMarkers() {
 		return wpseoPostScraperL10n.show_markers === "1";
@@ -98,7 +98,7 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 	/**
 	 * Returns the marker callback method for the assessor.
 	 *
-	 * @returns {*|bool}
+	 * @returns {*|bool} False when tinyMCE is undefined or when there are no markers.
 	 */
 	function getMarker() {
 		// Only add markers when tinyMCE is loaded and show_markers is enabled (can be disabled by a WordPress hook).

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -40,7 +40,9 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 
 	/**
 	 * Retrieves either a generated slug or the page title as slug for the preview.
+	 *
 	 * @param {Object} response The AJAX response object.
+	 *
 	 * @returns {String} The url path.
 	 */
 	function getUrlPathFromResponse( response ) {
@@ -77,6 +79,7 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 	 * Initializes the snippet preview.
 	 *
 	 * @param {PostDataCollector} postScraper Object for getting post data.
+	 *
 	 * @returns {SnippetPreview} The created snippetpreview element.
 	 */
 	function initSnippetPreview( postScraper ) {
@@ -121,9 +124,9 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 	/**
 	 * Initializes keyword analysis.
 	 *
-	 * @param {App} app The App object.
+	 * @param {App} app                       The App object.
 	 * @param {PostDataCollector} postScraper The post scraper object.
-	 * @param {Object} publishBox The publish box object.
+	 * @param {Object} publishBox             The publish box object.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/wp-seo-recalculate.js
+++ b/js/src/wp-seo-recalculate.js
@@ -128,6 +128,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	 * Returns the score
 	 *
 	 * @param {json} item Item to get te score for.
+	 *
 	 * @returns {{item_id: int, score}} Object with score for item.
 	 */
 	YoastRecalculateScore.prototype.getScore = function( item ) {
@@ -142,6 +143,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	 * Returns the item id
 	 *
 	 * @param {json} item Item to get the id from.
+	 *
 	 * @returns {int} The id from the item.
 	 */
 	YoastRecalculateScore.prototype.getItemID = function( item ) {

--- a/js/src/wp-seo-recalculate.js
+++ b/js/src/wp-seo-recalculate.js
@@ -23,6 +23,8 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Constructs the recalculate score.
 	 *
+	 * @param {int} total_count The total amount of items to calculate.
+	 *
 	 * @constructor
 	 */
 	var YoastRecalculateScore = function( total_count ) {
@@ -55,10 +57,10 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Starts the recalculation
 	 *
-	 * @param {int} items_to_fetch
-	 * @param {string} fetch_type
-	 * @param {string} id_field
-	 * @param {Function|bool} callback
+	 * @param {int} items_to_fetch     The amount of items to fetch.
+	 * @param {string} fetch_type      The fetch type.
+	 * @param {string} id_field        The ID field to extract from each item.
+	 * @param {Function|bool} callback Callback when calculating has been completed.
 	 *
 	 * @returns {void}
 	 */
@@ -80,7 +82,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Updates the progressbar
 	 *
-	 * @param {int} total_posts
+	 * @param {int} total_posts Total amount of posts.
 	 *
 	 * @returns {void}
 	 */
@@ -97,7 +99,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Updates the element with the new count value
 	 *
-	 * @param {int} new_value
+	 * @param {int} new_value The new value for count element.
 	 *
 	 * @returns {void}
 	 */
@@ -108,10 +110,10 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Calculate the scores
 	 *
-	 * @param {int}   total_items
-	 * @param {array} items
+	 * @param {int}   total_items Total amount of items.
+	 * @param {array} items       The items to calculate the score for.
 	 *
-	 * @returns {void}
+	 * @returns {array} The calculated scores
 	 */
 	YoastRecalculateScore.prototype.calculateScores = function( total_items, items ) {
 		var scores = [];
@@ -125,8 +127,8 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Returns the score
 	 *
-	 * @param {json} item
-	 * @returns {{item_id: int, score}}
+	 * @param {json} item Item to get te score for.
+	 * @returns {{item_id: int, score}} Object with score for item.
 	 */
 	YoastRecalculateScore.prototype.getScore = function( item ) {
 		return {
@@ -139,8 +141,8 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Returns the item id
 	 *
-	 * @param {json} item
-	 * @returns {int}
+	 * @param {json} item Item to get the id from.
+	 * @returns {int} The id from the item.
 	 */
 	YoastRecalculateScore.prototype.getItemID = function( item ) {
 		this.items_to_fetch--;
@@ -151,7 +153,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Pass the post to the analyzer to calculates it's core
 	 *
-	 * @param {Object} item
+	 * @param {Object} item Item to calculate the score for.
 	 *
 	 * @returns {void}
 	 */
@@ -174,7 +176,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Parse the response given by request in getItemsToRecalculate.
 	 *
-	 * @param {Object} response
+	 * @param {Object} response Response to parse.
 	 *
 	 * @returns {void}
 	 */
@@ -217,7 +219,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Sends the scores to the backend
 	 *
-	 * @param {array} scores
+	 * @param {array} scores Scores to send.
 	 *
 	 * @returns {void}
 	 */
@@ -236,7 +238,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Get the posts which have to be recalculated.
 	 *
-	 * @param {int} current_page
+	 * @param {int} current_page The current page.
 	 *
 	 * @returns {void}
 	 */
@@ -257,7 +259,7 @@ var isUndefined = require( "lodash/isUndefined" );
 	/**
 	 * Starting the recalculation process
 	 *
-	 * @param {object} response
+	 * @param {object} response The response.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -23,6 +23,8 @@ var ReplaceVar = require( "./values/replaceVar" );
 	/**
 	 * Variable replacement plugin for WordPress.
 	 *
+	 * @param {app} app The app object.
+	 *
 	 * @returns {void}
 	 */
 	var YoastReplaceVarPlugin = function( app ) {
@@ -317,7 +319,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 	 * Replace the custom taxonomies.
 	 *
 	 * @param {string} text The text to have its custom taxonomy placeholders replaced.
-	 * @return {string} The text in which the custom taxonomy placeholders have been replaced.
+	 * @returns {string} The text in which the custom taxonomy placeholders have been replaced.
 	 */
 	YoastReplaceVarPlugin.prototype.replaceCustomTaxonomy = function( text ) {
 		forEach( taxonomyElements, function( taxonomy, taxonomyName ) {
@@ -501,6 +503,8 @@ var ReplaceVar = require( "./values/replaceVar" );
 	/**
 	 * Checks whether or not there's a parent title available.
 	 *
+	 * @param {Object} parent The parent element.
+ 	 *
 	 * @returns {boolean} Whether or not there is a parent title present.
 	 */
 	YoastReplaceVarPlugin.prototype.hasParentTitle = function( parent ) {

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -319,6 +319,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 	 * Replace the custom taxonomies.
 	 *
 	 * @param {string} text The text to have its custom taxonomy placeholders replaced.
+	 *
 	 * @returns {string} The text in which the custom taxonomy placeholders have been replaced.
 	 */
 	YoastReplaceVarPlugin.prototype.replaceCustomTaxonomy = function( text ) {
@@ -339,6 +340,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 	 * Returns the string to replace the category taxonomy placeholders.
 	 *
 	 * @param {string} taxonomyName The name of the taxonomy needed for the lookup.
+	 *
 	 * @returns {string} The categories as a comma separated list.
 	 */
 	YoastReplaceVarPlugin.prototype.getTaxonomyReplaceVar = function( taxonomyName ) {

--- a/js/src/wp-seo-shortcode-plugin.js
+++ b/js/src/wp-seo-shortcode-plugin.js
@@ -91,6 +91,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * The callback used to replace the shortcodes.
 	 *
 	 * @param {string} data The text to replace the shortcodes in.
+	 *
 	 * @returns {string} The text with replaced shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.replaceShortcodes = function( data ) {
@@ -149,7 +150,9 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	};
 
 	/**
-	 * Gets content from the content field, if tinyMCE is initialized, use the getContent function to get the data from tinyMCE.
+	 * Gets content from the content field, if tinyMCE is initialized, use the getContent function to
+	 * get the data from tinyMCE.
+	 *
 	 * @returns {String} Content from tinyMCE.
 	 */
 	YoastShortcodePlugin.prototype.getContentTinyMCE = function() {
@@ -167,6 +170,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * Returns the unparsed shortcodes out of a collection of shortcodes.
 	 *
 	 * @param {Array} shortcodes The shortcodes to check.
+	 *
 	 * @returns {Array} Array with unparsed shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.getUnparsedShortcodes = function( shortcodes ) {
@@ -191,6 +195,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * Checks if a given shortcode was already parsed.
 	 *
 	 * @param {string} shortcode The shortcode to check.
+	 *
 	 * @returns {boolean} True when shortcode is not parsed yet.
 	 */
 	YoastShortcodePlugin.prototype.isUnparsedShortcode = function( shortcode ) {
@@ -209,6 +214,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * Gets the shortcodes from a given piece of text.
 	 *
 	 * @param {string} text Text to extract shortcodes from.
+	 *
 	 * @returns {array} The matched shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.getShortcodes = function( text ) {
@@ -235,6 +241,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * Matches the capturing shortcodes from a given piece of text.
 	 *
 	 * @param {string} text Text to get the capturing shortcodes from.
+	 *
 	 * @returns {Array} The capturing shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.matchCapturingShortcodes = function( text ) {
@@ -259,6 +266,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * Matches the non capturing shortcodes from a given piece of text.
 	 *
 	 * @param {string} text Text to get the non capturing shortcodes from.
+	 *
 	 * @returns {Array}     The non capturing shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.matchNonCapturingShortcodes = function( text ) {

--- a/js/src/wp-seo-shortcode-plugin.js
+++ b/js/src/wp-seo-shortcode-plugin.js
@@ -21,6 +21,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * @property {RegExp} closingTagRegex Used to match a given string for shortcode closing tags.
 	 * @property {RegExp} nonCaptureRegex Used to match a given string for non capturing shortcodes.
 	 * @property {Array} parsedShortcodes Used to store parsed shortcodes.
+	 *
+	 * @param {app} app The app object.
 	 */
 	var YoastShortcodePlugin = function( app ) {
 		this._app = app;
@@ -88,8 +90,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	/**
 	 * The callback used to replace the shortcodes.
 	 *
-	 * @param {string} data
-	 * @returns {string}
+	 * @param {string} data The text to replace the shortcodes in.
+	 * @returns {string} The text with replaced shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.replaceShortcodes = function( data ) {
 		var parsedShortcodes = this.parsedShortcodes;
@@ -147,8 +149,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	};
 
 	/**
-	 * gets content from the content field, if tinyMCE is initialized, use the getContent function to get the data from tinyMCE
-	 * @returns {String}
+	 * Gets content from the content field, if tinyMCE is initialized, use the getContent function to get the data from tinyMCE.
+	 * @returns {String} Content from tinyMCE.
 	 */
 	YoastShortcodePlugin.prototype.getContentTinyMCE = function() {
 		var val = document.getElementById( "content" ) && document.getElementById( "content" ).value || "";
@@ -164,8 +166,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	/**
 	 * Returns the unparsed shortcodes out of a collection of shortcodes.
 	 *
-	 * @param {Array} shortcodes
-	 * @returns {Array}
+	 * @param {Array} shortcodes The shortcodes to check.
+	 * @returns {Array} Array with unparsed shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.getUnparsedShortcodes = function( shortcodes ) {
 		if ( typeof shortcodes !== "object" ) {
@@ -188,8 +190,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	/**
 	 * Checks if a given shortcode was already parsed.
 	 *
-	 * @param {string} shortcode
-	 * @returns {boolean}
+	 * @param {string} shortcode The shortcode to check.
+	 * @returns {boolean} True when shortcode is not parsed yet.
 	 */
 	YoastShortcodePlugin.prototype.isUnparsedShortcode = function( shortcode ) {
 		var already_exists = false;
@@ -206,8 +208,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	/**
 	 * Gets the shortcodes from a given piece of text.
 	 *
-	 * @param {string} text
-	 * @returns {array} The matched shortcodes
+	 * @param {string} text Text to extract shortcodes from.
+	 * @returns {array} The matched shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.getShortcodes = function( text ) {
 		if ( typeof text !== "string" ) {
@@ -232,8 +234,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	/**
 	 * Matches the capturing shortcodes from a given piece of text.
 	 *
-	 * @param {string} text
-	 * @returns {Array}
+	 * @param {string} text Text to get the capturing shortcodes from.
+	 * @returns {Array} The capturing shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.matchCapturingShortcodes = function( text ) {
 		var captures = [];
@@ -256,8 +258,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	/**
 	 * Matches the non capturing shortcodes from a given piece of text.
 	 *
-	 * @param {string} text
-	 * @returns {Array}
+	 * @param {string} text Text to get the non capturing shortcodes from.
+	 * @returns {Array}     The non capturing shortcodes.
 	 */
 	YoastShortcodePlugin.prototype.matchNonCapturingShortcodes = function( text ) {
 		return text.match( this.nonCaptureRegex ) || [];
@@ -298,8 +300,8 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	/**
 	 * Saves the shortcodes that were parsed with AJAX to `this.parsedShortcodes`
 	 *
-	 * @param {Array} shortcodeResults
-	 * @param {function} callback
+	 * @param {Array}    shortcodeResults Shortcodes that must be saved.
+	 * @param {function} callback         Callback to execute of saving shortcodes.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -77,6 +77,7 @@ window.yoastHideMarkers = true;
 	 * Initializes the snippet preview.
 	 *
 	 * @param {TermDataCollector} termScraper Object for getting term data.
+	 *
 	 * @returns {SnippetPreview} Instance of snippetpreview.
 	 */
 	function initSnippetPreview( termScraper ) {

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -76,8 +76,8 @@ window.yoastHideMarkers = true;
 	/**
 	 * Initializes the snippet preview.
 	 *
-	 * @param {TermDataCollector} termScraper
-	 * @returns {SnippetPreview}
+	 * @param {TermDataCollector} termScraper Object for getting term data.
+	 * @returns {SnippetPreview} Instance of snippetpreview.
 	 */
 	function initSnippetPreview( termScraper ) {
 		return snippetPreviewHelpers.create( snippetContainer, {

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -25,6 +25,7 @@ var termsTmceId = "description";
 	 * Gets content from the content field by element id.
 	 *
 	 * @param {String} content_id The (HTML) id attribute for the TinyMCE field.
+	 *
 	 * @returns {String} The tinyMCE content.
 	 */
 	function tinyMCEElementContent( content_id ) {

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -25,7 +25,7 @@ var termsTmceId = "description";
 	 * Gets content from the content field by element id.
 	 *
 	 * @param {String} content_id The (HTML) id attribute for the TinyMCE field.
-	 * @returns {String}
+	 * @returns {String} The tinyMCE content.
 	 */
 	function tinyMCEElementContent( content_id ) {
 		return document.getElementById( content_id ) && document.getElementById( content_id ).value || "";
@@ -34,7 +34,7 @@ var termsTmceId = "description";
 	/**
 	 * Returns whether or not the tinyMCE script is available on the page.
 	 *
-	 * @returns {boolean}
+	 * @returns {boolean} True when tinyMCE is loaded.
 	 */
 	function isTinyMCELoaded() {
 		return (


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Improved the JS documentation.

## Relevant technical choices:

* Added documentation for `@param` and `@returns`.
* Lower the amount of maxWarnings in the eslint config
* Because of all `valid-jsdoc` are solved I made this required to enforce this in the future.

## Test instructions

This PR can be tested by following these steps:

* Do a `grunt build:js` and verify if everything works as it does before.
