### PR TITLE
CS/XSS: always escape output - 12

### DIFF
--- a/admin/views/tabs/metas/archives.php
+++ b/admin/views/tabs/metas/archives.php
@@ -10,11 +10,18 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 echo '<p>';
-/* translators: %1$s / %2$s: links to an article about duplicate content on yoast.com */
-printf( __( 'If you\'re running a one author blog, the author archive will be exactly the same as your homepage. This is what\'s called a %1$sduplicate content problem%2$s.', 'wordpress-seo' ), '<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/duplicate-content' ) . '">', '</a>' );
+printf(
+	/* translators: %1$s / %2$s: links to an article about duplicate content on yoast.com */
+	esc_html__( 'If you\'re running a one author blog, the author archive will be exactly the same as your homepage. This is what\'s called a %1$sduplicate content problem%2$s.', 'wordpress-seo' ),
+	'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/duplicate-content' ) ) . '">',
+	'</a>'
+);
 echo ' ';
-/* translators: %s expands to <code>noindex, follow</code> */
-printf( __( 'If this is the case on your site, you can choose to either disable it (which makes it redirect to the homepage), or to add %s to it so it doesn\'t show up in the search results.', 'wordpress-seo' ), '<code>noindex,follow</code>' );
+printf(
+	/* translators: %s expands to <code>noindex, follow</code> */
+	esc_html__( 'If this is the case on your site, you can choose to either disable it (which makes it redirect to the homepage), or to add %s to it so it doesn\'t show up in the search results.', 'wordpress-seo' ),
+	'<code>noindex,follow</code>'
+);
 echo ' ';
 echo esc_html__( 'Note that links to archives might be still output by your theme and you would need to remove them separately.', 'wordpress-seo' );
 echo ' ';
@@ -58,9 +65,14 @@ echo '<br/>';
 
 echo '<div id="special-pages-titles-metas">';
 echo '<h2>' . esc_html__( 'Special Pages', 'wordpress-seo' ) . '</h2>';
-/* translators: %s expands to <code>noindex, follow</code> */
-echo '<p>' . sprintf( __( 'These pages will be %s by default, so they will never show up in search results.', 'wordpress-seo' ), '<code>noindex, follow</code>' ) . '</p>';
-echo '<p><strong>' . __( 'Search pages', 'wordpress-seo' ) . '</strong><br/>';
+echo '<p>';
+printf(
+	/* translators: %s expands to <code>noindex, follow</code> */
+	esc_html__( 'These pages will be %s by default, so they will never show up in search results.', 'wordpress-seo' ),
+	'<code>noindex, follow</code>'
+);
+echo '</p>';
+echo '<p><strong>' . esc_html__( 'Search pages', 'wordpress-seo' ) . '</strong><br/>';
 $yform->textinput( 'title-search-wpseo', __( 'Title template', 'wordpress-seo' ), 'template search-template' );
 echo '</p>';
 echo '<p><strong>' . esc_html__( '404 pages', 'wordpress-seo' ) . '</strong><br/>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.