### PR TITLE
Add functionality to disable and hide marker buttons and add tooltips

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -113,9 +113,11 @@ class WPSEO_Metabox_Formatter {
 			'content-analysis.improvements'         => __( 'Improvements', 'wordpress-seo' ),
 			'content-analysis.considerations'       => __( 'Considerations', 'wordpress-seo' ),
 			'content-analysis.good'                 => __( 'Good', 'wordpress-seo' ),
-			'content-analysis.highlight'            => __( 'Highlight this result in the text', 'wordpress-seo' ),
 			'content-analysis.language-notice'      => __( 'Your site language is set to {language}.', 'wordpress-seo' ),
 			'content-analysis.language-notice-contact-admin' => __( 'Your site language is set to {language}. If this is not correct, contact your site administrator.', 'wordpress-seo' ),
+			'content-analysis.highlight'            => __( 'Highlight this result in the text', 'wordpress-seo' ),
+			'content-analysis.nohighlight'          => __( 'Remove highlight from the text', 'wordpress-seo' ),
+			'content-analysis.disabledButton'       => __( 'Marks are disabled in current view', 'wordpress-seo' ),
 		);
 	}
 

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -116,8 +116,7 @@ PostDataCollector.prototype.getUrl = function() {
 	var newPostSlug = $( "#new-post-slug" );
 	if ( 0 < newPostSlug.length ) {
 		url = newPostSlug.val();
-	}
-	else if ( document.getElementById( "editable-post-name-full" ) !== null ) {
+	} else if ( document.getElementById( "editable-post-name-full" ) !== null ) {
 		url = document.getElementById( "editable-post-name-full" ).textContent;
 	}
 
@@ -378,8 +377,14 @@ PostDataCollector.prototype.saveScores = function( score ) {
 
 		if ( "" === currentKeyword ) {
 			indicator.className = "na";
-			indicator.screenReaderText = this.app.i18n.dgettext( "js-text-analysis", "Enter a focus keyword to calculate the SEO score" );
-			indicator.fullText = this.app.i18n.dgettext( "js-text-analysis", "Content optimization: Enter a focus keyword to calculate the SEO score" );
+			indicator.screenReaderText = this.app.i18n.dgettext(
+				"js-text-analysis",
+				"Enter a focus keyword to calculate the SEO score"
+			);
+			indicator.fullText = this.app.i18n.dgettext(
+				"js-text-analysis",
+				"Content optimization: Enter a focus keyword to calculate the SEO score"
+			);
 		}
 
 		this._tabManager.updateKeywordTab( score, currentKeyword );

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -25,7 +25,10 @@ class ReadabilityAnalysis extends React.Component {
 				showLanguageNotice={ true }
 				changeLanguageLink={ localizedData.settings_link }
 				language={ localizedData.language }
-				results={ this.props.results } />
+				results={ this.props.results }
+				markButtonClassName="yoast-tooltip yoast-tooltip-s"
+				buttonsDisabled={ false }
+			/>
 		);
 	}
 }

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -5,7 +5,6 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import Results from "./Results";
-import { setStore } from "../../wp-seo-tinymce";
 
 let localizedData = {};
 if( window.wpseoPostScraperL10n ) {
@@ -18,22 +17,6 @@ if( window.wpseoPostScraperL10n ) {
  * Redux container for the readability analysis.
  */
 class ReadabilityAnalysis extends React.Component {
-	setButtonsDisabled() {
-		if ( this.props.markerStatus === "disabled" ) {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	setButtonsHidden() {
-		if ( this.props.markerStatus === "hidden" ) {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
 	render() {
 		return (
 			<Results
@@ -42,9 +25,8 @@ class ReadabilityAnalysis extends React.Component {
 				changeLanguageLink={ localizedData.settings_link }
 				language={ localizedData.language }
 				results={ this.props.results }
-				markButtonClassName="yoast-tooltip yoast-tooltip-s"
-				buttonsDisabled={ this.setButtonsDisabled() }
-				buttonsHidden={ this.setButtonsHidden() }
+				marksButtonClassName="yoast-tooltip yoast-tooltip-s"
+				marksButtonStatus={ this.props.marksButtonStatus }
 			/>
 		);
 	}
@@ -52,20 +34,27 @@ class ReadabilityAnalysis extends React.Component {
 
 ReadabilityAnalysis.propTypes = {
 	results: PropTypes.array,
-	markerStatus: PropTypes.string,
+	marksButtonStatus: PropTypes.string,
 };
 
 /**
  * Maps redux state to ContentAnalysis props.
  *
  * @param {Object} state The redux state.
+ * @param {Object} ownProps The components own props.
  *
  * @returns {Object} Props that should be passed to ContentAnalysis.
  */
-function mapStateToProps( state ) {
+function mapStateToProps( state, ownProps ) {
+	let marksButtonStatus = state.marksButtonStatus;
+
+	if ( ownProps.hideMarksButtons ) {
+		marksButtonStatus = "hidden";
+	}
+
 	return {
 		results: state.analysis.readability,
-		markerStatus: state.markerStatus,
+		marksButtonStatus: marksButtonStatus,
 	};
 }
 

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import Results from "./Results";
+import { setStore } from "../../wp-seo-tinymce";
 
 let localizedData = {};
 if( window.wpseoPostScraperL10n ) {
@@ -13,11 +14,26 @@ if( window.wpseoPostScraperL10n ) {
 	localizedData = wpseoTermScraperL10n;
 }
 
-
 /**
  * Redux container for the readability analysis.
  */
 class ReadabilityAnalysis extends React.Component {
+	setButtonsDisabled() {
+		if ( this.props.markerStatus === "disabled" ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	setButtonsHidden() {
+		if ( this.props.markerStatus === "hidden" ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
 	render() {
 		return (
 			<Results
@@ -27,7 +43,8 @@ class ReadabilityAnalysis extends React.Component {
 				language={ localizedData.language }
 				results={ this.props.results }
 				markButtonClassName="yoast-tooltip yoast-tooltip-s"
-				buttonsDisabled={ false }
+				buttonsDisabled={ this.setButtonsDisabled() }
+				buttonsHidden={ this.setButtonsHidden() }
 			/>
 		);
 	}
@@ -35,6 +52,7 @@ class ReadabilityAnalysis extends React.Component {
 
 ReadabilityAnalysis.propTypes = {
 	results: PropTypes.array,
+	markerStatus: PropTypes.string,
 };
 
 /**
@@ -47,6 +65,7 @@ ReadabilityAnalysis.propTypes = {
 function mapStateToProps( state ) {
 	return {
 		results: state.analysis.readability,
+		markerStatus: state.markerStatus,
 	};
 }
 

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -60,7 +60,10 @@ class Results extends React.Component {
 				language={ this.props.language }
 				showLanguageNotice={ this.props.showLanguageNotice }
 				canChangeLanguage={ this.props.canChangeLanguage }
-				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) } />
+				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
+				markButtonClassName={ this.props.markButtonClassName }
+				buttonsDisabled={ false }
+			/>
 		);
 	}
 }
@@ -71,6 +74,7 @@ Results.propTypes = {
 	changeLanguageLink: PropTypes.string,
 	showLanguageNotice: PropTypes.bool.isRequired,
 	canChangeLanguage: PropTypes.bool,
+	markButtonClassName: PropTypes.string,
 };
 
 Results.defaultProps = {

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -62,7 +62,7 @@ class Results extends React.Component {
 				canChangeLanguage={ this.props.canChangeLanguage }
 				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
 				markButtonClassName={ this.props.markButtonClassName }
-				buttonsDisabled={ false }
+				buttonsDisabled={ this.props.buttonsDisabled }
 			/>
 		);
 	}

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -63,6 +63,7 @@ class Results extends React.Component {
 				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
 				markButtonClassName={ this.props.markButtonClassName }
 				buttonsDisabled={ this.props.buttonsDisabled }
+				buttonsHidden={ this.props.buttonsHidden }
 			/>
 		);
 	}
@@ -75,12 +76,16 @@ Results.propTypes = {
 	showLanguageNotice: PropTypes.bool.isRequired,
 	canChangeLanguage: PropTypes.bool,
 	markButtonClassName: PropTypes.string,
+	buttonsDisabled: PropTypes.bool,
+	buttonsHidden: PropTypes.bool,
 };
 
 Results.defaultProps = {
 	language: "",
 	changeLanguageLink: "#",
 	canChangeLanguage: false,
+	buttonsDisabled: false,
+	buttonsHidden: false,
 };
 
 export default Results;

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -61,9 +61,8 @@ class Results extends React.Component {
 				showLanguageNotice={ this.props.showLanguageNotice }
 				canChangeLanguage={ this.props.canChangeLanguage }
 				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
-				markButtonClassName={ this.props.markButtonClassName }
-				buttonsDisabled={ this.props.buttonsDisabled }
-				buttonsHidden={ this.props.buttonsHidden }
+				marksButtonClassName={ this.props.marksButtonClassName }
+				marksButtonStatus={ this.props.marksButtonStatus }
 			/>
 		);
 	}
@@ -75,17 +74,14 @@ Results.propTypes = {
 	changeLanguageLink: PropTypes.string,
 	showLanguageNotice: PropTypes.bool.isRequired,
 	canChangeLanguage: PropTypes.bool,
-	markButtonClassName: PropTypes.string,
-	buttonsDisabled: PropTypes.bool,
-	buttonsHidden: PropTypes.bool,
+	marksButtonClassName: PropTypes.string,
+	marksButtonStatus: PropTypes.string.isRequired,
 };
 
 Results.defaultProps = {
 	language: "",
 	changeLanguageLink: "#",
 	canChangeLanguage: false,
-	buttonsDisabled: false,
-	buttonsHidden: false,
 };
 
 export default Results;

--- a/js/src/components/contentAnalysis/mapResults.js
+++ b/js/src/components/contentAnalysis/mapResults.js
@@ -106,5 +106,6 @@ export default function mapResults( results ) {
 		const mappedResult = mapResult( result );
 		mappedResults = processResult( mappedResult, mappedResults );
 	}
+	console.log(mappedResults)
 	return mappedResults;
 }

--- a/js/src/components/contentAnalysis/mapResults.js
+++ b/js/src/components/contentAnalysis/mapResults.js
@@ -71,8 +71,6 @@ function processResult( mappedResult, mappedResults ) {
 		case "good":
 			mappedResults.goodResults.push( mappedResult );
 			break;
-		default:
-			console.log( "Unmapped score" );
 	}
 	return mappedResults;
 }
@@ -106,6 +104,5 @@ export default function mapResults( results ) {
 		const mappedResult = mapResult( result );
 		mappedResults = processResult( mappedResult, mappedResults );
 	}
-	console.log(mappedResults)
 	return mappedResults;
 }

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -8,6 +8,7 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { IntlProvider, addLocaleData } from "react-intl";
 
+import markerStatus from "./redux/reducers/markerButtons";
 import analysis from "yoast-components/composites/Plugin/ContentAnalysis/reducers/contentAnalysisReducer";
 import activeKeyword from "./redux/reducers/activeKeyword";
 import ContentAnalysis from "./components/contentAnalysis/ReadabilityAnalysis";
@@ -37,6 +38,7 @@ function configureStore() {
 	}
 
 	const rootReducer = combineReducers( {
+		markerStatus: markerStatus,
 		analysis: analysis,
 		activeKeyword: activeKeyword,
 	} );

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -59,7 +59,7 @@ function wrapInTopLevelComponents( Component, store ) {
 			locale={ localizedData.intl.locale }
 			messages={ localizedData.intl } >
 			<Provider store={ store } >
-				<Component hideMarksButtons={ localizedData.show_marker !== "1" } />
+				<Component hideMarksButtons={ localizedData.show_markers !== "1" } />
 			</Provider>
 		</IntlProvider>
 	);

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -8,14 +8,13 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { IntlProvider, addLocaleData } from "react-intl";
 
-import markerStatus from "./redux/reducers/markerButtons";
+import markerStatusReducer from "./redux/reducers/markerButtons";
 import analysis from "yoast-components/composites/Plugin/ContentAnalysis/reducers/contentAnalysisReducer";
 import activeKeyword from "./redux/reducers/activeKeyword";
 import ContentAnalysis from "./components/contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "./components/contentAnalysis/SeoAnalysis";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
-
 let localizedData = {};
 if( window.wpseoPostScraperL10n ) {
 	localizedData = wpseoPostScraperL10n;
@@ -38,7 +37,7 @@ function configureStore() {
 	}
 
 	const rootReducer = combineReducers( {
-		markerStatus: markerStatus,
+		marksButtonStatus: markerStatusReducer,
 		analysis: analysis,
 		activeKeyword: activeKeyword,
 	} );
@@ -60,7 +59,7 @@ function wrapInTopLevelComponents( Component, store ) {
 			locale={ localizedData.intl.locale }
 			messages={ localizedData.intl } >
 			<Provider store={ store } >
-				<Component />
+				<Component hideMarksButtons={ localizedData.show_marker !== "1" } />
 			</Provider>
 		</IntlProvider>
 	);

--- a/js/src/redux/actions/markerButtons.js
+++ b/js/src/redux/actions/markerButtons.js
@@ -1,17 +1,17 @@
-const PREFIX = "WPSEO_";
 
-export const SET_MARKER_STATUS = `${ PREFIX }SET_MARKER_STATUS`;
+
+export const SET_MARKER_STATUS = `WPSEO_SET_MARKER_STATUS`;
 
 /**
- * An action creator for setting the marker button status.
+ * An action creator for setting the marks button status.
  *
- * @param {string} markerStatus The markerStatus.
+ * @param {string} marksButtonStatus The marksButtonStatus.
  *
- * @returns {Object} The setting marker button state action.
+ * @returns {Object} The setting marks button state action.
  */
-export const setMarkerStatus = function( markerStatus ) {
+export const setMarkerStatus = function( marksButtonStatus ) {
 	return {
 		type: SET_MARKER_STATUS,
-		markerStatus: markerStatus,
+		marksButtonStatus: marksButtonStatus,
 	};
 };

--- a/js/src/redux/actions/markerButtons.js
+++ b/js/src/redux/actions/markerButtons.js
@@ -1,6 +1,6 @@
 
 
-export const SET_MARKER_STATUS = `WPSEO_SET_MARKER_STATUS`;
+export const SET_MARKER_STATUS = "WPSEO_SET_MARKER_STATUS";
 
 /**
  * An action creator for setting the marks button status.

--- a/js/src/redux/actions/markerButtons.js
+++ b/js/src/redux/actions/markerButtons.js
@@ -1,5 +1,3 @@
-
-
 export const SET_MARKER_STATUS = "WPSEO_SET_MARKER_STATUS";
 
 /**

--- a/js/src/redux/actions/markerButtons.js
+++ b/js/src/redux/actions/markerButtons.js
@@ -1,0 +1,17 @@
+const PREFIX = "WPSEO_";
+
+export const SET_MARKER_STATUS = `${ PREFIX }SET_MARKER_STATUS`;
+
+/**
+ * An action creator for setting the marker button status.
+ *
+ * @param {string} markerStatus The markerStatus.
+ *
+ * @returns {Object} The setting marker button state action.
+ */
+export const setMarkerStatus = function( markerStatus ) {
+	return {
+		type: SET_MARKER_STATUS,
+		markerStatus: markerStatus,
+	};
+};

--- a/js/src/redux/reducers/markerButtons.js
+++ b/js/src/redux/reducers/markerButtons.js
@@ -1,0 +1,34 @@
+import { SET_MARKER_STATUS } from "../actions/markerButtons";
+
+const INITIAL_STATE = null;
+
+/**
+ * Sets the marker status.
+ *
+ * @param {Object} state The state.
+ * @param {Object} action The action.
+ *
+ * @returns {Object} The SEO results per keyword.
+ */
+function setMarkerStatus( state, action ) {
+	return action.markerStatus
+}
+
+/**
+ * A reducer for the active keyword.
+ *
+ * @param {Object} state The current state of the object.
+ * @param {Object} action The received action .
+ *
+ * @returns {Object} The state.
+ */
+function markerStatusReducer( state = INITIAL_STATE, action ) {
+	switch( action.type ) {
+		case SET_MARKER_STATUS:
+			return setMarkerStatus( state, action );
+		default:
+			return state;
+	}
+}
+
+export default markerStatusReducer;

--- a/js/src/redux/reducers/markerButtons.js
+++ b/js/src/redux/reducers/markerButtons.js
@@ -11,7 +11,7 @@ const INITIAL_STATE = null;
  * @returns {Object} The SEO results per keyword.
  */
 function setMarkerStatus( state, action ) {
-	return action.markerStatus
+	return action.marksButtonStatus;
 }
 
 /**

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -2,7 +2,7 @@
 import { App } from "yoastseo";
 import isUndefined from "lodash/isUndefined";
 
-import { tmceId } from "./wp-seo-tinymce";
+import { tmceId, setStore } from "./wp-seo-tinymce";
 import YoastMarkdownPlugin from "./wp-seo-markdown-plugin";
 
 import initializeEdit from "./edit";
@@ -23,6 +23,7 @@ import isKeywordAnalysisActive from "./analysis/isKeywordAnalysisActive";
 import isContentAnalysisActive from "./analysis/isContentAnalysisActive";
 import snippetPreviewHelpers from "./analysis/snippetPreview";
 import UsedKeywords from "./analysis/usedKeywords";
+import { setMarkerStatus } from "./redux/actions/markerButtons";
 
 ( function( $ ) {
 	"use strict"; // eslint-disable-line
@@ -95,7 +96,7 @@ import UsedKeywords from "./analysis/usedKeywords";
 	 * @returns {boolean} True when markers should be shown.
 	 */
 	function displayMarkers() {
-		return wpseoPostScraperL10n.show_markers === "1";
+		return wpseoPostScraperL10n.show_markers === "0";
 	}
 
 	/**
@@ -107,6 +108,10 @@ import UsedKeywords from "./analysis/usedKeywords";
 		// Only add markers when tinyMCE is loaded and show_markers is enabled (can be disabled by a WordPress hook).
 		// Only check for the tinyMCE object because the actual editor isn't loaded at this moment yet.
 		if ( typeof tinyMCE === "undefined" || ! displayMarkers() ) {
+			if ( ! isUndefined( store ) ) {
+				store.dispatch( setMarkerStatus( "hidden" ) );
+				console.log(store.getState())
+			}
 			return false;
 		}
 
@@ -402,6 +407,7 @@ import UsedKeywords from "./analysis/usedKeywords";
 
 		exposeGlobals( app, tabManager, replaceVarsPlugin, shortcodePlugin );
 
+		setStore( store );
 		tinyMCEHelper.wpTextViewOnInitCheck();
 
 		activateEnabledAnalysis( tabManager );

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -96,7 +96,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 	 * @returns {boolean} True when markers should be shown.
 	 */
 	function displayMarkers() {
-		return wpseoPostScraperL10n.show_markers === "0";
+		return wpseoPostScraperL10n.show_markers === "1";
 	}
 
 	/**
@@ -110,7 +110,6 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		if ( typeof tinyMCE === "undefined" || ! displayMarkers() ) {
 			if ( ! isUndefined( store ) ) {
 				store.dispatch( setMarkerStatus( "hidden" ) );
-				console.log(store.getState())
 			}
 			return false;
 		}

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -153,7 +153,6 @@ var termsTmceId = "description";
 	function disableMarkerButtons() {
 		if ( ! isUndefined( store ) ) {
 			store.dispatch( setMarkerStatus( "disabled" ) );
-			console.log(store.getState())
 		}
 	}
 
@@ -165,7 +164,6 @@ var termsTmceId = "description";
 	function enableMarkerButtons() {
 		if ( ! isUndefined( store ) ) {
 			store.dispatch( setMarkerStatus( "enabled" ) );
-			console.log(store.getState())
 		}
 	}
 

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -4,6 +4,8 @@ var forEach = require( "lodash/forEach" );
 var isUndefined = require( "lodash/isUndefined" );
 var editorHasMarks = require( "./decorator/tinyMCE" ).editorHasMarks;
 var editorRemoveMarks = require( "./decorator/tinyMCE" ).editorRemoveMarks;
+import { setMarkerStatus } from "./redux/actions/markerButtons";
+let store;
 
 /**
  * The HTML 'id' attribute for the TinyMCE editor.
@@ -20,6 +22,15 @@ var tmceId = "content";
 var termsTmceId = "description";
 
 ( function() {
+	/**
+	 * Sets the store.
+	 *
+	 * @param {Object} newStore The store to set.
+	 * @returns {void}
+	 */
+	function setStore( newStore ) {
+		store = newStore;
+	}
 
 	/**
 	 * Gets content from the content field by element id.
@@ -140,12 +151,9 @@ var termsTmceId = "description";
 	 * @returns {void}
 	 */
 	function disableMarkerButtons() {
-		if ( ! isUndefined( YoastSEO.app.contentAssessorPresenter ) ) {
-			YoastSEO.app.contentAssessorPresenter.disableMarkerButtons();
-		}
-
-		if ( ! isUndefined( YoastSEO.app.seoAssessorPresenter ) ) {
-			YoastSEO.app.seoAssessorPresenter.disableMarkerButtons();
+		if ( ! isUndefined( store ) ) {
+			store.dispatch( setMarkerStatus( "disabled" ) );
+			console.log(store.getState())
 		}
 	}
 
@@ -155,12 +163,9 @@ var termsTmceId = "description";
 	 * @returns {void}
 	 */
 	function enableMarkerButtons() {
-		if ( ! isUndefined( YoastSEO.app.contentAssessorPresenter ) ) {
-			YoastSEO.app.contentAssessorPresenter.enableMarkerButtons();
-		}
-
-		if ( ! isUndefined( YoastSEO.app.seoAssessorPresenter ) ) {
-			YoastSEO.app.seoAssessorPresenter.enableMarkerButtons();
+		if ( ! isUndefined( store ) ) {
+			store.dispatch( setMarkerStatus( "enabled" ) );
+			console.log(store.getState())
 		}
 	}
 
@@ -174,14 +179,7 @@ var termsTmceId = "description";
 		// If #wp-content-wrap has the 'html-active' class, text view is enabled in WordPress.
 		// TMCE is not available, the text cannot be marked and so the marker buttons are disabled.
 		if ( jQuery( "#wp-content-wrap" ).hasClass( "html-active" ) ) {
-			// The enable/disable marker functions are not called here,
-			// because the render function(in yoastseo lib) doesn't have to be called.
-			if ( ! isUndefined( YoastSEO.app.contentAssessorPresenter ) ) {
-				YoastSEO.app.contentAssessorPresenter._disableMarkerButtons = true;
-			}
-			if ( ! isUndefined( YoastSEO.app.seoAssessorPresenter ) ) {
-				YoastSEO.app.seoAssessorPresenter._disableMarkerButtons = true;
-			}
+			disableMarkerButtons();
 
 			if( isTinyMCELoaded() ) {
 				tinyMCE.on( "AddEditor", function() {
@@ -227,5 +225,6 @@ var termsTmceId = "description";
 		wpTextViewOnInitCheck: wpTextViewOnInitCheck,
 		tmceId,
 		termsTmceId,
+		setStore,
 	};
 }( jQuery ) );

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -107,7 +107,7 @@ var termsTmceId = "description";
 	 * @returns {String} Content from the TinyMCE editor.
 	 */
 	function getContentTinyMce( contentID ) {
-		// If no TinyMce object available
+		// If no TinyMCE object available
 		var content = "";
 		if ( isTinyMCEAvailable( contentID ) === false || isTinyMCEBodyAvailable( contentID ) === false ) {
 			content = tinyMCEElementContent( contentID );

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -107,12 +107,11 @@ var termsTmceId = "description";
 	 * @returns {String} Content from the TinyMCE editor.
 	 */
 	function getContentTinyMce( contentID ) {
-		// if no TinyMce object available
+		// If no TinyMce object available
 		var content = "";
 		if ( isTinyMCEAvailable( contentID ) === false || isTinyMCEBodyAvailable( contentID ) === false ) {
 			content = tinyMCEElementContent( contentID );
-		}
-		else {
+		} else {
 			content = tinyMCE.get( contentID ).getContent();
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Disables the mark buttons of the content analysis when in text view, and hides them when there is no TinyMCE or `has_marks` is false.

## Test instructions

This PR can be tested by following these steps:
- Check out this branch. 
- Link the `stories/8442-disabled-marking-buttons` branch of `yoast-components` using `yarn link`.
- `composer install`, `yarn install`, `grunt build:js`.
- Write a text that triggers at least one mark button. For example, use `because` in your text to trigger the transition word button.

### Test scenarios
#### 1. Visual editor
The buttons should be enabled and have the corresponding tooltip when hovered.

#### 2. Text editor
The buttons should be disabled and have the corresponding tooltip when hovered.

#### 3. For some reason show_markers is false.
This happens, for example, when a page builder has disabled marks. On line 70 of `class-metabox-formatter.php`, change 'true' to 'false'
The buttons should be hidden. 

#### 4. There is no TinyMCE
* Add the following code on line 25 of `wp-seo-main.php`:
```
add_action('init', function(){
	remove_post_type_support( 'post', 'editor' );
}, 99); 
```
* Add the following code on line 43 of `PostDataCollector.js`: 
```
text = "Because this is one very very very very very very very very very very very very very long sentence with over twenty words.";
```
`grunt build:js`
Switch to the readability tab. The buttons (for the transition words and sentence length) should be hidden. (In this scenario, there is a console error that has to do with the featured image. I've created an issue for that: #8499)

## Not fixed in this PR:
Tooltips don't break out of the metabox. This has always be the case. I've created an issue: https://github.com/Yoast/wordpress-seo/issues/8500
<img width="220" alt="schermafbeelding 2017-12-12 om 09 48 06" src="https://user-images.githubusercontent.com/17744553/33875143-93165e40-df21-11e7-9b40-cba4ca1e5d0a.png">

<img width="174" alt="schermafbeelding 2017-12-12 om 09 45 35" src="https://user-images.githubusercontent.com/17744553/33875069-46dadd62-df21-11e7-9d3b-83026a24d837.png">


Fixes #8442
