### PR TITLE
Allow orphaned attachments to be redirected

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1456,9 +1456,18 @@ class WPSEO_Frontend {
 	 */
 	function attachment_redirect() {
 		global $post;
-		if ( is_attachment() && ( ( is_object( $post ) && isset( $post->post_parent ) ) && ( is_numeric( $post->post_parent ) && $post->post_parent != 0 ) ) ) {
-			wp_safe_redirect( get_permalink( $post->post_parent ), 301 );
-			exit;
+		if ( is_attachment() ) {
+			if ( ( is_object( $post ) && isset( $post->post_parent ) ) && ( is_numeric( $post->post_parent ) && $post->post_parent != 0 ) ) {
+				wp_safe_redirect( get_permalink( $post->post_parent ), 301 );
+				exit;
+			}
+
+			/**
+			 * Filter: 'wpseo_attachment_redirect_orphan' - Give a chance to orphaned attachements to be redirected.
+			 *
+			 * @api WP_Post|null $post The attachment post.
+			 */
+			do_action( 'wpseo_attachment_redirect_orphan', $post );
 		}
 
 		return false;


### PR DESCRIPTION
Attachment pages that have a post parent are redirected to the parent
for SEO purposes, if the setting is switched on. For orphaned
attachments there's no such chance. Add an action called
`wpseo_attachment_redirect_orphan` to allow redirects on the user side
if desired.

## Summary

This PR can be summarized in the following changelog entry:

* Introduce `wpseo_attachment_redirect_orphan` action to allow unattached attachment pages to be redirected in tune with the relevant setting.

## Relevant technical choices:

* An action allows users of the plugin to decide via custom code what should be done by orphaned images.

## Test instructions

This PR can be tested by following these steps:

* Upload a media file without attaching it to a post.
* Visit the attachment page with the https://kb.yoast.com/kb/redirect-image-attachment-urls/ setting turned on.
* See no redirect.
* User adds `do_action( 'wpseo_attachment_redirect_orphan', function() { wp_safe_redirect( site_url(), 301 ); exit; } );`.
* Instant profit where needed.

Fixes #6625