### PR TITLE
CS/XSS: always escape output /escape complete string - 10

### DIFF
--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -33,14 +33,14 @@ if ( ! $active ) {
 }
 
 ?>
-<h3><span class="dashicons dashicons-<?php echo $dashicon; ?>"></span> <?php echo $i18n_title; ?> (<?php echo $active_total; ?>)</h3>
+<h3><span class="dashicons <?php echo esc_attr( 'dashicons-' . $dashicon ); ?>"></span> <?php echo $i18n_title; ?> (<?php echo $active_total; ?>)</h3>
 
-<div id="yoast-<?php echo $type; ?>">
+<div id="<?php echo esc_attr( 'yoast-' . $type ); ?>">
 
 	<?php if ( $total ) : ?>
 		<p><?php echo ( ! $active ) ? $i18n_no_issues : $i18n_issues; ?></p>
 
-		<div class="container" id="yoast-<?php echo $type; ?>-active">
+		<div class="container" id="<?php echo esc_attr( 'yoast-' . $type . '-active' ); ?>">
 			<?php _yoast_display_alerts( $active, 'active' ); ?>
 		</div>
 
@@ -48,7 +48,7 @@ if ( ! $active ) {
 			<h4 class="yoast-muted-title"><?php echo esc_html( $i18n_muted_issues_title ); ?></h4>
 		<?php endif; ?>
 
-		<div class="container" id="yoast-<?php echo $type; ?>-dismissed">
+		<div class="container" id="<?php echo esc_attr( 'yoast-' . $type . '-dismissed' ); ?>">
 			<?php _yoast_display_alerts( $dismissed, 'dismissed' ); ?>
 		</div>
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.