### PR TITLE
Add grunt deploy:master command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,8 @@ module.exports = function( grunt ) {
 	// Define project configuration
 	var project = {
 		pluginVersion: pluginVersion,
+		pluginSlug: "wordpress-seo",
+		pluginMainFile: "wp-seo.php",
 		paths: {
 			get config() {
 				return this.grunt + "config/";

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -87,6 +87,10 @@ release:
   - artifact
   - wp_deploy:trunk
 
+'deploy:master':
+  - artifact
+  - wp_deploy:master
+
 # Default task
 default:
   - build

--- a/grunt/config/wp_deploy.js
+++ b/grunt/config/wp_deploy.js
@@ -3,12 +3,23 @@
 module.exports = {
 	trunk: {
 		options: {
-			plugin_slug: "wordpress-seo",
+			plugin_slug: "<%= pluginSlug %>",
 			build_dir: "artifact",
-			plugin_main_file: "wp-seo.php",
+			plugin_main_file: "<%= pluginMainFile %>",
 			deploy_trunk: true,
 			deploy_tag: false,
-			max_buffer: 3000 * 1024, // Equals about 3MB
+			// Equals about 3MB.
+			max_buffer: 3000 * 1024,
+		},
+	},
+	master: {
+		options: {
+			plugin_slug: "<%= pluginSlug %>",
+			build_dir: "artifact",
+			plugin_main_file: "<%= pluginMainFile %>",
+			deploy_trunk: true,
+			deploy_tag: true,
+			max_buffer: 3000 * 1024,
 		},
 	},
 };


### PR DESCRIPTION
This can deploy the actual release. When this is merged we don't need the release.sh script in the wiki for Yoast SEO 🎉