### PR TITLE
Resolve sitemap fatal error

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -212,7 +212,7 @@ class WPSEO_Sitemap_Image_Parser {
 	 *
 	 * @return array Set of attachment objects.
 	 */
-	private function parse_galleries( $content, $post_id = 0 ) {
+	protected function parse_galleries( $content, $post_id = 0 ) {
 
 		$attachments = array();
 		$galleries   = $this->get_content_galleries( $content );

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -236,7 +236,12 @@ class WPSEO_Sitemap_Image_Parser {
 			$attachments = array_merge( $attachments, $gallery_attachments );
 		}
 
-		return array_unique( $attachments );
+		if ( PHP_VERSION_ID >= 50209 ) {
+			// phpcs:ignore PHPCompatibility.PHP.NewFunctionParameters.array_unique_sort_flagsFound -- Wrapped in version check.
+			return array_unique( $attachments, SORT_REGULAR );
+		}
+
+		return $attachments;
 	}
 
 	/**

--- a/tests/doubles/class-sitemap-image-parser-double.php
+++ b/tests/doubles/class-sitemap-image-parser-double.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPSEO_Sitemap_Image_Parser_Double extends WPSEO_Sitemap_Image_Parser {
+	/**
+	 * @inheritdoc
+	 */
+	public function parse_galleries( $content, $id = 0 ) {
+		return parent::parse_galleries( $content, $id);
+	}
+}

--- a/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
+++ b/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
@@ -19,6 +19,8 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		require_once dirname( dirname( __FILE__ ) ) . '/doubles/class-sitemap-image-parser-double.php';
+
 		self::$class_instance = new WPSEO_Sitemap_Image_Parser();
 	}
 
@@ -40,5 +42,39 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $content_src, $content_image['src'] );
 		$this->assertEquals( $content_title, $content_image['title'] );
 		$this->assertEquals( $content_alt, $content_image['alt'] );
+	}
+
+	/**
+	 * @covers WPSEO_Sitemap_Image_Parser::get_gallery_attachments
+	 *
+	 * Related: https://github.com/Yoast/wordpress-seo/issues/8634
+	 */
+	public function test_parse_galleries() {
+		/** @var WPSEO_Sitemap_Image_Parser_Double $image_parser */
+		$image_parser = $this->getMockBuilder( 'WPSEO_Sitemap_Image_Parser_Double' )
+			->setMethods( array( 'get_content_galleries', 'get_gallery_attachments' ) )
+			->getMock();
+
+		$image_parser
+			->expects( $this->once() )
+			->method( 'get_content_galleries' )
+			->will( $this->returnValue( array( array( 'id' => 1 ) ) ) );
+
+		$a = (object) array( 'a', 'b' );
+		$b = (object) 1234;
+		$c = (object) 'some string';
+
+		$attachments = array( $a, $b, $c, $a, $c );
+
+		$image_parser
+			->expects( $this->once() )
+			->method( 'get_gallery_attachments' )
+			->will( $this->returnValue( $attachments ) );
+
+		$attachments = $image_parser->parse_galleries( '' );
+
+		$this->assertContains( $a, $attachments );
+		$this->assertContains( $b, $attachments );
+		$this->assertContains( $c, $attachments );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where sitemaps could not be generated when there are galleries in the content.

## Relevant technical choices:

* See https://github.com/Yoast/wordpress-seo/pull/8636

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/wordpress-seo/pull/8636

Fixes #8634 
