### PR TITLE
CS/XSS: always escape output / embedded php - 6

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -112,14 +112,15 @@ if ( class_exists( 'Woocommerce' ) ) {
 		)
 	);
 }
+
+/* translators: %1$s expands to Yoast SEO. */
+$wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );
+
 ?>
 
 <div class="wrap yoast wpseo_table_page">
 
-	<h1 id="wpseo-title" class="yoast-h1"><?php
-		/* translators: %1$s expands to Yoast SEO */
-		printf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );
-		?></h1>
+	<h1 id="wpseo-title" class="yoast-h1"><?php echo esc_html( $wpseo_extensions_header ); ?></h1>
 
 	<div id="extensions">
 		<section class="yoast-seo-premium-extension">

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -128,10 +128,15 @@ $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Y
 			$extension = $extensions->get( 'wordpress-seo-premium' );
 			$extensions->remove( 'wordpress-seo-premium' );
 			?>
-			<h2><?php
-				/* translators: %1$s expands to Yoast SEO Premium */
-				printf( __( '%1$s, take your optimization to the next level!', 'wordpress-seo' ), '<span class="yoast-heading-highlight">' . $extension->get_title() . '</span>' );
-				?></h2>
+			<h2>
+				<?php
+				printf(
+					/* translators: %1$s expands to Yoast SEO Premium */
+					esc_html__( '%1$s, take your optimization to the next level!', 'wordpress-seo' ),
+					'<span class="yoast-heading-highlight">' . $extension->get_title() . '</span>'
+				);
+				?>
+			</h2>
 
 			<ul class="yoast-seo-premium-benefits yoast-list--usp">
 				<li class="yoast-seo-premium-benefits__item">


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Multi-statement embedded PHP should be layed-out with the PHP open/close tags each on their own line.
However, if this is embedded in HTML tags where the layout listens quite closely, this can cause extra whitespace to show or CSS to break.

For those type of embedded PHP blocks, it's therefore often better to move initial creation of the output out of the inline HTML and only escape & echo the resulting variable out in the inline HTML, making the embedded PHP single statement.

In the second case, creating the text first and escaping in a single-line embedded PHP statement is not an option as the replacement variables contain HTML.

As this is a `<h2>` tag, I don't expect any layout issues, but careful scrutiny of the output is recommended.



## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.