### PR TITLE
Fixes some eslint warnings

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 106,
+			maxWarnings: 100,
 		},
 	},
 	grunt: {

--- a/js/src/wp-seo-quick-edit-handler.js
+++ b/js/src/wp-seo-quick-edit-handler.js
@@ -128,5 +128,4 @@
 			wpseoShowNotification();
 		}
 	} );
-
 }( jQuery ) )  );

--- a/js/src/wp-seo-recalculate.js
+++ b/js/src/wp-seo-recalculate.js
@@ -9,8 +9,6 @@ var TaxonomyAssessor = require( "./assessors/taxonomyAssessor" );
 var isUndefined = require( "lodash/isUndefined" );
 
 ( function( $ ) {
-	"use strict";
-
 	var i18n = new Jed( {
 		domain: "js-text-analysis",
 		locale_data: {
@@ -192,11 +190,10 @@ var isUndefined = require( "lodash/isUndefined" );
 				this.updateProgressBar( response.total_items );
 			}
 
-			if ( ! isUndefined( response.next_page ) ) {
-				this.getItemsToRecalculate( response.next_page );
-			}
-			else {
+			if ( isUndefined( response.next_page ) ) {
 				this.onCompleteRequest();
+			} else {
+				this.getItemsToRecalculate( response.next_page );
 			}
 
 			return true;

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -5,8 +5,6 @@ var isUndefined = require( "lodash/isUndefined" );
 var ReplaceVar = require( "./values/replaceVar" );
 
 ( function() {
-	"use strict";
-
 	var modifiableFields = [
 		"content",
 		"title",

--- a/js/src/wp-seo-shortcode-plugin.js
+++ b/js/src/wp-seo-shortcode-plugin.js
@@ -11,10 +11,9 @@ const shortcodeStartRegex = new RegExp( "\\[" + shortcodeNameMatcher + shortcode
 const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g" );
 
 ( function() {
-	"use strict";
-
 	/**
-	 * The Yoast Shortcode plugin parses the shortcodes in a given piece of text. It analyzes multiple input fields for shortcodes which it will preload using AJAX.
+	 * The Yoast Shortcode plugin parses the shortcodes in a given piece of text. It analyzes multiple input fields for
+	 * shortcodes which it will preload using AJAX.
 	 *
 	 * @constructor
 	 * @property {RegExp} keywordRegex Used to match a given string for valid shortcode keywords.
@@ -299,8 +298,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 					this.saveParsedShortcodes( shortcodeResults, callback );
 				}.bind( this )
 			);
-		}
-		else {
+		} else {
 			return callback();
 		}
 	};


### PR DESCRIPTION
In the releasebranch for 6.0 the amount of maxWarnings config has been lowered. But it seems the there are no warnings being fixed. This is resulting in failing builds on travis. The config value is 106 and the amount of found warnings is 108. 

I've chosen to fix some warnings, instead of setting the config value to 108. If I've done my job correctly Travis will be happy.

