### PR TITLE
Check wpseo_manage_options instead of manage_options on saving settings

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -79,6 +79,8 @@ class WPSEO_Admin {
 		add_action( 'admin_init', array( 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'import_plugin_hooks' ) );
 
+		add_action( 'admin_init', array( $this, 'map_manage_options_cap' ) );
+
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
 
 		if ( WPSEO_Utils::is_yoast_seo_page() ) {
@@ -162,6 +164,17 @@ class WPSEO_Admin {
 		 * @api string unsigned The capability
 		 */
 		return apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Maps the manage_options cap on saving an options page to wpseo_manage_options.
+	 */
+	public function map_manage_options_cap() {
+		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : '';
+
+		if ( false !== strpos( $option_page, 'yoast_wpseo' ) ) {
+			add_filter( "option_page_capability_{$option_page}", array( $this, 'get_manage_options_cap' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Check `wpseo_manage_options` capability instead of `manage_options` on saving settings.

## Relevant technical choices:

The `SEO Manager` role has the `wpseo_manage_options` capability for providing access to the plugin settings pages, but lacks `manage_options`, which is required to actually save the changes. This results in a "Cheatin’ uh? Sorry, you are not allowed to manage these options" error when saving the plugin settings.

The [`option_page_capability_{$option_page}` filter](https://developer.wordpress.org/reference/hooks/option_page_capability_option_page/) could be used to check `wpseo_manage_options` instead of `manage_options` on saving the plugin settings.

## Test instructions

This PR can be tested by following these steps:

* Create a user with a `SEO Manager` role.
* Log in as that user.
* Go to SEO → Dashboard and click "Save Changes".

Fixes #8024.