### PR TITLE
 QA/Tests: load test mock classes using `setUpBeforeClass()` method 

### DIFF
--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -1,13 +1,20 @@
 <?php
 
-require_once WPSEO_TESTS_PATH . 'admin/test-class-wpseo-plugin-availability-double.php';
-
 class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @var WPSEO_Plugin_Availability
 	 */
 	private static $class_instance;
+
+	/**
+	 * Load the test mock class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'admin/test-class-wpseo-plugin-availability-double.php';
+	}
 
 	/**
 	 * Set up our double class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,10 +23,10 @@ $GLOBALS['wp_tests_options'] = array(
 );
 
 if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
-	require getenv( 'WP_DEVELOP_DIR' ) . 'tests/phpunit/includes/bootstrap.php';
+	require_once getenv( 'WP_DEVELOP_DIR' ) . 'tests/phpunit/includes/bootstrap.php';
 }
 else {
-	require '../../../../tests/phpunit/includes/bootstrap.php';
+	require_once '../../../../tests/phpunit/includes/bootstrap.php';
 }
 
 define( 'WPSEO_TESTS_PATH', dirname( __FILE__ ) . '/' );

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -3,8 +3,6 @@
  * @package WPSEO\Unittests
  */
 
-require_once WPSEO_TESTS_PATH . 'recalculate/class-recalculate-posts-double.php';
-
 
 class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 
@@ -22,6 +20,15 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	 * @var string
 	 */
 	private $mock_image = "<img src='' />";
+
+	/**
+	 * Load the test mock class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'recalculate/class-recalculate-posts-double.php';
+	}
 
 	/**
 	 * Setup the class instance and create some posts

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -3,8 +3,6 @@
  * @package WPSEO\Unittests
  */
 
-require_once WPSEO_TESTS_PATH . 'sitemaps/class-wpseo-sitemaps-double.php';
-
 /**
  * Class WPSEO_Sitemaps_Test
  */
@@ -14,6 +12,15 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	 * @var WPSEO_Sitemaps
 	 */
 	private static $class_instance;
+
+	/**
+	 * Load the test mock class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'sitemaps/class-wpseo-sitemaps-double.php';
+	}
 
 	/**
 	 * Set up our double class

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -15,7 +15,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		ob_start();
 
 		// create instance of WPSEO_Twitter class
-		require WPSEO_TESTS_PATH . 'framework/class-expose-wpseo-twitter.php';
+		require_once WPSEO_TESTS_PATH . 'framework/class-expose-wpseo-twitter.php';
 		self::$class_instance = new Expose_WPSEO_Twitter();
 		WPSEO_Frontend::get_instance()->reset();
 		// clean output which was outputted by WPSEO_Twitter constructor


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

Load the test mock class using `setUpBeforeClass()` rather than a top-of-file include.
Also make sure all includes in the test suite are done using `require_once`.

**Review note:** the PR will be easiest to review by looking at the individual commits.

## Test instructions

_N/A_