### PR TITLE
Add logic for exclude post type archives from sitemaps

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -453,15 +453,14 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return false;
 		}
 
-		$archive_url = get_post_type_archive_link( $post_type );
-
 		// Post archive should be excluded if it isn't front page or posts page.
 		if ( $post_type === 'post' && get_option( 'show_on_front' ) !== 'posts' && ! $this->get_page_for_posts_id() ) {
 			return false;
 		}
 
-		return $archive_url;
+		$archive_url = get_post_type_archive_link( $post_type );
 
+		return $archive_url;
 	}
 
 	/**

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -436,15 +436,15 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		return $links;
 	}
 
-        /**
-         * Get URL for a post type archive.
-         *
-         * @since  5.3
-         *
-         * @param  string $post_type Post type.
-         *
-         * @return string|bool URL or false if it should be excluded.
-         */
+	/**
+	 * Get URL for a post type archive.
+	 *
+	 * @since  5.3
+	 *
+	 * @param  string $post_type Post type.
+	 *
+	 * @return string|bool URL or false if it should be excluded.
+	 */
 	protected function get_post_type_archive_link( $post_type ) {
 
 		$options = $this->get_options();

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -401,19 +401,12 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			$needs_archive = false;
 		}
-		else {
-			$options = $this->get_options();
-
-			if ( isset( $options[ 'noindex-ptarchive-' . $post_type ] ) && $options[ 'noindex-ptarchive-' . $post_type ] === true ) {
-				$needs_archive = false;
-			}
-		}
 
 		if ( ! $needs_archive ) {
 			return $links;
 		}
 
-		$archive_url = get_post_type_archive_link( $post_type );
+		$archive_url = $this->get_post_type_archive_link( $post_type );
 
 		/**
 		 * Filter the URL Yoast SEO uses in the XML sitemap for this post type archive.
@@ -441,6 +434,34 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		}
 
 		return $links;
+	}
+
+        /**
+         * Get URL for a post type archive.
+         *
+         * @since  5.3
+         *
+         * @param  string $post_type Post type.
+         *
+         * @return string|bool URL or false if it should be excluded.
+         */
+	protected function get_post_type_archive_link( $post_type ) {
+
+		$options = $this->get_options();
+
+		if ( isset( $options[ 'noindex-ptarchive-' . $post_type ] ) && $options[ 'noindex-ptarchive-' . $post_type ] ) {
+			return false;
+		}
+
+		$archive_url = get_post_type_archive_link( $post_type );
+
+		// Post archive should be excluded if it isn't front page or posts page.
+		if ( $post_type === 'post' && get_option( 'show_on_front' ) !== 'posts' && ! $this->get_page_for_posts_id() ) {
+			return false;
+		}
+
+		return $archive_url;
+
 	}
 
 	/**

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -401,6 +401,13 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			$needs_archive = false;
 		}
+		else {
+			$options = $this->get_options();
+
+			if ( isset( $options[ 'noindex-ptarchive-' . $post_type ] ) && $options[ 'noindex-ptarchive-' . $post_type ] === true ) {
+				$needs_archive = false;
+			}
+		}
 
 		if ( ! $needs_archive ) {
 			return $links;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Archive pages are included in sitemap based on meta robots tag.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Create new post_type with archive page (or install woocommerce - post_type product).
* Open Titles & Metas -> Post Types -> Custom Post Type Archives -> Set noindex for archive page
* Open sitemap for this post_type. Archive page URL isn't included into sitemap.


Fixes #7667 
It's workaround for #7002, #7557 and similar issues.
