### PR TITLE
QA: Remove fall-back for new WP function

### DIFF
--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -50,12 +50,7 @@ if ( get_blog_count() > 100 ) {
 }
 else {
 
-	if ( function_exists( 'get_sites' ) ) { // WP 4.6+.
-		$sites = array_map( 'get_object_vars', get_sites( array( 'deleted' => 0 ) ) );
-	}
-	else {
-		$sites = wp_get_sites( array( 'deleted' => 0 ) );
-	}
+	$sites = array_map( 'get_object_vars', get_sites( array( 'deleted' => 0 ) ) );
 
 	if ( is_array( $sites ) && $sites !== array() ) {
 		$dropdown_input = array(


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

Minimum supported WP version is now 4.8, so no need to still support WP 4.6.


## Test instructions
_N/A_
