### PR TITLE
Added URL filter to the image_url function

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -381,16 +381,15 @@ class WPSEO_Sitemap_Image_Parser {
 
 		// Check that the upload base exists in the file location.
 		if ( 0 === strpos( $file, $uploads['basedir'] ) ) {
-			return str_replace( $uploads['basedir'], $uploads['baseurl'], $file );
+			$src = str_replace( $uploads['basedir'], $uploads['baseurl'], $file );
+		} elseif ( false !== strpos( $file, 'wp-content/uploads' ) ) {
+			$src = $uploads['baseurl'] . substr( $file, ( strpos( $file, 'wp-content/uploads' ) + 18 ) );
+		} else {
+			// It's a newly uploaded file, therefore $file is relative to the baseurl.
+			$src = $uploads['baseurl'] . "/$file";
 		}
 
-		// Replace file location with url location.
-		if ( false !== strpos( $file, 'wp-content/uploads' ) ) {
-			return $uploads['baseurl'] . substr( $file, ( strpos( $file, 'wp-content/uploads' ) + 18 ) );
-		}
-
-		// It's a newly uploaded file, therefore $file is relative to the baseurl.
-		return $uploads['baseurl'] . "/$file";
+		return apply_filters( 'wp_get_attachment_url', $src, $post_id );
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -355,7 +355,7 @@ class WPSEO_Sitemap_Image_Parser {
 	}
 
 	/**
-	 * Get attached image URL. Adapted from core for speed.
+	 * Get attached image URL with filters applied. Adapted from core for speed.
 	 *
 	 * @param int $post_id ID of the post.
 	 *

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -386,7 +386,7 @@ class WPSEO_Sitemap_Image_Parser {
 			$src = $uploads['baseurl'] . substr( $file, ( strpos( $file, 'wp-content/uploads' ) + 18 ) );
 		} else {
 			// It's a newly uploaded file, therefore $file is relative to the baseurl.
-			$src = $uploads['baseurl'] . "/$file";
+			$src = $uploads['baseurl'] . '/' . $file;
 		}
 
 		return apply_filters( 'wp_get_attachment_url', $src, $post_id );


### PR DESCRIPTION
The image urls in the sitemap are incorrect when used alongside the amazon-s3-and-cloudfront plugin, and presumably other similar plugins. 

## Summary

This PR can be summarized in the following changelog entry:

* Added wp_get_attachment_url filter to the class-sitemap-image-parser image_url method. 

## Relevant technical choices:

* The Post ID of the asset is required for this filter, therefore it cannot be applied later alongside the 'wpseo_xml_sitemap_img_src' filter as only the parent Post ID is provided. 

## Test instructions

This PR can be tested by following these steps:

* Generating a sitemap with the amazon-s3-and-cloudfront plugin and verifying the article images point to the correct location. 

Fixes #
