### PR TITLE
CS/QA: escape a URL at the correct place

### DIFF
--- a/admin/class-social-facebook-form.php
+++ b/admin/class-social-facebook-form.php
@@ -58,7 +58,7 @@ class Yoast_Social_Facebook_Form {
 		}
 
 		$return  = '<li><a target="_blank" href="' . esc_url( $admin['link'] ) . '">' . esc_html( $admin['name'] ) . '</a>';
-		$return .= ' - <strong><a href="' . $this->admin_delete_link( $admin_id, $nonce ) . '">X</a></strong></li>';
+		$return .= ' - <strong><a href="' . esc_url( $this->admin_delete_link( $admin_id, $nonce ) ) . '">X</a></strong></li>';
 
 		return $return;
 	}
@@ -200,14 +200,12 @@ class Yoast_Social_Facebook_Form {
 	 * @return string
 	 */
 	private function admin_delete_link( $admin_id, $nonce ) {
-		return esc_url(
-			add_query_arg(
-				array(
-					'delfbadmin' => esc_attr( $admin_id ),
-					'nonce'      => $nonce,
-				),
-				admin_url( $this->admin_url . '#top#facebook' )
-			)
+		return add_query_arg(
+			array(
+				'delfbadmin' => esc_attr( $admin_id ),
+				'nonce'      => $nonce,
+			),
+			admin_url( $this->admin_url . '#top#facebook' )
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Escape the url when the context in which it will be used is clear, i.e. when it's added to an HTML string, not before.



## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.
