### PR TITLE
Jdv/ultimate seo importer rebased

### DIFF
--- a/admin/class-import-ultimate-seo.php
+++ b/admin/class-import-ultimate-seo.php
@@ -7,8 +7,9 @@
  * Class with functionality to import Yoast SEO settings from Ultimate SEO.
  */
 class WPSEO_Import_Ultimate_SEO extends WPSEO_Import_External {
+
 	/**
-	 * Import Ultimate SEO settings
+	 * Constructs the import Ultimate SEO settings.
 	 *
 	 * @param boolean $replace Boolean replace switch.
 	 */
@@ -23,7 +24,9 @@ class WPSEO_Import_Ultimate_SEO extends WPSEO_Import_External {
 	}
 
 	/**
-	 * Import All In One SEO meta values.
+	 * Imports the Ultimate SEO  meta values.
+	 *
+	 * @returns void
 	 */
 	private function import_metas() {
 		WPSEO_Meta::replace_meta( '_su_description', WPSEO_Meta::$meta_prefix . 'metadesc', $this->replace );
@@ -37,6 +40,8 @@ class WPSEO_Import_Ultimate_SEO extends WPSEO_Import_External {
 
 	/**
 	 * Removes all leftover SEO ultimate data from the database.
+	 *
+	 * @return void
 	 */
 	private function cleanup() {
 		if ( ! $this->replace ) {

--- a/admin/class-import-ultimate-seo.php
+++ b/admin/class-import-ultimate-seo.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package WPSEO\Admin\Import\External
+ */
+
+/**
+ * Class with functionality to import Yoast SEO settings from Ultimate SEO.
+ */
+class WPSEO_Import_Ultimate_SEO extends WPSEO_Import_External {
+	/**
+	 * Import Ultimate SEO settings
+	 *
+	 * @param boolean $replace Boolean replace switch.
+	 */
+	public function __construct( $replace = false ) {
+		parent::__construct( $replace );
+
+		$this->import_metas();
+		$this->cleanup();
+
+		$this->set_msg( __( 'Ultimate SEO data successfully imported.', 'wordpress-seo' ) );
+
+	}
+
+	/**
+	 * Import All In One SEO meta values.
+	 */
+	private function import_metas() {
+		WPSEO_Meta::replace_meta( '_su_description', WPSEO_Meta::$meta_prefix . 'metadesc', $this->replace );
+		WPSEO_Meta::replace_meta( '_su_meta_robots_nofollow', WPSEO_Meta::$meta_prefix . 'meta-robots-nofollow', $this->replace );
+		WPSEO_Meta::replace_meta( '_su_meta_robots_noindex', WPSEO_Meta::$meta_prefix . 'meta-robots-nofollow', $this->replace );
+		WPSEO_Meta::replace_meta( '_su_og_title', WPSEO_Meta::$meta_prefix . 'opengraph-title', $this->replace );
+		WPSEO_Meta::replace_meta( '_su_og_description', WPSEO_Meta::$meta_prefix . 'opengraph-description', $this->replace );
+		WPSEO_Meta::replace_meta( '_su_og_image', WPSEO_Meta::$meta_prefix . 'opengraph-image', $this->replace );
+		WPSEO_Meta::replace_meta( '_su_title', WPSEO_Meta::$meta_prefix . 'title', $this->replace );
+	}
+
+	/**
+	 * Removes all leftover SEO ultimate data from the database.
+	 */
+	private function cleanup() {
+		if ( ! $this->replace ) {
+			return;
+		}
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}postmeta WHERE meta_key LIKE '_su_%'" );
+	}
+}

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -31,6 +31,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	$yform->checkbox( 'importheadspace', __( 'Import from HeadSpace2', 'wordpress-seo' ) );
 	$yform->checkbox( 'importaioseo', __( 'Import from All-in-One SEO', 'wordpress-seo' ) );
 	$yform->checkbox( 'importjetpackseo', __( 'Import from Jetpack SEO', 'wordpress-seo' ) );
+	$yform->checkbox( 'importseoultimate', __( 'Import from Ultimate SEO', 'wordpress-seo' ) );
 	$yform->checkbox( 'importwoo', __( 'Import from WooThemes SEO framework', 'wordpress-seo' ) );
 	$yform->checkbox( 'importwpseo', __( 'Import from wpSEO', 'wordpress-seo' ) );
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -50,8 +50,8 @@ if ( filter_input( INPUT_POST, 'import' ) || filter_input( INPUT_GET, 'import' )
 
 	if ( ! empty( $post_wpseo['importseoultimate'] ) || filter_input( INPUT_GET, 'importseoultimate' ) ) {
 		$import = new WPSEO_Import_Ultimate_SEO( $replace );
-  }
-  
+	}
+
 	if ( ! empty( $post_wpseo['importseopressor'] ) || filter_input( INPUT_GET, 'importseopressor' ) ) {
 		$import = new WPSEO_Import_SEOPressor( $replace );
 	}

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -47,6 +47,10 @@ if ( filter_input( INPUT_POST, 'import' ) || filter_input( INPUT_GET, 'import' )
 	if ( ! empty( $post_wpseo['importwpseo'] ) || filter_input( INPUT_GET, 'importwpseo' ) ) {
 		$import = new WPSEO_Import_WPSEO( $replace );
 	}
+
+	if ( ! empty( $post_wpseo['importseoultimate'] ) || filter_input( INPUT_GET, 'importseoultimate' ) ) {
+		$import = new WPSEO_Import_Ultimate_SEO( $replace );
+	}
 }
 
 if ( isset( $_FILES['settings_import_file'] ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added an importer for Ultimate SEO.

## Relevant technical choices:

* Straight up importer as the data structure is quite similar.
* This import class imports:
  * SEO title
  * meta description
  * OpenGraph (Facebook) title, description and image

## Test instructions

This PR can be tested by following these steps:

* Enable Ultimate SEO on a test site (it's available on the WordPress plugin repository).
* Create a few posts with relevant SEO metadata.
* Run the importer (from SEO -> Tools -> Import), and validate that metadata is imported properly.
* Validate that Ultimate SEO metadata is actually deleted when the checkbox is checked.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #6934