### PR TITLE
CS (non-)compliance: use `:` for `case` statements

### DIFF
--- a/admin/class-remote-request.php
+++ b/admin/class-remote-request.php
@@ -56,10 +56,10 @@ class WPSEO_Remote_Request {
 	 */
 	public function send( $method = self::METHOD_POST ) {
 		switch ( $method ) {
-			case self::METHOD_POST;
+			case self::METHOD_POST:
 				$response = $this->post();
 				break;
-			case self::METHOD_GET;
+			case self::METHOD_GET:
 				$response = $this->get();
 				break;
 			default :


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. While `;` is in actual fact valid, it is not commonly used and discouraged. As of WPCS 0.12.0 an error will also be thrown for this.


## Test instructions

_N/A_