### PR TITLE
Disable method usage when unhooked

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1828,7 +1828,7 @@ class WPSEO_Frontend {
 		wp_reset_query();
 
 		// Only replace the debug marker when it is hooked.
-		if ( $this->has_debug_mark_action() ) {
+		if ( $this->show_debug_marker() ) {
 			$title = $this->title( '' );
 
 			// Find all titles, strip them out and add the new one in within the debug marker, so it's easily identified whether a site uses force rewrite.
@@ -1970,7 +1970,7 @@ class WPSEO_Frontend {
 	 *
 	 * @return bool True when the action exists.
 	 */
-	protected function has_debug_mark_action() {
+	protected function show_debug_marker() {
 		return has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) !== false;
 	}
 
@@ -1980,7 +1980,7 @@ class WPSEO_Frontend {
 	 * @return string The closing debug mark comment.
 	 */
 	protected function show_closing_debug_mark() {
-		if ( ! $this->has_debug_mark_action() ) {
+		if ( ! $this->show_debug_marker() ) {
 			return '';
 		}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -603,12 +603,10 @@ class WPSEO_Frontend {
 		return $title;
 	}
 
-
-
 	/**
 	 * Outputs or returns the debug marker, which is also used for title replacement when force rewrite is active.
 	 *
-	 * @param bool $echo Whether or not to echo the debug marker.
+	 * @param bool $echo Deprecated. Since 5.9. Whether or not to echo the debug marker.
 	 *
 	 * @return string The marker that will be echoed.
 	 */

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -683,12 +683,7 @@ class WPSEO_Frontend {
 		 */
 		do_action( 'wpseo_head' );
 
-		if ( has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) ) {
-			printf(
-				"<!-- / %s. -->\n\n",
-				esc_html( $this->head_product_name() )
-			);
-		}
+		echo $this->show_closing_debug_mark();
 
 		if ( ! empty( $old_wp_query ) ) {
 			$GLOBALS['wp_query'] = $old_wp_query;
@@ -1977,6 +1972,22 @@ class WPSEO_Frontend {
 	 */
 	protected function has_debug_mark_action() {
 		return has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) !== false;
+	}
+
+	/**
+	 * Show the closing debug mark.
+	 *
+	 * @return string The closing debug mark comment.
+	 */
+	protected function show_closing_debug_mark() {
+		if ( ! $this->has_debug_mark_action() ) {
+			return '';
+		}
+
+		return sprintf(
+			"<!-- / %s. -->\n\n",
+			esc_html( $this->head_product_name() )
+		);
 	}
 
 	/** Deprecated functions */

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1823,11 +1823,14 @@ class WPSEO_Frontend {
 
 		wp_reset_query();
 
-		$title = $this->title( '' );
+		// Only replace the debug marker when it is hooked.
+		if ( has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) ) {
+			$title   = $this->title( '' );
 
-		// Find all titles, strip them out and add the new one in within the debug marker, so it's easily identified whether a site uses force rewrite.
-		$content = preg_replace( '/<title.*?\/title>/i', '', $content );
-		$content = str_replace( $this->debug_mark( false ), $this->debug_mark( false ) . "\n" . '<title>' . $title . '</title>', $content );
+			// Find all titles, strip them out and add the new one in within the debug marker, so it's easily identified whether a site uses force rewrite.
+			$content = preg_replace( '/<title.*?\/title>/i', '', $content );
+			$content = str_replace( $this->debug_mark( false ), $this->debug_mark( false ) . "\n" . '<title>' . $title . '</title>', $content );
+		}
 
 		$GLOBALS['wp_query'] = $old_wp_query;
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -20,7 +20,7 @@ class WPSEO_Frontend {
 	public $options = array();
 
 	/**
-	 * @var boolean Boolean indicating wether output buffering has been started.
+	 * @var boolean Boolean indicating whether output buffering has been started.
 	 */
 	private $ob_started = false;
 
@@ -250,19 +250,19 @@ class WPSEO_Frontend {
 			$object = $GLOBALS['wp_query']->get_queried_object();
 		}
 
-		if ( is_object( $object ) ) {
-			$title = WPSEO_Meta::get_value( 'title', $object->ID );
-
-			if ( $title !== '' ) {
-				return wpseo_replace_vars( $title, $object );
-			}
-
-			$post_type = ( isset( $object->post_type ) ? $object->post_type : $object->query_var );
-
-			return $this->get_title_from_options( 'title-' . $post_type, $object );
+		if ( ! is_object( $object ) ) {
+			return $this->get_title_from_options( 'title-404-wpseo' );
 		}
 
-		return $this->get_title_from_options( 'title-404-wpseo' );
+		$title = WPSEO_Meta::get_value( 'title', $object->ID );
+
+		if ( $title !== '' ) {
+			return wpseo_replace_vars( $title, $object );
+		}
+
+		$post_type = ( isset( $object->post_type ) ? $object->post_type : $object->query_var );
+
+		return $this->get_title_from_options( 'title-' . $post_type, $object );
 	}
 
 	/**
@@ -278,9 +278,8 @@ class WPSEO_Frontend {
 		if ( is_string( $title ) && $title !== '' ) {
 			return wpseo_replace_vars( $title, $object );
 		}
-		else {
-			return $this->get_title_from_options( 'title-tax-' . $object->taxonomy, $object );
-		}
+
+		return $this->get_title_from_options( 'title-tax-' . $object->taxonomy, $object );
 	}
 
 	/**
@@ -314,13 +313,11 @@ class WPSEO_Frontend {
 			if ( is_singular() ) {
 				return wpseo_replace_vars( '%%title%% %%sep%% %%sitename%%', $var_source );
 			}
-			else {
-				return '';
-			}
+
+			return '';
 		}
-		else {
-			return wpseo_replace_vars( $this->options[ $index ], $var_source );
-		}
+
+		return wpseo_replace_vars( $this->options[ $index ], $var_source );
 	}
 
 	/**
@@ -611,7 +608,7 @@ class WPSEO_Frontend {
 	 *
 	 * @param bool $echo Whether or not to echo the debug marker.
 	 *
-	 * @return string
+	 * @return string The marker that will be echoed.
 	 */
 	public function debug_mark( $echo = true ) {
 		$marker = sprintf(
@@ -628,9 +625,9 @@ class WPSEO_Frontend {
 		if ( $echo === false ) {
 			return $marker;
 		}
-		else {
-			echo "\n${marker}\n";
-		}
+
+		echo "\n${marker}\n";
+		return '';
 	}
 
 	/**
@@ -701,7 +698,7 @@ class WPSEO_Frontend {
 		$robots['follow'] = 'follow';
 		$robots['other']  = array();
 
-		if ( is_singular() && is_object( $post ) ) {
+		if ( is_object( $post ) && is_singular() ) {
 
 			$option_name = 'noindex-' . $post->post_type;
 			$noindex     = isset( $this->options[ $option_name ] ) && $this->options[ $option_name ] === true;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1975,7 +1975,7 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * Show the closing debug mark.
+	 * Shows the closing debug mark.
 	 *
 	 * @return string The closing debug mark comment.
 	 */

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1833,8 +1833,8 @@ class WPSEO_Frontend {
 		wp_reset_query();
 
 		// Only replace the debug marker when it is hooked.
-		if ( has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) ) {
-			$title   = $this->title( '' );
+		if ( $this->has_debug_mark_action() ) {
+			$title = $this->title( '' );
 
 			// Find all titles, strip them out and add the new one in within the debug marker, so it's easily identified whether a site uses force rewrite.
 			$content = preg_replace( '/<title.*?\/title>/i', '', $content );
@@ -1968,6 +1968,15 @@ class WPSEO_Frontend {
 	protected function redirect( $location, $status = 302 ) {
 		wp_safe_redirect( $location, $status );
 		exit;
+	}
+
+	/**
+	 * Checks if the debug mark action has been added.
+	 *
+	 * @return bool True when the action exists.
+	 */
+	protected function has_debug_mark_action() {
+		return has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) !== false;
 	}
 
 	/** Deprecated functions */

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -673,10 +673,12 @@ class WPSEO_Frontend {
 		 */
 		do_action( 'wpseo_head' );
 
-		printf(
-			"<!-- / %s. -->\n\n",
-			esc_html( $this->head_product_name() )
-		);
+		if ( has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) ) {
+			printf(
+				"<!-- / %s. -->\n\n",
+				esc_html( $this->head_product_name() )
+			);
+		}
 
 		if ( ! empty( $old_wp_query ) ) {
 			$GLOBALS['wp_query'] = $old_wp_query;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1970,6 +1970,7 @@ class WPSEO_Frontend {
 	 * @return string
 	 */
 	public function debug_marker( $echo = false ) {
+		_deprecated_function( 'WPSEO_Frontend::debug_marker', '4.4', 'WPSEO_Frontend::debug_mark' );
 		return $this->debug_mark( $echo );
 	}
 	// @codeCoverageIgnoreEnd

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -143,7 +143,7 @@ class WPSEO_Frontend {
 		add_filter( 'the_excerpt_rss', array( $this, 'embed_rssfooter_excerpt' ) );
 
 		// For WordPress functions below 4.4.
-		if ( ! current_theme_supports( 'title-tag' ) && $this->options['forcerewritetitle'] === true ) {
+		if ( $this->options['forcerewritetitle'] === true && ! current_theme_supports( 'title-tag' ) ) {
 			add_action( 'template_redirect', array( $this, 'force_rewrite_output_buffer' ), 99999 );
 			add_action( 'wp_footer', array( $this, 'flush_cache' ), - 1 );
 		}

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1450,8 +1450,8 @@ class WPSEO_Frontend {
 			( $this->options['disable-author'] === true && $wp_query->is_author ) ||
 			( $this->options['disable-post_format'] === true && $wp_query->is_tax( 'post_format' ) )
 		) {
-			wp_safe_redirect( get_bloginfo( 'url' ), 301 );
-			exit;
+			$this->redirect( get_bloginfo( 'url' ), 301 );
+			return true;
 		}
 
 		return false;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -84,7 +84,7 @@ class WPSEO_Frontend {
 		add_action( 'wp_head', array( $this, 'head' ), 1 );
 
 		// The head function here calls action wpseo_head, to which we hook all our functionality.
-		add_action( 'wpseo_head', array( $this, 'show_debug_mark' ), 2 );
+		add_action( 'wpseo_head', array( $this, 'debug_mark' ), 2 );
 		add_action( 'wpseo_head', array( $this, 'metadesc' ), 6 );
 		add_action( 'wpseo_head', array( $this, 'robots' ), 10 );
 		add_action( 'wpseo_head', array( $this, 'metakeywords' ), 11 );
@@ -603,15 +603,25 @@ class WPSEO_Frontend {
 		return $title;
 	}
 
+
+
 	/**
-	 * Outputs the debug marker.
+	 * Outputs or returns the debug marker, which is also used for title replacement when force rewrite is active.
 	 *
-	 * @return void.
+	 * @param bool $echo Whether or not to echo the debug marker.
+	 *
+	 * @return string The marker that will be echoed.
 	 */
-	public function show_debug_mark() {
+	public function debug_mark( $echo = true ) {
 		$marker = $this->get_debug_mark();
+		if ( $echo === false ) {
+			_deprecated_argument( 'WPSEO_Frontend::debug_mark', '5.9', 'WPSEO_Frontend::get_debug_mark' );
+
+			return $marker;
+		}
 
 		echo "\n${marker}\n";
+		return '';
 	}
 
 	/**
@@ -675,7 +685,7 @@ class WPSEO_Frontend {
 		 */
 		do_action( 'wpseo_head' );
 
-		if ( has_action( 'wpseo_head', array( $this, 'show_debug_mark' ) ) ) {
+		if ( has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) ) {
 			printf(
 				"<!-- / %s. -->\n\n",
 				esc_html( $this->head_product_name() )
@@ -1825,7 +1835,7 @@ class WPSEO_Frontend {
 		wp_reset_query();
 
 		// Only replace the debug marker when it is hooked.
-		if ( has_action( 'wpseo_head', array( $this, 'show_debug_mark' ) ) ) {
+		if ( has_action( 'wpseo_head', array( $this, 'debug_mark' ) ) ) {
 			$title   = $this->title( '' );
 
 			// Find all titles, strip them out and add the new one in within the debug marker, so it's easily identified whether a site uses force rewrite.
@@ -1975,29 +1985,6 @@ class WPSEO_Frontend {
 	public function debug_marker( $echo = false ) {
 		_deprecated_function( 'WPSEO_Frontend::debug_marker', '4.4', 'WPSEO_Frontend::debug_mark' );
 		return $this->debug_mark( $echo );
-	}
-
-	/**
-	 * Outputs or returns the debug marker, which is also used for title replacement when force rewrite is active.
-	 *
-	 * @deprecated 5.9
-	 *
-	 * @param bool $echo Whether or not to echo the debug marker.
-	 *
-	 * @return string The marker that will be echoed.
-	 */
-	public function debug_mark( $echo = true ) {
-
-		if ( $echo === false ) {
-			_deprecated_function( 'WPSEO_Frontend::debug_mark', '5.9', 'WPSEO_Frontend::get_debug_mark' );
-
-			return $this->get_debug_mark();
-		}
-
-		_deprecated_function( 'WPSEO_Frontend::debug_mark', '5.9', 'WPSEO_Frontend::show_debug_mark' );
-
-		$this->show_debug_mark();
-		return '';
 	}
 	// @codeCoverageIgnoreEnd
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: SEO, XML sitemap, Google Search Console, Content analysis, Readability
 Requires at least: 4.6
-Tested up to: 4.8.3
+Tested up to: 4.9
 Stable tag: 5.8
 Requires PHP: 5.2.4
 
@@ -128,6 +128,9 @@ You'll find answers to many of your questions on [kb.yoast.com](https://kb.yoast
 = 5.8.0 =
 
 Release Date: November 15th, 2017
+
+Security:
+    * Fixes an XSS vulnerability in the Google Search Console configuration page, when connected to any profile.
 
 Bugfixes:
     * Fixes a bug where inactive suggested plugins weren't displaying a notification.

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -5,6 +5,8 @@
 
 /**
  * Unit Test Class.
+ *
+ * @group test
  */
 class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
@@ -779,15 +781,17 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_debug_mark' ) )
+			->setMethods( array( 'has_debug_mark_action', 'get_debug_mark' ) )
 			->getMock();
 
 		$frontend
 			->expects( $this->never() )
 			->method( 'get_debug_mark' );
 
-		// First remove the action
-		remove_action( 'wpseo_head', array( $frontend, 'debug_mark' ), 2 );
+		$frontend
+			->expects( $this->once() )
+			->method( 'has_debug_mark_action' )
+			->will( $this->returnValue( false ) );
 
 		// Enables the output buffering.
 		$frontend->force_rewrite_output_buffer();
@@ -800,6 +804,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Checks the value of the debug mark getter when the premium version is 'active'.
 	 * @covers WPSEO_Frontend::head_product_name()
 	 */
 	public function test_head_get_debug_mark_for_premium() {
@@ -818,6 +823,8 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Checks the value of the debug mark getter when the free version is 'active'.
+	 *
 	 * @covers WPSEO_Frontend::head_product_name()
 	 */
 	public function test_head_get_debug_mark_for_free() {
@@ -844,8 +851,13 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_debug_mark' ) )
+			->setMethods( array( 'has_debug_mark_action', 'get_debug_mark' ) )
 			->getMock();
+
+		$frontend
+			->expects( $this->once() )
+			->method( 'has_debug_mark_action' )
+			->will( $this->returnValue( true ) );
 
 		$frontend
 			->expects( $this->exactly(2) )
@@ -859,6 +871,52 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 		// Run assertions.
 		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests the situation where the closing debug mark should be shown.
+	 *
+	 * @covers WPSEO_Frontend::show_closing_debug_mark
+	 */
+	public function test_show_closing_debug_mark_with_debug_mark_hook_being_set() {
+		/** @var $frontend WPSEO_Frontend_Double */
+		$frontend = $this
+			->getMockBuilder( 'WPSEO_Frontend_Double' )
+			->setMethods( array( 'has_debug_mark_action' ) )
+			->getMock();
+
+		$frontend
+			->expects( $this->once() )
+			->method( 'has_debug_mark_action' )
+			->will( $this->returnValue( true ) );
+
+		$frontend->head();
+
+		$this->expectOutputContains( '<!-- / Yoast SEO plugin. -->'  );
+	}
+
+	/**
+	 * Tests the situation where the closing debug mark shouldn't be shown.
+	 *
+	 * @covers WPSEO_Frontend::show_closing_debug_mark
+	 */
+	public function test_show_closing_debug_mark_with_debug_mark_hook_not_being_set() {
+		/** @var $frontend WPSEO_Frontend_Double */
+		$frontend = $this
+			->getMockBuilder( 'WPSEO_Frontend_Double' )
+			->setMethods( array( 'has_debug_mark_action' ) )
+			->getMock();
+
+		$frontend
+			->expects( $this->once() )
+			->method( 'has_debug_mark_action' )
+			->will( $this->returnValue( false ) );
+
+		$frontend->head();
+
+		$output = $this->getActualOutput();
+
+		$this->assertFalse( stripos( $output, '<!-- / Yoast SEO plugin. -->' )  );
 	}
 
 	/**

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -761,11 +761,44 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the situation for flush cash when the debug_mark is not being hooked.
+	 *
 	 * @covers WPSEO_Frontend::flush_cache
 	 */
-	public function test_flush_cache() {
+	public function test_flush_cache_with_debug_mark_hook_not_being_set() {
 
 		$c = self::$class_instance;
+
+		// Should not run when output buffering is not turned on.
+		$this->assertFalse( self::$class_instance->flush_cache() );
+
+		// Turn on output buffering.
+		self::$class_instance->force_rewrite_output_buffer();
+
+		$content = '<!DOCTYPE><html><head><title>TITLETOBEREPLACED</title>' . self::$class_instance->debug_mark( false ) . '</head><body>Some body content. Should remain unchanged.</body></html>';
+
+		// Create expected output.
+		$expected = $content;
+		echo $content;
+
+		// Run function.
+		$result = self::$class_instance->flush_cache();
+
+		// Run assertions.
+		$this->expectOutput( $expected, $result );
+		$this->assertTrue( $result );
+	}
+
+
+	/**
+	 * Tests the situation for flush cash when the debug_mark is being hooked.
+	 *
+	 * @covers WPSEO_Frontend::flush_cache
+	 */
+	public function test_flush_cache_with_debug_mark_hook_being_set() {
+
+		$c = self::$class_instance;
+		add_action( 'wpseo_head', array( $c, 'debug_mark' ) );
 
 		// Should not run when output buffering is not turned on.
 		$this->assertFalse( self::$class_instance->flush_cache() );

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -787,7 +787,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 			->method( 'get_debug_mark' );
 
 		// First remove the action
-		remove_action( 'wpseo_head', array( $frontend, 'show_debug_mark' ), 2 );
+		remove_action( 'wpseo_head', array( $frontend, 'debug_mark' ), 2 );
 
 		// Enables the output buffering.
 		$frontend->force_rewrite_output_buffer();

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -516,6 +516,25 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the situation where the archive redirect has been redirected.
+	 *
+	 * @covers WPSEO_Frontend::archive_redirect()
+	 */
+	public function test_archive_redirect_being_redirected() {
+		global $wp_query;
+
+		$frontend = self::$class_instance;
+
+		$wp_query->is_author                 = true;
+		$frontend->options['disable-author'] = true;
+		$this->assertTrue( $frontend->archive_redirect() );
+
+		$wp_query->is_date                 = true;
+		$frontend->options['disable-date'] = true;
+		$this->assertTrue( $frontend->archive_redirect() );
+	}
+
+	/**
 	 * Tests for attachment redirect an attachment page with parent.
 	 *
 	 * @covers WPSEO_Frontend::attachment_redirect

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -781,7 +781,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'has_debug_mark_action', 'get_debug_mark' ) )
+			->setMethods( array( 'show_debug_marker', 'get_debug_mark' ) )
 			->getMock();
 
 		$frontend
@@ -790,7 +790,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 
 		$frontend
 			->expects( $this->once() )
-			->method( 'has_debug_mark_action' )
+			->method( 'show_debug_marker' )
 			->will( $this->returnValue( false ) );
 
 		// Enables the output buffering.
@@ -851,12 +851,12 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'has_debug_mark_action', 'get_debug_mark' ) )
+			->setMethods( array( 'show_debug_marker', 'get_debug_mark' ) )
 			->getMock();
 
 		$frontend
 			->expects( $this->once() )
-			->method( 'has_debug_mark_action' )
+			->method( 'show_debug_marker' )
 			->will( $this->returnValue( true ) );
 
 		$frontend
@@ -882,12 +882,12 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'has_debug_mark_action' ) )
+			->setMethods( array( 'show_debug_marker' ) )
 			->getMock();
 
 		$frontend
 			->expects( $this->once() )
-			->method( 'has_debug_mark_action' )
+			->method( 'show_debug_marker' )
 			->will( $this->returnValue( true ) );
 
 		$frontend->head();
@@ -904,12 +904,12 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'has_debug_mark_action' ) )
+			->setMethods( array( 'show_debug_marker' ) )
 			->getMock();
 
 		$frontend
 			->expects( $this->once() )
-			->method( 'has_debug_mark_action' )
+			->method( 'show_debug_marker' )
 			->will( $this->returnValue( false ) );
 
 		$frontend->head();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the title isn't added back to the HTML, when the debug marker has been disabled.
* Makes it easier to unhook the logic for adding the debug marker.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout `trunk`
* Remove the action `remove_action( 'wpseo_head', array( $this, 'debug_mark' ), 2 );`
* Go to the front page and view the source. See the line: `<!-- This site is optimized with the Yoast SEO plugin v5.8 - https://yoast.com/wordpress/plugins/seo/ -->` being removed. Note: `<!-- / Yoast SEO plugin. -->` will be still visible.
* Checkout this branch and do step 2 and 3. It should be solved now.

Additional
* There has been made a code change for WordPress < 4.4 and themes that hasn't title-tag support. You might want to test this as well (good luck). I've added a unit test, to cover this. 
* If you want to test this just have a WordPress version below 4.4 and have a team without title-tag support. This last thing can be achieved by remove the line `add_theme_support('title-tag');` that might be somewhere in that theme. And in the Yoast SEO settings there is an option (I guess under titles & metas) that forces the rewrite of the title.

Fixes #8287 
Fixes #8286 