### PR TITLE
CS/QA: enable two disabled tests

### DIFF
--- a/tests/test-class-wpseo-frontend-robots.php
+++ b/tests/test-class-wpseo-frontend-robots.php
@@ -60,7 +60,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( '', self::$class_instance->robots() );
 	}
 
-	public function _test_robots_on_private_blog() {
+	public function test_robots_on_private_blog() {
 		// Go to home.
 		$this->go_to_home();
 
@@ -73,7 +73,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 	}
 
 
-	public function _test_with_replytocom_attribute() {
+	public function test_with_replytocom_attribute() {
 		// Go to home.
 		$this->go_to_home();
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

These tests were disabled without any reason to be found in the git history. Test methods should start with `test`.

Let's see if the build passes :grimacing: 


## Test instructions
_N/A_