### PR TITLE
CS/QA: use `wp_strip_all_tags()`

### DIFF
--- a/admin/tracking/class-tracking-plugin-data.php
+++ b/admin/tracking/class-tracking-plugin-data.php
@@ -50,7 +50,7 @@ class WPSEO_Tracking_Plugin_Data implements WPSEO_Collection {
 			'url'     => $plugin['PluginURI'],
 			'version' => $plugin['Version'],
 			'author'  => array(
-				'name' => strip_tags( $plugin['Author'] ),
+				'name' => wp_strip_all_tags( $plugin['Author'], true ),
 				'url'  => $plugin['AuthorURI'],
 			),
 		);

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -692,7 +692,7 @@ class WPSEO_Breadcrumbs {
 		$link['text'] = WPSEO_Meta::get_value( 'bctitle', $id );
 
 		if ( $link['text'] === '' ) {
-			$link['text'] = strip_tags( get_the_title( $id ) );
+			$link['text'] = wp_strip_all_tags( get_the_title( $id ), true );
 		}
 
 		/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -346,13 +346,13 @@ class WPSEO_Frontend {
 		if ( ! is_string( $title ) || ( is_string( $title ) && $title === '' ) ) {
 			$title = get_bloginfo( 'name' );
 			$title = $this->add_paging_to_title( $sep, $seplocation, $title );
-			$title = $this->add_to_title( $sep, $seplocation, $title, strip_tags( get_bloginfo( 'description' ) ) );
+			$title = $this->add_to_title( $sep, $seplocation, $title, wp_strip_all_tags( get_bloginfo( 'description' ) ) );
 
 			return $title;
 		}
 
 		$title = $this->add_paging_to_title( $sep, $seplocation, $title );
-		$title = $this->add_to_title( $sep, $seplocation, $title, strip_tags( get_bloginfo( 'name' ) ) );
+		$title = $this->add_to_title( $sep, $seplocation, $title, wp_strip_all_tags( get_bloginfo( 'name' ), true ) );
 
 		return $title;
 	}
@@ -574,7 +574,7 @@ class WPSEO_Frontend {
 		 * @api string $title The page title being put out.
 		 */
 
-		return esc_html( strip_tags( stripslashes( apply_filters( 'wpseo_title', $title ) ) ) );
+		return esc_html( wp_strip_all_tags( stripslashes( apply_filters( 'wpseo_title', $title ) ), true ) );
 	}
 
 	/**
@@ -1237,7 +1237,7 @@ class WPSEO_Frontend {
 		$keywords = apply_filters( 'wpseo_metakeywords', trim( $keywords ) ); // More appropriately named.
 
 		if ( is_string( $keywords ) && $keywords !== '' ) {
-			echo '<meta name="keywords" content="', esc_attr( strip_tags( stripslashes( $keywords ) ) ), '"/>', "\n";
+			echo '<meta name="keywords" content="', esc_attr( wp_strip_all_tags( stripslashes( $keywords ), true ) ), '"/>', "\n";
 		}
 	}
 
@@ -1255,7 +1255,7 @@ class WPSEO_Frontend {
 
 		if ( $echo !== false ) {
 			if ( is_string( $this->metadesc ) && $this->metadesc !== '' ) {
-				echo '<meta name="description" content="', esc_attr( strip_tags( stripslashes( $this->metadesc ) ) ), '"/>', "\n";
+				echo '<meta name="description" content="', esc_attr( wp_strip_all_tags( stripslashes( $this->metadesc ) ) ), '"/>', "\n";
 			}
 			elseif ( current_user_can( 'wpseo_manage_options' ) && is_singular() ) {
 				echo '<!-- ', esc_html__( 'Admin only notice: this page doesn\'t show a meta description because it doesn\'t have one, either write it for this page specifically or go into the SEO -> Titles menu and set up a template.', 'wordpress-seo' ), ' -->', "\n";

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -344,9 +344,9 @@ class WPSEO_Frontend {
 		$title = preg_replace( $regex, '', $title );
 
 		if ( ! is_string( $title ) || ( is_string( $title ) && $title === '' ) ) {
-			$title = get_bloginfo( 'name' );
+			$title = WPSEO_Utils::get_site_name();
 			$title = $this->add_paging_to_title( $sep, $seplocation, $title );
-			$title = $this->add_to_title( $sep, $seplocation, $title, wp_strip_all_tags( get_bloginfo( 'description' ) ) );
+			$title = $this->add_to_title( $sep, $seplocation, $title, wp_strip_all_tags( get_bloginfo( 'description' ), true ) );
 
 			return $title;
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -642,7 +642,7 @@ class WPSEO_OpenGraph {
 
 			// Tag og:description is still blank so grab it from get_the_excerpt().
 			if ( ! is_string( $ogdesc ) || ( is_string( $ogdesc ) && $ogdesc === '' ) ) {
-				$ogdesc = str_replace( '[&hellip;]', '&hellip;', strip_tags( get_the_excerpt() ) );
+				$ogdesc = str_replace( '[&hellip;]', '&hellip;', wp_strip_all_tags( get_the_excerpt() ) );
 			}
 		}
 
@@ -653,7 +653,7 @@ class WPSEO_OpenGraph {
 			}
 
 			if ( $ogdesc === '' ) {
-				$ogdesc = trim( strip_tags( term_description() ) );
+				$ogdesc = trim( wp_strip_all_tags( term_description() ) );
 			}
 
 			if ( $ogdesc === '' ) {

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -653,7 +653,7 @@ class WPSEO_OpenGraph {
 			}
 
 			if ( $ogdesc === '' ) {
-				$ogdesc = trim( wp_strip_all_tags( term_description() ) );
+				$ogdesc = wp_strip_all_tags( term_description() );
 			}
 
 			if ( $ogdesc === '' ) {

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -209,7 +209,7 @@ class WPSEO_Twitter {
 			return $meta_desc;
 		}
 
-		return strip_tags( get_the_excerpt() );
+		return wp_strip_all_tags( get_the_excerpt() );
 	}
 
 
@@ -229,7 +229,7 @@ class WPSEO_Twitter {
 			return $meta_desc;
 		}
 
-		return trim( strip_tags( term_description() ) );
+		return trim( wp_strip_all_tags( term_description() ) );
 
 	}
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -229,7 +229,7 @@ class WPSEO_Twitter {
 			return $meta_desc;
 		}
 
-		return trim( wp_strip_all_tags( term_description() ) );
+		return wp_strip_all_tags( term_description() );
 
 	}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -413,7 +413,7 @@ class WPSEO_Replace_Vars {
 		static $replacement;
 
 		if ( ! isset( $replacement ) ) {
-			$description = trim( wp_strip_all_tags( get_bloginfo( 'description' ) ) );
+			$description = wp_strip_all_tags( get_bloginfo( 'description' ) );
 			if ( $description !== '' ) {
 				$replacement = $description;
 			}
@@ -479,7 +479,7 @@ class WPSEO_Replace_Vars {
 		if ( isset( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
 			$term_desc = get_term_field( 'description', $this->args->term_id, $this->args->taxonomy );
 			if ( $term_desc !== '' ) {
-				$replacement = trim( wp_strip_all_tags( $term_desc ) );
+				$replacement = wp_strip_all_tags( $term_desc );
 			}
 		}
 
@@ -724,7 +724,7 @@ class WPSEO_Replace_Vars {
 					$term      = current( $terms );
 					$term_desc = get_term_field( 'description', $term->term_id, $tax );
 					if ( $term_desc !== '' ) {
-						$replacement = trim( wp_strip_all_tags( $term_desc ) );
+						$replacement = wp_strip_all_tags( $term_desc );
 					}
 				}
 			}

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -139,7 +139,7 @@ class WPSEO_Replace_Vars {
 	 */
 	public function replace( $string, $args, $omit = array() ) {
 
-		$string = strip_tags( $string );
+		$string = wp_strip_all_tags( $string );
 
 		// Let's see if we can bail super early.
 		if ( strpos( $string, '%%' ) === false ) {
@@ -331,7 +331,7 @@ class WPSEO_Replace_Vars {
 		// The check `post_password_required` is because excerpt must be hidden for a post with a password.
 		if ( ! empty( $this->args->ID ) && ! post_password_required( $this->args->ID ) ) {
 			if ( $this->args->post_excerpt !== '' ) {
-				$replacement = strip_tags( $this->args->post_excerpt );
+				$replacement = wp_strip_all_tags( $this->args->post_excerpt );
 			}
 			elseif ( $this->args->post_content !== '' ) {
 				$replacement = wp_html_excerpt( strip_shortcodes( $this->args->post_content ), 155 );
@@ -351,7 +351,7 @@ class WPSEO_Replace_Vars {
 
 		// The check `post_password_required` is because excerpt must be hidden for a post with a password.
 		if ( ! empty( $this->args->ID ) && $this->args->post_excerpt !== ''  && ! post_password_required( $this->args->ID ) ) {
-			$replacement = strip_tags( $this->args->post_excerpt );
+			$replacement = wp_strip_all_tags( $this->args->post_excerpt );
 		}
 
 		return $replacement;
@@ -413,7 +413,7 @@ class WPSEO_Replace_Vars {
 		static $replacement;
 
 		if ( ! isset( $replacement ) ) {
-			$description = trim( strip_tags( get_bloginfo( 'description' ) ) );
+			$description = trim( wp_strip_all_tags( get_bloginfo( 'description' ) ) );
 			if ( $description !== '' ) {
 				$replacement = $description;
 			}
@@ -479,7 +479,7 @@ class WPSEO_Replace_Vars {
 		if ( isset( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
 			$term_desc = get_term_field( 'description', $this->args->term_id, $this->args->taxonomy );
 			if ( $term_desc !== '' ) {
-				$replacement = trim( strip_tags( $term_desc ) );
+				$replacement = trim( wp_strip_all_tags( $term_desc ) );
 			}
 		}
 
@@ -724,7 +724,7 @@ class WPSEO_Replace_Vars {
 					$term      = current( $terms );
 					$term_desc = get_term_field( 'description', $term->term_id, $tax );
 					if ( $term_desc !== '' ) {
-						$replacement = trim( strip_tags( $term_desc ) );
+						$replacement = trim( wp_strip_all_tags( $term_desc ) );
 					}
 				}
 			}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -766,7 +766,7 @@ class WPSEO_Utils {
 	 * @return string
 	 */
 	public static function get_site_name() {
-		return trim( strip_tags( get_bloginfo( 'name' ) ) );
+		return trim( wp_strip_all_tags( get_bloginfo( 'name' ), true ) );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -766,7 +766,7 @@ class WPSEO_Utils {
 	 * @return string
 	 */
 	public static function get_site_name() {
-		return trim( wp_strip_all_tags( get_bloginfo( 'name' ), true ) );
+		return wp_strip_all_tags( get_bloginfo( 'name' ), true );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:

The `wp_strip_all_tags()` function is more comprehensive than the PHP native `strip_tags()` function.

The advantage of `wp_strip_all_tags()` over `strip_tags()` is that it does not leave the content of removed `<script>` and `<style>` tags behind.

> This differs from `strip_tags()` because it removes the contents of the `<script>` and `<style>` tags. E.g. `strip_tags( '<script>something</script>' )` will return ‘something’. `wp_strip_all_tags()` will return ”

It can also remove superfluous whitespace within the string which may be left behind after removing the tags. For this, the second parameter `$remove_breaks` needs to be passed and set to `true`.

For those function calls where the original input is always expected to be single line, I've added this second parameter.

Refs:
* https://developer.wordpress.org/reference/functions/wp_strip_all_tags/
* http://php.net/manual/en/function.strip-tags.php



## Test instructions

* Verify that the SEO meta tag block of a test page is the same as before for a "normal" page.
* Add a `<script>` or `<style>` tag in one of the values - such as the site description or meta description - and see the improved output.
