### PR TITLE
CS/XSS: always escape output - 25

### DIFF
--- a/admin/class-bulk-description-editor-list-table.php
+++ b/admin/class-bulk-description-editor-list-table.php
@@ -62,8 +62,8 @@ class WPSEO_Bulk_Description_List_Table extends WPSEO_Bulk_List_Table {
 			case 'col_new_yoast_seo_metadesc':
 				return sprintf(
 					'<textarea id="%1$s" name="%1$s" class="wpseo-new-metadesc" data-id="%2$s" aria-labelledby="col_new_yoast_seo_metadesc"></textarea>',
-					'wpseo-new-metadesc-' . $record->ID,
-					$record->ID
+					esc_attr( 'wpseo-new-metadesc-' . $record->ID ),
+					esc_attr( $record->ID )
 				);
 
 			case 'col_existing_yoast_seo_metadesc':


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.

** While this function does not echo out the HTML, it is clearly preparing it for output and it's easier to escape when the HTML is being build, then after.

## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.