### PR TITLE
Always show "Premium" as License page link title

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -170,7 +170,7 @@ class WPSEO_Admin {
 
 		$admin_page_hooks[ self::PAGE_IDENTIFIER ] = 'seo'; // Wipe notification bits from hooks. R.
 
-		$license_page_title = WPSEO_Utils::is_yoast_seo_premium() ? __( 'Premium', 'wordpress-seo' ) : __( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator();
+		$license_page_title = __( 'Premium', 'wordpress-seo' );
 
 		// Sub menu pages.
 		$submenu_pages = array(
@@ -679,38 +679,6 @@ class WPSEO_Admin {
 		);
 
 		return esc_url( add_query_arg( $arr_params ) );
-	}
-
-	/**
-	 * @return string
-	 */
-	private function get_premium_indicator() {
-		/**
-		 * The class that will be applied to the premium indicator.
-		 *
-		 * @type array Classes that will be applied tot the premium indicator.
-		 */
-		$classes = apply_filters( 'wpseo_premium_indicator_classes', array(
-			'wpseo-premium-indicator',
-			'wpseo-premium-indicator--no',
-			'wpseo-js-premium-indicator',
-			'update-plugins',
-		) );
-
-		/**
-		 * The text to put inside the premium indicator.
-		 *
-		 * @type string The text to read to screen readers.
-		 */
-		$text = apply_filters( 'wpseo_premium_indicator_text', __( 'Disabled', 'wordpress-seo' ) );
-
-		$premium_indicator = sprintf(
-			"<span class='%s' aria-hidden='true'><svg width=\"20\" height=\"20\" viewBox=\"0 0 1792 1792\" xmlns=\"http://www.w3.org/2000/svg\"><path fill=\"currentColor\" d=\"M1728 647q0 22-26 48l-363 354 86 500q1 7 1 20 0 21-10.5 35.5t-30.5 14.5q-19 0-40-12l-449-236-449 236q-22 12-40 12-21 0-31.5-14.5t-10.5-35.5q0-6 2-20l86-500-364-354q-25-27-25-48 0-37 56-46l502-73 225-455q19-41 49-41t49 41l225 455 502 73q56 9 56 46z\"/></svg></span><span class='screen-reader-text'>%s</span>",
-			esc_attr( implode( ' ', $classes ) ),
-			esc_html( $text )
-		);
-
-		return $premium_indicator;
 	}
 
 	/**

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -255,7 +255,6 @@ function wpseo_admin_bar_menu() {
 	if ( $user_is_admin_or_networkadmin ) {
 
 		$advanced_settings = wpseo_advanced_settings_enabled( $options );
-		$license_page_title = WPSEO_Utils::is_yoast_seo_premium() ? __( 'Premium', 'wordpress-seo' ) : __( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator();
 
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-menu',
@@ -310,7 +309,7 @@ function wpseo_admin_bar_menu() {
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-settings',
 			'id'     => 'wpseo-licenses',
-			'title'  => $license_page_title,
+			'title'  => __( 'Premium', 'wordpress-seo' ),
 			'href'   => admin_url( 'admin.php?page=wpseo_licenses' ),
 		) );
 	}

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -255,6 +255,7 @@ function wpseo_admin_bar_menu() {
 	if ( $user_is_admin_or_networkadmin ) {
 
 		$advanced_settings = wpseo_advanced_settings_enabled( $options );
+		$license_page_title = WPSEO_Utils::is_yoast_seo_premium() ? __( 'Premium', 'wordpress-seo' ) : __( 'Go Premium', 'wordpress-seo' ) . ' ' . $this->get_premium_indicator();
 
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-menu',
@@ -309,7 +310,7 @@ function wpseo_admin_bar_menu() {
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-settings',
 			'id'     => 'wpseo-licenses',
-			'title'  => __( 'Go Premium', 'wordpress-seo' ),
+			'title'  => $license_page_title,
 			'href'   => admin_url( 'admin.php?page=wpseo_licenses' ),
 		) );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the title of admin menu entry for the licenses page to "Premium".

## Test instructions

This PR can be tested by following these steps:

* See the issue for the location of the copy
* Create a branch on premium
* Merge this branch in a branch of premium and see the copy change

```
git remote add free https://github.com/Yoast/wordpress-seo.git
git fetch --all
git pull free stories/change-admin-menu-licenses-title
```
Resolve merge conflicts.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/900
