### PR TITLE
YoastSEO.js 1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "yoast-components": "^2.11.9",
-    "yoastseo": "^1.27"
+    "yoastseo": "^1.28"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8507,9 +8507,9 @@ yoast-components@^2.11.9:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.24:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.24.0.tgz#64237c4ca7666efc9e0832a66819528b81c7b128"
+yoastseo@^1.28:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.28.0.tgz#c242a30d41405f46be7fc9bd9881a76beb9fe81d"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
Bump YoastSEO.js to 1.28.

The changes from YoastSEO.js are already reflected in the changelog.