### PR TITLE
Reverts the shortlink to the previous hard link

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -653,15 +653,14 @@ class WPSEO_Frontend {
 	 */
 	public function get_debug_mark() {
 		return sprintf(
-			'<!-- This site is optimized with the %1$s %2$s - %3$s -->',
+			'<!-- This site is optimized with the %1$s %2$s - https://yoast.com/wordpress/plugins/seo/ -->',
 			esc_html( $this->head_product_name() ),
 			/**
 			 * Filter: 'wpseo_hide_version' - can be used to hide the Yoast SEO version in the debug marker (only available in Yoast SEO Premium).
 			 *
 			 * @api bool
 			 */
-			( ( apply_filters( 'wpseo_hide_version', false ) && $this->is_premium() ) ? '' : 'v' . WPSEO_VERSION ),
-			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yg' ) )
+			( ( apply_filters( 'wpseo_hide_version', false ) && $this->is_premium() ) ? '' : 'v' . WPSEO_VERSION )
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Reverts the shortlink in the HTML comment back to the hard link it was before.

## Test instructions

This PR can be tested by following these steps:

* Open a page on the frontend of the site, see the shortlink not being used anymore

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #8731 
