### PR TITLE
Buffer output on REST request

### DIFF
--- a/admin/links/class-link-reindex-post-service.php
+++ b/admin/links/class-link-reindex-post-service.php
@@ -59,9 +59,15 @@ class WPSEO_Link_Reindex_Post_Service {
 	 * @return void
 	 */
 	protected function process_post( $post ) {
+
+		// Some plugins might output data, so let's buffer this to prevent wrong responses.
+		ob_start();
+
 		// Apply the filters to have the same content as shown on the frontend.
 		$content = apply_filters( 'the_content', $post->post_content );
 		$content = str_replace( ']]>', ']]&gt;', $content );
+
+		ob_end_clean();
 
 		$content_processor = $this->get_content_processor();
 		$content_processor->process( $post->ID, $content );

--- a/admin/links/class-link-reindex-post-service.php
+++ b/admin/links/class-link-reindex-post-service.php
@@ -59,7 +59,6 @@ class WPSEO_Link_Reindex_Post_Service {
 	 * @return void
 	 */
 	protected function process_post( $post ) {
-
 		// Some plugins might output data, so let's buffer this to prevent wrong responses.
 		ob_start();
 

--- a/admin/links/class-link-reindex-post-service.php
+++ b/admin/links/class-link-reindex-post-service.php
@@ -54,7 +54,7 @@ class WPSEO_Link_Reindex_Post_Service {
 	/**
 	 * Processes the post.
 	 *
-	 * @param WP_Post $post The post to process.
+	 * @param stdObject $post The post to process.
 	 *
 	 * @return void
 	 */

--- a/admin/links/class-link-reindex-post-service.php
+++ b/admin/links/class-link-reindex-post-service.php
@@ -58,7 +58,7 @@ class WPSEO_Link_Reindex_Post_Service {
 	 *
 	 * @return void
 	 */
-	protected function process_post( WP_Post $post ) {
+	protected function process_post( $post ) {
 		// Apply the filters to have the same content as shown on the frontend.
 		$content = apply_filters( 'the_content', $post->post_content );
 		$content = str_replace( ']]>', ']]&gt;', $content );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where possibly output on filter calling (`the_content`) results in wrong AJAX requests.

## Relevant technical choices:

* Using output buffering to get rid of unnecessary output.
* Don't force the object type for the method to be `WP_Post`

## Test instructions

This PR can be tested by following these steps:

* Install the MP3-jPlayer and past `http://sjward.org/seven.mp3` into a post
* Checkout trunk and set the link count values for the post to `NULL`
* Run the reindexing of the links and see a bad response.
* Checkout this branch, make sure the link count values for the post still being `NULL`
* Run the reindexing of the links and see the request done successful without any errors.

Fixes #8209 
