### PR TITLE
Remove 1.0.0 composer version lock in composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ before_install:
 
 install:
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.6.13; fi
-- composer selfupdate 1.0.0 --no-interaction
 - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then composer require --dev phpunit/phpunit ^5.7; fi
 - composer install --no-interaction
 - composer config-yoastcs


### PR DESCRIPTION
In our efforts to speed up the travis builds, remove this hard version lock.
Composer is a lot faster starting 1.3 and up, because xdebug will not be loaded when installing.

As this is one of the slower processes in the build steps, this should speed up things considerably.

Related:
Originally introduced in https://github.com/Yoast/wordpress-seo/pull/4361
No longer needed since https://github.com/composer-php52/composer-php52/releases/tag/v1.0.20
