### PR TITLE
trim auto-generated meta description to 320 characters

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -334,9 +334,9 @@ class WPSEO_Replace_Vars {
 				$replacement = wp_strip_all_tags( $this->args->post_excerpt );
 			}
 			elseif ( $this->args->post_content !== '' ) {
-                $replacement = wp_html_excerpt( strip_shortcodes( $this->args->post_content ), 320 );
-                // trim the auto-generated string to a word boundary
-                $replacement = substr($replacement, 0, strrpos($replacement, ' '));
+				$replacement = wp_html_excerpt( strip_shortcodes( $this->args->post_content ), 320 );
+				// Trim the auto-generated string to a word boundary.
+				$replacement = substr( $replacement, 0, strrpos( $replacement, ' ' ) );
 			}
 		}
 


### PR DESCRIPTION
## Summary
fix for issue https://github.com/Yoast/wordpress-seo/issues/8661

This PR can be summarized in the following changelog entry:

Auto-generated meta descriptions are now trimmed to the first word boundary before 320 characters.

## Relevant technical choices:

change trim length to 320 chacters as per Google's most recent snippet length; use substr to trim again to `strrpos($replacement, ' ')` so the meta description is trimmed to the last word boundary

## Test instructions

This PR can be tested by following these steps:

create post with no manually entered excerpt or snippet; set Yoast to create a meta description from %%excerpt%%; check that the generated meta description is trimmed to the nearest word boundary to character 320.

Fixes #
