### PR TITLE
QA: parse_url() vs wp_parse_url()

### DIFF
--- a/admin/class-social-facebook.php
+++ b/admin/class-social-facebook.php
@@ -97,6 +97,7 @@ class Yoast_Social_Facebook {
 			return $matches_full_meta[1];
 		}
 
+		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
 		return trim( parse_url( $admin_id, PHP_URL_PATH ), '/' );
 	}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -896,6 +896,7 @@ class WPSEO_Utils {
 			return $home_url;
 		}
 
+		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
 		$home_path = parse_url( $home_url, PHP_URL_PATH );
 
 		if ( '/' === $home_path ) { // Home at site root, already slashed.

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -288,6 +288,7 @@ class WPSEO_Sitemaps_Renderer {
 			return $url;
 		}
 
+		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
 		$path = parse_url( $url, PHP_URL_PATH );
 
 		if ( ! empty( $path ) && '/' !== $path ) {
@@ -303,6 +304,7 @@ class WPSEO_Sitemaps_Renderer {
 			$url = str_replace( $path, $encoded_path, $url );
 		}
 
+		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
 		$query = parse_url( $url, PHP_URL_QUERY );
 
 		if ( ! empty( $query ) ) {

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -93,6 +93,7 @@ class WPSEO_Sitemaps_Router {
 		$base = apply_filters( 'wpseo_sitemaps_base_url', $base );
 
 		// Get the scheme from the configured home url instead of letting WordPress determine the scheme based on the requested URI.
+		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
 		return home_url( $base . $page, parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
 	}
 }

--- a/tests/admin/links/test-class-link-type-classifier.php
+++ b/tests/admin/links/test-class-link-type-classifier.php
@@ -59,7 +59,7 @@ class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 		$classifier
 			->expects( $this->once() )
 			->method( 'contains_protocol' )
-			->with( parse_url( 'http://test.com/page' ) )
+			->with( wp_parse_url( 'http://test.com/page' ) )
 			->will( $this->returnValue( true ) );
 
 		$classifier->classify( 'http://test.com/page' );
@@ -79,7 +79,7 @@ class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 		$classifier
 			->expects( $this->once() )
 			->method( 'is_external_link' )
-			->with( parse_url( 'http://test.com/page' ) )
+			->with( wp_parse_url( 'http://test.com/page' ) )
 			->will( $this->returnValue( true ) );
 
 		$classifier->classify( 'http://test.com/page' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

The PHP native `parse_url()` function behaves differently across PHP versions which can lead to unexpected results.

WP offers a cross-PHP-version compatible alternative `wp_parse_url()` which is recommended to use instead.

Using this should give more reliable and consistent test results as the `WPSEO_Link_Type_Classifier` class also uses the WP version of the function.

The WP `wp_parse_url()` function did however not support the `$component` parameter which `parse_url()` has.

This has been fixed in WP 4.7, so calls to `parse_url()` using the `$component` parameter have not been replaced (yet), but a note has been made with each of them to remind the team to do so in the near future.

**Review note**: the PR will be easiest to review by looking at the individual commits.


Refs:
* http://php.net/manual/en/function.parse-url.php
* https://developer.wordpress.org/reference/functions/wp_parse_url/
* https://core.trac.wordpress.org/ticket/36356

## Test instructions

_N/A_