### PR TITLE
CS/XSS: always escape output - 21

### DIFF
--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -13,9 +13,13 @@ echo '<h2>' . esc_html__( 'Twitter settings', 'wordpress-seo' ) . '</h2>';
 
 $yform->light_switch( 'twitter', __( 'Add Twitter card meta data', 'wordpress-seo' ) );
 
-/* translators: %s expands to <code>&lt;head&gt;</code> */
-$p = sprintf( __( 'Add Twitter card meta data to your site\'s %s section.', 'wordpress-seo' ), '<code>&lt;head&gt;</code>' );
-printf( '<p>%s</p>', $p );
+echo '<p>';
+printf(
+	/* translators: %s expands to <code>&lt;head&gt;</code> */
+	esc_html__( 'Add Twitter card meta data to your site\'s %s section.', 'wordpress-seo' ),
+	'<code>&lt;head&gt;</code>'
+);
+echo '</p>';
 
 echo '<br />';
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.