### PR TITLE
Add Post ID as a parameter to check user capability correctly

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1591,7 +1591,7 @@ class WPSEO_Frontend {
 			unset( $matches );
 
 			// Prevent cleaning out posts & page previews for people capable of viewing them.
-			if ( isset( $_GET['preview'], $_GET['preview_nonce'] ) && current_user_can( 'edit_post' ) ) {
+			if ( isset( $_GET['preview'], $_GET['preview_nonce'] ) && current_user_can( 'edit_post', $post->ID ) ) {
 				$properurl = '';
 			}
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The `current_user_can()` function accepts two arguments `capability` and `object_id`. The `object_id` wasn't added as a parameter before and as such `Undefined offset: 0` PHP notice occur.

## Test instructions

This PR can be tested by following these steps:

* Enable _Redirect ugly URLs to clean permalinks_ option
* Preview any existing post or page

Fixes #8428 