### PR TITLE
CS/XSS: always escape output /escape complete string - 12

### DIFF
--- a/admin/views/form/fieldset.php
+++ b/admin/views/form/fieldset.php
@@ -19,6 +19,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 ?>
 
 <fieldset id="<?php echo esc_attr( $id ); ?>"<?php echo $attributes; ?>>
-	<legend id="<?php echo esc_attr( $id ); ?>-legend"<?php echo $legend_attributes; ?>><?php echo esc_html( $legend_content ); ?></legend>
+	<legend id="<?php echo esc_attr( $id . '-legend' ); ?>"<?php echo $legend_attributes; ?>><?php echo esc_html( $legend_content ); ?></legend>
 	<?php echo $content; ?>
 </fieldset>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable or at the end of the variable value will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.



## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that the page layout has not been affected by this change.