### PR TITLE
CS/XSS: always escape output - 32

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1822,11 +1822,12 @@ class WPSEO_Frontend {
 
 		// Only replace the debug marker when it is hooked.
 		if ( $this->show_debug_marker() ) {
-			$title = $this->title( '' );
+			$title      = $this->title( '' );
+			$debug_mark = $this->get_debug_mark();
 
 			// Find all titles, strip them out and add the new one in within the debug marker, so it's easily identified whether a site uses force rewrite.
 			$content = preg_replace( '/<title.*?\/title>/i', '', $content );
-			$content = str_replace( $this->get_debug_mark(), $this->get_debug_mark() . "\n" . '<title>' . $title . '</title>', $content );
+			$content = str_replace( $debug_mark, $debug_mark . "\n" . '<title>' . esc_html( $title ) . '</title>', $content );
 		}
 
 		$GLOBALS['wp_query'] = $old_wp_query;

--- a/tests/test-class-wpseo-frontend.php
+++ b/tests/test-class-wpseo-frontend.php
@@ -878,7 +878,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( true ) );
 
 		$frontend
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->exactly( 1 ) )
 			->method( 'get_debug_mark' );
 
 		// Enables the output buffering.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

** The `title()` method retrieves the pre-escaped title from the `generate_title()` method. This pre-escaping is incorrect, however as not all theme authors escape correctly and the `esc_html()` method protects against double escaping, I think it's prudent to leave the pre-escaping in place.

https://github.com/Yoast/wordpress-seo/blob/c12c0926044dfc32dded185028637b8945e6fae6/frontend/class-frontend.php#L577

All the same, it makes sense to escape the title when it's being force replaced in the `flush_cache()` method.

Includes a minor efficiency fix within that same function by removing a duplicate function call.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.