### PR TITLE
Bump YoastSEO version to 1.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "yoast-components": "^2.11.9",
-    "yoastseo": "^1.28"
+    "yoastseo": "^1.29"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8507,9 +8507,9 @@ yoast-components@^2.11.9:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.28:
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.28.0.tgz#c242a30d41405f46be7fc9bd9881a76beb9fe81d"
+yoastseo@^1.29:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.29.0.tgz#296de8f08c677d8a25fb776ed3f77e2ce26d461c"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Bumps the YoastSEO version to 1.29.

## Test instructions

This PR can be tested by following these steps:

* Do a `yarn install`.
