### PR TITLE
Add screen reader text to clarify the in sitemap - not in sitemap settings

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -600,7 +600,7 @@ class Yoast_Form {
 			$key_esc = esc_attr( $key );
 			$for     = $var_esc . '-' . $key_esc;
 			echo '<input type="radio" id="' . $for . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $this->options[ $var ], $key_esc, false ) . ' />',
-			'<label for="', $for, '">', $value, '<span class="screen-reader-text"> ' , $screen_reader_text,'</span></label>';
+			'<label for="', $for, '">', esc_html( $value ), '<span class="screen-reader-text"> ' , esc_html( $screen_reader_text ),'</span></label>';
 		}
 
 		echo '<a></a></div></fieldset><div class="clear"></div></div>' . "\n\n";

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -288,13 +288,13 @@ class Yoast_Form {
 	}
 
 	/**
-	 * Create a light switch input field.
+	 * Create a light switch input field using a single checkbox.
 	 *
 	 * @since 3.1
 	 *
 	 * @param string  $var        The variable within the option to create the checkbox for.
-	 * @param string  $label      The label to show for the variable.
-	 * @param array   $buttons    Array of two labels for the buttons (defaults Off/On).
+	 * @param string  $label      The label element text for the checkbox.
+	 * @param array   $buttons    Array of two visual labels for the buttons (defaults Disabled/Enabled).
 	 * @param boolean $reverse    Reverse order of buttons (default true).
 	 */
 	public function light_switch( $var, $label, $buttons = array(), $reverse = true ) {
@@ -559,13 +559,15 @@ class Yoast_Form {
 
 
 	/**
-	 * Create a toggle switch input field.
+	 * Create a toggle switch input field using two radio buttons.
 	 *
 	 * @since 3.1
 	 *
-	 * @param string $var    The variable within the option to create the file upload field for.
-	 * @param array  $values The radio options to choose from.
-	 * @param string $label  The label to show for the variable.
+	 * @param string $var    The variable within the option to create the radio buttons for.
+	 * @param array  $values Associative array of on/off keys and their values to be used as
+	 *                       the label elements text for the radio buttons. Optionally, each
+	 *                       value can be an array of visible label text and screen reader text.
+	 * @param string $label  The visual label for the radio buttons group, used as the fieldset legend.
 	 */
 	public function toggle_switch( $var, $values, $label ) {
 		if ( ! is_array( $values ) || $values === array() ) {
@@ -588,10 +590,17 @@ class Yoast_Form {
 		<div class="switch-toggle switch-candy switch-yoast-seo">';
 
 		foreach ( $values as $key => $value ) {
+			$screen_reader_text = '';
+
+			if ( is_array( $value ) ) {
+				$screen_reader_text = $value['screen_reader_text'];
+				$value = $value['text'];
+			}
+
 			$key_esc = esc_attr( $key );
 			$for     = $var_esc . '-' . $key_esc;
 			echo '<input type="radio" id="' . $for . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $this->options[ $var ], $key_esc, false ) . ' />',
-			'<label for="', $for, '">', $value, '</label>';
+			'<label for="', $for, '">', $value, '<span class="screen-reader-text"> ' , $screen_reader_text,'</span></label>';
 		}
 
 		echo '<a></a></div></fieldset><div class="clear"></div></div>' . "\n\n";

--- a/admin/pages/xml-sitemaps.php
+++ b/admin/pages/xml-sitemaps.php
@@ -24,7 +24,7 @@ $yform->admin_header( true, 'wpseo_xml' );
 $options = get_option( 'wpseo_xml' );
 
 echo '<br/>';
-$yform->light_switch( 'enablexmlsitemap', __( 'XML sitemap functionality', 'wordpress-seo' ) );
+$yform->light_switch( 'enablexmlsitemap', __( 'Enable XML sitemap functionality', 'wordpress-seo' ) );
 
 $tabs = new WPSEO_Option_Tabs( 'sitemaps' );
 $tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ), array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-sitemaps' ) ) ) );

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -16,8 +16,8 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
  */
 $post_types          = get_post_types( array( 'public' => true ), 'objects' );
 $index_switch_values = array(
-	'off' => '<code>index</code>',
-	'on'  => '<code>noindex</code>',
+	'off' => 'index',
+	'on'  => 'noindex',
 );
 
 if ( is_array( $post_types ) && $post_types !== array() ) {

--- a/admin/views/tabs/sitemaps/post-types.php
+++ b/admin/views/tabs/sitemaps/post-types.php
@@ -11,11 +11,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 echo '<h2>' . esc_html__( 'Post types sitemap settings', 'wordpress-seo' ) . '</h2>';
 
-$switch_values = array(
-	'off' => __( 'In sitemap', 'wordpress-seo' ),
-	'on'  => __( 'Not in sitemap', 'wordpress-seo' ),
-);
-
 // Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
 $post_types = get_post_types( array( 'public' => true ), 'objects' );
 
@@ -29,8 +24,23 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 	foreach ( $post_types as $pt ) {
 		$yform->toggle_switch(
 			'post_types-' . $pt->name . '-not_in_sitemap',
-			$switch_values,
-			$pt->labels->name . ' (<code>' . $pt->name . '</code>)'
+			array(
+				'off' => array(
+					'text' => __( 'In sitemap', 'wordpress-seo' ),
+					'screen_reader_text' => sprintf(
+						'(%s)',
+						$pt->labels->name
+					),
+				),
+				'on'  => array(
+					'text' => __( 'Not in sitemap', 'wordpress-seo' ),
+					'screen_reader_text' => sprintf(
+						'(%s)',
+						$pt->labels->name
+					),
+				),
+			),
+			$pt->labels->name
 		);
 
 		/**

--- a/admin/views/tabs/sitemaps/taxonomies.php
+++ b/admin/views/tabs/sitemaps/taxonomies.php
@@ -33,8 +33,23 @@ if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 		if ( isset( $tax->labels->name ) && trim( $tax->labels->name ) !== '' ) {
 			$yform->toggle_switch(
 				'taxonomies-' . $tax->name . '-not_in_sitemap',
-				$switch_values,
-				$tax->labels->name . ' (<code>' . $tax->name . '</code>)'
+				array(
+					'off' => array(
+						'text' => __( 'In sitemap', 'wordpress-seo' ),
+						'screen_reader_text' => sprintf(
+							'(%s)',
+							$tax->labels->name
+						),
+					),
+					'on' => array(
+						'text' => __( 'Not in sitemap', 'wordpress-seo' ),
+						'screen_reader_text' => sprintf(
+							'(%s)',
+							$tax->labels->name
+						),
+					),
+				),
+				$tax->labels->name
 			);
 		}
 	}

--- a/admin/views/tabs/sitemaps/user-sitemap.php
+++ b/admin/views/tabs/sitemaps/user-sitemap.php
@@ -14,8 +14,20 @@ echo '<h2>' . esc_html__( 'User sitemap settings', 'wordpress-seo' ) . '</h2>';
 $yform->toggle_switch(
 	'disable_author_sitemap',
 	array(
-		'off' => __( 'Enabled', 'wordpress-seo' ),
-		'on'  => __( 'Disabled', 'wordpress-seo' ),
+		'off' => array(
+			'text' => __( 'Enabled', 'wordpress-seo' ),
+			'screen_reader_text' => sprintf(
+				'(%s)',
+				__( 'author / user sitemap', 'wordpress-seo' )
+			),
+		),
+		'on' => array(
+			'text' => __( 'Disabled', 'wordpress-seo' ),
+			'screen_reader_text' => sprintf(
+				'(%s)',
+				__( 'author / user sitemap', 'wordpress-seo' )
+			),
+		),
 	),
 	__( 'Author / user sitemap', 'wordpress-seo' )
 );
@@ -27,11 +39,26 @@ printf(
 
 echo '<div id="xml_user_block">';
 
-$switch_values = array(
-	'off' => __( 'In sitemap', 'wordpress-seo' ),
-	'on'  => __( 'Not in sitemap', 'wordpress-seo' ),
+$yform->toggle_switch(
+	'disable_author_noposts',
+	array(
+		'off' => array(
+			'text' => __( 'In sitemap', 'wordpress-seo' ),
+			'screen_reader_text' => sprintf(
+				'(%s)',
+				__( 'Users without posts', 'wordpress-seo' )
+			),
+		),
+		'on'  => array(
+			'text' => __( 'Not in sitemap', 'wordpress-seo' ),
+			'screen_reader_text' => sprintf(
+				'(%s)',
+				__( 'Users without posts', 'wordpress-seo' )
+			),
+		),
+	),
+	__( 'Users without posts', 'wordpress-seo' )
 );
-$yform->toggle_switch( 'disable_author_noposts', $switch_values, __( 'Users without posts', 'wordpress-seo' ) );
 
 printf(
 	'<p class="expl">%s</p>',
@@ -43,7 +70,26 @@ unset( $roles['subscriber'] );
 if ( is_array( $roles ) && $roles !== array() ) {
 	echo '<h2>' . esc_html__( 'Filter specific user roles', 'wordpress-seo' ) . '</h2>';
 	foreach ( $roles as $role_key => $role_name ) {
-		$yform->toggle_switch( 'user_role-' . $role_key . '-not_in_sitemap', $switch_values, $role_name );
+		$yform->toggle_switch(
+			'user_role-' . $role_key . '-not_in_sitemap',
+			array(
+				'off' => array(
+					'text' => __( 'In sitemap', 'wordpress-seo' ),
+					'screen_reader_text' => sprintf(
+						'(%s)',
+						$role_name
+					),
+				),
+				'on'  => array(
+					'text' => __( 'Not in sitemap', 'wordpress-seo' ),
+					'screen_reader_text' => sprintf(
+						'(%s)',
+						$role_name
+					),
+				),
+			),
+			$role_name
+		);
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve the switch toggle settings for assistive technologies

## Relevant technical choices:

This is a first step to partially address #8756.

- adds the ability to pass an array of visible text and screen reader text to the `toggle_switch()` control
- uses it for all the "In sitemap / Not in sitemap" settings, to start with
- improves docs

## Test instructions

- verify each "In sitemap / Not in sitemap" setting has a screen reader text to give context to the option, for example: `In sitemap (posts)`

See #8756
