### PR TITLE
CS/best practices: use `wp_rand()` instead of `rand()`

### DIFF
--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -111,7 +111,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 * @return string
 	 */
 	public static function get_fbconnectkey() {
-		return md5( get_bloginfo( 'url' ) . rand() );
+		return md5( get_bloginfo( 'url' ) . wp_rand() );
 	}
 
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

WP offers a `wp_rand()` function as an alternative to the PHP native `rand()` function. Using the WP variant is recommended as it is more secure and less predictable than the values generated by the PHP native functions.

Use of the PHP native `rand()` related functions is discouraged anyway as the values they generate are not not secure. Using functions like `random_int()`, `random_bytes()` and `openssl_random_pseudo_bytes()` are suggested as alternatives.

The WP wrapper function makes use of these alternatives under the hood whenever possible.

Refs:
* https://developer.wordpress.org/reference/functions/wp_rand/
* http://php.net/manual/en/function.rand.php



## Test instructions

This PR can be tested by following these steps:
* Verify that the Facebook related functionality on the Social Admin page still works as expected.
