### PR TITLE
CS/QA: correct method parameter type & default value

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -218,11 +218,11 @@ class WPSEO_Meta_Columns {
 	 *
 	 * @param string $value       The option's value.
 	 * @param string $label       The option's label.
-	 * @param bool   $selected    Whether or not the option should be selected.
+	 * @param string $selected    HTML selected attribute for an option.
 	 *
 	 * @return string The generated <option> element.
 	 */
-	protected function generate_option( $value, $label, $selected = false ) {
+	protected function generate_option( $value, $label, $selected = '' ) {
 		return '<option ' . $selected . ' value="' . $value . '">' . $label . '</option>';
 	}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

This method is called four times from within this same file and always passed the output of a call to the WP `selected()` function.

This PR fixes the default parameter value as well as the documentation to be in line with the reality.


## Test instructions
_N/A_
