### PR TITLE
CS compliance: fix missing semi-colons in embedded PHP

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -132,13 +132,13 @@ class WPSEO_Help_Center {
 		$id = sprintf( 'tab-help-center-%s-%s', $this->group_name, $this->tab->get_name() );
 		?>
 		<div class="wpseo-tab-video-container">
-			<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo $id ?>"
+			<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo $id; ?>"
 				aria-expanded="false">
 					<span
-						class="dashicons-before dashicons-editor-help"><?php _e( 'Help center', 'wordpress-seo' ) ?></span>
+						class="dashicons-before dashicons-editor-help"><?php _e( 'Help center', 'wordpress-seo' ); ?></span>
 				<span class="dashicons dashicons-arrow-down toggle__arrow"></span>
 			</button>
-			<div id="<?php echo $id ?>" class="wpseo-tab-video-slideout hidden">
+			<div id="<?php echo $id; ?>" class="wpseo-tab-video-slideout hidden">
 				<div class="yoast-help-center-tabs">
 					<ul>
 						<?php
@@ -156,7 +156,7 @@ class WPSEO_Help_Center {
 
 							<li id="<?php echo esc_attr( $link_id ); ?>" class="<?php echo $class; ?>">
 								<a href="<?php echo esc_url( "#$panel_id" ); ?>"
-									class="<?php echo $id . ' ' . $dashicon?>"
+									class="<?php echo $id . ' ' . $dashicon; ?>"
 									aria-controls="<?php echo esc_attr( $panel_id ); ?>"><?php echo esc_html( $help_center_item->get_label() ); ?></a>
 							</li>
 							<?php

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -123,7 +123,7 @@ class WPSEO_Configuration_Page {
 		<body class="wp-admin wp-core-ui">
 		<div id="wizard"></div>
 		<div role="contentinfo" class="yoast-wizard-return-link-container">
-			<a class="button yoast-wizard-return-link" href="<?php echo $dashboard_url ?>">
+			<a class="button yoast-wizard-return-link" href="<?php echo $dashboard_url; ?>">
 				<span aria-hidden="true" class="dashicons dashicons-no"></span>
 				<?php
 				printf(

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -298,8 +298,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	public function do_tab( $id, $heading, $content ) {
 		?>
-		<div id="wpseo_<?php echo esc_attr( $id ) ?>" class="wpseotab <?php echo esc_attr( $id ) ?>">
-			<?php echo $content ?>
+		<div id="wpseo_<?php echo esc_attr( $id ); ?>" class="wpseotab <?php echo esc_attr( $id ); ?>">
+			<?php echo $content; ?>
 		</div>
 	<?php
 	}

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -156,10 +156,10 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 				<?php if ( $extensions->is_activated( 'wordpress-seo-premium' ) ) : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php _e( 'Activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ) ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
 				<?php else : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php _e( 'Not activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ) ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
 				<?php endif; ?>
 				</a>
 
@@ -214,10 +214,10 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 							<?php if ( $extensions->is_activated( $id ) ) : ?>
 								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php _e( 'Activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ) ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
 							<?php else : ?>
 								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php _e( 'Not activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ) ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
 							<?php endif; ?>
 						<?php else : ?>
 							<a target="_blank" class="yoast-button yoast-button--noarrow yoast-button-go-to  yoast-button--extension yoast-button--extension-buy" href="<?php echo esc_url( $extension->get_buy_url() ); ?>">

--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -33,14 +33,14 @@ if ( ! $active ) {
 }
 
 ?>
-<h3><span class="dashicons dashicons-<?php echo $dashicon; ?>"></span> <?php echo $i18n_title ?> (<?php echo $active_total ?>)</h3>
+<h3><span class="dashicons dashicons-<?php echo $dashicon; ?>"></span> <?php echo $i18n_title; ?> (<?php echo $active_total; ?>)</h3>
 
-<div id="yoast-<?php echo $type ?>">
+<div id="yoast-<?php echo $type; ?>">
 
 	<?php if ( $total ) : ?>
 		<p><?php echo ( ! $active ) ? $i18n_no_issues : $i18n_issues; ?></p>
 
-		<div class="container" id="yoast-<?php echo $type ?>-active">
+		<div class="container" id="yoast-<?php echo $type; ?>-active">
 			<?php _yoast_display_alerts( $active, 'active' ); ?>
 		</div>
 
@@ -48,7 +48,7 @@ if ( ! $active ) {
 			<h4 class="yoast-muted-title"><?php echo esc_html( $i18n_muted_issues_title ); ?></h4>
 		<?php endif; ?>
 
-		<div class="container" id="yoast-<?php echo $type ?>-dismissed">
+		<div class="container" id="yoast-<?php echo $type; ?>-dismissed">
 			<?php _yoast_display_alerts( $dismissed, 'dismissed' ); ?>
 		</div>
 

--- a/admin/views/partial-help-center-video.php
+++ b/admin/views/partial-help-center-video.php
@@ -13,9 +13,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 if ( ! empty( $tab_video_url ) ) :
 
 	?>
-	<h2 class="screen-reader-text"><?php esc_html_e( 'Video tutorial', 'wordpress-seo' ) ?></h2>
+	<h2 class="screen-reader-text"><?php esc_html_e( 'Video tutorial', 'wordpress-seo' ); ?></h2>
 	<div class="wpseo-tab-video__panel wpseo-tab-video__panel--video">
-		<div class="wpseo-tab-video__data yoast-video-container" data-url="<?php echo $tab_video_url ?>"></div>
+		<div class="wpseo-tab-video__data yoast-video-container" data-url="<?php echo $tab_video_url; ?>"></div>
 	</div>
 	<div class="wpseo-tab-video__panel wpseo-tab-video__panel--text">
 		<?php
@@ -25,7 +25,7 @@ if ( ! empty( $tab_video_url ) ) :
 			?>
 			<div class="wpseo-tab-video__panel__textarea">
 				<h3><?php _e( 'Need some help?', 'wordpress-seo' ); ?></h3>
-				<p><?php _e( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ) ?></p>
+				<p><?php _e( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ); ?></p>
 				<p><a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/seo-premium-vt' ); ?>" target="_blank"><?php
 				/* translators: %s expands to Yoast SEO Premium */
 				printf( __( 'Get %s now &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );

--- a/admin/views/partial-settings-tab-video.php
+++ b/admin/views/partial-settings-tab-video.php
@@ -15,11 +15,11 @@ if ( ! empty( $tab_video_url ) ) :
 
 	?>
 	<div class="wpseo-tab-video-container">
-		<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo $id ?>" aria-expanded="false">
-			<span class="dashicons-before dashicons-editor-help"><?php _e( 'Help center', 'wordpress-seo' ) ?></span>
+		<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo $id; ?>" aria-expanded="false">
+			<span class="dashicons-before dashicons-editor-help"><?php _e( 'Help center', 'wordpress-seo' ); ?></span>
 			<span class="dashicons dashicons-arrow-down toggle__arrow"></span>
 		</button>
-		<div id="<?php echo $id ?>" class="wpseo-tab-video-slideout hidden">
+		<div id="<?php echo $id; ?>" class="wpseo-tab-video-slideout hidden">
 			<?php include WPSEO_PATH . 'admin/views/partial-help-center-video.php'; ?>
 		</div>
 	</div>

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -50,7 +50,7 @@ function render_help_center( $id ) {
  */
 function get_rendered_tab( $table, $id ) {
 	?>
-	<div id="<?php echo $id ?>" class="wpseotab">
+	<div id="<?php echo $id; ?>" class="wpseotab">
 		<?php
 		render_help_center( $id );
 		$table->show_page();
@@ -78,7 +78,7 @@ function get_rendered_tab( $table, $id ) {
 	</h2>
 
 	<div class="tabwrapper">
-		<?php get_rendered_tab( $wpseo_bulk_titles_table, 'title' )?>
-		<?php get_rendered_tab( $wpseo_bulk_description_table, 'description' )?>
+		<?php get_rendered_tab( $wpseo_bulk_titles_table, 'title' ); ?>
+		<?php get_rendered_tab( $wpseo_bulk_description_table, 'description' ); ?>
 	</div>
 </div>

--- a/css/xml-sitemap-xsl.php
+++ b/css/xml-sitemap-xsl.php
@@ -130,7 +130,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 				<p class="expl">
 					This XML Sitemap contains <xsl:value-of select="count(sitemap:urlset/sitemap:url)"/> URLs.
 				</p>
-				<p class="expl"><a href="<?php echo esc_url( home_url( 'sitemap_index.xml' ) ) ?>">&#8593; Sitemap Index</a></p>
+				<p class="expl"><a href="<?php echo esc_url( home_url( 'sitemap_index.xml' ) ); ?>">&#8593; Sitemap Index</a></p>
 				<table id="sitemap" cellpadding="3">
 					<thead>
 					<tr>
@@ -164,8 +164,8 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 				</table>
 			</xsl:if>
 		</div>
-		<script type="text/javascript" src="<?php echo includes_url( 'js/jquery/jquery.js' ) ?>"></script>
-		<script type="text/javascript" src="<?php echo plugins_url( 'js/dist/jquery.tablesorter.min.js', WPSEO_FILE ) ?>"></script>
+		<script type="text/javascript" src="<?php echo includes_url( 'js/jquery/jquery.js' ); ?>"></script>
+		<script type="text/javascript" src="<?php echo plugins_url( 'js/dist/jquery.tablesorter.min.js', WPSEO_FILE ); ?>"></script>
 		<script	type="text/javascript"><![CDATA[
 			jQuery(document).ready(function() {
 				jQuery("#sitemap").tablesorter( { widgets: ['zebra'] } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Single statement embedded PHP snippets should have a semi-colon at the end of the statement.
    As of WPCS 0.12.0 this will be enforced via the `Squiz.PHP.EmbeddedPhp` sniff.

## Test instructions

_N/A_