### PR TITLE
8148 remove instant articles integration

### DIFF
--- a/admin/views/about.php
+++ b/admin/views/about.php
@@ -233,10 +233,6 @@ function wpseo_display_contributors( $contributors ) {
 					AMP</a> - an integration between <a href="https://wordpress.org/plugins/amp/">the WordPress AMP
 					plugin</a> and Yoast SEO.
 			</li>
-			<li>
-				<a target="_blank" href="https://wordpress.org/plugins/fb-instant-articles/">Instant Articles for WP</a>
-				- Enable Instant Articles for Facebook on your WordPress site and integrates with Yoast SEO.
-			</li>
 		</ol>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

This PR can be tested by following these steps:

* Visit the Integrations tab on the about page (SEO > General > Credits)

Fixes https://github.com/Yoast/wordpress-seo/issues/8148
