### PR TITLE
Consolidate template variables

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -166,8 +166,12 @@ class WPSEO_Admin {
 
 	/**
 	 * Adds contextual help to the titles & metas page.
+	 *
+	 * @deprecated
 	 */
 	public function title_metas_help_tab() {
+		_deprecated_function( __METHOD__, '5.6.0' );
+
 		$screen = get_current_screen();
 
 		$screen->set_help_sidebar( '

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -53,7 +53,7 @@ function yoast_add_meta_options_help_center_tabs( $tabs ) {
 function add_template_variables_helpcenter() {
 	$explanation = sprintf(
 		/* translators: %1$s expands to Yoast SEO. */
-		__( 'The title &amp; metas settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The tabs on the left explain the available variables.', 'wordpress-seo' ),
+		__( 'The title &amp; metas settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The table below contains a list of the available variables.', 'wordpress-seo' ),
 		'Yoast SEO'
 	);
 

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -28,41 +28,53 @@ $tabs->display( $yform, $options );
 $yform->admin_footer();
 
 /**
- * Add help tabs
+ * Add help tabs.
  *
  * @param array $tabs Current help center tabs.
  *
- * @return array
+ * @return array Array containing all the additional tabs.
  */
 function yoast_add_meta_options_help_center_tabs( $tabs ) {
+
 	$tabs[] = new WPSEO_Help_Center_Item(
-		'basic-help',
+		'template-variables',
 		__( 'Template explanation', 'wordpress-seo' ),
-		array(
-			'content' => "\n\t\t<h2>" . __( 'Template explanation', 'wordpress-seo' ) . "</h2>\n\t\t" . '<p><p>' .
-				sprintf(
-					/* translators: %1$s expands to Yoast SEO. */
-					__( 'The title &amp; metas settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The tabs on the left explain the available variables.', 'wordpress-seo' ),
-					'Yoast SEO' ) .
-				'</p><p>' . __( 'Note that not all variables can be used in every template.', 'wordpress-seo' ) . '</p>',
-		)
-	);
-
-	$tabs[] = new WPSEO_Help_Center_Item(
-		'title-vars',
-		__( 'Basic Variables', 'wordpress-seo' ),
-		array(
-			'content' => '<h2>' . __( 'Basic Variables', 'wordpress-seo' ) . '</h2>' . WPSEO_Replace_Vars::get_basic_help_texts(),
-		)
-	);
-
-	$tabs[] = new WPSEO_Help_Center_Item(
-		'title-vars-advanced',
-		__( 'Advanced Variables', 'wordpress-seo' ),
-		array(
-			'content' => '<h2>' . __( 'Advanced Variables', 'wordpress-seo' ) . '</h2>' . WPSEO_Replace_Vars::get_advanced_help_texts(),
-		)
+		array( 'content' => add_template_variables_helpcenter() )
 	);
 
 	return $tabs;
+}
+
+/**
+ * Adds template variables to the help center.
+ *
+ * @return string The tabs for template variables.
+ */
+function add_template_variables_helpcenter() {
+	$explanation = sprintf(
+	/* translators: %1$s expands to Yoast SEO. */
+		__( 'The title &amp; metas settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The tabs on the left explain the available variables.', 'wordpress-seo' ),
+		'Yoast SEO'
+	);
+
+	$output_explanation = sprintf(
+		'<h2>%s</h2><p>%s</p><p>%s</p>',
+		esc_html( __( 'Template explanation', 'wordpress-seo' ) ),
+		esc_html( $explanation ),
+		esc_html( __( 'Note that not all variables can be used in every template.', 'wordpress-seo' ) )
+	);
+
+	$output_basic = sprintf(
+		'<h2>%s</h2>%s',
+		esc_html( __( 'Basic Variables', 'wordpress-seo' ) ),
+		WPSEO_Replace_Vars::get_basic_help_texts()
+	);
+
+	$output_advanced = sprintf(
+		'<h2>%s</h2>%s',
+		esc_html( __( 'Advanced Variables', 'wordpress-seo' ) ),
+		WPSEO_Replace_Vars::get_advanced_help_texts()
+	);
+
+	return $output_explanation . $output_basic . $output_advanced;
 }

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -28,11 +28,11 @@ $tabs->display( $yform, $options );
 $yform->admin_footer();
 
 /**
- * Add help tabs.
+ * Adds help tabs.
  *
  * @param array $tabs Current help center tabs.
  *
- * @return array Array containing all the additional tabs.
+ * @return array List containing all the additional tabs.
  */
 function yoast_add_meta_options_help_center_tabs( $tabs ) {
 
@@ -48,11 +48,11 @@ function yoast_add_meta_options_help_center_tabs( $tabs ) {
 /**
  * Adds template variables to the help center.
  *
- * @return string The tabs for template variables.
+ * @return string The content for the template variables tab.
  */
 function add_template_variables_helpcenter() {
 	$explanation = sprintf(
-	/* translators: %1$s expands to Yoast SEO. */
+		/* translators: %1$s expands to Yoast SEO. */
 		__( 'The title &amp; metas settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The tabs on the left explain the available variables.', 'wordpress-seo' ),
 		'Yoast SEO'
 	);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Consolidates the three template variable tabs into a single tab.

## Test instructions

This PR can be tested by following these steps:

* Navigate to the Titles & Metas option page in Yoast SEO.
* Open the Helpcenter and determine that there is now only one tab referring to template variables.
* Ensure all the old content in present in the tab.

Fixes #7964 
