### PR TITLE
CS compliance: consistently use parenthesis when instantiating a new object

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -422,10 +422,10 @@ function wpseo_remove_stopwords_sample_permalink( $permalink, $post_id, $title, 
 add_action( 'get_sample_permalink', 'wpseo_remove_stopwords_sample_permalink', 10, 4 );
 
 // Crawl Issue Manager AJAX hooks.
-new WPSEO_GSC_Ajax;
+new WPSEO_GSC_Ajax();
 
 // SEO Score Recalculations.
-new WPSEO_Recalculate_Scores_Ajax;
+new WPSEO_Recalculate_Scores_Ajax();
 
 new Yoast_Dashboard_Widget();
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -35,7 +35,7 @@ class WPSEO_Admin_Init {
 	public function __construct() {
 		$this->options = WPSEO_Options::get_option( 'wpseo_xml' );
 
-		$GLOBALS['wpseo_admin'] = new WPSEO_Admin;
+		$GLOBALS['wpseo_admin'] = new WPSEO_Admin();
 
 		$this->pagenow = $GLOBALS['pagenow'];
 
@@ -397,7 +397,7 @@ class WPSEO_Admin_Init {
 		 */
 		if ( $is_editor || $is_inline_save || apply_filters( 'wpseo_always_register_metaboxes_on_admin', false )
 		) {
-			$GLOBALS['wpseo_metabox']      = new WPSEO_Metabox;
+			$GLOBALS['wpseo_metabox']      = new WPSEO_Metabox();
 			$GLOBALS['wpseo_meta_columns'] = new WPSEO_Meta_Columns();
 		}
 	}
@@ -410,7 +410,7 @@ class WPSEO_Admin_Init {
 			WPSEO_Taxonomy::is_term_edit( $this->pagenow )
 			|| WPSEO_Taxonomy::is_term_overview( $this->pagenow )
 		) {
-			new WPSEO_Taxonomy;
+			new WPSEO_Taxonomy();
 		}
 	}
 
@@ -421,7 +421,7 @@ class WPSEO_Admin_Init {
 	 */
 	private function load_admin_user_class() {
 		if ( in_array( $this->pagenow, array( 'user-edit.php', 'profile.php' ) ) && current_user_can( 'edit_users' ) ) {
-			new WPSEO_Admin_User_Profile;
+			new WPSEO_Admin_User_Profile();
 		}
 	}
 
@@ -434,7 +434,7 @@ class WPSEO_Admin_Init {
 
 		if ( $this->on_wpseo_admin_page() ) {
 			// For backwards compatabilty, this still needs a global, for now...
-			$GLOBALS['wpseo_admin_pages'] = new WPSEO_Admin_Pages;
+			$GLOBALS['wpseo_admin_pages'] = new WPSEO_Admin_Pages();
 
 			// Only register the yoast i18n when the page is a Yoast SEO page.
 			if ( WPSEO_Utils::is_yoast_seo_free_page( filter_input( INPUT_GET, 'page' ) ) ) {
@@ -500,7 +500,7 @@ class WPSEO_Admin_Init {
 	 */
 	private function load_xml_sitemaps_admin() {
 		if ( $this->options['enablexmlsitemap'] === true ) {
-			new WPSEO_Sitemaps_Admin;
+			new WPSEO_Sitemaps_Admin();
 		}
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -86,7 +86,7 @@ class WPSEO_Admin {
 		}
 
 		if ( WPSEO_Utils::is_api_available() ) {
-			$configuration = new WPSEO_Configuration_Page;
+			$configuration = new WPSEO_Configuration_Page();
 			$configuration->set_hooks();
 			$configuration->catch_configuration_request();
 		}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -198,7 +198,7 @@ class Yoast_Form {
 
 		$sidebar_renderer = new WPSEO_Admin_Banner_Sidebar_Renderer( new WPSEO_Admin_Banner_Spot_Renderer() );
 
-		$banner_renderer = new WPSEO_Admin_Banner_Renderer;
+		$banner_renderer = new WPSEO_Admin_Banner_Renderer();
 		$banner_renderer->set_base_path( plugins_url( 'images/banner/', WPSEO_FILE ) );
 
 		$sidebar = new WPSEO_Admin_Banner_Sidebar( sprintf( __( '%1s recommendations for you', 'wordpress-seo' ), 'Yoast' ), $banner_renderer );

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -15,7 +15,7 @@ if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== 
 <?php } ?>
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<?php echo $platform_tabs = new WPSEO_GSC_Platform_Tabs; ?>
+		<?php echo $platform_tabs = new WPSEO_GSC_Platform_Tabs(); ?>
 	</h2>
 
 <?php

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -169,7 +169,7 @@ class WPSEO_Taxonomy_Metabox {
 	private function get_social_meta_section() {
 		$options = WPSEO_Options::get_option( 'wpseo_social' );
 		$taxonomy_social_fields = new WPSEO_Taxonomy_Social_Fields( $this->term );
-		$social_admin = new WPSEO_Social_Admin;
+		$social_admin = new WPSEO_Social_Admin();
 
 		$tabs = array();
 		$single = true;

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -487,7 +487,7 @@ class WPSEO_Sitemap_Image_Parser {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$get_attachments = new WP_Query;
+		$get_attachments = new WP_Query();
 		return $get_attachments->query( $args );
 	}
 

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -130,7 +130,7 @@ function wpseo_invalid_custom_taxonomy() {
  */
 function wpseo_get_terms( $id, $taxonomy, $return_single = false ) {
 	_deprecated_function( __FUNCTION__, 'WPSEO 1.5.4', 'WPSEO_Replace_Vars::get_terms()' );
-	$replacer = new WPSEO_Replace_Vars;
+	$replacer = new WPSEO_Replace_Vars();
 
 	return $replacer->get_terms( $id, $taxonomy, $return_single );
 }

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -89,7 +89,7 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
  * @return string
  */
 function wpseo_replace_vars( $string, $args, $omit = array() ) {
-	$replacer = new WPSEO_Replace_Vars;
+	$replacer = new WPSEO_Replace_Vars();
 
 	return $replacer->replace( $string, $args, $omit );
 }

--- a/tests/admin/banner/test-class-admin-banner-renderer.php
+++ b/tests/admin/banner/test-class-admin-banner-renderer.php
@@ -9,7 +9,7 @@ class WPSEO_Admin_Banner_Renderer_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_render() {
 
-		$admin_banner_renderer = new WPSEO_Admin_Banner_Renderer;
+		$admin_banner_renderer = new WPSEO_Admin_Banner_Renderer();
 
 		$expected_output = '<a class="wpseo-banner__link" target="_blank" href="http://url"><img class="wpseo-banner__image" width="200" height="300" src="/image.png" alt="alt"/></a>';
 		$actual_output   = $admin_banner_renderer->render( new WPSEO_Admin_Banner( 'url', 'image.png', 200, 300, 'alt' ) );
@@ -27,7 +27,7 @@ class WPSEO_Admin_Banner_Renderer_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_set_base_path() {
 
-		$admin_banner_renderer = new WPSEO_Admin_Banner_Renderer;
+		$admin_banner_renderer = new WPSEO_Admin_Banner_Renderer();
 		$admin_banner_renderer->set_base_path( 'test_path' );
 
 		$expected_output = '<a class="wpseo-banner__link" target="_blank" href="http://url"><img class="wpseo-banner__image" width="200" height="300" src="test_path/image.png" alt="alt"/></a>';

--- a/tests/admin/banner/test-class-admin-banner-spot-renderer.php
+++ b/tests/admin/banner/test-class-admin-banner-spot-renderer.php
@@ -8,7 +8,7 @@ class WPSEO_Admin_Banner_Spot_Renderer_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->admin_banner_spot_renderer = new WPSEO_Admin_Banner_Spot_Renderer;
+		$this->admin_banner_spot_renderer = new WPSEO_Admin_Banner_Spot_Renderer();
 	}
 
 	/**

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -15,7 +15,7 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		self::$class_instance = new WPSEO_Plugin_Availability_Double;
+		self::$class_instance = new WPSEO_Plugin_Availability_Double();
 	}
 
 	public function test_plugin_existence() {

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -25,7 +25,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$class_instance = new WPSEO_Author_Sitemap_Provider;
+		self::$class_instance = new WPSEO_Author_Sitemap_Provider();
 	}
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -21,7 +21,7 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		self::$class_instance = new WPSEO_Sitemaps_Double;
+		self::$class_instance = new WPSEO_Sitemaps_Double();
 	}
 
 	/**

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -17,7 +17,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		self::$class_instance = new WPSEO_OpenGraph;
+		self::$class_instance = new WPSEO_OpenGraph();
 	}
 
 	/**

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -17,7 +17,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$class_instance = new WPSEO_Rewrite;
+		self::$class_instance = new WPSEO_Rewrite();
 	}
 
 	/**

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -12,7 +12,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$class_instance = new WPSEO_Metabox;
+		self::$class_instance = new WPSEO_Metabox();
 	}
 
 	/**
@@ -72,7 +72,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		$post = get_post( $post_id );
 
 		// Setup.
-		$GLOBALS['wpseo_admin'] = new WPSEO_Admin;
+		$GLOBALS['wpseo_admin'] = new WPSEO_Admin();
 
 		// vars.
 		$meta_fields = apply_filters( 'wpseo_save_metaboxes', array() );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -274,11 +274,11 @@ function wpseo_init() {
 	}
 
 	if ( $options['stripcategorybase'] === true ) {
-		$GLOBALS['wpseo_rewrite'] = new WPSEO_Rewrite;
+		$GLOBALS['wpseo_rewrite'] = new WPSEO_Rewrite();
 	}
 
 	if ( $options['enablexmlsitemap'] === true ) {
-		$GLOBALS['wpseo_sitemaps'] = new WPSEO_Sitemaps;
+		$GLOBALS['wpseo_sitemaps'] = new WPSEO_Sitemaps();
 	}
 
 	if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
@@ -343,7 +343,7 @@ function wpseo_frontend_head_init() {
 	}
 
 	if ( $options['opengraph'] === true ) {
-		$GLOBALS['wpseo_og'] = new WPSEO_OpenGraph;
+		$GLOBALS['wpseo_og'] = new WPSEO_OpenGraph();
 	}
 
 }


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Class instantiation - with/without parenthesis - was until now done quite inconsistently.
    Consistency is now enforced via the `WordPress.Classes.ClassInstantion` sniff as added in WPCS 0.12.0.


## Test instructions

_N/A_