### PR TITLE
Show bullet for the changelog entry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 This PR can be summarized in the following changelog entry:
 
+*
+
 ## Relevant technical choices:
 
 *


### PR DESCRIPTION
It isn't clear enough to add an entry for the changelog. 
I've added a bullet below the line 
> This PR can be summarized in the following changelog entry: 

I think this triggers people (like me) to enter something over there.
