### PR TITLE
Always use WPSEO_Shortlinker.

### DIFF
--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -196,7 +196,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 			sprintf(
 				__( 'You are not receiving updates or support! Fix this problem by adding this site and enabling %1$s for it in %2$s.', 'wordpress-seo' ),
 				$product_name,
-				'<a href="https://yoa.st/13j" target="_blank">My Yoast</a>'
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/13j' ) . '" target="_blank">My Yoast</a>'
 			),
 			$notification_options
 		);

--- a/admin/config-ui/fields/class-field-google-search-console-intro.php
+++ b/admin/config-ui/fields/class-field-google-search-console-intro.php
@@ -22,7 +22,7 @@ class WPSEO_Config_Field_Google_Search_Console_Intro extends WPSEO_Config_Field 
  Find out %2$show to connect Google Search Console to your site.%3$s',
 				'wordpress-seo' ),
 			'Yoast SEO',
-			'<a href="https://yoa.st/1ex">',
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1ex' ) . '">',
 			'</a>' );
 
 		$disclaimer = __( 'Note: we don\'t store your data in any way and don\'t have full access to your account. 

--- a/admin/config-ui/fields/class-field-social-profiles-intro.php
+++ b/admin/config-ui/fields/class-field-social-profiles-intro.php
@@ -20,7 +20,7 @@ class WPSEO_Config_Field_Social_Profiles_Intro extends WPSEO_Config_Field {
  These will be used in Google\'s Knowledge Graph. There are additional
  sharing options in the advanced settings. More %2$sinfo%3$s.', 'wordpress-seo' ),
 			'Yoast SEO',
-			'<a href="https://yoa.st/1ey">',
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1ey' ) . '">',
 			'</a>'
 		);
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -156,10 +156,10 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 				<?php if ( $extensions->is_activated( 'wordpress-seo-premium' ) ) : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php _e( 'Activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="https://yoa.st/13k" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ) ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
 				<?php else : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php _e( 'Not activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="https://yoa.st/13i" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ) ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
 				<?php endif; ?>
 				</a>
 
@@ -214,10 +214,10 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 							<?php if ( $extensions->is_activated( $id ) ) : ?>
 								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php _e( 'Activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="https://yoa.st/13k" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ) ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
 							<?php else : ?>
 								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php _e( 'Not activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="https://yoa.st/13i" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ) ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
 							<?php endif; ?>
 						<?php else : ?>
 							<a target="_blank" class="yoast-button yoast-button--noarrow yoast-button-go-to  yoast-button--extension yoast-button--extension-buy" href="<?php echo esc_url( $extension->get_buy_url() ); ?>">

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -105,7 +105,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 					'wordpress-seo'
 				),
 				$post_type_label,
-				'<a href="' . WPSEO_Shortlinker::get('https://yoa.st/1d0') . '" target="_blank">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">',
 				'</a>'
 			), array( 'type' => 'notice-info' )
 		);

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -105,7 +105,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 					'wordpress-seo'
 				),
 				$post_type_label,
-				'<a href="https://yoa.st/1d0" target="_blank">',
+				'<a href="' . WPSEO_Shortlinker::get('https://yoa.st/1d0') . '" target="_blank">',
 				'</a>'
 			), array( 'type' => 'notice-info' )
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

No functional changes.

## Relevant technical choices:

* Always uses `WPSEO_Shortlinker` for yoa.st urls.

## Test instructions

This PR can be tested by following these steps:

* All URLs on the affected pages should work as they used to.