### PR TITLE
CS/XSS: always escape output & move HTML out of translatable string - 1

### DIFF
--- a/admin/views/tabs/advanced/permalinks.php
+++ b/admin/views/tabs/advanced/permalinks.php
@@ -33,7 +33,14 @@ echo '<p>' . esc_html__( 'This helps you to create cleaner URLs by automatically
 
 /* translators: %s expands to <code>?replytocom</code> */
 $yform->light_switch( 'cleanreplytocom', sprintf( __( 'Remove the %s variables.', 'wordpress-seo' ), '<code>?replytocom</code>' ), $remove_buttons, false );
-echo '<p>' . __( 'This prevents threaded replies from working when the user has JavaScript disabled, but on a large site can mean a <em>huge</em> improvement in crawl efficiency for search engines when you have a lot of comments.', 'wordpress-seo' ) . '</p>';
+echo '<p>';
+printf(
+	/* translators: 1: emphasis open tag; 2: emphasis close tag. */
+	esc_html__( 'This prevents threaded replies from working when the user has JavaScript disabled, but on a large site can mean a %1$shuge%2$s improvement in crawl efficiency for search engines when you have a lot of comments.', 'wordpress-seo' ),
+	'<em>',
+	'</em>'
+);
+echo '</p>';
 
 $options = WPSEO_Options::get_all();
 if ( substr( get_option( 'permalink_structure' ), -1 ) !== '/' && $options['trailingslash'] ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

** Includes moving some HTML out of the translatable string.

## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
