### PR TITLE
Remove unsupported argument in PHP 5.2

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -236,7 +236,7 @@ class WPSEO_Sitemap_Image_Parser {
 			$attachments = array_merge( $attachments, $gallery_attachments );
 		}
 
-		return array_unique( $attachments, SORT_REGULAR );
+		return array_unique( $attachments );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove unsupported arguments in PHP 5.2 for a `array_unique` call in the Term image sitemap.

## Test instructions

This PR can be tested by following these steps:

* Create a post with images inside
* Check the sitemap code to see the list of images being present as before

Fixes #8529 
