### PR TITLE
6877 change i18n promo hook

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -497,7 +497,7 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Register the promotion class for our GlotPress instance. Then creates a notification with the i18n_promo.
+	 * Register the promotion class for our GlotPress instance. Then creates a notification with the i18n promo.
 	 *
 	 * @link https://github.com/Yoast/i18n-module
 	 */
@@ -513,10 +513,9 @@ class WPSEO_Admin_Init {
 
 		$message = $i18n_module->get_promo_message();
 
-
 		$notification_center = Yoast_Notification_Center::get();
 
-		$notification        = new Yoast_Notification(
+		$notification = new Yoast_Notification(
 			$message,
 			array(
 				'type' => Yoast_Notification::WARNING,

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -507,7 +507,7 @@ class WPSEO_Admin_Init {
 			array(
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',
-				'hook'        => 'wpseo_admin_promo_footer',
+				'hook'        => 'init',
 			)
 		);
 	}

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -480,9 +480,6 @@ class WPSEO_Admin_Init {
 			if ( WPSEO_Utils::is_yoast_seo_free_page( filter_input( INPUT_GET, 'page' ) ) ) {
 				$this->register_i18n_promo_class();
 				$this->register_premium_upsell_admin_block();
-
-				// Checks whether a translation promo notice needs to be added or removed.
-				do_action( 'wpseo_admin_i18n_promo' );
 			}
 		}
 	}
@@ -506,13 +503,33 @@ class WPSEO_Admin_Init {
 	 */
 	private function register_i18n_promo_class() {
 		// BC, because an older version of the i18n-module didn't have this class.
-		new Yoast_I18n_WordPressOrg_v2(
+		$i18n_module = new Yoast_I18n_WordPressOrg_v2(
 			array(
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',
 				'hook'        => 'wpseo_admin_i18n_promo',
 			)
+
 		);
+
+		$notification_center = Yoast_Notification_Center::get();
+
+		$notification        = new Yoast_Notification(
+			$i18n_module->promo_message(),
+			array(
+				'type' => Yoast_Notification::WARNING,
+				'id'   => 'i18nModuleTranslationAssistance',
+			)
+		);
+
+		$notification_center->add_notification( $notification );
+
+		if ( $i18n_module->is_admin_in_other_language() ) {
+			$notification_center->add_notification( $notification );
+		}
+		else {
+			$notification_center->remove_notification( $notification );
+		}
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -508,20 +508,23 @@ class WPSEO_Admin_Init {
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',
 				'hook'        => 'wpseo_admin_promo_footer',
-			), false
+			), true
 		);
+
+		$message = $i18n_module->get_promo_message();
+
 
 		$notification_center = Yoast_Notification_Center::get();
 
 		$notification        = new Yoast_Notification(
-			$i18n_module->promo_message(),
+			$message,
 			array(
 				'type' => Yoast_Notification::WARNING,
 				'id'   => 'i18nModuleTranslationAssistance',
 			)
 		);
 
-		if ( $i18n_module->is_admin_in_other_language() ) {
+		if ( $message ) {
 			$notification_center->add_notification( $notification );
 		}
 		else {

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -513,6 +513,10 @@ class WPSEO_Admin_Init {
 
 		$message = $i18n_module->get_promo_message();
 
+		if( $message !== "" ) {
+			$message .= $i18n_module->get_dismiss_i18n_message_button();
+		}
+
 		$notification_center = Yoast_Notification_Center::get();
 
 		$notification = new Yoast_Notification(
@@ -525,7 +529,6 @@ class WPSEO_Admin_Init {
 
 		if ( $message ) {
 			$notification_center->add_notification( $notification );
-
 			return;
 		}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -513,7 +513,7 @@ class WPSEO_Admin_Init {
 
 		$message = $i18n_module->get_promo_message();
 
-		if( $message !== "" ) {
+		if ( $message !== '' ) {
 			$message .= $i18n_module->get_dismiss_i18n_message_button();
 		}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -497,7 +497,7 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Register the promotion class for our GlotPress instance
+	 * Register the promotion class for our GlotPress instance. Then creates a notification with the i18n_promo.
 	 *
 	 * @link https://github.com/Yoast/i18n-module
 	 */
@@ -507,9 +507,8 @@ class WPSEO_Admin_Init {
 			array(
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',
-				'hook'        => 'wpseo_admin_i18n_promo',
-			)
-
+				'hook'        => 'wpseo_admin_promo_footer',
+			), false
 		);
 
 		$notification_center = Yoast_Notification_Center::get();

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -480,6 +480,9 @@ class WPSEO_Admin_Init {
 			if ( WPSEO_Utils::is_yoast_seo_free_page( filter_input( INPUT_GET, 'page' ) ) ) {
 				$this->register_i18n_promo_class();
 				$this->register_premium_upsell_admin_block();
+
+				// Checks whether a translation promo notice needs to be added or removed.
+				do_action( 'wpseo_admin_i18n_promo' );
 			}
 		}
 	}
@@ -507,7 +510,7 @@ class WPSEO_Admin_Init {
 			array(
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',
-				'hook'        => 'init',
+				'hook'        => 'wpseo_admin_i18n_promo',
 			)
 		);
 	}

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -508,7 +508,7 @@ class WPSEO_Admin_Init {
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',
 				'hook'        => 'wpseo_admin_promo_footer',
-			), true
+			), false
 		);
 
 		$message = $i18n_module->get_promo_message();

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -521,8 +521,6 @@ class WPSEO_Admin_Init {
 			)
 		);
 
-		$notification_center->add_notification( $notification );
-
 		if ( $i18n_module->is_admin_in_other_language() ) {
 			$notification_center->add_notification( $notification );
 		}

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -497,7 +497,7 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Register the promotion class for our GlotPress instance. Then creates a notification with the i18n promo.
+	 * Registers the promotion class for our GlotPress instance, then creates a notification with the i18n promo.
 	 *
 	 * @link https://github.com/Yoast/i18n-module
 	 */
@@ -525,10 +525,11 @@ class WPSEO_Admin_Init {
 
 		if ( $message ) {
 			$notification_center->add_notification( $notification );
+
+			return;
 		}
-		else {
-			$notification_center->remove_notification( $notification );
-		}
+
+		$notification_center->remove_notification( $notification );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the place where the i18n-promobox notification is added. This is done to ensure the first page visited after the language has been changed also has the notification (used to be done in the footer, but the problem is  should the notification center be the first page visited, the added/removed i18n-notification isn't included). 

only should be merged after https://github.com/Yoast/i18n-module/pull/20 is merged

## Relevant technical choices:

* Place where the hook is added. I looked for a place which is both added before the notification center is loaded on that admin page and which is loaded on every admin page. 

If you know a better place to do the action, please suggest. 

## Test instructions

This PR can be tested by following these steps:

* In trunk, Check https://github.com/Yoast/i18n-module/pull/20, and notice that, in the event you change the language from en_us to nl and immediately after, you visit the dashboard, that the notifications are wrong. After you reload this fixes itself.
* Now check this branch out, change the language again, and notice that the notice is updated immediately. 

Fixes #6877 