### PR TITLE
Stories/7899 consistent filter behaviour

### DIFF
--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -50,6 +50,10 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 
 		add_filter( 'posts_where', array( $this, 'filter_posts' ) );
 
+		if ( $this->is_filter_active() ) {
+			add_action( 'restrict_manage_posts', array( $this, 'render_hidden_input' ) );
+		}
+
 		if ( $this->get_explanation() !== null && $this->is_filter_active() ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_explanation_assets' ) );
 		}
@@ -100,14 +104,25 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	}
 
 	/**
+	 * Renders a hidden input to preserve this filter's state when using sub-filters.
+	 *
+	 * @return void
+	 */
+	public function render_hidden_input() {
+		echo '<input type="hidden" name="' . self::FILTER_QUERY_ARG . '" value="' . $this->get_query_val() . '">';
+	}
+
+	/**
 	 * Removes the post_status from the REQUEST URL because of the filter is in the same line.
 	 * After removing the post_status it will add a query arg for this filter.
 	 *
 	 * @return string The url to activate this filter.
 	 */
 	protected function get_filter_url() {
-		$filter_url = remove_query_arg( array( 'post_status' ) );
-		$filter_url = add_query_arg( self::FILTER_QUERY_ARG, $this->get_query_val(), $filter_url );
+		$filter_url = add_query_arg( array(
+			self::FILTER_QUERY_ARG => $this->get_query_val(),
+			'post_type' => $this->get_current_post_type(),
+		), 'edit.php' );
 
 		return $filter_url;
 	}

--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -113,8 +113,7 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	}
 
 	/**
-	 * Removes the post_status from the REQUEST URL because of the filter is in the same line.
-	 * After removing the post_status it will add a query arg for this filter.
+	 * Returns an url to edit.php with post_type and this filter as the query arguments.
 	 *
 	 * @return string The url to activate this filter.
 	 */

--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -119,12 +119,10 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	 * @return string The url to activate this filter.
 	 */
 	protected function get_filter_url() {
-		$filter_url = add_query_arg( array(
+		return add_query_arg( array(
 			self::FILTER_QUERY_ARG => $this->get_query_val(),
 			'post_type' => $this->get_current_post_type(),
 		), 'edit.php' );
-
-		return $filter_url;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The Cornerstone Content filter now behaves consistently with existing WordPress Filters.

## Test instructions

This PR can be tested by following these steps:

* Filter on Cornerstone content.
* Then filter using one of the dropdown sub-filters.
* The cornerstone content filter should remain active.

* Filter on All ( or Published ).
* Then filter using one of the dropdown sub-filters.
* Then click on the Cornerstone content filter.
* The dropdown sub-filters should reset.

Fixes #7899.
