### PR TITLE
Use yoastseo npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
     "react-tap-event-plugin": "^2.0.0",
     "select2": "^4.0.3",
     "yoast-components": "2.10.1",
-    "yoastseo": "https://github.com/Yoast/YoastSEO.js#release/1.21"
+    "yoastseo": "^1.22.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3168,6 +3168,10 @@ growly@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
+grunt-babel@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/grunt-babel/-/grunt-babel-7.0.0.tgz#13c90c01f154dec214e0eeb5d66ac7c70cedf2d3"
+
 grunt-browserify@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/grunt-browserify/-/grunt-browserify-5.2.0.tgz#37ae44fbdc75f7d81e9725264e11b05e62537c46"
@@ -7911,10 +7915,12 @@ yoast-components@2.10.1:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-"yoastseo@https://github.com/Yoast/YoastSEO.js#release/1.21":
-  version "1.20.0"
-  resolved "https://github.com/Yoast/YoastSEO.js#b9385ae7d01e1070b23de88d72c22e25a88a9fc8"
+yoastseo@^1.22.4:
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.22.4.tgz#adafee55ed3b88bd1997e22faab760c492e9f37e"
   dependencies:
+    babel-core "^6.26.0"
+    grunt-babel "^7.0.0"
     htmlparser2 "^3.9.2"
     jed "^1.1.0"
     lodash "^4.14.1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changed the github repository in `package.json` to the `yoastseo` npm package.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* `yarn install`
* `grunt build`
* See if the pages that use `YoastSEO.js` work properly and no javascript errors are being thrown.
* Also test in wordpress-seo premium.

Fixes #
