### PR TITLE
Use WooCommerce Shop Page SEO data

### DIFF
--- a/frontend/class-frontend-woocommerce-shop-page.php
+++ b/frontend/class-frontend-woocommerce-shop-page.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @package WPSEO\Frontend
+ */
+
+/**
+ * Implements SEO Title and Meta Description for WooCommerce Shop page.
+ */
+class WPSEO_Frontend_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
+	/** @var WPSEO_Frontend Frontend class. */
+	protected $frontend;
+
+	/**
+	 * Initializes the class.
+	 *
+	 * @param WPSEO_Frontend $frontend Frontend instance to use.
+	 */
+	public function __construct( WPSEO_Frontend $frontend ) {
+		$this->frontend = $frontend;
+	}
+
+	/**
+	 * Registers the hooks.
+	 */
+	public function register_hooks() {
+		add_filter( 'wpseo_title', array( $this, 'apply_shop_page_title' ) );
+		add_filter( 'wpseo_metadesc', array( $this, 'apply_shop_page_metadesc' ) );
+	}
+
+	/**
+	 * Overrides title for shop page.
+	 *
+	 * @param string $title The current title.
+	 *
+	 * @return string Title of the shop page if applicable.
+	 */
+	public function apply_shop_page_title( $title ) {
+		// This check must be done in the filter, as the function is not present when registering hooks.
+		if ( ! $this->is_wc_shop_page() ) {
+			return $title;
+		}
+
+		return $this->frontend->get_content_title( get_post( $this->get_shop_id() ) );
+	}
+
+	/**
+	 * Overrides the meta description.
+	 *
+	 * @param string $description The current meta description.
+	 *
+	 * @return string Meta description of the shop page if applicable.
+	 */
+	public function apply_shop_page_metadesc( $description ) {
+		global $post;
+
+		// This check must be done in the filter, as the function is not present when registering hooks.
+		if ( ! $this->is_wc_shop_page() ) {
+			return $description;
+		}
+
+		$post_type = '';
+		if ( is_object( $post ) && ( isset( $post->post_type ) && $post->post_type !== '' ) ) {
+			$post_type = $post->post_type;
+		}
+
+		$metadesc = WPSEO_Meta::get_value( 'metadesc', $this->get_shop_id() );
+		if ( ( $metadesc === '' && $post_type !== '' ) && isset( $this->frontend->options[ 'metadesc-' . $post_type ] ) ) {
+			$metadesc = $this->frontend->options[ 'metadesc-' . $post_type ];
+
+		}
+
+		return trim( wpseo_replace_vars( $metadesc, get_queried_object() ) );
+	}
+
+	/**
+	 * Determine whether this is the WooCommerce shop page.
+	 *
+	 * @return bool True if we are on a shop page.
+	 */
+	protected function is_wc_shop_page() {
+		if ( function_exists( 'is_shop' ) && function_exists( 'wc_get_page_id' ) ) {
+			return is_shop();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the page ID of the WooCommerce shop.
+	 *
+	 * @return int The Page ID of the shop.
+	 */
+	protected function get_shop_id() {
+		return wc_get_page_id( 'shop' );
+	}
+}

--- a/frontend/class-frontend-woocommerce-shop-page.php
+++ b/frontend/class-frontend-woocommerce-shop-page.php
@@ -7,6 +7,7 @@
  * Implements SEO Title and Meta Description for WooCommerce Shop page.
  */
 class WPSEO_Frontend_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
+
 	/** @var WPSEO_Frontend Frontend class. */
 	protected $frontend;
 
@@ -40,7 +41,7 @@ class WPSEO_Frontend_WooCommerce_Shop_Page implements WPSEO_WordPress_Integratio
 			return $title;
 		}
 
-		return $this->frontend->get_content_title( get_post( $this->get_shop_id() ) );
+		return $this->frontend->get_content_title( get_post( $this->get_shop_page_id() ) );
 	}
 
 	/**
@@ -58,12 +59,9 @@ class WPSEO_Frontend_WooCommerce_Shop_Page implements WPSEO_WordPress_Integratio
 			return $description;
 		}
 
-		$post_type = '';
-		if ( is_object( $post ) && ( isset( $post->post_type ) && $post->post_type !== '' ) ) {
-			$post_type = $post->post_type;
-		}
+		$post_type = $this->get_post_type( $post );
 
-		$metadesc = WPSEO_Meta::get_value( 'metadesc', $this->get_shop_id() );
+		$metadesc = WPSEO_Meta::get_value( 'metadesc', $this->get_shop_page_id() );
 		if ( ( $metadesc === '' && $post_type !== '' ) && isset( $this->frontend->options[ 'metadesc-' . $post_type ] ) ) {
 			$metadesc = $this->frontend->options[ 'metadesc-' . $post_type ];
 
@@ -90,7 +88,22 @@ class WPSEO_Frontend_WooCommerce_Shop_Page implements WPSEO_WordPress_Integratio
 	 *
 	 * @return int The Page ID of the shop.
 	 */
-	protected function get_shop_id() {
+	protected function get_shop_page_id() {
 		return wc_get_page_id( 'shop' );
+	}
+
+	/**
+	 * Gets the post type of the supplied post.
+	 *
+	 * @param WP_Post|null $post Post to retrieve post type from.
+	 *
+	 * @return string Post type of the post if applicable.
+	 */
+	protected function get_post_type( $post ) {
+		if ( is_object( $post ) && ! empty( $post->post_type ) ) {
+			return $post->post_type;
+		}
+
+		return '';
 	}
 }

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -67,11 +67,6 @@ class WPSEO_Frontend {
 	private $required_options = array( 'wpseo', 'wpseo_rss', 'wpseo_social', 'wpseo_permalinks', 'wpseo_titles' );
 
 	/**
-	 * @var array
-	 */
-	private $hooks;
-
-	/**
 	 * Class constructor.
 	 *
 	 * Adds and removes a lot of filters.
@@ -152,13 +147,15 @@ class WPSEO_Frontend {
 			add_filter( 'wpseo_title', array( $this, 'title_test_helper' ) );
 		}
 
-		$primary_category = new WPSEO_Frontend_Primary_Category();
-		$primary_category->register_hooks();
+		$integrations = array(
+			new WPSEO_Frontend_Primary_Category(),
+			new WPSEO_JSON_LD(),
+			new WPSEO_Frontend_WooCommerce_Shop_Page( $this ),
+		);
 
-		$json_ld = new WPSEO_JSON_LD();
-		$json_ld->register_hooks();
-
-		$this->hooks = array( $primary_category, $json_ld );
+		foreach ( $integrations as $integration ) {
+			$integration->register_hooks();
+		}
 	}
 
 	/**
@@ -236,19 +233,6 @@ class WPSEO_Frontend {
 	 */
 	public function is_posts_page() {
 		return ( is_home() && 'page' === get_option( 'show_on_front' ) );
-	}
-
-	/**
-	 * Determine whether this is the WooCommerce shop page.
-	 *
-	 * @return bool
-	 */
-	public function is_wc_shop_page() {
-		if ( function_exists( 'is_shop' ) && function_exists( 'wc_get_page_id' ) ) {
-			return is_shop();
-		}
-
-		return false;
 	}
 
 	/**
@@ -466,9 +450,6 @@ class WPSEO_Frontend {
 		}
 		elseif ( $this->is_posts_page() ) {
 			$title = $this->get_content_title( get_post( get_option( 'page_for_posts' ) ) );
-		}
-		elseif ( $this->is_wc_shop_page() ) {
-			$title = $this->get_content_title( get_post( wc_get_page_id( 'shop' ) ) );
 		}
 		elseif ( is_singular() ) {
 			$title = $this->get_content_title();
@@ -1327,12 +1308,6 @@ class WPSEO_Frontend {
 			}
 			elseif ( $this->is_home_static_page() ) {
 				$metadesc = WPSEO_Meta::get_value( 'metadesc' );
-				if ( ( $metadesc === '' && $post_type !== '' ) && isset( $this->options[ 'metadesc-' . $post_type ] ) ) {
-					$template = $this->options[ 'metadesc-' . $post_type ];
-				}
-			}
-			elseif ( $this->is_wc_shop_page() ) {
-				$metadesc = WPSEO_Meta::get_value( 'metadesc', wc_get_page_id( 'shop' ) );
 				if ( ( $metadesc === '' && $post_type !== '' ) && isset( $this->options[ 'metadesc-' . $post_type ] ) ) {
 					$template = $this->options[ 'metadesc-' . $post_type ];
 				}

--- a/frontend/class-primary-category.php
+++ b/frontend/class-primary-category.php
@@ -6,7 +6,7 @@
 /**
  * Adds customizations to the front end for the primary category.
  */
-class WPSEO_Frontend_Primary_Category {
+class WPSEO_Frontend_Primary_Category implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Registers the hooks necessary for correct primary category behaviour.

--- a/tests/frontend/test-class-frontend-woocommerce-shop-page.php
+++ b/tests/frontend/test-class-frontend-woocommerce-shop-page.php
@@ -7,8 +7,11 @@
  * Unit Test Class.
  */
 class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
+
 	/**
 	 * Tests for original title on non-shop page.
+	 *
+	 * @covers WPSEO_Frontend_WooCommerce_Shop_Page::apply_shop_page_title()
 	 */
 	public function test_apply_shop_page_title_not_applied() {
 		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
@@ -26,6 +29,8 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests for shop page title on shop page.
+	 *
+	 * @covers WPSEO_Frontend_WooCommerce_Shop_Page::apply_shop_page_title()
 	 */
 	public function test_apply_shop_page_title_applied() {
 		$shop_page_id = $this->factory->post->create(
@@ -40,7 +45,7 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
 						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
-						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_id' ) )
+						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_page_id' ) )
 						 ->getMock();
 
 		$instance->expects( $this->once() )
@@ -48,7 +53,7 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 				 ->will( $this->returnValue( true ) );
 
 		$instance->expects( $this->once() )
-				 ->method( 'get_shop_id' )
+				 ->method( 'get_shop_page_id' )
 				 ->will( $this->returnValue( $shop_page_id ) );
 
 		$this->assertEquals( 'SEO Title', $instance->apply_shop_page_title( 'Original Title' ) );
@@ -56,6 +61,8 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests for original meta description for non-shop pages.
+	 *
+	 * @covers WPSEO_Frontend_WooCommerce_Shop_Page::apply_shop_page_metadesc()
 	 */
 	public function test_apply_shop_page_metadesc_not_applied() {
 		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
@@ -75,6 +82,8 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests for applied Meta Description on the shop page.
+	 *
+	 * @covers WPSEO_Frontend_WooCommerce_Shop_Page::apply_shop_page_metadesc()
 	 */
 	public function test_apply_shop_page_metadesc_applied() {
 		$shop_page_id = $this->factory->post->create(
@@ -86,7 +95,7 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
 						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
-						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_id' ) )
+						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_page_id' ) )
 						 ->getMock();
 
 		$instance->expects( $this->once() )
@@ -94,7 +103,7 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 				 ->will( $this->returnValue( true ) );
 
 		$instance->expects( $this->once() )
-				 ->method( 'get_shop_id' )
+				 ->method( 'get_shop_page_id' )
 				 ->will( $this->returnValue( $shop_page_id ) );
 
 		// Set SEO Metadata on the page.
@@ -105,6 +114,8 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests for fallback method on the post type description.
+	 *
+	 * @covers WPSEO_Frontend_WooCommerce_Shop_Page::apply_shop_page_metadesc()
 	 */
 	public function test_apply_shop_page_metadesc_post_type_fallback() {
 		$frontend                           = WPSEO_Frontend::get_instance();
@@ -119,7 +130,7 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
 						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
-						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_id' ) )
+						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_page_id' ) )
 						 ->getMock();
 
 		$instance->expects( $this->once() )
@@ -127,7 +138,7 @@ class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 				 ->will( $this->returnValue( true ) );
 
 		$instance->expects( $this->once() )
-				 ->method( 'get_shop_id' )
+				 ->method( 'get_shop_page_id' )
 				 ->will( $this->returnValue( $shop_page_id ) );
 
 		// Set the global post to allow post type to be fetched.

--- a/tests/frontend/test-class-frontend-woocommerce-shop-page.php
+++ b/tests/frontend/test-class-frontend-woocommerce-shop-page.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @package WPSEO\Tests\Frontend
+ */
+
+/**
+ * Unit Test Class.
+ */
+class WPSEO_Frontend_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Tests for original title on non-shop page.
+	 */
+	public function test_apply_shop_page_title_not_applied() {
+		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
+						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
+						 ->setMethods( array( 'is_wc_shop_page' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'is_wc_shop_page' )
+				 ->will( $this->returnValue( false ) );
+
+		$this->assertEquals( 'Not modified', $instance->apply_shop_page_title( 'Not modified' ) );
+	}
+
+	/**
+	 * Tests for shop page title on shop page.
+	 */
+	public function test_apply_shop_page_title_applied() {
+		$shop_page_id = $this->factory->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		// Set SEO Metadata on the page.
+		WPSEO_Meta::set_value( 'title', 'SEO Title', $shop_page_id );
+
+		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
+						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
+						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_id' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'is_wc_shop_page' )
+				 ->will( $this->returnValue( true ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_shop_id' )
+				 ->will( $this->returnValue( $shop_page_id ) );
+
+		$this->assertEquals( 'SEO Title', $instance->apply_shop_page_title( 'Original Title' ) );
+	}
+
+	/**
+	 * Tests for original meta description for non-shop pages.
+	 */
+	public function test_apply_shop_page_metadesc_not_applied() {
+		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
+						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
+						 ->setMethods( array( 'is_wc_shop_page' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'is_wc_shop_page' )
+				 ->will( $this->returnValue( false ) );
+
+		$description = 'Not modified';
+
+		$this->assertEquals( $description, $instance->apply_shop_page_metadesc( $description ) );
+	}
+
+	/**
+	 * Tests for applied Meta Description on the shop page.
+	 */
+	public function test_apply_shop_page_metadesc_applied() {
+		$shop_page_id = $this->factory->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
+						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
+						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_id' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'is_wc_shop_page' )
+				 ->will( $this->returnValue( true ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_shop_id' )
+				 ->will( $this->returnValue( $shop_page_id ) );
+
+		// Set SEO Metadata on the page.
+		WPSEO_Meta::set_value( 'metadesc', 'SEO Description', $shop_page_id );
+
+		$this->assertEquals( 'SEO Description', $instance->apply_shop_page_metadesc( 'Original description' ) );
+	}
+
+	/**
+	 * Tests for fallback method on the post type description.
+	 */
+	public function test_apply_shop_page_metadesc_post_type_fallback() {
+		$frontend                           = WPSEO_Frontend::get_instance();
+		$frontend->options['metadesc-page'] = 'Post type metadescription';
+
+		$shop_page_id = $this->factory->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		/** @var WPSEO_Frontend_WooCommerce_Shop_Page $instance */
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_WooCommerce_Shop_Page' )
+						 ->setConstructorArgs( array( WPSEO_Frontend::get_instance() ) )
+						 ->setMethods( array( 'is_wc_shop_page', 'get_shop_id' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'is_wc_shop_page' )
+				 ->will( $this->returnValue( true ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_shop_id' )
+				 ->will( $this->returnValue( $shop_page_id ) );
+
+		// Set the global post to allow post type to be fetched.
+		$GLOBALS['post'] = get_post( $shop_page_id );
+
+		// Set SEO Metadata on the page to empty, to make sure the post type version is used.
+		WPSEO_Meta::set_value( 'metadesc', '', $shop_page_id );
+
+		$this->assertEquals( 'Post type metadescription', $instance->apply_shop_page_metadesc( 'Original description' ) );
+	}
+}


### PR DESCRIPTION
## Summary

This moves the code supplied by @WPprodigy to a separate class and adds unit tests to verify behaviour.

This PR can be summarized in the following changelog entry:

* Add support for custom page titles and meta descriptions on the WooCommerce shop page. Props [Caleb Burks](https://github.com/WPprodigy).

## Relevant technical choices:

* Injected Frontend for testing purposes.
* Created protected helper function to make testing easier.

## Test instructions

This PR can be tested by following these steps:

* Install WooCommerce and assign a page as the shop page. Edit the shop page's title and meta description, then view shop page.

Fixes https://github.com/Yoast/wordpress-seo/issues/4362
Related https://github.com/Yoast/wordpress-seo/pull/8409
