### PR TITLE
Exclude a newly created post from link counting

### DIFF
--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -48,6 +48,11 @@ class WPSEO_Link_Watcher {
 			return;
 		}
 
+		// When the post status is auto-draft.
+		if ( $post->post_status === 'auto-draft' ) {
+			return;
+		}
+
 		// When the post isn't processable, just remove the saved links.
 		if ( ! $this->is_processable( $post_id ) ) {
 			return;


### PR DESCRIPTION
## Summary

Since PR #8068 is merged (versions 5.7 and 5.8), link watcher processes all "public" posts ( regardless post_status). Before #8068 (version 5.6.x), it was processing only published posts (`post_status === 'publish'`). I added again logic for checking [post_status](https://codex.wordpress.org/Post_Status) and I excluded 'auto-draft' - a newly created post (and maybe auto saved post in some cases).

## Relevant technical choices:

* Added logic for checking `post_status` in hook save_post.

## Test instructions

This PR can be tested by following these steps:

* Install [QM](https://wordpress.org/plugins/query-monitor/).
* Add new page or post. [QM](https://wordpress.org/plugins/query-monitor/) doesn't show more "Mysql error" (and red status on admin bar).

Fixes #7566, #8158.
