### PR TITLE
CS/cleanup: don't use assignments in conditions

### DIFF
--- a/admin/class-admin-help-panel.php
+++ b/admin/class-admin-help-panel.php
@@ -73,7 +73,8 @@ class WPSEO_Admin_Help_Panel {
 			return '';
 		}
 
-		$wrapper_start = $wrapper_end = '';
+		$wrapper_start = '';
+		$wrapper_end   = '';
 
 		if ( 'has-wrapper' === $this->wrapper ) {
 			$wrapper_start = '<div class="yoast-seo-help-container">';

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -199,7 +199,9 @@ class WPSEO_Admin_Asset {
 	 * @return string
 	 */
 	protected function get_relative_path( $type, $force_suffix = null ) {
-		$relative_path = $rtl_path = $rtl_suffix = '';
+		$relative_path = '';
+		$rtl_path      = '';
+		$rtl_suffix    = '';
 
 		$suffix = ( is_null( $force_suffix ) ) ? $this->get_suffix() : $force_suffix;
 

--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -62,13 +62,11 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 	 */
 	private function import_post_robot( $post_id ) {
 		$wpseo_robots = get_post_meta( $post_id, '_wpseo_edit_robots', true );
+		$robot_value  = $this->get_robot_value( $wpseo_robots );
 
-		// Does the value exists in our mapping.
-		if ( $robot_value = $this->get_robot_value( $wpseo_robots ) ) {
-			// Saving the new meta values for Yoast SEO.
-			WPSEO_Meta::set_value( $robot_value['index'], 'meta-robots-noindex', $post_id );
-			WPSEO_Meta::set_value( $robot_value['follow'], 'meta-robots-nofollow', $post_id );
-		}
+		// Saving the new meta values for Yoast SEO.
+		WPSEO_Meta::set_value( $robot_value['index'], 'meta-robots-noindex', $post_id );
+		WPSEO_Meta::set_value( $robot_value['follow'], 'meta-robots-nofollow', $post_id );
 
 		$this->delete_post_robot( $post_id );
 	}

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -631,8 +631,11 @@ class WPSEO_Meta_Columns {
 	 * @return  bool        Whether or not the meta box (and associated columns etc) should be hidden
 	 */
 	private function is_metabox_hidden( $post_type = null ) {
-		if ( ! isset( $post_type ) && $current_post_type = $this->get_current_post_type() ) {
-			$post_type = sanitize_text_field( $current_post_type );
+		if ( ! isset( $post_type ) ) {
+			$current_post_type = $this->get_current_post_type();
+			if ( ! empty( $current_post_type ) ) {
+				$post_type = sanitize_text_field( $current_post_type );
+			}
 		}
 
 		if ( isset( $post_type ) ) {

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -117,7 +117,8 @@ class WPSEO_Primary_Term_Admin {
 			$post_id = $this->get_current_id();
 		}
 
-		if ( false !== ( $taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_id, 'wpseo' ) ) ) {
+		$taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_id, 'wpseo' );
+		if ( false !== $taxonomies ) {
 			return $taxonomies;
 		}
 

--- a/admin/class-social-facebook.php
+++ b/admin/class-social-facebook.php
@@ -131,7 +131,8 @@ class Yoast_Social_Facebook {
 	 * This method will hook into the defined get params
 	 */
 	private function get_listener() {
-		if ( $delfbadmin = filter_input( INPUT_GET, 'delfbadmin' ) ) {
+		$delfbadmin = filter_input( INPUT_GET, 'delfbadmin' );
+		if ( ! empty( $delfbadmin ) ) {
 			$this->delete_admin( $delfbadmin );
 		}
 		elseif ( filter_input( INPUT_GET, 'fbclearall' ) ) {

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -94,7 +94,7 @@ class Yoast_Notification_Center {
 		$user_id       = ( ! is_null( $user_id ) ? $user_id : get_current_user_id() );
 		$dismissal_key = $notification->get_dismissal_key();
 
-		$current_value = get_user_meta( $user_id, $dismissal_key, $single = true );
+		$current_value = get_user_meta( $user_id, $dismissal_key, true );
 
 		return ! empty( $current_value );
 	}
@@ -169,7 +169,7 @@ class Yoast_Notification_Center {
 		}
 
 		// Remove notification dismissal for all users.
-		$deleted = delete_metadata( 'user', $user_id = 0, $dismissal_key, $meta_value = '', $delete_all = true );
+		$deleted = delete_metadata( 'user', 0, $dismissal_key, '', true );
 
 		return $deleted;
 	}

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -123,7 +123,8 @@ class Yoast_Plugin_Conflict {
 
 		$plugin_names = array();
 		foreach ( $plugins as $plugin ) {
-			if ( $name = WPSEO_Utils::get_plugin_name( $plugin ) ) {
+			$name = WPSEO_Utils::get_plugin_name( $plugin );
+			if ( ! empty( $name ) ) {
 				$plugin_names[] = '<em>' . $name . '</em>';
 			}
 		}

--- a/admin/config-ui/class-configuration-translations.php
+++ b/admin/config-ui/class-configuration-translations.php
@@ -41,8 +41,11 @@ class WPSEO_Configuration_Translations {
 	protected function get_translations_from_file() {
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/yoast-components-' . $this->locale . '.json';
-		if ( file_exists( $file ) && $file = file_get_contents( $file ) ) {
-			return json_decode( $file, true );
+		if ( file_exists( $file ) ) {
+			$file = file_get_contents( $file );
+			if ( is_string( $file ) && $file !== '' ) {
+				return json_decode( $file, true );
+			}
 		}
 
 		return array();

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -92,8 +92,11 @@ class WPSEO_Metabox_Formatter {
 		$locale = WPSEO_Utils::get_user_locale();
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . $locale . '.json';
-		if ( file_exists( $file ) && $file = file_get_contents( $file ) ) {
-			return json_decode( $file, true );
+		if ( file_exists( $file ) ) {
+			$file = file_get_contents( $file );
+			if ( is_string( $file ) && $file !== '' ) {
+				return json_decode( $file, true );
+			}
 		}
 
 		return array();

--- a/admin/google_search_console/class-gsc-bulk-action.php
+++ b/admin/google_search_console/class-gsc-bulk-action.php
@@ -54,7 +54,8 @@ class WPSEO_GSC_Bulk_Action {
 	 * @return array
 	 */
 	private function posted_issues() {
-		if ( $issues = filter_input( INPUT_POST, 'wpseo_crawl_issues', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ) ) {
+		$issues = filter_input( INPUT_POST, 'wpseo_crawl_issues', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+		if ( ! empty( $issues ) ) {
 			return $issues;
 		}
 

--- a/admin/google_search_console/class-gsc-bulk-action.php
+++ b/admin/google_search_console/class-gsc-bulk-action.php
@@ -21,7 +21,8 @@ class WPSEO_GSC_Bulk_Action {
 	 * Handles the bulk action when there is an action posted
 	 */
 	private function handle_bulk_action() {
-		if ( $bulk_action = $this->determine_bulk_action() ) {
+		$bulk_action = $this->determine_bulk_action();
+		if ( $bulk_action !== false ) {
 			$this->run_bulk_action( $bulk_action, $this->posted_issues() );
 
 			wp_redirect( filter_input( INPUT_POST, '_wp_http_referer' ) );

--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -80,7 +80,8 @@ class WPSEO_GSC_Category_Filters {
 	 * Getting the current view
 	 */
 	private function get_current_category() {
-		if ( $current_category = filter_input( INPUT_GET, 'category' ) ) {
+		$current_category = filter_input( INPUT_GET, 'category' );
+		if ( ! empty( $current_category ) ) {
 			return $current_category;
 		}
 

--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -159,7 +159,8 @@ class WPSEO_GSC_Category_Filters {
 			$class .= ' current';
 		}
 
-		$help_button = $help_panel = '';
+		$help_button = '';
+		$help_panel  = '';
 		if ( $this->filter_values[ $category ]['description'] !== '' ) {
 			$help        = new WPSEO_Admin_Help_Panel( $category, $this->filter_values[ $category ]['help-button'], $this->filter_values[ $category ]['description'], 'has-wrapper' );
 			$help_button = $help->get_button_html();

--- a/admin/google_search_console/class-gsc-count.php
+++ b/admin/google_search_console/class-gsc-count.php
@@ -169,7 +169,8 @@ class WPSEO_GSC_Count {
 	private function list_category_issues( array $counts, $platform, $category ) {
 		// When the issues have to be fetched.
 		if ( array_key_exists( $category, $counts ) && $counts[ $category ]['count'] > 0 && $counts[ $category ]['last_fetch'] <= strtotime( '-12 hours' ) ) {
-			if ( $issues = $this->service->fetch_category_issues( WPSEO_GSC_Mapper::platform_to_api( $platform ), WPSEO_GSC_Mapper::category_to_api( $category ) ) ) {
+			$issues = $this->service->fetch_category_issues( WPSEO_GSC_Mapper::platform_to_api( $platform ), WPSEO_GSC_Mapper::category_to_api( $category ) );
+			if ( ! empty( $issues ) ) {
 				$this->issues = $issues;
 			}
 

--- a/admin/google_search_console/class-gsc-mapper.php
+++ b/admin/google_search_console/class-gsc-mapper.php
@@ -44,7 +44,8 @@ class WPSEO_GSC_Mapper {
 	 * @return mixed
 	 */
 	public static function get_current_platform( $platform ) {
-		if ( $current_platform = filter_input( INPUT_GET, $platform ) ) {
+		$current_platform = filter_input( INPUT_GET, $platform );
+		if ( ! empty( $current_platform ) ) {
 			return $current_platform;
 		}
 

--- a/admin/google_search_console/class-gsc-mapper.php
+++ b/admin/google_search_console/class-gsc-mapper.php
@@ -74,8 +74,11 @@ class WPSEO_GSC_Mapper {
 	 * @return string
 	 */
 	public static function platform_from_api( $platform ) {
-		if ( ! empty( $platform ) && $platform = array_search( $platform, self::$platforms, true ) ) {
-			return $platform;
+		if ( ! empty( $platform ) ) {
+			$platform = array_search( $platform, self::$platforms, true );
+			if ( $platform !== false ) {
+				return $platform;
+			}
 		}
 
 		return $platform;
@@ -104,8 +107,11 @@ class WPSEO_GSC_Mapper {
 	 * @return string
 	 */
 	public static function category_from_api( $category ) {
-		if ( ! empty( $category ) && $category = array_search( $category, self::$categories, true ) ) {
-			return $category;
+		if ( ! empty( $category ) ) {
+			$category = array_search( $category, self::$categories, true );
+			if ( $category !== false ) {
+				return $category;
+			}
 		}
 
 		return $category;

--- a/admin/google_search_console/class-gsc-platform-tabs.php
+++ b/admin/google_search_console/class-gsc-platform-tabs.php
@@ -69,7 +69,8 @@ class WPSEO_GSC_Platform_Tabs {
 	 */
 	private function set_current_tab( array $platforms ) {
 		$this->current_tab = key( $platforms );
-		if ( $current_platform = filter_input( INPUT_GET, 'tab' ) ) {
+		$current_platform  = filter_input( INPUT_GET, 'tab' );
+		if ( ! empty( $current_platform ) ) {
 			$this->current_tab = $current_platform;
 		}
 	}

--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -84,7 +84,8 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	public function prepare_items() {
 		// Get variables needed for pagination.
 		$this->per_page     = $this->get_items_per_page( 'errors_per_page', $this->per_page );
-		$this->current_page = intval( ( $paged = filter_input( INPUT_GET, 'paged' ) ) ? $paged : 1 );
+		$paged              = filter_input( INPUT_GET, 'paged' );
+		$this->current_page = intval( ( ! empty( $paged ) ) ? $paged : 1 );
 
 		$this->setup_columns();
 		$this->views();
@@ -308,11 +309,14 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	 * @return int
 	 */
 	private function do_reorder( $a, $b ) {
+		$orderby = filter_input( INPUT_GET, 'orderby' );
+		$order   = filter_input( INPUT_GET, 'order' );
+
 		// If no sort, default to title.
-		$orderby = ( $orderby = filter_input( INPUT_GET, 'orderby' ) ) ? $orderby : 'url';
+		$orderby = ( ! empty( $orderby ) ) ? $orderby : 'url';
 
 		// If no order, default to asc.
-		$order = ( $order = filter_input( INPUT_GET, 'order' ) ) ? $order : 'asc';
+		$order = ( ! empty( $order ) ) ? $order : 'asc';
 
 		// When there is a raw field of it, sort by this field.
 		if ( array_key_exists( $orderby . '_raw', $a ) && array_key_exists( $orderby . '_raw', $b ) ) {

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -6,6 +6,8 @@
 // Admin header.
 Yoast_Form::get_instance()->admin_header( false, 'wpseo-gsc', false, 'yoast_wpseo_gsc_options' );
 
+$platform_tabs = new WPSEO_GSC_Platform_Tabs();
+
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== '' ) { ?>
 	<form action="" method="post" class="wpseo-gsc-reload-crawl-issues-form">
 		<input type='hidden' name='reload-crawl-issues-nonce' value='<?php echo wp_create_nonce( 'reload-crawl-issues' ); ?>' />
@@ -15,7 +17,7 @@ if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== 
 <?php } ?>
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<?php echo $platform_tabs = new WPSEO_GSC_Platform_Tabs(); ?>
+		<?php echo $platform_tabs; ?>
 	</h2>
 
 <?php

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -57,7 +57,8 @@ switch ( $platform_tabs->current_tab() ) {
 		else {
 			$reset_button = '<a class="button" href="' . add_query_arg( 'gsc_reset', 1 ) . '">' . __( 'Reauthenticate with Google ', 'wordpress-seo' ) . '</a>';
 			echo '<h3>',  __( 'Current profile', 'wordpress-seo' ), '</h3>';
-			if ( ( $profile = WPSEO_GSC_Settings::get_profile() ) !== '' ) {
+			$profile = WPSEO_GSC_Settings::get_profile();
+			if ( $profile !== '' ) {
 				echo '<p>';
 				echo $profile;
 				echo '</p>';
@@ -74,7 +75,8 @@ switch ( $platform_tabs->current_tab() ) {
 				Yoast_Form::get_instance()->set_option( 'wpseo-gsc' );
 
 				echo '<p>';
-				if ( $profiles = $this->service->get_sites() ) {
+				$profiles = $this->service->get_sites();
+				if ( ! empty( $profiles ) ) {
 					$show_save = true;
 					echo Yoast_Form::get_instance()->select( 'profile', __( 'Profile', 'wordpress-seo' ), $profiles );
 				}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -569,7 +569,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$placeholder = $meta_field_def['placeholder'];
 		}
 
-		$aria_describedby = $description = '';
+		$aria_describedby = '';
+		$description      = '';
 		if ( isset( $meta_field_def['description'] ) ) {
 			$aria_describedby = ' aria-describedby="' . $esc_form_key . '-desc"';
 			$description      = '<p id="' . $esc_form_key . '-desc" class="yoast-metabox__description">' . $meta_field_def['description'] . '</p>';
@@ -725,7 +726,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$label = '<label for="' . $esc_form_key . '">' . $title . '</label>';
 
 			// Set the inline help and help panel, if any.
-			$help_button = $help_panel = '';
+			$help_button = '';
+			$help_panel  = '';
 			if ( isset( $meta_field_def['help'] ) && $meta_field_def['help'] !== '' ) {
 				$help        = new WPSEO_Admin_Help_Panel( $key, $meta_field_def['help-button'], $meta_field_def['help'] );
 				$help_button = $help->get_button_html();

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -955,7 +955,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @returns WP_Post|array
 	 */
 	protected function get_metabox_post() {
-		if ( $post = filter_input( INPUT_GET, 'post' ) ) {
+		$post = filter_input( INPUT_GET, 'post' );
+		if ( ! empty( $post ) ) {
 			$post_id = (int) WPSEO_Utils::validate_int( $post );
 
 			return get_post( $post_id );

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -67,26 +67,29 @@ class WPSEO_OnPage {
 	 * @return bool
 	 */
 	public function fetch_from_onpage() {
-		if ( $this->onpage_option->should_be_fetched() && false !== ( $new_status = $this->request_indexability() ) ) {
+		if ( $this->onpage_option->should_be_fetched() ) {
+			$new_status = $this->request_indexability();
+			if ( false !== $new_status ) {
 
-			// Updates the timestamp in the option.
-			$this->onpage_option->set_last_fetch( time() );
+				// Updates the timestamp in the option.
+				$this->onpage_option->set_last_fetch( time() );
 
-			// The currently indexability status.
-			$old_status = $this->onpage_option->get_status();
+				// The currently indexability status.
+				$old_status = $this->onpage_option->get_status();
 
-			// Saving the new status.
-			$this->onpage_option->set_status( $new_status );
+				// Saving the new status.
+				$this->onpage_option->set_status( $new_status );
 
-			// Saving the option.
-			$this->onpage_option->save_option();
+				// Saving the option.
+				$this->onpage_option->save_option();
 
-			// Check if the status has been changed.
-			if ( $old_status !== $new_status && $new_status !== WPSEO_OnPage_Option::CANNOT_FETCH ) {
-				$this->notify_admins();
+				// Check if the status has been changed.
+				if ( $old_status !== $new_status && $new_status !== WPSEO_OnPage_Option::CANNOT_FETCH ) {
+					$this->notify_admins();
+				}
+
+				return true;
 			}
-
-			return true;
 		}
 
 		return false;

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -196,7 +196,8 @@ class WPSEO_Taxonomy_Columns {
 	 * @return string
 	 */
 	private function get_focus_keyword( $term ) {
-		if ( $focus_keyword = WPSEO_Taxonomy_Meta::get_term_meta( 'focuskw', $term->term_id, $term->taxonomy ) ) {
+		$focus_keyword = WPSEO_Taxonomy_Meta::get_term_meta( 'focuskw', $term->term_id, $term->taxonomy );
+		if ( $focus_keyword !== false ) {
 			return $focus_keyword;
 		}
 

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -114,18 +114,11 @@ class WPSEO_Taxonomy_Columns {
 		}
 
 		// When there is a focus key word.
-		if ( $focus_keyword = $this->get_focus_keyword( $term ) ) {
-			$score = (int) WPSEO_Taxonomy_Meta::get_term_meta( $term_id, $this->taxonomy, 'linkdex' );
-			$rank  = WPSEO_Rank::from_numeric_score( $score );
+		$focus_keyword = $this->get_focus_keyword( $term );
+		$score         = (int) WPSEO_Taxonomy_Meta::get_term_meta( $term_id, $this->taxonomy, 'linkdex' );
+		$rank          = WPSEO_Rank::from_numeric_score( $score );
 
-			return $this->create_score_icon( $rank, $rank->get_label() );
-		}
-
-		// Default icon.
-		return $this->create_score_icon(
-			new WPSEO_Rank( WPSEO_Rank::NO_FOCUS ),
-			__( 'Focus keyword not set.', 'wordpress-seo' )
-		);
+		return $this->create_score_icon( $rank, $rank->get_label() );
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -75,8 +75,10 @@ class WPSEO_Taxonomy_Fields_Presenter {
 	 */
 	private function get_field( $field_type, $field_name, $field_value, array $options ) {
 
-		$class = $this->get_class( $options );
-		$field = $description = $aria_describedby = '';
+		$class            = $this->get_class( $options );
+		$field            = '';
+		$description      = '';
+		$aria_describedby = '';
 
 		if ( ! empty( $options['description'] ) ) {
 			$aria_describedby = ' aria-describedby="' . $field_name . '-desc"';

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -129,7 +129,8 @@ class WPSEO_Taxonomy {
 		/* Create post array with only our values */
 		$new_meta_data = array();
 		foreach ( WPSEO_Taxonomy_Meta::$defaults_per_term as $key => $default ) {
-			if ( $posted_value = filter_input( INPUT_POST, $key ) ) {
+			$posted_value = filter_input( INPUT_POST, $key );
+			if ( isset( $posted_value ) && $posted_value !== false ) {
 				$new_meta_data[ $key ] = $posted_value;
 			}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -198,7 +198,8 @@ class WPSEO_OpenGraph_Image {
 	 * Check if taxonomy has an image and add this image
 	 */
 	private function get_opengraph_image_taxonomy() {
-		if ( ( $ogimg = WPSEO_Taxonomy_Meta::get_meta_without_term( 'opengraph-image' ) ) !== '' ) {
+		$ogimg = WPSEO_Taxonomy_Meta::get_meta_without_term( 'opengraph-image' );
+		if ( $ogimg !== '' ) {
 			$this->add_image( $ogimg );
 		}
 	}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -137,9 +137,12 @@ class WPSEO_Upgrade {
 		if ( ! empty( $taxonomies ) ) {
 			foreach ( $taxonomies as $taxonomy => $tax_metas ) {
 				foreach ( $tax_metas as $term_id => $tax_meta ) {
-					if ( function_exists( 'wp_get_split_term' ) && $new_term_id = wp_get_split_term( $term_id, $taxonomy ) ) {
-						$taxonomies[ $taxonomy ][ $new_term_id ] = $taxonomies[ $taxonomy ][ $term_id ];
-						unset( $taxonomies[ $taxonomy ][ $term_id ] );
+					if ( function_exists( 'wp_get_split_term' ) ) {
+						$new_term_id = wp_get_split_term( $term_id, $taxonomy );
+						if ( $new_term_id !== false ) {
+							$taxonomies[ $taxonomy ][ $new_term_id ] = $taxonomies[ $taxonomy ][ $term_id ];
+							unset( $taxonomies[ $taxonomy ][ $term_id ] );
+						}
 					}
 				}
 			}

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -618,7 +618,8 @@ class WPSEO_Replace_Vars {
 
 		if ( $post_type !== '' ) {
 			$pt        = get_post_type_object( $post_type );
-			$pt_plural = $pt_single = $pt->name;
+			$pt_single = $pt->name;
+			$pt_plural = $pt->name;
 			if ( isset( $pt->labels->singular_name ) ) {
 				$pt_single = $pt->labels->singular_name;
 			}

--- a/inc/options/class-wpseo-option-xml.php
+++ b/inc/options/class-wpseo-option-xml.php
@@ -187,11 +187,11 @@ class WPSEO_Option_XML extends WPSEO_Option {
 
 				case 'excluded-posts':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
-						if ( $filtered_array = filter_var_array( explode( ',', $dirty[ $key ] ), FILTER_VALIDATE_INT ) ) {
-							$clean[ $key ] = implode( ',', array_filter( $filtered_array, 'is_integer' ) );
-
-							unset( $filtered_array );
+						$filtered_array = filter_var_array( explode( ',', $dirty[ $key ] ), FILTER_VALIDATE_INT );
+						if ( is_array( $filtered_array ) ) {
+							$clean[ $key ]  = implode( ',', array_filter( $filtered_array, 'is_integer' ) );
 						}
+						unset( $filtered_array );
 					}
 
 					break;

--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -69,12 +69,14 @@ class WPSEO_Sitemap_Timezone {
 	private function determine_timezone_string() {
 
 		// If site timezone string exists, return it.
-		if ( $timezone = get_option( 'timezone_string' ) ) {
+		$timezone = get_option( 'timezone_string' );
+		if ( ! empty( $timezone ) ) {
 			return $timezone;
 		}
 
 		// Get UTC offset, if it isn't set then return UTC.
-		if ( 0 === ( $utc_offset = (int) get_option( 'gmt_offset', 0 ) ) ) {
+		$utc_offset = (int) get_option( 'gmt_offset', 0 );
+		if ( 0 === $utc_offset ) {
 			return 'UTC';
 		}
 

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -58,7 +58,8 @@ function wpseo_admin_bar_menu() {
 	}
 
 	// Never display notifications for network admin.
-	$counter = $alert_popup = '';
+	$counter     = '';
+	$alert_popup = '';
 
 	// Determine is user is admin or network admin.
 	$can_manage_seo = WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );

--- a/tests/framework/class-wpseo-unit-test-case.php
+++ b/tests/framework/class-wpseo-unit-test-case.php
@@ -13,7 +13,8 @@ class WPSEO_UnitTestCase extends WP_UnitTestCase {
 	 * @param mixed  $value Value to assign to it.
 	 */
 	protected function set_post( $key, $value ) {
-		$_POST[ $key ] = $_REQUEST[ $key ] = addslashes( $value );
+		$_POST[ $key ]    = addslashes( $value );
+		$_REQUEST[ $key ] = $_POST[ $key ];
 	}
 
 	/**

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -829,7 +829,8 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		// note: the WP and WP_Query classes like to silently fetch parameters
 		// from all over the place (globals, GET, etc), which makes it tricky
 		// to run them more than once without very carefully clearing everything
-		$_GET = $_POST = array();
+		$_GET  = array();
+		$_POST = array();
 
 		$keys = array(
 			'query_string',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.

Assignments in conditions makes for hard to debug, hard to read code and is considered a code smell.

Compliance with the following two sniffs:
* `Squiz.PHP.DisallowMultipleAssignments` - introduced in WPCS 0.11.0
* `WordPress.CodeAnalysis.AssignmentInCondition` - will be introduced in WPCS 0.14.0

**Review note:** the PR will be easiest to review by looking at the individual commits.

## Test instructions

_N/A_