### PR TITLE
Don't enqueue adminbar css if the adminbar when it's disabled in feat…

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -385,7 +385,7 @@ add_action( 'admin_bar_menu', 'wpseo_admin_bar_menu', 95 );
  * Enqueue CSS to format the Yoast SEO adminbar item.
  */
 function wpseo_admin_bar_style() {
-	$options = WPSEO_Options::get_options( array( 'wpseo' ) );
+	$options = WPSEO_Options::get_option( 'wpseo' );
 
 	if ( ! is_admin_bar_showing() || $options['enable_admin_bar_menu'] !== true ) {
 		return;

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -385,8 +385,10 @@ add_action( 'admin_bar_menu', 'wpseo_admin_bar_menu', 95 );
  * Enqueue CSS to format the Yoast SEO adminbar item.
  */
 function wpseo_admin_bar_style() {
+	
+	$options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_ms' ) );
 
-	if ( ! is_admin_bar_showing() ) {
+	if ( ! is_admin_bar_showing() || $options['enable_admin_bar_menu'] !== true ) {
 		return;
 	}
 

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -385,8 +385,7 @@ add_action( 'admin_bar_menu', 'wpseo_admin_bar_menu', 95 );
  * Enqueue CSS to format the Yoast SEO adminbar item.
  */
 function wpseo_admin_bar_style() {
-	
-	$options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_ms' ) );
+	$options = WPSEO_Options::get_options( array( 'wpseo' ) );
 
 	if ( ! is_admin_bar_showing() || $options['enable_admin_bar_menu'] !== true ) {
 		return;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Don't enqueue adminbar css if the feature is disabled in options

## Test instructions

This PR can be tested by following these steps:

* Disable the admin bar menu in Yoast >> Dashboard >> Features
* View source to see if yoast-seo-adminbar-css is loaded

Fixes #6616
