### PR TITLE
CS/best practices: Tests - only one class per file

### DIFF
--- a/tests/admin/banner/test-class-admin-banner-sidebar.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar.php
@@ -4,28 +4,21 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Features_Mock extends WPSEO_Features {
-
-	/**
-	 * Checks if using the free version of the plugin.
-	 *
-	 * @return bool
-	 */
-	public function is_free() {
-		return false;
-	}
-
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 
 	/** @var WPSEO_Admin_Banner_Sidebar */
 	protected $admin_banner_sidebar;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-features-mock.php';
+	}
 
 	/**
 	 * Set up the class which will be tested.

--- a/tests/admin/banner/test-class-admin-banner-spot.php
+++ b/tests/admin/banner/test-class-admin-banner-spot.php
@@ -4,35 +4,18 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Admin_Banner_Renderer_Mock extends WPSEO_Admin_Banner_Renderer {
-
-	/**
-	 * Overrides the render method to get a render method for the test.
-	 *
-	 * @param WPSEO_Admin_Banner $banner The mock banner to render.
-	 *
-	 * @return string
-	 */
-	public function render( WPSEO_Admin_Banner $banner ) {
-
-		return sprintf(
-			'url:%s|image:%s|width:%i|height:%i|alt:%s',
-			$banner->get_url(),
-			$banner->get_image(),
-			$banner->get_width(),
-			$banner->get_height(),
-			$banner->get_alt()
-		);
-	}
-
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Admin_Banner_Spot_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-admin-banner-renderer-mock.php';
+	}
 
 	/**
 	 * Tests the url getter.

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -19,7 +19,7 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		require_once WPSEO_TESTS_PATH . 'admin/test-class-wpseo-plugin-availability-double.php';
+		require_once WPSEO_TESTS_PATH . 'doubles/test-class-wpseo-plugin-availability-double.php';
 	}
 
 	/**

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -4,38 +4,21 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Capability_Manager_Test extends WPSEO_Abstract_Capability_Manager {
-	/**
-	 * Adds the registerd capabilities to the system.
-	 */
-	public function add() {
-
-	}
-
-	/**
-	 * Removes the registered capabilities from the system
-	 */
-	public function remove() {
-
-	}
-
-	public function get_registered_capabilities() {
-		return $this->capabilities;
-	}
-
-	public function filter_roles( $capability, array $roles ) {
-		return parent::filter_roles( $capability, $roles );
-	}
-}
-
-/**
  * Unit Test Class.
  */
 class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-capability-manager-double.php';
+	}
+
 	public function test_register() {
-		$instance = new WPSEO_Capability_Manager_Test();
+		$instance = new WPSEO_Capability_Manager_Double();
 
 		$this->assertNotContains( 'capability', $instance->get_capabilities() );
 
@@ -48,7 +31,7 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_register_overwrite() {
-		$instance = new WPSEO_Capability_Manager_Test();
+		$instance = new WPSEO_Capability_Manager_Double();
 
 		$instance->register( 'capability', array( 'role1' ) );
 		$instance->register( 'capability', array( 'role2' ), true );
@@ -61,7 +44,7 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_register_add() {
-		$instance = new WPSEO_Capability_Manager_Test();
+		$instance = new WPSEO_Capability_Manager_Double();
 
 		$instance->register( 'capability', array( 'role1' ) );
 		$instance->register( 'capability', array( 'role2' ) );
@@ -74,7 +57,7 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_filter_roles() {
-		$instance = new WPSEO_Capability_Manager_Test();
+		$instance = new WPSEO_Capability_Manager_Double();
 
 		add_filter( 'capability_roles', array( $this, 'do_filter_roles' ) );
 

--- a/tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/tests/config-ui/components/test-class-component-connect-gsc.php
@@ -4,87 +4,6 @@
  */
 
 /**
- * Class WPSEO_Config_Component_Connect_Google_Search_Console_Mock
- */
-class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Config_Component_Connect_Google_Search_Console {
-	/** @var string */
-	protected $profile;
-
-	/** @var WPSEO_UnitTestCase */
-	protected $test;
-
-	/**
-	 * WPSEO_Config_Component_Connect_Google_Search_Console_Mock constructor.
-	 */
-	public function __construct( $test ) {
-		$this->test = $test;
-
-		parent::__construct();
-	}
-
-	/**
-	 * Make function public
-	 *
-	 * @param array $current_data Saved data before changes.
-	 * @param array $data         Data after changes.
-	 */
-	public function handle_profile_change( $current_data, $data ) {
-		return parent::handle_profile_change( $current_data, $data );
-	}
-
-	/**
-	 * Get the set service
-	 *
-	 * @return WPSEO_GSC_Service
-	 */
-	public function get_service() {
-		return $this->gsc_service;
-	}
-
-	/**
-	 * Get the current settings
-	 *
-	 * @return string
-	 */
-	public function get_settings() {
-		return $this->gsc_settings;
-	}
-
-	/**
-	 * Get mappings
-	 *
-	 * @return array
-	 */
-	public function get_mapping() {
-		return $this->mapping;
-	}
-
-	/**
-	 * Get a mocked profile.
-	 *
-	 * @return string
-	 */
-	public function get_profile() {
-		return $this->profile;
-	}
-
-	public function set_profile( $profile ) {
-		$this->profile = $profile;
-	}
-
-	/**
-	 * Mock reloading the GSC issues.
-	 */
-	public function reload_issues() {
-		$this->test->stub_call_register( 'reload_issues' );
-	}
-
-	public function clear_gsc_data() {
-		$this->test->stub_call_register( 'clear_data' );
-	}
-}
-
-/**
  * Class WPSEO_Config_Component_Connect_Google_Search_Console_Test
  */
 class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_Framework_TestCase {
@@ -94,6 +13,15 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 
 	/** @var array List of stub calls */
 	protected $stub_calls = array();
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-config-component-connect-google-search-console-mock.php';
+	}
 
 	/**
 	 * Set up

--- a/tests/config-ui/fields/test-class-config-field-choice.php
+++ b/tests/config-ui/fields/test-class-config-field-choice.php
@@ -4,12 +4,6 @@
  */
 
 /**
- * Class WPSEO_Config_Field_Choice_
- */
-class WPSEO_Config_Field_Choice_ extends WPSEO_Config_Field_Choice {
-}
-
-/**
  * Class WPSEO_Config_Field_Choice_Test
  */
 class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
@@ -18,7 +12,7 @@ class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Config_Field_Choice::__construct
 	 */
 	public function test_component() {
-		$field = new WPSEO_Config_Field_Choice_( 'field' );
+		$field = new WPSEO_Config_Field_Choice( 'field' );
 
 		$this->assertEquals( 'Choice', $field->get_component() );
 	}
@@ -27,7 +21,7 @@ class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
 	 * Test choices exist as property
 	 */
 	public function test_choices_property() {
-		$field = new WPSEO_Config_Field_Choice_( 'field' );
+		$field = new WPSEO_Config_Field_Choice( 'field' );
 		$this->assertEquals( array( 'choices' => array() ), $field->get_properties() );
 	}
 
@@ -48,7 +42,7 @@ class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
 			),
 		);
 
-		$field = new WPSEO_Config_Field_Choice_( 'field' );
+		$field = new WPSEO_Config_Field_Choice( 'field' );
 
 		$this->assertEquals( null, $field->add_choice( $value, $label, $screen_reader_text ) );
 		$this->assertEquals( $expected, $field->get_properties() );

--- a/tests/config-ui/fields/test-class-config-field.php
+++ b/tests/config-ui/fields/test-class-config-field.php
@@ -4,22 +4,18 @@
  */
 
 /**
- * Class WPSEO_Config_Field_
- */
-class WPSEO_Config_Field_ extends WPSEO_Config_Field {
-
-	/**
-	 * @param array|mixed $data Value of this field.
-	 */
-	public function set_data( $data ) {
-		$this->data = $data;
-	}
-}
-
-/**
  * Class WPSEO_Config_Field_Test
  */
 class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-config-field-double.php';
+	}
 
 	/**
 	 * @covers WPSEO_Config_Field::__construct()
@@ -31,7 +27,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 		$identifier = 'i';
 		$component  = 'c';
 
-		$field = new WPSEO_Config_Field_( $identifier, $component );
+		$field = new WPSEO_Config_Field_Double( $identifier, $component );
 
 		$this->assertEquals( $identifier, $field->get_identifier() );
 		$this->assertEquals( $component, $field->get_component() );
@@ -45,7 +41,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 		$property       = 'p';
 		$property_value = 'pv';
 
-		$field = new WPSEO_Config_Field_( 'a', 'b' );
+		$field = new WPSEO_Config_Field_Double( 'a', 'b' );
 		$field->set_property( $property, $property_value );
 
 		$properties = $field->get_properties();
@@ -62,7 +58,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	public function test_get_data() {
 		$data = 'test';
 
-		$field = new WPSEO_Config_Field_( 'a', 'b' );
+		$field = new WPSEO_Config_Field_Double( 'a', 'b' );
 		$field->set_data( $data );
 
 		$this->assertEquals( $data, $field->get_data() );

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -4,37 +4,21 @@
  */
 
 /**
- * Class WPSEO_Configuration_Components_Mock
- */
-class WPSEO_Configuration_Components_Mock extends WPSEO_Configuration_Components {
-
-	/**
-	 * Retrieve all components
-	 *
-	 * @return array
-	 */
-	public function get_components() {
-		return $this->components;
-	}
-
-	/**
-	 * Get the current adapter
-	 *
-	 * @return WPSEO_Configuration_Options_Adapter
-	 */
-	public function get_adapter() {
-		return $this->adapter;
-	}
-}
-
-
-/**
  * Class WPSEO_Configuration_Components_Tests
  */
 class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 
 	/** @var WPSEO_Configuration_Components_Mock */
 	protected $components;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-components-mock.php';
+	}
 
 	/**
 	 * Set up

--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -4,34 +4,21 @@
  */
 
 /**
- * Class WPSEO_Configuration_Endpoint_Mock
- */
-class WPSEO_Configuration_Endpoint_Mock extends WPSEO_Configuration_Endpoint {
-	public function get_service() {
-		return $this->service;
-	}
-}
-
-if ( class_exists( 'WP_REST_Server' ) ) :
-	/**
-	 * Class WPSEO_WP_REST_Server_Mock
-	 */
-	class WPSEO_WP_REST_Server_Mock extends WP_REST_Server {
-		/**
-		 * @return array
-		 */
-		public function get_endpoints() {
-			return $this->endpoints;
-		}
-	}
-endif;
-
-/**
  * Class WPSEO_Configuration_Endpoint_Test
  */
 class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	/** @var WPSEO_Configuration_Endpoint_Mock */
 	protected $endpoint;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-endpoint-mock.php';
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-wp-rest-server-mock.php';
+	}
 
 	/**
 	 * Set up

--- a/tests/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/config-ui/test-class-configuration-options-adapter.php
@@ -4,33 +4,21 @@
  */
 
 /**
- * Class WPSEO_Configuration_Options_Adapter_Mock
- */
-class WPSEO_Configuration_Options_Adapter_Mock extends WPSEO_Configuration_Options_Adapter {
-	public function get_lookups() {
-		return $this->lookup;
-	}
-
-	public function add_lookup( $class_name, $type, $option ) {
-		return parent::add_lookup( $class_name, $type, $option );
-	}
-
-	public function get_option_type( $class_name ) {
-		return parent::get_option_type( $class_name );
-	}
-
-	public function get_option( $class_name ) {
-		return parent::get_option( $class_name );
-	}
-}
-
-/**
  * Class WPSEO_Configuration_Options_Adapter_Test
  */
 class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCase {
 
 	/** @var WPSEO_Configuration_Options_Adapter_Mock */
 	protected $adapter;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-options-adapter-mock.php';
+	}
 
 	/**
 	 * Set up

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -4,30 +4,21 @@
  */
 
 /**
- * Class WPSEO_Configuration_Service_Mock
- */
-class WPSEO_Configuration_Service_Mock extends WPSEO_Configuration_Service {
-	/**
-	 * @param string $item Property to get.
-	 *
-	 * @return null|mixed
-	 */
-	public function get( $item ) {
-		if ( isset( $this->{$item} ) ) {
-			return $this->{$item};
-		}
-
-		return null;
-	}
-}
-
-/**
  * Class WPSEO_Configuration_Service_Test
  */
 class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 
 	/** @var WPSEO_Configuration_Service instance */
 	protected $configuration_service;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-service-mock.php';
+	}
 
 	/**
 	 * Preparation

--- a/tests/config-ui/test-class-configuration-storage.php
+++ b/tests/config-ui/test-class-configuration-storage.php
@@ -4,28 +4,20 @@
  */
 
 /**
- * Class WPSEO_Configuration_Storage_Mock
- */
-class WPSEO_Configuration_Storage_Mock extends WPSEO_Configuration_Storage {
-	public function get_fields() {
-		return $this->fields;
-	}
-
-	public function is_not_null( $input ) {
-		return parent::is_not_null( $input );
-	}
-
-	public function get_field_data( WPSEO_Config_Field $field ) {
-		return parent::get_field_data( $field );
-	}
-}
-
-/**
  * Class WPSEO_Configuration_Storage_Test
  */
 class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	/** @var WPSEO_Configuration_Storage_Mock */
 	protected $storage;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-storage-mock.php';
+	}
 
 	/**
 	 * Set up

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -4,31 +4,21 @@
  */
 
 /**
- * Class WPSEO_Configuration_Structure_Mock
- */
-class WPSEO_Configuration_Structure_Mock extends WPSEO_Configuration_Structure {
-
-	/**
-	 * Make add_step public
-	 *
-	 * @param string $identifier Identifier for this step.
-	 * @param string $title      Title to display for this step.
-	 * @param array  $fields     Fields to use on the step.
-	 * @param bool   $navigation Show navigation buttons.
-	 * @param bool   $full_width Wheter the step content is full width or not.
-	 */
-	public function add_step_mock( $identifier, $title, $fields, $navigation = true, $full_width = false ) {
-		$this->add_step( $identifier, $title, $fields, $navigation, $full_width );
-	}
-}
-
-/**
  * Class WPSEO_Configuration_Structure_Test
  */
 class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 
 	/** @var WPSEO_Configuration_Service_Mock Mock holder */
 	protected $structure;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-structure-mock.php';
+	}
 
 	/**
 	 * Set up

--- a/tests/doubles/class-expose-wpseo-twitter.php
+++ b/tests/doubles/class-expose-wpseo-twitter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package WPSEO\Tests\Framework
+ * @package WPSEO\Tests\Doubles
  */
 
 /**

--- a/tests/doubles/class-recalculate-posts-double.php
+++ b/tests/doubles/class-recalculate-posts-double.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package WPSEO\Tests\Recalculate
+ * @package WPSEO\Tests\Doubles
  */
 
 /**

--- a/tests/doubles/class-wpseo-sitemaps-double.php
+++ b/tests/doubles/class-wpseo-sitemaps-double.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package WPSEO\Tests\Sitemaps
+ * @package WPSEO\Tests\Doubles
  */
 
 /**

--- a/tests/doubles/onpage-option-mock.php
+++ b/tests/doubles/onpage-option-mock.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class OnPage_Option_Mock extends WPSEO_OnPage_Option {
+	private $enabled;
+	private $status;
+	private $can_fetch;
+
+	public function __construct( $enabled, $status, $can_fetch ) {
+		$this->enabled = $enabled;
+		$this->status = $status;
+		$this->can_fetch = $can_fetch;
+	}
+
+	public function is_enabled() {
+		return $this->enabled;
+	}
+
+	public function get_status() {
+		return $this->status;
+	}
+
+	public function should_be_fetched() {
+		return $this->can_fetch;
+	}
+}

--- a/tests/doubles/statistics-mock.php
+++ b/tests/doubles/statistics-mock.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class Statistics_Mock extends WPSEO_Statistics {
+	private $rank_counts;
+
+	public function __construct( array $rank_counts ) {
+		$this->rank_counts = $rank_counts;
+	}
+
+	public function get_post_count( $rank ) {
+		if ( array_key_exists( $rank->get_rank(), $this->rank_counts ) ) {
+			return $this->rank_counts[ $rank->get_rank() ];
+		}
+
+		return 0;
+	}
+}

--- a/tests/doubles/test-class-wpseo-plugin-availability-double.php
+++ b/tests/doubles/test-class-wpseo-plugin-availability-double.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package WPSEO\Tests\Admin
+ * @package WPSEO\Tests\Doubles
  */
 
 /**

--- a/tests/doubles/wpseo-admin-banner-renderer-mock.php
+++ b/tests/doubles/wpseo-admin-banner-renderer-mock.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Admin_Banner_Renderer_Mock extends WPSEO_Admin_Banner_Renderer {
+
+	/**
+	 * Overrides the render method to get a render method for the test.
+	 *
+	 * @param WPSEO_Admin_Banner $banner The mock banner to render.
+	 *
+	 * @return string
+	 */
+	public function render( WPSEO_Admin_Banner $banner ) {
+
+		return sprintf(
+			'url:%s|image:%s|width:%i|height:%i|alt:%s',
+			$banner->get_url(),
+			$banner->get_image(),
+			$banner->get_width(),
+			$banner->get_height(),
+			$banner->get_alt()
+		);
+	}
+
+}

--- a/tests/doubles/wpseo-capability-manager-double.php
+++ b/tests/doubles/wpseo-capability-manager-double.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Capability_Manager_Double extends WPSEO_Abstract_Capability_Manager {
+	/**
+	 * Adds the registered capabilities to the system.
+	 */
+	public function add() {
+
+	}
+
+	/**
+	 * Removes the registered capabilities from the system
+	 */
+	public function remove() {
+
+	}
+
+	public function get_registered_capabilities() {
+		return $this->capabilities;
+	}
+
+	public function filter_roles( $capability, array $roles ) {
+		return parent::filter_roles( $capability, $roles );
+	}
+}

--- a/tests/doubles/wpseo-config-component-connect-google-search-console-mock.php
+++ b/tests/doubles/wpseo-config-component-connect-google-search-console-mock.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Config_Component_Connect_Google_Search_Console_Mock
+ */
+class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Config_Component_Connect_Google_Search_Console {
+	/** @var string */
+	protected $profile;
+
+	/** @var WPSEO_UnitTestCase */
+	protected $test;
+
+	/**
+	 * WPSEO_Config_Component_Connect_Google_Search_Console_Mock constructor.
+	 */
+	public function __construct( $test ) {
+		$this->test = $test;
+
+		parent::__construct();
+	}
+
+	/**
+	 * Make function public
+	 *
+	 * @param array $current_data Saved data before changes.
+	 * @param array $data         Data after changes.
+	 */
+	public function handle_profile_change( $current_data, $data ) {
+		return parent::handle_profile_change( $current_data, $data );
+	}
+
+	/**
+	 * Get the set service
+	 *
+	 * @return WPSEO_GSC_Service
+	 */
+	public function get_service() {
+		return $this->gsc_service;
+	}
+
+	/**
+	 * Get the current settings
+	 *
+	 * @return string
+	 */
+	public function get_settings() {
+		return $this->gsc_settings;
+	}
+
+	/**
+	 * Get mappings
+	 *
+	 * @return array
+	 */
+	public function get_mapping() {
+		return $this->mapping;
+	}
+
+	/**
+	 * Get a mocked profile.
+	 *
+	 * @return string
+	 */
+	public function get_profile() {
+		return $this->profile;
+	}
+
+	public function set_profile( $profile ) {
+		$this->profile = $profile;
+	}
+
+	/**
+	 * Mock reloading the GSC issues.
+	 */
+	public function reload_issues() {
+		$this->test->stub_call_register( 'reload_issues' );
+	}
+
+	public function clear_gsc_data() {
+		$this->test->stub_call_register( 'clear_data' );
+	}
+}

--- a/tests/doubles/wpseo-config-field-double.php
+++ b/tests/doubles/wpseo-config-field-double.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Config_Field_Double
+ */
+class WPSEO_Config_Field_Double extends WPSEO_Config_Field {
+
+	/**
+	 * @param array|mixed $data Value of this field.
+	 */
+	public function set_data( $data ) {
+		$this->data = $data;
+	}
+}

--- a/tests/doubles/wpseo-configuration-components-mock.php
+++ b/tests/doubles/wpseo-configuration-components-mock.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Configuration_Components_Mock
+ */
+class WPSEO_Configuration_Components_Mock extends WPSEO_Configuration_Components {
+
+	/**
+	 * Retrieve all components
+	 *
+	 * @return array
+	 */
+	public function get_components() {
+		return $this->components;
+	}
+
+	/**
+	 * Get the current adapter
+	 *
+	 * @return WPSEO_Configuration_Options_Adapter
+	 */
+	public function get_adapter() {
+		return $this->adapter;
+	}
+}

--- a/tests/doubles/wpseo-configuration-endpoint-mock.php
+++ b/tests/doubles/wpseo-configuration-endpoint-mock.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Configuration_Endpoint_Mock
+ */
+class WPSEO_Configuration_Endpoint_Mock extends WPSEO_Configuration_Endpoint {
+	public function get_service() {
+		return $this->service;
+	}
+}

--- a/tests/doubles/wpseo-configuration-options-adapter-mock.php
+++ b/tests/doubles/wpseo-configuration-options-adapter-mock.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Configuration_Options_Adapter_Mock
+ */
+class WPSEO_Configuration_Options_Adapter_Mock extends WPSEO_Configuration_Options_Adapter {
+	public function get_lookups() {
+		return $this->lookup;
+	}
+
+	public function add_lookup( $class_name, $type, $option ) {
+		return parent::add_lookup( $class_name, $type, $option );
+	}
+
+	public function get_option_type( $class_name ) {
+		return parent::get_option_type( $class_name );
+	}
+
+	public function get_option( $class_name ) {
+		return parent::get_option( $class_name );
+	}
+}

--- a/tests/doubles/wpseo-configuration-service-mock.php
+++ b/tests/doubles/wpseo-configuration-service-mock.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Configuration_Service_Mock
+ */
+class WPSEO_Configuration_Service_Mock extends WPSEO_Configuration_Service {
+	/**
+	 * @param string $item Property to get.
+	 *
+	 * @return null|mixed
+	 */
+	public function get( $item ) {
+		if ( isset( $this->{$item} ) ) {
+			return $this->{$item};
+		}
+
+		return null;
+	}
+}

--- a/tests/doubles/wpseo-configuration-storage-mock.php
+++ b/tests/doubles/wpseo-configuration-storage-mock.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Configuration_Storage_Mock
+ */
+class WPSEO_Configuration_Storage_Mock extends WPSEO_Configuration_Storage {
+	public function get_fields() {
+		return $this->fields;
+	}
+
+	public function is_not_null( $input ) {
+		return parent::is_not_null( $input );
+	}
+
+	public function get_field_data( WPSEO_Config_Field $field ) {
+		return parent::get_field_data( $field );
+	}
+}

--- a/tests/doubles/wpseo-configuration-structure-mock.php
+++ b/tests/doubles/wpseo-configuration-structure-mock.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Class WPSEO_Configuration_Structure_Mock
+ */
+class WPSEO_Configuration_Structure_Mock extends WPSEO_Configuration_Structure {
+
+	/**
+	 * Make add_step public
+	 *
+	 * @param string $identifier Identifier for this step.
+	 * @param string $title      Title to display for this step.
+	 * @param array  $fields     Fields to use on the step.
+	 * @param bool   $navigation Show navigation buttons.
+	 * @param bool   $full_width Wheter the step content is full width or not.
+	 */
+	public function add_step_mock( $identifier, $title, $fields, $navigation = true, $full_width = false ) {
+		$this->add_step( $identifier, $title, $fields, $navigation, $full_width );
+	}
+}

--- a/tests/doubles/wpseo-features-mock.php
+++ b/tests/doubles/wpseo-features-mock.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Features_Mock extends WPSEO_Features {
+
+	/**
+	 * Checks if using the free version of the plugin.
+	 *
+	 * @return bool
+	 */
+	public function is_free() {
+		return false;
+	}
+
+}

--- a/tests/doubles/wpseo-meta-columns-double.php
+++ b/tests/doubles/wpseo-meta-columns-double.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Meta_Columns_Double extends WPSEO_Meta_Columns {
+	public function determine_seo_filters( $seo_filter ) {
+		return parent::determine_seo_filters( $seo_filter );
+	}
+
+	public function determine_readability_filters( $readability_filter ) {
+		return parent::determine_readability_filters( $readability_filter );
+	}
+
+	public function is_valid_filter( $filter ) {
+		return parent::is_valid_filter( $filter );
+	}
+
+	public function build_filter_query( $vars, $filter ) {
+		return parent::build_filter_query( $vars, $filter );
+	}
+}

--- a/tests/doubles/wpseo-onpage-double.php
+++ b/tests/doubles/wpseo-onpage-double.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_OnPage_Double extends WPSEO_OnPage {
+
+	/**
+	 * Overwrite the request_indexibility method, because it uses a dependency
+	 *
+	 * @return int
+	 */
+	protected function request_indexability() {
+		if ( home_url() === 'http://example.org' ) {
+			return 1;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Overwrite the method because is has a dependency.
+	 *
+	 * @return void
+	 */
+	protected function notify_admins() {
+
+	}
+
+}

--- a/tests/doubles/wpseo-onpage-request-double.php
+++ b/tests/doubles/wpseo-onpage-request-double.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_OnPage_Request_Double extends WPSEO_OnPage_Request {
+
+	/**
+	 * Overwrite the get_remote method, because this is a dependency.
+	 *
+	 * @param string $target_url The home url.
+	 * @param array  $parameters Array of extra parameters.
+	 *
+	 * @return array
+	 */
+	protected function get_remote( $target_url, $parameters = array() ) {
+		$remote_data = array(
+			'is_indexable'    => '0',
+			'passes_juice_to' => '',
+		);
+
+		switch ( $target_url ) {
+			case home_url():
+				$remote_data['is_indexable'] = '1';
+				break;
+
+			case 'http:://will-be-redirected.wp':
+				$remote_data = array(
+					'is_indexable'    => '0',
+					'passes_juice_to' => 'http://is-redirected.wp',
+				);
+				break;
+
+			case 'http://is-redirected.wp':
+				$remote_data['is_indexable'] = '1';
+				break;
+
+			case 'http://not_indexable.wp':
+				// Do noting.
+				break;
+		}
+
+		return $remote_data;
+
+	}
+
+}

--- a/tests/doubles/wpseo-option-xml-double.php
+++ b/tests/doubles/wpseo-option-xml-double.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Exposes protected defaults from WPSEO_Option_XML class
+ */
+class WPSEO_Option_XML_Double extends WPSEO_Option_XML {
+	public function get_defaults() {
+		return $this->defaults;
+	}
+}

--- a/tests/doubles/wpseo-primary-term-double.php
+++ b/tests/doubles/wpseo-primary-term-double.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Primary_Term_Double extends WPSEO_Primary_Term {
+
+	/**
+	 * Overwrite the get_terms method, because it uses a dependency
+	 *
+	 * @return array
+	 */
+	protected function get_terms() {
+		return array(
+			(object) array(
+				'term_id' => 54,
+			),
+		);
+	}
+}

--- a/tests/doubles/wpseo-role-manager-mock.php
+++ b/tests/doubles/wpseo-role-manager-mock.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Role_Manager_Mock extends WPSEO_Abstract_Role_Manager {
+	public $added_roles = array();
+	public $removed_roles = array();
+
+	public function get_registered_roles() {
+		return $this->roles;
+	}
+
+	public function filter_existing_capabilties( $role, array $capabilities ) {
+		return parent::filter_existing_capabilities( $role, $capabilities );
+	}
+
+	public function get_capabilities( $role ) {
+		return parent::get_capabilities( $role );
+	}
+
+	/**
+	 * Adds a role to the system.
+	 *
+	 * @param string $role         Role to add.
+	 * @param string $display_name Name to display for the role.
+	 * @param array  $capabilities Capabilities to add to the role.
+	 *
+	 * @return void
+	 */
+	protected function add_role( $role, $display_name, array $capabilities = array() ) {
+		$this->added_roles[] = array(
+			'role'         => $role,
+			'display_name' => $display_name,
+			'capabilities' => $capabilities,
+		);
+	}
+
+	/**
+	 * Removes a role from the system
+	 *
+	 * @param string $role Role to remove.
+	 *
+	 * @return void
+	 */
+	protected function remove_role( $role ) {
+		$this->removed_roles[] = $role;
+	}
+}

--- a/tests/doubles/wpseo-taxonomy-content-fields-double.php
+++ b/tests/doubles/wpseo-taxonomy-content-fields-double.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Taxonomy_Content_Fields_Double extends WPSEO_Taxonomy_Content_Fields {
+
+	/**
+	 * Override an option value
+	 *
+	 * @param string $option_name  The target key which will be overwritten
+	 * @param string $option_value The new value for the option.
+	 */
+	public function set_option( $option_name, $option_value ) {
+		$this->options[ $option_name ] = $option_value;
+
+	}
+
+}

--- a/tests/doubles/wpseo-taxonomy-fields-double.php
+++ b/tests/doubles/wpseo-taxonomy-fields-double.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Taxonomy_Fields_Double extends WPSEO_Taxonomy_Fields {
+
+	/**
+	 * This method should return the fields
+	 *
+	 * @return array
+	 */
+	public function get() {
+		return $this->options;
+	}
+
+}

--- a/tests/doubles/wpseo-taxonomy-settings-fields-double.php
+++ b/tests/doubles/wpseo-taxonomy-settings-fields-double.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Taxonomy_Settings_Fields_Double extends WPSEO_Taxonomy_Settings_Fields {
+
+	/**
+	 * Override an option value
+	 *
+	 * @param string $option_name  The target key which will be overwritten
+	 * @param string $option_value The new value for the option.
+	 */
+	public function set_option( $option_name, $option_value ) {
+		$this->options[ $option_name ] = $option_value;
+
+	}
+
+}

--- a/tests/doubles/wpseo-wp-rest-server-mock.php
+++ b/tests/doubles/wpseo-wp-rest-server-mock.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+if ( class_exists( 'WP_REST_Server' ) ) :
+	/**
+	 * Class WPSEO_WP_REST_Server_Mock
+	 */
+	class WPSEO_WP_REST_Server_Mock extends WP_REST_Server {
+		/**
+		 * @return array
+		 */
+		public function get_endpoints() {
+			return $this->endpoints;
+		}
+	}
+endif;

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -4,25 +4,6 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Primary_Term_Double extends WPSEO_Primary_Term {
-
-	/**
-	 * Overwrite the get_terms method, because it uses a dependency
-	 *
-	 * @return array
-	 */
-	protected function get_terms() {
-		return array(
-			(object) array(
-				'term_id' => 54,
-			),
-		);
-	}
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
@@ -41,6 +22,15 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 	 * @var int id of the primary term
 	 */
 	private $primary_term_id = 54;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-primary-term-double.php';
+	}
 
 	/**
 	 * Return the correct primary term when primary term already exists.

--- a/tests/onpage/test-class-onpage-request.php
+++ b/tests/onpage/test-class-onpage-request.php
@@ -4,55 +4,18 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_OnPage_Request_Double extends WPSEO_OnPage_Request {
-
-	/**
-	 * Overwrite the get_remote method, because this is a dependency.
-	 *
-	 * @param string $target_url The home url.
-	 * @param array  $parameters Array of extra parameters.
-	 *
-	 * @return array
-	 */
-	protected function get_remote( $target_url, $parameters = array() ) {
-		$remote_data = array(
-			'is_indexable'    => '0',
-			'passes_juice_to' => '',
-		);
-
-		switch ( $target_url ) {
-			case home_url():
-				$remote_data['is_indexable'] = '1';
-				break;
-
-			case 'http:://will-be-redirected.wp':
-				$remote_data = array(
-					'is_indexable'    => '0',
-					'passes_juice_to' => 'http://is-redirected.wp',
-				);
-				break;
-
-			case 'http://is-redirected.wp':
-				$remote_data['is_indexable'] = '1';
-				break;
-
-			case 'http://not_indexable.wp':
-				// Do noting.
-				break;
-		}
-
-		return $remote_data;
-
-	}
-
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-onpage-request-double.php';
+	}
 
 	/**
 	 * Test if there is a response

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -4,35 +4,6 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_OnPage_Double extends WPSEO_OnPage {
-
-	/**
-	 * Overwrite the request_indexibility method, because it uses a dependency
-	 *
-	 * @return int
-	 */
-	protected function request_indexability() {
-		if ( home_url() === 'http://example.org' ) {
-			return 1;
-		}
-
-		return 0;
-	}
-
-	/**
-	 * Overwrite the method because is has a dependency.
-	 *
-	 * @return void
-	 */
-	protected function notify_admins() {
-
-	}
-
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
@@ -46,6 +17,15 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	 * @var WPSEO_OnPage_Option
 	 */
 	private $option_instance;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-onpage-double.php';
+	}
 
 	/**
 	 * Setup the class instance

--- a/tests/onpage/test-class-ryte-service.php
+++ b/tests/onpage/test-class-ryte-service.php
@@ -4,36 +4,19 @@
  */
 
 /**
- * Test Helper Class.
- */
-class OnPage_Option_Mock extends WPSEO_OnPage_Option {
-	private $enabled;
-	private $status;
-	private $can_fetch;
-
-	public function __construct( $enabled, $status, $can_fetch ) {
-		$this->enabled = $enabled;
-		$this->status = $status;
-		$this->can_fetch = $can_fetch;
-	}
-
-	public function is_enabled() {
-		return $this->enabled;
-	}
-
-	public function get_status() {
-		return $this->status;
-	}
-
-	public function should_be_fetched() {
-		return $this->can_fetch;
-	}
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Ryte_Service_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/onpage-option-mock.php';
+	}
+
 	public function test_cannot_view_ryte() {
 		$onpage     = new OnPage_Option_Mock( false, WPSEO_OnPage_Option::IS_INDEXABLE, true );
 

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -29,7 +29,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		require_once WPSEO_TESTS_PATH . 'recalculate/class-recalculate-posts-double.php';
+		require_once WPSEO_TESTS_PATH . 'doubles/class-recalculate-posts-double.php';
 	}
 
 	/**

--- a/tests/roles/test-class-role-manager.php
+++ b/tests/roles/test-class-role-manager.php
@@ -4,59 +4,21 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Role_Manager_Test extends WPSEO_Abstract_Role_Manager {
-	public $added_roles = array();
-	public $removed_roles = array();
-
-	public function get_registered_roles() {
-		return $this->roles;
-	}
-
-	public function filter_existing_capabilties( $role, array $capabilities ) {
-		return parent::filter_existing_capabilities( $role, $capabilities );
-	}
-
-	public function get_capabilities( $role ) {
-		return parent::get_capabilities( $role );
-	}
-
-	/**
-	 * Adds a role to the system.
-	 *
-	 * @param string $role         Role to add.
-	 * @param string $display_name Name to display for the role.
-	 * @param array  $capabilities Capabilities to add to the role.
-	 *
-	 * @return void
-	 */
-	protected function add_role( $role, $display_name, array $capabilities = array() ) {
-		$this->added_roles[] = array(
-			'role'         => $role,
-			'display_name' => $display_name,
-			'capabilities' => $capabilities,
-		);
-	}
-
-	/**
-	 * Removes a role from the system
-	 *
-	 * @param string $role Role to remove.
-	 *
-	 * @return void
-	 */
-	protected function remove_role( $role ) {
-		$this->removed_roles[] = $role;
-	}
-}
-
-/**
  * Unit Test Class.
  */
 class Capability_Role_Tests extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-role-manager-mock.php';
+	}
+
 	public function test_register() {
-		$instance = new WPSEO_Role_Manager_Test();
+		$instance = new WPSEO_Role_Manager_Mock();
 
 		$this->assertNotContains( 'role', $instance->get_roles() );
 
@@ -66,7 +28,7 @@ class Capability_Role_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_capabilities() {
-		$instance = new WPSEO_Role_Manager_Test();
+		$instance = new WPSEO_Role_Manager_Mock();
 		$capabilities = $instance->get_capabilities( 'administrator' );
 
 		$this->assertNotEmpty( $capabilities );
@@ -75,7 +37,7 @@ class Capability_Role_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_capabilities_bad_input() {
-		$instance = new WPSEO_Role_Manager_Test();
+		$instance = new WPSEO_Role_Manager_Mock();
 
 		$result = $instance->get_capabilities( false );
 		$this->assertEquals( array(), $result );

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -4,16 +4,6 @@
  */
 
 /**
- * Exposes protected defaults from WPSEO_Option_XML class
- */
-class WPSEO_Option_XML_Double extends WPSEO_Option_XML {
-	public function get_defaults() {
-		return $this->defaults;
-	}
-}
-
-
-/**
  * Class Test_WPSEO_Author_Sitemap_Provider
  */
 class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
@@ -28,6 +18,9 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-option-xml-double.php';
+
 		self::$class_instance = new WPSEO_Author_Sitemap_Provider();
 	}
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -19,7 +19,7 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		require_once WPSEO_TESTS_PATH . 'sitemaps/class-wpseo-sitemaps-double.php';
+		require_once WPSEO_TESTS_PATH . 'doubles/class-wpseo-sitemaps-double.php';
 	}
 
 	/**

--- a/tests/statistics/test-class-statistics-service.php
+++ b/tests/statistics/test-class-statistics-service.php
@@ -4,28 +4,18 @@
  */
 
 /**
- * Test Helper Class.
- */
-class Statistics_Mock extends WPSEO_Statistics {
-	private $rank_counts;
-
-	public function __construct( array $rank_counts ) {
-		$this->rank_counts = $rank_counts;
-	}
-
-	public function get_post_count( $rank ) {
-		if ( array_key_exists( $rank->get_rank(), $this->rank_counts ) ) {
-			return $this->rank_counts[ $rank->get_rank() ];
-		}
-
-		return 0;
-	}
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/statistics-mock.php';
+	}
 
 	/**
 	 * Reset after each test.

--- a/tests/taxonomy/test-class-taxonomy-content-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-content-fields.php
@@ -4,24 +4,6 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Taxonomy_Content_Fields_Double extends WPSEO_Taxonomy_Content_Fields {
-
-	/**
-	 * Override an option value
-	 *
-	 * @param string $option_name  The target key which will be overwritten
-	 * @param string $option_value The new value for the option.
-	 */
-	public function set_option( $option_name, $option_value ) {
-		$this->options[ $option_name ] = $option_value;
-
-	}
-
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
@@ -35,6 +17,15 @@ class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 	 * @var stdClass The created term.
 	 */
 	private $term;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-taxonomy-content-fields-double.php';
+	}
 
 	/**
 	 * Adding a term and set the class instance

--- a/tests/taxonomy/test-class-taxonomy-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-fields.php
@@ -4,25 +4,18 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Taxonomy_Fields_Double extends WPSEO_Taxonomy_Fields {
-
-	/**
-	 * This method should return the fields
-	 *
-	 * @return array
-	 */
-	public function get() {
-		return $this->options;
-	}
-
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Taxonomy_Fields_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-taxonomy-fields-double.php';
+	}
 
 	public function test_construct_with_options() {
 		$class = new WPSEO_Taxonomy_Fields_Double( (object) array( 'term' ), array( 'has' => 'options' ) );

--- a/tests/taxonomy/test-class-taxonomy-settings-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-settings-fields.php
@@ -4,24 +4,6 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Taxonomy_Settings_Fields_Double extends WPSEO_Taxonomy_Settings_Fields {
-
-	/**
-	 * Override an option value
-	 *
-	 * @param string $option_name  The target key which will be overwritten
-	 * @param string $option_value The new value for the option.
-	 */
-	public function set_option( $option_name, $option_value ) {
-		$this->options[ $option_name ] = $option_value;
-
-	}
-
-}
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
@@ -35,6 +17,15 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	 * @var stdClass The created term.
 	 */
 	private $term;
+
+	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-taxonomy-settings-fields-double.php';
+	}
 
 	/**
 	 * Adding a term and set the class instance

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -20,11 +20,11 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		parent::setUpBeforeClass();
 		ob_start();
 
-		// create instance of WPSEO_Twitter class
-		require_once WPSEO_TESTS_PATH . 'framework/class-expose-wpseo-twitter.php';
+		// Create instance of WPSEO_Twitter class.
+		require_once WPSEO_TESTS_PATH . 'doubles/class-expose-wpseo-twitter.php';
 		self::$class_instance = new Expose_WPSEO_Twitter();
 		WPSEO_Frontend::get_instance()->reset();
-		// clean output which was outputted by WPSEO_Twitter constructor
+		// Clean output which was outputted by WPSEO_Twitter constructor.
 		ob_end_clean();
 	}
 

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -4,28 +4,6 @@
  */
 
 /**
- * Test Helper Class.
- */
-class WPSEO_Meta_Columns_Double extends WPSEO_Meta_Columns {
-	public function determine_seo_filters( $seo_filter ) {
-		return parent::determine_seo_filters( $seo_filter );
-	}
-
-	public function determine_readability_filters( $readability_filter ) {
-		return parent::determine_readability_filters( $readability_filter );
-	}
-
-	public function is_valid_filter( $filter ) {
-		return parent::is_valid_filter( $filter );
-	}
-
-	public function build_filter_query( $vars, $filter ) {
-		return parent::build_filter_query( $vars, $filter );
-	}
-}
-
-
-/**
  * Unit Test Class.
  */
 class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
@@ -40,6 +18,9 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-meta-columns-double.php';
+
 		self::$class_instance = new WPSEO_Meta_Columns_Double();
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.
* Split test helper classes off to their own files in a dedicated "doubles" directory.
* Move other test doubles/mock classes which already were contained in their own file to the same "doubles" directory.

Includes renaming of a couple of these classes and the removal of one (empty) class.

**Review note:** the PR will be easiest to review by looking at the individual commits.

## Test instructions

_N/A_
