### PR TITLE
Restrict deployment stage to `deploy` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     - php: nightly
       env: WP_VERSION=master
     - stage: 🚀 deployment
-      if: branch = deploy # Skip building for general branches because of long duration and no direct use.
+      if: branch = deploy # Only build when on the `deploy` branch, this functionality is not used yet and is taking a long time to complete.
       before_script: skip
       script: grunt artifact
       before_install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
     - php: nightly
       env: WP_VERSION=master
     - stage: 🚀 deployment
+      if: branch = deploy # Skip building for general branches because of long duration and no direct use.
       before_script: skip
       script: grunt artifact
       before_install: skip


### PR DESCRIPTION
As the deployment stage is taking a long time (minutes) to complete, this PR is restricting the moment it is being triggered to the `deploy` branch.

This branch is not used at the moment and should be not be used accidentally because of the branch naming conventions we are using.

Fixes #7998 