### PR TITLE
Link to Google's Knowledge Graph.

### DIFF
--- a/admin/views/tabs/dashboard/knowledge-graph.php
+++ b/admin/views/tabs/dashboard/knowledge-graph.php
@@ -24,8 +24,9 @@ echo '<h2>' . esc_html__( 'Company or person', 'wordpress-seo' ) . '</h2>';
 ?>
 <p>
 	<?php
-	// @todo add KB link - JdV.
-	esc_html_e( 'This data is shown as metadata in your site. It is intended to appear in Google\'s Knowledge Graph. You can be either a company, or a person, choose either:', 'wordpress-seo' );
+	/* translators: %1$s and %2$s link to the KB article for Google's Knowledge Graph */
+	printf( __( 'This data is shown as metadata in your site. It is intended to appear in %1$sGoogle\'s Knowledge Graph%2$s. You can be either a company, or a person, choose either:', 'wordpress-seo' ),
+	'<a href="' . esc_url('https://yoast.com/google-knowledge-graph/') . '" target="_blank" title="Google\'s Knowledge Graph">', '</a>' );
 	?>
 </p>
 <?php


### PR DESCRIPTION
Added link to the Google’s Knowledge Graph article.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a link to the Google Knowledge Graph article on Yoast.com.

## Testing instructions
Go to the `/wp-admin/admin.php?page=wpseo_dashboard#top#knowledge-graph` page and verify the link is working and brings you to Yoast.com.
