### PR TITLE
CS (non-)compliance/XSS: use the correct escaping function

### DIFF
--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -49,7 +49,7 @@ if ( is_array( $options['blocking_files'] ) && count( $options['blocking_files']
 			echo '<br/>', '<code>', esc_html( $file ), '</code>';
 		}
 		unset( $file );
-		echo '<br><button type="button" data-nonce="', esc_js( wp_create_nonce( 'wpseo-blocking-files' ) ), '" class="button">', esc_html__( 'Fix it', 'wordpress-seo' ), '</button>';
+		echo '<br><button type="button" data-nonce="', esc_attr( wp_create_nonce( 'wpseo-blocking-files' ) ), '" class="button">', esc_html__( 'Fix it', 'wordpress-seo' ), '</button>';
 		echo '</p></div>';
 	}
 }

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -67,7 +67,7 @@ if ( '' === $tool_page ) {
 		$attr = ( ! empty( $tool['attr'] ) ) ? $tool['attr'] : '';
 
 		echo '<li>';
-		echo '<strong><a href="' , esc_attr( $href ) , '" ' , $attr , '>', esc_html( $tool['title'] ), '</a></strong><br/>';
+		echo '<strong><a href="', esc_url( $href ), '" ', $attr , '>', esc_html( $tool['title'] ), '</a></strong><br/>';
 		echo $tool['desc'];
 		echo '</li>';
 	}

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -18,7 +18,7 @@ printf( __( 'If you\'ve used another SEO plugin, try the %1$sSEO Data Transporte
 ?></p>
 
 <form
-	action="<?php echo esc_attr( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#import-seo' ) ); ?>"
+	action="<?php echo esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#import-seo' ) ); ?>"
 	method="post" accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php
 	wp_nonce_field( 'wpseo-import', '_wpnonce', true, true );

--- a/admin/views/tabs/tool/wpseo-export.php
+++ b/admin/views/tabs/tool/wpseo-export.php
@@ -17,7 +17,7 @@ $submit_button_value = sprintf( __( 'Export your %1$s settings', 'wordpress-seo'
 	printf( __( 'Export your %1$s settings here, to import them again later or to import them on another site.', 'wordpress-seo' ), 'Yoast SEO' );
 	?></p>
 <form
-	action="<?php echo esc_attr( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#wpseo-export' ) ); ?>"
+	action="<?php echo esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#wpseo-export' ) ); ?>"
 	method="post"
 	accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php $yform->checkbox( 'include_taxonomy_meta', __( 'Include Taxonomy Metadata', 'wordpress-seo' ) ); ?><br />

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -22,7 +22,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 </p>
 
 <form
-	action="<?php echo esc_attr( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#wpseo-import' ) ); ?>"
+	action="<?php echo esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#wpseo-import' ) ); ?>"
 	method="post" enctype="multipart/form-data"
 	accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php wp_nonce_field( 'wpseo-import-file', '_wpnonce', true, true ); ?>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Part of a series of PRs to fix these kind of issues.

** Variables should be escaped based on the context in which they are used.
In each of these cases, the _wrong_ escaping function was used for the context.


## Test instructions

Testing recommended, but no problems expected.

Test this by opening the relevant admin page in a browser and checking that the page layout has not been affected by this change.