### PR TITLE
CS/XSS: always escape output - 27

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -102,13 +102,21 @@ class WPSEO_Meta_Columns {
 				break;
 			case 'wpseo-metadesc':
 				$metadesc_val = apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) );
-				$metadesc     = ( '' === $metadesc_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Meta description not set.', 'wordpress-seo' ) . '</span>' : esc_html( $metadesc_val );
-				echo $metadesc;
+				if ( '' === $metadesc_val ) {
+					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Meta description not set.', 'wordpress-seo' ) . '</span>';
+				}
+				else {
+					echo esc_html( $metadesc_val );
+				}
 				break;
 			case 'wpseo-focuskw':
 				$focuskw_val = WPSEO_Meta::get_value( 'focuskw', $post_id );
-				$focuskw     = ( '' === $focuskw_val ) ? '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>' : esc_html( $focuskw_val );
-				echo $focuskw;
+				if ( '' === $focuskw_val ) {
+					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>';
+				}
+				else {
+					echo esc_html( $focuskw_val );
+				}
 				break;
 		}
 	}

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -93,31 +93,47 @@ class WPSEO_Meta_Columns {
 		switch ( $column_name ) {
 			case 'wpseo-score':
 				echo $this->parse_column_score( $post_id );
-				break;
+				return;
+
 			case 'wpseo-score-readability':
 				echo $this->parse_column_score_readability( $post_id );
-				break;
+				return;
+
 			case 'wpseo-title':
-				echo esc_html( apply_filters( 'wpseo_title', wpseo_replace_vars( $this->page_title( $post_id ), get_post( $post_id, ARRAY_A ) ) ) );
-				break;
+				$post  = get_post( $post_id, ARRAY_A );
+				$title = wpseo_replace_vars( $this->page_title( $post_id ), $post );
+				$title = apply_filters( 'wpseo_title', $title );
+
+				echo esc_html( $title );
+				return;
+
 			case 'wpseo-metadesc':
-				$metadesc_val = apply_filters( 'wpseo_metadesc', wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), get_post( $post_id, ARRAY_A ) ) );
+				$post         = get_post( $post_id, ARRAY_A );
+				$metadesc_val = wpseo_replace_vars( WPSEO_Meta::get_value( 'metadesc', $post_id ), $post );
+				$metadesc_val = apply_filters( 'wpseo_metadesc', $metadesc_val );
+
 				if ( '' === $metadesc_val ) {
-					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Meta description not set.', 'wordpress-seo' ) . '</span>';
+					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">',
+						esc_html__( 'Meta description not set.', 'wordpress-seo' ),
+						'</span>';
+					return;
 				}
-				else {
-					echo esc_html( $metadesc_val );
-				}
-				break;
+
+				echo esc_html( $metadesc_val );
+				return;
+
 			case 'wpseo-focuskw':
 				$focuskw_val = WPSEO_Meta::get_value( 'focuskw', $post_id );
+
 				if ( '' === $focuskw_val ) {
-					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . esc_html__( 'Focus keyword not set.', 'wordpress-seo' ) . '</span>';
+					echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">',
+						esc_html__( 'Focus keyword not set.', 'wordpress-seo' ),
+						'</span>';
+					return;
 				}
-				else {
-					echo esc_html( $focuskw_val );
-				}
-				break;
+
+				echo esc_html( $focuskw_val );
+				return;
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.

** Remove superfluous variable setting, making it clear that the output is escaped when echo-ed out.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
