### PR TITLE
Add SEOpressor importer

### DIFF
--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -6,7 +6,7 @@
 /**
  * Class WPSEO_Import_SEOPressor
  *
- * Class with functionality to import Yoast SEO settings from SEOpressor
+ * Class with functionality to import Yoast SEO settings from SEOpressor.
  */
 class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	/**
@@ -106,7 +106,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	}
 
 	/**
-	 * Getting the wpSEO robot value and map this to Yoast SEO values.
+	 * Getting the SEOpressor robot value and map this to Yoast SEO values.
 	 *
 	 * @param string  $meta_rules The meta rules taken from the SEOpressor settings array.
 	 * @param integer $post_id    The post id of the current post.
@@ -123,7 +123,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	}
 
 	/**
-	 * Getting the robot config by given wpSEO robots value.
+	 * Getting the robot config by given SEOpressor robots value.
 	 *
 	 * @param array $seopressor_robots The value in SEOpressor that needs to be converted to the Yoast format.
 	 *

--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -32,10 +32,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 			foreach ( array_values( $query_posts->posts ) as $post_id ) {
 				$this->import_post_focus_keywords( $post_id );
 				$this->import_seopressor_post_settings( $post_id );
-
-				if ( $this->replace ) {
-					$this->seopressor_post_cleanup( $post_id );
-				}
+				$this->seopressor_post_cleanup( $post_id );
 			}
 		}
 	}
@@ -163,6 +160,10 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	 * @param integer $post_id Post ID
 	 */
 	private function seopressor_post_cleanup( $post_id ) {
+		if ( ! $this->replace ) {
+			return;
+		}
+
 		// If we get to replace the data, let's do some proper cleanup
 		foreach (
 			array(

--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -40,7 +40,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	/**
 	 * SEOpressor stores most of the data in one post array, this loops over it.
 	 *
-	 * @param int $post_id
+	 * @param int $post_id Post ID.
 	 */
 	private function import_seopressor_post_settings( $post_id ) {
 		$settings = get_post_meta( $post_id, '_seop_settings', true );
@@ -57,9 +57,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 				'tw_description'   => 'twitter-description',
 				'tw_title'         => 'twitter-title',
 				'tw_image'         => 'twitter-image',
-			)
-			as $seopressor_key => $yoast_key
-		) {
+			) as $seopressor_key => $yoast_key ) {
 			$this->import_meta_helper( $seopressor_key, $yoast_key, $settings, $post_id );
 		}
 
@@ -86,11 +84,11 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	 * @param integer $post_id Post ID.
 	 */
 	private function import_post_focus_keywords( $post_id ) {
-		// Import the focus keyword
+		// Import the focus keyword.
 		$focuskw = trim( get_post_meta( $post_id, '_seop_kw_1', true ) );
 		WPSEO_Meta::set_value( 'focuskw', $focuskw, $post_id );
 
-		// Import additional focus keywords for use in premium
+		// Import additional focus keywords for use in premium.
 		$focuskw2 = trim( get_post_meta( $post_id, '_seop_kw_2', true ) );
 		$focuskw3 = trim( get_post_meta( $post_id, '_seop_kw_3', true ) );
 
@@ -103,7 +101,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 		}
 
 		if ( $focus_keywords !== array() ) {
-			WPSEO_Meta::set_value( 'focuskeywords', json_encode( $focus_keywords ), $post_id );
+			WPSEO_Meta::set_value( 'focuskeywords', wp_json_encode( $focus_keywords ), $post_id );
 		}
 	}
 
@@ -138,14 +136,14 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 			'advanced' => '',
 		);
 
-		if ( in_array( 'noindex', $seopressor_robots ) ) {
+		if ( in_array( 'noindex', $seopressor_robots, true ) ) {
 			$return['index'] = 1;
 		}
-		if ( in_array( 'nofollow', $seopressor_robots ) ) {
+		if ( in_array( 'nofollow', $seopressor_robots, true ) ) {
 			$return['follow'] = 0;
 		}
 		foreach ( array( 'noarchive', 'nosnippet', 'noimageindex' ) as $needle ) {
-			if ( in_array( $needle, $seopressor_robots ) ) {
+			if ( in_array( $needle, $seopressor_robots, true ) ) {
 				$return['advanced'] .= $needle . ',';
 			}
 		}
@@ -157,14 +155,14 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	/**
 	 * Removes all the post meta fields SEOpressor creates.
 	 *
-	 * @param integer $post_id Post ID
+	 * @param integer $post_id Post ID.
 	 */
 	private function seopressor_post_cleanup( $post_id ) {
 		if ( ! $this->replace ) {
 			return;
 		}
 
-		// If we get to replace the data, let's do some proper cleanup
+		// If we get to replace the data, let's do some proper cleanup.
 		foreach (
 			array(
 				'_seop_settings',
@@ -177,8 +175,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 				'_seop_kw_1',
 				'_seop_kw_2',
 				'_seop_kw_3',
-			) as $key
-		) {
+			) as $key ) {
 			echo $key;
 			delete_post_meta( $post_id, $key );
 		}

--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -163,21 +163,8 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 		}
 
 		// If we get to replace the data, let's do some proper cleanup.
-		foreach (
-			array(
-				'_seop_settings',
-				'_seop_upgrade_v6',
-				'_seop_site_audit',
-				'_seop_cache_result',
-				'_seop_cache_score',
-				'_seop_cache_md5',
-				'_seop_link_last_check',
-				'_seop_kw_1',
-				'_seop_kw_2',
-				'_seop_kw_3',
-			) as $key ) {
-			echo $key;
-			delete_post_meta( $post_id, $key );
-		}
+		global $wpdb;
+		$query = $wpdb->prepare( "DELETE FROM $wpdb->postmeta WHERE post_id = %d AND meta_key LIKE '_seop_%'", $post_id );
+		$wpdb->query( $query );
 	}
 }

--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * @package WPSEO\Admin\Import\External
+ */
+
+/**
+ * Class WPSEO_Import_SEOPressor
+ *
+ * Class with functionality to import Yoast SEO settings from SEOpressor
+ */
+class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
+	/**
+	 * Import SEOpressor settings
+	 *
+	 * @param boolean $replace Boolean replace switch.
+	 */
+	public function __construct( $replace = false ) {
+		parent::__construct( $replace );
+
+		$this->import_post_metas();
+
+		$this->set_msg( __( 'SEOpressor data successfully imported.', 'wordpress-seo' ) );
+	}
+
+	/**
+	 * Import the post meta values to Yoast SEO
+	 */
+	private function import_post_metas() {
+		// Query for all the posts that have an _seop_settings meta set.
+		$query_posts = new WP_Query( 'post_type=any&meta_key=_seop_settings&order=ASC&fields=ids&nopaging=true' );
+		if ( ! empty( $query_posts->posts ) ) {
+			foreach ( array_values( $query_posts->posts ) as $post_id ) {
+				$this->import_post_focus_keywords( $post_id );
+				$this->import_seopressor_post_settings( $post_id );
+
+				if ( $this->replace ) {
+					$this->seopressor_post_cleanup( $post_id );
+				}
+			}
+		}
+	}
+
+	/**
+	 * SEOpressor stores most of the data in one post array, this loops over it.
+	 *
+	 * @param int $post_id
+	 */
+	private function import_seopressor_post_settings( $post_id ) {
+		$settings = get_post_meta( $post_id, '_seop_settings', true );
+
+		foreach (
+			array(
+				'fb_description'   => 'opengraph-description',
+				'fb_title'         => 'opengraph-title',
+				'fb_type'          => 'og_type',
+				'fb_img'           => 'opengraph-image',
+				'meta_title'       => 'title',
+				'meta_description' => 'metadesc',
+				'meta_canonical'   => 'canonical',
+				'tw_description'   => 'twitter-description',
+				'tw_title'         => 'twitter-title',
+				'tw_image'         => 'twitter-image',
+			)
+			as $seopressor_key => $yoast_key
+		) {
+			$this->import_meta_helper( $seopressor_key, $yoast_key, $settings, $post_id );
+		}
+
+		$this->import_post_robots( $settings['meta_rules'], $post_id );
+	}
+
+	/**
+	 * Helper function to store the meta value should it be set in SEOPressor's settings
+	 *
+	 * @param string $seo_pressor_key     The key in the SEOPressor array.
+	 * @param string $yoast_key           The identifier we use in our meta settings.
+	 * @param array  $seopressor_settings The array of settings for this post in SEOpressor.
+	 * @param int    $post_id             The post ID.
+	 */
+	private function import_meta_helper( $seo_pressor_key, $yoast_key, $seopressor_settings, $post_id ) {
+		if ( ! empty( $seopressor_settings[ $seo_pressor_key ] ) ) {
+			WPSEO_Meta::set_value( $yoast_key, $seopressor_settings[ $seo_pressor_key ], $post_id );
+		}
+	}
+
+	/**
+	 * Imports the focus keywords, and stores them for later use.
+	 *
+	 * @param integer $post_id Post ID.
+	 */
+	private function import_post_focus_keywords( $post_id ) {
+		// Import the focus keyword
+		$focuskw = trim( get_post_meta( $post_id, '_seop_kw_1', true ) );
+		WPSEO_Meta::set_value( 'focuskw', $focuskw, $post_id );
+
+		// Import additional focus keywords for use in premium
+		$focuskw2 = trim( get_post_meta( $post_id, '_seop_kw_2', true ) );
+		$focuskw3 = trim( get_post_meta( $post_id, '_seop_kw_3', true ) );
+
+		$focus_keywords = array();
+		if ( ! empty( $focuskw2 ) ) {
+			$focus_keywords[] = $focuskw2;
+		}
+		if ( ! empty( $focuskw3 ) ) {
+			$focus_keywords[] = $focuskw3;
+		}
+
+		if ( $focus_keywords !== array() ) {
+			WPSEO_Meta::set_value( 'focuskeywords', json_encode( $focus_keywords ), $post_id );
+		}
+	}
+
+	/**
+	 * Getting the wpSEO robot value and map this to Yoast SEO values.
+	 *
+	 * @param string  $meta_rules The meta rules taken from the SEOpressor settings array.
+	 * @param integer $post_id    The post id of the current post.
+	 */
+	private function import_post_robots( $meta_rules, $post_id ) {
+		$seopressor_robots = explode( '#|#|#', $meta_rules );
+
+		$robot_value = $this->get_robot_value( $seopressor_robots );
+
+		// Saving the new meta values for Yoast SEO.
+		WPSEO_Meta::set_value( 'meta-robots-noindex', $robot_value['index'], $post_id );
+		WPSEO_Meta::set_value( 'meta-robots-nofollow',$robot_value['follow'], $post_id );
+		WPSEO_Meta::set_value( 'meta-robots-adv', $robot_value['advanced'], $post_id );
+	}
+
+	/**
+	 * Getting the robot config by given wpSEO robots value.
+	 *
+	 * @param array $seopressor_robots The value in SEOpressor that needs to be converted to the Yoast format.
+	 *
+	 * @return array
+	 */
+	private function get_robot_value( $seopressor_robots ) {
+		$return = array(
+			'index'    => 2,
+			'follow'   => 0,
+			'advanced' => '',
+		);
+
+		if ( in_array( 'noindex', $seopressor_robots ) ) {
+			$return['index'] = 1;
+		}
+		if ( in_array( 'nofollow', $seopressor_robots ) ) {
+			$return['follow'] = 0;
+		}
+		foreach ( array( 'noarchive', 'nosnippet', 'noimageindex' ) as $needle ) {
+			if ( in_array( $needle, $seopressor_robots ) ) {
+				$return['advanced'] .= $needle . ',';
+			}
+		}
+		$return['advanced'] = rtrim( $return['advanced'], ',' );
+
+		return $return;
+	}
+
+	/**
+	 * Removes all the post meta fields SEOpressor creates.
+	 *
+	 * @param integer $post_id Post ID
+	 */
+	private function seopressor_post_cleanup( $post_id ) {
+		// If we get to replace the data, let's do some proper cleanup
+		foreach (
+			array(
+				'_seop_settings',
+				'_seop_upgrade_v6',
+				'_seop_site_audit',
+				'_seop_cache_result',
+				'_seop_cache_score',
+				'_seop_cache_md5',
+				'_seop_link_last_check',
+				'_seop_kw_1',
+				'_seop_kw_2',
+				'_seop_kw_3',
+			) as $key
+		) {
+			echo $key;
+			delete_post_meta( $post_id, $key );
+		}
+	}
+}

--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -9,8 +9,9 @@
  * Class with functionality to import Yoast SEO settings from SEOpressor.
  */
 class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
+
 	/**
-	 * Import SEOpressor settings
+	 * Imports the SEOpressor settings.
 	 *
 	 * @param boolean $replace Boolean replace switch.
 	 */
@@ -23,7 +24,9 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	}
 
 	/**
-	 * Import the post meta values to Yoast SEO
+	 * Imports the post meta values to Yoast SEO.
+	 *
+	 * @return void
 	 */
 	private function import_post_metas() {
 		// Query for all the posts that have an _seop_settings meta set.
@@ -38,9 +41,11 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	}
 
 	/**
-	 * SEOpressor stores most of the data in one post array, this loops over it.
+	 * Imports the data. SEOpressor stores most of the data in one post array, this loops over it.
 	 *
 	 * @param int $post_id Post ID.
+	 *
+	 * @return void
 	 */
 	private function import_seopressor_post_settings( $post_id ) {
 		$settings = get_post_meta( $post_id, '_seop_settings', true );
@@ -65,12 +70,14 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	}
 
 	/**
-	 * Helper function to store the meta value should it be set in SEOPressor's settings
+	 * Represents the Helper function to store the meta value should it be set in SEOPressor's settings.
 	 *
 	 * @param string $seo_pressor_key     The key in the SEOPressor array.
 	 * @param string $yoast_key           The identifier we use in our meta settings.
 	 * @param array  $seopressor_settings The array of settings for this post in SEOpressor.
 	 * @param int    $post_id             The post ID.
+	 *
+	 * @return void
 	 */
 	private function import_meta_helper( $seo_pressor_key, $yoast_key, $seopressor_settings, $post_id ) {
 		if ( ! empty( $seopressor_settings[ $seo_pressor_key ] ) ) {
@@ -82,6 +89,8 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	 * Imports the focus keywords, and stores them for later use.
 	 *
 	 * @param integer $post_id Post ID.
+	 *
+	 * @return void
 	 */
 	private function import_post_focus_keywords( $post_id ) {
 		// Import the focus keyword.
@@ -106,10 +115,12 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	}
 
 	/**
-	 * Getting the SEOpressor robot value and map this to Yoast SEO values.
+	 * Retrieves the SEOpressor robot value and map this to Yoast SEO values.
 	 *
 	 * @param string  $meta_rules The meta rules taken from the SEOpressor settings array.
 	 * @param integer $post_id    The post id of the current post.
+	 *
+	 * @return void
 	 */
 	private function import_post_robots( $meta_rules, $post_id ) {
 		$seopressor_robots = explode( '#|#|#', $meta_rules );
@@ -123,11 +134,11 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	}
 
 	/**
-	 * Getting the robot config by given SEOpressor robots value.
+	 * Gets the robot config by given SEOpressor robots value.
 	 *
 	 * @param array $seopressor_robots The value in SEOpressor that needs to be converted to the Yoast format.
 	 *
-	 * @return array
+	 * @return array The robots values in Yoast format.
 	 */
 	private function get_robot_value( $seopressor_robots ) {
 		$return = array(
@@ -156,6 +167,8 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 	 * Removes all the post meta fields SEOpressor creates.
 	 *
 	 * @param integer $post_id Post ID.
+	 *
+	 * @return void
 	 */
 	private function seopressor_post_cleanup( $post_id ) {
 		if ( ! $this->replace ) {

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -31,6 +31,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	$yform->checkbox( 'importheadspace', __( 'Import from HeadSpace2', 'wordpress-seo' ) );
 	$yform->checkbox( 'importaioseo', __( 'Import from All-in-One SEO', 'wordpress-seo' ) );
 	$yform->checkbox( 'importjetpackseo', __( 'Import from Jetpack SEO', 'wordpress-seo' ) );
+	$yform->checkbox( 'importseopressor', __( 'Import from SEOpressor', 'wordpress-seo' ) );
 	$yform->checkbox( 'importwoo', __( 'Import from WooThemes SEO framework', 'wordpress-seo' ) );
 	$yform->checkbox( 'importwpseo', __( 'Import from wpSEO', 'wordpress-seo' ) );
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -47,6 +47,10 @@ if ( filter_input( INPUT_POST, 'import' ) || filter_input( INPUT_GET, 'import' )
 	if ( ! empty( $post_wpseo['importwpseo'] ) || filter_input( INPUT_GET, 'importwpseo' ) ) {
 		$import = new WPSEO_Import_WPSEO( $replace );
 	}
+
+	if ( ! empty( $post_wpseo['importseopressor'] ) || filter_input( INPUT_GET, 'importseopressor' ) ) {
+		$import = new WPSEO_Import_SEOPressor( $replace );
+	}
 }
 
 if ( isset( $_FILES['settings_import_file'] ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add an importer for people wishing to switch over from SEOpressor.

## Relevant technical choices:

* Adds a new class for the SEOpressor importer.
* This import class imports:
  * SEO title
  * meta description
  * canonical
  * OpenGraph (Facebook) title, description, type and image
  * Twitter title, description and image
  * focus keywords

SEOpressor allows for 3 keywords per post, I've decided to import the first one as the main focus keyword and keyword 2 and 3 are stored in the `focuskeywords` array that Yoast SEO Premium uses.

## Test instructions

This PR can be tested by following these steps:

* Enable SEOpressor on a test site (I have a copy I can send to tester).
* To activate SEOPressor without a license, find `WPPostsRateKeys_Options` in the `wp_options` table (this is an array) and set the `active` key to `'1'` (string) instead of `'0'`.
* Create a few posts with relevant SEOpressor metadata.
* Run the importer (from SEO -> Tools -> Import), and validate that metadata is imported properly.
* Validate that SEOpressor metadata is actually deleted when the checkbox is checked.

## Quality ensurance

* [x] I have tested this code to the best of my abilities

Fixes #7192 