### PR TITLE
Remove PHP 5.2 incompatible arguments

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -253,7 +253,7 @@ class Yoast_Notification_Center {
 				$notification_json[] = $notification->render();
 			}
 
-			echo json_encode( $notification_json, ( JSON_HEX_QUOT | JSON_HEX_TAG ) );
+			echo json_encode( $notification_json );
 
 			return;
 		}


### PR DESCRIPTION
These still give the same results after testing this.

## Summary

This PR can be summarized in the following changelog entry:

* Remove PHP 5.3 arguments on a `json_encode` call in the notification functionality.

## Test instructions

This PR can be tested by following these steps:

* This piece of code is triggered on the `Quick edit` of a post
* Change the slug of a post and save in the quick edit
* A notification should be shown about using premium to create redirects

Fixes #8527 
