### PR TITLE
Make 'summary with large image' default Twitter card option.

### DIFF
--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -38,7 +38,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 		'plus-publisher'     => '', // Text field.
 		'twitter'            => true,
 		'twitter_site'       => '', // Text field.
-		'twitter_card_type'  => 'summary',
+		'twitter_card_type'  => 'summary_large_image',
 		'youtube_url'        => '',
 		'google_plus_url'    => '',
 		// Form field, but not always available:

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -48,7 +48,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 
 		self::$class_instance->twitter();
 
-		$expected = '<meta name="twitter:card" content="summary" />
+		$expected = '<meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:description" content="Twitter Test Excerpt" />
 <meta name="twitter:title" content="Twitter Test Post - Test Blog" />
 ';


### PR DESCRIPTION
Sets default Twitter Card option to 'Summary with large image'.

Closes: #6553 