### PR TITLE
Documentation/Tests: add perfunctory documentation to mock classes

### DIFF
--- a/tests/admin/banner/test-class-admin-banner-sidebar.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar.php
@@ -2,6 +2,11 @@
 
 class WPSEO_Features_Mock extends WPSEO_Features {
 
+	/**
+	 * Checks if using the free version of the plugin.
+	 *
+	 * @return bool
+	 */
 	public function is_free() {
 		return false;
 	}

--- a/tests/admin/banner/test-class-admin-banner-spot.php
+++ b/tests/admin/banner/test-class-admin-banner-spot.php
@@ -5,7 +5,7 @@ class WPSEO_Admin_Banner_Renderer_Mock extends WPSEO_Admin_Banner_Renderer {
 	/**
 	 * Overrides the render method to get a render method for the test.
 	 *
-	 * @param WPSEO_Admin_Banner $banner
+	 * @param WPSEO_Admin_Banner $banner The mock banner to render.
 	 *
 	 * @return string
 	 */

--- a/tests/admin/test-class-wpseo-plugin-availability-double.php
+++ b/tests/admin/test-class-wpseo-plugin-availability-double.php
@@ -7,6 +7,9 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 
 	private $available_dependencies = array( 'test-plugin', 'test-plugin-dependency' );
 
+	/**
+	 * Mock register all the available Yoast SEO plugins.
+	 */
 	public function register_yoast_plugins() {
 		$this->plugins = array(
 			'test-plugin' => array(
@@ -59,12 +62,22 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 		);
 	}
 
+	/**
+	 * Sets certain plugin properties based on WordPress' status.
+	 */
 	protected function register_yoast_plugins_status() {
 		$this->plugins['test-plugin']['installed'] = true;
 		$this->plugins['test-plugin-dependency']['installed'] = true;
 		$this->plugins['test-plugin-invalid-version']['installed'] = true;
 	}
 
+	/**
+	 * Checks whether a dependency is available.
+	 *
+	 * @param {string} $dependency The dependency to look for.
+	 *
+	 * @return bool Whether or not the dependency is available.
+	 */
 	public function is_dependency_available( $dependency ) {
 		return in_array( $dependency, $this->available_dependencies );
 	}

--- a/tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/tests/config-ui/components/test-class-component-connect-gsc.php
@@ -7,11 +7,15 @@
  * Class WPSEO_Config_Component_Connect_Google_Search_Console_Mock
  */
 class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Config_Component_Connect_Google_Search_Console {
+	/** @var string */
 	protected $profile;
 
 	/** @var WPSEO_UnitTestCase */
 	protected $test;
 
+	/**
+	 * WPSEO_Config_Component_Connect_Google_Search_Console_Mock constructor.
+	 */
 	public function __construct( $test ) {
 		$this->test = $test;
 
@@ -21,8 +25,8 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Co
 	/**
 	 * Make function public
 	 *
-	 * @param array $current_data
-	 * @param array $data
+	 * @param array $current_data Saved data before changes.
+	 * @param array $data         Data after changes.
 	 */
 	public function handle_profile_change( $current_data, $data ) {
 		return parent::handle_profile_change( $current_data, $data );
@@ -55,6 +59,11 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Co
 		return $this->mapping;
 	}
 
+	/**
+	 * Get a mocked profile.
+	 *
+	 * @return string
+	 */
 	public function get_profile() {
 		return $this->profile;
 	}
@@ -63,6 +72,9 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Co
 		$this->profile = $profile;
 	}
 
+	/**
+	 * Mock reloading the GSC issues.
+	 */
 	public function reload_issues() {
 		$this->test->stub_call_register( 'reload_issues' );
 	}

--- a/tests/config-ui/fields/test-class-config-field.php
+++ b/tests/config-ui/fields/test-class-config-field.php
@@ -9,7 +9,7 @@
 class WPSEO_Config_Field_ extends WPSEO_Config_Field {
 
 	/**
-	 * @param $data
+	 * @param array|mixed $data Value of this field.
 	 */
 	public function set_data( $data ) {
 		$this->data = $data;

--- a/tests/onpage/test-class-onpage-request.php
+++ b/tests/onpage/test-class-onpage-request.php
@@ -8,8 +8,8 @@ class WPSEO_OnPage_Request_Double extends WPSEO_OnPage_Request {
 	/**
 	 * Overwrite the get_remote method, because this is a dependency.
 	 *
-	 * @param string $target_url
-	 * @param array  $parameters
+	 * @param string $target_url The home url.
+	 * @param array  $parameters Array of extra parameters.
 	 *
 	 * @return array
 	 */

--- a/tests/recalculate/class-recalculate-posts-double.php
+++ b/tests/recalculate/class-recalculate-posts-double.php
@@ -8,7 +8,7 @@ class WPSEO_Recalculate_Posts_Test_Double extends WPSEO_Recalculate_Posts {
 	/**
 	 * Wraps the protected method so we can access it in our tests.
 	 *
-	 * @param WP_Post $item
+	 * @param WP_Post $item The post for which to build the analyzer data.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

Mock classes: Copied over the self-same documentation from the original class if applicable or added perfunctory docs otherwise.

Incomplete as the Mock classes will be split to their own files in a separate directory and will be exempt from some of the documentation rules.
These are fixes I'd already made before that decision was taken.


## Test instructions

_N/A_