### PR TITLE
CS/XSS: always escape output - 7

### DIFF
--- a/admin/views/tabs/advanced/breadcrumbs.php
+++ b/admin/views/tabs/advanced/breadcrumbs.php
@@ -92,7 +92,11 @@ unset( $taxonomies, $post_types );
 <h2><?php esc_html_e( 'How to insert breadcrumbs in your theme', 'wordpress-seo' ); ?></h2>
 <p>
 	<?php
-	/* translators: %1$s / %2$s: links to the breadcrumbs implementation page on the Yoast knowledgebase */
-	printf( __( 'Usage of this breadcrumbs feature is explained in %1$sour knowledge-base article on breadcrumbs implementation%2$s.', 'wordpress-seo' ), '<a href="' . WPSEO_Shortlinker::get( 'http://yoa.st/breadcrumbs' ) . '" target="_blank">', '</a>' );
+	printf(
+		/* translators: %1$s / %2$s: links to the breadcrumbs implementation page on the Yoast knowledgebase */
+		esc_html__( 'Usage of this breadcrumbs feature is explained in %1$sour knowledge-base article on breadcrumbs implementation%2$s.', 'wordpress-seo' ),
+		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'http://yoa.st/breadcrumbs' ) ) . '" target="_blank">',
+		'</a>'
+	);
 	?>
 </p>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.