### PR TITLE
Fixes a bug where a notice is shown on post creation

### DIFF
--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -58,7 +58,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		}
 
 		// If the post URL wasn't visible before, or isn't visible now, don't advise creating a redirect.
-		if ( ! $this->check_visible_post_status( get_post_status( $post_before->ID ) ) || ! $this->check_visible_post_status( get_post_status( $post->ID ) ) ) {
+		if ( ! $this->check_visible_post_status( $post_before->post_status ) || ! $this->check_visible_post_status( $post->post_status ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
I was creating a new post and a notice telling me to add a redirect became visible. This isn't intended. The notice should only be visible on post slug update.

## Relevant technical choices:

* I have used the `$post->post_status` instead of `get_post_status( $post->ID );` because of the old and new post objects do have the same ID resulting in getting the same status. Because of this status a notice became visible on post creation. 

## Test instructions

This PR can be tested by following these steps:

* Checkout `trunk`
* Create a new post and save it
* See a redirect notice popping up.
* Checkout this branch
* Do the same, no notice is popping up.
