### PR TITLE
Clean assets before building them

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -72,6 +72,7 @@ artifact:
 # Get the project ready for release
 release:
   - 'build:images'
+  - 'clean:build-assets'
   - 'release:css'
   - 'release:js'
   - 'build:i18n'


### PR DESCRIPTION
This makes sure the assets are only included with the correct version.