### PR TITLE
Add toggle for advanced settings to wizard

### DIFF
--- a/admin/config-ui/class-configuration-storage.php
+++ b/admin/config-ui/class-configuration-storage.php
@@ -44,8 +44,6 @@ class WPSEO_Configuration_Storage {
 			new WPSEO_Config_Field_Company_Logo(),
 			new WPSEO_Config_Field_Person_Name(),
 			new WPSEO_Config_Field_Post_Type_Visibility(),
-
-			// Advanced settings.
 			new WPSEO_Config_Field_Advanced_Settings(),
 		);
 

--- a/admin/config-ui/class-configuration-storage.php
+++ b/admin/config-ui/class-configuration-storage.php
@@ -44,6 +44,9 @@ class WPSEO_Configuration_Storage {
 			new WPSEO_Config_Field_Company_Logo(),
 			new WPSEO_Config_Field_Person_Name(),
 			new WPSEO_Config_Field_Post_Type_Visibility(),
+
+			// Advanced settings.
+			new WPSEO_Config_Field_Advanced_Settings(),
 		);
 
 		$post_type_factory = new WPSEO_Config_Factory_Post_Type();

--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -58,6 +58,9 @@ class WPSEO_Configuration_Structure {
 			'siteName',
 			'separator',
 		) );
+
+		$this->add_step( 'advancedSettings', __( 'Advanced settings', 'wordpress-seo' ), array( 'enable_setting_pages' ) );
+
 		$this->add_step( 'newsletter', __( 'Newsletter', 'wordpress-seo' ), array(
 			'mailchimpSignup',
 		), true, true );

--- a/admin/config-ui/fields/class-field-advanced-settings.php
+++ b/admin/config-ui/fields/class-field-advanced-settings.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @package WPSEO\Admin\ConfigurationUI
+ */
+
+/**
+ * Class WPSEO_Config_Field_Advanced_Settings
+ */
+class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
+	/**
+	 * WPSEO_Config_Field_Environment constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'enable_setting_pages' );
+
+		$this->set_property( 'description', $this->get_description() );
+
+		$this->add_choice( 'true', __( 'Show the Advanced settings', 'wordpress-seo' ) );
+		$this->add_choice( 'false', __( 'Hide the Advanced settings for now', 'wordpress-seo' ) );
+	}
+
+	/**
+	 * Set adapter
+	 *
+	 * @param WPSEO_Configuration_Options_Adapter $adapter Adapter to register lookup on.
+	 */
+	public function set_adapter( WPSEO_Configuration_Options_Adapter $adapter ) {
+		$adapter->add_custom_lookup(
+			$this->get_identifier(),
+			array( $this, 'get_data' ),
+			array( $this, 'set_data' )
+		);
+	}
+
+	/**
+	 * Gets the option that is set for this field.
+	 *
+	 * @return string The value for the environment_type wpseo option.
+	 */
+	public function get_data() {
+		if ( $this->get_option_value() === true ) {
+			return 'true';
+		}
+
+		return 'false';
+	}
+
+	/**
+	 * Set new data.
+	 *
+	 * @param string $value_to_save The value to save.
+	 *
+	 * @return bool Returns whether the value is successfully set.
+	 */
+	public function set_data( $value_to_save ) {
+		// Make sure the value is a boolean.
+		$value_to_save  = ( $value_to_save === 'true' );
+
+		$this->set_option_value( $value_to_save );
+
+		return ( $this->get_option_value() === $value_to_save );
+	}
+
+	/**
+	 * Returns the value from the options.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool True if settings pages are enabled.
+	 */
+	protected function get_option_value() {
+		$option = WPSEO_Options::get_option( 'wpseo' );
+
+		return $option['enable_setting_pages'];
+	}
+
+	/**
+	 * Sets the option value.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $value True or false.
+	 *
+	 * @return void
+	 */
+	protected function set_option_value( $value ) {
+		$option = WPSEO_Options::get_option( 'wpseo' );
+		$option['enable_setting_pages'] = $value;
+
+		update_option( 'wpseo', $option );
+	}
+
+	/**
+	 * Returns the description for the field.
+	 *
+	 * @return string
+	 */
+	protected function get_description() {
+		return sprintf(
+			/* translators: %1$s expands to Yoast SEO  */
+			esc_html__( '
+				%1$s also has a number of advanced settings. We have determined that the (dynamic) 
+				defaults we set for those are fine for most sites. However, if you want to change 
+				them, you can. To get access to these advanced settings, enable them here.',
+				'wordpress-seo'
+			),
+			'Yoast SEO'
+		);
+	}
+}

--- a/admin/config-ui/fields/class-field-advanced-settings.php
+++ b/admin/config-ui/fields/class-field-advanced-settings.php
@@ -4,11 +4,11 @@
  */
 
 /**
- * Class WPSEO_Config_Field_Advanced_Settings.
+ * Adds the Advanced settings toggle to the configuration wizard.
  */
 class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	/**
-	 * WPSEO_Config_Field_Environment constructor.
+	 * Set up the class.
 	 */
 	public function __construct() {
 		parent::__construct( 'enable_setting_pages' );
@@ -23,6 +23,8 @@ class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	 * Set adapter.
 	 *
 	 * @param WPSEO_Configuration_Options_Adapter $adapter Adapter to register lookup on.
+	 *
+	 * @return void
 	 */
 	public function set_adapter( WPSEO_Configuration_Options_Adapter $adapter ) {
 		$adapter->add_custom_lookup(
@@ -33,9 +35,9 @@ class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	}
 
 	/**
-	 * Gets the option that is set for this field.
+	 * Gets the value that is set for this field.
 	 *
-	 * @return string The value for the environment_type wpseo option.
+	 * @return string The value for the environment_type option.
 	 */
 	public function get_data() {
 		if ( $this->get_option_value() === true ) {
@@ -46,7 +48,7 @@ class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	}
 
 	/**
-	 * Set new data.
+	 * Sets the new value for the option.
 	 *
 	 * @param string $value_to_save The value to save.
 	 *
@@ -62,11 +64,11 @@ class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	}
 
 	/**
-	 * Returns the value from the options.
+	 * Returns the value from the option.
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return bool True if settings pages are enabled.
+	 * @return bool True if advanced settings pages are enabled.
 	 */
 	protected function get_option_value() {
 		$option = WPSEO_Options::get_option( 'wpseo' );
@@ -93,12 +95,12 @@ class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	/**
 	 * Returns the description for the field.
 	 *
-	 * @return string
+	 * @return string The description for the field.
 	 */
 	protected function get_description() {
 		return sprintf(
 			/* translators: %1$s expands to Yoast SEO  */
-			esc_html__( '
+			__( '
 				%1$s also has a number of advanced settings. We have determined that the (dynamic) 
 				defaults we set for those are fine for most sites. However, if you want to change 
 				them, you can. To get access to these advanced settings, enable them here.',

--- a/admin/config-ui/fields/class-field-advanced-settings.php
+++ b/admin/config-ui/fields/class-field-advanced-settings.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Class WPSEO_Config_Field_Advanced_Settings
+ * Class WPSEO_Config_Field_Advanced_Settings.
  */
 class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	/**
@@ -20,7 +20,7 @@ class WPSEO_Config_Field_Advanced_Settings extends WPSEO_Config_Field_Choice {
 	}
 
 	/**
-	 * Set adapter
+	 * Set adapter.
 	 *
 	 * @param WPSEO_Configuration_Options_Adapter $adapter Adapter to register lookup on.
 	 */

--- a/tests/config-ui/fields/test-class-config-field-advanced-settings.php
+++ b/tests/config-ui/fields/test-class-config-field-advanced-settings.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @package WPSEO\Tests\ConfigUI\Fields
+ */
+
+/**
+ * WPSEO_Config_Field_Advanced_Settings_Test
+ *
+ * @group configuration-wizard
+ */
+class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider get_data_values
+	 *
+	 * @param string $expected     The expected result.
+	 * @param bool   $option_value The saved option value.
+	 */
+	public function test_get_data( $expected, $option_value ) {
+		$class_instance = $this
+			->getMockBuilder( 'WPSEO_Config_Field_Advanced_Settings' )
+			->setMethods( array( 'get_option_value' ) )
+			->getMock();
+
+		$class_instance
+			->expects( $this->once() )
+			->method( 'get_option_value' )
+			->will( $this->returnValue( $option_value ) );
+
+		$this->assertEquals( $expected, $class_instance->get_data() );
+	}
+
+	/**
+	 * @dataProvider set_data_values
+	 *
+	 * @param bool   $expected      The expected result.
+	 * @param string $value_to_save The value to save.
+	 * @param bool   $option_value  The saved option value.
+	 */
+	public function test_set_data( $expected, $value_to_save, $option_value ) {
+		$class_instance = $this
+			->getMockBuilder( 'WPSEO_Config_Field_Advanced_Settings' )
+			->setMethods( array( 'get_option_value', 'set_option_value' ) )
+			->getMock();
+
+		$class_instance
+			->expects( $this->once() )
+			->method( 'get_option_value' )
+			->will( $this->returnValue( $option_value ) );
+
+		$this->assertEquals( $expected, $class_instance->set_data( $value_to_save ) );
+	}
+
+	/**
+	 * Returns an array with data values for the get_data test.
+	 *
+	 * Format:
+	 * [0] string is the expected value.
+	 * [1] bool   is the value that get_option_value will return.
+	 *
+	 * @return array The data values.
+	 */
+	public function get_data_values() {
+		return array(
+			array( 'true', true ),
+			array( 'false', false ),
+		);
+	}
+
+	/**
+	 * Returns an array with data values for the set_data test.
+	 *
+	 * Format:
+	 * [0] bool   is the expected value.
+	 * [1] string is the value to save.
+	 * [2] bool   is the value that get_option_value will return.
+	 *
+	 * @return array The data values.
+	 */
+	public function set_data_values() {
+		return array(
+			array( true, 'true', true ),
+			array( false, 'true', false ),
+			array( true, 'false', false ),
+			array( false, 'false', true ),
+		);
+	}
+}

--- a/tests/config-ui/fields/test-class-config-field-advanced-settings.php
+++ b/tests/config-ui/fields/test-class-config-field-advanced-settings.php
@@ -11,6 +11,8 @@
 class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCase {
 
 	/**
+	 * Tests the get data method.
+	 *
 	 * @dataProvider get_data_values
 	 *
 	 * @param string $expected     The expected result.
@@ -31,6 +33,8 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	}
 
 	/**
+	 * Tests the set data method.
+	 *
 	 * @dataProvider set_data_values
 	 *
 	 * @param bool   $expected      The expected result.

--- a/tests/config-ui/fields/test-class-config-field-advanced-settings.php
+++ b/tests/config-ui/fields/test-class-config-field-advanced-settings.php
@@ -17,8 +17,9 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 *
 	 * @param string $expected     The expected result.
 	 * @param bool   $option_value The saved option value.
+	 * @param string $description  The description of the test purpose.
 	 */
-	public function test_get_data( $expected, $option_value ) {
+	public function test_get_data( $expected, $option_value, $description ) {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Config_Field_Advanced_Settings' )
 			->setMethods( array( 'get_option_value' ) )
@@ -29,7 +30,7 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 			->method( 'get_option_value' )
 			->will( $this->returnValue( $option_value ) );
 
-		$this->assertEquals( $expected, $class_instance->get_data() );
+		$this->assertEquals( $expected, $class_instance->get_data(), $description );
 	}
 
 	/**
@@ -40,8 +41,9 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 * @param bool   $expected      The expected result.
 	 * @param string $value_to_save The value to save.
 	 * @param bool   $option_value  The saved option value.
+	 * @param string $description   The description of the test purpose.
 	 */
-	public function test_set_data( $expected, $value_to_save, $option_value ) {
+	public function test_set_data( $expected, $value_to_save, $option_value, $description ) {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Config_Field_Advanced_Settings' )
 			->setMethods( array( 'get_option_value', 'set_option_value' ) )
@@ -52,7 +54,7 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 			->method( 'get_option_value' )
 			->will( $this->returnValue( $option_value ) );
 
-		$this->assertEquals( $expected, $class_instance->set_data( $value_to_save ) );
+		$this->assertEquals( $expected, $class_instance->set_data( $value_to_save ), $description );
 	}
 
 	/**
@@ -61,13 +63,15 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 * Format:
 	 * [0] string is the expected value.
 	 * [1] bool   is the value that get_option_value will return.
+	 * [2] string is the description of the test.
 	 *
 	 * @return array The data values.
 	 */
 	public function get_data_values() {
 		return array(
-			array( 'true', true ),
-			array( 'false', false ),
+			array( 'true', true, 'Boolean true converted to string true.' ),
+			array( 'false', false, 'Boolean false converted to string false' ),
+			array( 'false', 'foo', 'Unexpected string foo converted to string false' ),
 		);
 	}
 
@@ -78,15 +82,18 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 * [0] bool   is the expected value.
 	 * [1] string is the value to save.
 	 * [2] bool   is the value that get_option_value will return.
+	 * [3] string is the description of the test.
 	 *
 	 * @return array The data values.
 	 */
 	public function set_data_values() {
 		return array(
-			array( true, 'true', true ),
-			array( false, 'true', false ),
-			array( true, 'false', false ),
-			array( false, 'false', true ),
+			array( true, 'true', true, 'Saving the value true when old value is false.' ),
+			array( false, 'true', false, 'Saving the value true when old value already is true.' ),
+			array( true, 'false', false, 'Saving the value false when old value is true' ),
+			array( false, 'false', true, 'Saving the value false when old value already is false.' ),
+			array( true, 'foo', false, 'Saving unexpected value converted to false when old value is true.' ),
+			array( false, 'foo', true, 'Saving unexpected value converted to false when old value already is false.' ),
 		);
 	}
 }

--- a/tests/config-ui/fields/test-class-config-field-advanced-settings.php
+++ b/tests/config-ui/fields/test-class-config-field-advanced-settings.php
@@ -17,9 +17,9 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 *
 	 * @param string $expected     The expected result.
 	 * @param bool   $option_value The saved option value.
-	 * @param string $description  The description of the test purpose.
+	 * @param string $message      The message to display after the assertion is completed.
 	 */
-	public function test_get_data( $expected, $option_value, $description ) {
+	public function test_get_data( $expected, $option_value, $message ) {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Config_Field_Advanced_Settings' )
 			->setMethods( array( 'get_option_value' ) )
@@ -30,7 +30,7 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 			->method( 'get_option_value' )
 			->will( $this->returnValue( $option_value ) );
 
-		$this->assertEquals( $expected, $class_instance->get_data(), $description );
+		$this->assertEquals( $expected, $class_instance->get_data(), $message );
 	}
 
 	/**
@@ -41,9 +41,9 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 * @param bool   $expected      The expected result.
 	 * @param string $value_to_save The value to save.
 	 * @param bool   $option_value  The saved option value.
-	 * @param string $description   The description of the test purpose.
+	 * @param string $message       The message to display after the assertion is completed.
 	 */
-	public function test_set_data( $expected, $value_to_save, $option_value, $description ) {
+	public function test_set_data( $expected, $value_to_save, $option_value, $message ) {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Config_Field_Advanced_Settings' )
 			->setMethods( array( 'get_option_value', 'set_option_value' ) )
@@ -54,7 +54,7 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 			->method( 'get_option_value' )
 			->will( $this->returnValue( $option_value ) );
 
-		$this->assertEquals( $expected, $class_instance->set_data( $value_to_save ), $description );
+		$this->assertEquals( $expected, $class_instance->set_data( $value_to_save ), $message );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 * Format:
 	 * [0] string is the expected value.
 	 * [1] bool   is the value that get_option_value will return.
-	 * [2] string is the description of the test.
+	 * [2] string is the message to display after the assertion is completed.
 	 *
 	 * @return array The data values.
 	 */
@@ -82,7 +82,7 @@ class WPSEO_Config_Field_Advanced_Settings_Test extends PHPUnit_Framework_TestCa
 	 * [0] bool   is the expected value.
 	 * [1] string is the value to save.
 	 * [2] bool   is the value that get_option_value will return.
-	 * [3] string is the description of the test.
+	 * [3] string is the message to display after the assertion is completed.
 	 *
 	 * @return array The data values.
 	 */

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -47,6 +47,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 			'multipleAuthors',
 			'connectGoogleSearchConsole',
 			'titleTemplate',
+			'advancedSettings',
 			'newsletter',
 			'suggestions',
 			'success',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added a step in the configuration wizard for enabling (or disabling) the advanced settings.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch
* Open the wizard and navigate to step 10.
* Set the advanced settings to show and go to the next step (is for saving the value)
* Navigate to the admin and see that the advanced settings pages are visible.
* Open the wizard again and navigate to step 10
* Set the advanced settings to hide and go to the next step (is still for saving the value)
* Navigate to the admin and see that the advanced settings pages are hidden

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #6919
