### PR TITLE
Hide opened help toggles

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 125,
+			maxWarnings: 120,
 		},
 	},
 	grunt: {

--- a/js/src/wp-seo-admin-gsc.js
+++ b/js/src/wp-seo-admin-gsc.js
@@ -1,9 +1,6 @@
-/* jshint unused:false */
 /* global ajaxurl */
 /* global tb_click */
 jQuery( function() {
-	"use strict";
-
 	jQuery( ".subsubsub .yoast_help" ).on(
 		"click active",
 		function() {
@@ -23,7 +20,12 @@ jQuery( function() {
 				h = 500,
 				left = ( screen.width / 2 ) - ( w / 2 ),
 				top = ( screen.height / 2 ) - ( h / 2 );
-			return window.open( authUrl, "wpseogscauthcode", "toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=no, copyhistory=no, width=" + w + ", height=" + h + ", top=" + top + ", left=" + left );
+			return window.open(
+				authUrl,
+				"wpseogscauthcode",
+				"toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=no, " +
+				"copyhistory=no, width=" + w + ", height=" + h + ", top=" + top + ", left=" + left
+			);
 		}
 	);
 
@@ -100,8 +102,6 @@ jQuery( function() {
  * @returns {void}
  */
 function wpseoUpdateCategoryCount( category ) {
-	"use strict";
-
 	var countElement = jQuery( "#gsc_count_" + category + "" );
 	var newCount     = parseInt( countElement.text(), 10 ) - 1;
 	if( newCount < 0 ) {
@@ -149,8 +149,6 @@ function wpseoSendMarkAsFixed( nonce, platform, category, url ) {
  * @returns {void}
  */
 function wpseoMarkAsFixed( url ) {
-	"use strict";
-
 	wpseoSendMarkAsFixed(
 		jQuery( ".wpseo-gsc-ajax-security" ).val(),
 		jQuery( "#field_platform" ).val(),

--- a/js/src/wp-seo-admin-gsc.js
+++ b/js/src/wp-seo-admin-gsc.js
@@ -4,6 +4,15 @@
 jQuery( function() {
 	"use strict";
 
+	jQuery( ".subsubsub .yoast_help" ).on(
+		"click active",
+		function() {
+			let targetElementID = "#" + jQuery( this ).attr( "aria-controls" );
+			jQuery( ".yoast-help-panel" ).not( targetElementID ).hide();
+		}
+	);
+
+
 	// Store the control that opened the modal dialog for later use.
 	var $gscModalFocusedBefore;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where multiple help panels show up when clicking on different help buttons.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk and visit the Google Search Console page
* Press on each help button (that button is behind every filter)
![search_console_-_yoast_seo_ _local_wordpress_dev_ _wordpress](https://user-images.githubusercontent.com/325040/32379726-a3590c3a-c0ae-11e7-9cc6-0a7267c88c29.png)
* The result should be something like this:
![search_console_-_yoast_seo_ _local_wordpress_dev_ _wordpress](https://user-images.githubusercontent.com/325040/32379830-e04a1828-c0ae-11e7-9b8f-c0df65099614.png)
* Checkout this branch and do a `grunt build:js`
* Follow the same steps and see the issue being fixed.

Fixes #4402 
