### PR TITLE
CS/XSS: always escape output - 30

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -151,8 +151,7 @@ function wpseo_ajax_replace_vars() {
 	$wp_query->queried_object_id = $post->ID;
 
 	$omit = array( 'excerpt', 'excerpt_only', 'title' );
-	echo wpseo_replace_vars( stripslashes( filter_input( INPUT_POST, 'string' ) ), $post, $omit );
-	die;
+	wpseo_ajax_json_echo_die( wp_strip_all_tags( wpseo_replace_vars( stripslashes( filter_input( INPUT_POST, 'string' ) ), $post, $omit ) ) );
 }
 
 add_action( 'wp_ajax_wpseo_replace_vars', 'wpseo_ajax_replace_vars' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

** The `WPSEO_Replace_Vars::replace()` method strips all tags from the `$post` before doing the replacements.
While replacements should not contain HTML, they could when used inappropriately, so using `wp_strip_all_tags()` in combination with `wp_json_encode()` - as the output is send to js - is the most appropriate way of escaping the output of this function call.
As the result is then echo-ed out, followed by a `die()`, the utility method `wpseo_ajax_json_echo_die()` can be used instead.

## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.