### PR TITLE
CS/XSS: always escape output - 13

### DIFF
--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -11,12 +11,13 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 if ( ! current_theme_supports( 'title-tag' ) ) {
 	$yform->light_switch( 'forcerewritetitle', __( 'Force rewrite titles', 'wordpress-seo' ) );
-	echo '<p class="description">',
-		sprintf(
-			/* translators: %1$s expands to Yoast SEO */
-			__( '%1$s has auto-detected whether it needs to force rewrite the titles for your pages, if you think it\'s wrong and you know what you\'re doing, you can change the setting here.', 'wordpress-seo' ),
-			'Yoast SEO'
-		) . '</p>';
+	echo '<p class="description">';
+	printf(
+		/* translators: %1$s expands to Yoast SEO */
+		esc_html__( '%1$s has auto-detected whether it needs to force rewrite the titles for your pages, if you think it\'s wrong and you know what you\'re doing, you can change the setting here.', 'wordpress-seo' ),
+		'Yoast SEO'
+	);
+	echo '</p>';
 }
 
 echo '<h2>' . esc_html__( 'Title Separator', 'wordpress-seo' ) . '</h2>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.