### PR TITLE
CS (non-)compliance: Use strict comparisons with array functions

### DIFF
--- a/admin/ajax/class-yoast-plugin-conflict-ajax.php
+++ b/admin/ajax/class-yoast-plugin-conflict-ajax.php
@@ -98,7 +98,7 @@ class Yoast_Plugin_Conflict_Ajax {
 	 * @param string $posted_plugin Plugin to check against dismissed conflicts.
 	 */
 	private function compare_plugin( $posted_plugin ) {
-		if ( ! in_array( $posted_plugin, $this->dismissed_conflicts ) ) {
+		if ( ! in_array( $posted_plugin, $this->dismissed_conflicts, true ) ) {
 			$this->dismissed_conflicts[] = $posted_plugin;
 		}
 	}

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -475,7 +475,7 @@ class WPSEO_Admin_Init {
 	 * Loads admin page class for all admin pages starting with `wpseo_`.
 	 */
 	private function load_admin_user_class() {
-		if ( in_array( $this->pagenow, array( 'user-edit.php', 'profile.php' ) ) && current_user_can( 'edit_users' ) ) {
+		if ( in_array( $this->pagenow, array( 'user-edit.php', 'profile.php' ), true ) && current_user_can( 'edit_users' ) ) {
 			new WPSEO_Admin_User_Profile();
 		}
 	}

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -647,7 +647,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			'post_date',
 		);
 
-		if ( in_array( $orderby, $valid_column_names ) ) {
+		if ( in_array( $orderby, $valid_column_names, true ) ) {
 			return $orderby;
 		}
 
@@ -662,7 +662,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 * @return string $order SQL order string (ASC, DESC).
 	 */
 	protected function sanitize_order( $order ) {
-		if ( in_array( strtoupper( $order ), array( 'ASC', 'DESC' ) ) ) {
+		if ( in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ) {
 			return $order;
 		}
 
@@ -697,7 +697,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 		if ( ! empty( $_GET['post_status'] ) ) {
 			$requested_state = sanitize_text_field( $_GET['post_status'] );
-			if ( in_array( $requested_state, $states ) ) {
+			if ( in_array( $requested_state, $states, true ) ) {
 				$states = array( $requested_state );
 			}
 		}
@@ -764,7 +764,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$attributes = '';
 		$class = array( $column_name, "column-$column_name$classes" );
 
-		if ( in_array( $column_name, $hidden ) ) {
+		if ( in_array( $column_name, $hidden, true ) ) {
 			$class[] = 'hidden';
 		}
 
@@ -806,7 +806,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		}
 
 		if ( $post_type_object->public ) {
-			if ( in_array( $rec->post_status, array( 'pending', 'draft', 'future' ) ) ) {
+			if ( in_array( $rec->post_status, array( 'pending', 'draft', 'future' ), true ) ) {
 				if ( $can_edit_post ) {
 					$actions['view'] = sprintf(
 						'<a href="%s" aria-label="%s">%s</a>',

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -87,7 +87,7 @@ class WPSEO_Admin_Pages {
 
 		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
 
-		if ( in_array( $page, array( 'wpseo_social', WPSEO_Admin::PAGE_IDENTIFIER ) ) ) {
+		if ( in_array( $page, array( 'wpseo_social', WPSEO_Admin::PAGE_IDENTIFIER ), true ) ) {
 			wp_enqueue_media();
 
 			$this->asset_manager->enqueue_script( 'admin-media' );

--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -126,7 +126,7 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 		$wpseo_robots = get_option( 'wpseo_' . $taxonomy . '_' . $term_id . '_robots', false );
 		if ( $wpseo_robots !== false ) {
 			// The value 1, 2 and 6 are the index values in wpSEO.
-			$new_robot_value = ( in_array( $wpseo_robots, array( 1, 2, 6 ) ) ) ? 'index' : 'noindex';
+			$new_robot_value = ( in_array( (int) $wpseo_robots, array( 1, 2, 6 ), true ) ) ? 'index' : 'noindex';
 
 			$tax_meta[ $taxonomy ][ $term_id ]['wpseo_noindex'] = $new_robot_value;
 		}

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -640,7 +640,7 @@ class WPSEO_Meta_Columns {
 			$cpts    = get_post_types( array( 'public' => true ), 'names' );
 			$options = get_option( 'wpseo_titles' );
 
-			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $cpts ) === false );
+			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $cpts, true ) === false );
 		}
 
 		return false;

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -93,7 +93,7 @@ class Yoast_Plugin_Conflict {
 			$sections_checked = array();
 		}
 
-		if ( ! in_array( $plugin_section, $sections_checked ) ) {
+		if ( ! in_array( $plugin_section, $sections_checked, true ) ) {
 			$sections_checked[] = $plugin_section;
 			$has_conflicts      = ( ! empty( $this->active_plugins[ $plugin_section ] ) );
 
@@ -266,7 +266,7 @@ class Yoast_Plugin_Conflict {
 	 * @return bool
 	 */
 	protected function check_plugin_is_active( $plugin ) {
-		return in_array( $plugin, $this->all_active_plugins );
+		return in_array( $plugin, $this->all_active_plugins, true );
 	}
 
 	/**
@@ -284,7 +284,7 @@ class Yoast_Plugin_Conflict {
 			$this->active_plugins[ $plugin_section ] = array();
 		}
 
-		if ( ! in_array( $plugin, $this->active_plugins[ $plugin_section ] ) ) {
+		if ( ! in_array( $plugin, $this->active_plugins[ $plugin_section ], true ) ) {
 			$this->active_plugins[ $plugin_section ][] = $plugin;
 		}
 	}
@@ -301,7 +301,7 @@ class Yoast_Plugin_Conflict {
 	protected function find_plugin_category( $plugin ) {
 
 		foreach ( $this->plugins as $plugin_section => $plugins ) {
-			if ( in_array( $plugin, $plugins ) ) {
+			if ( in_array( $plugin, $plugins, true ) ) {
 				return $plugin_section;
 			}
 		}
@@ -313,7 +313,7 @@ class Yoast_Plugin_Conflict {
 	 */
 	private function remove_deactivated_plugin() {
 		$deactivated_plugin = filter_input( INPUT_GET, 'plugin' );
-		$key_to_remove      = array_search( $deactivated_plugin, $this->all_active_plugins );
+		$key_to_remove      = array_search( $deactivated_plugin, $this->all_active_plugins, true );
 
 		if ( $key_to_remove !== false ) {
 			unset( $this->all_active_plugins[ $key_to_remove ] );

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -109,7 +109,7 @@ class WPSEO_Metabox_Formatter {
 		if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'get_active_modules' ) ) {
 			$active_modules = Jetpack::get_active_modules();
 
-			return in_array( 'markdown', $active_modules );
+			return in_array( 'markdown', $active_modules, true );
 		}
 
 		return false;

--- a/admin/google_search_console/class-gsc-mapper.php
+++ b/admin/google_search_console/class-gsc-mapper.php
@@ -73,7 +73,7 @@ class WPSEO_GSC_Mapper {
 	 * @return string
 	 */
 	public static function platform_from_api( $platform ) {
-		if ( ! empty( $platform ) && $platform = array_search( $platform, self::$platforms ) ) {
+		if ( ! empty( $platform ) && $platform = array_search( $platform, self::$platforms, true ) ) {
 			return $platform;
 		}
 
@@ -103,7 +103,7 @@ class WPSEO_GSC_Mapper {
 	 * @return string
 	 */
 	public static function category_from_api( $category ) {
-		if ( ! empty( $category ) && $category = array_search( $category, self::$categories ) ) {
+		if ( ! empty( $category ) && $category = array_search( $category, self::$categories, true ) ) {
 			return $category;
 		}
 

--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -226,7 +226,7 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	 * @return bool
 	 */
 	private function can_create_redirect() {
-		return in_array( $this->current_view, array( 'soft_404', 'not_found', 'access_denied' ) );
+		return in_array( $this->current_view, array( 'soft_404', 'not_found', 'access_denied' ), true );
 	}
 
 	/**

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -145,7 +145,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$cpts    = get_post_types( array( 'public' => true ), 'names' );
 			$options = get_option( 'wpseo_titles' );
 
-			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $cpts ) === false );
+			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $cpts, true ) === false );
 		}
 		return false;
 	}

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -80,7 +80,7 @@ else {
 		$tool_pages[] = 'file-editor';
 	}
 
-	if ( in_array( $tool_page, $tool_pages ) ) {
+	if ( in_array( $tool_page, $tool_pages, true ) ) {
 		require_once WPSEO_PATH . 'admin/views/tool-' . $tool_page . '.php';
 	}
 }

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -238,7 +238,7 @@ class WPSEO_Taxonomy_Columns {
 			$custom_taxonomies = get_taxonomies( array( 'public' => true ), 'names' );
 			$options           = get_option( 'wpseo_titles' );
 
-			return ( ( isset( $options[ 'hideeditbox-tax-' . $taxonomy ] ) && $options[ 'hideeditbox-tax-' . $taxonomy ] === true ) || in_array( $taxonomy, $custom_taxonomies ) === false );
+			return ( ( isset( $options[ 'hideeditbox-tax-' . $taxonomy ] ) && $options[ 'hideeditbox-tax-' . $taxonomy ] === true ) || in_array( $taxonomy, $custom_taxonomies, true ) === false );
 		}
 
 		return false;

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -56,7 +56,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 		$help_button_text = isset( $field_configuration['options']['help-button'] ) ? $field_configuration['options']['help-button'] : '';
 		$help             = new WPSEO_Admin_Help_Panel( $field_name, $help_button_text, $help_content );
 
-		if ( in_array( $field_configuration['type'], array( 'focuskeyword', 'pageanalysis', 'snippetpreview' ) ) ) {
+		if ( in_array( $field_configuration['type'], array( 'focuskeyword', 'pageanalysis', 'snippetpreview' ), true ) ) {
 			return $this->parse_section_row( $field, $field_configuration['type'], $help );
 		}
 

--- a/admin/views/tabs/metas/taxonomies.php
+++ b/admin/views/tabs/metas/taxonomies.php
@@ -13,7 +13,7 @@ $taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
 if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 	foreach ( $taxonomies as $tax ) {
 		// Explicitly hide all the core taxonomies we never want to do stuff for.
-		if ( in_array( $tax->name, array( 'link_category', 'nav_menu' ) ) ) {
+		if ( in_array( $tax->name, array( 'link_category', 'nav_menu' ), true ) ) {
 			continue;
 		}
 

--- a/admin/views/tabs/sitemaps/taxonomies.php
+++ b/admin/views/tabs/sitemaps/taxonomies.php
@@ -20,7 +20,7 @@ $taxonomies = apply_filters( 'wpseo_sitemaps_supported_taxonomies', get_taxonomi
 if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 	foreach ( $taxonomies as $tax ) {
 		// Explicitly hide all the core taxonomies we never want in our sitemap.
-		if ( in_array( $tax->name, array( 'link_category', 'nav_menu' ) ) ) {
+		if ( in_array( $tax->name, array( 'link_category', 'nav_menu' ), true ) ) {
 			continue;
 		}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -506,9 +506,9 @@ class WPSEO_OpenGraph {
 		);
 
 		// Check to see if the locale is a valid FB one, if not, use en_US as a fallback.
-		if ( ! in_array( $locale, $fb_valid_fb_locales ) ) {
+		if ( ! in_array( $locale, $fb_valid_fb_locales, true ) ) {
 			$locale = strtolower( substr( $locale, 0, 2 ) ) . '_' . strtoupper( substr( $locale, 0, 2 ) );
-			if ( ! in_array( $locale, $fb_valid_fb_locales ) ) {
+			if ( ! in_array( $locale, $fb_valid_fb_locales, true ) ) {
 				$locale = 'en_US';
 			}
 		}
@@ -870,7 +870,7 @@ class WPSEO_OpenGraph_Image {
 			$img = $this->get_relative_path( $img );
 		}
 
-		if ( in_array( $img, $this->images ) ) {
+		if ( in_array( $img, $this->images, true ) ) {
 			return false;
 		}
 		array_push( $this->images, $img );

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -125,7 +125,7 @@ class WPSEO_Twitter {
 			'summary_large_image',
 			'app',
 			'player',
-		) )
+		), true )
 		) {
 			$this->type = 'summary';
 		}
@@ -501,7 +501,7 @@ class WPSEO_Twitter {
 
 		$escaped_img = esc_url( $img );
 
-		if ( in_array( $escaped_img, $this->shown_images ) ) {
+		if ( in_array( $escaped_img, $this->shown_images, true ) ) {
 			return false;
 		}
 

--- a/inc/class-wpseo-advanced-settings.php
+++ b/inc/class-wpseo-advanced-settings.php
@@ -42,7 +42,7 @@ class WPSEO_Advanced_Settings {
 	 * @returns void
 	 */
 	public static function add_advanced_page( $page ) {
-		if ( ! in_array( $page, self::$default_advanced_pages ) && ! in_array( $page, self::$additional_advanced_pages ) ) {
+		if ( ! in_array( $page, self::$default_advanced_pages, true ) && ! in_array( $page, self::$additional_advanced_pages, true ) ) {
 			self::$additional_advanced_pages[] = $page;
 		}
 	}
@@ -56,7 +56,7 @@ class WPSEO_Advanced_Settings {
 	 */
 	public static function is_advanced_settings_page( $page ) {
 		if ( is_string( $page ) ) {
-			return in_array( $page, self::$default_advanced_pages ) || in_array( $page, self::$additional_advanced_pages );
+			return in_array( $page, self::$default_advanced_pages, true ) || in_array( $page, self::$additional_advanced_pages, true );
 		}
 
 		return false;

--- a/inc/class-wpseo-rank.php
+++ b/inc/class-wpseo-rank.php
@@ -58,7 +58,7 @@ class WPSEO_Rank {
 	 * @param int $rank The actual rank.
 	 */
 	public function __construct( $rank ) {
-		if ( ! in_array( $rank, self::$ranks ) ) {
+		if ( ! in_array( $rank, self::$ranks, true ) ) {
 			$rank = self::BAD;
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -836,7 +836,7 @@ class WPSEO_Utils {
 			'wpseo_licenses',
 		);
 
-		return in_array( $current_page, $yoast_seo_free_pages );
+		return in_array( $current_page, $yoast_seo_free_pages, true );
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -158,7 +158,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 				case 'company_or_person':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
-						if ( in_array( $dirty[ $key ], array( 'company', 'person' ) ) ) {
+						if ( in_array( $dirty[ $key ], array( 'company', 'person' ), true ) ) {
 							$clean[ $key ] = $dirty[ $key ];
 						}
 					}

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -305,7 +305,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return false;
 		}
 
-		if ( ! in_array( $post_type, get_post_types( array( 'public' => true ) ) ) ) {
+		if ( ! in_array( $post_type, get_post_types( array( 'public' => true ), 'names' ), true ) ) {
 			return false;
 		}
 

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -198,7 +198,7 @@ class WPSEO_Sitemaps_Cache {
 			update_user_meta( $user_id, '_yoast_wpseo_profile_updated', time() );
 		}
 
-		if ( ! in_array( 'subscriber', $user->roles ) ) {
+		if ( ! in_array( 'subscriber', $user->roles, true ) ) {
 			self::invalidate( 'author' );
 		}
 	}

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -118,7 +118,7 @@ class WPSEO_Sitemaps {
 		$request_uri = $_SERVER['REQUEST_URI'];
 		$extension   = substr( $request_uri, -4 );
 
-		if ( false !== stripos( $request_uri, 'sitemap' ) && in_array( $extension, array( '.xml', '.xsl' ) ) ) {
+		if ( false !== stripos( $request_uri, 'sitemap' ) && in_array( $extension, array( '.xml', '.xsl' ), true ) ) {
 			remove_all_actions( 'widgets_init' );
 		}
 	}
@@ -577,7 +577,7 @@ class WPSEO_Sitemaps {
 			'monthly',
 			'yearly',
 			'never',
-		) )
+		), true )
 		) {
 			$change_freq = $default;
 		}

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -253,7 +253,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return false;
 		}
 
-		if ( in_array( $taxonomy_name, array( 'link_category', 'nav_menu' ) ) ) {
+		if ( in_array( $taxonomy_name, array( 'link_category', 'nav_menu' ), true ) ) {
 			return false;
 		}
 

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -422,7 +422,7 @@ function allow_custom_field_edits( $allcaps, $cap, $args ) {
 	// $args[3] holds the custom field.
 	// Make sure the request is to edit or add a post meta (this is usually also the second value in $cap,
 	// but this is safer to check).
-	if ( in_array( $args[0], array( 'edit_post_meta', 'add_post_meta' ) ) ) {
+	if ( in_array( $args[0], array( 'edit_post_meta', 'add_post_meta' ), true ) ) {
 		// Only allow editing rights for users who have the rights to edit this post and make sure
 		// the meta value starts with _yoast_wpseo (WPSEO_Meta::$meta_prefix).
 		if ( ( isset( $args[2] ) && current_user_can( 'edit_post', $args[2] ) ) && ( ( isset( $args[3] ) && $args[3] !== '' ) && strpos( $args[3], WPSEO_Meta::$meta_prefix ) === 0 ) ) {

--- a/tests/admin/test-class-wpseo-plugin-availability-double.php
+++ b/tests/admin/test-class-wpseo-plugin-availability-double.php
@@ -66,6 +66,6 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 	}
 
 	public function is_dependency_available( $dependency ) {
-		return in_array( $dependency, $this->available_dependencies );
+		return in_array( $dependency, $this->available_dependencies, true );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

For array functions which do loose type comparisons, setting the third `$strict` parameter to `false` can be seen as a clear indication that this is a conscious, well thought out decision by the developer.
In all other cases, `$strict` `true` should be used.

For the changes made here, I've done a perfunctory analysis of whether these function calls could be changed to strict without issue and have in a few cases, made slight adjustments to the function call to ensure it could.


## Test instructions

Testing recommended, though I don't expect any issues.