### PR TITLE
Help center premium upsell link now opens in new tab

### DIFF
--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -79,7 +79,7 @@ class WPSEO_Premium_Popup {
 	<img class="alignright wpseo-premium-popup-icon" src="{$assets_uri}images/Yoast_SEO_Icon.svg" width="150" height="150" alt="Yoast SEO"/>
 	<{$this->heading_level} id="wpseo-contact-support-popup-title" class="wpseo-premium-popup-title">{$this->title}</{$this->heading_level}>
 	{$this->content}
-	<a id="wpseo-{$this->identifier}-popup-button" class="button button-primary" href="{$premium_uri}">{$cta_text}</a><br/>
+	<a id="wpseo-{$this->identifier}-popup-button" class="button button-primary" href="{$premium_uri}" target="_blank" rel="noreferrer noopener">{$cta_text}</a><br/>
 	<small>{$micro_copy}</small>
 </div>
 EO_POPUP;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Help center upsell link opens in new tab.

## Test instructions

This PR can be tested by following these steps:

* Go to the help center in the free plugin and click the link in the "Get support" tab.

Fixes #8011 
