### PR TITLE
Use the new license page by default

### DIFF
--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -115,7 +115,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 	 * @return int The version number
 	 */
 	protected function get_version() {
-		return get_option( $this->get_option_name(), self::VERSION_LEGACY );
+		return get_option( $this->get_option_name(), self::VERSION_BACKWARDS_COMPATIBILITY );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses the new licence page by default
