### PR TITLE
CS/XSS: always escape output - 14

### DIFF
--- a/admin/views/tabs/metas/home.php
+++ b/admin/views/tabs/metas/home.php
@@ -22,11 +22,21 @@ if ( 'posts' === get_option( 'show_on_front' ) ) {
 else {
 	echo '<h2>', esc_html__( 'Homepage &amp; Front page', 'wordpress-seo' ), '</h2>';
 	echo '<p>';
-	/* translators: 1: link open tag; 2: link close tag. */
-	printf( __( 'You can determine the title and description for the front page by %1$sediting the front page itself &raquo;%2$s', 'wordpress-seo' ), '<a href="' . esc_url( get_edit_post_link( get_option( 'page_on_front' ) ) ) . '">', '</a>' );
+	printf(
+		/* translators: 1: link open tag; 2: link close tag. */
+		esc_html__( 'You can determine the title and description for the front page by %1$sediting the front page itself &raquo;%2$s', 'wordpress-seo' ),
+		'<a href="' . esc_url( get_edit_post_link( get_option( 'page_on_front' ) ) ) . '">',
+		'</a>'
+	);
 	echo '</p>';
 	if ( get_option( 'page_for_posts' ) > 0 ) {
-		/* translators: 1: link open tag; 2: link close tag. */
-		echo '<p>', sprintf( __( 'You can determine the title and description for the blog page by %1$sediting the blog page itself &raquo;%2$s', 'wordpress-seo' ), '<a href="' . esc_url( get_edit_post_link( get_option( 'page_for_posts' ) ) ) . '">', '</a>' ), '</p>';
+		echo '<p>';
+		printf(
+			/* translators: 1: link open tag; 2: link close tag. */
+			esc_html__( 'You can determine the title and description for the blog page by %1$sediting the blog page itself &raquo;%2$s', 'wordpress-seo' ),
+			'<a href="' . esc_url( get_edit_post_link( get_option( 'page_for_posts' ) ) ) . '">',
+			'</a>'
+		);
+		echo '</p>';
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.