### PR TITLE
Adds a new hook to allow OG Images to be added

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -118,6 +118,13 @@ class WPSEO_OpenGraph_Image {
 			$this->get_opengraph_image_taxonomy();
 		}
 
+		/**
+		 * Filter: wpseo_add_opengraph_additional_images - Allows to add additional images to the OpenGraph tags.
+		 *
+		 * @api WPSEO_OpenGraph_Image The current object.
+		 */
+		do_action( 'wpseo_add_opengraph_additional_images', $this );
+
 		$this->get_default_image();
 	}
 


### PR DESCRIPTION
This allows to prioritize snippet preview/featured image configuration to be above additionally added images, like the WooCommerce Image Gallery images.

## Summary

This PR can be summarized in the following changelog entry:

* Introduced `wpseo_add_opengraph_additional_images` to allow adding OpenGraph Images which should complement any Facebook Image or Featured image set on a post/page.

## Relevant technical choices:

* Adding a new filter at the specific location in the code provides the flexibility needed for the purpose.
* The alternative was adding priority based add_image calls, which would make the functionality and usability a lot more complicated.

## Test instructions

This PR can be tested by following these steps:

* 

Related https://github.com/Yoast/wpseo-woocommerce/issues/169
