### PR TITLE
Bumped YoastSEO.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "yoast-components": "^2.11.6",
-    "yoastseo": "^1.24"
+    "yoastseo": "^1.26"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8507,9 +8507,9 @@ yoast-components@^2.11.6:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.24:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.24.0.tgz#64237c4ca7666efc9e0832a66819528b81c7b128"
+yoastseo@^1.26:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.26.0.tgz#d64e4da825e647c8d3d96bed544374507d47ff9e"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Bumps YoastSEO.js to version 1.26, which includes some new copy and a link for the `previouslyUsedKeywords` assessment.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and run `yarn`.
* Make sure to build the JS files by running `grunt build:js`.
* Create a post with a particular keyword.
* Create another post and use the same keyword as before. You shouldn't be seeing the new copy, but a different message regarding reusing keywords.
* Repeat the previous step once more and see that the `previouslyUsedKeyword` assessment now displays the new copy.
* Please verify that the link works as well.

Fixes #8490 
