### PR TITLE
Update incoming link count to zero

### DIFF
--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -95,8 +95,15 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 
 		$results = $wpdb->get_results( $query );
 
+		$post_ids_non_zero = array();
 		foreach ( $results as $result ) {
 			$this->save_meta_data( $result->post_id, array( 'incoming_link_count' => $result->incoming ) );
+			$post_ids_non_zero[] = $result->post_id;
+		}
+
+		$post_ids_zero = array_diff( $post_ids, $post_ids_non_zero );
+		foreach ( $post_ids_zero as $post_id ) {
+			$this->save_meta_data( $post_id, array( 'incoming_link_count' => 0 ) );
 		}
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -401,7 +401,14 @@ class WPSEO_Upgrade {
 	 * Updates legacy license page options to the latest version.
 	 */
 	private function upgrade_56() {
+		global $wpdb;
+
+		// Make sure License Server checks are on the latest server version by default.
 		update_option( 'wpseo_license_server_version', WPSEO_License_Page_Manager::VERSION_BACKWARDS_COMPATIBILITY );
+
+		// Make sure incoming link count entries are at least 0, not NULL.
+		$count_storage = new WPSEO_Meta_Storage();
+		$wpdb->query( 'UPDATE ' . $count_storage->get_table_name() . ' SET incoming_link_count = 0 WHERE incoming_link_count IS NULL' );
 	}
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the internal link count is not updated when there are no links to an object.

## Test instructions

This PR can be tested by following these steps:

* Create a post (A)
* Create a post (B)
* Create a link from B to A
* See the internal link count going to 1 for A
* Remove the link in B
* See the internal link count going from 1 to 0 for A --- without the patch this stayed at 1
* Without the patch, saving A does also not resolve the problem!
