### PR TITLE
CS/best practices: use `require` for unconditional file includes

### DIFF
--- a/admin/views/partial-alerts-errors.php
+++ b/admin/views/partial-alerts-errors.php
@@ -17,4 +17,4 @@ $total = $alerts_data['metrics']['errors'];
 $active = $alerts_data['errors']['active'];
 $dismissed = $alerts_data['errors']['dismissed'];
 
-include WPSEO_PATH . 'admin/views/partial-alerts-template.php';
+require WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/admin/views/partial-alerts-warnings.php
+++ b/admin/views/partial-alerts-warnings.php
@@ -17,4 +17,4 @@ $total = $alerts_data['metrics']['warnings'];
 $active = $alerts_data['warnings']['active'];
 $dismissed = $alerts_data['warnings']['dismissed'];
 
-include WPSEO_PATH . 'admin/views/partial-alerts-template.php';
+require WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -14,11 +14,11 @@ $alerts_data = Yoast_Alerts::get_template_variables();
 		printf( __( '%1$s Dashboard', 'wordpress-seo' ), 'Yoast SEO' );
 		?></h2>
 	<div class="yoast-container yoast-container__alert">
-		<?php include WPSEO_PATH . 'admin/views/partial-alerts-errors.php'; ?>
+		<?php require WPSEO_PATH . 'admin/views/partial-alerts-errors.php'; ?>
 	</div>
 
 	<div class="yoast-container yoast-container__warning">
-		<?php include WPSEO_PATH . 'admin/views/partial-alerts-warnings.php'; ?>
+		<?php require WPSEO_PATH . 'admin/views/partial-alerts-warnings.php'; ?>
 	</div>
 
 </div>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

If a `require` fails, it will produce a fatal `E_COMPILE_ERROR` which for an unconditional file include is warranted.
If a `include` fails, it will produce a warning for the file include and possibly a plenitude of other warnings/errors if the include was not used conditionally.

There were a couple of cases where `include` was used for unconditional file includes. This PR changes those to `require`.

As the files being included are setting variables for views and there could be the possibility that the same view is used more than once in a page load, uses `require` instead of `require_once`.

## Test instructions

_N/A_
