### PR TITLE
Stories/yoast i18n module 3.0.0 rc1

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -458,7 +458,7 @@ class WPSEO_Admin_Init {
 	 */
 	private function register_i18n_promo_class() {
 		// BC, because an older version of the i18n-module didn't have this class.
-		$i18n_module = new Yoast_I18n_WordPressOrg_v2(
+		$i18n_module = new Yoast_I18n_WordPressOrg_v3(
 			array(
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require": {
 		"composer/installers": "~1.0",
 		"yoast/license-manager": "1.6.0",
-		"yoast/i18n-module": "2.1.0-RC1",
+		"yoast/i18n-module": "3.0.0-RC1",
 		"yoast/api-libs": "^2.0",
 		"xrstf/composer-php52": "^1.0.20",
 		"yoast/whip": "^1.1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9609f9e03988eb51f849cb84771f445d",
+    "hash": "4a0be1acccb491247e904e4fb3352d24",
+    "content-hash": "8e10ff96df8b94a1ad50f24752e32101",
     "packages": [
         {
             "name": "composer/installers",
@@ -118,7 +119,7 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2017-04-24T06:37:16+00:00"
+            "time": "2017-04-24 06:37:16"
         },
         {
             "name": "xrstf/composer-php52",
@@ -149,7 +150,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2016-04-16T21:52:24+00:00"
+            "time": "2016-04-16 21:52:24"
         },
         {
             "name": "yoast/api-libs",
@@ -187,20 +188,20 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2015-07-14T10:25:59+00:00"
+            "time": "2015-07-14 10:25:59"
         },
         {
             "name": "yoast/i18n-module",
-            "version": "2.1.0-RC1",
+            "version": "3.0.0-RC1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/i18n-module.git",
-                "reference": "70acb469a4ea9d2628ebb34961a892f15bc75975"
+                "reference": "c46cc543085c8937d93c6a10f766d3437533396d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/70acb469a4ea9d2628ebb34961a892f15bc75975",
-                "reference": "70acb469a4ea9d2628ebb34961a892f15bc75975",
+                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/c46cc543085c8937d93c6a10f766d3437533396d",
+                "reference": "c46cc543085c8937d93c6a10f766d3437533396d",
                 "shasum": ""
             },
             "type": "library",
@@ -225,7 +226,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2017-08-30T08:06:28+00:00"
+            "time": "2017-08-31 13:38:31"
         },
         {
             "name": "yoast/license-manager",
@@ -270,7 +271,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2017-08-22T07:59:16+00:00"
+            "time": "2017-08-22 07:59:16"
         },
         {
             "name": "yoast/whip",
@@ -312,7 +313,7 @@
                 }
             ],
             "description": "A WordPress package to nudge users to upgrade their software versions (starting with PHP)",
-            "time": "2017-08-04T10:00:35+00:00"
+            "time": "2017-08-04 10:00:35"
         }
     ],
     "packages-dev": [
@@ -373,7 +374,7 @@
                 "codeclimate",
                 "coverage"
             ],
-            "time": "2017-06-01T13:19:55+00:00"
+            "time": "2017-06-01 13:19:55"
         },
         {
             "name": "guzzle/guzzle",
@@ -469,7 +470,7 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2015-03-18T18:23:50+00:00"
+            "time": "2015-03-18 18:23:50"
         },
         {
             "name": "padraic/humbug_get_contents",
@@ -526,7 +527,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2015-04-22T18:45:00+00:00"
+            "time": "2015-04-22 18:45:00"
         },
         {
             "name": "padraic/phar-updater",
@@ -566,7 +567,7 @@
             ],
             "authors": [
                 {
-                    "name": "Pádraic Brady",
+                    "name": "Padraic Brady",
                     "email": "padraic.brady@gmail.com",
                     "homepage": "http://blog.astrumfutura.com"
                 }
@@ -578,7 +579,7 @@
                 "self-update",
                 "update"
             ],
-            "time": "2017-07-12T22:42:45+00:00"
+            "time": "2017-07-12 22:42:45"
         },
         {
             "name": "pdepend/pdepend",
@@ -618,7 +619,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-01-19T14:23:36+00:00"
+            "time": "2017-01-19 14:23:36"
         },
         {
             "name": "phpmd/phpmd",
@@ -684,7 +685,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2017-01-20T14:41:10+00:00"
+            "time": "2017-01-20 14:41:10"
         },
         {
             "name": "psr/container",
@@ -733,7 +734,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2017-02-14 16:28:37"
         },
         {
             "name": "psr/log",
@@ -780,7 +781,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -838,7 +839,7 @@
                 "github",
                 "test"
             ],
-            "time": "2016-01-20T17:35:46+00:00"
+            "time": "2016-01-20 17:35:46"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -916,7 +917,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-03-01 22:17:45"
         },
         {
             "name": "symfony/config",
@@ -978,7 +979,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-19T07:37:29+00:00"
+            "time": "2017-07-19 07:37:29"
         },
         {
             "name": "symfony/console",
@@ -1047,7 +1048,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:27:59+00:00"
+            "time": "2017-07-29 21:27:59"
         },
         {
             "name": "symfony/debug",
@@ -1103,7 +1104,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-28T15:27:31+00:00"
+            "time": "2017-07-28 15:27:31"
         },
         {
             "name": "symfony/dependency-injection",
@@ -1173,7 +1174,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-28T15:27:31+00:00"
+            "time": "2017-07-28 15:27:31"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1233,7 +1234,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T07:47:27+00:00"
+            "time": "2017-06-02 07:47:27"
         },
         {
             "name": "symfony/filesystem",
@@ -1282,7 +1283,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-11T07:17:58+00:00"
+            "time": "2017-07-11 07:17:58"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1341,7 +1342,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09T14:24:12+00:00"
+            "time": "2017-06-09 14:24:12"
         },
         {
             "name": "symfony/stopwatch",
@@ -1390,7 +1391,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12T14:14:56+00:00"
+            "time": "2017-04-12 14:14:56"
         },
         {
             "name": "symfony/yaml",
@@ -1445,7 +1446,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-23T12:43:26+00:00"
+            "time": "2017-07-23 12:43:26"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1481,7 +1482,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-08-29T20:04:47+00:00"
+            "time": "2016-08-29 20:04:47"
         },
         {
             "name": "yoast/php-development-environment",
@@ -1519,7 +1520,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2016-06-16T10:12:26+00:00"
+            "time": "2016-06-16 10:12:26"
         },
         {
             "name": "yoast/yoastcs",
@@ -1561,7 +1562,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-08-02T07:45:07+00:00"
+            "time": "2017-08-02 07:45:07"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Update yoast/i18n-module to 3.0.0-RC1.

## Test instructions

This PR can be tested by following these steps:

* Go to the SEO -> Dashboard.
* Check that it doesn't crash because the Yoast_I18n_WOrdPressOrg_v{2,3} class does not exist.
