### PR TITLE
Allow other plugins to toggle support tab in Help Center.  

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -16,13 +16,19 @@ class WPSEO_Help_Center {
 	/** @var array Additional help center items */
 	protected $help_center_items = array();
 
+	/** @var bool Show premium support tab */
+	protected $premium_support;
+
 	/**
 	 * WPSEO_Help_Center constructor.
 	 *
-	 * @param string                             $unused      Backwards compatible argument.
-	 * @param WPSEO_Option_Tabs|WPSEO_Option_Tab $option_tabs Currently displayed tabs.
+	 * @param string                             $unused                     Backwards compatible argument.
+	 * @param WPSEO_Option_Tabs|WPSEO_Option_Tab $option_tabs                Currently displayed tabs.
+	 * @param boolean                            $premium_support (optional) Show premium support tab.
 	 */
-	public function __construct( $unused, $option_tabs ) {
+	public function __construct( $unused, $option_tabs, $premium_support = false ) {
+		$this->premium_support = $premium_support;
+
 		$tabs = new WPSEO_Option_Tabs( '' );
 
 		if ( $option_tabs instanceof WPSEO_Option_Tabs ) {
@@ -76,7 +82,7 @@ class WPSEO_Help_Center {
 		$formatted_data['pluginVersion'] = WPSEO_VERSION;
 
 		// Open HelpScout on activating this tab ID.
-		$formatted_data['premiumSupportId'] = ( $is_premium ) ? 'contact-support' : '';
+		$formatted_data['premiumSupportId'] = ( $this->premium_support ) ? 'contact-support' : '';
 
 		$formatted_data['translations'] = self::get_translated_texts();
 

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -22,9 +22,9 @@ class WPSEO_Help_Center {
 	/**
 	 * WPSEO_Help_Center constructor.
 	 *
-	 * @param string                             $unused                     Backwards compatible argument.
-	 * @param WPSEO_Option_Tabs|WPSEO_Option_Tab $option_tabs                Currently displayed tabs.
-	 * @param boolean                            $premium_support (optional) Show premium support tab.
+	 * @param string                             $unused          Backwards compatible argument.
+	 * @param WPSEO_Option_Tabs|WPSEO_Option_Tab $option_tabs     Currently displayed tabs.
+	 * @param boolean                            $premium_support Show premium support tab.
 	 */
 	public function __construct( $unused, $option_tabs, $premium_support = false ) {
 		$this->premium_support = $premium_support;

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -82,7 +82,7 @@ class WPSEO_Help_Center {
 		$formatted_data['pluginVersion'] = WPSEO_VERSION;
 
 		// Open HelpScout on activating this tab ID.
-		$formatted_data['premiumSupportId'] = ( $this->premium_support ) ? 'contact-support' : '';
+		$formatted_data['shouldDisplayContactForm'] = $this->premium_support;
 
 		$formatted_data['translations'] = self::get_translated_texts();
 

--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -31,7 +31,7 @@ class WPSEO_Option_Tabs_Formatter {
 		}
 		echo '</h2>';
 
-		$help_center = new WPSEO_Help_Center( '', $option_tabs );
+		$help_center = new WPSEO_Help_Center( '', $option_tabs, WPSEO_Utils::is_yoast_seo_premium() );
 		$help_center->localize_data();
 		$help_center->mount();
 

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -29,7 +29,7 @@ else {
 }
 
 $tab = new WPSEO_Option_Tab( 'GSC', __( 'Google Search Console', 'wordpress-seo' ), array( 'video_url' => $video_url ) );
-$gsc_help_center = new WPSEO_Help_Center( 'google-search-console', $tab );
+$gsc_help_center = new WPSEO_Help_Center( 'google-search-console', $tab, WPSEO_Utils::is_yoast_seo_premium() );
 $gsc_help_center->localize_data();
 $gsc_help_center->mount();
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -313,7 +313,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', 'Meta box',
 			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ) ) );
 
-		$help_center = new WPSEO_Help_Center( '', $helpcenter_tab );
+		$help_center = new WPSEO_Help_Center( '', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );
 		$help_center->localize_data();
 		$help_center->mount();
 

--- a/admin/pages/advanced.php
+++ b/admin/pages/advanced.php
@@ -53,7 +53,7 @@ foreach ( $tabs->get_tabs() as $tab ) {
 }
 echo '</h2>';
 
-$help_center = new WPSEO_Help_Center( '', $tabs );
+$help_center = new WPSEO_Help_Center( '', $tabs, WPSEO_Utils::is_yoast_seo_premium() );
 $help_center->localize_data();
 $help_center->mount();
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -60,7 +60,7 @@ class WPSEO_Taxonomy_Metabox {
 		$helpcenter_tab = new WPSEO_Option_Tab( 'tax-metabox', 'Meta box',
 			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-taxonomy-screencast' ) ) );
 
-		$helpcenter = new WPSEO_Help_Center( 'tax-metabox', $helpcenter_tab );
+		$helpcenter = new WPSEO_Help_Center( 'tax-metabox', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );
 		$helpcenter->localize_data();
 		$helpcenter->mount();
 

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -31,11 +31,9 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 
 /**
  * Outputs a help center.
- *
- * @param string $id The id for the tab.
  */
 function render_help_center() {
-	$tabs = new WPSEO_Option_Tabs('', '' );
+	$tabs = new WPSEO_Option_Tabs( '', '' );
 	$tabs->add_tab( new WPSEO_Option_Tab( 'title', __( 'Bulk editor', 'wordpress-seo' ),
 		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
 

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -42,7 +42,7 @@ function render_help_center() {
 	$tabs->add_tab( new WPSEO_Option_Tab( 'description', __( 'Bulk editor', 'wordpress-seo' ),
 		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
 
-	$helpcenter = new WPSEO_Help_Center( '', $tabs );
+	$helpcenter = new WPSEO_Help_Center( '', $tabs, WPSEO_Utils::is_yoast_seo_premium() );
 	$helpcenter->localize_data();
 	$helpcenter->mount();
 }

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -78,7 +78,7 @@ echo '<br><br>';
 $helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', 'Bulk editor',
 	array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-file-editor' ) ) );
 
-$helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab );
+$helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );
 $helpcenter->localize_data();
 $helpcenter->mount();
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -128,7 +128,7 @@ foreach ( $tabs as $identifier => $tab ) {
 	$helpcenter_tabs->add_tab( $helpcenter_tab );
 }
 
-$helpcenter = new WPSEO_Help_Center( '', $helpcenter_tabs );
+$helpcenter = new WPSEO_Help_Center( '', $helpcenter_tabs, WPSEO_Utils::is_yoast_seo_premium() );
 $helpcenter->localize_data();
 $helpcenter->mount();
 

--- a/js/src/wp-seo-help-center.js
+++ b/js/src/wp-seo-help-center.js
@@ -168,7 +168,7 @@ class HelpCenter extends React.Component {
 
 		this.props.additionalHelpCenterTabs.map( tab => {
 			let content;
-			if( tab.identifier === this.props.premiumSupportTabId ) {
+			if( this.props.shouldDisplayContactForm === "1" ) {
 				const supportButton = this.props.intl.formatMessage( { id: "contactSupport.button" } );
 				content = <ContactSupport
 					buttonText={ supportButton }
@@ -210,7 +210,7 @@ HelpCenter.propTypes = {
 	adminTabsData: PropTypes.object.isRequired,
 	additionalHelpCenterTabs: PropTypes.array,
 	videoTutorialParagraphs: PropTypes.object,
-	premiumSupportTabId: PropTypes.string,
+	shouldDisplayContactForm: PropTypes.string,
 	initialTab: PropTypes.string,
 	intl: intlShape.isRequired,
 };
@@ -254,7 +254,7 @@ if ( window.wpseoHelpCenterData ) {
 				adminTabsData={wpseoHelpCenterData.tabs}
 				additionalHelpCenterTabs={wpseoHelpCenterData.extraTabs}
 				videoTutorialParagraphs={wpseoHelpCenterData.videoDescriptions}
-				premiumSupportTabId={wpseoHelpCenterData.premiumSupportId}
+				shouldDisplayContactForm={wpseoHelpCenterData.shouldDisplayContactForm}
 			/>
 		</IntlProvider>,
 		document.getElementById( wpseoHelpCenterData.mountId )


### PR DESCRIPTION
## Summary

**Changes to other repo's are needed to implement this fix!**

This PR can be summarized in the following changelog entry:

* Allow other plugins to toggle support tab in Help Center. 

## Relevant technical choices:

* Adds a new (optional) parameter to `WPSEO_Help_Center`, to determine whether the support form should be shown.

## Test instructions

This PR can be tested by following these steps:

* 

Fixes #8021 