### PR TITLE
Introduce autoload dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,11 @@
 			"deprecated/"
 		]
 	},
+	"autoload-dev": {
+		"classmap": [
+			"tests/"
+		]
+	},
 	"scripts": {
 		"config-yoastcs": [
 			"\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",

--- a/tests/admin/banner/test-class-admin-banner-sidebar.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar.php
@@ -12,13 +12,6 @@ class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 	protected $admin_banner_sidebar;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up the class which will be tested.
 	 */
 	public function setUp() {

--- a/tests/admin/banner/test-class-admin-banner-sidebar.php
+++ b/tests/admin/banner/test-class-admin-banner-sidebar.php
@@ -16,8 +16,6 @@ class WPSEO_Admin_Banner_Sidebar_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-features-mock.php';
 	}
 
 	/**

--- a/tests/admin/banner/test-class-admin-banner-spot.php
+++ b/tests/admin/banner/test-class-admin-banner-spot.php
@@ -9,13 +9,6 @@
 class WPSEO_Admin_Banner_Spot_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Tests the url getter.
 	 *
 	 * @covers WPSEO_Admin_Banner_Spot::__construct

--- a/tests/admin/banner/test-class-admin-banner-spot.php
+++ b/tests/admin/banner/test-class-admin-banner-spot.php
@@ -13,8 +13,6 @@ class WPSEO_Admin_Banner_Spot_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-admin-banner-renderer-mock.php';
 	}
 
 	/**

--- a/tests/admin/test-class-extension-manager.php
+++ b/tests/admin/test-class-extension-manager.php
@@ -14,13 +14,6 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 	private $class_instance;
 
 	/**
-	 * Set up a WPSEO_Extension_Manager object.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Sets up the test class.
 	 */
 	public function setUp() {

--- a/tests/admin/test-class-extension-manager.php
+++ b/tests/admin/test-class-extension-manager.php
@@ -18,9 +18,6 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		// Create instance of WPSEO_Extension_Manager class.
-		require_once WPSEO_TESTS_PATH . 'doubles/class-extension-manager-double.php';
 	}
 
 	/**

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -14,13 +14,6 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 	private static $class_instance;
 
 	/**
-	 * Load the test mock class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up our double class.
 	 */
 	public function setUp() {

--- a/tests/admin/test-class-plugin-availability.php
+++ b/tests/admin/test-class-plugin-availability.php
@@ -18,8 +18,6 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/class-wpseo-plugin-availability-double.php';
 	}
 
 	/**

--- a/tests/admin/test-class-plugin-suggestions.php
+++ b/tests/admin/test-class-plugin-suggestions.php
@@ -19,13 +19,6 @@ class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 	protected $notification_center;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up our double class.
 	 */
 	public function setUp() {

--- a/tests/admin/test-class-plugin-suggestions.php
+++ b/tests/admin/test-class-plugin-suggestions.php
@@ -23,8 +23,6 @@ class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/class-wpseo-suggested-plugins-double.php';
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,6 +31,9 @@ else {
 
 define( 'WPSEO_TESTS_PATH', dirname( __FILE__ ) . '/' );
 
-// Include unit test base class.
-require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case.php';
-require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
+// Load autoloader.
+if ( PHP_VERSION_ID <= 53000 ) {
+	require_once dirname( WPSEO_TESTS_PATH ) . '/vendor/autoload_52.php';
+} else {
+	require_once dirname( WPSEO_TESTS_PATH ) . '/vendor/autoload.php';
+}

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -13,8 +13,6 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-capability-manager-double.php';
 	}
 
 	public function test_register() {

--- a/tests/capabilities/test-class-capability-manager.php
+++ b/tests/capabilities/test-class-capability-manager.php
@@ -8,13 +8,6 @@
  */
 class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 
-	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
 	public function test_register() {
 		$instance = new WPSEO_Capability_Manager_Double();
 

--- a/tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/tests/config-ui/components/test-class-component-connect-gsc.php
@@ -15,13 +15,6 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	protected $stub_calls = array();
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up
 	 */
 	public function setUp() {

--- a/tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/tests/config-ui/components/test-class-component-connect-gsc.php
@@ -19,8 +19,6 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-config-component-connect-google-search-console-mock.php';
 	}
 
 	/**

--- a/tests/config-ui/fields/test-class-config-field.php
+++ b/tests/config-ui/fields/test-class-config-field.php
@@ -13,8 +13,6 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-config-field-double.php';
 	}
 
 	/**

--- a/tests/config-ui/fields/test-class-config-field.php
+++ b/tests/config-ui/fields/test-class-config-field.php
@@ -9,13 +9,6 @@
 class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * @covers WPSEO_Config_Field::__construct()
 	 * @covers WPSEO_Config_Field::get_identifier()
 	 * @covers WPSEO_Config_Field::get_component()

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -12,13 +12,6 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	protected $components;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up
 	 */
 	public function setUp() {

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -16,8 +16,6 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-components-mock.php';
 	}
 
 	/**

--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -15,9 +15,6 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-endpoint-mock.php';
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-wp-rest-server-mock.php';
 	}
 
 	/**

--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -11,13 +11,6 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	protected $endpoint;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up
 	 */
 	public function setUp() {

--- a/tests/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/config-ui/test-class-configuration-options-adapter.php
@@ -12,13 +12,6 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	protected $adapter;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up
 	 */
 	public function setUp() {

--- a/tests/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/config-ui/test-class-configuration-options-adapter.php
@@ -16,8 +16,6 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-options-adapter-mock.php';
 	}
 
 	/**

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -16,8 +16,6 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-service-mock.php';
 	}
 
 	/**

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -12,13 +12,6 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	protected $configuration_service;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Preparation
 	 */
 	public function setUp() {

--- a/tests/config-ui/test-class-configuration-storage.php
+++ b/tests/config-ui/test-class-configuration-storage.php
@@ -15,8 +15,6 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-storage-mock.php';
 	}
 
 	/**

--- a/tests/config-ui/test-class-configuration-storage.php
+++ b/tests/config-ui/test-class-configuration-storage.php
@@ -11,13 +11,6 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	protected $storage;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up
 	 */
 	public function setUp() {

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -16,8 +16,6 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-configuration-structure-mock.php';
 	}
 
 	/**

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -12,13 +12,6 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 	protected $structure;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up
 	 */
 	public function setUp() {

--- a/tests/framework/class-wpseo-unit-test-case-frontend.php
+++ b/tests/framework/class-wpseo-unit-test-case-frontend.php
@@ -16,8 +16,6 @@ abstract class WPSEO_UnitTestCase_Frontend extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		require_once WPSEO_TESTS_PATH . 'doubles/frontend-double.php';
-
 		self::$class_instance = WPSEO_Frontend_Double::get_instance();
 	}
 }

--- a/tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -3,8 +3,6 @@
  * @package WPSEO\Tests\Frontend
  */
 
-require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
-
 /**
  * Unit Test Class.
  *

--- a/tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/tests/frontend/test-class-wpseo-frontend-robots.php
@@ -3,8 +3,6 @@
  * @package WPSEO\Tests\Frontend
  */
 
-require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
-
 /**
  * Unit Test Class.
  *

--- a/tests/frontend/test-class-wpseo-frontend-title.php
+++ b/tests/frontend/test-class-wpseo-frontend-title.php
@@ -3,8 +3,6 @@
  * @package WPSEO\Tests
  */
 
-require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
-
 /**
  * Unit Test Class.
  *

--- a/tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
+++ b/tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
@@ -3,8 +3,6 @@
  * @package WPSEO\Tests
  */
 
-require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
-
 /**
  * Unit Test Class.
  *

--- a/tests/frontend/test-class-wpseo-frontend.php
+++ b/tests/frontend/test-class-wpseo-frontend.php
@@ -3,8 +3,6 @@
  * @package WPSEO\Tests
  */
 
-require_once WPSEO_TESTS_PATH . 'framework/class-wpseo-unit-test-case-frontend.php';
-
 /**
  * Unit Test Class.
  *
@@ -17,8 +15,6 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/frontend-double.php';
 
 		self::$class_instance = WPSEO_Frontend_Double::get_instance();
 	}

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -28,8 +28,6 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-primary-term-double.php';
 	}
 
 	/**

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -24,13 +24,6 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 	private $primary_term_id = 54;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Return the correct primary term when primary term already exists.
 	 *
 	 * @covers WPSEO_Primary_Term::get_primary_term

--- a/tests/onpage/test-class-onpage-request.php
+++ b/tests/onpage/test-class-onpage-request.php
@@ -13,8 +13,6 @@ class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-onpage-request-double.php';
 	}
 
 	/**

--- a/tests/onpage/test-class-onpage-request.php
+++ b/tests/onpage/test-class-onpage-request.php
@@ -9,13 +9,6 @@
 class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Test if there is a response
 	 *
 	 * @covers WPSEO_OnPage_Request::get_response

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -23,8 +23,6 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-onpage-double.php';
 	}
 
 	/**

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -19,13 +19,6 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	private $option_instance;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Setup the class instance
 	 */
 	public function setUp() {

--- a/tests/onpage/test-class-ryte-service.php
+++ b/tests/onpage/test-class-ryte-service.php
@@ -8,13 +8,6 @@
  */
 class WPSEO_Ryte_Service_Test extends WPSEO_UnitTestCase {
 
-	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
 	public function test_cannot_view_ryte() {
 		$onpage = new OnPage_Option_Mock( false, WPSEO_OnPage_Option::IS_INDEXABLE, true );
 

--- a/tests/onpage/test-class-ryte-service.php
+++ b/tests/onpage/test-class-ryte-service.php
@@ -13,8 +13,6 @@ class WPSEO_Ryte_Service_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/onpage-option-mock.php';
 	}
 
 	public function test_cannot_view_ryte() {

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -24,13 +24,6 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	private $mock_image = "<img src='' />";
 
 	/**
-	 * Load the test mock class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Setup the class instance and create some posts
 	 */
 	public function setUp() {

--- a/tests/recalculate/test-class-recalculate-posts.php
+++ b/tests/recalculate/test-class-recalculate-posts.php
@@ -28,8 +28,6 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/class-recalculate-posts-double.php';
 	}
 
 	/**

--- a/tests/roles/test-class-role-manager.php
+++ b/tests/roles/test-class-role-manager.php
@@ -13,8 +13,6 @@ class Capability_Role_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-role-manager-mock.php';
 	}
 
 	public function test_register() {

--- a/tests/roles/test-class-role-manager.php
+++ b/tests/roles/test-class-role-manager.php
@@ -8,13 +8,6 @@
  */
 class Capability_Role_Tests extends PHPUnit_Framework_TestCase {
 
-	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
 	public function test_register() {
 		$instance = new WPSEO_Role_Manager_Mock();
 

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -19,8 +19,6 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-option-xml-double.php';
-
 		self::$class_instance = new WPSEO_Author_Sitemap_Provider();
 	}
 

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -19,8 +19,6 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		require_once WPSEO_TESTS_PATH . 'doubles/class-wpseo-post-type-sitemap-provider-double.php';
-
 		self::$class_instance = new WPSEO_Post_Type_Sitemap_Provider();
 	}
 

--- a/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
+++ b/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
@@ -19,8 +19,6 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		require_once dirname( dirname( __FILE__ ) ) . '/doubles/class-sitemap-image-parser-double.php';
-
 		self::$class_instance = new WPSEO_Sitemap_Image_Parser();
 	}
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -18,8 +18,6 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/class-wpseo-sitemaps-double.php';
 	}
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -14,13 +14,6 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	private static $class_instance;
 
 	/**
-	 * Load the test mock class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Set up our double class.
 	 */
 	public function setUp() {

--- a/tests/statistics/test-class-statistics-service.php
+++ b/tests/statistics/test-class-statistics-service.php
@@ -9,13 +9,6 @@
 class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Reset after each test.
 	 */
 	public function tearDown() {

--- a/tests/statistics/test-class-statistics-service.php
+++ b/tests/statistics/test-class-statistics-service.php
@@ -13,8 +13,6 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/statistics-mock.php';
 	}
 
 	/**

--- a/tests/taxonomy/test-class-taxonomy-content-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-content-fields.php
@@ -23,8 +23,6 @@ class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-taxonomy-content-fields-double.php';
 	}
 
 	/**

--- a/tests/taxonomy/test-class-taxonomy-content-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-content-fields.php
@@ -19,13 +19,6 @@ class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 	private $term;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Adding a term and set the class instance
 	 */
 	public function setUp() {

--- a/tests/taxonomy/test-class-taxonomy-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-fields.php
@@ -8,13 +8,6 @@
  */
 class WPSEO_Taxonomy_Fields_Test extends WPSEO_UnitTestCase {
 
-	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
 	public function test_construct_with_options() {
 		$class = new WPSEO_Taxonomy_Fields_Double( (object) array( 'term' ), array( 'has' => 'options' ) );
 

--- a/tests/taxonomy/test-class-taxonomy-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-fields.php
@@ -13,8 +13,6 @@ class WPSEO_Taxonomy_Fields_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-taxonomy-fields-double.php';
 	}
 
 	public function test_construct_with_options() {

--- a/tests/taxonomy/test-class-taxonomy-settings-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-settings-fields.php
@@ -23,8 +23,6 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-taxonomy-settings-fields-double.php';
 	}
 
 	/**

--- a/tests/taxonomy/test-class-taxonomy-settings-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-settings-fields.php
@@ -19,13 +19,6 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	private $term;
 
 	/**
-	 * Include helper class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Adding a term and set the class instance
 	 */
 	public function setUp() {

--- a/tests/test-class-twitter.php
+++ b/tests/test-class-twitter.php
@@ -21,7 +21,6 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		ob_start();
 
 		// Create instance of WPSEO_Twitter class.
-		require_once WPSEO_TESTS_PATH . 'doubles/class-expose-wpseo-twitter.php';
 		self::$class_instance = new Expose_WPSEO_Twitter();
 		WPSEO_Frontend::get_instance()->reset();
 		// Clean output which was outputted by WPSEO_Twitter constructor.

--- a/tests/test-class-wpseo-breadcrumbs.php
+++ b/tests/test-class-wpseo-breadcrumbs.php
@@ -9,13 +9,6 @@
 class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * Set up the test object by requiring the test double.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Placeholder test to prevent PHPUnit from throwing errors.
 	 */
 	/*public function test_breadcrumb_home() {

--- a/tests/test-class-wpseo-breadcrumbs.php
+++ b/tests/test-class-wpseo-breadcrumbs.php
@@ -13,9 +13,6 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		// Requires the test double.
-		require_once WPSEO_TESTS_PATH . 'doubles/class-breadcrumbs-double.php';
 	}
 
 	/**

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -19,8 +19,6 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		require_once WPSEO_TESTS_PATH . 'doubles/wpseo-meta-columns-double.php';
-
 		self::$class_instance = new WPSEO_Meta_Columns_Double();
 	}
 


### PR DESCRIPTION
Use composer autoloader to load the doubles and mocks required for tests.
Removed all `require_once` calls in the tests folder.

When all tests pass, this can be merged.