### PR TITLE
CS/XSS: always escape output - 34

### DIFF
--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -167,18 +167,23 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 			$network_name = __( 'Twitter', 'wordpress-seo' );
 		}
 
-		return sprintf( "<div class='notice inline yoast-notice yoast-notice-go-premium'>
-			<p>%s</p>
-			<p><a href='%s' target='_blank'>%s</a></p>
-		</div>",
-			/* translators: %1$s expands to the social network's name, %2$s to Yoast SEO Premium. */
-			sprintf( __( 'Do you want to preview what it will look like if people share this post on %1$s? You can, with %2$s.', 'wordpress-seo' ),
-				$network_name,
+		return sprintf(
+			'<div class="notice inline yoast-notice yoast-notice-go-premium">
+				<p>%1$s</p>
+				<p><a href="%2$s" target="_blank">%3$s</a></p>
+			</div>',
+			sprintf(
+				/* translators: %1$s expands to the social network's name, %2$s to Yoast SEO Premium. */
+				esc_html__( 'Do you want to preview what it will look like if people share this post on %1$s? You can, with %2$s.', 'wordpress-seo' ),
+				esc_html( $network_name ),
 				'<strong>Yoast SEO Premium</strong>'
 			),
-			WPSEO_Shortlinker::get( 'https://yoa.st/179' ),
-			/* translators: %s expands to Yoast SEO Premium. */
-			sprintf( esc_html__( 'Find out why you should upgrade to %s', 'wordpress-seo' ), 'Yoast SEO Premium' )
+			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/179' ) ),
+			sprintf(
+				/* translators: %s expands to Yoast SEO Premium. */
+				esc_html__( 'Find out why you should upgrade to %s', 'wordpress-seo' ),
+				'Yoast SEO Premium'
+			)
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

** While this function does not directly output HTML, the return value of this function will be send to screen and is easier to escape while building up the HTML, than afterwards.

* Includes layout changes to the statement.
* Includes numbering the placeholders in the top-level string.
* ~~Includes making one previously untranslatable string translatable (`Find out why you should upgrade to`).~~ Already merged via https://github.com/Yoast/wordpress-seo/commit/5e3399c55922e0e2e9bd3ea0c016cc84952fff37


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
  