### PR TITLE
Stories/fix grunt 18n dynamic import

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,17 +7,6 @@
       ]
     }
   } ] ],
-  "plugins": [ "transform-react-jsx" ],
-  "comments": true,
-  "env": {
-    "test": {
-      "plugins": [ "dynamic-import-webpack" ]
-    },
-    "production": {
-      "plugins": [ "syntax-dynamic-import" ]
-    },
-    "development": {
-      "plugins": [ "syntax-dynamic-import" ]
-    }
-  }
+  "plugins": [ "transform-react-jsx", "dynamic-import-webpack" ],
+  "comments": true
 }

--- a/js/src/components/IntlProvider.js
+++ b/js/src/components/IntlProvider.js
@@ -28,7 +28,7 @@ function loadLocaleData( locale ) {
 		return new Promise( ( resolve ) => resolve() );
 	}
 
-	return import(
+	return System.import(
 		`react-intl/locale-data/${ locale }`
 		).then( localeData => {
 			addLocaleData( localeData );

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "babel-jest": "^18.0.0",
     "babel-loader": "^7.1.1",
     "babel-plugin-dynamic-import-webpack": "^1.0.2",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "algoliasearch": "^3.16.0",
     "autoprefixer": "^6.3.1",
+    "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
     "babel-jest": "^18.0.0",
     "babel-loader": "^7.1.1",
@@ -67,7 +68,7 @@
     "grunt-webpack": "^3.0.2",
     "grunt-wp-css": "cedaro/grunt-wp-css#develop",
     "grunt-wp-i18n": "^0.5.4",
-    "i18n-calypso": "^1.6.3",
+    "i18n-calypso": "^1.8.4",
     "jest": "^18.0.0",
     "load-grunt-config": "^0.19.2",
     "react": "^15.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,7 +4081,7 @@ hyphenate-style-name@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
-i18n-calypso@^1.6.3:
+i18n-calypso@^1.8.4:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/i18n-calypso/-/i18n-calypso-1.8.4.tgz#9f3aa9c9e58d72cdd4a8ea70f964d48813f5da28"
   dependencies:


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes `grunt build:i18n` crash because of Babylon syntax error on `import()`.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Run `grunt build:i18n`. Check if no errors occur.
* Build the project and see whether the dynamic imports still work properly on the Content Analysis and Help Center.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #
