### PR TITLE
Hide elements according to accessible post type filter

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -725,6 +725,19 @@ class WPSEO_Meta_Columns {
 	 * @return bool Whether or the current page can display the filter drop downs.
 	 */
 	public function can_display_filter() {
-		return $GLOBALS['pagenow'] !== 'upload.php' && $this->is_metabox_hidden() === false;
+		if ( $GLOBALS['pagenow'] === 'upload.php' ) {
+			return false;
+		}
+
+		if ( $this->is_metabox_hidden() !== false ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		if ( null === $screen ) {
+			return false;
+		}
+
+		return in_array( $screen->post_type, WPSEO_Post_Type::get_accessible_post_types(), true );
 	}
 }

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -584,7 +584,7 @@ class WPSEO_Meta_Columns {
 	 * Sets up the hooks for the post_types.
 	 */
 	private function set_post_type_hooks() {
-		$post_types = get_post_types( array( 'public' => true ), 'names' );
+		$post_types = WPSEO_Post_Type::get_accessible_post_types();
 
 		if ( is_array( $post_types ) && $post_types !== array() ) {
 			foreach ( $post_types as $post_type ) {
@@ -640,7 +640,7 @@ class WPSEO_Meta_Columns {
 
 		if ( isset( $post_type ) ) {
 			// Don't make static as post_types may still be added during the run.
-			$cpts    = get_post_types( array( 'public' => true ), 'names' );
+			$cpts    = WPSEO_Post_Type::get_accessible_post_types();
 			$options = get_option( 'wpseo_titles' );
 
 			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $cpts, true ) === false );

--- a/admin/config-ui/factories/class-factory-post-type.php
+++ b/admin/config-ui/factories/class-factory-post-type.php
@@ -20,6 +20,7 @@ class WPSEO_Config_Factory_Post_Type {
 
 			$fields = array();
 
+			// WPSEO_Post_type::get_accessible_post_types() should *not* be used to get a similar experience from the settings.
 			$post_types = get_post_types( array( 'public' => true ), 'objects' );
 			if ( ! empty( $post_types ) ) {
 				foreach ( $post_types as $post_type => $post_type_object ) {

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -92,6 +92,10 @@ class WPSEO_Link_Watcher {
 	 * @return bool True when the post is processable.
 	 */
 	protected function is_processable( $post_id ) {
+		/*
+		 * Do not use the `wpseo_link_count_post_types` because we want to always count the links,
+		 * even if we don't show them.
+		 */
 		$post_types = WPSEO_Post_Type::get_accessible_post_types();
 
 		return isset( $post_types[ get_post_type( $post_id ) ] );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -142,7 +142,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		if ( isset( $post_type ) ) {
 			// Don't make static as post_types may still be added during the run.
-			$cpts    = get_post_types( array( 'public' => true ), 'names' );
+			$cpts    = WPSEO_Post_Type::get_accessible_post_types();
 			$options = get_option( 'wpseo_titles' );
 
 			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $cpts, true ) === false );
@@ -195,7 +195,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * attachment, and custom post types pages.
 	 */
 	public function add_meta_box() {
-		$post_types = get_post_types( array( 'public' => true ) );
+		$post_types = WPSEO_Post_Type::get_accessible_post_types();
 
 		if ( is_array( $post_types ) && $post_types !== array() ) {
 			foreach ( $post_types as $post_type ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -142,10 +142,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		if ( isset( $post_type ) ) {
 			// Don't make static as post_types may still be added during the run.
-			$cpts    = WPSEO_Post_Type::get_accessible_post_types();
-			$options = get_option( 'wpseo_titles' );
+			$post_types = WPSEO_Post_Type::get_accessible_post_types();
+			$options    = get_option( 'wpseo_titles' );
 
-			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $cpts, true ) === false );
+			return ( ( isset( $options[ 'hideeditbox-' . $post_type ] ) && $options[ 'hideeditbox-' . $post_type ] === true ) || in_array( $post_type, $post_types, true ) === false );
 		}
 		return false;
 	}

--- a/admin/views/tabs/advanced/breadcrumbs.php
+++ b/admin/views/tabs/advanced/breadcrumbs.php
@@ -38,6 +38,10 @@ $yform->toggle_switch( 'breadcrumbs-boldlast', array(
 ), __( 'Bold the last page', 'wordpress-seo' ) );
 echo '<br/><br/>';
 
+/*
+ * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
+ * Even posts that are not indexed, should be able to get breadcrumbs for accessibility/usability.
+ */
 $post_types = get_post_types( array( 'public' => true ), 'objects' );
 if ( is_array( $post_types ) && $post_types !== array() ) {
 	echo '<h2>' . esc_html__( 'Taxonomy to show in breadcrumbs for post types', 'wordpress-seo' ) . '</h2>';

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -9,6 +9,11 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
+/*
+ * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
+ * Otherwise setting a post-type to `noindex` will remove it from the list,
+ * making it very hard to restore the setting again.
+ */
 $post_types          = get_post_types( array( 'public' => true ), 'objects' );
 $index_switch_values = array(
 	'off' => '<code>index</code>',

--- a/admin/views/tabs/sitemaps/post-types.php
+++ b/admin/views/tabs/sitemaps/post-types.php
@@ -16,12 +16,15 @@ $switch_values = array(
 	'on'  => __( 'Not in sitemap', 'wordpress-seo' ),
 );
 
+// Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
+$post_types = get_post_types( array( 'public' => true ), 'objects' );
+
 /**
  * Filter the post types to present in interface for exclusion.
  *
  * @param array $post_types Array of post type objects.
  */
-$post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', get_post_types( array( 'public' => true ), 'objects' ) );
+$post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', $post_types );
 if ( is_array( $post_types ) && $post_types !== array() ) {
 	foreach ( $post_types as $pt ) {
 		$yform->toggle_switch(
@@ -29,6 +32,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 			$switch_values,
 			$pt->labels->name . ' (<code>' . $pt->name . '</code>)'
 		);
+
 		/**
 		 * Allow adding custom checkboxes to the admin sitemap page - Post Types tab
 		 *

--- a/inc/options/class-wpseo-option-internallinks.php
+++ b/inc/options/class-wpseo-option-internallinks.php
@@ -79,7 +79,6 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 	 * @return  void
 	 */
 	public function enrich_defaults() {
-
 		/*
 		 * Retrieve all the relevant post type and taxonomy arrays.
 		 *

--- a/inc/options/class-wpseo-option-internallinks.php
+++ b/inc/options/class-wpseo-option-internallinks.php
@@ -80,7 +80,11 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 	 */
 	public function enrich_defaults() {
 
-		// Retrieve all the relevant post type and taxonomy arrays.
+		/*
+		 * Retrieve all the relevant post type and taxonomy arrays.
+		 *
+		 * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
+		 */
 		$post_type_names       = get_post_types( array( 'public' => true ), 'names' );
 		$taxonomy_names_custom = get_taxonomies(
 			array(
@@ -254,6 +258,9 @@ class WPSEO_Option_InternalLinks extends WPSEO_Option {
 	protected function get_allowed_post_types() {
 		$allowed_post_types = array();
 
+		/*
+		 * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
+		 */
 		$post_types = get_post_types( array( 'public' => true ), 'objects' );
 
 		if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) > 0 ) {

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -188,7 +188,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @return  void
 	 */
 	public function enrich_defaults() {
-
 		/*
 		 * Retrieve all the relevant post type and taxonomy arrays.
 		 *

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -189,7 +189,12 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 */
 	public function enrich_defaults() {
 
-		// Retrieve all the relevant post type and taxonomy arrays.
+		/*
+		 * Retrieve all the relevant post type and taxonomy arrays.
+		 *
+		 * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
+		 * These are the defaults and can be prepared for any public post type.
+		 */
 		$post_type_names = get_post_types( array( 'public' => true ), 'names' );
 
 		$post_type_objects_custom = get_post_types(

--- a/inc/options/class-wpseo-option-xml.php
+++ b/inc/options/class-wpseo-option-xml.php
@@ -95,6 +95,7 @@ class WPSEO_Option_XML extends WPSEO_Option {
 		}
 		unset( $user_roles, $filtered_user_roles );
 
+		// Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
 		$post_type_names     = get_post_types( array( 'public' => true ), 'names' );
 		$filtered_post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', $post_type_names );
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -119,6 +119,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		global $wpdb;
 
+		// Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
 		$post_types          = get_post_types( array( 'public' => true ) );
 		$post_types          = array_filter( $post_types, array( $this, 'is_valid_post_type' ) );
 		$last_modified_times = WPSEO_Sitemaps::get_last_modified_gmt( $post_types, true );
@@ -305,6 +306,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return false;
 		}
 
+		// Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
 		if ( ! in_array( $post_type, get_post_types( array( 'public' => true ), 'names' ), true ) ) {
 			return false;
 		}

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -447,26 +447,30 @@ class WPSEO_Sitemaps {
 
 		if ( is_null( $post_type_dates ) ) {
 
-			$sql = "
+			$post_type_dates = array();
+
+			// Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
+			$post_type_names = get_post_types( array( 'public' => true ) );
+
+			if ( ! empty( $post_type_names ) ) {
+				$sql = "
 				SELECT post_type, MAX(post_modified_gmt) AS date
 				FROM $wpdb->posts
 				WHERE post_status IN ('publish','inherit')
-					AND post_type IN ('" . implode( "','", get_post_types( array( 'public' => true ) ) ) . "')
+					AND post_type IN ('" . implode( "','", $post_type_names ) . "')
 				GROUP BY post_type
 				ORDER BY post_modified_gmt DESC
 			";
 
-			$post_type_dates = array();
-
-			foreach ( $wpdb->get_results( $sql ) as $obj ) {
-				$post_type_dates[ $obj->post_type ] = $obj->date;
+				foreach ( $wpdb->get_results( $sql ) as $obj ) {
+					$post_type_dates[ $obj->post_type ] = $obj->date;
+				}
 			}
 		}
 
 		$dates = array_intersect_key( $post_type_dates, array_flip( $post_types ) );
 
 		if ( count( $dates ) > 0 ) {
-
 			if ( $return_all ) {
 				return $dates;
 			}

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -60,8 +60,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 
 		self::$class_instance->add_meta_box();
 
-		$post_types = get_post_types( array( 'public' => true ) );
-		unset( $post_types['attachment'] );
+		$post_types = WPSEO_Post_Type::get_accessible_post_types();
 
 		// Test if all post types have the wpseo_meta metabox.
 		foreach ( $post_types as $post_type ) {


### PR DESCRIPTION
## Summary

## Relevant technical choices:

* Added code documentation about choices on not to use the helper function for now.

## Test instructions

This PR can be tested by following these steps:

* Add the following code to your WordPress installation:
```
add_filter( 'wpseo_accessible_post_types', function( $post_types ) {
	return array();
});
```
* No post/page overview should have the Yoast Columns
* No post/page overview should have the Yoast Metabox

Fixes #8413 
