### PR TITLE
CS: rename two functions

### DIFF
--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -32,7 +32,7 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 /**
  * Outputs a help center.
  */
-function render_help_center() {
+function yoast_render_help_center() {
 	$tabs = new WPSEO_Option_Tabs( '', '' );
 	$tabs->add_tab( new WPSEO_Option_Tab( 'title', __( 'Bulk editor', 'wordpress-seo' ),
 		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
@@ -51,7 +51,7 @@ function render_help_center() {
  * @param WPSEO_Bulk_List_Table $table The table to render.
  * @param string                $id    The id for the tab.
  */
-function get_rendered_tab( $table, $id ) {
+function wpseo_get_rendered_tab( $table, $id ) {
 	?>
 	<div id="<?php echo esc_attr( $id ); ?>" class="wpseotab">
 		<?php
@@ -79,10 +79,10 @@ function get_rendered_tab( $table, $id ) {
 			href="#top#description"><?php esc_html_e( 'Description', 'wordpress-seo' ); ?></a>
 	</h2>
 
-	<?php render_help_center(); ?>
+	<?php yoast_render_help_center(); ?>
 
 	<div class="tabwrapper">
-		<?php get_rendered_tab( $wpseo_bulk_titles_table, 'title' ); ?>
-		<?php get_rendered_tab( $wpseo_bulk_description_table, 'description' ); ?>
+		<?php wpseo_get_rendered_tab( $wpseo_bulk_titles_table, 'title' ); ?>
+		<?php wpseo_get_rendered_tab( $wpseo_bulk_description_table, 'description' ); ?>
 	</div>
 </div>

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -32,7 +32,7 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 /**
  * Outputs a help center.
  */
-function yoast_render_help_center() {
+function wpseo_render_help_center() {
 	$tabs = new WPSEO_Option_Tabs( '', '' );
 	$tabs->add_tab( new WPSEO_Option_Tab( 'title', __( 'Bulk editor', 'wordpress-seo' ),
 		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
@@ -79,7 +79,7 @@ function wpseo_get_rendered_tab( $table, $id ) {
 			href="#top#description"><?php esc_html_e( 'Description', 'wordpress-seo' ); ?></a>
 	</h2>
 
-	<?php yoast_render_help_center(); ?>
+	<?php wpseo_render_help_center(); ?>
 
 	<div class="tabwrapper">
 		<?php wpseo_get_rendered_tab( $wpseo_bulk_titles_table, 'title' ); ?>


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Functions should be prefixed with a plugin specific prefix.

These are two internal functions defined within a view, so the impact on userland code hooking into WPSEO should be negligible.

## Test instructions
Yes, please!