### PR TITLE
Escape content of RSS links.

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1702,12 +1702,12 @@ class WPSEO_Frontend {
 
 		$author_link = '';
 		if ( is_object( $post ) ) {
-			$author_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_author_posts_url( $post->post_author ) ) . '">' . strip_tags( get_the_author() ) . '</a>';
+			$author_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_author_posts_url( $post->post_author ) ) . '">' . esc_html( get_the_author() ) . '</a>';
 		}
 
-		$post_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . strip_tags( get_the_title() ) . '</a>';
-		$blog_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . strip_tags( get_bloginfo( 'name' ) ) . '</a>';
-		$blog_desc_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . strip_tags( get_bloginfo( 'name' ) ) . ' - ' . strip_tags( get_bloginfo( 'description' ) ) . '</a>';
+		$post_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
+		$blog_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . '</a>';
+		$blog_desc_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . ' - ' . esc_html( get_bloginfo( 'description' ) ) . '</a>';
 
 		$content = stripslashes( trim( $content ) );
 		$content = str_replace( '%%AUTHORLINK%%', $author_link, $content );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1702,7 +1702,7 @@ class WPSEO_Frontend {
 
 		$author_link = '';
 		if ( is_object( $post ) ) {
-			$author_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_author_posts_url( $post->post_author ) ) . '">' . get_the_author() . '</a>';
+			$author_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_author_posts_url( $post->post_author ) ) . '">' . strip_tags( get_the_author() ) . '</a>';
 		}
 
 		$post_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . strip_tags( get_the_title() ) . '</a>';

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1705,9 +1705,9 @@ class WPSEO_Frontend {
 			$author_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_author_posts_url( $post->post_author ) ) . '">' . get_the_author() . '</a>';
 		}
 
-		$post_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . get_the_title() . '</a>';
-		$blog_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . get_bloginfo( 'name' ) . '</a>';
-		$blog_desc_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . get_bloginfo( 'name' ) . ' - ' . strip_tags( get_bloginfo( 'description' ) ) . '</a>';
+		$post_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_permalink() ) . '">' . strip_tags( get_the_title() ) . '</a>';
+		$blog_link      = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . strip_tags( get_bloginfo( 'name' ) ) . '</a>';
+		$blog_desc_link = '<a ' . $no_follow_attr . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . strip_tags( get_bloginfo( 'name' ) ) . ' - ' . strip_tags( get_bloginfo( 'description' ) ) . '</a>';
 
 		$content = stripslashes( trim( $content ) );
 		$content = str_replace( '%%AUTHORLINK%%', $author_link, $content );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Escapes all input when generating links for the RSS feed.

## Relevant technical choices:

* `strip_tags` was used to remain consistent with usage throughout the plugin. 

## Test instructions

This PR can be tested by following these steps:

* Set your site name, post title or author name to something including script or HTML tags. This has to be done directly in the database as the default wordpress forms escape HTML before saving meaning there are no actual tags in the final value to be stripped.
* Set your RSS content in SEO -> Advanced -> RSS to include '%%AUTHORLINK%%', '%%POSTLINK%%', '%%BLOGLINK%%' and '%%BLOGDESCLINK%%'.
* Check if HTML tags appear on `/feed` inside the generated links.

Fixes #7706.