### PR TITLE
Fix php notice after importing plugin data

### DIFF
--- a/admin/class-import-aioseo.php
+++ b/admin/class-import-aioseo.php
@@ -25,6 +25,7 @@ class WPSEO_Import_AIOSEO extends WPSEO_Import_External {
 
 		$this->aioseo_options = get_option( 'aioseop_options' );
 
+		$this->success = true;
 		$this->import_metas();
 		$this->import_ga();
 	}

--- a/admin/class-import-external.php
+++ b/admin/class-import-external.php
@@ -24,6 +24,9 @@ class WPSEO_Import_External {
 	 */
 	public $msg = '';
 
+	/** @var bool When import has been successful */
+	public $success = false;
+
 	/**
 	 * Import class constructor.
 	 *
@@ -100,6 +103,7 @@ class WPSEO_Import_External {
 			}
 			unset( $hs_meta, $meta );
 		}
+		$this->success = true;
 		$this->set_msg( __( 'HeadSpace2 data successfully imported', 'wordpress-seo' ) );
 	}
 }

--- a/admin/class-import-external.php
+++ b/admin/class-import-external.php
@@ -24,10 +24,10 @@ class WPSEO_Import_External {
 	 */
 	public $msg = '';
 
-	/** 
+	/**
 	 * Whether import has been successful.
 	 *
-	 * @var bool 
+	 * @var bool
 	 */
 	public $success = false;
 

--- a/admin/class-import-external.php
+++ b/admin/class-import-external.php
@@ -11,20 +11,24 @@
 class WPSEO_Import_External {
 
 	/**
-	 * Whether or not to delete old data
+	 * Whether or not to delete old data.
 	 *
 	 * @var boolean
 	 */
 	protected $replace;
 
 	/**
-	 * Message about the import
+	 * Message about the import status.
 	 *
 	 * @var string
 	 */
 	public $msg = '';
 
-	/** @var bool When import has been successful */
+	/** 
+	 * Whether import has been successful.
+	 *
+	 * @var bool 
+	 */
 	public $success = false;
 
 	/**

--- a/admin/class-import-jetpack.php
+++ b/admin/class-import-jetpack.php
@@ -18,6 +18,7 @@ class WPSEO_Import_Jetpack_SEO extends WPSEO_Import_External {
 	public function __construct( $replace = false ) {
 		parent::__construct( $replace );
 
+		$this->success = true;
 		$this->import_metas();
 	}
 

--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -20,6 +20,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 
 		$this->import_post_metas();
 
+		$this->success = true;
 		$this->set_msg( __( 'SEOpressor data successfully imported.', 'wordpress-seo' ) );
 	}
 

--- a/admin/class-import-ultimate-seo.php
+++ b/admin/class-import-ultimate-seo.php
@@ -19,6 +19,7 @@ class WPSEO_Import_Ultimate_SEO extends WPSEO_Import_External {
 		$this->import_metas();
 		$this->cleanup();
 
+		$this->success = true;
 		$this->set_msg( __( 'SEO Ultimate data successfully imported.', 'wordpress-seo' ) );
 
 	}

--- a/admin/class-import-woothemes-seo.php
+++ b/admin/class-import-woothemes-seo.php
@@ -18,6 +18,7 @@ class WPSEO_Import_WooThemes_SEO extends WPSEO_Import_External {
 	public function __construct( $replace = false ) {
 		parent::__construct( $replace );
 
+		$this->success = true;
 		$this->import_home();
 		$this->import_option( 'seo_woo_single_layout', 'post' );
 		$this->import_option( 'seo_woo_page_layout', 'page' );

--- a/admin/class-import-wpseo.php
+++ b/admin/class-import-wpseo.php
@@ -21,6 +21,7 @@ class WPSEO_Import_WPSEO extends WPSEO_Import_External {
 		$this->import_post_metas();
 		$this->import_taxonomy_metas();
 
+		$this->success = true;
 		$this->set_msg(
 			sprintf(
 				/* translators: 1: link open tag; 2: link close tag. */

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -84,7 +84,7 @@ if ( $import ) {
 			$msg .= ' ' . __( 'The old data of the imported plugin was deleted successfully.', 'wordpress-seo' );
 		}
 
-		$status = (  ! empty( $import->success ) ) ? 'updated' : 'error';
+		$status = ( ! empty( $import->success ) ) ? 'updated' : 'error';
 
 		echo '<div id="message" class="message ', $status, '"><p>', $msg, '</p></div>';
 	}

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -84,7 +84,7 @@ if ( $import ) {
 			$msg .= ' ' . __( 'The old data of the imported plugin was deleted successfully.', 'wordpress-seo' );
 		}
 
-		$status = ( $import->success ) ? 'updated' : 'error';
+		$status = (  ! empty( $import->success ) ) ? 'updated' : 'error';
 
 		echo '<div id="message" class="message ', $status, '"><p>', $msg, '</p></div>';
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a PHP notice was given (only in debug mode) when a plugin import has been done. This also fixes the red (error) color of the success notice.

## Test instructions

This PR can be tested by following these steps:

* Do a plugin update on trunk with debug mode enabled. You can install the Query Monitor plugin to get the php notice.
* The color of the success notification is red, this is the error color.
* Checkout this branch and see the php notice gone en the success notification is green (success)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] N/A. I have added unittests to verify the code works as intended

Fixes #8785 
Fixes #8744
