### PR TITLE
CS/XSS: always escape output - 6

### DIFF
--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -48,8 +48,13 @@ if ( '' === $tool_page ) {
 		}
 	*/
 
-	/* translators: %1$s expands to Yoast SEO */
-	echo '<p>', sprintf( __( '%1$s comes with some very powerful built-in tools:', 'wordpress-seo' ), 'Yoast SEO' ), '</p>';
+	echo '<p>';
+	printf(
+		/* translators: %1$s expands to Yoast SEO */
+		esc_html__( '%1$s comes with some very powerful built-in tools:', 'wordpress-seo' ),
+		'Yoast SEO'
+	);
+	echo '</p>';
 
 	asort( $tools );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.