### PR TITLE
Documentation: use PSR-5 compliant styling for @internal tags

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -771,7 +771,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	/**
 	 * Save the WP SEO metadata for posts.
 	 *
-	 * @internal $_POST parameters are validated via sanitize_post_meta()
+	 * {@internal $_POST parameters are validated via sanitize_post_meta().}}
 	 *
 	 * @param int $post_id Post ID.
 	 *

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -94,7 +94,7 @@ echo '<h2>', __( 'MultiSite Settings', 'wordpress-seo' ), '</h2>';
 echo '<form method="post" accept-charset="', esc_attr( get_bloginfo( 'charset' ) ), '">';
 wp_nonce_field( 'wpseo-network-settings', '_wpnonce', true, true );
 
-/* @internal Important: Make sure the options added to the array here are in line with the options set in the WPSEO_Option_MS::$allowed_access_options property */
+/* {@internal Important: Make sure the options added to the array here are in line with the options set in the WPSEO_Option_MS::$allowed_access_options property.}} */
 $yform->select(
 	'access',
 	/* translators: %1$s expands to Yoast SEO */

--- a/admin/taxonomy/class-taxonomy-settings-fields.php
+++ b/admin/taxonomy/class-taxonomy-settings-fields.php
@@ -71,8 +71,8 @@ class WPSEO_Taxonomy_Settings_Fields extends WPSEO_Taxonomy_Fields {
 	/**
 	 * Translate options text strings for use in the select fields
 	 *
-	 * @internal IMPORTANT: if you want to add a new string (option) somewhere, make sure you add
-	 * that array key to the main options definition array in the class WPSEO_Taxonomy_Meta() as well!!!!
+	 * {@internal IMPORTANT: if you want to add a new string (option) somewhere, make sure you add
+	 * that array key to the main options definition array in the class WPSEO_Taxonomy_Meta() as well!!!!}}
 	 */
 	private function translate_meta_options() {
 		$this->no_index_options        = WPSEO_Taxonomy_Meta::$no_index_options;

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -385,8 +385,8 @@ class WPSEO_Taxonomy {
 	 *
 	 * Translate options text strings for use in the select fields
 	 *
-	 * @internal IMPORTANT: if you want to add a new string (option) somewhere, make sure you add
-	 * that array key to the main options definition array in the class WPSEO_Taxonomy_Meta() as well!!!!
+	 * {@internal IMPORTANT: if you want to add a new string (option) somewhere, make sure you add
+	 * that array key to the main options definition array in the class WPSEO_Taxonomy_Meta() as well!!!!}}
 	 */
 	public function translate_meta_options() {
 		_deprecated_function( __METHOD__, 'WPSEO 3.2', 'WPSEO_Taxonomy_Settings_Fields::translate_meta_options' );

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -18,12 +18,13 @@
  *        This method can also retrieve a complete set of WPSEO meta values for one specific post, see
  *        the method documentation for the parameters.
  *
- * @internal   Unfortunately there isn't a filter available to hook into before returning the results
- * for get_post_meta(), get_post_custom() and the likes. That would have been the preferred solution.
+ * {@internal Unfortunately there isn't a filter available to hook into before returning the results
+ *            for get_post_meta(), get_post_custom() and the likes. That would have been the
+ *            preferred solution.}}
  *
- * @internal   all WP native get_meta() results get cached internally, so no need to cache locally.
- * @internal   use $key when the key is the WPSEO internal name (without prefix), $meta_key when it
- *             includes the prefix
+ * {@internal All WP native get_meta() results get cached internally, so no need to cache locally.}}
+ * {@internal Use $key when the key is the WPSEO internal name (without prefix), $meta_key when it
+ *            includes the prefix.}}
  */
 class WPSEO_Meta {
 
@@ -31,8 +32,8 @@ class WPSEO_Meta {
 	 * @var    string    Prefix for all WPSEO meta values in the database
 	 * @static
 	 *
-	 * @internal if at any point this would change, quite apart from an upgrade routine, this also will need to
-	 * be changed in the wpml-config.xml file.
+	 * {@internal If at any point this would change, quite apart from an upgrade routine,
+	 *            this also will need to be changed in the wpml-config.xml file.}}
 	 */
 	public static $meta_prefix = '_yoast_wpseo_';
 
@@ -92,10 +93,10 @@ class WPSEO_Meta {
 	 *
 	 * @static
 	 *
-	 * @internal
+	 * {@internal
 	 * - Titles, help texts, description text and option labels are added via a translate_meta_boxes() method
 	 *     in the relevant child classes (WPSEO_Metabox and WPSEO_Social_admin) as they are only needed there.
-	 * - Beware: even though the meta keys are divided into subsets, they still have to be uniquely named!
+	 * - Beware: even though the meta keys are divided into subsets, they still have to be uniquely named!}}
 	 */
 	public static $meta_fields = array(
 		'general'  => array(
@@ -658,8 +659,9 @@ class WPSEO_Meta {
 	 * Get a custom post meta value
 	 * Returns the default value if the meta value has not been set
 	 *
-	 * @internal Unfortunately there isn't a filter available to hook into before returning the results
-	 * for get_post_meta(), get_post_custom() and the likes. That would have been the preferred solution.
+	 * {@internal Unfortunately there isn't a filter available to hook into before returning
+	 *            the results for get_post_meta(), get_post_custom() and the likes. That
+	 *            would have been the preferred solution.}}
 	 *
 	 * @static
 	 *
@@ -765,7 +767,8 @@ class WPSEO_Meta {
 		/*
 		 * Get only those rows where no wpseo meta values exist for the same post
 		 * (with the exception of linkdex as that will be set independently of whether the post has been edited).
-		 * @internal Query is pretty well optimized this way.
+		 *
+		 * {@internal Query is pretty well optimized this way.}}
 		 */
 		$query  = $wpdb->prepare(
 			"
@@ -816,7 +819,7 @@ class WPSEO_Meta {
 		 *
 		 * Retrieve all '_yoast_wpseo_meta-robots' meta values and convert if no new values found
 		 *
-		 * @internal Query is pretty well optimized this way
+		 * {@internal Query is pretty well optimized this way.}}
 		 *
 		 * @todo [JRF => Yoast] find out all possible values which the old '_yoast_wpseo_meta-robots' could contain
 		 * to convert the data correctly
@@ -864,14 +867,15 @@ class WPSEO_Meta {
 		 * Remove all default values and (most) invalid option values
 		 * Invalid option values for the multiselect (meta-robots-adv) field will be dealt with seperately
 		 *
-		 * @internal some of the defaults have changed in v1.5, but as the defaults will be removed and
-		 * new defaults will now automatically be passed when no data found, this update is automatic
-		 * (as long as we remove the old values which we do in the below routine)
+		 * {@internal Some of the defaults have changed in v1.5, but as the defaults will
+		 *            be removed and new defaults will now automatically be passed when no
+		 *            data found, this update is automatic (as long as we remove the old
+		 *            values which we do in the below routine).}}
 		 *
-		 * @internal unfortunately we can't use the normal delete_meta() with key/value combination as ''
-		 * (empty string) values will be ignored and would result in all metas with that key being deleted,
-		 * not just the empty fields.
-		 * Still, the below implementation is largely based on the delete_meta() function
+		 * {@internal Unfortunately we can't use the normal delete_meta() with key/value combination
+		 *            as '' (empty string) values will be ignored and would result in all metas
+		 *            with that key being deleted, not just the empty fields.
+		 *            Still, the below implementation is largely based on the delete_meta() function.}}
 		 */
 		$query = array();
 
@@ -986,7 +990,7 @@ class WPSEO_Meta {
 	 *
 	 * Freely based on information found on http://www.php.net/manual/en/function.array-merge-recursive.php
 	 *
-	 * @internal Should be moved to a general utility class
+	 * {@internal Should be moved to a general utility class.}}
 	 *
 	 * @return array
 	 */

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -51,7 +51,7 @@ class WPSEO_Utils {
 	/**
 	 * Check whether file editing is allowed for the .htaccess and robots.txt files
 	 *
-	 * @internal current_user_can() checks internally whether a user is on wp-ms and adjusts accordingly.
+	 * {@internal current_user_can() checks internally whether a user is on wp-ms and adjusts accordingly.}}
 	 *
 	 * @static
 	 *

--- a/inc/options/class-wpseo-option-internallinks.php
+++ b/inc/options/class-wpseo-option-internallinks.php
@@ -16,7 +16,8 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 	/**
 	 * @var  array  Array of defaults for the option
 	 *        Shouldn't be requested directly, use $this->get_defaults();
-	 * @internal  Note: Some of the default values are added via the translate_defaults() method
+	 *
+	 * {@internal Note: Some of the default values are added via the translate_defaults() method.}}
 	 */
 	protected $defaults = array(
 		'breadcrumbs-404crumb'      => '', // Text field.
@@ -238,7 +239,7 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 	 * Retrieve a list of the allowed post types as breadcrumb parent for a taxonomy
 	 * Helper method for validation
 	 *
-	 * @internal don't make static as new types may still be registered
+	 * {@internal Don't make static as new types may still be registered.}}
 	 *
 	 * @return array
 	 */

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -46,8 +46,9 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	 *
 	 * @static
 	 *
-	 * @internal Important: Make sure the options added to the array here are in line with the keys
-	 * for the options set for the select box in the admin/pages/network.php file
+	 * {@internal Important: Make sure the options added to the array here are in line
+	 *            with the keys for the options set for the select box in the
+	 *            admin/pages/network.php file.}}
 	 */
 	public static $allowed_access_options = array(
 		'admin',

--- a/inc/options/class-wpseo-option-permalinks.php
+++ b/inc/options/class-wpseo-option-permalinks.php
@@ -4,8 +4,8 @@
  */
 
 /**
- * @internal Clean routine for 1.5 not needed as values used to be saved as string 'on' and those will convert
- * automatically
+ * {@internal Clean routine for 1.5 not needed as values used to be saved as string 'on'
+ *            and those will convert automatically.}}
  */
 class WPSEO_Option_Permalinks extends WPSEO_Option {
 

--- a/inc/options/class-wpseo-option-rss.php
+++ b/inc/options/class-wpseo-option-rss.php
@@ -16,7 +16,8 @@ class WPSEO_Option_RSS extends WPSEO_Option {
 	/**
 	 * @var  array  Array of defaults for the option
 	 *        Shouldn't be requested directly, use $this->get_defaults();
-	 * @internal  Note: Some of the default values are added via the translate_defaults() method
+	 *
+	 * {@internal Note: Some of the default values are added via the translate_defaults() method.}}
 	 */
 	protected $defaults = array(
 		'rssbefore' => '', // Text area.

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -62,8 +62,8 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 *              While we only have the options summary and summary_large_image in the
 	 *              interface now, we might change that at some point.
 	 *
-	 * @internal Uncomment any of these to allow them in validation *and* automatically add them as a choice
-	 * in the options page
+	 * {@internal Uncomment any of these to allow them in validation *and* automatically
+	 *            add them as a choice in the options page.}}
 	 */
 	public static $twitter_card_types = array(
 		'summary'             => '',

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -16,7 +16,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	/**
 	 * @var  array  Array of defaults for the option
 	 *        Shouldn't be requested directly, use $this->get_defaults();
-	 * @internal  Note: Some of the default values are added via the translate_defaults() method
+	 *
+	 * {@internal Note: Some of the default values are added via the translate_defaults() method.}}
 	 */
 	protected $defaults = array(
 		// Non-form fields, set via (ajax) function.
@@ -393,8 +394,10 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 		/*
 		 * Move options from very old option to this one.
-		 * @internal Don't rename to the 'current' names straight away as that would prevent
-		 * the rename/unset combi below from working.
+		 *
+		 * {@internal Don't rename to the 'current' names straight away as that would prevent
+		 *            the rename/unset combi below from working.}}
+		 *
 		 * @todo [JRF] maybe figure out a smarter way to deal with this.
 		 */
 		$old_option = null;
@@ -466,8 +469,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 
 		/**
-		 * @internal This clean-up action can only be done effectively once the taxonomies and post_types
-		 * have been registered, i.e. at the end of the init action.
+		 * {@internal This clean-up action can only be done effectively once the taxonomies
+		 *            and post_types have been registered, i.e. at the end of the init action.}}
 		 */
 		if ( isset( $original ) && current_filter() === 'wpseo_double_clean_titles' || did_action( 'wpseo_double_clean_titles' ) > 0 ) {
 			$rename          = array(
@@ -566,8 +569,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * Make sure that any set option values relating to post_types and/or taxonomies are retained,
 	 * even when that post_type or taxonomy may not yet have been registered.
 	 *
-	 * @internal Overrule the abstract class version of this to make sure one extra renamed variable key
-	 * does not get removed. IMPORTANT: keep this method in line with the parent on which it is based!
+	 * {@internal Overrule the abstract class version of this to make sure one extra renamed
+	 *            variable key does not get removed. IMPORTANT: keep this method in line with
+	 *            the parent on which it is based!}}
 	 *
 	 * @param  array $dirty Original option as retrieved from the database.
 	 * @param  array $clean Filtered option where any options which shouldn't be in our option

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -178,7 +178,8 @@ abstract class WPSEO_Option {
 
 	/**
 	 * All concrete classes *must* contain the get_instance method
-	 * @internal Unfortunately I can't define it as an abstract as it also *has* to be static....
+	 *
+	 * {@internal Unfortunately I can't define it as an abstract as it also *has* to be static...}}
 	 */
 	// abstract protected static function get_instance();
 
@@ -345,8 +346,8 @@ abstract class WPSEO_Option {
 	 *
 	 * Checks if the concrete class contains an enrich_defaults() method and if so, runs it.
 	 *
-	 * @internal the enrich_defaults method is used to set defaults for variable array keys in an option,
-	 * such as array keys depending on post_types and/or taxonomies
+	 * {@internal The enrich_defaults method is used to set defaults for variable array keys
+	 *            in an option, such as array keys depending on post_types and/or taxonomies.}}
 	 *
 	 * @return  array
 	 */
@@ -523,12 +524,13 @@ abstract class WPSEO_Option {
 	/**
 	 * Update a site_option
 	 *
-	 * @internal This special method is only needed for multisite options, but very needed indeed there.
-	 * The order in which certain functions and hooks are run is different between get_option() and
-	 * get_site_option() which means in practice that the removing of the default filters would be
-	 * done too late and the re-adding of the default filters might not be done at all.
-	 * Aka: use the WPSEO_Options::update_site_option() method (which calls this method) for
-	 * safely adding/updating multisite options.
+	 * {@internal This special method is only needed for multisite options, but very needed indeed there.
+	 *            The order in which certain functions and hooks are run is different between
+	 *            get_option() and get_site_option() which means in practice that the removing
+	 *            of the default filters would be done too late and the re-adding of the default
+	 *            filters might not be done at all.
+	 *            Aka: use the WPSEO_Options::update_site_option() method (which calls this method)
+	 *            for safely adding/updating multisite options.}}
 	 *
 	 * @param mixed $value The new value for the option.
 	 *
@@ -653,8 +655,8 @@ abstract class WPSEO_Option {
 	 * Make sure that any set option values relating to post_types and/or taxonomies are retained,
 	 * even when that post_type or taxonomy may not yet have been registered.
 	 *
-	 * @internal The wpseo_titles concrete class overrules this method. Make sure that any changes
-	 * applied here, also get ported to that version.
+	 * {@internal The wpseo_titles concrete class overrules this method. Make sure that any
+	 *            changes applied here, also get ported to that version.}}
 	 *
 	 * @param  array $dirty Original option as retrieved from the database.
 	 * @param  array $clean Filtered option where any options which shouldn't be in our option

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -21,10 +21,11 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * @var  array  Array of defaults for the option
 	 *        Shouldn't be requested directly, use $this->get_defaults();
-	 * @internal  Important: in contrast to most defaults, the below array format is
-	 *        very bare. The real option is in the format [taxonomy_name][term_id][...]
-	 *        where [...] is any of the $defaults_per_term options shown below.
-	 *        This is of course taken into account in the below methods.
+	 *
+	 * {@internal Important: in contrast to most defaults, the below array format is
+	 *            very bare. The real option is in the format [taxonomy_name][term_id][...]
+	 *            where [...] is any of the $defaults_per_term options shown below.
+	 *            This is of course taken into account in the below methods.}}
 	 */
 	protected $defaults = array();
 
@@ -66,7 +67,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 *
 	 * @static
 	 *
-	 * @internal  Labels (translation) added on admin_init via WPSEO_Taxonomy::translate_meta_options()
+	 * {@internal Labels (translation) added on admin_init via WPSEO_Taxonomy::translate_meta_options().}}
 	 */
 	public static $no_index_options = array(
 		'default' => '',
@@ -80,7 +81,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 *
 	 * @static
 	 *
-	 * @internal  Labels (translation) added on admin_init via WPSEO_Taxonomy::translate_meta_options()
+	 * {@internal Labels (translation) added on admin_init via WPSEO_Taxonomy::translate_meta_options().}}
 	 */
 	public static $sitemap_include_options = array(
 		'-'      => '',
@@ -157,9 +158,9 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 			}
 
 			/ *
-			@internal Adding the defaults to all taxonomy terms each time the option is retrieved
-			will be quite inefficient if there are a lot of taxonomy terms
-			As long as taxonomy_meta is only retrieved via methods in this class, we shouldn't need this
+			{@internal Adding the defaults to all taxonomy terms each time the option is retrieved
+			will be quite inefficient if there are a lot of taxonomy terms.
+			As long as taxonomy_meta is only retrieved via methods in this class, we shouldn't need this.}}
 
 			$options  = (array) $options;
 			$filtered = array();

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -485,7 +485,7 @@ function wpseo_translate_score( $val, $css_value = true ) {
  * @deprecated use WPSEO_Utils::allow_system_file_edit()
  * @see        WPSEO_Utils::allow_system_file_edit()
  *
- * @internal   current_user_can() checks internally whether a user is on wp-ms and adjusts accordingly.
+ * {@internal  current_user_can() checks internally whether a user is on wp-ms and adjusts accordingly.}}
  *
  * @return bool
  */

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -10,8 +10,8 @@ if ( ! function_exists( 'add_filter' ) ) {
 }
 
 /**
- * @internal Nobody should be able to overrule the real version number as this can cause serious issues
- * with the options, so no if ( ! defined() )
+ * {@internal Nobody should be able to overrule the real version number as this can cause
+ *            serious issues with the options, so no if ( ! defined() ).}}
  */
 define( 'WPSEO_VERSION', '5.5.1' );
 
@@ -217,8 +217,8 @@ function _wpseo_deactivate() {
  *
  * Will only be called by multisite actions.
  *
- * @internal Unfortunately will fail if the plugin is in the must-use directory
- * @see      https://core.trac.wordpress.org/ticket/24205
+ * {@internal Unfortunately will fail if the plugin is in the must-use directory.
+ *            {@link https://core.trac.wordpress.org/ticket/24205} }}
  *
  * @param int $blog_id Blog ID.
  */
@@ -324,8 +324,8 @@ function wpseo_frontend_init() {
 		 * If breadcrumbs are active (which they supposedly are if the users has enabled this settings,
 		 * there's no reason to have bbPress breadcrumbs as well.
 		 *
-		 * @internal The class itself is only loaded when the template tag is encountered via
-		 * the template tag function in the wpseo-functions.php file
+		 * {@internal The class itself is only loaded when the template tag is encountered
+		 *            via the template tag function in the wpseo-functions.php file.}}
 		 */
 		add_filter( 'bbp_get_breadcrumb', '__return_false' );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

While PSR 5 is still in draft/under review with no notable action at this time, the recommendation to use `{@internal ...text...}}` style to distinguish _internal_ functions/methods/properties from _internal team comments_ has been long standing.

This should also improve the compatibility with PHP Storm.

Refs:
* https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#78-internal
* https://youtrack.jetbrains.com/oauth?state=%2Fissue%2FWI-22284

Includes improved comment alignment, punctuation and compliance with the "empty comment line before tag" rule.

## Test instructions

_N/A_