### PR TITLE
CS compliance: each array item in a multi-line array should end in a comma

### DIFF
--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -62,7 +62,7 @@ class WPSEO_Configuration_Structure {
 			'mailchimpSignup',
 		), true, true );
 		$this->add_step( 'suggestions', __( 'You might like', 'wordpress-seo' ), array(
-			'suggestions'
+			'suggestions',
 		), true, true );
 		$this->add_step( 'success', __( 'Success!', 'wordpress-seo' ), array(
 			'successMessage',

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1059,7 +1059,7 @@ class WPSEO_Meta {
 				array(
 					'key'   => '_yoast_wpseo_focuskw',
 					'value' => $keyword,
-				)
+				),
 			),
 			'post__not_in'   => array( $post_id ),
 			'fields'         => 'ids',

--- a/inc/class-wpseo-statistics.php
+++ b/inc/class-wpseo-statistics.php
@@ -26,7 +26,7 @@ class WPSEO_Statistics {
 						'key'     => WPSEO_Meta::$meta_prefix . 'focuskw',
 						'value'   => 'needs-a-value-anyway',
 						'compare' => 'NOT EXISTS',
-					)
+					),
 				),
 			);
 		}

--- a/tests/admin/links/test-class-link-factory.php
+++ b/tests/admin/links/test-class-link-factory.php
@@ -51,21 +51,21 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 				$this->getLookUpMock( 2 ),
 				$this->getFilterMock( 'currentpage', true ),
 				'test',
-				array( new WPSEO_Link( 'test',  2,'internal' ) )
+				array( new WPSEO_Link( 'test',  2,'internal' ) ),
 			),
 			array(
 				$this->getClassifierMock( 'internal' ),
 				$this->getLookUpMock( 2 ),
 				$this->getFilterMock( 'test.html', false ),
 				'test.html#hastag',
-				array()
+				array(),
 			),
 			array(
 				$this->getClassifierMock( 'internal' ),
 				$this->getLookUpMock( 2 ),
 				$this->getFilterMock( 'test.html', false ),
 				'test.html?foo=bar',
-				array()
+				array(),
 			),
 		);
 	}

--- a/tests/admin/links/test-class-link-storage.php
+++ b/tests/admin/links/test-class-link-storage.php
@@ -69,7 +69,7 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 		$storage->save_links(
 			1,
 			array(
-				new WPSEO_Link( 'page', 0, 'outbound' )
+				new WPSEO_Link( 'page', 0, 'outbound' ),
 			)
 		);
 	}

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -90,7 +90,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 
 		$post = $this->factory->post->create_and_get(
 			array(
-				'post_content' => ''
+				'post_content' => '',
 			));
 
 		$processor = $this->get_processor();
@@ -110,7 +110,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 
 		$post = $this->factory->post->create_and_get(
 			array(
-				'post_content' => 'This is content'
+				'post_content' => 'This is content',
 			)
 		);
 
@@ -127,7 +127,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_delete_post() {
 		$post = $this->factory->post->create_and_get(
 			array(
-				'post_content' => 'This is content that will be deleted'
+				'post_content' => 'This is content that will be deleted',
 			)
 		);
 

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -24,7 +24,7 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 			'title' => 'Test Plugin',
 			'description' => '',
 			'version' => '3.3',
-			'installed' => true
+			'installed' => true,
 		);
 
 		$this->assertEquals( self::$class_instance->get_plugin( 'test-plugin' ), $expected );

--- a/tests/admin/test-class-plugin-compatibility.php
+++ b/tests/admin/test-class-plugin-compatibility.php
@@ -36,7 +36,7 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 				'description' => "",
 				'version' => "3.3",
 				'installed' => true,
-				'compatible' => true
+				'compatible' => true,
 			),
 			'test-plugin-dependency' => array(
 				'url' => "https://yoast.com/",
@@ -45,7 +45,7 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 				'version' => "3.3",
 				'installed' => true,
 				'_dependencies' => array( 'test-plugin' ),
-				'compatible' => true
+				'compatible' => true,
 			),
 			'test-plugin-invalid-version' => array(
 				'url' => "https://yoast.com/",
@@ -53,8 +53,8 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 				'description' => "",
 				'version' => "1.3",
 				'installed' => true,
-				'compatible' => false
-			)
+				'compatible' => false,
+			),
 		);
 
 		$this->assertEquals( self::$class_instance->get_installed_plugins_compatibility(), $expected );
@@ -73,7 +73,7 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 				'title' => "Test Plugin",
 				'description' => "",
 				'version' => "3.3",
-				'installed' => true
+				'installed' => true,
 			),
 			'test-plugin-dependency' => array(
 				'url' => "https://yoast.com/",
@@ -81,15 +81,15 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 				'description' => "",
 				'version' => "3.3",
 				'installed' => true,
-				'_dependencies' => array( 'test-plugin' )
+				'_dependencies' => array( 'test-plugin' ),
 			),
 			'test-plugin-invalid-version' => array(
 				'url' => "https://yoast.com/",
 				'title' => "Test Plugin",
 				'description' => "",
 				'version' => "1.3",
-				'installed' => true
-			)
+				'installed' => true,
+			),
 		);
 
 		$this->assertEquals( $expected, self::$class_instance->get_installed_plugins() );

--- a/tests/admin/test-class-wpseo-plugin-availability-double.php
+++ b/tests/admin/test-class-wpseo-plugin-availability-double.php
@@ -23,7 +23,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'description' => '',
 				'version' => '3.3',
 				'installed' => false,
-				'_dependencies' => array( 'test-plugin' )
+				'_dependencies' => array( 'test-plugin' ),
 			),
 
 			'unavailable-test-plugin' => array(

--- a/tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/tests/config-ui/components/test-class-component-connect-gsc.php
@@ -125,7 +125,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 		$expected = array(
 			'profile'        => 'c',
 			'profileList'    => array(),
-			'hasAccessToken' => false
+			'hasAccessToken' => false,
 		);
 
 		$this->component->set_profile( 'c' );

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -156,7 +156,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 			array(
 				'fields' => array(),
 				'steps'  => array(),
-				'translations' => array()
+				'translations' => array(),
 			),
 			$result
 		);

--- a/tests/formatter/test-post-metabox-formatter.php
+++ b/tests/formatter/test-post-metabox-formatter.php
@@ -65,7 +65,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		$options  = array(
 			'title-post'    => 'This is the title',
 			'metadesc-post' => 'This is the metadescription',
-			'showdate-post' => true
+			'showdate-post' => true,
 		);
 		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, $options, '' );
 		$result   = $instance->get_values();
@@ -128,7 +128,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	public function test_with_missing_option() {
 		$options  = array(
 			'title-post'    => 'This is the title',
-			'showdate-post' => true
+			'showdate-post' => true,
 		);
 		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, $options, '' );
 		$result   = $instance->get_values();

--- a/tests/formatter/test-term-metabox-formatter.php
+++ b/tests/formatter/test-term-metabox-formatter.php
@@ -102,7 +102,7 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	public function test_with_taxonomy_term_and_options() {
 		$options  = array(
 			'title-tax-post_tag'    => 'This is a title',
-			'metadesc-tax-post_tag' => 'This is a meta description'
+			'metadesc-tax-post_tag' => 'This is a meta description',
 		);
 		$instance = new WPSEO_Term_Metabox_Formatter( $this->taxonomy, $this->term, $options );
 		$result   = $instance->get_values();

--- a/tests/frontend/test-class-primary-category.php
+++ b/tests/frontend/test-class-primary-category.php
@@ -16,7 +16,7 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 		$this->subject =
 			$this
 				->getMockBuilder( 'WPSEO_Frontend_Primary_Category' )
-				->setMethods( array( 'get_category', 'get_primary_category', ) )
+				->setMethods( array( 'get_category', 'get_primary_category' ) )
 				->getMock();
 	}
 
@@ -32,7 +32,7 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( '54' ) );
 
 		$expect = (object) array(
-			'term_id' => 54
+			'term_id' => 54,
 		);
 
 		$this->subject

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -11,7 +11,7 @@ class WPSEO_Primary_Term_Double extends WPSEO_Primary_Term {
 		return array(
 			(object) array(
 				'term_id' => 54,
-			)
+			),
 		);
 	}
 }

--- a/tests/roles/test-class-role-manager.php
+++ b/tests/roles/test-class-role-manager.php
@@ -29,7 +29,7 @@ class WPSEO_Role_Manager_Test extends WPSEO_Abstract_Role_Manager {
 		$this->added_roles[] = array(
 			'role' => $role,
 			'display_name' => $display_name,
-			'capabilities' => $capabilities
+			'capabilities' => $capabilities,
 		);
 	}
 

--- a/tests/taxonomy/test-class-taxonomy-presenter.php
+++ b/tests/taxonomy/test-class-taxonomy-presenter.php
@@ -39,7 +39,7 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'type'        => 'text',
 					'description' => 'this is a test field',
 					'options'     => '',
-				)
+				),
 			)
 		);
 
@@ -61,8 +61,8 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'label'       => '',
 					'type'        => 'text',
 					'description' => 'this is a test field',
-					'options'     => ''
-				)
+					'options'     => '',
+				),
 			)
 		);
 
@@ -84,8 +84,8 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'label'       => 'test field',
 					'type'        => 'text',
 					'description' => '',
-					'options'     => array()
-				)
+					'options'     => array(),
+				),
 			)
 		);
 
@@ -106,10 +106,10 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'description' => '',
 					'options'     => array(
 						'options' => array(
-							'value' => 'option_value'
-						)
-					)
-				)
+							'value' => 'option_value',
+						),
+					),
+				),
 			)
 		);
 
@@ -130,10 +130,10 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'description' => '',
 					'options'     => array(
 						'options' => array(
-							'value' => 'option_value'
-						)
-					)
-				)
+							'value' => 'option_value',
+						),
+					),
+				),
 			)
 		);
 
@@ -153,7 +153,7 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'type'        => 'hidden',
 					'description' => '',
 					'options'     => '',
-				)
+				),
 			)
 		);
 
@@ -172,8 +172,8 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'label'       => 'test field',
 					'type'        => 'upload',
 					'description' => '',
-					'options'     => ''
-				)
+					'options'     => '',
+				),
 			)
 		);
 
@@ -193,8 +193,8 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 					'label'       => 'test field',
 					'type'        => 'upload',
 					'description' => 'description for the field',
-					'options'     => ''
-				)
+					'options'     => '',
+				),
 			)
 		);
 

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -311,7 +311,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	public function test_image_IS_SINGULAR_and_HAS_open_graph_image_AND_HAS_content_images() {
 		$post_id = $this->factory->post->create(
 			array(
-				'post_content' => '<img class="alignnone size-medium wp-image-490" src="' . get_site_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />'
+				'post_content' => '<img class="alignnone size-medium wp-image-490" src="' . get_site_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />',
 			)
 		);
 
@@ -401,7 +401,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	public function test_image_get_content_image() {
 		$post_id = $this->factory->post->create(
 			array(
-				'post_content' => '<img class="alignnone size-medium wp-image-490" src="' . get_site_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />'
+				'post_content' => '<img class="alignnone size-medium wp-image-490" src="' . get_site_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />',
 			)
 		);
 

--- a/tests/test-class-primary-term-admin.php
+++ b/tests/test-class-primary-term-admin.php
@@ -39,7 +39,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_wp_footer_INCLUDE_WITH_taxonomies() {
 		$taxonomies = array(
-			'category' => (object) array()
+			'category' => (object) array(),
 		);
 
 		$this->class_instance
@@ -164,7 +164,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 					'manage_terms' => 'manage_categories',
 					'edit_terms' => 'manage_categories',
 					'delete_terms' => 'manage_categories',
-					'assign_terms' => 'edit_posts'
+					'assign_terms' => 'edit_posts',
 				),
 				'name' => 'category',
 				'object_type' => array(

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -834,7 +834,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 				'multipage',
 				'more',
 				'numpages',
-				'pagenow'
+				'pagenow',
 			) as $v
 		) {
 			if ( isset( $GLOBALS[ $v ] ) ) {

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -128,7 +128,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 						'value' => array( 1, 40 ),
 						'type' => 'numeric',
 						'compare' => 'BETWEEN',
-					)
+					),
 				),
 				array(
 					'meta_query' => array(
@@ -138,10 +138,10 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 								'value' => array( 1, 40 ),
 								'type' => 'numeric',
 								'compare' => 'BETWEEN',
-							)
+							),
 						),
-					)
-				)
+					),
+				),
 			),
 
 			array(
@@ -158,7 +158,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 						'value' => array( 1, 40 ),
 						'type' => 'numeric',
 						'compare' => 'BETWEEN',
-					)
+					),
 				),
 				array(
 					'meta_query' => array(
@@ -175,16 +175,16 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 								'value' => array( 1, 40 ),
 								'type' => 'numeric',
 								'compare' => 'BETWEEN',
-							)
+							),
 						),
-					)
-				)
+					),
+				),
 			),
 
 			array(
 				array(),
 				array(),
-				array()
+				array(),
 			),
 
 			array(
@@ -201,7 +201,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 						'value' => array( 1, 40 ),
 						'type' => 'numeric',
 						'compare' => 'BETWEEN',
-					)
+					),
 				),
 				array(
 					'm' => 0,
@@ -220,11 +220,11 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 								'value' => array( 1, 40 ),
 								'type' => 'numeric',
 								'compare' => 'BETWEEN',
-							)
+							),
 						),
-					)
-				)
-			)
+					),
+				),
+			),
 		);
 	}
 

--- a/tests/test-class-wpseo-statistics.php
+++ b/tests/test-class-wpseo-statistics.php
@@ -39,7 +39,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_filled_statistics_no_focus() {
 		$posts = $this->factory->post->create_many( 2, array(
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		) );
 
 		add_post_meta( $posts[1], '_yoast_wpseo_focuskw', 'focus keyword' );
@@ -54,7 +54,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_filled_statistics_bad() {
 		$posts = $this->factory->post->create_many( 4, array(
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		) );
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // not bad
@@ -72,7 +72,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_filled_statistics_ok() {
 		$posts = $this->factory->post->create_many( 4, array(
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		) );
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 40 ); // not ok
@@ -90,7 +90,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_filled_statistics_good() {
 		$posts = $this->factory->post->create_many( 4, array(
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		) );
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 70 ); // not good
@@ -108,7 +108,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_all_statistics_published_posts() {
 		$posts = $this->factory->post->create_many( 4, array(
-			'post_status' => 'publish'
+			'post_status' => 'publish',
 		) );
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // no-focus
@@ -135,7 +135,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_only_published_posts() {
 		$posts = $this->factory->post->create_many( 4, array(
-			'post_status' => 'draft'
+			'post_status' => 'draft',
 		) );
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // no-focus


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Compliance with the `WordPress.Arrays.CommaAfterArrayItem` sniff as included in WPCS 0.12.0.

Having a comma after each item in a multi-line array makes the diffs when adding new array items cleaner and the chance of parse errors smaller.

## Test instructions

_N/A_