### PR TITLE
Update home_url to use the WP defined home_url rather than the DB value

### DIFF
--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -91,9 +91,7 @@ class WPSEO_Sitemaps_Router {
 		 * @param string $base The string that should be added to home_url() to make the full base URL.
 		 */
 		$base = apply_filters( 'wpseo_sitemaps_base_url', $base );
-
-		// Get the scheme from the configured home url instead of letting WordPress determine the scheme based on the requested URI.
-		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
+		
 		return home_url( $base . $page );
 	}
 }

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -94,6 +94,6 @@ class WPSEO_Sitemaps_Router {
 
 		// Get the scheme from the configured home url instead of letting WordPress determine the scheme based on the requested URI.
 		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
-		return home_url( $base . $page, parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
+		return home_url( $base . $page );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Update to base_url to utilize the WordPress generated home URL rather than the direct database value of the home URL

## Relevant technical choices:

* This is in reference to issues #6927 and #7278 where the sitemap doesn't update the URL scheme after updating to HTTPS in some instances. The reason I found is that the function I altered is using the get_option('home') function rather than the home_url() or get_home_url() offered in the WordPress core. The issue is that if a user uses the WP_HOME and WP_SITEURL constant values (referenced here: https://codex.wordpress.org/Changing_The_Site_URL#Edit_wp-config.php) to define an HTTPS scheme but they keep the database value in the wp_options table (option_names 'home' and 'siteurl') with an HTTP scheme, the sitemap doesn't update because it is referencing the database. Using the constants is a proper way to update the home and siteurls in WP currently (as seen in their docs above) so the plugin should support using this IMO. There is a reference in the comments of that function mentioning that it is explicitly pulling the scheme from the database instead of letting WP do it but I'm not sure why that would be needed (no explanation as to _why_).

## Test instructions

This PR can be tested by following these steps:

* Set your site's home and siteurl with an http:// scheme in the database (or on an initial installation; which subsequently updates the DB).
- Enable the sitemap if it has not been enabled in the Yoast SEO plugin.
- View the sitemap. Note the http:// scheme.
- Update the wp-config file with the two constants, WP_HOME and WP_SITEURL, with an https:// scheme as follows:

define('WP_HOME','https://example.com');
define('WP_SITEURL','https://example.com');

- View the sitemap. It will still have an http:// scheme.
- Disable the sitemap and re-enable it.
- View the sitemap. It will still have an http:// scheme.
- You can go into the DB and delete the transient in the wp_options table for the sitemap. Reload the sitemap. It will still have an http:// scheme.
- Go into the DB directly and run the commands (of course, replacing the URL with your own URL):
`update wp_options set option_value='https://www.example.com' where option_name='home';`
`update wp_options set option_value='https://www.example.com' where option_name='siteurl';`
- Disable and re-enable the sitemap. View the sitemap. You will now see the https:// scheme.

Fixes #
