### PR TITLE
QA: potential bug fix

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -255,13 +255,14 @@ class WPSEO_Breadcrumbs {
 			$parents = $this->get_term_parents( $term );
 
 			if ( count( $parents ) >= $parents_count ) {
-				$parents_count = count( $parents );
 
 				// If higher count.
 				if ( count( $parents ) > $parents_count ) {
 					// Reset order.
 					$term_order = 9999;
 				}
+
+				$parents_count = count( $parents );
 
 				$parent_order = 9999; // Set default order.
 				foreach ( $parents as $parent ) {

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -256,12 +256,6 @@ class WPSEO_Breadcrumbs {
 
 			if ( count( $parents ) >= $parents_count ) {
 
-				// If higher count.
-				if ( count( $parents ) > $parents_count ) {
-					// Reset order.
-					$term_order = 9999;
-				}
-
 				$parents_count = count( $parents );
 
 				$parent_order = 9999; // Set default order.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
Came across this while working on something else.

The second `if()` could never be `true` as `$parents_count` was being overwritten before the comparison.

https://github.com/Yoast/wordpress-seo/blob/390f1b8e70542ebb7a2a73ab4cdc2df8163d2241/frontend/class-breadcrumbs.php#L257-L261

Looks like this has been in the codebase since 2013 or even earlier...

## Test instructions
_N/A_
