### PR TITLE
CS/XSS: always escape output / embedded php - 5

### DIFF
--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -12,10 +12,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 ?>
 <p><?php esc_html_e( 'No doubt you\'ve used an SEO plugin before if this site isn\'t new. Let\'s make it easy on you, you can import the data below. If you want, you can import first, check if it was imported correctly, and then import &amp; delete. No duplicate data will be imported.', 'wordpress-seo' ); ?></p>
 
-<p><?php
-/* translators: 1: link open tag; 2: link close tag. */
-printf( __( 'If you\'ve used another SEO plugin, try the %1$sSEO Data Transporter%2$s plugin to move your data into this plugin, it rocks!', 'wordpress-seo' ), '<a href="https://wordpress.org/plugins/seo-data-transporter/">', '</a>' );
-?></p>
+<p>
+	<?php
+	printf(
+		/* translators: 1: link open tag; 2: link close tag. */
+		esc_html__( 'If you\'ve used another SEO plugin, try the %1$sSEO Data Transporter%2$s plugin to move your data into this plugin, it rocks!', 'wordpress-seo' ),
+		'<a href="https://wordpress.org/plugins/seo-data-transporter/">',
+		'</a>'
+	);
+	?>
+</p>
 
 <form
 	action="<?php echo esc_attr( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#import-seo' ) ); ?>"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Multi-statement embedded PHP should be layed-out with the PHP open/close tags each on their own line.
However, if this is embedded in HTML tags where the layout listens quite closely, this can cause extra whitespace to show or CSS to break.

In this case, creating the text first and escaping in a single-line embedded PHP statement is not an option as the replacement variables contain HTML.

As this is a `<p>` tag, I don't expect any layout issues, but careful scrutiny of the output is recommended.




## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
