### PR TITLE
Replace invalid placeholder `%1$d` with `%d`

### DIFF
--- a/admin/links/class-link-query.php
+++ b/admin/links/class-link-query.php
@@ -94,7 +94,7 @@ class WPSEO_Link_Query {
 				 WHERE posts.post_status = "publish"
 				   AND posts.post_type IN ( ' . $post_types . ' )
 				   AND yoast_meta.internal_link_count IS NULL
-				 LIMIT %1$d
+				 LIMIT %d
 				',
 				$limit
 			)

--- a/admin/links/class-link-query.php
+++ b/admin/links/class-link-query.php
@@ -71,7 +71,6 @@ class WPSEO_Link_Query {
 
 	/**
 	 * Returns a limited set of unindexed posts.
-	 * *
 	 *
 	 * @param array $post_types The post type.
 	 * @param int   $limit      The limit for the resultset.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replace invalid placeholder `%1$d` with `%d` in function `get_unprocessed_posts`

## Relevant technical choices:

* https://wordpress.org/news/2017/09/wordpress-4-8-2-security-and-maintenance-release/

## Test instructions

This PR can be tested by following these steps:

* Update Yoast SEO to 5.4.1 and WP to 4.8.2
* Click on **Count links in your texts**
* Check debug.log or error_log

Fixes #7886
