### PR TITLE
CS/XSS: always escape output - 18

### DIFF
--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -16,8 +16,11 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 ?>
 	<p>
 		<?php
-		/* translators: %s expands to <code>&lt;head&gt;</code> */
-		printf( __( 'Add Open Graph meta data to your site\'s %s section, Facebook and other social networks use this data when your pages are shared.', 'wordpress-seo' ), '<code>&lt;head&gt;</code>' );
+		printf(
+			/* translators: %s expands to <code>&lt;head&gt;</code> */
+			esc_html__( 'Add Open Graph meta data to your site\'s %s section, Facebook and other social networks use this data when your pages are shared.', 'wordpress-seo' ),
+			'<code>&lt;head&gt;</code>'
+		);
 		?>
 	</p>
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.