### PR TITLE
CS/XSS: always escape output / embedded php - 1

### DIFF
--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -3,14 +3,14 @@
  * @package WPSEO\Admin
  */
 
+/* translators: %1$s expands to Yoast SEO */
+$wpseo_up_settings_header = sprintf( __( '%1$s settings', 'wordpress-seo' ), 'Yoast SEO' );
+
 ?>
 
 <div class="yoast yoast-settings">
 
-	<h2 id="wordpress-seo"><?php
-		/* translators: %1$s expands to Yoast SEO */
-		printf( __( '%1$s settings', 'wordpress-seo' ), 'Yoast SEO' );
-		?></h2>
+	<h2 id="wordpress-seo"><?php echo esc_html( $wpseo_up_settings_header ); ?></h2>
 
 	<label for="wpseo_author_title"><?php esc_html_e( 'Title to use for Author page', 'wordpress-seo' ); ?></label>
 	<input class="yoast-settings__text regular-text" type="text" id="wpseo_author_title" name="wpseo_author_title"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Multi-statement embedded PHP should be layed-out with the PHP open/close tags each on their own line.
However, if this is embedded in HTML tags where the layout listens quite closely, this can cause extra whitespace to show or CSS to break.

For those type of embedded PHP blocks, it's therefore often better to move initial creation of the output out of the inline HTML and only escape & echo the resulting variable out in the inline HTML, making the embedded PHP single statement.



## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.