### PR TITLE
Remove premium prices.

### DIFF
--- a/admin/banner/class-admin-banner-sidebar.php
+++ b/admin/banner/class-admin-banner-sidebar.php
@@ -98,8 +98,7 @@ class WPSEO_Admin_Banner_Sidebar {
 			'<li><strong>' . __( 'No ads!', 'wordpress-seo' ) . '</strong></li>' .
 			'</ul>' .
 			/* translators: %s expands to Yoast SEO Premium */
-		    '<a id="wpseo-premium-button" class="button button-primary" href="' . $premium_uri . '" target="_blank">' . sprintf( __( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' ) . '</a><br/>' .
-			'<small>' . __( 'Prices start as low as 69,- for one site', 'wordpress-seo' ) . '</small><br/><br/>'
+		    '<a id="wpseo-premium-button" class="button button-primary" href="' . $premium_uri . '" target="_blank">' . sprintf( __( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' ) . '</a><br/>'
 		);
 
 		/*

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -62,7 +62,6 @@ class Premium_Upsell_Admin_Block {
 		echo '<ul class="' . $class . '--motivation">' . $arguments_html . '</ul>';
 
 		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . sprintf( __( 'Find out why you should upgrade to %s &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' ) . '</a><br />';
-		echo '<small>' . __( 'Prices start as low as 69,- for one site', 'wordpress-seo' ) . '</small></p>';
 		echo '</div>';
 
 		echo '</div>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the prices in the premium suggestions.

## Test instructions

This PR can be tested by following these steps:

* Go to SEO -> Dashboard.
* Check if any exact prices are listed in the premium suggestions.

Fixes #7797.

Note: If you get an error relating to the I18n promo message please do a `composer install` with #7795.
