### PR TITLE
Stories/2105 export keywords

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -101,6 +101,7 @@ class WPSEO_Admin {
 
 		$integrations[] = new WPSEO_Yoast_Columns();
 		$integrations[] = new WPSEO_License_Page_Manager();
+		$integrations[] = new WPSEO_Export_Keywords_Manager();
 		$integrations = array_merge( $integrations, $this->initialize_seo_links() );
 
 		/** @var WPSEO_WordPress_Integration $integration */

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -95,13 +95,13 @@ class Yoast_Form {
 	/**
 	 * Sets a value in the options.
 	 *
-	 * @param string $key The key of the option to set.
-	 * @param mixed $value The value to set the option to.
-	 * @param bool $overwrite Whether to overwrite existing options, default is false.
+	 * @param string $key       The key of the option to set.
+	 * @param mixed  $value     The value to set the option to.
+	 * @param bool   $overwrite Whether to overwrite existing options, default is false.
 	 */
 	public function set_options_value( $key, $value, $overwrite = false ) {
 		if ( $overwrite || ! array_key_exists( $key, $this->options ) ) {
-			$this->options[$key] = $value;
+			$this->options[ $key ] = $value;
 		}
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -93,6 +93,19 @@ class Yoast_Form {
 	}
 
 	/**
+	 * Sets a value in the options.
+	 *
+	 * @param string $key The key of the option to set.
+	 * @param mixed $value The value to set the option to.
+	 * @param bool $overwrite Whether to overwrite existing options, default is false.
+	 */
+	public function set_options_value( $key, $value, $overwrite = false ) {
+		if ( $overwrite || ! array_key_exists( $key, $this->options ) ) {
+			$this->options[$key] = $value;
+		}
+	}
+
+	/**
 	 * Retrieve options based on whether we're on multisite or not.
 	 *
 	 * @since 1.2.4

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -97,7 +97,7 @@ class Yoast_Form {
 	 *
 	 * @param string $key       The key of the option to set.
 	 * @param mixed  $value     The value to set the option to.
-	 * @param bool   $overwrite Whether to overwrite existing options, default is false.
+	 * @param bool   $overwrite Whether to overwrite existing options. Default is false.
 	 */
 	public function set_options_value( $key, $value, $overwrite = false ) {
 		if ( $overwrite || ! array_key_exists( $key, $this->options ) ) {

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -122,7 +122,7 @@ class WPSEO_Export_Keywords_CSV {
 	 * Returns a CSV column including comma from the result object by the specified key.
 	 *
 	 * @param array[string]string $result The result object to get the CSV column from.
-	 * @param string $key The key of the value to get the CSV column for.
+	 * @param string              $key    The key of the value to get the CSV column for.
 	 *
 	 * @return string A CSV column including comma.
 	 */

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -31,12 +31,12 @@ class WPSEO_Export_Keywords_CSV {
 	/**
 	 * Returns the CSV headers based on the queried columns.
 	 *
-	 * @param array[int]string $columns  The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
+	 * @param array[int]string $columns The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
 	 *
 	 * @return string A line of CSV.
 	 */
 	protected function get_headers( $columns ) {
-		$csv = $this->format_csv_column( __( 'ID' ) );
+		$csv = $this->format_csv_column( __( 'ID', 'wordpress-seo' ) );
 
 		if ( in_array( 'post_title', $columns, true ) ) {
 			$csv .= ',' . $this->format_csv_column( __( 'post title', 'wordpress-seo' ) );

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -13,14 +13,15 @@ class WPSEO_Export_Keywords_CSV {
 	/**
 	 * Exports the supplied keyword query to a CSV string.
 	 *
-	 * @param WPSEO_Export_Keywords_Query $keywords_query The query to export to CSV.
+	 * @param array[int][string]string $data    An array of results from WPSEO_Export_Keywords_Query::get_data.
+	 * @param array[int]string         $columns An array of columns that should be presented.
 	 *
 	 * @return string A CSV string.
 	 */
 	public function export( $data, $columns ) {
 		$csv = $this->get_headers( $columns );
 
-		foreach( $data as $result ) {
+		foreach ( $data as $result ) {
 			$csv .= $this->format( $result, $columns );
 		}
 
@@ -64,14 +65,14 @@ class WPSEO_Export_Keywords_CSV {
 	 * Formats a WPSEO_Export_Keywords_Query result as a CSV line.
 	 * In case of multiple keywords it will return multiple lines.
 	 *
-	 * @param array[string]string $result A result as returned from WPSEO_Export_Keywords_Query::get_data.
-	 * @param array[int]string $columns The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
+	 * @param array[string]string $result  A result as returned from WPSEO_Export_Keywords_Query::get_data.
+	 * @param array[int]string    $columns The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
 	 *
 	 * @return string A line of CSV, beginning with EOL.
 	 */
 	protected function format( $result, $columns ) {
 		// If our input is malformed return an empty string.
-		if ( ! is_array( $result) || ! array_key_exists( 'ID', $result ) ) {
+		if ( ! is_array( $result ) || ! array_key_exists( 'ID', $result ) ) {
 			return '';
 		}
 
@@ -109,7 +110,7 @@ class WPSEO_Export_Keywords_CSV {
 			if ( in_array( 'keywords_score', $columns, true ) ) {
 				$csv .= ',' . $this->format_csv_column( array_shift( $keywords_score ) );
 			}
-		} while( count( $keywords ) > 0 );
+		} while ( count( $keywords ) > 0 );
 
 		return $csv;
 	}

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @package WPSEO\Admin\Export
+ */
+
+class WPSEO_Export_Keywords_CSV {
+
+	/**
+	 * Exports the supplied keyword query to a CSV string.
+	 *
+	 * @param WPSEO_Export_Keywords_Query $keywords_query The query to export to CSV.
+	 *
+	 * @return string A CSV string.
+	 */
+	public function export( WPSEO_Export_Keywords_Query $keywords_query ) {
+		$csv = $this->get_headers( $keywords_query->get_columns() );
+
+		foreach( $keywords_query->get_data() as $result ) {
+			$csv .= $this->format( $result, $keywords_query->get_columns() );
+		}
+
+		return $csv;
+	}
+
+	/**
+	 * Returns the CSV headers based on the queried columns.
+	 *
+	 * @param array[int]string $columns  The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
+	 *
+	 * @return string A line of CSV, including EOL.
+	 */
+	protected function get_headers( $columns ) {
+		$csv = __( 'ID' );
+
+		if ( in_array( 'post_title', $columns) ) {
+			$csv .= ',' . __( 'post title', 'wordpress-seo' );
+		}
+
+		if ( in_array( 'post_url', $columns) ) {
+			$csv .= ',' . __( 'post url', 'wordpress-seo' );
+		}
+
+		if ( in_array( 'seo_score', $columns) ) {
+			$csv .= ',' . __( 'seo score', 'wordpress-seo' );
+		}
+
+		if ( in_array( 'keywords', $columns) ) {
+			$csv .= ',' . __( 'keyword', 'wordpress-seo' );
+		}
+
+		if ( in_array( 'keywords_score', $columns) ) {
+			$csv .= ',' . __( 'keyword score', 'wordpress-seo' );
+		}
+
+		$csv .= PHP_EOL;
+
+		return $csv;
+	}
+
+	/**
+	 * Formats a WPSEO_Export_Keywords_Query result as a CSV line.
+	 * In case of multiple keywords it will return multiple lines.
+	 *
+	 * @param array[string]string $result A result as returned from WPSEO_Export_Keywords_Query::get_data.
+	 * @param array[int]string $columns The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
+	 *
+	 * @return string A line of CSV, including EOL.
+	 */
+	protected function format( $result, $columns ) {
+		$keywords = array_key_exists( 'keywords' , $result ) ? $result['keywords'] : array();
+		$keywords_score = array_key_exists( 'keywords_score' , $result ) ? $result['keywords_score'] : array();
+		$csv = '';
+
+		// Add at least one row plus additional ones if we have more keywords.
+		do {
+			var_dump( $result );
+			echo PHP_EOL;
+
+			$csv .= '"' . addslashes( $result['ID'] ) . '"';
+
+			if ( in_array( 'post_title', $columns ) ) {
+				$csv .= ',"' . addslashes( $result['post_title'] ) . '"';
+			}
+
+			if ( in_array( 'post_url', $columns ) ) {
+				$csv .= ',"' . addslashes( $result['post_url'] ) . '"';
+			}
+
+			if ( in_array( 'seo_score', $columns ) ) {
+				$csv .= ',"' . addslashes( $result['seo_score'] ) . '"';
+			}
+
+			if ( in_array( 'keywords', $columns ) && count( $keywords ) > 0 ) {
+				$csv .= ',"' . addslashes( array_shift( $keywords ) ) . '"';
+			}
+
+			if ( in_array( 'keywords_score', $columns ) && count( $keywords_score ) > 0 ) {
+				$csv .= ',"' . addslashes( array_shift( $keywords_score ) ) . '"';
+			}
+
+			$csv .= PHP_EOL;
+		} while( count( $keywords ) > 0 );
+
+		return $csv;
+	}
+}

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -27,32 +27,30 @@ class WPSEO_Export_Keywords_CSV {
 	 *
 	 * @param array[int]string $columns  The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
 	 *
-	 * @return string A line of CSV, including EOL.
+	 * @return string A line of CSV.
 	 */
 	protected function get_headers( $columns ) {
-		$csv = __( 'ID' );
+		$csv = $this->format_csv_column( __( 'ID' ) );
 
 		if ( in_array( 'post_title', $columns) ) {
-			$csv .= ',' . __( 'post title', 'wordpress-seo' );
+			$csv .= ',' . $this->format_csv_column( __( 'post title', 'wordpress-seo' ) );
 		}
 
 		if ( in_array( 'post_url', $columns) ) {
-			$csv .= ',' . __( 'post url', 'wordpress-seo' );
+			$csv .= ',' . $this->format_csv_column( __( 'post url', 'wordpress-seo' ) );
 		}
 
 		if ( in_array( 'seo_score', $columns) ) {
-			$csv .= ',' . __( 'seo score', 'wordpress-seo' );
+			$csv .= ',' . $this->format_csv_column( __( 'seo score', 'wordpress-seo' ) );
 		}
 
 		if ( in_array( 'keywords', $columns) ) {
-			$csv .= ',' . __( 'keyword', 'wordpress-seo' );
+			$csv .= ',' . $this->format_csv_column( __( 'keyword', 'wordpress-seo' ) );
 		}
 
 		if ( in_array( 'keywords_score', $columns) ) {
-			$csv .= ',' . __( 'keyword score', 'wordpress-seo' );
+			$csv .= ',' . $this->format_csv_column( __( 'keyword score', 'wordpress-seo' ) );
 		}
-
-		$csv .= PHP_EOL;
 
 		return $csv;
 	}
@@ -64,7 +62,7 @@ class WPSEO_Export_Keywords_CSV {
 	 * @param array[string]string $result A result as returned from WPSEO_Export_Keywords_Query::get_data.
 	 * @param array[int]string $columns The columns as returned from WPSEO_Export_Keywords_Query::get_columns.
 	 *
-	 * @return string A line of CSV, including EOL.
+	 * @return string A line of CSV, beginning with EOL.
 	 */
 	protected function format( $result, $columns ) {
 		$keywords = array_key_exists( 'keywords' , $result ) ? $result['keywords'] : array();
@@ -73,34 +71,40 @@ class WPSEO_Export_Keywords_CSV {
 
 		// Add at least one row plus additional ones if we have more keywords.
 		do {
-			var_dump( $result );
-			echo PHP_EOL;
-
-			$csv .= '"' . addslashes( $result['ID'] ) . '"';
+			$csv .= PHP_EOL . $this->format_csv_column( $result['ID'] );
 
 			if ( in_array( 'post_title', $columns ) ) {
-				$csv .= ',"' . addslashes( $result['post_title'] ) . '"';
+				$csv .= ',' . $this->format_csv_column( $result['post_title'] );
 			}
 
 			if ( in_array( 'post_url', $columns ) ) {
-				$csv .= ',"' . addslashes( $result['post_url'] ) . '"';
+				$csv .= ',' . $this->format_csv_column( $result['post_url'] );
 			}
 
 			if ( in_array( 'seo_score', $columns ) ) {
-				$csv .= ',"' . addslashes( $result['seo_score'] ) . '"';
+				$csv .= ',' . $this->format_csv_column( $result['seo_score'] );
 			}
 
 			if ( in_array( 'keywords', $columns ) && count( $keywords ) > 0 ) {
-				$csv .= ',"' . addslashes( array_shift( $keywords ) ) . '"';
+				$csv .= ',' . $this->format_csv_column( array_shift( $keywords ) );
 			}
 
 			if ( in_array( 'keywords_score', $columns ) && count( $keywords_score ) > 0 ) {
-				$csv .= ',"' . addslashes( array_shift( $keywords_score ) ) . '"';
+				$csv .= ',' . $this->format_csv_column( array_shift( $keywords_score ) );
 			}
-
-			$csv .= PHP_EOL;
 		} while( count( $keywords ) > 0 );
 
 		return $csv;
+	}
+
+	/**
+	 * Surrounds a value with double quotes and escapes existing double quotes.
+	 *
+	 * @param string $value The value to sanitize.
+	 *
+	 * @return string The sanitized value.
+	 */
+	protected function format_csv_column( $value ) {
+		return '"' . str_replace( '"', '""', (string) $value ) . '"';
 	}
 }

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -91,27 +91,46 @@ class WPSEO_Export_Keywords_CSV {
 		do {
 			$csv .= PHP_EOL . $this->format_csv_column( $result['ID'] );
 
-			if ( in_array( 'post_title', $columns, true ) && array_key_exists( 'post_title', $result ) ) {
-				$csv .= ',' . $this->format_csv_column( $result['post_title'] );
-			}
-
-			if ( in_array( 'post_url', $columns, true ) && array_key_exists( 'post_url', $result ) ) {
-				$csv .= ',' . $this->format_csv_column( $result['post_url'] );
-			}
-
-			if ( in_array( 'seo_score', $columns, true ) && array_key_exists( 'seo_score', $result ) ) {
-				$csv .= ',' . $this->format_csv_column( $result['seo_score'] );
-			}
-
-			if ( in_array( 'keywords', $columns, true ) ) {
-				$csv .= ',' . $this->format_csv_column( array_shift( $keywords ) );
-			}
-
-			if ( in_array( 'keywords_score', $columns, true ) ) {
-				$csv .= ',' . $this->format_csv_column( array_shift( $keywords_score ) );
+			foreach ( $columns as $column ) {
+				if ( ! is_string( $column ) ) {
+					continue;
+				}
+				switch ( $column ) {
+					case 'post_title':
+						$csv .= $this->get_csv_column_from_result( $result, 'post_title' );
+						break;
+					case 'post_url':
+						$csv .= $this->get_csv_column_from_result( $result, 'post_url' );
+						break;
+					case 'seo_score':
+						$csv .= $this->get_csv_column_from_result( $result, 'seo_score' );
+						break;
+					case 'keywords':
+						$csv .= ',' . $this->format_csv_column( array_shift( $keywords ) );
+						break;
+					case 'keywords_score':
+						$csv .= ',' . $this->format_csv_column( array_shift( $keywords_score ) );
+						break;
+				}
 			}
 		} while ( count( $keywords ) > 0 );
 
+		return $csv;
+	}
+
+	/**
+	 * Returns a CSV column including comma from the result object by the specified key.
+	 *
+	 * @param array[string]string $result The result object to get the CSV column from.
+	 * @param string $key The key of the value to get the CSV column for.
+	 *
+	 * @return string A CSV column including comma.
+	 */
+	protected function get_csv_column_from_result( $result, $key ) {
+		$csv = ',';
+		if ( is_array( $result ) && is_string( $key ) && array_key_exists( $key, $result ) ) {
+			$csv .= $this->format_csv_column( $result[ $key ] );
+		}
 		return $csv;
 	}
 

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -76,14 +76,8 @@ class WPSEO_Export_Keywords_CSV {
 			return '';
 		}
 
-		$keywords = array();
-		if ( array_key_exists( 'keywords' , $result ) && is_array( $result['keywords'] ) ) {
-			$keywords = $result['keywords'];
-		}
-		$keywords_score = array();
-		if ( array_key_exists( 'keywords_score' , $result ) && is_array( $result['keywords_score'] ) ) {
-			$keywords_score = $result['keywords_score'];
-		}
+		$keywords = $this->get_array_from_result( $result, 'keywords' );
+		$keywords_score = $this->get_array_from_result( $result, 'keywords_score' );
 
 		$csv = '';
 
@@ -116,6 +110,21 @@ class WPSEO_Export_Keywords_CSV {
 		} while ( count( $keywords ) > 0 );
 
 		return $csv;
+	}
+
+	/**
+	 * Returns an array from the result object.
+	 *
+	 * @param array[string]string $result The result object.
+	 * @param string              $key    The key of the array to retrieve.
+	 *
+	 * @return array
+	 */
+	protected function get_array_from_result( $result, $key ) {
+		if ( array_key_exists( $key , $result ) && is_array( $result[ $key ] ) ) {
+			return $result[ $key ];
+		}
+		return array();
 	}
 
 	/**

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -66,7 +66,7 @@ class WPSEO_Export_Keywords_CSV {
 	 */
 	protected function format( $result, $columns ) {
 		// If our input is malformed return an empty string.
-		if ( ! is_array( $result) || ! array_key_exists( 'ID', $result ) || ! is_int( $result['ID'] ) ) {
+		if ( ! is_array( $result) || ! array_key_exists( 'ID', $result ) ) {
 			return '';
 		}
 

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -163,7 +163,7 @@ class WPSEO_Export_Keywords_CSV {
 	 * @return string
 	 */
 	protected function get_csv_array_column_from_result( $result, $key, $index ) {
-		if ( $index < count( $result[ $key ]  ) ) {
+		if ( $index < count( $result[ $key ] ) ) {
 			return ',' . $this->sanitize_csv_column( $result[ $key ][ $index ] );
 		}
 

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -23,7 +23,7 @@ class WPSEO_Export_Keywords_CSV {
 	 *
 	 * @param array $columns An array of columns that should be presented.
 	 */
-	public function __construct( $columns ) {
+	public function __construct( array $columns ) {
 		$this->columns = array_filter( $columns, 'is_string' );
 	}
 
@@ -34,7 +34,7 @@ class WPSEO_Export_Keywords_CSV {
 	 *
 	 * @return string A CSV string.
 	 */
-	public function export( $data ) {
+	public function export( array $data ) {
 
 		$csv = $this->get_headers();
 

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -30,7 +30,7 @@ class WPSEO_Export_Keywords_CSV {
 	/**
 	 * Exports the supplied keyword query to a CSV string.
 	 *
-	 * @param array $data    An array of results from WPSEO_Export_Keywords_Query::get_data.
+	 * @param array $data An array of results from WPSEO_Export_Keywords_Query::get_data.
 	 *
 	 * @return string A CSV string.
 	 */
@@ -74,7 +74,7 @@ class WPSEO_Export_Keywords_CSV {
 	 * Formats a WPSEO_Export_Keywords_Query result as a CSV line.
 	 * In case of multiple keywords it will return multiple lines.
 	 *
-	 * @param array $result  A result as returned from WPSEO_Export_Keywords_Query::get_data.
+	 * @param array $result A result as returned from WPSEO_Export_Keywords_Query::get_data.
 	 *
 	 * @return string A line of CSV, beginning with EOL.
 	 */
@@ -85,7 +85,7 @@ class WPSEO_Export_Keywords_CSV {
 		}
 
 		// Ensure we have arrays in the keywords.
-		$result['keywords'] = $this->get_array_from_result( $result, 'keywords' );
+		$result['keywords']       = $this->get_array_from_result( $result, 'keywords' );
 		$result['keywords_score'] = $this->get_array_from_result( $result, 'keywords_score' );
 
 		$csv = '';

--- a/admin/export/class-export-keywords-csv.php
+++ b/admin/export/class-export-keywords-csv.php
@@ -3,6 +3,11 @@
  * @package WPSEO\Admin\Export
  */
 
+/**
+ * Class WPSEO_Export_Keywords_CSV
+ *
+ * Exports data as returned by WPSEO_Export_Keywords_Presenter to CSV.
+ */
 class WPSEO_Export_Keywords_CSV {
 
 	/**

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -57,10 +57,8 @@ class WPSEO_Export_Keywords_Manager {
 	 * Sets the headers to trigger an CSV download in the browser.
 	 */
 	protected function set_csv_headers() {
-		$datestring = preg_replace( '/\s/', '-', date_i18n( get_option( 'date_format' ) ) );
-
 		header( 'Content-type: text/csv' );
-		header( 'Content-Disposition: attachment; filename=' . $datestring . 'wordpress-seo-keywords.csv' );
+		header( 'Content-Disposition: attachment; filename=' . date('Y-m-d') . '-wordpress-seo-keywords.csv' );
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
 	}

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -62,7 +62,8 @@ class WPSEO_Export_Keywords_Manager {
 	 * @return string A CSV string.
 	 */
 	protected function get_csv_contents() {
-		$query = new WPSEO_Export_Keywords_Query( $this->get_export_columns() );
+		global $wpdb;
+		$query = new WPSEO_Export_Keywords_Query( $this->get_export_columns(), $wpdb );
 
 		$builder = new WPSEO_Export_Keywords_CSV();
 		return $builder->export( $query );

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @package WPSEO\Admin\Export
+ */
+
+class WPSEO_Export_Keywords_Manager {
+	/**
+	 * Registers all hooks to WordPress.
+	 */
+	public function register_hooks() {
+		// Hijack the request in case of CSV download and return our generated CSV instead.
+		add_action( 'admin_init', array( $this, 'keywords_csv_export' ) );
+	}
+
+	/**
+	 * Hijacks the request and returns a CSV file if we're on the right page with the right method and the right capabilities.
+	 */
+	public function keywords_csv_export() {
+		if ( $this->is_valid_csv_export_request() && current_user_can( 'export' ) ) {
+			// Check if we have a valid nonce.
+			check_admin_referer( 'wpseo-export' );
+
+			// Clean any content that has been already outputted, for example by other plugins or faulty PHP files.
+			if ( ob_get_contents() ) {
+				ob_clean();
+			}
+
+			// Set CSV headers and content.
+			$this->set_csv_headers();
+			echo $this->get_csv_contents();
+
+			// And exit so we don't start appending HTML to our CSV file.
+			// NOTE: this makes this entire class untestable as it will exit all tests but WordPress seems to have no elegant way of handling this.
+			exit();
+		}
+	}
+
+	/**
+	 * Are we on the wpseo_tools page in the import-export tool and have we received an export-keywords post request?
+	 *
+	 * @return bool
+	 */
+	protected function is_valid_csv_export_request() {
+		return filter_input( INPUT_GET, 'page' ) === 'wpseo_tools' &&
+			   filter_input( INPUT_GET, 'tool' ) === 'import-export' &&
+			   filter_input( INPUT_POST, 'export-posts' );
+	}
+
+	/**
+	 * Sets the headers to trigger an CSV download in the browser.
+	 */
+	protected function set_csv_headers() {
+		header( 'Content-type: text/csv' );
+		header( 'Content-Disposition: attachment; filename=wordpress-seo-keywords.csv' );
+		header( 'Pragma: no-cache' );
+		header( 'Expires: 0' );
+	}
+
+	/**
+	 * Generates CSV from all posts.
+	 *
+	 * @return string A CSV string.
+	 */
+	protected function get_csv_contents() {
+		$query = new WPSEO_Export_Keywords_Query( $this->get_export_columns() );
+
+		$builder = new WPSEO_Export_Keywords_CSV();
+		return $builder->export( $query );
+	}
+
+	/**
+	 * Returns a string array of the requested columns.
+	 *
+	 * @return array[int]string
+	 */
+	protected function get_export_columns() {
+		$columns = array();
+		$post_wpseo = filter_input( INPUT_POST, 'wpseo', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+
+		if ( ! empty( $post_wpseo['export-post-title'] ) ) {
+			$columns[] = 'post_title';
+		}
+
+		if ( ! empty( $post_wpseo['export-post-url'] ) ) {
+			$columns[] = 'post_url';
+		}
+
+		if ( ! empty( $post_wpseo['export-seo-score'] ) ) {
+			$columns[] = 'seo_score';
+		}
+
+		if ( ! empty( $post_wpseo['export-keywords'] ) ) {
+			$columns[] = 'keywords';
+		}
+
+		if ( ! empty( $post_wpseo['export-keywords-score'] ) ) {
+			$columns[] = 'keywords_score';
+		}
+
+		return $columns;
+	}
+}

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -13,12 +13,12 @@ class WPSEO_Export_Keywords_Manager {
 	 * Registers all hooks to WordPress.
 	 */
 	public function register_hooks() {
-		// Hijack the request in case of CSV download and return our generated CSV instead.
+		// Hook into the request in case of CSV download and return our generated CSV instead.
 		add_action( 'admin_init', array( $this, 'keywords_csv_export' ) );
 	}
 
 	/**
-	 * Hijacks the request and returns a CSV file if we're on the right page with the right method and the right capabilities.
+	 * Hooks into the request and returns a CSV file if we're on the right page with the right method and the right capabilities.
 	 */
 	public function keywords_csv_export() {
 		if ( $this->is_valid_csv_export_request() && current_user_can( 'export' ) ) {
@@ -41,9 +41,9 @@ class WPSEO_Export_Keywords_Manager {
 	}
 
 	/**
-	 * Are we on the wpseo_tools page in the import-export tool and have we received an export-keywords post request?
+	 * Returns whether this is a POST request for a CSV export of posts and keywords.
 	 *
-	 * @return bool
+	 * @return bool True if this is a valid CSV export request.
 	 */
 	protected function is_valid_csv_export_request() {
 		return filter_input( INPUT_GET, 'page' ) === 'wpseo_tools' &&
@@ -71,9 +71,10 @@ class WPSEO_Export_Keywords_Manager {
 		$columns = $this->get_export_columns();
 
 		$query = new WPSEO_Export_Keywords_Query( $columns, $wpdb );
+		$presenter = new WPSEO_Export_Keywords_Presenter( $columns );
+
 		$results = $query->get_data();
 
-		$presenter = new WPSEO_Export_Keywords_Presenter( $columns );
 		$data = array_map( array( $presenter, 'present' ), $results );
 
 		$builder = new WPSEO_Export_Keywords_CSV();
@@ -83,7 +84,7 @@ class WPSEO_Export_Keywords_Manager {
 	/**
 	 * Returns a string array of the requested columns.
 	 *
-	 * @return array[int]string
+	 * @return array The requested columns.
 	 */
 	protected function get_export_columns() {
 		$columns = array();

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -66,9 +66,10 @@ class WPSEO_Export_Keywords_Manager {
 		$columns = $this->get_export_columns();
 
 		$query = new WPSEO_Export_Keywords_Query( $columns, $wpdb );
+		$results = $query->get_data();
 
 		$presenter = new WPSEO_Export_Keywords_Presenter( $columns );
-		$data = array_map( array( $presenter, 'present' ), $query->get_data() );
+		$data = array_map( array( $presenter, 'present' ), $results );
 
 		$builder = new WPSEO_Export_Keywords_CSV();
 		return $builder->export( $data, $columns );

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -8,7 +8,7 @@
  *
  * Manages exporting keywords.
  */
-class WPSEO_Export_Keywords_Manager {
+class WPSEO_Export_Keywords_Manager implements WPSEO_WordPress_Integration {
 	/**
 	 * Registers all hooks to WordPress.
 	 */

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -58,7 +58,7 @@ class WPSEO_Export_Keywords_Manager {
 	 */
 	protected function set_csv_headers() {
 		header( 'Content-type: text/csv' );
-		header( 'Content-Disposition: attachment; filename=' . date('Y-m-d') . '-wordpress-seo-keywords.csv' );
+		header( 'Content-Disposition: attachment; filename=' . date( 'Y-m-d' ) . '-wordpress-seo-keywords.csv' );
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
 	}

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -3,6 +3,11 @@
  * @package WPSEO\Admin\Export
  */
 
+/**
+ * Class WPSEO_Export_Keywords_Manager
+ *
+ * Manages exporting keywords.
+ */
 class WPSEO_Export_Keywords_Manager {
 	/**
 	 * Registers all hooks to WordPress.

--- a/admin/export/class-export-keywords-manager.php
+++ b/admin/export/class-export-keywords-manager.php
@@ -63,10 +63,15 @@ class WPSEO_Export_Keywords_Manager {
 	 */
 	protected function get_csv_contents() {
 		global $wpdb;
-		$query = new WPSEO_Export_Keywords_Query( $this->get_export_columns(), $wpdb );
+		$columns = $this->get_export_columns();
+
+		$query = new WPSEO_Export_Keywords_Query( $columns, $wpdb );
+
+		$presenter = new WPSEO_Export_Keywords_Presenter( $columns );
+		$data = array_map( array( $presenter, 'present' ), $query->get_data() );
 
 		$builder = new WPSEO_Export_Keywords_CSV();
-		return $builder->export( $query );
+		return $builder->export( $data, $columns );
 	}
 
 	/**

--- a/admin/export/class-export-keywords-presenter.php
+++ b/admin/export/class-export-keywords-presenter.php
@@ -88,7 +88,8 @@ class WPSEO_Export_Keywords_Presenter {
 					foreach( $keywords as $keyword ) {
 						$result['keywords'][] = $keyword['keyword'];
 						if ( in_array( 'keywords_score', $this->columns, true ) ) {
-							$result['keywords_score'][] = ( new WPSEO_Rank( $keyword['score'] ) )->get_rank();
+							$rank = new WPSEO_Rank( $keyword['score'] );
+							$result['keywords_score'][] = $rank->get_rank();
 						}
 					}
 				}

--- a/admin/export/class-export-keywords-presenter.php
+++ b/admin/export/class-export-keywords-presenter.php
@@ -100,22 +100,18 @@ class WPSEO_Export_Keywords_Presenter {
 		if ( array_key_exists( 'primary_keyword', $result ) && $result['primary_keyword'] ) {
 			$result['keywords'][] = $result['primary_keyword'];
 
+			// Convert multiple keywords from the Premium plugin from json to string arrays.
+			$keywords = $this->parse_result_keywords_json( $result, 'other_keywords' );
+			foreach ( $keywords as $keyword ) {
+				$result['keywords'][] = $keyword['keyword'];
+			}
+
 			if ( in_array( 'keywords_score', $this->columns, true ) ) {
 				$rank = WPSEO_Rank::from_numeric_score( intval( $result['primary_keyword_score'] ) );
 				$result['keywords_score'][] = $rank->get_rank();
-			}
-
-			// Convert multiple keywords from the Premium plugin from json to string arrays.
-			if ( array_key_exists( 'other_keywords', $result ) && $result['other_keywords'] ) {
-				$keywords = json_decode( $result['other_keywords'], true );
-				if ( $keywords ) {
-					foreach ( $keywords as $keyword ) {
-						$result['keywords'][] = $keyword['keyword'];
-						if ( in_array( 'keywords_score', $this->columns, true ) ) {
-							$rank = new WPSEO_Rank( $keyword['score'] );
-							$result['keywords_score'][] = $rank->get_rank();
-						}
-					}
+				foreach ( $keywords as $keyword ) {
+					$rank = new WPSEO_Rank( $keyword['score'] );
+					$result['keywords_score'][] = $rank->get_rank();
 				}
 			}
 		}
@@ -126,5 +122,24 @@ class WPSEO_Export_Keywords_Presenter {
 		unset( $result['other_keywords'] );
 
 		return $result;
+	}
+
+	/**
+	 * Parses keywords JSON in the result object from the specified key.
+	 *
+	 * @param array[string]string $result The result object.
+	 * @param string              $key    The key containing the JSON.
+	 *
+	 * @return array[string]string The parsed keywords.
+	 */
+	protected function parse_result_keywords_json( $result, $key ) {
+		if ( array_key_exists( $key, $result ) && $result[ $key ] ) {
+			$parsed = json_decode( $result[ $key ], true );
+			if ( $parsed ) {
+				return $parsed;
+			}
+		}
+
+		return array();
 	}
 }

--- a/admin/export/class-export-keywords-presenter.php
+++ b/admin/export/class-export-keywords-presenter.php
@@ -109,7 +109,7 @@ class WPSEO_Export_Keywords_Presenter {
 			}
 
 			if ( in_array( 'keywords_score', $this->columns, true ) ) {
-				$result['keywords)score'] = $this->get_result_keywords_scores( $result, $keywords );
+				$result['keywords_score'] = $this->get_result_keywords_scores( $result, $keywords );
 			}
 		}
 

--- a/admin/export/class-export-keywords-presenter.php
+++ b/admin/export/class-export-keywords-presenter.php
@@ -3,6 +3,11 @@
  * @package WPSEO\Admin\Export
  */
 
+/**
+ * Class WPSEO_Export_Keywords_Presenter
+ *
+ * Readies data as returned by WPSEO_Export_Keywords_Query for exporting.
+ */
 class WPSEO_Export_Keywords_Presenter {
 	/**
 	 * @var array[int]string The columns to query for, an array of strings.

--- a/admin/export/class-export-keywords-presenter.php
+++ b/admin/export/class-export-keywords-presenter.php
@@ -35,7 +35,7 @@ class WPSEO_Export_Keywords_Presenter {
 	 */
 	public function present( $result ) {
 		// If our input is malformed return false.
-		if ( ! is_array( $result) || ! array_key_exists( 'ID', $result ) ) {
+		if ( ! is_array( $result ) || ! array_key_exists( 'ID', $result ) ) {
 			return false;
 		}
 
@@ -90,7 +90,7 @@ class WPSEO_Export_Keywords_Presenter {
 			if ( array_key_exists( 'other_keywords', $result ) && $result['other_keywords'] ) {
 				$keywords = json_decode( $result['other_keywords'], true );
 				if ( $keywords ) {
-					foreach( $keywords as $keyword ) {
+					foreach ( $keywords as $keyword ) {
 						$result['keywords'][] = $keyword['keyword'];
 						if ( in_array( 'keywords_score', $this->columns, true ) ) {
 							$rank = new WPSEO_Rank( $keyword['score'] );

--- a/admin/export/class-export-keywords-presenter.php
+++ b/admin/export/class-export-keywords-presenter.php
@@ -30,7 +30,7 @@ class WPSEO_Export_Keywords_Presenter {
 	 */
 	public function present( $result ) {
 		// If our input is malformed return false.
-		if ( ! is_array( $result) || ! array_key_exists( 'ID', $result ) || ! is_int( $result['ID'] ) ) {
+		if ( ! is_array( $result) || ! array_key_exists( 'ID', $result ) ) {
 			return false;
 		}
 

--- a/admin/export/class-export-keywords-presenter.php
+++ b/admin/export/class-export-keywords-presenter.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @package WPSEO\Admin\Export
+ */
+
+class WPSEO_Export_Keywords_Presenter {
+	/**
+	 * @var array[int]string The columns to query for, an array of strings.
+	 */
+	protected $columns;
+
+	/**
+	 * WPSEO_Export_Keywords_Presenter constructor.
+	 *
+	 * Supported values for columns are 'post_title', 'post_url', 'keywords', 'seo_score' and 'keywords_score'.
+	 * Requesting 'keywords_score' will always also return 'keywords'.
+	 *
+	 * @param array[int]string $columns The columns we want our query to return.
+	 */
+	public function __construct( $columns ) {
+		$this->columns = $columns;
+	}
+
+	/**
+	 * Updates a result by modifying and adding the requested fields.
+	 *
+	 * @param array[string]string $result The result to modify.
+	 *
+	 * @return bool|array[string]string The modified result, false if the result could not be modified.
+	 */
+	public function present( $result ) {
+		// If our input is malformed return false.
+		if ( ! is_array( $result) || ! array_key_exists( 'ID', $result ) || ! is_int( $result['ID'] ) ) {
+			return false;
+		}
+
+		// If post titles were selected run their filters.
+		if ( in_array( 'post_title', $this->columns, true ) ) {
+			if ( ! array_key_exists( 'post_title', $result ) || ! is_string( $result['post_title'] ) ) {
+				return false;
+			}
+
+			$result['post_title'] = apply_filters( 'the_title', $result['post_title'], $result['ID'] );
+		}
+
+		// If post urls were selected add them to our results.
+		if ( in_array( 'post_url', $this->columns, true ) ) {
+			$result['post_url'] = get_permalink( $result['ID'] );
+		}
+
+		// If SEO scores were selected convert them to nice ratings.
+		if ( in_array( 'seo_score', $this->columns, true ) ) {
+			$result['seo_score'] = WPSEO_Rank::from_numeric_score( intval( $result['seo_score'] ) )->get_rank();
+		}
+
+		// If keywords were selected we need to convert them to a better format.
+		if ( in_array( 'keywords', $this->columns, true ) || in_array( 'keywords_score', $this->columns, true ) ) {
+			$result = $this->convert_result_keywords( $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Converts the results of the query from strings and JSON string to keyword arrays.
+	 *
+	 * @param array[string]string $result The result to convert.
+	 *
+	 * @return array[string]string The converted result.
+	 */
+	protected function convert_result_keywords( $result ) {
+		$result['keywords'] = array();
+		if ( in_array( 'keywords_score', $this->columns, true ) ) {
+			$result['keywords_score'] = array();
+		}
+
+		if ( $result['primary_keyword'] ) {
+			$result['keywords'][] = $result['primary_keyword'];
+
+			if ( in_array( 'keywords_score', $this->columns, true ) ) {
+				$result['keywords_score'][] = WPSEO_Rank::from_numeric_score( intval( $result['primary_keyword_score'] ) )->get_rank();
+			}
+
+			// Convert multiple keywords from the Premium plugin from json to string arrays.
+			if ( array_key_exists( 'other_keywords', $result ) && $result['other_keywords'] ) {
+				$keywords = json_decode( $result['other_keywords'], true );
+				if ( $keywords ) {
+					foreach( $keywords as $keyword ) {
+						$result['keywords'][] = $keyword['keyword'];
+						if ( in_array( 'keywords_score', $this->columns, true ) ) {
+							$result['keywords_score'][] = ( new WPSEO_Rank( $keyword['score'] ) )->get_rank();
+						}
+					}
+				}
+			}
+		}
+
+		// Unset all old variables, if they do not exist nothing will happen.
+		unset( $result['primary_keyword'] );
+		unset( $result['primary_keyword_score'] );
+		unset( $result['other_keywords'] );
+
+		return $result;
+	}
+}

--- a/admin/export/class-export-keywords-query.php
+++ b/admin/export/class-export-keywords-query.php
@@ -37,6 +37,7 @@ class WPSEO_Export_Keywords_Query {
 	 * Requesting 'keywords_score' will always also return 'keywords'.
 	 *
 	 * @param array[int]string $columns The columns we want our query to return.
+	 * @param wpdb             $wpdb    A Wordpress Database object.
 	 */
 	public function __construct( $columns, $wpdb ) {
 		$this->columns = $columns;
@@ -47,13 +48,13 @@ class WPSEO_Export_Keywords_Query {
 	 * Constructs the query and executes it, returning an array of objects containing the columns this object was constructed with.
 	 * Every object will always contain the ID column.
 	 *
-	 * @return array[int][tring]string array of associative arrays containing the keys as requested in the constructor.
+	 * @return array[int][string]string array of associative arrays containing the keys as requested in the constructor.
 	 */
 	public function get_data() {
 		$this->set_columns();
 
 		// Get all public post types and run esc_sql on them.
-		$post_types = join('", "', array_map( 'esc_sql', get_post_types( array( 'public' => true ), 'names' ) ) );
+		$post_types = join( '", "', array_map( 'esc_sql', get_post_types( array( 'public' => true ), 'names' ) ) );
 
 		// Construct the query.
 		$query = 'SELECT ' . join( ', ', $this->selects ) . ' FROM ' . $this->wpdb->prefix . 'posts ' . join( ' ', $this->joins ) .

--- a/admin/export/class-export-keywords-query.php
+++ b/admin/export/class-export-keywords-query.php
@@ -103,6 +103,6 @@ class WPSEO_Export_Keywords_Query {
 		$this->selects[] = $alias . '_join.meta_value AS ' . $alias;
 		$this->joins[] = 'LEFT OUTER JOIN ' . $this->wpdb->prefix . 'postmeta AS ' . $alias . '_join ' .
 						 'ON ' . $alias . '_join.post_id = ' . $this->wpdb->prefix . 'posts.ID ' .
-						 'AND ' .$alias . '_join.meta_key = "' . $key . '"';
+						 'AND ' . $alias . '_join.meta_key = "' . $key . '"';
 	}
 }

--- a/admin/export/class-export-keywords-query.php
+++ b/admin/export/class-export-keywords-query.php
@@ -11,7 +11,7 @@
 class WPSEO_Export_Keywords_Query {
 
 	/**
-	 * @var wpdb wpdb The WordPress database object.
+	 * @var wpdb The WordPress database object.
 	 */
 	protected $wpdb;
 

--- a/admin/export/class-export-keywords-query.php
+++ b/admin/export/class-export-keywords-query.php
@@ -11,22 +11,22 @@
 class WPSEO_Export_Keywords_Query {
 
 	/**
-	 * @var wpdb wpdb The wordpress database object.
+	 * @var wpdb wpdb The WordPress database object.
 	 */
 	protected $wpdb;
 
 	/**
-	 * @var array[int]string The columns to query for, an array of strings.
+	 * @var array The columns to query for, an array of strings.
 	 */
 	protected $columns;
 
 	/**
-	 * @var array[int]string The database columns to select in the query, an array of strings.
+	 * @var array The database columns to select in the query, an array of strings.
 	 */
 	protected $selects;
 
 	/**
-	 * @var array[int]string The database tables to join in the query, an array of strings.
+	 * @var array The database tables to join in the query, an array of strings.
 	 */
 	protected $joins = array();
 
@@ -36,8 +36,8 @@ class WPSEO_Export_Keywords_Query {
 	 * Supported values for columns are 'post_title', 'post_url', 'keywords', 'seo_score' and 'keywords_score'.
 	 * Requesting 'keywords_score' will always also return 'keywords'.
 	 *
-	 * @param array[int]string $columns The columns we want our query to return.
-	 * @param wpdb             $wpdb    A Wordpress Database object.
+	 * @param array $columns The columns we want our query to return.
+	 * @param wpdb  $wpdb    A WordPress Database object.
 	 */
 	public function __construct( $columns, $wpdb ) {
 		$this->columns = $columns;
@@ -48,7 +48,7 @@ class WPSEO_Export_Keywords_Query {
 	 * Constructs the query and executes it, returning an array of objects containing the columns this object was constructed with.
 	 * Every object will always contain the ID column.
 	 *
-	 * @return array[int][string]string array of associative arrays containing the keys as requested in the constructor.
+	 * @return array An array of associative arrays containing the keys as requested in the constructor.
 	 */
 	public function get_data() {
 		$this->set_columns();
@@ -64,7 +64,7 @@ class WPSEO_Export_Keywords_Query {
 	}
 
 	/**
-	 * Constructs our query by preparing the necessary selects and joins to get all our data in a single query.
+	 * Prepares the necessary selects and joins to get all data in a single query.
 	 */
 	protected function set_columns() {
 		$this->selects = array( $this->wpdb->prefix . 'posts.ID' );
@@ -84,14 +84,14 @@ class WPSEO_Export_Keywords_Query {
 		}
 
 		if ( in_array( 'keywords_score', $this->columns, true ) ) {
+			// Score for other keywords is already in the other_keywords select so only join for the primary_keyword_score.
 			$this->add_meta_join( 'primary_keyword_score', WPSEO_Meta::$meta_prefix . 'linkdex' );
-			// Score for other keywords is already in the other_keywords select.
 		}
 	}
 
 	/**
 	 * Adds an aliased join to the $wpdb->postmeta table so that multiple meta values can be selected in a single row.
-	 * While this function should never be used with user input all non-word non-digit characters are removed from both params to be idiot-proof.
+	 * While this function should never be used with user input all non-word non-digit characters are removed from both params for increased robustness.
 	 *
 	 * @param string $alias The alias to use in our query output.
 	 * @param string $key The meta_key to select.

--- a/admin/export/class-export-keywords-query.php
+++ b/admin/export/class-export-keywords-query.php
@@ -3,10 +3,15 @@
  * @package WPSEO\Admin\Export
  */
 
+/**
+ * Class WPSEO_Export_Keywords_Query
+ *
+ * Creates a SQL query to gather all data for a keywords export.
+ */
 class WPSEO_Export_Keywords_Query {
 
 	/**
-	 * @var wpdb The wordpress database object.
+	 * @var wpdb wpdb The wordpress database object.
 	 */
 	protected $wpdb;
 

--- a/admin/export/class-export-keywords-query.php
+++ b/admin/export/class-export-keywords-query.php
@@ -39,7 +39,7 @@ class WPSEO_Export_Keywords_Query {
 	 * @param array $columns The columns we want our query to return.
 	 * @param wpdb  $wpdb    A WordPress Database object.
 	 */
-	public function __construct( $columns, $wpdb ) {
+	public function __construct( array $columns, $wpdb ) {
 		$this->columns = $columns;
 		$this->wpdb = $wpdb;
 	}

--- a/admin/export/class-export-keywords-query.php
+++ b/admin/export/class-export-keywords-query.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * @package WPSEO\Admin\Export
+ */
+
+class WPSEO_Export_Keywords_Query {
+
+	/**
+	 * @var array[int]string The columns to query for, an array of strings.
+	 */
+	private $columns;
+
+	/**
+	 * @var array[int][string]string The results of the query, an array of associative arrays.
+	 */
+	private $results;
+
+	/**
+	 * @var array[int]string The database columns to select in the query, an array of strings.
+	 */
+	private $selects;
+
+	/**
+	 * @var array[int]string The database tables to join in the query, an array of strings.
+	 */
+	private $joins = array();
+
+	/**
+	 * WPSEO_Export_Keywords_Query constructor.
+	 *
+	 * Supported values for columns are 'post_title', 'post_url', 'keywords', 'seo_score' and 'keywords_score'.
+	 * Requesting 'keywords_score' will always also return 'keywords'.
+	 *
+	 * @param array[int]string $columns The columns we want our query to return.
+	 */
+	public function __construct( $columns ) {
+		$this->columns = $columns;
+	}
+
+	/**
+	 * @return array[int]string The columns to query for, an array of strings.
+	 */
+	public function get_columns() {
+		return $this->columns;
+	}
+
+	/**
+	 * Constructs the query and executes it, returning an array of objects containing the columns this object was constructed with.
+	 * Every object will always contain the ID column.
+	 *
+	 * @return array[int][tring]string array of associative arrays containing the keys as requested in the constructor.
+	 */
+	public function get_data() {
+		global $wpdb;
+
+		$this->set_columns();
+
+		$post_types = join('", "', array_map( 'esc_sql', get_post_types( array( 'public' => true ), 'names' ) ) );
+		$query = 'SELECT ' . join( ', ', $this->selects ) . ' FROM ' . $wpdb->prefix . 'posts ' . join( ' ', $this->joins ) .
+				 ' WHERE ' . $wpdb->prefix . 'posts.post_status = "publish" AND ' . $wpdb->prefix . 'posts.post_type IN ("' . $post_types . '");';
+		$this->results = $wpdb->get_results( $query, ARRAY_A );
+
+		// If post urls were selected we need to add them to our results.
+		if ( in_array( 'post_url', $this->columns ) ) {
+			$this->add_post_urls();
+		}
+
+		// If keywords were selected we need to convert them to a better format.
+		if ( in_array( 'keywords', $this->columns ) || in_array( 'keywords_score', $this->columns ) ) {
+			$this->convert_result_keywords();
+		}
+
+		return $this->results;
+	}
+
+	/**
+	 * Constructs our query by preparing the necessary selects and joins to get all our data in a single query.
+	 */
+	protected function set_columns() {
+		global $wpdb;
+
+		$this->selects = array( $wpdb->prefix . 'posts.ID' );
+
+		if ( in_array( 'post_title', $this->columns ) ) {
+			array_push( $this->selects, $wpdb->prefix . 'posts.post_title' );
+		}
+
+		// If we're selecting keywords_score then we always want the keywords as well.
+		if ( in_array( 'keywords', $this->columns ) || in_array( 'keywords_score', $this->columns ) ) {
+			$this->add_meta_join( 'primary_keyword', WPSEO_Meta::$meta_prefix . 'focuskw' );
+			$this->add_meta_join( 'other_keywords', WPSEO_Meta::$meta_prefix . 'focuskeywords' );
+		}
+
+		if ( in_array( 'seo_score', $this->columns ) ) {
+			$this->add_meta_join( 'seo_score', WPSEO_Meta::$meta_prefix . 'content_score' );
+		}
+
+		if ( in_array( 'keywords_score', $this->columns ) ) {
+			$this->add_meta_join( 'primary_keyword_score', WPSEO_Meta::$meta_prefix . 'linkdex' );
+			// Score for other keywords is already in the other_keywords select.
+		}
+	}
+
+	/**
+	 * Adds an aliased join to the $wpdb->postmeta table so that multiple meta values can be selected in a single row.
+	 * While this function should never be used with user input all non-word non-digit characters are removed from both params to be idiot-proof.
+	 *
+	 * @param string $alias The alias to use in our query output.
+	 * @param string $key The meta_key to select.
+	 */
+	protected function add_meta_join( $alias, $key ) {
+		global $wpdb;
+
+		$alias = preg_replace( '/[^\w\d]/', '', $alias );
+		$key = preg_replace( '/[^\w\d]/', '', $key );
+
+		array_push( $this->selects, $alias . '_join.meta_value AS ' . $alias );
+		array_push( $this->joins,
+			'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS ' . $alias . '_join ' .
+			'ON ' . $alias . '_join.post_id = ' . $wpdb->prefix . 'posts.ID AND ' . $alias . '_join.meta_key = "' . $key . '"');
+	}
+
+	/**
+	 * Add post URLs to all results.
+	 */
+	protected function add_post_urls() {
+		$converted = array();
+
+		foreach ( $this->results as $result ) {
+			$result['post_url'] = get_permalink( $result['ID'] );
+
+			$converted[] = $result;
+		}
+
+		$this->results = $converted;
+	}
+
+	/**
+	 * Converts the results of the query from strings and JSON string to keyword arrays.
+	 */
+	protected function convert_result_keywords() {
+		$converted = array();
+
+		foreach ( $this->results as $result ) {
+			$result['keywords'] = array( $result['primary_keyword'] );
+
+			if ( in_array( 'keywords_score', $this->columns ) ) {
+				$result['keywords_score'] = array( $this->get_rating_from_int_score( $result['primary_keyword_score'] ) );
+			}
+
+			// Convert multiple keywords from the Premium plugin from json to string arrays.
+			if ( array_key_exists( 'other_keywords', $result ) && $result['other_keywords'] ) {
+				$keywords = json_decode( $result['other_keywords'], true );
+				foreach( $keywords as $keyword ) {
+					$result['keywords'][] = $keyword['keyword'];
+					if ( in_array( 'keywords_score', $this->columns ) ) {
+						$result['keywords_score'][] = $this->get_rating_from_string_score( $keyword['score'] );
+					}
+				}
+			}
+
+			// Unset all old variables, if they do not exist nothing will happen.
+			unset( $result['primary_keyword'] );
+			unset( $result['primary_keyword_score'] );
+			unset( $result['other_keywords'] );
+
+			$converted[] = $result;
+		}
+
+		$this->results = $converted;
+	}
+
+	/**
+	 * Converts an integer keyword score to a friendly rating.
+	 *
+	 * @param int $score A score, normally from 0 to 100.
+	 *
+	 * @return string
+	 */
+	protected function get_rating_from_int_score( $score ) {
+		if ( $score > 0 && $score <= 40 ) {
+			return __( "needs improvement" );
+		}
+
+		if ( $score > 40 && $score <= 70 ) {
+			return __( "ok" );
+		}
+
+		if ( $score > 70 ) {
+			return __( "good" );
+		}
+
+		return __( "none" );
+	}
+
+	/**
+	 * Converts an unfriendly integer keyword score to a friendly rating.
+	 *
+	 * @param string $score A score, normally 'na', 'bad', 'ok' or 'good'.
+	 *
+	 * @return string
+	 */
+	protected function get_rating_from_string_score( $score ) {
+		if ( $score === 'bad' ) {
+			return __( "needs improvement" );
+		}
+
+		if ( $score === 'ok' ) {
+			return __( 'ok' );
+		}
+
+		if ( $score === 'good' ) {
+			return __( 'good' );
+		}
+
+		return __( 'none' );
+	}
+}

--- a/admin/views/tabs/tool/export-keywords.php
+++ b/admin/views/tabs/tool/export-keywords.php
@@ -13,12 +13,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 <h2><?php __( 'Export keywords to a CSV file', 'wordpress-seo' ); ?></h2>
 <form action="" method="post" accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php
-    wp_nonce_field( 'wpseo-export', '_wpnonce', true );
-    $yform->checkbox( 'export-post-title', __( 'Export post title', 'wordpress-seo' ) );
+	wp_nonce_field( 'wpseo-export', '_wpnonce', true );
+	$yform->set_options_value( 'export-post-title', true );
+	$yform->checkbox( 'export-post-title', __( 'Export post title', 'wordpress-seo' ) );
+	$yform->set_options_value( 'export-post-url', true );
 	$yform->checkbox( 'export-post-url', __( 'Export post URL', 'wordpress-seo' ) );
-    $yform->checkbox( 'export-seo-score', __( 'Export SEO score', 'wordpress-seo' ) );
-    $yform->checkbox( 'export-keywords', __( 'Export keywords', 'wordpress-seo' ) );
-    $yform->checkbox( 'export-keywords-score', __( 'Export keyword scores', 'wordpress-seo' ) );
+	$yform->checkbox( 'export-seo-score', __( 'Export SEO score', 'wordpress-seo' ) );
+	$yform->set_options_value( 'export-keywords', true );
+	$yform->checkbox( 'export-keywords', __( 'Export keywords', 'wordpress-seo' ) );
+	$yform->checkbox( 'export-keywords-score', __( 'Export keyword scores', 'wordpress-seo' ) );
 	?>
 	<input type="submit" class="button button-primary" name="export-posts" value="<?php echo __( 'Export keywords', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tabs/tool/export-keywords.php
+++ b/admin/views/tabs/tool/export-keywords.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package WPSEO\Admin\Views
+ */
+
+if ( ! defined( 'WPSEO_VERSION' ) ) {
+	header( 'Status: 403 Forbidden' );
+	header( 'HTTP/1.1 403 Forbidden' );
+	exit();
+}
+
+?>
+<h2><?php __( 'Export keywords to a CSV file', 'wordpress-seo' ); ?></h2>
+<form action="" method="post" accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
+	<?php
+    wp_nonce_field( 'wpseo-export', '_wpnonce', true );
+    $yform->checkbox( 'export-post-title', __( 'Export post title', 'wordpress-seo' ) );
+	$yform->checkbox( 'export-post-url', __( 'Export post URL', 'wordpress-seo' ) );
+    $yform->checkbox( 'export-seo-score', __( 'Export SEO score', 'wordpress-seo' ) );
+    $yform->checkbox( 'export-keywords', __( 'Export keywords', 'wordpress-seo' ) );
+    $yform->checkbox( 'export-keywords-score', __( 'Export keyword scores', 'wordpress-seo' ) );
+	?>
+	<input type="submit" class="button button-primary" name="export-posts" value="<?php echo __( 'Export keywords', 'wordpress-seo' ); ?>"/>
+</form>

--- a/admin/views/tabs/tool/export-keywords.php
+++ b/admin/views/tabs/tool/export-keywords.php
@@ -10,7 +10,10 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 ?>
-<h2><?php __( 'Export keywords to a CSV file', 'wordpress-seo' ); ?></h2>
+<h2><?php _e( 'Export keywords to a CSV file', 'wordpress-seo' ) ?></h2>
+<p><?php _e( 'If you need to have a list of all public posts and related keywords, you can generate a CSV file using the button below.', 'wordpress-seo' ) ?></p>
+<p><?php _e( 'You can add or remove columns to be included in the export using the checkboxes below.', 'wordpress-seo' ) ?></p>
+<p><?php _e( 'Please note that the first row in this file is a header. This row should be ignored when parsing or importing the data from the export.', 'wordpress-seo' ) ?></p>
 <form action="" method="post" accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php
 	wp_nonce_field( 'wpseo-export', '_wpnonce', true );
@@ -23,5 +26,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	$yform->checkbox( 'export-keywords', __( 'Export keywords', 'wordpress-seo' ) );
 	$yform->checkbox( 'export-keywords-score', __( 'Export keyword scores', 'wordpress-seo' ) );
 	?>
+    <br class="clear">
 	<input type="submit" class="button button-primary" name="export-posts" value="<?php echo __( 'Export keywords', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tabs/tool/export-keywords.php
+++ b/admin/views/tabs/tool/export-keywords.php
@@ -26,6 +26,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	$yform->checkbox( 'export-keywords', __( 'Export keywords', 'wordpress-seo' ) );
 	$yform->checkbox( 'export-keywords-score', __( 'Export keyword scores', 'wordpress-seo' ) );
 	?>
-    <br class="clear">
+	<br class="clear">
 	<input type="submit" class="button button-primary" name="export-posts" value="<?php echo __( 'Export keywords', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -95,9 +95,9 @@ $tabs = array(
 		'label'                => __( 'Import from other SEO plugins', 'wordpress-seo' ),
 		'screencast_video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-import-export' ),
 	),
-    'export-keywords' => array (
+	'export-keywords' => array(
 		'label'                => __( 'Export keywords', 'wordpress-seo' ),
-    ),
+	),
 );
 
 ?>

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -95,6 +95,9 @@ $tabs = array(
 		'label'                => __( 'Import from other SEO plugins', 'wordpress-seo' ),
 		'screencast_video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-import-export' ),
 	),
+    'export-keywords' => array (
+		'label'                => __( 'Export keywords', 'wordpress-seo' ),
+    ),
 );
 
 ?>

--- a/tests/admin/export/test-class-export-keywords-csv.php
+++ b/tests/admin/export/test-class-export-keywords-csv.php
@@ -62,6 +62,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with simple input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_simple() {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
@@ -81,6 +82,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with complex input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_complex() {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
@@ -109,6 +111,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with random input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_random() {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
@@ -138,6 +141,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with null input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_null() {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
@@ -160,6 +164,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with bad column input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_bad_columns() {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();

--- a/tests/admin/export/test-class-export-keywords-csv.php
+++ b/tests/admin/export/test-class-export-keywords-csv.php
@@ -1,12 +1,12 @@
 <?php
 
 class WPSEO_Export_Keywords_CSV_Double extends WPSEO_Export_Keywords_CSV {
-	public function return_get_headers( $columns ) {
-		return $this->get_headers( $columns );
+	public function return_get_headers() {
+		return $this->get_headers();
 	}
 
-	public function return_format( $result, $columns ) {
-		return $this->format( $result, $columns );
+	public function return_format( $result ) {
+		return $this->format( $result );
 	}
 
 	public function return_format_csv_column( $value ) {
@@ -25,7 +25,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::sanitize_csv_column
 	 */
 	public function test_format_csv_column() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array() );
 
 		$this->assertEquals('"simple value"', $class_instance->return_format_csv_column( 'simple value' ) );
 		$this->assertEquals('"""quotes"""', $class_instance->return_format_csv_column( '"quotes"' ) );
@@ -37,7 +37,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	}
 
 	public function test_get_csv_column_from_result() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array() );
 
 		$fake_result = array(
 			'ID' => '0',
@@ -49,12 +49,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( ',"http://www.example.org"', $class_instance->return_get_csv_column_from_result( $fake_result, 'post_url' ) );
 		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, 'key that does not exist' ) );
 		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, 5 ) );
-		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, true ) );
-		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, null ) );
-		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( 5, 'key that does not exist' ) );
-		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( 'foo', 'key that does not exist' ) );
-		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( true, 'key that does not exist' ) );
-		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( null, 'key that does not exist' ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( array(), 'key that does not exist' ) );
 
 	}
 
@@ -66,7 +61,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_simple() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url' ) );
 
 		$fake_result = array(
 			'ID' => '0',
@@ -74,7 +69,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 			'post_url' => 'http://www.example.org',
 		);
 
-		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url' ) );
+		$csv = $class_instance->return_format( $fake_result );
 
 		$this->assertEquals( "\n\"0\",\"fake title\",\"http://www.example.org\"", $csv );
 	}
@@ -87,7 +82,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_complex() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
 
 		$fake_result = array(
 			'ID' => '0',
@@ -98,7 +93,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 			'keywords_score' => array( 'ok', 'good', 'na' )
 		);
 
-		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+		$csv = $class_instance->return_format( $fake_result );
 
 		$lines = preg_split( "/\n/", $csv, null, PREG_SPLIT_NO_EMPTY );
 
@@ -117,25 +112,13 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_random() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
 
-		$csv = $class_instance->return_format( 'foo', array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
-
-		$this->assertEmpty( $csv );
-
-		$csv = $class_instance->return_format( 5, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+		$csv = $class_instance->return_format( array() );
 
 		$this->assertEmpty( $csv );
 
-		$csv = $class_instance->return_format( true, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
-
-		$this->assertEmpty( $csv );
-
-		$csv = $class_instance->return_format( array(), array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
-
-		$this->assertEmpty( $csv );
-
-		$csv = $class_instance->return_format( array( 'foo' => 'bar' ), array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+		$csv = $class_instance->return_format( array( 'foo' => 'bar' ) );
 
 		$this->assertEmpty( $csv );
 	}
@@ -148,7 +131,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_null() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
 
 		$fake_result = array(
 			'ID' => '0',
@@ -159,7 +142,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 			'keywords_score' => null
 		);
 
-		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+		$csv = $class_instance->return_format( $fake_result );
 
 		$this->assertEquals( "\n\"0\",,,,,", $csv );
 	}
@@ -172,7 +155,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_bad_columns() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'foo', 5, true, null ) );
 
 		$fake_result = array(
 			'ID' => '0',
@@ -180,7 +163,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 			'post_url' => 'http://www.example.org',
 		);
 
-		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url', 'foo', 5, true, null ) );
+		$csv = $class_instance->return_format( $fake_result );
 
 		$this->assertEquals( "\n\"0\",\"fake title\",\"http://www.example.org\"", $csv );
 	}
@@ -191,9 +174,9 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::get_headers
 	 */
 	public function test_get_headers() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
 
-		$csv = $class_instance->return_get_headers( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+		$csv = $class_instance->return_get_headers();
 
 		$this->assertEquals( '"ID","post title","post url","seo score","keyword","keyword score"', $csv );
 	}
@@ -204,9 +187,9 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::get_headers
 	 */
 	public function test_get_headers_bad() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'foo', 5, true, null ) );
 
-		$csv = $class_instance->return_get_headers( array( 'post_title', 'post_url', 'foo', 5, true, null ) );
+		$csv = $class_instance->return_get_headers();
 
 		$this->assertEquals( '"ID","post title","post url"', $csv );
 	}
@@ -217,7 +200,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::export
 	 */
 	public function test_export() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
 
 		$fake_results = array(
 			array(
@@ -246,7 +229,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 			),
 		);
 
-		$csv = $class_instance->export( $fake_results, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+		$csv = $class_instance->export( $fake_results );
 
 		$lines = preg_split( "/\n/", $csv, null, PREG_SPLIT_NO_EMPTY );
 
@@ -267,7 +250,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Export_Keywords_CSV::export
 	 */
 	public function test_export_bad() {
-		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
 
 		$fake_results = array(
 			array(
@@ -286,13 +269,10 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 				'keywords' => true,
 				'foo' => 'bar',
 			),
-			5,
-			'baz',
-			true,
-			null,
+			array(),
 		);
 
-		$csv = $class_instance->export( $fake_results, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+		$csv = $class_instance->export( $fake_results );
 
 		$lines = preg_split( "/\n/", $csv, null, PREG_SPLIT_NO_EMPTY );
 

--- a/tests/admin/export/test-class-export-keywords-csv.php
+++ b/tests/admin/export/test-class-export-keywords-csv.php
@@ -12,6 +12,10 @@ class WPSEO_Export_Keywords_CSV_Double extends WPSEO_Export_Keywords_CSV {
 	public function return_format_csv_column( $value ) {
 		return $this->format_csv_column( $value );
 	}
+
+	public function return_get_csv_column_from_result( $result, $key ) {
+		return $this->get_csv_column_from_result( $result, $key );
+	}
 }
 
 class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
@@ -30,6 +34,28 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals('"true"', $class_instance->return_format_csv_column( true ) );
 		$this->assertEquals('"new line"', $class_instance->return_format_csv_column( "new\nline" ) );
 		$this->assertEquals('', $class_instance->return_format_csv_column( null ) );
+	}
+
+	public function test_get_csv_column_from_result() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$fake_result = array(
+			'ID' => '0',
+			'post_title' => 'fake title',
+			'post_url' => 'http://www.example.org',
+		);
+
+		$this->assertEquals( ',"fake title"', $class_instance->return_get_csv_column_from_result( $fake_result, 'post_title' ) );
+		$this->assertEquals( ',"http://www.example.org"', $class_instance->return_get_csv_column_from_result( $fake_result, 'post_url' ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, 'key that does not exist' ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, 5 ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, true ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( $fake_result, null ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( 5, 'key that does not exist' ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( 'foo', 'key that does not exist' ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( true, 'key that does not exist' ) );
+		$this->assertEquals( ',', $class_instance->return_get_csv_column_from_result( null, 'key that does not exist' ) );
+
 	}
 
 	/**

--- a/tests/admin/export/test-class-export-keywords-csv.php
+++ b/tests/admin/export/test-class-export-keywords-csv.php
@@ -10,11 +10,11 @@ class WPSEO_Export_Keywords_CSV_Double extends WPSEO_Export_Keywords_CSV {
 	}
 
 	public function return_format_csv_column( $value ) {
-		return $this->format_csv_column( $value );
+		return $this->sanitize_csv_column( $value );
 	}
 
 	public function return_get_csv_column_from_result( $result, $key ) {
-		return $this->get_csv_column_from_result( $result, $key );
+		return $this->get_csv_string_column_from_result( $result, $key );
 	}
 }
 
@@ -22,7 +22,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the format_csv_column function with input of various types.
 	 *
-	 * @covers WPSEO_Export_Keywords_CSV::format_csv_column
+	 * @covers WPSEO_Export_Keywords_CSV::sanitize_csv_column
 	 */
 	public function test_format_csv_column() {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
@@ -62,6 +62,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with simple input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_csv_column_from_result
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_simple() {
@@ -82,6 +83,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with complex input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_csv_column_from_result
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_complex() {
@@ -111,6 +113,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with random input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_csv_column_from_result
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_random() {
@@ -141,6 +144,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with null input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_csv_column_from_result
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_null() {
@@ -164,6 +168,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 	 * Tests the format function with bad column input.
 	 *
 	 * @covers WPSEO_Export_Keywords_CSV::format
+	 * @covers WPSEO_Export_Keywords_CSV::get_csv_column_from_result
 	 * @covers WPSEO_Export_Keywords_CSV::get_array_from_result
 	 */
 	public function test_format_bad_columns() {

--- a/tests/admin/export/test-class-export-keywords-csv.php
+++ b/tests/admin/export/test-class-export-keywords-csv.php
@@ -41,7 +41,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
 
 		$fake_result = array(
-			'ID' => 0,
+			'ID' => '0',
 			'post_title' => 'fake title',
 			'post_url' => 'http://www.example.org',
 		);
@@ -60,7 +60,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
 
 		$fake_result = array(
-			'ID' => 0,
+			'ID' => '0',
 			'post_title' => 'fake title',
 			'post_url' => 'http://www.example.org',
 			'seo_score' => 'bad',
@@ -117,7 +117,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
 
 		$fake_result = array(
-			'ID' => 0,
+			'ID' => '0',
 			'post_title' => null,
 			'post_url' => null,
 			'seo_score' => null,
@@ -139,7 +139,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
 
 		$fake_result = array(
-			'ID' => 0,
+			'ID' => '0',
 			'post_title' => 'fake title',
 			'post_url' => 'http://www.example.org',
 		);
@@ -185,7 +185,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 
 		$fake_results = array(
 			array(
-				'ID' => 0,
+				'ID' => '0',
 				'post_title' => 'fake title',
 				'post_url' => 'http://www.example.org/fake_title',
 				'seo_score' => 'bad',
@@ -193,7 +193,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 				'keywords_score' => array( 'ok', 'good', 'na' )
 			),
 			array(
-				'ID' => 1,
+				'ID' => '1',
 				'post_title' => 'another title',
 				'post_url' => 'http://www.example.org/another_title',
 				'seo_score' => 'good',
@@ -201,7 +201,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 				'keywords_score' => array( 'bad', 'bad' )
 			),
 			array(
-				'ID' => 2,
+				'ID' => '2',
 				'post_title' => 'last title',
 				'post_url' => 'http://www.example.org/last_title',
 				'seo_score' => 'ok',
@@ -235,7 +235,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 
 		$fake_results = array(
 			array(
-				'ID' => 0,
+				'ID' => '0',
 				'post_title' => 'fake title',
 				'post_url' => 'http://www.example.org/fake_title',
 				'seo_score' => 'bad',
@@ -243,7 +243,7 @@ class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
 				'keywords_score' => array( 'ok', 'good', 'na' )
 			),
 			array(
-				'ID' => 1,
+				'ID' => '1',
 				'post_title' => 'another title',
 				'post_url' => 'http://www.example.org/another_title',
 				'seo_score' => 50,

--- a/tests/admin/export/test-class-export-keywords-csv.php
+++ b/tests/admin/export/test-class-export-keywords-csv.php
@@ -1,0 +1,271 @@
+<?php
+
+class WPSEO_Export_Keywords_CSV_Double extends WPSEO_Export_Keywords_CSV {
+	public function return_get_headers( $columns ) {
+		return $this->get_headers( $columns );
+	}
+
+	public function return_format( $result, $columns ) {
+		return $this->format( $result, $columns );
+	}
+
+	public function return_format_csv_column( $value ) {
+		return $this->format_csv_column( $value );
+	}
+}
+
+class WPSEO_Export_Keywords_CSV_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Tests the format_csv_column function with input of various types.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::format_csv_column
+	 */
+	public function test_format_csv_column() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$this->assertEquals('"simple value"', $class_instance->return_format_csv_column( 'simple value' ) );
+		$this->assertEquals('"""quotes"""', $class_instance->return_format_csv_column( '"quotes"' ) );
+		$this->assertEquals('"3"', $class_instance->return_format_csv_column( 3 ) );
+		$this->assertEquals('"3.5"', $class_instance->return_format_csv_column( 3.5 ) );
+		$this->assertEquals('"true"', $class_instance->return_format_csv_column( true ) );
+		$this->assertEquals('"new line"', $class_instance->return_format_csv_column( "new\nline" ) );
+		$this->assertEquals('', $class_instance->return_format_csv_column( null ) );
+	}
+
+	/**
+	 * Tests the format function with simple input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::format
+	 */
+	public function test_format_simple() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$fake_result = array(
+			'ID' => 0,
+			'post_title' => 'fake title',
+			'post_url' => 'http://www.example.org',
+		);
+
+		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url' ) );
+
+		$this->assertEquals( "\n\"0\",\"fake title\",\"http://www.example.org\"", $csv );
+	}
+
+	/**
+	 * Tests the format function with complex input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::format
+	 */
+	public function test_format_complex() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$fake_result = array(
+			'ID' => 0,
+			'post_title' => 'fake title',
+			'post_url' => 'http://www.example.org',
+			'seo_score' => 'bad',
+			'keywords' => array( 'foo', 'bar', 'baz' ),
+			'keywords_score' => array( 'ok', 'good', 'na' )
+		);
+
+		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$lines = preg_split( "/\n/", $csv, null, PREG_SPLIT_NO_EMPTY );
+
+		// One line for each keyword
+		$this->assertCount( 3, $lines );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org\",\"bad\",\"foo\",\"ok\"", $lines[0] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org\",\"bad\",\"bar\",\"good\"", $lines[1] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org\",\"bad\",\"baz\",\"na\"", $lines[2] );
+	}
+
+	/**
+	 * Tests the format function with random input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::format
+	 */
+	public function test_format_random() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$csv = $class_instance->return_format( 'foo', array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$this->assertEmpty( $csv );
+
+		$csv = $class_instance->return_format( 5, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$this->assertEmpty( $csv );
+
+		$csv = $class_instance->return_format( true, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$this->assertEmpty( $csv );
+
+		$csv = $class_instance->return_format( array(), array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$this->assertEmpty( $csv );
+
+		$csv = $class_instance->return_format( array( 'foo' => 'bar' ), array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$this->assertEmpty( $csv );
+	}
+
+	/**
+	 * Tests the format function with null input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::format
+	 */
+	public function test_format_null() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$fake_result = array(
+			'ID' => 0,
+			'post_title' => null,
+			'post_url' => null,
+			'seo_score' => null,
+			'keywords' => null,
+			'keywords_score' => null
+		);
+
+		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$this->assertEquals( "\n\"0\",,,,,", $csv );
+	}
+
+	/**
+	 * Tests the format function with bad column input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::format
+	 */
+	public function test_format_bad_columns() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$fake_result = array(
+			'ID' => 0,
+			'post_title' => 'fake title',
+			'post_url' => 'http://www.example.org',
+		);
+
+		$csv = $class_instance->return_format( $fake_result, array( 'post_title', 'post_url', 'foo', 5, true, null ) );
+
+		$this->assertEquals( "\n\"0\",\"fake title\",\"http://www.example.org\"", $csv );
+	}
+
+	/**
+	 * Tests the get_headers function with expected input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::get_headers
+	 */
+	public function test_get_headers() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$csv = $class_instance->return_get_headers( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$this->assertEquals( '"ID","post title","post url","seo score","keyword","keyword score"', $csv );
+	}
+
+	/**
+	 * Tests the get_headers function with bad input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::get_headers
+	 */
+	public function test_get_headers_bad() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$csv = $class_instance->return_get_headers( array( 'post_title', 'post_url', 'foo', 5, true, null ) );
+
+		$this->assertEquals( '"ID","post title","post url"', $csv );
+	}
+
+	/**
+	 * Tests the export function with expected input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::export
+	 */
+	public function test_export() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$fake_results = array(
+			array(
+				'ID' => 0,
+				'post_title' => 'fake title',
+				'post_url' => 'http://www.example.org/fake_title',
+				'seo_score' => 'bad',
+				'keywords' => array( 'foo', 'bar', 'baz' ),
+				'keywords_score' => array( 'ok', 'good', 'na' )
+			),
+			array(
+				'ID' => 1,
+				'post_title' => 'another title',
+				'post_url' => 'http://www.example.org/another_title',
+				'seo_score' => 'good',
+				'keywords' => array( 'foo', 'bar' ),
+				'keywords_score' => array( 'bad', 'bad' )
+			),
+			array(
+				'ID' => 2,
+				'post_title' => 'last title',
+				'post_url' => 'http://www.example.org/last_title',
+				'seo_score' => 'ok',
+				'keywords' => array( 'last' ),
+				'keywords_score' => array( 'good' )
+			),
+		);
+
+		$csv = $class_instance->export( $fake_results, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$lines = preg_split( "/\n/", $csv, null, PREG_SPLIT_NO_EMPTY );
+
+		$this->assertCount( 7, $lines );
+
+		$this->assertEquals( '"ID","post title","post url","seo score","keyword","keyword score"', $lines[0] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org/fake_title\",\"bad\",\"foo\",\"ok\"", $lines[1] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org/fake_title\",\"bad\",\"bar\",\"good\"", $lines[2] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org/fake_title\",\"bad\",\"baz\",\"na\"", $lines[3] );
+		$this->assertEquals( "\"1\",\"another title\",\"http://www.example.org/another_title\",\"good\",\"foo\",\"bad\"", $lines[4] );
+		$this->assertEquals( "\"1\",\"another title\",\"http://www.example.org/another_title\",\"good\",\"bar\",\"bad\"", $lines[5] );
+		$this->assertEquals( "\"2\",\"last title\",\"http://www.example.org/last_title\",\"ok\",\"last\",\"good\"", $lines[6] );
+	}
+
+	/**
+	 * Tests the export function with bad input.
+	 *
+	 * @covers WPSEO_Export_Keywords_CSV::export
+	 */
+	public function test_export_bad() {
+		$class_instance = new WPSEO_Export_Keywords_CSV_Double();
+
+		$fake_results = array(
+			array(
+				'ID' => 0,
+				'post_title' => 'fake title',
+				'post_url' => 'http://www.example.org/fake_title',
+				'seo_score' => 'bad',
+				'keywords' => array( 'foo', 'bar', 'baz' ),
+				'keywords_score' => array( 'ok', 'good', 'na' )
+			),
+			array(
+				'ID' => 1,
+				'post_title' => 'another title',
+				'post_url' => 'http://www.example.org/another_title',
+				'seo_score' => 50,
+				'keywords' => true,
+				'foo' => 'bar',
+			),
+			5,
+			'baz',
+			true,
+			null,
+		);
+
+		$csv = $class_instance->export( $fake_results, array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ) );
+
+		$lines = preg_split( "/\n/", $csv, null, PREG_SPLIT_NO_EMPTY );
+
+		$this->assertCount( 5, $lines );
+
+		$this->assertEquals( '"ID","post title","post url","seo score","keyword","keyword score"', $lines[0] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org/fake_title\",\"bad\",\"foo\",\"ok\"", $lines[1] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org/fake_title\",\"bad\",\"bar\",\"good\"", $lines[2] );
+		$this->assertEquals( "\"0\",\"fake title\",\"http://www.example.org/fake_title\",\"bad\",\"baz\",\"na\"", $lines[3] );
+		$this->assertEquals( "\"1\",\"another title\",\"http://www.example.org/another_title\",\"50\",,", $lines[4] );
+	}
+}

--- a/tests/admin/export/test-class-export-keywords-presenter.php
+++ b/tests/admin/export/test-class-export-keywords-presenter.php
@@ -65,6 +65,7 @@ class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Export_Keywords_Presenter::__construct
 	 * @covers WPSEO_Export_Keywords_Presenter::convert_result_keywords
+	 * @covers WPSEO_Export_Keywords_Presenter::parse_result_keywords_json
 	 */
 	public function test_convert_result_keywords() {
 		global $wpdb;
@@ -93,6 +94,7 @@ class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Export_Keywords_Presenter::__construct
 	 * @covers WPSEO_Export_Keywords_Presenter::convert_result_keywords
+	 * @covers WPSEO_Export_Keywords_Presenter::parse_result_keywords_json
 	 */
 	public function test_convert_result_keywords_malformed() {
 		global $wpdb;

--- a/tests/admin/export/test-class-export-keywords-presenter.php
+++ b/tests/admin/export/test-class-export-keywords-presenter.php
@@ -6,6 +6,10 @@
  * A double for testing protected method.
  */
 class WPSEO_Export_Keywords_Presenter_Double extends WPSEO_Export_Keywords_Presenter {
+	public function return_validate_result( $result ) {
+		return $this->validate_result( $result );
+	}
+
 	public function return_convert_result_keywords( $result ) {
 		return $this->convert_result_keywords( $result );
 	}
@@ -23,6 +27,39 @@ class WPSEO_Export_Keywords_Presenter_Test_Filter {
 }
 
 class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Tests if validate_result works with expected input.
+	 */
+	public function test_validate_result() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title' ), $wpdb );
+
+		$fake_result = array(
+			'ID'         => '1',
+			'post_title' => 'fake post',
+		);
+
+		$this->assertTrue( $class_instance->return_validate_result( $fake_result ) );
+	}
+
+	public function test_validate_input_false() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title' ), $wpdb );
+
+		$fake_result = array(
+			'ID'         => '1',
+			'post_title' => true,
+		);
+
+		$this->assertFalse( $class_instance->return_validate_result( $fake_result ) );
+		$this->assertFalse( $class_instance->return_validate_result( 'foo' ) );
+		$this->assertFalse( $class_instance->return_validate_result( 5 ) );
+		$this->assertFalse( $class_instance->return_validate_result( true ) );
+		$this->assertFalse( $class_instance->return_validate_result( null ) );
+	}
+
 	/**
 	 * Tests if convert_result_keywords works with expected input.
 	 *

--- a/tests/admin/export/test-class-export-keywords-presenter.php
+++ b/tests/admin/export/test-class-export-keywords-presenter.php
@@ -54,10 +54,7 @@ class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
 		);
 
 		$this->assertFalse( $class_instance->return_validate_result( $fake_result ) );
-		$this->assertFalse( $class_instance->return_validate_result( 'foo' ) );
-		$this->assertFalse( $class_instance->return_validate_result( 5 ) );
-		$this->assertFalse( $class_instance->return_validate_result( true ) );
-		$this->assertFalse( $class_instance->return_validate_result( null ) );
+		$this->assertFalse( $class_instance->return_validate_result( array() ) );
 	}
 
 	/**
@@ -181,7 +178,6 @@ class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title' ), $wpdb );
 
-		$this->assertFalse( $class_instance->present( 'foo' ) );
 		$this->assertFalse( $class_instance->present( array( 'ID' => 'foo' ) ) );
 		$this->assertFalse( $class_instance->present( array( 'ID' => 0, 'post_title' => true ) ) );
 	}

--- a/tests/admin/export/test-class-export-keywords-presenter.php
+++ b/tests/admin/export/test-class-export-keywords-presenter.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Class WPSEO_Export_Keywords_Presenter_Double\
+ *
+ * A double for testing protected method.
+ */
+class WPSEO_Export_Keywords_Presenter_Double extends WPSEO_Export_Keywords_Presenter {
+	public function return_convert_result_keywords( $result ) {
+		return $this->convert_result_keywords( $result );
+	}
+}
+
+/**
+ * Class WPSEO_Export_Keywords_Presenter_Test_Filter
+ *
+ * Provides a simple filter to test against.
+ */
+class WPSEO_Export_Keywords_Presenter_Test_Filter {
+	public function filter( $title, $id ) {
+		return "filtered";
+	}
+}
+
+class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Tests if convert_result_keywords works with expected input.
+	 *
+	 * @covers WPSEO_Export_Keywords_Presenter::__construct
+	 * @covers WPSEO_Export_Keywords_Presenter::convert_result_keywords
+	 */
+	public function test_convert_result_keywords() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'keywords', 'keywords_score' ), $wpdb );
+
+		$fake_result = array(
+			'primary_keyword' => 'foo',
+			'primary_keyword_score' => '90',
+			'other_keywords' => '[{"keyword": "bar", "score": "bad"}]'
+		);
+
+		$result = $class_instance->return_convert_result_keywords( $fake_result );
+
+		$this->assertEquals( 'foo', $result['keywords'][0] );
+		$this->assertEquals( 'bar', $result['keywords'][1] );
+		$this->assertCount( 2, $result['keywords'] );
+
+		$this->assertEquals( 'good', $result['keywords_score'][0] );
+		$this->assertEquals( 'bad', $result['keywords_score'][1] );
+		$this->assertCount( 2, $result['keywords_score'] );
+	}
+
+	/**
+	 * Tests if convert_result_keywords works with malformed input.
+	 *
+	 * @covers WPSEO_Export_Keywords_Presenter::__construct
+	 * @covers WPSEO_Export_Keywords_Presenter::convert_result_keywords
+	 */
+	public function test_convert_result_keywords_malformed() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'keywords', 'keywords_score' ), $wpdb );
+
+		$fake_result = array(
+			'primary_keyword' => 'foo',
+			'primary_keyword_score' => '90',
+			'other_keywords' => '[{"keyword" => "bar", what_even_is_this?}]'
+		);
+
+		$result = $class_instance->return_convert_result_keywords( $fake_result );
+
+		$this->assertEquals( 'foo', $result['keywords'][0] );
+		$this->assertCount( 1, $result['keywords'] );
+
+		$this->assertEquals( 'good', $result['keywords_score'][0] );
+		$this->assertCount( 1, $result['keywords_score'] );
+	}
+
+	/**
+	 * Tests the present function with it's intended use case.
+	 *
+	 * @covers WPSEO_Export_Keywords_Presenter::present
+	 */
+	public function test_present() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ), $wpdb );
+
+		$fake_post = $this->factory->post->create( array( 'post_title' => 'fake post' ) );
+		$fake_result = array(
+			'ID' => $fake_post,
+			'post_title' => 'fake post',
+			'seo_score' => '50',
+			'primary_keyword' => 'bar',
+			'primary_keyword_score' => '60',
+			'other_keywords' => '[{"keyword": "foo", "score": "good"},{"keyword": "baz", "score": "bad"}]'
+		);
+
+		$result = $class_instance->present( $fake_result );
+
+		$this->assertEquals( $fake_post, $result['ID'] );
+		$this->assertEquals( 'fake post', $result['post_title'] );
+		$this->assertEquals( get_permalink( $fake_post ), $result['post_url'] );
+		$this->assertEquals( 'ok', $result['seo_score'] );
+		$this->assertEquals( array( 'bar', 'foo', 'baz' ), $result['keywords'] );
+		$this->assertEquals( array( 'ok', 'good', 'bad' ), $result['keywords_score'] );
+	}
+
+	/**
+	 * Tests the present function for filter functionality.
+	 *
+	 * @covers WPSEO_Export_Keywords_Presenter::present
+	 */
+	public function test_present_filter() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title' ), $wpdb );
+
+		$fake_result = array(
+			'ID'         => 1,
+			'post_title' => 'fake post',
+		);
+
+		$filter_class = new WPSEO_Export_Keywords_Presenter_Test_Filter();
+		add_filter( 'the_title', array( $filter_class, 'filter'), 10, 2 );
+
+		$result = $class_instance->present( $fake_result );
+
+		$this->assertEquals( 'filtered', $result['post_title'] );
+
+		remove_filter( 'the_title', array( $filter_class, 'filter'), 10 );
+	}
+
+	/**
+	 * Tests the export function with malformed input.
+	 *
+	 * @covers WPSEO_Export_Keywords_Presenter::present
+	 */
+	public function test_present_malformed() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title' ), $wpdb );
+
+		$this->assertFalse( $class_instance->present( 'foo' ) );
+		$this->assertFalse( $class_instance->present( array( 'ID' => 'foo' ) ) );
+		$this->assertFalse( $class_instance->present( array( 'ID' => 0, 'post_title' => true ) ) );
+	}
+
+	/**
+	 * Tests the present function with null meta.
+	 *
+	 * @covers WPSEO_Export_Keywords_Presenter::present
+	 */
+	public function test_present_null() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title', 'post_url', 'seo_score', 'keywords', 'keywords_score' ), $wpdb );
+
+		$fake_post = $this->factory->post->create( array( 'post_title' => 'fake post' ) );
+		$fake_result = array(
+			'ID' => $fake_post,
+			'post_title' => 'fake post',
+			'seo_score' => null,
+			'primary_keyword' => null,
+			'primary_keyword_score' => null,
+			'other_keywords' => null
+		);
+
+		$result = $class_instance->present( $fake_result );
+
+		$this->assertEquals( $fake_post, $result['ID'] );
+		$this->assertEquals( 'fake post', $result['post_title'] );
+		$this->assertEquals( get_permalink( $fake_post ), $result['post_url'] );
+		$this->assertEquals( 'na', $result['seo_score'] );
+		$this->assertEquals( array(), $result['keywords'] );
+		$this->assertEquals( array(), $result['keywords_score'] );
+	}
+}

--- a/tests/admin/export/test-class-export-keywords-presenter.php
+++ b/tests/admin/export/test-class-export-keywords-presenter.php
@@ -89,7 +89,7 @@ class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
 
 		$fake_post = $this->factory->post->create( array( 'post_title' => 'fake post' ) );
 		$fake_result = array(
-			'ID' => $fake_post,
+			'ID' => var_export( $fake_post, true ),
 			'post_title' => 'fake post',
 			'seo_score' => '50',
 			'primary_keyword' => 'bar',
@@ -118,7 +118,7 @@ class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
 		$class_instance = new WPSEO_Export_Keywords_Presenter_Double( array( 'post_title' ), $wpdb );
 
 		$fake_result = array(
-			'ID'         => 1,
+			'ID'         => '1',
 			'post_title' => 'fake post',
 		);
 
@@ -159,7 +159,7 @@ class WPSEO_Export_Keywords_Presenter_Test extends WPSEO_UnitTestCase {
 
 		$fake_post = $this->factory->post->create( array( 'post_title' => 'fake post' ) );
 		$fake_result = array(
-			'ID' => $fake_post,
+			'ID' => var_export( $fake_post, true ),
 			'post_title' => 'fake post',
 			'seo_score' => null,
 			'primary_keyword' => null,

--- a/tests/admin/export/test-class-export-keywords-query.php
+++ b/tests/admin/export/test-class-export-keywords-query.php
@@ -31,11 +31,14 @@ class WPSEO_Export_Keywords_Query_Test extends WPSEO_UnitTestCase {
 
 		$class_instance->run_add_meta_join( 'meta_alias', 'meta_key' );
 
-		$this->assertEquals( 'meta_alias_join.meta_value AS meta_alias', $class_instance->get_selects()[0] );
+		$selects = $class_instance->get_selects();
+		$joins = $class_instance->get_joins();
+
+		$this->assertEquals( 'meta_alias_join.meta_value AS meta_alias', $selects[0] );
 
 		$this->assertEquals( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS meta_alias_join ' .
 							 'ON meta_alias_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
-							 'AND meta_alias_join.meta_key = "meta_key"', $class_instance->get_joins()[0] );
+							 'AND meta_alias_join.meta_key = "meta_key"', $joins[0] );
 	}
 
 	/**
@@ -50,9 +53,12 @@ class WPSEO_Export_Keywords_Query_Test extends WPSEO_UnitTestCase {
 
 		$class_instance->run_add_meta_join( '; DROP TABLE wp_posts;', '; DROP TABLE wp_posts;' );
 
-		$this->assertNotContains( 'DROP TABLE wp_posts', $class_instance->get_selects()[0] );
+		$selects = $class_instance->get_selects();
+		$joins = $class_instance->get_joins();
 
-		$this->assertNotContains( 'DROP TABLE wp_posts', $class_instance->get_joins()[0] );
+		$this->assertNotContains( 'DROP TABLE wp_posts', $selects[0] );
+
+		$this->assertNotContains( 'DROP TABLE wp_posts', $joins[0] );
 	}
 
 	/**
@@ -86,25 +92,30 @@ class WPSEO_Export_Keywords_Query_Test extends WPSEO_UnitTestCase {
 
 		$class_instance->run_set_columns();
 
-		$this->assertContains( $wpdb->prefix . 'posts.ID', $class_instance->get_selects() );
-		$this->assertContains( $wpdb->prefix . 'posts.post_title', $class_instance->get_selects() );
-		$this->assertContains( 'primary_keyword_join.meta_value AS primary_keyword', $class_instance->get_selects() );
-		$this->assertContains( 'primary_keyword_score_join.meta_value AS primary_keyword_score', $class_instance->get_selects() );
-		$this->assertContains( 'other_keywords_join.meta_value AS other_keywords', $class_instance->get_selects() );
-		$this->assertContains( 'seo_score_join.meta_value AS seo_score', $class_instance->get_selects() );
+		$selects = $class_instance->get_selects();
+		$joins = $class_instance->get_joins();
 
+		$this->assertCount( 6, $selects );
+		$this->assertContains( $wpdb->prefix . 'posts.ID', $selects );
+		$this->assertContains( $wpdb->prefix . 'posts.post_title', $selects );
+		$this->assertContains( 'primary_keyword_join.meta_value AS primary_keyword', $selects );
+		$this->assertContains( 'primary_keyword_score_join.meta_value AS primary_keyword_score', $selects );
+		$this->assertContains( 'other_keywords_join.meta_value AS other_keywords', $selects );
+		$this->assertContains( 'seo_score_join.meta_value AS seo_score', $selects );
+
+		$this->assertCount( 4, $joins );
 		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS primary_keyword_join ' .
 							   'ON primary_keyword_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
-							   'AND primary_keyword_join.meta_key = "_yoast_wpseo_focuskw"', $class_instance->get_joins() );
+							   'AND primary_keyword_join.meta_key = "_yoast_wpseo_focuskw"', $joins );
 		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS primary_keyword_score_join ' .
 							   'ON primary_keyword_score_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
-							   'AND primary_keyword_score_join.meta_key = "_yoast_wpseo_linkdex"', $class_instance->get_joins() );
+							   'AND primary_keyword_score_join.meta_key = "_yoast_wpseo_linkdex"', $joins );
 		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS seo_score_join ' .
 							   'ON seo_score_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
-							   'AND seo_score_join.meta_key = "_yoast_wpseo_content_score"', $class_instance->get_joins() );
+							   'AND seo_score_join.meta_key = "_yoast_wpseo_content_score"', $joins );
 		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS other_keywords_join ' .
 							   'ON other_keywords_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
-							   'AND other_keywords_join.meta_key = "_yoast_wpseo_focuskeywords"', $class_instance->get_joins() );
+							   'AND other_keywords_join.meta_key = "_yoast_wpseo_focuskeywords"', $joins );
 	}
 
 	/**
@@ -120,10 +131,13 @@ class WPSEO_Export_Keywords_Query_Test extends WPSEO_UnitTestCase {
 
 		$class_instance->run_set_columns();
 
-		$this->assertCount( 1, $class_instance->get_selects() );
-		$this->assertEquals( $wpdb->prefix . 'posts.ID', $class_instance->get_selects()[0] );
+		$selects = $class_instance->get_selects();
+		$joins = $class_instance->get_joins();
 
-		$this->assertEmpty( $class_instance->get_joins() );
+		$this->assertCount( 1, $class_instance->get_selects() );
+		$this->assertEquals( $wpdb->prefix . 'posts.ID', $selects[0] );
+
+		$this->assertEmpty( $joins );
 	}
 
 	/**

--- a/tests/admin/export/test-class-export-keywords-query.php
+++ b/tests/admin/export/test-class-export-keywords-query.php
@@ -1,0 +1,215 @@
+<?php
+
+class WPSEO_Export_Keywords_Query_Double extends WPSEO_Export_Keywords_Query {
+	public function get_selects() {
+		return $this->selects;
+	}
+
+	public function get_joins() {
+		return $this->joins;
+	}
+
+	public function run_add_meta_join( $alias, $key ) {
+		$this->add_meta_join( $alias, $key );
+	}
+
+	public function run_set_columns() {
+		$this->set_columns();
+	}
+
+	public function return_convert_result_keywords( $result ) {
+		return $this->convert_result_keywords( $result );
+	}
+
+	public function return_get_rating_from_int_score( $score ) {
+		return $this->get_rating_from_int_score( $score );
+	}
+
+	public function return_get_rating_from_string_score( $score ) {
+		return $this->get_rating_from_string_score( $score );
+	}
+}
+
+class WPSEO_Export_Keywords_Query_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Tests the add_meta_join function for constructing joins.
+	 */
+	public function test_add_meta_join() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( ), $wpdb );
+
+		$class_instance->run_add_meta_join( 'meta_alias', 'meta_key' );
+
+		$this->assertEquals( 'meta_alias_join.meta_value AS meta_alias', $class_instance->get_selects()[0] );
+
+		$this->assertEquals( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS meta_alias_join ' .
+							 'ON meta_alias_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
+							 'AND meta_alias_join.meta_key = "meta_key"', $class_instance->get_joins()[0] );
+	}
+
+	/**
+	 * Tests that you can't add snippets of SQL by using add_meta_join.
+	 */
+	public function test_add_meta_join_no_sql_injection() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( ), $wpdb );
+
+		$class_instance->run_add_meta_join( '; DROP TABLE wp_posts;', '; DROP TABLE wp_posts;' );
+
+		$this->assertNotContains( 'DROP TABLE wp_posts', $class_instance->get_selects()[0] );
+
+		$this->assertNotContains( 'DROP TABLE wp_posts', $class_instance->get_joins()[0] );
+	}
+
+	/**
+	 * Tests if set_columns works with simple columns that exist on the posts table.
+	 */
+	public function test_set_columns_simple() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( 'post_title' ), $wpdb );
+
+		$class_instance->run_set_columns();
+
+		$this->assertContains( $wpdb->prefix . 'posts.ID', $class_instance->get_selects() );
+		$this->assertContains( $wpdb->prefix . 'posts.post_title', $class_instance->get_selects() );
+		$this->assertEmpty( $class_instance->get_joins() );
+	}
+
+	/**
+	 * Tests if set_columns works with all possible columns.
+	 */
+	public function test_set_columns_complete() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( 'post_title', 'post_url', 'keywords', 'seo_score', 'keywords_score' ), $wpdb );
+
+		$class_instance->run_set_columns();
+
+		$this->assertContains( $wpdb->prefix . 'posts.ID', $class_instance->get_selects() );
+		$this->assertContains( $wpdb->prefix . 'posts.post_title', $class_instance->get_selects() );
+		$this->assertContains( 'primary_keyword_join.meta_value AS primary_keyword', $class_instance->get_selects() );
+		$this->assertContains( 'primary_keyword_score_join.meta_value AS primary_keyword_score', $class_instance->get_selects() );
+		$this->assertContains( 'other_keywords_join.meta_value AS other_keywords', $class_instance->get_selects() );
+		$this->assertContains( 'seo_score_join.meta_value AS seo_score', $class_instance->get_selects() );
+
+		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS primary_keyword_join ' .
+							   'ON primary_keyword_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
+							   'AND primary_keyword_join.meta_key = "_yoast_wpseo_focuskw"', $class_instance->get_joins() );
+		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS primary_keyword_score_join ' .
+							   'ON primary_keyword_score_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
+							   'AND primary_keyword_score_join.meta_key = "_yoast_wpseo_linkdex"', $class_instance->get_joins() );
+		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS seo_score_join ' .
+							   'ON seo_score_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
+							   'AND seo_score_join.meta_key = "_yoast_wpseo_content_score"', $class_instance->get_joins() );
+		$this->assertContains( 'LEFT OUTER JOIN ' . $wpdb->prefix . 'postmeta AS other_keywords_join ' .
+							   'ON other_keywords_join.post_id = ' . $wpdb->prefix . 'posts.ID ' .
+							   'AND other_keywords_join.meta_key = "_yoast_wpseo_focuskeywords"', $class_instance->get_joins() );
+	}
+
+	/**
+	 * Tests how set_columns deals with random input.
+	 */
+	public function test_set_columns_random_input() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( 'bla', 'foo', 'DROP TABLE wp_posts;', 2, true ), $wpdb );
+
+		$class_instance->run_set_columns();
+
+		$this->assertCount( 1, $class_instance->get_selects() );
+		$this->assertEquals( $wpdb->prefix . 'posts.ID', $class_instance->get_selects()[0] );
+
+		$this->assertEmpty( $class_instance->get_joins() );
+	}
+
+	/**
+	 * Tests if convert_result_keywords works with expected input.
+	 */
+	public function test_convert_result_keywords() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( 'keywords', 'keywords_score' ), $wpdb );
+
+		$fake_result = array(
+			'primary_keyword' => 'foo',
+			'primary_keyword_score' => '90',
+			'other_keywords' => '[{"keyword": "bar", "score": "bad"}]'
+		);
+
+		$result = $class_instance->return_convert_result_keywords( $fake_result );
+
+		$this->assertEquals( 'foo', $result['keywords'][0] );
+		$this->assertEquals( 'bar', $result['keywords'][1] );
+		$this->assertCount( 2, $result['keywords'] );
+
+		$this->assertEquals( 'good', $result['keywords_score'][0] );
+		$this->assertEquals( 'needs improvement', $result['keywords_score'][1] );
+		$this->assertCount( 2, $result['keywords_score'] );
+	}
+
+	/**
+	 * Tests if convert_result_keywords works with malformed input.
+	 */
+	public function test_convert_result_keywords_malformed() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( 'keywords', 'keywords_score' ), $wpdb );
+
+		$fake_result = array(
+			'primary_keyword' => 'foo',
+			'primary_keyword_score' => '90',
+			'other_keywords' => '[{"keyword" => "bar", what_even_is_this?}]'
+		);
+
+		$result = $class_instance->return_convert_result_keywords( $fake_result );
+
+		$this->assertEquals( 'foo', $result['keywords'][0] );
+		$this->assertCount( 1, $result['keywords'] );
+
+		$this->assertEquals( 'good', $result['keywords_score'][0] );
+		$this->assertCount( 1, $result['keywords_score'] );
+	}
+
+	/**
+	 * Tests the get_rating_from_int_score function
+	 */
+	public function test_get_rating_from_int_score() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( ), $wpdb );
+
+		// Check legitimate input.
+		$this->assertEquals('none', $class_instance->return_get_rating_from_int_score( 0 ) );
+		$this->assertEquals('needs improvement', $class_instance->return_get_rating_from_int_score( 5 ) );
+		$this->assertEquals('ok', $class_instance->return_get_rating_from_int_score( 50 ) );
+		$this->assertEquals('good', $class_instance->return_get_rating_from_int_score( 80 ) );
+
+		// Check malformed input.
+		$this->assertEquals('none', $class_instance->return_get_rating_from_int_score( true ) );
+		$this->assertEquals('none', $class_instance->return_get_rating_from_int_score( 'bar' ) );
+		$this->assertEquals('none', $class_instance->return_get_rating_from_int_score( array() ) );
+	}
+
+	/**
+	 * Tests the get_rating_from_string_score function
+	 */
+	public function test_get_rating_from_string_score() {
+		global $wpdb;
+
+		$class_instance = new WPSEO_Export_Keywords_Query_Double( array( ), $wpdb );
+
+		// Check legitimate input.
+		$this->assertEquals('none', $class_instance->return_get_rating_from_string_score( 'none' ) );
+		$this->assertEquals('needs improvement', $class_instance->return_get_rating_from_string_score( 'bad' ) );
+		$this->assertEquals('ok', $class_instance->return_get_rating_from_string_score( 'ok' ) );
+		$this->assertEquals('good', $class_instance->return_get_rating_from_string_score( 'good' ) );
+
+		// Check malformed input.
+		$this->assertEquals('none', $class_instance->return_get_rating_from_string_score( true ) );
+		$this->assertEquals('none', $class_instance->return_get_rating_from_string_score( 25 ) );
+		$this->assertEquals('none', $class_instance->return_get_rating_from_string_score( array() ) );
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds an option to SEO -> Tools -> Import and Export to Export Keywords to a CSV file.

## Relevant technical choices:

* All data for the export is gathered in a single query using the new `WPSEO_Export_Keywords_Query` class.

## Test instructions

This PR can be tested by following these steps:

* Go to SEO -> Tools -> Import and Export -> Export Keywords.
* Select the columns you wish to export.
* Click the "Export keywords" button.
* Validate the downloaded CSV.

Fixes #2105.
