### PR TITLE
Remove trashed posts from bulk editor overview

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -286,7 +286,6 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$status_links = array();
 
 		$states          = get_post_stati( array( 'show_in_admin_all_list' => true ) );
-		$states['trash'] = 'trash';
 		$states          = esc_sql( $states );
 		$all_states      = "'" . implode( "', '", $states ) . "'";
 

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -387,7 +387,6 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				$post_types = "'" . implode( "', '", $post_types ) . "'";
 
 				$states          = get_post_stati( array( 'show_in_admin_all_list' => true ) );
-				$states['trash'] = 'trash';
 				$states          = esc_sql( $states );
 				$all_states      = "'" . implode( "', '", $states ) . "'";
 
@@ -702,7 +701,6 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 */
 	protected function get_all_states() {
 		$states          = get_post_stati( array( 'show_in_admin_all_list' => true ) );
-		$states['trash'] = 'trash';
 
 		if ( ! empty( $_GET['post_status'] ) ) {
 			$requested_state = sanitize_text_field( $_GET['post_status'] );

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -387,6 +387,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				$post_types = "'" . implode( "', '", $post_types ) . "'";
 
 				$states          = get_post_stati( array( 'show_in_admin_all_list' => true ) );
+				$states['trash'] = 'trash';
 				$states          = esc_sql( $states );
 				$all_states      = "'" . implode( "', '", $states ) . "'";
 
@@ -701,12 +702,18 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 */
 	protected function get_all_states() {
 		$states          = get_post_stati( array( 'show_in_admin_all_list' => true ) );
+		$states['trash'] = 'trash';
 
 		if ( ! empty( $_GET['post_status'] ) ) {
 			$requested_state = sanitize_text_field( $_GET['post_status'] );
 			if ( in_array( $requested_state, $states, true ) ) {
 				$states = array( $requested_state );
 			}
+
+			if ( $requested_state !== 'trash') {
+				unset( $states['trash'] );
+			}
+
 		}
 
 		$states     = esc_sql( $states );

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -713,7 +713,6 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			if ( $requested_state !== 'trash' ) {
 				unset( $states['trash'] );
 			}
-
 		}
 
 		$states     = esc_sql( $states );

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -710,7 +710,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				$states = array( $requested_state );
 			}
 
-			if ( $requested_state !== 'trash') {
+			if ( $requested_state !== 'trash' ) {
 				unset( $states['trash'] );
 			}
 
@@ -721,7 +721,6 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 		return $all_states;
 	}
-
 
 	/**
 	 * Based on $this->items and the defined columns, the table rows will be displayed.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove trashed posts from bulk editor overview

Fixes #5959

