### PR TITLE
Use WC shop page title & desc

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -239,6 +239,19 @@ class WPSEO_Frontend {
 	}
 
 	/**
+	 * Determine whether this is the WooCommerce shop page.
+	 *
+	 * @return bool
+	 */
+	public function is_wc_shop_page() {
+		if ( function_exists( 'is_shop' ) && function_exists( 'wc_get_page_id' ) ) {
+			return is_shop();
+		}
+
+		return false;
+	}
+
+	/**
 	 * Used for static home and posts pages as well as singular titles.
 	 *
 	 * @param object|null $object If filled, object to get the title for.
@@ -453,6 +466,9 @@ class WPSEO_Frontend {
 		}
 		elseif ( $this->is_posts_page() ) {
 			$title = $this->get_content_title( get_post( get_option( 'page_for_posts' ) ) );
+		}
+		elseif ( $this->is_wc_shop_page() ) {
+			$title = $this->get_content_title( get_post( wc_get_page_id( 'shop' ) ) );
 		}
 		elseif ( is_singular() ) {
 			$title = $this->get_content_title();
@@ -1311,6 +1327,12 @@ class WPSEO_Frontend {
 			}
 			elseif ( $this->is_home_static_page() ) {
 				$metadesc = WPSEO_Meta::get_value( 'metadesc' );
+				if ( ( $metadesc === '' && $post_type !== '' ) && isset( $this->options[ 'metadesc-' . $post_type ] ) ) {
+					$template = $this->options[ 'metadesc-' . $post_type ];
+				}
+			}
+			elseif ( $this->is_wc_shop_page() ) {
+				$metadesc = WPSEO_Meta::get_value( 'metadesc', wc_get_page_id( 'shop' ) );
 				if ( ( $metadesc === '' && $post_type !== '' ) && isset( $this->options[ 'metadesc-' . $post_type ] ) ) {
 					$template = $this->options[ 'metadesc-' . $post_type ];
 				}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add support for custom page titles and meta descriptions on the WC shop page.

## Relevant technical choices:

Only added support for title and description, rather than allthethings. I see there is a plugin specifically for WC enhancements - and this issue was originally moved there, but this feels like something that the core version could support imo. Talked a bit with @jdevalk at WCUS about this.

For background: WooCommerce doesn't have a traditional post archive setup - the site assigns a normal WP page as the shop page. This works similar to how the blog post index system works. As a result, the user can edit the shop page like any other page and do things like change meta descriptions there. However, this page ID needs to be "mapped" for when the actual PT archive is in use.

In the past, users would be able to edit this in the plugin settings, though I can't find a way to do this now. I heard there was an "advanced settings" option that could be enabled - that allows you to edit CPT archive title/metas, but I'm not able to find that with the new UI (well, new to me). Mentioning this as I'm not sure how/if that should be supported along with this PR.

Allowing editing on the shop page itself though makes the most sense to a user, especially since CPT's are a foreign concept for many.

## Test instructions

This PR can be tested by following these steps:

- Install WooCommerce and assign a page as the shop page. Edit the shop page's title and meta description, then view shop page.

Fixes #4362
