### PR TITLE
CS compliance: fix unnecessary usage of double quotes.

### DIFF
--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -97,7 +97,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 		$processor
 			->expects( $this->once() )
 			->method( 'process' )
-			->with( $post->ID, "" );
+			->with( $post->ID, '' );
 
 		$watcher = new WPSEO_Link_Watcher( $processor );
 		$watcher->save_post( $post->ID, $post );

--- a/tests/admin/test-class-plugin-compatibility.php
+++ b/tests/admin/test-class-plugin-compatibility.php
@@ -31,27 +31,27 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 	public function test_plugin_version_matches() {
 		$expected = array(
 			'test-plugin' => array(
-				'url' => "https://yoast.com/",
-				'title' => "Test Plugin",
-				'description' => "",
-				'version' => "3.3",
+				'url' => 'https://yoast.com/',
+				'title' => 'Test Plugin',
+				'description' => '',
+				'version' => '3.3',
 				'installed' => true,
 				'compatible' => true
 			),
 			'test-plugin-dependency' => array(
-				'url' => "https://yoast.com/",
-				'title' => "Test Plugin With Dependency",
-				'description' => "",
-				'version' => "3.3",
+				'url' => 'https://yoast.com/',
+				'title' => 'Test Plugin With Dependency',
+				'description' => '',
+				'version' => '3.3',
 				'installed' => true,
 				'_dependencies' => array( 'test-plugin' ),
 				'compatible' => true
 			),
 			'test-plugin-invalid-version' => array(
-				'url' => "https://yoast.com/",
-				'title' => "Test Plugin",
-				'description' => "",
-				'version' => "1.3",
+				'url' => 'https://yoast.com/',
+				'title' => 'Test Plugin',
+				'description' => '',
+				'version' => '1.3',
 				'installed' => true,
 				'compatible' => false
 			)
@@ -69,25 +69,25 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 	public function test_get_installed_plugins() {
 		$expected = array(
 			'test-plugin' => array(
-				'url' => "https://yoast.com/",
-				'title' => "Test Plugin",
-				'description' => "",
-				'version' => "3.3",
+				'url' => 'https://yoast.com/',
+				'title' => 'Test Plugin',
+				'description' => '',
+				'version' => '3.3',
 				'installed' => true
 			),
 			'test-plugin-dependency' => array(
-				'url' => "https://yoast.com/",
-				'title' => "Test Plugin With Dependency",
-				'description' => "",
-				'version' => "3.3",
+				'url' => 'https://yoast.com/',
+				'title' => 'Test Plugin With Dependency',
+				'description' => '',
+				'version' => '3.3',
 				'installed' => true,
 				'_dependencies' => array( 'test-plugin' )
 			),
 			'test-plugin-invalid-version' => array(
-				'url' => "https://yoast.com/",
-				'title' => "Test Plugin",
-				'description' => "",
-				'version' => "1.3",
+				'url' => 'https://yoast.com/',
+				'title' => 'Test Plugin',
+				'description' => '',
+				'version' => '1.3',
 				'installed' => true
 			)
 		);

--- a/tests/onpage/test-class-onpage-option.php
+++ b/tests/onpage/test-class-onpage-option.php
@@ -54,7 +54,7 @@ class WPSEO_OnPage_Option_Test extends WPSEO_UnitTestCase {
 	 * WPSEO_OnPage_Option::can_fetch
 	 */
 	public function test_cannot_fetch() {
-		$this->class_instance->set_last_fetch( strtotime( "-5 seconds" ) );
+		$this->class_instance->set_last_fetch( strtotime( '-5 seconds' ) );
 		$this->assertFalse( $this->class_instance->should_be_fetched() );
 	}
 
@@ -64,7 +64,7 @@ class WPSEO_OnPage_Option_Test extends WPSEO_UnitTestCase {
 	 * WPSEO_OnPage_Option::can_fetch
 	 */
 	public function test_cannot_fetch_two_hours_ago() {
-		$this->class_instance->set_last_fetch( strtotime( "-2 hours" ) );
+		$this->class_instance->set_last_fetch( strtotime( '-2 hours' ) );
 		$this->assertTrue( $this->class_instance->should_be_fetched() );
 	}
 }

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -132,8 +132,8 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_add_featured_image_to_content() {
 		$test_double = new WPSEO_Recalculate_Posts_Test_Double();
 
-		add_filter( "get_post_metadata", array( $this, 'mock_post_metadata' ), 10, 3 );
-		add_filter( "post_thumbnail_html", array( $this, 'mock_thumbnail' ), 10, 3 );
+		add_filter( 'get_post_metadata', array( $this, 'mock_post_metadata' ), 10, 3 );
+		add_filter( 'post_thumbnail_html', array( $this, 'mock_thumbnail' ), 10, 3 );
 
 		$post = get_post( $this->posts[1] );
 		$expected = $post->post_content . " <img src='' />";
@@ -141,8 +141,8 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( $expected, $response['text'] );
 
-		remove_filter( "get_post_metadata", array( $this, 'mock_post_metadata' ), 10, 3 );
-		remove_filter( "post_thumbnail_html", array( $this, 'mock_thumbnail' ), 10, 3 );
+		remove_filter( 'get_post_metadata', array( $this, 'mock_post_metadata' ), 10, 3 );
+		remove_filter( 'post_thumbnail_html', array( $this, 'mock_thumbnail' ), 10, 3 );
 
 		$post = get_post( $this->posts[2] );
 		$expected = $post->post_content;

--- a/tests/recalculate/test-class-recalculate-scores-ajax.php
+++ b/tests/recalculate/test-class-recalculate-scores-ajax.php
@@ -32,7 +32,7 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	public function test_get_total() {
 		add_filter( 'wp_die_handler', array( $this, 'set_total_response_no_posts' ) );
 
-		$ajax_nonce        = wp_create_nonce( "wpseo_recalculate" );
+		$ajax_nonce        = wp_create_nonce( 'wpseo_recalculate' );
 		$_REQUEST['nonce'] = $ajax_nonce;
 
 		$this->instance->get_total();
@@ -69,7 +69,7 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	public function test_get_total_with_posts() {
 		add_filter( 'wp_die_handler', array( $this, 'set_total_response_two_posts' ) );
 
-		$ajax_nonce        = wp_create_nonce( "wpseo_recalculate" );
+		$ajax_nonce        = wp_create_nonce( 'wpseo_recalculate' );
 		$_REQUEST['nonce'] = $ajax_nonce;
 
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -421,7 +421,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		$expected = $this->metatag( 'card', 'summary_large_image' );
 
 		// Insert image into DB so we have something to test against
-		$filename = "image.jpg";
+		$filename = 'image.jpg';
 		$id       = $this->factory->attachment->create_object( $filename, 0, array(
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -37,7 +37,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 
 	public function determine_seo_filters_dataprovider() {
 		return array(
-			array( "bad", array(
+			array( 'bad', array(
 				array(
 					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
 					'value' => array( 1, 40 ),
@@ -45,7 +45,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 					'compare' => 'BETWEEN',
 				)
 			) ),
-			array( "ok", array(
+			array( 'ok', array(
 				array(
 					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
 					'value' => array( 41, 70 ),
@@ -53,7 +53,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 					'compare' => 'BETWEEN',
 				)
 			) ),
-			array( "good", array(
+			array( 'good', array(
 				array(
 					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
 					'value' => array( 71, 100 ),
@@ -61,7 +61,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 					'compare' => 'BETWEEN',
 				)
 			) ),
-			array( "na", array(
+			array( 'na', array(
 				array(
 					'key' => '_yoast_wpseo_meta-robots-noindex',
 					'value' => 'needs-a-value-anyway',
@@ -73,7 +73,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 					'compare' => 'NOT EXISTS',
 				),
 			) ),
-			array( "", array(
+			array( '', array(
 				array(
 					'key' => WPSEO_Meta::$meta_prefix . 'linkdex',
 					'value' => array( 1, 40 ),
@@ -81,7 +81,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 					'compare' => 'BETWEEN',
 				)
 			) ),
-			array( "noindex", array(array(
+			array( 'noindex', array(array(
 				'key'     => WPSEO_Meta::$meta_prefix . 'meta-robots-noindex',
 				'value'   => '1',
 				'compare' => '=',
@@ -91,7 +91,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 
 	public function determine_readability_filters_dataprovider() {
 		return array(
-			array( "bad", array(
+			array( 'bad', array(
 				array(
 					'key' => WPSEO_Meta::$meta_prefix . 'content_score',
 					'value' => array( 1, 40 ),
@@ -99,7 +99,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 					'compare' => 'BETWEEN',
 				)
 			) ),
-			array( "ok", array(
+			array( 'ok', array(
 				array(
 					'key' => WPSEO_Meta::$meta_prefix . 'content_score',
 					'value' => array( 41, 70 ),
@@ -107,7 +107,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 					'compare' => 'BETWEEN',
 				)
 			) ),
-			array( "good", array(
+			array( 'good', array(
 				array(
 					'key' => WPSEO_Meta::$meta_prefix . 'content_score',
 					'value' => array( 71, 100 ),
@@ -321,14 +321,14 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta_Columns::is_valid_filter()
 	 */
 	public function test_is_valid_filter() {
-		$this->assertTrue( self::$class_instance->is_valid_filter( "needs improvement" ) );
+		$this->assertTrue( self::$class_instance->is_valid_filter( 'needs improvement' ) );
 	}
 
 	/**
 	 * @covers WPSEO_Meta_Columns::is_valid_filter()
 	 */
 	public function test_is_invalid_filter() {
-		$this->assertFalse( self::$class_instance->is_valid_filter( "" ) );
+		$this->assertFalse( self::$class_instance->is_valid_filter( '' ) );
 		$this->assertFalse( self::$class_instance->is_valid_filter( null ) );
 		$this->assertFalse( self::$class_instance->is_valid_filter( 0 ) );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Compliance with the `Squiz.Strings.DoubleQuoteUsage` sniff.

Using double quotes is marginally slower than single quotes as PHP will try and find interpolated variables in the string. Whenever reasonable, using single quotes is preferred.

Valid use cases for double quoted strings:
* When there is an interpolated variable
* When the string contains single quotes

## Test instructions

_N/A_