### PR TITLE
CS compliance: consistent method and property modifiers

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -102,7 +102,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * Class constructor
 	 */
-	function __construct() {
+	public function __construct() {
 		parent::__construct( $this->settings );
 
 		$this->request_url    = $_SERVER['REQUEST_URI'];
@@ -205,7 +205,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 *
 	 * @param string $which Table nav location (such as top).
 	 */
-	function display_tablenav( $which ) {
+	public function display_tablenav( $which ) {
 		$post_status = sanitize_text_field( filter_input( INPUT_GET, 'post_status' ) );
 		?>
 		<div class="tablenav <?php echo esc_attr( $which ); ?>">
@@ -249,7 +249,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 *
 	 * @return string $subquery The subquery, which should always be used in $wpdb->prepare(), passing the current user_id in as the first parameter.
 	 */
-	function get_base_subquery() {
+	public function get_base_subquery() {
 		global $wpdb;
 
 		$all_posts_string = "'" . implode( "', '", $this->all_posts ) . "'";
@@ -274,7 +274,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * @return array
 	 */
-	function get_views() {
+	public function get_views() {
 		global $wpdb;
 
 		$status_links = array();
@@ -348,7 +348,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * @param string $which Table nav location (such as top).
 	 */
-	function extra_tablenav( $which ) {
+	public function extra_tablenav( $which ) {
 
 		if ( 'top' === $which ) {
 			$post_types = get_post_types( array( 'public' => true, 'exclude_from_search' => false ) );
@@ -406,7 +406,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 *
 	 * @return array
 	 */
-	function get_sortable_columns() {
+	public function get_sortable_columns() {
 		return array(
 			'col_page_title' => array( 'post_title', true ),
 			'col_post_type'  => array( 'post_type', false ),
@@ -417,7 +417,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * Sets the correct pagenumber and pageurl for the navigation
 	 */
-	function prepare_page_navigation() {
+	public function prepare_page_navigation() {
 
 		$request_url = $this->request_url . $this->page_url;
 
@@ -457,7 +457,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * Preparing the requested pagerows and setting the needed variables
 	 */
-	function prepare_items() {
+	public function prepare_items() {
 
 		$post_type_clause = $this->get_post_type_clause();
 		$all_states       = $this->get_all_states();
@@ -686,7 +686,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * Based on $this->items and the defined columns, the table rows will be displayed.
 	 */
-	function display_rows() {
+	public function display_rows() {
 
 		$records = $this->items;
 

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -25,7 +25,7 @@ class WPSEO_Admin_Pages {
 	/**
 	 * Class constructor, which basically only hooks the init function on the init hook
 	 */
-	function __construct() {
+	public function __construct() {
 		add_action( 'init', array( $this, 'init' ), 20 );
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 	}
@@ -33,7 +33,7 @@ class WPSEO_Admin_Pages {
 	/**
 	 * Make sure the needed scripts are loaded for admin pages
 	 */
-	function init() {
+	public function init() {
 		if ( filter_input( INPUT_GET, 'wpseo_reset_defaults' ) && wp_verify_nonce( filter_input( INPUT_GET, 'nonce' ), 'wpseo_reset_defaults' ) && current_user_can( 'manage_options' ) ) {
 			WPSEO_Options::reset();
 			wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) );
@@ -61,7 +61,7 @@ class WPSEO_Admin_Pages {
 	/**
 	 * Loads the required styles for the config page.
 	 */
-	function config_page_styles() {
+	public function config_page_styles() {
 		wp_enqueue_style( 'dashboard' );
 		wp_enqueue_style( 'thickbox' );
 		wp_enqueue_style( 'global' );
@@ -76,7 +76,7 @@ class WPSEO_Admin_Pages {
 	/**
 	 * Loads the required scripts for the config page.
 	 */
-	function config_page_scripts() {
+	public function config_page_scripts() {
 		$this->asset_manager->enqueue_script( 'admin-script' );
 
 		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
@@ -239,7 +239,7 @@ class WPSEO_Admin_Pages {
 	 * @param string $label  The label to show for the variable.
 	 * @param string $option The option the variable belongs to.
 	 */
-	function textinput( $var, $label, $option = '' ) {
+	public function textinput( $var, $label, $option = '' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please use the <code>Yoast_Form</code> class.' );
 
 		if ( $option !== '' ) {
@@ -258,7 +258,7 @@ class WPSEO_Admin_Pages {
 	 * @param string $option The option the variable belongs to.
 	 * @param array  $attr   The CSS class to assign to the textarea.
 	 */
-	function textarea( $var, $label, $option = '', $attr = array() ) {
+	public function textarea( $var, $label, $option = '', $attr = array() ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please use the <code>Yoast_Form</code> class.' );
 
 		if ( $option !== '' ) {
@@ -276,7 +276,7 @@ class WPSEO_Admin_Pages {
 	 * @param string $var    The variable within the option to create the hidden input for.
 	 * @param string $option The option the variable belongs to.
 	 */
-	function hidden( $var, $option = '' ) {
+	public function hidden( $var, $option = '' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please use the <code>Yoast_Form</code> class.' );
 
 		if ( $option !== '' ) {
@@ -296,7 +296,7 @@ class WPSEO_Admin_Pages {
 	 * @param array  $values The select options to choose from.
 	 * @param string $option The option the variable belongs to.
 	 */
-	function select( $var, $label, $values, $option = '' ) {
+	public function select( $var, $label, $values, $option = '' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please use the <code>Yoast_Form</code> class.' );
 
 		if ( $option !== '' ) {
@@ -315,7 +315,7 @@ class WPSEO_Admin_Pages {
 	 * @param string $label  The label to show for the variable.
 	 * @param string $option The option the variable belongs to.
 	 */
-	function file_upload( $var, $label, $option = '' ) {
+	public function file_upload( $var, $label, $option = '' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please use the <code>Yoast_Form</code> class.' );
 
 		if ( $option !== '' ) {
@@ -334,7 +334,7 @@ class WPSEO_Admin_Pages {
 	 * @param string $label  Label message.
 	 * @param string $option Optional option key.
 	 */
-	function media_input( $var, $label, $option = '' ) {
+	public function media_input( $var, $label, $option = '' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please use the <code>Yoast_Form</code> class.' );
 
 		if ( $option !== '' ) {
@@ -354,7 +354,7 @@ class WPSEO_Admin_Pages {
 	 * @param string $label  The label to show for the variable.
 	 * @param string $option The option the variable belongs to.
 	 */
-	function radio( $var, $values, $label, $option = '' ) {
+	public function radio( $var, $values, $label, $option = '' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please use the <code>Yoast_Form</code> class.' );
 
 		if ( $option !== '' ) {
@@ -373,7 +373,7 @@ class WPSEO_Admin_Pages {
 	 * @param string $title   Title of the postbox.
 	 * @param string $content Content of the postbox.
 	 */
-	function postbox( $id, $title, $content ) {
+	public function postbox( $id, $title, $content ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please re-implement the admin pages.' );
 
 		?>
@@ -393,7 +393,7 @@ class WPSEO_Admin_Pages {
 	 *
 	 * @return string
 	 */
-	function form_table( $rows ) {
+	public function form_table( $rows ) {
 		_deprecated_function( __METHOD__, 'WPSEO 2.0', 'This method is deprecated, please re-implement the admin pages.' );
 
 		if ( ! is_array( $rows ) || $rows === array() ) {
@@ -429,7 +429,7 @@ class WPSEO_Admin_Pages {
 	 * @deprecated use WPSEO_Options::reset()
 	 * @see        WPSEO_Options::reset()
 	 */
-	function reset_defaults() {
+	public function reset_defaults() {
 		_deprecated_function( __METHOD__, 'WPSEO 1.5.0', 'WPSEO_Options::reset()' );
 		WPSEO_Options::reset();
 	}

--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -17,28 +17,28 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	 *
 	 * @return string The modified query.
 	 */
-	public abstract function filter_posts( $where );
+	abstract public function filter_posts( $where );
 
 	/**
 	 * Returns the query value this filter uses.
 	 *
 	 * @return string The query value this filter uses.
 	 */
-	public abstract function get_query_val();
+	abstract public function get_query_val();
 
 	/**
 	 * Returns the total number of posts that match this filter.
 	 *
 	 * @return int The total number of posts that match this filter.
 	 */
-	protected abstract function get_post_total();
+	abstract protected function get_post_total();
 
 	/**
 	 * Returns the label for this filter.
 	 *
 	 * @return string The label for this filter.
 	 */
-	protected abstract function get_label();
+	abstract protected function get_label();
 
 	/**
 	 * Registers the hooks.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -133,7 +133,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @return  bool        Whether or not the meta box (and associated columns etc) should be hidden
 	 */
-	function is_metabox_hidden( $post_type = null ) {
+	public function is_metabox_hidden( $post_type = null ) {
 		if ( ! isset( $post_type ) && ( isset( $GLOBALS['post'] ) && ( is_object( $GLOBALS['post'] ) && isset( $GLOBALS['post']->post_type ) ) ) ) {
 			$post_type = $GLOBALS['post']->post_type;
 		}
@@ -548,7 +548,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @return  string
 	 */
-	function do_meta_box( $meta_field_def, $key = '' ) {
+	public function do_meta_box( $meta_field_def, $key = '' ) {
 		$content      = '';
 		$esc_form_key = esc_attr( self::$form_prefix . $key );
 		$meta_value   = self::get_value( $key, $this->get_metabox_post()->ID );
@@ -777,7 +777,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @return  bool|void   Boolean false if invalid save post request
 	 */
-	function save_postdata( $post_id ) {
+	public function save_postdata( $post_id ) {
 		// Bail if this is a multisite installation and the site has been switched.
 		if ( is_multisite() && ms_is_switched() ) {
 			return false;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -583,7 +583,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return string
 	 */
-	function force_wp_title() {
+	public function force_wp_title() {
 		global $wp_query;
 		$old_wp_query = null;
 
@@ -1374,7 +1374,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return boolean
 	 */
-	function page_redirect() {
+	public function page_redirect() {
 		if ( is_singular() ) {
 			global $post;
 			if ( ! isset( $post ) || ! is_object( $post ) ) {
@@ -1432,7 +1432,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return boolean False when no redirect was triggered
 	 */
-	function archive_redirect() {
+	public function archive_redirect() {
 		global $wp_query;
 
 		if (
@@ -1454,7 +1454,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return boolean False when no redirect was triggered
 	 */
-	function attachment_redirect() {
+	public function attachment_redirect() {
 		global $post;
 		if ( is_attachment() && ( ( is_object( $post ) && isset( $post->post_parent ) ) && ( is_numeric( $post->post_parent ) && $post->post_parent != 0 ) ) ) {
 			wp_safe_redirect( get_permalink( $post->post_parent ), 301 );
@@ -1474,7 +1474,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return string
 	 */
-	function add_trailingslash( $url, $type ) {
+	public function add_trailingslash( $url, $type ) {
 		if ( 'single' === $type || 'single_paged' === $type ) {
 			return $url;
 		}
@@ -1502,7 +1502,7 @@ class WPSEO_Frontend {
 	 * @since 1.4.13
 	 * @return boolean
 	 */
-	function replytocom_redirect() {
+	public function replytocom_redirect() {
 
 		if ( isset( $_GET['replytocom'] ) && is_singular() ) {
 			$url          = get_permalink( $GLOBALS['post']->ID );
@@ -1684,7 +1684,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return string
 	 */
-	function rss_replace_vars( $content ) {
+	public function rss_replace_vars( $content ) {
 		global $post;
 
 		/**
@@ -1725,7 +1725,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return string
 	 */
-	function embed_rssfooter( $content ) {
+	public function embed_rssfooter( $content ) {
 		return $this->embed_rss( $content, 'full' );
 	}
 
@@ -1736,7 +1736,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return string
 	 */
-	function embed_rssfooter_excerpt( $content ) {
+	public function embed_rssfooter_excerpt( $content ) {
 		return $this->embed_rss( $content, 'excerpt' );
 	}
 
@@ -1750,7 +1750,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return string
 	 */
-	function embed_rss( $content, $context = 'full' ) {
+	public function embed_rss( $content, $context = 'full' ) {
 
 		/**
 		 * Filter: 'wpseo_include_rss_footer' - Allow the RSS footer to be dynamically shown/hidden.
@@ -1789,7 +1789,7 @@ class WPSEO_Frontend {
 	 * Used in the force rewrite functionality this retrieves the output, replaces the title with the proper SEO
 	 * title and then flushes the output.
 	 */
-	function flush_cache() {
+	public function flush_cache() {
 
 		global $wp_query;
 
@@ -1819,7 +1819,7 @@ class WPSEO_Frontend {
 	/**
 	 * Starts the output buffer so it can later be fixed by flush_cache()
 	 */
-	function force_rewrite_output_buffer() {
+	public function force_rewrite_output_buffer() {
 		$this->ob_started = true;
 		ob_start();
 	}
@@ -1831,7 +1831,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return string
 	 */
-	function title_test_helper( $title ) {
+	public function title_test_helper( $title ) {
 		$wpseo_titles = get_option( 'wpseo_titles' );
 
 		$wpseo_titles['title_test'] ++;

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -11,7 +11,7 @@ class WPSEO_Rewrite {
 	/**
 	 * Class constructor
 	 */
-	function __construct() {
+	public function __construct() {
 		add_filter( 'query_vars', array( $this, 'query_vars' ) );
 		add_filter( 'category_link', array( $this, 'no_category_base' ) );
 		add_filter( 'request', array( $this, 'request' ) );
@@ -29,7 +29,7 @@ class WPSEO_Rewrite {
 	 *
 	 * @since 1.2.8
 	 */
-	function schedule_flush() {
+	public function schedule_flush() {
 		update_option( 'wpseo_flush_rewrite', 1 );
 	}
 
@@ -39,7 +39,7 @@ class WPSEO_Rewrite {
 	 * @since 1.2.8
 	 * @return bool
 	 */
-	function flush() {
+	public function flush() {
 		if ( get_option( 'wpseo_flush_rewrite' ) ) {
 
 			add_action( 'shutdown', 'flush_rewrite_rules' );
@@ -58,7 +58,7 @@ class WPSEO_Rewrite {
 	 *
 	 * @return string
 	 */
-	function no_category_base( $link ) {
+	public function no_category_base( $link ) {
 		$category_base = get_option( 'category_base' );
 
 		if ( '' == $category_base ) {
@@ -82,7 +82,7 @@ class WPSEO_Rewrite {
 	 *
 	 * @return array
 	 */
-	function query_vars( $query_vars ) {
+	public function query_vars( $query_vars ) {
 		$options = WPSEO_Options::get_option( 'wpseo_permalinks' );
 
 		if ( $options['stripcategorybase'] === true ) {
@@ -99,7 +99,7 @@ class WPSEO_Rewrite {
 	 *
 	 * @return array
 	 */
-	function request( $query_vars ) {
+	public function request( $query_vars ) {
 		if ( isset( $query_vars['wpseo_category_redirect'] ) ) {
 			$catlink = trailingslashit( get_option( 'home' ) ) . user_trailingslashit( $query_vars['wpseo_category_redirect'], 'category' );
 
@@ -115,7 +115,7 @@ class WPSEO_Rewrite {
 	 *
 	 * @return array
 	 */
-	function category_rewrite_rules() {
+	public function category_rewrite_rules() {
 		global $wp_rewrite;
 
 		$category_rewrite = array();

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -428,7 +428,7 @@ class WPSEO_Sitemaps {
 	 *
 	 * @return string|array|false
 	 */
-	static public function get_last_modified_gmt( $post_types, $return_all = false ) {
+	public static function get_last_modified_gmt( $post_types, $return_all = false ) {
 
 		global $wpdb;
 
@@ -558,7 +558,7 @@ class WPSEO_Sitemaps {
 	 *
 	 * @return mixed|void
 	 */
-	static public function filter_frequency( $filter, $default, $url ) {
+	public static function filter_frequency( $filter, $default, $url ) {
 		_deprecated_function( __METHOD__, 'WPSEO 3.5' );
 
 		/**

--- a/tests/sitemaps/class-wpseo-sitemaps-double.php
+++ b/tests/sitemaps/class-wpseo-sitemaps-double.php
@@ -20,14 +20,14 @@ class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
 	/**
 	 * Overwrite sitemap_close() so we don't die on outputting the sitemap
 	 */
-	function sitemap_close() {
+	public function sitemap_close() {
 		remove_all_actions( 'wp_footer' );
 	}
 
 	/**
 	 * Reset
 	 */
-	function reset() {
+	public function reset() {
 		$this->bad_sitemap = false;
 		$this->sitemap = '';
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.
    * All methods and properties should have visibility declared.
        The default visibility is `public`, so for those methods and properties where the visibility was missing, I've elected to set them all to `public` so as not to break backward-compatibility.
    * Comply with the PSR 2 method and property modifier order.
        The order of property and method scope modifiers should follow this pattern:
`abstract visibility static`

Sniffs checking for the above have been added in the upcoming WPCS 0.14.0 release.

Refs:
* http://www.php-fig.org/psr/psr-2/#42-properties
* http://www.php-fig.org/psr/psr-2/#43-methods
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1101

## Test instructions

_N/A_