### PR TITLE
Wrap the CSS with a selector that is present on metabox containing page.

### DIFF
--- a/css/src/help-center-metabox.scss
+++ b/css/src/help-center-metabox.scss
@@ -1,18 +1,20 @@
-.yoast-help-center {
+.postbox {
 	.yoast-help-center {
-		&__button {
-			border: none;
-			box-shadow: none;
-			text-transform: none;
-			text-decoration: underline;
-			color: #0073aa;
-			margin: 0;
-			min-height: 0;
-			font: inherit;
-			padding: 8px 0;
+		.yoast-help-center {
+			&__button {
+				border:          none;
+				box-shadow:      none;
+				text-transform:  none;
+				text-decoration: underline;
+				color:           #0073aa;
+				margin:          0;
+				min-height:      0;
+				font:            inherit;
+				padding:         8px 0;
 
-			svg {
-				margin: 0 13px;
+				svg {
+					margin: 0 13px;
+				}
 			}
 		}
 	}

--- a/css/src/help-center-metabox.scss
+++ b/css/src/help-center-metabox.scss
@@ -1,20 +1,18 @@
 .postbox {
 	.yoast-help-center {
-		.yoast-help-center {
-			&__button {
-				border:          none;
-				box-shadow:      none;
-				text-transform:  none;
-				text-decoration: underline;
-				color:           #0073aa;
-				margin:          0;
-				min-height:      0;
-				font:            inherit;
-				padding:         8px 0;
+		&__button {
+			border: none;
+			box-shadow: none;
+			text-transform: none;
+			text-decoration: underline;
+			color: #0073aa;
+			margin: 0;
+			min-height: 0;
+			font: inherit;
+			padding: 8px 0;
 
-				svg {
-					margin: 0 13px;
-				}
+			svg {
+				margin: 0 13px;
 			}
 		}
 	}

--- a/css/src/help-center-metabox.scss
+++ b/css/src/help-center-metabox.scss
@@ -1,18 +1,20 @@
 .postbox {
 	.yoast-help-center {
-		&__button {
-			border: none;
-			box-shadow: none;
-			text-transform: none;
-			text-decoration: underline;
-			color: #0073aa;
-			margin: 0;
-			min-height: 0;
-			font: inherit;
-			padding: 8px 0;
+		.yoast-help-center {
+			&__button {
+				border: none;
+				box-shadow: none;
+				text-transform: none;
+				text-decoration: underline;
+				color: #0073aa;
+				margin: 0;
+				min-height: 0;
+				font: inherit;
+				padding: 8px 0;
 
-			svg {
-				margin: 0 13px;
+				svg {
+					margin: 0 13px;
+				}
 			}
 		}
 	}

--- a/css/src/help-center-metabox.scss
+++ b/css/src/help-center-metabox.scss
@@ -1,20 +1,18 @@
 .postbox {
 	.yoast-help-center {
-		.yoast-help-center {
-			&__button {
-				border: none;
-				box-shadow: none;
-				text-transform: none;
-				text-decoration: underline;
-				color: #0073aa;
-				margin: 0;
-				min-height: 0;
-				font: inherit;
-				padding: 8px 0;
+		&__button {
+			border: none;
+			box-shadow: none;
+			text-transform: none;
+			text-decoration: underline;
+			color: #0073aa;
+			margin: 0;
+			min-height: 0;
+			font: inherit;
+			padding: 8px 0;
 
-				svg {
-					margin: 0 13px;
-				}
+			svg {
+				margin: 0 13px;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the styling of the help button on the Google Search Console page.

## Relevant technical choices:

* I've chosen for wrapping the CSS selector, because the meta box file is required for the help icons. We might consider putting the styling of those buttons in a separate file.

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk.
* View the metabox page on a post edit and the metabox on a taxonomy (category for example) edit page. 
* Go the the Google Search console page and see the button having the same styling as the buttons you've seen on the previous step.
* Now visit another Yoast SEO admin page like the dashboard and see another styling being visible.
* Checkout this branch and do a `grunt build:css` 
* Follow the same steps and see the styling of the button on the GSC page being the same as the other admin pages.

Fixes #8184
