### PR TITLE
CS/XSS: always escape output / embedded php - 4

### DIFF
--- a/admin/views/about.php
+++ b/admin/views/about.php
@@ -24,14 +24,14 @@ function wpseo_display_contributors( $contributors ) {
 	}
 }
 
+/* translators: %1$s expands to Yoast SEO */
+$wpseo_thanks_for_updating = sprintf( __( 'Thank you for updating %1$s!', 'wordpress-seo' ), 'Yoast SEO' );
+
 ?>
 
 <div class="wrap about-wrap">
 
-	<h1><?php
-		/* translators: %1$s expands to Yoast SEO */
-		printf( __( 'Thank you for updating %1$s!', 'wordpress-seo' ), 'Yoast SEO' );
-		?></h1>
+	<h1><?php echo esc_html( $wpseo_thanks_for_updating ); ?></h1>
 
 	<p class="about-text">
 		<?php


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Multi-statement embedded PHP should be layed-out with the PHP open/close tags each on their own line.
However, if this is embedded in HTML tags where the layout listens quite closely, this can cause extra whitespace to show or CSS to break.

For those type of embedded PHP blocks, it's therefore often better to move initial creation of the output out of the inline HTML and only escape & echo the resulting variable out in the inline HTML, making the embedded PHP single statement.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.