### PR TITLE
Pass right parameter when calling wpcom_vip_remove_role_caps()

### DIFF
--- a/admin/capabilities/class-capability-manager-vip.php
+++ b/admin/capabilities/class-capability-manager-vip.php
@@ -19,7 +19,7 @@ final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manag
 		}
 
 		foreach ( $role_capabilities as $role => $capabilities ) {
-			wpcom_vip_add_role_caps( $role, array( $capabilities ) );
+			wpcom_vip_add_role_caps( $role, $capabilities );
 		}
 	}
 
@@ -40,7 +40,7 @@ final class WPSEO_Capability_Manager_VIP extends WPSEO_Abstract_Capability_Manag
 		}
 
 		foreach ( $role_capabilities as $role => $capabilities ) {
-			wpcom_vip_remove_role_caps( $role, array( $capabilities ) );
+			wpcom_vip_remove_role_caps( $role, $capabilities );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes VIP compatibility for maintaining role capabilities.

## Relevant technical choices:
Both WPSEO_Capability_Manager_VIP::add() and WPSEO_Capability_Manager_VIP::remove() call wpcom_vip_remove_role_caps() passing an array of arrays as the second parameter, but this function expects an one-dimensional array of capabilities. This resulted in the following PHP warning when I tried to update WordPress SEO on a VIP Go site:

`Warning: Illegal offset type in wp-content/mu-plugins/vip-helpers/vip-roles.php:139`

Call stack:

```
wpcom_vip_add_role_caps()
wp-content/plugins/wordpress-seo/admin/capabilities/class-capability-manager-vip.php:22
WPSEO_Capability_Manager_VIP->add()
wp-content/plugins/wordpress-seo/inc/class-upgrade.php:401
WPSEO_Upgrade->upgrade_55()
wp-content/plugins/wordpress-seo/inc/class-upgrade.php:86
WPSEO_Upgrade->__construct()
wp-content/plugins/wordpress-seo/wp-seo-main.php:271
wpseo_init()
wp-includes/class-wp-hook.php:286
do_action('plugins_loaded')
wp-settings.php:327
```

After updating WordPress SEO from version 4.8 to 5.9.3, the SEO menu in the WP admin was missing since the creation of the new capabilities failed. This commit fixes this issue by passing the right parameter to wpcom_vip_remove_role_caps(). There is no need to `array( $capabilities )` as `$capabilities` is already an array created in the line below:

https://github.com/rodrigoprimo/wordpress-seo/blob/5.9.3/admin/capabilities/class-capability-manager-vip.php#L65
