### PR TITLE
Remove G++ / APT install option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,11 @@ branches:
     - /^release\/\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^hotfix\/\d+\.\d+(\.\d+)?(-\S*)?$/
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-
 jobs:
   fast_finish: true
   include:
     - php: 7.0
-      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node CXX=g++-4.8
+      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise


### PR DESCRIPTION
Remove the APT usage from the travis build.
This reduces the amount of packages that need to be built in the travis.

The functionality was needed to be able to build from source for dependencies.

Builds in ~11 minutes instead of ~14 minutes