### PR TITLE
CS/XSS: always escape output - 22

### DIFF
--- a/admin/views/about.php
+++ b/admin/views/about.php
@@ -35,11 +35,20 @@ function wpseo_display_contributors( $contributors ) {
 
 	<p class="about-text">
 		<?php
-		/* translators: %1$s and %2$s expands to anchor tags, %3$s expands to Yoast SEO */
-		printf( __( 'While most of the development team is at %1$sYoast%2$s in the Netherlands, %3$s is created by a worldwide team.', 'wordpress-seo' ), '<a target="_blank" href="https://yoast.com/">', '</a>', 'Yoast SEO' );
+		printf(
+			/* translators: %1$s and %2$s expands to anchor tags, %3$s expands to Yoast SEO */
+			esc_html__( 'While most of the development team is at %1$sYoast%2$s in the Netherlands, %3$s is created by a worldwide team.', 'wordpress-seo' ),
+			'<a target="_blank" href="https://yoast.com/">',
+			'</a>',
+			'Yoast SEO'
+		);
 		echo ' ';
-		/* translators: 1: link open tag; 2: link close tag. */
-		printf( __( 'Want to help us develop? Read our %1$scontribution guidelines%2$s!', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/wpseocontributionguidelines' ) . '">', '</a>' );
+		printf(
+			/* translators: 1: link open tag; 2: link close tag. */
+			esc_html__( 'Want to help us develop? Read our %1$scontribution guidelines%2$s!', 'wordpress-seo' ),
+			'<a target="_blank" href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/wpseocontributionguidelines' ) ) . '">',
+			'</a>'
+		);
 		?>
 	</p>
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.