### PR TITLE
fix bug that caused dev bundle to be used in production

### DIFF
--- a/webpack/webpack.config.default.js
+++ b/webpack/webpack.config.default.js
@@ -41,7 +41,7 @@ const defaultWebpackConfig = {
 };
 
 const defaults = ( config ) => {
-	return _defaultsDeep( defaultWebpackConfig, config );
+	return _defaultsDeep( config, defaultWebpackConfig );
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Configuration wizard bundle size fixed.

## Relevant technical choices:

## Test instructions

This PR can be tested by following these steps:

* Execute `grunt webpack:buildProd` in this branch and in the old situation and see the reduced bundle size.
