### PR TITLE
Documentation/Plugin: add perfunctory class constant documentation

### DIFF
--- a/admin/ajax/class-yoast-dismissable-notice.php
+++ b/admin/ajax/class-yoast-dismissable-notice.php
@@ -9,8 +9,19 @@
  */
 class Yoast_Dismissable_Notice_Ajax {
 
+	/**
+	 * @var string Notice type toggle value for user notices.
+	 */
 	const FOR_USER = 'user_meta';
+
+	/**
+	 * @var string Notice type toggle value for network notices.
+	 */
 	const FOR_NETWORK = 'site_option';
+
+	/**
+	 * @var string Notice type toggle value for site notices.
+	 */
 	const FOR_SITE = 'option';
 
 

--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -8,7 +8,14 @@
  */
 class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 
+	/**
+	 * @var string Version number for License Page Manager.
+	 */
 	const VERSION_LEGACY = '1';
+
+	/**
+	 * @var string Version number for License Page Manager.
+	 */
 	const VERSION_BACKWARDS_COMPATIBILITY = '2';
 
 	/**

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -9,11 +9,29 @@
  */
 class Yoast_Notification {
 
+	/**
+	 * @var string Type of capability check.
+	 */
 	const MATCH_ALL = 'all';
+
+	/**
+	 * @var string Type of capability check.
+	 */
 	const MATCH_ANY = 'any';
 
+	/**
+	 * @var string Notification type.
+	 */
 	const ERROR = 'error';
+
+	/**
+	 * @var string Notification type.
+	 */
 	const WARNING = 'warning';
+
+	/**
+	 * @var string Notification type.
+	 */
 	const UPDATED = 'updated';
 
 	/**

--- a/admin/google_search_console/class-gsc-count.php
+++ b/admin/google_search_console/class-gsc-count.php
@@ -9,12 +9,12 @@
 class WPSEO_GSC_Count {
 
 	/**
-	 * @var string The name of the option containing the last checked timestamp. 
+	 * @var string The name of the option containing the last checked timestamp.
 	 */
 	const OPTION_CI_LAST_FETCH = 'wpseo_gsc_last_fetch';
 
-	/** 
-	 * @var string The option name where the issues counts are saved. 
+	/**
+	 * @var string The option name where the issues counts are saved.
 	 */
 	const OPTION_CI_COUNTS = 'wpseo_gsc_issues_counts';
 

--- a/admin/google_search_console/class-gsc-count.php
+++ b/admin/google_search_console/class-gsc-count.php
@@ -8,11 +8,11 @@
  */
 class WPSEO_GSC_Count {
 
-	// The last checked timestamp.
+	/** @var string The name of the option containing the last checked timestamp. */
 	const OPTION_CI_LAST_FETCH = 'wpseo_gsc_last_fetch';
 
-	// The option name where the issues counts are saved.
-	const OPTION_CI_COUNTS     = 'wpseo_gsc_issues_counts';
+	/** @var string The option name where the issues counts are saved. */
+	const OPTION_CI_COUNTS = 'wpseo_gsc_issues_counts';
 
 	/**
 	 * @var WPSEO_GSC_Service

--- a/admin/google_search_console/class-gsc-count.php
+++ b/admin/google_search_console/class-gsc-count.php
@@ -8,10 +8,14 @@
  */
 class WPSEO_GSC_Count {
 
-	/** @var string The name of the option containing the last checked timestamp. */
+	/**
+	 * @var string The name of the option containing the last checked timestamp. 
+	 */
 	const OPTION_CI_LAST_FETCH = 'wpseo_gsc_last_fetch';
 
-	/** @var string The option name where the issues counts are saved. */
+	/** 
+	 * @var string The option name where the issues counts are saved. 
+	 */
 	const OPTION_CI_COUNTS = 'wpseo_gsc_issues_counts';
 
 	/**

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -8,28 +8,28 @@
  */
 class WPSEO_Link_Columns {
 
-	/** 
-	 * @var string Partial column name. 
+	/**
+	 * @var string Partial column name.
 	 */
 	const COLUMN_LINKED = 'linked';
 
-	/** 
-	 * @var string Partial column name. 
+	/**
+	 * @var string Partial column name.
 	 */
 	const COLUMN_LINKS = 'links';
 
-	/** 
-	 * @var WPSEO_Link_Column_Count 
+	/**
+	 * @var WPSEO_Link_Column_Count
 	 */
 	protected $link_count;
 
-	/** 
-	 * @var WPSEO_Meta_Storage Storage to use. 
+	/**
+	 * @var WPSEO_Meta_Storage Storage to use.
 	 */
 	protected $storage;
 
-	/** 
-	 * @var array List of public post types. 
+	/**
+	 * @var array List of public post types.
 	 */
 	protected $public_post_types = array();
 

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -8,7 +8,10 @@
  */
 class WPSEO_Link_Columns {
 
+	/** @var string Partial column name. */
 	const COLUMN_LINKED = 'linked';
+
+	/** @var string Partial column name. */
 	const COLUMN_LINKS = 'links';
 
 	/** @var WPSEO_Link_Column_Count */

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -8,19 +8,29 @@
  */
 class WPSEO_Link_Columns {
 
-	/** @var string Partial column name. */
+	/** 
+	 * @var string Partial column name. 
+	 */
 	const COLUMN_LINKED = 'linked';
 
-	/** @var string Partial column name. */
+	/** 
+	 * @var string Partial column name. 
+	 */
 	const COLUMN_LINKS = 'links';
 
-	/** @var WPSEO_Link_Column_Count */
+	/** 
+	 * @var WPSEO_Link_Column_Count 
+	 */
 	protected $link_count;
 
-	/** @var WPSEO_Meta_Storage Storage to use. */
+	/** 
+	 * @var WPSEO_Meta_Storage Storage to use. 
+	 */
 	protected $storage;
 
-	/** @var array List of public post types. */
+	/** 
+	 * @var array List of public post types. 
+	 */
 	protected $public_post_types = array();
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

In a number of classes, constants did not have docblocks.
This fixes that in a minimalist fashion.

Side-note: For some places I wonder if this isn't taking abstraction too far and a `switch` would have been a more appropriate solution.


## Test instructions

_N/A_