### PR TITLE
Build/Travis: don't lint code from external dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ before_script:
 - phpenv rehash
 
 script:
-- if [[ "$PHPLINT" == "1" ]]; then find -L .  -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+- if [[ "$PHPLINT" == "1" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
 - if [[ "$PHPCS" == "1" ]]; then vendor/bin/phpcs -v --runtime-set ignore_warnings_on_exit 1; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check:js; fi
 - if [[ -z "$CODECLIMATE_REPO_TOKEN" ]]; then COVERAGE="0"; fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

Just like the `vendor` directory, there is no need for the build to lint the code in the `node_modules`.
The build should be about this repo, not about other people's code.

I'm presuming that the upgrade process for the node modules themselves is managed and tested thoroughly on upgrade. If not, that's another matter and this PR should in that case not be merged until the node module upgrade process has been formalized.


## Test instructions

_N/A_