### PR TITLE
CS/XSS: always escape output - 9

### DIFF
--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -14,8 +14,11 @@ if ( WPSEO_Utils::is_api_available() && current_user_can( WPSEO_Configuration_En
 	?>
 	<p>
 		<?php
+		printf(
 			/* translators: %1$s expands to Yoast SEO */
-			printf( __( 'Need help determining your settings? Configure %1$s step-by-step.', 'wordpress-seo' ), 'Yoast SEO' );
+			esc_html__( 'Need help determining your settings? Configure %1$s step-by-step.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
 		?>
 	</p>
 <p>
@@ -36,8 +39,11 @@ echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 ?>
 <p>
 	<?php
+	printf(
 		/* translators: %1$s expands to Yoast SEO */
-		printf( __( 'Take a look at the people that create %1$s.', 'wordpress-seo' ), 'Yoast SEO' );
+		esc_html__( 'Take a look at the people that create %1$s.', 'wordpress-seo' ),
+		'Yoast SEO'
+	);
 	?>
 </p>
 
@@ -51,8 +57,11 @@ echo '<h2>' . esc_html__( 'Restore default settings', 'wordpress-seo' ) . '</h2>
 ?>
 <p>
 	<?php
-	/* translators: %s expands to Yoast SEO. */
-	printf( __( 'If you want to restore a site to the default %s settings, press this button.', 'wordpress-seo' ), 'Yoast SEO' );
+	printf(
+		/* translators: %s expands to Yoast SEO. */
+		esc_html__( 'If you want to restore a site to the default %s settings, press this button.', 'wordpress-seo' ),
+		'Yoast SEO'
+	);
 	?>
 </p>
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.