### PR TITLE
CS compliance: fix multi-line control structure formatting

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -767,8 +767,8 @@ class WPSEO_Breadcrumbs {
 				$inner_elm = 'strong';
 			}
 
-			if ( ( isset( $link['url'] ) && ( is_string( $link['url'] ) && $link['url'] !== '' ) ) &&
-			     ( $i < ( $this->crumb_count - 1 ) )
+			if ( ( isset( $link['url'] ) && ( is_string( $link['url'] ) && $link['url'] !== '' ) )
+				&& ( $i < ( $this->crumb_count - 1 ) )
 			) {
 				if ( $i === 0 ) {
 					$link_output .= '<' . $this->element . ' typeof="v:Breadcrumb">';

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -115,9 +115,9 @@ class WPSEO_Frontend {
 		// Fix the WooThemes woo_title() output.
 		add_filter( 'woo_title', array( $this, 'fix_woo_title' ), 99 );
 
-		if ( $this->options['disable-date'] === true ||
-		     $this->options['disable-author'] === true ||
-		     $this->options['disable-post_format'] === true
+		if ( $this->options['disable-date'] === true
+			|| $this->options['disable-author'] === true
+			|| $this->options['disable-post_format'] === true
 		) {
 			add_action( 'wp', array( $this, 'archive_redirect' ) );
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -77,7 +77,8 @@ class WPSEO_Upgrade {
 		}
 
 		if ( version_compare( $this->options['version'], '5.0', '>=' )
-			 && version_compare( $this->options['version'], '5.1', '<' ) ) {
+			&& version_compare( $this->options['version'], '5.1', '<' )
+		) {
 			$this->upgrade_50_51();
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -984,7 +984,7 @@ class WPSEO_Utils {
 	 */
 	public static function is_api_available( $minimum_version = '2.0' ) {
 		return ( defined( 'REST_API_VERSION' )
-		         && version_compare( REST_API_VERSION, $minimum_version, '>=' ) );
+			&& version_compare( REST_API_VERSION, $minimum_version, '>=' ) );
 	}
 
 	/********************** DEPRECATED METHODS **********************/

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -487,8 +487,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 						if (
 							( isset( $original[ $old_prefix . $tax ] ) && ! isset( $original[ $new_prefix . $tax ] ) )
 							&& ( ! isset( $option_value[ $new_prefix . $tax ] )
-							     || ( isset( $option_value[ $new_prefix . $tax ] )
-							          && $option_value[ $new_prefix . $tax ] === $defaults[ $new_prefix . $tax ] ) )
+								|| ( isset( $option_value[ $new_prefix . $tax ] )
+									&& $option_value[ $new_prefix . $tax ] === $defaults[ $new_prefix . $tax ] ) )
 						) {
 							$option_value[ $new_prefix . $tax ] = $original[ $old_prefix . $tax ];
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.

For multi-line control structures, the following guidelines apply:
* Subsequent lines should be indented by one, not (precision) aligned.
* For ease of readability, the logical operator should be on the same line as the following statement (not a hard rule, but best practice).
* The control structure closing parenthesis and opening brace should be on a line by itself and be aligned with the control structure keyword.


## Test instructions

_N/A_