### PR TITLE
Use Gutenberg content if it is available

### DIFF
--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -40,6 +40,12 @@ let PostDataCollector = function( args ) {
  */
 PostDataCollector.prototype.getData = function() {
 	let text = this.getText();
+
+	/*
+	 * We are put into an iframe with Gutenberg. So we need to get the content of the parent.
+	 * Gutenberg then exposes a global on that window. Which is `_wpGutenbergPost`. The post has two content
+	 * properties: `rendered` and `raw`. For the content analysis we are interested in the rendered content.
+	 */
 	let gutenbergContent = _get( window, 'parent._wpGutenbergPost.content.rendered', '' );
 	if ( gutenbergContent !== '' ) {
 		text = gutenbergContent;

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -10,6 +10,8 @@ import { update as updateTrafficLight } from "../ui/trafficLight";
 import { update as updateAdminBar }from "../ui/adminBar";
 
 import publishBox from "../ui/publishBox";
+import _isUndefined from "lodash/isUndefined";
+import _get from "lodash/get";
 
 let $ = jQuery;
 let currentKeyword = "";
@@ -37,10 +39,16 @@ let PostDataCollector = function( args ) {
  * @returns {void}
  */
 PostDataCollector.prototype.getData = function() {
+	let text = this.getText();
+	let gutenbergContent = _get( window, 'parent._wpGutenbergPost.content.rendered', '' );
+	if ( gutenbergContent !== '' ) {
+		text = gutenbergContent;
+	}
+
 	return {
 		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",
 		meta: this.getMeta(),
-		text: this.getText(),
+		text,
 		title: this.getTitle(),
 		url: this.getUrl(),
 		excerpt: this.getExcerpt(),

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -10,7 +10,6 @@ import { update as updateTrafficLight } from "../ui/trafficLight";
 import { update as updateAdminBar }from "../ui/adminBar";
 
 import publishBox from "../ui/publishBox";
-import _isUndefined from "lodash/isUndefined";
 import _get from "lodash/get";
 
 let $ = jQuery;
@@ -46,8 +45,8 @@ PostDataCollector.prototype.getData = function() {
 	 * Gutenberg then exposes a global on that window. Which is `_wpGutenbergPost`. The post has two content
 	 * properties: `rendered` and `raw`. For the content analysis we are interested in the rendered content.
 	 */
-	let gutenbergContent = _get( window, 'parent._wpGutenbergPost.content.rendered', '' );
-	if ( gutenbergContent !== '' ) {
+	let gutenbergContent = _get( window, "parent._wpGutenbergPost.content.rendered", "" );
+	if ( gutenbergContent !== "" ) {
 		text = gutenbergContent;
 	}
 


### PR DESCRIPTION
This will add rudimentary Gutenberg support to Yoast SEO. The only thing this adds is that on pageload the content will be retrieved from the available global variable. The analysis won't be automatically updated after a change of content. This is because Gutenberg doesn't expose any method for this yet.