### PR TITLE
CS/XSS: always escape output - 17

### DIFF
--- a/admin/views/tabs/sitemaps/user-sitemap.php
+++ b/admin/views/tabs/sitemaps/user-sitemap.php
@@ -20,7 +20,10 @@ $yform->toggle_switch(
 	__( 'Author / user sitemap', 'wordpress-seo' )
 );
 
-printf( '<p class="expl">%s</p>', __( 'The user sitemap contains the author archive URLs for every user on your site.', 'wordpress-seo' ) );
+printf(
+	'<p class="expl">%s</p>',
+	esc_html__( 'The user sitemap contains the author archive URLs for every user on your site.', 'wordpress-seo' )
+);
 
 echo '<div id="xml_user_block">';
 
@@ -30,7 +33,10 @@ $switch_values = array(
 );
 $yform->toggle_switch( 'disable_author_noposts', $switch_values, __( 'Users without posts', 'wordpress-seo' ) );
 
-printf( '<p class="expl">%s</p>', __( 'You can choose to not include users without posts.', 'wordpress-seo' ) );
+printf(
+	'<p class="expl">%s</p>',
+	esc_html__( 'You can choose to not include users without posts.', 'wordpress-seo' )
+);
 
 $roles = WPSEO_Utils::get_roles();
 unset( $roles['subscriber'] );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.