### PR TITLE
8146 add woocommerce seo suggestion

### DIFF
--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -74,6 +74,11 @@ class WPSEO_Plugin_Availability {
 					__( 'Seamlessly integrate WooCommerce with %1$s and get extra features!', 'wordpress-seo' ),
 					'Yoast SEO'
 				),
+				'_dependencies' => array(
+					'WooCommerce' => array(
+						'slug' => 'woocommerce/woocommerce.php',
+					),
+				),
 				'installed'    => false,
 				'slug'         => 'wpseo-woocommerce/wpseo-woocommerce.php',
 				'version_sync' => true,

--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -67,7 +67,7 @@ class WPSEO_Plugin_Availability {
 			),
 
 			'yoast-woocommerce-seo' => array(
-				'url'          => 'https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/',
+				'url'          => WPSEO_Shortlinker::get( 'https://yoa.st/1o0' ),
 				'title'        => 'Yoast WooCommerce SEO',
 				'description'  => sprintf(
 					/* translators: %1$s expands to Yoast SEO */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a plugin suggestion for WooCommerce SEO when WooCommerce is installed.

## Relevant technical choices:

* Add a WooCommerce dependency

## Test instructions

This PR can be tested by following these steps:

* Install WooCommerce
* Remove `woocommerce-seo` (or rename directory)
* See the suggestion being triggered with the correct shortlink

Fixes https://github.com/Yoast/wordpress-seo/issues/8146
