### PR TITLE
CS/XSS: always escape output /escape complete string - 11

### DIFF
--- a/admin/pages/advanced.php
+++ b/admin/pages/advanced.php
@@ -48,8 +48,13 @@ Yoast_Form::get_instance()->admin_header( true, $active_tab->get_opt_group() );
 
 echo '<h2 class="nav-tab-wrapper">';
 foreach ( $tabs->get_tabs() as $tab ) {
-	$active = ( $tabs->is_active_tab( $tab ) ) ? ' nav-tab-active' : '';
-	echo '<a class="nav-tab' . $active . '" id="' . $tab->get_name() . '-tab" href="' . esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=' . $tab->get_name() ) ) . '">' . $tab->get_label() . '</a>';
+	printf(
+		'<a class="nav-tab %1$s" id="%2$s" href="%3$s">%4$s</a>',
+		( $tabs->is_active_tab( $tab ) ? 'nav-tab-active' : '' ),
+		esc_attr( $tab->get_name() . '-tab' ),
+		esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=' . $tab->get_name() ) ),
+		$tab->get_label()
+	);
 }
 echo '</h2>';
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variables value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

PRs in this series includes some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.