### PR TITLE
Added notice the cornerstone content filter.

### DIFF
--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -47,6 +47,20 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 	}
 
 	/**
+	 * Returns a text explaining this filter. Null if no explanation is necessary.
+	 *
+	 * @return string|null The explanation or null.
+	 */
+	protected function get_explanation() {
+		return sprintf(
+			/* translators: %1$s expands anchor to knowledge base article, %2$s expands to </a> */
+			__( 'You can mark the most important articles or pages on your website as \'cornerstone content\' to improve your site structure. %1$sRead more about cornerstone content%2$s.'),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1i9' ) . '" target="_blank">',
+			'</a>'
+		);
+	}
+
+	/**
 	 * Returns the total amount of articles marked as cornerstone content.
 	 *
 	 * @return integer

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -47,9 +47,9 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 	}
 
 	/**
-	 * Returns a text explaining this filter. Null if no explanation is necessary.
+	 * Returns a text explaining this filter.
 	 *
-	 * @return string|null The explanation or null.
+	 * @return string The explanation.
 	 */
 	protected function get_explanation() {
 		return sprintf(

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -54,7 +54,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 	protected function get_explanation() {
 		return sprintf(
 			/* translators: %1$s expands anchor to knowledge base article, %2$s expands to </a> */
-			__( 'You can mark the most important articles or pages on your website as \'cornerstone content\' to improve your site structure. %1$sRead more about cornerstone content%2$s.'),
+			__( 'You can mark the most important articles or pages on your website as \'cornerstone content\' to improve your site structure. %1$sRead more about cornerstone content%2$s.', 'wordpress-seo' ),
 			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1i9' ) . '" target="_blank">',
 			'</a>'
 		);

--- a/css/dist/filter-explanation-540-rtl.css
+++ b/css/dist/filter-explanation-540-rtl.css
@@ -1,4 +1,3 @@
 #posts-filter .wpseo-filter-explanation {
-	margin-top: 10px;
-	margin-bottom: 5px;
+	margin: 10px 1px 5px;
 }

--- a/css/dist/filter-explanation-540-rtl.min.css
+++ b/css/dist/filter-explanation-540-rtl.min.css
@@ -1,1 +1,1 @@
-#posts-filter .wpseo-filter-explanation{margin-top:10px;margin-bottom:5px}
+#posts-filter .wpseo-filter-explanation{margin:10px 1px 5px}

--- a/css/dist/filter-explanation-540.css
+++ b/css/dist/filter-explanation-540.css
@@ -1,4 +1,3 @@
 #posts-filter .wpseo-filter-explanation {
-	margin-top: 10px;
-	margin-bottom: 5px;
+	margin: 10px 1px 5px;
 }

--- a/css/dist/filter-explanation-540.min.css
+++ b/css/dist/filter-explanation-540.min.css
@@ -1,1 +1,1 @@
-#posts-filter .wpseo-filter-explanation{margin-top:10px;margin-bottom:5px}
+#posts-filter .wpseo-filter-explanation{margin:10px 1px 5px}

--- a/css/src/filter-explanation.scss
+++ b/css/src/filter-explanation.scss
@@ -1,4 +1,3 @@
 #posts-filter .wpseo-filter-explanation {
-  margin-top: 10px;
-  margin-bottom: 5px;
+  margin: 10px 1px 5px;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added an explanation to the cornerstone content filter.

## Relevant technical choices:

* Added an additional 1px margin to the explanation to make it line up with the table.

## Test instructions

This PR can be tested by following these steps:

* Filter using the `Cornerstone content` filter.
* You should see an explanation describing what cornerstone content is.

Fixes #7725.
