### PR TITLE
Open link indexing when hash contains reIndexLinks

### DIFF
--- a/js/src/wp-seo-reindex-links.js
+++ b/js/src/wp-seo-reindex-links.js
@@ -149,8 +149,8 @@ function init() {
 
 	jQuery( "#noticeRunLinkIndex" ).click( openLinkIndexing );
 
-	if ( window.location.hash.indexOf( "#reIndexLinks" ) !== -1 ) {
-		openLinkIndexing();
+	if ( window.location.href.indexOf( "&reIndexLinks=1" ) !== -1 ) {
+		jQuery( openLinkIndexing );
 	}
 }
 

--- a/js/src/wp-seo-reindex-links.js
+++ b/js/src/wp-seo-reindex-links.js
@@ -148,6 +148,10 @@ function init() {
 	} );
 
 	jQuery( "#noticeRunLinkIndex" ).click( openLinkIndexing );
+
+	if ( window.location.hash.indexOf( "#reIndexLinks" ) !== -1 ) {
+		openLinkIndexing();
+	}
 }
 
 jQuery( init );


### PR DESCRIPTION
This pull request is needed for: https://github.com/Yoast/wordpress-seo-premium/pull/1333

You can test this:
Do a `grunt build:js`
By having the yoast meta table (database) being empty (truncate when necessary). Go to the Yoast dashboard page and add `&reIndexLinks=1` to the url in the addressbar. 
Press enter after you've done this. The reindexing will be started.