### PR TITLE
Wrap characters to be stripped in apply_filters to allow for this arr…

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -518,7 +518,9 @@ class WPSEO_Meta {
 				}
 
 				if ( $meta_key === self::$meta_prefix . 'focuskw' ) {
-					$clean = str_replace( array(
+					$clean = str_replace(
+					    apply_filters('wpseo_focuskw_strip_chars',
+					    array(
 						'&lt;',
 						'&gt;',
 						'&quot',
@@ -527,7 +529,7 @@ class WPSEO_Meta {
 						'>',
 						'"',
 						'`',
-					), '', $clean );
+					)), '', $clean );
 				}
 				break;
 		}


### PR DESCRIPTION
…ay to be altered.

## Summary

This PR can be summarized in the following changelog entry:

* This wraps the characters being stripped from the focus keyword in a filter hook

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:
* Add a filter to this hook that removes the " character from the array, 
* Attempt to save a focus keyword value that contains a double quote


Fixes #8476 
