### PR TITLE
Remove empty meta_query when there are no filters.

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -423,7 +423,7 @@ class WPSEO_Meta_Columns {
 
 		// If no filters were applied, just return everything.
 		if ( count( $filters ) === 0 ) {
-			return array_merge( $vars, $result );
+			return $vars;
 		}
 
 		$result['meta_query'] = array_merge( $result['meta_query'], array( $this->determine_score_filters( $filters ) ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Prevent empty meta_query from breaking post queries.

## Test instructions

This PR can be tested by following these steps:

* Merge `$result`, with an empty `meta_query`, over `$vars` to reproduce #7750.

Fixes #7750 .
Closes wpninjas/ninja-forms#3007 .