### PR TITLE
Introduced a function to determine if a post type is REST enabled

### DIFF
--- a/inc/class-post-type.php
+++ b/inc/class-post-type.php
@@ -62,4 +62,21 @@ class WPSEO_Post_Type {
 
 		return $post_types;
 	}
+
+	/**
+	 * Checks if the post type is enabled in the REST API.
+	 *
+	 * @param string $post_type The post type to check.
+	 *
+	 * @return bool Whether or not the post type is available in the REST API.
+	 */
+	public static function is_rest_enabled( $post_type ) {
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( is_null( $post_type_object ) ) {
+			return false;
+		}
+
+		return $post_type_object->show_in_rest === true;
+	}
 }

--- a/tests/inc/test-class-post-type.php
+++ b/tests/inc/test-class-post-type.php
@@ -193,12 +193,13 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::is_rest_enabled()
 	 */
 	public function test_rest_enabled_post_types() {
-		register_post_type( 'custom-post-type', array( 'public' => true ) );
 		$this->assertTrue( WPSEO_Post_Type::is_rest_enabled( 'post' ) );
 		$this->assertFalse( WPSEO_Post_Type::is_rest_enabled( 'invalid_post_type' ) );
 
 		register_post_type( 'custom-post-type-api', array( 'public' => true, 'show_in_rest' => true ) );
 		$this->assertTrue( WPSEO_Post_Type::is_rest_enabled( 'custom-post-type-api' ) );
+
+		register_post_type( 'custom-post-type', array( 'public' => true ) );
 		$this->assertFalse( WPSEO_Post_Type::is_rest_enabled( 'custom-post-type' ) );
 	}
 }

--- a/tests/inc/test-class-post-type.php
+++ b/tests/inc/test-class-post-type.php
@@ -188,7 +188,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether or not a (custom) post types are enabled in the REST API.
+	 * Tests whether or (custom) post types are enabled in the REST API.
 	 *
 	 * @covers WPSEO_Post_Type::is_rest_enabled()
 	 */

--- a/tests/inc/test-class-post-type.php
+++ b/tests/inc/test-class-post-type.php
@@ -188,7 +188,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether or not a .
+	 * Tests whether or not a (custom) post types are enabled in the REST API.
 	 *
 	 * @covers WPSEO_Post_Type::is_rest_enabled()
 	 */

--- a/tests/inc/test-class-post-type.php
+++ b/tests/inc/test-class-post-type.php
@@ -16,6 +16,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 
 		// Remove possibly set post type.
 		unregister_post_type( 'custom-post-type' );
+		unregister_post_type( 'custom-post-type-api' );
 	}
 
 	/**
@@ -184,5 +185,20 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 		unset( $post_types['attachment'] );
 
 		return $post_types;
+	}
+
+	/**
+	 * Tests whether or not a .
+	 *
+	 * @covers WPSEO_Post_Type::is_rest_enabled()
+	 */
+	public function test_rest_enabled_post_types() {
+		register_post_type( 'custom-post-type', array( 'public' => true ) );
+		$this->assertTrue( WPSEO_Post_Type::is_rest_enabled( 'post' ) );
+		$this->assertFalse( WPSEO_Post_Type::is_rest_enabled( 'invalid_post_type' ) );
+
+		register_post_type( 'custom-post-type-api', array( 'public' => true, 'show_in_rest' => true ) );
+		$this->assertTrue( WPSEO_Post_Type::is_rest_enabled( 'custom-post-type-api' ) );
+		$this->assertFalse( WPSEO_Post_Type::is_rest_enabled( 'custom-post-type' ) );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a function that can be used to determine whether or not a (custom) post type is enabled in the REST API.

## Test instructions

Please test this in conjunction with https://github.com/Yoast/wordpress-seo-premium/pull/1551 as there's no real proper way to test this otherwise. 

Fixes #8647 
