### PR TITLE
CS/XSS: always escape JS output - 1

### DIFF
--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -63,7 +63,7 @@ function wpseo_get_rendered_tab( $table, $id ) {
 
 ?>
 <script>
-	var wpseoBulkEditorNonce = '<?php echo wp_create_nonce( 'wpseo-bulk-editor' ); ?>';
+	var wpseoBulkEditorNonce = '<?php echo wp_json_encode( wp_create_nonce( 'wpseo-bulk-editor' ) ); ?>';
 
 	// eslint-disable-next-line
 	var wpseo_bulk_editor_nonce = wpseoBulkEditorNonce;

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -63,7 +63,7 @@ function wpseo_get_rendered_tab( $table, $id ) {
 
 ?>
 <script>
-	var wpseoBulkEditorNonce = '<?php echo wp_json_encode( wp_create_nonce( 'wpseo-bulk-editor' ) ); ?>';
+	var wpseoBulkEditorNonce = <?php echo wp_json_encode( wp_create_nonce( 'wpseo-bulk-editor' ) ); ?>;
 
 	// eslint-disable-next-line
 	var wpseo_bulk_editor_nonce = wpseoBulkEditorNonce;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped. Part of a series of PRs to fix these kind of issues.

** Variables echo-ed out into an inline javascript block should be escaped using `wp_json_encode()`


## Test instructions

Testing recommended, but no problems expected.

Test this by opening a relevant admin page in a browser and checking that things still work as expected.

