### PR TITLE
Replace overflow hidden with after pseudo element clearing.

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -210,7 +210,12 @@ ul.wpseo-metabox-tabs li {
 
 #wpseo_meta .inside {
 	margin: 0;
-	overflow: hidden;
+
+	&::after {
+		content: "";
+		display: table;
+		clear: both;
+	}
 }
 
 #wpseo_meta .postbox .inside .wpseotab {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Allow tooltips to overflow the metabox

## Relevant technical choices:

* Replaces an `overflow: hidden` introduced in https://github.com/Yoast/wordpress-seo/commit/9fbc20062429e29f368c183918cd88f99a5c2c88 with an `after` pseudo element clearfix.

## Test instructions

- enable Yoast Seo Video
- in the metabox, switch to the video tab (in a post with no videos so the tab content is very short)
- verify at the bottom fo the metabox there's no visual breakage

with the fix:

![screen shot 2017-12-14 at 15 11 22](https://user-images.githubusercontent.com/1682452/33997605-4076f85a-e0e5-11e7-81cf-43403d25b9bf.png)

without the fix:

![screen shot 2017-12-14 at 15 11 29](https://user-images.githubusercontent.com/1682452/33997632-4d58e9a2-e0e5-11e7-874a-81f1f1b94bb7.png)

Recommendation: avoid to use `overflow: hidden` to contain floated elements. While handy, it cuts-off anything from the element it's applied to, e.g. tooltips, focus styles.
 
Fixes #8500
