### PR TITLE
Refrain from suggesting plugin update for Glue plugins

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -344,7 +344,7 @@ class WPSEO_Admin_Init {
 			if ( $plugin['compatible'] === false ) {
 				$notification_center->add_notification( $notification );
 
-				return;
+				continue;
 			}
 
 			$notification_center->remove_notification( $notification );

--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -27,73 +27,93 @@ class WPSEO_Plugin_Availability {
 	protected function register_yoast_plugins() {
 		$this->plugins = array(
 			'yoast-seo-premium' => array(
-				'url'         => 'https://yoast.com/wordpress/plugins/seo-premium/',
-				'title'       => 'Yoast SEO Premium',
-				/* translators: %1$s expands to Yoast SEO */
-				'description' => sprintf( __( 'The premium version of %1$s with more features & support.', 'wordpress-seo' ), 'Yoast SEO' ),
-				'installed'   => false,
-				'slug'        => 'wordpress-seo-premium/wp-seo-premium.php',
+				'url'          => 'https://yoast.com/wordpress/plugins/seo-premium/',
+				'title'        => 'Yoast SEO Premium',
+				'description'  => sprintf(
+					/* translators: %1$s expands to Yoast SEO */
+					__( 'The premium version of %1$s with more features & support.', 'wordpress-seo' ),
+					'Yoast SEO'
+				),
+				'installed'    => false,
+				'slug'         => 'wordpress-seo-premium/wp-seo-premium.php',
+				'version_sync' => true,
 			),
 
 			'video-seo-for-wordpress-seo-by-yoast' => array(
-				'url'         => 'https://yoast.com/wordpress/plugins/video-seo/',
-				'title'       => 'Video SEO',
-				'description' => __( 'Optimize your videos to show them off in search results and get more clicks!', 'wordpress-seo' ),
-				'installed'   => false,
-				'slug'        => 'wpseo-video/video-seo.php',
+				'url'          => 'https://yoast.com/wordpress/plugins/video-seo/',
+				'title'        => 'Video SEO',
+				'description'  => __( 'Optimize your videos to show them off in search results and get more clicks!', 'wordpress-seo' ),
+				'installed'    => false,
+				'slug'         => 'wpseo-video/video-seo.php',
+				'version_sync' => true,
 			),
 
 			'yoast-news-seo' => array(
-				'url'         => 'https://yoast.com/wordpress/plugins/news-seo/',
-				'title'       => 'News SEO',
-				'description' => __( 'Are you in Google News? Increase your traffic from Google News by optimizing for it!', 'wordpress-seo' ),
-				'installed'   => false,
-				'slug'        => 'wpseo-news/wpseo-news.php',
+				'url'          => 'https://yoast.com/wordpress/plugins/news-seo/',
+				'title'        => 'News SEO',
+				'description'  => __( 'Are you in Google News? Increase your traffic from Google News by optimizing for it!', 'wordpress-seo' ),
+				'installed'    => false,
+				'slug'         => 'wpseo-news/wpseo-news.php',
+				'version_sync' => true,
 			),
 
 			'local-seo-for-yoast-seo' => array(
-				'url'         => 'https://yoast.com/wordpress/plugins/local-seo/',
-				'title'       => 'Local SEO',
-				'description' => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
-				'installed'   => false,
-				'slug'        => 'wordpress-seo-local/local-seo.php',
+				'url'          => 'https://yoast.com/wordpress/plugins/local-seo/',
+				'title'        => 'Local SEO',
+				'description'  => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
+				'installed'    => false,
+				'slug'         => 'wordpress-seo-local/local-seo.php',
+				'version_sync' => true,
 			),
 
 			'yoast-woocommerce-seo' => array(
-				'url'         => 'https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/',
-				'title'       => 'Yoast WooCommerce SEO',
-				/* translators: %1$s expands to Yoast SEO */
-				'description' => sprintf( __( 'Seamlessly integrate WooCommerce with %1$s and get extra features!', 'wordpress-seo' ), 'Yoast SEO' ),
-				'installed'   => false,
-				'slug'        => 'wpseo-woocommerce/wpseo-woocommerce.php',
+				'url'          => 'https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/',
+				'title'        => 'Yoast WooCommerce SEO',
+				'description'  => sprintf(
+					/* translators: %1$s expands to Yoast SEO */
+					__( 'Seamlessly integrate WooCommerce with %1$s and get extra features!', 'wordpress-seo' ),
+					'Yoast SEO'
+				),
+				'installed'    => false,
+				'slug'         => 'wpseo-woocommerce/wpseo-woocommerce.php',
+				'version_sync' => true,
 			),
 
 			'yoast-acf-analysis' => array(
-				'url'         => 'https://wordpress.org/plugins/acf-content-analysis-for-yoast-seo/',
-				'title'       => 'ACF Content Analysis for Yoast SEO',
-				/* translators: %1$s expands to Yoast SEO */
-				'description' => sprintf( __( 'Seamlessly integrate ACF with %1$s for the content analysis!', 'wordpress-seo' ), 'Yoast SEO' ),
-				'installed'   => false,
-				'slug'        => 'acf-content-analysis-for-yoast-seo/yoast-acf-analysis.php',
+				'url'           => 'https://wordpress.org/plugins/acf-content-analysis-for-yoast-seo/',
+				'title'         => 'ACF Content Analysis for Yoast SEO',
+				'description'   => sprintf(
+					/* translators: %1$s expands to Yoast SEO, %2$s expands to Advanced Custom Fields */
+					__( 'Seamlessly integrate %2$s with %1$s for the content analysis!', 'wordpress-seo' ),
+					'Yoast SEO',
+					'Advanced Custom Fields'
+				),
+				'installed'     => false,
+				'slug'          => 'acf-content-analysis-for-yoast-seo/yoast-acf-analysis.php',
 				'_dependencies' => array(
 					'Advanced Custom Fields' => array(
 						'slug' => 'advanced-custom-fields/acf.php',
 					),
 				),
+				'version_sync'  => false,
 			),
 
 			'yoastseo-amp' => array(
-				'url'         => 'https://wordpress.org/plugins/glue-for-yoast-seo-amp/',
-				'title'       => 'Yoast SEO AMP Glue',
-				/* translators: %1$s expands to Yoast SEO */
-				'description' => sprintf( __( 'Seamlessly integrate %1$s into your AMP pages!', 'wordpress-seo' ), 'Yoast SEO' ),
-				'installed'   => false,
-				'slug'        => 'glue-for-yoast-seo-amp/yoastseo-amp.php',
+				'url'           => 'https://wordpress.org/plugins/glue-for-yoast-seo-amp/',
+				'title'         => 'Yoast SEO AMP Glue',
+				'description'   => sprintf(
+					/* translators: %1$s expands to Yoast SEO */
+					__( 'Seamlessly integrate %1$s into your AMP pages!', 'wordpress-seo' ),
+					'Yoast SEO'
+				),
+				'installed'     => false,
+				'slug'          => 'glue-for-yoast-seo-amp/yoastseo-amp.php',
 				'_dependencies' => array(
 					'AMP' => array(
 						'slug' => 'amp/amp.php',
 					),
 				),
+				'version_sync'  => false,
 			),
 		);
 	}

--- a/admin/class-plugin-compatibility.php
+++ b/admin/class-plugin-compatibility.php
@@ -83,13 +83,13 @@ class WPSEO_Plugin_Compatibility {
 	 */
 	public function is_compatible( $plugin ) {
 		$plugin = $this->availability_checker->get_plugin( $plugin );
-		$plugin_version = $this->availability_checker->get_version( $plugin );
 
 		// If we are not syncing versions, we are always compatible.
-		if ( $plugin['version_sync'] === false ) {
+		if ( ! isset( $plugin['version_sync'] ) || $plugin['version_sync'] !== true ) {
 			return true;
 		}
 
+		$plugin_version = $this->availability_checker->get_version( $plugin );
 		return $this->get_major_minor_version( $plugin_version ) === $this->current_wpseo_version;
 	}
 

--- a/admin/class-plugin-compatibility.php
+++ b/admin/class-plugin-compatibility.php
@@ -85,6 +85,11 @@ class WPSEO_Plugin_Compatibility {
 		$plugin = $this->availability_checker->get_plugin( $plugin );
 		$plugin_version = $this->availability_checker->get_version( $plugin );
 
+		// If we are not syncing versions, we are always compatible.
+		if ( $plugin['version_sync'] === false ) {
+			return true;
+		}
+
 		return $this->get_major_minor_version( $plugin_version ) === $this->current_wpseo_version;
 	}
 

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -50,7 +50,10 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test with a
+	 * Test with a draft post.
+	 *
+	 * This should be processed, but will not be displayed.
+	 * See https://github.com/Yoast/wordpress-seo/pull/8068#issuecomment-338146035
 	 */
 	public function test_is_processable_draft() {
 
@@ -60,7 +63,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 
 		$processor = $this->get_processor();
 		$processor
-			->expects( $this->never() )
+			->expects( $this->once() )
 			->method( 'process' );
 
 		$watcher = new WPSEO_Link_Watcher( $processor );

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -20,11 +20,12 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 
 	public function test_plugin_existence() {
 		$expected = array(
-			'url'         => 'https://yoast.com/',
-			'title'       => 'Test Plugin',
-			'description' => '',
-			'version'     => '3.3',
-			'installed'   => true,
+			'url'          => 'https://yoast.com/',
+			'title'        => 'Test Plugin',
+			'description'  => '',
+			'version'      => '3.3',
+			'installed'    => true,
+			'version_sync' => true,
 		);
 
 		$this->assertEquals( self::$class_instance->get_plugin( 'test-plugin' ), $expected );

--- a/tests/admin/test-class-plugin-compatibility.php
+++ b/tests/admin/test-class-plugin-compatibility.php
@@ -23,6 +23,8 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( self::$class_instance->is_compatible( 'test-plugin' ) );
 		$this->assertFalse( self::$class_instance->is_compatible( 'test-plugin-invalid-version' ) );
 		$this->assertTrue( self::$class_instance->is_compatible( 'unavailable-test-plugin' ) );
+
+		$this->assertTrue( self::$class_instance->is_compatible( 'test-plugin-non-version-synced' ) );
 	}
 
 	/**
@@ -30,30 +32,43 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_plugin_version_matches() {
 		$expected = array(
-			'test-plugin' => array(
-				'url'         => 'https://yoast.com/',
-				'title'       => 'Test Plugin',
-				'description' => '',
-				'version'     => '3.3',
-				'installed'   => true,
-				'compatible'  => true,
+			'test-plugin'                 => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '3.3',
+				'installed'    => true,
+				'version_sync' => true,
+				'compatible'   => true,
 			),
-			'test-plugin-dependency' => array(
+			'test-plugin-dependency'      => array(
 				'url'           => 'https://yoast.com/',
 				'title'         => 'Test Plugin With Dependency',
 				'description'   => '',
 				'version'       => '3.3',
 				'installed'     => true,
 				'_dependencies' => array( 'test-plugin' ),
+				'version_sync'  => true,
 				'compatible'    => true,
 			),
 			'test-plugin-invalid-version' => array(
-				'url'         => 'https://yoast.com/',
-				'title'       => 'Test Plugin',
-				'description' => '',
-				'version'     => '1.3',
-				'installed'   => true,
-				'compatible'  => false,
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '1.3',
+				'installed'    => true,
+				'version_sync' => true,
+				'compatible'   => false,
+			),
+
+			'test-plugin-non-version-synced' => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '1.3',
+				'installed'    => true,
+				'version_sync' => false,
+				'compatible'   => true,
 			),
 		);
 
@@ -63,32 +78,44 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 	public function test_WITHOUT_a_checker_object() {
 		$class_instance = new WPSEO_Plugin_Compatibility( '3.3' );
 
-		$this->assertFalse( $class_instance->is_compatible( 'test-plugin' ) );
+		// If we cannot determine if the plugin should be synced; it is always marked as compatible.
+		$this->assertTrue( $class_instance->is_compatible( 'test-plugin' ) );
 	}
 
 	public function test_get_installed_plugins() {
 		$expected = array(
-			'test-plugin' => array(
-				'url'         => 'https://yoast.com/',
-				'title'       => 'Test Plugin',
-				'description' => '',
-				'version'     => '3.3',
-				'installed'   => true,
+			'test-plugin'                    => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '3.3',
+				'installed'    => true,
+				'version_sync' => true,
 			),
-			'test-plugin-dependency' => array(
+			'test-plugin-dependency'         => array(
 				'url'           => 'https://yoast.com/',
 				'title'         => 'Test Plugin With Dependency',
 				'description'   => '',
 				'version'       => '3.3',
 				'installed'     => true,
 				'_dependencies' => array( 'test-plugin' ),
+				'version_sync'  => true,
 			),
-			'test-plugin-invalid-version' => array(
-				'url'         => 'https://yoast.com/',
-				'title'       => 'Test Plugin',
-				'description' => '',
-				'version'     => '1.3',
-				'installed'   => true,
+			'test-plugin-invalid-version'    => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '1.3',
+				'installed'    => true,
+				'version_sync' => true,
+			),
+			'test-plugin-non-version-synced' => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '1.3',
+				'installed'    => true,
+				'version_sync' => false,
 			),
 		);
 

--- a/tests/admin/test-class-wpseo-plugin-availability-double.php
+++ b/tests/admin/test-class-wpseo-plugin-availability-double.php
@@ -15,6 +15,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'description' => '',
 				'version'     => '3.3',
 				'installed'   => false,
+				'version_sync' => true,
 			),
 
 			'test-plugin-dependency' => array(
@@ -24,6 +25,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'version'       => '3.3',
 				'installed'     => false,
 				'_dependencies' => array( 'test-plugin' ),
+				'version_sync' => true,
 			),
 
 			'unavailable-test-plugin' => array(
@@ -32,6 +34,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'description' => '',
 				'version'     => '3.3',
 				'installed'   => false,
+				'version_sync' => true,
 			),
 
 			'unavailable-test-plugin-dependency' => array(
@@ -40,6 +43,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'description' => '',
 				'version'     => '3.3',
 				'installed'   => false,
+				'version_sync' => true,
 			),
 
 			'test-plugin-no-version' => array(
@@ -47,6 +51,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'title'       => 'Test Plugin With No Version',
 				'description' => '',
 				'installed'   => false,
+				'version_sync' => true,
 			),
 
 			'test-plugin-invalid-version' => array(
@@ -55,6 +60,16 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'description' => '',
 				'version'     => '1.3',
 				'installed'   => false,
+				'version_sync' => true,
+			),
+
+			'test-plugin-non-version-synced' => array(
+				'url'         => 'https://yoast.com/',
+				'title'       => 'Test Plugin',
+				'description' => '',
+				'version'     => '1.3',
+				'installed'   => true,
+				'version_sync' => false,
 			),
 		);
 	}


### PR DESCRIPTION
## Relevant technical choices:

* Introduced `version_sync` to refrain from showing expected version on Glue plugins.

## Test instructions

This PR can be tested by following these steps:

* Install `ACF Content Analysis for Yoast SEO` in the `acf-content-analysis-for-yoast-seo` folder (differs from repo!)
* Make sure the notification about the version mismatch is not shown

This also counts for the AMP Glue plugin

Fixes #8108
