### PR TITLE
CS/XSS: always escape output /escape complete string - 1

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -419,7 +419,12 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 					esc_attr( 'post-type-filter-' . $instance_type ),
 					esc_html__( 'Filter by post type', 'wordpress-seo' )
 				);
-				printf( '<select name="post_type_filter" id="post-type-filter-%2$s">%1$s</select>', $options, $instance_type );
+				printf(
+					'<select name="post_type_filter" id="%2$s">%1$s</select>',
+					$options,
+					esc_attr( 'post-type-filter-' . $instance_type )
+				);
+
 				submit_button( __( 'Filter', 'wordpress-seo' ), 'button', false, false, array( 'id' => 'post-query-submit' ) );
 				echo '</div>';
 			}
@@ -722,7 +727,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 			foreach ( $records as $rec ) {
 
-				echo '<tr id="record_', $rec->ID, '">';
+				echo '<tr id="', esc_attr( 'record_' . $rec->ID ), '">';
 
 				foreach ( $columns as $column_name => $column_display_name ) {
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.