### PR TITLE
Unquote placeholders.

### DIFF
--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -58,8 +58,8 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 			$wpdb->prepare( '
 				SELECT COUNT( 1 )
 				FROM ' . $wpdb->postmeta . '
-				WHERE post_id IN( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = "%s" ) && 
-				meta_value = "1" AND meta_key = "%s"
+				WHERE post_id IN( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = %s ) &&
+				meta_value = "1" AND meta_key = %s
 				',
 				$this->get_current_post_type(),
 				WPSEO_Cornerstone::META_NAME

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -288,7 +288,7 @@ class WPSEO_Upgrade {
 		// The meta key has to be private, so prefix it.
 		$wpdb->query(
 			$wpdb->prepare(
-				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = "%s" WHERE meta_key = "yst_is_cornerstone"',
+				'UPDATE ' . $wpdb->postmeta . ' SET meta_key = %s WHERE meta_key = "yst_is_cornerstone"',
 				WPSEO_Cornerstone::META_NAME
 			)
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

No functional changes.

## Relevant technical choices:

* Unquoted placeholders in `$wpdb->prepare` statements.

## Test instructions

This PR can be tested by following these steps:

For the cornerstone filter:
* Go to the posts overview and activate the cornerstone filter, it should work as expected.

For the upgrade:
* Activate Yoast SEO 4.6.
* Mark a post as cornerstone content.
* Upgrade Yoast SEO.
* That post should still be cornerstone content.

Fixes #7911 
