### PR TITLE
CS compliance: review of all include and require statements

### DIFF
--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -85,6 +85,6 @@ class WPSEO_Admin_User_Profile {
 
 		wp_nonce_field( 'wpseo_user_profile_update', 'wpseo_nonce' );
 
-		require_once( 'views/user-profile.php' );
+		require_once WPSEO_PATH . 'admin/views/user-profile.php';
 	}
 }

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -132,7 +132,7 @@ class WPSEO_Primary_Term_Admin {
 	 * Include templates file
 	 */
 	protected function include_js_templates() {
-		include_once WPSEO_PATH . '/admin/views/js-templates-primary-term.php';
+		include_once WPSEO_PATH . 'admin/views/js-templates-primary-term.php';
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -66,7 +66,7 @@ class Yoast_Form {
 		 *
 		 * @see settings_errors()
 		 */
-		require_once( ABSPATH . 'wp-admin/options-head.php' );
+		require_once ABSPATH . 'wp-admin/options-head.php';
 		?>
 		<h1 id="wpseo-title"><?php echo esc_html( get_admin_page_title() ); ?></h1>
 		<div class="wpseo_content_wrapper">

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -115,7 +115,7 @@ class Yoast_Plugin_Conflict {
 	 */
 	public function get_conflicting_plugins_as_string( $plugin_section ) {
 		if ( ! function_exists( 'get_plugin_data' ) ) {
-			require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		// Getting the active plugins by given section.

--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -4,7 +4,7 @@
  */
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
-	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 /**

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -115,7 +115,7 @@ class WPSEO_GSC {
 	 * Function that outputs the redirect page
 	 */
 	public function display() {
-		require_once WPSEO_PATH . '/admin/google_search_console/views/gsc-display.php';
+		require_once WPSEO_PATH . 'admin/google_search_console/views/gsc-display.php';
 	}
 
 	/**

--- a/admin/views/class-yoast-form-fieldset.php
+++ b/admin/views/class-yoast-form-fieldset.php
@@ -60,7 +60,7 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 		 */
 		extract( $this->get_parts() );
 
-		require dirname( WPSEO_FILE ) . '/admin/views/form/fieldset.php';
+		require WPSEO_PATH . 'admin/views/form/fieldset.php';
 	}
 
 	/**

--- a/admin/views/class-yoast-input-select.php
+++ b/admin/views/class-yoast-input-select.php
@@ -55,7 +55,7 @@ class Yoast_Input_Select {
 		// Extract it, because we want each value accessible via a variable instead of accessing it as an array.
 		extract( $this->get_select_values() );
 
-		require dirname( WPSEO_FILE ) . '/admin/views/form/select.php';
+		require WPSEO_PATH . 'admin/views/form/select.php';
 	}
 
 	/**

--- a/admin/views/partial-alerts-errors.php
+++ b/admin/views/partial-alerts-errors.php
@@ -17,4 +17,4 @@ $total = $alerts_data['metrics']['errors'];
 $active = $alerts_data['errors']['active'];
 $dismissed = $alerts_data['errors']['dismissed'];
 
-include 'partial-alerts-template.php';
+include WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/admin/views/partial-alerts-warnings.php
+++ b/admin/views/partial-alerts-warnings.php
@@ -17,4 +17,4 @@ $total = $alerts_data['metrics']['warnings'];
 $active = $alerts_data['warnings']['active'];
 $dismissed = $alerts_data['warnings']['dismissed'];
 
-include 'partial-alerts-template.php';
+include WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/admin/views/partial-settings-tab-video.php
+++ b/admin/views/partial-settings-tab-video.php
@@ -20,7 +20,7 @@ if ( ! empty( $tab_video_url ) ) :
 			<span class="dashicons dashicons-arrow-down toggle__arrow"></span>
 		</button>
 		<div id="<?php echo $id ?>" class="wpseo-tab-video-slideout hidden">
-			<?php include dirname( __FILE__ ) . '/partial-help-center-video.php'; ?>
+			<?php include WPSEO_PATH . 'admin/views/partial-help-center-video.php'; ?>
 		</div>
 	</div>
 	<?php

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -393,7 +393,7 @@ class WPSEO_Sitemaps {
 		header( 'Cache-Control: maxage=' . $expires );
 		header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', ( time() + $expires ) ) . ' GMT' );
 
-		require_once( WPSEO_PATH . 'css/xml-sitemap-xsl.php' );
+		require_once WPSEO_PATH . 'css/xml-sitemap-xsl.php';
 	}
 
 	/**

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'test-class-wpseo-plugin-availability-double.php';
+require_once WPSEO_TESTS_PATH . 'admin/test-class-wpseo-plugin-availability-double.php';
 
 class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,5 +29,7 @@ else {
 	require '../../../../tests/phpunit/includes/bootstrap.php';
 }
 
+define( 'WPSEO_TESTS_PATH', dirname( __FILE__ ) . '/' );
+
 // include unit test base class
-require_once dirname( __FILE__ ) . '/framework/class-wpseo-unit-test-case.php';
+require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case.php';

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -3,7 +3,7 @@
  * @package WPSEO\Unittests
  */
 
-require_once 'class-recalculate-posts-double.php';
+require_once WPSEO_TESTS_PATH . 'recalculate/class-recalculate-posts-double.php';
 
 
 class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -3,7 +3,7 @@
  * @package WPSEO\Unittests
  */
 
-require_once 'class-wpseo-sitemaps-double.php';
+require_once WPSEO_TESTS_PATH . 'sitemaps/class-wpseo-sitemaps-double.php';
 
 /**
  * Class WPSEO_Sitemaps_Test

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -15,7 +15,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		ob_start();
 
 		// create instance of WPSEO_Twitter class
-		require 'framework/class-expose-wpseo-twitter.php';
+		require WPSEO_TESTS_PATH . 'framework/class-expose-wpseo-twitter.php';
 		self::$class_instance = new Expose_WPSEO_Twitter();
 		WPSEO_Frontend::get_instance()->reset();
 		// clean output which was outputted by WPSEO_Twitter constructor

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -46,12 +46,12 @@ function wpseo_auto_load( $class ) {
 	$cn = strtolower( $class );
 
 	if ( ! class_exists( $class ) && isset( $classes[ $cn ] ) ) {
-		require_once( $classes[ $cn ] );
+		require_once $classes[ $cn ];
 	}
 }
 
-if ( file_exists( WPSEO_PATH . '/vendor/autoload_52.php' ) ) {
-	require WPSEO_PATH . '/vendor/autoload_52.php';
+if ( file_exists( WPSEO_PATH . 'vendor/autoload_52.php' ) ) {
+	require WPSEO_PATH . 'vendor/autoload_52.php';
 }
 elseif ( ! class_exists( 'WPSEO_Options' ) ) { // Still checking since might be site-level autoload R.
 	add_action( 'admin_init', 'yoast_wpseo_missing_autoload', 1 );
@@ -141,8 +141,8 @@ function wpseo_network_activate_deactivate( $activate = true ) {
  * Runs on activation of the plugin.
  */
 function _wpseo_activate() {
-	require_once( WPSEO_PATH . 'inc/wpseo-functions.php' );
-	require_once( WPSEO_PATH . 'inc/class-wpseo-installation.php' );
+	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
+	require_once WPSEO_PATH . 'inc/class-wpseo-installation.php';
 
 	wpseo_load_textdomain(); // Make sure we have our translations available for the defaults.
 
@@ -188,7 +188,7 @@ function _wpseo_activate() {
  * On deactivation, flush the rewrite rules so XML sitemaps stop working.
  */
 function _wpseo_deactivate() {
-	require_once( WPSEO_PATH . 'inc/wpseo-functions.php' );
+	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
 
 	if ( is_multisite() && ms_is_switched() ) {
 		delete_option( 'rewrite_rules' );
@@ -224,7 +224,7 @@ function _wpseo_deactivate() {
  */
 function wpseo_on_activate_blog( $blog_id ) {
 	if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-		require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
 
 	if ( is_plugin_active_for_network( plugin_basename( WPSEO_FILE ) ) ) {
@@ -259,8 +259,8 @@ add_action( 'plugins_loaded', 'wpseo_load_textdomain' );
  * On plugins_loaded: load the minimum amount of essential files for this plugin
  */
 function wpseo_init() {
-	require_once( WPSEO_PATH . 'inc/wpseo-functions.php' );
-	require_once( WPSEO_PATH . 'inc/wpseo-functions-deprecated.php' );
+	require_once WPSEO_PATH . 'inc/wpseo-functions.php';
+	require_once WPSEO_PATH . 'inc/wpseo-functions-deprecated.php';
 
 	// Make sure our option and meta value validation routines and default values are always registered and available.
 	WPSEO_Options::get_instance();
@@ -282,7 +282,7 @@ function wpseo_init() {
 	}
 
 	if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-		require_once( WPSEO_PATH . 'inc/wpseo-non-ajax-functions.php' );
+		require_once WPSEO_PATH . 'inc/wpseo-non-ajax-functions.php';
 	}
 
 	// Init it here because the filter must be present on the frontend as well or it won't work in the customizer.
@@ -377,7 +377,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 		new Yoast_Alerts();
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			require_once( WPSEO_PATH . 'admin/ajax.php' );
+			require_once WPSEO_PATH . 'admin/ajax.php';
 
 			// Plugin conflict ajax hooks.
 			new Yoast_Plugin_Conflict_Ajax();

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -44,4 +44,4 @@ if ( ! defined( 'WPSEO_FILE' ) ) {
 }
 
 // Load the Yoast SEO plugin.
-require_once( dirname( WPSEO_FILE ) . '/wp-seo-main.php' );
+require_once dirname( WPSEO_FILE ) . '/wp-seo-main.php';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

`include` and `require` are language constructs, not functions.

With that in mind there are a number of best practices surrounding them:
* There is no need to use parenthesis and not doing so will be, albeit marginally, faster.
     A sniff which will start checking for this - `PEAR.Files.IncludingFile` - has been introduced in the upcoming WPCS 0.14.0 release.
* Always pass an absolute path for maximum portability.
     The `wpseo-main.php` file defines the `WPSEO_PATH` constant to be used for that (includes trailing slash), WP itself has `ABSPATH` (includes trailing slash).
    The Yoast SEO unit tests did not have a good constant available for this so far, this has been fixed by adding a `WPSEO_TESTS_PATH` constant (including trailing slash) to the `bootstrap.php` file.
* As all the relevant PATH constants already contain a trailing slash, there is no need for a slash at the start of the text string pointing to the exact file to be included.
* As these constants are available, there is no need to have additional calls to `dirname( __FILE__ )`. Better to use the relevant constant.

Suggested additional review to be done (by team Yoast):
* Check whether the correct file inclusion structure is being used, i.e. `include(_once)` versus `require(_once)`.
    Most of the time, `require(_once)` is the better structure to use, but this does need to be reviewed on an individual basis.
    For input on the considerations to take into account during this review, see  WordPress-Coding-Standards/WordPress-Coding-Standards#1143

## Test instructions

**_It is strongly recommended to carefully test this PR._**

I do not expect any problems, but have not run any functional tests myself.