### PR TITLE
Replace invalid placeholder `%1$s` with `%d` to prevent invalid querys

### DIFF
--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -87,12 +87,10 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 
 		$query = $wpdb->prepare( '
 			SELECT COUNT( id ) AS incoming, target_post_id AS post_id
-			  FROM %2$s
-			 WHERE target_post_id IN( %3$s )
-		  GROUP BY target_post_id',
-			$this->get_table_name(),
-			$storage->get_table_name(),
-			implode( ', ', $post_ids )
+			FROM ' . $storage->get_table_name() . '
+			WHERE target_post_id IN(' . implode( ',', array_fill( 0, count( $post_ids ), '%d' ) ) . ')
+			GROUP BY target_post_id',
+			$post_ids
 		);
 
 		$results = $wpdb->get_results( $query );

--- a/admin/links/class-link-column-count.php
+++ b/admin/links/class-link-column-count.php
@@ -56,8 +56,8 @@ class WPSEO_Link_Column_Count {
 			$wpdb->prepare( '
 				SELECT internal_link_count, incoming_link_count, object_id
 				FROM ' . $storage->get_table_name() . '
-			    WHERE object_id IN ( %1$s )',
-				implode( ',', $post_ids )
+				WHERE object_id IN (' . implode( ',', array_fill( 0, count( $post_ids ), '%d' ) ) . ')',
+				$post_ids
 			),
 			ARRAY_A
 		);


### PR DESCRIPTION
`%1$s` is not supported by `$wpdb::prepare()`.

## Summary

This PR can be summarized in the following changelog entry:

* In SQL queries replace numbered placeholders with simple directives supported by the prepare method of WordPress' database layer.

## Relevant technical choices:

* https://wordpress.org/news/2017/09/wordpress-4-8-2-security-and-maintenance-release/

## Test instructions

This PR can be tested by following these steps:

* Visit post edit screen in debug mode.

Fixes #7878.
