### PR TITLE
CS compliance: multi-item associative arrays should be multi-line

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -178,7 +178,13 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 * Used in the constructor to build a reference list of post types the current user can edit.
 	 */
 	protected function populate_editable_post_types() {
-		$post_types = get_post_types( array( 'public' => true, 'exclude_from_search' => false ), 'object' );
+		$post_types = get_post_types(
+			array(
+				'public'              => true,
+				'exclude_from_search' => false,
+			),
+			'object'
+		);
 
 		$this->all_posts = array();
 		$this->own_posts = array();
@@ -351,7 +357,12 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	public function extra_tablenav( $which ) {
 
 		if ( 'top' === $which ) {
-			$post_types = get_post_types( array( 'public' => true, 'exclude_from_search' => false ) );
+			$post_types = get_post_types(
+				array(
+					'public'              => true,
+					'exclude_from_search' => false,
+				)
+			);
 
 			$instance_type = esc_attr( $this->page_type );
 
@@ -438,8 +449,10 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			$current_page   = 1;
 			$current_filter = '-1';
 			$current_status = '';
-			$current_order  = array( 'orderby' => 'post_title', 'order' => 'asc' );
-
+			$current_order  = array(
+				'orderby' => 'post_title',
+				'order'   => 'asc',
+			);
 		}
 
 		$_SERVER['REQUEST_URI'] = $request_url;

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -10,11 +10,26 @@ class WPSEO_Extensions {
 
 	/** @var array Array with the Yoast extensions */
 	protected $extensions = array(
-		'Yoast SEO Premium'     => array( 'slug' => 'yoast-seo-premium', 'classname' => 'WPSEO_Premium' ),
-		'News SEO'              => array( 'slug' => 'news-seo', 'classname' => 'WPSEO_News' ),
-		'Yoast WooCommerce SEO' => array( 'slug' => 'woocommerce-yoast-seo', 'classname' => 'Yoast_WooCommerce_SEO' ),
-		'Video SEO'             => array( 'slug' => 'video-seo-for-wordpress', 'classname' => 'WPSEO_Video_Sitemap' ),
-		'Local SEO'             => array( 'slug' => 'local-seo-for-wordpress', 'classname' => 'WPSEO_Local_Core' ),
+		'Yoast SEO Premium'     => array(
+			'slug'      => 'yoast-seo-premium',
+			'classname' => 'WPSEO_Premium',
+		),
+		'News SEO'              => array(
+			'slug'      => 'news-seo',
+			'classname' => 'WPSEO_News',
+		),
+		'Yoast WooCommerce SEO' => array(
+			'slug'      => 'woocommerce-yoast-seo',
+			'classname' => 'Yoast_WooCommerce_SEO',
+		),
+		'Video SEO'             => array(
+			'slug'      => 'video-seo-for-wordpress',
+			'classname' => 'WPSEO_Video_Sitemap',
+		),
+		'Local SEO'             => array(
+			'slug'      => 'local-seo-for-wordpress',
+			'classname' => 'WPSEO_Local_Core',
+		),
 	);
 
 	/**

--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -165,12 +165,36 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 			 * @var array
 			 */
 			$robot_values = array(
-				1 => array( 'index' => 2, 'follow' => 0 ), // In wpSEO: index, follow.
-				2 => array( 'index' => 2, 'follow' => 1 ), // In wpSEO: index, nofollow.
-				3 => array( 'index' => 1, 'follow' => 0 ), // In wpSEO: noindex.
-				4 => array( 'index' => 1, 'follow' => 0 ), // In wpSEO: noindex, follow.
-				5 => array( 'index' => 1, 'follow' => 1 ), // In wpSEO: noindex, nofollow.
-				6 => array( 'index' => 2, 'follow' => 0 ), // In wpSEO: index.
+				// In wpSEO: index, follow.
+				1 => array(
+					'index'  => 2,
+					'follow' => 0,
+				),
+				// In wpSEO: index, nofollow.
+				2 => array(
+					'index'  => 2,
+					'follow' => 1,
+				),
+				// In wpSEO: noindex.
+				3 => array(
+					'index'  => 1,
+					'follow' => 0,
+				),
+				// In wpSEO: noindex, follow.
+				4 => array(
+					'index'  => 1,
+					'follow' => 0,
+				),
+				// In wpSEO: noindex, nofollow.
+				5 => array(
+					'index'  => 1,
+					'follow' => 1,
+				),
+				// In wpSEO: index.
+				6 => array(
+					'index'  => 2,
+					'follow' => 0,
+				),
 			);
 		}
 
@@ -178,6 +202,6 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 			return $robot_values[ $wpseo_robots ];
 		}
 
-		return array( 'index' => 2, 'follow' => 0 );
+		return $robot_values[1];
 	}
 }

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -352,7 +352,13 @@ class Yoast_Form {
 		) );
 		$val  = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
 
-		$this->label( $label . ':', array( 'for' => $var, 'class' => 'textinput' ) );
+		$this->label(
+			$label . ':',
+			array(
+				'for'   => $var,
+				'class' => 'textinput',
+			)
+		);
 		echo '<input class="textinput ' . esc_attr( $attr['class'] ) . ' " placeholder="' . esc_attr( $attr['placeholder'] ) . '" type="text" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"/>', '<br class="clear" />';
 	}
 
@@ -378,7 +384,13 @@ class Yoast_Form {
 		) );
 		$val  = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
 
-		$this->label( $label . ':', array( 'for' => $var, 'class' => 'textinput' ) );
+		$this->label(
+			$label . ':',
+			array(
+				'for'   => $var,
+				'class' => 'textinput',
+			)
+		);
 		echo '<textarea cols="' . esc_attr( $attr['cols'] ) . '" rows="' . esc_attr( $attr['rows'] ) . '" class="textinput ' . esc_attr( $attr['class'] ) . '" id="' . esc_attr( $var ) . '" name="' . esc_attr( $this->option_name ) . '[' . esc_attr( $var ) . ']">' . esc_textarea( $val ) . '</textarea><br class="clear" />';
 	}
 
@@ -418,7 +430,13 @@ class Yoast_Form {
 			return;
 		}
 
-		$this->label( $label . ':', array( 'for' => $field_name, 'class' => 'select' ) );
+		$this->label(
+			$label . ':',
+			array(
+				'for'   => $field_name,
+				'class' => 'select',
+			)
+		);
 
 		$select_name   = esc_attr( $this->option_name ) . '[' . esc_attr( $field_name ) . ']';
 		$active_option = ( isset( $this->options[ $field_name ] ) ) ? $this->options[ $field_name ] : '';
@@ -445,7 +463,13 @@ class Yoast_Form {
 		}
 
 		$var_esc = esc_attr( $var );
-		$this->label( $label . ':', array( 'for' => $var, 'class' => 'select' ) );
+		$this->label(
+			$label . ':',
+			array(
+				'for'   => $var,
+				'class' => 'select',
+			)
+		);
 		echo '<input type="file" value="' . esc_attr( $val ) . '" class="textinput" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" id="' . $var_esc . '"/>';
 
 		// Need to save separate array items in hidden inputs, because empty file inputs type will be deleted by settings API.
@@ -473,7 +497,13 @@ class Yoast_Form {
 
 		$var_esc = esc_attr( $var );
 
-		$this->label( $label . ':', array( 'for' => 'wpseo_' . $var, 'class' => 'select' ) );
+		$this->label(
+			$label . ':',
+			array(
+				'for'   => 'wpseo_' . $var,
+				'class' => 'select',
+			)
+		);
 		echo '<input class="textinput" id="wpseo_', $var_esc, '" type="text" size="36" name="', esc_attr( $this->option_name ), '[', $var_esc, ']" value="', esc_attr( $val ), '" />';
 		echo '<input id="wpseo_', $var_esc, '_button" class="wpseo_image_upload_button button" type="button" value="', esc_attr__( 'Upload Image', 'wordpress-seo' ), '" />';
 		echo '<br class="clear"/>';
@@ -514,7 +544,13 @@ class Yoast_Form {
 		foreach ( $values as $key => $value ) {
 			$key_esc = esc_attr( $key );
 			echo '<input type="radio" class="radio" id="' . $var_esc . '-' . $key_esc . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $this->options[ $var ], $key_esc, false ) . ' />';
-			$this->label( $value, array( 'for' => $var_esc . '-' . $key_esc, 'class' => 'radio' ) );
+			$this->label(
+				$value,
+				array(
+					'for'   => $var_esc . '-' . $key_esc,
+					'class' => 'radio',
+				)
+			);
 		}
 		echo '</fieldset>';
 	}

--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -146,7 +146,12 @@ class WPSEO_GSC_Category_Filters {
 	 * @return string
 	 */
 	private function create_view_link( $category, $count ) {
-		$href  = add_query_arg( array( 'category' => $category, 'paged' => 1 ) );
+		$href  = add_query_arg(
+			array(
+				'category' => $category,
+				'paged'    => 1,
+			)
+		);
 
 		$class = 'gsc_category';
 

--- a/admin/onpage/class-onpage-option.php
+++ b/admin/onpage/class-onpage-option.php
@@ -109,7 +109,12 @@ class WPSEO_OnPage_Option {
 	 * @return array
 	 */
 	private function get_option() {
-		return get_option( self::OPTION_NAME, array( self::STATUS => self::NOT_FETCHED, self::LAST_FETCH => 0 ) );
+		$default = array(
+			self::STATUS     => self::NOT_FETCHED,
+			self::LAST_FETCH => 0,
+		);
+
+		return get_option( self::OPTION_NAME, $default );
 	}
 
 	/**

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -53,7 +53,10 @@ class WPSEO_OnPage {
 	 * @return array
 	 */
 	public function add_weekly_schedule( array $schedules ) {
-		$schedules['weekly'] = array( 'interval' => WEEK_IN_SECONDS, 'display' => __( 'Once Weekly', 'wordpress-seo' ) );
+		$schedules['weekly'] = array(
+			'interval' => WEEK_IN_SECONDS,
+			'display'  => __( 'Once Weekly', 'wordpress-seo' ),
+		);
 
 		return $schedules;
 	}

--- a/admin/views/tabs/advanced/breadcrumbs.php
+++ b/admin/views/tabs/advanced/breadcrumbs.php
@@ -57,7 +57,13 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 }
 echo '<br/>';
 
-$taxonomies = get_taxonomies( array( 'public' => true, '_builtin' => false ), 'objects' );
+$taxonomies = get_taxonomies(
+	array(
+		'public'   => true,
+		'_builtin' => false,
+	),
+	'objects'
+);
 if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 	echo '<h2>' . __( 'Post type archive to show in breadcrumbs for taxonomies', 'wordpress-seo' ) . '</h2>';
 	foreach ( $taxonomies as $tax ) {

--- a/admin/views/tabs/dashboard/security.php
+++ b/admin/views/tabs/dashboard/security.php
@@ -13,7 +13,10 @@ echo '<h2>' . esc_html__( 'Security setting', 'wordpress-seo' ) . '</h2>';
 
 $yform->toggle_switch(
 	'disableadvanced_meta',
-	array( 'off' => __( 'Enabled', 'wordpress-seo' ), 'on' => __( 'Disabled', 'wordpress-seo' ) ),
+	array(
+		'off' => __( 'Enabled', 'wordpress-seo' ),
+		'on'  => __( 'Disabled', 'wordpress-seo' ),
+	),
 	/* translators: %1$s expands to Yoast SEO */
 	sprintf( __( 'Advanced part of the %1$s meta box', 'wordpress-seo' ), 'Yoast SEO' )
 );

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -56,7 +56,13 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 }
 unset( $post_types );
 
-$post_types = get_post_types( array( '_builtin' => false, 'has_archive' => true ), 'objects' );
+$post_types = get_post_types(
+	array(
+		'_builtin'    => false,
+		'has_archive' => true,
+	),
+	'objects'
+);
 if ( is_array( $post_types ) && $post_types !== array() ) {
 	echo '<h2>' . esc_html__( 'Custom Post Type Archives', 'wordpress-seo' ) . '</h2>';
 	echo '<p>' . __( 'Note: instead of templates these are the actual titles and meta descriptions for these custom post type archive pages.', 'wordpress-seo' ) . '</p>';

--- a/admin/views/tabs/sitemaps/user-sitemap.php
+++ b/admin/views/tabs/sitemaps/user-sitemap.php
@@ -13,7 +13,10 @@ echo '<h2>' . esc_html__( 'User sitemap settings', 'wordpress-seo' ) . '</h2>';
 
 $yform->toggle_switch(
 	'disable_author_sitemap',
-	array( 'off' => __( 'Enabled', 'wordpress-seo' ), 'on' => __( 'Disabled', 'wordpress-seo' ) ),
+	array(
+		'off' => __( 'Enabled', 'wordpress-seo' ),
+		'on'  => __( 'Disabled', 'wordpress-seo' ),
+	),
 	__( 'Author / user sitemap', 'wordpress-seo' )
 );
 

--- a/inc/options/class-wpseo-option-internallinks.php
+++ b/inc/options/class-wpseo-option-internallinks.php
@@ -82,7 +82,13 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 
 		// Retrieve all the relevant post type and taxonomy arrays.
 		$post_type_names       = get_post_types( array( 'public' => true ), 'names' );
-		$taxonomy_names_custom = get_taxonomies( array( 'public' => true, '_builtin' => false ), 'names' );
+		$taxonomy_names_custom = get_taxonomies(
+			array(
+				'public'   => true,
+				'_builtin' => false,
+			),
+			'names'
+		);
 
 		if ( $post_type_names !== array() ) {
 			foreach ( $post_type_names as $pt ) {

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -191,7 +191,13 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		// Retrieve all the relevant post type and taxonomy arrays.
 		$post_type_names = get_post_types( array( 'public' => true ), 'names' );
 
-		$post_type_objects_custom = get_post_types( array( 'public' => true, '_builtin' => false ), 'objects' );
+		$post_type_objects_custom = get_post_types(
+			array(
+				'public'   => true,
+				'_builtin' => false,
+			),
+			'objects'
+		);
 
 		$taxonomy_names = get_taxonomies( array( 'public' => true ), 'names' );
 

--- a/tests/admin/links/test-class-link-columns-count.php
+++ b/tests/admin/links/test-class-link-columns-count.php
@@ -57,7 +57,16 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 		$column_count
 			->expects( $this->once() )
 			->method( 'get_results' )
-			->will( $this->returnValue( array( 1 => array( 'post_id' => 1, 'total' => 10 ) ) ) );
+			->will(
+				$this->returnValue(
+					array(
+						1 => array(
+							'post_id' => 1,
+							'total'   => 10,
+						),
+					)
+				)
+			);
 
 		$column_count->set( array( 1 ) );
 	}
@@ -104,7 +113,16 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 		$column_count
 			->expects( $this->once() )
 			->method( 'get_results' )
-			->will( $this->returnValue( array( 1 => array( 'post_id' => 1, 'total' => 10 ) ) ) );
+			->will(
+				$this->returnValue(
+					array(
+						1 => array(
+							'post_id' => 1,
+							'total'   => 10,
+						),
+					)
+				)
+			);
 
 		$column_count->set( array( 1 ) );
 

--- a/tests/admin/links/test-class-link-columns.php
+++ b/tests/admin/links/test-class-link-columns.php
@@ -70,7 +70,10 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_post_columns() {
 		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
-		$expected = array( 'wpseo-links' => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-label="Number of internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># links in post</span></span>', 'wpseo-linked' => '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-label="Number of internal links linking to this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># internal links to</span></span>' );
+		$expected = array(
+			'wpseo-links'  => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-label="Number of internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># links in post</span></span>',
+			'wpseo-linked' => '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-label="Number of internal links linking to this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># internal links to</span></span>',
+		);
 
 		$this->assertEquals(
 			$expected,
@@ -109,7 +112,10 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
 
 		$this->assertEquals(
-			array( 'wpseo-links' => 'wpseo-links', 'wpseo-linked' => 'wpseo-linked' ),
+			array(
+				'wpseo-links'  => 'wpseo-links',
+				'wpseo-linked' => 'wpseo-linked',
+			),
 			$link_columns->column_sort( array() )
 		);
 	}

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -34,7 +34,10 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 
 		$post_parent = $this->factory->post->create_and_get();
 		$post = $this->factory->post->create_and_get(
-			array( 'post_type' => 'revision', 'post_parent' => $post_parent->ID )
+			array(
+				'post_type'   => 'revision',
+				'post_parent' => $post_parent->ID,
+			)
 		);
 
 		$processor = $this->get_processor();

--- a/tests/admin/test-class-yoast-input-select.php
+++ b/tests/admin/test-class-yoast-input-select.php
@@ -12,7 +12,15 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Input_Select::get_attributes
 	 */
 	public function test_html_with_options() {
-		$select = new Yoast_Input_Select( 'test-id', 'test-field', array( 'foo' => 'bar', 'baz' => 'foo' ), false );
+		$select = new Yoast_Input_Select(
+			'test-id',
+			'test-field',
+			array(
+				'foo' => 'bar',
+				'baz' => 'foo',
+			),
+			false
+		);
 		$html   = $select->get_html();
 
 		$this->assertContains( '<select name="test-field" id="test-id">', $html );
@@ -47,7 +55,15 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Input_Select::get_select_values
 	 */
 	public function test_html_with_options_and_one_active() {
-		$select = new Yoast_Input_Select( 'test-id', 'test-field', array( 'foo' => 'bar', 'baz' => 'foo' ), 'baz' );
+		$select = new Yoast_Input_Select(
+			'test-id',
+			'test-field',
+			array(
+				'foo' => 'bar',
+				'baz' => 'foo',
+			),
+			'baz'
+		);
 		$html   = $select->get_html();
 
 		$this->assertContains( '<select name="test-field" id="test-id">', $html );

--- a/tests/config-ui/test-class-configuration-storage.php
+++ b/tests/config-ui/test-class-configuration-storage.php
@@ -169,7 +169,10 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_get_field_data_array() {
 		$data    = array( 'a' => '1' );
-		$default = array( 'a' => '2', 'b' => '2' );
+		$default = array(
+			'a' => '2',
+			'b' => '2',
+		);
 
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
@@ -195,7 +198,10 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 		$this->storage->set_adapter( $adapter );
 
 		$this->assertEquals(
-			array( 'a' => '1', 'b' => '2' ),
+			array(
+				'a' => '1',
+				'b' => '2',
+			),
 			$this->storage->get_field_data( $field )
 		);
 	}

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -90,7 +90,12 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue( isset( $steps[ $identifier ] ) );
 		$this->assertEquals(
-			array( 'title' => $title, 'fields' => $fields, 'hideNavigation' => false, 'fullWidth' => false ),
+			array(
+				'title'          => $title,
+				'fields'         => $fields,
+				'hideNavigation' => false,
+				'fullWidth'      => false,
+			),
 			$steps[ $identifier ]
 		);
 	}

--- a/tests/metabox/test-class-metabox-editor.php
+++ b/tests/metabox/test-class-metabox-editor.php
@@ -65,7 +65,12 @@ class WPSEO_Metabox_Editor_Test extends PHPUnit_Framework_TestCase {
 			'custom_elements' => '~yoastmark',
 		);
 
-		$actual = $this->subject->add_custom_element( array( 'custom_elements' => '', 'other_property' => 'hello world' ) );
+		$actual = $this->subject->add_custom_element(
+			array(
+				'custom_elements' => '',
+				'other_property'  => 'hello world',
+			)
+		);
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -241,10 +241,16 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_sorted_notifications_by_priority() {
 		$message_1 = '1';
-		$options_1 = array( 'type' => 'error', 'priority' => 0.5 );
+		$options_1 = array(
+			'type'     => 'error',
+			'priority' => 0.5,
+		);
 
 		$message_2 = '2';
-		$options_2 = array( 'type' => 'error', 'priority' => 1 );
+		$options_2 = array(
+			'type'     => 'error',
+			'priority' => 1,
+		);
 
 		$notification_1 = new Yoast_Notification( $message_1, $options_1 );
 		$notification_2 = new Yoast_Notification( $message_2, $options_2 );
@@ -333,7 +339,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_dismissal_key = 'dismissed';
 
 		$message = 'c';
-		$options = array( 'id' => 'my_id', 'dismissal_key' => $notification_dismissal_key );
+		$options = array(
+			'id'            => 'my_id',
+			'dismissal_key' => $notification_dismissal_key,
+		);
 
 		$notification = new Yoast_Notification( $message, $options );
 
@@ -360,7 +369,13 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$old_nonce = 'outdated';
 
-		$outdated = new Yoast_Notification( 'outdated', array( 'nonce' => $old_nonce, 'id' => 'test' ) );
+		$outdated = new Yoast_Notification(
+			'outdated',
+			array(
+				'nonce' => $old_nonce,
+				'id'    => 'test',
+			)
+		);
 		$new      = new Yoast_Notification( 'new', array( 'id' => 'test' ) );
 
 		$notification_center->add_notification( $outdated );

--- a/tests/notifications/test-class-yoast-notification.php
+++ b/tests/notifications/test-class-yoast-notification.php
@@ -238,7 +238,13 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 		$capabilities = array( 'caps' );
 		$id           = 'my_id';
 
-		$notification = new Yoast_Notification( 'message', array( 'id' => $id, 'capabilities' => $capabilities ) );
+		$notification = new Yoast_Notification(
+			'message',
+			array(
+				'id'           => $id,
+				'capabilities' => $capabilities,
+			)
+		);
 
 		$this->verify_capability_filter_args = array(
 			$capabilities,
@@ -278,7 +284,13 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 		$capabilities = array( 'caps' );
 		$id           = 'my_id';
 
-		$notification = new Yoast_Notification( 'message', array( 'id' => $id, 'capabilities' => $capabilities ) );
+		$notification = new Yoast_Notification(
+			'message',
+			array(
+				'id'           => $id,
+				'capabilities' => $capabilities,
+			)
+		);
 
 		$this->verify_capability_match_filter_args = array(
 			Yoast_Notification::MATCH_ALL,
@@ -314,7 +326,13 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Invalid filter return value
 	 */
 	public function test_invalid_filter_return_values() {
-		$subject = new Yoast_Notification( 'message', array( 'id' => 'id', 'capabilities' => 'not_an_array' ) );
+		$subject = new Yoast_Notification(
+			'message',
+			array(
+				'id'           => 'id',
+				'capabilities' => 'not_an_array',
+			)
+		);
 		$this->assertFalse( $subject->display_for_current_user() );
 	}
 

--- a/tests/onpage/test-class-onpage-request.php
+++ b/tests/onpage/test-class-onpage-request.php
@@ -56,7 +56,13 @@ class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 	public function test_get_response() {
 		$request = new WPSEO_OnPage_Request_Double();
 
-		$this->assertEquals( $request->do_request( home_url() ), array( 'is_indexable' => '1', 'passes_juice_to' => '' ) );
+		$this->assertEquals(
+			$request->do_request( home_url() ),
+			array(
+				'is_indexable'    => '1',
+				'passes_juice_to' => '',
+			)
+		);
 	}
 
 	/**
@@ -67,7 +73,13 @@ class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 	public function test_get_response_redirected() {
 		$request = new WPSEO_OnPage_Request_Double();
 
-		$this->assertEquals( $request->do_request( 'http:://will-be-redirected.wp' ), array( 'is_indexable' => '1', 'passes_juice_to' => '' ) );
+		$this->assertEquals(
+			$request->do_request( 'http:://will-be-redirected.wp' ),
+			array(
+				'is_indexable'    => '1',
+				'passes_juice_to' => '',
+			)
+		);
 	}
 
 	/**
@@ -78,7 +90,13 @@ class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 	public function test_get_response_not_indexable() {
 		$request = new WPSEO_OnPage_Request_Double();
 
-		$this->assertEquals( $request->do_request( 'http://not_indexable.wp' ), array( 'is_indexable' => '0', 'passes_juice_to' => '' ) );
+		$this->assertEquals(
+			$request->do_request( 'http://not_indexable.wp' ),
+			array(
+				'is_indexable'    => '0',
+				'passes_juice_to' => '',
+			)
+		);
 	}
 
 }

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -66,7 +66,13 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_get_items_to_recalculate_no_focus_keywords() {
 		$response = $this->instance->get_items_to_recalculate( 1 );
 
-		$this->assertEquals( array( 'items' => array(), 'total_items' => 0 ), $response );
+		$this->assertEquals(
+			array(
+				'items'       => array(),
+				'total_items' => 0,
+			),
+			$response
+		);
 	}
 
 	/**

--- a/tests/recalculate/test-class-recalculate-terms.php
+++ b/tests/recalculate/test-class-recalculate-terms.php
@@ -24,9 +24,24 @@ class WPSEO_Recalculate_Terms_Test extends WPSEO_UnitTestCase {
 		$this->instance = new WPSEO_Recalculate_Terms();
 
 		$this->terms = array(
-			1 => $this->factory->term->create( array( 'name' => 'Term with focus keyword', 'taxonomy' => 'category' ) ),
-			2 => $this->factory->term->create( array( 'name' => '2nd Term', 'taxonomy' => 'category' ) ),
-			3 => $this->factory->term->create( array( 'name' => 'Term 3', 'taxonomy' => 'category' ) ),
+			1 => $this->factory->term->create(
+				array(
+					'name'     => 'Term with focus keyword',
+					'taxonomy' => 'category',
+				)
+			),
+			2 => $this->factory->term->create(
+				array(
+					'name'     => '2nd Term',
+					'taxonomy' => 'category',
+				)
+			),
+			3 => $this->factory->term->create(
+				array(
+					'name'     => 'Term 3',
+					'taxonomy' => 'category',
+				)
+			),
 		);
 	}
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -82,10 +82,28 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 		$older_date  = '2015-01-01 12:00:00';
 		$newest_date = '2016-01-01 12:00:00';
 
-		register_post_type( 'yoast', array( 'public' => true, 'has_archive' => true ) );
+		register_post_type(
+			'yoast',
+			array(
+				'public'      => true,
+				'has_archive' => true,
+			)
+		);
 
-		$this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'yoast', 'post_date' => $newest_date ) );
-		$this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'yoast', 'post_date' => $older_date ) );
+		$this->factory->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'yoast',
+				'post_date'   => $newest_date,
+			)
+		);
+		$this->factory->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'yoast',
+				'post_date'   => $older_date,
+			)
+		);
 
 		$this->assertEquals( $newest_date, WPSEO_Sitemaps::get_last_modified_gmt( array( 'yoast' ) ) );
 	}

--- a/tests/statistics/test-class-statistics-service.php
+++ b/tests/statistics/test-class-statistics-service.php
@@ -22,7 +22,13 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	}
 
 	public function test_filter_zero_counts() {
-		$statistics = new Statistics_Mock( array( 'ok' => 10, 'na' => 0, 'bad' => 0 ) );
+		$statistics = new Statistics_Mock(
+			array(
+				'ok'  => 10,
+				'na'  => 0,
+				'bad' => 0,
+			)
+		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );
 		$rest_response  = $class_instance->get_statistics();
@@ -32,7 +38,13 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	}
 
 	public function test_seo_score_links() {
-		$statistics = new Statistics_Mock( array( 'ok' => 10, 'na' => 0, 'bad' => 0 ) );
+		$statistics = new Statistics_Mock(
+			array(
+				'ok'  => 10,
+				'na'  => 0,
+				'bad' => 0,
+			)
+		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );
 		$rest_response  = $class_instance->get_statistics();
@@ -48,7 +60,13 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 		$user = wp_get_current_user();
 		$user->add_cap( 'edit_others_posts' );
 
-		$statistics = new Statistics_Mock( array( 'ok' => 10, 'na' => 0, 'bad' => 0 ) );
+		$statistics = new Statistics_Mock(
+			array(
+				'ok'  => 10,
+				'na'  => 0,
+				'bad' => 0,
+			)
+		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );
 		$rest_response  = $class_instance->get_statistics();
@@ -63,7 +81,13 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	}
 
 	public function test_page_counts() {
-		$statistics = new Statistics_Mock( array( 'ok' => 10, 'na' => 0, 'bad' => 0 ) );
+		$statistics = new Statistics_Mock(
+			array(
+				'ok'  => 10,
+				'na'  => 0,
+				'bad' => 0,
+			)
+		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );
 		$rest_response  = $class_instance->get_statistics();

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -477,7 +477,12 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_static_front_page() {
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'front-page', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'front-page',
+				'post_type'  => 'page',
+			)
+		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
 		$this->go_to_home();
@@ -504,11 +509,21 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_static_posts_page() {
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'front-page', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'front-page',
+				'post_type'  => 'page',
+			)
+		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'blog-page', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'blog-page',
+				'post_type'  => 'page',
+			)
+		);
 		update_option( 'page_for_posts', $post_id );
 		$this->go_to( get_permalink( $post_id ) );
 

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -184,7 +184,12 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_static_front_page() {
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'front-page', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'front-page',
+				'post_type'  => 'page',
+			)
+		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
 		$this->go_to_home();
@@ -211,11 +216,21 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_static_posts_page() {
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'front-page', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'front-page',
+				'post_type'  => 'page',
+			)
+		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'blog-page', 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'blog-page',
+				'post_type'  => 'page',
+			)
+		);
 		update_option( 'page_for_posts', $post_id );
 		$this->go_to( get_permalink( $post_id ) );
 

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -331,7 +331,13 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	public function test_adjacent_rel_links_canonical_post_type() {
 		update_option( 'posts_per_page', 1 );
 
-		register_post_type( 'yoast', array( 'public' => true, 'has_archive' => true ) );
+		register_post_type(
+			'yoast',
+			array(
+				'public'      => true,
+				'has_archive' => true,
+			)
+		);
 
 		$this->factory->post->create_many( 3, array( 'post_type' => 'yoast' ) );
 

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -37,84 +37,113 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 
 	public function determine_seo_filters_dataprovider() {
 		return array(
-			array( 'bad', array(
+			array(
+				'bad',
 				array(
-					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
-					'value' => array( 1, 40 ),
-					'type' => 'numeric',
-					'compare' => 'BETWEEN',
-				)
-			) ),
-			array( 'ok', array(
-				array(
-					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
-					'value' => array( 41, 70 ),
-					'type' => 'numeric',
-					'compare' => 'BETWEEN',
-				)
-			) ),
-			array( 'good', array(
-				array(
-					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
-					'value' => array( 71, 100 ),
-					'type' => 'numeric',
-					'compare' => 'BETWEEN',
-				)
-			) ),
-			array( 'na', array(
-				array(
-					'key' => '_yoast_wpseo_meta-robots-noindex',
-					'value' => 'needs-a-value-anyway',
-					'compare' => 'NOT EXISTS',
+					array(
+						'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
+						'value' => array( 1, 40 ),
+						'type' => 'numeric',
+						'compare' => 'BETWEEN',
+					),
 				),
+			),
+			array(
+				'ok',
 				array(
-					'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-					'value'   => 'needs-a-value-anyway',
-					'compare' => 'NOT EXISTS',
+					array(
+						'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
+						'value' => array( 41, 70 ),
+						'type' => 'numeric',
+						'compare' => 'BETWEEN',
+					),
 				),
-			) ),
-			array( '', array(
+			),
+			array(
+				'good',
 				array(
-					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
-					'value' => array( 1, 40 ),
-					'type' => 'numeric',
-					'compare' => 'BETWEEN',
-				)
-			) ),
-			array( 'noindex', array(array(
-				'key'     => WPSEO_Meta::$meta_prefix . 'meta-robots-noindex',
-				'value'   => '1',
-				'compare' => '=',
-			)) )
+					array(
+						'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
+						'value' => array( 71, 100 ),
+						'type' => 'numeric',
+						'compare' => 'BETWEEN',
+					),
+				),
+			),
+			array(
+				'na',
+				array(
+					array(
+						'key' => '_yoast_wpseo_meta-robots-noindex',
+						'value' => 'needs-a-value-anyway',
+						'compare' => 'NOT EXISTS',
+					),
+					array(
+						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
+						'value'   => 'needs-a-value-anyway',
+						'compare' => 'NOT EXISTS',
+					),
+				),
+			),
+			array(
+				'',
+				array(
+					array(
+						'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
+						'value' => array( 1, 40 ),
+						'type' => 'numeric',
+						'compare' => 'BETWEEN',
+					),
+				),
+			),
+			array(
+				'noindex',
+				array(
+					array(
+						'key'     => WPSEO_Meta::$meta_prefix . 'meta-robots-noindex',
+						'value'   => '1',
+						'compare' => '=',
+					),
+				),
+			),
 		);
 	}
 
 	public function determine_readability_filters_dataprovider() {
 		return array(
-			array( 'bad', array(
+			array(
+				'bad',
 				array(
-					'key' => WPSEO_Meta::$meta_prefix . 'content_score',
-					'value' => array( 1, 40 ),
-					'type' => 'numeric',
-					'compare' => 'BETWEEN',
-				)
-			) ),
-			array( 'ok', array(
+					array(
+						'key' => WPSEO_Meta::$meta_prefix . 'content_score',
+						'value' => array( 1, 40 ),
+						'type' => 'numeric',
+						'compare' => 'BETWEEN',
+					),
+				),
+			),
+			array(
+				'ok',
 				array(
-					'key' => WPSEO_Meta::$meta_prefix . 'content_score',
-					'value' => array( 41, 70 ),
-					'type' => 'numeric',
-					'compare' => 'BETWEEN',
-				)
-			) ),
-			array( 'good', array(
+					array(
+						'key' => WPSEO_Meta::$meta_prefix . 'content_score',
+						'value' => array( 41, 70 ),
+						'type' => 'numeric',
+						'compare' => 'BETWEEN',
+					),
+				),
+			),
+			array(
+				'good',
 				array(
-					'key' => WPSEO_Meta::$meta_prefix . 'content_score',
-					'value' => array( 71, 100 ),
-					'type' => 'numeric',
-					'compare' => 'BETWEEN',
-				)
-			) )
+					array(
+						'key' => WPSEO_Meta::$meta_prefix . 'content_score',
+						'value' => array( 71, 100 ),
+						'type' => 'numeric',
+						'compare' => 'BETWEEN',
+					),
+				),
+			),
 		);
 	}
 
@@ -188,7 +217,10 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 			),
 
 			array(
-				array( 'm' => 0, 'cat' => 0 ),
+				array(
+					'm'   => 0,
+					'cat' => 0,
+				),
 				array(
 					array(
 						'key' => WPSEO_Meta::$meta_prefix . 'content_score',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.

According to the [WP Core Handbook](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation) multi-item associative arrays should be multi-line.
This is sniffed for since WPCS 0.11.0 with significant improvements to the sniff in 0.12.0 and 0.14.0.

Original this applied to all associative arrays. Recently though, the handbook and the sniff has been adjusted to only apply this rule to multi-item associative arrays which lessens the impact.

The changes mostly affect function call layouts.
I've now fixed this by making most of the calls "proper" multi-line calls.
An valid alternative would be to define the array passed in the arguments as a variable prior to the function call and passing the variable to the function call instead.

@moorscode Let me know if you prefer that.

Note:
* `admin/class-import-wpseo.php` contains a related non-functional change (last change in the file), deferring to the previously defined array instead of redefining.

## Test instructions

_N/A_