### PR TITLE
CS compliance: tabs vs spaces

### DIFF
--- a/admin/banner/class-admin-banner-sidebar-renderer.php
+++ b/admin/banner/class-admin-banner-sidebar-renderer.php
@@ -28,7 +28,7 @@ class WPSEO_Admin_Banner_Sidebar_Renderer {
 	 * @return string
 	 */
 	public function render( WPSEO_Admin_Banner_Sidebar $banner_sidebar ) {
-		 return sprintf( '
+		return sprintf( '
 			<div class="wpseo_content_cell" id="sidebar-container">
 				<div id="sidebar">
 					<div class="wpseo_content_cell_title yoast-sidebar__title ">
@@ -37,9 +37,9 @@ class WPSEO_Admin_Banner_Sidebar_Renderer {
 					%2$s
 				</div>
 			</div>',
-			 $banner_sidebar->get_title(),
-			 $this->render_banner_spots( $banner_sidebar->get_banner_spots() )
-		 );
+			$banner_sidebar->get_title(),
+			$this->render_banner_spots( $banner_sidebar->get_banner_spots() )
+		);
 	}
 
 	/**

--- a/admin/banner/class-admin-banner-sidebar.php
+++ b/admin/banner/class-admin-banner-sidebar.php
@@ -98,7 +98,7 @@ class WPSEO_Admin_Banner_Sidebar {
 			'<li><strong>' . __( 'No ads!', 'wordpress-seo' ) . '</strong></li>' .
 			'</ul>' .
 			/* translators: %s expands to Yoast SEO Premium */
-		    '<a id="wpseo-premium-button" class="button button-primary" href="' . $premium_uri . '" target="_blank">' . sprintf( __( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' ) . '</a><br/>'
+			'<a id="wpseo-premium-button" class="button button-primary" href="' . $premium_uri . '" target="_blank">' . sprintf( __( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' ) . '</a><br/>'
 		);
 
 		/*

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -217,11 +217,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				<input type="hidden" name="tool" value="bulk-editor"/>
 				<input type="hidden" name="type" value="<?php echo esc_attr( $this->page_type ); ?>"/>
 				<input type="hidden" name="orderby"
-				       value="<?php echo esc_attr( filter_input( INPUT_GET, 'orderby' ) ); ?>"/>
+					   value="<?php echo esc_attr( filter_input( INPUT_GET, 'orderby' ) ); ?>"/>
 				<input type="hidden" name="order"
-				       value="<?php echo esc_attr( filter_input( INPUT_GET, 'order' ) ); ?>"/>
+					   value="<?php echo esc_attr( filter_input( INPUT_GET, 'order' ) ); ?>"/>
 				<input type="hidden" name="post_type_filter"
-				       value="<?php echo esc_attr( filter_input( INPUT_GET, 'post_type_filter' ) ); ?>"/>
+					   value="<?php echo esc_attr( filter_input( INPUT_GET, 'post_type_filter' ) ); ?>"/>
 				<?php if ( ! empty( $post_status ) ) { ?>
 					<input type="hidden" name="post_status" value="<?php echo esc_attr( $post_status ); ?>"/>
 				<?php } ?>

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -217,11 +217,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				<input type="hidden" name="tool" value="bulk-editor"/>
 				<input type="hidden" name="type" value="<?php echo esc_attr( $this->page_type ); ?>"/>
 				<input type="hidden" name="orderby"
-					   value="<?php echo esc_attr( filter_input( INPUT_GET, 'orderby' ) ); ?>"/>
+					value="<?php echo esc_attr( filter_input( INPUT_GET, 'orderby' ) ); ?>"/>
 				<input type="hidden" name="order"
-					   value="<?php echo esc_attr( filter_input( INPUT_GET, 'order' ) ); ?>"/>
+					value="<?php echo esc_attr( filter_input( INPUT_GET, 'order' ) ); ?>"/>
 				<input type="hidden" name="post_type_filter"
-					   value="<?php echo esc_attr( filter_input( INPUT_GET, 'post_type_filter' ) ); ?>"/>
+					value="<?php echo esc_attr( filter_input( INPUT_GET, 'post_type_filter' ) ); ?>"/>
 				<?php if ( ! empty( $post_status ) ) { ?>
 					<input type="hidden" name="post_status" value="<?php echo esc_attr( $post_status ); ?>"/>
 				<?php } ?>

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -133,7 +133,7 @@ class WPSEO_Help_Center {
 		?>
 		<div class="wpseo-tab-video-container">
 			<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo $id ?>"
-					aria-expanded="false">
+				aria-expanded="false">
 					<span
 						class="dashicons-before dashicons-editor-help"><?php _e( 'Help center', 'wordpress-seo' ) ?></span>
 				<span class="dashicons dashicons-arrow-down toggle__arrow"></span>
@@ -156,8 +156,8 @@ class WPSEO_Help_Center {
 
 							<li id="<?php echo esc_attr( $link_id ); ?>" class="<?php echo $class; ?>">
 								<a href="<?php echo esc_url( "#$panel_id" ); ?>"
-								   class="<?php echo $id . ' ' . $dashicon?>"
-								   aria-controls="<?php echo esc_attr( $panel_id ); ?>"><?php echo esc_html( $help_center_item->get_label() ); ?></a>
+									class="<?php echo $id . ' ' . $dashicon?>"
+									aria-controls="<?php echo esc_attr( $panel_id ); ?>"><?php echo esc_html( $help_center_item->get_label() ); ?></a>
 							</li>
 							<?php
 							$class = 'wpseo-help-center-item';

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -133,7 +133,7 @@ class WPSEO_Help_Center {
 		?>
 		<div class="wpseo-tab-video-container">
 			<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo $id ?>"
-			        aria-expanded="false">
+					aria-expanded="false">
 					<span
 						class="dashicons-before dashicons-editor-help"><?php _e( 'Help center', 'wordpress-seo' ) ?></span>
 				<span class="dashicons dashicons-arrow-down toggle__arrow"></span>

--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -137,11 +137,11 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		if ( $social_options['opengraph'] ) {
 			/* translators: %1$s expands to Yoast SEO, %2%s: 'Facebook' plugin name of possibly conflicting plugin with regard to creating OpenGraph output. */
 			$plugin_sections['open_graph'] = __( 'Both %1$s and %2$s create OpenGraph output, which might make Facebook, Twitter, LinkedIn and other social networks use the wrong texts and images when your pages are being shared.', 'wordpress-seo' )
-											 . '<br/><br/>'
-											 . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_social#top#facebook' ) . '">'
-											 /* translators: %1$s expands to Yoast SEO. */
-											 . sprintf( __( 'Configure %1$s\'s OpenGraph settings', 'wordpress-seo' ), 'Yoast SEO' )
-											 . '</a>';
+				. '<br/><br/>'
+				. '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_social#top#facebook' ) . '">'
+				/* translators: %1$s expands to Yoast SEO. */
+				. sprintf( __( 'Configure %1$s\'s OpenGraph settings', 'wordpress-seo' ), 'Yoast SEO' )
+				. '</a>';
 		}
 
 		// Only check for XML conflicts if sitemaps are enabled.
@@ -149,11 +149,11 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		if ( $xml_sitemap_options['enablexmlsitemap'] ) {
 			/* translators: %1$s expands to Yoast SEO, %2$s: 'Google XML Sitemaps' plugin name of possibly conflicting plugin with regard to the creation of sitemaps. */
 			$plugin_sections['xml_sitemaps'] = __( 'Both %1$s and %2$s can create XML sitemaps. Having two XML sitemaps is not beneficial for search engines, yet might slow down your site.', 'wordpress-seo' )
-							  . '<br/><br/>'
-							  . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_xml' ) . '">'
-							  /* translators: %1$s expands to Yoast SEO. */
-							  . sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
-							  . '</a>';
+				. '<br/><br/>'
+				. '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_xml' ) . '">'
+				/* translators: %1$s expands to Yoast SEO. */
+				. sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
+				. '</a>';
 		}
 
 		/* translators: %2$s expands to 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to differentiating output between search engines and normal users. */

--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -137,11 +137,11 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		if ( $social_options['opengraph'] ) {
 			/* translators: %1$s expands to Yoast SEO, %2%s: 'Facebook' plugin name of possibly conflicting plugin with regard to creating OpenGraph output. */
 			$plugin_sections['open_graph'] = __( 'Both %1$s and %2$s create OpenGraph output, which might make Facebook, Twitter, LinkedIn and other social networks use the wrong texts and images when your pages are being shared.', 'wordpress-seo' )
-			                                 . '<br/><br/>'
-			                                 . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_social#top#facebook' ) . '">'
-			                                 /* translators: %1$s expands to Yoast SEO. */
-			                                 . sprintf( __( 'Configure %1$s\'s OpenGraph settings', 'wordpress-seo' ), 'Yoast SEO' )
-			                                 . '</a>';
+											 . '<br/><br/>'
+											 . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_social#top#facebook' ) . '">'
+											 /* translators: %1$s expands to Yoast SEO. */
+											 . sprintf( __( 'Configure %1$s\'s OpenGraph settings', 'wordpress-seo' ), 'Yoast SEO' )
+											 . '</a>';
 		}
 
 		// Only check for XML conflicts if sitemaps are enabled.
@@ -149,11 +149,11 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 		if ( $xml_sitemap_options['enablexmlsitemap'] ) {
 			/* translators: %1$s expands to Yoast SEO, %2$s: 'Google XML Sitemaps' plugin name of possibly conflicting plugin with regard to the creation of sitemaps. */
 			$plugin_sections['xml_sitemaps'] = __( 'Both %1$s and %2$s can create XML sitemaps. Having two XML sitemaps is not beneficial for search engines, yet might slow down your site.', 'wordpress-seo' )
-			                  . '<br/><br/>'
-			                  . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_xml' ) . '">'
-			                  /* translators: %1$s expands to Yoast SEO. */
-			                  . sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
-			                  . '</a>';
+							  . '<br/><br/>'
+							  . '<a class="button" href="' . admin_url( 'admin.php?page=wpseo_xml' ) . '">'
+							  /* translators: %1$s expands to Yoast SEO. */
+							  . sprintf( __( 'Configure %1$s\'s XML Sitemap settings', 'wordpress-seo' ), 'Yoast SEO' )
+							  . '</a>';
 		}
 
 		/* translators: %2$s expands to 'RS Head Cleaner' plugin name of possibly conflicting plugin with regard to differentiating output between search engines and normal users. */

--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -148,7 +148,7 @@ class WPSEO_Product_Upsell_Notice {
 		$message .= $this->get_premium_upsell_section() . "\n\n";
 
 		$message .= sprintf(
-		 	/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
+			/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
 			__( '%1$sPlease don\'t show me this notification anymore%2$s', 'wordpress-seo' ),
 			'<a class="button" href="' . admin_url( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=upsell' ) . '">',
 			'</a>'

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -10,7 +10,7 @@ if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== 
 	<form action="" method="post" class="wpseo-gsc-reload-crawl-issues-form">
 		<input type='hidden' name='reload-crawl-issues-nonce' value='<?php echo wp_create_nonce( 'reload-crawl-issues' ); ?>' />
 		<input type="submit" name="reload-crawl-issues" id="reload-crawl-issue" class="button button-primary alignright"
-			   value="<?php _e( 'Reload crawl issues', 'wordpress-seo' ); ?>">
+			value="<?php _e( 'Reload crawl issues', 'wordpress-seo' ); ?>">
 	</form>
 <?php } ?>
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -590,7 +590,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				$content .= '<div id="wpseofocuskeyword">';
 				$content .= '<section class="yoast-section" id="wpseo-focuskeyword-section">';
 				$content .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-key">' . esc_html( $meta_field_def['title'] ) . '</h3>';
-			    $content .= '<label for="' . $esc_form_key . '" class="screen-reader-text">' . esc_html( $meta_field_def['label'] ) . '</label>';
+				$content .= '<label for="' . $esc_form_key . '" class="screen-reader-text">' . esc_html( $meta_field_def['label'] ) . '</label>';
 				$content .= '<input type="text"' . $placeholder . ' id="' . $esc_form_key . '" autocomplete="off" name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '" class="large-text' . $class . '"/>';
 
 				if ( $this->options['enable_cornerstone_content'] ) {
@@ -605,7 +605,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				$content .= '<div id="wpseometakeywords">';
 				$content .= '<section class="yoast-section" id="wpseo-metakeywords-section">';
 				$content .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-edit">' . esc_html( $meta_field_def['title'] ) . '</h3>';
-			    $content .= '<label for="' . $esc_form_key . '" class="screen-reader-text">' . esc_html( $meta_field_def['label'] ) . '</label>';
+				$content .= '<label for="' . $esc_form_key . '" class="screen-reader-text">' . esc_html( $meta_field_def['label'] ) . '</label>';
 				$content .= '<input type="text" id="' . $esc_form_key . '" name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '" class="large-text' . $class . '"' . $aria_describedby . '/>';
 				$content .= $description;
 				$content .= '</section>';

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1013,7 +1013,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		return array(
 			'custom_fields' => $this->get_custom_fields_replace_vars( $post ),
 			'custom_taxonomies' => $this->get_custom_taxonomies_replace_vars( $post ),
-		 );
+		);
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -181,7 +181,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 	/**
 	 * Getting the label HTML
 	 *
-	 * @param string $label	     The label value.
+	 * @param string $label      The label value.
 	 * @param string $field_name The target field.
 	 *
 	 * @return string

--- a/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/admin/taxonomy/class-taxonomy-social-fields.php
@@ -108,7 +108,7 @@ class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
 	 * Returns array with the config fields for the social network
 	 *
 	 * @param string $network    The name of the social network.
-	 * @param string $label		 The label for the social network.
+	 * @param string $label      The label for the social network.
 	 * @param string $image_size The image dimensions.
 	 *
 	 * @return array

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -12,9 +12,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 <script type="text/html" id="tmpl-primary-term-input">
 	<input type="hidden" class="yoast-wpseo-primary-term"
-		   id="yoast-wpseo-primary-{{data.taxonomy.name}}"
-		   name="<?php echo WPSEO_Meta::$form_prefix; ?>primary_{{data.taxonomy.name}}_term"
-		   value="{{data.taxonomy.primary}}">
+		id="yoast-wpseo-primary-{{data.taxonomy.name}}"
+		name="<?php echo WPSEO_Meta::$form_prefix; ?>primary_{{data.taxonomy.name}}_term"
+		value="{{data.taxonomy.primary}}">
 
 	<?php wp_nonce_field( 'save-primary-term', WPSEO_Meta::$form_prefix . 'primary_{{data.taxonomy.name}}_nonce' ); ?>
 </script>

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -12,9 +12,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 <script type="text/html" id="tmpl-primary-term-input">
 	<input type="hidden" class="yoast-wpseo-primary-term"
-	       id="yoast-wpseo-primary-{{data.taxonomy.name}}"
-	       name="<?php echo WPSEO_Meta::$form_prefix; ?>primary_{{data.taxonomy.name}}_term"
-	       value="{{data.taxonomy.primary}}">
+		   id="yoast-wpseo-primary-{{data.taxonomy.name}}"
+		   name="<?php echo WPSEO_Meta::$form_prefix; ?>primary_{{data.taxonomy.name}}_term"
+		   value="{{data.taxonomy.primary}}">
 
 	<?php wp_nonce_field( 'save-primary-term', WPSEO_Meta::$form_prefix . 'primary_{{data.taxonomy.name}}_nonce' ); ?>
 </script>

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -20,7 +20,7 @@ if ( WPSEO_Utils::is_api_available() && current_user_can( WPSEO_Configuration_En
 	</p>
 <p>
 	<a class="button"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php esc_html_e( 'Open the configuration wizard', 'wordpress-seo' ); ?></a>
+		href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php esc_html_e( 'Open the configuration wizard', 'wordpress-seo' ); ?></a>
 </p>
 
 	<br/>
@@ -43,7 +43,7 @@ echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 
 <p>
 	<a class="button"
-	   href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php esc_html_e( 'View credits', 'wordpress-seo' ); ?></a>
+		href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php esc_html_e( 'View credits', 'wordpress-seo' ); ?></a>
 </p>
 <br/>
 <?php
@@ -58,6 +58,6 @@ echo '<h2>' . esc_html__( 'Restore default settings', 'wordpress-seo' ) . '</h2>
 
 <p>
 	<a onclick="if ( !confirm( '<?php esc_html_e( 'Are you sure you want to reset your SEO settings?', 'wordpress-seo' ); ?>' ) ) return false;"
-	   class="button"
-	   href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php esc_html_e( 'Restore default settings', 'wordpress-seo' ); ?></a>
+		class="button"
+		href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php esc_html_e( 'Restore default settings', 'wordpress-seo' ); ?></a>
 </p>

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -36,5 +36,5 @@ printf( __( 'If you\'ve used another SEO plugin, try the %1$sSEO Data Transporte
 	?>
 	<br/>
 	<input type="submit" class="button button-primary" name="import"
-	       value="<?php _e( 'Import', 'wordpress-seo' ); ?>"/>
+		   value="<?php _e( 'Import', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -36,5 +36,5 @@ printf( __( 'If you\'ve used another SEO plugin, try the %1$sSEO Data Transporte
 	?>
 	<br/>
 	<input type="submit" class="button button-primary" name="import"
-		   value="<?php _e( 'Import', 'wordpress-seo' ); ?>"/>
+		value="<?php _e( 'Import', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	<?php wp_nonce_field( 'wpseo-import-file', '_wpnonce', true, true ); ?>
 	<label class="screen-reader-text" for="settings-import-file"><?php _e( 'Choose your settings.zip file', 'wordpress-seo' ); ?></label>
 	<input type="file" name="settings_import_file" id="settings-import-file"
-		   accept="application/x-zip,application/x-zip-compressed,application/zip"/>
+		accept="application/x-zip,application/x-zip-compressed,application/zip"/>
 	<input type="hidden" name="action" value="wp_handle_upload"/><br/>
 	<br/>
 	<input type="submit" class="button button-primary" value="<?php _e( 'Import settings', 'wordpress-seo' ); ?>"/>

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	<?php wp_nonce_field( 'wpseo-import-file', '_wpnonce', true, true ); ?>
 	<label class="screen-reader-text" for="settings-import-file"><?php _e( 'Choose your settings.zip file', 'wordpress-seo' ); ?></label>
 	<input type="file" name="settings_import_file" id="settings-import-file"
-	       accept="application/x-zip,application/x-zip-compressed,application/zip"/>
+		   accept="application/x-zip,application/x-zip-compressed,application/zip"/>
 	<input type="hidden" name="action" value="wp_handle_upload"/><br/>
 	<br/>
 	<input type="submit" class="button button-primary" value="<?php _e( 'Import settings', 'wordpress-seo' ); ?>"/>

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -74,7 +74,7 @@ function get_rendered_tab( $table, $id ) {
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
 		<a class="nav-tab" id="title-tab" href="#top#title"><?php _e( 'Title', 'wordpress-seo' ); ?></a>
 		<a class="nav-tab" id="description-tab"
-		   href="#top#description"><?php _e( 'Description', 'wordpress-seo' ); ?></a>
+			href="#top#description"><?php _e( 'Description', 'wordpress-seo' ); ?></a>
 	</h2>
 
 	<div class="tabwrapper">

--- a/css/xml-sitemap-xsl.php
+++ b/css/xml-sitemap-xsl.php
@@ -23,10 +23,10 @@ if ( extension_loaded( 'newrelic' ) && function_exists( 'newrelic_disable_autoru
 echo '<?xml version="1.0" encoding="UTF-8"?>';
 ?>
 	<xsl:stylesheet version="2.0"
-	                xmlns:html="http://www.w3.org/TR/REC-html40"
-	                xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-	                xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
-	                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+					xmlns:html="http://www.w3.org/TR/REC-html40"
+					xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+					xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+					xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 	<xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
 	<xsl:template match="/">
 		<html xmlns="http://www.w3.org/1999/xhtml">

--- a/css/xml-sitemap-xsl.php
+++ b/css/xml-sitemap-xsl.php
@@ -23,10 +23,10 @@ if ( extension_loaded( 'newrelic' ) && function_exists( 'newrelic_disable_autoru
 echo '<?xml version="1.0" encoding="UTF-8"?>';
 ?>
 	<xsl:stylesheet version="2.0"
-					xmlns:html="http://www.w3.org/TR/REC-html40"
-					xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-					xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
-					xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+		xmlns:html="http://www.w3.org/TR/REC-html40"
+		xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+		xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 	<xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
 	<xsl:template match="/">
 		<html xmlns="http://www.w3.org/1999/xhtml">

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -42,7 +42,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'content_analysis_active'         => true,
 		'keyword_analysis_active'         => true,
 		'enable_setting_pages'            => true,
-		'enable_admin_bar_menu'			  => true,
+		'enable_admin_bar_menu'           => true,
 		'enable_cornerstone_content'      => true,
 		'enable_text_link_counter'        => true,
 		'show_onboarding_notice'          => false,

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -510,7 +510,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * Find the keyword usages in the metas for the taxonomies/terms
 	 *
-	 * @param string $keyword		   The keyword to look for.
+	 * @param string $keyword          The keyword to look for.
 	 * @param string $current_term_id  The current term id.
 	 * @param string $current_taxonomy The current taxonomy name.
 	 *

--- a/tests/admin/test-class-plugin-compatibility.php
+++ b/tests/admin/test-class-plugin-compatibility.php
@@ -32,29 +32,29 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 		$expected = array(
 			'test-plugin' => array(
 				'url' => "https://yoast.com/",
-			    'title' => "Test Plugin",
-			    'description' =>  "",
-			    'version' => "3.3",
-			    'installed' => true,
-			    'compatible' => true
+				'title' => "Test Plugin",
+				'description' =>  "",
+				'version' => "3.3",
+				'installed' => true,
+				'compatible' => true
 			),
-            'test-plugin-dependency' => array(
-	            'url' => "https://yoast.com/",
-	            'title' => "Test Plugin With Dependency",
-	            'description' =>  "",
-	            'version' => "3.3",
-	            'installed' => true,
-	            '_dependencies' => array( 'test-plugin' ),
-	            'compatible' => true
-            ),
-            'test-plugin-invalid-version' => array(
-	            'url' => "https://yoast.com/",
-	            'title' => "Test Plugin",
-	            'description' =>  "",
-	            'version' => "1.3",
-	            'installed' => true,
-	            'compatible' => false
-            )
+			'test-plugin-dependency' => array(
+				'url' => "https://yoast.com/",
+				'title' => "Test Plugin With Dependency",
+				'description' =>  "",
+				'version' => "3.3",
+				'installed' => true,
+				'_dependencies' => array( 'test-plugin' ),
+				'compatible' => true
+			),
+			'test-plugin-invalid-version' => array(
+				'url' => "https://yoast.com/",
+				'title' => "Test Plugin",
+				'description' =>  "",
+				'version' => "1.3",
+				'installed' => true,
+				'compatible' => false
+			)
 		);
 
 		$this->assertEquals( self::$class_instance->get_installed_plugins_compatibility(), $expected );

--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -114,7 +114,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 		$this->endpoint->register();
 
 		$endpoints = $wp_rest_server->get_endpoints();
-		
+
 		$this->assertTrue( isset( $endpoints[ '/' . WPSEO_Configuration_Endpoint::REST_NAMESPACE ] ) );
 		$this->assertTrue( isset( $endpoints[ '/' . WPSEO_Configuration_Endpoint::REST_NAMESPACE . '/' . WPSEO_Configuration_Endpoint::ENDPOINT_RETRIEVE ] ) );
 		$this->assertTrue( isset( $endpoints[ '/' . WPSEO_Configuration_Endpoint::REST_NAMESPACE . '/' . WPSEO_Configuration_Endpoint::ENDPOINT_STORE ] ) );

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -2,103 +2,103 @@
 
 class WPSEO_Primary_Term_Double extends WPSEO_Primary_Term {
 
-    /**
-     * Overwrite the get_terms method, because it uses a dependency
-     *
-     * @return array
-     */
-    protected function get_terms() {
-        return array(
-            ( object ) array(
-                'term_id' => 54,
-            )
-        );
-    }
+	/**
+	 * Overwrite the get_terms method, because it uses a dependency
+	 *
+	 * @return array
+	 */
+	protected function get_terms() {
+		return array(
+			( object ) array(
+				'term_id' => 54,
+			)
+		);
+	}
 }
 
 class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 
-    /**
-     * @var string name of the taxonomy
-     */
-    private $taxonomy_name = 'category';
+	/**
+	 * @var string name of the taxonomy
+	 */
+	private $taxonomy_name = 'category';
 
-    /**
-     * @var int post id
-     */
-    private $post_id = 1;
+	/**
+	 * @var int post id
+	 */
+	private $post_id = 1;
 
-    /**
-     * @var int id of the primary term
-     */
-    private $primary_term_id = 54;
+	/**
+	 * @var int id of the primary term
+	 */
+	private $primary_term_id = 54;
 
-    /**
-     * Return the correct primary term when primary term already exists.
-     *
-     * @covers WPSEO_Primary_Term::get_primary_term
-     */
-    public function test_get_primary_term_WHERE_primary_term_EXISTS() {
-        $class_instance = new WPSEO_Primary_Term_Double( $this->taxonomy_name, $this->post_id );
-        $class_instance->set_primary_term( $this->primary_term_id );
+	/**
+	 * Return the correct primary term when primary term already exists.
+	 *
+	 * @covers WPSEO_Primary_Term::get_primary_term
+	 */
+	public function test_get_primary_term_WHERE_primary_term_EXISTS() {
+		$class_instance = new WPSEO_Primary_Term_Double( $this->taxonomy_name, $this->post_id );
+		$class_instance->set_primary_term( $this->primary_term_id );
 
-        $this->assertEquals( $this->primary_term_id, $class_instance->get_primary_term() );
+		$this->assertEquals( $this->primary_term_id, $class_instance->get_primary_term() );
 
-    }
+	}
 
-    /**
-     * When there's no term for the post, return false.
-     *
-     * @covers WPSEO_Primary_Term::get_primary_term
-     */
-    public function test_get_primary_term_WHERE_primary_term_DOES_NOT_EXIST_AND_terms_ARE_EMPTY() {
-        $class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $this->post_id );
+	/**
+	 * When there's no term for the post, return false.
+	 *
+	 * @covers WPSEO_Primary_Term::get_primary_term
+	 */
+	public function test_get_primary_term_WHERE_primary_term_DOES_NOT_EXIST_AND_terms_ARE_EMPTY() {
+		$class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $this->post_id );
 
-        $this->assertFalse( $class_instance->get_primary_term() );
-    }
+		$this->assertFalse( $class_instance->get_primary_term() );
+	}
 
-    /**
-     * Return the term id when there's no primary term set
-     *
-     * @covers WPSEO_Primary_Term::get_primary_term
-     */
-    public function test_get_primary_term_WHERE_primary_term_DOES_NOT_EXIST_AND_term_EXISTS() {
-        $post_id = $this->factory->post->create();
+	/**
+	 * Return the term id when there's no primary term set
+	 *
+	 * @covers WPSEO_Primary_Term::get_primary_term
+	 */
+	public function test_get_primary_term_WHERE_primary_term_DOES_NOT_EXIST_AND_term_EXISTS() {
+		$post_id = $this->factory->post->create();
 
-        $class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $post_id );
+		$class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $post_id );
 
-        $this->assertFalse( $class_instance->get_primary_term() );
-    }
+		$this->assertFalse( $class_instance->get_primary_term() );
+	}
 
-    /**
-     * When there is more than one term, set the term with the lowest id as primary term.
-     *
-     * @covers WPSEO_Primary_Term::get_primary_term
-     */
-    public function test_get_primary_term_WHERE_primary_term_DOES_NOT_EXIST_AND_terms_EXIST() {
-        wp_insert_term( 'yoast', 'category' );
-        wp_insert_term( 'seo', 'category' );
+	/**
+	 * When there is more than one term, set the term with the lowest id as primary term.
+	 *
+	 * @covers WPSEO_Primary_Term::get_primary_term
+	 */
+	public function test_get_primary_term_WHERE_primary_term_DOES_NOT_EXIST_AND_terms_EXIST() {
+		wp_insert_term( 'yoast', 'category' );
+		wp_insert_term( 'seo', 'category' );
 
-        $term_first = get_term_by( 'name', 'yoast', 'category' );
-        $term_second = get_term_by( 'name', 'seo', 'category' );
+		$term_first = get_term_by( 'name', 'yoast', 'category' );
+		$term_second = get_term_by( 'name', 'seo', 'category' );
 
-        $post_id = $this->factory->post->create( array( 'post_category' => array( $term_first->term_id, $term_second->term_id ) ) );
+		$post_id = $this->factory->post->create( array( 'post_category' => array( $term_first->term_id, $term_second->term_id ) ) );
 
-        $class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $post_id );
+		$class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $post_id );
 
-        $this->assertFalse( $class_instance->get_primary_term() );
-    }
+		$this->assertFalse( $class_instance->get_primary_term() );
+	}
 
-    /**
-     * Test that set_primary_term succesfully updates the primary_term
-     *
-     * @covers WPSEO_Primary_Term::set_primary_term
-     */
-    public function test_set_primary_term_UPDATES_post_meta() {
-        $class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $this->post_id );
+	/**
+	 * Test that set_primary_term succesfully updates the primary_term
+	 *
+	 * @covers WPSEO_Primary_Term::set_primary_term
+	 */
+	public function test_set_primary_term_UPDATES_post_meta() {
+		$class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $this->post_id );
 
-        $class_instance->set_primary_term( $this->primary_term_id );
+		$class_instance->set_primary_term( $this->primary_term_id );
 
-        $this->assertEquals( array( $this->primary_term_id ), get_post_meta( $this->post_id, '_yoast_wpseo_primary_' . $this->taxonomy_name ) );
-    }
+		$this->assertEquals( array( $this->primary_term_id ), get_post_meta( $this->post_id, '_yoast_wpseo_primary_' . $this->taxonomy_name ) );
+	}
 }

--- a/tests/test-class-primary-term-admin.php
+++ b/tests/test-class-primary-term-admin.php
@@ -2,188 +2,188 @@
 
 class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 
-    protected $class_instance;
+	protected $class_instance;
 
-    public function setUp() {
-        parent::setUp();
+	public function setUp() {
+		parent::setUp();
 
-	    $this->class_instance =
-		    $this
-			    ->getMockBuilder( 'WPSEO_Primary_Term_Admin' )
-			    ->setMethods( array( 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ) )
-			    ->getMock();
-    }
+		$this->class_instance =
+			$this
+				->getMockBuilder( 'WPSEO_Primary_Term_Admin' )
+				->setMethods( array( 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ) )
+				->getMock();
+	}
 
-    /**
-     * When there are no taxonomies, make sure the js-templates-primary-term view is not included.
-     *
-     * @covers WPSEO_Primary_Term_Admin::wp_footer
-     */
-    public function test_wp_footer_INCLUDE_NO_taxonomies() {
-        $this->class_instance
-            ->expects( $this->once() )
-            ->method( 'get_primary_term_taxonomies' )
-            ->will( $this->returnValue( array() ));
+	/**
+	 * When there are no taxonomies, make sure the js-templates-primary-term view is not included.
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::wp_footer
+	 */
+	public function test_wp_footer_INCLUDE_NO_taxonomies() {
+		$this->class_instance
+			->expects( $this->once() )
+			->method( 'get_primary_term_taxonomies' )
+			->will( $this->returnValue( array() ));
 
-        $this->class_instance
-            ->expects( $this->never() )
-            ->method( 'include_js_templates' );
+		$this->class_instance
+			->expects( $this->never() )
+			->method( 'include_js_templates' );
 
-        $this->class_instance->wp_footer();
-    }
+		$this->class_instance->wp_footer();
+	}
 
-    /**
-     * When there are taxonomies, make sure the js-template-primary-term view is included
-     *
-     * @covers WPSEO_Primary_Term_Admin::wp_footer
-     */
-    public function test_wp_footer_INCLUDE_WITH_taxonomies() {
-        $taxonomies = array(
-            'category' => ( object ) array()
-        );
+	/**
+	 * When there are taxonomies, make sure the js-template-primary-term view is included
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::wp_footer
+	 */
+	public function test_wp_footer_INCLUDE_WITH_taxonomies() {
+		$taxonomies = array(
+			'category' => ( object ) array()
+		);
 
-        $this->class_instance
-            ->expects( $this->once() )
-            ->method( 'get_primary_term_taxonomies' )
-            ->will( $this->returnValue( $taxonomies ) );
+		$this->class_instance
+			->expects( $this->once() )
+			->method( 'get_primary_term_taxonomies' )
+			->will( $this->returnValue( $taxonomies ) );
 
-        $this->class_instance
-            ->expects( $this->once() )
-            ->method( 'include_js_templates' );
+		$this->class_instance
+			->expects( $this->once() )
+			->method( 'include_js_templates' );
 
-        $this->class_instance->wp_footer();
-    }
+		$this->class_instance->wp_footer();
+	}
 
-    /**
-     * When there are no taxonomies, make sure the following files are not registered:
-     * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
-     *
-     * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
-     */
-    public function test_enqueue_assets_EMPTY_taxonomies_DO_NOT_enqueue_scripts() {
-        $this->class_instance->enqueue_assets();
+	/**
+	 * When there are no taxonomies, make sure the following files are not registered:
+	 * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
+	 */
+	public function test_enqueue_assets_EMPTY_taxonomies_DO_NOT_enqueue_scripts() {
+		$this->class_instance->enqueue_assets();
 
-        $this->assertFalse( wp_style_is( 'wpseo-primary-category', 'registered' ) );
-        $this->assertFalse( wp_script_is( 'wpseo-primary-category', 'registered' ) );
-    }
+		$this->assertFalse( wp_style_is( 'wpseo-primary-category', 'registered' ) );
+		$this->assertFalse( wp_script_is( 'wpseo-primary-category', 'registered' ) );
+	}
 
-    /**
-     * Do not enqueue the following scripts when the page is not post edit
-     * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
-     *
-     * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
-     */
-    public function test_enqueue_assets_DO_NOT_enqueue_scripts() {
-        $this->class_instance
-            ->expects( $this->never() )
-            ->method( 'get_primary_term_taxonomies' );
+	/**
+	 * Do not enqueue the following scripts when the page is not post edit
+	 * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
+	 */
+	public function test_enqueue_assets_DO_NOT_enqueue_scripts() {
+		$this->class_instance
+			->expects( $this->never() )
+			->method( 'get_primary_term_taxonomies' );
 
-        $this->class_instance->enqueue_assets();
+		$this->class_instance->enqueue_assets();
 
-        $this->assertFalse( wp_style_is( 'wpseo-primary-category', 'registered' ) );
-        $this->assertFalse( wp_script_is( 'wpseo-primary-category', 'registered' ) );
-    }
+		$this->assertFalse( wp_style_is( 'wpseo-primary-category', 'registered' ) );
+		$this->assertFalse( wp_script_is( 'wpseo-primary-category', 'registered' ) );
+	}
 
-    /**
-     * When there are taxonomies and the page is post-new, make sure the following files are registered:
-     * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
-     *
-     * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
-     */
-    public function test_enqueue_assets_WITH_taxonomies_DO_enqueue_scripts() {
-        global $pagenow;
+	/**
+	 * When there are taxonomies and the page is post-new, make sure the following files are registered:
+	 * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
+	 */
+	public function test_enqueue_assets_WITH_taxonomies_DO_enqueue_scripts() {
+		global $pagenow;
 
-        $asset_manager = new WPSEO_Admin_Asset_Manager();
-        $asset_manager->register_assets();
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		$asset_manager->register_assets();
 
-        $pagenow = 'post-new.php';
+		$pagenow = 'post-new.php';
 
-        $taxonomies = array(
-            'category' => ( object ) array(
-                'labels' => ( object ) array(
-                    'singular_name' => 'Category',
-                ),
-                'name' => 'category',
-            ),
-        );
+		$taxonomies = array(
+			'category' => ( object ) array(
+				'labels' => ( object ) array(
+					'singular_name' => 'Category',
+				),
+				'name' => 'category',
+			),
+		);
 
-        $this->class_instance
-            ->expects( $this->once() )
-            ->method( 'get_primary_term_taxonomies' )
-            ->will( $this->returnValue( $taxonomies ) );
+		$this->class_instance
+			->expects( $this->once() )
+			->method( 'get_primary_term_taxonomies' )
+			->will( $this->returnValue( $taxonomies ) );
 
-        $this->class_instance->enqueue_assets();
+		$this->class_instance->enqueue_assets();
 
-        $this->assertTrue( wp_style_is( WPSEO_Admin_Asset_Manager::PREFIX . 'primary-category', 'registered' ) );
-        $this->assertTrue( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'primary-category', 'registered' ) );
-    }
+		$this->assertTrue( wp_style_is( WPSEO_Admin_Asset_Manager::PREFIX . 'primary-category', 'registered' ) );
+		$this->assertTrue( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'primary-category', 'registered' ) );
+	}
 
-    /**
-     * Make sure the primary terms are saved
-     *
-     * @covers WPSEO_Primary_Term_Admin::save_primary_terms()
-     */
-    public function test_save_primary_terms_CALLS_save_primary_term() {
-        $taxonomies = array(
-            'category' => ( object ) array(
-                'labels' => ( object ) array(
-                    'name' => 'Categories',
-                    'singular_name' => 'Category',
-                    'search_items' => 'Search Categories',
-                    'all_items' => 'All Categories',
-                    'parent_item' => 'Parent Category',
-                    'parent_item_colon' => 'Parent Category:',
-                    'edit_item' => 'Edit Category',
-                    'view_item' => 'View Category',
-                    'update_item' => 'Update Category',
-                    'add_new_item' => 'Add New Category',
-                    'new_item_name' => 'New Category Name',
-                    'not_found' => 'No categories found.',
-                    'no_terms' => 'No categories',
-                    'menu_name' => 'Categories',
-                    'name_admin_bar' => 'category',
-                ),
-                'description' => '',
-                'public' => true,
-                'hierarchical' => true,
-                'show_ui' => true,
-                'show_in_menu' => true,
-                'show_in_nav_menus' => true,
-                'show_tagcloud' => true,
-                'show_in_quick_edit' => true,
-                'meta_box_cb' => 'post_categories_meta_box',
-                'rewrite' => array(
-                    'with_font' => true,
-                    'hierarchical' => true,
-                    'ep_mask' => 512,
-                    'slug' => 'category',
-                ),
-                'query_var' => 'category_name',
-                '_builtin' => true,
-                'cap' => ( object ) array(
-                    'manage_terms' => 'manage_categories',
-                    'edit_terms' => 'manage_categories',
-                    'delete_terms' => 'manage_categories',
-                    'assign_terms' => 'edit_posts'
-                ),
-                'name' => 'category',
-                'object_type' => array(
-                    '0' => 'post',
-                    '1' => 'movie',
-                ),
-                'label' => 'categories',
-            ),
-        );
+	/**
+	 * Make sure the primary terms are saved
+	 *
+	 * @covers WPSEO_Primary_Term_Admin::save_primary_terms()
+	 */
+	public function test_save_primary_terms_CALLS_save_primary_term() {
+		$taxonomies = array(
+			'category' => ( object ) array(
+				'labels' => ( object ) array(
+					'name' => 'Categories',
+					'singular_name' => 'Category',
+					'search_items' => 'Search Categories',
+					'all_items' => 'All Categories',
+					'parent_item' => 'Parent Category',
+					'parent_item_colon' => 'Parent Category:',
+					'edit_item' => 'Edit Category',
+					'view_item' => 'View Category',
+					'update_item' => 'Update Category',
+					'add_new_item' => 'Add New Category',
+					'new_item_name' => 'New Category Name',
+					'not_found' => 'No categories found.',
+					'no_terms' => 'No categories',
+					'menu_name' => 'Categories',
+					'name_admin_bar' => 'category',
+				),
+				'description' => '',
+				'public' => true,
+				'hierarchical' => true,
+				'show_ui' => true,
+				'show_in_menu' => true,
+				'show_in_nav_menus' => true,
+				'show_tagcloud' => true,
+				'show_in_quick_edit' => true,
+				'meta_box_cb' => 'post_categories_meta_box',
+				'rewrite' => array(
+					'with_font' => true,
+					'hierarchical' => true,
+					'ep_mask' => 512,
+					'slug' => 'category',
+				),
+				'query_var' => 'category_name',
+				'_builtin' => true,
+				'cap' => ( object ) array(
+					'manage_terms' => 'manage_categories',
+					'edit_terms' => 'manage_categories',
+					'delete_terms' => 'manage_categories',
+					'assign_terms' => 'edit_posts'
+				),
+				'name' => 'category',
+				'object_type' => array(
+					'0' => 'post',
+					'1' => 'movie',
+				),
+				'label' => 'categories',
+			),
+		);
 
-        $this->class_instance
-            ->expects( $this->once() )
-            ->method( 'get_primary_term_taxonomies' )
-            ->will( $this->returnValue( $taxonomies ) );
+		$this->class_instance
+			->expects( $this->once() )
+			->method( 'get_primary_term_taxonomies' )
+			->will( $this->returnValue( $taxonomies ) );
 
-        $this->class_instance
-            ->expects( $this->once() )
-            ->method( 'save_primary_term' );
+		$this->class_instance
+			->expects( $this->once() )
+			->method( 'save_primary_term' );
 
-        $this->class_instance->save_primary_terms( 1 );
-    }
+		$this->class_instance->save_primary_terms( 1 );
+	}
 }

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -64,8 +64,8 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 			array( "na", array(
 				array(
 					'key' => '_yoast_wpseo_meta-robots-noindex',
-	                'value' => 'needs-a-value-anyway',
-	                'compare' => 'NOT EXISTS',
+					'value' => 'needs-a-value-anyway',
+					'compare' => 'NOT EXISTS',
 				),
 				array(
 					'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
@@ -338,7 +338,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @param $expected
 	 *
 	 * @dataProvider determine_seo_filters_dataprovider
- 	 * @covers WPSEO_Meta_Columns::determine_seo_filters()
+	 * @covers WPSEO_Meta_Columns::determine_seo_filters()
 	 */
 	public function test_determine_seo_filters( $filter, $expected ) {
 		$result = self::$class_instance->determine_seo_filters( $filter );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Compliance with the following CS rules:
    * `Generic.WhiteSpace.DisallowSpaceIndent`
    * `Squiz.WhiteSpace.SuperfluousWhitespace`
    * `WordPress.WhiteSpace.DisallowInlineTabs` (new in WPCS 0.12.0)
    * `WordPress.WhiteSpace.PrecisionAlignment` (new in WPCS 0.14.0)

Rule summary:
* Tabs should be used for indentation.
* Precision alignment is rarely justified and should be used sparingly.
* Spaces should be used for mid-line alignment (comment, assignment operators).
* No superfluous whitespace at the end of a line.

Review Hint:
* This PR will be easiest to review by going through each commit individually.
* When viewing the changes, adding `?w=1` to the URL shows the changes while ignoring whitespace differences making it easy to verify that the commits only contain whitespace changes.

## Test instructions

_N/A_