### PR TITLE
CS/XSS: always escape output / embedded php - 2

### DIFF
--- a/admin/views/tabs/tool/wpseo-export.php
+++ b/admin/views/tabs/tool/wpseo-export.php
@@ -12,10 +12,14 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 /* translators: %1$s expands to Yoast SEO */
 $submit_button_value = sprintf( __( 'Export your %1$s settings', 'wordpress-seo' ), 'Yoast SEO' );
 
-?><p><?php
+$wpseo_export_phrase = sprintf(
 	/* translators: %1$s expands to Yoast SEO */
-	printf( __( 'Export your %1$s settings here, to import them again later or to import them on another site.', 'wordpress-seo' ), 'Yoast SEO' );
-	?></p>
+	__( 'Export your %1$s settings here, to import them again later or to import them on another site.', 'wordpress-seo' ),
+	'Yoast SEO'
+);
+?>
+
+<p><?php echo esc_html( $wpseo_export_phrase ); ?></p>
 <form
 	action="<?php echo esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#wpseo-export' ) ); ?>"
 	method="post"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Multi-statement embedded PHP should be layed-out with the PHP open/close tags each on their own line.
However, if this is embedded in HTML tags where the layout listens quite closely, this can cause extra whitespace to show or CSS to break.

For those type of embedded PHP blocks, it's therefore often better to move initial creation of the output out of the inline HTML and only escape & echo the resulting variable out in the inline HTML, making the embedded PHP single statement.

## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
