### PR TITLE
Clarify open graph language in social tabs.

### DIFF
--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -16,11 +16,7 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 ?>
 	<p>
 		<?php
-		printf(
-			/* translators: %s expands to <code>&lt;head&gt;</code> */
-			esc_html__( 'Add Open Graph meta data to your site\'s %s section, Facebook and other social networks use this data when your pages are shared.', 'wordpress-seo' ),
-			'<code>&lt;head&gt;</code>'
-		);
+			esc_html_e( 'Enable this feature if you want Facebook and other social media to display a preview with images and a text excerpt when a link to your site is shared.', 'wordpress-seo' );
 		?>
 	</p>
 

--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -14,11 +14,7 @@ echo '<h2>' . esc_html__( 'Twitter settings', 'wordpress-seo' ) . '</h2>';
 $yform->light_switch( 'twitter', __( 'Add Twitter card meta data', 'wordpress-seo' ) );
 
 echo '<p>';
-printf(
-	/* translators: %s expands to <code>&lt;head&gt;</code> */
-	esc_html__( 'Add Twitter card meta data to your site\'s %s section.', 'wordpress-seo' ),
-	'<code>&lt;head&gt;</code>'
-);
+esc_html_e( 'Enable this feature if you want Twitter to display a preview with images and a text excerpt when a link to your site is shared.', 'wordpress-seo' );
 echo '</p>';
 
 echo '<br />';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Clarified Open Graph language for Facebook and Twitter in the Social settings

## Test instructions

Verify the new copy in the Facebook and Twitter tabs is OK.

Fixes #6302
