### PR TITLE
Fix the query to import robots in wpSEO import

### DIFF
--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -46,11 +46,11 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 	 * Importing the robot values from WPSEO plugin. These have to be converted to the Yoast format.
 	 */
 	private function import_post_robots() {
-		$query_posts = new WP_Query( 'post_type=any&meta_key=_wpseo_edit_robots&order=ASC' );
+		$query_posts = new WP_Query( 'post_type=any&meta_key=_wpseo_edit_robots&order=ASC&nopaging=true' );
 
 		if ( ! empty( $query_posts->posts ) ) {
-			foreach ( $query_posts->posts as $post ) {
-				$this->import_post_robot( $post->ID );
+			foreach ( array_values( $query_posts->posts ) as $post_id ) {
+				$this->import_post_robot( $post_id );
 			}
 		}
 	}

--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -46,7 +46,7 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 	 * Importing the robot values from WPSEO plugin. These have to be converted to the Yoast format.
 	 */
 	private function import_post_robots() {
-		$query_posts = new WP_Query( 'post_type=any&meta_key=_wpseo_edit_robots&order=ASC&nopaging=true' );
+		$query_posts = new WP_Query( 'post_type=any&meta_key=_wpseo_edit_robots&order=ASC&fields=ids&nopaging=true' );
 
 		if ( ! empty( $query_posts->posts ) ) {
 			foreach ( array_values( $query_posts->posts ) as $post_id ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Make sure we import meta robots for more than 10 posts when importing from wpseo.de

## Relevant technical choices:

* Switched to just querying ID's as that's all we need.

