### PR TITLE
Fixed ryte assessment showing up in db widget when Ryte is disabled

### DIFF
--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -68,6 +68,10 @@ class DashboardWidget extends React.Component {
 	 */
 	getRyte() {
 		wpseoApi.get( "ryte", ( response ) => {
+			if ( ! response.ryte ) {
+				return;
+			}
+
 			let ryte = {
 				scores: [ {
 					color: DashboardWidget.getColorFromScore( response.ryte.score ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Ryte assessment no longer showing up in dashboard widget when Ryte is disabled.

## Test instructions

This PR can be tested by following these steps:

* Disable Ryte in SEO > Dashboard > Features.
* Go to WordPress Dashboard, check the widget.
* Re-enable Ryte.
* Go to WordPress dashboard, check the widget.