### PR TITLE
Add a full width param config to the Configuration Wizard.

### DIFF
--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -17,7 +17,7 @@ class WPSEO_Configuration_Structure {
 	public function initialize() {
 		$this->add_step( 'intro', __( 'Welcome!', 'wordpress-seo' ), array(
 			'configurationChoices',
-		), false );
+		), false, true );
 
 		$this->add_step( 'environment_type', __( 'Environment', 'wordpress-seo' ), array( 'environment_type' ) );
 		$this->add_step( 'siteType', __( 'Site type', 'wordpress-seo' ), array( 'siteType' ) );
@@ -72,12 +72,14 @@ class WPSEO_Configuration_Structure {
 	 * @param string $title      Title to display for this step.
 	 * @param array  $fields     Fields to use on the step.
 	 * @param bool   $navigation Show navigation buttons.
+	 * @param bool   $full_width Wheter the step content is full width or not.
 	 */
-	protected function add_step( $identifier, $title, $fields, $navigation = true ) {
+	protected function add_step( $identifier, $title, $fields, $navigation = true, $full_width = false ) {
 		$this->steps[ $identifier ] = array(
 			'title'          => $title,
 			'fields'         => $fields,
 			'hideNavigation' => ! (bool) $navigation,
+			'fullWidth'      => $full_width,
 		);
 	}
 

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -42,7 +42,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_constructor() {
 		$this->structure->initialize();
-		
+
 		$steps = $this->structure->retrieve();
 
 		$expected = array(
@@ -84,7 +84,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue( isset( $steps[ $identifier ] ) );
 		$this->assertEquals(
-			array( 'title' => $title, 'fields' => $fields, 'hideNavigation' => false ),
+			array( 'title' => $title, 'fields' => $fields, 'hideNavigation' => false, 'fullWidth' => false ),
 			$steps[ $identifier ]
 		);
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add a full width param config to the Configuration Wizard.

## Relevant technical choices:

* Each step of the Configuration Wizard can now be configured to be full-width or not. By default, steps have a max-width.

## Test instructions

This PR can be tested by following these steps:

* build JS and CSS, yarn link the yoast-components (build CSS there) and test the steps: the Intro step should be full width, all the other ones have a max-width.

Fixes #7822 
Fixes https://github.com/Yoast/yoast-components/issues/259
