### PR TITLE
Use rawurldecode on display_slug

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -832,7 +832,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			case 'col_page_slug':
 				$permalink    = get_permalink( $rec->ID );
 				$display_slug = str_replace( get_bloginfo( 'url' ), '', $permalink );
-				$column_value = sprintf( '<a href="%2$s" target="_blank">%1$s</a>', stripslashes( $display_slug ), esc_url( $permalink ) );
+				$column_value = sprintf( '<a href="%2$s" target="_blank">%1$s</a>', stripslashes( rawurldecode( $display_slug ) ), esc_url( $permalink ) );
 				break;
 
 			case 'col_post_type':


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where hebrew slugs aren't decoded on display in the bulk editor.

## Relevant technical choices:

* Use `rawurldecode` for decoding the slug.

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk
* Add a post with `מקרוני` as a slug
* Go the the bulk editor
* See the slug being visible incorrectly 
* Checkout this branch and see the slug being visible as intended.

Fixes #7709
