### PR TITLE
Stop using uncached functions

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -467,8 +467,8 @@ class WPSEO_Sitemap_Image_Parser {
 			'order'            => 'DESC',
 			'exclude'          => array(),
 			'meta_key'         => '',
-			'meta_value'       =>'',
-			'suppress_filters' => true
+			'meta_value'       => '',
+			'suppress_filters' => true,
 		);
 
 		$args = wp_parse_args( $args, $default_args );

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -404,23 +404,12 @@ class WPSEO_Sitemap_Image_Parser {
 
 		// When there are posts to include.
 		if ( ! empty( $gallery['include'] ) ) {
-			$query = array(
-				'post_status'      => 'inherit',
-				'post_type'        => 'attachment',
-				'post_mime_type'   => 'image',
-				'include'          => $gallery['include'],
-				'numberposts'      => 5,
-				'category'         => 0,
-				'orderby'          => 'date',
-				'order'            => 'DESC',
-				'exclude'          => array(),
-				'meta_key'         => '',
-				'meta_value'       =>'',
-				'suppress_filters' => true
+			$_attachments = $this->get_attachments(
+				array(
+					'include'     => $gallery['include'],
+					'numberposts' => 5,
+				)
 			);
-
-			$get_attachments = new WP_Query;
-			$_attachments        = $get_attachments->query( $query );
 
 			$gallery_attachments = array();
 			foreach ( $_attachments as $key => $val ) {
@@ -447,11 +436,32 @@ class WPSEO_Sitemap_Image_Parser {
 	 */
 	protected function get_gallery_attachments_for_parent( $id, $gallery ) {
 		$query = array(
-			'numberposts'      => -1,
-			'post_parent'      => $id,
+			'numberposts' => -1,
+			'post_parent' => $id,
+		);
+
+		// When there are posts that should be excluded from result set.
+		if ( ! empty( $gallery['exclude'] ) ) {
+			$query['exclude'] = $gallery['exclude'];
+		}
+
+		return $this->get_attachments( $query );
+	}
+
+	/**
+	 * Returns the attachments.
+	 *
+	 * @param array $args Array with query args.
+	 *
+	 * @return array The found attachments.
+	 */
+	protected function get_attachments( $args ) {
+		$default_args = array(
 			'post_status'      => 'inherit',
 			'post_type'        => 'attachment',
 			'post_mime_type'   => 'image',
+
+			// Defaults taken from function get_posts
 			'category'         => 0,
 			'orderby'          => 'date',
 			'order'            => 'DESC',
@@ -461,13 +471,10 @@ class WPSEO_Sitemap_Image_Parser {
 			'suppress_filters' => true
 		);
 
-		// When there are posts that should be excluded from result set.
-		if ( ! empty( $gallery['exclude'] ) ) {
-			$query['exclude'] = $gallery['exclude'];
-		}
+		$args = wp_parse_args( $args, $default_args );
 
 		$get_attachments = new WP_Query;
-		return $get_attachments->query( $query );
+		return $get_attachments->query( $args );
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -429,7 +429,8 @@ class WPSEO_Sitemap_Image_Parser {
 
 	/**
 	 * Returns the attachments for the given id.
-	 * 	 * @param int   $id      The post id.
+	 *
+	 * @param int   $id      The post id.
 	 * @param array $gallery The gallery config.
 	 *
 	 * @return array The selected attachments

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -433,7 +433,7 @@ class WPSEO_Sitemap_Image_Parser {
 	 * @param int   $id      The post id.
 	 * @param array $gallery The gallery config.
 	 *
-	 * @return array The selected attachments
+	 * @return array The selected attachments.
 	 */
 	protected function get_gallery_attachments_for_parent( $id, $gallery ) {
 		$query = array(
@@ -462,7 +462,7 @@ class WPSEO_Sitemap_Image_Parser {
 			'post_type'        => 'attachment',
 			'post_mime_type'   => 'image',
 
-			// Defaults taken from function get_posts
+			// Defaults taken from function get_posts.
 			'category'         => 0,
 			'orderby'          => 'date',
 			'order'            => 'DESC',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaced the use of `get_posts` and `get_children` by `WP_Query`

## Test instructions

This PR can be tested by following these steps:

* Test if the attachment sitemaps still works as usual.

Fixes #7700
