### PR TITLE
Add a convenience function to get one value from an option

### DIFF
--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -221,15 +221,16 @@ class WPSEO_Options {
 	 *
 	 * @param string $option_name The option the key should come from.
 	 * @param string $key         The key it should return.
+	 * @param mixed  $default     The default value that should be returned if the key isn't set.
 	 *
-	 * @return mixed|null Returns value if found, null if not.
+	 * @return mixed|null Returns value if found, $default if not.
 	 */
-	public static function get_option_value( $option_name, $key ) {
+	public static function get_option_value( $option_name, $key, $default = null ) {
 		$option = self::get_option( $option_name );
 		if ( isset( $option[ $key ] ) ) {
 			return $option[ $key ];
 		}
-		return null;
+		return $default;
 	}
 
 	/**

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -222,11 +222,14 @@ class WPSEO_Options {
 	 * @param string $option_name The option the key should come from.
 	 * @param string $key         The key it should return.
 	 *
-	 * @return mixed
+	 * @return mixed|null Returns value if found, null if not.
 	 */
 	public static function get_option_value( $option_name, $key ) {
 		$option = self::get_option( $option_name );
-		return $option[ $key ];
+		if ( isset( $option[ $key ] ) ) {
+			return $option[ $key ];
+		}
+		return null;
 	}
 
 	/**

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -217,6 +217,19 @@ class WPSEO_Options {
 	}
 
 	/**
+	 * Retrieve a single field from an option for the SEO plugin.
+	 *
+	 * @param string $option_name The option the key should come from.
+	 * @param string $key         The key it should return.
+	 *
+	 * @return mixed
+	 */
+	public static function get_option_value( $option_name, $key ) {
+		$option = self::get_option( $option_name );
+		return $option[ $key ];
+	}
+
+	/**
 	 * Get an option only if it's been auto-loaded.
 	 *
 	 * @static

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -122,7 +122,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_option_value()
 	 */
 	public function test_get_option_value_returns_null_result() {
-		$result = WPSEO_Options::get_option_value( 'wpseo', 'xml_sitemap' );
+		$result = WPSEO_Options::get_option_value( 'wpseo', 'non_existent_value' );
 		$this->assertNull( $result );
 	}
 
@@ -132,7 +132,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_option_value()
 	 */
 	public function test_get_option_value_returns_default_result() {
-		$result = WPSEO_Options::get_option_value( 'wpseo', 'xml_sitemap', array() );
+		$result = WPSEO_Options::get_option_value( 'wpseo', 'non_existent_value', array() );
 		$this->assertEquals( array(), $result );
 	}
 }

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -7,7 +7,6 @@
  * Unit Test Class.
  */
 class WPSEO_Options_Test extends WPSEO_UnitTestCase {
-
 	/**
 	 * Set up the class which will be tested.
 	 */
@@ -27,7 +26,6 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 		$this->assertArrayHasKey( 'rssbefore', $result );
 		$this->assertArrayHasKey( 'breadcrumbs-prefix', $result );
 	}
-
 
 	/**
 	 * Test if the get_options function returns an empty array if you pass an empty array.
@@ -58,7 +56,6 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 		$result = WPSEO_Options::get_options( array( 'wpseo_social', 'wpseo_titles' ) );
 		$this->assertArrayHasKey( 'opengraph', $result );
 	}
-
 
 	/**
 	 * Test if the get_option function returns an empty array if you pass null.
@@ -106,11 +103,17 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_option_value()
 	 */
 	public function test_get_option_value_returns_valid_result() {
+		// Make sure these two have their default values
+		$option                            = WPSEO_Options::get_option( 'wpseo' );
+		$option['keyword_analysis_active'] = true;
+		$option['show_onboarding_notice']  = false;
+		update_option( 'wpseo', $option );
+
 		$result = WPSEO_Options::get_option_value( 'wpseo', 'keyword_analysis_active' );
-		$this->assertEquals( true, $result );
+		$this->assertTrue( $result );
 
 		$result = WPSEO_Options::get_option_value( 'wpseo', 'show_onboarding_notice' );
-		$this->assertEquals( false, $result );
+		$this->assertFalse( $result );
 	}
 
 	/**
@@ -120,9 +123,8 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_option_value_returns_null_result() {
 		$result = WPSEO_Options::get_option_value( 'wpseo', 'xml_sitemap' );
-		$this->assertEquals( null, $result );
+		$this->assertNull( $result );
 	}
-
 
 	/**
 	 * Tests if the get_option_value function returns a valid result.

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -122,4 +122,15 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 		$result = WPSEO_Options::get_option_value( 'wpseo', 'xml_sitemap' );
 		$this->assertEquals( null, $result );
 	}
+
+
+	/**
+	 * Tests if the get_option_value function returns a valid result.
+	 *
+	 * @covers WPSEO_Options::get_option_value()
+	 */
+	public function test_get_option_value_returns_default_result() {
+		$result = WPSEO_Options::get_option_value( 'wpseo', 'xml_sitemap', array() );
+		$this->assertEquals( array(), $result );
+	}
 }

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -99,4 +99,27 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 		$result = WPSEO_Options::get_option( 'wpseo' );
 		$this->assertArrayHasKey( 'website_name', $result );
 	}
+
+	/**
+	 * Tests if the get_option_value function returns a valid result.
+	 *
+	 * @covers WPSEO_Options::get_option_value()
+	 */
+	public function test_get_option_value_returns_valid_result() {
+		$result = WPSEO_Options::get_option_value( 'wpseo', 'keyword_analysis_active' );
+		$this->assertEquals( true, $result );
+
+		$result = WPSEO_Options::get_option_value( 'wpseo', 'show_onboarding_notice' );
+		$this->assertEquals( false, $result );
+	}
+
+	/**
+	 * Tests if the get_option_value function returns a valid result.
+	 *
+	 * @covers WPSEO_Options::get_option_value()
+	 */
+	public function test_get_option_value_returns_null_result() {
+		$result = WPSEO_Options::get_option_value( 'wpseo', 'xml_sitemap' );
+		$this->assertEquals( null, $result );
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* no changelog line needed

## Relevant technical choices:

* Adds a convenience function to quickly get one value from an option, leaving the cache in the `WPSEO_Options` class.
* Returns `null` if the key is not set.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have added unit tests to verify the code works as intended.
