### PR TITLE
CS (non-)compliance/XSS: always escape output - part 1

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -595,7 +595,7 @@ class WPSEO_Admin_Init {
 		foreach ( $deprecated_notices as $deprecated_filter ) {
 			_deprecated_function(
 				/* translators: %s expands to the actual filter/action that has been used. */
-				sprintf( __( '%s filter/action', 'wordpress-seo' ), $deprecated_filter ),
+				esc_html( sprintf( __( '%s filter/action', 'wordpress-seo' ), $deprecated_filter ) ),
 				'WPSEO 3.0',
 				'javascript'
 			);

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -218,7 +218,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 			<?php if ( 'top' === $which ) { ?>
 			<form id="posts-filter" action="" method="get">
-				<input type="hidden" name="nonce" value="<?php echo $this->nonce; ?>"/>
+				<input type="hidden" name="nonce" value="<?php echo esc_attr( $this->nonce ); ?>"/>
 				<input type="hidden" name="page" value="wpseo_tools"/>
 				<input type="hidden" name="tool" value="bulk-editor"/>
 				<input type="hidden" name="type" value="<?php echo esc_attr( $this->page_type ); ?>"/>
@@ -416,8 +416,8 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 				printf(
 					'<label for="%1$s" class="screen-reader-text">%2$s</label>',
-					'post-type-filter-' . $instance_type,
-					__( 'Filter by post type', 'wordpress-seo' )
+					esc_attr( 'post-type-filter-' . $instance_type ),
+					esc_html__( 'Filter by post type', 'wordpress-seo' )
 				);
 				printf( '<select name="post_type_filter" id="post-type-filter-%2$s">%1$s</select>', $options, $instance_type );
 				submit_button( __( 'Filter', 'wordpress-seo' ), 'button', false, false, array( 'id' => 'post-query-submit' ) );

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -145,7 +145,7 @@ class WPSEO_Help_Center {
 	 * Outputs the help center div.
 	 */
 	public function mount() {
-		echo '<div id="' . esc_attr( $this->identifier ) . '">' . __( 'Loading help center.', 'wordpress-seo' ) . '</div>';
+		echo '<div id="' . esc_attr( $this->identifier ) . '">' . esc_html__( 'Loading help center.', 'wordpress-seo' ) . '</div>';
 	}
 
 	/**

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -102,12 +102,12 @@ class WPSEO_Meta_Columns {
 				break;
 			case 'wpseo-metadesc':
 				$metadesc_val = apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) );
-				$metadesc     = ( '' === $metadesc_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
+				$metadesc     = ( '' === $metadesc_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
 				echo $metadesc;
 				break;
 			case 'wpseo-focuskw':
 				$focuskw_val = WPSEO_Meta::get_value( 'focuskw', $post_id );
-				$focuskw     = ( '' === $focuskw_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . __( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
+				$focuskw     = ( '' === $focuskw_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
 				echo $focuskw;
 				break;
 		}
@@ -173,7 +173,7 @@ class WPSEO_Meta_Columns {
 
 		$ranks = WPSEO_Rank::get_all_ranks();
 
-		echo '<label class="screen-reader-text" for="wpseo-filter">' . __( 'Filter by SEO Score', 'wordpress-seo' ) . '</label>';
+		echo '<label class="screen-reader-text" for="wpseo-filter">' . esc_html__( 'Filter by SEO Score', 'wordpress-seo' ) . '</label>';
 		echo '<select name="seo_filter" id="wpseo-filter">';
 
 		echo $this->generate_option( '', __( 'All SEO Scores', 'wordpress-seo' ) );
@@ -199,7 +199,7 @@ class WPSEO_Meta_Columns {
 
 		$ranks = WPSEO_Rank::get_all_readability_ranks();
 
-		echo '<label class="screen-reader-text" for="wpseo-readability-filter">' . __( 'Filter by Readability Score', 'wordpress-seo' ) . '</label>';
+		echo '<label class="screen-reader-text" for="wpseo-readability-filter">' . esc_html__( 'Filter by Readability Score', 'wordpress-seo' ) . '</label>';
 		echo '<select name="readability_filter" id="wpseo-readability-filter">';
 
 		echo $this->generate_option( '', __( 'All Readability Scores', 'wordpress-seo' ) );

--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -37,7 +37,7 @@ class WPSEO_Option_Tabs_Formatter {
 
 		foreach ( $option_tabs->get_tabs() as $tab ) {
 			$identifier = $tab->get_name();
-			printf( '<div id="%s" class="wpseotab">', $identifier );
+			printf( '<div id="%s" class="wpseotab">', esc_attr( $identifier ) );
 
 			// Output the settings view for all tabs.
 			$tab_view = $this->get_tab_view( $option_tabs, $tab );

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -59,14 +59,14 @@ class Premium_Upsell_Admin_Block {
 		/* translators: %s expands to "Yoast SEO Premium". */
 		$upgrade_msg = sprintf( __( 'Find out why you should upgrade to %s &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );
 
-		echo '<div class="' . $class . '">';
+		echo '<div class="' . esc_attr( $class ) . '">';
 		echo '<a href="' . esc_url( add_query_arg( array( $this->get_query_variable_name() => 1 ) ) ) . '" style="" class="alignright ' . $class . '--close" aria-label="' . esc_attr( $dismiss_msg ) . '">X</a>';
 
 		echo '<div>';
-		echo '<h2 class="' . $class . '--header">' . __( 'Go premium!', 'wordpress-seo' ) . '</h2>';
+		echo '<h2 class="' . $class . '--header">' . esc_html__( 'Go premium!', 'wordpress-seo' ) . '</h2>';
 		echo '<ul class="' . $class . '--motivation">' . $arguments_html . '</ul>';
 
-		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . $upgrade_msg . '</a><br />';
+		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $upgrade_msg ) . '</a><br />';
 		echo '</div>';
 
 		echo '</div>';

--- a/admin/class-recalculate-scores.php
+++ b/admin/class-recalculate-scores.php
@@ -35,7 +35,7 @@ class WPSEO_Recalculate_Scores {
 
 		$progress = sprintf(
 			/* translators: 1: expands to a <span> containing the number of posts recalculated. 2: expands to a <strong> containing the total number of posts. */
-			__( '%1$s of %2$s done.', 'wordpress-seo' ),
+			esc_html__( '%1$s of %2$s done.', 'wordpress-seo' ),
 			'<span id="wpseo_count">0</span>',
 			'<strong id="wpseo_count_total">0</strong>'
 		);

--- a/admin/class-social-facebook-form.php
+++ b/admin/class-social-facebook-form.php
@@ -102,16 +102,16 @@ class Yoast_Social_Facebook_Form {
 		printf( __( 'If you don\'t know where to find the needed ID, see %1$sthis knowledge base article%2$s.', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/facebook-insights' ) . '">', '</a>' );
 		echo '</p>';
 		echo '<div class="form-field form-required">';
-		echo '<label for="fb_admin_name">' . __( 'Admin\'s name:', 'wordpress-seo' ) . '</label>';
+		echo '<label for="fb_admin_name">' . esc_html__( 'Admin\'s name:', 'wordpress-seo' ) . '</label>';
 		echo '<input type="text" id="fb_admin_name" name="fb_admin_name" value="" maxlength="255" />';
 		echo '</div>';
 		echo '<div class="form-field form-required">';
-		echo '<label for="fb_admin_id">' . __( 'Admin\'s Facebook user ID:', 'wordpress-seo' ) . '</label>';
+		echo '<label for="fb_admin_id">' . esc_html__( 'Admin\'s Facebook user ID:', 'wordpress-seo' ) . '</label>';
 		echo '<input type="text" id="fb_admin_id" name="fb_admin_id" value="" maxlength="255"  />';
 		echo '</div>';
 		echo "<p class='submit'>";
-		echo '<input type="hidden" name="fb_admin_nonce" value="' . wp_create_nonce( 'wpseo_fb_admin_nonce' ) . '" />';
-		echo '<input type="submit" value="' . __( 'Add Facebook admin', 'wordpress-seo' ) . '" class="button button-primary" onclick="javascript:wpseo_add_fb_admin();" />';
+		echo '<input type="hidden" name="fb_admin_nonce" value="' . esc_attr( wp_create_nonce( 'wpseo_fb_admin_nonce' ) ) . '" />';
+		echo '<input type="submit" value="' . esc_attr__( 'Add Facebook admin', 'wordpress-seo' ) . '" class="button button-primary" onclick="javascript:wpseo_add_fb_admin();" />';
 		echo '</p>';
 		echo '</div>';
 		echo '</div>';
@@ -136,7 +136,7 @@ class Yoast_Social_Facebook_Form {
 		}
 
 		echo "<div id='connected_fb_admins'{$class_attr}>";
-		echo '<p>' . __( 'Currently connected Facebook admins:', 'wordpress-seo' ) . '</p>';
+		echo '<p>' . esc_html__( 'Currently connected Facebook admins:', 'wordpress-seo' ) . '</p>';
 		echo '<ul id="user_admin">';
 		$this->show_user_admins( $nonce );
 		echo '</ul>';

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -164,7 +164,7 @@ class Yoast_Form {
 			echo '
 			<div id="wpseo-debug-info" class="yoast-container">
 
-				<h2>' . __( 'Debug Information', 'wordpress-seo' ) . '</h2>
+				<h2>' . esc_html__( 'Debug Information', 'wordpress-seo' ) . '</h2>
 				<div>
 					<h3 class="wpseo-debug-heading">' . esc_html__( 'Current option:', 'wordpress-seo' ) . ' <span class="wpseo-debug">' . esc_html( $this->option_name ) . '</span></h3>
 					' . ( ( $xdebug ) ? '' : '<pre>' );
@@ -222,7 +222,7 @@ class Yoast_Form {
 				'for'   => '',
 			)
 		);
-		echo "<label class='" . $attr['class'] . "' for='" . esc_attr( $attr['for'] ) . "'>$text";
+		echo "<label class='" . esc_attr( $attr['class'] ) . "' for='" . esc_attr( $attr['for'] ) . "'>$text";
 		if ( $attr['close'] ) {
 			echo '</label>';
 		}
@@ -244,7 +244,7 @@ class Yoast_Form {
 		);
 
 		$id = ( '' === $attr['id'] ) ? '' : ' id="' . esc_attr( $attr['id'] ) . '"';
-		echo '<legend class="yoast-form-legend ' . $attr['class'] . '"' . $id . '>' . $text . '</legend>';
+		echo '<legend class="yoast-form-legend ' . esc_attr( $attr['class'] ) . '"' . $id . '>' . $text . '</legend>';
 	}
 
 	/**

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -103,7 +103,7 @@ class WPSEO_Configuration_Page {
 			<title><?php
 				printf(
 					/* translators: %s expands to Yoast SEO. */
-					__( '%s &rsaquo; Configuration Wizard', 'wordpress-seo' ),
+					esc_html__( '%s &rsaquo; Configuration Wizard', 'wordpress-seo' ),
 					'Yoast SEO' );
 			?></title>
 			<?php
@@ -123,7 +123,7 @@ class WPSEO_Configuration_Page {
 		<body class="wp-admin wp-core-ui">
 		<div id="wizard"></div>
 		<div role="contentinfo" class="yoast-wizard-return-link-container">
-			<a class="button yoast-wizard-return-link" href="<?php echo $dashboard_url; ?>">
+			<a class="button yoast-wizard-return-link" href="<?php echo esc_url( $dashboard_url ); ?>">
 				<span aria-hidden="true" class="dashicons dashicons-no"></span>
 				<?php
 				esc_html_e( 'Close wizard', 'wordpress-seo' );

--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -109,7 +109,7 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	 * @return void
 	 */
 	public function render_hidden_input() {
-		echo '<input type="hidden" name="' . self::FILTER_QUERY_ARG . '" value="' . $this->get_query_val() . '">';
+		echo '<input type="hidden" name="' . esc_attr( self::FILTER_QUERY_ARG ) . '" value="' . esc_attr( $this->get_query_val() ) . '">';
 	}
 
 	/**

--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -361,8 +361,8 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	 * @param string $platform Platform (desktop, mobile, feature phone).
 	 */
 	private function show_fields( $platform ) {
-		echo "<input type='hidden' name='wpseo_gsc_nonce' value='" . wp_create_nonce( 'wpseo_gsc_nonce' ) . "' />";
-		echo "<input id='field_platform' type='hidden' name='platform' value='{$platform}' />";
-		echo "<input id='field_category' type='hidden' name='category' value='{$this->current_view}' />";
+		echo '<input type="hidden" name="wpseo_gsc_nonce" value="' . esc_attr( wp_create_nonce( 'wpseo_gsc_nonce' ) ) . '" />';
+		echo '<input id="field_platform" type="hidden" name="platform" value="' . esc_attr( $platform ) . '" />';
+		echo '<input id="field_category" type="hidden" name="category" value="' . esc_attr( $this->current_view ) . '" />';
 	}
 }

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -10,9 +10,9 @@ $platform_tabs = new WPSEO_GSC_Platform_Tabs();
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== '' ) { ?>
 	<form action="" method="post" class="wpseo-gsc-reload-crawl-issues-form">
-		<input type='hidden' name='reload-crawl-issues-nonce' value='<?php echo wp_create_nonce( 'reload-crawl-issues' ); ?>' />
+		<input type='hidden' name='reload-crawl-issues-nonce' value='<?php echo esc_attr( wp_create_nonce( 'reload-crawl-issues' ) ); ?>' />
 		<input type="submit" name="reload-crawl-issues" id="reload-crawl-issue" class="button button-primary alignright"
-			value="<?php _e( 'Reload crawl issues', 'wordpress-seo' ); ?>">
+			value="<?php esc_attr_e( 'Reload crawl issues', 'wordpress-seo' ); ?>">
 	</form>
 <?php } ?>
 
@@ -44,19 +44,19 @@ switch ( $platform_tabs->current_tab() ) {
 			/* Translators: %1$s: expands to Yoast SEO, %2$s expands to Google Search Console. */
 			printf( __( 'To allow %1$s to fetch your %2$s information, please enter your Google Authorization Code. Clicking the button below will open a new window.', 'wordpress-seo' ), 'Yoast SEO', 'Google Search Console' );
 			echo "</p>\n";
-			echo '<input type="hidden" id="gsc_auth_url" value="', $this->service->get_client()->createAuthUrl() , '" />';
-			echo "<button type='button' id='gsc_auth_code' class='button'>" , __( 'Get Google Authorization Code', 'wordpress-seo' ) ,"</button>\n";
+			echo '<input type="hidden" id="gsc_auth_url" value="', esc_url( $this->service->get_client()->createAuthUrl() ) , '" />';
+			echo "<button type='button' id='gsc_auth_code' class='button'>" , esc_html__( 'Get Google Authorization Code', 'wordpress-seo' ) ,"</button>\n";
 
-			echo '<p id="gsc-enter-code-label">' . __( 'Enter your Google Authorization Code and press the Authenticate button.', 'wordpress-seo' ) . "</p>\n";
-			echo "<form action='" . admin_url( 'admin.php?page=wpseo_search_console&tab=settings' ) . "' method='post'>\n";
+			echo '<p id="gsc-enter-code-label">' . esc_html__( 'Enter your Google Authorization Code and press the Authenticate button.', 'wordpress-seo' ) . "</p>\n";
+			echo "<form action='" . esc_url( admin_url( 'admin.php?page=wpseo_search_console&tab=settings' ) ) . "' method='post'>\n";
 			echo "<input type='text' name='gsc[authorization_code]' value='' class='textinput' aria-labelledby='gsc-enter-code-label' />";
-			echo "<input type='hidden' name='gsc[gsc_nonce]' value='" . wp_create_nonce( 'wpseo-gsc_nonce' ) . "' />";
-			echo "<input type='submit' name='gsc[Submit]' value='" . __( 'Authenticate', 'wordpress-seo' ) . "' class='button button-primary' />";
+			echo "<input type='hidden' name='gsc[gsc_nonce]' value='" . esc_attr( wp_create_nonce( 'wpseo-gsc_nonce' ) ) . "' />";
+			echo "<input type='submit' name='gsc[Submit]' value='" . esc_attr__( 'Authenticate', 'wordpress-seo' ) . "' class='button button-primary' />";
 			echo "</form>\n";
 		}
 		else {
-			$reset_button = '<a class="button" href="' . add_query_arg( 'gsc_reset', 1 ) . '">' . __( 'Reauthenticate with Google ', 'wordpress-seo' ) . '</a>';
-			echo '<h3>',  __( 'Current profile', 'wordpress-seo' ), '</h3>';
+			$reset_button = '<a class="button" href="' . esc_url( add_query_arg( 'gsc_reset', 1 ) ) . '">' . esc_html__( 'Reauthenticate with Google ', 'wordpress-seo' ) . '</a>';
+			echo '<h3>', esc_html__( 'Current profile', 'wordpress-seo' ), '</h3>';
 			$profile = WPSEO_GSC_Settings::get_profile();
 			if ( $profile !== '' ) {
 				echo '<p>';
@@ -69,7 +69,7 @@ switch ( $platform_tabs->current_tab() ) {
 
 			}
 			else {
-				echo "<form action='" . admin_url( 'options.php' ) . "' method='post'>";
+				echo "<form action='" . esc_url( admin_url( 'options.php' ) ) . "' method='post'>";
 
 				settings_fields( 'yoast_wpseo_gsc_options' );
 				Yoast_Form::get_instance()->set_option( 'wpseo-gsc' );
@@ -82,14 +82,14 @@ switch ( $platform_tabs->current_tab() ) {
 				}
 				else {
 					$show_save = false;
-					echo __( 'There were no profiles found', 'wordpress-seo' );
+					esc_html_e( 'There were no profiles found', 'wordpress-seo' );
 				}
 				echo '</p>';
 
 				echo '<p>';
 
 				if ( $show_save ) {
-					echo '<input type="submit" name="submit" id="submit" class="button button-primary wpseo-gsc-save-profile" value="' . __( 'Save Profile', 'wordpress-seo' ) . '" /> ' . __( 'or', 'wordpress-seo' ) , ' ';
+					echo '<input type="submit" name="submit" id="submit" class="button button-primary wpseo-gsc-save-profile" value="' . esc_attr__( 'Save Profile', 'wordpress-seo' ) . '" /> ' . __( 'or', 'wordpress-seo' ) , ' ';
 				}
 				echo $reset_button;
 				echo '</p>';
@@ -109,10 +109,10 @@ switch ( $platform_tabs->current_tab() ) {
 		) );
 
 		// Open <form>.
-		echo "<form id='wpseo-crawl-issues-table-form' action='" . $form_action_url . "' method='post'>\n";
+		echo "<form id='wpseo-crawl-issues-table-form' action='" . esc_url( $form_action_url ) . "' method='post'>\n";
 
 		// AJAX nonce.
-		echo "<input type='hidden' class='wpseo-gsc-ajax-security' value='" . wp_create_nonce( 'wpseo-gsc-ajax-security' ) . "' />\n";
+		echo "<input type='hidden' class='wpseo-gsc-ajax-security' value='" . esc_attr( wp_create_nonce( 'wpseo-gsc-ajax-security' ) ) . "' />\n";
 
 		$this->display_table();
 

--- a/admin/google_search_console/views/gsc-redirect-nopremium.php
+++ b/admin/google_search_console/views/gsc-redirect-nopremium.php
@@ -10,9 +10,9 @@ echo '<h1 class="wpseo-redirect-url-title">', sprintf( __( 'Creating redirects i
 echo '<p>';
 printf(
 	/* Translators: %1$s: expands to 'Yoast SEO Premium', %2$s: links to Yoast SEO Premium plugin page. */
-	__( 'To be able to create a redirect and fix this issue, you need %1$s. You can buy the plugin, including one year of support and updates, on %2$s.', 'wordpress-seo' ),
+	esc_html__( 'To be able to create a redirect and fix this issue, you need %1$s. You can buy the plugin, including one year of support and updates, on %2$s.', 'wordpress-seo' ),
 	'Yoast SEO Premium',
-	'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/redirects' ) . '" target="_blank">yoast.com</a>'
+	'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/redirects' ) ) . '" target="_blank">yoast.com</a>'
 );
 echo '</p>';
-echo '<button type="button" class="button wpseo-redirect-close">' . __( 'Close', 'wordpress-seo' ) . '</button>';
+echo '<button type="button" class="button wpseo-redirect-close">' . esc_html__( 'Close', 'wordpress-seo' ) . '</button>';

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -114,7 +114,7 @@ class WPSEO_Link_Reindex_Dashboard {
 		<div id="wpseo_index_links_wrapper" class="hidden">
 			<?php echo implode( '<hr />', $blocks ); ?>
 			<button onclick="tb_remove();" type="button"
-					class="button"><?php _e( 'Stop counting', 'wordpress-seo' ); ?></button>
+					class="button"><?php esc_html_e( 'Stop counting', 'wordpress-seo' ); ?></button>
 		</div>
 		<?php
 	}

--- a/admin/metabox/class-metabox-add-keyword-tab.php
+++ b/admin/metabox/class-metabox-add-keyword-tab.php
@@ -23,7 +23,7 @@ class Metabox_Add_Keyword_Tab implements WPSEO_Metabox_Tab {
 		<li class="wpseo-tab-add-keyword">
 			<button type="button" class="wpseo-add-keyword button button-link">
 				<span class="wpseo-add-keyword-plus" aria-hidden="true">+</span>
-				<?php _e( 'Add keyword', 'wordpress-seo' ); ?>
+				<?php esc_html_e( 'Add keyword', 'wordpress-seo' ); ?>
 			</button>
 		</li>
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1264,7 +1264,7 @@ SVG;
 	 * @return string
 	 */
 	public function strtolower_utf8( $string ) {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 
 		return $string;
 	}
@@ -1286,7 +1286,7 @@ SVG;
 	 * @return string
 	 */
 	public function snippet() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 
 		return '';
 	}

--- a/admin/pages/advanced.php
+++ b/admin/pages/advanced.php
@@ -49,7 +49,7 @@ Yoast_Form::get_instance()->admin_header( true, $active_tab->get_opt_group() );
 echo '<h2 class="nav-tab-wrapper">';
 foreach ( $tabs->get_tabs() as $tab ) {
 	$active = ( $tabs->is_active_tab( $tab ) ) ? ' nav-tab-active' : '';
-	echo '<a class="nav-tab' . $active . '" id="' . $tab->get_name() . '-tab" href="' . admin_url( 'admin.php?page=wpseo_advanced&tab=' . $tab->get_name() ) . '">' . $tab->get_label() . '</a>';
+	echo '<a class="nav-tab' . $active . '" id="' . $tab->get_name() . '-tab" href="' . esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=' . $tab->get_name() ) ) . '">' . $tab->get_label() . '</a>';
 }
 echo '</h2>';
 

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -42,14 +42,14 @@ if ( is_array( $options['blocking_files'] ) && count( $options['blocking_files']
 		echo '<div class="notice notice-error inline yoast-notice-blocking-files"><p id="blocking_files">';
 		printf(
 			/* translators: %1$s expands to Yoast SEO */
-			_n( 'The following file is blocking your XML sitemaps from working properly. Either delete it (this can be done with the "Fix it" button) or disable %1$s XML sitemaps.', 'The following files are blocking your XML sitemaps from working properly. Either delete them (this can be done with the "Fix it" button) or disable %1$s XML sitemaps.', count( $options['blocking_files'] ), 'wordpress-seo' ),
+			esc_html( _n( 'The following file is blocking your XML sitemaps from working properly. Either delete it (this can be done with the "Fix it" button) or disable %1$s XML sitemaps.', 'The following files are blocking your XML sitemaps from working properly. Either delete them (this can be done with the "Fix it" button) or disable %1$s XML sitemaps.', count( $options['blocking_files'] ), 'wordpress-seo' ) ),
 			'Yoast SEO'
 		);
 		foreach ( $options['blocking_files'] as $file ) {
 			echo '<br/>', '<code>', esc_html( $file ), '</code>';
 		}
 		unset( $file );
-		echo '<br><button type="button" data-nonce="', esc_js( wp_create_nonce( 'wpseo-blocking-files' ) ), '" class="button">', __( 'Fix it', 'wordpress-seo' ), '</button>';
+		echo '<br><button type="button" data-nonce="', esc_js( wp_create_nonce( 'wpseo-blocking-files' ) ), '" class="button">', esc_html__( 'Fix it', 'wordpress-seo' ), '</button>';
 		echo '</p></div>';
 	}
 }

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -92,7 +92,7 @@ else {
 
 $yform->admin_header( false, 'wpseo_ms' );
 
-echo '<h2>', __( 'MultiSite Settings', 'wordpress-seo' ), '</h2>';
+echo '<h2>', esc_html__( 'MultiSite Settings', 'wordpress-seo' ), '</h2>';
 echo '<form method="post" accept-charset="', esc_attr( get_bloginfo( 'charset' ) ), '">';
 wp_nonce_field( 'wpseo-network-settings', '_wpnonce', true, true );
 
@@ -115,23 +115,23 @@ if ( $use_dropdown === true ) {
 		$dropdown_input,
 		'wpseo_ms'
 	);
-	echo '<p>' . __( 'Choose the site whose settings you want to use as default for all sites that are added to your network. If you choose \'None\', the normal plugin defaults will be used.', 'wordpress-seo' ) . '</p>';
+	echo '<p>' . esc_html__( 'Choose the site whose settings you want to use as default for all sites that are added to your network. If you choose \'None\', the normal plugin defaults will be used.', 'wordpress-seo' ) . '</p>';
 }
 else {
 	$yform->textinput( 'defaultblog', __( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ), 'wpseo_ms' );
 	/* translators: 1: link open tag; 2: link close tag. */
 	echo '<p>' . sprintf( __( 'Enter the %1$sSite ID%2$s for the site whose settings you want to use as default for all sites that are added to your network. Leave empty for none (i.e. the normal plugin defaults will be used).', 'wordpress-seo' ), '<a href="' . esc_url( network_admin_url( 'sites.php' ) ) . '">', '</a>' ) . '</p>';
 }
-	echo '<p><strong>' . __( 'Take note:', 'wordpress-seo' ) . '</strong> ' . __( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';
+	echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';
 
 
-echo '<input type="submit" name="wpseo_submit" class="button button-primary" value="' . __( 'Save MultiSite Settings', 'wordpress-seo' ) . '"/>';
+echo '<input type="submit" name="wpseo_submit" class="button button-primary" value="' . esc_attr__( 'Save MultiSite Settings', 'wordpress-seo' ) . '"/>';
 echo '</form>';
 
-echo '<h2>' . __( 'Restore site to default settings', 'wordpress-seo' ) . '</h2>';
+echo '<h2>' . esc_html__( 'Restore site to default settings', 'wordpress-seo' ) . '</h2>';
 echo '<form method="post" accept-charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
 wp_nonce_field( 'wpseo-network-restore', '_wpnonce', true, true );
-echo '<p>' . __( 'Using this form you can reset a site to the default SEO settings.', 'wordpress-seo' ) . '</p>';
+echo '<p>' . esc_html__( 'Using this form you can reset a site to the default SEO settings.', 'wordpress-seo' ) . '</p>';
 
 if ( $use_dropdown === true ) {
 	unset( $dropdown_input['-'] );
@@ -146,7 +146,7 @@ else {
 	$yform->textinput( 'restoreblog', __( 'Blog ID', 'wordpress-seo' ), 'wpseo_ms' );
 }
 
-echo '<input type="submit" name="wpseo_restore_blog" value="' . __( 'Restore site to defaults', 'wordpress-seo' ) . '" class="button"/>';
+echo '<input type="submit" name="wpseo_restore_blog" value="' . esc_attr__( 'Restore site to defaults', 'wordpress-seo' ) . '" class="button"/>';
 echo '</form>';
 
 $yform->admin_footer( false );

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -68,11 +68,11 @@ if ( '' === $tool_page ) {
 	}
 	echo '</ul>';
 
-	echo '<input type="hidden" id="wpseo_recalculate_nonce" name="wpseo_recalculate_nonce" value="' . wp_create_nonce( 'wpseo_recalculate' ) . '" />';
+	echo '<input type="hidden" id="wpseo_recalculate_nonce" name="wpseo_recalculate_nonce" value="' . esc_attr( wp_create_nonce( 'wpseo_recalculate' ) ) . '" />';
 
 }
 else {
-	echo '<a href="', admin_url( 'admin.php?page=wpseo_tools' ), '">', __( '&laquo; Back to Tools page', 'wordpress-seo' ), '</a>';
+	echo '<a href="', esc_url( admin_url( 'admin.php?page=wpseo_tools' ) ), '">', esc_html__( '&laquo; Back to Tools page', 'wordpress-seo' ), '</a>';
 
 	$tool_pages = array( 'bulk-editor', 'import-export' );
 

--- a/admin/views/about.php
+++ b/admin/views/about.php
@@ -19,7 +19,7 @@ $version = '3.4';
 function wpseo_display_contributors( $contributors ) {
 	foreach ( $contributors as $username => $dev ) {
 		echo '<li class="wp-person">';
-		echo '<a href="https://github.com/', $username, '" class="web"><img src="//gravatar.com/avatar/', $dev->gravatar, '?s=120" class="gravatar" alt="">', $dev->name, '</a>';
+		echo '<a href="', esc_url( 'https://github.com/' . $username ), '" class="web"><img src="//gravatar.com/avatar/', $dev->gravatar, '?s=120" class="gravatar" alt="">', $dev->name, '</a>';
 		echo '<span class="title">', $dev->role, "</span></li>\n";
 	}
 }
@@ -46,14 +46,14 @@ function wpseo_display_contributors( $contributors ) {
 	<div class="wp-badge"></div>
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<a class="nav-tab" href="#top#credits" id="credits-tab"><?php _e( 'Credits', 'wordpress-seo' ); ?></a>
-		<a class="nav-tab" href="#top#integrations" id="integrations-tab"><?php _e( 'Integrations', 'wordpress-seo' ); ?></a>
+		<a class="nav-tab" href="#top#credits" id="credits-tab"><?php esc_html_e( 'Credits', 'wordpress-seo' ); ?></a>
+		<a class="nav-tab" href="#top#integrations" id="integrations-tab"><?php esc_html_e( 'Integrations', 'wordpress-seo' ); ?></a>
 	</h2>
 
 	<div id="credits" class="wpseotab">
 		<h2 class="screen-reader-text"><?php esc_html_e( 'Team and contributors', 'wordpress-seo' ); ?></h2>
 
-		<h3 class="wp-people-group"><?php _e( 'Product Management', 'wordpress-seo' ); ?></h3>
+		<h3 class="wp-people-group"><?php esc_html_e( 'Product Management', 'wordpress-seo' ); ?></h3>
 		<ul class="wp-people-group " id="wp-people-group-project-leaders">
 			<?php
 			$people = array(
@@ -77,7 +77,7 @@ function wpseo_display_contributors( $contributors ) {
 			wpseo_display_contributors( $people );
 			?>
 		</ul>
-		<h3 class="wp-people-group"><?php _e( 'Development Leaders', 'wordpress-seo' ); ?></h3>
+		<h3 class="wp-people-group"><?php esc_html_e( 'Development Leaders', 'wordpress-seo' ); ?></h3>
 		<ul class="wp-people-group " id="wp-people-group-development-leaders">
 			<?php
 			$people = array(
@@ -101,7 +101,7 @@ function wpseo_display_contributors( $contributors ) {
 			wpseo_display_contributors( $people );
 			?>
 		</ul>
-		<h3 class="wp-people-group"><?php _e( 'Yoast Developers', 'wordpress-seo' ); ?></h3>
+		<h3 class="wp-people-group"><?php esc_html_e( 'Yoast Developers', 'wordpress-seo' ); ?></h3>
 		<ul class="wp-people-group " id="wp-people-group-core-developers">
 			<?php
 			$people = array(
@@ -155,7 +155,7 @@ function wpseo_display_contributors( $contributors ) {
 			wpseo_display_contributors( $people );
 			?>
 		</ul>
-		<h3 class="wp-people-group"><?php _e( 'Quality Assurance & Testing', 'wordpress-seo' ); ?></h3>
+		<h3 class="wp-people-group"><?php esc_html_e( 'Quality Assurance & Testing', 'wordpress-seo' ); ?></h3>
 		<ul class="wp-people-group " id="wp-people-group-qa-testing">
 			<?php
 			$people = array(
@@ -194,7 +194,7 @@ function wpseo_display_contributors( $contributors ) {
 				$version
 			);
 			?>
-			<h3 class="wp-people-group"><?php _e( 'Community contributors', 'wordpress-seo' ); ?></h3>
+			<h3 class="wp-people-group"><?php esc_html_e( 'Community contributors', 'wordpress-seo' ); ?></h3>
 			<p><?php echo $call_to_contribute; ?></p>
 			<ul class="ul-square">
 				<?php

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -13,7 +13,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 <script type="text/html" id="tmpl-primary-term-input">
 	<input type="hidden" class="yoast-wpseo-primary-term"
 		id="yoast-wpseo-primary-{{data.taxonomy.name}}"
-		name="<?php echo WPSEO_Meta::$form_prefix; ?>primary_{{data.taxonomy.name}}_term"
+		name="<?php echo esc_attr( WPSEO_Meta::$form_prefix ); ?>primary_{{data.taxonomy.name}}_term"
 		value="{{data.taxonomy.primary}}">
 
 	<?php wp_nonce_field( 'save-primary-term', WPSEO_Meta::$form_prefix . 'primary_{{data.taxonomy.name}}_nonce' ); ?>
@@ -33,14 +33,14 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		);
 		?>
 
-	<span class="wpseo-is-primary-term" aria-hidden="true"><?php _e( 'Primary', 'wordpress-seo' ); ?></span>
+	<span class="wpseo-is-primary-term" aria-hidden="true"><?php esc_html_e( 'Primary', 'wordpress-seo' ); ?></span>
 </script>
 
 <script type="text/html" id="tmpl-primary-term-screen-reader">
 	<span class="screen-reader-text wpseo-primary-category-label"><?php
 		printf(
 			/* translators: %s is the taxonomy title. This will be shown to screenreaders */
-			'(' . __( 'Primary %s', 'wordpress-seo' ) . ')',
+			'(' . esc_html__( 'Primary %s', 'wordpress-seo' ) . ')',
 			'{{data.taxonomy.title}}'
 		);
 		?></span>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -134,32 +134,32 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 			<ul class="yoast-seo-premium-benefits yoast-list--usp">
 				<li class="yoast-seo-premium-benefits__item">
-					<span class="yoast-seo-premium-benefits__title"><?php _e( 'Redirect manager', 'wordpress-seo' ); ?></span>
-					<span class="yoast-seo-premium-benefits__description"><?php _e( 'create and manage redirects from within your WordPress install.', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Redirect manager', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'create and manage redirects from within your WordPress install.', 'wordpress-seo' ); ?></span>
 				</li>
 				<li class="yoast-seo-premium-benefits__item">
-					<span class="yoast-seo-premium-benefits__title"><?php _e( 'Multiple focus keywords', 'wordpress-seo' ); ?></span>
-					<span class="yoast-seo-premium-benefits__description"><?php _e( 'optimize a single post for up to 5 keywords.', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Multiple focus keywords', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'optimize a single post for up to 5 keywords.', 'wordpress-seo' ); ?></span>
 				</li>
 				<li class="yoast-seo-premium-benefits__item">
-					<span class="yoast-seo-premium-benefits__title"><?php _e( 'Social previews', 'wordpress-seo' ); ?></span>
-					<span class="yoast-seo-premium-benefits__description"><?php _e( 'check what your Facebook or Twitter post will look like.', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Social previews', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'check what your Facebook or Twitter post will look like.', 'wordpress-seo' ); ?></span>
 				</li>
 				<li class="yoast-seo-premium-benefits__item">
-					<span class="yoast-seo-premium-benefits__title"><?php _e( 'Premium support', 'wordpress-seo' ); ?></span>
-					<span class="yoast-seo-premium-benefits__description"><?php _e( 'gain access to our 24/7 support team.', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Premium support', 'wordpress-seo' ); ?></span>
+					<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'gain access to our 24/7 support team.', 'wordpress-seo' ); ?></span>
 				</li>
 			</ul>
 
 			<?php if ( $extension_list->is_installed( $extension->get_title() ) ) : ?>
-				<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-installed"><?php _e( 'Installed', 'wordpress-seo' ); ?></div>
+				<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
 
 				<?php if ( $extensions->is_activated( 'wordpress-seo-premium' ) ) : ?>
-					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php _e( 'Activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
 				<?php else : ?>
-					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php _e( 'Not activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
 				<?php endif; ?>
 				</a>
 
@@ -181,7 +181,7 @@ if ( class_exists( 'Woocommerce' ) ) {
 					?></a>
 			<?php endif; ?>
 
-			<p><small class="yoast-money-back-guarantee"><?php _e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small></p>
+			<p><small class="yoast-money-back-guarantee"><?php esc_html_e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small></p>
 		</section>
 
 		<hr class="yoast-hr" aria-hidden="true" />
@@ -210,14 +210,14 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 					<div class="yoast-button-container">
 						<?php if ( $extension_list->is_installed( $extension->get_title() ) ) : ?>
-							<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-installed"><?php _e( 'Installed', 'wordpress-seo' ); ?></div>
+							<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
 
 							<?php if ( $extensions->is_activated( $id ) ) : ?>
-								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php _e( 'Activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php _e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
 							<?php else : ?>
-								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php _e( 'Not activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php _e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
 							<?php endif; ?>
 						<?php else : ?>
 							<a target="_blank" class="yoast-button yoast-button--noarrow yoast-button-go-to  yoast-button--extension yoast-button--extension-buy" href="<?php echo esc_url( $extension->get_buy_url() ); ?>">

--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -15,11 +15,11 @@ if ( ! function_exists( '_yoast_display_alerts' ) ) {
 
 			switch ( $status ) {
 				case 'active':
-					$button = sprintf( '<button type="button" class="button dismiss"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-no-alt"></span></button>', __( 'Dismiss this item.', 'wordpress-seo' ) );
+					$button = sprintf( '<button type="button" class="button dismiss"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-no-alt"></span></button>', esc_html__( 'Dismiss this item.', 'wordpress-seo' ) );
 					break;
 
 				case 'dismissed':
-					$button = sprintf( '<button type="button" class="button restore"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-hidden"></span></button>', __( 'Restore this item.', 'wordpress-seo' ) );
+					$button = sprintf( '<button type="button" class="button restore"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-hidden"></span></button>', esc_html__( 'Restore this item.', 'wordpress-seo' ) );
 					break;
 			}
 

--- a/admin/views/partial-help-center-video.php
+++ b/admin/views/partial-help-center-video.php
@@ -15,7 +15,7 @@ if ( ! empty( $tab_video_url ) ) :
 	?>
 	<h2 class="screen-reader-text"><?php esc_html_e( 'Video tutorial', 'wordpress-seo' ); ?></h2>
 	<div class="wpseo-tab-video__panel wpseo-tab-video__panel--video">
-		<div class="wpseo-tab-video__data yoast-video-container" data-url="<?php echo $tab_video_url; ?>"></div>
+		<div class="wpseo-tab-video__data yoast-video-container" data-url="<?php echo esc_url( $tab_video_url ); ?>"></div>
 	</div>
 	<div class="wpseo-tab-video__panel wpseo-tab-video__panel--text">
 		<?php
@@ -24,11 +24,11 @@ if ( ! empty( $tab_video_url ) ) :
 		if ( ! WPSEO_Utils::is_yoast_seo_premium() ) :
 			?>
 			<div class="wpseo-tab-video__panel__textarea">
-				<h3><?php _e( 'Need some help?', 'wordpress-seo' ); ?></h3>
-				<p><?php _e( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ); ?></p>
+				<h3><?php esc_html_e( 'Need some help?', 'wordpress-seo' ); ?></h3>
+				<p><?php esc_html_e( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ); ?></p>
 				<p><a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/seo-premium-vt' ); ?>" target="_blank"><?php
 				/* translators: %s expands to Yoast SEO Premium */
-				printf( __( 'Get %s now &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );
+				printf( esc_html__( 'Get %s now &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );
 				?></a>
 				</p>
 			</div>
@@ -37,12 +37,12 @@ if ( ! empty( $tab_video_url ) ) :
 		?>
 		<div class="wpseo-tab-video__panel__textarea">
 			<?php /* translators: %s expands to Yoast SEO. */ ?>
-			<h3><?php printf( __( 'Want to be a %s Expert?', 'wordpress-seo' ), 'Yoast SEO' ); ?></h3>
+			<h3><?php printf( esc_html__( 'Want to be a %s Expert?', 'wordpress-seo' ), 'Yoast SEO' ); ?></h3>
 			<?php /* translators: %$1s expands to Yoast SEO */ ?>
-			<p><?php printf( __( 'Follow our %1$s for WordPress training and become a certified %1$s Expert!', 'wordpress-seo' ), 'Yoast SEO' ); ?></p>
+			<p><?php printf( esc_html__( 'Follow our %1$s for WordPress training and become a certified %1$s Expert!', 'wordpress-seo' ), 'Yoast SEO' ); ?></p>
 			<p><a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/wordpress-training-vt' ); ?>" target="_blank"><?php
 			/* translators: %s expands to Yoast SEO for WordPress */
-			printf( __( 'Enroll in the %s training &raquo;', 'wordpress-seo' ), 'Yoast SEO for WordPress' );
+			printf( esc_html__( 'Enroll in the %s training &raquo;', 'wordpress-seo' ), 'Yoast SEO for WordPress' );
 			?></a>
 			</p>
 		</div>

--- a/admin/views/partial-settings-tab-video.php
+++ b/admin/views/partial-settings-tab-video.php
@@ -15,11 +15,11 @@ if ( ! empty( $tab_video_url ) ) :
 
 	?>
 	<div class="wpseo-tab-video-container">
-		<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo $id; ?>" aria-expanded="false">
-			<span class="dashicons-before dashicons-editor-help"><?php _e( 'Help center', 'wordpress-seo' ); ?></span>
+		<button type="button" class="wpseo-tab-video-container__handle" aria-controls="<?php echo esc_attr( $id ); ?>" aria-expanded="false">
+			<span class="dashicons-before dashicons-editor-help"><?php esc_html_e( 'Help center', 'wordpress-seo' ); ?></span>
 			<span class="dashicons dashicons-arrow-down toggle__arrow"></span>
 		</button>
-		<div id="<?php echo $id; ?>" class="wpseo-tab-video-slideout hidden">
+		<div id="<?php echo esc_attr( $id ); ?>" class="wpseo-tab-video-slideout hidden">
 			<?php include WPSEO_PATH . 'admin/views/partial-help-center-video.php'; ?>
 		</div>
 	</div>

--- a/admin/views/tabs/advanced/breadcrumbs.php
+++ b/admin/views/tabs/advanced/breadcrumbs.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $yform                = Yoast_Form::get_instance();
 $yform->currentoption = 'wpseo_internallinks';
 
-echo '<h2>' . __( 'Breadcrumbs settings', 'wordpress-seo' ) . '</h2>';
+echo '<h2>' . esc_html__( 'Breadcrumbs settings', 'wordpress-seo' ) . '</h2>';
 
 if ( ! current_theme_supports( 'yoast-seo-breadcrumbs' ) ) {
 	$yform->light_switch( 'breadcrumbs-enable', __( 'Enable Breadcrumbs', 'wordpress-seo' ) );
@@ -40,7 +40,7 @@ echo '<br/><br/>';
 
 $post_types = get_post_types( array( 'public' => true ), 'objects' );
 if ( is_array( $post_types ) && $post_types !== array() ) {
-	echo '<h2>' . __( 'Taxonomy to show in breadcrumbs for post types', 'wordpress-seo' ) . '</h2>';
+	echo '<h2>' . esc_html__( 'Taxonomy to show in breadcrumbs for post types', 'wordpress-seo' ) . '</h2>';
 	foreach ( $post_types as $pt ) {
 		$taxonomies = get_object_taxonomies( $pt->name, 'objects' );
 		if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
@@ -65,7 +65,7 @@ $taxonomies = get_taxonomies(
 	'objects'
 );
 if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
-	echo '<h2>' . __( 'Post type archive to show in breadcrumbs for taxonomies', 'wordpress-seo' ) . '</h2>';
+	echo '<h2>' . esc_html__( 'Post type archive to show in breadcrumbs for taxonomies', 'wordpress-seo' ) . '</h2>';
 	foreach ( $taxonomies as $tax ) {
 		$values = array( 0 => __( 'None', 'wordpress-seo' ) );
 		if ( get_option( 'show_on_front' ) == 'page' && get_option( 'page_for_posts' ) > 0 ) {
@@ -89,7 +89,7 @@ unset( $taxonomies, $post_types );
 ?>
 <br class="clear"/>
 </div>
-<h2><?php _e( 'How to insert breadcrumbs in your theme', 'wordpress-seo' ); ?></h2>
+<h2><?php esc_html_e( 'How to insert breadcrumbs in your theme', 'wordpress-seo' ); ?></h2>
 <p>
 	<?php
 	/* translators: %1$s / %2$s: links to the breadcrumbs implementation page on the Yoast knowledgebase */

--- a/admin/views/tabs/advanced/permalinks.php
+++ b/admin/views/tabs/advanced/permalinks.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $yform                = Yoast_Form::get_instance();
 $yform->currentoption = 'wpseo_permalinks';
 
-echo '<h2>', __( 'Change URLs', 'wordpress-seo' ), '</h2>';
+echo '<h2>', esc_html__( 'Change URLs', 'wordpress-seo' ), '</h2>';
 
 $remove_buttons = array( __( 'Keep', 'wordpress-seo' ), __( 'Remove', 'wordpress-seo' ) );
 $yform->light_switch(
@@ -25,11 +25,11 @@ $yform->light_switch(
 
 $redirect_buttons = array( __( 'No redirect', 'wordpress-seo' ), __( 'Redirect', 'wordpress-seo' ) );
 $yform->light_switch( 'redirectattachment', __( 'Redirect attachment URLs to parent post URL.', 'wordpress-seo' ), $redirect_buttons );
-echo '<p>' . __( 'Attachments to posts are stored in the database as posts, this means they\'re accessible under their own URLs if you do not redirect them, enabling this will redirect them to the post they were attached to.', 'wordpress-seo' ) . '</p>';
+echo '<p>' . esc_html__( 'Attachments to posts are stored in the database as posts, this means they\'re accessible under their own URLs if you do not redirect them, enabling this will redirect them to the post they were attached to.', 'wordpress-seo' ) . '</p>';
 
-echo '<h2>', __( 'Clean up permalinks', 'wordpress-seo' ), '</h2>';
+echo '<h2>', esc_html__( 'Clean up permalinks', 'wordpress-seo' ), '</h2>';
 $yform->light_switch( 'cleanslugs', __( 'Stop words in slugs.', 'wordpress-seo' ), $remove_buttons, false );
-echo '<p>' . __( 'This helps you to create cleaner URLs by automatically removing the stopwords from them.', 'wordpress-seo' ) . '</p>';
+echo '<p>' . esc_html__( 'This helps you to create cleaner URLs by automatically removing the stopwords from them.', 'wordpress-seo' ) . '</p>';
 
 /* translators: %s expands to <code>?replytocom</code> */
 $yform->light_switch( 'cleanreplytocom', sprintf( __( 'Remove the %s variables.', 'wordpress-seo' ), '<code>?replytocom</code>' ), $remove_buttons, false );
@@ -44,16 +44,16 @@ if ( substr( get_option( 'permalink_structure' ), -1 ) !== '/' && $options['trai
 }
 
 $yform->light_switch( 'cleanpermalinks', __( 'Redirect ugly URLs to clean permalinks. (Not recommended in many cases!)', 'wordpress-seo' ), $redirect_buttons );
-echo '<p>' . __( 'People make mistakes in their links towards you sometimes, or unwanted parameters are added to the end of your URLs, this allows you to redirect them all away. Please note that while this is a feature that is actively maintained, it is known to break several plugins, and should for that reason be the first feature you disable when you encounter issues after installing this plugin.', 'wordpress-seo' ) . '</p>';
+echo '<p>' . esc_html__( 'People make mistakes in their links towards you sometimes, or unwanted parameters are added to the end of your URLs, this allows you to redirect them all away. Please note that while this is a feature that is actively maintained, it is known to break several plugins, and should for that reason be the first feature you disable when you encounter issues after installing this plugin.', 'wordpress-seo' ) . '</p>';
 
 echo '<div id="cleanpermalinksdiv">';
 $yform->light_switch( 'cleanpermalink-googlesitesearch', __( 'Prevent cleaning out Google Site Search URLs.', 'wordpress-seo' ) );
-echo '<p>' . __( 'Google Site Search URLs look weird, and ugly, but if you\'re using Google Site Search, you probably do not want them cleaned out.', 'wordpress-seo' ) . '</p>';
+echo '<p>' . esc_html__( 'Google Site Search URLs look weird, and ugly, but if you\'re using Google Site Search, you probably do not want them cleaned out.', 'wordpress-seo' ) . '</p>';
 
 $yform->light_switch( 'cleanpermalink-googlecampaign', __( 'Prevent cleaning out Google Analytics Campaign & Google AdWords Parameters.', 'wordpress-seo' ) );
 /* translators: %s expands to <code>?utm_</code> */
 echo '<p>' . sprintf( __( 'If you use Google Analytics campaign parameters starting with %s, check this box. However, you\'re advised not to use these. Instead, use the version with a hash.', 'wordpress-seo' ), '<code>?utm_</code>' ) . '</p>';
 
 $yform->textinput( 'cleanpermalink-extravars', __( 'Other variables not to clean', 'wordpress-seo' ) );
-echo '<p>' . __( 'You might have extra variables you want to prevent from cleaning out, add them here, comma separated.', 'wordpress-seo' ) . '</p>';
+echo '<p>' . esc_html__( 'You might have extra variables you want to prevent from cleaning out, add them here, comma separated.', 'wordpress-seo' ) . '</p>';
 echo '</div>';

--- a/admin/views/tabs/advanced/rss.php
+++ b/admin/views/tabs/advanced/rss.php
@@ -12,9 +12,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $yform = Yoast_Form::get_instance();
 $yform->set_option( 'wpseo_rss' );
 
-echo '<h2>' . __( 'RSS feed settings', 'wordpress-seo' ) . '</h2>';
+echo '<h2>' . esc_html__( 'RSS feed settings', 'wordpress-seo' ) . '</h2>';
 
-echo '<p>' . __( "This feature is used to automatically add content to your RSS, more specifically, it's meant to add links back to your blog and your blog posts, so dumb scrapers will automatically add these links too, helping search engines identify you as the original source of the content.", 'wordpress-seo' ) . '</p>';
+echo '<p>' . esc_html__( "This feature is used to automatically add content to your RSS, more specifically, it's meant to add links back to your blog and your blog posts, so dumb scrapers will automatically add these links too, helping search engines identify you as the original source of the content.", 'wordpress-seo' ) . '</p>';
 
 $textarea_atts = array(
 	'cols' => '50',
@@ -23,33 +23,33 @@ $textarea_atts = array(
 $yform->textarea( 'rssbefore', __( 'Content to put before each post in the feed', 'wordpress-seo' ), '', $textarea_atts );
 $yform->textarea( 'rssafter', __( 'Content to put after each post in the feed', 'wordpress-seo' ), '', $textarea_atts );
 
-echo '<h2>' . __( 'Available variables', 'wordpress-seo' ) . '</h2>';
+echo '<h2>' . esc_html__( 'Available variables', 'wordpress-seo' ) . '</h2>';
 ?>
 
-<p><?php _e( 'You can use the following variables within the content, they will be replaced by the value on the right.', 'wordpress-seo' ); ?></p>
+<p><?php esc_html_e( 'You can use the following variables within the content, they will be replaced by the value on the right.', 'wordpress-seo' ); ?></p>
 <table class="wpseo yoast_help yoast-table-scrollable">
 <thead>
 	<tr>
-		<th scope="col"><?php _e( 'Variable', 'wordpress-seo' ); ?></th>
-		<th scope="col"><?php _e( 'Description', 'wordpress-seo' ); ?></th>
+		<th scope="col"><?php esc_html_e( 'Variable', 'wordpress-seo' ); ?></th>
+		<th scope="col"><?php esc_html_e( 'Description', 'wordpress-seo' ); ?></th>
 	</tr>
 </thead>
 <tbody>
 	<tr>
 		<td class="yoast-variable-name">%%AUTHORLINK%%</td>
-		<td class="yoast-variable-desc"><?php _e( 'A link to the archive for the post author, with the authors name as anchor text.', 'wordpress-seo' ); ?></td>
+		<td class="yoast-variable-desc"><?php esc_html_e( 'A link to the archive for the post author, with the authors name as anchor text.', 'wordpress-seo' ); ?></td>
 	</tr>
 	<tr>
 		<td class="yoast-variable-name">%%POSTLINK%%</td>
-		<td class="yoast-variable-desc"><?php _e( 'A link to the post, with the title as anchor text.', 'wordpress-seo' ); ?></td>
+		<td class="yoast-variable-desc"><?php esc_html_e( 'A link to the post, with the title as anchor text.', 'wordpress-seo' ); ?></td>
 	</tr>
 	<tr>
 		<td class="yoast-variable-name">%%BLOGLINK%%</td>
-		<td class="yoast-variable-desc"><?php _e( "A link to your site, with your site's name as anchor text.", 'wordpress-seo' ); ?></td>
+		<td class="yoast-variable-desc"><?php esc_html_e( "A link to your site, with your site's name as anchor text.", 'wordpress-seo' ); ?></td>
 	</tr>
 	<tr>
 		<td class="yoast-variable-name">%%BLOGDESCLINK%%</td>
-		<td class="yoast-variable-desc"><?php _e( "A link to your site, with your site's name and description as anchor text.", 'wordpress-seo' ); ?></td>
+		<td class="yoast-variable-desc"><?php esc_html_e( "A link to your site, with your site's name and description as anchor text.", 'wordpress-seo' ); ?></td>
 	</tr>
 </tbody>
 </table>

--- a/admin/views/tabs/dashboard/knowledge-graph.php
+++ b/admin/views/tabs/dashboard/knowledge-graph.php
@@ -13,7 +13,7 @@ echo '<h2>' . esc_html__( 'Website name', 'wordpress-seo' ) . '</h2>';
 ?>
 <p>
 	<?php
-	_e( 'Google shows your website\'s name in the search results, we will default to your site name but you can adapt it here. You can also provide an alternate website name you want Google to consider.', 'wordpress-seo' );
+	esc_html_e( 'Google shows your website\'s name in the search results, we will default to your site name but you can adapt it here. You can also provide an alternate website name you want Google to consider.', 'wordpress-seo' );
 	?>
 </p>
 <?php
@@ -25,7 +25,7 @@ echo '<h2>' . esc_html__( 'Company or person', 'wordpress-seo' ) . '</h2>';
 <p>
 	<?php
 	// @todo add KB link - JdV.
-	_e( 'This data is shown as metadata in your site. It is intended to appear in Google\'s Knowledge Graph. You can be either a company, or a person, choose either:', 'wordpress-seo' );
+	esc_html_e( 'This data is shown as metadata in your site. It is intended to appear in Google\'s Knowledge Graph. You can be either a company, or a person, choose either:', 'wordpress-seo' );
 	?>
 </p>
 <?php

--- a/admin/views/tabs/metas/archives.php
+++ b/admin/views/tabs/metas/archives.php
@@ -16,9 +16,9 @@ echo ' ';
 /* translators: %s expands to <code>noindex, follow</code> */
 printf( __( 'If this is the case on your site, you can choose to either disable it (which makes it redirect to the homepage), or to add %s to it so it doesn\'t show up in the search results.', 'wordpress-seo' ), '<code>noindex,follow</code>' );
 echo ' ';
-echo __( 'Note that links to archives might be still output by your theme and you would need to remove them separately.', 'wordpress-seo' );
+echo esc_html__( 'Note that links to archives might be still output by your theme and you would need to remove them separately.', 'wordpress-seo' );
 echo ' ';
-_e( 'Date-based archives could in some cases also be seen as duplicate content.', 'wordpress-seo' );
+esc_html_e( 'Date-based archives could in some cases also be seen as duplicate content.', 'wordpress-seo' );
 echo '</p>';
 
 echo "<div id='author-archives-titles-metas'>";
@@ -63,7 +63,7 @@ echo '<p>' . sprintf( __( 'These pages will be %s by default, so they will never
 echo '<p><strong>' . __( 'Search pages', 'wordpress-seo' ) . '</strong><br/>';
 $yform->textinput( 'title-search-wpseo', __( 'Title template', 'wordpress-seo' ), 'template search-template' );
 echo '</p>';
-echo '<p><strong>' . __( '404 pages', 'wordpress-seo' ) . '</strong><br/>';
+echo '<p><strong>' . esc_html__( '404 pages', 'wordpress-seo' ) . '</strong><br/>';
 $yform->textinput( 'title-404-wpseo', __( 'Title template', 'wordpress-seo' ), 'template error404-template' );
 echo '</p>';
 echo '</div>';

--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -24,4 +24,4 @@ echo '<h2>' . esc_html__( 'Title Separator', 'wordpress-seo' ) . '</h2>';
 $legend      = __( 'Title separator symbol', 'wordpress-seo' );
 $legend_attr = array( 'class' => 'radiogroup screen-reader-text' );
 $yform->radio( 'separator', WPSEO_Option_Titles::get_instance()->get_separator_options(), $legend, $legend_attr );
-echo '<p class="description">', __( 'Choose the symbol to use as your title separator. This will display, for instance, between your post title and site name.', 'wordpress-seo' ), ' ', __( 'Symbols are shown in the size they\'ll appear in the search results.', 'wordpress-seo' ), '</p>';
+echo '<p class="description">', esc_html__( 'Choose the symbol to use as your title separator. This will display, for instance, between your post title and site name.', 'wordpress-seo' ), ' ', esc_html__( 'Symbols are shown in the size they\'ll appear in the search results.', 'wordpress-seo' ), '</p>';

--- a/admin/views/tabs/metas/other.php
+++ b/admin/views/tabs/metas/other.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 echo '<h2>', esc_html__( 'Sitewide meta settings', 'wordpress-seo' ), '</h2>';
 
 $yform->toggle_switch( 'noindex-subpages-wpseo', $index_switch_values, __( 'Subpages of archives', 'wordpress-seo' ) );
-echo '<p>', __( 'If you want to prevent /page/2/ and further of any archive to show up in the search results, set this to "noindex".', 'wordpress-seo' ), '</p>';
+echo '<p>', esc_html__( 'If you want to prevent /page/2/ and further of any archive to show up in the search results, set this to "noindex".', 'wordpress-seo' ), '</p>';
 
 $yform->light_switch( 'usemetakeywords', __( 'Use meta keywords tag?', 'wordpress-seo' ) );
-echo '<p>', __( 'I don\'t know why you\'d want to use meta keywords, but if you want to, enable this.', 'wordpress-seo' ), '</p>';
+echo '<p>', esc_html__( 'I don\'t know why you\'d want to use meta keywords, but if you want to, enable this.', 'wordpress-seo' ), '</p>';

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -65,7 +65,7 @@ $post_types = get_post_types(
 );
 if ( is_array( $post_types ) && $post_types !== array() ) {
 	echo '<h2>' . esc_html__( 'Custom Post Type Archives', 'wordpress-seo' ) . '</h2>';
-	echo '<p>' . __( 'Note: instead of templates these are the actual titles and meta descriptions for these custom post type archive pages.', 'wordpress-seo' ) . '</p>';
+	echo '<p>' . esc_html__( 'Note: instead of templates these are the actual titles and meta descriptions for these custom post type archive pages.', 'wordpress-seo' ) . '</p>';
 	foreach ( $post_types as $post_type ) {
 		$name = $post_type->name;
 		echo '<h3>' . esc_html( ucfirst( $post_type->labels->name ) ) . '</h3>';

--- a/admin/views/tabs/sitemaps/general.php
+++ b/admin/views/tabs/sitemaps/general.php
@@ -25,7 +25,7 @@ if ( $options['enablexmlsitemap'] === true ) {
 	echo '</p>';
 }
 else {
-	echo '<p>', __( 'Save your settings to activate your XML Sitemap.', 'wordpress-seo' ), '</p>';
+	echo '<p>', esc_html__( 'Save your settings to activate your XML Sitemap.', 'wordpress-seo' ), '</p>';
 }
 
 echo '<h2>' . esc_html__( 'Entries per sitemap page', 'wordpress-seo' ) . '</h2>';
@@ -33,9 +33,9 @@ echo '<h2>' . esc_html__( 'Entries per sitemap page', 'wordpress-seo' ) . '</h2>
 	<p>
 		<?php
 		printf(
-			/* translators: %s expands to default number of entries per sitemap. */
-			__( 'Please enter the maximum number of entries per sitemap page (defaults to %s, you might want to lower this to prevent memory issues on some installs):', 'wordpress-seo' ),
-			WPSEO_Options::get_default( 'wpseo_xml', 'entries-per-page' )
+			/* translators: %d expands to default number of entries per sitemap. */
+			esc_html__( 'Please enter the maximum number of entries per sitemap page (defaults to %d, you might want to lower this to prevent memory issues on some installs):', 'wordpress-seo' ),
+			(int) WPSEO_Options::get_default( 'wpseo_xml', 'entries-per-page' )
 		);
 		?>
 	</p>

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 echo '<h2>' . esc_html__( 'Your social profiles', 'wordpress-seo' ) . '</h2>';
 
 echo '<p>';
-_e( 'To let search engines know which social profiles are associated to this site, enter them below:', 'wordpress-seo' );
+esc_html_e( 'To let search engines know which social profiles are associated to this site, enter them below:', 'wordpress-seo' );
 echo '</p>';
 
 $yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ) );

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 ?>
-<p><?php _e( 'No doubt you\'ve used an SEO plugin before if this site isn\'t new. Let\'s make it easy on you, you can import the data below. If you want, you can import first, check if it was imported correctly, and then import &amp; delete. No duplicate data will be imported.', 'wordpress-seo' ); ?></p>
+<p><?php esc_html_e( 'No doubt you\'ve used an SEO plugin before if this site isn\'t new. Let\'s make it easy on you, you can import the data below. If you want, you can import first, check if it was imported correctly, and then import &amp; delete. No duplicate data will be imported.', 'wordpress-seo' ); ?></p>
 
 <p><?php
 /* translators: 1: link open tag; 2: link close tag. */
@@ -36,5 +36,5 @@ printf( __( 'If you\'ve used another SEO plugin, try the %1$sSEO Data Transporte
 	?>
 	<br/>
 	<input type="submit" class="button button-primary" name="import"
-		value="<?php _e( 'Import', 'wordpress-seo' ); ?>"/>
+		value="<?php esc_attr_e( 'Import', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -10,17 +10,17 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 ?>
-<p><?php _e( 'Import settings by locating <em>settings.zip</em> and clicking "Import settings"', 'wordpress-seo' ); ?></p>
+<p><?php esc_html_e( 'Import settings by locating <em>settings.zip</em> and clicking "Import settings"', 'wordpress-seo' ); ?></p>
 
 <form
 	action="<?php echo esc_attr( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#wpseo-import' ) ); ?>"
 	method="post" enctype="multipart/form-data"
 	accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php wp_nonce_field( 'wpseo-import-file', '_wpnonce', true, true ); ?>
-	<label class="screen-reader-text" for="settings-import-file"><?php _e( 'Choose your settings.zip file', 'wordpress-seo' ); ?></label>
+	<label class="screen-reader-text" for="settings-import-file"><?php esc_html_e( 'Choose your settings.zip file', 'wordpress-seo' ); ?></label>
 	<input type="file" name="settings_import_file" id="settings-import-file"
 		accept="application/x-zip,application/x-zip-compressed,application/zip"/>
 	<input type="hidden" name="action" value="wp_handle_upload"/><br/>
 	<br/>
-	<input type="submit" class="button button-primary" value="<?php _e( 'Import settings', 'wordpress-seo' ); ?>"/>
+	<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Import settings', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -10,7 +10,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 ?>
-<p><?php esc_html_e( 'Import settings by locating <em>settings.zip</em> and clicking "Import settings"', 'wordpress-seo' ); ?></p>
+<p>
+	<?php
+	printf(
+		/* translators: 1: emphasis opener; 2: emphasis closer. */
+		esc_html_e( 'Import settings by locating %1$ssettings.zip%2$s and clicking "Import settings"', 'wordpress-seo' ),
+		'<em>',
+		'</em>'
+	);
+	?>
+</p>
 
 <form
 	action="<?php echo esc_attr( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#wpseo-import' ) ); ?>"

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	<?php
 	printf(
 		/* translators: 1: emphasis opener; 2: emphasis closer. */
-		esc_html( 'Import settings by locating %1$ssettings.zip%2$s and clicking "Import settings"', 'wordpress-seo' ),
+		esc_html__( 'Import settings by locating %1$ssettings.zip%2$s and clicking "Import settings"', 'wordpress-seo' ),
 		'<em>',
 		'</em>'
 	);

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	<?php
 	printf(
 		/* translators: 1: emphasis opener; 2: emphasis closer. */
-		esc_html_e( 'Import settings by locating %1$ssettings.zip%2$s and clicking "Import settings"', 'wordpress-seo' ),
+		esc_html( 'Import settings by locating %1$ssettings.zip%2$s and clicking "Import settings"', 'wordpress-seo' ),
 		'<em>',
 		'</em>'
 	);

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -53,7 +53,7 @@ function render_help_center() {
  */
 function get_rendered_tab( $table, $id ) {
 	?>
-	<div id="<?php echo $id; ?>" class="wpseotab">
+	<div id="<?php echo esc_attr( $id ); ?>" class="wpseotab">
 		<?php
 		$table->show_page();
 		?>
@@ -74,9 +74,9 @@ function get_rendered_tab( $table, $id ) {
 <div class="wpseo_table_page">
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<a class="nav-tab" id="title-tab" href="#top#title"><?php _e( 'Title', 'wordpress-seo' ); ?></a>
+		<a class="nav-tab" id="title-tab" href="#top#title"><?php esc_html_e( 'Title', 'wordpress-seo' ); ?></a>
 		<a class="nav-tab" id="description-tab"
-			href="#top#description"><?php _e( 'Description', 'wordpress-seo' ); ?></a>
+			href="#top#description"><?php esc_html_e( 'Description', 'wordpress-seo' ); ?></a>
 	</h2>
 
 	<?php render_help_center(); ?>

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -14,7 +14,7 @@ $ht_access_file = get_home_path() . '.htaccess';
 
 if ( isset( $_POST['create_robots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		die( __( 'You cannot create a robots.txt file.', 'wordpress-seo' ) );
+		die( esc_html__( 'You cannot create a robots.txt file.', 'wordpress-seo' ) );
 	}
 
 	check_admin_referer( 'wpseo_create_robots' );
@@ -30,7 +30,7 @@ if ( isset( $_POST['create_robots'] ) ) {
 
 if ( isset( $_POST['submitrobots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		die( __( 'You cannot edit the robots.txt file.', 'wordpress-seo' ) );
+		die( esc_html__( 'You cannot edit the robots.txt file.', 'wordpress-seo' ) );
 	}
 
 	check_admin_referer( 'wpseo-robotstxt' );
@@ -48,7 +48,7 @@ if ( isset( $_POST['submitrobots'] ) ) {
 
 if ( isset( $_POST['submithtaccess'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		die( __( 'You cannot edit the .htaccess file.', 'wordpress-seo' ) );
+		die( esc_html__( 'You cannot edit the .htaccess file.', 'wordpress-seo' ) );
 	}
 
 	check_admin_referer( 'wpseo-htaccess' );
@@ -82,19 +82,19 @@ $helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab, WPSEO_Utils
 $helpcenter->localize_data();
 $helpcenter->mount();
 
-echo '<h2>', __( 'Robots.txt', 'wordpress-seo' ), '</h2>';
+echo '<h2>', esc_html__( 'Robots.txt', 'wordpress-seo' ), '</h2>';
 
 
 if ( ! file_exists( $robots_file ) ) {
 	if ( is_writable( get_home_path() ) ) {
 		echo '<form action="', esc_url( $action_url ), '" method="post" id="robotstxtcreateform">';
 		wp_nonce_field( 'wpseo_create_robots', '_wpnonce', true, true );
-		echo '<p>', __( 'You don\'t have a robots.txt file, create one here:', 'wordpress-seo' ), '</p>';
-		echo '<input type="submit" class="button" name="create_robots" value="', __( 'Create robots.txt file', 'wordpress-seo' ), '">';
+		echo '<p>', esc_html__( 'You don\'t have a robots.txt file, create one here:', 'wordpress-seo' ), '</p>';
+		echo '<input type="submit" class="button" name="create_robots" value="', esc_attr__( 'Create robots.txt file', 'wordpress-seo' ), '">';
 		echo '</form>';
 	}
 	else {
-		echo '<p>', __( 'If you had a robots.txt file and it was editable, you could edit it from here.', 'wordpress-seo' ), '</p>';
+		echo '<p>', esc_html__( 'If you had a robots.txt file and it was editable, you could edit it from here.', 'wordpress-seo' ), '</p>';
 	}
 }
 else {
@@ -104,24 +104,23 @@ else {
 	if ( filesize( $robots_file ) > 0 ) {
 		$content = fread( $f, filesize( $robots_file ) );
 	}
-	$robots_txt_content = esc_textarea( $content );
 
 	if ( ! is_writable( $robots_file ) ) {
-		echo '<p><em>', __( 'If your robots.txt were writable, you could edit it from here.', 'wordpress-seo' ), '</em></p>';
-		echo '<textarea class="large-text code" disabled="disabled" rows="15" name="robotsnew">', $robots_txt_content, '</textarea><br/>';
+		echo '<p><em>', esc_html__( 'If your robots.txt were writable, you could edit it from here.', 'wordpress-seo' ), '</em></p>';
+		echo '<textarea class="large-text code" disabled="disabled" rows="15" name="robotsnew">', esc_textarea( $content ), '</textarea><br/>';
 	}
 	else {
 		echo '<form action="', esc_url( $action_url ), '" method="post" id="robotstxtform">';
 		wp_nonce_field( 'wpseo-robotstxt', '_wpnonce', true, true );
-		echo '<p><label for="robotsnew" class="yoast-inline-label">', __( 'Edit the content of your robots.txt:', 'wordpress-seo' ), '</label></p>';
-		echo '<textarea class="large-text code" rows="15" name="robotsnew" id="robotsnew">', $robots_txt_content, '</textarea><br/>';
-		echo '<div class="submit"><input class="button" type="submit" name="submitrobots" value="', __( 'Save changes to Robots.txt', 'wordpress-seo' ), '" /></div>';
+		echo '<p><label for="robotsnew" class="yoast-inline-label">', esc_html__( 'Edit the content of your robots.txt:', 'wordpress-seo' ), '</label></p>';
+		echo '<textarea class="large-text code" rows="15" name="robotsnew" id="robotsnew">', esc_textarea( $content ), '</textarea><br/>';
+		echo '<div class="submit"><input class="button" type="submit" name="submitrobots" value="', esc_attr__( 'Save changes to Robots.txt', 'wordpress-seo' ), '" /></div>';
 		echo '</form>';
 	}
 }
 if ( ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWARE'], 'nginx' ) === false ) ) {
 
-	echo '<h2>', __( '.htaccess file', 'wordpress-seo' ), '</h2>';
+	echo '<h2>', esc_html__( '.htaccess file', 'wordpress-seo' ), '</h2>';
 
 	if ( file_exists( $ht_access_file ) ) {
 		$f = fopen( $ht_access_file, 'r' );
@@ -130,22 +129,21 @@ if ( ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWAR
 		if ( filesize( $ht_access_file ) > 0 ) {
 			$contentht = fread( $f, filesize( $ht_access_file ) );
 		}
-		$contentht = esc_textarea( $contentht );
 
 		if ( ! is_writable( $ht_access_file ) ) {
-			echo '<p><em>', __( 'If your .htaccess were writable, you could edit it from here.', 'wordpress-seo' ), '</em></p>';
-			echo '<textarea class="large-text code" disabled="disabled" rows="15" name="robotsnew">', $contentht, '</textarea><br/>';
+			echo '<p><em>', esc_html__( 'If your .htaccess were writable, you could edit it from here.', 'wordpress-seo' ), '</em></p>';
+			echo '<textarea class="large-text code" disabled="disabled" rows="15" name="robotsnew">', esc_textarea( $contentht ), '</textarea><br/>';
 		}
 		else {
 			echo '<form action="', esc_url( $action_url ), '" method="post" id="htaccessform">';
 			wp_nonce_field( 'wpseo-htaccess', '_wpnonce', true, true );
-			echo '<p><label for="htaccessnew" class="yoast-inline-label">', __( 'Edit the content of your .htaccess:', 'wordpress-seo' ), '</label></p>';
-			echo '<textarea class="large-text code" rows="15" name="htaccessnew" id="htaccessnew">', $contentht, '</textarea><br/>';
-			echo '<div class="submit"><input class="button" type="submit" name="submithtaccess" value="', __( 'Save changes to .htaccess', 'wordpress-seo' ), '" /></div>';
+			echo '<p><label for="htaccessnew" class="yoast-inline-label">', esc_html__( 'Edit the content of your .htaccess:', 'wordpress-seo' ), '</label></p>';
+			echo '<textarea class="large-text code" rows="15" name="htaccessnew" id="htaccessnew">', esc_textarea( $contentht ), '</textarea><br/>';
+			echo '<div class="submit"><input class="button" type="submit" name="submithtaccess" value="', esc_attr__( 'Save changes to .htaccess', 'wordpress-seo' ), '" /></div>';
 			echo '</form>';
 		}
 	}
 	else {
-		echo '<p>', __( 'If you had a .htaccess file and it was editable, you could edit it from here.', 'wordpress-seo' ), '</p>';
+		echo '<p>', esc_html__( 'If you had a .htaccess file and it was editable, you could edit it from here.', 'wordpress-seo' ), '</p>';
 	}
 }

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -14,7 +14,12 @@ $ht_access_file = get_home_path() . '.htaccess';
 
 if ( isset( $_POST['create_robots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		die( esc_html__( 'You cannot create a robots.txt file.', 'wordpress-seo' ) );
+		$die_msg = sprintf
+			/* translators: %s expands to robots.txt. */
+			__( 'You cannot create a %s file.', 'wordpress-seo' ),
+			'robots.txt'
+		);
+		die( esc_html( $die_msg ) );
 	}
 
 	check_admin_referer( 'wpseo_create_robots' );
@@ -30,7 +35,12 @@ if ( isset( $_POST['create_robots'] ) ) {
 
 if ( isset( $_POST['submitrobots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		die( esc_html__( 'You cannot edit the robots.txt file.', 'wordpress-seo' ) );
+		$die_msg = sprintf
+			/* translators: %s expands to robots.txt. */
+			__( 'You cannot edit the %s file.', 'wordpress-seo' ),
+			'robots.txt'
+		);
+		die( esc_html( $die_msg ) );
 	}
 
 	check_admin_referer( 'wpseo-robotstxt' );
@@ -41,14 +51,23 @@ if ( isset( $_POST['submitrobots'] ) ) {
 			$f = fopen( $robots_file, 'w+' );
 			fwrite( $f, $robotsnew );
 			fclose( $f );
-			$msg = __( 'Updated Robots.txt', 'wordpress-seo' );
+			$msg = sprintf(
+				/* translators: %s expands to robots.txt. */
+				__( 'Updated %s', 'wordpress-seo' ),
+				'robots.txt'
+			);
 		}
 	}
 }
 
 if ( isset( $_POST['submithtaccess'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		die( esc_html__( 'You cannot edit the .htaccess file.', 'wordpress-seo' ) );
+		$die_msg = sprintf
+			/* translators: %s expands to ".htaccess". */
+			__( 'You cannot edit the %s file.', 'wordpress-seo' ),
+			'.htaccess'
+		);
+		die( esc_html( $die_msg ) );
 	}
 
 	check_admin_referer( 'wpseo-htaccess' );
@@ -82,19 +101,40 @@ $helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab, WPSEO_Utils
 $helpcenter->localize_data();
 $helpcenter->mount();
 
-echo '<h2>', esc_html__( 'Robots.txt', 'wordpress-seo' ), '</h2>';
+// N.B.: "robots.txt" is a fixed file name and should not be translatable.
+echo '<h2>robots.txt</h2>';
 
 
 if ( ! file_exists( $robots_file ) ) {
 	if ( is_writable( get_home_path() ) ) {
 		echo '<form action="', esc_url( $action_url ), '" method="post" id="robotstxtcreateform">';
 		wp_nonce_field( 'wpseo_create_robots', '_wpnonce', true, true );
-		echo '<p>', esc_html__( 'You don\'t have a robots.txt file, create one here:', 'wordpress-seo' ), '</p>';
-		echo '<input type="submit" class="button" name="create_robots" value="', esc_attr__( 'Create robots.txt file', 'wordpress-seo' ), '">';
+		echo '<p>';
+		printf(
+			/* translators: %s expands to robots.txt. */
+			esc_html__( 'You don\'t have a %s file, create one here:', 'wordpress-seo' ),
+			'robots.txt'
+		);
+		echo '</p>';
+
+		printf(
+			'<input type="submit" class="button" name="create_robots" value="%s">',
+			sprintf(
+				/* translators: %s expands to robots.txt. */
+				esc_attr__( 'Create %s file', 'wordpress-seo' ),
+				'robots.txt'
+			)
+		);
 		echo '</form>';
 	}
 	else {
-		echo '<p>', esc_html__( 'If you had a robots.txt file and it was editable, you could edit it from here.', 'wordpress-seo' ), '</p>';
+		echo '<p>';
+		printf(
+			/* translators: %s expands to robots.txt. */
+			esc_html__( 'If you had a %s file and it was editable, you could edit it from here.', 'wordpress-seo' ),
+			'robots.txt'
+		);
+		echo '</p>';
 	}
 }
 else {
@@ -106,21 +146,46 @@ else {
 	}
 
 	if ( ! is_writable( $robots_file ) ) {
-		echo '<p><em>', esc_html__( 'If your robots.txt were writable, you could edit it from here.', 'wordpress-seo' ), '</em></p>';
+		echo '<p><em>';
+		printf(
+			/* translators: %s expands to robots.txt. */
+			esc_html__( 'If your %s were writable, you could edit it from here.', 'wordpress-seo' ),
+			'robots.txt'
+		);
+		echo '</em></p>';
 		echo '<textarea class="large-text code" disabled="disabled" rows="15" name="robotsnew">', esc_textarea( $content ), '</textarea><br/>';
 	}
 	else {
 		echo '<form action="', esc_url( $action_url ), '" method="post" id="robotstxtform">';
 		wp_nonce_field( 'wpseo-robotstxt', '_wpnonce', true, true );
-		echo '<p><label for="robotsnew" class="yoast-inline-label">', esc_html__( 'Edit the content of your robots.txt:', 'wordpress-seo' ), '</label></p>';
+		echo '<p><label for="robotsnew" class="yoast-inline-label">';
+		printf(
+			/* translators: %s expands to robots.txt. */
+			esc_html__( 'Edit the content of your %s:', 'wordpress-seo' ),
+			'robots.txt'
+		);
+		echo '</label></p>';
 		echo '<textarea class="large-text code" rows="15" name="robotsnew" id="robotsnew">', esc_textarea( $content ), '</textarea><br/>';
-		echo '<div class="submit"><input class="button" type="submit" name="submitrobots" value="', esc_attr__( 'Save changes to Robots.txt', 'wordpress-seo' ), '" /></div>';
+		printf(
+			'<div class="submit"><input class="button" type="submit" name="submitrobots" value="%s" /></div>',
+			sprintf(
+				/* translators: %s expands to robots.txt. */
+				esc_attr__( 'Save changes to %s', 'wordpress-seo' ),
+				'robots.txt'
+			)
+		);
 		echo '</form>';
 	}
 }
 if ( ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWARE'], 'nginx' ) === false ) ) {
 
-	echo '<h2>', esc_html__( '.htaccess file', 'wordpress-seo' ), '</h2>';
+	echo '<h2>';
+	printf(
+		/* translators: %s expands to ".htaccess". */
+		esc_html__( '%s file', 'wordpress-seo' ),
+		'.htaccess'
+	);
+	echo '</h2>';
 
 	if ( file_exists( $ht_access_file ) ) {
 		$f = fopen( $ht_access_file, 'r' );
@@ -131,19 +196,44 @@ if ( ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWAR
 		}
 
 		if ( ! is_writable( $ht_access_file ) ) {
-			echo '<p><em>', esc_html__( 'If your .htaccess were writable, you could edit it from here.', 'wordpress-seo' ), '</em></p>';
+			echo '<p><em>';
+			printf(
+				/* translators: %s expands to ".htaccess". */
+				esc_html__( 'If your %s were writable, you could edit it from here.', 'wordpress-seo' ),
+				'.htaccess'
+			);
+			echo '</em></p>';
 			echo '<textarea class="large-text code" disabled="disabled" rows="15" name="robotsnew">', esc_textarea( $contentht ), '</textarea><br/>';
 		}
 		else {
 			echo '<form action="', esc_url( $action_url ), '" method="post" id="htaccessform">';
 			wp_nonce_field( 'wpseo-htaccess', '_wpnonce', true, true );
-			echo '<p><label for="htaccessnew" class="yoast-inline-label">', esc_html__( 'Edit the content of your .htaccess:', 'wordpress-seo' ), '</label></p>';
+			echo '<p><label for="htaccessnew" class="yoast-inline-label">';
+			printf(
+				/* translators: %s expands to ".htaccess". */
+				esc_html__( 'Edit the content of your %s:', 'wordpress-seo' ),
+				'.htaccess'
+			);
+			echo '</label></p>';
 			echo '<textarea class="large-text code" rows="15" name="htaccessnew" id="htaccessnew">', esc_textarea( $contentht ), '</textarea><br/>';
-			echo '<div class="submit"><input class="button" type="submit" name="submithtaccess" value="', esc_attr__( 'Save changes to .htaccess', 'wordpress-seo' ), '" /></div>';
+			printf(
+				'<div class="submit"><input class="button" type="submit" name="submithtaccess" value="%s" /></div>',
+				sprintf(
+					/* translators: %s expands to ".htaccess". */
+					esc_attr__( 'Save changes to %s', 'wordpress-seo' ),
+					'.htaccess'
+				)
+			);
 			echo '</form>';
 		}
 	}
 	else {
-		echo '<p>', esc_html__( 'If you had a .htaccess file and it was editable, you could edit it from here.', 'wordpress-seo' ), '</p>';
+		echo '<p>';
+		printf(
+			/* translators: %s expands to ".htaccess". */
+			esc_html__( 'If you had a %s file and it was editable, you could edit it from here.', 'wordpress-seo' ),
+			'.htaccess'
+		);
+		echo '</p>';
 	}
 }

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -14,7 +14,7 @@ $ht_access_file = get_home_path() . '.htaccess';
 
 if ( isset( $_POST['create_robots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		$die_msg = sprintf
+		$die_msg = sprintf(
 			/* translators: %s expands to robots.txt. */
 			__( 'You cannot create a %s file.', 'wordpress-seo' ),
 			'robots.txt'
@@ -35,7 +35,7 @@ if ( isset( $_POST['create_robots'] ) ) {
 
 if ( isset( $_POST['submitrobots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		$die_msg = sprintf
+		$die_msg = sprintf(
 			/* translators: %s expands to robots.txt. */
 			__( 'You cannot edit the %s file.', 'wordpress-seo' ),
 			'robots.txt'
@@ -62,7 +62,7 @@ if ( isset( $_POST['submitrobots'] ) ) {
 
 if ( isset( $_POST['submithtaccess'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
-		$die_msg = sprintf
+		$die_msg = sprintf(
 			/* translators: %s expands to ".htaccess". */
 			__( 'You cannot edit the %s file.', 'wordpress-seo' ),
 			'.htaccess'

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -133,7 +133,7 @@ $helpcenter->localize_data();
 $helpcenter->mount();
 
 foreach ( $tabs as $identifier => $tab ) {
-	printf( '<div id="%s" class="wpseotab">', $identifier );
+	printf( '<div id="%s" class="wpseotab">', esc_attr( $identifier ) );
 	require_once WPSEO_PATH . 'admin/views/tabs/tool/' . $identifier . '.php';
 	echo '</div>';
 }

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -12,16 +12,16 @@
 		printf( __( '%1$s settings', 'wordpress-seo' ), 'Yoast SEO' );
 		?></h2>
 
-	<label for="wpseo_author_title"><?php _e( 'Title to use for Author page', 'wordpress-seo' ); ?></label>
+	<label for="wpseo_author_title"><?php esc_html_e( 'Title to use for Author page', 'wordpress-seo' ); ?></label>
 	<input class="yoast-settings__text regular-text" type="text" id="wpseo_author_title" name="wpseo_author_title"
 		value="<?php echo esc_attr( get_the_author_meta( 'wpseo_title', $user->ID ) ); ?>"/><br>
 
-	<label for="wpseo_author_metadesc"><?php _e( 'Meta description to use for Author page', 'wordpress-seo' ); ?></label>
+	<label for="wpseo_author_metadesc"><?php esc_html_e( 'Meta description to use for Author page', 'wordpress-seo' ); ?></label>
 	<textarea rows="5" cols="30" id="wpseo_author_metadesc" class="yoast-settings__textarea yoast-settings__textarea--medium"
 		name="wpseo_author_metadesc"><?php echo esc_textarea( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea><br>
 
 	<?php if ( $options_titles['usemetakeywords'] === true ) { ?>
-		<label for="wpseo_author_metakey"><?php _e( 'Meta keywords to use for Author page', 'wordpress-seo' ); ?></label>
+		<label for="wpseo_author_metakey"><?php esc_html_e( 'Meta keywords to use for Author page', 'wordpress-seo' ); ?></label>
 		<input class="yoast-settings__text regular-text" type="text" id="wpseo_author_metakey"
 			name="wpseo_author_metakey"
 			value="<?php echo esc_attr( get_the_author_meta( 'wpseo_metakey', $user->ID ) ); ?>"/><br>
@@ -29,15 +29,15 @@
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_author_exclude"
 			name="wpseo_author_exclude"
 			value="on" <?php echo ( get_the_author_meta( 'wpseo_excludeauthorsitemap', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
-		<label class="yoast-label-strong" for="wpseo_author_exclude"><?php _e( 'Exclude user from Author-sitemap', 'wordpress-seo' ); ?></label><br>
+		<label class="yoast-label-strong" for="wpseo_author_exclude"><?php esc_html_e( 'Exclude user from Author-sitemap', 'wordpress-seo' ); ?></label><br>
 
 	<?php if ( $options['keyword_analysis_active'] === true ) { ?>
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_keyword_analysis_disable"
 			name="wpseo_keyword_analysis_disable" aria-describedby="wpseo_keyword_analysis_disable_desc"
 			value="on" <?php echo ( get_the_author_meta( 'wpseo_keyword_analysis_disable', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
-		<label class="yoast-label-strong" for="wpseo_keyword_analysis_disable"><?php _e( 'Disable SEO analysis', 'wordpress-seo' ); ?></label><br>
+		<label class="yoast-label-strong" for="wpseo_keyword_analysis_disable"><?php esc_html_e( 'Disable SEO analysis', 'wordpress-seo' ); ?></label><br>
 		<p class="description" id="wpseo_keyword_analysis_disable_desc">
-			<?php _e( 'Removes the keyword tab from the metabox and disables all SEO-related suggestions.', 'wordpress-seo' ); ?>
+			<?php esc_html_e( 'Removes the keyword tab from the metabox and disables all SEO-related suggestions.', 'wordpress-seo' ); ?>
 		</p>
 	<?php } ?>
 
@@ -45,9 +45,9 @@
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_content_analysis_disable"
 			name="wpseo_content_analysis_disable" aria-describedby="wpseo_content_analysis_disable_desc"
 			value="on" <?php echo ( get_the_author_meta( 'wpseo_content_analysis_disable', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
-		<label class="yoast-label-strong" for="wpseo_content_analysis_disable"><?php _e( 'Disable readability analysis', 'wordpress-seo' ); ?></label><br>
+		<label class="yoast-label-strong" for="wpseo_content_analysis_disable"><?php esc_html_e( 'Disable readability analysis', 'wordpress-seo' ); ?></label><br>
 		<p class="description" id="wpseo_content_analysis_disable_desc">
-			<?php _e( 'Removes the readability tab from the metabox and disables all readability-related suggestions.', 'wordpress-seo' ); ?>
+			<?php esc_html_e( 'Removes the readability tab from the metabox and disables all readability-related suggestions.', 'wordpress-seo' ); ?>
 		</p>
 	<?php } ?>
 </div>

--- a/css/xml-sitemap-xsl.php
+++ b/css/xml-sitemap-xsl.php
@@ -164,8 +164,8 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 				</table>
 			</xsl:if>
 		</div>
-		<script type="text/javascript" src="<?php echo includes_url( 'js/jquery/jquery.js' ); ?>"></script>
-		<script type="text/javascript" src="<?php echo plugins_url( 'js/dist/jquery.tablesorter.min.js', WPSEO_FILE ); ?>"></script>
+		<script type="text/javascript" src="<?php echo esc_url( includes_url( 'js/jquery/jquery.js' ) ); ?>"></script>
+		<script type="text/javascript" src="<?php echo esc_url( plugins_url( 'js/dist/jquery.tablesorter.min.js', WPSEO_FILE ) ); ?>"></script>
 		<script	type="text/javascript"><![CDATA[
 			jQuery(document).ready(function() {
 				jQuery("#sitemap").tablesorter( { widgets: ['zebra'] } );

--- a/deprecated/class-snippet-preview.php
+++ b/deprecated/class-snippet-preview.php
@@ -6,7 +6,7 @@
  * @deprecated 3.0 Class inside file is removed.
  */
 
-_deprecated_file( __FILE__, 'WPSEO 3.0', null, __( 'Use javascript instead.', 'wordpress-seo' ) );
+_deprecated_file( __FILE__, 'WPSEO 3.0', null, esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 
 /**
  * Class WPSEO_Snippet_Preview
@@ -96,7 +96,7 @@ class WPSEO_Snippet_Preview {
 	 * @deprecated 3.0 Removed, use javascript instead.
 	 */
 	public function get_content() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 		return $this->content;
 	}
 
@@ -106,7 +106,7 @@ class WPSEO_Snippet_Preview {
 	 * @deprecated 3.0 Removed, use javascript instead.
 	 */
 	protected function set_date() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class WPSEO_Snippet_Preview {
 	 * @deprecated 3.0 Removed, use javascript instead.
 	 */
 	protected function get_post_date() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 		return '';
 	}
 
@@ -127,7 +127,7 @@ class WPSEO_Snippet_Preview {
 	 * @deprecated 3.0 Removed, use javascript instead.
 	 */
 	protected function set_url() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 	}
 
 	/**
@@ -138,7 +138,7 @@ class WPSEO_Snippet_Preview {
 	 * @deprecated 3.0 Removed, use javascript instead.
 	 */
 	protected function set_slug() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 	}
 
 	/**
@@ -147,7 +147,7 @@ class WPSEO_Snippet_Preview {
 	 * @deprecated 3.0 Removed, use javascript instead.
 	 */
 	protected function set_content() {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 	}
 
 	/**
@@ -158,6 +158,6 @@ class WPSEO_Snippet_Preview {
 	 * @deprecated 3.0 Removed, use javascript instead.
 	 */
 	protected function set_content_through_filter( $content ) {
-		_deprecated_function( __METHOD__, 'WPSEO 3.0', __( 'Use javascript instead.', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.0', esc_html__( 'Use javascript instead.', 'wordpress-seo' ) );
 	}
 }

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1257,7 +1257,7 @@ class WPSEO_Frontend {
 				echo '<meta name="description" content="', esc_attr( strip_tags( stripslashes( $this->metadesc ) ) ), '"/>', "\n";
 			}
 			elseif ( current_user_can( 'wpseo_manage_options' ) && is_singular() ) {
-				echo '<!-- ', __( 'Admin only notice: this page doesn\'t show a meta description because it doesn\'t have one, either write it for this page specifically or go into the SEO -> Titles menu and set up a template.', 'wordpress-seo' ), ' -->', "\n";
+				echo '<!-- ', esc_html__( 'Admin only notice: this page doesn\'t show a meta description because it doesn\'t have one, either write it for this page specifically or go into the SEO -> Titles menu and set up a template.', 'wordpress-seo' ), ' -->', "\n";
 			}
 		}
 		else {

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -103,10 +103,10 @@ class WPSEO_Replace_Vars {
 			$var = self::remove_var_delimiter( $var );
 
 			if ( preg_match( '`^[A-Z0-9_-]+$`i', $var ) === false ) {
-				trigger_error( __( 'A replacement variable can only contain alphanumeric characters, an underscore or a dash. Try renaming your variable.', 'wordpress-seo' ), E_USER_WARNING );
+				trigger_error( esc_html__( 'A replacement variable can only contain alphanumeric characters, an underscore or a dash. Try renaming your variable.', 'wordpress-seo' ), E_USER_WARNING );
 			}
 			elseif ( strpos( $var, 'cf_' ) === 0 || strpos( $var, 'ct_' ) === 0 ) {
-				trigger_error( __( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'wordpress-seo' ), E_USER_WARNING );
+				trigger_error( esc_html__( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'wordpress-seo' ), E_USER_WARNING );
 			}
 			elseif ( ! method_exists( __CLASS__, 'retrieve_' . $var ) ) {
 				if ( ! isset( self::$external_replacements[ $var ] ) ) {
@@ -115,11 +115,11 @@ class WPSEO_Replace_Vars {
 					$success = true;
 				}
 				else {
-					trigger_error( __( 'A replacement variable with the same name has already been registered. Try making your variable name unique.', 'wordpress-seo' ), E_USER_WARNING );
+					trigger_error( esc_html__( 'A replacement variable with the same name has already been registered. Try making your variable name unique.', 'wordpress-seo' ), E_USER_WARNING );
 				}
 			}
 			else {
-				trigger_error( __( 'You cannot overrule a WPSEO standard variable replacement by registering a variable with the same name. Use the "wpseo_replacements" filter instead to adjust the replacement value.', 'wordpress-seo' ), E_USER_WARNING );
+				trigger_error( esc_html__( 'You cannot overrule a WPSEO standard variable replacement by registering a variable with the same name. Use the "wpseo_replacements" filter instead to adjust the replacement value.', 'wordpress-seo' ), E_USER_WARNING );
 			}
 		}
 

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -286,7 +286,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 * @return int 0 if equal, 1 if $a is larger else or -1;
 	 */
 	public function user_map_sorter( $first, $second ) {
-		_deprecated_function( __METHOD__, 'WPSEO 3.3', __( 'Use queries instead', 'wordpress-seo' ) );
+		_deprecated_function( __METHOD__, 'WPSEO 3.3', esc_html__( 'Use queries instead', 'wordpress-seo' ) );
 
 		if ( ! isset( $first->_yoast_wpseo_profile_updated ) ) {
 			$first->_yoast_wpseo_profile_updated = time();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -505,7 +505,7 @@ function yoast_wpseo_missing_filter_notice() {
  * @param string $message Message string.
  */
 function yoast_wpseo_activation_failed_notice( $message ) {
-	echo '<div class="error"><p>' . __( 'Activation failed:', 'wordpress-seo' ) . ' ' . $message . '</p></div>';
+	echo '<div class="error"><p>' . esc_html__( 'Activation failed:', 'wordpress-seo' ) . ' ' . $message . '</p></div>';
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

First in a series of PRs to fix these kind of issues.

These are the simple non-controversial ones. Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.
These should not give any problems.

Let me know if you have any questions.

## Test instructions

Testing recommended, but no problems expected.