### PR TITLE
Return unmodified input data when our filters are not used in a list table

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -419,13 +419,12 @@ class WPSEO_Meta_Columns {
 	 * @return array Array containing the complete filter query.
 	 */
 	protected function build_filter_query( $vars, $filters ) {
-		$result = array( 'meta_query' => array() );
-
 		// If no filters were applied, just return everything.
 		if ( count( $filters ) === 0 ) {
-			return array_merge( $vars, $result );
+			return $vars;
 		}
 
+		$result = array( 'meta_query' => array() );
 		$result['meta_query'] = array_merge( $result['meta_query'], array( $this->determine_score_filters( $filters ) ) );
 
 		$current_seo_filter = $this->get_current_seo_filter();

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -184,9 +184,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 			array(
 				array(),
 				array(),
-				array(
-					'meta_query' => array()
-				)
+				array()
 			),
 
 			array(


### PR DESCRIPTION
Replaces https://github.com/Yoast/wordpress-seo/pull/7757

Props [Kyle B. Johnson](https://github.com/kjohnson)

## Summary

This PR can be summarized in the following changelog entry:

* Bugfix: Returns unmodified query arguments when no filters are active.

## Test instructions

This PR can be tested by following these steps:

* Install Ninja Forms
* Create two forms
* Add some entry for both forms
* Go to Submissions and filter on a form
* On `master` multiple lines will be shown
* On this branch, only the items that are expected are shown

Fixes #7750
Closes wpninjas/ninja-forms#3007
