### PR TITLE
CS/QA: don't use a function call within a loop construct

### DIFF
--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -91,7 +91,8 @@ class WPSEO_Sitemap_Timezone {
 		}
 
 		// Last try, guess timezone string manually.
-		foreach ( timezone_abbreviations_list() as $abbr ) {
+		$timezone_list = timezone_abbreviations_list();
+		foreach ( $timezone_list as $abbr ) {
 			foreach ( $abbr as $city ) {
 				if ( $city['offset'] == $utc_offset ) {
 					return $city['timezone_id'];


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

Using a function call in the looping condition of a control structure is generally inefficient and should be avoided.


## Test instructions
_N/A_