### PR TITLE
fix for #8473 - warning message with language-only locales (et, fi)

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -65,8 +65,9 @@ class WPSEO_Admin_Asset_Manager {
 	 * Calls the functions that register scripts and styles with the scripts and styles to be registered as arguments.
 	 */
 	public function register_assets() {
-		$locale = get_locale();
-		list( $language, $territory ) = explode( '_', $locale );
+
+		$user_locale = WPSEO_Utils::get_user_locale();
+		$language    = WPSEO_Utils::get_language( $user_locale );
 
 		wp_register_script(
 			self::PREFIX . 'intl-polyfill',

--- a/inc/language-utils.php
+++ b/inc/language-utils.php
@@ -19,8 +19,12 @@ class WPSEO_Language_Utils {
 	public static function get_language( $locale = null ) {
 		$language = 'en';
 
-		if ( ! empty( $locale ) && strlen( $locale ) >= 2 ) {
-			$language = substr( $locale, 0, 2 );
+		if ( ! empty( $locale ) ) {
+			if ( strpos( $locale, '_' ) !== false ) {
+				list( $language, $territory ) = explode( '_', $locale );
+			} else {
+				$language = $locale;
+			}
 		}
 
 		return $language;

--- a/inc/language-utils.php
+++ b/inc/language-utils.php
@@ -19,11 +19,12 @@ class WPSEO_Language_Utils {
 	public static function get_language( $locale = null ) {
 		$language = 'en';
 
-		if ( ! empty( $locale ) ) {
-			if ( strpos( $locale, '_' ) !== false ) {
-				list( $language, $territory ) = explode( '_', $locale );
-			} else {
-				$language = $locale;
+		if ( ! empty( $locale ) && is_string( $locale ) ) {
+
+			$locale_parts = explode( '_', $locale );
+
+			if ( ! empty( $locale_parts[0] ) && ( strlen( $locale_parts[0] ) === 2 || strlen( $locale_parts[0] ) === 3 ) ) {
+				$language = $locale_parts[0];
 			}
 		}
 

--- a/inc/language-utils.php
+++ b/inc/language-utils.php
@@ -19,13 +19,14 @@ class WPSEO_Language_Utils {
 	public static function get_language( $locale = null ) {
 		$language = 'en';
 
-		if ( ! empty( $locale ) && is_string( $locale ) ) {
+		if ( empty( $locale ) || ! is_string( $locale ) ) {
+			return $language;
+		}
 
-			$locale_parts = explode( '_', $locale );
+		$locale_parts = explode( '_', $locale );
 
-			if ( ! empty( $locale_parts[0] ) && ( strlen( $locale_parts[0] ) === 2 || strlen( $locale_parts[0] ) === 3 ) ) {
-				$language = $locale_parts[0];
-			}
+		if ( ! empty( $locale_parts[0] ) && ( strlen( $locale_parts[0] ) === 2 || strlen( $locale_parts[0] ) === 3 ) ) {
+			$language = $locale_parts[0];
 		}
 
 		return $language;

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -173,5 +173,10 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 'nl', WPSEO_Utils::get_language( 'nl_NL' ) );
 		$this->assertEquals( 'nl', WPSEO_Utils::get_language( 'nl_XX' ) );
 		$this->assertEquals( 'nl', WPSEO_Utils::get_language( 'nl' ) );
+		$this->assertEquals( 'haw', WPSEO_Utils::get_language( 'haw_US' ) );
+		$this->assertEquals( 'rhg', WPSEO_Utils::get_language( 'rhg' ) );
+		$this->assertEquals( 'en', WPSEO_Utils::get_language( 'xxxx' ) );
+		$this->assertEquals( 'en', WPSEO_Utils::get_language( 'xxxx_XX' ) );
+		$this->assertEquals( 'en', WPSEO_Utils::get_language( '_XX' ) );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* extract language correctly from locales without country (et, fi), also support 3-letter language codes (rhg)

## Relevant technical choices:

* use same WPSEO_Utils methods as in scripts_to_be_registered, use user's locale if available (polyfills are related to user's browser)
* fix WPSEO_Language_Utils to split locale when _ is present, else presume locale is language (unless empty)

## Test instructions

This PR can be tested by following these steps:

* set WP install to Estonian (et), Finnish (fi) before applying fix
* you get error :  Undefined offset: 1 in ... /wordpress-seo/admin/class-admin-asset-manager.php
* fix removes error, when inspecting $language variable in debugger it contains correct code
* tested with site running Polylang, worked correctly with et (language only), en_US (but also default), ru_RU (non-default with coutry). did not test with rhg

Fixes #8473
