### PR TITLE
CS/QA: improve validation of `$_SERVER['HTTPS']`

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1554,7 +1554,7 @@ class WPSEO_Frontend {
 
 		// Recreate current URL.
 		$cururl = 'http';
-		if ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] == 'on' ) {
+		if ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) {
 			$cururl .= 's';
 		}
 		$cururl .= '://';

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -320,7 +320,7 @@ function wpseo_xml_sitemaps_init() {
 function wpseo_xml_redirect_sitemap() {
 	_deprecated_function( __FUNCTION__, 'WPSEO 2.4', 'WPSEO_Sitemaps_Router' );
 
-	$current_url  = ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] == 'on' ) ? 'https://' : 'http://';
+	$current_url  = ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) ? 'https://' : 'http://';
 	$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 
 	// Must be 'sitemap.xml' and must be 404.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

According to the documentation, the value will be _non-empty_ when queried through the HTTPS protocol, not necessarily the string `on`.
However, when used with IIS, an `off` value can be encountered.

The change made here should deal with this properly.

All the same, I wonder if it may be more appropriate to change over to using the WP native `is_ssl()` function.

Refs:
* http://php.net/manual/en/reserved.variables.server.php
* https://developer.wordpress.org/reference/functions/is_ssl/

## Test instructions
_N/A_