### PR TITLE
CS/XSS: always escape output /escape complete string - 6

### DIFF
--- a/admin/metabox/class-metabox-form-tab.php
+++ b/admin/metabox/class-metabox-form-tab.php
@@ -108,7 +108,8 @@ class WPSEO_Metabox_Form_Tab implements WPSEO_Metabox_Tab {
 	 */
 	public function content() {
 		return sprintf(
-			'<div id="wpseo_%1$s" class="wpseotab %1$s">%2$s</div>',
+			'<div id="%1$s" class="wpseotab %2$s">%3$s</div>',
+			esc_attr( 'wpseo_' . $this->name ),
 			esc_attr( $this->name ),
 			$this->content
 		);

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -300,7 +300,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	public function do_tab( $id, $heading, $content ) {
 		?>
-		<div id="wpseo_<?php echo esc_attr( $id ); ?>" class="wpseotab <?php echo esc_attr( $id ); ?>">
+		<div id="<?php echo esc_attr( 'wpseo_' . $id ); ?>" class="wpseotab <?php echo esc_attr( $id ); ?>">
 			<?php echo $content; ?>
 		</div>
 	<?php


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.