### PR TITLE
Use WPSEO_Link_Type_Classifier to check link type in WPSEO_Post_Type_Sitemap

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -82,6 +82,7 @@ class WPSEO_Admin {
 		add_action( 'admin_init', array( $this, 'map_manage_options_cap' ) );
 
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
+		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'home' );
 
 		if ( WPSEO_Utils::is_yoast_seo_page() ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -8,8 +8,11 @@
  */
 class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
-	/** @var string $home_url Holds the home_url() value to speed up loops. */
+	/** @var string $home_url Holds the home_url() value. */
 	protected static $home_url;
+
+	/** @var string $home_proto_rel_url Holds home protocol-relative url value to speed up loops. */
+	protected static $home_proto_rel_url;
 
 	/** @var array $options All of plugin options. */
 	protected static $options;
@@ -83,6 +86,21 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		}
 
 		return self::$home_url;
+	}
+
+	/**
+	 * Get Home protocol relative URL
+	 *
+	 * It will be used for validating URLs to keep both protocols (http or https) in sitemaps.
+	 *
+	 * @return string
+	 */
+	protected function get_home_proto_rel_url() {
+		if ( ! isset( self::$home_proto_rel_url ) ) {
+			self::$home_proto_rel_url = preg_replace( '`^(https?:)`', '', $this->get_home_url() );
+		}
+
+		return self::$home_proto_rel_url;
 	}
 
 	/**
@@ -591,7 +609,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 *
 		 * @see https://wordpress.org/plugins/page-links-to/ can rewrite permalinks to external URLs.
 		 */
-		if ( false === strpos( $url['loc'], $this->get_home_url() ) ) {
+		if ( false === strpos( $url['loc'], $this->get_home_proto_rel_url() ) ) {
 			return false;
 		}
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -11,19 +11,19 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	/** @var string $home_url Holds the home_url() value. */
 	protected static $home_url;
 
-	/** @var string $home_proto_rel_url Holds home protocol-relative url value to speed up loops. */
-	protected static $home_proto_rel_url;
-
 	/** @var array $options All of plugin options. */
 	protected static $options;
 
 	/** @var WPSEO_Sitemap_Image_Parser $image_parser Holds image parser instance. */
 	protected static $image_parser;
 
-	/** @var int $page_on_front_id Static front page ID.  */
+	/** @var object $classifier Holds instance of classifier for a link. */
+	protected static $classifier;
+
+	/** @var int $page_on_front_id Static front page ID. */
 	protected static $page_on_front_id;
 
-	/** @var int $page_for_posts_id Posts page ID.  */
+	/** @var int $page_for_posts_id Posts page ID. */
 	protected static $page_for_posts_id;
 
 	/**
@@ -73,6 +73,19 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	}
 
 	/**
+	 * Get the Classifier for a link
+	 *
+	 * @return WPSEO_Link_Type_Classifier
+	 */
+	protected function get_classifier() {
+		if ( ! isset( self::$classifier ) ) {
+			self::$classifier = new WPSEO_Link_Type_Classifier( $this->get_home_url() );
+		}
+
+		return self::$classifier;
+	}
+
+	/**
 	 * Get Home URL
 	 *
 	 * This has been moved from the constructor because wp_rewrite is not available on plugins_loaded in multisite.
@@ -86,21 +99,6 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		}
 
 		return self::$home_url;
-	}
-
-	/**
-	 * Get Home protocol relative URL
-	 *
-	 * It will be used for validating URLs to keep both protocols (http or https) in sitemaps.
-	 *
-	 * @return string
-	 */
-	protected function get_home_proto_rel_url() {
-		if ( ! isset( self::$home_proto_rel_url ) ) {
-			self::$home_proto_rel_url = preg_replace( '`^(https?:)`', '', $this->get_home_url() );
-		}
-
-		return self::$home_proto_rel_url;
 	}
 
 	/**
@@ -609,7 +607,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 *
 		 * @see https://wordpress.org/plugins/page-links-to/ can rewrite permalinks to external URLs.
 		 */
-		if ( false === strpos( $url['loc'], $this->get_home_proto_rel_url() ) ) {
+		if ( $this->get_classifier()->classify( $url['loc'] ) === WPSEO_Link::TYPE_EXTERNAL ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Use _WPSEO_Link_Type_Classifier_ to determine link type in post_type sitemap.
* Clear sitemap cache if option 'home' is changed (Site URL).

## Relevant technical choices:

* Add option 'home' in array `$cache_clear` ( _WPSEO_Sitemaps_Cache_ ). It purges all sitemaps cache at each changing of _Site URL_.
* WPML uses [debug_backtrace](http://php.net/manual/en/function.debug-backtrace.php) to check 'caller' (_classes/compatibility/wpseo/class-wpml-wpseo-xml-sitemaps-filter.php_) - we need to keep function _get_home_url_.

## Test instructions

This PR can be tested by following these steps:

* Improve compatibility with _Really Simple SSL plugin_ - #8488 props @rlankhorst.
* Move Site URL to HTTPS (Settings/General). Check sitemaps. All sitemaps should contain https in urls.

Fixes #8488, #6927
