### PR TITLE
CS/XSS: always escape output - 23

### DIFF
--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -21,17 +21,17 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 <script type="text/html" id="tmpl-primary-term-ui">
 	<?php
-		printf(
-			'<button type="button" class="wpseo-make-primary-term" aria-label="%1$s">%2$s</button>',
-			esc_attr( sprintf(
-				/* translators: accessibility text. %1$s expands to the term title, %2$s to the taxonomy title. */
-				__( 'Make %1$s primary %2$s', 'wordpress-seo' ),
-				'{{data.term}}',
-				'{{data.taxonomy.title}}'
-			) ),
-			__( 'Make primary', 'wordpress-seo' )
-		);
-		?>
+	printf(
+		'<button type="button" class="wpseo-make-primary-term" aria-label="%1$s">%2$s</button>',
+		esc_attr( sprintf(
+			/* translators: accessibility text. %1$s expands to the term title, %2$s to the taxonomy title. */
+			__( 'Make %1$s primary %2$s', 'wordpress-seo' ),
+			'{{data.term}}',
+			'{{data.taxonomy.title}}'
+		) ),
+		esc_html__( 'Make primary', 'wordpress-seo' )
+	);
+	?>
 
 	<span class="wpseo-is-primary-term" aria-hidden="true"><?php esc_html_e( 'Primary', 'wordpress-seo' ); ?></span>
 </script>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.