### PR TITLE
CS/XSS: always escape output & move HTML out of translatable string - 2

### DIFF
--- a/admin/views/tabs/sitemaps/general.php
+++ b/admin/views/tabs/sitemaps/general.php
@@ -21,7 +21,12 @@ if ( $options['enablexmlsitemap'] === true ) {
 	);
 	echo '<br/>';
 	echo '<br/>';
-	_e( 'You do <strong>not</strong> need to generate the XML sitemap, nor will it take up time to generate after publishing a post.', 'wordpress-seo' );
+	printf(
+		/* translators: 1: <strong> open tag; 2: close tag. */
+		esc_html__( 'You do %1$snot%2$s need to generate the XML sitemap, nor will it take up time to generate after publishing a post.', 'wordpress-seo' ),
+		'<strong>',
+		'</strong>'
+	);
 	echo '</p>';
 }
 else {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

Simple one(s). Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.

** Includes moving some HTML out of the translatable string.

## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
