### PR TITLE
CS/XSS: always escape output - 4

### DIFF
--- a/admin/google_search_console/views/gsc-redirect-nopremium.php
+++ b/admin/google_search_console/views/gsc-redirect-nopremium.php
@@ -5,8 +5,13 @@
  * This is the view for the modal box that appears when premium isn't loaded.
  */
 
-/* Translators: %s: expands to Yoast SEO Premium */
-echo '<h1 class="wpseo-redirect-url-title">', sprintf( __( 'Creating redirects is a %s feature', 'wordpress-seo' ), 'Yoast SEO Premium' ), '</h1>';
+echo '<h1 class="wpseo-redirect-url-title">';
+printf(
+	/* Translators: %s: expands to Yoast SEO Premium */
+	esc_html__( 'Creating redirects is a %s feature', 'wordpress-seo' ),
+	'Yoast SEO Premium'
+);
+echo '</h1>';
 echo '<p>';
 printf(
 	/* Translators: %1$s: expands to 'Yoast SEO Premium', %2$s: links to Yoast SEO Premium plugin page. */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.