### PR TITLE
Use user locale for Help Center

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -194,7 +194,7 @@ class WPSEO_Help_Center {
 	public static function get_translated_texts() {
 		// Esc_html is not needed because React already handles HTML in the (translations of) these strings.
 		return array(
-			'locale'                             => get_locale(),
+			'locale'                             => WPSEO_Utils::get_user_locale(),
 			'videoTutorial'                      => __( 'Video tutorial', 'wordpress-seo' ),
 			'knowledgeBase'                      => __( 'Knowledge base', 'wordpress-seo' ),
 			'getSupport'                         => __( 'Get support', 'wordpress-seo' ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the user locale is not used for the Help Center

## Test instructions

This PR can be tested by following these steps:

* Modify your user language to be different from the global site language
