### PR TITLE
CS compliance: fix variety of whitespace issues

### DIFF
--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -88,7 +88,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 	public function handle_response( array $response, $request_arguments, $url ) {
 		$response_code = wp_remote_retrieve_response_code( $response );
 
-		if ( $response_code === 200 && $this->is_expected_endpoint( $url )  ) {
+		if ( $response_code === 200 && $this->is_expected_endpoint( $url ) ) {
 			$response_data = $this->parse_response( $response );
 			$this->detect_version( $response_data );
 		}

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -91,21 +91,21 @@ class WPSEO_Meta_Columns {
 		}
 
 		switch ( $column_name ) {
-			case 'wpseo-score' :
+			case 'wpseo-score':
 				echo $this->parse_column_score( $post_id );
 				break;
 			case 'wpseo-score-readability':
 				echo $this->parse_column_score_readability( $post_id );
 				break;
-			case 'wpseo-title' :
+			case 'wpseo-title':
 				echo esc_html( apply_filters( 'wpseo_title', wpseo_replace_vars( $this->page_title( $post_id ), get_post( $post_id, ARRAY_A ) ) ) );
 				break;
-			case 'wpseo-metadesc' :
+			case 'wpseo-metadesc':
 				$metadesc_val = apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) );
 				$metadesc = ( '' === $metadesc_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
 				echo $metadesc;
 				break;
-			case 'wpseo-focuskw' :
+			case 'wpseo-focuskw':
 				$focuskw_val = WPSEO_Meta::get_value( 'focuskw', $post_id );
 				$focuskw = ( '' === $focuskw_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
 				echo $focuskw;
@@ -519,13 +519,13 @@ class WPSEO_Meta_Columns {
 	 */
 	private function filter_order_by( $order_by ) {
 		switch ( $order_by ) {
-			case 'wpseo-metadesc' :
+			case 'wpseo-metadesc':
 				return  array(
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'metadesc',
 					'orderby'  => 'meta_value',
 				);
 				break;
-			case 'wpseo-focuskw' :
+			case 'wpseo-focuskw':
 				return array(
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'focuskw',
 					'orderby'  => 'meta_value',

--- a/admin/class-remote-request.php
+++ b/admin/class-remote-request.php
@@ -62,7 +62,7 @@ class WPSEO_Remote_Request {
 			case self::METHOD_GET;
 				$response = $this->get();
 				break;
-			default :
+			default:
 				/* translators: %1$s expands to the request method  */
 				$response = new WP_Error( 1, sprintf( __( 'Request method %1$s is not valid.' , 'wordpress-seo' ), $method ) );
 				break;

--- a/admin/google_search_console/class-gsc-bulk-action.php
+++ b/admin/google_search_console/class-gsc-bulk-action.php
@@ -70,7 +70,7 @@ class WPSEO_GSC_Bulk_Action {
 	 */
 	private function run_bulk_action( $bulk_action, $issues ) {
 		switch ( $bulk_action ) {
-			case 'mark_as_fixed' :
+			case 'mark_as_fixed':
 				array_map( array( $this, 'action_mark_as_fixed' ), $issues );
 
 				break;

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -33,7 +33,7 @@ $gsc_help_center = new WPSEO_Help_Center( 'google-search-console', $tab );
 $gsc_help_center->output_help_center();
 
 switch ( $platform_tabs->current_tab() ) {
-	case 'settings' :
+	case 'settings':
 		// Check if there is an access token.
 		if ( null === $this->service->get_client()->getAccessToken() ) {
 			// Print auth screen.
@@ -93,7 +93,7 @@ switch ( $platform_tabs->current_tab() ) {
 		}
 		break;
 
-	default :
+	default:
 		$form_action_url = add_query_arg( 'page', esc_attr( filter_input( INPUT_GET, 'page' ) ) );
 
 		get_current_screen()->set_screen_reader_content( array(

--- a/admin/links/class-link-column-count.php
+++ b/admin/links/class-link-column-count.php
@@ -17,7 +17,7 @@ class WPSEO_Link_Column_Count {
 	 * @param array $post_ids The posts to get the count for.
 	 */
 	public function set( $post_ids ) {
-		if ( empty( $post_ids )  ) {
+		if ( empty( $post_ids ) ) {
 			return;
 		}
 

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -207,10 +207,10 @@ class WPSEO_Link_Columns {
 	 */
 	public function column_content( $column_name, $post_id ) {
 		switch ( $column_name ) {
-			case 'wpseo-' . self::COLUMN_LINKS :
+			case 'wpseo-' . self::COLUMN_LINKS:
 				echo $this->link_count->get( $post_id, 'internal_link_count' );
 				break;
-			case 'wpseo-' . self::COLUMN_LINKED :
+			case 'wpseo-' . self::COLUMN_LINKED:
 				echo $this->link_count->get( $post_id, 'incoming_link_count' );
 				break;
 		}

--- a/admin/links/class-link-notifier.php
+++ b/admin/links/class-link-notifier.php
@@ -29,7 +29,7 @@ class WPSEO_Link_Notifier {
 	 * Removes the notification when it is set and the amount of unindexed items is lower than the threshold.
 	 */
 	public function cleanup_notification() {
-		if ( ! $this->has_notification() || $this->requires_notification()  ) {
+		if ( ! $this->has_notification() || $this->requires_notification() ) {
 			return;
 		}
 

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -84,14 +84,14 @@ class WPSEO_Taxonomy_Fields_Presenter {
 		}
 
 		switch ( $field_type ) {
-			case 'div' :
+			case 'div':
 				$field .= '<div id="' . $field_name . '"></div>';
 				break;
 
 			case 'snippetpreview':
 				$field .= '<div id="wpseosnippet" class="wpseosnippet"></div>';
 				break;
-			case 'pageanalysis' :
+			case 'pageanalysis':
 				$field .= '<div id="pageanalysis">';
 				$field .= '<section class="yoast-section" id="wpseo-pageanalysis-section">';
 				$field .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-list">' . __( 'Analysis', 'wordpress-seo' ) . '</h3>';
@@ -108,24 +108,24 @@ class WPSEO_Taxonomy_Fields_Presenter {
 				$field .= '</section>';
 				$field .= '</div>';
 				break;
-			case 'text' :
+			case 'text':
 				$field .= '<input name="' . $field_name . '" id="' . $field_name . '" ' . $class . ' type="text" value="' . esc_attr( $field_value ) . '" size="40"' . $aria_describedby . '/>';
 				break;
-			case 'checkbox' :
+			case 'checkbox':
 				$field .= '<input name="' . $field_name . '" id="' . $field_name . '" type="checkbox" ' . checked( $field_value ) . $aria_describedby . '/>';
 				break;
-			case 'textarea' :
+			case 'textarea':
 				$rows = 3;
 				if ( ! empty( $options['rows'] ) ) {
 					$rows = $options['rows'];
 				}
 				$field .= '<textarea class="large-text" rows="' . esc_attr( $rows ) . '" id="' . $field_name . '" name="' . $field_name . '"' . $aria_describedby . '>' . esc_textarea( $field_value ) . '</textarea>';
 				break;
-			case 'upload' :
+			case 'upload':
 				$field .= '<input id="' . $field_name . '" type="text" size="36" name="' . $field_name . '" value="' . esc_attr( $field_value ) . '"' . $aria_describedby . ' />';
 				$field .= '<input id="' . $field_name . '_button" class="wpseo_image_upload_button button" type="button" value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '" />';
 				break;
-			case 'select' :
+			case 'select':
 				if ( is_array( $options ) && $options !== array() ) {
 					$field .= '<select name="' . $field_name . '" id="' . $field_name . '"' . $aria_describedby . '>';
 
@@ -140,7 +140,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 					$field .= '</select>';
 				}
 				break;
-			case 'hidden' :
+			case 'hidden':
 				$field .= '<input name="' . $field_name . '" id="hidden_' . $field_name . '" type="hidden" value="' . esc_attr( $field_value ) . '" />';
 				break;
 		}

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -9,7 +9,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( WPSEO_Utils::is_api_available() && current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE )  ) :
+if ( WPSEO_Utils::is_api_available() && current_user_can( WPSEO_Configuration_Endpoint::CAPABILITY_RETRIEVE ) ) :
 	echo '<h2>' . esc_html__( 'Configuration wizard', 'wordpress-seo' ) . '</h2>';
 	?>
 	<p>

--- a/admin/views/tabs/tool/wpseo-export.php
+++ b/admin/views/tabs/tool/wpseo-export.php
@@ -21,6 +21,6 @@ $submit_button_value = sprintf( __( 'Export your %1$s settings', 'wordpress-seo'
 	method="post"
 	accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php $yform->checkbox( 'include_taxonomy_meta', __( 'Include Taxonomy Metadata', 'wordpress-seo' ) ); ?><br />
-	<?php wp_nonce_field( WPSEO_Export::NONCE_ACTION, WPSEO_Export::NONCE_NAME );  ?>
+	<?php wp_nonce_field( WPSEO_Export::NONCE_ACTION, WPSEO_Export::NONCE_NAME ); ?>
 	<button type="submit" class="button button-primary" id="export-button"><?php echo esc_html( $submit_button_value ); ?></button>
 </form>

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -29,7 +29,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	public function enqueue_assets() {
 		global $pagenow;
 
-		if ( ! in_array( $pagenow, array( 'edit.php' ), true )  ) {
+		if ( ! in_array( $pagenow, array( 'edit.php' ), true ) ) {
 			return;
 		}
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -220,7 +220,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 					break;
 
-				case 'first_activated_on' :
+				case 'first_activated_on':
 					$clean[ $key ] = false;
 					if ( isset( $dirty[ $key ] ) ) {
 						if ( $dirty[ $key ] === false || WPSEO_Utils::validate_int( $dirty[ $key ] ) ) {

--- a/inc/options/class-wpseo-option-xml.php
+++ b/inc/options/class-wpseo-option-xml.php
@@ -143,7 +143,6 @@ class WPSEO_Option_XML extends WPSEO_Option {
 			switch ( $switch_key ) {
 				/* integer fields */
 				case 'entries-per-page':
-
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 
 						$int = WPSEO_Utils::validate_int( $dirty[ $key ] );
@@ -185,7 +184,7 @@ class WPSEO_Option_XML extends WPSEO_Option {
 					}
 					break;
 
-				case 'excluded-posts' :
+				case 'excluded-posts':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 						if ( $filtered_array = filter_var_array( explode( ',', $dirty[ $key ] ), FILTER_VALIDATE_INT ) ) {
 							$clean[ $key ] = implode( ',', array_filter( $filtered_array, 'is_integer' ) );

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -525,7 +525,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 		foreach ( $tax_meta as $taxonomy_name => $terms ) {
 			foreach ( $terms as $term_id => $meta_values ) {
 				$is_current = ( $current_taxonomy === $taxonomy_name && (string) $current_term_id === (string) $term_id );
-				if ( ! $is_current  && ! empty( $meta_values['wpseo_focuskw'] ) && $meta_values['wpseo_focuskw'] === $keyword ) {
+				if ( ! $is_current && ! empty( $meta_values['wpseo_focuskw'] ) && $meta_values['wpseo_focuskw'] === $keyword ) {
 					$found[] = $term_id;
 				}
 			}

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -48,7 +48,7 @@ function wpseo_admin_bar_menu() {
 		}
 	}
 
-	if ( is_category() || is_tag() || (WPSEO_Taxonomy::is_term_edit( $GLOBALS['pagenow'] ) && ! WPSEO_Taxonomy::is_term_overview( $GLOBALS['pagenow'] ) )  || is_tax() ) {
+	if ( is_category() || is_tag() || (WPSEO_Taxonomy::is_term_edit( $GLOBALS['pagenow'] ) && ! WPSEO_Taxonomy::is_term_overview( $GLOBALS['pagenow'] ) ) || is_tax() ) {
 		if ( $analysis_seo->is_enabled() ) {
 			$score = wpseo_tax_adminbar_seo_score();
 		}

--- a/tests/admin/banner/test-class-admin-banner-sidebar-renderer.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar-renderer.php
@@ -5,7 +5,7 @@ class WPSEO_Admin_Banner_Sidebar_Renderer_Test extends WPSEO_UnitTestCase {
 	/** @var  WPSEO_Admin_Banner_Sidebar */
 	protected $sidebar;
 
-	public function setUp(  ) {
+	public function setUp() {
 		parent::setUp();
 		$this->sidebar = new WPSEO_Admin_Banner_Sidebar( 'test_title', new WPSEO_Admin_Banner_Renderer() );
 		$this->sidebar->initialize( new WPSEO_Features() );
@@ -18,7 +18,7 @@ class WPSEO_Admin_Banner_Sidebar_Renderer_Test extends WPSEO_UnitTestCase {
 
 		$sidebar_renderer = new WPSEO_Admin_Banner_Sidebar_Renderer( new WPSEO_Admin_Banner_Spot_Renderer() );
 
-		$output = $sidebar_renderer->render(  $this->sidebar );
+		$output = $sidebar_renderer->render( $this->sidebar );
 
 		$this->stringContains(
 			'<div class="wpseo_content_cell" id="sidebar-container">', $output
@@ -48,7 +48,7 @@ class WPSEO_Admin_Banner_Sidebar_Renderer_Test extends WPSEO_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'render_banner_spots' );
 
-		$mock->render(  $this->sidebar );
+		$mock->render( $this->sidebar );
 	}
 
 

--- a/tests/admin/banner/test-class-admin-banner-sidebar.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar.php
@@ -38,7 +38,7 @@ class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Admin_Banner_Sidebar::__construct
 	 */
-	public function test_constructor( ) {
+	public function test_constructor() {
 		$admin_banner_sidebar = new WPSEO_Admin_Banner_Sidebar( 'test-title', new WPSEO_Admin_Banner_Renderer() );
 
 		$this->assertEquals( 'test-title', $admin_banner_sidebar->get_title() );
@@ -49,7 +49,7 @@ class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Admin_Banner_Sidebar::get_title
 	 */
-	public function test_get_title(  ) {
+	public function test_get_title() {
 		$this->assertEquals( 'test-title', $this->admin_banner_sidebar->get_title() );
 	}
 
@@ -74,7 +74,7 @@ class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Admin_Banner_Sidebar::get_banner_spots
 	 */
-	public function test_get_banner_spots(  ) {
+	public function test_get_banner_spots() {
 		$this->admin_banner_sidebar->initialize( new WPSEO_Features() );
 
 		if ( ! method_exists( $this, 'assertContainsOnlyInstancesOf' ) ) {
@@ -94,7 +94,7 @@ class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Admin_Banner_Sidebar::add_banner_spot()
 	 */
-	public function test_add_banner_spot(  ) {
+	public function test_add_banner_spot() {
 		$mock = $this->getSidebarMock( array( 'add_banner_spot' ) );
 		$mock
 			->expects( $this->any() )

--- a/tests/admin/banner/test-class-admin-banner-spot.php
+++ b/tests/admin/banner/test-class-admin-banner-spot.php
@@ -9,7 +9,7 @@ class WPSEO_Admin_Banner_Renderer_Mock extends WPSEO_Admin_Banner_Renderer {
 	 *
 	 * @return string
 	 */
-	public function render( WPSEO_Admin_Banner $banner  ) {
+	public function render( WPSEO_Admin_Banner $banner ) {
 
 		return sprintf(
 			'url:%s|image:%s|width:%i|height:%i|alt:%s',
@@ -52,7 +52,7 @@ class WPSEO_Admin_Banner_Spot_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Admin_Banner_Spot::set_description
 	 */
-	public function test_set_description(   ) {
+	public function test_set_description() {
 		$admin_banner_spot = new WPSEO_Admin_Banner_Spot( 'title' );
 
 		$admin_banner_spot->set_description( 'description' );

--- a/tests/admin/links/test-class-link-factory.php
+++ b/tests/admin/links/test-class-link-factory.php
@@ -5,7 +5,7 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the processing of an external link.
 	 */
-	public function test_process_external_link(  ) {
+	public function test_process_external_link() {
 		$populator = $this
 			->getMockBuilder( 'WPSEO_Link_Internal_Lookup' )
 			->getMock();
@@ -17,7 +17,7 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 		$processor = new WPSEO_Link_Factory( $this->getClassifierMock( 'external' ), $populator, $this->getFilterMock( 'page', true ) );
 
 		$this->assertEquals(
-			array( new WPSEO_Link( 'test', 0,'external'  ) ),
+			array( new WPSEO_Link( 'test', 0,'external' ) ),
 			$processor->build( array( 'test' ) )
 		);
 	}
@@ -51,7 +51,7 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 				$this->getLookUpMock( 2 ),
 				$this->getFilterMock( 'currentpage', true ),
 				'test',
-				array( new WPSEO_Link( 'test',  2,'internal'  )  )
+				array( new WPSEO_Link( 'test',  2,'internal' ) )
 			),
 			array(
 				$this->getClassifierMock( 'internal' ),

--- a/tests/admin/links/test-class-link-internal-lookup.php
+++ b/tests/admin/links/test-class-link-internal-lookup.php
@@ -24,7 +24,7 @@ class WPSEO_Link_Internal_Lookup_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals(
 			$post->ID,
-			$lookup->lookup( '?p='. $post->ID )
+			$lookup->lookup( '?p=' . $post->ID )
 		);
 	}
 

--- a/tests/admin/test-class-plugin-compatibility.php
+++ b/tests/admin/test-class-plugin-compatibility.php
@@ -33,7 +33,7 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 			'test-plugin' => array(
 				'url' => "https://yoast.com/",
 				'title' => "Test Plugin",
-				'description' =>  "",
+				'description' => "",
 				'version' => "3.3",
 				'installed' => true,
 				'compatible' => true
@@ -41,7 +41,7 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 			'test-plugin-dependency' => array(
 				'url' => "https://yoast.com/",
 				'title' => "Test Plugin With Dependency",
-				'description' =>  "",
+				'description' => "",
 				'version' => "3.3",
 				'installed' => true,
 				'_dependencies' => array( 'test-plugin' ),
@@ -50,7 +50,7 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 			'test-plugin-invalid-version' => array(
 				'url' => "https://yoast.com/",
 				'title' => "Test Plugin",
-				'description' =>  "",
+				'description' => "",
 				'version' => "1.3",
 				'installed' => true,
 				'compatible' => false
@@ -66,19 +66,19 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( $class_instance->is_compatible( 'test-plugin' ) );
 	}
 
-	public function test_get_installed_plugins(  ) {
+	public function test_get_installed_plugins() {
 		$expected = array(
 			'test-plugin' => array(
 				'url' => "https://yoast.com/",
 				'title' => "Test Plugin",
-				'description' =>  "",
+				'description' => "",
 				'version' => "3.3",
 				'installed' => true
 			),
 			'test-plugin-dependency' => array(
 				'url' => "https://yoast.com/",
 				'title' => "Test Plugin With Dependency",
-				'description' =>  "",
+				'description' => "",
 				'version' => "3.3",
 				'installed' => true,
 				'_dependencies' => array( 'test-plugin' )
@@ -86,7 +86,7 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 			'test-plugin-invalid-version' => array(
 				'url' => "https://yoast.com/",
 				'title' => "Test Plugin",
-				'description' =>  "",
+				'description' => "",
 				'version' => "1.3",
 				'installed' => true
 			)

--- a/tests/admin/test-class-wpseo-plugin-availability-double.php
+++ b/tests/admin/test-class-wpseo-plugin-availability-double.php
@@ -60,9 +60,9 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 	}
 
 	protected function register_yoast_plugins_status() {
-		$this->plugins[ 'test-plugin' ]['installed'] = true;
-		$this->plugins[ 'test-plugin-dependency' ]['installed'] = true;
-		$this->plugins[ 'test-plugin-invalid-version' ]['installed'] = true;
+		$this->plugins['test-plugin']['installed'] = true;
+		$this->plugins['test-plugin-dependency']['installed'] = true;
+		$this->plugins['test-plugin-invalid-version']['installed'] = true;
 	}
 
 	public function is_dependency_available( $dependency ) {

--- a/tests/admin/test-class-yoast-input-select.php
+++ b/tests/admin/test-class-yoast-input-select.php
@@ -118,7 +118,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_html_with_adding_attribute() {
 		$select = new Yoast_Input_Select( 'test-id', 'test-field', array( 'foo' => '' ), false );
-		$select->add_attribute( 'class', 'test');
+		$select->add_attribute( 'class', 'test' );
 		$html   = $select->get_html();
 
 		$this->assertContains( '<select class="test" name="test-field" id="test-id">', $html );

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -41,8 +41,8 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	public function test_register_overwrite() {
 		$instance = new WPSEO_Capability_Manager_Test();
 
-		$instance->register( 'capability', array(  'role1' ) );
-		$instance->register( 'capability', array(  'role2' ), true );
+		$instance->register( 'capability', array( 'role1' ) );
+		$instance->register( 'capability', array( 'role2' ), true );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
 

--- a/tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/tests/config-ui/components/test-class-component-connect-gsc.php
@@ -128,7 +128,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 			'hasAccessToken' => false
 		);
 
-		$this->component->set_profile('c');
+		$this->component->set_profile( 'c' );
 
 		$result = $this->component->get_data();
 

--- a/tests/config-ui/fields/test-class-config-field.php
+++ b/tests/config-ui/fields/test-class-config-field.php
@@ -129,6 +129,6 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 
 		$this->assertArrayHasKey( 'properties', $result );
 		$this->assertArrayHasKey( $property, $result['properties'] );
-		$this->assertEquals( $property_value, $result['properties'][$property] );
+		$this->assertEquals( $property_value, $result['properties'][ $property ] );
 	}
 }

--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -12,7 +12,7 @@ class WPSEO_Configuration_Endpoint_Mock extends WPSEO_Configuration_Endpoint {
 	}
 }
 
-if ( class_exists( 'WP_REST_Server' ) ):
+if ( class_exists( 'WP_REST_Server' ) ) :
 	/**
 	 * Class WPSEO_WP_REST_Server_Mock
 	 */

--- a/tests/frontend/test-class-primary-category.php
+++ b/tests/frontend/test-class-primary-category.php
@@ -27,11 +27,11 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_link_category_primary_term_IS_NOT_category_id() {
 		$this->subject
-			->expects ( $this->once() )
+			->expects( $this->once() )
 			->method( 'get_primary_category' )
-			->will ( $this->returnValue( '54' ) );
+			->will( $this->returnValue( '54' ) );
 
-		$expect = ( object ) array(
+		$expect = (object) array(
 			'term_id' => 54
 		);
 
@@ -40,7 +40,7 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 			->method( 'get_category' )
 			->will( $this->returnValue( $expect ) );
 
-		$category = ( object ) array(
+		$category = (object) array(
 			'cat_ID' => 52,
 		);
 
@@ -54,15 +54,15 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_link_category_primary_term_IS_category_id() {
 		$this->subject
-			->expects ( $this->once() )
+			->expects( $this->once() )
 			->method( 'get_primary_category' )
-			->will ( $this->returnValue( 1 ) );
+			->will( $this->returnValue( 1 ) );
 
 		$this->subject
 			->expects( $this->never() )
 			->method( 'get_category' );
 
-		$category = ( object ) array(
+		$category = (object) array(
 			'term_id' => 1,
 			'name' => 'test',
 			'term_taxonomy_id' => 1,
@@ -79,15 +79,15 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_link_category_primary_term_IS_false() {
 		$this->subject
-			->expects ( $this->once() )
+			->expects( $this->once() )
 			->method( 'get_primary_category' )
-			->will ( $this->returnValue( false ) );
+			->will( $this->returnValue( false ) );
 
 		$this->subject
 			->expects( $this->never() )
 			->method( 'get_category' );
 
-		$category = ( object ) array(
+		$category = (object) array(
 			'term_id' => 1,
 			'name' => 'test',
 			'term_taxonomy_id' => 1,
@@ -105,7 +105,7 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_link_category_primary_term_with_post() {
 		$post     = $this->factory->post->create_and_get();
-		$category = ( object ) array(
+		$category = (object) array(
 			'term_id'          => 1,
 			'name'             => 'test',
 			'term_taxonomy_id' => 1,
@@ -113,9 +113,9 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 		);
 
 		$this->subject
-			->expects ( $this->once() )
+			->expects( $this->once() )
 			->method( 'get_primary_category' )
-			->will ( $this->returnValue( 1 ) );
+			->will( $this->returnValue( 1 ) );
 
 		$this->assertEquals( $category, $this->subject->post_link_category( $category, null, $post ) );
 	}
@@ -127,7 +127,7 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_link_category_primary_term_with_invalid_post_ID() {
 		$post     = 99;
-		$category = ( object ) array(
+		$category = (object) array(
 			'term_id'          => 1,
 			'name'             => 'test',
 			'term_taxonomy_id' => 1,
@@ -135,9 +135,9 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 		);
 
 		$this->subject
-			->expects ( $this->once() )
+			->expects( $this->once() )
 			->method( 'get_primary_category' )
-			->will ( $this->returnValue( false ) );
+			->will( $this->returnValue( false ) );
 
 		$this->subject
 			->expects( $this->never() )

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -26,7 +26,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_options
 	 */
 	public function test_get_options_IS_EMPTY_with_empty_array() {
-		$result = WPSEO_Options::get_options(array());
+		$result = WPSEO_Options::get_options( array() );
 		$this->assertEmpty( $result );
 	}
 
@@ -36,7 +36,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_options
 	 */
 	public function test_get_options_IS_EMPTY_with_invalid_option_names() {
-		$result = WPSEO_Options::get_options( array('nonexistent_option_one', 'nonexistent_option_two') );
+		$result = WPSEO_Options::get_options( array( 'nonexistent_option_one', 'nonexistent_option_two' ) );
 		$this->assertEmpty( $result );
 	}
 
@@ -88,7 +88,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_option
 	 */
 	public function test_get_option_IS_VALID_with_valid_option_name() {
-		$result = WPSEO_Options::get_option( 'wpseo'  );
+		$result = WPSEO_Options::get_option( 'wpseo' );
 		$this->assertArrayHasKey( 'website_name', $result );
 	}
 }

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -9,7 +9,7 @@ class WPSEO_Primary_Term_Double extends WPSEO_Primary_Term {
 	 */
 	protected function get_terms() {
 		return array(
-			( object ) array(
+			(object) array(
 				'term_id' => 54,
 			)
 		);

--- a/tests/onpage/test-class-onpage-option.php
+++ b/tests/onpage/test-class-onpage-option.php
@@ -54,7 +54,7 @@ class WPSEO_OnPage_Option_Test extends WPSEO_UnitTestCase {
 	 * WPSEO_OnPage_Option::can_fetch
 	 */
 	public function test_cannot_fetch() {
-		$this->class_instance->set_last_fetch( strtotime("-5 seconds") );
+		$this->class_instance->set_last_fetch( strtotime( "-5 seconds" ) );
 		$this->assertFalse( $this->class_instance->should_be_fetched() );
 	}
 
@@ -64,7 +64,7 @@ class WPSEO_OnPage_Option_Test extends WPSEO_UnitTestCase {
 	 * WPSEO_OnPage_Option::can_fetch
 	 */
 	public function test_cannot_fetch_two_hours_ago() {
-		$this->class_instance->set_last_fetch( strtotime("-2 hours") );
+		$this->class_instance->set_last_fetch( strtotime( "-2 hours" ) );
 		$this->assertTrue( $this->class_instance->should_be_fetched() );
 	}
 }

--- a/tests/onpage/test-class-onpage-request.php
+++ b/tests/onpage/test-class-onpage-request.php
@@ -20,22 +20,22 @@ class WPSEO_OnPage_Request_Double extends WPSEO_OnPage_Request {
 		);
 
 		switch ( $target_url ) {
-			case home_url() :
+			case home_url():
 				$remote_data['is_indexable'] = '1';
 				break;
 
-			case 'http:://will-be-redirected.wp' :
+			case 'http:://will-be-redirected.wp':
 				$remote_data = array(
 					'is_indexable'    => '0',
 					'passes_juice_to' => 'http://is-redirected.wp',
 				);
 				break;
 
-			case 'http://is-redirected.wp' :
+			case 'http://is-redirected.wp':
 				$remote_data['is_indexable'] = '1';
 				break;
 
-			case 'http://not_indexable.wp' :
+			case 'http://not_indexable.wp':
 				// Do noting.
 				break;
 		}

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -64,7 +64,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Recalculate_Posts::get_items_to_recalculate
 	 */
 	public function test_get_items_to_recalculate_no_focus_keywords() {
-		$response = $this->instance->get_items_to_recalculate(1);
+		$response = $this->instance->get_items_to_recalculate( 1 );
 
 		$this->assertEquals( array( 'items' => array(), 'total_items' => 0 ), $response );
 	}
@@ -79,7 +79,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
 		WPSEO_Meta::set_value( 'focuskw', 'testable', $this->posts[3] );
 
-		$response = $this->instance->get_items_to_recalculate(1);
+		$response = $this->instance->get_items_to_recalculate( 1 );
 
 		$this->assertEquals( 2, $response['total_items'] );
 		$this->assertTrue( is_array( $response['items'] ) );
@@ -94,12 +94,12 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_add_content() {
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
 
-		$post = get_post($this->posts[1]);
+		$post = get_post( $this->posts[1] );
 		$expected = $this->add_dummy_content( $post->post_content );
 
 		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content' ), 10, 2 );
 
-		$response = $this->instance->get_items_to_recalculate(1);
+		$response = $this->instance->get_items_to_recalculate( 1 );
 
 		remove_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content' ) );
 
@@ -114,12 +114,12 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_add_content_with_shortcode() {
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
 
-		$post = get_post($this->posts[1]);
+		$post = get_post( $this->posts[1] );
 		$expected = do_shortcode( $this->add_dummy_content_with_shortcode( $post->post_content ) );
 
 		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content_with_shortcode' ), 10, 2 );
 
-		$response = $this->instance->get_items_to_recalculate(1);
+		$response = $this->instance->get_items_to_recalculate( 1 );
 
 		remove_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content_with_shortcode' ) );
 
@@ -132,19 +132,19 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_add_featured_image_to_content() {
 		$test_double = new WPSEO_Recalculate_Posts_Test_Double();
 
-		add_filter( "get_post_metadata", array( $this, 'mock_post_metadata' ), 10, 3);
-		add_filter( "post_thumbnail_html", array( $this, 'mock_thumbnail' ), 10, 3);
+		add_filter( "get_post_metadata", array( $this, 'mock_post_metadata' ), 10, 3 );
+		add_filter( "post_thumbnail_html", array( $this, 'mock_thumbnail' ), 10, 3 );
 
-		$post = get_post($this->posts[1]);
+		$post = get_post( $this->posts[1] );
 		$expected = $post->post_content . " <img src='' />";
 		$response = $test_double->call_item_to_response( $post );
 
 		$this->assertEquals( $expected, $response['text'] );
 
-		remove_filter( "get_post_metadata", array( $this, 'mock_post_metadata' ), 10, 3);
-		remove_filter( "post_thumbnail_html", array( $this, 'mock_thumbnail' ), 10, 3);
+		remove_filter( "get_post_metadata", array( $this, 'mock_post_metadata' ), 10, 3 );
+		remove_filter( "post_thumbnail_html", array( $this, 'mock_thumbnail' ), 10, 3 );
 
-		$post = get_post($this->posts[2]);
+		$post = get_post( $this->posts[2] );
 		$expected = $post->post_content;
 		$response = $test_double->call_item_to_response( $post );
 

--- a/tests/recalculate/test-class-recalculate-terms.php
+++ b/tests/recalculate/test-class-recalculate-terms.php
@@ -56,7 +56,7 @@ class WPSEO_Recalculate_Terms_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Recalculate_Posts::get_items_to_recalculate
 	 */
 	public function test_get_items_to_recalculate() {
-		$response = $this->instance->get_items_to_recalculate(1);
+		$response = $this->instance->get_items_to_recalculate( 1 );
 
 		$this->assertEquals( 4, $response['total_items'] );
 		$this->assertTrue( is_array( $response['items'] ) );

--- a/tests/taxonomy/test-class-taxonomy-content-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-content-fields.php
@@ -11,7 +11,7 @@ class WPSEO_Taxonomy_Content_Fields_Double extends WPSEO_Taxonomy_Content_Fields
 	 * @param string $option_name  The target key which will be overwritten
 	 * @param string $option_value The new value for the option.
 	 */
-	public function set_option($option_name, $option_value) {
+	public function set_option( $option_name, $option_value ) {
 		$this->options[ $option_name ] = $option_value;
 
 	}
@@ -23,7 +23,7 @@ class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @var WPSEO_Taxonomy_Social_Fields_Double
 	 */
-	private  $class_instance;
+	private $class_instance;
 
 	/**
 	 * @var stdClass The created term.

--- a/tests/taxonomy/test-class-taxonomy-presenter.php
+++ b/tests/taxonomy/test-class-taxonomy-presenter.php
@@ -9,7 +9,7 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @var WPSEO_Taxonomy_Fields_Presenter
 	 */
-	private  $class_instance;
+	private $class_instance;
 
 	/**
 	 * @var stdClass The created term.

--- a/tests/taxonomy/test-class-taxonomy-settings-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-settings-fields.php
@@ -11,7 +11,7 @@ class WPSEO_Taxonomy_Settings_Fields_Double extends WPSEO_Taxonomy_Settings_Fiel
 	 * @param string $option_name  The target key which will be overwritten
 	 * @param string $option_value The new value for the option.
 	 */
-	public function set_option($option_name, $option_value) {
+	public function set_option( $option_name, $option_value ) {
 		$this->options[ $option_name ] = $option_value;
 
 	}
@@ -23,7 +23,7 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @var WPSEO_Taxonomy_Settings_Fields_Double
 	 */
-	private  $class_instance;
+	private $class_instance;
 
 	/**
 	 * @var stdClass The created term.

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -451,7 +451,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 			->getMock();
 
 		$stub
-			->expects( $this->exactly(2) )
+			->expects( $this->exactly( 2 ) )
 			->method( 'og_tag' )
 			->with( $this->logicalOr( 'og:image', 'og:image:secure_url' ) );
 
@@ -751,7 +751,7 @@ EXPECTED;
 
 		$output = ob_get_clean();
 
-		$this->assertContains( '<meta property="og:image" content="'.home_url( 'custom_twitter_image.png' ). '" />', $output );
+		$this->assertContains( '<meta property="og:image" content="' . home_url( 'custom_twitter_image.png' ) . '" />', $output );
 	}
 
 

--- a/tests/test-class-primary-term-admin.php
+++ b/tests/test-class-primary-term-admin.php
@@ -23,7 +23,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 		$this->class_instance
 			->expects( $this->once() )
 			->method( 'get_primary_term_taxonomies' )
-			->will( $this->returnValue( array() ));
+			->will( $this->returnValue( array() ) );
 
 		$this->class_instance
 			->expects( $this->never() )
@@ -39,7 +39,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_wp_footer_INCLUDE_WITH_taxonomies() {
 		$taxonomies = array(
-			'category' => ( object ) array()
+			'category' => (object) array()
 		);
 
 		$this->class_instance
@@ -99,8 +99,8 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 		$pagenow = 'post-new.php';
 
 		$taxonomies = array(
-			'category' => ( object ) array(
-				'labels' => ( object ) array(
+			'category' => (object) array(
+				'labels' => (object) array(
 					'singular_name' => 'Category',
 				),
 				'name' => 'category',
@@ -125,8 +125,8 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_save_primary_terms_CALLS_save_primary_term() {
 		$taxonomies = array(
-			'category' => ( object ) array(
-				'labels' => ( object ) array(
+			'category' => (object) array(
+				'labels' => (object) array(
 					'name' => 'Categories',
 					'singular_name' => 'Category',
 					'search_items' => 'Search Categories',
@@ -160,7 +160,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 				),
 				'query_var' => 'category_name',
 				'_builtin' => true,
-				'cap' => ( object ) array(
+				'cap' => (object) array(
 					'manage_terms' => 'manage_categories',
 					'edit_terms' => 'manage_categories',
 					'delete_terms' => 'manage_categories',

--- a/tests/test-class-wpseo-frontend-robots.php
+++ b/tests/test-class-wpseo-frontend-robots.php
@@ -57,7 +57,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( '', self::$class_instance->robots() );
 	}
 
-	public function _test_robots_on_private_blog(  ) {
+	public function _test_robots_on_private_blog() {
 		// go to home
 		$this->go_to_home();
 
@@ -70,7 +70,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 	}
 
 
-	public function _test_with_replytocom_attribute(  ) {
+	public function _test_with_replytocom_attribute() {
 		// go to home
 		$this->go_to_home();
 
@@ -95,7 +95,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		set_query_var( 'paged', 0 );
 	}
 
-	public function test_subpages_robots_noindex(  ) {
+	public function test_subpages_robots_noindex() {
 		// go to home
 		$this->go_to_home();
 
@@ -124,7 +124,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 
 
 
-	public function test_post_noindex(  ) {
+	public function test_post_noindex() {
 		// create and go to post
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
@@ -166,7 +166,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 	}
 
-	public function test_category_noindex(  ) {
+	public function test_category_noindex() {
 		// go to category page
 		$category_id = wp_create_category( 'Category Name' );
 		flush_rewrite_rules();
@@ -186,7 +186,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		self::$class_instance->options['noindex-tax-category'] = false;
 	}
 
-	public function test_subpages_category_archives(  ) {
+	public function test_subpages_category_archives() {
 
 		// go to category page
 		$category_id = wp_create_category( 'Category Name' );
@@ -222,7 +222,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 
 	}
 
-	public function test_author_archive_noindex(  ) {
+	public function test_author_archive_noindex() {
 
 		// go to author page
 		$user_id = $this->factory->user->create();

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -321,7 +321,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta_Columns::is_valid_filter()
 	 */
 	public function test_is_valid_filter() {
-		$this->assertTrue(self::$class_instance->is_valid_filter( "needs improvement" ) );
+		$this->assertTrue( self::$class_instance->is_valid_filter( "needs improvement" ) );
 	}
 
 	/**

--- a/tests/test-class-wpseo-rank.php
+++ b/tests/test-class-wpseo-rank.php
@@ -80,9 +80,9 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	public function provider_get_drop_down_label() {
 		return array(
 			array( WPSEO_Rank::NO_FOCUS, 'SEO: No Focus Keyword' ),
-			array( WPSEO_Rank::BAD     , 'SEO: Needs improvement' ),
-			array( WPSEO_Rank::OK      , 'SEO: OK' ),
-			array( WPSEO_Rank::GOOD    , 'SEO: Good' ),
+			array( WPSEO_Rank::BAD, 'SEO: Needs improvement' ),
+			array( WPSEO_Rank::OK, 'SEO: OK' ),
+			array( WPSEO_Rank::GOOD, 'SEO: Good' ),
 			array( WPSEO_Rank::NO_INDEX, 'SEO: Post Noindexed' ),
 		);
 	}
@@ -104,9 +104,9 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 		return array(
 			array( WPSEO_Rank::NO_INDEX, -1 ),
 			array( WPSEO_Rank::NO_FOCUS, 0 ),
-			array( WPSEO_Rank::BAD     , 1 ),
-			array( WPSEO_Rank::OK      , 41 ),
-			array( WPSEO_Rank::GOOD    , 71 ),
+			array( WPSEO_Rank::BAD, 1 ),
+			array( WPSEO_Rank::OK, 41 ),
+			array( WPSEO_Rank::GOOD, 71 ),
 		);
 	}
 
@@ -127,9 +127,9 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 		return array(
 			array( WPSEO_Rank::NO_INDEX, -1 ),
 			array( WPSEO_Rank::NO_FOCUS, 0 ),
-			array( WPSEO_Rank::BAD     , 40 ),
-			array( WPSEO_Rank::OK      , 70 ),
-			array( WPSEO_Rank::GOOD    , 100 ),
+			array( WPSEO_Rank::BAD, 40 ),
+			array( WPSEO_Rank::OK, 70 ),
+			array( WPSEO_Rank::GOOD, 100 ),
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.

There are a number of rules regarding whitespace and some may be counter-intuitive as they are applied differently in different situations.

* For function calls and declarations: no space between the function name and the open parenthesis, one space on the inside of the open/close parenthesis - unless there are no parameters, in that case: no spaces on the inside -.
* One space on either side of all operators (logical, assignment, concatenation etc). New line allowed.
* No space on the inside of the parenthesis for type casts like `(int)`.
* No space between the condition and the colon for `case` statements.
* One space between the condition and the colon when using the alternative control structure syntax.
* No space on the inside of array brackets for scalar keys - like `$array['key']`.
* One space on the inside of array both brackets for variable or compound keys - like `$array[ $key ]` or `$array[ 'key' . $part . 'key' ]`.

Fixes (partial) compliance with the following sniffs:
* `WordPress.WhiteSpace.ControlStructureSpacing`
* `PSR2.ControlStructures.SwitchDeclaration` - introduced in WPCS 0.12.0
* `Squiz.Controlstructures.ControlSignature`
* `Squiz.ControlStructures.ForEachLoopDeclaration`
* `Squiz.Functions.FunctionDeclarationArgumentSpacing`
* `PEAR.Functions.FunctionCallSignature`
* `Squiz.WhiteSpace.CastSpacing` - introduced in WPCS 0.11.0
* `WordPress.WhiteSpace.OperatorSpacing`
* `Squiz.Strings.ConcatenationSpacing` - introduced in WPCS 0.10.0
* `Squiz.WhiteSpace.ScopeKeywordSpacing` - introduced in WPCS 0.14.0
* `WordPress.Arrays.ArrayKeySpacingRestrictions`
* `WordPress.Arrays.ArrayDeclarationSpacing`

## Test instructions

_N/A_