### PR TITLE
Fix local SEO slug

### DIFF
--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -32,7 +32,7 @@ class WPSEO_Extensions {
 		),
 		'Local SEO'             => array(
 			'slug'       => 'local-seo-for-wordpress',
-			'identifier' => 'wpseo-local-woocommerce',
+			'identifier' => 'wpseo-local',
 			'classname'  => 'WPSEO_Local_Core',
 		),
 	);

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -32,7 +32,7 @@ class WPSEO_Extensions {
 		),
 		'Local SEO'             => array(
 			'slug'       => 'local-seo-for-wordpress',
-			'identifier' => 'wpseo-local',
+			'identifier' => 'wordpress-seo-local',
 			'classname'  => 'WPSEO_Local_Core',
 		),
 	);

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -69,7 +69,7 @@ $extensions->add(
 );
 
 $extensions->add(
-	'wpseo-local',
+	'wordpress-seo-local',
 	new WPSEO_Extension(
 		array(
 			'buyUrl'    => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the identifier to use for Local SEO.

## Test instructions

This PR can be tested by following these steps:

* Activate Local SEO on My Yoast, but deactivate Local for WooCommerce

Fixes #
