### PR TITLE
Fixed issue where links to premium plugins were being created

### DIFF
--- a/admin/class-admin-utils.php
+++ b/admin/class-admin-utils.php
@@ -43,4 +43,26 @@ class WPSEO_Admin_Utils {
 			'activate-plugin_' . $slug
 		);
 	}
+
+	/**
+	 * Creates a link if the passed plugin is deemend a directly-installable plugin.
+	 *
+	 * @param array $plugin The plugin to create the link for.
+	 *
+	 * @return string The link to the plugin install. Returns the title if the plugin is deemed a Premium product.
+	 */
+	public static function get_install_link( $plugin ) {
+		$install_url = WPSEO_Admin_Utils::get_install_url( $plugin['slug'] );
+
+		if ( $install_url === '' || ( isset( $plugin['premium'] ) && $plugin['premium'] === true ) ) {
+			return $plugin['title'];
+		}
+
+		return sprintf(
+			'<a href="%s">%s</a>',
+			$install_url,
+			$plugin['title']
+		);
+
+	}
 }

--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -37,6 +37,7 @@ class WPSEO_Plugin_Availability {
 				'installed'    => false,
 				'slug'         => 'wordpress-seo-premium/wp-seo-premium.php',
 				'version_sync' => true,
+				'premium'       => true,
 			),
 
 			'video-seo-for-wordpress-seo-by-yoast' => array(
@@ -46,6 +47,7 @@ class WPSEO_Plugin_Availability {
 				'installed'    => false,
 				'slug'         => 'wpseo-video/video-seo.php',
 				'version_sync' => true,
+				'premium'       => true,
 			),
 
 			'yoast-news-seo' => array(
@@ -55,6 +57,7 @@ class WPSEO_Plugin_Availability {
 				'installed'    => false,
 				'slug'         => 'wpseo-news/wpseo-news.php',
 				'version_sync' => true,
+				'premium'       => true,
 			),
 
 			'local-seo-for-yoast-seo' => array(
@@ -64,6 +67,7 @@ class WPSEO_Plugin_Availability {
 				'installed'    => false,
 				'slug'         => 'wordpress-seo-local/local-seo.php',
 				'version_sync' => true,
+				'premium'       => true,
 			),
 
 			'yoast-woocommerce-seo' => array(
@@ -82,6 +86,7 @@ class WPSEO_Plugin_Availability {
 				'installed'     => false,
 				'slug'          => 'wpseo-woocommerce/wpseo-woocommerce.php',
 				'version_sync'  => true,
+				'premium'       => true,
 			),
 
 			'yoast-acf-analysis' => array(
@@ -322,5 +327,16 @@ class WPSEO_Plugin_Availability {
 	 */
 	public function is_active( $plugin ) {
 		return is_plugin_active( $plugin );
+	}
+
+	/**
+	 * Determines whether or not a plugin is a Premium product.
+	 *
+	 * @param array $plugin The plugin to check.
+	 *
+	 * @return bool Whether or not the plugin is a Premium product.
+	 */
+	public function is_premium( $plugin ) {
+		return isset( $plugin['premium'] ) && $plugin['premium'] === true;
 	}
 }

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -104,14 +104,14 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 */
 	protected function create_install_suggested_plugin_message( $suggested_plugin, $third_party_plugin ) {
 		/* translators: %1$s expands to Yoast SEO, %2$s expands to the dependency name, %3$s expands to the install link, %4$s expands to the more info link. */
-		$message     = __( '%1$s and %2$s can work together a lot better by adding a helper plugin. Please install %3$s to make your life better. %4$s.', 'wordpress-seo' );
-		$install_url = WPSEO_Admin_Utils::get_install_url( $suggested_plugin['slug'] );
+		$message        = __( '%1$s and %2$s can work together a lot better by adding a helper plugin. Please install %3$s to make your life better. %4$s.', 'wordpress-seo' );
+		$install_link   = WPSEO_Admin_Utils::get_install_link( $suggested_plugin );
 
 		return sprintf(
 			$message,
 			'Yoast SEO',
 			$third_party_plugin,
-			sprintf( '<a href="%s">%s</a>', $install_url, $suggested_plugin['title'] ),
+			$install_link,
 			$this->create_more_information_link( $suggested_plugin['url'], $suggested_plugin['title'] )
 		);
 	}

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -23,7 +23,7 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Set up our double class
+	 * Set up our double class.
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -34,6 +34,9 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 		self::$class_instance = $plugin_availability;
 	}
 
+	/**
+	 * Tests whether or not a plugin exists.
+	 */
 	public function test_plugin_existence() {
 		$expected = array(
 			'url'          => 'https://yoast.com/',
@@ -49,6 +52,9 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( self::$class_instance->get_plugin( 'non-exisiting-test-plugin' ), array() );
 	}
 
+	/**
+	 * Tests whether or not plugins are available.
+	 */
 	public function test_plugin_availability() {
 		$plugin    = self::$class_instance->get_plugin( 'test-plugin' );
 		$available = self::$class_instance->is_available( $plugin );
@@ -61,6 +67,9 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( $available );
 	}
 
+	/**
+	 * Tests whether or not plugins are installed.
+	 */
 	public function test_plugin_is_installed() {
 		$plugin    = self::$class_instance->get_plugin( 'test-plugin' );
 		$installed = self::$class_instance->is_installed( $plugin );
@@ -73,6 +82,9 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( $installed );
 	}
 
+	/**
+	 * Tests for the plugin version.
+	 */
 	public function test_plugin_version() {
 		$plugin  = self::$class_instance->get_plugin( 'test-plugin' );
 		$version = self::$class_instance->get_version( $plugin );
@@ -85,4 +97,16 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $version, '' );
 	}
 
+	/**
+	 * Tests for the detection of Premium plugins.
+	 */
+	public function test_plugin_is_premium() {
+		$is_premium_plugin  = self::$class_instance->is_premium( self::$class_instance->get_plugin( 'test-plugin' ) );
+
+		$this->assertFalse( $is_premium_plugin );
+
+		$is_premium_plugin  = self::$class_instance->is_premium( self::$class_instance->get_plugin( 'test-premium-plugin' ) );
+
+		$this->assertTrue( $is_premium_plugin );
+	}
 }

--- a/tests/admin/test-class-plugin-compatibility.php
+++ b/tests/admin/test-class-plugin-compatibility.php
@@ -85,6 +85,16 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 				'version_sync' => false,
 				'compatible'   => true,
 			),
+			'test-premium-plugin' => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '1.3',
+				'installed'    => true,
+				'version_sync' => false,
+				'compatible'   => true,
+				'premium'      => true,
+			),
 		);
 
 		$this->assertEquals( self::$class_instance->get_installed_plugins_compatibility(), $expected );
@@ -140,10 +150,18 @@ class WPSEO_Plugin_Compatibility_Test extends WPSEO_UnitTestCase {
 				'version_sync' => false,
 				'compatible'   => true,
 			),
+			'test-premium-plugin' => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '1.3',
+				'installed'    => true,
+				'version_sync' => false,
+				'compatible'   => true,
+				'premium'      => true,
+			),
 		);
 
 		$this->assertEquals( $expected, self::$class_instance->get_installed_plugins() );
 	}
-
-
 }

--- a/tests/doubles/class-wpseo-plugin-availability-double.php
+++ b/tests/doubles/class-wpseo-plugin-availability-double.php
@@ -104,6 +104,16 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'version_sync' => false,
 				'compatible'   => true,
 			),
+			'test-premium-plugin' => array(
+				'url'          => 'https://yoast.com/',
+				'title'        => 'Test Plugin',
+				'description'  => '',
+				'version'      => '1.3',
+				'installed'    => true,
+				'version_sync' => false,
+				'compatible'   => true,
+				'premium'      => true,
+			),
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes how install links are generated for Suggested Plugins by checking whether or not the suggestion is a Premium product or not.

## Test instructions

This PR can be tested by following these steps:

* Install Yoast SEO (`trunk`)
* Install WooCommerce
* Go to YoastSEO -> Dashboard and see that there's a notification suggesting you install Yoast WooCommerce SEO (the name should be a link that is broken)
* Checkout this branch
* Go through the same steps and determine that the name is no longer a link.

Fixes #8303 
