### PR TITLE
Use the identifier returned from the License Manager

### DIFF
--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -17,22 +17,22 @@ class WPSEO_Extensions {
 		),
 		'News SEO'              => array(
 			'slug'       => 'news-seo',
-			'identifier' => 'wordpress-seo-news',
+			'identifier' => 'wpseo-news',
 			'classname'  => 'WPSEO_News',
 		),
 		'Yoast WooCommerce SEO' => array(
 			'slug'       => 'woocommerce-yoast-seo',
-			'identifier' => 'yoast-woo-seo',
+			'identifier' => 'wpseo-woocommerce',
 			'classname'  => 'Yoast_WooCommerce_SEO',
 		),
 		'Video SEO'             => array(
 			'slug'       => 'video-seo-for-wordpress',
-			'identifier' => 'yoast-video-seo',
+			'identifier' => 'wpseo-video',
 			'classname'  => 'WPSEO_Video_Sitemap',
 		),
 		'Local SEO'             => array(
 			'slug'       => 'local-seo-for-wordpress',
-			'identifier' => 'yoast-local-seo',
+			'identifier' => 'wpseo-local-woocommerce',
 			'classname'  => 'WPSEO_Local_Core',
 		),
 	);


### PR DESCRIPTION
Instead of the identifier of the plugin, as the logic was first build on.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the message "You are not receiving updates or support!" is shown incorrectly.

## Relevant technical choices:

* Change the identifier for the plugins to the correct one.

## Test instructions

This PR can be tested by following these steps:

* Have installed and activated premium plugins on your site
* Make sure they are activated in My Yoast - check on the extensions page (SEO > Premium)
    * (using http://local.wordpress.dev/ will make this happen)
* There should be no notification about not receiving updates or support

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1440
