### PR TITLE
CS/XSS: always escape output /escape complete string - 3

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -60,11 +60,16 @@ class Premium_Upsell_Admin_Block {
 		$upgrade_msg = sprintf( __( 'Find out why you should upgrade to %s &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );
 
 		echo '<div class="' . esc_attr( $class ) . '">';
-		echo '<a href="' . esc_url( add_query_arg( array( $this->get_query_variable_name() => 1 ) ) ) . '" style="" class="alignright ' . $class . '--close" aria-label="' . esc_attr( $dismiss_msg ) . '">X</a>';
+		printf(
+			'<a href="%1$s" style="" class="alignright %2$s" aria-label="%3$s">X</a>',
+			esc_url( add_query_arg( array( $this->get_query_variable_name() => 1 ) ) ),
+			esc_attr( $class . '--close' ),
+			esc_attr( $dismiss_msg )
+		);
 
 		echo '<div>';
-		echo '<h2 class="' . $class . '--header">' . esc_html__( 'Go premium!', 'wordpress-seo' ) . '</h2>';
-		echo '<ul class="' . $class . '--motivation">' . $arguments_html . '</ul>';
+		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' . esc_html__( 'Go premium!', 'wordpress-seo' ) . '</h2>';
+		echo '<ul class="' . esc_attr( $class . '--motivation' ) . '">' . $arguments_html . '</ul>';
 
 		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $upgrade_msg ) . '</a><br />';
 		echo '</div>';
@@ -82,7 +87,11 @@ class Premium_Upsell_Admin_Block {
 	protected function get_argument_html( $argument ) {
 		$class = $this->get_html_class();
 
-		return sprintf( '<li><div class="%s--argument">%s</div></li>', $class, $argument );
+		return sprintf(
+			'<li><div class="%1$s">%2$s</div></li>',
+			esc_attr( $class . '--argument' ),
+			$argument
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.