### PR TITLE
CS (non-)compliance: align multiple subsequent assignment statements

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -60,8 +60,8 @@ function wpseo_set_ignore() {
 	check_ajax_referer( 'wpseo-ignore' );
 
 	$ignore_key = sanitize_text_field( filter_input( INPUT_POST, 'option' ) );
+	$options    = get_option( 'wpseo' );
 
-	$options                          = get_option( 'wpseo' );
 	$options[ 'ignore_' . $ignore_key ] = true;
 	update_option( 'wpseo', $options );
 
@@ -147,8 +147,9 @@ function wpseo_ajax_replace_vars() {
 
 	$post = get_post( intval( filter_input( INPUT_POST, 'post_id' ) ) );
 	global $wp_query;
-	$wp_query->queried_object = $post;
+	$wp_query->queried_object    = $post;
 	$wp_query->queried_object_id = $post->ID;
+
 	$omit = array( 'excerpt', 'excerpt_only', 'title' );
 	echo wpseo_replace_vars( stripslashes( filter_input( INPUT_POST, 'string' ) ), $post, $omit );
 	die;
@@ -374,8 +375,8 @@ add_action( 'wp_ajax_get_focus_keyword_usage', 'ajax_get_keyword_usage' );
  * Retrieves the keyword for the keyword doubles of the termpages.
  */
 function ajax_get_term_keyword_usage() {
-	$post_id = filter_input( INPUT_POST, 'post_id' );
-	$keyword = filter_input( INPUT_POST, 'keyword' );
+	$post_id       = filter_input( INPUT_POST, 'post_id' );
+	$keyword       = filter_input( INPUT_POST, 'keyword' );
 	$taxonomy_name = filter_input( INPUT_POST, 'taxonomy' );
 
 	$taxonomy = get_taxonomy( $taxonomy_name );

--- a/admin/banner/class-admin-banner-sidebar.php
+++ b/admin/banner/class-admin-banner-sidebar.php
@@ -24,7 +24,7 @@ class WPSEO_Admin_Banner_Sidebar {
 	 * @param WPSEO_Admin_Banner_Renderer $banner_renderer The render class for banners.
 	 */
 	public function __construct( $title, WPSEO_Admin_Banner_Renderer $banner_renderer ) {
-		$this->title = $title;
+		$this->title           = $title;
 		$this->banner_renderer = $banner_renderer;
 	}
 

--- a/admin/banner/class-admin-banner-spot-renderer.php
+++ b/admin/banner/class-admin-banner-spot-renderer.php
@@ -16,7 +16,7 @@ class WPSEO_Admin_Banner_Spot_Renderer {
 	 * @return string
 	 */
 	public function render( WPSEO_Admin_Banner_Spot $banner_spot ) {
-		$output  = '<div class="yoast-sidebar__spot">';
+		$output = '<div class="yoast-sidebar__spot">';
 		if ( $banner_spot->get_title() !== '' ) {
 			$output .= '<strong>' . $banner_spot->get_title() . '</strong>';
 		}

--- a/admin/capabilities/class-capability-manager-integration.php
+++ b/admin/capabilities/class-capability-manager-integration.php
@@ -104,7 +104,7 @@ class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integratio
 	 */
 	public function filter_ure_custom_capability_groups( $groups = array(), $cap_id = '' ) {
 		if ( in_array( $cap_id, $this->get_capabilities(), true ) ) {
-			$groups = (array) $groups;
+			$groups   = (array) $groups;
 			$groups[] = 'wordpress-seo';
 		}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -85,8 +85,8 @@ class WPSEO_Admin_Init {
 	 */
 	public function tagline_notice() {
 
-		$current_url = ( is_ssl() ? 'https://' : 'http://' );
-		$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
+		$current_url   = ( is_ssl() ? 'https://' : 'http://' );
+		$current_url  .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 		$customize_url = add_query_arg( array(
 			'url' => urlencode( $current_url ),
 		), wp_customize_url() );
@@ -120,7 +120,7 @@ class WPSEO_Admin_Init {
 	 */
 	public function blog_public_notice() {
 
-		$info_message = '<strong>' . __( 'Huge SEO Issue: You\'re blocking access to robots.', 'wordpress-seo' ) . '</strong> ';
+		$info_message  = '<strong>' . __( 'Huge SEO Issue: You\'re blocking access to robots.', 'wordpress-seo' ) . '</strong> ';
 		$info_message .= sprintf(
 			/* translators: %1$s resolves to the opening tag of the link to the reading settings, %1$s resolves to the closing tag for the link */
 			__( 'You must %1$sgo to your Reading Settings%2$s and uncheck the box for Search Engine Visibility.', 'wordpress-seo' ),
@@ -151,7 +151,7 @@ class WPSEO_Admin_Init {
 	 */
 	public function page_comments_notice() {
 
-		$info_message = __( 'Paging comments is enabled, this is not needed in 999 out of 1000 cases, we recommend to disable it.', 'wordpress-seo' );
+		$info_message  = __( 'Paging comments is enabled, this is not needed in 999 out of 1000 cases, we recommend to disable it.', 'wordpress-seo' );
 		$info_message .= '<br/>';
 
 		$info_message .= sprintf(
@@ -184,8 +184,8 @@ class WPSEO_Admin_Init {
 	 * @return bool
 	 */
 	public function has_default_tagline() {
-		$blog_description = get_bloginfo( 'description' );
-		$default_blog_description    = 'Just another WordPress site';
+		$blog_description         = get_bloginfo( 'description' );
+		$default_blog_description = 'Just another WordPress site';
 
 		// We are checking against the WordPress internal translation.
 		// @codingStandardsIgnoreLine
@@ -199,7 +199,7 @@ class WPSEO_Admin_Init {
 	 */
 	public function permalink_notice() {
 
-		$info_message = __( 'You do not have your postname in the URL of your posts and pages, it is highly recommended that you do. Consider setting your permalink structure to <strong>/%postname%/</strong>.', 'wordpress-seo' );
+		$info_message  = __( 'You do not have your postname in the URL of your posts and pages, it is highly recommended that you do. Consider setting your permalink structure to <strong>/%postname%/</strong>.', 'wordpress-seo' );
 		$info_message .= '<br/>';
 		$info_message .= sprintf(
 			/* translators: %1$s resolves to the starting tag of the link to the permalink settings page, %2$s resolves to the closing tag of the link */
@@ -281,7 +281,7 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	public function yoast_plugin_suggestions_notification() {
-		$checker = new WPSEO_Plugin_Availability();
+		$checker             = new WPSEO_Plugin_Availability();
 		$notification_center = Yoast_Notification_Center::get();
 
 		// Get all Yoast plugins that have dependencies.
@@ -289,7 +289,7 @@ class WPSEO_Admin_Init {
 
 		foreach ( $plugins as $plugin_name => $plugin ) {
 			$dependency_names = $checker->get_dependency_names( $plugin );
-			$notification = $this->get_yoast_seo_suggested_plugins_notification( $plugin_name, $plugin, $dependency_names[0] );
+			$notification     = $this->get_yoast_seo_suggested_plugins_notification( $plugin_name, $plugin, $dependency_names[0] );
 
 			if ( $checker->dependencies_are_satisfied( $plugin ) && ! $checker->is_installed( $plugin ) ) {
 				$notification_center->add_notification( $notification );
@@ -333,12 +333,12 @@ class WPSEO_Admin_Init {
 	 */
 	public function yoast_plugin_compatibility_notification() {
 		$compatibility_checker = new WPSEO_Plugin_Compatibility( WPSEO_VERSION );
-		$plugins = $compatibility_checker->get_installed_plugins_compatibility();
+		$plugins               = $compatibility_checker->get_installed_plugins_compatibility();
 
 		$notification_center = Yoast_Notification_Center::get();
 
 		foreach ( $plugins as $name => $plugin ) {
-			$type = ( $plugin['active'] ) ? Yoast_Notification::ERROR : Yoast_Notification::WARNING;
+			$type         = ( $plugin['active'] ) ? Yoast_Notification::ERROR : Yoast_Notification::WARNING;
 			$notification = $this->get_yoast_seo_compatibility_notification( $name, $plugin, $type );
 
 			if ( $plugin['compatible'] === false ) {

--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -80,7 +80,7 @@ class WPSEO_Admin_User_Profile {
 	 * @param WP_User $user User instance to output for.
 	 */
 	public function user_profile( $user ) {
-		$options = WPSEO_Options::get_option( 'wpseo' );
+		$options        = WPSEO_Options::get_option( 'wpseo' );
 		$options_titles = WPSEO_Options::get_option( 'wpseo_titles' );
 
 		wp_nonce_field( 'wpseo_user_profile_update', 'wpseo_nonce' );

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -103,7 +103,7 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_Statistic_Integration();
 		$integrations[] = new WPSEO_Slug_Change_Watcher();
 		$integrations[] = new WPSEO_Capability_Manager_Integration( WPSEO_Capability_Manager_Factory::get() );
-		$integrations = array_merge( $integrations, $this->initialize_seo_links() );
+		$integrations   = array_merge( $integrations, $this->initialize_seo_links() );
 
 		/** @var WPSEO_WordPress_Integration $integration */
 		foreach ( $integrations as $integration ) {

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -409,7 +409,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 				if ( is_array( $post_types ) && $post_types !== array() ) {
 					foreach ( $post_types as $post_type ) {
-						$obj = get_post_type_object( $post_type->post_type );
+						$obj      = get_post_type_object( $post_type->post_type );
 						$options .= sprintf( '<option value="%2$s" %3$s>%1$s</option>', $obj->labels->name, $post_type->post_type, selected( $selected, $post_type->post_type, false ) );
 					}
 				}
@@ -762,7 +762,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	protected function column_attributes( $column_name, $hidden, $classes, $column_display_name ) {
 
 		$attributes = '';
-		$class = array( $column_name, "column-$column_name$classes" );
+		$class      = array( $column_name, "column-$column_name$classes" );
 
 		if ( in_array( $column_name, $hidden, true ) ) {
 			$class[] = 'hidden';

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -180,6 +180,7 @@ class WPSEO_Help_Center {
 			array( 'content' => $premium_popup->get_premium_message( false ) ),
 			'dashicons-email-alt'
 		);
+
 		$this->help_center_items[] = $contact_support_help_center_item;
 	}
 

--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -46,7 +46,7 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 	 * Importing the robot values from WPSEO plugin. These have to be converted to the Yoast format.
 	 */
 	private function import_post_robots() {
-		$query_posts  = new WP_Query( 'post_type=any&meta_key=_wpseo_edit_robots&order=ASC' );
+		$query_posts = new WP_Query( 'post_type=any&meta_key=_wpseo_edit_robots&order=ASC' );
 
 		if ( ! empty( $query_posts->posts ) ) {
 			foreach ( $query_posts->posts as $post ) {

--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -50,7 +50,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 		}
 
 		$extension_list = new WPSEO_Extensions();
-		$extensions = $extension_list->get();
+		$extensions     = $extension_list->get();
 
 		$notification_center = Yoast_Notification_Center::get();
 
@@ -73,7 +73,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 	 */
 	public function remove_faulty_notifications() {
 		$extension_list = new WPSEO_Extensions();
-		$extensions = $extension_list->get();
+		$extensions     = $extension_list->get();
 
 		$notification_center = Yoast_Notification_Center::get();
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -26,7 +26,7 @@ class WPSEO_Meta_Columns {
 			add_action( 'admin_init', array( $this, 'setup_hooks' ) );
 		}
 
-		$this->analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+		$this->analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 	}
 
@@ -73,7 +73,7 @@ class WPSEO_Meta_Columns {
 		$added_columns['wpseo-metadesc'] = __( 'Meta Desc.', 'wordpress-seo' );
 
 		if ( $this->analysis_seo->is_enabled() ) {
-			$added_columns['wpseo-focuskw']  = __( 'Focus KW', 'wordpress-seo' );
+			$added_columns['wpseo-focuskw'] = __( 'Focus KW', 'wordpress-seo' );
 		}
 
 		return array_merge( $columns, $added_columns );
@@ -102,12 +102,12 @@ class WPSEO_Meta_Columns {
 				break;
 			case 'wpseo-metadesc':
 				$metadesc_val = apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) );
-				$metadesc = ( '' === $metadesc_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
+				$metadesc     = ( '' === $metadesc_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
 				echo $metadesc;
 				break;
 			case 'wpseo-focuskw':
 				$focuskw_val = WPSEO_Meta::get_value( 'focuskw', $post_id );
-				$focuskw = ( '' === $focuskw_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
+				$focuskw     = ( '' === $focuskw_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
 				echo $focuskw;
 				break;
 		}
@@ -294,8 +294,8 @@ class WPSEO_Meta_Columns {
 	protected function collect_filters() {
 		$active_filters = array();
 
-		$seo_filter = $this->get_current_seo_filter();
-		$readability_filter = $this->get_current_readability_filter();
+		$seo_filter             = $this->get_current_seo_filter();
+		$readability_filter     = $this->get_current_readability_filter();
 		$current_keyword_filter = $this->get_current_keyword_filter();
 
 		if ( $this->is_valid_filter( $seo_filter ) ) {
@@ -424,7 +424,7 @@ class WPSEO_Meta_Columns {
 			return $vars;
 		}
 
-		$result = array( 'meta_query' => array() );
+		$result               = array( 'meta_query' => array() );
 		$result['meta_query'] = array_merge( $result['meta_query'], array( $this->determine_score_filters( $filters ) ) );
 
 		$current_seo_filter = $this->get_current_seo_filter();
@@ -575,7 +575,7 @@ class WPSEO_Meta_Columns {
 	 */
 	private function parse_column_score_readability( $post_id ) {
 		$score = (int) WPSEO_Meta::get_value( 'content_score', $post_id );
-		$rank = WPSEO_Rank::from_numeric_score( $score );
+		$rank  = WPSEO_Rank::from_numeric_score( $score );
 
 		return $this->render_score_indicator( $rank );
 	}

--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -229,7 +229,7 @@ class WPSEO_Plugin_Availability {
 			return true;
 		}
 
-		$dependencies = $this->get_dependencies( $plugin );
+		$dependencies           = $this->get_dependencies( $plugin );
 		$installed_dependencies = array_filter( $dependencies, array( $this, 'is_dependency_available' ) );
 
 		return count( $installed_dependencies ) === count( $dependencies );

--- a/admin/class-plugin-compatibility.php
+++ b/admin/class-plugin-compatibility.php
@@ -32,8 +32,8 @@ class WPSEO_Plugin_Compatibility {
 	public function __construct( $version, $availability_checker = null ) {
 		// We trim off the patch version, as this shouldn't break the comparison.
 		$this->current_wpseo_version = $this->get_major_minor_version( $version );
-		$this->availability_checker = $this->retrieve_availability_checker( $availability_checker );
-		$this->installed_plugins = $this->availability_checker->get_installed_plugins();
+		$this->availability_checker  = $this->retrieve_availability_checker( $availability_checker );
+		$this->installed_plugins     = $this->availability_checker->get_installed_plugins();
 	}
 
 	/**

--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -76,7 +76,7 @@ class WPSEO_Premium_Popup {
 
 		/* translators: %s expands to Yoast SEO Premium */
 		$cta_text = sprintf( __( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' );
-		$classes = '';
+		$classes  = '';
 		if ( $popup ) {
 			$classes = ' hidden';
 		}

--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -31,13 +31,16 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 */
 	public static function translate_meta_boxes() {
 		/* translators: %s expands to the social network's name */
-		$title_text       = __( 'If you don\'t want to use the post title for sharing the post on %s but instead want another title there, write it here.', 'wordpress-seo' );
+		$title_text = __( 'If you don\'t want to use the post title for sharing the post on %s but instead want another title there, write it here.', 'wordpress-seo' );
+
 		/* translators: %s expands to the social network's name */
 		$description_text = __( 'If you don\'t want to use the meta description for sharing the post on %s but want another description there, write it here.', 'wordpress-seo' );
+
 		/* translators: %s expands to the social network's name */
-		$image_text       = __( 'If you want to override the image used on %s for this post, upload / choose an image or add the URL here.', 'wordpress-seo' );
+		$image_text = __( 'If you want to override the image used on %s for this post, upload / choose an image or add the URL here.', 'wordpress-seo' );
+
 		/* translators: %1$s expands to the social network, %2$s to the recommended image size */
-		$image_size_text  = __( 'The recommended image size for %1$s is %2$s pixels.', 'wordpress-seo' );
+		$image_size_text = __( 'The recommended image size for %1$s is %2$s pixels.', 'wordpress-seo' );
 
 		$options = WPSEO_Options::get_option( 'wpseo_social' );
 
@@ -77,9 +80,9 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 * @return WPSEO_Metabox_Tab_Section
 	 */
 	public function get_meta_section() {
-		$tabs = array();
+		$tabs               = array();
 		$social_meta_fields = $this->get_meta_field_defs( 'social' );
-		$single = true;
+		$single             = true;
 
 		if ( $this->options['opengraph'] === true && $this->options['twitter'] === true ) {
 			$single = null;

--- a/admin/class-social-facebook-form.php
+++ b/admin/class-social-facebook-form.php
@@ -57,7 +57,7 @@ class Yoast_Social_Facebook_Form {
 			$nonce = $this->get_delete_nonce();
 		}
 
-		$return = '<li><a target="_blank" href="' . esc_url( $admin['link'] ) . '">' . esc_html( $admin['name'] ) . '</a>';
+		$return  = '<li><a target="_blank" href="' . esc_url( $admin['link'] ) . '">' . esc_html( $admin['name'] ) . '</a>';
 		$return .= ' - <strong><a href="' . $this->admin_delete_link( $admin_id, $nonce ) . '">X</a></strong></li>';
 
 		return $return;

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -28,7 +28,7 @@ class Yoast_Dashboard_Widget {
 			$statistics = new WPSEO_Statistics();
 		}
 
-		$this->statistics = $statistics;
+		$this->statistics    = $statistics;
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_assets' ) );

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -242,6 +242,7 @@ class Yoast_Form {
 				'class' => '',
 			)
 		);
+
 		$id = ( '' === $attr['id'] ) ? '' : ' id="' . esc_attr( $attr['id'] ) . '"';
 		echo '<legend class="yoast-form-legend ' . $attr['class'] . '"' . $id . '>' . $text . '</legend>';
 	}
@@ -304,7 +305,7 @@ class Yoast_Form {
 			$this->options[ $var ] = 'on';
 		}
 
-		$class = 'switch-light switch-candy switch-yoast-seo';
+		$class           = 'switch-light switch-candy switch-yoast-seo';
 		$aria_labelledby = esc_attr( $var ) . '-label';
 
 		if ( $reverse ) {

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -239,7 +239,7 @@ class Yoast_Notification_Center {
 		}
 
 		$sorted_notifications = $this->get_sorted_notifications();
-		$notifications = array_filter( $sorted_notifications, array( $this, 'is_notification_persistent' ) );
+		$notifications        = array_filter( $sorted_notifications, array( $this, 'is_notification_persistent' ) );
 
 		if ( empty( $notifications ) ) {
 			return;

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -225,7 +225,7 @@ class Yoast_Plugin_Conflict {
 		$identifier = $this->get_notification_identifier( $plugin_file );
 
 		$notification_center = Yoast_Notification_Center::get();
-		$notification = $notification_center->get_notification_by_id( 'wpseo-conflict-' . $identifier );
+		$notification        = $notification_center->get_notification_by_id( 'wpseo-conflict-' . $identifier );
 
 		if ( $notification ) {
 			$notification_center->remove_notification( $notification );

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -161,8 +161,8 @@ class WPSEO_Configuration_Page {
 	 * @return array The API endpoint config.
 	 */
 	public function get_config() {
-		$service      = new WPSEO_GSC_Service();
-		$config       = array(
+		$service = new WPSEO_GSC_Service();
+		$config  = array(
 			'namespace'         => WPSEO_Configuration_Endpoint::REST_NAMESPACE,
 			'endpoint_retrieve' => WPSEO_Configuration_Endpoint::ENDPOINT_RETRIEVE,
 			'endpoint_store'    => WPSEO_Configuration_Endpoint::ENDPOINT_STORE,
@@ -224,7 +224,7 @@ class WPSEO_Configuration_Page {
 	 * @return Yoast_Notification
 	 */
 	private static function get_notification() {
-		$message = __( 'The configuration wizard helps you to easily configure your site to have the optimal SEO settings.', 'wordpress-seo' );
+		$message  = __( 'The configuration wizard helps you to easily configure your site to have the optimal SEO settings.', 'wordpress-seo' );
 		$message .= '<br/>';
 		$message .= sprintf(
 			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to the starting tag of the link to the wizard, %3$s resolves to the closing link tag */

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -134,8 +134,8 @@ class WPSEO_Configuration_Service {
 	 */
 	public function get_configuration() {
 		$this->populate_configuration();
-		$fields = $this->storage->retrieve();
-		$steps  = $this->structure->retrieve();
+		$fields       = $this->storage->retrieve();
+		$steps        = $this->structure->retrieve();
 		$translations = $this->translations->retrieve();
 
 		return array(

--- a/admin/config-ui/class-configuration-storage.php
+++ b/admin/config-ui/class-configuration-storage.php
@@ -47,7 +47,7 @@ class WPSEO_Configuration_Storage {
 		);
 
 		$post_type_factory = new WPSEO_Config_Factory_Post_Type();
-		$fields = array_merge( $fields, $post_type_factory->get_fields() );
+		$fields            = array_merge( $fields, $post_type_factory->get_fields() );
 
 		foreach ( $fields as $field ) {
 			$this->add_field( $field );

--- a/admin/config-ui/fields/class-field-mailchimp-signup.php
+++ b/admin/config-ui/fields/class-field-mailchimp-signup.php
@@ -15,7 +15,7 @@ class WPSEO_Config_Field_Mailchimp_Signup extends WPSEO_Config_Field {
 		parent::__construct( 'mailchimpSignup', 'MailchimpSignup' );
 
 		$current_user = wp_get_current_user();
-		$user_email = ( $current_user->ID > 0 ) ? $current_user->user_email : '';
+		$user_email   = ( $current_user->ID > 0 ) ? $current_user->user_email : '';
 
 		$this->set_property( 'title' , __( 'Stay up-to-date', 'wordpress-seo' ) );
 		$this->set_property(

--- a/admin/config-ui/fields/class-field-site-name.php
+++ b/admin/config-ui/fields/class-field-site-name.php
@@ -56,7 +56,7 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	public function set_data( $data ) {
 		$value = $data;
 
-		$option                   = WPSEO_Options::get_option( 'wpseo' );
+		$option                 = WPSEO_Options::get_option( 'wpseo' );
 		$option['website_name'] = $value;
 
 		update_option( 'wpseo', $option );

--- a/admin/config-ui/fields/class-field-upsell-configuration-service.php
+++ b/admin/config-ui/fields/class-field-upsell-configuration-service.php
@@ -29,7 +29,7 @@ class WPSEO_Config_Field_Upsell_Configuration_Service extends WPSEO_Config_Field
 			'</a>'
 		);
 
-		$html = '<p>' . esc_html( $intro_text ) . '</p>';
+		$html  = '<p>' . esc_html( $intro_text ) . '</p>';
 		$html .= '<p><em>' . wp_kses( $upsell_text, array(
 				'a' => array(
 					'target' => array( '_blank' ),

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -40,7 +40,7 @@ class WPSEO_Metabox_Formatter {
 	 * @return array
 	 */
 	private function get_defaults() {
-		$analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+		$analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 
 		return array(

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -102,7 +102,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return array
 	 */
 	private function get_focus_keyword_usage() {
-		$focuskw  = WPSEO_Taxonomy_Meta::get_term_meta( $this->term, $this->term->taxonomy, 'focuskw' );
+		$focuskw = WPSEO_Taxonomy_Meta::get_term_meta( $this->term, $this->term->taxonomy, 'focuskw' );
 
 		return WPSEO_Taxonomy_Meta::get_keyword_usage( $focuskw, $this->term->term_id, $this->term->taxonomy );
 	}

--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -23,7 +23,7 @@ class WPSEO_GSC_Category_Filters {
 	 *
 	 * @var array
 	 */
-	private $filter_values   = array();
+	private $filter_values = array();
 
 	/**
 	 * The current category
@@ -146,7 +146,7 @@ class WPSEO_GSC_Category_Filters {
 	 * @return string
 	 */
 	private function create_view_link( $category, $count ) {
-		$href  = add_query_arg(
+		$href = add_query_arg(
 			array(
 				'category' => $category,
 				'paged'    => 1,

--- a/admin/google_search_console/class-gsc-count.php
+++ b/admin/google_search_console/class-gsc-count.php
@@ -149,6 +149,7 @@ class WPSEO_GSC_Count {
 
 			foreach ( $categories as $category_name => $category ) {
 				$new_category = WPSEO_GSC_Mapper::category_from_api( $category_name );
+
 				$counts[ $new_platform ][ $new_category ] = $category;
 			}
 		}

--- a/admin/google_search_console/class-gsc-marker.php
+++ b/admin/google_search_console/class-gsc-marker.php
@@ -129,7 +129,7 @@ class WPSEO_GSC_Marker {
 	 * @param WPSEO_GSC_Service $service Service object instance.
 	 */
 	private function update_issue_count( WPSEO_GSC_Service $service ) {
-		$counts  = new WPSEO_GSC_Count( $service );
+		$counts = new WPSEO_GSC_Count( $service );
 
 		// Get the issues.
 		$total_issues = $counts->get_issue_count( $this->platform, $this->category );

--- a/admin/google_search_console/class-gsc-modal.php
+++ b/admin/google_search_console/class-gsc-modal.php
@@ -25,8 +25,8 @@ class WPSEO_GSC_Modal {
 	 * @param array  $view_vars The attributes to use in the view.
 	 */
 	public function __construct( $view, $height, array $view_vars = array() ) {
-		$this->view   = $view;
-		$this->height = $height;
+		$this->view      = $view;
+		$this->height    = $height;
 		$this->view_vars = $view_vars;
 	}
 

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -270,20 +270,20 @@ class WPSEO_GSC {
 	 */
 	private function set_dependencies() {
 		// Setting the service object.
-		$this->service         = new WPSEO_GSC_Service( WPSEO_GSC_Settings::get_profile() );
+		$this->service = new WPSEO_GSC_Service( WPSEO_GSC_Settings::get_profile() );
 
 		// Setting the platform.
-		$this->platform        = WPSEO_GSC_Mapper::get_current_platform( 'tab' );
+		$this->platform = WPSEO_GSC_Mapper::get_current_platform( 'tab' );
 
 		// Loading the issue counter.
-		$issue_count           = new WPSEO_GSC_Count( $this->service );
+		$issue_count = new WPSEO_GSC_Count( $this->service );
 		$issue_count->fetch_counts();
 
 		// Loading the category filters.
 		$this->category_filter = new WPSEO_GSC_Category_Filters( $issue_count->get_platform_counts( $this->platform ) );
 
 		// Setting the current category.
-		$this->category        = $this->category_filter->get_category();
+		$this->category = $this->category_filter->get_category();
 
 		// Listing the issues.
 		$issue_count->list_issues( $this->platform, $this->category );

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -28,7 +28,7 @@ else {
 	$video_url = WPSEO_Shortlinker::get( 'https://yoa.st/screencast-connect-search-console' );
 }
 
-$tab = new WPSEO_Option_Tab( 'GSC', __( 'Google Search Console', 'wordpress-seo' ), array( 'video_url' => $video_url ) );
+$tab             = new WPSEO_Option_Tab( 'GSC', __( 'Google Search Console', 'wordpress-seo' ), array( 'video_url' => $video_url ) );
 $gsc_help_center = new WPSEO_Help_Center( 'google-search-console', $tab, WPSEO_Utils::is_yoast_seo_premium() );
 $gsc_help_center->localize_data();
 $gsc_help_center->mount();

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -141,7 +141,7 @@ class WPSEO_Link_Columns {
 
 		$table = $this->storage->get_table_name();
 
-		$pieces['join']    .= " LEFT JOIN $table AS yst_links ON yst_links.object_id = {$wpdb->posts}.ID ";
+		$pieces['join']   .= " LEFT JOIN $table AS yst_links ON yst_links.object_id = {$wpdb->posts}.ID ";
 		$pieces['orderby'] = "{$field} $order, FIELD( {$wpdb->posts}.post_status, 'publish' ) $order, {$pieces['orderby']}";
 
 		return $pieces;

--- a/admin/links/class-link-extractor.php
+++ b/admin/links/class-link-extractor.php
@@ -26,7 +26,7 @@ class WPSEO_Link_Extractor {
 	 * @return array All the extracted links
 	 */
 	public function extract() {
-		$links  = array();
+		$links = array();
 
 		if ( strpos( $this->content, 'href' ) === false ) {
 			return $links;

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -102,7 +102,7 @@ class WPSEO_Link_Reindex_Dashboard {
 				sprintf( '<strong id="wpseo_count_total">%d</strong>', $this->unprocessed )
 			);
 
-			$inner_text = '<div id="wpseo_index_links_progressbar" class="wpseo-progressbar"></div>';
+			$inner_text  = '<div id="wpseo_index_links_progressbar" class="wpseo-progressbar"></div>';
 			$inner_text .= sprintf( '<p>%s</p>', $progress );
 		}
 

--- a/admin/links/class-link.php
+++ b/admin/links/class-link.php
@@ -28,9 +28,9 @@ class WPSEO_Link {
 	 * @param string $type           The url type: internal or outbound.
 	 */
 	public function __construct( $url, $target_post_id, $type ) {
-		$this->url = $url;
+		$this->url            = $url;
 		$this->target_post_id = $target_post_id;
-		$this->type = $type;
+		$this->type           = $type;
 	}
 
 	/**

--- a/admin/metabox/class-metabox-add-keyword-tab.php
+++ b/admin/metabox/class-metabox-add-keyword-tab.php
@@ -30,7 +30,7 @@ class Metabox_Add_Keyword_Tab implements WPSEO_Metabox_Tab {
 		<?php
 		$popup_title = __( 'Want to add more than one keyword?', 'wordpress-seo' );
 		/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
-		$popup_content = '<p>' . sprintf( __( 'Great news: you can, with %1$s!', 'wordpress-seo' ),
+		$popup_content  = '<p>' . sprintf( __( 'Great news: you can, with %1$s!', 'wordpress-seo' ),
 				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ) . '">Yoast SEO Premium</a>'
 				) . '</p>';
 		$popup_content .= '<p>' . sprintf(
@@ -50,7 +50,7 @@ class Metabox_Add_Keyword_Tab implements WPSEO_Metabox_Tab {
 		$popup_content .= '<li><strong>' . __( '24/7 support', 'wordpress-seo' ) . '</strong></li>';
 		$popup_content .= '<li><strong>' . __( 'No ads!', 'wordpress-seo' ) . '</strong></li>';
 		$popup_content .= '</ul>';
-		$premium_popup = new WPSEO_Premium_Popup( 'add-keyword', 'h1', $popup_title, $popup_content, WPSEO_Shortlinker::get( 'https://yoa.st/add-keywords-popup' ) );
+		$premium_popup  = new WPSEO_Premium_Popup( 'add-keyword', 'h1', $popup_title, $popup_content, WPSEO_Shortlinker::get( 'https://yoa.st/add-keywords-popup' ) );
 		echo $premium_popup->get_premium_message();
 
 		return ob_get_clean();

--- a/admin/metabox/class-metabox-editor.php
+++ b/admin/metabox/class-metabox-editor.php
@@ -24,7 +24,7 @@ class WPSEO_Metabox_Editor {
 	 */
 	public function add_css_inside_editor( $css_files ) {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		$styles = $asset_manager->special_styles();
+		$styles        = $asset_manager->special_styles();
 		/** @var WPSEO_Admin_Asset $inside_editor */
 		$inside_editor = $styles['inside-editor'];
 

--- a/admin/metabox/class-metabox-form-tab.php
+++ b/admin/metabox/class-metabox-form-tab.php
@@ -64,6 +64,7 @@ class WPSEO_Metabox_Form_Tab implements WPSEO_Metabox_Tab {
 			'link_aria_label' => '',
 			'single'          => false,
 		);
+
 		$options = array_merge( $default_options, $options );
 
 		$this->name            = $name;

--- a/admin/metabox/class-metabox-tab-section.php
+++ b/admin/metabox/class-metabox-tab-section.php
@@ -52,6 +52,7 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 			'link_class'      => '',
 			'link_aria_label' => '',
 		);
+
 		$options = array_merge( $default_options, $options );
 
 		$this->name = $name;
@@ -85,7 +86,7 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 	 */
 	public function display_content() {
 		if ( $this->has_tabs() ) {
-			$html = '<div id="wpseo-meta-section-%1$s" class="wpseo-meta-section">';
+			$html  = '<div id="wpseo-meta-section-%1$s" class="wpseo-meta-section">';
 			$html .= '<div class="wpseo-metabox-tabs-div">';
 			$html .= '<ul class="wpseo-metabox-tabs wpseo-metabox-tab-%1$s">%2$s</ul>%3$s';
 			$html .= '</div></div>';

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -53,7 +53,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$this->editor = new WPSEO_Metabox_Editor();
 		$this->editor->register_hooks();
 
-		$this->analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+		$this->analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 	}
 
@@ -64,28 +64,28 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * the main meta box definition array in the class WPSEO_Meta() as well!!!!
 	 */
 	public static function translate_meta_boxes() {
-		self::$meta_fields['general']['snippetpreview']['title']       = __( 'Snippet editor', 'wordpress-seo' );
+		self::$meta_fields['general']['snippetpreview']['title'] = __( 'Snippet editor', 'wordpress-seo' );
 		/* translators: 1: link open tag; 2: link close tag. */
 		self::$meta_fields['general']['snippetpreview']['help']        = sprintf( __( 'This is a rendering of what this post might look like in Google\'s search results. %1$sLearn more about the Snippet Preview%2$s.', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/snippet-preview' ) . '">', '</a>' );
 		self::$meta_fields['general']['snippetpreview']['help-button'] = __( 'Show information about the snippet editor', 'wordpress-seo' );
 
-		self::$meta_fields['general']['pageanalysis']['title']       = __( 'Analysis', 'wordpress-seo' );
+		self::$meta_fields['general']['pageanalysis']['title'] = __( 'Analysis', 'wordpress-seo' );
 		/* translators: 1: link open tag; 2: link close tag. */
 		self::$meta_fields['general']['pageanalysis']['help']        = sprintf( __( 'This is the content analysis, a collection of content checks that analyze the content of your page. %1$sLearn more about the Content Analysis Tool%2$s.', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/content-analysis' ) . '">', '</a>' );
 		self::$meta_fields['general']['pageanalysis']['help-button'] = __( 'Show information about the content analysis', 'wordpress-seo' );
 
-		self::$meta_fields['general']['focuskw_text_input']['title']       = __( 'Focus keyword', 'wordpress-seo' );
-		self::$meta_fields['general']['focuskw_text_input']['label']       = __( 'Enter a focus keyword', 'wordpress-seo' );
+		self::$meta_fields['general']['focuskw_text_input']['title'] = __( 'Focus keyword', 'wordpress-seo' );
+		self::$meta_fields['general']['focuskw_text_input']['label'] = __( 'Enter a focus keyword', 'wordpress-seo' );
 		/* translators: 1: link open tag; 2: link close tag. */
 		self::$meta_fields['general']['focuskw_text_input']['help']        = sprintf( __( 'Pick the main keyword or keyphrase that this post/page is about. %1$sLearn more about the Focus Keyword%2$s.', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/focus-keyword' ) . '">', '</a>' );
 		self::$meta_fields['general']['focuskw_text_input']['help-button'] = __( 'Show information about the focus keyword', 'wordpress-seo' );
 
-		self::$meta_fields['general']['title']['title']              = __( 'SEO title', 'wordpress-seo' );
+		self::$meta_fields['general']['title']['title'] = __( 'SEO title', 'wordpress-seo' );
 
-		self::$meta_fields['general']['metadesc']['title']           = __( 'Meta description', 'wordpress-seo' );
+		self::$meta_fields['general']['metadesc']['title'] = __( 'Meta description', 'wordpress-seo' );
 
-		self::$meta_fields['general']['metakeywords']['title']       = __( 'Meta keywords', 'wordpress-seo' );
-		self::$meta_fields['general']['metakeywords']['label']       = __( 'Enter the meta keywords', 'wordpress-seo' );
+		self::$meta_fields['general']['metakeywords']['title'] = __( 'Meta keywords', 'wordpress-seo' );
+		self::$meta_fields['general']['metakeywords']['label'] = __( 'Enter the meta keywords', 'wordpress-seo' );
 		/* translators: 1: link open tag; 2: link close tag. */
 		self::$meta_fields['general']['metakeywords']['description'] = __( 'If you type something above it will override your %1$smeta keywords template%2$s.', 'wordpress-seo' );
 
@@ -115,7 +115,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		self::$meta_fields['advanced']['bctitle']['title']       = __( 'Breadcrumbs Title', 'wordpress-seo' );
 		self::$meta_fields['advanced']['bctitle']['description'] = __( 'Title to use for this page in breadcrumb paths', 'wordpress-seo' );
 
-		self::$meta_fields['advanced']['canonical']['title']       = __( 'Canonical URL', 'wordpress-seo' );
+		self::$meta_fields['advanced']['canonical']['title'] = __( 'Canonical URL', 'wordpress-seo' );
 		/* translators: 1: link open tag; 2: link close tag. */
 		self::$meta_fields['advanced']['canonical']['description'] = sprintf( __( 'The canonical URL that this page should point to, leave empty to default to permalink. %1$sCross domain canonical%2$s supported too.', 'wordpress-seo' ), '<a target="_blank" href="http://googlewebmastercentral.blogspot.com/2009/12/handling-legitimate-cross-domain.html">', '</a>' );
 
@@ -572,7 +572,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$aria_describedby = $description = '';
 		if ( isset( $meta_field_def['description'] ) ) {
 			$aria_describedby = ' aria-describedby="' . $esc_form_key . '-desc"';
-			$description = '<p id="' . $esc_form_key . '-desc" class="yoast-metabox__description">' . $meta_field_def['description'] . '</p>';
+			$description      = '<p id="' . $esc_form_key . '-desc" class="yoast-metabox__description">' . $meta_field_def['description'] . '</p>';
 		}
 
 		switch ( $meta_field_def['type'] ) {
@@ -690,8 +690,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				break;
 
 			case 'checkbox':
-				$checked = checked( $meta_value, 'on', false );
-				$expl    = ( isset( $meta_field_def['expl'] ) ) ? esc_html( $meta_field_def['expl'] ) : '';
+				$checked  = checked( $meta_value, 'on', false );
+				$expl     = ( isset( $meta_field_def['expl'] ) ) ? esc_html( $meta_field_def['expl'] ) : '';
 				$content .= '<input type="checkbox" id="' . $esc_form_key . '" name="' . $esc_form_key . '" ' . $checked . ' value="on" class="yoast' . $class . '"' . $aria_describedby . '/> <label for="' . $esc_form_key . '">' . $expl . '</label>';
 				unset( $checked, $expl );
 				break;
@@ -699,7 +699,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			case 'radio':
 				if ( isset( $meta_field_def['options'] ) && is_array( $meta_field_def['options'] ) && $meta_field_def['options'] !== array() ) {
 					foreach ( $meta_field_def['options'] as $val => $option ) {
-						$checked = checked( $meta_value, $val, false );
+						$checked  = checked( $meta_value, $val, false );
 						$content .= '<input type="radio" ' . $checked . ' id="' . $esc_form_key . '_' . esc_attr( $val ) . '" name="' . $esc_form_key . '" value="' . esc_attr( $val ) . '"/> <label for="' . $esc_form_key . '_' . esc_attr( $val ) . '">' . esc_html( $option ) . '</label> ';
 					}
 					unset( $val, $option, $checked );
@@ -727,7 +727,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			// Set the inline help and help panel, if any.
 			$help_button = $help_panel = '';
 			if ( isset( $meta_field_def['help'] ) && $meta_field_def['help'] !== '' ) {
-				$help = new WPSEO_Admin_Help_Panel( $key, $meta_field_def['help-button'], $meta_field_def['help'] );
+				$help        = new WPSEO_Admin_Help_Panel( $key, $meta_field_def['help-button'], $meta_field_def['help'] );
 				$help_button = $help->get_button_html();
 				$help_panel  = $help->get_panel_html();
 			}
@@ -776,7 +776,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return string
 	 */
 	private function create_content_box( $content, $hidden_help_name, $help_button, $help_panel ) {
-		$html = $content;
+		$html  = $content;
 		$html .= '<div class="wpseo_hidden" id="help-yoast-' . $hidden_help_name . '">' . $help_button . $help_panel . '</div>';
 		return $html;
 	}
@@ -1038,7 +1038,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return array Array containing all the replacement variables.
 	 */
 	private function get_custom_taxonomies_replace_vars( $post ) {
-		$taxonomies = get_object_taxonomies( $post, 'objects' );
+		$taxonomies          = get_object_taxonomies( $post, 'objects' );
 		$custom_replace_vars = array();
 
 		foreach ( $taxonomies as $taxonomy_name => $taxonomy ) {

--- a/admin/onpage/class-onpage-request.php
+++ b/admin/onpage/class-onpage-request.php
@@ -38,7 +38,7 @@ class WPSEO_OnPage_Request {
 
 		// When the request is successful, the response code will be 200.
 		if ( $response_code === 200 ) {
-			$response_body  = wp_remote_retrieve_body( $response );
+			$response_body = wp_remote_retrieve_body( $response );
 
 			return json_decode( $response_body, true );
 		}

--- a/admin/pages/licenses.php
+++ b/admin/pages/licenses.php
@@ -11,5 +11,5 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $license_page_manager = new WPSEO_License_Page_Manager();
-$licenses_page = $license_page_manager->get_license_page();
+$licenses_page        = $license_page_manager->get_license_page();
 require WPSEO_PATH . 'admin/views/' . $licenses_page . '.php';

--- a/admin/recalculate/class-recalculate-posts.php
+++ b/admin/recalculate/class-recalculate-posts.php
@@ -37,7 +37,7 @@ class WPSEO_Recalculate_Posts extends WPSEO_Recalculate {
 	 */
 	protected function get_items( $paged ) {
 		$items_per_page = max( 1, $this->items_per_page );
-		$post_query = new WP_Query(
+		$post_query     = new WP_Query(
 			array(
 				'post_type'      => 'any',
 				'meta_key'       => '_yoast_wpseo_focuskw',

--- a/admin/recalculate/class-recalculate.php
+++ b/admin/recalculate/class-recalculate.php
@@ -54,7 +54,7 @@ abstract class WPSEO_Recalculate {
 	public function get_items_to_recalculate( $paged ) {
 		$return = array();
 
-		$paged = abs( $paged );
+		$paged         = abs( $paged );
 		$this->options = WPSEO_Options::get_all();
 
 		$items = $this->get_items( $paged );

--- a/admin/statistics/class-statistics-service.php
+++ b/admin/statistics/class-statistics-service.php
@@ -27,7 +27,7 @@ class WPSEO_Statistics_Service {
 	 */
 	public function __construct( WPSEO_Statistics $statistics ) {
 		$this->statistics = $statistics;
-		$this->labels = $this->labels();
+		$this->labels     = $this->labels();
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -25,7 +25,7 @@ class WPSEO_Taxonomy_Columns {
 			add_filter( 'manage_' . $this->taxonomy . '_custom_column', array( $this, 'parse_column' ), 10, 3 );
 		}
 
-		$this->analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+		$this->analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 	}
 
@@ -137,7 +137,7 @@ class WPSEO_Taxonomy_Columns {
 	 */
 	private function get_score_readability_value( $term_id ) {
 		$score = (int) WPSEO_Taxonomy_Meta::get_term_meta( $term_id, $this->taxonomy, 'content_score' );
-		$rank = WPSEO_Rank::from_numeric_score( $score );
+		$rank  = WPSEO_Rank::from_numeric_score( $score );
 
 		return $this->create_score_icon( $rank );
 	}

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -80,7 +80,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 
 		if ( ! empty( $options['description'] ) ) {
 			$aria_describedby = ' aria-describedby="' . $field_name . '-desc"';
-			$description = '<p id="' . $field_name . '-desc" class="yoast-metabox__description">' . $options['description'] . '</p>';
+			$description      = '<p id="' . $field_name . '-desc" class="yoast-metabox__description">' . $options['description'] . '</p>';
 		}
 
 		switch ( $field_type ) {
@@ -133,7 +133,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 
 					foreach ( $select_options as $option => $option_label ) {
 						$selected = selected( $option, $field_value, false );
-						$field .= '<option ' . $selected . ' value="' . esc_attr( $option ) . '">' . esc_html( $option_label ) . '</option>';
+						$field   .= '<option ' . $selected . ' value="' . esc_attr( $option ) . '">' . esc_html( $option_label ) . '</option>';
 					}
 					unset( $option, $option_label, $selected );
 
@@ -221,7 +221,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 	 * @return string
 	 */
 	private function parse_section_row( $content, $esc_form_key, WPSEO_Admin_Help_Panel $help ) {
-		$html = $content;
+		$html  = $content;
 		$html .= '<div class="wpseo_hidden" id="help-yoast-' . $esc_form_key . '">' . $help->get_button_html() . $help->get_panel_html() . '</div>';
 		return $html;
 	}

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -114,7 +114,7 @@ class WPSEO_Taxonomy_Metabox {
 	 */
 	private function get_content_meta_section() {
 		$taxonomy_content_fields = new WPSEO_Taxonomy_Content_Fields( $this->term );
-		$content = $this->taxonomy_tab_content->html( $taxonomy_content_fields->get() );
+		$content                 = $this->taxonomy_tab_content->html( $taxonomy_content_fields->get() );
 
 		$tab = new WPSEO_Metabox_Form_Tab(
 			'content',
@@ -143,7 +143,7 @@ class WPSEO_Taxonomy_Metabox {
 	 */
 	private function get_settings_meta_section() {
 		$taxonomy_settings_fields = new WPSEO_Taxonomy_Settings_Fields( $this->term );
-		$content = $this->taxonomy_tab_content->html( $taxonomy_settings_fields->get() );
+		$content                  = $this->taxonomy_tab_content->html( $taxonomy_settings_fields->get() );
 
 		$tab = new WPSEO_Metabox_Form_Tab(
 			'settings',
@@ -171,11 +171,11 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return WPSEO_Metabox_Section
 	 */
 	private function get_social_meta_section() {
-		$options = WPSEO_Options::get_option( 'wpseo_social' );
+		$options                = WPSEO_Options::get_option( 'wpseo_social' );
 		$taxonomy_social_fields = new WPSEO_Taxonomy_Social_Fields( $this->term );
-		$social_admin = new WPSEO_Social_Admin();
+		$social_admin           = new WPSEO_Social_Admin();
 
-		$tabs = array();
+		$tabs   = array();
 		$single = true;
 
 		if ( $options['opengraph'] === true && $options['twitter'] === true ) {

--- a/admin/taxonomy/class-taxonomy-settings-fields.php
+++ b/admin/taxonomy/class-taxonomy-settings-fields.php
@@ -95,7 +95,7 @@ class WPSEO_Taxonomy_Settings_Fields extends WPSEO_Taxonomy_Fields {
 	 */
 	private function get_noindex_options() {
 		$noindex_options['options']            = $this->no_index_options;
-			$noindex_options['options']['default'] = sprintf( $noindex_options['options']['default'], $this->get_robot_index() );
+		$noindex_options['options']['default'] = sprintf( $noindex_options['options']['default'], $this->get_robot_index() );
 
 		if ( get_option( 'blog_public' ) === 0 ) {
 			$noindex_options['description'] = '<br /><span class="error-message">' . esc_html__( 'Warning: even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, so these settings won\'t have an effect.', 'wordpress-seo' ) . '</span>';

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -38,7 +38,7 @@ class WPSEO_Taxonomy {
 		if ( self::is_term_overview( $GLOBALS['pagenow'] ) ) {
 			new WPSEO_Taxonomy_Columns();
 		}
-		$this->analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+		$this->analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 	}
 
@@ -297,7 +297,8 @@ class WPSEO_Taxonomy {
 	 */
 	private function get_replace_vars() {
 		$term_id = filter_input( INPUT_GET, 'tag_ID' );
-		$term  = get_term_by( 'id', $term_id, $this->get_taxonomy() );
+		$term    = get_term_by( 'id', $term_id, $this->get_taxonomy() );
+
 		$cached_replacement_vars = array();
 
 		$vars_to_cache = array(

--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -30,13 +30,13 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 		// Validate if the server address is a valid IP-address.
 		$ipaddress = filter_input( INPUT_SERVER, 'SERVER_ADDR', FILTER_VALIDATE_IP );
 		if ( $ipaddress ) {
-			$server_data['ip']   = $ipaddress;
+			$server_data['ip']       = $ipaddress;
 			$server_data['Hostname'] = gethostbyaddr( $ipaddress );
 		}
 
-		$server_data['os']          = php_uname( 's r' );
-		$server_data['PhpVersion']  = PHP_VERSION;
-		$server_data['CurlVersion'] = $this->get_curl_info();
+		$server_data['os']            = php_uname( 's r' );
+		$server_data['PhpVersion']    = PHP_VERSION;
+		$server_data['CurlVersion']   = $this->get_curl_info();
 		$server_data['PhpExtensions'] = $this->get_php_extensions();
 
 		return $server_data;

--- a/admin/views/class-yoast-input-select.php
+++ b/admin/views/class-yoast-input-select.php
@@ -42,10 +42,10 @@ class Yoast_Input_Select {
 	 * @param string $selected_option The current selected option.
 	 */
 	public function __construct( $select_id, $select_name, array $select_options, $selected_option ) {
-		$this->select_id         = $select_id;
-		$this->select_name       = $select_name;
-		$this->select_options    = $select_options;
-		$this->selected_option   = $selected_option;
+		$this->select_id       = $select_id;
+		$this->select_name     = $select_name;
+		$this->select_options  = $select_options;
+		$this->selected_option = $selected_option;
 	}
 
 	/**

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -11,7 +11,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $extension_list = new WPSEO_Extensions();
-$extensions = $extension_list->get();
+$extensions     = $extension_list->get();
 
 // First invalidate all licenses.
 array_map( array( $extension_list, 'invalidate' ), $extensions );

--- a/admin/views/partial-alerts-errors.php
+++ b/admin/views/partial-alerts-errors.php
@@ -3,18 +3,18 @@
  * @package WPSEO\Admin
  */
 
-$type = 'alerts';
+$type     = 'alerts';
 $dashicon = 'warning';
 
-$i18n_title = __( 'Problems', 'wordpress-seo' );
-$i18n_issues = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
-$i18n_no_issues = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
+$i18n_title              = __( 'Problems', 'wordpress-seo' );
+$i18n_issues             = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
+$i18n_no_issues          = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
 $i18n_muted_issues_title = __( 'Muted problems:', 'wordpress-seo' );
 
 $active_total = count( $alerts_data['errors']['active'] );
-$total = $alerts_data['metrics']['errors'];
+$total        = $alerts_data['metrics']['errors'];
 
-$active = $alerts_data['errors']['active'];
+$active    = $alerts_data['errors']['active'];
 $dismissed = $alerts_data['errors']['dismissed'];
 
 require WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/admin/views/partial-alerts-warnings.php
+++ b/admin/views/partial-alerts-warnings.php
@@ -3,18 +3,18 @@
  * @package WPSEO\Admin
  */
 
-$type = 'warnings';
+$type     = 'warnings';
 $dashicon = 'flag';
 
-$i18n_title = __( 'Notifications', 'wordpress-seo' );
-$i18n_issues = '';
-$i18n_no_issues = __( 'No new notifications.', 'wordpress-seo' );
+$i18n_title              = __( 'Notifications', 'wordpress-seo' );
+$i18n_issues             = '';
+$i18n_no_issues          = __( 'No new notifications.', 'wordpress-seo' );
 $i18n_muted_issues_title = __( 'Muted notifications:', 'wordpress-seo' );
 
 $active_total = count( $alerts_data['warnings']['active'] );
-$total = $alerts_data['metrics']['warnings'];
+$total        = $alerts_data['metrics']['warnings'];
 
-$active = $alerts_data['warnings']['active'];
+$active    = $alerts_data['warnings']['active'];
 $dismissed = $alerts_data['warnings']['dismissed'];
 
 require WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -352,7 +352,7 @@ class WPSEO_Breadcrumbs {
 				}
 			}
 			elseif ( is_author() ) {
-				$user = $wp_query->get_queried_object();
+				$user         = $wp_query->get_queried_object();
 				$display_name = get_the_author_meta( 'display_name', $user->ID );
 				$this->add_predefined_crumb(
 					$this->options['breadcrumbs-archiveprefix'] . ' ' . $display_name,

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -778,7 +778,7 @@ class WPSEO_Frontend {
 
 		if ( $robots['other'] !== array() ) {
 			$robots['other'] = array_unique( $robots['other'] ); // @todo Most likely no longer needed, needs testing.
-			$robotsstr .= ',' . implode( ',', $robots['other'] );
+			$robotsstr      .= ',' . implode( ',', $robots['other'] );
 		}
 
 		$robotsstr = preg_replace( '`^index,follow,?`', '', $robotsstr );

--- a/frontend/class-primary-category.php
+++ b/frontend/class-primary-category.php
@@ -25,7 +25,7 @@ class WPSEO_Frontend_Primary_Category {
 	 * @return array|null|object|WP_Error The category we want to use for the post link.
 	 */
 	public function post_link_category( $category, $categories = null, $post = null ) {
-		$post = get_post( $post );
+		$post             = get_post( $post );
 		$primary_category = $this->get_primary_category( $post );
 
 		if ( false !== $primary_category && $primary_category !== $category->cat_ID ) {

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -120,7 +120,7 @@ class WPSEO_Rewrite {
 
 		$category_rewrite = array();
 
-		$taxonomy = get_taxonomy( 'category' );
+		$taxonomy            = get_taxonomy( 'category' );
 		$permalink_structure = get_option( 'permalink_structure' );
 
 		$blog_prefix = '';
@@ -146,7 +146,7 @@ class WPSEO_Rewrite {
 
 				$category_rewrite[ $blog_prefix . '(' . $category_nicename . ')/(?:feed/)?(feed|rdf|rss|rss2|atom)/?$' ]                = 'index.php?category_name=$matches[1]&feed=$matches[2]';
 				$category_rewrite[ $blog_prefix . '(' . $category_nicename . ')/' . $wp_rewrite->pagination_base . '/?([0-9]{1,})/?$' ] = 'index.php?category_name=$matches[1]&paged=$matches[2]';
-				$category_rewrite[ $blog_prefix . '(' . $category_nicename . ')/?$' ]                                                   = 'index.php?category_name=$matches[1]';
+				$category_rewrite[ $blog_prefix . '(' . $category_nicename . ')/?$' ] = 'index.php?category_name=$matches[1]';
 			}
 			unset( $categories, $category, $category_nicename );
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -270,7 +270,7 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_44() {
 		$option_titles = WPSEO_Options::get_option( 'wpseo_titles' );
-		$option_wpseo = WPSEO_Options::get_option( 'wpseo' );
+		$option_wpseo  = WPSEO_Options::get_option( 'wpseo' );
 
 		if ( isset( $option_titles['content-analysis-active'] ) && isset( $option_titles['keyword-analysis-active'] ) ) {
 			$option_wpseo['content_analysis_active'] = $option_titles['content-analysis-active'];

--- a/inc/class-wpseo-primary-term.php
+++ b/inc/class-wpseo-primary-term.php
@@ -26,7 +26,7 @@ class WPSEO_Primary_Term {
 	 */
 	public function __construct( $taxonomy_name, $post_id ) {
 		$this->taxonomy_name = $taxonomy_name;
-		$this->post_ID = $post_id;
+		$this->post_ID       = $post_id;
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -373,7 +373,7 @@ class WPSEO_Utils {
 	 * @return bool
 	 */
 	public static function emulate_filter_bool( $value ) {
-		$true  = array(
+		$true = array(
 			'1',
 			'true',
 			'True',

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -482,7 +482,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		 *            and post_types have been registered, i.e. at the end of the init action.}}
 		 */
 		if ( isset( $original ) && current_filter() === 'wpseo_double_clean_titles' || did_action( 'wpseo_double_clean_titles' ) > 0 ) {
-			$rename          = array(
+			$rename = array(
 				'title-'           => 'title-tax-',
 				'metadesc-'        => 'metadesc-tax-',
 				'metakey-'         => 'metakey-tax-',

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -410,7 +410,7 @@ class WPSEO_Options {
 	 * @return boolean Returns true if the option is successfully saved in the database.
 	 */
 	public static function save_option( $wpseo_options_group_name, $option_name, $option_value ) {
-		$options                           = WPSEO_Options::get_option( $wpseo_options_group_name );
+		$options                 = WPSEO_Options::get_option( $wpseo_options_group_name );
 		$options[ $option_name ] = $option_value;
 		update_option( $wpseo_options_group_name, $options );
 

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -485,8 +485,8 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 */
 	public static function set_values( $term_id, $taxonomy, array $meta_values ) {
 		/* Validate the post values */
-		$old      = self::get_term_meta( $term_id, $taxonomy );
-		$clean    = self::validate_term_meta_data( $meta_values, $old );
+		$old   = self::get_term_meta( $term_id, $taxonomy );
+		$clean = self::validate_term_meta_data( $meta_values, $old );
 
 		self::save_clean_values( $term_id, $taxonomy, $clean );
 	}
@@ -521,7 +521,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 		$tax_meta = self::get_tax_meta();
 
 
-		$found    = array();
+		$found = array();
 		// @todo Check for terms of all taxonomies, not only the current taxonomy.
 		foreach ( $tax_meta as $taxonomy_name => $terms ) {
 			foreach ( $terms as $term_id => $meta_values ) {

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -142,7 +142,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			if ( $max_pages > 1 ) {
 
-				$sql       = "
+				$sql = "
 				SELECT post_modified_gmt
 				    FROM ( SELECT @rownum:=0 ) init 
 				    JOIN {$wpdb->posts} USE INDEX( type_status_date )
@@ -351,7 +351,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		$where = $this->get_sql_where_clause( $post_type );
 
-		$sql   = "
+		$sql = "
 			SELECT COUNT({$wpdb->posts}.ID)
 			FROM {$wpdb->posts}
 			{$join_filter}

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -91,8 +91,8 @@ class WPSEO_Sitemap_Image_Parser {
 
 		if ( 'attachment' === $post->post_type && wp_attachment_is_image( $post ) ) {
 
-			$src      = $this->get_absolute_url( $this->image_url( $post->ID ) );
-			$alt      = get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
+			$src = $this->get_absolute_url( $this->image_url( $post->ID ) );
+			$alt = get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
 
 			$images[] = $this->get_image_item( $post, $src, $post->post_title, $alt );
 		}

--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -80,7 +80,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 		 * We need to use a timeout on the transient, otherwise the values get autoloaded, this adds
 		 * another restriction to the length.
 		 */
-		$max_length = 45; // 64 - 19 ('_transient_timeout_')
+		$max_length  = 45; // 64 - 19 ('_transient_timeout_')
 		$max_length -= strlen( $prefix );
 		$max_length -= strlen( $postfix );
 

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -189,7 +189,7 @@ class WPSEO_Sitemaps_Renderer {
 
 		$url['loc'] = htmlspecialchars( $url['loc'] );
 
-		$output = "\t<sitemap>\n";
+		$output  = "\t<sitemap>\n";
 		$output .= "\t\t<loc>" . $url['loc'] . "</loc>\n";
 		$output .= empty( $date ) ? '' : "\t\t<lastmod>" . htmlspecialchars( $date ) . "</lastmod>\n";
 		$output .= "\t</sitemap>\n";
@@ -218,7 +218,7 @@ class WPSEO_Sitemaps_Renderer {
 
 		$url['loc'] = htmlspecialchars( $url['loc'] );
 
-		$output = "\t<url>\n";
+		$output  = "\t<url>\n";
 		$output .= "\t\t<loc>" . $this->encode_url_rfc3986( $url['loc'] ) . "</loc>\n";
 		$output .= empty( $date ) ? '' : "\t\t<lastmod>" . htmlspecialchars( $date ) . "</lastmod>\n";
 
@@ -243,7 +243,7 @@ class WPSEO_Sitemaps_Renderer {
 					$title = mb_convert_encoding( $title, $this->output_charset, $this->charset );
 				}
 
-				$title = _wp_specialchars( html_entity_decode( $title, ENT_QUOTES, $this->output_charset ) );
+				$title   = _wp_specialchars( html_entity_decode( $title, ENT_QUOTES, $this->output_charset ) );
 				$output .= "\t\t\t<image:title><![CDATA[{$title}]]></image:title>\n";
 			}
 
@@ -255,7 +255,7 @@ class WPSEO_Sitemaps_Renderer {
 					$alt = mb_convert_encoding( $alt, $this->output_charset, $this->charset );
 				}
 
-				$alt = _wp_specialchars( html_entity_decode( $alt, ENT_QUOTES, $this->output_charset ) );
+				$alt     = _wp_specialchars( html_entity_decode( $alt, ENT_QUOTES, $this->output_charset ) );
 				$output .= "\t\t\t<image:caption><![CDATA[{$alt}]]></image:caption>\n";
 			}
 

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -91,7 +91,7 @@ class WPSEO_Sitemaps {
 	 */
 	public function init_sitemaps_providers() {
 
-		$this->providers   = array(
+		$this->providers = array(
 			new WPSEO_Post_Type_Sitemap_Provider(),
 			new WPSEO_Taxonomy_Sitemap_Provider(),
 			new WPSEO_Author_Sitemap_Provider(),

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -320,7 +320,7 @@ function wpseo_xml_sitemaps_init() {
 function wpseo_xml_redirect_sitemap() {
 	_deprecated_function( __FUNCTION__, 'WPSEO 2.4', 'WPSEO_Sitemaps_Router' );
 
-	$current_url = ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] == 'on' ) ? 'https://' : 'http://';
+	$current_url  = ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] == 'on' ) ? 'https://' : 'http://';
 	$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 
 	// Must be 'sitemap.xml' and must be 404.

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -33,7 +33,7 @@ function wpseo_admin_bar_menu() {
 	// By default, make the no-link top level menu item focusable.
 	$top_level_link_tabindex = '0';
 
-	$analysis_seo = new WPSEO_Metabox_Analysis_SEO();
+	$analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 	$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 
 	if ( ( is_singular() || ( is_admin() && WPSEO_Metabox::is_post_edit( $GLOBALS['pagenow'] ) ) ) && isset( $post ) && is_object( $post ) && apply_filters( 'wpseo_use_page_analysis', true ) === true
@@ -83,6 +83,7 @@ function wpseo_admin_bar_menu() {
 				// Always show Alerts page when clicking on the main link.
 				/* translators: %s: number of notifications */
 				$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
+
 				$counter = sprintf( ' <div class="wp-core-ui wp-ui-notification yoast-issue-counter"><span aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>', $notification_count, $counter_screen_reader_text );
 			}
 

--- a/tests/admin/links/test-class-link-columns-count.php
+++ b/tests/admin/links/test-class-link-columns-count.php
@@ -26,7 +26,7 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 
 		global $wpdb;
 
-		$storage = new WPSEO_Link_Storage();
+		$storage      = new WPSEO_Link_Storage();
 		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );

--- a/tests/admin/links/test-class-link-columns.php
+++ b/tests/admin/links/test-class-link-columns.php
@@ -26,7 +26,7 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 
 		global $wpdb;
 
-		$storage = new WPSEO_Link_Storage();
+		$storage      = new WPSEO_Link_Storage();
 		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
@@ -79,7 +79,7 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_post_columns() {
 		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
-		$expected = array(
+		$expected     = array(
 			'wpseo-links'  => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-label="Number of internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># links in post</span></span>',
 			'wpseo-linked' => '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-label="Number of internal links linking to this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># internal links to</span></span>',
 		);

--- a/tests/admin/links/test-class-link-storage.php
+++ b/tests/admin/links/test-class-link-storage.php
@@ -26,7 +26,7 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 
 		global $wpdb;
 
-		$storage = new WPSEO_Link_Storage();
+		$storage      = new WPSEO_Link_Storage();
 		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -26,7 +26,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 
 		global $wpdb;
 
-		$storage = new WPSEO_Link_Storage();
+		$storage      = new WPSEO_Link_Storage();
 		$meta_storage = new WPSEO_Meta_Storage();
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
@@ -39,7 +39,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_is_processable_post_revision() {
 
 		$post_parent = $this->factory->post->create_and_get();
-		$post = $this->factory->post->create_and_get(
+		$post        = $this->factory->post->create_and_get(
 			array(
 				'post_type'   => 'revision',
 				'post_parent' => $post_parent->ID,

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -46,37 +46,37 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 	}
 
 	public function test_plugin_availability() {
-		$plugin     = self::$class_instance->get_plugin( 'test-plugin' );
-		$available  = self::$class_instance->is_available( $plugin );
+		$plugin    = self::$class_instance->get_plugin( 'test-plugin' );
+		$available = self::$class_instance->is_available( $plugin );
 
 		$this->assertTrue( $available );
 
-		$plugin     = self::$class_instance->get_plugin( 'unavailable-test-plugin' );
-		$available  = self::$class_instance->is_available( $plugin );
+		$plugin    = self::$class_instance->get_plugin( 'unavailable-test-plugin' );
+		$available = self::$class_instance->is_available( $plugin );
 
 		$this->assertFalse( $available );
 	}
 
 	public function test_plugin_is_installed() {
-		$plugin     = self::$class_instance->get_plugin( 'test-plugin' );
-		$installed  = self::$class_instance->is_installed( $plugin );
+		$plugin    = self::$class_instance->get_plugin( 'test-plugin' );
+		$installed = self::$class_instance->is_installed( $plugin );
 
 		$this->assertTrue( $installed );
 
-		$plugin     = self::$class_instance->get_plugin( 'unavailable-test-plugin' );
-		$installed  = self::$class_instance->is_installed( $plugin );
+		$plugin    = self::$class_instance->get_plugin( 'unavailable-test-plugin' );
+		$installed = self::$class_instance->is_installed( $plugin );
 
 		$this->assertFalse( $installed );
 	}
 
 	public function test_plugin_version() {
-		$plugin     = self::$class_instance->get_plugin( 'test-plugin' );
-		$version    = self::$class_instance->get_version( $plugin );
+		$plugin  = self::$class_instance->get_plugin( 'test-plugin' );
+		$version = self::$class_instance->get_version( $plugin );
 
 		$this->assertEquals( $version, '3.3' );
 
-		$plugin     = self::$class_instance->get_plugin( 'test-plugin-no-version' );
-		$version    = self::$class_instance->get_version( $plugin );
+		$plugin  = self::$class_instance->get_plugin( 'test-plugin-no-version' );
+		$version = self::$class_instance->get_version( $plugin );
 
 		$this->assertEquals( $version, '' );
 	}

--- a/tests/admin/test-class-yoast-input-select.php
+++ b/tests/admin/test-class-yoast-input-select.php
@@ -141,7 +141,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	public function test_html_with_adding_attribute() {
 		$select = new Yoast_Input_Select( 'test-id', 'test-field', array( 'foo' => '' ), false );
 		$select->add_attribute( 'class', 'test' );
-		$html   = $select->get_html();
+		$html = $select->get_html();
 
 		$this->assertContains( '<select class="test" name="test-field" id="test-id">', $html );
 	}

--- a/tests/capabilities/test-class-capability-manager-factory.php
+++ b/tests/capabilities/test-class-capability-manager-factory.php
@@ -8,7 +8,7 @@
  */
 class WPSEO_Capability_Manager_Factory_Tests extends PHPUnit_Framework_TestCase {
 	public function test_get() {
-		$instance = WPSEO_Capability_Manager_Factory::get();
+		$instance  = WPSEO_Capability_Manager_Factory::get();
 		$instance2 = WPSEO_Capability_Manager_Factory::get();
 
 		$this->assertEquals( $instance, $instance2 );

--- a/tests/config-ui/fields/test-class-config-field.php
+++ b/tests/config-ui/fields/test-class-config-field.php
@@ -70,7 +70,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_set_requires() {
 		$field_b = 'field_b';
-		$value = 'value';
+		$value   = 'value';
 
 		$expected = array(
 			'field' => $field_b,
@@ -115,7 +115,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Config_Field::to_array()
 	 */
 	public function test_to_array_properties() {
-		$property = 'p';
+		$property       = 'p';
 		$property_value = 'pv';
 
 		$field = new WPSEO_Config_Field( 'a', 'b' );

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -35,8 +35,8 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	public function test_constructor() {
 		$components = new WPSEO_Configuration_Components_Mock();
 		$components->initialize();
-		$list       = $components->get_components();
 
+		$list = $components->get_components();
 		$this->assertEquals( 4, count( $list ) );
 	}
 

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -121,7 +121,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	public function test_get_configuration() {
 		$storage   = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->setMethods( array( 'retrieve' ) )->getMock();
 		$structure = $this->getMockBuilder( 'WPSEO_Configuration_Structure' )->setMethods( array( 'retrieve' ) )->getMock();
-		$adapter = new WPSEO_Configuration_Options_Adapter();
+		$adapter   = new WPSEO_Configuration_Options_Adapter();
 
 		$storage
 			->expects( $this->once() )

--- a/tests/doubles/class-wpseo-sitemaps-double.php
+++ b/tests/doubles/class-wpseo-sitemaps-double.php
@@ -29,6 +29,6 @@ class WPSEO_Sitemaps_Double extends WPSEO_Sitemaps {
 	 */
 	public function reset() {
 		$this->bad_sitemap = false;
-		$this->sitemap = '';
+		$this->sitemap     = '';
 	}
 }

--- a/tests/doubles/onpage-option-mock.php
+++ b/tests/doubles/onpage-option-mock.php
@@ -12,8 +12,8 @@ class OnPage_Option_Mock extends WPSEO_OnPage_Option {
 	private $can_fetch;
 
 	public function __construct( $enabled, $status, $can_fetch ) {
-		$this->enabled = $enabled;
-		$this->status = $status;
+		$this->enabled   = $enabled;
+		$this->status    = $status;
 		$this->can_fetch = $can_fetch;
 	}
 

--- a/tests/doubles/test-class-wpseo-plugin-availability-double.php
+++ b/tests/doubles/test-class-wpseo-plugin-availability-double.php
@@ -85,8 +85,8 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 	 * Sets certain plugin properties based on WordPress' status.
 	 */
 	protected function register_yoast_plugins_status() {
-		$this->plugins['test-plugin']['installed'] = true;
-		$this->plugins['test-plugin-dependency']['installed'] = true;
+		$this->plugins['test-plugin']['installed']                 = true;
+		$this->plugins['test-plugin-dependency']['installed']      = true;
 		$this->plugins['test-plugin-invalid-version']['installed'] = true;
 	}
 

--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -24,6 +24,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 				''
 			)
 		);
+
 		$result = $class_instance->get_values();
 
 		$this->assertEquals( 'Readability', $result['contentTab'] );
@@ -54,6 +55,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 				''
 			)
 		);
+
 		$result = $class_instance->get_values();
 
 		$this->assertTrue( array_key_exists( 'translations', $result ) );

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -78,7 +78,7 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 		wp_insert_term( 'yoast', 'category' );
 		wp_insert_term( 'seo', 'category' );
 
-		$term_first = get_term_by( 'name', 'yoast', 'category' );
+		$term_first  = get_term_by( 'name', 'yoast', 'category' );
 		$term_second = get_term_by( 'name', 'seo', 'category' );
 
 		$post_id = $this->factory->post->create( array( 'post_category' => array( $term_first->term_id, $term_second->term_id ) ) );

--- a/tests/onpage/test-class-ryte-service.php
+++ b/tests/onpage/test-class-ryte-service.php
@@ -18,7 +18,7 @@ class WPSEO_Ryte_Service_Test extends WPSEO_UnitTestCase {
 	}
 
 	public function test_cannot_view_ryte() {
-		$onpage     = new OnPage_Option_Mock( false, WPSEO_OnPage_Option::IS_INDEXABLE, true );
+		$onpage = new OnPage_Option_Mock( false, WPSEO_OnPage_Option::IS_INDEXABLE, true );
 
 		$class_instance = new WPSEO_Ryte_Service( $onpage );
 		$rest_response  = $class_instance->get_statistics();
@@ -31,7 +31,7 @@ class WPSEO_Ryte_Service_Test extends WPSEO_UnitTestCase {
 		$user = wp_get_current_user();
 		$user->add_cap( 'manage_options' );
 
-		$onpage     = new OnPage_Option_Mock( true, WPSEO_OnPage_Option::IS_INDEXABLE, true );
+		$onpage = new OnPage_Option_Mock( true, WPSEO_OnPage_Option::IS_INDEXABLE, true );
 
 		$class_instance = new WPSEO_Ryte_Service( $onpage );
 		$rest_response  = $class_instance->get_statistics();

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -109,7 +109,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_add_content() {
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
 
-		$post = get_post( $this->posts[1] );
+		$post     = get_post( $this->posts[1] );
 		$expected = $this->add_dummy_content( $post->post_content );
 
 		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content' ), 10, 2 );
@@ -129,7 +129,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_add_content_with_shortcode() {
 		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $this->posts[1] );
 
-		$post = get_post( $this->posts[1] );
+		$post     = get_post( $this->posts[1] );
 		$expected = do_shortcode( $this->add_dummy_content_with_shortcode( $post->post_content ) );
 
 		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content_with_shortcode' ), 10, 2 );
@@ -150,7 +150,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		add_filter( 'get_post_metadata', array( $this, 'mock_post_metadata' ), 10, 3 );
 		add_filter( 'post_thumbnail_html', array( $this, 'mock_thumbnail' ), 10, 3 );
 
-		$post = get_post( $this->posts[1] );
+		$post     = get_post( $this->posts[1] );
 		$expected = $post->post_content . " <img src='' />";
 		$response = $test_double->call_item_to_response( $post );
 
@@ -159,7 +159,7 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		remove_filter( 'get_post_metadata', array( $this, 'mock_post_metadata' ), 10, 3 );
 		remove_filter( 'post_thumbnail_html', array( $this, 'mock_thumbnail' ), 10, 3 );
 
-		$post = get_post( $this->posts[2] );
+		$post     = get_post( $this->posts[2] );
 		$expected = $post->post_content;
 		$response = $test_double->call_item_to_response( $post );
 

--- a/tests/roles/test-class-role-manager-factory.php
+++ b/tests/roles/test-class-role-manager-factory.php
@@ -8,7 +8,7 @@
  */
 class WPSEO_Role_Manager_Factory_Tests extends PHPUnit_Framework_TestCase {
 	public function test_get() {
-		$instance = WPSEO_Role_Manager_Factory::get();
+		$instance  = WPSEO_Role_Manager_Factory::get();
 		$instance2 = WPSEO_Role_Manager_Factory::get();
 
 		$this->assertEquals( $instance, $instance2 );

--- a/tests/roles/test-class-role-manager.php
+++ b/tests/roles/test-class-role-manager.php
@@ -28,7 +28,7 @@ class Capability_Role_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_get_capabilities() {
-		$instance = new WPSEO_Role_Manager_Mock();
+		$instance     = new WPSEO_Role_Manager_Mock();
 		$capabilities = $instance->get_capabilities( 'administrator' );
 
 		$this->assertNotEmpty( $capabilities );

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -47,6 +47,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 */
 	public function get_user() {
 		static $user_id = 1;
+
 		$user        = new stdClass();
 		$user->roles = array( 'administrator' );
 		$user->ID    = $user_id++;

--- a/tests/taxonomy/test-class-taxonomy-social-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-social-fields.php
@@ -24,11 +24,11 @@ class WPSEO_Taxonomy_Social_Fields_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->term           = $this->factory->term->create_and_get();
+		$this->term = $this->factory->term->create_and_get();
 
 		// Setting the social networks to true
 		$this->options['opengraph'] = true;
-		$this->options['twitter'] = true;
+		$this->options['twitter']   = true;
 	}
 
 	public function get_class_instance() {
@@ -51,7 +51,7 @@ class WPSEO_Taxonomy_Social_Fields_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_show_social_hidden() {
 		$this->options['opengraph'] = false;
-		$this->options['twitter'] = false;
+		$this->options['twitter']   = false;
 
 		$this->assertFalse( $this->get_class_instance()->show_social() );
 	}

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -283,8 +283,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_OpenGraph::image
 	 */
 	public function test_image_IS_SINGULAR_and_HAS_open_graph_image() {
-		$post_id   = $this->factory->post->create();
-		$image = get_site_url() . '/wp-content/plugins/wordpress-seo/tests/assets/small.png';
+		$post_id = $this->factory->post->create();
+		$image   = get_site_url() . '/wp-content/plugins/wordpress-seo/tests/assets/small.png';
 
 		$this->go_to( get_permalink( $post_id ) );
 
@@ -356,7 +356,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 
 		$output = ob_get_clean();
 
-		list( $src ) = wp_get_attachment_image_src( $attach_id, 'full' );
+		list( $src )     = wp_get_attachment_image_src( $attach_id, 'full' );
 		$expected_output = '<meta property="og:image" content="' . $src . '" />';
 
 		wp_delete_attachment( $attach_id, true );
@@ -385,7 +385,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 
 		$output = ob_get_clean();
 
-		list( $src ) = wp_get_attachment_image_src( $attach_id, 'full' );
+		list( $src )     = wp_get_attachment_image_src( $attach_id, 'full' );
 		$expected_output = '<meta property="og:image" content="' . $src . '" />';
 
 		wp_delete_attachment( $attach_id, true );
@@ -600,7 +600,7 @@ EXPECTED;
 
 		// Checking with the excerpt
 		$expected = get_the_excerpt();
-		$excerpt = self::$class_instance->description( false );
+		$excerpt  = self::$class_instance->description( false );
 
 		$this->assertEquals( $expected, $excerpt );
 	}
@@ -644,7 +644,7 @@ EXPECTED;
 
 		// add tags to post
 		wp_set_post_tags( $post_id, 'Tag1, Tag2' );
-		$expected_tags = '<meta property="article:tag" content="Tag1" />' . "\n";
+		$expected_tags  = '<meta property="article:tag" content="Tag1" />' . "\n";
 		$expected_tags .= '<meta property="article:tag" content="Tag2" />' . "\n";
 
 		// test again, this time with tags

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -95,7 +95,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 
 		$c = self::$class_instance;
 
-		$categories = get_categories( array( 'hide_empty' => false ) );
+		$categories          = get_categories( array( 'hide_empty' => false ) );
 		$permalink_structure = get_option( 'permalink_structure' );
 
 		if ( ! ( is_multisite() && 0 === strpos( $permalink_structure, '/blog/' ) ) ) {

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -70,14 +70,14 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 
 		// test invalid option, should default to summary
 		self::$class_instance->options['twitter_card_type'] = 'something_invalid';
-		$expected                                           = $this->metatag( 'card', 'summary' );
+		$expected = $this->metatag( 'card', 'summary' );
 
 		self::$class_instance->type();
 		$this->expectOutput( $expected );
 
 		// test valid option
 		self::$class_instance->options['twitter_card_type'] = 'summary_large_image';
-		$expected                                           = $this->metatag( 'card', 'summary_large_image' );
+		$expected = $this->metatag( 'card', 'summary_large_image' );
 
 		self::$class_instance->type();
 		$this->expectOutput( $expected );
@@ -310,7 +310,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		$image_url = 'http://url-default-image.jpg';
 
 		self::$class_instance->options['og_default_image'] = $image_url;
-		$expected                                          = $this->get_expected_image_output( $image_url );
+		$expected = $this->get_expected_image_output( $image_url );
 
 		self::$class_instance->image();
 		$this->expectOutput( $expected );
@@ -355,8 +355,8 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Twitter::image()
 	 */
 	public function test_post_thumbnail_image() {
-		$post_id = $this->factory->post->create();
-		$filename = 'post-thumbnail.jpg';
+		$post_id       = $this->factory->post->create();
+		$filename      = 'post-thumbnail.jpg';
 		$attachment_id = $this->factory->attachment->create_object( $filename, 0, array(
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
@@ -375,7 +375,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Twitter::image()
 	 */
 	public function test_post_content_image() {
-		$url = 'http://example.com/example.jpg';
+		$url     = 'http://example.com/example.jpg';
 		$post_id = $this->factory->post->create( array( 'post_content' => "Bla <img src='$url'/> bla" ) );
 		$this->go_to( get_permalink( $post_id ) );
 
@@ -444,8 +444,8 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		$expected = $this->metatag( 'card', 'summary_large_image' );
 
 		// Insert image into DB so we have something to test against
-		$filename = 'image.jpg';
-		$id       = $this->factory->attachment->create_object( $filename, 0, array(
+		$filename  = 'image.jpg';
+		$id        = $this->factory->attachment->create_object( $filename, 0, array(
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
 		) );

--- a/tests/test-class-wpseo-frontend-robots.php
+++ b/tests/test-class-wpseo-frontend-robots.php
@@ -181,7 +181,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->go_to( $category_link );
 
 		// test category with noindex-tax-category option
-		$expected                                              = 'noindex,follow';
+		$expected = 'noindex,follow';
 		self::$class_instance->options['noindex-tax-category'] = true;
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 
@@ -233,7 +233,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 
 
 		// test author archive with 'noindex-author-wpseo'
-		$expected                                              = 'noindex,follow';
+		$expected = 'noindex,follow';
 		self::$class_instance->options['noindex-author-wpseo'] = true;
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -51,8 +51,8 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 	 * Test having person markup and one social profile
 	 */
 	public function test_person() {
-		$name                                               = 'Joost de Valk';
-		$instagram                                          = 'http://instagram.com/yoast';
+		$name      = 'Joost de Valk';
+		$instagram = 'http://instagram.com/yoast';
 		self::$class_instance->options['company_or_person'] = 'person';
 		self::$class_instance->options['person_name']       = $name;
 		self::$class_instance->options['instagram_url']     = $instagram;
@@ -78,9 +78,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 	 * Test having organization markup and two social profiles
 	 */
 	public function test_organization() {
-		$name                                               = 'Yoast';
-		$facebook                                           = 'https://www.facebook.com/Yoast';
-		$instagram                                          = 'http://instagram.com/yoast';
+		$name      = 'Yoast';
+		$facebook  = 'https://www.facebook.com/Yoast';
+		$instagram = 'http://instagram.com/yoast';
 		self::$class_instance->options['company_or_person'] = 'company';
 		self::$class_instance->options['company_name']      = $name;
 		self::$class_instance->options['facebook_site']     = $facebook;

--- a/tests/test-class-wpseo-meta.php
+++ b/tests/test-class-wpseo-meta.php
@@ -136,7 +136,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta::get_post_value
 	 */
 	public function test_get_post_value() {
-		$key = 'my_test_key';
+		$key   = 'my_test_key';
 		$value = 'my_test_key_value';
 		$this->set_post( $key, $value );
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -309,12 +309,12 @@ function wpseo_init_rest_api() {
 		$link_reindex_endpoint = new WPSEO_Link_Reindex_Post_Endpoint( new WPSEO_Link_Reindex_Post_Service() );
 		$link_reindex_endpoint->register();
 
-		$statistics_service = new WPSEO_Statistics_Service( new WPSEO_Statistics() );
+		$statistics_service  = new WPSEO_Statistics_Service( new WPSEO_Statistics() );
 		$statistics_endpoint = new WPSEO_Endpoint_Statistics( $statistics_service );
 		$statistics_endpoint->register();
 
 		$ryte_endpoint_service = new WPSEO_Ryte_Service( new WPSEO_OnPage_Option() );
-		$ryte_endpoint = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
+		$ryte_endpoint         = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
 		$ryte_endpoint->register();
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. When several lines containing assignments directly follow each other, it increases readability for the assignment operator - `=` and its variants - to be aligned.
    Compliance with the `Generic.Formatting.MultipleStatementAlignment` sniff as will be in the upcoming WPCS 0.14.0 release.

Notes:
* The sniff is configured in WPCS to limit the padding to max 40 spaces.
* A blank line will break an "assignment group", so sometimes that has been chosen as the better solution.

## Test instructions

_N/A_