### PR TITLE
Cast ids to integers in class WPSEO_Post_Type_Sitemap_Provider

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -281,7 +281,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 				$stacked_urls[] = $url['loc'];
 
-				if ( (int) $post->ID === $this->get_page_for_posts_id() || (int) $post->ID === $this->get_page_on_front_id() ) {
+				if ( $post->ID === $this->get_page_for_posts_id() || $post->ID === $this->get_page_on_front_id() ) {
 
 					array_unshift( $links, $url );
 					continue;
@@ -544,6 +544,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$post->post_type   = $post_type;
 			$post->post_status = 'publish';
 			$post->filter      = 'sample';
+			$post->ID          = (int) $post->ID;
+			$post->post_parent = (int) $post->post_parent;
+			$post->post_author = (int) $post->post_author;
 			$post_ids[]        = $post->ID;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*  Cast ids to integers in class WPSEO_Post_Type_Sitemap_Provider

## Relevant technical choices:

* Function get_posts (class `WPSEO_Post_Type_Sitemap_Provider` ) retrieve array of posts (as objects, but they are `stdClass` instead `WP_Post`).  All properties are strings, but some properties should be integers ( https://github.com/WordPress/WordPress/blob/4.9.2/wp-includes/post.php#L1973 https://github.com/WordPress/WordPress/blob/4.9.2/wp-includes/post.php#L3003-L3039 ).

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
