### PR TITLE
Bump yoast-components version to 2.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-intl": "^2.4.0",
     "react-tap-event-plugin": "^2.0.0",
     "select2": "^4.0.3",
-    "yoast-components": "^2.11.2",
+    "yoast-components": "^2.11.3",
     "yoastseo": "^1.23.1"
   }
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Change dashboard widget progress bar size to `24px`.
* Make Onboarding Wizard `Next` and `Back` buttons focussable.
