### PR TITLE
Removes dashboard alert box max-width

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -121,7 +121,9 @@ h4 {
 }
 
 .yoast .search-box,
-.wpseo_content_wrapper .notice p {
+.wpseo_content_wrapper .notice p,
+.yoast-container .container,
+.yoast-alert p {
 	max-width: none;
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the max-width on alerts to present a better UI that is not so compact.

## Relevant technical choices:

* Despite the recommendation to set the overall max-width to 720px I didn't see the reason behind setting this limit.

## Test instructions

This PR can be tested by following these steps:

* Install the plugin on a fresh WordPress install.
* Perform minimal configuration with the settings wizard.
* Review the display of the alert notifications.

Fixes #7443
