### PR TITLE
Remove noindex post type filter

### DIFF
--- a/inc/class-post-type.php
+++ b/inc/class-post-type.php
@@ -17,7 +17,6 @@ class WPSEO_Post_Type {
 	 */
 	public static function get_accessible_post_types() {
 		$post_types = get_post_types( array( 'public' => true ) );
-		$post_types = array_filter( $post_types, array( 'self', 'is_post_type_indexable' ) );
 
 		/**
 		 * Filter: 'wpseo_accessible_post_types' - Allow changing the accessible post types.

--- a/tests/inc/test-class-post-type.php
+++ b/tests/inc/test-class-post-type.php
@@ -38,10 +38,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	public function test_get_accessible_post_types_with_a_custom_post_type() {
 		register_post_type( 'custom-post-type', array( 'public' => true ) );
 
-		$this->assertEquals(
-			array( 'post' => 'post', 'page' => 'page', 'attachment' => 'attachment', 'custom-post-type' => 'custom-post-type' ),
-			WPSEO_Post_Type::get_accessible_post_types()
-		);
+		$this->assertContains( 'custom-post-type', WPSEO_Post_Type::get_accessible_post_types() );
 	}
 
 	/**
@@ -52,10 +49,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	public function test_get_accessible_post_types_with_a_custom_private_post_type() {
 		register_post_type( 'custom-post-type', array( 'public' => false ) );
 
-		$this->assertEquals(
-			array( 'post' => 'post', 'page' => 'page', 'attachment' => 'attachment' ),
-			WPSEO_Post_Type::get_accessible_post_types()
-		);
+		$this->assertNotContains( 'custom-post-type', WPSEO_Post_Type::get_accessible_post_types() );
 	}
 
 	/**
@@ -72,10 +66,8 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 			true
 		);
 
-		$this->assertEquals(
-			array( 'post' => 'post', 'page' => 'page', 'attachment' => 'attachment' ),
-			WPSEO_Post_Type::get_accessible_post_types()
-		);
+		// Noindexed post types -should- remain in the list.
+		$this->assertContains( 'custom-post-type', WPSEO_Post_Type::get_accessible_post_types() );
 	}
 
 	/**
@@ -92,23 +84,17 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 			false
 		);
 
-		$this->assertEquals(
-			array( 'post' => 'post', 'page' => 'page', 'attachment' => 'attachment', 'custom-post-type' => 'custom-post-type' ),
-			WPSEO_Post_Type::get_accessible_post_types()
-		);
+		$this->assertContains( 'custom-post-type', WPSEO_Post_Type::get_accessible_post_types() );
 	}
 
 	/**
 	 * Tests the situation where a post type will be filtered by using the 'wpseo_accessible_post_types filter'.
 	 */
 	public function test_get_accessible_post_types_with_a_filter_hook() {
+		$this->assertContains( 'attachment', WPSEO_Post_Type::get_accessible_post_types() );
+
 		add_filter( 'wpseo_accessible_post_types', array( $this, 'filter_attachment' ) );
-
-		$this->assertEquals(
-			array( 'post' => 'post', 'page' => 'page' ),
-			WPSEO_Post_Type::get_accessible_post_types()
-		);
-
+		$this->assertNotContains( 'attachment', WPSEO_Post_Type::get_accessible_post_types() );
 		remove_filter( 'wpseo_accessible_post_types', array( $this, 'filter_attachment' ) );
 	}
 
@@ -172,9 +158,14 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::filter_attachment_post_type()
 	 */
 	public function test_filter_attachment_post_type() {
-		$this->assertEquals(
-			array( 'post' => 'post' ),
-			WPSEO_Post_Type::filter_attachment_post_type( array( 'post' => 'post', 'attachment' => 'attachment' ) )
+		$this->assertNotContains(
+			'attachment',
+			WPSEO_Post_Type::filter_attachment_post_type(
+				array(
+					'post' => 'post',
+					'attachment' => 'attachment',
+				)
+			)
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [bugfix] Remove the `noindex` post-types from the list of relevant post types to show the Yoast SEO Metabox on.

## Relevant technical choices:

* Remove the filter from the code.

## Test instructions

This PR can be tested by following these steps:

* Configure a post type to have robots `noindex` in the Titles & Metas menu

Fixes https://github.com/Yoast/wordpress-seo/issues/8445
