### PR TITLE
Expose ReplaceVar and TinyMCEHelper. Renamed TinyMCEHelper from tmceH…

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -9,7 +9,7 @@ var isUndefined = require( "lodash/isUndefined" );
 var getIndicatorForScore = require( "./analysis/getIndicatorForScore" );
 var TabManager = require( "./analysis/tabManager" );
 
-var tmceHelper = require( "./wp-seo-tinymce" );
+var tinyMCEHelper = require( "./wp-seo-tinymce" );
 
 var tinyMCEDecorator = require( "./decorator/tinyMCE" ).tinyMCEDecorator;
 var publishBox = require( "./ui/publishBox" );
@@ -111,7 +111,7 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 		}
 
 		return function( paper, marks ) {
-			if ( tmceHelper.isTinyMCEAvailable( tmceId ) ) {
+			if ( tinyMCEHelper.isTinyMCEAvailable( tmceId ) ) {
 				if ( null === decorator ) {
 					decorator = tinyMCEDecorator( tinyMCE.get( tmceId ) );
 				}
@@ -302,11 +302,12 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 		window.YoastSEO.app = app;
 
 		// Init Plugins.
-		YoastSEO.wp = {};
-		YoastSEO.wp.replaceVarsPlugin = replaceVarsPlugin;
-		YoastSEO.wp.shortcodePlugin = shortcodePlugin;
+		window.YoastSEO.wp = {};
+		window.YoastSEO.wp.replaceVarsPlugin = replaceVarsPlugin;
+		window.YoastSEO.wp.shortcodePlugin = shortcodePlugin;
 
 		window.YoastSEO.wp._tabManager = tabManager;
+		window.YoastSEO.wp._tinyMCEHelper = tinyMCEHelper;
 	}
 
 	/**
@@ -360,7 +361,7 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 
 		exposeGlobals( app, tabManager, replaceVarsPlugin, shortcodePlugin );
 
-		tmceHelper.wpTextViewOnInitCheck();
+		tinyMCEHelper.wpTextViewOnInitCheck();
 
 		activateEnabledAnalysis( tabManager );
 

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -529,5 +529,14 @@ var ReplaceVar = require( "./values/replaceVar" );
 		return parentText;
 	};
 
+	/**
+	 * STATIC VARIABLES
+	 */
+
+	/**
+	 * Exposes the ReplaceVar class for functionality of plugins integrating.
+	 */
+	YoastReplaceVarPlugin.ReplaceVar = ReplaceVar;
+
 	window.YoastReplaceVarPlugin = YoastReplaceVarPlugin;
 }() );

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -533,9 +533,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 	 * STATIC VARIABLES
 	 */
 
-	/**
-	 * Exposes the ReplaceVar class for functionality of plugins integrating.
-	 */
+	// Exposes the ReplaceVar class for functionality of plugins integrating.
 	YoastReplaceVarPlugin.ReplaceVar = ReplaceVar;
 
 	window.YoastReplaceVarPlugin = YoastReplaceVarPlugin;

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -36,9 +36,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 		this.registerEvents();
 	};
 
-	/**
-	 * GENERIC
-	 */
+	/* GENERIC */
 
 	/**
 	 * Registers all the placeholders and their replacements.
@@ -233,9 +231,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 		this._app.pluginReloaded( "replaceVariablePlugin" );
 	};
 
-	/**
-	 * TAXONOMIES
-	 */
+	/* TAXONOMIES */
 
 	/**
 	 * Gets the taxonomy name from categories.
@@ -363,9 +359,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 		return jQuery.unique( filtered ).join( ", " );
 	};
 
-	/**
-	 * CUSTOM FIELDS
-	 */
+	/* CUSTOM FIELDS */
 
 	/**
 	 * Get the custom fields that are available on the current page and adds them to the placeholders.
@@ -468,9 +462,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 		}.bind( this ) );
 	};
 
-	/**
-	 * SPECIALIZED REPLACES
-	 */
+	/* SPECIALIZED REPLACES */
 
 	/**
 	 * Replaces %%term_title%% with the title of the term.
@@ -529,9 +521,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 		return parentText;
 	};
 
-	/**
-	 * STATIC VARIABLES
-	 */
+	/* STATIC VARIABLES */
 
 	/**
 	 * Exposes the ReplaceVar class for functionality of plugins integrating.

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -233,7 +233,9 @@ var ReplaceVar = require( "./values/replaceVar" );
 		this._app.pluginReloaded( "replaceVariablePlugin" );
 	};
 
-	/* TAXONOMIES */
+	/*
+	 * TAXONOMIES
+	 */
 
 	/**
 	 * Gets the taxonomy name from categories.

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -36,7 +36,9 @@ var ReplaceVar = require( "./values/replaceVar" );
 		this.registerEvents();
 	};
 
-	/* GENERIC */
+	/*
+	 * GENERIC
+	 */
 
 	/**
 	 * Registers all the placeholders and their replacements.
@@ -359,7 +361,9 @@ var ReplaceVar = require( "./values/replaceVar" );
 		return jQuery.unique( filtered ).join( ", " );
 	};
 
-	/* CUSTOM FIELDS */
+	/*
+	 * CUSTOM FIELDS
+	 */
 
 	/**
 	 * Get the custom fields that are available on the current page and adds them to the placeholders.
@@ -462,7 +466,9 @@ var ReplaceVar = require( "./values/replaceVar" );
 		}.bind( this ) );
 	};
 
-	/* SPECIALIZED REPLACES */
+	/*
+	 * SPECIALIZED REPLACES
+	 */
 
 	/**
 	 * Replaces %%term_title%% with the title of the term.
@@ -521,7 +527,9 @@ var ReplaceVar = require( "./values/replaceVar" );
 		return parentText;
 	};
 
-	/* STATIC VARIABLES */
+	/*
+	 * STATIC VARIABLES
+	 */
 
 	/**
 	 * Exposes the ReplaceVar class for functionality of plugins integrating.


### PR DESCRIPTION
…elper for clarity and consistency.

## Summary

This PR can be summarized in the following changelog entry:

* Exposes the `ReplaceVar` class in `YoastReplaceVarPlugin` as `window.YoastReplaceVarPlugin.ReplaceVar`.
* Renames `tinyMCEHelper` from `tmceHelper` in wp-seo-post-scraper.js for consistency and clarity.
* Exposes `tinyMCEHelper` as `window.YoastSEO.wp._tinyMCEHelper`.

## Relevant technical choices:

* `tinyMCEHelper` has been renamed to be consistent with `tinyMCEDecorator`.
* The window has been explicitly referenced in the `exposeGlobals` function in wp-seo-post-scraper.js for clarity.

## Test instructions

This PR can be tested by following these steps:

* Access `window.YoastReplaceVarPlugin.ReplaceVar` or `window.YoastSEO.wp._tinyMCEHelper`.

Fixes #7606 
Fixes #5632 ( in combination with Yoast/yoast-acf-analysis#34 )
