### PR TITLE
Travis: More stable solution for removing Xdebug when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-- if [[ $TRAVIS_PHP_VERSION != "nightly" && "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini; fi
+- if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
 - if [[ "$CHECKJS" == "1" ]]; then nvm install $TRAVIS_NODE_VERSION; fi
 - if [[ "$CHECKJS" == "1" ]]; then curl -o- -L https://yarnpkg.com/install.sh | bash; fi
 - if [[ "$CHECKJS" == "1" ]]; then export PATH=$HOME/.yarn/bin:$PATH; fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Improves on #8659

As per https://twitter.com/kelunik/status/954242454676475904

When newer images of PHP versions become available, Xdebug isn't always installed.
Using this little titbit, the builds won't break because of it.

## Test instructions

This PR can be tested by following these steps:
* Check that the Travis builds still work as expected for all PHP versions, independently of whether Xdebug is installed or not.

## Quality ensurance
_N/A_
