### PR TITLE
CS (non-)compliance: Use strict comparisons

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -251,7 +251,7 @@ function wpseo_upsert_meta( $post_id, $new_meta_value, $orig_meta_value, $meta_k
 		return $upsert_results;
 	}
 
-	if ( ! current_user_can( $post_type_object->cap->edit_others_posts ) && $the_post->post_author != get_current_user_id() ) {
+	if ( ! current_user_can( $post_type_object->cap->edit_others_posts ) && (int) $the_post->post_author !== get_current_user_id() ) {
 
 		$upsert_results['status']  = 'failure';
 		$upsert_results['results'] = sprintf(

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -574,7 +574,7 @@ class WPSEO_Admin_Init {
 	 * @return bool
 	 */
 	private function is_blog_public() {
-		return '1' == get_option( 'blog_public' );
+		return '1' === (string) get_option( 'blog_public' );
 	}
 
 	/**

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -846,7 +846,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 		static $date_format;
 
-		if ( $date_format == null ) {
+		if ( ! isset( $date_format ) ) {
 			$date_format = get_option( 'date_format' );
 		}
 

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -451,7 +451,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$current_order  = $this->current_order;
 
 		// If current type doesn't compare with objects page_type, than we have to unset some vars in the requested url (which will be use for internal table urls).
-		if ( $_GET['type'] != $this->page_type ) {
+		if ( $_GET['type'] !== $this->page_type ) {
 			$request_url = remove_query_arg( 'paged', $request_url ); // Page will be set with value 1 below.
 			$request_url = remove_query_arg( 'post_type_filter', $request_url );
 			$request_url = remove_query_arg( 'post_status', $request_url );

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -400,13 +400,13 @@ class WPSEO_Admin_Pages {
 		$content = '<table class="form-table">';
 		foreach ( $rows as $row ) {
 			$content .= '<tr><th scope="row">';
-			if ( isset( $row['id'] ) && $row['id'] != '' ) {
+			if ( ! empty( $row['id'] ) ) {
 				$content .= '<label for="' . esc_attr( $row['id'] ) . '">' . esc_html( $row['label'] ) . ':</label>';
 			}
 			else {
 				$content .= esc_html( $row['label'] );
 			}
-			if ( isset( $row['desc'] ) && $row['desc'] != '' ) {
+			if ( ! empty( $row['desc'] ) ) {
 				$content .= '<br/><small>' . esc_html( $row['desc'] ) . '</small>';
 			}
 			$content .= '</th><td>';

--- a/admin/class-import-woothemes-seo.php
+++ b/admin/class-import-woothemes-seo.php
@@ -92,7 +92,7 @@ class WPSEO_Import_WooThemes_SEO extends WPSEO_Import_External {
 	 */
 	private function import_custom_values( $option, $key ) {
 		// Import the custom homepage description.
-		if ( 'c' == get_option( $option ) ) {
+		if ( 'c' === get_option( $option ) ) {
 			$this->options[ $key ] = get_option( $option . '_custom' );
 		}
 		$this->perhaps_delete( $option );
@@ -130,12 +130,12 @@ class WPSEO_Import_WooThemes_SEO extends WPSEO_Import_External {
 		}
 
 		// If WooSEO is set to use the Woo meta descriptions, import those.
-		if ( 'b' == get_option( 'seo_woo_meta_single_desc' ) ) {
+		if ( 'b' === get_option( 'seo_woo_meta_single_desc' ) ) {
 			WPSEO_Meta::replace_meta( 'seo_description', WPSEO_Meta::$meta_prefix . 'metadesc', $this->replace );
 		}
 
 		// If WooSEO is set to use the Woo meta keywords, import those.
-		if ( 'b' == get_option( 'seo_woo_meta_single_key' ) ) {
+		if ( 'b' === get_option( 'seo_woo_meta_single_key' ) ) {
 			WPSEO_Meta::replace_meta( 'seo_keywords', WPSEO_Meta::$meta_prefix . 'metakeywords', $this->replace );
 		}
 

--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -205,7 +205,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 		// Check if post data is available, if post_id is set and if original post_status is publish.
 		// @codingStandardsIgnoreStart
 		if (
-			! empty( $_POST ) && ! empty( $post->ID ) && $post->post_status == 'publish' &&
+			! empty( $_POST ) && ! empty( $post->ID ) && $post->post_status === 'publish' &&
 			isset( $_POST['original_post_status'] ) && $_POST['original_post_status'] === 'publish'
 		) {
 			// @codingStandardsIgnoreEnd

--- a/admin/class-social-facebook.php
+++ b/admin/class-social-facebook.php
@@ -211,7 +211,7 @@ class Yoast_Social_Facebook {
 	 * @param string $nonce_name Nonce name string.
 	 */
 	private function verify_nonce( $nonce_name ) {
-		if ( wp_verify_nonce( filter_input( INPUT_GET, 'nonce' ), $nonce_name ) != 1 ) {
+		if ( wp_verify_nonce( filter_input( INPUT_GET, 'nonce' ), $nonce_name ) !== 1 ) {
 			die( "I don't think that's really nice of you!." );
 		}
 	}

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -159,7 +159,7 @@ class WPSEO_GSC {
 	 * @return mixed
 	 */
 	public function set_screen_option( $status, $option, $value ) {
-		if ( 'errors_per_page' == $option ) {
+		if ( 'errors_per_page' === $option ) {
 			return $value;
 		}
 	}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -899,7 +899,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 		else {
 
-			if ( 0 != get_queried_object_id() ) {
+			if ( 0 !== get_queried_object_id() ) {
 				wp_enqueue_media( array( 'post' => get_queried_object_id() ) ); // Enqueue files needed for upload functionality.
 			}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -91,7 +91,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 
 		self::$meta_fields['advanced']['meta-robots-noindex']['title'] = __( 'Meta robots index', 'wordpress-seo' );
-		if ( '0' == get_option( 'blog_public' ) ) {
+		if ( '0' === (string) get_option( 'blog_public' ) ) {
 			self::$meta_fields['advanced']['meta-robots-noindex']['description'] = '<p class="error-message">' . __( 'Warning: even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, so these settings won\'t have an effect.', 'wordpress-seo' ) . '</p>';
 		}
 		/* translators: %s expands to the robots (no)index setting default as set in the site-wide settings.*/

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -20,7 +20,7 @@ if ( filter_input( INPUT_GET, 'intro' ) ) {
 $options = get_option( 'wpseo' );
 
 if ( isset( $_GET['allow_tracking'] ) && check_admin_referer( 'wpseo_activate_tracking', 'nonce' ) ) {
-	$options['yoast_tracking'] = ( $_GET['allow_tracking'] == 'yes' );
+	$options['yoast_tracking'] = ( $_GET['allow_tracking'] === 'yes' );
 	update_option( 'wpseo', $options );
 
 	if ( isset( $_SERVER['HTTP_REFERER'] ) ) {

--- a/admin/views/tabs/advanced/breadcrumbs.php
+++ b/admin/views/tabs/advanced/breadcrumbs.php
@@ -26,7 +26,7 @@ $yform->textinput( 'breadcrumbs-archiveprefix', __( 'Prefix for Archive breadcru
 $yform->textinput( 'breadcrumbs-searchprefix', __( 'Prefix for Search Page breadcrumbs', 'wordpress-seo' ) );
 $yform->textinput( 'breadcrumbs-404crumb', __( 'Breadcrumb for 404 Page', 'wordpress-seo' ) );
 echo '<br/>';
-if ( get_option( 'show_on_front' ) == 'page' && get_option( 'page_for_posts' ) > 0 ) {
+if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) > 0 ) {
 	$yform->toggle_switch( 'breadcrumbs-blog-remove', array(
 		'off' => __( 'Show', 'wordpress-seo' ),
 		'on'  => __( 'Hide', 'wordpress-seo' ),
@@ -68,7 +68,7 @@ if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 	echo '<h2>' . esc_html__( 'Post type archive to show in breadcrumbs for taxonomies', 'wordpress-seo' ) . '</h2>';
 	foreach ( $taxonomies as $tax ) {
 		$values = array( 0 => __( 'None', 'wordpress-seo' ) );
-		if ( get_option( 'show_on_front' ) == 'page' && get_option( 'page_for_posts' ) > 0 ) {
+		if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) > 0 ) {
 			$values['post'] = __( 'Blog', 'wordpress-seo' );
 		}
 

--- a/admin/views/tabs/metas/home.php
+++ b/admin/views/tabs/metas/home.php
@@ -9,7 +9,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( 'posts' == get_option( 'show_on_front' ) ) {
+if ( 'posts' === get_option( 'show_on_front' ) ) {
 	echo '<div id="homepage-titles-metas">';
 	echo '<h2>', esc_html__( 'Homepage', 'wordpress-seo' ), '</h2>';
 	$yform->textinput( 'title-home-wpseo', __( 'Title template', 'wordpress-seo' ), 'template homepage-template' );

--- a/admin/views/tabs/sitemaps/taxonomies.php
+++ b/admin/views/tabs/sitemaps/taxonomies.php
@@ -30,7 +30,7 @@ if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 			continue;
 		}
 
-		if ( isset( $tax->labels->name ) && trim( $tax->labels->name ) != '' ) {
+		if ( isset( $tax->labels->name ) && trim( $tax->labels->name ) !== '' ) {
 			$yform->toggle_switch(
 				'taxonomies-' . $tax->name . '-not_in_sitemap',
 				$switch_values,

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -22,7 +22,7 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 	</p>
 
 <?php
-if ( 'posts' == get_option( 'show_on_front' ) ) {
+if ( 'posts' === get_option( 'show_on_front' ) ) {
 	echo '<h2>' . esc_html__( 'Frontpage settings', 'wordpress-seo' ) . '</h2>';
 	echo '<p>' . esc_html__( 'These are the title, description and image used in the Open Graph meta tags on the front page of your site.', 'wordpress-seo' ) . '</p>';
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -70,7 +70,7 @@ if ( $import ) {
 	 */
 	$msg = apply_filters( 'wpseo_import_message', isset( $import->msg ) ? $import->msg : '' );
 
-	if ( $msg != '' ) {
+	if ( ! empty( $msg ) ) {
 		// Check if we've deleted old data and adjust message to match it.
 		if ( $replace ) {
 			$msg .= ' ' . __( 'The old data of the imported plugin was deleted successfully.', 'wordpress-seo' );

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -508,7 +508,7 @@ class WPSEO_Breadcrumbs {
 	 * Add taxonomy crumbs to the crumbs property for a single post
 	 */
 	private function maybe_add_taxonomy_crumbs_for_post() {
-		if ( isset( $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ] ) && $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ] != '0' ) {
+		if ( isset( $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ] ) && (string) $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ] !== '0' ) {
 			$main_tax = $this->options[ 'post_types-' . $this->post->post_type . '-maintax' ];
 			if ( isset( $this->post->ID ) ) {
 				$terms = get_the_terms( $this->post, $main_tax );
@@ -568,7 +568,7 @@ class WPSEO_Breadcrumbs {
 	 * @param object $term Term data object.
 	 */
 	private function maybe_add_preferred_term_parent_crumb( $term ) {
-		if ( isset( $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] ) && $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] != '0' ) {
+		if ( isset( $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] ) && (string) $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] !== '0' ) {
 			if ( 'post' === $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] && $this->show_on_front === 'page' ) {
 				if ( $this->page_for_posts ) {
 					$this->add_blog_crumb();

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -214,7 +214,7 @@ class WPSEO_Breadcrumbs {
 	private function get_term_parents( $term ) {
 		$tax     = $term->taxonomy;
 		$parents = array();
-		while ( $term->parent != 0 ) {
+		while ( $term->parent !== 0 ) {
 			$term      = get_term( $term->parent, $tax );
 			$parents[] = $term;
 		}
@@ -265,7 +265,7 @@ class WPSEO_Breadcrumbs {
 
 				$parent_order = 9999; // Set default order.
 				foreach ( $parents as $parent ) {
-					if ( $parent->parent == 0 && isset( $parent->term_order ) ) {
+					if ( $parent->parent === 0 && isset( $parent->term_order ) ) {
 						$parent_order = $parent->term_order;
 					}
 				}
@@ -342,7 +342,7 @@ class WPSEO_Breadcrumbs {
 		elseif ( is_singular() ) {
 			$this->maybe_add_pt_archive_crumb_for_post();
 
-			if ( isset( $this->post->post_parent ) && 0 == $this->post->post_parent ) {
+			if ( isset( $this->post->post_parent ) && 0 === $this->post->post_parent ) {
 				$this->maybe_add_taxonomy_crumbs_for_post();
 			}
 			else {
@@ -523,7 +523,7 @@ class WPSEO_Breadcrumbs {
 						$breadcrumb_term = $this->find_deepest_term( $terms );
 					}
 
-					if ( is_taxonomy_hierarchical( $main_tax ) && $breadcrumb_term->parent != 0 ) {
+					if ( is_taxonomy_hierarchical( $main_tax ) && $breadcrumb_term->parent !== 0 ) {
 						$parent_terms = $this->get_term_parents( $breadcrumb_term );
 						foreach ( $parent_terms as $parent_term ) {
 							$this->add_term_crumb( $parent_term );
@@ -586,7 +586,7 @@ class WPSEO_Breadcrumbs {
 	 * @param object $term Term data object.
 	 */
 	private function maybe_add_term_parent_crumbs( $term ) {
-		if ( is_taxonomy_hierarchical( $term->taxonomy ) && $term->parent != 0 ) {
+		if ( is_taxonomy_hierarchical( $term->taxonomy ) && $term->parent !== 0 ) {
 			foreach ( $this->get_term_parents( $term ) as $parent_term ) {
 				$this->add_term_crumb( $parent_term );
 			}

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -336,7 +336,7 @@ class WPSEO_Breadcrumbs {
 			// Do nothing.
 			// @codingStandardsIgnoreEnd
 		}
-		elseif ( $this->show_on_front == 'page' && is_home() ) {
+		elseif ( $this->show_on_front === 'page' && is_home() ) {
 			$this->add_blog_crumb();
 		}
 		elseif ( is_singular() ) {
@@ -569,7 +569,7 @@ class WPSEO_Breadcrumbs {
 	 */
 	private function maybe_add_preferred_term_parent_crumb( $term ) {
 		if ( isset( $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] ) && $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] != '0' ) {
-			if ( 'post' == $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] && $this->show_on_front == 'page' ) {
+			if ( 'post' === $this->options[ 'taxonomy-' . $term->taxonomy . '-ptparent' ] && $this->show_on_front === 'page' ) {
 				if ( $this->page_for_posts ) {
 					$this->add_blog_crumb();
 				}

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -177,7 +177,7 @@ class WPSEO_Frontend {
 	 */
 	public function reset() {
 		foreach ( get_class_vars( __CLASS__ ) as $name => $default ) {
-			if ( $name == 'instance' ) {
+			if ( $name === 'instance' ) {
 				self::$instance = null;
 			}
 			else {
@@ -217,7 +217,7 @@ class WPSEO_Frontend {
 	 * @return bool
 	 */
 	public function is_home_posts_page() {
-		return ( is_home() && 'posts' == get_option( 'show_on_front' ) );
+		return ( is_home() && 'posts' === get_option( 'show_on_front' ) );
 	}
 
 	/**
@@ -226,7 +226,7 @@ class WPSEO_Frontend {
 	 * @return bool
 	 */
 	public function is_home_static_page() {
-		return ( is_front_page() && 'page' == get_option( 'show_on_front' ) && is_page( get_option( 'page_on_front' ) ) );
+		return ( is_front_page() && 'page' === get_option( 'show_on_front' ) && is_page( get_option( 'page_on_front' ) ) );
 	}
 
 	/**
@@ -235,7 +235,7 @@ class WPSEO_Frontend {
 	 * @return bool
 	 */
 	public function is_posts_page() {
-		return ( is_home() && 'page' == get_option( 'show_on_front' ) );
+		return ( is_home() && 'page' === get_option( 'show_on_front' ) );
 	}
 
 	/**
@@ -338,7 +338,7 @@ class WPSEO_Frontend {
 	 * @return string
 	 */
 	public function get_default_title( $sep, $seplocation, $title = '' ) {
-		if ( 'right' == $seplocation ) {
+		if ( 'right' === $seplocation ) {
 			$regex = '`\s*' . preg_quote( trim( $sep ), '`' ) . '\s*`u';
 		}
 		else {
@@ -1559,7 +1559,7 @@ class WPSEO_Frontend {
 		}
 		$cururl .= '://';
 
-		if ( $_SERVER['SERVER_PORT'] != '80' && $_SERVER['SERVER_PORT'] != '443' ) {
+		if ( $_SERVER['SERVER_PORT'] !== '80' && $_SERVER['SERVER_PORT'] !== '443' ) {
 			$cururl .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['REQUEST_URI'];
 		}
 		else {
@@ -1621,7 +1621,7 @@ class WPSEO_Frontend {
 		}
 		elseif ( is_404() ) {
 			if ( is_multisite() && ! is_subdomain_install() && is_main_site() ) {
-				if ( $cururl == get_bloginfo( 'url' ) . '/blog/' || $cururl == get_bloginfo( 'url' ) . '/blog' ) {
+				if ( $cururl === get_bloginfo( 'url' ) . '/blog/' || $cururl === get_bloginfo( 'url' ) . '/blog' ) {
 					if ( $this->is_home_static_page() ) {
 						$properurl = get_permalink( get_option( 'page_for_posts' ) );
 					}

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1056,11 +1056,11 @@ class WPSEO_Frontend {
 			if ( is_string( $url ) && $url !== '' ) {
 				$paged = get_query_var( 'paged' );
 
-				if ( 0 == $paged ) {
+				if ( 0 === $paged ) {
 					$paged = 1;
 				}
 
-				if ( $paged == 2 ) {
+				if ( $paged === 2 ) {
 					$this->adjacent_rel_link( 'prev', $url, ( $paged - 1 ), true );
 				}
 
@@ -1632,7 +1632,7 @@ class WPSEO_Frontend {
 			}
 		}
 
-		if ( ! empty( $properurl ) && $wp_query->query_vars['paged'] != 0 && $wp_query->post_count != 0 ) {
+		if ( ! empty( $properurl ) && $wp_query->query_vars['paged'] !== 0 && $wp_query->post_count !== 0 ) {
 			if ( is_search() && ! empty( $s ) ) {
 				$properurl = get_bloginfo( 'url' ) . '/page/' . $wp_query->query_vars['paged'] . '/?s=' . $s;
 			}

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -773,7 +773,7 @@ class WPSEO_Frontend {
 		}
 
 		// Force override to respect the WP settings.
-		if ( '0' == get_option( 'blog_public' ) || isset( $_GET['replytocom'] ) ) {
+		if ( '0' === (string) get_option( 'blog_public' ) || isset( $_GET['replytocom'] ) ) {
 			$robots['index'] = 'noindex';
 		}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1692,7 +1692,7 @@ class WPSEO_Frontend {
 		}
 		unset( $get );
 
-		if ( ! empty( $properurl ) && $cururl != $properurl ) {
+		if ( ! empty( $properurl ) && $cururl !== $properurl ) {
 			$this->redirect( $properurl, 301 );
 		}
 	}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -309,7 +309,7 @@ class WPSEO_OpenGraph_Image {
 	 * @return bool|string
 	 */
 	private function get_relative_path( $img ) {
-		if ( $img[0] != '/' ) {
+		if ( $img[0] !== '/' ) {
 			return false;
 		}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -781,7 +781,7 @@ class WPSEO_OpenGraph {
 		$this->og_tag( 'article:published_time', $pub );
 
 		$mod = get_the_modified_date( DATE_W3C );
-		if ( $mod != $pub ) {
+		if ( $mod !== $pub ) {
 			$this->og_tag( 'article:modified_time', $mod );
 			$this->og_tag( 'og:updated_time', $mod );
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -357,7 +357,7 @@ class WPSEO_OpenGraph {
 		}
 
 		// Convert locales like "es" to "es_ES", in case that works for the given locale (sometimes it does).
-		if ( strlen( $locale ) == 2 ) {
+		if ( strlen( $locale ) === 2 ) {
 			$locale = strtolower( $locale ) . '_' . strtoupper( $locale );
 		}
 

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -136,7 +136,7 @@ class WPSEO_Rewrite {
 					// Recursive recursion.
 					$category->parent = 0;
 				}
-				elseif ( $taxonomy->rewrite['hierarchical'] != 0 && $category->parent != 0 ) {
+				elseif ( $taxonomy->rewrite['hierarchical'] != 0 && $category->parent !== 0 ) {
 					$parents = get_category_parents( $category->parent, false, '/', true );
 					if ( ! is_wp_error( $parents ) ) {
 						$category_nicename = $parents . $category_nicename;

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -61,7 +61,7 @@ class WPSEO_Rewrite {
 	public function no_category_base( $link ) {
 		$category_base = get_option( 'category_base' );
 
-		if ( '' == $category_base ) {
+		if ( empty( $category_base ) ) {
 			$category_base = 'category';
 		}
 

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -66,7 +66,7 @@ class WPSEO_Rewrite {
 		}
 
 		// Remove initial slash, if there is one (we remove the trailing slash in the regex replacement and don't want to end up short a slash).
-		if ( '/' == substr( $category_base, 0, 1 ) ) {
+		if ( '/' === substr( $category_base, 0, 1 ) ) {
 			$category_base = substr( $category_base, 1 );
 		}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -881,7 +881,7 @@ class WPSEO_Replace_Vars {
 
 		$user_id     = $this->retrieve_userid();
 		$description = get_the_author_meta( 'description', $user_id );
-		if ( $description != '' ) {
+		if ( $description !== '' ) {
 			$replacement = $description;
 		}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -559,7 +559,7 @@ class WPSEO_Replace_Vars {
 				$page_number = 1;
 			}
 
-			if ( isset( $wp_query->max_num_pages ) && ( $wp_query->max_num_pages != '' && $wp_query->max_num_pages != 0 ) ) {
+			if ( ! empty( $wp_query->max_num_pages ) ) {
 				$max_num_pages = $wp_query->max_num_pages;
 			}
 		}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -751,7 +751,7 @@ class WPSEO_Utils {
 	public static function get_plugin_name( $plugin ) {
 		$plugin_details = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
 
-		if ( $plugin_details['Name'] != '' ) {
+		if ( $plugin_details['Name'] !== '' ) {
 			return $plugin_details['Name'];
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -731,7 +731,7 @@ class WPSEO_Utils {
 		}
 
 		// Append 'query' string if it exists.
-		if ( isset( $parsed_url['query'] ) && '' != $parsed_url['query'] ) {
+		if ( ! empty( $parsed_url['query'] ) ) {
 			$formatted_url .= '?' . $parsed_url['query'];
 		}
 

--- a/inc/options/class-wpseo-option-internallinks.php
+++ b/inc/options/class-wpseo-option-internallinks.php
@@ -256,7 +256,7 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 
 		$post_types = get_post_types( array( 'public' => true ), 'objects' );
 
-		if ( get_option( 'show_on_front' ) == 'page' && get_option( 'page_for_posts' ) > 0 ) {
+		if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) > 0 ) {
 			$allowed_post_types[] = 'post';
 		}
 

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -164,7 +164,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 						if ( $int !== false && $int > 0 ) {
 							// Check if a valid blog number has been received.
 							$exists = get_blog_details( $int, false );
-							if ( $exists && $exists->deleted == 0 ) {
+							if ( $exists && $exists->deleted === '0' ) {
 								$clean[ $key ] = $int;
 							}
 							elseif ( function_exists( 'add_settings_error' ) ) {

--- a/inc/options/class-wpseo-option-xml.php
+++ b/inc/options/class-wpseo-option-xml.php
@@ -115,7 +115,7 @@ class WPSEO_Option_XML extends WPSEO_Option {
 		$filtered_taxonomies = apply_filters( 'wpseo_sitemaps_supported_taxonomies', $taxonomy_objects );
 		if ( is_array( $filtered_taxonomies ) && $filtered_taxonomies !== array() ) {
 			foreach ( $filtered_taxonomies as $tax ) {
-				if ( isset( $tax->labels->name ) && trim( $tax->labels->name ) != '' ) {
+				if ( isset( $tax->labels->name ) && trim( $tax->labels->name ) !== '' ) {
 					$this->defaults[ 'taxonomies-' . $tax->name . '-not_in_sitemap' ] = false;
 				}
 			}

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -374,7 +374,7 @@ class WPSEO_Options {
 
 			if ( is_array( $option_names ) && $option_names !== array() ) {
 				$base_blog_id = $blog_id;
-				if ( $options['defaultblog'] !== '' && $options['defaultblog'] != 0 ) {
+				if ( $options['defaultblog'] !== '' && $options['defaultblog'] !== 0 ) {
 					$base_blog_id = $options['defaultblog'];
 				}
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -637,7 +637,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		_deprecated_function( __METHOD__, 'WPSEO 3.5' );
 
 		$return = 0.6;
-		if ( $post->post_parent == 0 && $post->post_type === 'page' ) {
+		if ( $post->post_parent === 0 && $post->post_type === 'page' ) {
 			$return = 0.8;
 		}
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -375,7 +375,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		$needs_archive = true;
 
-		if ( ! $this->get_page_on_front_id() && ( $post_type == 'post' || $post_type == 'page' ) ) {
+		if ( ! $this->get_page_on_front_id() && ( $post_type === 'post' || $post_type === 'page' ) ) {
 
 			$links[] = array(
 				'loc' => $this->get_home_url(),
@@ -637,7 +637,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		_deprecated_function( __METHOD__, 'WPSEO 3.5' );
 
 		$return = 0.6;
-		if ( $post->post_parent == 0 && $post->post_type == 'page' ) {
+		if ( $post->post_parent == 0 && $post->post_type === 'page' ) {
 			$return = 0.8;
 		}
 

--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -109,7 +109,7 @@ class WPSEO_Sitemap_Timezone {
 	 * @return string
 	 */
 	private function get_timezone_string() {
-		if ( '' == $this->timezone_string ) {
+		if ( '' === $this->timezone_string ) {
 			$this->timezone_string = $this->determine_timezone_string();
 		}
 

--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -93,7 +93,7 @@ class WPSEO_Sitemap_Timezone {
 		// Last try, guess timezone string manually.
 		foreach ( timezone_abbreviations_list() as $abbr ) {
 			foreach ( $abbr as $city ) {
-				if ( $city['offset'] == $utc_offset ) {
+				if ( $city['offset'] === $utc_offset ) {
 					return $city['timezone_id'];
 				}
 			}

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -105,7 +105,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 				$current_page = ( $max_pages > 1 ) ? ( $page_counter + 1 ) : '';
 
-				if ( ! is_array( $tax->object_type ) || count( $tax->object_type ) == 0 ) {
+				if ( ! is_array( $tax->object_type ) || count( $tax->object_type ) === 0 ) {
 					continue;
 				}
 

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -324,7 +324,7 @@ function wpseo_xml_redirect_sitemap() {
 	$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 
 	// Must be 'sitemap.xml' and must be 404.
-	if ( home_url( '/sitemap.xml' ) == $current_url && $GLOBALS['wp_query']->is_404 ) {
+	if ( home_url( '/sitemap.xml' ) === $current_url && $GLOBALS['wp_query']->is_404 ) {
 		wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
 		exit;
 	}

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -59,7 +59,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 		}
 
 		// Remove initial slash, if there is one (we remove the trailing slash in the regex replacement and don't want to end up short a slash).
-		if ( '/' == substr( $category_base, 0, 1 ) ) {
+		if ( '/' === substr( $category_base, 0, 1 ) ) {
 			$category_base = substr( $category_base, 1 );
 		}
 

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -31,7 +31,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_schedule_flush() {
 		self::$class_instance->schedule_flush();
-		$this->assertTrue( get_option( $this->flush_option_name ) == true );
+		$this->assertTrue( get_option( $this->flush_option_name ) === 1 );
 	}
 
 	/**

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -54,7 +54,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 		$input         = 'http://yoast.com/cat/link/';
 		$category_base = get_option( 'category_base' );
 
-		if ( '' == $category_base ) {
+		if ( empty( $category_base ) ) {
 			$category_base = 'category';
 		}
 


### PR DESCRIPTION

## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

**Review note:** the PR will be easiest to review by looking at the individual commits, including the additional comments I've added to the individual commits..

## Test instructions
Testing recommended, though I don't expect any issues.