### PR TITLE
Use primary category

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -729,12 +729,17 @@ class WPSEO_OpenGraph {
 			return false;
 		}
 
-		$terms = get_the_category();
+		$post = get_post();
+		if ( ! $post ) {
+			return false;
+		}
 
-		if ( ! is_wp_error( $terms ) && ( is_array( $terms ) && $terms !== array() ) ) {
+		$primary_term      = new WPSEO_Primary_Term( 'category', $post->ID );
+		$primary_category = $primary_term->get_primary_term();
 
+		if ( ! $primary_category ) {
 			// We can only show one section here, so we take the first one.
-			$this->og_tag( 'article:section', $terms[0]->name );
+			$this->og_tag( 'article:section', $primary_category );
 
 			return true;
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -741,6 +741,14 @@ class WPSEO_OpenGraph {
 			// We can only show one section here, so we take the first one.
 			$this->og_tag( 'article:section', get_cat_name( $primary_category ) );
 
+			return true;
+		}
+
+		$terms = get_the_category();
+
+		if ( ! is_wp_error( $terms ) && ( is_array( $terms ) && $terms !== array() ) ) {
+			// We can only show one section here, so we take the first one.
+			$this->og_tag( 'article:section', $terms[0]->name );
 
 			return true;
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -737,9 +737,10 @@ class WPSEO_OpenGraph {
 		$primary_term      = new WPSEO_Primary_Term( 'category', $post->ID );
 		$primary_category = $primary_term->get_primary_term();
 
-		if ( ! $primary_category ) {
+		if ( $primary_category ) {
 			// We can only show one section here, so we take the first one.
-			$this->og_tag( 'article:section', $primary_category );
+			$this->og_tag( 'article:section', get_cat_name( $primary_category ) );
+
 
 			return true;
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -734,8 +734,8 @@ class WPSEO_OpenGraph {
 			return false;
 		}
 
-		$primary_term      = new WPSEO_Primary_Term( 'category', $post->ID );
-		$primary_category = $primary_term->get_primary_term();
+		$primary_term		 = new WPSEO_Primary_Term( 'category', $post->ID );
+		$primary_category 	 = $primary_term->get_primary_term();
 
 		if ( $primary_category ) {
 			// We can only show one section here, so we take the first one.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Use the primary set category when this has been set

## Test instructions

This PR can be tested by following these steps:

* Follow the steps to reproduce the issue in #4757 -> having a parent and child category assigned to a post. Select the child as the primary one. This one should be used for the metatag. 

Fixes #4757
