### PR TITLE
Use protocol-relative url for comparing in post_type sitemap

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -82,6 +82,7 @@ class WPSEO_Admin {
 		add_action( 'admin_init', array( $this, 'map_manage_options_cap' ) );
 
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
+		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'home' );
 
 		if ( WPSEO_Utils::is_yoast_seo_page() ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -380,7 +380,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		if ( ! $this->get_page_on_front_id() && ( $post_type === 'post' || $post_type === 'page' ) ) {
 
 			$links[] = array(
-				'loc' => $this->home_url(),
+				'loc' => home_url(),
 
 				// Deprecated, kept for backwards data compat. R.
 				'chf' => 'daily',

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -8,6 +8,9 @@
  */
 class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
+	/** @var string $home_url Holds the home_url() value. */
+	protected static $home_url;
+
 	/** @var string $home_proto_rel_url Holds home protocol-relative url value to speed up loops. */
 	protected static $home_proto_rel_url;
 
@@ -70,16 +73,31 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	}
 
 	/**
-	 * Get Home protocol relative URL
+	 * Get Home URL
 	 *
 	 * This has been moved from the constructor because wp_rewrite is not available on plugins_loaded in multisite.
 	 * It will now be requested on need and not on initialization.
 	 *
 	 * @return string
 	 */
+	protected function get_home_url() {
+		if ( ! isset( self::$home_url ) ) {
+			self::$home_url = WPSEO_Utils::home_url();
+		}
+
+		return self::$home_url;
+	}
+
+	/**
+	 * Get Home protocol relative URL
+	 *
+	 * It will be used for validating URLs to keep both protocols (http or https) in sitemaps.
+	 *
+	 * @return string
+	 */
 	protected function get_home_proto_rel_url() {
 		if ( ! isset( self::$home_proto_rel_url ) ) {
-			self::$home_proto_rel_url = preg_replace( '`^(https?:)`', '', WPSEO_Utils::home_url() );
+			self::$home_proto_rel_url = preg_replace( '`^(https?:)`', '', $this->get_home_url() );
 		}
 
 		return self::$home_proto_rel_url;
@@ -380,7 +398,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		if ( ! $this->get_page_on_front_id() && ( $post_type === 'post' || $post_type === 'page' ) ) {
 
 			$links[] = array(
-				'loc' => WPSEO_Utils::home_url(),
+				'loc' => $this->get_home_url(),
 
 				// Deprecated, kept for backwards data compat. R.
 				'chf' => 'daily',

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -8,8 +8,8 @@
  */
 class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
-	/** @var string $home_url Holds the home_url() value to speed up loops. */
-	protected static $home_url;
+	/** @var string $home_proto_rel_url Holds home protocol-relative url value to speed up loops. */
+	protected static $home_proto_rel_url;
 
 	/** @var array $options All of plugin options. */
 	protected static $options;
@@ -70,19 +70,19 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	}
 
 	/**
-	 * Get Home URL
+	 * Get Home protocol relative URL
 	 *
 	 * This has been moved from the constructor because wp_rewrite is not available on plugins_loaded in multisite.
 	 * It will now be requested on need and not on initialization.
 	 *
 	 * @return string
 	 */
-	protected function get_home_url() {
-		if ( ! isset( self::$home_url ) ) {
-			self::$home_url = WPSEO_Utils::home_url();
+	protected function get_home_proto_rel_url() {
+		if ( ! isset( self::$home_proto_rel_url ) ) {
+			self::$home_proto_rel_url = preg_replace( '`^(https?:)`', '', WPSEO_Utils::home_url() );
 		}
 
-		return self::$home_url;
+		return self::$home_proto_rel_url;
 	}
 
 	/**
@@ -380,7 +380,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		if ( ! $this->get_page_on_front_id() && ( $post_type === 'post' || $post_type === 'page' ) ) {
 
 			$links[] = array(
-				'loc' => $this->get_home_url(),
+				'loc' => $this->home_url(),
 
 				// Deprecated, kept for backwards data compat. R.
 				'chf' => 'daily',
@@ -591,7 +591,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 *
 		 * @see https://wordpress.org/plugins/page-links-to/ can rewrite permalinks to external URLs.
 		 */
-		if ( false === strpos( $url['loc'], $this->get_home_url() ) ) {
+		if ( false === strpos( $url['loc'], $this->get_home_proto_rel_url() ) ) {
 			return false;
 		}
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -380,7 +380,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		if ( ! $this->get_page_on_front_id() && ( $post_type === 'post' || $post_type === 'page' ) ) {
 
 			$links[] = array(
-				'loc' => home_url(),
+				'loc' => WPSEO_Utils::home_url(),
 
 				// Deprecated, kept for backwards data compat. R.
 				'chf' => 'daily',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Use protocol-relative home url for checking of URLs in post_type sitemap.
* Clear sitemap cache if option 'home' is changed (Site URL).

## Test instructions

This PR can be tested by following these steps:

* Improve compatibility with _Really Simple SSL plugin_ - #8488.
* Move Site URL to HTTPS (Settings/General). Check sitemaps. All sitemaps should contain https urls.

Fixes #8488, #6927
