### PR TITLE
Update travis matrix by adding php 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,20 @@ branches:
 jobs:
   fast_finish: true
   include:
-    - php: 7.0
-      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
+    - php: 7.2
+      env: WP_VERSION=4.9 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 COVERAGE=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
-      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1
+      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1
     - php: 5.3
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
-      env: WP_VERSION=4.6
+      env: WP_VERSION=4.9
     - php: 5.6
-      env: WP_VERSION=4.6
+      env: WP_VERSION=4.9
     # WP >= 4.8 is needed for PHP 7.1
-    - php: 7.2
+    - php: 7.0
       env: WP_VERSION=4.9
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ jobs:
     - php: 5.6
       env: WP_VERSION=4.6
     # WP >= 4.8 is needed for PHP 7.1
-    - php: 7.1
-      env: WP_VERSION=4.8
+    - php: 7.2
+      env: WP_VERSION=4.9
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -385,7 +385,9 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$this->assertInternalType( 'array', $notifications );
 
-		$this->assertNotEquals( $notifications[0]->get_nonce(), $old_nonce );
+		$notification = array_shift( $notifications );
+
+		$this->assertNotEquals( $notification->get_nonce(), $old_nonce );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updated the travis matrix by replacing php 7.1 for 7.2 and the WordPress version (4.8) has been replaced for 4.9.

## Test instructions

This PR can be tested by following these steps:

* See if travis passes.

Fixes #8415
