### PR TITLE
CS/cleanup: remove unreachable code

### DIFF
--- a/admin/class-bulk-description-editor-list-table.php
+++ b/admin/class-bulk-description-editor-list-table.php
@@ -65,7 +65,6 @@ class WPSEO_Bulk_Description_List_Table extends WPSEO_Bulk_List_Table {
 					'wpseo-new-metadesc-' . $record->ID,
 					$record->ID
 				);
-				break;
 
 			case 'col_existing_yoast_seo_metadesc':
 				// @todo Inconsistent return/echo behavior R.

--- a/admin/class-bulk-title-editor-list-table.php
+++ b/admin/class-bulk-title-editor-list-table.php
@@ -78,7 +78,6 @@ class WPSEO_Bulk_Title_Editor_List_Table extends WPSEO_Bulk_List_Table {
 					'wpseo-new-title-' . $record->ID,
 					$record->ID
 				);
-				break;
 		}
 
 		unset( $meta_data );

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -524,13 +524,12 @@ class WPSEO_Meta_Columns {
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'metadesc',
 					'orderby'  => 'meta_value',
 				);
-				break;
+
 			case 'wpseo-focuskw':
 				return array(
 					'meta_key' => WPSEO_Meta::$meta_prefix . 'focuskw',
 					'orderby'  => 'meta_value',
 				);
-				break;
 		}
 
 		return array();

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -74,11 +74,8 @@ class WPSEO_Taxonomy_Columns {
 			case 'wpseo-score':
 				return $this->get_score_value( $term_id );
 
-				break;
-
 			case 'wpseo-score-readability':
 				return $this->get_score_readability_value( $term_id );
-				break;
 		}
 
 		return $content;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -681,8 +681,6 @@ class WPSEO_Frontend {
 			$GLOBALS['wp_query'] = $old_wp_query;
 			unset( $old_wp_query );
 		}
-
-		return;
 	}
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

A `break` after a `return` is useless as it will never be read.


## Test instructions

_N/A_