### PR TITLE
CS/XSS: always escape output /escape complete string - 9

### DIFF
--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -102,7 +102,7 @@ $tabs = array(
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
 		<?php foreach ( $tabs as $identifier => $tab ) : ?>
-			<a class="nav-tab" id="<?php echo $identifier; ?>-tab" href="#top#<?php echo $identifier; ?>"><?php echo $tab['label']; ?></a>
+			<a class="nav-tab" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo $tab['label']; ?></a>
 		<?php endforeach; ?>
 
 		<?php


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.