### PR TITLE
Adjust language notice for non admins

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -105,14 +105,16 @@ class WPSEO_Metabox_Formatter {
 	 */
 	private function get_content_analysis_component_translations() {
 		return array(
-			'locale'                                => WPSEO_Utils::get_user_locale(),
-			'content-analysis.language-notice-link' => __( 'Change language', 'wordpress-seo' ),
-			'content-analysis.errors'               => __( 'Errors', 'wordpress-seo' ),
-			'content-analysis.problems'             => __( 'Problems', 'wordpress-seo' ),
-			'content-analysis.improvements'         => __( 'Improvements', 'wordpress-seo' ),
-			'content-analysis.considerations'       => __( 'Considerations', 'wordpress-seo' ),
-			'content-analysis.good'                 => __( 'Good', 'wordpress-seo' ),
-			'content-analysis.highlight'            => __( 'Highlight this result in the text', 'wordpress-seo' ),
+			'locale'                                         => WPSEO_Utils::get_user_locale(),
+			'content-analysis.language-notice-link'          => __( 'Change language', 'wordpress-seo' ),
+			'content-analysis.errors'                        => __( 'Errors', 'wordpress-seo' ),
+			'content-analysis.problems'                      => __( 'Problems', 'wordpress-seo' ),
+			'content-analysis.improvements'                  => __( 'Improvements', 'wordpress-seo' ),
+			'content-analysis.considerations'                => __( 'Considerations', 'wordpress-seo' ),
+			'content-analysis.good'                          => __( 'Good', 'wordpress-seo' ),
+			'content-analysis.highlight'                     => __( 'Highlight this result in the text', 'wordpress-seo' ),
+			'content-analysis.language-notice'               => __( 'Your site language is set to {language}.', 'wordpress-seo' ),
+			'content-analysis.language-notice-contact-admin' => __( 'Contact your site administrator, if this is not correct.', 'wordpress-seo' ),
 		);
 	}
 

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -114,7 +114,7 @@ class WPSEO_Metabox_Formatter {
 			'content-analysis.good'                          => __( 'Good', 'wordpress-seo' ),
 			'content-analysis.highlight'                     => __( 'Highlight this result in the text', 'wordpress-seo' ),
 			'content-analysis.language-notice'               => __( 'Your site language is set to {language}.', 'wordpress-seo' ),
-			'content-analysis.language-notice-contact-admin' => __( 'Contact your site administrator, if this is not correct.', 'wordpress-seo' ),
+			'content-analysis.language-notice-contact-admin' => __( 'Your site language is set to {language}. If this is not correct, contact your site administrator.', 'wordpress-seo' ),
 		);
 	}
 

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -21,7 +21,8 @@ class ReadabilityAnalysis extends React.Component {
 	render() {
 		return (
 			<Results
-				showLanguageNotice={ ! ( localizedData.settings_link === "" ) }
+				canChangeLanguage={ ! ( localizedData.settings_link === "" ) }
+				showLanguageNotice={ true }
 				changeLanguageLink={ localizedData.settings_link }
 				language={ localizedData.language }
 				results={ this.props.results } />

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -59,6 +59,7 @@ class Results extends React.Component {
 				changeLanguageLink={ this.props.changeLanguageLink }
 				language={ this.props.language }
 				showLanguageNotice={ this.props.showLanguageNotice }
+				canChangeLanguage={ this.props.canChangeLanguage }
 				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) } />
 		);
 	}
@@ -69,11 +70,13 @@ Results.propTypes = {
 	language: PropTypes.string,
 	changeLanguageLink: PropTypes.string,
 	showLanguageNotice: PropTypes.bool.isRequired,
+	canChangeLanguage: PropTypes.bool,
 };
 
 Results.defaultProps = {
 	language: "",
 	changeLanguageLink: "#",
+	canChangeLanguage: false,
 };
 
 export default Results;

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -55,7 +55,7 @@ function configureStore() {
 function wrapInTopLevelComponents( Component, store ) {
 	return (
 		<IntlProvider
-			locale={ localizedData.intl.locale }
+			locale={ localizedData.intl.locale.substr( 0, 2 ).toLowerCase() }
 			messages={ localizedData.intl } >
 			<Provider store={ store } >
 				<Component />


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The language notice in the content analysis can be changed for non-admin users that cannot change the language.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Needs a release of `yoast-components` with Yoast/yoast-components#389 merged.

Fixes Yoast/yoast-components#384