### PR TITLE
CS/XSS: always escape output - 16

### DIFF
--- a/admin/views/tabs/sitemaps/exclude-post.php
+++ b/admin/views/tabs/sitemaps/exclude-post.php
@@ -11,6 +11,12 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 echo '<h2>' . esc_html__( 'Excluded posts settings', 'wordpress-seo' ) . '</h2>';
 
-/* Translators: %1$s: expands to '<code>1,2,99,100</code>' */
-echo '<p>', sprintf( __( 'You can exclude posts from the sitemap by entering a comma separated string with the Post ID\'s. The format will become something like: %1$s.', 'wordpress-seo' ), '<code>1,2,99,100</code>' ), '</p>';
+echo '<p>';
+printf(
+	/* Translators: %1$s: expands to '<code>1,2,99,100</code>' */
+	esc_html__( 'You can exclude posts from the sitemap by entering a comma separated string with the Post ID\'s. The format will become something like: %1$s.', 'wordpress-seo' ),
+	'<code>1,2,99,100</code>'
+);
+echo '</p>';
+
 $yform->textinput( 'excluded-posts', __( 'Posts to exclude', 'wordpress-seo' ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.