### PR TITLE
Stories/6921 tell me to add redirect

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -101,6 +101,7 @@ class WPSEO_Admin {
 
 		$integrations[] = new WPSEO_Yoast_Columns();
 		$integrations[] = new WPSEO_License_Page_Manager();
+		$integrations[] = new WPSEO_Slug_Change_Watcher();
 		$integrations = array_merge( $integrations, $this->initialize_seo_links() );
 
 		/** @var WPSEO_WordPress_Integration $integration */

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -1,5 +1,9 @@
 <?php
+/** @package WPSEO\Admin\Watchers */
 
+/**
+ * Class WPSEO_Slug_Change_Watcher
+ */
 class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 
 	/**
@@ -36,36 +40,48 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		// If the post URL wasn't public before, or isn't public now, don't even check if we have to redirect.
-		if ( ! $this->check_public_post_status( get_post_status( $post_before->ID ) ) || ! $this->check_public_post_status( get_post_status( $post->ID ) ) ) {
+		// If the post URL wasn't visible before, or isn't visible now, don't even check if we have to redirect.
+		if ( ! $this->check_visible_post_status( get_post_status( $post_before->ID ) ) || ! $this->check_visible_post_status( get_post_status( $post->ID ) ) ) {
 			return;
 		}
 
-		add_action( 'admin_notices', array( $this, 'show_notice' ) );
-	}
-
-
-	public function show_notice() {
-		$class = 'notice notice-error';
-		$message = __( 'Irks! An error has occurred.', 'sample-text-domain' );
-
-		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+		$this->add_notification();
 	}
 
 	/**
-	 * Checks whether the given post status is public or not
+	 * Checks whether the given post status is visible or not
 	 *
 	 * @param string $post_status The post status to check.
 	 *
 	 * @return bool
 	 */
-	protected function check_public_post_status( $post_status ) {
-		$public_post_statuses = array(
+	protected function check_visible_post_status( $post_status ) {
+		$visible_post_statuses = array(
 			'publish',
 			'static',
 			'private',
 		);
 
-		return in_array( $post_status, $public_post_statuses, true );
+		return in_array( $post_status, $visible_post_statuses, true );
+	}
+
+	/**
+	 * Adds a notification to be shown on the next page request since posts are updated in an ajax request.
+	 */
+	protected function add_notification() {
+		$notification = new Yoast_Notification(
+			sprintf(
+			/* translators: %1$s expands to the anchor opening tag, %2$s to the anchor closing tag. */
+				__(
+					'You just changed the URL of a post. To ensure your visitors do not see a 404, you should create a redirect. %1$sLearn how to create redirects here.%2$s',
+					'wordpress-seo'
+				),
+				'<a href="https://yoast.com/which-redirect/">',
+				'</a>'
+			), array( 'type' => 'notice-info' )
+		);
+
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->add_notification( $notification );
 	}
 }

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -1,0 +1,71 @@
+<?php
+
+class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
+
+	/**
+	 * Registers all hooks to WordPress
+	 */
+	public function register_hooks() {
+
+		// When plugin is premium, just do nothing.
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			return;
+		}
+
+		// Detect a post slug change.
+		add_action( 'post_updated', array( $this, 'detect_slug_change' ), 12, 3 );
+	}
+
+	/**
+	 * Detect if the slug changed, hooked into 'post_updated'
+	 *
+	 * @param integer $post_id     The ID of the post. Unused.
+	 * @param WP_Post $post        The post with the new values.
+	 * @param WP_Post $post_before The post with the previous values.
+	 *
+	 * @return void
+	 */
+	public function detect_slug_change( $post_id, $post, $post_before ) {
+		// If post is a revision do not create redirect.
+		if ( wp_is_post_revision( $post_before ) && wp_is_post_revision( $post ) ) {
+			return;
+		}
+
+		// There is no slug change.
+		if ( $post->post_name === $post_before->post_name ) {
+			return;
+		}
+
+		// If the post URL wasn't public before, or isn't public now, don't even check if we have to redirect.
+		if ( ! $this->check_public_post_status( get_post_status( $post_before->ID ) ) || ! $this->check_public_post_status( get_post_status( $post->ID ) ) ) {
+			return;
+		}
+
+		add_action( 'admin_notices', array( $this, 'show_notice' ) );
+	}
+
+
+	public function show_notice() {
+		$class = 'notice notice-error';
+		$message = __( 'Irks! An error has occurred.', 'sample-text-domain' );
+
+		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+	}
+
+	/**
+	 * Checks whether the given post status is public or not
+	 *
+	 * @param string $post_status The post status to check.
+	 *
+	 * @return bool
+	 */
+	protected function check_public_post_status( $post_status ) {
+		$public_post_statuses = array(
+			'publish',
+			'static',
+			'private',
+		);
+
+		return in_array( $post_status, $public_post_statuses, true );
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a notification after changing the slug of a post informing the user about redirects.

## Relevant technical choices:

* Uses a non-permanent `Yoast_Notification`.

## Test instructions

This PR can be tested by following these steps:

* Edit the slug of a post.
* See if a notification appears.

Fixes #6921.

Note: Should not be merged until the link with more information is changed to a shortcode but can be code reviewed and tested.
