### PR TITLE
Add set_options_value method to Yoast_Form.

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -95,6 +95,8 @@ class Yoast_Form {
 	/**
 	 * Sets a value in the options.
 	 *
+	 * @since 5.4
+	 *
 	 * @param string $key       The key of the option to set.
 	 * @param mixed  $value     The value to set the option to.
 	 * @param bool   $overwrite Whether to overwrite existing options. Default is false.

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -93,6 +93,19 @@ class Yoast_Form {
 	}
 
 	/**
+	 * Sets a value in the options.
+	 *
+	 * @param string $key       The key of the option to set.
+	 * @param mixed  $value     The value to set the option to.
+	 * @param bool   $overwrite Whether to overwrite existing options. Default is false.
+	 */
+	public function set_options_value( $key, $value, $overwrite = false ) {
+		if ( $overwrite || ! array_key_exists( $key, $this->options ) ) {
+			$this->options[ $key ] = $value;
+		}
+	}
+
+	/**
 	 * Retrieve options based on whether we're on multisite or not.
 	 *
 	 * @since 1.2.4


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the `set_options_value` method to `Yoast_Form` to set default values.

## Relevant technical choices:

* It has an optional parameter whether or not to overwrite existing values.

## Test instructions

This PR can be tested by following these steps:

* Use the `set_options_value` to set a new key's value to true.
* Create a checkbox with Yoast_Form on a new key.
* Check if the checkbox is checked.

Fixes #7787.
