### PR TITLE
Check if both analysis are available

### DIFF
--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -94,6 +94,12 @@ class WPSEO_Taxonomy_Fields_Presenter {
 				$field .= '<div id="wpseosnippet" class="wpseosnippet"></div>';
 				break;
 			case 'pageanalysis':
+				$options = WPSEO_Options::get_option( 'wpseo' );
+
+ 				if ( $options['content_analysis_active'] === false && $options['keyword_analysis_active'] === false ) {
+ 					break;
+			    }
+
 				$field .= '<div id="pageanalysis">';
 				$field .= '<section class="yoast-section" id="wpseo-pageanalysis-section">';
 				$field .= '<h3 class="yoast-section__heading yoast-section__heading-icon yoast-section__heading-icon-list">' . __( 'Analysis', 'wordpress-seo' ) . '</h3>';

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -96,9 +96,9 @@ class WPSEO_Taxonomy_Fields_Presenter {
 			case 'pageanalysis':
 				$options = WPSEO_Options::get_option( 'wpseo' );
 
- 				if ( $options['content_analysis_active'] === false && $options['keyword_analysis_active'] === false ) {
- 					break;
-			    }
+				if ( $options['content_analysis_active'] === false && $options['keyword_analysis_active'] === false ) {
+					break;
+				}
 
 				$field .= '<div id="pageanalysis">';
 				$field .= '<section class="yoast-section" id="wpseo-pageanalysis-section">';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where an empty div is visible when both content and readability analysis are disabled.


## Test instructions

This PR can be tested by following these steps:

* Checkout `trunk`
* Disable the content and readability analysis
* Go the a term edit page and see an empty div appearing in the metabox.
* Checkout this branch and see it being solved.

Fixes #8319
