### PR TITLE
Deprecate hooks

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -613,6 +613,14 @@ class WPSEO_Admin_Init {
 				'version'     => '5.8',
 				'alternative' => 'wpseo_breadcrumb_single_link_info',
 			),
+			'wpseo_metakey'                => array(
+				'version'     => '6.3',
+				'alternative' => null,
+			),
+			'wpseo_metakeywords'           => array(
+				'version'     => '6.3',
+				'alternative' => null,
+			),
 		);
 
 		// Determine which filters have been registered.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Deprecated the hooks `wpseo_metakey` and `wpseo_metakeywords` because these aren't used anymore. There are no alternatives for these.

## Test instructions

This PR can be tested by following these steps:

* Make sure errors and notices will be visible on your installation. Or you can use the  `Query Monitor` plugin
* Add a filter `wpseo_metakey` and a filter `wpseo_metakeywords`. `add_filter( 'wpseo_metakeywords', '__return_false');` This filter can be added on `wp-seo-main.php`
 * A notice will be visible.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] N/A I have added unittests to verify the code works as intended

Fixes #8775
