### PR TITLE
Clear both options for invalidation

### DIFF
--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -64,6 +64,16 @@ class WPSEO_Extensions {
 	 * @param string $extension The extension to invalidate.
 	 */
 	public function invalidate( $extension ) {
+		/*
+		 * Make sure we clear the current site and multisite options.
+		 *
+		 * Because plugins can be site-activated or multi-site activated we need to clear
+		 * all possible options.
+		 *
+		 * If we knew here that the extension in question was network activated
+		 * we could do this a lot more easily.
+		 */
+		delete_option( $this->get_option_name( $extension ) );
 		delete_site_option( $this->get_option_name( $extension ) );
 	}
 


### PR DESCRIPTION
## Summary

## Relevant technical choices:

* Remove both the site option as the network equivalent of the option

This will make sure the plugins are activated/deactivated on subsites of a multisite installation.

## Test instructions

This PR can be tested by following these steps:

* Install Free on a multisite-subsite
* Install another plugin on a multisite-subsite
* Activate both plugins
* Toggle activation status on each plugin
* If done on the first domain in a multisite they should give the same result on the network admin as on the first domain

As on multisite the `delete_option` is not called, which should remove the option from `wp_options` table.

This is the option that the plugin will look at when testing for valid license.
So even if we are on a multisite, that does not mean that the plugin is installed as network plugin.

By clearing both options, we force the re-check of the plugin status for the currently active state of the plugin.