### PR TITLE
Travis/Build: validate the composer.json file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,9 @@ script:
 # assume that PHPUnit is in the vendor directory.
 - if [[ "$COVERAGE" == "1" ]]; then vendor/bin/phpunit -c phpunit.xml --coverage-clover build/logs/clover.xml; fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn test; fi
+# Validate the composer.json file.
+# @link https://getcomposer.org/doc/03-cli.md#validate
+- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
 
 after_success:
 - if [[ "$COVERAGE" == "1" ]]; then vendor/bin/test-reporter; fi

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"seo"
 	],
 	"homepage": "https://yoa.st/1ui",
-	"license": "GPL-2.0+",
+	"license": "GPL-2.0-or-later",
 	"authors": [
 		{
 			"name": "Team Yoast",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Validate the composer.json file on highest/lowest Composer compatible PHP build.
Ref: https://getcomposer.org/doc/03-cli.md#validate

Also updates the license identifier in the `composer.json` file to `LGPL-2.0-or-later` (see more about this below).

Notes:
* This check has not been restricted to a specific PHP version as there may be different versions of Composer being run on different Travis PHP images, so validating the file once against the lowest and highest PHP/Composer combi should make sure the file is properly validated.
* `--strict` checking is disabled with reason. As of Composer 1.6.0, the SPDX license identifiers v3.0 for GPL/LGPL/AGPL are supported and the old license identifiers are deprecated.
    So using the "new" license identifier would fail the validation for Composer < 1.6.0, using the old license identifier would fail the validation for Composer 1.6.0+. By ignoring warnings, this issue is bypassed.

Refs:
* https://github.com/composer/composer/releases/tag/1.6.0
* https://spdx.org/news/news/2018/01/license-list-30-released


## Test instructions

This PR can be tested by following these steps:
* Verify that the check in the two relevant Travis builds is correctly executed.
