### PR TITLE
Added check for metabox to initializePostAnalysis

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -345,6 +345,11 @@ var UsedKeywords = require( "./analysis/usedKeywords" );
 	function initializePostAnalysis() {
 		snippetContainer = $( "#wpseosnippet" );
 
+		// Avoid error when snippet metabox is not rendered.
+		if ( snippetContainer.length === 0 ) {
+			return;
+		}
+
 		tabManager = initializeTabManager();
 		postDataCollector = initializePostDataCollector();
 		publishBox.initalise();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes Snippet preview error when Yoast metabox has been removed.

## Test instructions

This PR can be tested by following these steps:

* Add the following function to `WPSEO_Admin` class in `class-admin.php`.
```php
public function remove_yoast_from_gbs_ecommunicator() {
    echo "<script>console.log('removing metaboxes');</script>";
    remove_meta_box( 'wpseo_meta', 'post', 'normal' );
}
```
* Add the following line to the constructor in `WPSEO_Admin` class in `class-admin.php`.
```php
add_action( 'add_meta_boxes', array( $this, 'remove_yoast_from_gbs_ecommunicator' ), 11 );
```
* Edit a post, check if the error is still being thrown.
* Comment the line from step 2 to check if the error returns.

Fixes #7527
