### PR TITLE
Bump Yoast Coding Standards to 0.4.3

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -580,6 +580,7 @@ class WPSEO_Admin {
 
 		// Don't change slug if the post is a draft, this conflicts with polylang.
 		// Doesn't work with filter_input() since need current value, not originally submitted one.
+		// @codingStandardsIgnoreLine
 		if ( 'draft' === $_POST['post_status'] ) {
 			return $slug;
 		}

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -78,6 +78,6 @@ class WPSEO_Extensions {
 	 * @return string Returns the option name.
 	 */
 	protected function get_option_name( $extension ) {
-		return sanitize_title_with_dashes( $this->extensions[ $extension ]['slug']. '_', null, 'save' ) . 'license';
+		return sanitize_title_with_dashes( $this->extensions[ $extension ]['slug'] . '_', null, 'save' ) . 'license';
 	}
 }

--- a/admin/class-help-center-item.php
+++ b/admin/class-help-center-item.php
@@ -83,7 +83,10 @@ class WPSEO_Help_Center_Item {
 			}
 
 			if ( ! empty( $this->args['view_arguments'] ) ) {
+				// As we are going to move UI to React, this will be resolved in that project.
+				// @codingStandardsIgnoreStart
 				extract( $this->args['view_arguments'] );
+				// @codingStandardsIgnoreEnd
 			}
 
 			include WPSEO_PATH . 'admin/views/' . $view . '.php';

--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -198,10 +198,12 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	public function og_data_compare( $post ) {
 
 		// Check if post data is available, if post_id is set and if original post_status is publish.
+		// @codingStandardsIgnoreStart
 		if (
 			! empty( $_POST ) && ! empty( $post->ID ) && $post->post_status == 'publish' &&
 			isset( $_POST['original_post_status'] ) && $_POST['original_post_status'] === 'publish'
 		) {
+			// @codingStandardsIgnoreEnd
 
 			$fields_to_compare = array(
 				'opengraph-title',

--- a/admin/class-yoast-columns.php
+++ b/admin/class-yoast-columns.php
@@ -31,7 +31,7 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 					'Yoast SEO',
 					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
 					'</a>',
-					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16q' )  .'">',
+					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16q' ) . '">',
 					'<em>',
 					'</em>'
 				),

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -104,8 +104,7 @@ class WPSEO_Configuration_Page {
 				printf(
 					/* translators: %s expands to Yoast SEO. */
 					__( '%s &rsaquo; Configuration Wizard', 'wordpress-seo' ),
-					'Yoast SEO'
-				);
+					'Yoast SEO' );
 			?></title>
 			<?php
 			wp_print_head_scripts();

--- a/admin/google_search_console/class-gsc-issues.php
+++ b/admin/google_search_console/class-gsc-issues.php
@@ -99,9 +99,12 @@ class WPSEO_GSC_Issues {
 	 * @param stdClass $issue        Issue object to check against the list.
 	 */
 	private function issue_compare( &$crawl_issues, $issue ) {
-		$issue->pageUrl = WPSEO_Utils::format_url( (string) $issue->pageUrl );
+		// Ignore coding standards for object properties.
+		// @codingStandardsIgnoreStart
+		$page_url = $issue->pageUrl = WPSEO_Utils::format_url( (string) $issue->pageUrl );
+		// @codingStandardsIgnoreEnd
 
-		if ( ! in_array( $issue->pageUrl, $this->current_issues ) ) {
+		if ( ! in_array( $page_url, $this->current_issues, true ) ) {
 			array_push(
 				$crawl_issues,
 				$this->get_issue( $this->create_issue( $issue ) )
@@ -118,11 +121,17 @@ class WPSEO_GSC_Issues {
 	 * @return WPSEO_GSC_Issue
 	 */
 	private function create_issue( $issue ) {
+		// Ignore coding standards for object properties.
+		// @codingStandardsIgnoreStart
+		$response_code = $issue->responseCode;
+		$page_url = $issue->pageUrl;
+		// @codingStandardsIgnoreEnd
+
 		return new WPSEO_GSC_Issue(
-			$issue->pageUrl,
+			$page_url,
 			new DateTime( (string) $issue->first_detected ),
 			new DateTime( (string) $issue->last_crawled ),
-			(string) ( ! empty( $issue->responseCode ) ) ? $issue->responseCode : null
+			(string) ( ! empty( $response_code ) ) ? $response_code : null
 		);
 	}
 

--- a/admin/google_search_console/class-gsc-modal.php
+++ b/admin/google_search_console/class-gsc-modal.php
@@ -45,11 +45,14 @@ class WPSEO_GSC_Modal {
 	 * @param string $unique_id An unique identifier for the modal.
 	 */
 	public function load_view( $unique_id ) {
+		// As we are going to move UI to React, this will be resolved in that project.
+		// @codingStandardsIgnoreStart
 		extract( $this->view_vars );
+		// @codingStandardsIgnoreEnd
 
 		echo '<div id="redirect-' . $unique_id . '" class="hidden">';
 		echo '<div class="form-wrap wpseo_content_wrapper">';
-		require( $this->view );
+		require $this->view;
 		echo '</div>';
 		echo '</div>';
 	}

--- a/admin/google_search_console/class-gsc-service.php
+++ b/admin/google_search_console/class-gsc-service.php
@@ -57,9 +57,14 @@ class WPSEO_GSC_Service {
 		$response_json = $this->client->do_request( 'sites', true );
 
 		// Do list sites request.
+		// Ignore coding standarsd for object properties.
+		// @codingStandardsIgnoreStart
 		if ( ! empty( $response_json->siteEntry ) ) {
 			foreach ( $response_json->siteEntry as $entry ) {
-				$sites[ str_ireplace( 'sites/', '', (string) $entry->siteUrl ) ] = (string) $entry->siteUrl;
+				$site_url = (string) $entry->siteUrl;
+				// @codingStandardsIgnoreEnd
+
+				$sites[ str_ireplace( 'sites/', '', $site_url ) ] = $site_url;
 			}
 
 			// Sorting the retrieved sites.
@@ -79,8 +84,11 @@ class WPSEO_GSC_Service {
 		$crawl_error_counts = $this->get_crawl_error_counts( $this->profile );
 
 		$return = array();
+		// Ignore coding standards for object properties.
+		// @codingStandardsIgnoreStart
 		if ( ! empty( $crawl_error_counts->countPerTypes ) ) {
 			foreach ( $crawl_error_counts->countPerTypes as $category ) {
+				// @codingStandardsIgnoreEnd
 				$return[ $category->platform ][ $category->category ] = array(
 					'count'      => $category->entries[0]->count,
 					'last_fetch' => null,
@@ -119,9 +127,12 @@ class WPSEO_GSC_Service {
 			true
 		);
 
+		// Ignore coding standards for object properties.
+		// @codingStandardsIgnoreStart
 		if ( ! empty( $issues->urlCrawlErrorSample ) ) {
 			return $issues->urlCrawlErrorSample;
 		}
+		// @codingStandardsIgnoreEnd
 	}
 
 	/**

--- a/admin/links/class-link-notifier.php
+++ b/admin/links/class-link-notifier.php
@@ -95,7 +95,7 @@ class WPSEO_Link_Notifier {
 					The Text link counter feature provides insights in how many links are found in your text and how many links are referring to your text. This is very helpful when you are improving your %1$sinternal linking%2$s.',
 					'wordpress-seo'
 				),
-				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15m' ). '" target="_blank">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15m' ) . '" target="_blank">',
 				'</a>',
 				'<button type="button" id="noticeRunLinkIndex" class="button">',
 				'</button>'

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -50,7 +50,7 @@ class WPSEO_Link_Reindex_Dashboard {
 		$html .= '<p>' . sprintf(
 			/* translators: 1: link to yoast.com post about internal linking suggestion. 4: is Yoast.com 3: is anchor closing. */
 			__( 'The links in all your public texts need to be counted. This will provide insights of which texts need more links to them. If you want to know more about the why and how of internal linking, check out %1$sthe article about internal linking on %2$s%3$s.', 'wordpress-seo' ),
-				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15n' ). '" target="_blank">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15n' ) . '" target="_blank">',
 				'Yoast.com',
 				'</a>'
 		) . '</p>';

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -795,9 +795,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		 * Determine we're not accidentally updating a different post.
 		 * We can't use filter_input here as the ID isn't available at this point, other than in the $_POST data.
 		 */
+		// @codingStandardsIgnoreStart
 		if ( ! isset( $_POST['ID'] ) || $post_id !== (int) $_POST['ID'] ) {
 			return false;
 		}
+		// @codingStandardsIgnoreEnd
 
 		clean_post_cache( $post_id );
 		$post = get_post( $post_id );
@@ -822,10 +824,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 			$data = null;
 			if ( 'checkbox' === $meta_box['type'] ) {
+				// @codingStandardsIgnoreLine
 				$data = isset( $_POST[ self::$form_prefix . $key ] ) ? 'on' : 'off';
 			}
 			else {
+				// @codingStandardsIgnoreLine
 				if ( isset( $_POST[ self::$form_prefix . $key ] ) ) {
+					// @codingStandardsIgnoreLine
 					$data = $_POST[ self::$form_prefix . $key ];
 				}
 			}

--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -54,14 +54,14 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 
 		$curl = curl_version();
 
-		$sslSupport = true;
+		$ssl_support = true;
 		if ( ! $curl['features'] && CURL_VERSION_SSL ) {
-			$sslSupport = false;
+			$ssl_support = false;
 		}
 
 		return array(
 			'version'    => $curl['version'],
-			'sslSupport' => $sslSupport,
+			'sslSupport' => $ssl_support,
 		);
 	}
 

--- a/admin/views/class-yoast-form-fieldset.php
+++ b/admin/views/class-yoast-form-fieldset.php
@@ -58,9 +58,12 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 		 * Extract because we want values accessible via variables for later use
 		 * in the view instead of accessing them as an array.
 		 */
+		// As we are going to move UI to React, this will be resolved in that project.
+		// @codingStandardsIgnoreStart
 		extract( $this->get_parts() );
+		// @codingStandardsIgnoreEnd
 
-		require( dirname( WPSEO_FILE ) . '/admin/views/form/fieldset.php' );
+		require dirname( WPSEO_FILE ) . '/admin/views/form/fieldset.php';
 	}
 
 	/**

--- a/admin/views/class-yoast-input-select.php
+++ b/admin/views/class-yoast-input-select.php
@@ -53,9 +53,12 @@ class Yoast_Input_Select {
 	 */
 	public function output_html() {
 		// Extract it, because we want each value accessible via a variable instead of accessing it as an array.
+		// As we are going to move UI to React, this will be resolved in that project.
+		// @codingStandardsIgnoreStart
 		extract( $this->get_select_values() );
+		// @codingStandardsIgnoreEnd
 
-		require( dirname( WPSEO_FILE ) . '/admin/views/form/select.php' );
+		require dirname( WPSEO_FILE ) . '/admin/views/form/select.php';
 	}
 
 	/**

--- a/admin/views/licenses-legacy.php
+++ b/admin/views/licenses-legacy.php
@@ -182,8 +182,13 @@ elseif ( class_exists( 'Yoast_WooCommerce_SEO' ) ) {
 				<?php unset( $extensions['seo-premium'] ); ?>
 
 				<?php foreach ( $extensions as $id => $extension ) : ?>
-					<?php $buy_url = $extension->buyUrl;
-					$info_url = $extension->infoUrl; ?>
+					<?php
+					// Ignore coding standards for object properties.
+					// @codingStandardsIgnoreStart
+					$buy_url = $extension->buyUrl;
+					$info_url = $extension->infoUrl;
+					// @codingStandardsIgnoreEnd
+					?>
 
 
 					<section class="yoast-promoblock secondary yoast-promo-extension">

--- a/admin/views/licenses-legacy.php
+++ b/admin/views/licenses-legacy.php
@@ -190,7 +190,6 @@ elseif ( class_exists( 'Yoast_WooCommerce_SEO' ) ) {
 					// @codingStandardsIgnoreEnd
 					?>
 
-
 					<section class="yoast-promoblock secondary yoast-promo-extension">
 						<img alt="" width="280" height="147" src="<?php echo esc_attr( $extension->image ); ?>" />
 						<h3><?php echo esc_html( $extension->title ); ?></h3>
@@ -218,8 +217,7 @@ elseif ( class_exists( 'Yoast_WooCommerce_SEO' ) ) {
 								__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 								'<span class="screen-reader-text">',
 								'</span>',
-								$extension->title
-							);
+								$extension->title );
 							?></a>
 					</section>
 				<?php endforeach; ?>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -177,8 +177,7 @@ if ( class_exists( 'Woocommerce' ) ) {
 						__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 						'<span class="screen-reader-text">',
 						'</span>',
-						$extension->get_title()
-					);
+						$extension->get_title() );
 					?></a>
 			<?php endif; ?>
 
@@ -232,8 +231,7 @@ if ( class_exists( 'Woocommerce' ) ) {
 									__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 									'<span class="screen-reader-text">',
 									'</span>',
-									$extension->get_title()
-								);
+									$extension->get_title() );
 								?>
 							</a>
 						<?php endif; ?>

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -43,7 +43,7 @@ $feature_toggles = array(
 		/* translators: 1: open link tag 2: close link tag */
 		'label'   => sprintf(
 			__( 'The Cornerstone content functionality enables you to mark and filter cornerstone content on your website. %1$sRead more about how cornerstone content can help you improve your site structure.%2$s', 'wordpress-seo' ),
-			'<a href="' .  WPSEO_Shortlinker::get( 'https://yoa.st/dashboard-help-cornerstone' ) . '" target="_blank">',
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/dashboard-help-cornerstone' ) . '" target="_blank">',
 			'</a>'
 		),
 	),
@@ -52,7 +52,7 @@ $feature_toggles = array(
 		'setting' => 'enable_text_link_counter',
 		'label'   => sprintf(
 			__( 'This feature helps you improve the internal link structure of your site. If you want to know more about the why and how of internal linking, check out the %1$sarticle about internal linking on Yoast.com%2$s.', 'wordpress-seo' ),
-			'<a href="' .  WPSEO_Shortlinker::get( 'https://yoa.st/17g' ) . '" target="_blank">',
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/17g' ) . '" target="_blank">',
 			'</a>'
 		),
 	),

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
 		"yoast/whip": "^1.1.0"
 	},
 	"require-dev": {
-		"yoast/yoastcs": "0.3",
 		"codeclimate/php-test-reporter": "dev-master",
-		"yoast/php-development-environment": "^1.0"
+		"yoast/php-development-environment": "^1.0",
+		"yoast/yoastcs": "0.4.3"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -48,6 +48,12 @@
 		"config-yoastcs": [
 			"\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
+		],
+		"check-cs": [
+			"\"vendor/bin/phpcs\""
+		],
+		"fix-cs": [
+			"\"vendor/bin/phpcbf\""
 		],
 		"post-install-cmd": [
 			"xrstf\\Composer52\\Generator::onPostInstallCmd"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1b0a787f5bcb217a56beadd3cef9de8",
+    "content-hash": "132441231a4a074fbb989c2bd9ec234e",
     "packages": [
         {
             "name": "composer/installers",
@@ -373,7 +373,7 @@
                 "codeclimate",
                 "coverage"
             ],
-            "time": "2017-06-01 13:19:55"
+            "time": "2017-06-01T13:19:55+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -842,19 +842,20 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.5.1",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6731851d6aaf1d0d6c58feff1065227b7fda3ba8"
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6731851d6aaf1d0d6c58feff1065227b7fda3ba8",
-                "reference": "6731851d6aaf1d0d6c58feff1065227b7fda3ba8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
                 "shasum": ""
             },
             "require": {
+                "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
                 "php": ">=5.1.2"
@@ -915,7 +916,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-01-19T23:39:10+00:00"
+            "time": "2017-03-01T22:17:45+00:00"
         },
         {
             "name": "symfony/config",
@@ -1448,20 +1449,20 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.9.0",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "b415094aa5fd24da6eba2295323bcff840902dd3"
+                "reference": "b39490465f6fd7375743a395019cd597e12119c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/b415094aa5fd24da6eba2295323bcff840902dd3",
-                "reference": "b415094aa5fd24da6eba2295323bcff840902dd3",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/b39490465f6fd7375743a395019cd597e12119c9",
+                "reference": "b39490465f6fd7375743a395019cd597e12119c9",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "~2.2"
+                "squizlabs/php_codesniffer": "^2.6"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -1480,7 +1481,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-02-01T16:14:59+00:00"
+            "time": "2016-08-29T20:04:47+00:00"
         },
         {
             "name": "yoast/php-development-environment",
@@ -1522,22 +1523,22 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "0.3",
+            "version": "0.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "f568cc6fc1194c5ef67ccc24b7cfd24259e92a16"
+                "reference": "0573753b5e8b939e83894bb6a9830ab1bd296cfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f568cc6fc1194c5ef67ccc24b7cfd24259e92a16",
-                "reference": "f568cc6fc1194c5ef67ccc24b7cfd24259e92a16",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/0573753b5e8b939e83894bb6a9830ab1bd296cfe",
+                "reference": "0573753b5e8b939e83894bb6a9830ab1bd296cfe",
                 "shasum": ""
             },
             "require": {
                 "phpmd/phpmd": "^2.2.3",
-                "squizlabs/php_codesniffer": "2.5.1",
-                "wp-coding-standards/wpcs": "0.9"
+                "squizlabs/php_codesniffer": "~2.8.1",
+                "wp-coding-standards/wpcs": "~0.10.0"
             },
             "conflict": {
                 "squizlabs/php_codesniffer": "2.3.1"
@@ -1560,7 +1561,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-05-03T09:58:54+00:00"
+            "time": "2017-08-02T07:45:07+00:00"
         }
     ],
     "aliases": [],

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -305,8 +305,11 @@ class WPSEO_Breadcrumbs {
 		$this->maybe_add_home_crumb();
 		$this->maybe_add_blog_crumb();
 
+		// Ignore coding standards for empty if statement.
+		// @codingStandardsIgnoreStart
 		if ( ( $this->show_on_front === 'page' && is_front_page() ) || ( $this->show_on_front === 'posts' && is_home() ) ) {
 			// Do nothing.
+			// @codingStandardsIgnoreEnd
 		}
 		elseif ( $this->show_on_front == 'page' && is_home() ) {
 			$this->add_blog_crumb();

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1350,7 +1350,7 @@ class WPSEO_Frontend {
 				$post_data = $term;
 			}
 		}
-		else if ( ( ! is_string( $metadesc ) || '' === $metadesc ) && '' !== $template ) {
+		elseif ( ( ! is_string( $metadesc ) || '' === $metadesc ) && '' !== $template ) {
 			if ( ! isset( $term ) ) {
 				$term = $wp_query->get_queried_object();
 			}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -205,7 +205,7 @@ class WPSEO_OpenGraph {
 
 			return true;
 		}
-		else if ( isset( $this->options['fb_admins'] ) && is_array( $this->options['fb_admins'] ) && $this->options['fb_admins'] !== array() ) {
+		elseif ( isset( $this->options['fb_admins'] ) && is_array( $this->options['fb_admins'] ) && $this->options['fb_admins'] !== array() ) {
 			$adminstr = implode( ',', array_keys( $this->options['fb_admins'] ) );
 			/**
 			 * Filter: 'wpseo_opengraph_admin' - Allow developer to filter the fb:admins string put out by Yoast SEO
@@ -256,7 +256,7 @@ class WPSEO_OpenGraph {
 				$title = wpseo_replace_vars( $title, $post );
 			}
 		}
-		else if ( is_front_page() ) {
+		elseif ( is_front_page() ) {
 			$title = ( isset( $this->options['og_frontpage_title'] ) && $this->options['og_frontpage_title'] !== '' ) ? $this->options['og_frontpage_title'] : $frontend->title( '' );
 		}
 		elseif ( is_category() || is_tax() || is_tag() ) {

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -806,10 +806,8 @@ class WPSEO_OpenGraph_Image {
 	public function __construct( $options, $image = false ) {
 		$this->options = $options;
 
-		if ( ! empty( $image ) && $this->add_image( $image ) ) {
-			// Safely assume an image was added so we don't need to automatically determine it anymore.
-		}
-		else {
+		// If an image was not supplied or could not be added.
+		if ( empty( $image ) || ! $this->add_image( $image ) ) {
 			$this->set_images();
 		}
 	}

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1031,6 +1031,7 @@ class WPSEO_Meta {
 	 *                     Will return empty string if key does not exists in $_POST
 	 */
 	public static function get_post_value( $key ) {
+		// @codingStandardsIgnoreLine
 		return ( array_key_exists( $key, $_POST ) ) ? $_POST[ $key ] : '';
 	}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -106,7 +106,10 @@ class WPSEO_Replace_Vars {
 				trigger_error( __( 'A replacement variable can only contain alphanumeric characters, an underscore or a dash. Try renaming your variable.', 'wordpress-seo' ), E_USER_WARNING );
 			}
 			elseif ( strpos( $var, 'cf_' ) === 0 || strpos( $var, 'ct_' ) === 0 ) {
+				// Ignore invalid placeholder detection, there is no (s)printf usage in the following line.
+				// @codingStandardsIgnoreStart
 				trigger_error( __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'wordpress-seo' ), E_USER_WARNING );
+				// @codingStandardsIgnoreEnd
 			}
 			elseif ( ! method_exists( __CLASS__, 'retrieve_' . $var ) ) {
 				if ( ! isset( self::$external_replacements[ $var ] ) ) {

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -405,18 +405,18 @@ class WPSEO_Utils {
 		if ( is_bool( $value ) ) {
 			return $value;
 		}
-		else if ( is_int( $value ) && ( $value === 0 || $value === 1 ) ) {
+		elseif ( is_int( $value ) && ( $value === 0 || $value === 1 ) ) {
 			return (bool) $value;
 		}
-		else if ( ( is_float( $value ) && ! is_nan( $value ) ) && ( $value === (float) 0 || $value === (float) 1 ) ) {
+		elseif ( ( is_float( $value ) && ! is_nan( $value ) ) && ( $value === (float) 0 || $value === (float) 1 ) ) {
 			return (bool) $value;
 		}
-		else if ( is_string( $value ) ) {
+		elseif ( is_string( $value ) ) {
 			$value = trim( $value );
 			if ( in_array( $value, $true, true ) ) {
 				return true;
 			}
-			else if ( in_array( $value, $false, true ) ) {
+			elseif ( in_array( $value, $false, true ) ) {
 				return false;
 			}
 			else {
@@ -466,7 +466,7 @@ class WPSEO_Utils {
 		if ( is_int( $value ) ) {
 			return $value;
 		}
-		else if ( is_float( $value ) ) {
+		elseif ( is_float( $value ) ) {
 			if ( (int) $value == $value && ! is_nan( $value ) ) {
 				return (int) $value;
 			}
@@ -474,15 +474,15 @@ class WPSEO_Utils {
 				return false;
 			}
 		}
-		else if ( is_string( $value ) ) {
+		elseif ( is_string( $value ) ) {
 			$value = trim( $value );
 			if ( $value === '' ) {
 				return false;
 			}
-			else if ( ctype_digit( $value ) ) {
+			elseif ( ctype_digit( $value ) ) {
 				return (int) $value;
 			}
-			else if ( strpos( $value, '-' ) === 0 && ctype_digit( substr( $value, 1 ) ) ) {
+			elseif ( strpos( $value, '-' ) === 0 && ctype_digit( substr( $value, 1 ) ) ) {
 				return (int) $value;
 			}
 			else {

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -127,7 +127,7 @@ abstract class WPSEO_Option {
 
 			add_action( 'update_option', array( $this, 'add_default_filters' ) );
 		}
-		else if ( is_multisite() ) {
+		elseif ( is_multisite() ) {
 			/*
 			The option validation routines remove the default filters to prevent failing
 			   to insert an option if it's new. Let's add them back afterwards.

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -351,7 +351,7 @@ class WPSEO_Options {
 				self::reset_ms_blog( get_current_blog_id() );
 				self::initialize();
 			}
-			else if ( $force_init === true ) {
+			elseif ( $force_init === true ) {
 				self::initialize();
 			}
 		}

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -80,7 +80,7 @@ class WPSEO_Sitemaps_Renderer {
 
 		$urlset = '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" '
 			. 'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd '
-			.                     'http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" '
+			. 'http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" '
 			. 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 
 		/**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0"?>
 <ruleset name="Yoast SEO">
-	<description>Yoast SEO rules for PHP_CodeSniffer</description>
+    <description>Yoast SEO rules for PHP_CodeSniffer</description>
 
     <file>.</file>
 
-	<exclude-pattern>tests/*</exclude-pattern>
-	<exclude-pattern>vendor/*</exclude-pattern>
-	<exclude-pattern>node_modules/*</exclude-pattern>
-	<exclude-pattern>deprecated/*</exclude-pattern>
-	<exclude-pattern>languages/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>deprecated/*</exclude-pattern>
+    <exclude-pattern>languages/*</exclude-pattern>
 
-    <arg name="extensions" value="php" />
+    <arg name="extensions" value="php"/>
     <arg value="sp"/>
 
     <rule ref="Yoast">
-        <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" /><!-- TODO audit and fix nonces -->
-        <exclude name="WordPress.WP.PreparedSQL.NotPrepared" /><!-- TODO audit raw queries -->
+        <exclude name="WordPress.WP.PreparedSQL.NotPrepared"/><!-- TODO audit raw queries -->
     </rule>
 
     <rule ref="WordPress.WP.EnqueuedResources.NonEnqueuedScript">


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updated Yoast Coding Standards to latest version.

## Relevant technical choices:

* Added CS Ignore rules to specific code blocks.
* Fixed all the errors, there were more than the 5 mentioned.

## Test instructions

This PR can be tested by following these steps:

* Run `composer check-cs`

Fixes https://github.com/Yoast/wordpress-seo/pull/6875
