### PR TITLE
Docs: clean up after latest merges and miscellaneous other test doc fixes

### DIFF
--- a/tests/admin/banner/test-class-admin-banner-sidebar.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar.php
@@ -32,7 +32,7 @@ class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Returns a mock from the WPSEO_Admin_Banner_Sidebar.
 	 *
-	 * @param array $methods_to_mock
+	 * @param array $methods_to_mock Array of method names.
 	 *
 	 * @return WPSEO_Admin_Banner_Sidebar
 	 */

--- a/tests/admin/test-class-plugin-suggestions.php
+++ b/tests/admin/test-class-plugin-suggestions.php
@@ -1,5 +1,11 @@
 <?php
+/**
+ * @package WPSEO\Tests\Admin
+ */
 
+/**
+ * Unit Test Class.
+ */
 class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 
 	/**
@@ -13,12 +19,19 @@ class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 	protected $notification_center;
 
 	/**
+	 * Include helper class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/class-wpseo-suggested-plugins-double.php';
+	}
+
+	/**
 	 * Set up our double class.
 	 */
 	public function setUp() {
 		parent::setUp();
-
-		require_once WPSEO_TESTS_PATH . 'admin/class-wpseo-suggested-plugins-double.php';
 
 		$plugin_availability = new WPSEO_Plugin_Availability_Double();
 

--- a/tests/doubles/class-breadcrumbs-double.php
+++ b/tests/doubles/class-breadcrumbs-double.php
@@ -3,6 +3,9 @@
  * @package WPSEO\Tests\Doubles
  */
 
+/**
+ * Test Helper Class.
+ */
 class WPSEO_Breadcrumbs_Double extends WPSEO_Breadcrumbs {
 
 	/**
@@ -15,7 +18,7 @@ class WPSEO_Breadcrumbs_Double extends WPSEO_Breadcrumbs {
 	/**
 	 * Returns the link url for the id.
 	 *
-	 * @param int $id
+	 * @param int $id ID.
 	 *
 	 * @return string
 	 */

--- a/tests/doubles/class-wpseo-suggested-plugins-double.php
+++ b/tests/doubles/class-wpseo-suggested-plugins-double.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
 
 /**
  * Class WPSEO_Suggested_Plugins_Double

--- a/tests/doubles/frontend-double.php
+++ b/tests/doubles/frontend-double.php
@@ -1,5 +1,11 @@
 <?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
 
+/**
+ * Test Helper Class.
+ */
 class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	/**
 	 * Get the singleton instance of this class
@@ -17,7 +23,10 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	}
 
 	/**
-	 * @inheritdoc
+	 * Short-circuit redirecting.
+	 *
+	 * @param string $location The path to redirect to.
+	 * @param int    $status   Status code to use.
 	 */
 	public function redirect( $location, $status = 302 ) {
 		// Intentionally left empty to remove actual redirection code to be able to test it.

--- a/tests/doubles/wpseo-config-component-connect-google-search-console-mock.php
+++ b/tests/doubles/wpseo-config-component-connect-google-search-console-mock.php
@@ -15,6 +15,8 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Co
 
 	/**
 	 * WPSEO_Config_Component_Connect_Google_Search_Console_Mock constructor.
+	 *
+	 * @param \WPSEO_Config_Component_Connect_Google_Search_Console_Test $test Test object.
 	 */
 	public function __construct( $test ) {
 		$this->test = $test;

--- a/tests/doubles/wpseo-role-manager-mock.php
+++ b/tests/doubles/wpseo-role-manager-mock.php
@@ -7,17 +7,43 @@
  * Test Helper Class.
  */
 class WPSEO_Role_Manager_Mock extends WPSEO_Abstract_Role_Manager {
+
+	/** @var array Added roles. */
 	public $added_roles = array();
+
+	/** @var array Removed roles. */
 	public $removed_roles = array();
 
+	/**
+	 * Get registered roles.
+	 *
+	 * @return array
+	 */
 	public function get_registered_roles() {
 		return $this->roles;
 	}
 
+	/**
+	 * Filters out capabilities that are already set for the role.
+	 *
+	 * This makes sure we don't override configurations that have been previously set.
+	 *
+	 * @param string $role         The role to check against.
+	 * @param array  $capabilities The capabilities that should be set.
+	 *
+	 * @return array Capabilties that can be safely set.
+	 */
 	public function filter_existing_capabilties( $role, array $capabilities ) {
 		return parent::filter_existing_capabilities( $role, $capabilities );
 	}
 
+	/**
+	 * Returns the capabilities for the specified role.
+	 *
+	 * @param string $role Role to fetch capabilities from.
+	 *
+	 * @return array List of capabilities.
+	 */
 	public function get_capabilities( $role ) {
 		return parent::get_capabilities( $role );
 	}

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -571,7 +571,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::attachment_redirect
 	 */
 	public function test_attachment_redirect_no_parent() {
-		// create and go to post
+		// Create and go to post.
 		$post_id = $this->factory->post->create( array(
 			'post_type' => 'attachment',
 			'post_parent' => 0,
@@ -807,7 +807,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 
 	/**
-	 * @param string $initial_url
+	 * @param string $initial_url URL to start off from.
 	 *
 	 * @return void
 	 */
@@ -845,7 +845,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param string $name
+	 * @param string $name Option name.
 	 *
 	 * @return string
 	 */
@@ -854,8 +854,8 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param string $option_name
-	 * @param string $expected
+	 * @param string $option_name Option name.
+	 * @param string $expected    Expected output.
 	 *
 	 * @return void
 	 */
@@ -866,7 +866,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param string $expected
+	 * @param string $expected Expected output.
 	 *
 	 * @return void
 	 */
@@ -879,7 +879,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 *
 	 * Can be removed when https://core.trac.wordpress.org/ticket/31417 is fixed and in all releases we're testing (so when 4.2 is the lowest common denominator).
 	 *
-	 * @param string $url
+	 * @param string $url URL.
 	 */
 	public function go_to( $url ) {
 		// Note: the WP and WP_Query classes like to silently fetch parameters

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -355,8 +355,8 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param $filter
-	 * @param $expected
+	 * @param string $filter   SEO filter.
+	 * @param array  $expected The resulting SEO score filter.
 	 *
 	 * @dataProvider determine_seo_filters_dataprovider
 	 * @covers WPSEO_Meta_Columns::determine_seo_filters()
@@ -368,8 +368,8 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param $filter
-	 * @param $expected
+	 * @param string $filter   The Readability filter to use to determine what further filter to apply.
+	 * @param array  $expected The Readability score filter.
 	 *
 	 * @dataProvider determine_readability_filters_dataprovider
 	 * @covers WPSEO_Meta_Columns::determine_readability_filters()
@@ -381,9 +381,9 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param $vars
-	 * @param $filters
-	 * @param $expected
+	 * @param array $vars     Array containing the variables that will be used in the meta query.
+	 * @param array $filters  Array containing the filters that we need to apply in the meta query.
+	 * @param array $expected Array containing the complete filter query.
 	 *
 	 * @dataProvider build_filter_query_dataprovider
 	 * @covers WPSEO_Meta_Columns::build_filter_query()

--- a/tests/test-class-wpseo-rank.php
+++ b/tests/test-class-wpseo-rank.php
@@ -28,8 +28,8 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @dataProvider provider_get_css_class
 	 *
-	 * @param int    $rank
-	 * @param string $expected
+	 * @param int    $rank     Ranking.
+	 * @param string $expected Expected CSS class.
 	 */
 	public function test_get_css_class( $rank, $expected ) {
 		$rank = new WPSEO_Rank( $rank );
@@ -37,6 +37,11 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, $rank->get_css_class() );
 	}
 
+	/**
+	 * Data provider for test_get_css_class().
+	 *
+	 * @return array
+	 */
 	public function provider_get_css_class() {
 		return array(
 			array( WPSEO_Rank::BAD, 'bad' ),
@@ -50,8 +55,8 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @dataProvider provider_get_label
 	 *
-	 * @param int    $rank
-	 * @param string $expected
+	 * @param int    $rank     Ranking.
+	 * @param string $expected Expected label.
 	 */
 	public function test_get_label( $rank, $expected ) {
 		$rank = new WPSEO_Rank( $rank );
@@ -59,6 +64,11 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, $rank->get_label() );
 	}
 
+	/**
+	 * Data provider for test_get_label().
+	 *
+	 * @return array
+	 */
 	public function provider_get_label() {
 		return array(
 			array( WPSEO_Rank::NO_FOCUS, 'Not available' ),
@@ -72,8 +82,8 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @dataProvider provider_get_drop_down_label
 	 *
-	 * @param int    $rank
-	 * @param string $expected
+	 * @param int    $rank     Ranking.
+	 * @param string $expected Expected drop-down label.
 	 */
 	public function test_get_drop_down_label( $rank, $expected ) {
 		$rank = new WPSEO_Rank( $rank );
@@ -82,6 +92,11 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	}
 
+	/**
+	 * Data provider for test_get_drop_down_label().
+	 *
+	 * @return array
+	 */
 	public function provider_get_drop_down_label() {
 		return array(
 			array( WPSEO_Rank::NO_FOCUS, 'SEO: No Focus Keyword' ),
@@ -95,8 +110,8 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @dataProvider provider_get_starting_score
 	 *
-	 * @param int    $rank
-	 * @param string $expected
+	 * @param int    $rank     Ranking.
+	 * @param string $expected Expected start score.
 	 */
 	public function test_get_starting_score( $rank, $expected ) {
 		$rank = new WPSEO_Rank( $rank );
@@ -105,6 +120,11 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	}
 
+	/**
+	 * Data provider for test_get_starting_score().
+	 *
+	 * @return array
+	 */
 	public function provider_get_starting_score() {
 		return array(
 			array( WPSEO_Rank::NO_INDEX, -1 ),
@@ -118,8 +138,8 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @dataProvider provider_get_end_score
 	 *
-	 * @param int    $rank
-	 * @param string $expected
+	 * @param int    $rank     Ranking.
+	 * @param string $expected Expected end score.
 	 */
 	public function test_get_end_score( $rank, $expected ) {
 		$rank = new WPSEO_Rank( $rank );
@@ -128,6 +148,11 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	}
 
+	/**
+	 * Data provider for test_get_end_score().
+	 *
+	 * @return array
+	 */
 	public function provider_get_end_score() {
 		return array(
 			array( WPSEO_Rank::NO_INDEX, -1 ),
@@ -141,8 +166,8 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @dataProvider provider_from_numeric_score
 	 *
-	 * @param int $score
-	 * @param int $expected
+	 * @param int $score    Numeric score.
+	 * @param int $expected Expected ranking.
 	 */
 	public function test_from_numeric_score( $score, $expected ) {
 		$rank = WPSEO_Rank::from_numeric_score( $score );
@@ -150,6 +175,11 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, $rank->get_rank() );
 	}
 
+	/**
+	 * Data provider for test_from_numeric_score().
+	 *
+	 * @return array
+	 */
 	public function provider_from_numeric_score() {
 		return array(
 			array( 0, WPSEO_Rank::NO_FOCUS ),

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -94,6 +94,10 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider translate_score_provider
 	 * @covers WPSEO_Utils::translate_score()
+	 *
+	 * @param int    $score     The decimal score to translate.
+	 * @param bool   $css_value Whether to return the i18n translated score or the CSS class value.
+	 * @param string $expected  Expected function result.
 	 */
 	public function test_translate_score( $score, $css_value, $expected ) {
 		$this->assertEquals( $expected, WPSEO_Utils::translate_score( $score, $css_value ) );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Fix up test documentation and move new double class file to the `doubles` subdirectory.

## Test instructions
_N/A_