### PR TITLE
CS/XSS: always escape output - 31

### DIFF
--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -31,7 +31,7 @@ class WPSEO_Option_Tabs_Formatter {
 				'<a class="nav-tab" id="%1$s" href="%2$s">%3$s</a>',
 				esc_attr( $tab->get_name() . '-tab' ),
 				esc_url( '#top#' . $tab->get_name() ),
-				$tab->get_label()
+				esc_html( $tab->get_label() )
 			);
 		}
 		echo '</h2>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

PRs in this series include some function changes for `printf()` versus `echo sprintf()` and some function call layout changes.

** I've verified all instantiations of the `WPSEO_Option_Tab` class and none of the labels contain HTML, so escaping this output with `esc_html()` is the most appropriate course of action and should be safe.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
