### PR TITLE
CS/I18n: make three strings translatable

### DIFF
--- a/admin/class-option-tab.php
+++ b/admin/class-option-tab.php
@@ -21,7 +21,7 @@ class WPSEO_Option_Tab {
 	 * WPSEO_Option_Tab constructor.
 	 *
 	 * @param string $name      Name of the tab.
-	 * @param string $label     Label of the tab.
+	 * @param string $label     Localized label of the tab.
 	 * @param array  $arguments Optional arguments.
 	 */
 	public function __construct( $name, $label, $arguments = array() ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -312,7 +312,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	public function meta_box() {
 		$content_sections = $this->get_content_sections();
 
-		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', 'Meta box',
+		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', __( 'Meta box', 'wordpress-seo' ),
 			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ) ) );
 
 		$help_center = new WPSEO_Help_Center( '', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -57,7 +57,7 @@ class WPSEO_Taxonomy_Metabox {
 
 		echo '<div class="inside">';
 
-		$helpcenter_tab = new WPSEO_Option_Tab( 'tax-metabox', 'Meta box',
+		$helpcenter_tab = new WPSEO_Option_Tab( 'tax-metabox', __( 'Meta box', 'wordpress-seo' ),
 			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-taxonomy-screencast' ) ) );
 
 		$helpcenter = new WPSEO_Help_Center( 'tax-metabox', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -94,7 +94,7 @@ else {
 }
 
 echo '<br><br>';
-$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', 'Bulk editor',
+$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', __( 'Bulk editor', 'wordpress-seo' ),
 	array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-file-editor' ) ) );
 
 $helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_Allow more strings to be localized_

## Relevant technical choices:

These three strings are intended to be translatable labels for the tab, but weren't translatable in these instances.

I've included a minor documentation improvement to clarify this for future usage.


## Test instructions
_N/A_