### PR TITLE
Travis: speed up build times by disabling Xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
+- if [[ $TRAVIS_PHP_VERSION != "nightly" && "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini; fi
 - if [[ "$CHECKJS" == "1" ]]; then nvm install $TRAVIS_NODE_VERSION; fi
 - if [[ "$CHECKJS" == "1" ]]; then curl -o- -L https://yarnpkg.com/install.sh | bash; fi
 - if [[ "$CHECKJS" == "1" ]]; then export PATH=$HOME/.yarn/bin:$PATH; fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

As suggested by @johnbillion in https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/ , when not creating code coverage reports, Xdebug is not needed and disabling it will speed up the build.

## Test instructions
* Check that the Travis builds still work as expected.
* Take note of the lower build times for all builds, but the ones creating coverage reports / on PHP nightly.
