### PR TITLE
CS/XSS: always escape output - 28

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -223,7 +223,7 @@ class WPSEO_Meta_Columns {
 	 * @return string The generated <option> element.
 	 */
 	protected function generate_option( $value, $label, $selected = '' ) {
-		return '<option ' . $selected . ' value="' . $value . '">' . $label . '</option>';
+		return '<option ' . $selected . ' value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.

** While this function does not echo out the HTML, it is clearly preparing it for output and it's easier to escape when the HTML is being build, then after.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.