### PR TITLE
CS/QA: SQL LIKE wildcards should be passed through a replacement variable

### DIFF
--- a/admin/class-import-seopressor.php
+++ b/admin/class-import-seopressor.php
@@ -177,7 +177,12 @@ class WPSEO_Import_SEOPressor extends WPSEO_Import_External {
 
 		// If we get to replace the data, let's do some proper cleanup.
 		global $wpdb;
-		$query = $wpdb->prepare( "DELETE FROM $wpdb->postmeta WHERE post_id = %d AND meta_key LIKE '_seop_%'", $post_id );
+		$query = $wpdb->prepare(
+			"DELETE FROM $wpdb->postmeta
+			WHERE post_id = %d AND meta_key LIKE %s",
+			$post_id,
+			'_seop_%'
+		);
 		$wpdb->query( $query );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Correctly pass in SQL wildcards. Similar to #8565. Part of clean up after merges.

> Literal percentage signs (%) in the query string must be written as %%. Percentage wildcards (for example, to use in LIKE syntax) must be passed via a substitution argument containing the complete LIKE string, these cannot be inserted directly in the query string. Also see esc_like().

Ref: https://developer.wordpress.org/reference/classes/wpdb/prepare/

## Test instructions
_N/A_

