### PR TITLE
Show proper notification in subsite for license state

### DIFF
--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -49,9 +49,24 @@ class WPSEO_Extensions {
 	 * @return bool Returns true when valid.
 	 */
 	public function is_valid( $extension ) {
-		$extension_option = $this->get_option( $extension );
+		$options = array();
 
-		return ( is_array( $extension_option ) && isset( $extension_option['status'] ) && $extension_option['status'] === 'valid' );
+		// On multisite we need to take the network activated state into account.
+		if ( is_multisite() ) {
+			$options[] = $this->get_site_option( $extension );
+		}
+
+		// Fetch the option for the current site.
+		$options[] = $this->get_option( $extension );
+
+		// If the site is either active on multisite level or current site level.
+		foreach ( $options as $extension_option ) {
+			if ( is_array( $extension_option ) && isset( $extension_option['status'] ) && $extension_option['status'] === 'valid' ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -75,7 +90,7 @@ class WPSEO_Extensions {
 	}
 
 	/**
-	 * Convert the extension to an option.
+	 * Retrieves the extension settings form a single site environment.
 	 *
 	 * @param string $extension The extension to get the name for.
 	 *
@@ -83,6 +98,17 @@ class WPSEO_Extensions {
 	 */
 	protected function get_option( $extension ) {
 		return get_option( $this->get_option_name( $extension ) );
+	}
+
+	/**
+	 * Retrieves the extension settings from a multisite environment.
+	 *
+	 * @param string $extension The extension to get the name for.
+	 *
+	 * @return mixed Returns the option.
+	 */
+	protected function get_site_option( $extension ) {
+		return get_site_option( $this->get_option_name( $extension ) );
 	}
 
 	/**

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -55,9 +55,7 @@ class WPSEO_Extensions {
 	 */
 	public function is_valid( $extension ) {
 		$extensions = new WPSEO_Extension_Manager();
-		$activated  = $extensions->is_activated( $this->extensions[ $extension ]['identifier'] );
-
-		return $activated;
+		return $extensions->is_activated( $this->extensions[ $extension ]['identifier'] );
 	}
 
 	/**

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -11,24 +11,29 @@ class WPSEO_Extensions {
 	/** @var array Array with the Yoast extensions */
 	protected $extensions = array(
 		'Yoast SEO Premium'     => array(
-			'slug'      => 'yoast-seo-premium',
-			'classname' => 'WPSEO_Premium',
+			'slug'       => 'yoast-seo-premium',
+			'identifier' => 'wordpress-seo-premium',
+			'classname'  => 'WPSEO_Premium',
 		),
 		'News SEO'              => array(
-			'slug'      => 'news-seo',
-			'classname' => 'WPSEO_News',
+			'slug'       => 'news-seo',
+			'identifier' => 'wordpress-seo-news',
+			'classname'  => 'WPSEO_News',
 		),
 		'Yoast WooCommerce SEO' => array(
-			'slug'      => 'woocommerce-yoast-seo',
-			'classname' => 'Yoast_WooCommerce_SEO',
+			'slug'       => 'woocommerce-yoast-seo',
+			'identifier' => 'yoast-woo-seo',
+			'classname'  => 'Yoast_WooCommerce_SEO',
 		),
 		'Video SEO'             => array(
-			'slug'      => 'video-seo-for-wordpress',
-			'classname' => 'WPSEO_Video_Sitemap',
+			'slug'       => 'video-seo-for-wordpress',
+			'identifier' => 'yoast-video-seo',
+			'classname'  => 'WPSEO_Video_Sitemap',
 		),
 		'Local SEO'             => array(
-			'slug'      => 'local-seo-for-wordpress',
-			'classname' => 'WPSEO_Local_Core',
+			'slug'       => 'local-seo-for-wordpress',
+			'identifier' => 'yoast-local-seo',
+			'classname'  => 'WPSEO_Local_Core',
 		),
 	);
 
@@ -49,24 +54,10 @@ class WPSEO_Extensions {
 	 * @return bool Returns true when valid.
 	 */
 	public function is_valid( $extension ) {
-		$options = array();
+		$extensions = new WPSEO_Extension_Manager();
+		$activated  = $extensions->is_activated( $this->extensions[ $extension ]['identifier'] );
 
-		// On multisite we need to take the network activated state into account.
-		if ( is_multisite() ) {
-			$options[] = $this->get_site_option( $extension );
-		}
-
-		// Fetch the option for the current site.
-		$options[] = $this->get_option( $extension );
-
-		// If the site is either active on multisite level or current site level.
-		foreach ( $options as $extension_option ) {
-			if ( is_array( $extension_option ) && isset( $extension_option['status'] ) && $extension_option['status'] === 'valid' ) {
-				return true;
-			}
-		}
-
-		return false;
+		return $activated;
 	}
 
 	/**
@@ -87,28 +78,6 @@ class WPSEO_Extensions {
 	 */
 	public function is_installed( $extension ) {
 		return class_exists( $this->extensions[ $extension ]['classname'] );
-	}
-
-	/**
-	 * Retrieves the extension settings form a single site environment.
-	 *
-	 * @param string $extension The extension to get the name for.
-	 *
-	 * @return mixed Returns the option.
-	 */
-	protected function get_option( $extension ) {
-		return get_option( $this->get_option_name( $extension ) );
-	}
-
-	/**
-	 * Retrieves the extension settings from a multisite environment.
-	 *
-	 * @param string $extension The extension to get the name for.
-	 *
-	 * @return mixed Returns the option.
-	 */
-	protected function get_site_option( $extension ) {
-		return get_site_option( $this->get_option_name( $extension ) );
 	}
 
 	/**


### PR DESCRIPTION
Whenever the plugin is activated on the network admin or on a specific sub-site, we should only show the notification when it is completely disabled.

Whenever the plugin is deactivated in network-admin it will get the state of `deactivated`.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the notification is shown to activate the plugin in My Yoast on a sub-site in a multisite installation with Yoast SEO not being network-active.

## Test instructions

This PR can be tested by following these steps:

**This needs to be tested by creating a branch on Premium and pulling these changes in!**

Multisite:
* Network activate the plugin and make sure the license is active
* Network de-activate the plugin and activate it on the first site
* This should be the same URL, so it should register as activated
* Activate the plugin on another sub-site
* This sub-site should not be activated and should show a notification that you are not receiving updates and support
* Network activating the plugin again should remove all notifications for all sub-sites and show the plugin as activated everywhere

Single Site:
* Also test this on a non-multisite installation to verify the notification is only shown when the state on the `Premium` page is displaying `deactivated`

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1389