### PR TITLE
CS/XSS: always escape output - 8

### DIFF
--- a/admin/views/tabs/advanced/permalinks.php
+++ b/admin/views/tabs/advanced/permalinks.php
@@ -38,9 +38,15 @@ echo '<p>' . __( 'This prevents threaded replies from working when the user has 
 $options = WPSEO_Options::get_all();
 if ( substr( get_option( 'permalink_structure' ), -1 ) !== '/' && $options['trailingslash'] ) {
 	$yform->light_switch( 'trailingslash', __( 'Enforce a trailing slash on all category and tag URLs', 'wordpress-seo' ) );
-	echo '<p><strong>' . __( 'Note: this feature has been deprecated, as the SEO value is close to 0 these days. If you disable it you will not be able to put it back on.', 'wordpress-seo' ) . '</strong></p>';
-	/* translators: %1$s expands to <code>.html</code>, %2$s expands to <code>/</code> */
-	echo '<p>' . sprintf( __( 'If you choose a permalink for your posts with %1$s, or anything else but a %2$s at the end, this will force WordPress to add a trailing slash to non-post pages nonetheless.', 'wordpress-seo' ), '<code>.html</code>', '<code>/</code>' ) . '</p>';
+	echo '<p><strong>' . esc_html__( 'Note: this feature has been deprecated, as the SEO value is close to 0 these days. If you disable it you will not be able to put it back on.', 'wordpress-seo' ) . '</strong></p>';
+	echo '<p>';
+	printf(
+		/* translators: %1$s expands to <code>.html</code>, %2$s expands to <code>/</code> */
+		esc_html__( 'If you choose a permalink for your posts with %1$s, or anything else but a %2$s at the end, this will force WordPress to add a trailing slash to non-post pages nonetheless.', 'wordpress-seo' ),
+		'<code>.html</code>',
+		'<code>/</code>'
+	);
+	echo '</p>';
 }
 
 $yform->light_switch( 'cleanpermalinks', __( 'Redirect ugly URLs to clean permalinks. (Not recommended in many cases!)', 'wordpress-seo' ), $redirect_buttons );
@@ -51,8 +57,13 @@ $yform->light_switch( 'cleanpermalink-googlesitesearch', __( 'Prevent cleaning o
 echo '<p>' . esc_html__( 'Google Site Search URLs look weird, and ugly, but if you\'re using Google Site Search, you probably do not want them cleaned out.', 'wordpress-seo' ) . '</p>';
 
 $yform->light_switch( 'cleanpermalink-googlecampaign', __( 'Prevent cleaning out Google Analytics Campaign & Google AdWords Parameters.', 'wordpress-seo' ) );
-/* translators: %s expands to <code>?utm_</code> */
-echo '<p>' . sprintf( __( 'If you use Google Analytics campaign parameters starting with %s, check this box. However, you\'re advised not to use these. Instead, use the version with a hash.', 'wordpress-seo' ), '<code>?utm_</code>' ) . '</p>';
+echo '<p>';
+printf(
+	/* translators: %s expands to <code>?utm_</code> */
+	esc_html__( 'If you use Google Analytics campaign parameters starting with %s, check this box. However, you\'re advised not to use these. Instead, use the version with a hash.', 'wordpress-seo' ),
+	'<code>?utm_</code>'
+);
+echo '</p>';
 
 $yform->textinput( 'cleanpermalink-extravars', __( 'Other variables not to clean', 'wordpress-seo' ) );
 echo '<p>' . esc_html__( 'You might have extra variables you want to prevent from cleaning out, add them here, comma separated.', 'wordpress-seo' ) . '</p>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.