### PR TITLE
CS/XSS: always escape output /escape complete string - 7

### DIFF
--- a/admin/metabox/class-metabox-tab-section.php
+++ b/admin/metabox/class-metabox-tab-section.php
@@ -86,12 +86,18 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 	 */
 	public function display_content() {
 		if ( $this->has_tabs() ) {
-			$html  = '<div id="wpseo-meta-section-%1$s" class="wpseo-meta-section">';
+			$html  = '<div id="%1$s" class="wpseo-meta-section">';
 			$html .= '<div class="wpseo-metabox-tabs-div">';
-			$html .= '<ul class="wpseo-metabox-tabs wpseo-metabox-tab-%1$s">%2$s</ul>%3$s';
+			$html .= '<ul class="wpseo-metabox-tabs %2$s">%3$s</ul>%4$s';
 			$html .= '</div></div>';
 
-			printf( $html, esc_attr( $this->name ), $this->tab_links(), $this->tab_content() );
+			printf(
+				$html,
+				esc_attr( 'wpseo-meta-section-' . $this->name ),
+				esc_attr( 'wpseo-metabox-tab-' . $this->name ),
+				$this->tab_links(),
+				$this->tab_content()
+			);
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.