### PR TITLE
Add aria-current on the list table views current link.

### DIFF
--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -84,9 +84,9 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	 */
 	public function add_filter_link( array $views ) {
 		$views[ 'yoast_' . $this->get_query_val() ] = sprintf(
-			'<a href="%1$s" class="%2$s">%3$s</a> (%4$s)',
+			'<a href="%1$s"%2$s>%3$s</a> (%4$s)',
 			esc_url( $this->get_filter_url() ),
-			( $this->is_filter_active() ) ? 'current' : '',
+			( $this->is_filter_active() ) ? ' class="current" aria-current="page"' : '',
 			$this->get_label(),
 			$this->get_post_total()
 		);

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -31,11 +31,9 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 
 /**
  * Outputs a help center.
- *
- * @param string $id The id for the tab.
  */
 function render_help_center() {
-	$tabs = new WPSEO_Option_Tabs('', '' );
+	$tabs = new WPSEO_Option_Tabs( '', '' );
 	$tabs->add_tab( new WPSEO_Option_Tab( 'title', __( 'Bulk editor', 'wordpress-seo' ),
 		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added `aria-current="page"` on the list tables views current link

## Test instructions

Verify the current link (Cornerstone content) in the list table "views" links has an `aria-current="page"` attribute. When ported to Premium, this should work also on the Orphaned Content link:

<img width="946" alt="screen shot 2017-10-11 at 09 21 34" src="https://user-images.githubusercontent.com/1682452/31428723-126f567e-ae6c-11e7-8267-9a9e8a457155.png">

Fixes #8029
