### PR TITLE
CS/best practices: use `wp_parse_url()` instead of `parse_url()`

### DIFF
--- a/admin/class-social-facebook.php
+++ b/admin/class-social-facebook.php
@@ -97,8 +97,7 @@ class Yoast_Social_Facebook {
 			return $matches_full_meta[1];
 		}
 
-		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
-		return trim( parse_url( $admin_id, PHP_URL_PATH ), '/' );
+		return trim( wp_parse_url( $admin_id, PHP_URL_PATH ), '/' );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -896,8 +896,7 @@ class WPSEO_Utils {
 			return $home_url;
 		}
 
-		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
-		$home_path = parse_url( $home_url, PHP_URL_PATH );
+		$home_path = wp_parse_url( $home_url, PHP_URL_PATH );
 
 		if ( '/' === $home_path ) { // Home at site root, already slashed.
 			return $home_url;

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -288,8 +288,7 @@ class WPSEO_Sitemaps_Renderer {
 			return $url;
 		}
 
-		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
-		$path = parse_url( $url, PHP_URL_PATH );
+		$path = wp_parse_url( $url, PHP_URL_PATH );
 
 		if ( ! empty( $path ) && '/' !== $path ) {
 			$encoded_path = explode( '/', $path );
@@ -304,8 +303,7 @@ class WPSEO_Sitemaps_Renderer {
 			$url = str_replace( $path, $encoded_path, $url );
 		}
 
-		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
-		$query = parse_url( $url, PHP_URL_QUERY );
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
 
 		if ( ! empty( $query ) ) {
 

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -93,7 +93,6 @@ class WPSEO_Sitemaps_Router {
 		$base = apply_filters( 'wpseo_sitemaps_base_url', $base );
 
 		// Get the scheme from the configured home url instead of letting WordPress determine the scheme based on the requested URI.
-		// @todo Replace with call to wp_parse_url() once minimum requirement has gone up to WP 4.7.
-		return home_url( $base . $page, parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
+		return home_url( $base . $page, wp_parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

The PHP native `parse_url()` function behaves differently across PHP versions which can lead to unexpected results.

WP offers a cross-PHP-version compatible alternative `wp_parse_url()` which is recommended to use instead.

As of WP 4.7, the WP function supports the `$component` parameter as well and as the WPSEO minimum WP requirements have gone up to WP 4.8, the last remaining calls to the PHP `parse_url()` function can now be replaced with calls to `wp_parse_url()`.

Also see #8035


## Test instructions
_N/A_