### PR TITLE
Implement Roles and Capabilities

### DIFF
--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -28,16 +28,6 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 	}
 
 	/**
-	 * Adds the registerd capabilities to the system.
-	 */
-	abstract public function add();
-
-	/**
-	 * Removes the registered capabilities from the system
-	 */
-	abstract public function remove();
-
-	/**
 	 * @return string[] List of registered capabilities
 	 */
 	public function get_capabilities() {

--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -13,12 +13,12 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 	/**
 	 * Registers a capability.
 	 *
-	 * @param string $capability Capability to add.
+	 * @param string $capability Capability to register.
 	 * @param array  $roles      Roles to add the capability to.
-	 * @param bool   $add        Optional. Use add or overwrite as registration method.
+	 * @param bool   $overwrite        Optional. Use add or overwrite as registration method.
 	 */
-	public function register( $capability, array $roles, $add = true ) {
-		if ( ! $add || ! isset( $this->capabilities[ $capability ] ) ) {
+	public function register( $capability, array $roles, $overwrite = false ) {
+		if ( $overwrite || ! isset( $this->capabilities[ $capability ] ) ) {
 			$this->capabilities[ $capability ] = $roles;
 
 			return;
@@ -34,7 +34,7 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 	/**
 	 * Returns the list of registered capabilitities.
 	 *
-	 * @return string[] Registered capabilities
+	 * @return string[] Registered capabilities.
 	 */
 	public function get_capabilities() {
 		return array_keys( $this->capabilities );
@@ -42,6 +42,9 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 
 	/**
 	 * Returns a list of WP_Role roles.
+	 *
+	 * The string array of role names are converted to actual WP_Role objects.
+	 * These are needed to be able to use the API on them.
 	 *
 	 * @param array $roles Roles to retrieve the objects for.
 	 *
@@ -57,7 +60,7 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 	 * Filter capability roles.
 	 *
 	 * @param string $capability Capability to filter roles for.
-	 * @param array  $roles      Default roles.
+	 * @param array  $roles      List of roles which can be filtered.
 	 *
 	 * @return array Filtered list of roles for the capability.
 	 */

--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -3,7 +3,11 @@
  * @package WPSEO\Admin\Capabilities
  */
 
+/**
+ * Abstract Capability Manager shared code.
+ */
 abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Manager {
+	/** @var array Registered capabilities */
 	protected $capabilities = array();
 
 	/**
@@ -28,14 +32,18 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 	}
 
 	/**
-	 * @return string[] List of registered capabilities
+	 * Returns the list of registered capabilitities.
+	 *
+	 * @return string[] Registered capabilities
 	 */
 	public function get_capabilities() {
 		return array_keys( $this->capabilities );
 	}
 
 	/**
-	 * @param array $roles
+	 * Returns a list of WP_Role roles.
+	 *
+	 * @param array $roles Roles to retrieve the objects for.
 	 *
 	 * @return WP_Role[] List of WP_Role objects.
 	 */

--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -65,7 +65,9 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 	 */
 	protected function filter_roles( $capability, array $roles ) {
 		/**
-		 * @todo add filter documentation
+		 * Filter: Allow changing roles that a capability is added to.
+		 *
+		 * @api array $roles The default roles to be filtered.
 		 */
 		$filtered = apply_filters( $capability . '_roles', $roles );
 

--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @package WPSEO\Admin\Capabilities
+ */
+
+abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Manager {
+	protected $capabilities = array();
+
+	/**
+	 * Registers a capability.
+	 *
+	 * @param string $capability Capability to add.
+	 * @param array  $roles      Roles to add the capability to.
+	 * @param bool   $add        Optional. Use add or overwrite as registration method.
+	 */
+	public function register( $capability, array $roles, $add = true ) {
+		if ( ! $add || ! isset( $this->capabilities[ $capability ] ) ) {
+			$this->capabilities[ $capability ] = $roles;
+
+			return;
+		}
+
+		// Combine configurations.
+		$this->capabilities[ $capability ] = array_merge( $roles, $this->capabilities[ $capability ] );
+
+		// Remove doubles.
+		$this->capabilities[ $capability ] = array_unique( $this->capabilities[ $capability ] );
+	}
+
+	/**
+	 * Adds the registerd capabilities to the system.
+	 */
+	abstract public function add();
+
+	/**
+	 * Removes the registered capabilities from the system
+	 */
+	abstract public function remove();
+
+	/**
+	 * @return string[] List of registered capabilities
+	 */
+	public function get_capabilities() {
+		return array_keys( $this->capabilities );
+	}
+
+	/**
+	 * @param array $roles
+	 *
+	 * @return WP_Role[] List of WP_Role objects.
+	 */
+	protected function get_wp_roles( array $roles ) {
+		$wp_roles = array_map( 'get_role', $roles );
+
+		return array_filter( $wp_roles );
+	}
+
+	/**
+	 * Filter capability roles.
+	 *
+	 * @param string $capability Capability to filter roles for.
+	 * @param array  $roles      Default roles.
+	 *
+	 * @return array Filtered list of roles for the capability.
+	 */
+	protected function filter_roles( $capability, array $roles ) {
+		/**
+		 * @todo add filter documentation
+		 */
+		$filtered = apply_filters( $capability . '_roles', $roles );
+
+		// Make sure we have the expected type.
+		if ( ! is_array( $filtered ) ) {
+			return array();
+		}
+
+		return $filtered;
+	}
+}

--- a/admin/capabilities/class-capability-manager-factory.php
+++ b/admin/capabilities/class-capability-manager-factory.php
@@ -3,11 +3,14 @@
  * @package WPSEO\Admin\Capabilities
  */
 
+/**
+ * Capability Manager Factory
+ */
 class WPSEO_Capability_Manager_Factory {
 	/**
 	 * Returns the Manager to use.
 	 *
-	 * @return WPSEO_Capability_Manager
+	 * @return WPSEO_Capability_Manager Manager to use.
 	 */
 	public static function get() {
 		static $manager = null;
@@ -15,7 +18,9 @@ class WPSEO_Capability_Manager_Factory {
 		if ( null === $manager ) {
 			if ( function_exists( 'wpcom_vip_add_role_caps' ) ) {
 				$manager = new WPSEO_Capability_Manager_VIP();
-			} else {
+			}
+
+			if ( ! function_exists( 'wpcom_vip_add_role_caps' ) ) {
 				$manager = new WPSEO_Capability_Manager_WP();
 			}
 		}

--- a/admin/capabilities/class-capability-manager-factory.php
+++ b/admin/capabilities/class-capability-manager-factory.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Capability Manager Factory
+ * Capability Manager Factory.
  */
 class WPSEO_Capability_Manager_Factory {
 	/**
@@ -15,7 +15,7 @@ class WPSEO_Capability_Manager_Factory {
 	public static function get() {
 		static $manager = null;
 
-		if ( null === $manager ) {
+		if ( $manager === null ) {
 			if ( function_exists( 'wpcom_vip_add_role_caps' ) ) {
 				$manager = new WPSEO_Capability_Manager_VIP();
 			}

--- a/admin/capabilities/class-capability-manager-factory.php
+++ b/admin/capabilities/class-capability-manager-factory.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Capabilities
+ */
 
 class WPSEO_Capability_Manager_Factory {
 	/**

--- a/admin/capabilities/class-capability-manager-factory.php
+++ b/admin/capabilities/class-capability-manager-factory.php
@@ -1,0 +1,22 @@
+<?php
+
+class WPSEO_Capability_Manager_Factory {
+	/**
+	 * Returns the Manager to use.
+	 *
+	 * @return WPSEO_Capability_Manager
+	 */
+	public static function get() {
+		static $manager = null;
+
+		if ( null === $manager ) {
+			if ( function_exists( 'wpcom_vip_add_role_caps' ) ) {
+				$manager = new WPSEO_Capability_Manager_VIP();
+			} else {
+				$manager = new WPSEO_Capability_Manager_WP();
+			}
+		}
+
+		return $manager;
+	}
+}

--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Capabilities
+ */
 
 class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
 	protected $capabilities = array();

--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -32,6 +32,7 @@ final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manag
 	public function remove() {
 		// Remove from any role it has been added to.
 		$roles = wp_roles()->get_names();
+		$roles = array_keys( $roles );
 
 		$add_role_caps = array();
 		foreach ( $this->capabilities as $capability => $_roles ) {

--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -3,9 +3,14 @@
  * @package WPSEO\Admin\Capabilities
  */
 
+/**
+ * VIP implementation of the Capability Manager.
+ */
 final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manager {
 	/**
 	 * Adds the registerd capabilities to the system.
+	 *
+	 * @return void
 	 */
 	public function add() {
 		$add_role_caps = array();
@@ -28,6 +33,8 @@ final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manag
 
 	/**
 	 * Removes the registered capabilities from the system
+	 *
+	 * @return void
 	 */
 	public function remove() {
 		// Remove from any role it has been added to.

--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -17,7 +17,7 @@ class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
 	}
 
 	/**
-	 *
+	 * Adds the registerd capabilities to the system.
 	 */
 	public function add() {
 
@@ -40,16 +40,11 @@ class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
 	}
 
 	/**
-	 *
+	 * Removes the registered capabilities from the system
 	 */
 	public function remove() {
 		// Remove from any role it has been added to.
-		$roles = array(
-			'administrator',
-			'editor',
-			'author',
-			'contributor'
-		);
+		$roles = wp_roles()->get_names();
 
 		$add_role_caps = array();
 		foreach( $this->capabilities as $capability => $roles ) {
@@ -87,7 +82,7 @@ class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
 	 */
 	protected function filter_roles( $capability, array $roles ) {
 		/**
-		 *
+		 * @todo filter documentation
 		 */
 		return apply_filters( $capability . '_roles', $roles );
 	}

--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -8,25 +8,17 @@
  */
 final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manager {
 	/**
-	 * Adds the registerd capabilities to the system.
+	 * Adds the registered capabilities to the system.
 	 *
 	 * @return void
 	 */
 	public function add() {
-		$add_role_caps = array();
+		$role_capabilities = array();
 		foreach ( $this->capabilities as $capability => $roles ) {
-			// Allow filtering of roles.
-			$filtered_roles = $this->filter_roles( $capability, $roles );
-
-			foreach ( $filtered_roles as $role ) {
-				if ( ! isset( $add_role_caps[ $role ] ) ) {
-					$add_role_caps[ $role ] = array();
-				}
-				$add_role_caps[ $role ][] = $capability;
-			}
+			$role_capabilities = $this->get_role_capabilities( $role_capabilities, $capability, $roles );
 		}
 
-		foreach ( $add_role_caps as $role => $capabilities ) {
+		foreach ( $role_capabilities as $role => $capabilities ) {
 			wpcom_vip_add_role_caps( $role, array( $capabilities ) );
 		}
 	}
@@ -41,21 +33,38 @@ final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manag
 		$roles = wp_roles()->get_names();
 		$roles = array_keys( $roles );
 
-		$add_role_caps = array();
-		foreach ( $this->capabilities as $capability => $_roles ) {
+		$role_capabilities = array();
+		foreach ( array_keys( $this->capabilities ) as $capability ) {
 			// Allow filtering of roles.
-			$filtered_roles = $this->filter_roles( $capability, $roles );
-
-			foreach ( $filtered_roles as $role ) {
-				if ( ! isset( $add_role_caps[ $role ] ) ) {
-					$add_role_caps[ $role ] = array();
-				}
-				$add_role_caps[ $role ][] = $capability;
-			}
+			$role_capabilities = $this->get_role_capabilities( $role_capabilities, $capability, $roles );
 		}
 
-		foreach ( $add_role_caps as $role => $capabilities ) {
+		foreach ( $role_capabilities as $role => $capabilities ) {
 			wpcom_vip_remove_role_caps( $role, array( $capabilities ) );
 		}
+	}
+
+	/**
+	 * Returns the roles which the capability is registered on.
+	 *
+	 * @param array  $role_capabilities List of all roles with their capabilities.
+	 * @param string $capability        Capability to filter roles for.
+	 * @param array  $roles             List of default roles.
+	 *
+	 * @return array List of capabilities.
+	 */
+	protected function get_role_capabilities( $role_capabilities, $capability, $roles ) {
+		// Allow filtering of roles.
+		$filtered_roles = $this->filter_roles( $capability, $roles );
+
+		foreach ( $filtered_roles as $role ) {
+			if ( ! isset( $add_role_caps[ $role ] ) ) {
+				$role_capabilities[ $role ] = array();
+			}
+
+			$role_capabilities[ $role ][] = $capability;
+		}
+
+		return $role_capabilities;
 	}
 }

--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -3,30 +3,17 @@
  * @package WPSEO\Admin\Capabilities
  */
 
-class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
-	protected $capabilities = array();
-
-	/**
-	 * Registers a capability.
-	 *
-	 * @param string $capability Capability to add.
-	 * @param array  $roles      Roles to add the capability to.
-	 */
-	public function register( $capability, array $roles ) {
-		$this->capabilities[ $capability ] = $roles;
-	}
-
+final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manager {
 	/**
 	 * Adds the registerd capabilities to the system.
 	 */
 	public function add() {
-
 		$add_role_caps = array();
-		foreach( $this->capabilities as $capability => $roles ) {
+		foreach ( $this->capabilities as $capability => $roles ) {
 			// Allow filtering of roles.
 			$filtered_roles = $this->filter_roles( $capability, $roles );
 
-			foreach ($filtered_roles as $role) {
+			foreach ( $filtered_roles as $role ) {
 				if ( ! isset( $add_role_caps[ $role ] ) ) {
 					$add_role_caps[ $role ] = array();
 				}
@@ -47,11 +34,11 @@ class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
 		$roles = wp_roles()->get_names();
 
 		$add_role_caps = array();
-		foreach( $this->capabilities as $capability => $roles ) {
+		foreach ( $this->capabilities as $capability => $_roles ) {
 			// Allow filtering of roles.
 			$filtered_roles = $this->filter_roles( $capability, $roles );
 
-			foreach ($filtered_roles as $role) {
+			foreach ( $filtered_roles as $role ) {
 				if ( ! isset( $add_role_caps[ $role ] ) ) {
 					$add_role_caps[ $role ] = array();
 				}
@@ -62,35 +49,5 @@ class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
 		foreach ( $add_role_caps as $role => $capabilities ) {
 			wpcom_vip_remove_role_caps( $role, array( $capabilities ) );
 		}
-	}
-
-	/**
-	 * @param array $roles
-	 *
-	 * @return WP_Role[] List of WP_Role objects.
-	 */
-	protected function get_wp_roles( array $roles ) {
-		$wp_roles = array_map( 'get_role', $roles );
-		return array_filter($wp_roles );
-	}
-
-	/**
-	 * @param string $capability
-	 * @param array $roles
-	 *
-	 * @return array
-	 */
-	protected function filter_roles( $capability, array $roles ) {
-		/**
-		 * @todo filter documentation
-		 */
-		return apply_filters( $capability . '_roles', $roles );
-	}
-
-	/**
-	 * @return string[] List of registered capabilities
-	 */
-	public function get_capabilities() {
-		return array_keys( $this->capabilities );
 	}
 }

--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -1,0 +1,98 @@
+<?php
+
+class WPSEO_Capability_Manager_VIP implements WPSEO_Capability_Manager {
+	protected $capabilities = array();
+
+	/**
+	 * Registers a capability.
+	 *
+	 * @param string $capability Capability to add.
+	 * @param array  $roles      Roles to add the capability to.
+	 */
+	public function register( $capability, array $roles ) {
+		$this->capabilities[ $capability ] = $roles;
+	}
+
+	/**
+	 *
+	 */
+	public function add() {
+
+		$add_role_caps = array();
+		foreach( $this->capabilities as $capability => $roles ) {
+			// Allow filtering of roles.
+			$filtered_roles = $this->filter_roles( $capability, $roles );
+
+			foreach ($filtered_roles as $role) {
+				if ( ! isset( $add_role_caps[ $role ] ) ) {
+					$add_role_caps[ $role ] = array();
+				}
+				$add_role_caps[ $role ][] = $capability;
+			}
+		}
+
+		foreach ( $add_role_caps as $role => $capabilities ) {
+			wpcom_vip_add_role_caps( $role, array( $capabilities ) );
+		}
+	}
+
+	/**
+	 *
+	 */
+	public function remove() {
+		// Remove from any role it has been added to.
+		$roles = array(
+			'administrator',
+			'editor',
+			'author',
+			'contributor'
+		);
+
+		$add_role_caps = array();
+		foreach( $this->capabilities as $capability => $roles ) {
+			// Allow filtering of roles.
+			$filtered_roles = $this->filter_roles( $capability, $roles );
+
+			foreach ($filtered_roles as $role) {
+				if ( ! isset( $add_role_caps[ $role ] ) ) {
+					$add_role_caps[ $role ] = array();
+				}
+				$add_role_caps[ $role ][] = $capability;
+			}
+		}
+
+		foreach ( $add_role_caps as $role => $capabilities ) {
+			wpcom_vip_remove_role_caps( $role, array( $capabilities ) );
+		}
+	}
+
+	/**
+	 * @param array $roles
+	 *
+	 * @return WP_Role[] List of WP_Role objects.
+	 */
+	protected function get_wp_roles( array $roles ) {
+		$wp_roles = array_map( 'get_role', $roles );
+		return array_filter($wp_roles );
+	}
+
+	/**
+	 * @param string $capability
+	 * @param array $roles
+	 *
+	 * @return array
+	 */
+	protected function filter_roles( $capability, array $roles ) {
+		/**
+		 *
+		 */
+		return apply_filters( $capability . '_roles', $roles );
+	}
+
+	/**
+	 * @return string[] List of registered capabilities
+	 */
+	public function get_capabilities() {
+		return array_keys( $this->capabilities );
+	}
+}

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -65,18 +65,21 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 	 */
 	protected function get_wp_roles( array $roles ) {
 		$wp_roles = array_map( 'get_role', $roles );
-		return array_filter($wp_roles );
+
+		return array_filter( $wp_roles );
 	}
 
 	/**
-	 * @param string $capability
-	 * @param array $roles
+	 * Filter capability roles.
 	 *
-	 * @return array
+	 * @param string $capability Capability to filter roles for.
+	 * @param array  $roles      Default roles.
+	 *
+	 * @return array Filtered list of roles for the capability.
 	 */
 	protected function filter_roles( $capability, array $roles ) {
 		/**
-		 *
+		 * @todo add filter documentation
 		 */
 		return apply_filters( $capability . '_roles', $roles );
 	}

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -24,6 +24,7 @@ final class WPSEO_Capability_Manager_WP extends WPSEO_Abstract_Capability_Manage
 	public function remove() {
 		// Remove from any roles it has been added to.
 		$roles = wp_roles()->get_names();
+		$roles = array_keys( $roles );
 
 		foreach ( $this->capabilities as $capability => $_roles ) {
 			$registered_roles = array_unique( array_merge( $roles, $this->capabilities[ $capability ] ) );

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Capabilities
+ */
 
 class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 	protected $capabilities = array();
@@ -14,7 +17,16 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 	}
 
 	/**
+	 * Returns the list of registered capabilities
 	 *
+	 * @return string[] List of registered capabilities
+	 */
+	public function get_capabilities() {
+		return array_keys( $this->capabilities );
+	}
+
+	/**
+	 * Adds the capabilities to the roles.
 	 */
 	public function add() {
 		foreach ( $this->capabilities as $capability => $roles ) {
@@ -28,7 +40,7 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 	}
 
 	/**
-	 *
+	 * Unregisters the capabilities from the system.
 	 */
 	public function remove() {
 		// Remove from any role it has been added to.
@@ -73,14 +85,5 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 		 *
 		 */
 		return apply_filters( $capability . '_roles', $roles );
-	}
-
-	/**
-	 * Returns the list of registered capabilities
-	 *
-	 * @return string[] List of registered capabilities
-	 */
-	public function get_capabilities() {
-		return array_keys( $this->capabilities );
 	}
 }

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -81,6 +81,13 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 		/**
 		 * @todo add filter documentation
 		 */
-		return apply_filters( $capability . '_roles', $roles );
+		$filtered = apply_filters( $capability . '_roles', $roles );
+
+		// Make sure we have the expected type.
+		if ( ! is_array( $filtered ) ) {
+			return array();
+		}
+
+		return $filtered;
 	}
 }

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -1,0 +1,86 @@
+<?php
+
+class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
+	protected $capabilities = array();
+
+	/**
+	 * Registers a capability.
+	 *
+	 * @param string $capability Capability to add.
+	 * @param array  $roles      Roles to add the capability to.
+	 */
+	public function register( $capability, array $roles ) {
+		$this->capabilities[ $capability ] = $roles;
+	}
+
+	/**
+	 *
+	 */
+	public function add() {
+		foreach ( $this->capabilities as $capability => $roles ) {
+			$filtered_roles = $this->filter_roles( $capability, $roles );
+
+			$wp_roles = $this->get_wp_roles( $filtered_roles );
+			foreach ( $wp_roles as $wp_role ) {
+				$wp_role->add_cap( $capability );
+			}
+		}
+	}
+
+	/**
+	 *
+	 */
+	public function remove() {
+		// Remove from any role it has been added to.
+		$roles = array(
+			'administrator',
+			'editor',
+			'author',
+			'contributor'
+		);
+
+		foreach ( $this->capabilities as $capability => $capability_roles ) {
+			$registered_roles = array_unique( array_merge( $roles, $this->capabilities[ $capability ] ) );
+
+			// Allow filtering of roles.
+			$filtered_roles = $this->filter_roles( $capability, $registered_roles );
+
+			$wp_roles = $this->get_wp_roles( $filtered_roles );
+			foreach ( $wp_roles as $wp_role ) {
+				$wp_role->remove_cap( $capability );
+			}
+		}
+	}
+
+	/**
+	 * @param array $roles
+	 *
+	 * @return WP_Role[] List of WP_Role objects.
+	 */
+	protected function get_wp_roles( array $roles ) {
+		$wp_roles = array_map( 'get_role', $roles );
+		return array_filter($wp_roles );
+	}
+
+	/**
+	 * @param string $capability
+	 * @param array $roles
+	 *
+	 * @return array
+	 */
+	protected function filter_roles( $capability, array $roles ) {
+		/**
+		 *
+		 */
+		return apply_filters( $capability . '_roles', $roles );
+	}
+
+	/**
+	 * Returns the list of registered capabilities
+	 *
+	 * @return string[] List of registered capabilities
+	 */
+	public function get_capabilities() {
+		return array_keys( $this->capabilities );
+	}
+}

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -3,28 +3,7 @@
  * @package WPSEO\Admin\Capabilities
  */
 
-class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
-	protected $capabilities = array();
-
-	/**
-	 * Registers a capability.
-	 *
-	 * @param string $capability Capability to add.
-	 * @param array  $roles      Roles to add the capability to.
-	 */
-	public function register( $capability, array $roles ) {
-		$this->capabilities[ $capability ] = $roles;
-	}
-
-	/**
-	 * Returns the list of registered capabilities
-	 *
-	 * @return string[] List of registered capabilities
-	 */
-	public function get_capabilities() {
-		return array_keys( $this->capabilities );
-	}
-
+final class WPSEO_Capability_Manager_WP extends WPSEO_Abstract_Capability_Manager {
 	/**
 	 * Adds the capabilities to the roles.
 	 */
@@ -43,9 +22,10 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 	 * Unregisters the capabilities from the system.
 	 */
 	public function remove() {
+		// Remove from any roles it has been added to.
 		$roles = wp_roles()->get_names();
 
-		foreach ( $this->capabilities as $capability => $capability_roles ) {
+		foreach ( $this->capabilities as $capability => $_roles ) {
 			$registered_roles = array_unique( array_merge( $roles, $this->capabilities[ $capability ] ) );
 
 			// Allow filtering of roles.
@@ -56,38 +36,5 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 				$wp_role->remove_cap( $capability );
 			}
 		}
-	}
-
-	/**
-	 * @param array $roles
-	 *
-	 * @return WP_Role[] List of WP_Role objects.
-	 */
-	protected function get_wp_roles( array $roles ) {
-		$wp_roles = array_map( 'get_role', $roles );
-
-		return array_filter( $wp_roles );
-	}
-
-	/**
-	 * Filter capability roles.
-	 *
-	 * @param string $capability Capability to filter roles for.
-	 * @param array  $roles      Default roles.
-	 *
-	 * @return array Filtered list of roles for the capability.
-	 */
-	protected function filter_roles( $capability, array $roles ) {
-		/**
-		 * @todo add filter documentation
-		 */
-		$filtered = apply_filters( $capability . '_roles', $roles );
-
-		// Make sure we have the expected type.
-		if ( ! is_array( $filtered ) ) {
-			return array();
-		}
-
-		return $filtered;
 	}
 }

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -43,13 +43,7 @@ class WPSEO_Capability_Manager_WP implements WPSEO_Capability_Manager {
 	 * Unregisters the capabilities from the system.
 	 */
 	public function remove() {
-		// Remove from any role it has been added to.
-		$roles = array(
-			'administrator',
-			'editor',
-			'author',
-			'contributor'
-		);
+		$roles = wp_roles()->get_names();
 
 		foreach ( $this->capabilities as $capability => $capability_roles ) {
 			$registered_roles = array_unique( array_merge( $roles, $this->capabilities[ $capability ] ) );

--- a/admin/capabilities/class-capability-manager-wp.php
+++ b/admin/capabilities/class-capability-manager-wp.php
@@ -3,9 +3,14 @@
  * @package WPSEO\Admin\Capabilities
  */
 
+/**
+ * Default WordPress capability manager implementation.
+ */
 final class WPSEO_Capability_Manager_WP extends WPSEO_Abstract_Capability_Manager {
 	/**
 	 * Adds the capabilities to the roles.
+	 *
+	 * @return void
 	 */
 	public function add() {
 		foreach ( $this->capabilities as $capability => $roles ) {
@@ -20,6 +25,8 @@ final class WPSEO_Capability_Manager_WP extends WPSEO_Abstract_Capability_Manage
 
 	/**
 	 * Unregisters the capabilities from the system.
+	 *
+	 * @return void
 	 */
 	public function remove() {
 		// Remove from any roles it has been added to.

--- a/admin/capabilities/class-capability-manager.php
+++ b/admin/capabilities/class-capability-manager.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Admin\Capabilities
  */
 
+/**
+ * Capability Manager interface.
+ */
 interface WPSEO_Capability_Manager {
 	/**
 	 * Registers a capability.

--- a/admin/capabilities/class-capability-manager.php
+++ b/admin/capabilities/class-capability-manager.php
@@ -9,8 +9,9 @@ interface WPSEO_Capability_Manager {
 	 *
 	 * @param string $capability Capability to add.
 	 * @param array  $roles      Roles to add the capability to.
+	 * @param bool   $add        Optional. Use add or overwrite as registration method.
 	 */
-	public function register( $capability, array $roles );
+	public function register( $capability, array $roles, $add = true );
 
 	/**
 	 * Adds the registerd capabilities to the system.

--- a/admin/capabilities/class-capability-manager.php
+++ b/admin/capabilities/class-capability-manager.php
@@ -10,11 +10,11 @@ interface WPSEO_Capability_Manager {
 	/**
 	 * Registers a capability.
 	 *
-	 * @param string $capability Capability to add.
+	 * @param string $capability Capability to register.
 	 * @param array  $roles      Roles to add the capability to.
-	 * @param bool   $add        Optional. Use add or overwrite as registration method.
+	 * @param bool   $overwrite  Optional. Use add or overwrite as registration method.
 	 */
-	public function register( $capability, array $roles, $add = true );
+	public function register( $capability, array $roles, $overwrite = false );
 
 	/**
 	 * Adds the registerd capabilities to the system.
@@ -22,14 +22,14 @@ interface WPSEO_Capability_Manager {
 	public function add();
 
 	/**
-	 * Removes the registered capabilities from the system
+	 * Removes the registered capabilities from the system.
 	 */
 	public function remove();
 
 	/**
-	 * Returns the list of registered capabilities
+	 * Returns the list of registered capabilities.
 	 *
-	 * @return string[] List of registered capabilities
+	 * @return string[] List of registered capabilities.
 	 */
 	public function get_capabilities();
 }

--- a/admin/capabilities/class-capability-manager.php
+++ b/admin/capabilities/class-capability-manager.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Capabilities
+ */
 
 interface WPSEO_Capability_Manager {
 	/**

--- a/admin/capabilities/class-capability-manager.php
+++ b/admin/capabilities/class-capability-manager.php
@@ -1,0 +1,28 @@
+<?php
+
+interface WPSEO_Capability_Manager {
+	/**
+	 * Registers a capability.
+	 *
+	 * @param string $capability Capability to add.
+	 * @param array  $roles      Roles to add the capability to.
+	 */
+	public function register( $capability, array $roles );
+
+	/**
+	 * Adds the registerd capabilities to the system.
+	 */
+	public function add();
+
+	/**
+	 * Removes the registered capabilities from the system
+	 */
+	public function remove();
+
+	/**
+	 * Returns the list of registered capabilities
+	 *
+	 * @return string[] List of registered capabilities
+	 */
+	public function get_capabilities();
+}

--- a/admin/capabilities/class-capability-utils.php
+++ b/admin/capabilities/class-capability-utils.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Admin\Capabilities
  */
 
+/**
+ * Capability Utils collection.
+ */
 class WPSEO_Capability_Utils {
 	/**
 	 * Checks if the user has the proper capabilities.

--- a/admin/capabilities/class-capability-utils.php
+++ b/admin/capabilities/class-capability-utils.php
@@ -11,7 +11,7 @@ class WPSEO_Capability_Utils {
 	 *
 	 * @return bool True if the user has the proper rights.
 	 */
-	public static function can( $capability ) {
+	public static function current_user_can( $capability ) {
 		if ( $capability === 'wpseo_manage_options' ) {
 			return self::has( $capability );
 		}
@@ -26,7 +26,7 @@ class WPSEO_Capability_Utils {
 	 *
 	 * @return bool True if the user has at least one capability.
 	 */
-	public static function has_any( array $capabilities ) {
+	protected static function has_any( array $capabilities ) {
 		foreach ( $capabilities as $capability ) {
 			if ( self::has( $capability ) ) {
 				return true;
@@ -43,7 +43,7 @@ class WPSEO_Capability_Utils {
 	 *
 	 * @return bool True if the user has the capability.
 	 */
-	public static function has( $capability ) {
+	protected static function has( $capability ) {
 		return current_user_can( $capability );
 	}
 }

--- a/admin/capabilities/class-capability-utils.php
+++ b/admin/capabilities/class-capability-utils.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @package WPSEO\Admin\Capabilities
+ */
+
+class WPSEO_Capability_Utils {
+	/**
+	 * Checks if the user has the proper capabilities.
+	 *
+	 * @param string $capability Capability to check.
+	 *
+	 * @return bool True if the user has the proper rights.
+	 */
+	public static function can( $capability ) {
+		if ( $capability === 'wpseo_manage_options' ) {
+			return self::has( $capability );
+		}
+
+		return self::has_any( array( 'wpseo_manage_options', $capability ) );
+	}
+
+	/**
+	 * Checks if the current user has at least one of the supplied capabilities.
+	 *
+	 * @param array $capabilities Capabilities to check against.
+	 *
+	 * @return bool True if the user has at least one capability.
+	 */
+	public static function has_any( array $capabilities ) {
+		foreach ( $capabilities as $capability ) {
+			if ( self::has( $capability ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if the user has a certain capability.
+	 *
+	 * @param string $capability Capability to check against.
+	 *
+	 * @return bool True if the user has the capability.
+	 */
+	public static function has( $capability ) {
+		return current_user_can( $capability );
+	}
+}

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -3,9 +3,14 @@
  * @package WPSEO\Admin\Capabilities
  */
 
+/**
+ * Capabilities registration class.
+ */
 class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	/**
 	 * Registers the hooks.
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		add_action( 'wpseo_register_capabilities', array( $this, 'register' ) );
@@ -13,6 +18,8 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Registers the capabilities.
+	 *
+	 * @return void
 	 */
 	public function register() {
 		$manager = WPSEO_Capability_Manager_Factory::get();

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -18,6 +18,18 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		$manager = WPSEO_Capability_Manager_Factory::get();
 
 		$manager->register( 'wpseo_bulk_edit', array( 'editor' ) );
-		$manager->register( 'wpseo_manage_options', array( 'administrator' ) );
+
+		/*
+		 * Respect MultiSite 'access' setting if set to 'super admins only'.
+		 * This means that local admins do not get the `wpseo_manage_options` capability.
+		 */
+		$ms_options = WPSEO_Options::get_option( 'ms' );
+		if ( $ms_options['access'] !== 'superadmins' ) {
+			$manager->register( 'wpseo_manage_options', array( 'administrator' ) );
+		}
+
+		// Add capabilities to WPSEO Roles.
+		$manager->register( 'wpseo_bulk_edit', array( 'wpseo_editor' ) );
+		$manager->register( 'wpseo_manage_options', array( 'wpseo_manager' ) );
 	}
 }

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -17,7 +17,8 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	public function register() {
 		$manager = WPSEO_Capability_Manager_Factory::get();
 
-		$manager->register( 'wpseo_bulk_edit', array( 'editor', 'wpseo_editor' ) );
+		$manager->register( 'wpseo_bulk_edit', array( 'editor', 'wpseo_editor', 'wpseo_manager' ) );
+		$manager->register( 'wpseo_edit_advanced_metadata', array( 'wpseo_editor', 'wpseo_manager' ) );
 
 		$manager->register( 'wpseo_manage_options', array( 'wpseo_manager' ) );
 

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Capabilities
+ */
 
 class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	/**

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -17,7 +17,9 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	public function register() {
 		$manager = WPSEO_Capability_Manager_Factory::get();
 
-		$manager->register( 'wpseo_bulk_edit', array( 'editor' ) );
+		$manager->register( 'wpseo_bulk_edit', array( 'editor', 'wpseo_editor' ) );
+
+		$manager->register( 'wpseo_manage_options', array( 'wpseo_manager' ) );
 
 		/*
 		 * Respect MultiSite 'access' setting if set to 'super admins only'.
@@ -27,9 +29,5 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		if ( $ms_options['access'] !== 'superadmins' ) {
 			$manager->register( 'wpseo_manage_options', array( 'administrator' ) );
 		}
-
-		// Add capabilities to WPSEO Roles.
-		$manager->register( 'wpseo_bulk_edit', array( 'wpseo_editor' ) );
-		$manager->register( 'wpseo_manage_options', array( 'wpseo_manager' ) );
 	}
 }

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -17,7 +17,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	public function register() {
 		$manager = WPSEO_Capability_Manager_Factory::get();
 
-		$manager->register( 'wpseo_bulk_edit', array( 'administrator', 'editor' ) );
-		$manager->register( 'wpseo_manage_options', array( 'administrator', 'editor' ) );
+		$manager->register( 'wpseo_bulk_edit', array( 'editor' ) );
+		$manager->register( 'wpseo_manage_options', array( 'administrator' ) );
 	}
 }

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
+	/**
+	 * Registers the hooks.
+	 */
+	public function register_hooks() {
+		add_action( 'wpseo_register_capabilities', array( $this, 'register' ) );
+	}
+
+	/**
+	 * Registers the capabilities.
+	 */
+	public function register() {
+		$manager = WPSEO_Capability_Manager_Factory::get();
+
+		$manager->register( 'wpseo_bulk_edit', array( 'administrator', 'editor' ) );
+		$manager->register( 'wpseo_manage_options', array( 'administrator', 'editor' ) );
+	}
+}

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -100,7 +100,7 @@ class WPSEO_Admin_Init {
 		$notification_options = array(
 			'type'         => Yoast_Notification::ERROR,
 			'id'           => 'wpseo-dismiss-tagline-notice',
-			'capabilities' => 'manage_options',
+			'capabilities' => 'wpseo_manage_options',
 		);
 
 		$tagline_notification = new Yoast_Notification( $info_message, $notification_options );
@@ -131,7 +131,7 @@ class WPSEO_Admin_Init {
 			'type'         => Yoast_Notification::ERROR,
 			'id'           => 'wpseo-dismiss-blog-public-notice',
 			'priority'     => 1.0,
-			'capabilities' => 'manage_options',
+			'capabilities' => 'wpseo_manage_options',
 		);
 
 		$notification = new Yoast_Notification( $info_message, $notification_options );
@@ -163,7 +163,7 @@ class WPSEO_Admin_Init {
 		$notification_options = array(
 			'type'         => Yoast_Notification::WARNING,
 			'id'           => 'wpseo-dismiss-page_comments-notice',
-			'capabilities' => 'manage_options',
+			'capabilities' => 'wpseo_manage_options',
 		);
 
 		$tagline_notification = new Yoast_Notification( $info_message, $notification_options );
@@ -210,7 +210,7 @@ class WPSEO_Admin_Init {
 		$notification_options = array(
 			'type'         => Yoast_Notification::WARNING,
 			'id'           => 'wpseo-dismiss-permalink-notice',
-			'capabilities' => 'manage_options',
+			'capabilities' => 'wpseo_manage_options',
 			'priority'     => 0.8,
 		);
 
@@ -335,24 +335,29 @@ class WPSEO_Admin_Init {
 			return;
 		}
 
-		$can_access = is_multisite() ? WPSEO_Utils::grant_access() : current_user_can( 'manage_options' );
-		if ( $can_access && ! $this->is_site_notice_dismissed( 'wpseo_dismiss_recalculate' ) ) {
-			Yoast_Notification_Center::get()->add_notification(
-				new Yoast_Notification(
-					sprintf(
-						/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
-						__( 'We\'ve updated our SEO score algorithm. %1$sRecalculate the SEO scores%2$s for all posts and pages.', 'wordpress-seo' ),
-						'<a href="' . admin_url( 'admin.php?page=wpseo_tools&recalculate=1' ) . '">',
-						'</a>'
-					),
-					array(
-						'type'  => 'updated yoast-dismissible',
-						'id'    => 'wpseo-dismiss-recalculate',
-						'nonce' => wp_create_nonce( 'wpseo-dismiss-recalculate' ),
-					)
-				)
-			);
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
+			return;
 		}
+
+		if ( $this->is_site_notice_dismissed( 'wpseo_dismiss_recalculate' ) ) {
+			return;
+		}
+
+		Yoast_Notification_Center::get()->add_notification(
+			new Yoast_Notification(
+				sprintf(
+					/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
+					__( 'We\'ve updated our SEO score algorithm. %1$sRecalculate the SEO scores%2$s for all posts and pages.', 'wordpress-seo' ),
+					'<a href="' . admin_url( 'admin.php?page=wpseo_tools&recalculate=1' ) . '">',
+					'</a>'
+				),
+				array(
+					'type'  => 'updated yoast-dismissible',
+					'id'    => 'wpseo-dismiss-recalculate',
+					'nonce' => wp_create_nonce( 'wpseo-dismiss-recalculate' ),
+				)
+			)
+		);
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -31,6 +31,9 @@ class WPSEO_Admin {
 
 		global $pagenow;
 
+		$wpseo_menu = new WPSEO_Menu();
+		$wpseo_menu->register_hooks();
+
 		$this->options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_permalinks' ) );
 
 		if ( is_multisite() ) {
@@ -57,10 +60,6 @@ class WPSEO_Admin {
 			new WPSEO_Recalculate_Scores();
 		}
 
-		// Needs the lower than default priority so other plugins can hook underneath it without issue.
-		add_action( 'admin_menu', array( $this, 'register_settings_page' ), 5 );
-		add_action( 'network_admin_menu', array( $this, 'register_network_settings_page' ) );
-
 		add_filter( 'plugin_action_links_' . WPSEO_BASENAME, array( $this, 'add_action_link' ), 10, 2 );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'config_page_scripts' ) );
@@ -79,8 +78,6 @@ class WPSEO_Admin {
 
 		add_action( 'admin_init', array( 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'import_plugin_hooks' ) );
-
-		add_filter( 'wpseo_submenu_pages', array( $this, 'filter_settings_pages' ) );
 
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
 
@@ -136,147 +133,6 @@ class WPSEO_Admin {
 	 */
 	public function get_admin_features() {
 		return $this->admin_features;
-	}
-
-	/**
-	 * Register the menu item and its sub menu's.
-	 *
-	 * @global array $submenu used to change the label on the first item.
-	 */
-	public function register_settings_page() {
-		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
-			return;
-		}
-
-		global $admin_page_hooks;
-
-		// Base 64 encoded SVG image.
-		$icon_svg = WPSEO_Utils::get_icon_svg();
-
-		$manage_options_cap = $this->get_manage_options_cap();
-
-		$notification_center = Yoast_Notification_Center::get();
-		$notification_count  = $notification_center->get_notification_count();
-
-		// Add main page.
-		/* translators: %s: number of notifications */
-		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
-		$counter = sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $counter_screen_reader_text );
-
-		$admin_page = add_menu_page( 'Yoast SEO: ' . __( 'Dashboard', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ) . ' ' . $counter, $manage_options_cap, self::PAGE_IDENTIFIER, array(
-			$this,
-			'load_page',
-		), $icon_svg, '99.31337' );
-
-		$admin_page_hooks[ self::PAGE_IDENTIFIER ] = 'seo'; // Wipe notification bits from hooks. R.
-
-		$license_page_title = __( 'Premium', 'wordpress-seo' );
-
-		// Sub menu pages.
-		$submenu_pages = array(
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				__( 'General', 'wordpress-seo' ),
-				$manage_options_cap,
-				self::PAGE_IDENTIFIER,
-				array( $this, 'load_page' ),
-				null,
-			),
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				__( 'Titles &amp; Metas', 'wordpress-seo' ),
-				$manage_options_cap,
-				'wpseo_titles',
-				array( $this, 'load_page' ),
-			),
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				__( 'Social', 'wordpress-seo' ),
-				$manage_options_cap,
-				'wpseo_social',
-				array( $this, 'load_page' ),
-				null,
-			),
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				__( 'XML Sitemaps', 'wordpress-seo' ),
-				$manage_options_cap,
-				'wpseo_xml',
-				array( $this, 'load_page' ),
-				null,
-			),
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				__( 'Advanced', 'wordpress-seo' ),
-				$manage_options_cap,
-				'wpseo_advanced',
-				array( $this, 'load_page' ),
-				null,
-			),
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				__( 'Tools', 'wordpress-seo' ),
-				$manage_options_cap,
-				'wpseo_tools',
-				array( $this, 'load_page' ),
-				null,
-			),
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				__( 'Search Console', 'wordpress-seo' ),
-				$manage_options_cap,
-				'wpseo_search_console',
-				array( $this->admin_features['google_search_console'], 'display' ),
-				array( array( $this->admin_features['google_search_console'], 'set_help' ) ),
-			),
-			array(
-				self::PAGE_IDENTIFIER,
-				'',
-				$license_page_title,
-				$manage_options_cap,
-				'wpseo_licenses',
-				array( $this, 'load_page' ),
-				null,
-			),
-		);
-
-		// Allow submenu pages manipulation.
-		$submenu_pages = apply_filters( 'wpseo_submenu_pages', $submenu_pages );
-
-		// Loop through submenu pages and add them.
-		if ( count( $submenu_pages ) ) {
-			foreach ( $submenu_pages as $submenu_page ) {
-
-				$page_title = $submenu_page[2] . ' - Yoast SEO';
-
-				// We cannot use $submenu_page[1] because add-ons define that, so hard-code this value.
-				if ( 'wpseo_licenses' === $submenu_page[4] ) {
-					$page_title = __( 'Premium', 'wordpress-seo' ) . ' - Yoast SEO';
-				}
-
-				// Add submenu page.
-				$admin_page = add_submenu_page( $submenu_page[0], $page_title, $submenu_page[2], $submenu_page[3], $submenu_page[4], $submenu_page[5] );
-
-				// Check if we need to hook.
-				if ( isset( $submenu_page[6] ) && ( is_array( $submenu_page[6] ) && $submenu_page[6] !== array() ) ) {
-					foreach ( $submenu_page[6] as $submenu_page_action ) {
-						add_action( 'load-' . $admin_page, $submenu_page_action );
-					}
-				}
-			}
-		}
-
-		global $submenu;
-		if ( isset( $submenu[ self::PAGE_IDENTIFIER ] ) && current_user_can( $manage_options_cap ) ) {
-			$submenu[ self::PAGE_IDENTIFIER ][0][0] = __( 'Dashboard', 'wordpress-seo' );
-		}
 	}
 
 	/**
@@ -348,93 +204,7 @@ class WPSEO_Admin {
 		);
 	}
 
-	/**
-	 * Register the settings page for the Network settings.
-	 */
-	public function register_network_settings_page() {
-		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
-			return;
-		}
 
-		// Base 64 encoded SVG image.
-		$icon_svg = WPSEO_Utils::get_icon_svg();
-
-		add_menu_page( 'Yoast SEO: ' . __( 'MultiSite Settings', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ), 'delete_users', self::PAGE_IDENTIFIER, array(
-			$this,
-			'network_config_page',
-		), $icon_svg );
-
-		if ( WPSEO_Utils::allow_system_file_edit() === true ) {
-			add_submenu_page( self::PAGE_IDENTIFIER, 'Yoast SEO: ' . __( 'Edit Files', 'wordpress-seo' ), __( 'Edit Files', 'wordpress-seo' ), 'delete_users', 'wpseo_files', array(
-				$this,
-				'load_page',
-			) );
-		}
-
-		// Add Extension submenu page.
-		add_submenu_page( self::PAGE_IDENTIFIER, 'Yoast SEO: ' . __( 'Extensions', 'wordpress-seo' ), __( 'Extensions', 'wordpress-seo' ), 'delete_users', 'wpseo_licenses', array(
-			$this,
-			'load_page',
-		) );
-	}
-
-
-	/**
-	 * Load the form for a WPSEO admin page
-	 */
-	public function load_page() {
-		$page = filter_input( INPUT_GET, 'page' );
-
-		switch ( $page ) {
-			case 'wpseo_advanced':
-				require_once( WPSEO_PATH . 'admin/pages/advanced.php' );
-				break;
-
-			case 'wpseo_tools':
-				require_once( WPSEO_PATH . 'admin/pages/tools.php' );
-				break;
-
-			case 'wpseo_titles':
-				require_once( WPSEO_PATH . 'admin/pages/metas.php' );
-				break;
-
-			case 'wpseo_social':
-				require_once( WPSEO_PATH . 'admin/pages/social.php' );
-				break;
-
-			case 'wpseo_xml':
-				require_once( WPSEO_PATH . 'admin/pages/xml-sitemaps.php' );
-				break;
-
-			case 'wpseo_licenses':
-				require_once( WPSEO_PATH . 'admin/pages/licenses.php' );
-				break;
-
-			case 'wpseo_files':
-				require_once( WPSEO_PATH . 'admin/views/tool-file-editor.php' );
-				break;
-
-			case 'wpseo_tutorial_videos':
-				require_once( WPSEO_PATH . 'admin/pages/tutorial-videos.php' );
-				break;
-
-			case 'wpseo_configurator':
-				require_once( WPSEO_PATH . 'admin/config-ui/class-configuration-page.php' );
-				break;
-
-			case self::PAGE_IDENTIFIER:
-			default:
-				require_once( WPSEO_PATH . 'admin/pages/dashboard.php' );
-				break;
-		}
-	}
-
-	/**
-	 * Loads the form for the network configuration page.
-	 */
-	public function network_config_page() {
-		require_once( WPSEO_PATH . 'admin/pages/network.php' );
-	}
 
 
 	/**
@@ -506,10 +276,6 @@ class WPSEO_Admin {
 	 * Enqueues the (tiny) global JS needed for the plugin.
 	 */
 	public function config_page_scripts() {
-		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
-			return;
-		}
-
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'admin-global-script' );
 
@@ -593,54 +359,6 @@ class WPSEO_Admin {
 
 		$stop_words = new WPSEO_Admin_Stop_Words();
 		return $stop_words->remove_in( $new_slug );
-	}
-
-	/**
-	 * Filters all advanced settings pages from the given pages.
-	 *
-	 * @param array $pages The pages to filter.
-	 *
-	 * @return array
-	 */
-	public function filter_settings_pages( array $pages ) {
-		if ( wpseo_advanced_settings_enabled( $this->options ) ) {
-			return $pages;
-		}
-
-		$pages_to_hide = WPSEO_Advanced_Settings::get_advanced_pages();
-		$page = filter_input( INPUT_GET, 'page' );
-
-		if ( WPSEO_Advanced_Settings::is_advanced_settings_page( $page ) ) {
-			$pages_to_hide = $this->temporarily_enable_page( $pages_to_hide, $page );
-		}
-
-		foreach ( $pages as $page_key => $page ) {
-			$page_name = $page[4];
-
-			if ( in_array( $page_name, $pages_to_hide ) ) {
-				unset( $pages[ $page_key ] );
-			}
-		}
-
-		return $pages;
-	}
-
-	/**
-	 * Given a list of passed pages that will be disabled, removes the given page from the list so that it will no longer be disabled.
-	 *
-	 * @param array  $pages The pages to search through.
-	 * @param string $page  The page to temporarily enable.
-	 *
-	 * @return array The remaining pages that need to be disabled.
-	 */
-	private function temporarily_enable_page( $pages, $page ) {
-		$enable_page = array_search( $page, $pages );
-
-		if ( $enable_page !== false ) {
-			unset( $pages[ $enable_page ] );
-		}
-
-		return $pages;
 	}
 
 	/**
@@ -852,6 +570,54 @@ class WPSEO_Admin {
 	}
 
 	/**
+	 * Register the menu item and its sub menu's.
+	 *
+	 * @deprecated 5.5
+	 */
+	public function register_settings_page() {
+		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
+	}
+
+	/**
+	 * Register the settings page for the Network settings.
+	 *
+	 * @deprecated 5.5
+	 */
+	public function register_network_settings_page() {
+		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
+	}
+
+	/**
+	 * Load the form for a WPSEO admin page
+	 *
+	 * @deprecated 5.5
+	 */
+	public function load_page() {
+		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
+	}
+
+	/**
+	 * Loads the form for the network configuration page.
+	 *
+	 * @deprecated 5.5
+	 */
+	public function network_config_page() {
+		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
+	}
+
+	/**
+	 * Filters all advanced settings pages from the given pages.
+	 *
+	 * @deprecated 5.5
+	 * @param array $pages The pages to filter.
+	 *
+	 * @return array
+	 */
+	public function filter_settings_pages( array $pages ) {
+		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
+	}
+
+	/**
 	 * Display an error message when the blog is set to private.
 	 *
 	 * @deprecated 3.3
@@ -868,7 +634,7 @@ class WPSEO_Admin {
 	 * @deprecated 3.3
 	 */
 	public function meta_description_warning() {
-		_deprecated_function( __FUNCTION__, 'WPSEO 3.3.0' );
+		_deprecated_function( __METHOD__, 'WPSEO 3.3.0' );
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -144,7 +144,7 @@ class WPSEO_Admin {
 	 * @global array $submenu used to change the label on the first item.
 	 */
 	public function register_settings_page() {
-		if ( WPSEO_Utils::grant_access() !== true ) {
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			return;
 		}
 
@@ -353,28 +353,30 @@ class WPSEO_Admin {
 	 * Register the settings page for the Network settings.
 	 */
 	public function register_network_settings_page() {
-		if ( WPSEO_Utils::grant_access() ) {
-			// Base 64 encoded SVG image.
-			$icon_svg = WPSEO_Utils::get_icon_svg();
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
+			return;
+		}
 
-			add_menu_page( 'Yoast SEO: ' . __( 'MultiSite Settings', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ), 'delete_users', self::PAGE_IDENTIFIER, array(
-				$this,
-				'network_config_page',
-			), $icon_svg );
+		// Base 64 encoded SVG image.
+		$icon_svg = WPSEO_Utils::get_icon_svg();
 
-			if ( WPSEO_Utils::allow_system_file_edit() === true ) {
-				add_submenu_page( self::PAGE_IDENTIFIER, 'Yoast SEO: ' . __( 'Edit Files', 'wordpress-seo' ), __( 'Edit Files', 'wordpress-seo' ), 'delete_users', 'wpseo_files', array(
-					$this,
-					'load_page',
-				) );
-			}
+		add_menu_page( 'Yoast SEO: ' . __( 'MultiSite Settings', 'wordpress-seo' ), __( 'SEO', 'wordpress-seo' ), 'delete_users', self::PAGE_IDENTIFIER, array(
+			$this,
+			'network_config_page',
+		), $icon_svg );
 
-			// Add Extension submenu page.
-			add_submenu_page( self::PAGE_IDENTIFIER, 'Yoast SEO: ' . __( 'Extensions', 'wordpress-seo' ), __( 'Extensions', 'wordpress-seo' ), 'delete_users', 'wpseo_licenses', array(
+		if ( WPSEO_Utils::allow_system_file_edit() === true ) {
+			add_submenu_page( self::PAGE_IDENTIFIER, 'Yoast SEO: ' . __( 'Edit Files', 'wordpress-seo' ), __( 'Edit Files', 'wordpress-seo' ), 'delete_users', 'wpseo_files', array(
 				$this,
 				'load_page',
 			) );
 		}
+
+		// Add Extension submenu page.
+		add_submenu_page( self::PAGE_IDENTIFIER, 'Yoast SEO: ' . __( 'Extensions', 'wordpress-seo' ), __( 'Extensions', 'wordpress-seo' ), 'delete_users', 'wpseo_licenses', array(
+			$this,
+			'load_page',
+		) );
 	}
 
 
@@ -478,7 +480,7 @@ class WPSEO_Admin {
 	 * @return array $links
 	 */
 	public function add_action_link( $links, $file ) {
-		if ( WPSEO_BASENAME === $file && WPSEO_Utils::grant_access() ) {
+		if ( WPSEO_BASENAME === $file && WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			$settings_link = '<a href="' . esc_url( admin_url( 'admin.php?page=' . self::PAGE_IDENTIFIER ) ) . '">' . __( 'Settings', 'wordpress-seo' ) . '</a>';
 			array_unshift( $links, $settings_link );
 		}
@@ -505,12 +507,14 @@ class WPSEO_Admin {
 	 * Enqueues the (tiny) global JS needed for the plugin.
 	 */
 	public function config_page_scripts() {
-		if ( WPSEO_Utils::grant_access() ) {
-			$asset_manager = new WPSEO_Admin_Asset_Manager();
-			$asset_manager->enqueue_script( 'admin-global-script' );
-
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_admin_global_script() );
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
+			return;
 		}
+
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		$asset_manager->enqueue_script( 'admin-global-script' );
+
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_admin_global_script() );
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -610,8 +610,6 @@ class WPSEO_Admin {
 	 *
 	 * @deprecated 5.5
 	 * @param array $pages The pages to filter.
-	 *
-	 * @return array
 	 */
 	public function filter_settings_pages( array $pages ) {
 		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -297,6 +297,7 @@ class WPSEO_Admin {
 	 * @return mixed|void
 	 */
 	private function get_manage_options_cap() {
+		// @todo deprecate filter
 		/**
 		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages
 		 *

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -302,9 +302,7 @@ class WPSEO_Admin {
 		 *
 		 * @api string unsigned The capability
 		 */
-		$manage_options_cap = apply_filters( 'wpseo_manage_options_capability', 'manage_options' );
-
-		return $manage_options_cap;
+		return apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
 	}
 
 	/**

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -39,7 +39,7 @@ class WPSEO_Admin_Pages {
 			wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) );
 		}
 
-		if ( WPSEO_Utils::grant_access() ) {
+		if ( WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			add_action( 'admin_init', array( $this, 'admin_init' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'config_page_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'config_page_styles' ) );
@@ -134,7 +134,7 @@ class WPSEO_Admin_Pages {
 	private function do_yoast_export() {
 		check_admin_referer( WPSEO_Export::NONCE_ACTION, WPSEO_Export::NONCE_NAME );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			return;
 		}
 

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -39,11 +39,9 @@ class WPSEO_Admin_Pages {
 			wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) );
 		}
 
-		if ( WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
-			add_action( 'admin_init', array( $this, 'admin_init' ) );
-			add_action( 'admin_enqueue_scripts', array( $this, 'config_page_scripts' ) );
-			add_action( 'admin_enqueue_scripts', array( $this, 'config_page_styles' ) );
-		}
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'config_page_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'config_page_styles' ) );
 	}
 
 	/**

--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -26,7 +26,7 @@ class WPSEO_Customizer {
 	 * @param WP_Customize_Manager $wp_customize Manager class instance.
 	 */
 	public function wpseo_customize_register( $wp_customize ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			return;
 		}
 

--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -188,7 +188,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 		$notification_options = array(
 			'type'         => Yoast_Notification::ERROR,
 			'id'           => 'wpseo-dismiss-' . sanitize_title_with_dashes( $product_name,  null, 'save' ),
-			'capabilities' => 'manage_options',
+			'capabilities' => 'wpseo_manage_options',
 		);
 
 		$notification = new Yoast_Notification(

--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -159,7 +159,7 @@ class WPSEO_Product_Upsell_Notice {
 			array(
 				'type'         => Yoast_Notification::WARNING,
 				'id'           => 'wpseo-upsell-notice',
-				'capabilities' => 'manage_options',
+				'capabilities' => 'wpseo_manage_options',
 				'priority'     => 0.8,
 			)
 		);

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -285,7 +285,7 @@ class Yoast_Notification {
 
 		// Set default capabilities when not supplied.
 		if ( empty( $options['capabilities'] ) || array() === $options['capabilities'] ) {
-			$options['capabilities'] = array( 'manage_options' );
+			$options['capabilities'] = array( 'wpseo_manage_options' );
 		}
 
 		return $options;

--- a/admin/config-ui/class-configuration-endpoint.php
+++ b/admin/config-ui/class-configuration-endpoint.php
@@ -12,8 +12,8 @@ class WPSEO_Configuration_Endpoint {
 	const ENDPOINT_RETRIEVE = 'configurator';
 	const ENDPOINT_STORE = 'configurator';
 
-	const CAPABILITY_RETRIEVE = 'manage_options';
-	const CAPABILITY_STORE = 'manage_options';
+	const CAPABILITY_RETRIEVE = 'wpseo_manage_options';
+	const CAPABILITY_STORE = 'wpseo_manage_options';
 
 	/** @var WPSEO_Configuration_Service Service to use */
 	protected $service;

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -51,7 +51,7 @@ class WPSEO_Configuration_Page {
 	 *  Registers the page for the wizard.
 	 */
 	public function add_wizard_page() {
-		add_dashboard_page( '', '', 'manage_options', self::PAGE_IDENTIFIER, '' );
+		add_dashboard_page( '', '', 'wpseo_manage_options', self::PAGE_IDENTIFIER, '' );
 	}
 
 	/**
@@ -236,7 +236,7 @@ class WPSEO_Configuration_Page {
 			array(
 				'type'         => Yoast_Notification::WARNING,
 				'id'           => 'wpseo-dismiss-onboarding-notice',
-				'capabilities' => 'manage_options',
+				'capabilities' => 'wpseo_manage_options',
 				'priority'     => 0.8,
 			)
 		);

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -99,7 +99,7 @@ class WPSEO_GSC {
 			array(
 				'type'         => Yoast_Notification::WARNING,
 				'id'           => 'wpseo-dismiss-gsc',
-				'capabilities' => 'manage_options',
+				'capabilities' => 'wpseo_manage_options',
 			)
 		);
 	}

--- a/admin/links/class-link-compatibility-notifier.php
+++ b/admin/links/class-link-compatibility-notifier.php
@@ -48,7 +48,7 @@ class WPSEO_Link_Compatibility_Notifier {
 			array(
 				'type'         => Yoast_Notification::WARNING,
 				'id'           => self::NOTIFICATION_ID,
-				'capabilities' => 'manage_options',
+				'capabilities' => 'wpseo_manage_options',
 				'priority'     => 0.8,
 			)
 		);

--- a/admin/links/class-link-notifier.php
+++ b/admin/links/class-link-notifier.php
@@ -103,7 +103,7 @@ class WPSEO_Link_Notifier {
 			array(
 				'type'         => Yoast_Notification::WARNING,
 				'id'           => self::NOTIFICATION_ID,
-				'capabilities' => 'manage_options',
+				'capabilities' => 'wpseo_manage_options',
 				'priority'     => 0.8,
 			)
 		);

--- a/admin/links/class-link-table-accessible-notifier.php
+++ b/admin/links/class-link-table-accessible-notifier.php
@@ -46,7 +46,7 @@ class WPSEO_Link_Table_Accessible_Notifier {
 			array(
 				'type'         => Yoast_Notification::WARNING,
 				'id'           => self::NOTIFICATION_ID,
-				'capabilities' => 'manage_options',
+				'capabilities' => 'wpseo_manage_options',
 				'priority'     => 0.8,
 			)
 		);

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -129,11 +129,12 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 			$this->get_submenu_page( $this->get_license_page_title(), 'wpseo_licenses' ),
 		);
 
-		// Allow submenu pages manipulation.
-		$submenu_pages = apply_filters( 'wpseo_submenu_pages', $submenu_pages );
-		$submenu_pages = $this->ensure_wpseo_capability( $submenu_pages );
-
-		return $submenu_pages;
+		/**
+		 * Filter: 'wpseo_submenu_pages' - Collects all submenus that need to be shown.
+		 *
+		 * @api array $submenu_pages List with all submenu pages.
+		 */
+		return (array) apply_filters( 'wpseo_submenu_pages', $submenu_pages );
 	}
 
 	/**

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -33,7 +33,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	 * Registers the menu item submenus.
 	 */
 	public function register_settings_page() {
-		$can_manage_options = WPSEO_Capability_Utils::current_user_can( $this->get_manage_options_cap() );
+		$can_manage_options = WPSEO_Capability_Utils::current_user_can( $this->get_manage_capability() );
 
 		if ( $can_manage_options ) {
 			/*
@@ -45,7 +45,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 			add_menu_page(
 				'Yoast SEO: ' . __( 'Dashboard', 'wordpress-seo' ),
 				__( 'SEO', 'wordpress-seo' ) . ' ' . $this->get_notification_counter(),
-				$this->get_manage_options_cap(),
+				$this->get_manage_capability(),
 				$this->menu->get_page_identifier(),
 				$this->get_admin_page_callback(),
 				WPSEO_Utils::get_icon_svg(),
@@ -84,7 +84,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 
 		// Loop through submenu pages and add them.
 		foreach ( $submenu_pages as $submenu_page ) {
-			if ( $submenu_page[3] === $this->get_manage_options_cap() ) {
+			if ( $submenu_page[3] === $this->get_manage_capability() ) {
 				continue;
 			}
 
@@ -156,7 +156,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 			$this->menu->get_page_identifier(),
 			'',
 			$page_title,
-			$this->get_manage_options_cap(),
+			$this->get_manage_capability(),
 			$page_slug,
 			$callback,
 			$hook,
@@ -196,7 +196,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 			 * will not be able to see the submenus which are configured with something else,
 			 * thus all submenu pages are registered with the `wpseo_manage_options` capability here.
 			 */
-			$admin_page = add_submenu_page( $submenu_page[0], $page_title, $submenu_page[2], $this->get_manage_options_cap(), $submenu_page[4], $submenu_page[5] );
+			$admin_page = add_submenu_page( $submenu_page[0], $page_title, $submenu_page[2], $this->get_manage_capability(), $submenu_page[4], $submenu_page[5] );
 
 			// Check if we need to hook.
 			if ( isset( $submenu_page[6] ) && ( is_array( $submenu_page[6] ) && $submenu_page[6] !== array() ) ) {
@@ -208,7 +208,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 
 		// Use WordPress global $submenu to directly access it's properties.
 		global $submenu;
-		if ( isset( $submenu[ $this->menu->get_page_identifier() ] ) && WPSEO_Capability_Utils::current_user_can( $this->get_manage_options_cap() ) ) {
+		if ( isset( $submenu[ $this->menu->get_page_identifier() ] ) && WPSEO_Capability_Utils::current_user_can( $this->get_manage_capability() ) ) {
 			$submenu[ $this->menu->get_page_identifier() ][0][0] = __( 'Dashboard', 'wordpress-seo' );
 		}
 	}
@@ -236,13 +236,8 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * @return string Capability to check against.
 	 */
-	protected function get_manage_options_cap() {
-		/**
-		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages
-		 *
-		 * @api string unsigned The capability
-		 */
-		return (string) apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
+	protected function get_manage_capability() {
+		return 'wpseo_manage_options';
 	}
 
 	/**

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -94,7 +94,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 				$submenu_page[2],
 				$submenu_page[3],
 				$submenu_page[4],
-				$this->get_admin_page_callback(),
+				$submenu_page[5],
 				WPSEO_Utils::get_icon_svg(),
 				'99.31337'
 			);

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -237,7 +237,13 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Capability to check against.
 	 */
 	protected function get_manage_capability() {
-		return 'wpseo_manage_options';
+		/**
+		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages
+		 *
+		 * @deprecated 5.5
+		 * @api string unsigned The capability
+		 */
+		return apply_filters_deprecated( 'wpseo_manage_options_capability', array( 'wpseo_manage_options' ), 'WPSEO 5.5.0', false,'Use the introduced wpseo_manage_options capability instead.' );
 	}
 
 	/**

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -11,7 +11,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	protected $menu;
 
 	/**
-	 * Constructs the Admin Menu
+	 * Constructs the Admin Menu.
 	 *
 	 * @param WPSEO_Menu $menu Menu to use.
 	 */
@@ -20,7 +20,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Registers all hooks to WordPress
+	 * Registers all hooks to WordPress.
 	 *
 	 * @return void
 	 */
@@ -35,11 +35,11 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	public function register_settings_page() {
 		$can_manage_options = WPSEO_Capability_Utils::current_user_can( $this->get_manage_options_cap() );
 
-		/*
-		 * If the current user has the capability to control anything.
-		 * This means that all submenus and dashboard can be shown.
-		 */
 		if ( $can_manage_options ) {
+			/*
+			 * The current user has the capability to control anything.
+			 * This means that all submenus and dashboard can be shown.
+			 */
 			global $admin_page_hooks;
 
 			add_menu_page(
@@ -112,7 +112,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 		/** WPSEO_Admin $wpseo_admin */
 		$admin_features = $wpseo_admin->get_admin_features();
 
-		// Sub menu pages.
+		// Submenu pages.
 		$submenu_pages = array(
 			$this->get_submenu_page( __( 'General', 'wordpress-seo' ), $this->menu->get_page_identifier() ),
 			$this->get_submenu_page( __( 'Titles &amp; Metas', 'wordpress-seo' ), 'wpseo_titles' ),
@@ -148,7 +148,9 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	 * @return array Formatted submenu.
 	 */
 	protected function get_submenu_page( $page_title, $page_slug, $callback = null, $hook = null ) {
-		$callback = ( $callback === null ) ? $this->get_admin_page_callback() : $callback;
+		if ( $callback === null ) {
+			$callback = $this->get_admin_page_callback();
+		}
 
 		return array(
 			$this->menu->get_page_identifier(),
@@ -164,8 +166,8 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Registers the submenu pages.
 	 *
-	 * This is only done when the user has the `wpseo_manage_options` capability.
-	 * Thus all capabilities can be set to this capability.
+	 * This is only done when the user has the `wpseo_manage_options` capability,
+	 * thus all capabilities can be set to this capability.
 	 *
 	 * @param array $submenu_pages List of submenu pages to register.
 	 *
@@ -181,7 +183,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 			$page_title = $submenu_page[2];
 
 			// We cannot use $submenu_page[1] because add-ons define that, so hard-code this value.
-			if ( 'wpseo_licenses' === $submenu_page[4] ) {
+			if ( $submenu_page[4] === 'wpseo_licenses' ) {
 				$page_title = $this->get_license_page_title();
 			}
 
@@ -190,10 +192,9 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 			/*
 			 * Add submenu page.
 			 *
-			 * If we don't register this on `wpseo_manage_options` admin users with only this capability
-			 * will not be able to see the submenus which are configured with something else.
-			 *
-			 * Thus all submenu pages are registered with the `wpseo_manage_options` capability here.
+			 * If we don't register this on `wpseo_manage_options`, admin users with only this capability
+			 * will not be able to see the submenus which are configured with something else,
+			 * thus all submenu pages are registered with the `wpseo_manage_options` capability here.
 			 */
 			$admin_page = add_submenu_page( $submenu_page[0], $page_title, $submenu_page[2], $this->get_manage_options_cap(), $submenu_page[4], $submenu_page[5] );
 
@@ -205,6 +206,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 			}
 		}
 
+		// Use WordPress global $submenu to directly access it's properties.
 		global $submenu;
 		if ( isset( $submenu[ $this->menu->get_page_identifier() ] ) && WPSEO_Capability_Utils::current_user_can( $this->get_manage_options_cap() ) ) {
 			$submenu[ $this->menu->get_page_identifier() ][0][0] = __( 'Dashboard', 'wordpress-seo' );

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -151,9 +151,9 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 
 		// Add main page.
 		/* translators: %s: number of notifications */
-		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
+		$notifications = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
-		$counter = sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $counter_screen_reader_text );
+		$counter = sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $notifications );
 
 		return $counter;
 	}

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * @package WPSEO\Admin\Menu
+ */
+
+class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
+	/** @var WPSEO_Menu Menu */
+	protected $menu;
+
+	/**
+	 * Constructs the Admin Menu
+	 *
+	 * @param WPSEO_Menu $menu Menu to use.
+	 */
+	public function __construct( WPSEO_Menu $menu ) {
+		$this->menu = $menu;
+	}
+
+	/**
+	 * Registers all hooks to WordPress
+	 */
+	public function register_hooks() {
+		// Needs the lower than default priority so other plugins can hook underneath it without issue.
+		add_action( 'admin_menu', array( $this, 'register_settings_page' ), 5 );
+	}
+
+	/**
+	 * Register the menu item and its sub menu's.
+	 *
+	 * @global array $submenu used to change the label on the first item.
+	 */
+	public function register_settings_page() {
+		global $admin_page_hooks;
+
+		$can_manage_options = WPSEO_Capability_Utils::current_user_can( $this->get_manage_options_cap() );
+
+		if ( $can_manage_options ) {
+			add_menu_page(
+				'Yoast SEO: ' . __( 'Dashboard', 'wordpress-seo' ),
+				__( 'SEO', 'wordpress-seo' ) . ' ' . $this->get_notification_counter(),
+				$this->get_manage_options_cap(),
+				$this->menu->get_page_identifier(),
+				$this->get_admin_page_handler(),
+				WPSEO_Utils::get_icon_svg(),
+				'99.31337'
+			);
+
+			$admin_page_hooks[ $this->menu->get_page_identifier() ] = 'seo'; // Wipe notification bits from hooks. R.
+		}
+
+		// Get all submenu pages.
+		$submenu_pages = $this->get_submenu_pages();
+
+		if ( $can_manage_options ) {
+			// Add submenu items.
+			$this->register_submenu_pages( $submenu_pages );
+		}
+
+		/*
+		 * If the user does not have the general manage options capability,
+		 * we need to make sure the desired sub-item can be reached.
+		 */
+		if ( ! $can_manage_options ) {
+			$this->register_menu_pages( $submenu_pages );
+		}
+	}
+
+	/**
+	 * Registers submenu pages as menu pages.
+	 *
+	 * @param array $submenu_pages List of submenu pages.
+	 */
+	protected function register_menu_pages( $submenu_pages ) {
+		// Loop through submenu pages and add them.
+		if ( ! is_array( $submenu_pages ) ) {
+			return;
+		}
+
+
+		foreach ( $submenu_pages as $submenu_page ) {
+			if ( $submenu_page[3] === $this->get_manage_options_cap() ) {
+				continue;
+			}
+
+			// Register submenu as menu page.
+			add_menu_page(
+				'Yoast SEO: ' . $submenu_page[2],
+				$submenu_page[2],
+				$submenu_page[3],
+				$submenu_page[4],
+				$this->get_admin_page_handler(),
+				WPSEO_Utils::get_icon_svg(),
+				'99.31337'
+			);
+		}
+	}
+
+	/**
+	 * Returns the manage_options cap
+	 *
+	 * @return string
+	 */
+	protected function get_manage_options_cap() {
+		/**
+		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages
+		 *
+		 * @api string unsigned The capability
+		 */
+		return (string) apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Returns the page handler callback.
+	 *
+	 * @return array Callback page handler.
+	 */
+	protected function get_admin_page_handler() {
+		return array( $this->menu, 'load_page' );
+	}
+
+	/**
+	 * Returns the page title to use for the licenses page.
+	 *
+	 * @return string The title for the license page.
+	 */
+	protected function get_license_page_title() {
+		static $title = null;
+
+		if ( $title === null ) {
+			$title = __( 'Premium', 'wordpress-seo' );
+		}
+
+		return $title;
+	}
+
+	/**
+	 * Returns the notification count in HTML format.
+	 *
+	 * @return string The notification count in HTML format.
+	 */
+	protected function get_notification_counter() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_count  = $notification_center->get_notification_count();
+
+		// Add main page.
+		/* translators: %s: number of notifications */
+		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
+
+		$counter = sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $counter_screen_reader_text );
+
+		return $counter;
+	}
+
+	/**
+	 * Returns the list of registered submenu pages.
+	 *
+	 * @return array
+	 */
+	protected function get_submenu_pages() {
+		global $wpseo_admin;
+
+		/** WPSEO_Admin $wpseo_admin */
+		$admin_features = $wpseo_admin->get_admin_features();
+
+		// Sub menu pages.
+		$submenu_pages = array(
+			$this->get_submenu_page( __( 'General', 'wordpress-seo' ), $this->menu->get_page_identifier() ),
+			$this->get_submenu_page( __( 'Titles &amp; Metas', 'wordpress-seo' ), 'wpseo_titles' ),
+			$this->get_submenu_page( __( 'Social', 'wordpress-seo' ), 'wpseo_social' ),
+			$this->get_submenu_page( __( 'XML Sitemaps', 'wordpress-seo' ), 'wpseo_xml' ),
+			$this->get_submenu_page( __( 'Advanced', 'wordpress-seo' ), 'wpseo_advanced' ),
+			$this->get_submenu_page( __( 'Tools', 'wordpress-seo' ), 'wpseo_tools' ),
+			$this->get_submenu_page(
+				__( 'Search Console', 'wordpress-seo' ),
+				'wpseo_search_console',
+				array( $admin_features['google_search_console'], 'display' ),
+				array( array( $admin_features['google_search_console'], 'set_help' ) )
+			),
+			$this->get_submenu_page( $this->get_license_page_title(), 'wpseo_licenses' ),
+		);
+
+		// Allow submenu pages manipulation.
+		$submenu_pages = apply_filters( 'wpseo_submenu_pages', $submenu_pages );
+		$submenu_pages = $this->ensure_wpseo_capability( $submenu_pages );
+
+		return $submenu_pages;
+	}
+
+	/**
+	 * Creates a submenu formatted array.
+	 *
+	 * @param string $page_title Page title to use.
+	 * @param string $page_slug  Page slug to use.
+	 * @param null   $callback   Optional. Callback which handles the page request.
+	 * @param null   $hook       Optional. Hook to trigger when the page is registered.
+	 *
+	 * @return array Formatted submenu.
+	 */
+	protected function get_submenu_page( $page_title, $page_slug, $callback = null, $hook = null ) {
+		$callback = ( $callback === null ) ? $this->get_admin_page_handler() : $callback;
+
+		return array(
+			$this->menu->get_page_identifier(),
+			'',
+			$page_title,
+			$this->get_manage_options_cap(),
+			$page_slug,
+			$callback,
+			$hook,
+		);
+	}
+
+	/**
+	 * Registers the submenu pages.
+	 *
+	 * @param array $submenu_pages List of submenu pages to register.
+	 *
+	 * @return void
+	 */
+	protected function register_submenu_pages( $submenu_pages ) {
+		// Loop through submenu pages and add them.
+		if ( ! is_array( $submenu_pages ) ) {
+			return;
+		}
+
+		foreach ( $submenu_pages as $submenu_page ) {
+
+			$page_title = $submenu_page[2];
+
+			// We cannot use $submenu_page[1] because add-ons define that, so hard-code this value.
+			if ( 'wpseo_licenses' === $submenu_page[4] ) {
+				$page_title = $this->get_license_page_title();
+			}
+
+			$page_title .= ' - Yoast SEO';
+
+			// Add submenu page.
+			$admin_page = add_submenu_page( $submenu_page[0], $page_title, $submenu_page[2], $submenu_page[3], $submenu_page[4], $submenu_page[5] );
+
+			// Check if we need to hook.
+			if ( isset( $submenu_page[6] ) && ( is_array( $submenu_page[6] ) && $submenu_page[6] !== array() ) ) {
+				foreach ( $submenu_page[6] as $submenu_page_action ) {
+					add_action( 'load-' . $admin_page, $submenu_page_action );
+				}
+			}
+		}
+
+		global $submenu;
+		if ( isset( $submenu[ $this->menu->get_page_identifier() ] ) && WPSEO_Capability_Utils::current_user_can( $this->get_manage_options_cap() ) ) {
+			$submenu[ $this->menu->get_page_identifier() ][0][0] = __( 'Dashboard', 'wordpress-seo' );
+		}
+	}
+
+	/**
+	 * Converts any `manage_options` to `wpseo_manage_options`.
+	 *
+	 * This is needed as the module plugins are not updated with the new capabilities directly,
+	 * but they should not be shown as main menu items.
+	 *
+	 * @param array $submenu_pages List of subpages to convert.
+	 *
+	 * @return array Converted subpages.
+	 */
+	protected function ensure_wpseo_capability( $submenu_pages ) {
+		foreach ( $submenu_pages as $index => $submenu_page ) {
+			if ( $submenu_page[3] === 'manage_options' ) {
+				$submenu_pages[ $index ][3] = 'wpseo_manage_options';
+			}
+		}
+
+		return $submenu_pages;
+	}
+}

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -230,26 +230,6 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Converts any `manage_options` to `wpseo_manage_options`.
-	 *
-	 * This is needed as the module plugins are not updated with the new capabilities directly,
-	 * but they should not be shown as main menu items.
-	 *
-	 * @param array $submenu_pages List of subpages to convert.
-	 *
-	 * @return array Converted subpages.
-	 */
-	protected function ensure_wpseo_capability( $submenu_pages ) {
-		foreach ( $submenu_pages as $index => $submenu_page ) {
-			if ( $submenu_page[3] === 'manage_options' ) {
-				$submenu_pages[ $index ][3] = 'wpseo_manage_options';
-			}
-		}
-
-		return $submenu_pages;
-	}
-
-	/**
 	 * Returns the capability that is required to manage all options.
 	 *
 	 * @return string Capability to check against.

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -184,8 +184,15 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 
 			$page_title .= ' - Yoast SEO';
 
-			// Add submenu page.
-			$admin_page = add_submenu_page( $submenu_page[0], $page_title, $submenu_page[2], $submenu_page[3], $submenu_page[4], $submenu_page[5] );
+			/*
+			 * Add submenu page.
+			 *
+			 * If we don't register this on `wpseo_manage_options` admin users with only this capability
+			 * will not be able to see the submenus which are configured with something else.
+			 *
+			 * Thus all submenu pages are registered with the `wpseo_manage_options` capability here.
+			 */
+			$admin_page = add_submenu_page( $submenu_page[0], $page_title, $submenu_page[2], $this->get_manage_options_cap(), $submenu_page[4], $submenu_page[5] );
 
 			// Check if we need to hook.
 			if ( isset( $submenu_page[6] ) && ( is_array( $submenu_page[6] ) && $submenu_page[6] !== array() ) ) {

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -164,6 +164,9 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Registers the submenu pages.
 	 *
+	 * This is only done when the user has the `wpseo_manage_options` capability.
+	 * Thus all capabilities can be set to this capability.
+	 *
 	 * @param array $submenu_pages List of submenu pages to register.
 	 *
 	 * @return void

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Admin\Menu
  */
 
+/**
+ * Registers the admin menu on the left of the admin area.
+ */
 class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	/** @var WPSEO_Menu Menu */
 	protected $menu;
@@ -18,6 +21,8 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Registers all hooks to WordPress
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		// Needs the lower than default priority so other plugins can hook underneath it without issue.
@@ -25,16 +30,18 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Register the menu item and its sub menu's.
-	 *
-	 * @global array $submenu used to change the label on the first item.
+	 * Registers the menu item submenus.
 	 */
 	public function register_settings_page() {
-		global $admin_page_hooks;
-
 		$can_manage_options = WPSEO_Capability_Utils::current_user_can( $this->get_manage_options_cap() );
 
+		/*
+		 * If the current user has the capability to control anything.
+		 * This means that all submenus and dashboard can be shown.
+		 */
 		if ( $can_manage_options ) {
+			global $admin_page_hooks;
+
 			add_menu_page(
 				'Yoast SEO: ' . __( 'Dashboard', 'wordpress-seo' ),
 				__( 'SEO', 'wordpress-seo' ) . ' ' . $this->get_notification_counter(),
@@ -51,8 +58,8 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 		// Get all submenu pages.
 		$submenu_pages = $this->get_submenu_pages();
 
+		// Add submenu items to the main menu if possible.
 		if ( $can_manage_options ) {
-			// Add submenu items.
 			$this->register_submenu_pages( $submenu_pages );
 		}
 
@@ -96,9 +103,9 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Returns the manage_options cap
+	 * Returns the capability that is required to manage all options.
 	 *
-	 * @return string
+	 * @return string Capability to check against.
 	 */
 	protected function get_manage_options_cap() {
 		/**
@@ -154,7 +161,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns the list of registered submenu pages.
 	 *
-	 * @return array
+	 * @return array List of registered submenu pages.
 	 */
 	protected function get_submenu_pages() {
 		global $wpseo_admin;

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -47,7 +47,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 				__( 'SEO', 'wordpress-seo' ) . ' ' . $this->get_notification_counter(),
 				$this->get_manage_options_cap(),
 				$this->menu->get_page_identifier(),
-				$this->get_admin_page_handler(),
+				$this->get_admin_page_callback(),
 				WPSEO_Utils::get_icon_svg(),
 				'99.31337'
 			);
@@ -78,12 +78,11 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	 * @param array $submenu_pages List of submenu pages.
 	 */
 	protected function register_menu_pages( $submenu_pages ) {
-		// Loop through submenu pages and add them.
-		if ( ! is_array( $submenu_pages ) ) {
+		if ( ! is_array( $submenu_pages ) || $submenu_pages === array() ) {
 			return;
 		}
 
-
+		// Loop through submenu pages and add them.
 		foreach ( $submenu_pages as $submenu_page ) {
 			if ( $submenu_page[3] === $this->get_manage_options_cap() ) {
 				continue;
@@ -95,67 +94,11 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 				$submenu_page[2],
 				$submenu_page[3],
 				$submenu_page[4],
-				$this->get_admin_page_handler(),
+				$this->get_admin_page_callback(),
 				WPSEO_Utils::get_icon_svg(),
 				'99.31337'
 			);
 		}
-	}
-
-	/**
-	 * Returns the capability that is required to manage all options.
-	 *
-	 * @return string Capability to check against.
-	 */
-	protected function get_manage_options_cap() {
-		/**
-		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages
-		 *
-		 * @api string unsigned The capability
-		 */
-		return (string) apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
-	}
-
-	/**
-	 * Returns the page handler callback.
-	 *
-	 * @return array Callback page handler.
-	 */
-	protected function get_admin_page_handler() {
-		return array( $this->menu, 'load_page' );
-	}
-
-	/**
-	 * Returns the page title to use for the licenses page.
-	 *
-	 * @return string The title for the license page.
-	 */
-	protected function get_license_page_title() {
-		static $title = null;
-
-		if ( $title === null ) {
-			$title = __( 'Premium', 'wordpress-seo' );
-		}
-
-		return $title;
-	}
-
-	/**
-	 * Returns the notification count in HTML format.
-	 *
-	 * @return string The notification count in HTML format.
-	 */
-	protected function get_notification_counter() {
-		$notification_center = Yoast_Notification_Center::get();
-		$notification_count  = $notification_center->get_notification_count();
-
-		// Add main page.
-		/* translators: %s: number of notifications */
-		$notifications = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
-
-		$counter = sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $notifications );
-
-		return $counter;
 	}
 
 	/**
@@ -196,15 +139,15 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Creates a submenu formatted array.
 	 *
-	 * @param string $page_title Page title to use.
-	 * @param string $page_slug  Page slug to use.
-	 * @param null   $callback   Optional. Callback which handles the page request.
-	 * @param null   $hook       Optional. Hook to trigger when the page is registered.
+	 * @param string     $page_title Page title to use.
+	 * @param string     $page_slug  Page slug to use.
+	 * @param callable   $callback   Optional. Callback which handles the page request.
+	 * @param callable[] $hook       Optional. Hook to trigger when the page is registered.
 	 *
 	 * @return array Formatted submenu.
 	 */
 	protected function get_submenu_page( $page_title, $page_slug, $callback = null, $hook = null ) {
-		$callback = ( $callback === null ) ? $this->get_admin_page_handler() : $callback;
+		$callback = ( $callback === null ) ? $this->get_admin_page_callback() : $callback;
 
 		return array(
 			$this->menu->get_page_identifier(),
@@ -225,13 +168,12 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	protected function register_submenu_pages( $submenu_pages ) {
-		// Loop through submenu pages and add them.
-		if ( ! is_array( $submenu_pages ) ) {
+		if ( ! is_array( $submenu_pages ) || $submenu_pages === array() ) {
 			return;
 		}
 
+		// Loop through submenu pages and add them.
 		foreach ( $submenu_pages as $submenu_page ) {
-
 			$page_title = $submenu_page[2];
 
 			// We cannot use $submenu_page[1] because add-ons define that, so hard-code this value.
@@ -259,6 +201,24 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 	}
 
 	/**
+	 * Returns the notification count in HTML format.
+	 *
+	 * @return string The notification count in HTML format.
+	 */
+	protected function get_notification_counter() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_count  = $notification_center->get_notification_count();
+
+		// Add main page.
+		/* translators: %s: number of notifications */
+		$notifications = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
+
+		$counter = sprintf( '<span class="update-plugins count-%1$d"><span class="plugin-count" aria-hidden="true">%1$d</span><span class="screen-reader-text">%2$s</span></span>', $notification_count, $notifications );
+
+		return $counter;
+	}
+
+	/**
 	 * Converts any `manage_options` to `wpseo_manage_options`.
 	 *
 	 * This is needed as the module plugins are not updated with the new capabilities directly,
@@ -276,5 +236,43 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		return $submenu_pages;
+	}
+
+	/**
+	 * Returns the capability that is required to manage all options.
+	 *
+	 * @return string Capability to check against.
+	 */
+	protected function get_manage_options_cap() {
+		/**
+		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages
+		 *
+		 * @api string unsigned The capability
+		 */
+		return (string) apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Returns the page handler callback.
+	 *
+	 * @return array Callback page handler.
+	 */
+	protected function get_admin_page_callback() {
+		return array( $this->menu, 'load_page' );
+	}
+
+	/**
+	 * Returns the page title to use for the licenses page.
+	 *
+	 * @return string The title for the license page.
+	 */
+	protected function get_license_page_title() {
+		static $title = null;
+
+		if ( $title === null ) {
+			$title = __( 'Premium', 'wordpress-seo' );
+		}
+
+		return $title;
 	}
 }

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @package WPSEO\Admin\Menu
+ */
+
+/**
+ * Registers the regular admin menu and network admin menu implementations.
+ */
+class WPSEO_Menu implements WPSEO_WordPress_Integration {
+	/** The page identifier used in WordPress to register the admin page !DO NOT CHANGE THIS! */
+	const PAGE_IDENTIFIER = 'wpseo_dashboard';
+
+	/**
+	 * Array of classes that add admin functionality
+	 *
+	 * @var array
+	 */
+	protected $admin_features;
+
+	/**
+	 * Registers all hooks to WordPress
+	 */
+	public function register_hooks() {
+		$admin_menu = new WPSEO_Admin_Menu( $this );
+		$admin_menu->register_hooks();
+
+		$network_admin_menu = new WPSEO_Network_Admin_Menu( $this );
+		$network_admin_menu->register_hooks();
+
+		$submenu_hider = new WPSEO_Submenu_Hider();
+		$submenu_hider->register_hooks();
+	}
+
+	/**
+	 * Returns the main menu page identifier.
+	 *
+	 * @return string
+	 */
+	public function get_page_identifier() {
+		return self::PAGE_IDENTIFIER;
+	}
+
+	/**
+	 * Loads the requested admin settings page.
+	 */
+	public function load_page() {
+		$page = filter_input( INPUT_GET, 'page' );
+		$this->show_page( $page );
+	}
+
+	/**
+	 * Shows an admin settings page.
+	 *
+	 * @param string $page
+	 */
+	protected function show_page( $page ) {
+		switch ( $page ) {
+			case 'wpseo_advanced':
+				require_once WPSEO_PATH . 'admin/pages/advanced.php';
+				break;
+
+			case 'wpseo_tools':
+				require_once WPSEO_PATH . 'admin/pages/tools.php';
+				break;
+
+			case 'wpseo_titles':
+				require_once WPSEO_PATH . 'admin/pages/metas.php';
+				break;
+
+			case 'wpseo_social':
+				require_once WPSEO_PATH . 'admin/pages/social.php';
+				break;
+
+			case 'wpseo_xml':
+				require_once WPSEO_PATH . 'admin/pages/xml-sitemaps.php';
+				break;
+
+			case 'wpseo_licenses':
+				require_once WPSEO_PATH . 'admin/pages/licenses.php';
+				break;
+
+			case 'wpseo_files':
+				require_once WPSEO_PATH . 'admin/views/tool-file-editor.php';
+				break;
+
+			case 'wpseo_tutorial_videos':
+				require_once WPSEO_PATH . 'admin/pages/tutorial-videos.php';
+				break;
+
+			case 'wpseo_configurator':
+				require_once WPSEO_PATH . 'admin/config-ui/class-configuration-page.php';
+				break;
+
+			default:
+				require_once WPSEO_PATH . 'admin/pages/dashboard.php';
+				break;
+		}
+	}
+}

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -27,6 +27,9 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 
 		$submenu_hider = new WPSEO_Submenu_Hider();
 		$submenu_hider->register_hooks();
+
+		$capability_normalizer = new WPSEO_Submenu_Capability_Normalize();
+		$capability_normalizer->register_hooks();
 	}
 
 	/**

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -41,7 +41,7 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Loads the requested admin settings page.
 	 *
-	 * return @void
+	 * @return void
 	 */
 	public function load_page() {
 		$page = filter_input( INPUT_GET, 'page' );

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -10,15 +10,13 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 	/** The page identifier used in WordPress to register the admin page !DO NOT CHANGE THIS! */
 	const PAGE_IDENTIFIER = 'wpseo_dashboard';
 
-	/**
-	 * Array of classes that add admin functionality
-	 *
-	 * @var array
-	 */
+	/** @var array List of classes that add admin functionality. */
 	protected $admin_features;
 
 	/**
-	 * Registers all hooks to WordPress
+	 * Registers all hooks to WordPress.
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		$admin_menu = new WPSEO_Admin_Menu( $this );
@@ -34,7 +32,7 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns the main menu page identifier.
 	 *
-	 * @return string
+	 * @return string Page identifier to use.
 	 */
 	public function get_page_identifier() {
 		return self::PAGE_IDENTIFIER;
@@ -42,6 +40,8 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Loads the requested admin settings page.
+	 *
+	 * return @void
 	 */
 	public function load_page() {
 		$page = filter_input( INPUT_GET, 'page' );
@@ -51,7 +51,9 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Shows an admin settings page.
 	 *
-	 * @param string $page
+	 * @param string $page Page to display.
+	 *
+	 * @return void
 	 */
 	protected function show_page( $page ) {
 		switch ( $page ) {

--- a/admin/menu/class-network-admin-menu.php
+++ b/admin/menu/class-network-admin-menu.php
@@ -10,14 +10,16 @@ class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * WPSEO_Network_Admin_Menu constructor.
 	 *
-	 * @param WPSEO_Menu $menu
+	 * @param WPSEO_Menu $menu Menu to use.
 	 */
 	public function __construct( WPSEO_Menu $menu ) {
 		$this->menu = $menu;
 	}
 
 	/**
-	 * Registers all hooks to WordPress
+	 * Registers all hooks to WordPress.
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		// Needs the lower than default priority so other plugins can hook underneath it without issue.
@@ -26,13 +28,14 @@ class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Register the settings page for the Network settings.
+	 *
+	 * @return void
 	 */
 	public function register_settings_page() {
 		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			return;
 		}
 
-		// Base 64 encoded SVG image.
 		$page_callback = array( $this->menu, 'load_page' );
 
 		add_menu_page(
@@ -67,6 +70,8 @@ class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Loads the form for the network configuration page.
+	 *
+	 * @return void
 	 */
 	public function network_config_page() {
 		require_once WPSEO_PATH . 'admin/pages/network.php';

--- a/admin/menu/class-network-admin-menu.php
+++ b/admin/menu/class-network-admin-menu.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @package WPSEO\Admin\Menu
+ */
+
+class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
+	/** @var WPSEO_Menu Menu */
+	protected $menu;
+
+	/**
+	 * WPSEO_Network_Admin_Menu constructor.
+	 *
+	 * @param WPSEO_Menu $menu
+	 */
+	public function __construct( WPSEO_Menu $menu ) {
+		$this->menu = $menu;
+	}
+
+	/**
+	 * Registers all hooks to WordPress
+	 */
+	public function register_hooks() {
+		// Needs the lower than default priority so other plugins can hook underneath it without issue.
+		add_action( 'network_admin_menu', array( $this, 'register_settings_page' ), 5 );
+	}
+
+	/**
+	 * Register the settings page for the Network settings.
+	 */
+	public function register_settings_page() {
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
+			return;
+		}
+
+		// Base 64 encoded SVG image.
+		$page_callback = array( $this->menu, 'load_page' );
+
+		add_menu_page(
+			'Yoast SEO: ' . __( 'MultiSite Settings', 'wordpress-seo' ),
+			__( 'SEO', 'wordpress-seo' ),
+			'delete_users',
+			$this->menu->get_page_identifier(),
+			array( $this, 'network_config_page' ),
+			WPSEO_Utils::get_icon_svg()
+		);
+
+		if ( WPSEO_Utils::allow_system_file_edit() === true ) {
+			add_submenu_page(
+				$this->menu->get_page_identifier(),
+				'Yoast SEO: ' . __( 'Edit Files', 'wordpress-seo' ),
+				__( 'Edit Files', 'wordpress-seo' ),
+				'delete_users', 'wpseo_files',
+				$page_callback
+			);
+		}
+
+		// Add Extension submenu page.
+		add_submenu_page(
+			$this->menu->get_page_identifier(),
+			'Yoast SEO: ' . __( 'Extensions', 'wordpress-seo' ),
+			__( 'Extensions', 'wordpress-seo' ),
+			'delete_users',
+			'wpseo_licenses',
+			$page_callback
+		);
+	}
+
+	/**
+	 * Loads the form for the network configuration page.
+	 */
+	public function network_config_page() {
+		require_once WPSEO_PATH . 'admin/pages/network.php';
+	}
+}

--- a/admin/menu/class-network-admin-menu.php
+++ b/admin/menu/class-network-admin-menu.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Admin\Menu
  */
 
+/**
+ * Network Admin Menu handler.
+ */
 class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
 	/** @var WPSEO_Menu Menu */
 	protected $menu;

--- a/admin/menu/class-submenu-capability-normalize.php
+++ b/admin/menu/class-submenu-capability-normalize.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Normalize submenu capabilities to `wpseo_manage_options`
+ */
+class WPSEO_Submenu_Capability_Normalize implements WPSEO_WordPress_Integration {
+
+	/**
+	 * Registers all hooks to WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_filter( 'wpseo_submenu_pages', array( $this, 'normalize_submenus_capability' ) );
+	}
+
+	/**
+	 * Converts any `manage_options` to `wpseo_manage_options`.
+	 *
+	 * This is needed as the module plugins are not updated with the new capabilities directly,
+	 * but they should not be shown as main menu items.
+	 *
+	 * @param array $submenu_pages List of subpages to convert.
+	 *
+	 * @return array Converted subpages.
+	 */
+	public function normalize_submenus_capability( $submenu_pages ) {
+		foreach ( $submenu_pages as $index => $submenu_page ) {
+			if ( $submenu_page[3] === 'manage_options' ) {
+				$submenu_pages[ $index ][3] = 'wpseo_manage_options';
+			}
+		}
+
+		return $submenu_pages;
+	}
+}

--- a/admin/menu/class-submenu-capability-normalize.php
+++ b/admin/menu/class-submenu-capability-normalize.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Normalize submenu capabilities to `wpseo_manage_options`
+ * Normalize submenu capabilities to `wpseo_manage_options`.
  */
 class WPSEO_Submenu_Capability_Normalize implements WPSEO_WordPress_Integration {
 
@@ -18,7 +18,7 @@ class WPSEO_Submenu_Capability_Normalize implements WPSEO_WordPress_Integration 
 	}
 
 	/**
-	 * Converts any `manage_options` to `wpseo_manage_options`.
+	 * Normalizes any `manage_options` to `wpseo_manage_options`.
 	 *
 	 * This is needed as the module plugins are not updated with the new capabilities directly,
 	 * but they should not be shown as main menu items.

--- a/admin/menu/class-submenu-capability-normalize.php
+++ b/admin/menu/class-submenu-capability-normalize.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Menu
+ */
 
 /**
  * Normalize submenu capabilities to `wpseo_manage_options`

--- a/admin/menu/class-submenu-hider.php
+++ b/admin/menu/class-submenu-hider.php
@@ -20,7 +20,7 @@ class WPSEO_Submenu_Hider implements WPSEO_WordPress_Integration {
 	 *
 	 * @param array $pages The pages to filter.
 	 *
-	 * @return array
+	 * @return array Filtered list of submenu pages to show.
 	 */
 	public function filter_settings_pages( array $pages ) {
 		$options = WPSEO_Options::get_options( array( 'wpseo' ) );

--- a/admin/menu/class-submenu-hider.php
+++ b/admin/menu/class-submenu-hider.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @package WPSEO\Admin\Menu
+ */
+
+/**
+ * Hides submenu items if the advanced settings are not enabled.
+ */
+class WPSEO_Submenu_Hider implements WPSEO_WordPress_Integration {
+
+	/**
+	 * Registers all hooks to WordPress
+	 */
+	public function register_hooks() {
+		add_filter( 'wpseo_submenu_pages', array( $this, 'filter_settings_pages' ) );
+	}
+
+	/**
+	 * Filters all advanced settings pages from the given pages.
+	 *
+	 * @param array $pages The pages to filter.
+	 *
+	 * @return array
+	 */
+	public function filter_settings_pages( array $pages ) {
+		$options = WPSEO_Options::get_options( array( 'wpseo' ) );
+
+		if ( wpseo_advanced_settings_enabled( $options ) ) {
+			return $pages;
+		}
+
+		$pages_to_hide = WPSEO_Advanced_Settings::get_advanced_pages();
+		$page          = filter_input( INPUT_GET, 'page' );
+
+		if ( WPSEO_Advanced_Settings::is_advanced_settings_page( $page ) ) {
+			$pages_to_hide = $this->unhide_page( $pages_to_hide, $page );
+		}
+
+		foreach ( $pages as $page_key => $page ) {
+			$page_name = $page[4];
+
+			if ( in_array( $page_name, $pages_to_hide, true ) ) {
+				unset( $pages[ $page_key ] );
+			}
+		}
+
+		return $pages;
+	}
+
+	/**
+	 * Given a list of passed pages that will be disabled, removes the given page from the list so that it will no longer be disabled.
+	 *
+	 * @param array  $hidden_pages The pages to search through.
+	 * @param string $page         The page to temporarily enable.
+	 *
+	 * @return array The remaining pages that need to be disabled.
+	 */
+	private function unhide_page( $hidden_pages, $page ) {
+		$enable_page = array_search( $page, $hidden_pages, true );
+
+		if ( $enable_page !== false ) {
+			unset( $hidden_pages[ $enable_page ] );
+		}
+
+		return $hidden_pages;
+	}
+}

--- a/admin/menu/class-submenu-hider.php
+++ b/admin/menu/class-submenu-hider.php
@@ -9,7 +9,7 @@
 class WPSEO_Submenu_Hider implements WPSEO_WordPress_Integration {
 
 	/**
-	 * Registers all hooks to WordPress
+	 * Registers all hooks to WordPress.
 	 */
 	public function register_hooks() {
 		add_filter( 'wpseo_submenu_pages', array( $this, 'filter_settings_pages' ) );
@@ -32,6 +32,7 @@ class WPSEO_Submenu_Hider implements WPSEO_WordPress_Integration {
 		$pages_to_hide = WPSEO_Advanced_Settings::get_advanced_pages();
 		$page          = filter_input( INPUT_GET, 'page' );
 
+		// If we are on the advanced settings page, don't hide this page from the list of items to display.
 		if ( WPSEO_Advanced_Settings::is_advanced_settings_page( $page ) ) {
 			$pages_to_hide = $this->unhide_page( $pages_to_hide, $page );
 		}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -350,7 +350,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$content_sections[] = $this->social_admin->get_meta_section();
 		}
 
-		if ( current_user_can( 'manage_options' ) || $this->options['disableadvanced_meta'] === false ) {
+		if ( WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options['disableadvanced_meta'] === false ) {
 			$content_sections[] = $this->get_advanced_meta_section();
 		}
 

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -124,7 +124,7 @@ class WPSEO_OnPage {
 			array(
 				'type'  => Yoast_Notification::ERROR,
 				'id'    => 'wpseo-dismiss-onpageorg',
-				'capabilities' => 'manage_options',
+				'capabilities' => 'wpseo_manage_options',
 			)
 		);
 	}

--- a/admin/roles/class-abstract-role-manager.php
+++ b/admin/roles/class-abstract-role-manager.php
@@ -9,19 +9,17 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 	/**
 	 * Registers a role.
 	 *
-	 * @param string $role                  Role to add.
-	 * @param string $display_name          Display name to use.
-	 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
-	 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
+	 * @param string      $role         Role to add.
+	 * @param string      $display_name Display name to use.
+	 * @param null|string $template     Optional. Role to base the new role on.
 	 *
 	 * @return void
 	 */
-	public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() ) {
+	public function register( $role, $display_name, $template = null ) {
 		$this->roles[ $role ] =
 			(object) array(
-				'display_name'          => $display_name,
-				'enabled_capabilities'  => $enabled_capabilities,
-				'disabled_capabilities' => $disabled_capabilities
+				'display_name' => $display_name,
+				'template'     => $template
 			);
 	}
 
@@ -41,7 +39,18 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 	 */
 	public function add() {
 		foreach ( $this->roles as $role => $data ) {
-			$this->add_role( $role, $data );
+			$capabilities = $this->get_capabilities( $data->template );
+
+			$wp_role = get_role( $role );
+			if ( $wp_role && $capabilities ) {
+				foreach ( $capabilities as $capability => $grant ) {
+					if ( $this->capability_exists( $wp_role, $capability ) ) {
+						unset( $capabilities[ $capability ] );
+					}
+				}
+			}
+
+			$this->add_role( $role, $data->display_name, $capabilities );
 		}
 	}
 
@@ -56,14 +65,43 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 	}
 
 	/**
+	 * Returns the capabilities for the specified role.
+	 *
+	 * @param string $role Role to fetch capabilities from.
+	 *
+	 * @return array List of capabilities.
+	 */
+	protected function get_capabilities( $role ) {
+		$wp_role = get_role( $role );
+		if ( ! $wp_role ) {
+			return array();
+		}
+
+		return $wp_role->capabilities;
+	}
+
+	/**
+	 * Returns true if the capability exists on the role.
+	 *
+	 * @param WP_Role $role       Role to check capability against.
+	 * @param string  $capability Capability to check.
+	 *
+	 * @return bool True if the capability is defined for the role.
+	 */
+	protected function capability_exists( \WP_Role $role, $capability ) {
+		return ! array_key_exists( $capability, $role->capabilities );
+	}
+
+	/**
 	 * Adds a role to the system.
 	 *
-	 * @param string $role Role to add.
-	 * @param object $data Data to use to add the role.
+	 * @param string $role         Role to add.
+	 * @param string $display_name Name to display for the role.
+	 * @param array  $capabilities Capabilities to add to the role.
 	 *
 	 * @return void
 	 */
-	abstract protected function add_role( $role, $data );
+	abstract protected function add_role( $role, $display_name, array $capabilities = array() );
 
 	/**
 	 * Removes a role from the system

--- a/admin/roles/class-abstract-role-manager.php
+++ b/admin/roles/class-abstract-role-manager.php
@@ -84,7 +84,7 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 	 *
 	 * @return bool True if the capability is defined for the role.
 	 */
-	protected function capability_exists( \WP_Role $role, $capability ) {
+	protected function capability_exists( WP_Role $role, $capability ) {
 		return ! array_key_exists( $capability, $role->capabilities );
 	}
 

--- a/admin/roles/class-abstract-role-manager.php
+++ b/admin/roles/class-abstract-role-manager.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package WPSEO\Admin\Roles
+ */
+
+abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
+	protected $roles = array();
+
+	/**
+	 * Registers a role.
+	 *
+	 * @param string $role                  Role to add.
+	 * @param string $display_name          Display name to use.
+	 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
+	 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
+	 *
+	 * @return void
+	 */
+	public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() ) {
+		$this->roles[ $role ] =
+			(object) array(
+				'display_name'          => $display_name,
+				'enabled_capabilities'  => $enabled_capabilities,
+				'disabled_capabilities' => $disabled_capabilities
+			);
+	}
+
+	/**
+	 * Returns the list of registered roles.
+	 *
+	 * @return string[] List or registered roles.
+	 */
+	public function get_roles() {
+		return array_keys( $this->roles );
+	}
+
+	/**
+	 * Adds the registered roles.
+	 *
+	 * @return void
+	 */
+	public function add() {
+		foreach ( $this->roles as $role => $data ) {
+			$this->add_role( $role, $data );
+		}
+	}
+
+	/**
+	 * Removes the registered roles.
+	 *
+	 * @return void
+	 */
+	public function remove() {
+		$roles = array_keys( $this->roles );
+		array_map( array( $this, 'remove_role' ), $roles );
+	}
+
+	/**
+	 * Adds a role to the system.
+	 *
+	 * @param string $role Role to add.
+	 * @param object $data Data to use to add the role.
+	 *
+	 * @return void
+	 */
+	abstract protected function add_role( $role, $data );
+
+	/**
+	 * Removes a role from the system
+	 *
+	 * @param string $role Role to remove.
+	 *
+	 * @return void
+	 */
+	abstract protected function remove_role( $role );
+}

--- a/admin/roles/class-abstract-role-manager.php
+++ b/admin/roles/class-abstract-role-manager.php
@@ -13,7 +13,7 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 	/**
 	 * Registers a role.
 	 *
-	 * @param string      $role         Role to add.
+	 * @param string      $role         Role to register.
 	 * @param string      $display_name Display name to use.
 	 * @param null|string $template     Optional. Role to base the new role on.
 	 *
@@ -95,15 +95,15 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 	/**
 	 * Filters out capabilities that are already set for the role.
 	 *
-	 * This makes sure we don't override configuration that has been done previously.
+	 * This makes sure we don't override configurations that have been previously set.
 	 *
 	 * @param string $role         The role to check against.
-	 * @param array  $capabilities The capabilties that are going to be set.
+	 * @param array  $capabilities The capabilities that should be set.
 	 *
 	 * @return array Capabilties that can be safely set.
 	 */
 	protected function filter_existing_capabilties( $role, array $capabilities ) {
-		if ( array() === $capabilities ) {
+		if ( $capabilities === array() ) {
 			return $capabilities;
 		}
 

--- a/admin/roles/class-abstract-role-manager.php
+++ b/admin/roles/class-abstract-role-manager.php
@@ -3,7 +3,11 @@
  * @package WPSEO\Admin\Roles
  */
 
+/**
+ * Abstract Role Manager template.
+ */
 abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
+	/** @var array Registered roles. */
 	protected $roles = array();
 
 	/**
@@ -19,7 +23,7 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 		$this->roles[ $role ] =
 			(object) array(
 				'display_name' => $display_name,
-				'template'     => $template
+				'template'     => $template,
 			);
 	}
 

--- a/admin/roles/class-register-roles.php
+++ b/admin/roles/class-register-roles.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Roles
+ */
 
 class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
 	/**

--- a/admin/roles/class-register-roles.php
+++ b/admin/roles/class-register-roles.php
@@ -17,12 +17,10 @@ class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
 	public function register() {
 		$role_manager = WPSEO_Role_Manager_Factory::get();
 
-		// Add all `wpseo_*` capabilities to the manager.
-		$capability_manager = WPSEO_Capability_Manager_Factory::get();
 		$role_manager->register(
 			'wpseo_manager',
 			'SEO Manager',
-			$this->combine_capabilities( 'editor', $capability_manager->get_capabilities(), true ),
+			$this->combine_capabilities( 'editor', array( 'wpseo_manage_options' ),true ),
 			$this->combine_capabilities( 'editor', array(), false )
 		);
 

--- a/admin/roles/class-register-roles.php
+++ b/admin/roles/class-register-roles.php
@@ -19,13 +19,71 @@ class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
 
 		// Add all `wpseo_*` capabilities to the manager.
 		$capability_manager = WPSEO_Capability_Manager_Factory::get();
-		$role_manager->register( 'wpseo_manager', 'SEO Manager', $capability_manager->get_capabilities() );
+		$role_manager->register(
+			'wpseo_manager',
+			'SEO Manager',
+			$this->combine_capabilities( 'editor', $capability_manager->get_capabilities(), true ),
+			$this->combine_capabilities( 'editor', array(), false )
+		);
 
 		// Only add specific editor capabilities.
-		$role_manager->register( 'wpseo_editor', 'SEO Editor', array(
-			'wpseo_bulk_edit',
-			'wpseo_manage_redirects',
-			'wpseo_edit_advanced_metadata'
-		) );
+		$role_manager->register(
+			'wpseo_editor',
+			'SEO Editor',
+			$this->combine_capabilities(
+				'editor',
+				array(
+					'wpseo_bulk_edit',
+					'wpseo_edit_advanced_metadata'
+				), true
+			),
+			$this->combine_capabilities( 'editor', array(), false )
+		);
+	}
+
+	/**
+	 * Combines existing role capabilities with provided capabilities.
+	 *
+	 * @param string $role         Role to fetch capabilities of.
+	 * @param array  $capabilities Capabilities to merge.
+	 * @param bool   $enabled      Fetch granted or restricted capabilities.
+	 *
+	 * @return array
+	 */
+	protected function combine_capabilities( $role, array $capabilities, $enabled ) {
+		$wp_role = get_role( $role );
+		if ( ! $wp_role ) {
+			return $capabilities;
+		}
+
+		$role_capabilities = $wp_role->capabilities;
+		$filter_callback   = $enabled ? 'is_enabled' : 'is_disabled';
+
+		$filtered_capabilities = array_filter( $role_capabilities, array( $this, $filter_callback ) );
+		$filtered_capabilities = array_keys( $filtered_capabilities );
+
+		return array_merge( $filtered_capabilities, $capabilities );
+	}
+
+	/**
+	 * Return true if true.
+	 *
+	 * @param bool $test Value to test against.
+	 *
+	 * @return bool If test is true.
+	 */
+	protected function is_enabled( $test ) {
+		return $test === true;
+	}
+
+	/**
+	 * Returns true if false.
+	 *
+	 * @param bool $test Value to test against.
+	 *
+	 * @return bool If test is false.
+	 */
+	protected function is_disabled( $test ) {
+		return $test === false;
 	}
 }

--- a/admin/roles/class-register-roles.php
+++ b/admin/roles/class-register-roles.php
@@ -3,9 +3,14 @@
  * @package WPSEO\Admin\Roles
  */
 
+/**
+ * Role registration class.
+ */
 class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
 	/**
 	 * Adds hooks.
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		add_action( 'wpseo_register_roles', array( $this, 'register' ) );
@@ -13,6 +18,8 @@ class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Registers the roles.
+	 *
+	 * @return void
 	 */
 	public function register() {
 		$role_manager = WPSEO_Role_Manager_Factory::get();

--- a/admin/roles/class-register-roles.php
+++ b/admin/roles/class-register-roles.php
@@ -17,71 +17,7 @@ class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
 	public function register() {
 		$role_manager = WPSEO_Role_Manager_Factory::get();
 
-		$role_manager->register(
-			'wpseo_manager',
-			'SEO Manager',
-			$this->combine_capabilities( 'editor', array( 'wpseo_manage_options' ),true ),
-			$this->combine_capabilities( 'editor', array(), false )
-		);
-
-		// Only add specific editor capabilities.
-		$role_manager->register(
-			'wpseo_editor',
-			'SEO Editor',
-			$this->combine_capabilities(
-				'editor',
-				array(
-					'wpseo_bulk_edit',
-					'wpseo_edit_advanced_metadata'
-				), true
-			),
-			$this->combine_capabilities( 'editor', array(), false )
-		);
-	}
-
-	/**
-	 * Combines existing role capabilities with provided capabilities.
-	 *
-	 * @param string $role         Role to fetch capabilities of.
-	 * @param array  $capabilities Capabilities to merge.
-	 * @param bool   $enabled      Fetch granted or restricted capabilities.
-	 *
-	 * @return array
-	 */
-	protected function combine_capabilities( $role, array $capabilities, $enabled ) {
-		$wp_role = get_role( $role );
-		if ( ! $wp_role ) {
-			return $capabilities;
-		}
-
-		$role_capabilities = $wp_role->capabilities;
-		$filter_callback   = $enabled ? 'is_enabled' : 'is_disabled';
-
-		$filtered_capabilities = array_filter( $role_capabilities, array( $this, $filter_callback ) );
-		$filtered_capabilities = array_keys( $filtered_capabilities );
-
-		return array_merge( $filtered_capabilities, $capabilities );
-	}
-
-	/**
-	 * Return true if true.
-	 *
-	 * @param bool $test Value to test against.
-	 *
-	 * @return bool If test is true.
-	 */
-	protected function is_enabled( $test ) {
-		return $test === true;
-	}
-
-	/**
-	 * Returns true if false.
-	 *
-	 * @param bool $test Value to test against.
-	 *
-	 * @return bool If test is false.
-	 */
-	protected function is_disabled( $test ) {
-		return $test === false;
+		$role_manager->register( 'wpseo_manager', 'SEO Manager', 'editor' );
+		$role_manager->register( 'wpseo_editor', 'SEO Editor', 'editor' );
 	}
 }

--- a/admin/roles/class-register-roles.php
+++ b/admin/roles/class-register-roles.php
@@ -14,9 +14,11 @@ class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
 	public function register() {
 		$role_manager = WPSEO_Role_Manager_Factory::get();
 
+		// Add all `wpseo_*` capabilities to the manager.
 		$capability_manager = WPSEO_Capability_Manager_Factory::get();
 		$role_manager->register( 'wpseo_manager', 'SEO Manager', $capability_manager->get_capabilities() );
 
+		// Only add specific editor capabilities.
 		$role_manager->register( 'wpseo_editor', 'SEO Editor', array(
 			'wpseo_bulk_edit',
 			'wpseo_manage_redirects',

--- a/admin/roles/class-register-roles.php
+++ b/admin/roles/class-register-roles.php
@@ -1,0 +1,26 @@
+<?php
+
+class WPSEO_Register_Roles implements WPSEO_WordPress_Integration {
+	/**
+	 * Adds hooks.
+	 */
+	public function register_hooks() {
+		add_action( 'wpseo_register_roles', array( $this, 'register' ) );
+	}
+
+	/**
+	 * Registers the roles.
+	 */
+	public function register() {
+		$role_manager = WPSEO_Role_Manager_Factory::get();
+
+		$capability_manager = WPSEO_Capability_Manager_Factory::get();
+		$role_manager->register( 'wpseo_manager', 'SEO Manager', $capability_manager->get_capabilities() );
+
+		$role_manager->register( 'wpseo_editor', 'SEO Editor', array(
+			'wpseo_bulk_edit',
+			'wpseo_manage_redirects',
+			'wpseo_edit_advanced_metadata'
+		) );
+	}
+}

--- a/admin/roles/class-role-manager-factory.php
+++ b/admin/roles/class-role-manager-factory.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Roles
+ */
 
 class WPSEO_Role_Manager_Factory {
 	/**

--- a/admin/roles/class-role-manager-factory.php
+++ b/admin/roles/class-role-manager-factory.php
@@ -1,0 +1,22 @@
+<?php
+
+class WPSEO_Role_Manager_Factory {
+	/**
+	 * Retrieves the Role manager to use.
+	 *
+	 * @return WPSEO_Role_Manager
+	 */
+	public static function get() {
+		static $manager = null;
+
+		if ( null === $manager ) {
+			if ( function_exists( 'wpcom_vip_add_role' ) ) {
+				$manager = new WPSEO_Role_Manager_VIP();
+			} else {
+				$manager = new WPSEO_Role_Manager_WP();
+			}
+		}
+
+		return $manager;
+	}
+}

--- a/admin/roles/class-role-manager-factory.php
+++ b/admin/roles/class-role-manager-factory.php
@@ -15,7 +15,7 @@ class WPSEO_Role_Manager_Factory {
 	public static function get() {
 		static $manager = null;
 
-		if ( null === $manager ) {
+		if ( $manager === null ) {
 			if ( function_exists( 'wpcom_vip_add_role' ) ) {
 				$manager = new WPSEO_Role_Manager_VIP();
 			}

--- a/admin/roles/class-role-manager-factory.php
+++ b/admin/roles/class-role-manager-factory.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Admin\Roles
  */
 
+/**
+ * Role Manager Factory.
+ */
 class WPSEO_Role_Manager_Factory {
 	/**
 	 * Retrieves the Role manager to use.
@@ -15,7 +18,9 @@ class WPSEO_Role_Manager_Factory {
 		if ( null === $manager ) {
 			if ( function_exists( 'wpcom_vip_add_role' ) ) {
 				$manager = new WPSEO_Role_Manager_VIP();
-			} else {
+			}
+
+			if ( ! function_exists( 'wpcom_vip_add_role' ) ) {
 				$manager = new WPSEO_Role_Manager_WP();
 			}
 		}

--- a/admin/roles/class-role-manager-vip.php
+++ b/admin/roles/class-role-manager-vip.php
@@ -1,53 +1,32 @@
 <?php
+/**
+ * @package WPSEO\Admin\Roles
+ */
 
-class WPSEO_Role_Manager_VIP implements WPSEO_Role_Manager {
-	protected $roles = array();
-
+final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 	/**
-	 * Registers a role.
+	 * Adds a role to the system.
 	 *
-	 * @param string $role                  Role to add.
-	 * @param string $display_name          Display name to use.
-	 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
-	 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
+	 * @param string $role Role to add.
+	 * @param object $data Data to use to add the role.
 	 *
 	 * @return void
 	 */
-	public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() ) {
-		$this->roles[ $role ] =
-			(object) array(
-				'display_name'          => $display_name,
-				'enabled_capabilities'  => $enabled_capabilities,
-				'disabled_capabilities' => $disabled_capabilities
-			);
-	}
-
-	/**
-	 * Adds the registered roles.
-	 */
-	public function add() {
-		foreach ( $this->roles as $role => $data ) {
-			wpcom_vip_add_role( $role, $data->display_name, $data->enabled_capabilities );
-			if ( array() !== $data->disabled_capabilities ) {
-				wpcom_vip_remove_role_caps( $role, $data->disabled_capabilities );
-			}
+	protected function add_role( $role, $data ) {
+		wpcom_vip_add_role( $role, $data->display_name, $data->enabled_capabilities );
+		if ( array() !== $data->disabled_capabilities ) {
+			wpcom_vip_remove_role_caps( $role, $data->disabled_capabilities );
 		}
 	}
 
 	/**
-	 * Removes the registered roles.
-	 */
-	public function remove() {
-		$roles = array_keys( $this->roles );
-		array_map( 'remove_role', $roles );
-	}
-
-	/**
-	 * Returns the list of registered roles.
+	 * Removes a role from the system
 	 *
-	 * @return string[] List or registered roles.
+	 * @param string $role Role to remove.
+	 *
+	 * @return void
 	 */
-	public function get_roles() {
-		return array_keys( $this->roles );
+	protected function remove_role( $role ) {
+		remove_role( $role );
 	}
 }

--- a/admin/roles/class-role-manager-vip.php
+++ b/admin/roles/class-role-manager-vip.php
@@ -1,0 +1,53 @@
+<?php
+
+class WPSEO_Role_Manager_VIP implements WPSEO_Role_Manager {
+	protected $roles = array();
+
+	/**
+	 * Registers a role.
+	 *
+	 * @param string $role                  Role to add.
+	 * @param string $display_name          Display name to use.
+	 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
+	 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
+	 *
+	 * @return void
+	 */
+	public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() ) {
+		$this->roles[ $role ] =
+			(object) array(
+				'display_name'          => $display_name,
+				'enabled_capabilities'  => $enabled_capabilities,
+				'disabled_capabilities' => $disabled_capabilities
+			);
+	}
+
+	/**
+	 * Adds the registered roles.
+	 */
+	public function add() {
+		foreach ( $this->roles as $role => $data ) {
+			wpcom_vip_add_role( $role, $data->display_name, $data->enabled_capabilities );
+			if ( array() !== $data->disabled_capabilities ) {
+				wpcom_vip_remove_role_caps( $role, $data->disabled_capabilities );
+			}
+		}
+	}
+
+	/**
+	 * Removes the registered roles.
+	 */
+	public function remove() {
+		$roles = array_keys( $this->roles );
+		array_map( 'remove_role', $roles );
+	}
+
+	/**
+	 * Returns the list of registered roles.
+	 *
+	 * @return string[] List or registered roles.
+	 */
+	public function get_roles() {
+		return array_keys( $this->roles );
+	}
+}

--- a/admin/roles/class-role-manager-vip.php
+++ b/admin/roles/class-role-manager-vip.php
@@ -32,13 +32,13 @@ final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 		}
 
 		wpcom_vip_add_role( $role, $display_name, $enabled_capabilities );
-		if ( array() !== $disabled_capabilities ) {
+		if ( $disabled_capabilities !== array() ) {
 			wpcom_vip_remove_role_caps( $role, $disabled_capabilities );
 		}
 	}
 
 	/**
-	 * Removes a role from the system
+	 * Removes a role from the system.
 	 *
 	 * @param string $role Role to remove.
 	 *

--- a/admin/roles/class-role-manager-vip.php
+++ b/admin/roles/class-role-manager-vip.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Admin\Roles
  */
 
+/**
+ * VIP implementation of the Role Manager.
+ */
 final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 	/**
 	 * Adds a role to the system.

--- a/admin/roles/class-role-manager-vip.php
+++ b/admin/roles/class-role-manager-vip.php
@@ -7,15 +7,30 @@ final class WPSEO_Role_Manager_VIP extends WPSEO_Abstract_Role_Manager {
 	/**
 	 * Adds a role to the system.
 	 *
-	 * @param string $role Role to add.
-	 * @param object $data Data to use to add the role.
+	 * @param string $role         Role to add.
+	 * @param string $display_name Name to display for the role.
+	 * @param array  $capabilities Capabilities to add to the role.
 	 *
 	 * @return void
 	 */
-	protected function add_role( $role, $data ) {
-		wpcom_vip_add_role( $role, $data->display_name, $data->enabled_capabilities );
-		if ( array() !== $data->disabled_capabilities ) {
-			wpcom_vip_remove_role_caps( $role, $data->disabled_capabilities );
+	protected function add_role( $role, $display_name, array $capabilities = array() ) {
+		$enabled_capabilities  = array();
+		$disabled_capabilities = array();
+
+		// Build lists of enabled and disabled capabilities.
+		foreach ( $capabilities as $capability => $grant ) {
+			if ( $grant ) {
+				$enabled_capabilities[] = $capability;
+			}
+
+			if ( ! $grant ) {
+				$disabled_capabilities[] = $capability;
+			}
+		}
+
+		wpcom_vip_add_role( $role, $display_name, $enabled_capabilities );
+		if ( array() !== $disabled_capabilities ) {
+			wpcom_vip_remove_role_caps( $role, $disabled_capabilities );
 		}
 	}
 

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Admin\Roles
  */
 
+/**
+ * WordPress default implementatino of the Role Manager.
+ */
 final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 
 	/**
@@ -25,6 +28,7 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 			return;
 		}
 
+		// @codingStandardsIgnoreLine
 		add_role( $role, $display_name, $capabilities );
 	}
 

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -47,7 +47,7 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 	 */
 	protected function format_capabilities( array $capabilities, $enabled = true ) {
 		// Flip keys and values.
-		array_flip( $capabilities );
+		$capabilities = array_flip( $capabilities );
 
 		// Set all values to $enabled.
 		return array_fill_keys( array_keys( $capabilities ), $enabled );

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -8,22 +8,24 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 	/**
 	 * Adds a role to the system.
 	 *
-	 * @param string $role Role to add.
-	 * @param object $data Data to use to add the role.
+	 * @param string $role         Role to add.
+	 * @param string $display_name Name to display for the role.
+	 * @param array  $capabilities Capabilities to add to the role.
 	 *
 	 * @return void
 	 */
-	protected function add_role( $role, $data ) {
-		$capabilities = array_merge( $this->format_capabilities( $data->enabled_capabilities ), $this->format_capabilities( $data->disabled_capabilities ) );
+	protected function add_role( $role, $display_name, array $capabilities = array() ) {
 		$wp_role = get_role( $role );
 		if ( $wp_role ) {
 			foreach ( $capabilities as $capability => $grant ) {
+
+
 				$wp_role->add_cap( $capability, $grant );
 			}
 			return;
 		}
 
-		add_role( $role, $data->display_name, $capabilities );
+		add_role( $role, $display_name, $capabilities );
 	}
 
 	/**

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -15,6 +15,14 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 	 */
 	protected function add_role( $role, $data ) {
 		$capabilities = array_merge( $this->format_capabilities( $data->enabled_capabilities ), $this->format_capabilities( $data->disabled_capabilities ) );
+		$wp_role = get_role( $role );
+		if ( $wp_role ) {
+			foreach ( $capabilities as $capability => $grant ) {
+				$wp_role->add_cap( $capability, $grant );
+			}
+			return;
+		}
+
 		add_role( $role, $data->display_name, $capabilities );
 	}
 

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * WordPress default implementatino of the Role Manager.
+ * WordPress' default implementation of the Role Manager.
  */
 final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 
@@ -21,10 +21,9 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 		$wp_role = get_role( $role );
 		if ( $wp_role ) {
 			foreach ( $capabilities as $capability => $grant ) {
-
-
 				$wp_role->add_cap( $capability, $grant );
 			}
+
 			return;
 		}
 
@@ -33,7 +32,7 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 	}
 
 	/**
-	 * Removes a role from the system
+	 * Removes a role from the system.
 	 *
 	 * @param string $role Role to remove.
 	 *
@@ -47,9 +46,9 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 	 * Formats the capabilities to the required format.
 	 *
 	 * @param array $capabilities Capabilities to format.
-	 * @param bool  $enabled      Should this capability be enabled.
+	 * @param bool  $enabled      Whether these capabilities should be enabled or not.
 	 *
-	 * @return array
+	 * @return array Formatted capabilities.
 	 */
 	protected function format_capabilities( array $capabilities, $enabled = true ) {
 		// Flip keys and values.

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -1,67 +1,47 @@
 <?php
+/**
+ * @package WPSEO\Admin\Roles
+ */
 
-class WPSEO_Role_Manager_WP implements WPSEO_Role_Manager {
-	protected $roles = array();
-
-		/**
-		 * Registers a role.
-		 *
-		 * @param string $role                  Role to add.
-		 * @param string $display_name          Display name to use.
-		 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
-		 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
-		 *
-		 * @return void
-		 */
-		public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() ) {
-			$this->roles[ $role ] =
-				(object) array(
-					'display_name'          => $display_name,
-					'enabled_capabilities'  => $enabled_capabilities,
-					'disabled_capabilities' => $disabled_capabilities
-				);
-		}
+final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 
 	/**
-	 * Adds the registered roles.
-	 */
-	public function add() {
-		foreach ( $this->roles as $role => $data ) {
-			$capabilities = array_merge( $this->format_capabilities( $data->enabled_capabilities ), $this->format_capabilities( $data->disabled_capabilities ) );
-			add_role( $role, $data->display_name, $capabilities );
-		}
-	}
-
-	/**
-	 * Removes the registered roles.
-	 */
-	public function remove() {
-		$roles = array_keys( $this->roles );
-		array_map( 'remove_role', $roles );
-	}
-
-	/**
-	 * Returns the list of registered roles.
+	 * Adds a role to the system.
 	 *
-	 * @return string[] List or registered roles.
+	 * @param string $role Role to add.
+	 * @param object $data Data to use to add the role.
+	 *
+	 * @return void
 	 */
-	public function get_roles() {
-		return array_keys( $this->roles );
+	protected function add_role( $role, $data ) {
+		$capabilities = array_merge( $this->format_capabilities( $data->enabled_capabilities ), $this->format_capabilities( $data->disabled_capabilities ) );
+		add_role( $role, $data->display_name, $capabilities );
+	}
+
+	/**
+	 * Removes a role from the system
+	 *
+	 * @param string $role Role to remove.
+	 *
+	 * @return void
+	 */
+	protected function remove_role( $role ) {
+		remove_role( $role );
 	}
 
 	/**
 	 * Formats the capabilities to the required format.
 	 *
 	 * @param array $capabilities Capabilities to format.
-	 *
 	 * @param bool  $enabled      Should this capability be enabled.
 	 *
 	 * @return array
 	 */
 	protected function format_capabilities( array $capabilities, $enabled = true ) {
+		// Flip keys and values.
 		array_flip( $capabilities );
 
-		// Set all values to 'true'.
+		// Set all values to $enabled.
 		return array_fill_keys( array_keys( $capabilities ), $enabled );
 	}
 }

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -1,0 +1,67 @@
+<?php
+
+class WPSEO_Role_Manager_WP implements WPSEO_Role_Manager {
+	protected $roles = array();
+
+		/**
+		 * Registers a role.
+		 *
+		 * @param string $role                  Role to add.
+		 * @param string $display_name          Display name to use.
+		 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
+		 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
+		 *
+		 * @return void
+		 */
+		public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() ) {
+			$this->roles[ $role ] =
+				(object) array(
+					'display_name'          => $display_name,
+					'enabled_capabilities'  => $enabled_capabilities,
+					'disabled_capabilities' => $disabled_capabilities
+				);
+		}
+
+	/**
+	 * Adds the registered roles.
+	 */
+	public function add() {
+		foreach ( $this->roles as $role => $data ) {
+			$capabilities = array_merge( $this->format_capabilities( $data->enabled_capabilities ), $this->format_capabilities( $data->disabled_capabilities ) );
+			add_role( $role, $data->display_name, $capabilities );
+		}
+	}
+
+	/**
+	 * Removes the registered roles.
+	 */
+	public function remove() {
+		$roles = array_keys( $this->roles );
+		array_map( 'remove_role', $roles );
+	}
+
+	/**
+	 * Returns the list of registered roles.
+	 *
+	 * @return string[] List or registered roles.
+	 */
+	public function get_roles() {
+		return array_keys( $this->roles );
+	}
+
+	/**
+	 * Formats the capabilities to the required format.
+	 *
+	 * @param array $capabilities Capabilities to format.
+	 *
+	 * @param bool  $enabled      Should this capability be enabled.
+	 *
+	 * @return array
+	 */
+	protected function format_capabilities( array $capabilities, $enabled = true ) {
+		array_flip( $capabilities );
+
+		// Set all values to 'true'.
+		return array_fill_keys( array_keys( $capabilities ), $enabled );
+	}
+}

--- a/admin/roles/class-role-manager.php
+++ b/admin/roles/class-role-manager.php
@@ -3,25 +3,32 @@
  * @package WPSEO\Admin\Roles
  */
 
+/**
+ * Role Manager interface.
+ */
 interface WPSEO_Role_Manager {
 	/**
 	 * Registers a role.
 	 *
-	 * @param string $role         Role to add.
-	 * @param string $display_name Display name to use.
-	 * @param null|string   $template     Optional. Role to base the new role on.
+	 * @param string      $role         Role to add.
+	 * @param string      $display_name Display name to use.
+	 * @param null|string $template     Optional. Role to base the new role on.
 	 *
-	 * @return
+	 * @return void
 	 */
 	public function register( $role, $display_name, $template = null );
 
 	/**
 	 * Adds the registered roles.
+	 *
+	 * @return void
 	 */
 	public function add();
 
 	/**
 	 * Removes the registered roles.
+	 *
+	 * @return void
 	 */
 	public function remove();
 

--- a/admin/roles/class-role-manager.php
+++ b/admin/roles/class-role-manager.php
@@ -10,7 +10,7 @@ interface WPSEO_Role_Manager {
 	/**
 	 * Registers a role.
 	 *
-	 * @param string      $role         Role to add.
+	 * @param string      $role         Role to register.
 	 * @param string      $display_name Display name to use.
 	 * @param null|string $template     Optional. Role to base the new role on.
 	 *

--- a/admin/roles/class-role-manager.php
+++ b/admin/roles/class-role-manager.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Admin\Roles
+ */
 
 interface WPSEO_Role_Manager {
 	/**

--- a/admin/roles/class-role-manager.php
+++ b/admin/roles/class-role-manager.php
@@ -7,14 +7,13 @@ interface WPSEO_Role_Manager {
 	/**
 	 * Registers a role.
 	 *
-	 * @param string $role                  Role to add.
-	 * @param string $display_name          Display name to use.
-	 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
-	 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
+	 * @param string $role         Role to add.
+	 * @param string $display_name Display name to use.
+	 * @param null|string   $template     Optional. Role to base the new role on.
 	 *
-	 * @internal param array $capabilities Capabilities to add.
+	 * @return
 	 */
-	public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() );
+	public function register( $role, $display_name, $template = null );
 
 	/**
 	 * Adds the registered roles.

--- a/admin/roles/class-role-manager.php
+++ b/admin/roles/class-role-manager.php
@@ -1,0 +1,32 @@
+<?php
+
+interface WPSEO_Role_Manager {
+	/**
+	 * Registers a role.
+	 *
+	 * @param string $role                  Role to add.
+	 * @param string $display_name          Display name to use.
+	 * @param array  $enabled_capabilities  Optional. List of capabilities that must be granted.
+	 * @param array  $disabled_capabilities Optional. List of capabilities that must be restricted.
+	 *
+	 * @internal param array $capabilities Capabilities to add.
+	 */
+	public function register( $role, $display_name, array $enabled_capabilities = array(), array $disabled_capabilities = array() );
+
+	/**
+	 * Adds the registered roles.
+	 */
+	public function add();
+
+	/**
+	 * Removes the registered roles.
+	 */
+	public function remove();
+
+	/**
+	 * Returns the list of registered roles.
+	 *
+	 * @return string[] List or registered roles.
+	 */
+	public function get_roles();
+}

--- a/admin/views/dashboard-widget.php
+++ b/admin/views/dashboard-widget.php
@@ -38,8 +38,8 @@
 	</li>
 	<?php endforeach; ?>
 </ul>
-<?php $can_access = is_multisite() ? WPSEO_Utils::grant_access() : current_user_can( 'manage_options' );
-if ( ! empty( $onpage ) && $can_access ) : ?>
+<?php
+if ( ! empty( $onpage ) && WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) : ?>
 <div class="onpage">
 	<h3><?php
 		printf(

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1250,7 +1250,7 @@ class WPSEO_Frontend {
 			if ( is_string( $this->metadesc ) && $this->metadesc !== '' ) {
 				echo '<meta name="description" content="', esc_attr( strip_tags( stripslashes( $this->metadesc ) ) ), '"/>', "\n";
 			}
-			elseif ( current_user_can( 'manage_options' ) && is_singular() ) {
+			elseif ( current_user_can( 'wpseo_manage_options' ) && is_singular() ) {
 				echo '<!-- ', __( 'Admin only notice: this page doesn\'t show a meta description because it doesn\'t have one, either write it for this page specifically or go into the SEO -> Titles menu and set up a template.', 'wordpress-seo' ), ' -->', "\n";
 			}
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -387,11 +387,11 @@ class WPSEO_Upgrade {
 	 * Register new capabilities and roles
 	 */
 	private function upgrade_55() {
-		// Register new roles.
+		// Register roles.
 		do_action( 'wpseo_register_roles' );
 		WPSEO_Role_Manager_Factory::get()->add();
 
-		// Register new capabilities.
+		// Register capabilities.
 		do_action( 'wpseo_register_capabilities' );
 		WPSEO_Capability_Manager_Factory::get()->add();
 	}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -81,6 +81,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_50_51();
 		}
 
+		if ( version_compare( $this->options['version'], '5.5', '<' ) ) {
+			$this->upgrade_55();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -377,5 +381,15 @@ class WPSEO_Upgrade {
 
 		$count_storage = new WPSEO_Meta_Storage();
 		$wpdb->query( 'ALTER TABLE ' . $count_storage->get_table_name() . ' MODIFY internal_link_count int(10) UNSIGNED NULL DEFAULT NULL' );
+	}
+
+	private function upgrade_55() {
+		// Register new capabilities.
+		do_action( 'wpseo_register_capabilities' );
+		WPSEO_Capability_Manager_Factory::get()->add();
+
+		// Register new roles.
+		do_action( 'wpseo_register_roles' );
+		WPSEO_Role_Manager_Factory::get()->add();
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -108,9 +108,6 @@ class WPSEO_Upgrade {
 		// Clean up options and meta.
 		WPSEO_Options::clean_up( null, $version );
 		WPSEO_Meta::clean_up();
-
-		// Add new capabilities on upgrade.
-		wpseo_add_capabilities();
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -383,6 +383,9 @@ class WPSEO_Upgrade {
 		$wpdb->query( 'ALTER TABLE ' . $count_storage->get_table_name() . ' MODIFY internal_link_count int(10) UNSIGNED NULL DEFAULT NULL' );
 	}
 
+	/**
+	 * Register new capabilities and roles
+	 */
 	private function upgrade_55() {
 		// Register new capabilities.
 		do_action( 'wpseo_register_capabilities' );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -387,12 +387,12 @@ class WPSEO_Upgrade {
 	 * Register new capabilities and roles
 	 */
 	private function upgrade_55() {
-		// Register new capabilities.
-		do_action( 'wpseo_register_capabilities' );
-		WPSEO_Capability_Manager_Factory::get()->add();
-
 		// Register new roles.
 		do_action( 'wpseo_register_roles' );
 		WPSEO_Role_Manager_Factory::get()->add();
+
+		// Register new capabilities.
+		do_action( 'wpseo_register_capabilities' );
+		WPSEO_Capability_Manager_Factory::get()->add();
 	}
 }

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -385,7 +385,7 @@ class WPSEO_Meta {
 
 				$options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_titles', 'wpseo_internallinks' ) );
 
-				if ( ! current_user_can( 'manage_options' ) && $options['disableadvanced_meta'] ) {
+				if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) && $options['disableadvanced_meta'] ) {
 					return array();
 				}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -34,6 +34,7 @@ class WPSEO_Utils {
 	 * @return boolean
 	 */
 	public static function grant_access() {
+		// @todo add deprecation warning
 		if ( ! is_multisite() ) {
 			return true;
 		}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -41,7 +41,7 @@ class WPSEO_Utils {
 		$options = get_site_option( 'wpseo_ms' );
 
 		if ( empty( $options['access'] ) || $options['access'] === 'admin' ) {
-			return current_user_can( 'manage_options' );
+			return current_user_can( 'wpseo_manage_options' );
 		}
 
 		return is_super_admin();

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -423,7 +423,7 @@ abstract class WPSEO_Option {
 	 * @return void
 	 */
 	public function register_setting() {
-		if ( WPSEO_Utils::grant_access() ) {
+		if ( WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			register_setting( $this->group_name, $this->option_name );
 		}
 	}

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -412,3 +412,27 @@ function wpseo_xml_sitemaps_base_url( $page ) {
 
 	return WPSEO_Sitemaps_Router::get_base_url( $page );
 }
+
+/**
+ * Remove the bulk edit capability from the proper default roles.
+ *
+ * Contributor is still removed for legacy reasons.
+ *
+ * @deprecated 5.5
+ */
+function wpseo_remove_capabilities() {
+	_deprecated_function( __FUNCTION__, 'WPSEO 5.5.0', 'WPSEO_Capability_Manager_Factory::get()->remove()' );
+
+	WPSEO_Capability_Manager_Factory::get()->remove();
+}
+
+/**
+ * Add the bulk edit capability to the proper default roles.
+ *
+ * @deprecated 5.5.0
+ */
+function wpseo_add_capabilities() {
+	_deprecated_function( __FUNCTION__, 'WPSEO 5.5.0', 'WPSEO_Capability_Manager_Factory::get()->add()' );
+
+	WPSEO_Capability_Manager_Factory::get()->add();
+}

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -83,6 +83,10 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
  * Add the bulk edit capability to the proper default roles.
  */
 function wpseo_add_capabilities() {
+	// @todo Add deprecation warning.
+	WPSEO_Capability_Manager_Factory::get()->add();
+	return;
+
 	$roles = array(
 		'administrator',
 		'editor',
@@ -97,31 +101,6 @@ function wpseo_add_capabilities() {
 		}
 	}
 }
-
-
-/**
- * Remove the bulk edit capability from the proper default roles.
- *
- * Contributor is still removed for legacy reasons.
- */
-function wpseo_remove_capabilities() {
-	$roles = array(
-		'administrator',
-		'editor',
-		'author',
-		'contributor',
-	);
-
-	$roles = apply_filters( 'wpseo_bulk_edit_roles', $roles );
-
-	foreach ( $roles as $role ) {
-		$r = get_role( $role );
-		if ( $r ) {
-			$r->remove_cap( 'wpseo_bulk_edit' );
-		}
-	}
-}
-
 
 /**
  * Replace `%%variable_placeholders%%` with their real value based on the current requested page/post/cpt

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -80,29 +80,6 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
 }
 
 /**
- * Add the bulk edit capability to the proper default roles.
- */
-function wpseo_add_capabilities() {
-	// @todo Add deprecation warning.
-	WPSEO_Capability_Manager_Factory::get()->add();
-	return;
-
-	$roles = array(
-		'administrator',
-		'editor',
-	);
-
-	$roles = apply_filters( 'wpseo_bulk_edit_roles', $roles );
-
-	foreach ( $roles as $role ) {
-		$r = get_role( $role );
-		if ( $r ) {
-			$r->add_cap( 'wpseo_bulk_edit' );
-		}
-	}
-}
-
-/**
  * Replace `%%variable_placeholders%%` with their real value based on the current requested page/post/cpt
  *
  * @param string $string the string to replace the variables in.

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -26,12 +26,6 @@ function wpseo_admin_bar_menu() {
 
 	global $wp_admin_bar, $post;
 
-	// Determine is user is admin or network admin.
-	$user_is_admin_or_networkadmin = current_user_can( 'manage_options' );
-	if ( ! $user_is_admin_or_networkadmin && is_multisite() ) {
-		$user_is_admin_or_networkadmin = ( $options['access'] === 'superadmin' && is_super_admin() );
-	}
-
 	$focuskw = '';
 	$score   = '';
 	// By default, the top level menu item has no link.
@@ -66,8 +60,11 @@ function wpseo_admin_bar_menu() {
 	// Never display notifications for network admin.
 	$counter = $alert_popup = '';
 
+	// Determine is user is admin or network admin.
+	$can_manage_seo = WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );
+
 	// Set the top level menu item content for admins and network admins.
-	if ( $user_is_admin_or_networkadmin ) {
+	if ( $can_manage_seo ) {
 
 		// Link the top level menu item to the Yoast Dashboard page.
 		$seo_url = get_admin_url( null, 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER );
@@ -252,7 +249,7 @@ function wpseo_admin_bar_menu() {
 	}
 
 	// @todo: add links to bulk title and bulk description edit pages.
-	if ( $user_is_admin_or_networkadmin ) {
+	if ( $can_manage_seo ) {
 
 		$advanced_settings = wpseo_advanced_settings_enabled( $options );
 

--- a/tests/capabilities/test-class-capability-manager-factory.php
+++ b/tests/capabilities/test-class-capability-manager-factory.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPSEO_Capability_Manager_Factory_Tests extends PHPUnit_Framework_TestCase {
+	public function test_get() {
+		$instance = WPSEO_Capability_Manager_Factory::get();
+		$instance2 = WPSEO_Capability_Manager_Factory::get();
+
+		$this->assertEquals( $instance, $instance2 );
+	}
+}

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -28,6 +28,8 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	public function test_register() {
 		$instance = new WPSEO_Capability_Manager_Test();
 
+		$this->assertNotContains( 'capability', $instance->get_capabilities() );
+
 		$instance->register( 'capability', array( 'role' ) );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -1,0 +1,74 @@
+<?php
+
+class WPSEO_Capability_Manager_Test extends WPSEO_Abstract_Capability_Manager {
+	/**
+	 * Adds the registerd capabilities to the system.
+	 */
+	public function add() {
+
+	}
+
+	/**
+	 * Removes the registered capabilities from the system
+	 */
+	public function remove() {
+
+	}
+
+	public function get_registered_capabilities() {
+		return $this->capabilities;
+	}
+
+	public function filter_roles( $capability, array $roles ) {
+		return parent::filter_roles( $capability, $roles );
+	}
+}
+
+class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
+	public function test_register() {
+		$instance = new WPSEO_Capability_Manager_Test();
+
+		$instance->register( 'capability', array( 'role' ) );
+
+		$this->assertContains( 'capability', $instance->get_capabilities() );
+		$this->assertContains( 'role', $instance->get_registered_capabilities()['capability'] );
+	}
+
+	public function test_register_overwrite() {
+		$instance = new WPSEO_Capability_Manager_Test();
+
+		$instance->register( 'capability', array(  'role1' ) );
+		$instance->register( 'capability', array(  'role2' ), false );
+
+		$this->assertContains( 'capability', $instance->get_capabilities() );
+		$this->assertContains( 'role2', $instance->get_registered_capabilities()['capability'] );
+		$this->assertNotContains( 'role1', $instance->get_registered_capabilities()['capability'] );
+	}
+
+	public function test_register_add() {
+		$instance = new WPSEO_Capability_Manager_Test();
+
+		$instance->register( 'capability', array( 'role1' ) );
+		$instance->register( 'capability', array( 'role2' ) );
+
+		$this->assertContains( 'capability', $instance->get_capabilities() );
+		$this->assertContains( 'role2', $instance->get_registered_capabilities()['capability'] );
+		$this->assertContains( 'role1', $instance->get_registered_capabilities()['capability'] );
+	}
+
+	public function test_filter_roles() {
+		$instance = new WPSEO_Capability_Manager_Test();
+
+		add_filter( 'capability_roles', array( $this, 'do_filter_roles' ) );
+
+		$filtered = $instance->filter_roles( 'capability', array( 'role' ) );
+
+		remove_filter( 'capability_roles', array( $this, 'do_filter_roles' ) );
+
+		$this->assertEquals( $this->do_filter_roles( array( 'role' ) ), $filtered );
+	}
+
+	public function do_filter_roles( $roles ) {
+		return array( 'elor' );
+	}
+}

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -42,7 +42,7 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 		$instance = new WPSEO_Capability_Manager_Test();
 
 		$instance->register( 'capability', array(  'role1' ) );
-		$instance->register( 'capability', array(  'role2' ), false );
+		$instance->register( 'capability', array(  'role2' ), true );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
 

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -33,7 +33,9 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 		$instance->register( 'capability', array( 'role' ) );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
-		$this->assertContains( 'role', $instance->get_registered_capabilities()['capability'] );
+
+		$registered = $instance->get_registered_capabilities();
+		$this->assertContains( 'role', $registered['capability'] );
 	}
 
 	public function test_register_overwrite() {
@@ -43,8 +45,10 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 		$instance->register( 'capability', array(  'role2' ), false );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
-		$this->assertContains( 'role2', $instance->get_registered_capabilities()['capability'] );
-		$this->assertNotContains( 'role1', $instance->get_registered_capabilities()['capability'] );
+
+		$registered = $instance->get_registered_capabilities();
+		$this->assertContains( 'role2', $registered['capability'] );
+		$this->assertNotContains( 'role1', $registered['capability'] );
 	}
 
 	public function test_register_add() {
@@ -54,8 +58,10 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 		$instance->register( 'capability', array( 'role2' ) );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
-		$this->assertContains( 'role2', $instance->get_registered_capabilities()['capability'] );
-		$this->assertContains( 'role1', $instance->get_registered_capabilities()['capability'] );
+
+		$registered = $instance->get_registered_capabilities();
+		$this->assertContains( 'role2', $registered['capability'] );
+		$this->assertContains( 'role1', $registered['capability'] );
 	}
 
 	public function test_filter_roles() {

--- a/tests/capabilities/test-class-register-capabilities.php
+++ b/tests/capabilities/test-class-register-capabilities.php
@@ -1,0 +1,15 @@
+<?php
+
+class WPSEO_Register_Capabilities_Tests extends PHPUnit_Framework_TestCase {
+	public function test_register() {
+		$manager = WPSEO_Capability_Manager_Factory::get();
+
+		$register = new WPSEO_Register_Capabilities();
+		$register->register();
+
+		$registered = $manager->get_capabilities();
+
+		$this->assertContains( 'wpseo_bulk_edit', $registered );
+		$this->assertContains( 'wpseo_manage_options', $registered );
+	}
+}

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -20,7 +20,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$this->user_id = $this->factory->user->create();
 
 		$user = new WP_User( $this->user_id );
-		$user->add_cap( 'manage_options' );
+		$user->add_cap( 'wpseo_manage_options' );
 
 		wp_set_current_user( $this->user_id );
 	}

--- a/tests/notifications/test-class-yoast-notification.php
+++ b/tests/notifications/test-class-yoast-notification.php
@@ -37,7 +37,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 				'priority'         => 0.5,
 				'data_json'        => array(),
 				'dismissal_key'    => null,
-				'capabilities'     => array( 'manage_options' ),
+				'capabilities'     => array( 'wpseo_manage_options' ),
 				'capability_check' => 'all',
 			),
 			$test['options']

--- a/tests/roles/test-class-register-roles.php
+++ b/tests/roles/test-class-register-roles.php
@@ -1,0 +1,15 @@
+<?php
+
+class WPSEO_Register_Roles_Tests extends PHPUnit_Framework_TestCase {
+	public function test_register() {
+		$manager = WPSEO_Role_Manager_Factory::get();
+
+		$register = new WPSEO_Register_Roles();
+		$register->register();
+
+		$registered = $manager->get_roles();
+
+		$this->assertContains( 'wpseo_manager', $registered );
+		$this->assertContains( 'wpseo_editor', $registered );
+	}
+}

--- a/tests/roles/test-class-role-manager-factory.php
+++ b/tests/roles/test-class-role-manager-factory.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPSEO_Role_Manager_Factory_Tests extends PHPUnit_Framework_TestCase {
+	public function test_get() {
+		$instance = WPSEO_Role_Manager_Factory::get();
+		$instance2 = WPSEO_Role_Manager_Factory::get();
+
+		$this->assertEquals( $instance, $instance2 );
+	}
+}

--- a/tests/roles/test-class-role-manager.php
+++ b/tests/roles/test-class-role-manager.php
@@ -1,0 +1,80 @@
+<?php
+
+class WPSEO_Role_Manager_Test extends WPSEO_Abstract_Role_Manager {
+	public $added_roles = array();
+	public $removed_roles = array();
+
+	public function get_registered_roles() {
+		return $this->roles;
+	}
+
+	public function filter_existing_capabilties( $role, array $capabilities ) {
+		return parent::filter_existing_capabilities( $role, $capabilities );
+	}
+
+	public function get_capabilities( $role ) {
+		return parent::get_capabilities( $role );
+	}
+
+	/**
+	 * Adds a role to the system.
+	 *
+	 * @param string $role         Role to add.
+	 * @param string $display_name Name to display for the role.
+	 * @param array  $capabilities Capabilities to add to the role.
+	 *
+	 * @return void
+	 */
+	protected function add_role( $role, $display_name, array $capabilities = array() ) {
+		$this->added_roles[] = array(
+			'role' => $role,
+			'display_name' => $display_name,
+			'capabilities' => $capabilities
+		);
+	}
+
+	/**
+	 * Removes a role from the system
+	 *
+	 * @param string $role Role to remove.
+	 *
+	 * @return void
+	 */
+	protected function remove_role( $role ) {
+		$this->removed_roles[] = $role;
+	}
+}
+
+class Capability_Role_Tests extends PHPUnit_Framework_TestCase {
+	public function test_register() {
+		$instance = new WPSEO_Role_Manager_Test();
+
+		$this->assertNotContains( 'role', $instance->get_roles() );
+
+		$instance->register( 'role', 'My Role', array() );
+
+		$this->assertContains( 'role', $instance->get_roles() );
+	}
+
+	public function test_get_capabilities() {
+		$instance = new WPSEO_Role_Manager_Test();
+		$capabilities = $instance->get_capabilities( 'administrator' );
+
+		$this->assertNotEmpty( $capabilities );
+		$this->assertContains( 'manage_options', array_keys( $capabilities ) );
+		$this->assertTrue( $capabilities['manage_options'] );
+	}
+
+	public function test_get_capabilities_bad_input() {
+		$instance = new WPSEO_Role_Manager_Test();
+
+		$result = $instance->get_capabilities( false );
+		$this->assertEquals( array(), $result );
+
+		$result = $instance->get_capabilities( new StdClass() );
+		$this->assertEquals( array(), $result );
+
+		$result = $instance->get_capabilities( 'fake_role' );
+		$this->assertEquals( array(), $result );
+	}
+}

--- a/tests/test-wpseo-functions.php
+++ b/tests/test-wpseo-functions.php
@@ -12,14 +12,6 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 		parent::setUp();
 	}
 
-	public function test_wpseo_add_capabilities() {
-		// TODO
-	}
-
-	public function test_wpseo_remove_capabilities() {
-
-	}
-
 	/**
 	 * @covers wpseo_replace_vars
 	 */
@@ -57,17 +49,5 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 			- Test all Basic Variables
 			- Test all Advanced Variables
 		 */
-	}
-
-	public function test_wpseo_get_terms() {
-		// TODO
-	}
-
-	public function test_wpseo_strip_shortcodes() {
-		// TODO
-	}
-
-	public function test_wpseo_wpml_config() {
-		// TODO
 	}
 }

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -205,6 +205,10 @@ function _wpseo_deactivate() {
 		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
+	// Register capabilities and roles, to make sure they are cleaned up.
+	do_action( 'wpseo_register_capabilities' );
+	do_action( 'wpseo_register_roles' );
+
 	// Clean up capabilities.
 	WPSEO_Capability_Manager_Factory::get()->remove();
 	WPSEO_Role_Manager_Factory::get()->remove();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -198,9 +198,11 @@ function _wpseo_deactivate() {
 	}
 
 	// Register capabilities, to make sure they are cleaned up.
+	do_action( 'wpseo_register_roles' );
 	do_action( 'wpseo_register_capabilities' );
 
 	// Clean up capabilities.
+	WPSEO_Role_Manager_Factory::get()->remove();
 	WPSEO_Capability_Manager_Factory::get()->remove();
 
 	// Clear cache so the changes are obvious.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -165,11 +165,11 @@ function _wpseo_activate() {
 		$wpseo_rewrite->schedule_flush();
 	}
 
-	do_action( 'wpseo_register_capabilities' );
-	WPSEO_Capability_Manager_Factory::get()->add();
-
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();
+
+	do_action( 'wpseo_register_capabilities' );
+	WPSEO_Capability_Manager_Factory::get()->add();
 
 	// Clear cache so the changes are obvious.
 	WPSEO_Utils::clear_cache();
@@ -197,13 +197,11 @@ function _wpseo_deactivate() {
 		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
-	// Register capabilities and roles, to make sure they are cleaned up.
+	// Register capabilities, to make sure they are cleaned up.
 	do_action( 'wpseo_register_capabilities' );
-	do_action( 'wpseo_register_roles' );
 
 	// Clean up capabilities.
 	WPSEO_Capability_Manager_Factory::get()->remove();
-	WPSEO_Role_Manager_Factory::get()->remove();
 
 	// Clear cache so the changes are obvious.
 	WPSEO_Utils::clear_cache();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -165,16 +165,8 @@ function _wpseo_activate() {
 		$wpseo_rewrite->schedule_flush();
 	}
 
-	// Registers the capabilities.
-	$register_capabilities = new WPSEO_Register_Capabilities();
-	$register_capabilities->register_hooks();
-
 	do_action( 'wpseo_register_capabilities' );
 	WPSEO_Capability_Manager_Factory::get()->add();
-
-	// Registers the roles.
-	$register_capabilities = new WPSEO_Register_Roles();
-	$register_capabilities->register_hooks();
 
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();
@@ -406,6 +398,13 @@ add_action( 'activate_blog', 'wpseo_on_activate_blog' );
 // Loading Ryte integration.
 new WPSEO_OnPage();
 
+// Registers SEO capabilities.
+$register_capabilities = new WPSEO_Register_Capabilities();
+$register_capabilities->register_hooks();
+
+// Registers SEO roles.
+$register_capabilities = new WPSEO_Register_Roles();
+$register_capabilities->register_hooks();
 
 /**
  * Wraps for notifications center class.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -137,7 +137,6 @@ function wpseo_network_activate_deactivate( $activate = true ) {
 	}
 }
 
-
 /**
  * Runs on activation of the plugin.
  */
@@ -166,7 +165,19 @@ function _wpseo_activate() {
 		$wpseo_rewrite->schedule_flush();
 	}
 
-	wpseo_add_capabilities();
+	// Registers the capabilities.
+	$register_capabilities = new WPSEO_Register_Capabilities();
+	$register_capabilities->register_hooks();
+
+	do_action( 'wpseo_register_capabilities' );
+	WPSEO_Capability_Manager_Factory::get()->add();
+
+	// Registers the roles.
+	$register_capabilities = new WPSEO_Register_Roles();
+	$register_capabilities->register_hooks();
+
+	do_action( 'wpseo_register_roles' );
+	WPSEO_Role_Manager_Factory::get()->add();
 
 	// Clear cache so the changes are obvious.
 	WPSEO_Utils::clear_cache();
@@ -194,7 +205,9 @@ function _wpseo_deactivate() {
 		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
-	wpseo_remove_capabilities();
+	// Clean up capabilities.
+	WPSEO_Capability_Manager_Factory::get()->remove();
+	WPSEO_Role_Manager_Factory::get()->remove();
 
 	// Clear cache so the changes are obvious.
 	WPSEO_Utils::clear_cache();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Introduces `wpseo_manager` and `wpseo_editor` roles.
* Introduces capabilities to control which user has access to the advanced SEO settings.

### Touches

* All SEO settings pages
* Network Admin SEO Settings
* SEO notifications
* Page/post/term edit pages (Advanced settings)
* Reindex internal links

## Relevant technical choices:

* Used abstract classes to reduce duplicating code
* Separated registering and adding/removing
* Introduced actions to register roles and capabilities on, making it extensible for premium
* `wpseo_manage_options` can do anything, thus this is always being added to the capability check
* menu registration is done the regular way when the `wpseo_manage_options` capability is present
* submenus with capabilities other than `wpseo_manage_options` are registered as main menu items when the used does not have `wpseo_manage_options`

## Test instructions

Recommended helper plugins:
* Members
* User switching

This PR can be tested by following these steps:

* Deactivate + activate the plugin to see the new roles and capabilities being added to the system
* Create a user with a specific role (wpseo_manager / wpseo_editor) and verify that that user can only do the things they should be able to do.

Notes:
* The `Advanced SEO Settings` in a post or page needs to be disabled in `General > Security` in order to hide it for users who don't have the proper capability.
* In a Network setup, we have a setting which disables `Administrators` from being able to modify SEO settings, if this is configured, we don't give this role the capability `wpseo_manage_options`

Fixes #7831