### PR TITLE
CS compliance: variable names should be lowercase

### DIFF
--- a/tests/admin/links/test-class-link-factory.php
+++ b/tests/admin/links/test-class-link-factory.php
@@ -28,12 +28,12 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	 * @param WPSEO_Link_Type_Classifier $classifier The classifier mock
 	 * @param WPSEO_Link_Internal_Lookup $lookup     The lookup mock
 	 * @param WPSEO_Link_Filter          $filter     The link filter.
-	 * @param string                     $linkURL    The link url to test.
+	 * @param string                     $link_url   The link url to test.
 	 * @param mixed                      $expected   The expected result
 	 */
-	public function test_process_internal_link( $classifier, $lookup, $filter, $linkURL, $expected ) {
+	public function test_process_internal_link( $classifier, $lookup, $filter, $link_url, $expected ) {
 		$processor = new WPSEO_Link_Factory( $classifier, $lookup, $filter );
-		$actual    = $processor->build( array( $linkURL ) );
+		$actual    = $processor->build( array( $link_url ) );
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -73,7 +73,7 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	/**
 	 *
 	 */
-	protected function getClassifierMock( $classifyResult ) {
+	protected function getClassifierMock( $classify_result ) {
 		/** @var WPSEO_Link_Type_Classifier $classifier */
 		$classifier = $this
 			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
@@ -83,12 +83,12 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 		$classifier
 			->expects( $this->once() )
 			->method( 'classify' )
-			->will( $this->returnValue( $classifyResult ) );
+			->will( $this->returnValue( $classify_result ) );
 
 		return $classifier;
 	}
 
-	protected function getLookUpMock( $lookupResult ) {
+	protected function getLookUpMock( $lookup_result ) {
 		$lookup = $this
 			->getMockBuilder( 'WPSEO_Link_Internal_Lookup' )
 			->getMock();
@@ -96,21 +96,21 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 		$lookup
 			->expects( $this->once() )
 			->method( 'lookup' )
-			->will( $this->returnValue( $lookupResult ) );
+			->will( $this->returnValue( $lookup_result ) );
 
 		return $lookup;
 	}
 
-	protected function getFilterMock( $currentPage, $filterResult ) {
+	protected function getFilterMock( $current_page, $filter_result ) {
 		$filter = $this
 			->getMockBuilder( 'WPSEO_Link_Filter' )
-			->setConstructorArgs( array( $currentPage ) )
+			->setConstructorArgs( array( $current_page ) )
 			->getMock();
 
 		$filter
 			->expects( $this->once() )
 			->method( 'internal_link_with_fragment_filter' )
-			->will( $this->returnValue( $filterResult ) );
+			->will( $this->returnValue( $filter_result ) );
 
 		return $filter;
 	}

--- a/tests/admin/links/test-class-link-filter.php
+++ b/tests/admin/links/test-class-link-filter.php
@@ -5,12 +5,12 @@ class WPSEO_Link_Filter_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @dataProvider link_provider
 	 *
-	 * @param string     $currentPage
+	 * @param string     $current_page
 	 * @param WPSEO_Link $link
 	 * @param bool       $expected
 	 */
-	public function test_internal_link_with_fragment_filter( $currentPage, WPSEO_Link $link, $expected ) {
-		$filter = new WPSEO_Link_Filter( $currentPage );
+	public function test_internal_link_with_fragment_filter( $current_page, WPSEO_Link $link, $expected ) {
+		$filter = new WPSEO_Link_Filter( $current_page );
 
 		$this->assertEquals( $expected, $filter->internal_link_with_fragment_filter( $link ) );
 	}

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -50,10 +50,10 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 * @return stdClass
 	 */
 	public function get_user() {
-		static $userID = 1;
+		static $user_id = 1;
 		$user        = new stdClass();
 		$user->roles = array( 'administrator' );
-		$user->ID    = $userID ++;
+		$user->ID    = $user_id++;
 
 		return $user;
 	}

--- a/tests/test-class-wpseo-meta.php
+++ b/tests/test-class-wpseo-meta.php
@@ -93,19 +93,19 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_array_merge_recursive_distinct() {
 
-		$inputArray1 = array(
+		$input_array1 = array(
 			'one' => array(
 				'one-one' => array(),
 			),
 		);
 
-		$inputArray2 = array(
+		$input_array2 = array(
 			'one' => array(
 				'one-one' => 'string',
 			),
 		);
 
-		$output = WPSEO_Meta::array_merge_recursive_distinct( $inputArray1, $inputArray2 );
+		$output = WPSEO_Meta::array_merge_recursive_distinct( $input_array1, $input_array2 );
 		$this->assertEquals( $output['one']['one-one'], 'string' );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* Code style compliance

Local variable names can be safely changed to comply with the lowercase variable names rule without breaking anything.

## Test instructions

_N/A_