### PR TITLE
QA: fix inconsistency

### DIFF
--- a/admin/links/class-link-column-count.php
+++ b/admin/links/class-link-column-count.php
@@ -30,7 +30,8 @@ class WPSEO_Link_Column_Count {
 	 * @param int    $post_id      The post id.
 	 * @param string $target_field The field to show.
 	 *
-	 * @return int The total amount of links.
+	 * @return int|null The total amount of links or null if the target field
+	 *                  does not exist for the given post id.
 	 */
 	public function get( $post_id, $target_field = 'internal_link_count' ) {
 		if ( array_key_exists( $post_id, $this->count ) && array_key_exists( $target_field, $this->count[ $post_id ] ) ) {

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -219,15 +219,21 @@ class WPSEO_Link_Columns {
 	 * @param int    $post_id     Post to display the column content for.
 	 */
 	public function column_content( $column_name, $post_id ) {
+		$link_count = null;
+
 		switch ( $column_name ) {
 			case 'wpseo-' . self::COLUMN_LINKS:
-				echo $this->link_count->get( $post_id, 'internal_link_count' );
+				$link_count = $this->link_count->get( $post_id, 'internal_link_count' );
 				break;
 			case 'wpseo-' . self::COLUMN_LINKED:
 				if ( get_post_status( $post_id ) === 'publish' ) {
-					echo $this->link_count->get( $post_id, 'incoming_link_count' );
+					$link_count = $this->link_count->get( $post_id, 'incoming_link_count' );
 				}
 				break;
+		}
+
+		if ( isset( $link_count ) ) {
+			echo (int) $link_count;
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:

The function documentation states that the return value should be an int, so `null` should be `0` in that case.

Alternatively the function docblock could be adjusted, but to be fair, this seemed like the more logical choice.

As it is now, the unit tests for the `WPSEO_Link_Columns::column_content()` will fail because of this change, so I need some clarification over the desired behaviour to either amend the `WPSEO_Link_Columns::column_content()` method or to amend the unit test.


## Test instructions

_N/A_
