### PR TITLE
Return if wpseoPostScraperL10n or YoastSEO is not defined

### DIFF
--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -117,11 +117,11 @@ import a11ySpeak from "a11y-speak";
 	$( document ).ready( function() {
 		var featuredImage = wp.media.featuredImage.frame();
 
-		featuredImagePlugin = new FeaturedImagePlugin( YoastSEO.app );
-
 		if ( typeof YoastSEO === "undefined" ) {
 			return;
 		}
+
+		featuredImagePlugin = new FeaturedImagePlugin( YoastSEO.app );
 
 		$postImageDiv = $( "#postimagediv" );
 		$postImageDivHeading = $postImageDiv.find( ".hndle" );

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -119,6 +119,11 @@ import a11ySpeak from "a11y-speak";
 
 		featuredImagePlugin = new FeaturedImagePlugin( YoastSEO.app );
 
+		if ( typeof YoastSEO === "undefined" ) {
+			console.log( "hoi" );
+			return;
+		}
+
 		$postImageDiv = $( "#postimagediv" );
 		$postImageDivHeading = $postImageDiv.find( ".hndle" );
 

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -120,7 +120,6 @@ import a11ySpeak from "a11y-speak";
 		featuredImagePlugin = new FeaturedImagePlugin( YoastSEO.app );
 
 		if ( typeof YoastSEO === "undefined" ) {
-			console.log( "hoi" );
 			return;
 		}
 

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -28,7 +28,7 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 ( function( $ ) {
 	"use strict";
 
-	if ( typeof wpseoPostScraperL18n === "undefined" ) {
+	if ( typeof wpseoPostScraperL10n === "undefined" ) {
 		return;
 	}
 

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -28,6 +28,10 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 ( function( $ ) {
 	"use strict";
 
+	if ( typeof wpseoPostScraperL18n === "undefined" ) {
+		return;
+	}
+
 	var snippetContainer;
 
 	var titleElement;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Prevent the throwing of an error when wpseoPostScraperL10n is not defined.

## Test instructions

This PR can be tested by following these steps:

* Remove this line https://github.com/Yoast/wordpress-seo/blob/trunk/admin/metabox/class-metabox.php#L907 to reproduce the error.

Fixes #7651
