### PR TITLE
8024 map manage options hotfix

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -169,7 +169,7 @@ class WPSEO_Admin {
 	 * Maps the manage_options cap on saving an options page to wpseo_manage_options.
 	 */
 	public function map_manage_options_cap() {
-		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : '';
+		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : ''; // WPCS: CSRF ok.
 
 		if ( false !== strpos( $option_page, 'yoast_wpseo' ) ) {
 			add_filter( "option_page_capability_{$option_page}", array( $this, 'get_manage_options_cap' ) );

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -171,7 +171,7 @@ class WPSEO_Admin {
 	public function map_manage_options_cap() {
 		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : ''; // WPCS: CSRF ok.
 
-		if ( false !== strpos( $option_page, 'yoast_wpseo' ) ) {
+		if ( 0 === strpos( $option_page, 'yoast_wpseo' ) ) {
 			add_filter( "option_page_capability_{$option_page}", array( $this, 'get_manage_options_cap' ) );
 		}
 	}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -154,7 +154,7 @@ class WPSEO_Admin {
 	/**
 	 * Returns the manage_options cap
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	public function get_manage_options_cap() {
 		/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -171,7 +171,7 @@ class WPSEO_Admin {
 	public function map_manage_options_cap() {
 		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : ''; // WPCS: CSRF ok.
 
-		if ( 0 === strpos( $option_page, 'yoast_wpseo' ) ) {
+		if ( strpos( $option_page, 'yoast_wpseo' ) === 0 ) {
 			add_filter( "option_page_capability_{$option_page}", array( $this, 'get_manage_options_cap' ) );
 		}
 	}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -152,9 +152,9 @@ class WPSEO_Admin {
 	}
 
 	/**
-	 * Returns the manage_options cap
+	 * Returns the manage_options capability.
 	 *
-	 * @return string
+	 * @return string The capability to use.
 	 */
 	public function get_manage_options_cap() {
 		/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -172,7 +172,7 @@ class WPSEO_Admin {
 		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : ''; // WPCS: CSRF ok.
 
 		if ( strpos( $option_page, 'yoast_wpseo' ) === 0 ) {
-			add_filter( "option_page_capability_{$option_page}", array( $this, 'get_manage_options_cap' ) );
+			add_filter( 'option_page_capability_' . $option_page, array( $this, 'get_manage_options_cap' ) );
 		}
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -79,6 +79,8 @@ class WPSEO_Admin {
 		add_action( 'admin_init', array( 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'import_plugin_hooks' ) );
 
+		add_action( 'admin_init', array( $this, 'map_manage_options_cap' ) );
+
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
 
 		if ( WPSEO_Utils::is_yoast_seo_page() ) {
@@ -162,6 +164,17 @@ class WPSEO_Admin {
 		 * @api string unsigned The capability
 		 */
 		return apply_filters( 'wpseo_manage_options_capability', 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Maps the manage_options cap on saving an options page to wpseo_manage_options.
+	 */
+	public function map_manage_options_cap() {
+		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : '';
+
+		if ( false !== strpos( $option_page, 'yoast_wpseo' ) ) {
+			add_filter( "option_page_capability_{$option_page}", array( $this, 'get_manage_options_cap' ) );
+		}
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -156,8 +156,7 @@ class WPSEO_Admin {
 	 *
 	 * @return mixed|void
 	 */
-	private function get_manage_options_cap() {
-		// @todo deprecate filter
+	public function get_manage_options_cap() {
 		/**
 		 * Filter: 'wpseo_manage_options_capability' - Allow changing the capability users need to view the settings pages
 		 *

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -31,11 +31,9 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 
 /**
  * Outputs a help center.
- *
- * @param string $id The id for the tab.
  */
 function render_help_center() {
-	$tabs = new WPSEO_Option_Tabs('', '' );
+	$tabs = new WPSEO_Option_Tabs( '', '' );
 	$tabs->add_tab( new WPSEO_Option_Tab( 'title', __( 'Bulk editor', 'wordpress-seo' ),
 		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,13 @@ You'll find answers to many of your questions on [kb.yoast.com](https://kb.yoast
 
 == Changelog ==
 
+= 5.6.1 =
+
+Release Date: October 13th, 2017
+
+Bugfixes
+	* Fixes a bug where the SEO Manager role was not being able to save SEO settings.
+
 = 5.6.0 =
 
 Release Date: October 10th, 2017


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Check `wpseo_manage_options` capability instead of `manage_options` on saving settings.

## Relevant technical choices:

The `SEO Manager` role has the `wpseo_manage_options` capability for providing access to the plugin settings pages, but lacks `manage_options`, which is required to actually save the changes. This results in a "Cheatin’ uh? Sorry, you are not allowed to manage these options" error when saving the plugin settings.

The [`option_page_capability_{$option_page}` filter](https://developer.wordpress.org/reference/hooks/option_page_capability_option_page/) could be used to check `wpseo_manage_options` instead of `manage_options` on saving the plugin settings.

## Test instructions

This PR can be tested by following these steps:

* Create a user with a `SEO Manager` role.
* Log in as that user.
* Go to SEO → Dashboard and click "Save Changes".

Replaces https://github.com/Yoast/wordpress-seo/pull/8041
Fixes #8024