### PR TITLE
Added additional check to determine support tab.

### DIFF
--- a/js/src/wp-seo-help-center.js
+++ b/js/src/wp-seo-help-center.js
@@ -168,7 +168,7 @@ class HelpCenter extends React.Component {
 
 		this.props.additionalHelpCenterTabs.map( tab => {
 			let content;
-			if( this.props.shouldDisplayContactForm === "1" ) {
+			if( this.props.shouldDisplayContactForm === "1" && tab.identifier === "contact-support" ) {
 				const supportButton = this.props.intl.formatMessage( { id: "contactSupport.button" } );
 				content = <ContactSupport
 					buttonText={ supportButton }

--- a/js/src/wp-seo-help-center.js
+++ b/js/src/wp-seo-help-center.js
@@ -168,7 +168,7 @@ class HelpCenter extends React.Component {
 
 		this.props.additionalHelpCenterTabs.map( tab => {
 			let content;
-			if( this.props.shouldDisplayContactForm === "1" && tab.identifier === "contact-support" ) {
+			if ( this.props.shouldDisplayContactForm === "1" && tab.identifier === "contact-support" ) {
 				const supportButton = this.props.intl.formatMessage( { id: "contactSupport.button" } );
 				content = <ContactSupport
 					buttonText={ supportButton }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes additional tabs being overwritten with support tab in premium.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Pull this branch into premium, and build the project.
* Go to `SEO` > `Titles & Metas`
* Open the help center
* Check the `Get support` and `Template Explanation` tabs and see if the show the expected content.

Fixes Yoast/wordpress-seo-premium#1454
