### PR TITLE
CS/XSS: always escape output / embedded php - 3

### DIFF
--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -9,13 +9,14 @@ $alerts_data = Yoast_Alerts::get_template_variables();
 $options  = WPSEO_Options::get_options( array( 'wpseo' ) );
 $notifier = new WPSEO_Configuration_Notifier( $options );
 $notifier->listen();
+
+/* translators: %1$s expands to Yoast SEO. */
+$wpseo_dashboard_header = sprintf( esc_html__( '%1$s Dashboard', 'wordpress-seo' ), 'Yoast SEO' );
+
 ?>
 <div class="yoast-alerts">
 
-	<h2><?php
-		/* translators: %1$s expands to Yoast SEO */
-		printf( __( '%1$s Dashboard', 'wordpress-seo' ), 'Yoast SEO' );
-		?></h2>
+	<h2><?php echo esc_html( $wpseo_dashboard_header ); ?></h2>
 
 	<?php echo $notifier->notify(); ?>
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Multi-statement embedded PHP should be layed-out with the PHP open/close tags each on their own line.
However, if this is embedded in HTML tags where the layout listens quite closely, this can cause extra whitespace to show or CSS to break.

For those type of embedded PHP blocks, it's therefore often better to move initial creation of the output out of the inline HTML and only escape & echo the resulting variable out in the inline HTML, making the embedded PHP single statement.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.