### PR TITLE
Cache active plugins

### DIFF
--- a/admin/class-extension-manager.php
+++ b/admin/class-extension-manager.php
@@ -80,8 +80,8 @@ class WPSEO_Extension_Manager {
 				self::$active_extensions = get_transient( self::TRANSIENT_CACHE_KEY );
 			}
 
-			if ( empty( self::$active_extensions ) ) {
-				self::$active_extensions = apply_filters( 'yoast-active-extensions', array() );
+			if ( ! is_array( self::$active_extensions ) ) {
+				self::$active_extensions = (array) apply_filters( 'yoast-active-extensions', array() );
 				set_transient( self::TRANSIENT_CACHE_KEY, self::$active_extensions, DAY_IN_SECONDS );
 			}
 		}

--- a/admin/class-extension-manager.php
+++ b/admin/class-extension-manager.php
@@ -8,8 +8,14 @@
  */
 class WPSEO_Extension_Manager {
 
+	/** The transient key to save the cache in */
+	const TRANSIENT_CACHE_KEY = 'wpseo_license_active_extensions';
+
 	/** @var WPSEO_Extension[] */
 	protected $extensions = array();
+
+	/** @var array List of active plugins */
+	static protected $active_extensions;
 
 	/**
 	 * Adds an extension to the manager.
@@ -64,12 +70,22 @@ class WPSEO_Extension_Manager {
 	 * @return bool True when the plugin is activated.
 	 */
 	public function is_activated( $extension_name ) {
-		static $active_extensions;
+		if ( self::$active_extensions === null ) {
+			// Force re-check on license & dashboard pages.
+			$current_page  = filter_input( INPUT_GET, 'page' );
+			$exclude_cache = ( $current_page === 'wpseo_licenses' || $current_page === 'wpseo_dashboard' );
 
-		if ( ! $active_extensions ) {
-			$active_extensions = apply_filters( 'yoast-active-extensions', array() );
+			// Fetch transient data on any other page.
+			if ( ! $exclude_cache ) {
+				self::$active_extensions = get_transient( self::TRANSIENT_CACHE_KEY );
+			}
+
+			if ( empty( self::$active_extensions ) ) {
+				self::$active_extensions = apply_filters( 'yoast-active-extensions', array() );
+				set_transient( self::TRANSIENT_CACHE_KEY, self::$active_extensions, DAY_IN_SECONDS );
+			}
 		}
 
-		return in_array( $extension_name, $active_extensions, true );
+		return in_array( $extension_name, self::$active_extensions, true );
 	}
 }


### PR DESCRIPTION
## Summary

## Relevant technical choices:

* Cache the results of the active plugins in a transient
* Ignore this transient on the `wpseo_license` page
* This caching is done at this location, because the License Manager has internal logic to do the request when the filter is being triggered. We need to avoid calling the filter whenever possible.

## Test instructions

This PR can be tested by following these steps:

* Visit any page to see the page load being fast, except when the transient is not set.
* The license page should take longer, as the license requests are being done there (for inactive plugins)

Tip: Install the `Query Monitor` plugin to see the HTTP request being done on the page.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1433
