### PR TITLE
CS/QA: Remove superfluous function call

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -201,7 +201,7 @@ class WPSEO_Replace_Vars {
 		// Remove superfluous whitespace.
 		$string = WPSEO_Utils::standardize_whitespace( $string );
 
-		return trim( $string );
+		return $string;
 	}
 
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

The `WPSEO_Utils::standardize_whitespace()` method is called on the line above and already uses `trim()` on the string.




## Test instructions
_N/A_
