### PR TITLE
Documentation: fix incorrect comment structures

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -206,9 +206,9 @@ class WPSEO_Breadcrumbs {
 	 */
 	private function find_deepest_term( $terms ) {
 		/*
-		Let's find the deepest term in this array, by looping through and then
-		   unsetting every term that is used as a parent by another one in the array.
-		*/
+		 * Let's find the deepest term in this array, by looping through and then
+		 * unsetting every term that is used as a parent by another one in the array.
+		 */
 		$terms_by_id = array();
 		foreach ( $terms as $term ) {
 			$terms_by_id[ $term->term_id ] = $term;
@@ -219,9 +219,9 @@ class WPSEO_Breadcrumbs {
 		unset( $term );
 
 		/*
-		As we could still have two subcategories, from different parent categories,
-		   let's pick the one with the lowest ordered ancestor.
-		*/
+		 * As we could still have two subcategories, from different parent categories,
+		 * let's pick the one with the lowest ordered ancestor.
+		 */
 		$parents_count = 0;
 		$term_order    = 9999; // Because ASC.
 		reset( $terms_by_id );

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -709,9 +709,9 @@ class WPSEO_Meta {
 		}
 		else {
 			/*
-			Shouldn't ever happen, means not one of our keys as there will always be a default available
-			   for all our keys
-			*/
+			 * Shouldn't ever happen, means not one of our keys as there will always be a default available
+			 * for all our keys.
+			 */
 			return '';
 		}
 	}
@@ -763,10 +763,10 @@ class WPSEO_Meta {
 		global $wpdb;
 
 		/*
-		Get only those rows where no wpseo meta values exist for the same post
-		   (with the exception of linkdex as that will be set independently of whether the post has been edited)
-		   @internal Query is pretty well optimized this way
-		*/
+		 * Get only those rows where no wpseo meta values exist for the same post
+		 * (with the exception of linkdex as that will be set independently of whether the post has been edited).
+		 * @internal Query is pretty well optimized this way.
+		 */
 		$query  = $wpdb->prepare(
 			"
 				SELECT `a`.*

--- a/inc/options/class-wpseo-option-internallinks.php
+++ b/inc/options/class-wpseo-option-internallinks.php
@@ -285,9 +285,9 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 		}
 
 		/*
-		Make sure the values of the variable option key options are cleaned as they
-			   may be retained and would not be cleaned/validated then
-		*/
+		 * Make sure the values of the variable option key options are cleaned as they
+		 * may be retained and would not be cleaned/validated then.
+		 */
 		if ( is_array( $option_value ) && $option_value !== array() ) {
 
 			$allowed_post_types = $this->get_allowed_post_types();

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -258,17 +258,17 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 			switch ( $switch_key ) {
 				/*
-				Text fields
-				*/
+				 * Text fields.
+				 */
 
 				/*
-				Covers:
-					   'title-home-wpseo', 'title-author-wpseo', 'title-archive-wpseo',
-					   'title-search-wpseo', 'title-404-wpseo'
-					   'title-' . $pt->name
-					   'title-ptarchive-' . $pt->name
-					   'title-tax-' . $tax->name
-				*/
+				 * Covers:
+				 *  'title-home-wpseo', 'title-author-wpseo', 'title-archive-wpseo',
+				 *  'title-search-wpseo', 'title-404-wpseo'
+				 *  'title-' . $pt->name
+				 *  'title-ptarchive-' . $pt->name
+				 *  'title-tax-' . $tax->name
+				 */
 				case 'title-':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
@@ -276,25 +276,25 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					break;
 
 				/*
-				Covers:
-					   'metadesc-home-wpseo', 'metadesc-author-wpseo', 'metadesc-archive-wpseo'
-					   'metadesc-' . $pt->name
-					   'metadesc-ptarchive-' . $pt->name
-					   'metadesc-tax-' . $tax->name
-				*/
+				 * Covers:
+				 *  'metadesc-home-wpseo', 'metadesc-author-wpseo', 'metadesc-archive-wpseo'
+				 *  'metadesc-' . $pt->name
+				 *  'metadesc-ptarchive-' . $pt->name
+				 *  'metadesc-tax-' . $tax->name
+				 */
 				case 'metadesc-':
 					/*
-					Covers:
-							 'metakey-home-wpseo', 'metakey-author-wpseo'
-							 'metakey-' . $pt->name
-							 'metakey-ptarchive-' . $pt->name
-							 'metakey-tax-' . $tax->name
-					*/
+					 * Covers:
+					 *  'metakey-home-wpseo', 'metakey-author-wpseo'
+					 *  'metakey-' . $pt->name
+					 *  'metakey-ptarchive-' . $pt->name
+					 *  'metakey-tax-' . $tax->name
+					 */
 				case 'metakey-':
 					/*
-					Covers:
-							 ''bctitle-ptarchive-' . $pt->name
-					*/
+					 * Covers:
+					 *  'bctitle-ptarchive-' . $pt->name
+					 */
 				case 'bctitle-ptarchive-':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
@@ -302,7 +302,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					break;
 
 
-				/* integer field - not in form*/
+				/* Integer field - not in form. */
 				case 'title_test':
 					if ( isset( $dirty[ $key ] ) ) {
 						$int = WPSEO_Utils::validate_int( $dirty[ $key ] );
@@ -333,28 +333,28 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					break;
 
 				/*
-				Boolean fields
-				*/
+				 * Boolean fields.
+				 */
 
 				/*
-				Covers:
-				 *		'noindex-subpages-wpseo', 'noindex-author-wpseo', 'noindex-archive-wpseo'
-				 *		'noindex-' . $pt->name
-				 *		'noindex-ptarchive-' . $pt->name
-				 *		'noindex-tax-' . $tax->name
-				 *		'forcerewritetitle':
-				 *		'usemetakeywords':
-				 *		'noodp':
-				 *		'noydir':
-				 *		'disable-author':
-				 *		'disable-date':
-				 *		'disable-post_format';
-				 *		'noindex-'
-				 *		'showdate-'
-				 *		'showdate-'. $pt->name
-				 *		'hideeditbox-'
-				 *	 	'hideeditbox-'. $pt->name
-				 *		'hideeditbox-tax-' . $tax->name
+				 * Covers:
+				 *  'noindex-subpages-wpseo', 'noindex-author-wpseo', 'noindex-archive-wpseo'
+				 *  'noindex-' . $pt->name
+				 *  'noindex-ptarchive-' . $pt->name
+				 *  'noindex-tax-' . $tax->name
+				 *  'forcerewritetitle':
+				 *  'usemetakeywords':
+				 *  'noodp':
+				 *  'noydir':
+				 *  'disable-author':
+				 *  'disable-date':
+				 *  'disable-post_format';
+				 *  'noindex-'
+				 *  'showdate-'
+				 *  'showdate-'. $pt->name
+				 *  'hideeditbox-'
+				 *  'hideeditbox-'. $pt->name
+				 *  'hideeditbox-tax-' . $tax->name
 				 */
 				default:
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );
@@ -392,11 +392,11 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		}
 
 		/*
-		Move options from very old option to this one
-			   @internal Don't rename to the 'current' names straight away as that would prevent
-			   the rename/unset combi below from working
-			   @todo [JRF] maybe figure out a smarter way to deal with this
-		*/
+		 * Move options from very old option to this one.
+		 * @internal Don't rename to the 'current' names straight away as that would prevent
+		 * the rename/unset combi below from working.
+		 * @todo [JRF] maybe figure out a smarter way to deal with this.
+		 */
 		$old_option = null;
 		if ( isset( $all_old_option_values ) ) {
 			// Ok, we have an import.
@@ -434,13 +434,13 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 
 		/*
-		Renaming these options to avoid ever overwritting these if a (bloody stupid) user /
-			   programmer would use any of the following as a custom post type or custom taxonomy:
-			   'home', 'author', 'archive', 'search', '404', 'subpages'
-
-			   Similarly, renaming the tax options to avoid a custom post type and a taxonomy
-			   with the same name occupying the same option
-		*/
+		 * Renaming these options to avoid ever overwritting these if a (bloody stupid) user /
+		 * programmer would use any of the following as a custom post type or custom taxonomy:
+		 * 'home', 'author', 'archive', 'search', '404', 'subpages'.
+		 *
+		 * Similarly, renaming the tax options to avoid a custom post type and a taxonomy
+		 * with the same name occupying the same option.
+		 */
 		$rename = array(
 			'title-home'       => 'title-home-wpseo',
 			'title-author'     => 'title-author-wpseo',
@@ -493,9 +493,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 							$option_value[ $new_prefix . $tax ] = $original[ $old_prefix . $tax ];
 
 							/*
-							Check if there is a cpt with the same name as the tax,
-								   if so, we should make sure that the old setting hasn't been removed
-							*/
+							 * Check if there is a cpt with the same name as the tax,
+							 * if so, we should make sure that the old setting hasn't been removed.
+							 */
 							if ( ! isset( $post_type_names[ $tax ] ) && isset( $option_value[ $old_prefix . $tax ] ) ) {
 								unset( $option_value[ $old_prefix . $tax ] );
 							}
@@ -517,9 +517,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 
 		/*
-		Make sure the values of the variable option key options are cleaned as they
-			   may be retained and would not be cleaned/validated then
-		*/
+		 * Make sure the values of the variable option key options are cleaned as they
+		 * may be retained and would not be cleaned/validated then.
+		 */
 		if ( is_array( $option_value ) && $option_value !== array() ) {
 			foreach ( $option_value as $key => $value ) {
 				$switch_key = $this->get_switch_key( $key );
@@ -541,14 +541,14 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 						break;
 
 					/*
-					Boolean fields
-					*/
+					 * Boolean fields.
+					 */
 
 					/*
-					Covers:
-					 * 		'noindex-'
-					 * 		'showdate-'
-					 * 		'hideeditbox-'
+					 * Covers:
+					 *  'noindex-'
+					 *  'showdate-'
+					 *  'hideeditbox-'
 					 */
 					default:
 						$option_value[ $key ] = WPSEO_Utils::validate_bool( $value );

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -144,7 +144,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 
 				case 'blocking_files':
-					/**
+					/*
 					 * @internal [JRF] to really validate this we should also do a file_exists()
 					 * on each array entry and remove files which no longer exist, but that might be overkill
 					 */
@@ -186,8 +186,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					break;
 
 				/*
-				Boolean dismiss warnings - not fields - may not be in form
-					   (and don't need to be either as long as the default is false)
+				 * Boolean dismiss warnings - not fields - may not be in form
+				 * (and don't need to be either as long as the default is false).
 				 */
 				case 'ms_defaults_set':
 					if ( isset( $dirty[ $key ] ) ) {
@@ -230,13 +230,13 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					break;
 
 				/*
-				Boolean (checkbox) fields
-				*/
+				 * Boolean (checkbox) fields.
+				 */
 
 				/*
-				Covers
-				 * 		'disableadvanced_meta'
-				 * 		'yoast_tracking'
+				 * Covers:
+				 *  'disableadvanced_meta'
+				 *  'yoast_tracking'
 				 */
 				default:
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );

--- a/inc/options/class-wpseo-option-xml.php
+++ b/inc/options/class-wpseo-option-xml.php
@@ -197,20 +197,20 @@ class WPSEO_Option_XML extends WPSEO_Option {
 					break;
 
 				/*
-				Boolean fields
-				*/
+				 * Boolean fields.
+				 */
 
 				/*
-				Covers:
-				 *		'disable_author_sitemap':
-				 * 		'disable_author_noposts':
-				 * 		'enablexmlsitemap':
-				 * 		'user_role-':
-				 * 		'user_role' . $role_name . '-not_in_sitemap' fields
-				 * 		'post_types-':
-				 * 		'post_types-' . $pt->name . '-not_in_sitemap' fields
-				 * 		'taxonomies-':
-				 *		'taxonomies-' . $tax->name . '-not_in_sitemap' fields
+				 * Covers:
+				 *  'disable_author_sitemap':
+				 *  'disable_author_noposts':
+				 *  'enablexmlsitemap':
+				 *  'user_role-':
+				 *  'user_role' . $role_name . '-not_in_sitemap' fields
+				 *  'post_types-':
+				 *  'post_types-' . $pt->name . '-not_in_sitemap' fields
+				 *  'taxonomies-':
+				 *  'taxonomies-' . $tax->name . '-not_in_sitemap' fields
 				 */
 				default:
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );
@@ -236,9 +236,9 @@ class WPSEO_Option_XML extends WPSEO_Option {
 	 */
 	protected function clean_option( $option_value, $current_version = null, $all_old_option_values = null ) {
 		/*
-		Make sure the values of the variable option key options are cleaned as they
-			   may be retained and would not be cleaned/validated then
-		*/
+		 * Make sure the values of the variable option key options are cleaned as they
+		 * may be retained and would not be cleaned/validated then.
+		 */
 		if ( is_array( $option_value ) && $option_value !== array() ) {
 
 			foreach ( $option_value as $key => $value ) {

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -129,13 +129,13 @@ abstract class WPSEO_Option {
 		}
 		elseif ( is_multisite() ) {
 			/*
-			The option validation routines remove the default filters to prevent failing
-			   to insert an option if it's new. Let's add them back afterwards.
-
-			   For site_options, this method is not foolproof as these actions are not fired
-			   on an insert/update failure. Please use the WPSEO_Options::update_site_option() method
-			   for updating site options to make sure the filters are in place.
-			*/
+			 * The option validation routines remove the default filters to prevent failing
+			 * to insert an option if it's new. Let's add them back afterwards.
+			 *
+			 * For site_options, this method is not foolproof as these actions are not fired
+			 * on an insert/update failure. Please use the WPSEO_Options::update_site_option() method
+			 * for updating site options to make sure the filters are in place.
+			 */
 			add_action( 'add_site_option_' . $this->option_name, array( $this, 'add_default_filters' ) );
 			add_action( 'update_site_option_' . $this->option_name, array( $this, 'add_default_filters' ) );
 
@@ -143,8 +143,8 @@ abstract class WPSEO_Option {
 
 
 		/*
-		Make sure the option will always get validated, independently of register_setting()
-			   (only available on back-end)
+		 * Make sure the option will always get validated, independently of register_setting()
+		 * (only available on back-end).
 		*/
 		add_filter( 'sanitize_option_' . $this->option_name, array( $this, 'validate' ) );
 
@@ -400,11 +400,11 @@ abstract class WPSEO_Option {
 		$filtered = $this->array_filter_merge( $options );
 
 		/*
-		If the option contains variable option keys, make sure we don't remove those settings
-			   - even if the defaults are not complete yet.
-			   Unfortunately this means we also won't be removing the settings for post types or taxonomies
-			   which are no longer in the WP install, but rather that than the other way around
-		*/
+		 * If the option contains variable option keys, make sure we don't remove those settings
+		 * - even if the defaults are not complete yet.
+		 * Unfortunately this means we also won't be removing the settings for post types or taxonomies
+		 * which are no longer in the WP install, but rather that than the other way around.
+		 */
 		if ( isset( $this->variable_array_key_patterns ) ) {
 			$filtered = $this->retain_variable_keys( $options, $filtered );
 		}
@@ -593,9 +593,9 @@ abstract class WPSEO_Option {
 		}
 
 		/*
-		Save the cleaned value - validation will take care of cleaning out array keys which
-			   should no longer be there
-		*/
+		 * Save the cleaned value - validation will take care of cleaning out array keys which
+		 * should no longer be there.
+		 */
 		if ( $this->multisite_only !== true ) {
 			update_option( $this->option_name, $option_value );
 		}

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -202,9 +202,9 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 */
 	protected function validate_option( $dirty, $clean, $old ) {
 		/*
-		Prevent complete validation (which can be expensive when there are lots of terms)
-			   if only one item has changed and has already been validated
-		*/
+		 * Prevent complete validation (which can be expensive when there are lots of terms)
+		 * if only one item has changed and has already been validated.
+		 */
 		if ( isset( $dirty['wpseo_already_validated'] ) && $dirty['wpseo_already_validated'] === true ) {
 			unset( $dirty['wpseo_already_validated'] );
 
@@ -446,9 +446,9 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 		$tax_meta = self::get_term_tax_meta( $term_id, $taxonomy );
 
 		/*
-		Either return the complete array or a single value from it or false if the value does not exist
-			   (shouldn't happen after merge with defaults, indicates typo in request)
-		*/
+		 * Either return the complete array or a single value from it or false if the value does not exist
+		 * (shouldn't happen after merge with defaults, indicates typo in request).
+		 */
 		if ( ! isset( $meta ) ) {
 			return $tax_meta;
 		}

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -605,10 +605,10 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		if ( $canonical !== '' && $canonical !== $url['loc'] ) {
 			/*
-			Let's assume that if a canonical is set for this page and it's different from
-			   the URL of this post, that page is either already in the XML sitemap OR is on
-			   an external site, either way, we shouldn't include it here.
-			*/
+			 * Let's assume that if a canonical is set for this page and it's different from
+			 * the URL of this post, that page is either already in the XML sitemap OR is on
+			 * an external site, either way, we shouldn't include it here.
+			 */
 			return false;
 		}
 		unset( $canonical );

--- a/tests/test-wpseo-functions.php
+++ b/tests/test-wpseo-functions.php
@@ -6,8 +6,8 @@
 class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 
 	/**
-	* Provision some options
-	*/
+	 * Provision some options
+	 */
 	public function setUp() {
 		parent::setUp();
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.

Multi-line inline comments should:
* Open with a `/*` - in contrast to a docblock opener: `/**`.
* Start each line (except the start line) with `space-star-space` and then the content.
* Comments should end in a full stop.

## Test instructions

_N/A_