### PR TITLE
Improve table accessibility checks

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -450,6 +450,14 @@ class WPSEO_Admin {
 		$link_table_compatibility_notifier->remove_notification();
 
 		// When the table doesn't exists, just add the notification and return early.
+		if ( ! WPSEO_Link_Table_Accessible::is_accessible() ) {
+			WPSEO_Link_Table_Accessible::cleanup();
+		}
+
+		if ( ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
+			WPSEO_Meta_Table_Accessible::cleanup();
+		}
+
 		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			$link_table_accessible_notifier->add_notification();
 

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -8,7 +8,7 @@
  */
 class WPSEO_Meta_Table_Accessible {
 
-	const ACCESSIBLE = '0';
+	const ACCESSIBLE   = '0';
 	const INACCESSBILE = '1';
 
 	/**

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -14,7 +14,14 @@ class WPSEO_Meta_Table_Accessible {
 	 * @return bool True when table is accessible.
 	 */
 	public static function is_accessible() {
-		return get_transient( self::transient_name() ) === false;
+		$value = get_transient( self::transient_name() );
+
+		// If the value is not set, check the table.
+		if ( null === $value ) {
+			return self::check_table();
+		}
+
+		return $value === 0;
 	}
 
 	/**
@@ -25,19 +32,39 @@ class WPSEO_Meta_Table_Accessible {
 	}
 
 	/**
+	 * Sets the transient value to 0, to indicate the table is accessbile.
+	 */
+	protected static function set_accessible() {
+		set_transient( self::transient_name(), 0 );
+	}
+
+	/**
 	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @deprecated 6.0
 	 *
 	 * @return bool True if table is accessible.
 	 */
 	public static function check_table_is_accessible() {
+		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
+		return self::is_accessible();
+	}
+
+	/**
+	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @return bool
+	 */
+	protected static function check_table() {
 		global $wpdb;
 
-		$storage = new WPSEO_Meta_Storage();
+		$storage = new WPSEO_Link_Storage();
 		if ( $wpdb->get_var( 'SHOW TABLES LIKE "' . $storage->get_table_name() . '"' ) !== $storage->get_table_name() ) {
 			self::set_inaccessible();
 			return false;
 		}
 
+		self::set_accessible();
 		return true;
 	}
 
@@ -56,6 +83,6 @@ class WPSEO_Meta_Table_Accessible {
 	 * @return string The name of the transient to use.
 	 */
 	protected static function transient_name() {
-		return 'wpseo_meta_table_accessible';
+		return 'wpseo_meta_table_inaccessible';
 	}
 }

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -29,13 +29,26 @@ class WPSEO_Meta_Table_Accessible {
 
 	/**
 	 * Sets the transient value to 1, to indicate the table is not accessible.
+	 *
+	 * @return void
 	 */
 	public static function set_inaccessible() {
 		set_transient( self::transient_name(), self::INACCESSBILE, HOUR_IN_SECONDS );
 	}
 
 	/**
-	 * Sets the transient value to 0, to indicate the table is accessbile.
+	 * Removes the transient.
+	 *
+	 * @return void
+	 */
+	public static function cleanup() {
+		delete_transient( self::transient_name() );
+	}
+
+	/**
+	 * Sets the transient value to 0, to indicate the table is accessible.
+	 *
+	 * @return void
 	 */
 	protected static function set_accessible() {
 		/*
@@ -50,19 +63,7 @@ class WPSEO_Meta_Table_Accessible {
 	/**
 	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
 	 *
-	 * @deprecated 6.0
-	 *
 	 * @return bool True if table is accessible.
-	 */
-	public static function check_table_is_accessible() {
-		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
-		return self::is_accessible();
-	}
-
-	/**
-	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
-	 *
-	 * @return bool
 	 */
 	protected static function check_table() {
 		global $wpdb;
@@ -78,20 +79,23 @@ class WPSEO_Meta_Table_Accessible {
 	}
 
 	/**
-	 * Removes the transient.
-	 *
-	 * @return void
-	 */
-	public static function cleanup() {
-		delete_transient( self::transient_name() );
-	}
-
-	/**
 	 * Returns the name of the transient.
 	 *
 	 * @return string The name of the transient to use.
 	 */
 	protected static function transient_name() {
 		return 'wpseo_meta_table_inaccessible';
+	}
+
+	/**
+	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @deprecated 6.0
+	 *
+	 * @return bool True if table is accessible.
+	 */
+	public static function check_table_is_accessible() {
+		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
+		return self::is_accessible();
 	}
 }

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -8,6 +8,9 @@
  */
 class WPSEO_Meta_Table_Accessible {
 
+	const ACCESSIBLE = '0';
+	const INACCESSBILE = '1';
+
 	/**
 	 * Checks if the given table name exists.
 	 *
@@ -17,25 +20,31 @@ class WPSEO_Meta_Table_Accessible {
 		$value = get_transient( self::transient_name() );
 
 		// If the value is not set, check the table.
-		if ( null === $value ) {
+		if ( false === $value ) {
 			return self::check_table();
 		}
 
-		return $value === 0;
+		return $value === self::ACCESSIBLE;
 	}
 
 	/**
 	 * Sets the transient value to 1, to indicate the table is not accessible.
 	 */
 	public static function set_inaccessible() {
-		set_transient( self::transient_name(), 1, HOUR_IN_SECONDS );
+		set_transient( self::transient_name(), self::INACCESSBILE, HOUR_IN_SECONDS );
 	}
 
 	/**
 	 * Sets the transient value to 0, to indicate the table is accessbile.
 	 */
 	protected static function set_accessible() {
-		set_transient( self::transient_name(), 0 );
+		/*
+		 * Prefer to set a 0 timeout, but if the timeout was set before WordPress will not delete the transient
+		 * correctly when overridden with a zero value.
+		 *
+		 * Setting a YEAR_IN_SECONDS instead.
+		 */
+		set_transient( self::transient_name(), self::ACCESSIBLE, YEAR_IN_SECONDS );
 	}
 
 	/**

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -68,7 +68,7 @@ class WPSEO_Meta_Table_Accessible {
 	protected static function check_table() {
 		global $wpdb;
 
-		$storage = new WPSEO_Link_Storage();
+		$storage = new WPSEO_Meta_Storage();
 		if ( $wpdb->get_var( 'SHOW TABLES LIKE "' . $storage->get_table_name() . '"' ) !== $storage->get_table_name() ) {
 			self::set_inaccessible();
 			return false;

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -53,8 +53,8 @@ class WPSEO_Link_Columns {
 			return;
 		}
 
-		// When table doesn't exists.
-		if ( ! WPSEO_Link_Table_Accessible::check_table_is_accessible() || ! WPSEO_Meta_Table_Accessible::check_table_is_accessible() ) {
+		// Exit when either table is not present or accessible.
+		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			return;
 		}
 

--- a/admin/links/class-link-reindex-post-service.php
+++ b/admin/links/class-link-reindex-post-service.php
@@ -52,7 +52,7 @@ class WPSEO_Link_Reindex_Post_Service {
 	 * @return bool True when the tables are accessible.
 	 */
 	protected function is_processable() {
-		return WPSEO_Link_Table_Accessible::check_table_is_accessible() && WPSEO_Meta_Table_Accessible::is_accessible();
+		return WPSEO_Link_Table_Accessible::is_accessible() && WPSEO_Meta_Table_Accessible::is_accessible();
 	}
 
 	/**

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -29,13 +29,26 @@ class WPSEO_Link_Table_Accessible {
 
 	/**
 	 * Sets the transient value to 1, to indicate the table is not accessible.
+	 *
+	 * @return void
 	 */
 	public static function set_inaccessible() {
 		set_transient( self::transient_name(), self::INACCESSBILE, HOUR_IN_SECONDS );
 	}
 
 	/**
-	 * Sets the transient value to 0, to indicate the table is accessbile.
+	 * Removes the transient.
+	 *
+	 * @return void
+	 */
+	public static function cleanup() {
+		delete_transient( self::transient_name() );
+	}
+
+	/**
+	 * Sets the transient value to 0, to indicate the table is accessible.
+	 *
+	 * @return void
 	 */
 	protected static function set_accessible() {
 		/*
@@ -50,19 +63,7 @@ class WPSEO_Link_Table_Accessible {
 	/**
 	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
 	 *
-	 * @deprecated 6.0
-	 *
 	 * @return bool True if table is accessible.
-	 */
-	public static function check_table_is_accessible() {
-		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
-		return self::is_accessible();
-	}
-
-	/**
-	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
-	 *
-	 * @return bool
 	 */
 	protected static function check_table() {
 		global $wpdb;
@@ -78,20 +79,23 @@ class WPSEO_Link_Table_Accessible {
 	}
 
 	/**
-	 * Removes the transient.
-	 *
-	 * @return void
-	 */
-	public static function cleanup() {
-		delete_transient( self::transient_name() );
-	}
-
-	/**
 	 * Returns the name of the transient.
 	 *
 	 * @return string The name of the transient to use.
 	 */
 	protected static function transient_name() {
 		return 'wpseo_link_table_inaccessible';
+	}
+
+	/**
+	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @deprecated 6.0
+	 *
+	 * @return bool True if table is accessible.
+	 */
+	public static function check_table_is_accessible() {
+		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
+		return self::is_accessible();
 	}
 }

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -8,6 +8,9 @@
  */
 class WPSEO_Link_Table_Accessible {
 
+	const ACCESSIBLE = '0';
+	const INACCESSBILE = '1';
+
 	/**
 	 * Checks if the given table name exists.
 	 *
@@ -17,25 +20,31 @@ class WPSEO_Link_Table_Accessible {
 		$value = get_transient( self::transient_name() );
 
 		// If the value is not set, check the table.
-		if ( null === $value ) {
+		if ( false === $value ) {
 			return self::check_table();
 		}
 
-		return $value === 0;
+		return $value === self::ACCESSIBLE;
 	}
 
 	/**
 	 * Sets the transient value to 1, to indicate the table is not accessible.
 	 */
 	public static function set_inaccessible() {
-		set_transient( self::transient_name(), 1, HOUR_IN_SECONDS );
+		set_transient( self::transient_name(), self::INACCESSBILE, HOUR_IN_SECONDS );
 	}
 
 	/**
 	 * Sets the transient value to 0, to indicate the table is accessbile.
 	 */
 	protected static function set_accessible() {
-		set_transient( self::transient_name(), 0 );
+		/*
+		 * Prefer to set a 0 timeout, but if the timeout was set before WordPress will not delete the transient
+		 * correctly when overridden with a zero value.
+		 *
+		 * Setting a YEAR_IN_SECONDS instead.
+		 */
+		set_transient( self::transient_name(), self::ACCESSIBLE, YEAR_IN_SECONDS );
 	}
 
 	/**

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -8,7 +8,7 @@
  */
 class WPSEO_Link_Table_Accessible {
 
-	const ACCESSIBLE = '0';
+	const ACCESSIBLE   = '0';
 	const INACCESSBILE = '1';
 
 	/**

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -14,7 +14,14 @@ class WPSEO_Link_Table_Accessible {
 	 * @return bool True when table is accessible.
 	 */
 	public static function is_accessible() {
-		return get_transient( self::transient_name() ) === false;
+		$value = get_transient( self::transient_name() );
+
+		// If the value is not set, check the table.
+		if ( null === $value ) {
+			return self::check_table();
+		}
+
+		return $value === 0;
 	}
 
 	/**
@@ -25,11 +32,30 @@ class WPSEO_Link_Table_Accessible {
 	}
 
 	/**
+	 * Sets the transient value to 0, to indicate the table is accessbile.
+	 */
+	protected static function set_accessible() {
+		set_transient( self::transient_name(), 0 );
+	}
+
+	/**
 	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @deprecated 6.0
 	 *
 	 * @return bool True if table is accessible.
 	 */
 	public static function check_table_is_accessible() {
+		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
+		return self::is_accessible();
+	}
+
+	/**
+	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @return bool
+	 */
+	protected static function check_table() {
 		global $wpdb;
 
 		$storage = new WPSEO_Link_Storage();
@@ -38,6 +64,7 @@ class WPSEO_Link_Table_Accessible {
 			return false;
 		}
 
+		self::set_accessible();
 		return true;
 	}
 
@@ -56,6 +83,6 @@ class WPSEO_Link_Table_Accessible {
 	 * @return string The name of the transient to use.
 	 */
 	protected static function transient_name() {
-		return 'wpseo_link_table_accessible';
+		return 'wpseo_link_table_inaccessible';
 	}
 }

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -39,7 +39,7 @@ class WPSEO_Link_Watcher {
 	 * @return void
 	 */
 	public function save_post( $post_id, WP_Post $post ) {
-		if ( ! WPSEO_Link_Table_Accessible::check_table_is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
+		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			return;
 		}
 
@@ -69,7 +69,7 @@ class WPSEO_Link_Watcher {
 	 * @return void
 	 */
 	public function delete_post( $post_id ) {
-		if ( ! WPSEO_Link_Table_Accessible::check_table_is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
+		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			return;
 		}
 

--- a/tests/admin/links/test-class-link-columns-count.php
+++ b/tests/admin/links/test-class-link-columns-count.php
@@ -31,6 +31,9 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
 		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
+
+		delete_transient( 'wpseo_link_table_inaccessible' );
+		delete_transient( 'wpseo_meta_table_inaccessible' );
 	}
 
 	/**

--- a/tests/admin/links/test-class-link-columns.php
+++ b/tests/admin/links/test-class-link-columns.php
@@ -31,6 +31,9 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
 		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
+
+		delete_transient( 'wpseo_link_table_inaccessible' );
+		delete_transient( 'wpseo_meta_table_inaccessible' );
 	}
 
 	/**

--- a/tests/admin/links/test-class-link-content-processor.php
+++ b/tests/admin/links/test-class-link-content-processor.php
@@ -31,6 +31,9 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
 		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
+
+		delete_transient( 'wpseo_link_table_inaccessible' );
+		delete_transient( 'wpseo_meta_table_inaccessible' );
 	}
 
 	/**

--- a/tests/admin/links/test-class-link-storage.php
+++ b/tests/admin/links/test-class-link-storage.php
@@ -31,6 +31,9 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
 		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
+
+		delete_transient( 'wpseo_link_table_inaccessible' );
+		delete_transient( 'wpseo_meta_table_inaccessible' );
 	}
 
 	/**

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -31,6 +31,9 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 
 		$wpdb->query( 'DROP TABLE ' . $storage->get_table_name() );
 		$wpdb->query( 'DROP TABLE ' . $meta_storage->get_table_name() );
+
+		delete_transient( 'wpseo_link_table_inaccessible' );
+		delete_transient( 'wpseo_meta_table_inaccessible' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Avoids calling SHOW TABLES queries to check if link and meta tables are present.

## Relevant technical choices:

* Using a transient name which reflects the value that it holds.

## Test instructions

This PR can be tested by following these steps:

* On each post overview page, two requests are being done to verify the tables are accessible.
* _Use the Query Monitor plugin to get insights in the queries that have been executed_
![cursor_and_posts_ _local_wordpress_ _wordpress](https://user-images.githubusercontent.com/2005352/33549333-6dbd6702-d8ea-11e7-90bf-64eb5a61c7ec.png)

* On this PR, this only has to be done initially (if the tables exist and are accessible).
* After that only transient requests are needed `wpseo_link_table_inaccessible` & `wpseo_meta_table_inaccessible`.

Fixes #8190
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1477
