### PR TITLE
Removes esc_html__ for the Admin Only Notice.

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1258,7 +1258,7 @@ class WPSEO_Frontend {
 				echo '<meta name="description" content="', esc_attr( wp_strip_all_tags( stripslashes( $this->metadesc ) ) ), '"/>', "\n";
 			}
 			elseif ( current_user_can( 'wpseo_manage_options' ) && is_singular() ) {
-				echo '<!-- ', esc_html__( 'Admin only notice: this page doesn\'t show a meta description because it doesn\'t have one, either write it for this page specifically or go into the SEO -> Titles menu and set up a template.', 'wordpress-seo' ), ' -->', "\n";
+				echo '<!-- ', __( 'Admin only notice: this page doesn\'t show a meta description because it doesn\'t have one, either write it for this page specifically or go into the SEO -> Titles menu and set up a template.', 'wordpress-seo' ), ' -->', "\n";
 			}
 		}
 		else {


### PR DESCRIPTION
Removes esc_html__ for the Admin Only Notice in the page's source. Don't need to esc_html__ as the notice is only visible when viewing the source code.

Before:

![image 2018-01-17 at 9 35 21 am](https://user-images.githubusercontent.com/3751021/35048886-5f3f3f62-fb6c-11e7-8df6-10b10f9a658f.png)

After:

![image 2018-01-17 at 9 35 41 am](https://user-images.githubusercontent.com/3751021/35048891-6340cb76-fb6c-11e7-8cb6-d0c8b8e5db8b.png)

## Summary

This PR can be summarized in the following changelog entry:

* Remove esc_html__ for the "Admin Only" notice

This was done according to the [WordPress I18n Standards](https://codex.wordpress.org/I18n_for_WordPress_Developers).

- [x] I have tested this code to the best of my abilities
- [x] I have added unittests to verify the code works as intended
