### PR TITLE
Unlink private pages

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -155,10 +155,10 @@ class WPSEO_Breadcrumbs {
 	 */
 	protected function get_link_url_for_id( $id ) {
 		$post_status = get_post_status( $id );
-		$post_type   = get_post_type( $id );
+		$post_type   = get_post_type_object( get_post_type( $id ) );
 
 		// Don't link if item is private and user does't have capability to read it.
-		if ( $post_status === 'private' && ! current_user_can( 'read_private_' . $post_type ) ) {
+		if ( $post_status === 'private' && $post_type !== null  && ! current_user_can( $post_type->cap->read_private_posts ) ) {
 			return '';
 		}
 

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -163,7 +163,7 @@ class WPSEO_Breadcrumbs {
 		}
 
 		$url = get_permalink( $id );
-		if( $url === false ) {
+		if ( $url === false ) {
 			return '';
 		}
 

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -91,7 +91,7 @@ class WPSEO_Breadcrumbs {
 	/**
 	 * Create the breadcrumb
 	 */
-	private function __construct() {
+	protected function __construct() {
 		$this->options        = WPSEO_Options::get_options( array( 'wpseo_titles', 'wpseo_internallinks', 'wpseo_xml' ) );
 		$this->post           = ( isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null );
 		$this->show_on_front  = get_option( 'show_on_front' );
@@ -142,6 +142,28 @@ class WPSEO_Breadcrumbs {
 	 */
 	public function __toString() {
 		return self::$before . $this->output . self::$after;
+	}
+
+	/**
+	 * Returns the link url for a single id.
+	 *
+	 * When the target is private and the user isn't allowed to access it, just return an empty string.
+	 *
+	 * @param int $id The target id.
+	 *
+	 * @return string Empty string when post isn't accessible. An URL if accessible.
+	 */
+	protected function get_link_url_for_id( $id ) {
+		$status = get_post_status( $id );
+		$cpt 	= get_post_type( $id );
+		$url    = get_permalink( $id );
+
+		// Don't link if item is private and user does't have capability to read it.
+		if ( $url === false || ( $status === 'private' && ! current_user_can( 'read_private_' . $cpt ) ) ) {
+			return '';
+		}
+
+		return $url;
 	}
 
 
@@ -873,27 +895,6 @@ class WPSEO_Breadcrumbs {
 		}
 
 		return $class;
-	}
-
-	/**
-	 * Returns the link url for a single id.
-	 *
-	 * When the target is private and the user isn't allowed to access it, just return an empty string.
-	 *
-	 * @param int $id The target id.
-	 *
-	 * @return string Empty string when post isn't accessible. An URL if accessible.
-	 */
-	private function get_link_url_for_id( $id ) {
-		$status = get_post_status( $id );
-		$cpt 	= get_post_type( $id );
-
-		// Don't link if item is private and user does't have capability to read it.
-		if ( $status === 'private' && ! current_user_can( 'read_private_' . $cpt ) ) {
-			return '';
-		}
-
-		return (string) get_permalink( $id );
 	}
 
 	/********************** DEPRECATED METHODS **********************/

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -114,7 +114,7 @@ class WPSEO_Breadcrumbs {
 	 * @param string $after   Optional string to append.
 	 * @param bool   $display Echo or return flag.
 	 *
-	 * @return object
+	 * @return string Returns the breadcrumbs as a string.
 	 */
 	public static function breadcrumb( $before = '', $after = '', $display = true ) {
 		if ( ! ( self::$instance instanceof self ) ) {
@@ -129,11 +129,10 @@ class WPSEO_Breadcrumbs {
 		if ( $display === true ) {
 			echo $output;
 
-			return true;
+			return '';
 		}
-		else {
-			return $output;
-		}
+
+		return $output;
 	}
 
 	/**

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -154,12 +154,16 @@ class WPSEO_Breadcrumbs {
 	 * @return string Empty string when post isn't accessible. An URL if accessible.
 	 */
 	protected function get_link_url_for_id( $id ) {
-		$status = get_post_status( $id );
-		$cpt 	= get_post_type( $id );
-		$url    = get_permalink( $id );
+		$post_status = get_post_status( $id );
+		$post_type   = get_post_type( $id );
 
 		// Don't link if item is private and user does't have capability to read it.
-		if ( $url === false || ( $status === 'private' && ! current_user_can( 'read_private_' . $cpt ) ) ) {
+		if ( $post_status === 'private' && ! current_user_can( 'read_private_' . $post_type ) ) {
+			return '';
+		}
+
+		$url = get_permalink( $id );
+		if( $url === false ) {
 			return '';
 		}
 

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -667,9 +667,8 @@ class WPSEO_Breadcrumbs {
 	 * @return array Array of link text and url
 	 */
 	private function get_link_info_for_id( $id ) {
-
 		$link         = array();
-		$link['url']  = get_permalink( $id );
+		$link['url']  = $this->get_link_url_for_id( $id );
 		$link['text'] = WPSEO_Meta::get_value( 'bctitle', $id );
 
 		if ( $link['text'] === '' ) {
@@ -877,6 +876,26 @@ class WPSEO_Breadcrumbs {
 		return $class;
 	}
 
+	/**
+	 * Returns the link url for a single id.
+	 *
+	 * When the target is private and the user isn't allowed to access it, just return an empty string.
+	 *
+	 * @param int $id The target id.
+	 *
+	 * @return string Empty string when post isn't accessible. An URL if accessible.
+	 */
+	private function get_link_url_for_id( $id ) {
+		$status = get_post_status( $id );
+		$cpt 	= get_post_type( $id );
+
+		// Don't link if item is private and user does't have capability to read it.
+		if ( $status === 'private' && ! current_user_can( 'read_private_' . $cpt ) ) {
+			return '';
+		}
+
+		return (string) get_permalink( $id );
+	}
 
 	/********************** DEPRECATED METHODS **********************/
 

--- a/tests/doubles/class-breadcrumbs-double.php
+++ b/tests/doubles/class-breadcrumbs-double.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+class WPSEO_Breadcrumbs_Double extends WPSEO_Breadcrumbs {
+
+	/**
+	 * Overrides the protected constructor in the parent.
+	 */
+	public function __construct() {
+
+	}
+
+	/**
+	 * Returns the link url for the id.
+	 *
+	 * @param int $id
+	 *
+	 * @return string
+	 */
+	public function get_link_url_for_id( $id ) {
+		return parent::get_link_url_for_id( $id );
+	}
+}

--- a/tests/test-class-wpseo-breadcrumbs.php
+++ b/tests/test-class-wpseo-breadcrumbs.php
@@ -13,7 +13,6 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		ob_start();
 
 		// Requires the test double.
 		require_once WPSEO_TESTS_PATH . 'doubles/class-breadcrumbs-double.php';
@@ -93,7 +92,7 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	public function test_getting_url_of_a_non_existing_post() {
 		$breadcrumbs = new WPSEO_Breadcrumbs_Double();
 
-		$this->assertEquals( '', $breadcrumbs->get_link_url_for_id( 500000 ) );
+		$this->assertEquals( '', $breadcrumbs->get_link_url_for_id( 0 ) );
 	}
 
 }

--- a/tests/test-class-wpseo-breadcrumbs.php
+++ b/tests/test-class-wpseo-breadcrumbs.php
@@ -9,6 +9,17 @@
 class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 
 	/**
+	 * Set up the test object by requiring the test double.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		ob_start();
+
+		// Requires the test double.
+		require_once WPSEO_TESTS_PATH . 'doubles/class-breadcrumbs-double.php';
+	}
+
+	/**
 	 * Placeholder test to prevent PHPUnit from throwing errors.
 	 */
 	/*public function test_breadcrumb_home() {
@@ -48,6 +59,41 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 		$this->assertStringEndsWith( $expected, $output );
 
 		// @todo Test actual breadcrumb output.
+	}
+
+	/**
+	 * Tests getting the url for a private post.
+	 *
+	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id()
+	 */
+	public function test_getting_url_of_private_post() {
+		$breadcrumbs = new WPSEO_Breadcrumbs_Double();
+
+		$post = $this->factory()->post->create_and_get( array( 'post_status' => 'private' ));
+		$this->assertEquals( '', $breadcrumbs->get_link_url_for_id( $post->ID ) );
+	}
+
+	/**
+	 * Tests getting the url for a public post.
+	 *
+	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id()
+	 */
+	public function test_getting_url_of_public_post() {
+		$breadcrumbs = new WPSEO_Breadcrumbs_Double();
+
+		$post = $this->factory()->post->create_and_get();
+		$this->assertEquals( get_permalink( $post->ID ), $breadcrumbs->get_link_url_for_id( $post->ID ) );
+	}
+
+	/**
+	 * Tests getting the url for a non existing post id.
+	 *
+	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id()
+	 */
+	public function test_getting_url_of_a_non_existing_post() {
+		$breadcrumbs = new WPSEO_Breadcrumbs_Double();
+
+		$this->assertEquals( '', $breadcrumbs->get_link_url_for_id( 500000 ) );
 	}
 
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where private pages are links in the breadcrumbs

## Test instructions

This PR can be tested by following these steps:

* Have breadcrumbs enabled in the theme (https://kb.yoast.com/kb/implement-wordpress-seo-breadcrumbs/)
* Make a private page
* Make another page (public) and make that a child of the private page, you've just made.
* The parent page shouldn't be linked

Note: I might be possible to have a public parent page first, that has to be made private afterwards.

Fixes #8240 
