### PR TITLE
Allow WPSEO_Primary_Term_Admin to get the id of a new post

### DIFF
--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -28,7 +28,12 @@ class WPSEO_Primary_Term_Admin {
 	 * @return integer The post ID.
 	 */
 	protected function get_current_id() {
-		return get_the_ID();
+		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		if ( empty( $post_id ) && isset( $GLOBALS['post_ID'] ) ) {
+			$post_id = filter_var( $GLOBALS['post_ID'], FILTER_SANITIZE_NUMBER_INT );
+		}
+
+		return $post_id;
 	}
 
 	/**

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -28,7 +28,7 @@ class WPSEO_Primary_Term_Admin {
 	 * @return integer The post ID.
 	 */
 	protected function get_current_id() {
-		return filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		return $GLOBALS['post_ID'];
 	}
 
 	/**

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -28,7 +28,7 @@ class WPSEO_Primary_Term_Admin {
 	 * @return integer The post ID.
 	 */
 	protected function get_current_id() {
-		return $GLOBALS['post_ID'];
+		return get_the_ID();
 	}
 
 	/**


### PR DESCRIPTION
The goal fo this PR is to allow Polylang to synchronize the primary category across post translations. 

Although it is not possible to do this in the wpml-config.xml file (due to the fact that the primary category id must be translated during the process), the basic idea is to obtain the same result for `_yoast_wpseo_primary_category` as already done for [other custom fields](https://github.com/Yoast/wordpress-seo/blob/5.9.1/wpml-config.xml#L8-L10).

This is easily achievable in Polylang, but the issue is that a newly created translation doesn't populate the primary category in the metabox, because the class  `WPSEO_Primary_Term_Admin` does not get the post ID of new posts. The PR allows to get the post ID even for new posts.

Here is the Polylang branch to test the feature if you like to: https://github.com/polylang/polylang/tree/yoast_primary_category 