### PR TITLE
CS/XSS: always escape output - 5

### DIFF
--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -119,8 +119,14 @@ if ( $use_dropdown === true ) {
 }
 else {
 	$yform->textinput( 'defaultblog', __( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ), 'wpseo_ms' );
-	/* translators: 1: link open tag; 2: link close tag. */
-	echo '<p>' . sprintf( __( 'Enter the %1$sSite ID%2$s for the site whose settings you want to use as default for all sites that are added to your network. Leave empty for none (i.e. the normal plugin defaults will be used).', 'wordpress-seo' ), '<a href="' . esc_url( network_admin_url( 'sites.php' ) ) . '">', '</a>' ) . '</p>';
+	echo '<p>';
+	printf(
+		/* translators: 1: link open tag; 2: link close tag. */
+		esc_html__( 'Enter the %1$sSite ID%2$s for the site whose settings you want to use as default for all sites that are added to your network. Leave empty for none (i.e. the normal plugin defaults will be used).', 'wordpress-seo' ),
+		'<a href="' . esc_url( network_admin_url( 'sites.php' ) ) . '">',
+		'</a>'
+	);
+	echo '</p>';
 }
 	echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.