### PR TITLE
Clean up: remove left-over code from WP < 4.5 support

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -270,8 +270,7 @@ class WPSEO_Taxonomy {
 	 * @return bool
 	 */
 	public static function is_term_edit( $page ) {
-		return 'term.php' === $page
-		       || 'edit-tags.php' === $page; // After we drop support for <4.5 this can be removed.
+		return 'term.php' === $page;
 	}
 
 	/**

--- a/tests/taxonomy/test-class-taxonomy.php
+++ b/tests/taxonomy/test-class-taxonomy.php
@@ -7,7 +7,6 @@ class WPSEO_Taxonomy_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_is_term_edit() {
 		$this->assertTrue( WPSEO_Taxonomy::is_term_edit( 'term.php' ) );
-		$this->assertTrue( WPSEO_Taxonomy::is_term_edit( 'edit-tags.php' ) );
 		$this->assertFalse( WPSEO_Taxonomy::is_term_edit( '' ) );
 		$this->assertFalse( WPSEO_Taxonomy::is_term_edit( 'random' ) );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes. Minimum required WP version for Yoast SEO is now 4.6, so this code snippet can be removed as per the inline comment.

## Test instructions

* Check whether the term related functionality still works as expected.