### PR TITLE
Added logic to determine how to check used keywords for premium

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -128,7 +128,6 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return array The keyword usage, including the additional keywords.
 	 */
 	protected function get_premium_keywords( $usage ) {
-
 		$additional_keywords = json_decode( WPSEO_Meta::get_value( 'focuskeywords', $this->post->ID ), true );
 
 		if ( empty( $additional_keywords ) ) {

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -105,16 +105,54 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	}
 
 	/**
-	 * Counting the number of given keyword used for other posts than given post_id
+	 * Counts the number of given keywords used for other posts other than the given post_id.
 	 *
-	 * @return array
+	 * @return array The keyword and the associated posts that use it.
 	 */
 	private function get_focus_keyword_usage() {
 		$keyword = WPSEO_Meta::get_value( 'focuskw', $this->post->ID );
+		$usage   = array( $keyword => $this->get_keyword_usage_for_current_post( $keyword ) );
 
-		return array(
-			$keyword => WPSEO_Meta::keyword_usage( $keyword, $this->post->ID ),
-		);
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			return $this->get_premium_keywords( $usage );
+		}
+
+		return $usage;
+	}
+
+	/**
+	 * Retrieves the additional keywords from Premium, that are associated with the post.
+	 *
+	 * @param array $usage The original keyword usage for the main keyword.
+	 *
+	 * @return array The keyword usage, including the additional keywords.
+	 */
+	protected function get_premium_keywords( $usage ) {
+
+		$additional_keywords = json_decode( WPSEO_Meta::get_value( 'focuskeywords', $this->post->ID ), true );
+
+		if ( empty( $additional_keywords ) ) {
+			return $usage;
+		}
+
+		foreach ( $additional_keywords as $additional_keyword ) {
+			$keyword = $additional_keyword['keyword'];
+
+			$usage[ $keyword ] = $this->get_keyword_usage_for_current_post( $keyword );
+		}
+
+		return $usage;
+	}
+
+	/**
+	 * Gets the keyword usage for the current post and the specified keyword.
+	 *
+	 * @param string $keyword The keyword to check the usage of.
+	 *
+	 * @return array The post IDs which use the passed keyword.
+	 */
+	protected function get_keyword_usage_for_current_post( $keyword ) {
+		return WPSEO_Meta::keyword_usage( $keyword, $this->post->ID );
 	}
 
 	/**

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1049,23 +1049,37 @@ class WPSEO_Meta {
 			return array();
 		}
 
-		$get_posts = new WP_Query(
-			array(
-				'meta_key'       => '_yoast_wpseo_focuskw',
-				'meta_value'     => $keyword,
-				'post__not_in'   => array( $post_id ),
-				'fields'         => 'ids',
-				'post_type'      => 'any',
+		$query = array(
+			'meta_query'     => array(
+				'relation' => 'OR',
+				array(
+					'key'   => '_yoast_wpseo_focuskw',
+					'value' => $keyword,
+				)
+			),
+			'post__not_in'   => array( $post_id ),
+			'fields'         => 'ids',
+			'post_type'      => 'any',
 
-				/*
-				 * We only need to return zero, one or two results:
-				 * - Zero: keyword hasn't been used before
-				 * - One: Keyword has been used once before
-				 * - Two or more: Keyword has been used twice before
-				 */
-				'posts_per_page' => 2,
-			)
+			/*
+			 * We only need to return zero, one or two results:
+			 * - Zero: keyword hasn't been used before
+			 * - One: Keyword has been used once before
+			 * - Two or more: Keyword has been used twice before
+			 */
+			'posts_per_page' => 2,
 		);
+
+		// If Yoast SEO Premium is active, get the additional keywords as well.
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			$query['meta_query'][] = array(
+				'key' => '_yoast_wpseo_focuskeywords',
+				'value' => sprintf( '"keyword":"%s"', $keyword ),
+				'compare' => 'LIKE',
+			);
+		}
+
+		$get_posts = new WP_Query( $query );
 
 		return $get_posts->posts;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds extra logic to properly determine the usage of keywords.

This code is needed here as it is also used for the determination of used keywords in Free and Premium. 

## Relevant technical choices:

* Altered the query to also include additional keywords if Premium is active. This does result in bit of a delay due to the nature of meta queries and how additional keywords are saved in the database.

## Test instructions

This PR can be tested by following these steps:

**Please test this in both Free and Premium**

_In Free_
* Create a new post and set a keyword.
* Create another post and set a different keyword.
* Create a third post and use the same keyword as you did with the first post.
* Note that you receive the message that the keyword has been used previously.

_In Premium_
* Create a new post and set multiple keywords.
* Create another post and set the **first keyword** to an unused one. Set the **second keyword** to be equal to one of the keywords in the previously created post.
* Note that you receive the message that the keyword has been used previously. 
* Save the post as is, with the duplicate keyword.
* Create a third post and use the **same keyword** as you did in the previous post.
* Note that you receive the message that the keyword has been used **twice** before.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1284
