### PR TITLE
Add jsonpFunction to webpack configuration

### DIFF
--- a/webpack/webpack.config.default.js
+++ b/webpack/webpack.config.default.js
@@ -12,6 +12,7 @@ const defaultWebpackConfig = {
 	output: {
 		path: paths.jsDist,
 		filename: outputFilename,
+		jsonpFunction: "yoastJsonp",
 	},
 	resolve: {
 		extensions: [ ".js", ".jsx" ],

--- a/webpack/webpack.config.default.js
+++ b/webpack/webpack.config.default.js
@@ -12,7 +12,7 @@ const defaultWebpackConfig = {
 	output: {
 		path: paths.jsDist,
 		filename: outputFilename,
-		jsonpFunction: "yoastJsonp",
+		jsonpFunction: "yoastWebpackJsonp",
 	},
 	resolve: {
 		extensions: [ ".js", ".jsx" ],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the global `webpackJsonp` variable to `yoastWebpackJsonp` to avoid plugin conflicts.

## Relevant technical choices:

* Named the new `webpackJsonp` to `yoastWebpackJsonp`

## Test instructions

This PR can be tested by following these steps:

* Make sure `webpackJsonp` doesn't exist anymore in the global namespace and `yoastWebpackJsonp` does.

Fixes #
