### PR TITLE
CS/XSS: always escape output - 24

### DIFF
--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -35,7 +35,7 @@ if ( ! $active ) {
 }
 
 ?>
-<h3><span class="dashicons <?php echo esc_attr( 'dashicons-' . $dashicon ); ?>"></span> <?php echo $i18n_title; ?> (<?php echo $active_total; ?>)</h3>
+<h3><span class="dashicons <?php echo esc_attr( 'dashicons-' . $dashicon ); ?>"></span> <?php echo esc_html( $i18n_title ); ?> (<?php echo (int) $active_total; ?>)</h3>
 
 <div id="<?php echo esc_attr( 'yoast-' . $type ); ?>">
 
@@ -56,7 +56,7 @@ if ( ! $active ) {
 
 	<?php else : ?>
 
-		<p><?php echo $i18n_no_issues; ?></p>
+		<p><?php echo esc_html( $i18n_no_issues ); ?></p>
 
 	<?php endif; ?>
 </div>

--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -23,7 +23,14 @@ if ( ! function_exists( '_yoast_display_alerts' ) ) {
 					break;
 			}
 
-			printf( '<div class="yoast-alert-holder" id="%1$s" data-nonce="%2$s" data-json="%3$s">%4$s%5$s</div>', $notification->get_id(), $notification->get_nonce(), $notification->get_json(), $notification, $button );
+			printf(
+				'<div class="yoast-alert-holder" id="%1$s" data-nonce="%2$s" data-json="%3$s">%4$s%5$s</div>',
+				esc_attr( $notification->get_id() ),
+				esc_attr( $notification->get_nonce() ),
+				esc_attr( $notification->get_json() ),
+				$notification,
+				$button
+			);
 		}
 	}
 }

--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -28,8 +28,10 @@ if ( ! function_exists( '_yoast_display_alerts' ) ) {
 	}
 }
 
+$wpseo_i18n_summary = $i18n_issues;
 if ( ! $active ) {
-	$dashicon = 'yes';
+	$dashicon           = 'yes';
+	$wpseo_i18n_summary = $i18n_no_issues;
 }
 
 ?>
@@ -38,7 +40,7 @@ if ( ! $active ) {
 <div id="<?php echo esc_attr( 'yoast-' . $type ); ?>">
 
 	<?php if ( $total ) : ?>
-		<p><?php echo ( ! $active ) ? $i18n_no_issues : $i18n_issues; ?></p>
+		<p><?php echo esc_html( $wpseo_i18n_summary ); ?></p>
 
 		<div class="container" id="<?php echo esc_attr( 'yoast-' . $type . '-active' ); ?>">
 			<?php _yoast_display_alerts( $active, 'active' ); ?>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.

N.B.: see the commit notes for the individual commits in this PR for more extensive information.

## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.