### PR TITLE
CS/XSS: always escape output /escape complete string - 5

### DIFF
--- a/admin/google_search_console/class-gsc-modal.php
+++ b/admin/google_search_console/class-gsc-modal.php
@@ -47,7 +47,7 @@ class WPSEO_GSC_Modal {
 	public function load_view( $unique_id ) {
 		extract( $this->view_vars );
 
-		echo '<div id="redirect-' . $unique_id . '" class="hidden">';
+		echo '<div id="' . esc_attr( 'redirect-' . $unique_id ) . '" class="hidden">';
 		echo '<div class="form-wrap wpseo_content_wrapper">';
 		require $this->view;
 		echo '</div>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.