### PR TITLE
CS/XSS: always escape output /escape complete string - 2

### DIFF
--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -27,7 +27,12 @@ class WPSEO_Option_Tabs_Formatter {
 
 		echo '<h2 class="nav-tab-wrapper" id="wpseo-tabs">';
 		foreach ( $option_tabs->get_tabs() as $tab ) {
-			printf( '<a class="nav-tab" id="%1$s-tab" href="#top#%1$s">%2$s</a>', $tab->get_name(), $tab->get_label() );
+			printf(
+				'<a class="nav-tab" id="%1$s" href="%2$s">%3$s</a>',
+				esc_attr( $tab->get_name() . '-tab' ),
+				esc_url( '#top#' . $tab->get_name() ),
+				$tab->get_label()
+			);
 		}
 		echo '</h2>';
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.