### PR TITLE
Change Metabox behavoiur for keyword and readability analysis

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -571,11 +571,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		switch ( $meta_field_def['type'] ) {
 			case 'pageanalysis':
-			    $options = $this->options;
-				$content_analysis_active = $options['content_analysis_active'];
-				$keyword_analysis_active = $options['keyword_analysis_active'];
+				$content_analysis_active = $this->options['content_analysis_active'];
+				$keyword_analysis_active = $this->options['keyword_analysis_active'];
 
-				if($content_analysis_active === false && $keyword_analysis_active === false) {
+				if( $content_analysis_active === false && $keyword_analysis_active === false ) {
 				    break;
                 }
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -571,6 +571,14 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		switch ( $meta_field_def['type'] ) {
 			case 'pageanalysis':
+			    $options = $this->options;
+				$content_analysis_active = $options['content_analysis_active'];
+				$keyword_analysis_active = $options['keyword_analysis_active'];
+
+				if($content_analysis_active === false && $keyword_analysis_active === false) {
+				    break;
+                }
+
 				$content .= '<div id="pageanalysis">';
 				$content .= '<section class="yoast-section" id="wpseo-pageanalysis-section">';
 				$content .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-list">' . __( 'Analysis', 'wordpress-seo' ) . '</h3>';


### PR DESCRIPTION
When the keyword and readability analysis are both turned off in the settings, the Yoast SEO snippet editor don't show anymore the empty box.

Fixes #7144 
