### PR TITLE
Adds a specific WooCommerce shop page check

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -2064,5 +2064,4 @@ class WPSEO_Frontend {
 
 		return $post_type;
 	}
-
 }

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -278,9 +278,11 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * @param null $object
+	 * Retrieves the SEO title set in the SEO widget.
 	 *
-	 * @return string
+	 * @param null $object Object to retrieve the title from.
+	 *
+	 * @return string The SEO title for the specified object, or queried object if not supplied.
 	 */
 	public function get_seo_title( $object = null ) {
 		if ( $object === null ) {
@@ -486,7 +488,7 @@ class WPSEO_Frontend {
 		elseif ( $this->is_home_posts_page() ) {
 			$title = $this->get_title_from_options( 'title-home-wpseo' );
 		}
-		elseif( $this->woocommerce_shop_page->is_shop_page() ) {
+		elseif ( $this->woocommerce_shop_page->is_shop_page() ) {
 			$post  = get_post( $this->woocommerce_shop_page->get_shop_page_id() );
 			$title = $this->get_seo_title( $post );
 
@@ -1295,7 +1297,7 @@ class WPSEO_Frontend {
 			$post_type = $post->post_type;
 		}
 
-		if( $this->woocommerce_shop_page->is_shop_page() ) {
+		if ( $this->woocommerce_shop_page->is_shop_page() ) {
 			$post      = get_post( $this->woocommerce_shop_page->get_shop_page_id() );
 			$post_type = $this->get_queried_post_type();
 
@@ -1305,7 +1307,8 @@ class WPSEO_Frontend {
 				$term     = $post;
 			}
 			$metadesc_override = $this->get_seo_meta_value( 'metadesc', $post->ID );
-		} elseif ( $this->frontend_page_type->is_simple_page() ) {
+		}
+		elseif ( $this->frontend_page_type->is_simple_page() ) {
 			$post      = get_post( $this->frontend_page_type->get_simple_page_id() );
 			$post_type = $post->post_type;
 
@@ -2024,7 +2027,8 @@ class WPSEO_Frontend {
 
 			if ( isset( $post_type_obj->labels->menu_name ) ) {
 				$title_part = $post_type_obj->labels->menu_name;
-			} elseif ( isset( $post_type_obj->name ) ) {
+			}
+			elseif ( isset( $post_type_obj->name ) ) {
 				$title_part = $post_type_obj->name;
 			}
 
@@ -2061,12 +2065,14 @@ class WPSEO_Frontend {
 	}
 
 	/**
+	 * Replaces the dynamic variables in a string.
 	 *
-	 * @param string       $string
-	 * @param array|object $args
-	 * @param array        $omit
+	 * @param string $string The string to replace the variables in.
+	 * @param array  $args   The object some of the replacement values might come from,
+	 *                       could be a post, taxonomy or term.
+	 * @param array  $omit   Variables that should not be replaced by this function.
 	 *
-	 * @return string
+	 * @return string The replaced string.
 	 */
 	protected function replace_vars( $string, $args, $omit = array() ) {
 		$replacer = new WPSEO_Replace_Vars();

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -37,7 +37,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 *
 	 * @return bool Whether the current page is the WooCommerce shop page.
 	 */
-	protected function is_shop_page() {
+	public function is_shop_page() {
 		if ( function_exists( 'is_shop' ) && function_exists( 'wc_get_page_id' ) ) {
 			return is_shop() && ! is_search();
 		}
@@ -50,7 +50,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 *
 	 * @return int The ID of the set page.
 	 */
-	protected function get_shop_page_id() {
+	public function get_shop_page_id() {
 		static $shop_page_id;
 
 		if ( ! $shop_page_id ) {

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -18,7 +18,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Returns the  ID of the WooCommerce shop page when the currently opened page is the shop page.
+	 * Returns the ID of the WooCommerce shop page when the currently opened page is the shop page.
 	 *
 	 * @param int $page_id The page id.
 	 *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,3 +33,4 @@ define( 'WPSEO_TESTS_PATH', dirname( __FILE__ ) . '/' );
 
 // Include unit test base class.
 require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case.php';
+require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';

--- a/tests/doubles/frontend-double.php
+++ b/tests/doubles/frontend-double.php
@@ -14,6 +14,7 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	public function __construct() {
 		parent::__construct();
 	}
+
 	/**
 	 * Get the singleton instance of this class
 	 *
@@ -30,6 +31,13 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	}
 
 	/**
+	 * @param WPSEO_WooCommerce_Shop_Page $woocommerce_shop_page
+	 */
+	public function set_woocommerce_shop_page( WPSEO_WooCommerce_Shop_Page $woocommerce_shop_page ) {
+		$this->woocommerce_shop_page = $woocommerce_shop_page;
+	}
+
+	/**
 	 * Short-circuit redirecting.
 	 *
 	 * @param string $location The path to redirect to.
@@ -37,5 +45,19 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	 */
 	public function redirect( $location, $status = 302 ) {
 		// Intentionally left empty to remove actual redirection code to be able to test it.
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get_queried_post_type() {
+		return parent::get_queried_post_type();
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get_post_type_archive_title( $separator, $separator_location ) {
+		return parent::get_post_type_archive_title( $separator, $separator_location );
 	}
 }

--- a/tests/framework/class-wpseo-unit-test-case-frontend.php
+++ b/tests/framework/class-wpseo-unit-test-case-frontend.php
@@ -1,12 +1,10 @@
 <?php
 /**
- * @package WPSEO\Tests\Frontend
+ * @package WPSEO\Tests\Framework
  */
 
 /**
  * Helper class to provide needed shared code to implementations.
- *
- * @group frontend
  */
 class WPSEO_UnitTestCase_Frontend extends WPSEO_UnitTestCase {
 	/** @var WPSEO_Frontend_Double */
@@ -21,68 +19,5 @@ class WPSEO_UnitTestCase_Frontend extends WPSEO_UnitTestCase {
 		require_once WPSEO_TESTS_PATH . 'doubles/frontend-double.php';
 
 		self::$class_instance = WPSEO_Frontend_Double::get_instance();
-	}
-
-	/**
-	 * Override the go_to function in core as its broken when path isn't set.
-	 *
-	 * Can be removed when https://core.trac.wordpress.org/ticket/31417 is fixed and in all releases we're testing (so when 4.2 is the lowest common denominator).
-	 *
-	 * @param string $url URL.
-	 */
-	public function go_to( $url ) {
-		// Note: the WP and WP_Query classes like to silently fetch parameters
-		// from all over the place (globals, GET, etc), which makes it tricky
-		// to run them more than once without very carefully clearing everything.
-		$_GET  = array();
-		$_POST = array();
-
-		$keys = array(
-			'query_string',
-			'id',
-			'postdata',
-			'authordata',
-			'day',
-			'currentmonth',
-			'page',
-			'pages',
-			'multipage',
-			'more',
-			'numpages',
-			'pagenow',
-		);
-
-		foreach ( $keys as $v ) {
-			if ( isset( $GLOBALS[ $v ] ) ) {
-				unset( $GLOBALS[ $v ] );
-			}
-		}
-		$parts = wp_parse_url( $url );
-		if ( isset( $parts['scheme'] ) ) {
-			$req = isset( $parts['path'] ) ? $parts['path'] : '';
-			if ( isset( $parts['query'] ) ) {
-				$req .= '?' . $parts['query'];
-				// Parse the url query vars into $_GET.
-				parse_str( $parts['query'], $_GET );
-			}
-		}
-		else {
-			$req = $url;
-		}
-		if ( ! isset( $parts['query'] ) ) {
-			$parts['query'] = '';
-		}
-
-		$_SERVER['REQUEST_URI'] = $req;
-		unset( $_SERVER['PATH_INFO'] );
-
-		$this->flush_cache();
-		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
-		$GLOBALS['wp_the_query'] = new WP_Query();
-		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
-		$GLOBALS['wp']           = new WP();
-		_cleanup_query_vars();
-
-		$GLOBALS['wp']->main( $parts['query'] );
 	}
 }

--- a/tests/framework/class-wpseo-unit-test-case-frontend.php
+++ b/tests/framework/class-wpseo-unit-test-case-frontend.php
@@ -6,7 +6,7 @@
 /**
  * Helper class to provide needed shared code to implementations.
  */
-class WPSEO_UnitTestCase_Frontend extends WPSEO_UnitTestCase {
+abstract class WPSEO_UnitTestCase_Frontend extends WPSEO_UnitTestCase {
 	/** @var WPSEO_Frontend_Double */
 	protected static $class_instance;
 

--- a/tests/framework/class-wpseo-unit-test-case-frontend.php
+++ b/tests/framework/class-wpseo-unit-test-case-frontend.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @package WPSEO\Tests\Frontend
+ */
+
+/**
+ * Helper class to provide needed shared code to implementations.
+ *
+ * @group frontend
+ */
+class WPSEO_UnitTestCase_Frontend extends WPSEO_UnitTestCase {
+	/** @var WPSEO_Frontend_Double */
+	protected static $class_instance;
+
+	/**
+	 * Sets up the class instance to be a more usable double of the Frontend class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WPSEO_TESTS_PATH . 'doubles/frontend-double.php';
+
+		self::$class_instance = WPSEO_Frontend_Double::get_instance();
+	}
+
+	/**
+	 * Override the go_to function in core as its broken when path isn't set.
+	 *
+	 * Can be removed when https://core.trac.wordpress.org/ticket/31417 is fixed and in all releases we're testing (so when 4.2 is the lowest common denominator).
+	 *
+	 * @param string $url URL.
+	 */
+	public function go_to( $url ) {
+		// Note: the WP and WP_Query classes like to silently fetch parameters
+		// from all over the place (globals, GET, etc), which makes it tricky
+		// to run them more than once without very carefully clearing everything.
+		$_GET  = array();
+		$_POST = array();
+
+		$keys = array(
+			'query_string',
+			'id',
+			'postdata',
+			'authordata',
+			'day',
+			'currentmonth',
+			'page',
+			'pages',
+			'multipage',
+			'more',
+			'numpages',
+			'pagenow',
+		);
+
+		foreach ( $keys as $v ) {
+			if ( isset( $GLOBALS[ $v ] ) ) {
+				unset( $GLOBALS[ $v ] );
+			}
+		}
+		$parts = wp_parse_url( $url );
+		if ( isset( $parts['scheme'] ) ) {
+			$req = isset( $parts['path'] ) ? $parts['path'] : '';
+			if ( isset( $parts['query'] ) ) {
+				$req .= '?' . $parts['query'];
+				// Parse the url query vars into $_GET.
+				parse_str( $parts['query'], $_GET );
+			}
+		}
+		else {
+			$req = $url;
+		}
+		if ( ! isset( $parts['query'] ) ) {
+			$parts['query'] = '';
+		}
+
+		$_SERVER['REQUEST_URI'] = $req;
+		unset( $_SERVER['PATH_INFO'] );
+
+		$this->flush_cache();
+		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+		$GLOBALS['wp']           = new WP();
+		_cleanup_query_vars();
+
+		$GLOBALS['wp']->main( $parts['query'] );
+	}
+}

--- a/tests/framework/class-wpseo-unit-test-case.php
+++ b/tests/framework/class-wpseo-unit-test-case.php
@@ -6,7 +6,7 @@
 /**
  * TestCase base class for convenience methods.
  */
-class WPSEO_UnitTestCase extends WP_UnitTestCase {
+abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 
 	/**
 	 * @param string $key   Key to be used with PHP superglobals.

--- a/tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @package WPSEO\Tests\Frontend
+ */
+
+require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
+
+/**
+ * Unit Test Class.
+ *
+ * @group frontend
+ */
+final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
+	/**
+	 * Test if no redirect is done when not set.
+	 *
+	 * @covers WPSEO_Frontend::page_redirect
+	 */
+	public function test_page_redirect() {
+		// Should not redirect on home pages.
+		$this->go_to_home();
+		$this->assertFalse( self::$class_instance->page_redirect() );
+
+		// Create and go to post.
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Should not redirect when no redirect URL was set.
+		$this->assertFalse( self::$class_instance->page_redirect() );
+	}
+
+	/**
+	 * Tests that no redirects are done for archives.
+	 *
+	 * @covers WPSEO_Frontend::archive_redirect
+	 */
+	public function test_archive_redirect() {
+
+		global $wp_query;
+
+		$c = self::$class_instance;
+
+		// Test on author, authors enabled -> false.
+		$wp_query->is_author          = true;
+		$c->options['disable-author'] = false;
+		$this->assertFalse( $c->archive_redirect() );
+
+		// Test not on author, authors disabled -> false.
+		$wp_query->is_author          = false;
+		$c->options['disable-author'] = true;
+		$this->assertFalse( $c->archive_redirect() );
+
+		// Test on date, dates enabled -> false.
+		$wp_query->is_date          = true;
+		$c->options['disable-date'] = false;
+		$this->assertFalse( $c->archive_redirect() );
+
+		// Test not on date, dates disabled -> false.
+		$wp_query->is_date          = false;
+		$c->options['disable-date'] = true;
+		$this->assertFalse( $c->archive_redirect() );
+	}
+
+	/**
+	 * Tests the situation where the archive redirect has been redirected.
+	 *
+	 * @covers WPSEO_Frontend::archive_redirect()
+	 */
+	public function test_archive_redirect_being_redirected() {
+		global $wp_query;
+
+		$frontend = self::$class_instance;
+
+		$wp_query->is_author                 = true;
+		$frontend->options['disable-author'] = true;
+		$this->assertTrue( $frontend->archive_redirect() );
+
+		$wp_query->is_date                 = true;
+		$frontend->options['disable-date'] = true;
+		$this->assertTrue( $frontend->archive_redirect() );
+	}
+
+	/**
+	 * Tests for attachment redirect an attachment page with parent.
+	 *
+	 * @covers WPSEO_Frontend::attachment_redirect
+	 */
+	public function test_attachment_redirect() {
+		// Create parent post ID.
+		$parent_post_id = $this->factory->post->create();
+
+		// Create an attachment with parent.
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'attachment',
+				'post_parent' => $parent_post_id,
+			)
+		);
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Make sure the redirect is applied.
+		$this->assertTrue( self::$class_instance->attachment_redirect() );
+	}
+
+	/**
+	 * Tests for attachment redirect on a non-attachment page.
+	 *
+	 * @covers WPSEO_Frontend::attachment_redirect
+	 */
+	public function test_attachment_redirect_no_attachment() {
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Should not redirect on regular post pages.
+		$this->assertFalse( self::$class_instance->attachment_redirect() );
+	}
+
+	/**
+	 * Tests for a request without a valid post object.
+	 *
+	 * @covers WPSEO_Frontend::attachment_redirect
+	 */
+	public function test_attachment_redirect_no_post_object() {
+		global $post;
+
+		$saved_post = $post;
+		$post       = null;
+
+		$this->assertFalse( self::$class_instance->attachment_redirect() );
+
+		// Restore global Post.
+		$post = $saved_post;
+	}
+
+	/**
+	 * Tests for a request without a parent on an attachment.
+	 *
+	 * @covers WPSEO_Frontend::attachment_redirect
+	 */
+	public function test_attachment_redirect_no_parent() {
+		// Create and go to post.
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'attachment',
+				'post_parent' => 0,
+			)
+		);
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertFalse( self::$class_instance->attachment_redirect() );
+		$this->assertEquals( 1, did_action( 'wpseo_redirect_orphan_attachment' ) );
+	}
+}

--- a/tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/tests/frontend/test-class-wpseo-frontend-robots.php
@@ -1,26 +1,16 @@
 <?php
 /**
- * @package WPSEO\Tests
+ * @package WPSEO\Tests\Frontend
  */
+
+require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
 
 /**
  * Unit Test Class.
+ *
+ * @group frontend
  */
-class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
-
-	/**
-	 * @var WPSEO_Frontend
-	 */
-	private static $class_instance;
-
-	/**
-	 * Setting up.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		self::$class_instance = WPSEO_Frontend::get_instance();
-	}
+final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 
 	/**
 	 * Provision tests.
@@ -40,12 +30,10 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		parent::tearDown();
 
 		ob_clean();
-
-
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots
+	 * @covers WPSEO_Frontend::robots()
 	 *
 	 * @todo Test post type archives.
 	 * @todo Test with page_for_posts option.
@@ -60,6 +48,9 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( '', self::$class_instance->robots() );
 	}
 
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_robots_on_private_blog() {
 		// Go to home.
 		$this->go_to_home();
@@ -72,7 +63,9 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		update_option( 'blog_public', '1' );
 	}
 
-
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_with_replytocom_attribute() {
 		// Go to home.
 		$this->go_to_home();
@@ -86,9 +79,10 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		unset( $_GET['replytocom'] );
 	}
 
-
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_subpages_with_robots_using_default_state() {
-
 		// Go to home.
 		$this->go_to_home();
 
@@ -98,6 +92,9 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		set_query_var( 'paged', 0 );
 	}
 
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_subpages_robots_noindex() {
 		// Go to home.
 		$this->go_to_home();
@@ -110,10 +107,11 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		// Clean-up.
 		self::$class_instance->options['noindex-subpages-wpseo'] = false;
 		set_query_var( 'paged', 0 );
-
 	}
 
-
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_post_robots_default_state() {
 		// Create and go to post.
 		$post_id = $this->factory->post->create();
@@ -122,11 +120,11 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		// Test regular post with no special options.
 		$expected = '';
 		$this->assertEquals( $expected, self::$class_instance->robots() );
-
 	}
 
-
-
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_post_noindex() {
 		// Create and go to post.
 		$post_id = $this->factory->post->create();
@@ -135,13 +133,11 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		// Test noindex-post option.
 		WPSEO_Options::save_option( 'wpseo_titles', 'noindex-post', true );
 		$this->assertEquals( 'noindex,follow', self::$class_instance->robots() );
-
-		// clean-up
-//		self::$class_instance->options['noindex-post'] = false;
-
 	}
 
-
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_private_post() {
 		// Create and go to post.
 		$post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
@@ -151,9 +147,10 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 'noindex,follow', self::$class_instance->robots() );
 	}
 
-
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_category() {
-
 		// Go to category page.
 		$category_id = wp_create_category( 'Category Name' );
 		flush_rewrite_rules();
@@ -169,6 +166,9 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 	}
 
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_category_noindex() {
 		// Go to category page.
 		$category_id = wp_create_category( 'Category Name' );
@@ -189,8 +189,10 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		self::$class_instance->options['noindex-tax-category'] = false;
 	}
 
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_subpages_category_archives() {
-
 		// Go to category page.
 		$category_id = wp_create_category( 'Category Name' );
 		flush_rewrite_rules();
@@ -209,12 +211,12 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 
 		$expected = 'noindex,follow';
 		$this->assertEquals( $expected, self::$class_instance->robots() );
-
 	}
 
-
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_author_archive() {
-
 		// Go to author page.
 		$user_id = $this->factory->user->create();
 		$this->go_to( get_author_posts_url( $user_id ) );
@@ -222,15 +224,15 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		// Test author archive with no special options.
 		$expected = '';
 		$this->assertEquals( $expected, self::$class_instance->robots() );
-
 	}
 
+	/**
+	 * @covers WPSEO_Frontend::robots()
+	 */
 	public function test_author_archive_noindex() {
-
 		// Go to author page.
 		$user_id = $this->factory->user->create();
 		$this->go_to( get_author_posts_url( $user_id ) );
-
 
 		// Test author archive with 'noindex-author-wpseo'.
 		$expected = 'noindex,follow';
@@ -239,9 +241,7 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 
 		// Clean-up.
 		self::$class_instance->options['noindex-author-wpseo'] = false;
-
 	}
-
 
 	/**
 	 * This test was broken when it was located in test-class-wpseo-frontend.php.
@@ -266,7 +266,6 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend::robots_for_single_post
 	 */
 	public function test_robots_for_single_post() {
-
 		// Create and go to post.
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
@@ -306,12 +305,4 @@ class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase {
 		$this->expectOutput( $expected, self::$class_instance->noindex_page() );
 
 	}
-
-	/**
-	 * @covers WPSEO_Frontend::noindex_feed
-	 */
-	public function test_noindex_feed() {
-		// @todo
-	}
-
 }

--- a/tests/frontend/test-class-wpseo-frontend-title.php
+++ b/tests/frontend/test-class-wpseo-frontend-title.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * @package WPSEO\Tests
+ */
+
+require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
+
+/**
+ * Unit Test Class.
+ *
+ * @group frontend
+ */
+final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
+
+	/**
+	 * Tests expected output from get content title.
+	 *
+	 * @covers WPSEO_Frontend::get_content_title
+	 */
+	public function test_get_content_title() {
+		// Create and go to post.
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		$this->assertFalse( self::$class_instance->is_home_posts_page() );
+
+		// Test title according to format.
+		$expected_title = self::$class_instance->get_title_from_options( 'title-post', get_queried_object() );
+		$this->assertEquals( $expected_title, self::$class_instance->get_content_title() );
+
+		// Test explicit post title.
+		$explicit_title = 'WPSEO Post Title %%sitename%%';
+		WPSEO_Meta::set_value( 'title', $explicit_title, $post_id );
+
+		$post           = get_post( $post_id );
+		$expected_title = wpseo_replace_vars( $explicit_title, $post );
+
+		$this->assertEquals( $expected_title, self::$class_instance->get_content_title() );
+	}
+
+	/**
+	 * Tests expected output from taxonomy title.
+	 *
+	 * @covers WPSEO_Frontend::get_taxonomy_title
+	 */
+	public function test_get_taxonomy_title() {
+		// Create and go to cat archive.
+		$category_id = wp_create_category( 'Category Name' );
+		flush_rewrite_rules();
+
+		$this->go_to( get_category_link( $category_id ) );
+
+		// Test title according to format.
+		$expected_title = self::$class_instance->get_title_from_options( 'title-tax-category', (array) get_queried_object() );
+		$this->assertEquals( $expected_title, self::$class_instance->get_taxonomy_title() );
+
+		// @todo Add test for an explicit wpseo title format.
+		// We need an easy way to set taxonomy meta though...
+	}
+
+	/**
+	 * Tests expected output for author title.
+	 *
+	 * @covers WPSEO_Frontend::get_author_title
+	 */
+	public function test_get_author_title() {
+		// Create and go to author.
+		$user_id = $this->factory->user->create();
+		$this->go_to( get_author_posts_url( $user_id ) );
+
+		// Test general author title.
+		$expected_title = self::$class_instance->get_title_from_options( 'title-author-wpseo' );
+		$this->assertEquals( $expected_title, self::$class_instance->get_author_title() );
+
+		// Add explicit title to author meta.
+		$explicit_title = 'WPSEO Author Title %%sitename%%';
+		add_user_meta( $user_id, 'wpseo_title', $explicit_title );
+
+		// Test explicit title.
+		$expected_title = wpseo_replace_vars( 'WPSEO Author Title %%sitename%%', array() );
+		$this->assertEquals( $expected_title, self::$class_instance->get_author_title() );
+	}
+
+	/**
+	 * Tests expected results when getting the title from options.
+	 *
+	 * @covers WPSEO_Frontend::get_title_from_options
+	 */
+	public function test_get_title_from_options() {
+		// Should return an empty string.
+		$this->assertEmpty( self::$class_instance->get_title_from_options( '__not-existing-index' ) );
+
+		// Create and go to post.
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$var_source     = (array) get_queried_object();
+		$expected_title = wpseo_replace_vars( '%%title%% %%sep%% %%sitename%%', $var_source );
+		$this->assertEquals( $expected_title, self::$class_instance->get_title_from_options( '__not-existing-index', $var_source ) );
+
+		// Test with an option that exists.
+		$index          = 'title-post';
+		$expected_title = wpseo_replace_vars( self::$class_instance->options[ $index ], $var_source );
+		$this->assertEquals( $expected_title, self::$class_instance->get_title_from_options( $index, $var_source ) );
+	}
+
+	/**
+	 * Tests if pagination is added to the title.
+	 *
+	 * @covers WPSEO_Frontend::add_paging_to_title()
+	 */
+	public function test_add_paging_to_title() {
+		$input = 'Initial title';
+
+		// Test without paged query var set.
+		$expected = $input;
+		$this->assertEquals( $input, self::$class_instance->add_paging_to_title( '', '', $input ) );
+
+		// Test with paged set.
+		set_query_var( 'paged', 2 );
+		global $wp_query;
+		$expected = self::$class_instance->add_to_title( '', '', $input, $wp_query->query_vars['paged'] . '/' . $wp_query->max_num_pages );
+		$this->assertEquals( $expected, self::$class_instance->add_paging_to_title( '', '', $input ) );
+	}
+
+	/**
+	 * Tests the add tot title behaviour.
+	 *
+	 * @covers WPSEO_Frontend::add_to_title()
+	 */
+	public function test_add_to_title() {
+		$title      = 'Title';
+		$sep        = ' >> ';
+		$title_part = 'Title Part';
+
+		$expected = $title . $sep . $title_part;
+		$this->assertEquals( $expected, self::$class_instance->add_to_title( $sep, 'right', $title, $title_part ) );
+
+		$expected = $title_part . $sep . $title;
+		$this->assertEquals( $expected, self::$class_instance->add_to_title( $sep, 'left', $title, $title_part ) );
+	}
+
+	/**
+	 * Tests post type archive title.
+	 *
+	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 */
+	public function test_get_post_type_archive_title() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_queried_post_type', 'get_title_from_options' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_queried_post_type' )
+				 ->will( $this->returnValue( 'post_type' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_title_from_options' )
+				 ->with( 'title-ptarchive-post_type' )
+				 ->will( $this->returnValue( 'my title' ) );
+
+		/** @var WPSEO_Frontend_Double $instance */
+		$this->assertEquals( 'my title', $instance->get_post_type_archive_title( '', '' ) );
+	}
+
+	/**
+	 * Tests if the post type archive has a menu title fallback.
+	 *
+	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 */
+	public function test_get_post_type_archive_title_menu_title_fallback() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_queried_post_type' )
+				 ->will( $this->returnValue( 'post_type' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_title_from_options' )
+				 ->with( 'title-ptarchive-post_type' )
+				 ->will( $this->returnValue( '' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_default_title' )
+				 ->with( '1', '2', '3' )
+				 ->will( $this->returnValue( '123' ) );
+
+		$GLOBALS['wp_post_types'] = array(
+			'post_type' => new WP_Post_Type( 'post_type', array( 'labels' => array( 'menu_name' => '3' ) ) )
+		);
+
+		$this->assertEquals( '123', $instance->get_post_type_archive_title( '1', '2' ) );
+	}
+
+	/**
+	 * Tests if the post type archive has a post type name fallback.
+	 *
+	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 */
+	public function test_get_post_type_archive_title_name_fallback() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_queried_post_type' )
+				 ->will( $this->returnValue( 'post_type' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_title_from_options' )
+				 ->with( 'title-ptarchive-post_type' )
+				 ->will( $this->returnValue( '' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_default_title' )
+				 ->with( '1', '2', '4' )
+				 ->will( $this->returnValue( '124' ) );
+
+		$GLOBALS['wp_post_types'] = array(
+			'post_type' => new WP_Post_Type( 'post_type', array( 'labels' => array( 'name' => '4' ) ) )
+		);
+
+		$this->assertEquals( '124', $instance->get_post_type_archive_title( '1', '2' ) );
+	}
+
+	/**
+	 * Tests if the post type archive title falls back on post type name.
+	 *
+	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 */
+	public function test_get_post_type_archive_title_empty_fallback() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_queried_post_type' )
+				 ->will( $this->returnValue( 'post_type' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_title_from_options' )
+				 ->with( 'title-ptarchive-post_type' )
+				 ->will( $this->returnValue( '' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_default_title' )
+				 ->with( '1', '2', 'post_type' )
+				 ->will( $this->returnValue( '12post_type' ) );
+
+		$GLOBALS['wp_post_types'] = array(
+			'post_type' => new WP_Post_Type( 'post_type', array( 'labels' => array( 'menu_name' => null ) ) )
+		);
+
+		$this->assertEquals( '12post_type', $instance->get_post_type_archive_title( '1', '2' ) );
+	}
+
+	/**
+	 * Tests if the seo title is a 404 title when an invalid object is presented.
+	 *
+	 * @covers WPSEO_Frontend::get_seo_title()
+	 */
+	public function test_get_seo_title_no_valid_object() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_title_from_options' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_title_from_options' )
+				 ->with( 'title-404-wpseo' )
+				 ->will( $this->returnValue( '404 title' ) );
+
+		$this->assertEquals( '404 title', $instance->get_seo_title( '' ) );
+	}
+
+	/**
+	 * Tests for normal behaviour of the seo title with expected input.
+	 *
+	 * @covers WPSEO_Frontend::get_seo_title()
+	 */
+	public function test_get_seo_title_with_valid_object() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_meta_value', 'replace_vars' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_seo_meta_value' )
+				 ->with( 'title', 1 )
+				 ->will( $this->returnValue( '' ) );
+
+		$instance->expects( $this->never() )
+				 ->method( 'replace_vars' );
+
+		$this->assertEquals( '', $instance->get_seo_title( (object) array( 'ID' => 1 ) ) );
+	}
+
+	/**
+	 * Test if seo title applies replace vars as expected.
+
+	 * @covers WPSEO_Frontend::get_seo_title()
+	 */
+	public function test_get_seo_title_use_replace_vars() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_meta_value', 'replace_vars' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_seo_meta_value' )
+				 ->with( 'title', 1 )
+				 ->will( $this->returnValue( 'a title' ) );
+
+		$object = (object) array( 'ID' => 1 );
+
+		$instance->expects( $this->once() )
+				 ->method( 'replace_vars' )
+				 ->with( 'a title', $object )
+				 ->will( $this->returnValue( 'a title replaced' ) );
+
+		$this->assertEquals( 'a title replaced', $instance->get_seo_title( $object ) );
+	}
+
+	/**
+	 * Tests if the global queried object is being used with no supplied input.
+	 *
+	 * @covers WPSEO_Frontend::get_seo_title()
+	 */
+	public function test_get_seo_title_use_queried_object() {
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_meta_value', 'replace_vars' ) )
+						 ->getMock();
+
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
+						 ->setMethods( array( 'get_queried_object' ) )
+						 ->getMock();
+
+		$object = (object) array( 'ID' => 1 );
+
+		$wp_query->expects( $this->once() )
+				 ->method( 'get_queried_object' )
+				 ->will( $this->returnValue( $object ) );
+
+		$GLOBALS['wp_query'] = $wp_query;
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_seo_meta_value' )
+				 ->with( 'title', 1 )
+				 ->will( $this->returnValue( 'a title' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'replace_vars' )
+				 ->with( 'a title', $object )
+				 ->will( $this->returnValue( 'a title replaced' ) );
+
+		$this->assertEquals( 'a title replaced', $instance->get_seo_title() );
+	}
+}

--- a/tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
+++ b/tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * @package WPSEO\Tests
+ */
+
+require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
+
+/**
+ * Unit Test Class.
+ *
+ * @group frontend
+ */
+final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Creates a mock for the WooCommerce Shop Page.
+	 *
+	 * @param object $post Object that resembles a WP_Post
+	 *
+	 * @return WPSEO_WooCommerce_Shop_page
+	 */
+	protected function get_woocommerce_shop_page_mock( $post ) {
+		$woocommerce_shop_page = $this->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page' )
+									  ->setMethods( array( 'is_shop_page', 'get_shop_page_id' ) )
+									  ->getMock();
+
+		$woocommerce_shop_page->expects( $this->once() )
+							  ->method( 'get_shop_page_id' )
+							  ->will( $this->returnValue( $post->ID ) );
+
+		$woocommerce_shop_page->expects( $this->once() )
+							  ->method( 'is_shop_page' )
+							  ->will( $this->returnValue( true ) );
+
+		return $woocommerce_shop_page;
+	}
+
+	/**
+	 * Tests if the is_shop_page conditional is being respected.
+	 *
+	 * @covers WPSEO_Frontend::generate_title()
+	 */
+	public function test_get_shop_page_title() {
+		$post = self::factory()->post->create_and_get();
+
+		$woocommerce_shop_page = $this->get_woocommerce_shop_page_mock( $post );
+
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_title' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_seo_title' )
+				 ->with( $post )
+				 ->will( $this->returnValue( 'post title' ) );
+
+		$instance->set_woocommerce_shop_page( $woocommerce_shop_page );
+
+		$this->assertEquals( 'post title', $instance->title( 'original title' ) );
+	}
+
+	/**
+	 * Tests if the post type archive fallback is being used.
+	 *
+	 * @covers WPSEO_Frontend::generate_title()
+	 */
+	public function test_get_shop_page_title_post_archive_title_fallback() {
+		$post = self::factory()->post->create_and_get();
+
+		$woocommerce_shop_page = $this->get_woocommerce_shop_page_mock( $post );
+
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_title', 'get_post_type_archive_title' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_seo_title' )
+				 ->with( $post )
+				 ->will( $this->returnValue( '' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_post_type_archive_title' )
+				 ->will( $this->returnValue( 'post type archive title' ) );
+
+		$instance->set_woocommerce_shop_page( $woocommerce_shop_page );
+
+		$this->assertEquals( 'post type archive title', $instance->title( 'original title' ) );
+	}
+
+	/**
+	 * Tests if the metadescription is being used on the shop page.
+	 *
+	 * @covers WPSEO_Frontend::generate_metadesc()
+	 */
+	public function test_get_shop_page_meta_description() {
+		$post = self::factory()->post->create_and_get();
+
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_queried_post_type' )
+				 ->will( $this->returnValue( 'product' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_seo_meta_value' )
+				 ->with( 'metadesc', $post->ID )
+				 ->will( $this->returnValue( 'override' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'replace_vars' )
+				 ->with( 'override', $post )
+				 ->will( $this->returnValue( 'replaced' ) );
+
+		$instance->options[ 'metadesc-ptarchive-product' ] = 'product metadescription';
+
+		$woocommerce_shop_page = $this->get_woocommerce_shop_page_mock( $post );
+
+		$instance->set_woocommerce_shop_page( $woocommerce_shop_page );
+
+		$this->assertEquals( 'replaced', $instance->metadesc( false ) );
+	}
+
+	/**
+	 * Tests expected behaviour for an empty post type archive template.
+	 *
+	 * @covers WPSEO_Frontend::generate_metadesc()
+	 */
+	public function test_get_shop_page_meta_description_empty_template() {
+		$post = self::factory()->post->create_and_get();
+
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_queried_post_type' )
+				 ->will( $this->returnValue( 'product' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'replace_vars' )
+				 ->with( '', $post )
+				 ->will( $this->returnValue( 'replaced' ) );
+
+		$instance->options[ 'metadesc-ptarchive-product' ] = null;
+
+		$woocommerce_shop_page = $this->get_woocommerce_shop_page_mock( $post );
+		$instance->set_woocommerce_shop_page( $woocommerce_shop_page );
+
+		$this->assertEquals( 'replaced', $instance->metadesc( false ) );
+	}
+
+	/**
+	 * Tests expected behaviour for an undetermined post type.
+	 *
+	 * @covers WPSEO_Frontend::generate_metadesc()
+	 */
+	public function test_get_shop_page_meta_description_empty_post_type() {
+		$post = self::factory()->post->create_and_get();
+
+		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
+						 ->setMethods( array( 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ) )
+						 ->getMock();
+
+		$instance->expects( $this->once() )
+				 ->method( 'get_queried_post_type' )
+				 ->will( $this->returnValue( '' ) );
+
+		$instance->expects( $this->once() )
+				 ->method( 'replace_vars' )
+				 ->with( '', $post )
+				 ->will( $this->returnValue( 'replaced' ) );
+
+		$instance->options[ 'metadesc-ptarchive-product' ] = 'product metadescription';
+
+		$woocommerce_shop_page = $this->get_woocommerce_shop_page_mock( $post );
+		$instance->set_woocommerce_shop_page( $woocommerce_shop_page );
+
+		$this->assertEquals( 'replaced', $instance->metadesc( false ) );
+	}
+}

--- a/tests/frontend/test-class-wpseo-frontend.php
+++ b/tests/frontend/test-class-wpseo-frontend.php
@@ -3,15 +3,14 @@
  * @package WPSEO\Tests
  */
 
+require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
+
 /**
  * Unit Test Class.
+ *
+ * @group frontend
  */
-class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
-
-	/**
-	 * @var WPSEO_Frontend_Double
-	 */
-	private static $class_instance;
+class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 
 	/**
 	 * Setting up.
@@ -29,6 +28,8 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
+
+		$this->reset_post_types();
 
 		ob_clean();
 		self::$class_instance->reset();
@@ -100,145 +101,6 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertFalse( self::$class_instance->is_posts_page() );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::get_content_title
-	 */
-	public function test_get_content_title() {
-
-		// Create and go to post.
-		$post_id = $this->factory->post->create();
-		$this->go_to( get_permalink( $post_id ) );
-		$this->assertFalse( self::$class_instance->is_home_posts_page() );
-
-		// Test title according to format.
-		$expected_title = self::$class_instance->get_title_from_options( 'title-post', get_queried_object() );
-		$this->assertEquals( $expected_title, self::$class_instance->get_content_title() );
-
-		// Test explicit post title.
-		$explicit_title = 'WPSEO Post Title %%sitename%%';
-		WPSEO_Meta::set_value( 'title', $explicit_title, $post_id );
-
-		$post           = get_post( $post_id );
-		$expected_title = wpseo_replace_vars( $explicit_title, $post );
-		$this->assertEquals( $expected_title, self::$class_instance->get_content_title() );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::get_taxonomy_title
-	 */
-	public function test_get_taxonomy_title() {
-
-		// Create and go to cat archive.
-		$category_id = wp_create_category( 'Category Name' );
-		flush_rewrite_rules();
-
-		$this->go_to( get_category_link( $category_id ) );
-
-		// Test title according to format.
-		$expected_title = self::$class_instance->get_title_from_options( 'title-tax-category', (array) get_queried_object() );
-		$this->assertEquals( $expected_title, self::$class_instance->get_taxonomy_title() );
-
-		// @todo Add test for an explicit wpseo title format.
-		// We need an easy way to set taxonomy meta though...
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::get_author_title
-	 */
-	public function test_get_author_title() {
-
-		// Create and go to author.
-		$user_id = $this->factory->user->create();
-		$this->go_to( get_author_posts_url( $user_id ) );
-
-		// Test general author title.
-		$expected_title = self::$class_instance->get_title_from_options( 'title-author-wpseo' );
-		$this->assertEquals( $expected_title, self::$class_instance->get_author_title() );
-
-		// Add explicit title to author meta.
-		$explicit_title = 'WPSEO Author Title %%sitename%%';
-		add_user_meta( $user_id, 'wpseo_title', $explicit_title );
-
-		// Test explicit title.
-		$expected_title = wpseo_replace_vars( 'WPSEO Author Title %%sitename%%', array() );
-		$this->assertEquals( $expected_title, self::$class_instance->get_author_title() );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::get_title_from_options
-	 */
-	public function test_get_title_from_options() {
-		// Should return an empty string.
-		$this->assertEmpty( self::$class_instance->get_title_from_options( '__not-existing-index' ) );
-
-		// Create and go to post.
-		$post_id = $this->factory->post->create();
-		$this->go_to( get_permalink( $post_id ) );
-
-		$var_source     = (array) get_queried_object();
-		$expected_title = wpseo_replace_vars( '%%title%% %%sep%% %%sitename%%', $var_source );
-		$this->assertEquals( $expected_title, self::$class_instance->get_title_from_options( '__not-existing-index', $var_source ) );
-
-		// Test with an option that exists.
-		$index          = 'title-post';
-		$expected_title = wpseo_replace_vars( self::$class_instance->options[ $index ], $var_source );
-		$this->assertEquals( $expected_title, self::$class_instance->get_title_from_options( $index, $var_source ) );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::get_default_title
-	 */
-	public function test_get_default_title() {
-		// @todo
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::add_paging_to_title
-	 */
-	public function test_add_paging_to_title() {
-		$input = 'Initial title';
-
-		// Test without paged query var set.
-		$expected = $input;
-		$this->assertEquals( $input, self::$class_instance->add_paging_to_title( '', '', $input ) );
-
-		// Test with paged set.
-		set_query_var( 'paged', 2 );
-		global $wp_query;
-		$expected = self::$class_instance->add_to_title( '', '', $input, $wp_query->query_vars['paged'] . '/' . $wp_query->max_num_pages );
-		$this->assertEquals( $expected, self::$class_instance->add_paging_to_title( '', '', $input ) );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::add_to_title
-	 */
-	public function test_add_to_title() {
-
-		$title      = 'Title';
-		$sep        = ' >> ';
-		$title_part = 'Title Part';
-
-		$expected = $title . $sep . $title_part;
-		$this->assertEquals( $expected, self::$class_instance->add_to_title( $sep, 'right', $title, $title_part ) );
-
-		$expected = $title_part . $sep . $title;
-		$this->assertEquals( $expected, self::$class_instance->add_to_title( $sep, 'left', $title, $title_part ) );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::title
-	 */
-	public function test_title() {
-		// @todo
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::wp_title
-	 */
-	public function force_wp_title() {
-		// @todo
 	}
 
 	/**
@@ -445,162 +307,12 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::metakeywords
-	 */
-	public function test_metakeywords() {
-		// @todo
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::metadesc
-	 */
-	public function test_metadesc() {
-		// @todo
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::page_redirect
-	 */
-	public function test_page_redirect() {
-		// Should not redirect on home pages.
-		$this->go_to_home();
-		$this->assertFalse( self::$class_instance->page_redirect() );
-
-		// Create and go to post.
-		$post_id = $this->factory->post->create();
-		$this->go_to( get_permalink( $post_id ) );
-
-		// Should not redirect when no redirect URL was set.
-		$this->assertFalse( self::$class_instance->page_redirect() );
-	}
-
-	/**
 	 * @covers WPSEO_Frontend::nofollow_link
 	 */
 	public function test_nofollow_link() {
 		$input    = '<a href="#">A link</a>';
 		$expected = str_replace( '<a ', '<a rel="nofollow" ', $input );
 		$this->assertEquals( $expected, self::$class_instance->nofollow_link( $input ) );
-	}
-
-	/**
-	 * @covers WPSEO_Frontend::archive_redirect
-	 */
-	public function test_archive_redirect() {
-
-		global $wp_query;
-
-		$c = self::$class_instance;
-
-		// Test on author, authors enabled -> false.
-		$wp_query->is_author          = true;
-		$c->options['disable-author'] = false;
-		$this->assertFalse( $c->archive_redirect() );
-
-		// Test not on author, authors disabled -> false.
-		$wp_query->is_author          = false;
-		$c->options['disable-author'] = true;
-		$this->assertFalse( $c->archive_redirect() );
-
-		// Test on date, dates enabled -> false.
-		$wp_query->is_date          = true;
-		$c->options['disable-date'] = false;
-		$this->assertFalse( $c->archive_redirect() );
-
-		// Test not on date, dates disabled -> false.
-		$wp_query->is_date          = false;
-		$c->options['disable-date'] = true;
-		$this->assertFalse( $c->archive_redirect() );
-	}
-
-	/**
-	 * Tests the situation where the archive redirect has been redirected.
-	 *
-	 * @covers WPSEO_Frontend::archive_redirect()
-	 */
-	public function test_archive_redirect_being_redirected() {
-		global $wp_query;
-
-		$frontend = self::$class_instance;
-
-		$wp_query->is_author                 = true;
-		$frontend->options['disable-author'] = true;
-		$this->assertTrue( $frontend->archive_redirect() );
-
-		$wp_query->is_date                 = true;
-		$frontend->options['disable-date'] = true;
-		$this->assertTrue( $frontend->archive_redirect() );
-	}
-
-	/**
-	 * Tests for attachment redirect an attachment page with parent.
-	 *
-	 * @covers WPSEO_Frontend::attachment_redirect
-	 */
-	public function test_attachment_redirect() {
-		// Create parent post ID.
-		$parent_post_id = $this->factory->post->create();
-
-		// Create an attachment with parent.
-		$post_id = $this->factory->post->create(
-			array(
-				'post_type'   => 'attachment',
-				'post_parent' => $parent_post_id,
-			)
-		);
-		$this->go_to( get_permalink( $post_id ) );
-
-		// Make sure the redirect is applied.
-		$this->assertTrue( self::$class_instance->attachment_redirect() );
-	}
-
-	/**
-	 * Tests for attachment redirect on a non-attachment page.
-	 *
-	 * @covers WPSEO_Frontend::attachment_redirect
-	 */
-	public function test_attachment_redirect_no_attachment() {
-		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
-		$this->go_to( get_permalink( $post_id ) );
-
-		// Should not redirect on regular post pages.
-		$this->assertFalse( self::$class_instance->attachment_redirect() );
-	}
-
-	/**
-	 * Tests for a request without a valid post object.
-	 *
-	 * @covers WPSEO_Frontend::attachment_redirect
-	 */
-	public function test_attachment_redirect_no_post_object() {
-		global $post;
-
-		$saved_post = $post;
-		$post       = null;
-
-		$this->assertFalse( self::$class_instance->attachment_redirect() );
-
-		// Restore global Post.
-		$post = $saved_post;
-	}
-
-	/**
-	 * Tests for a request without a parent on an attachment.
-	 *
-	 * @covers WPSEO_Frontend::attachment_redirect
-	 */
-	public function test_attachment_redirect_no_parent() {
-		// Create and go to post.
-		$post_id = $this->factory->post->create(
-			array(
-				'post_type'   => 'attachment',
-				'post_parent' => 0,
-			)
-		);
-		$this->go_to( get_permalink( $post_id ) );
-
-		$this->assertFalse( self::$class_instance->attachment_redirect() );
-		$this->assertEquals( 1, did_action( 'wpseo_redirect_orphan_attachment' ) );
 	}
 
 	/**
@@ -947,15 +659,6 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::title_test_helper
-	 */
-	public function test_title_test_helper() {
-		// @todo
-	}
-
-
-
-	/**
 	 * @param string $initial_url URL to start off from.
 	 *
 	 * @return void
@@ -994,15 +697,6 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param string $name Option name.
-	 *
-	 * @return string
-	 */
-	private function get_option( $name ) {
-		return self::$class_instance->options[ $name ];
-	}
-
-	/**
 	 * @param string $option_name Option name.
 	 * @param string $expected    Expected output.
 	 *
@@ -1015,74 +709,40 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @param string $expected Expected output.
-	 *
-	 * @return void
+	 * @covers WPSEO_Frontend::get_queried_post_type()
 	 */
-	private function run_json_ld_test( $expected ) {
-		$this->expectOutput( $expected, self::$class_instance->internal_search_json_ld() );
+	public function test_get_queried_post_type() {
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
+						 ->setMethods( array( 'get' ) )
+						 ->getMock();
+
+		$wp_query
+			->expects( $this->once() )
+			->method( 'get' )
+			->with( 'post_type' )
+			->will( $this->returnValue( 'my_post_type' ) );
+
+		$GLOBALS['wp_query'] = $wp_query;
+
+		$this->assertEquals( 'my_post_type', self::$class_instance->get_queried_post_type() );
 	}
 
 	/**
-	 * Override the go_to function in core as its broken when path isn't set.
-	 *
-	 * Can be removed when https://core.trac.wordpress.org/ticket/31417 is fixed and in all releases we're testing (so when 4.2 is the lowest common denominator).
-	 *
-	 * @param string $url URL.
+	 * @covers WPSEO_Frontend::get_queried_post_type()
 	 */
-	public function go_to( $url ) {
-		// Note: the WP and WP_Query classes like to silently fetch parameters
-		// from all over the place (globals, GET, etc), which makes it tricky
-		// to run them more than once without very carefully clearing everything.
-		$_GET  = array();
-		$_POST = array();
+	public function test_get_queried_post_type_array() {
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
+						 ->setMethods( array( 'get' ) )
+						 ->getMock();
 
-		$keys = array(
-			'query_string',
-			'id',
-			'postdata',
-			'authordata',
-			'day',
-			'currentmonth',
-			'page',
-			'pages',
-			'multipage',
-			'more',
-			'numpages',
-			'pagenow',
-		);
+		$wp_query
+			->expects( $this->once() )
+			->method( 'get' )
+			->with( 'post_type' )
+			->will( $this->returnValue( array( 'my_post_type', 'your_post_type' ) ) );
 
-		foreach ( $keys as $v ) {
-			if ( isset( $GLOBALS[ $v ] ) ) {
-				unset( $GLOBALS[ $v ] );
-			}
-		}
-		$parts = wp_parse_url( $url );
-		if ( isset( $parts['scheme'] ) ) {
-			$req = isset( $parts['path'] ) ? $parts['path'] : '';
-			if ( isset( $parts['query'] ) ) {
-				$req .= '?' . $parts['query'];
-				// Parse the url query vars into $_GET.
-				parse_str( $parts['query'], $_GET );
-			}
-		}
-		else {
-			$req = $url;
-		}
-		if ( ! isset( $parts['query'] ) ) {
-			$parts['query'] = '';
-		}
+		$GLOBALS['wp_query'] = $wp_query;
 
-		$_SERVER['REQUEST_URI'] = $req;
-		unset( $_SERVER['PATH_INFO'] );
-
-		$this->flush_cache();
-		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
-		$GLOBALS['wp_the_query'] = new WP_Query();
-		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
-		$GLOBALS['wp']           = new WP();
-		_cleanup_query_vars();
-
-		$GLOBALS['wp']->main( $parts['query'] );
+		$this->assertEquals( 'my_post_type', self::$class_instance->get_queried_post_type() );
 	}
 }

--- a/tests/inc/test-class-post-type.php
+++ b/tests/inc/test-class-post-type.php
@@ -24,14 +24,10 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::get_accessible_post_types()
 	 */
 	public function test_get_accessible_post_types() {
-		$this->assertEquals(
-			array(
-				'post'       => 'post',
-				'page'       => 'page',
-				'attachment' => 'attachment',
-			),
-			WPSEO_Post_Type::get_accessible_post_types()
-		);
+		$post_types = WPSEO_Post_Type::get_accessible_post_types();
+		$this->assertContains( 'post', $post_types );
+		$this->assertContains( 'page', $post_types );
+		$this->assertContains( 'attachment', $post_types );
 	}
 
 	/**


### PR DESCRIPTION
As WooCommerce shop pages are treated as post type archives AND as regular pages, this specific exception needs to be handled.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the method of setting the title and meta description templates for the WooCommerce shop page would not work anymore.

## Relevant technical choices:

* Extracted code from the `get_content_title` which determines the SEO title. As this code applies a default when no SEO title is found. The WooCommerce Shop Page needs to fetch this default from another place, so we need to know if the SEO title is set or not.

## Test instructions

This PR can be tested by following these steps:

* Follow the instructions in the issue and the KB article mentioned.

## Quality ensurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8660
