### PR TITLE
Introduce get and set function for WPSEO_Options

### DIFF
--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -212,24 +212,6 @@ class WPSEO_Options {
 	}
 
 	/**
-	 * Retrieve a single field from an option for the SEO plugin.
-	 *
-	 * @param string $option_name The option the key should come from.
-	 * @param string $key         The key it should return.
-	 * @param mixed  $default     The default value that should be returned if the key isn't set.
-	 *
-	 * @return mixed|null Returns value if found, $default if not.
-	 */
-	public static function get_option_value( $option_name, $key, $default = null ) {
-		$option = self::get_option( $option_name );
-		if ( isset( $option[ $key ] ) ) {
-			return $option[ $key ];
-		}
-
-		return $default;
-	}
-
-	/**
 	 * Retrieve a single field from any option for the SEO plugin. Keys are always unique.
 	 *
 	 * @param string $key     The key it should return.
@@ -479,60 +461,4 @@ class WPSEO_Options {
 
 		return $lookup_table;
 	}
-
-
-	/********************** DEPRECATED FUNCTIONS **********************/
-
-	// @codeCoverageIgnoreStart
-	/**
-	 * Check whether the current user is allowed to access the configuration.
-	 *
-	 * @deprecated 1.5.6.1
-	 * @deprecated use WPSEO_Utils::grant_access()
-	 * @see        WPSEO_Utils::grant_access()
-	 *
-	 * @return boolean
-	 */
-	public static function grant_access() {
-		_deprecated_function( __METHOD__, 'WPSEO 1.5.6.1', 'WPSEO_Utils::grant_access()' );
-
-		return WPSEO_Utils::grant_access();
-	}
-
-	/**
-	 * Clears the WP or W3TC cache depending on which is used.
-	 *
-	 * @deprecated 1.5.6.1
-	 * @deprecated use WPSEO_Utils::clear_cache()
-	 * @see        WPSEO_Utils::clear_cache()
-	 */
-	public static function clear_cache() {
-		_deprecated_function( __METHOD__, 'WPSEO 1.5.6.1', 'WPSEO_Utils::clear_cache()' );
-		WPSEO_Utils::clear_cache();
-	}
-
-	/**
-	 * Flush W3TC cache after succesfull update/add of taxonomy meta option.
-	 *
-	 * @deprecated 1.5.6.1
-	 * @deprecated use WPSEO_Utils::flush_w3tc_cache()
-	 * @see        WPSEO_Utils::flush_w3tc_cache()
-	 */
-	public static function flush_w3tc_cache() {
-		_deprecated_function( __METHOD__, 'WPSEO 1.5.6.1', 'WPSEO_Utils::flush_w3tc_cache()' );
-		WPSEO_Utils::flush_w3tc_cache();
-	}
-
-	/**
-	 * Clear rewrite rules.
-	 *
-	 * @deprecated 1.5.6.1
-	 * @deprecated use WPSEO_Utils::clear_rewrites()
-	 * @see        WPSEO_Utils::clear_rewrites()
-	 */
-	public static function clear_rewrites() {
-		_deprecated_function( __METHOD__, 'WPSEO 1.5.6.1', 'WPSEO_Utils::clear_rewrites()' );
-		WPSEO_Utils::clear_rewrites();
-	}
-	// @codeCoverageIgnoreEnd
 }

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -233,6 +233,35 @@ class WPSEO_Options {
 	}
 
 	/**
+	 * Retrieve a single field from any option for the SEO plugin. Keys are always unique.
+	 *
+	 * @param string $key         The key it should return.
+	 * @param mixed  $default     The default value that should be returned if the key isn't set.
+	 *
+	 * @return mixed|null Returns value if found, $default if not.
+	 */
+	public static function get( $key, $default = null ) {
+		$option = self::get_all();
+		if ( isset( $option[ $key ] ) ) {
+			return $option[ $key ];
+		}
+		return $default;
+	}
+
+	/**
+	 * Retrieve a single field from an option for the SEO plugin.
+	 *
+	 * @param string $key   The key to set.
+	 * @param mixed  $value The value to set.
+	 *
+	 * @return mixed|null Returns value if found, $default if not.
+	 */
+	public static function set( $key, $value ) {
+		$lookup_table = self::get_lookup_table();
+		return self::save_option( $lookup_table[ $key ],$key, $value );
+	}
+
+	/**
 	 * Get an option only if it's been auto-loaded.
 	 *
 	 * @static
@@ -434,6 +463,24 @@ class WPSEO_Options {
 		$saved_option = self::get_option( $wpseo_options_group_name );
 		return $saved_option[ $option_name ] === $options[ $option_name ];
 	}
+
+	/**
+	 * Retrieves a lookup table to find in which option_group a key is stored.
+	 *
+	 * @return array The lookup table.
+	 */
+	private static function get_lookup_table() {
+		$lookup_table = array();
+		foreach( array_keys( self::$options ) as $option_name ) {
+			$full_option = self::get_option( $option_name );
+			foreach( $full_option as $key => $value ) {
+				$lookup_table[ $key ] = $option_name;
+			}
+		}
+
+		return $lookup_table;
+	}
+
 
 	/********************** DEPRECATED FUNCTIONS **********************/
 

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -9,7 +9,6 @@
  * Instantiates all the options and offers a number of utility methods to work with the options.
  */
 class WPSEO_Options {
-
 	/**
 	 * @var  array  Options this class uses.
 	 *              Array format:  (string) option_name  => (string) name of concrete class for the option
@@ -25,17 +24,14 @@ class WPSEO_Options {
 		'wpseo_ms'            => 'WPSEO_Option_MS',
 		'wpseo_taxonomy_meta' => 'WPSEO_Taxonomy_Meta',
 	);
-
 	/**
 	 * @var  array   Array of instantiated option objects.
 	 */
 	protected static $option_instances = array();
-
 	/**
 	 * @var  object  Instance of this class.
 	 */
 	protected static $instance;
-
 
 	/**
 	 * Instantiate all the WPSEO option management classes.
@@ -229,14 +225,15 @@ class WPSEO_Options {
 		if ( isset( $option[ $key ] ) ) {
 			return $option[ $key ];
 		}
+
 		return $default;
 	}
 
 	/**
 	 * Retrieve a single field from any option for the SEO plugin. Keys are always unique.
 	 *
-	 * @param string $key         The key it should return.
-	 * @param mixed  $default     The default value that should be returned if the key isn't set.
+	 * @param string $key     The key it should return.
+	 * @param mixed  $default The default value that should be returned if the key isn't set.
 	 *
 	 * @return mixed|null Returns value if found, $default if not.
 	 */
@@ -245,6 +242,7 @@ class WPSEO_Options {
 		if ( isset( $option[ $key ] ) ) {
 			return $option[ $key ];
 		}
+
 		return $default;
 	}
 
@@ -258,7 +256,8 @@ class WPSEO_Options {
 	 */
 	public static function set( $key, $value ) {
 		$lookup_table = self::get_lookup_table();
-		return self::save_option( $lookup_table[ $key ],$key, $value );
+
+		return self::save_option( $lookup_table[ $key ], $key, $value );
 	}
 
 	/**
@@ -317,7 +316,6 @@ class WPSEO_Options {
 			delete_option( 'wpseo_indexation' );
 		}
 	}
-
 
 	/**
 	 * Check that all options exist in the database and add any which don't.
@@ -461,6 +459,7 @@ class WPSEO_Options {
 
 		// Check if everything got saved properly.
 		$saved_option = self::get_option( $wpseo_options_group_name );
+
 		return $saved_option[ $option_name ] === $options[ $option_name ];
 	}
 
@@ -471,9 +470,9 @@ class WPSEO_Options {
 	 */
 	private static function get_lookup_table() {
 		$lookup_table = array();
-		foreach( array_keys( self::$options ) as $option_name ) {
+		foreach ( array_keys( self::$options ) as $option_name ) {
 			$full_option = self::get_option( $option_name );
-			foreach( $full_option as $key => $value ) {
+			foreach ( $full_option as $key => $value ) {
 				$lookup_table[ $key ] = $option_name;
 			}
 		}
@@ -512,7 +511,6 @@ class WPSEO_Options {
 		WPSEO_Utils::clear_cache();
 	}
 
-
 	/**
 	 * Flush W3TC cache after succesfull update/add of taxonomy meta option.
 	 *
@@ -524,7 +522,6 @@ class WPSEO_Options {
 		_deprecated_function( __METHOD__, 'WPSEO 1.5.6.1', 'WPSEO_Utils::flush_w3tc_cache()' );
 		WPSEO_Utils::flush_w3tc_cache();
 	}
-
 
 	/**
 	 * Clear rewrite rules.

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -195,4 +195,20 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 		$result = WPSEO_Options::get( 'show_onboarding_notice' );
 		$this->assertTrue( $result );
 	}
+
+	/**
+	 * Tests if unique keys are used in all options.
+	 */
+	public function test_make_sure_keys_are_unique_over_options() {
+		$keys = array();
+
+		foreach ( array_keys( WPSEO_Options::$options ) as $option_name ) {
+			$option_keys = array_keys( WPSEO_Options::get_option( $option_name ) );
+			$intersected = array_intersect( $option_keys, $keys );
+
+			$this->assertEquals( array(), $intersected, 'Option keys must be unique.' );
+
+			$keys = array_merge( $keys, $option_keys );
+		}
+	}
 }

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -100,45 +100,6 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the get_option_value function returns a valid result.
 	 *
-	 * @covers WPSEO_Options::get_option_value()
-	 */
-	public function test_get_option_value_returns_valid_result() {
-		// Make sure these two have their default values
-		$option                            = WPSEO_Options::get_option( 'wpseo' );
-		$option['keyword_analysis_active'] = true;
-		$option['show_onboarding_notice']  = false;
-		update_option( 'wpseo', $option );
-
-		$result = WPSEO_Options::get_option_value( 'wpseo', 'keyword_analysis_active' );
-		$this->assertTrue( $result );
-
-		$result = WPSEO_Options::get_option_value( 'wpseo', 'show_onboarding_notice' );
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Tests if the get_option_value function returns a valid result.
-	 *
-	 * @covers WPSEO_Options::get_option_value()
-	 */
-	public function test_get_option_value_returns_null_result() {
-		$result = WPSEO_Options::get_option_value( 'wpseo', 'non_existent_value' );
-		$this->assertNull( $result );
-	}
-
-	/**
-	 * Tests if the get_option_value function returns a valid result.
-	 *
-	 * @covers WPSEO_Options::get_option_value()
-	 */
-	public function test_get_option_value_returns_default_result() {
-		$result = WPSEO_Options::get_option_value( 'wpseo', 'non_existent_value', array() );
-		$this->assertEquals( array(), $result );
-	}
-
-	/**
-	 * Tests if the get_option_value function returns a valid result.
-	 *
 	 * @covers WPSEO_Options::get()
 	 */
 	public function test_get_returns_valid_result() {

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -206,7 +206,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 			$option_keys = array_keys( WPSEO_Options::get_option( $option_name ) );
 			$intersected = array_intersect( $option_keys, $keys );
 
-			$this->assertEquals( array(), $intersected, 'Option keys must be unique.' );
+			$this->assertEquals( array(), $intersected, 'Option keys must be unique (' . $option_name . ').' );
 
 			$keys = array_merge( $keys, $option_keys );
 		}

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -135,4 +135,64 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 		$result = WPSEO_Options::get_option_value( 'wpseo', 'non_existent_value', array() );
 		$this->assertEquals( array(), $result );
 	}
+
+	/**
+	 * Tests if the get_option_value function returns a valid result.
+	 *
+	 * @covers WPSEO_Options::get()
+	 */
+	public function test_get_returns_valid_result() {
+		$option                            = WPSEO_Options::get_option( 'wpseo' );
+		$option['keyword_analysis_active'] = true;
+		$option['show_onboarding_notice']  = false;
+		update_option( 'wpseo', $option );
+
+		$result = WPSEO_Options::get( 'keyword_analysis_active' );
+		$this->assertTrue( $result );
+
+		$result = WPSEO_Options::get( 'show_onboarding_notice' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests if the get_option_value function returns a valid result.
+	 *
+	 * @covers WPSEO_Options::get()
+	 */
+	public function test_get_returns_null_result() {
+		$result = WPSEO_Options::get( 'non_existent_value' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests if the get_option_value function returns a valid result.
+	 *
+	 * @covers WPSEO_Options::get()
+	 */
+	public function test_get_returns_default_result() {
+		$result = WPSEO_Options::get( 'non_existent_value', array() );
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
+	 * Tests if the get_option_value function returns a valid result.
+	 *
+	 * @covers WPSEO_Options::get()
+	 */
+	public function test_set_works() {
+		$option_before                            = WPSEO_Options::get_option( 'wpseo' );
+		$option_before['keyword_analysis_active'] = true;
+		$option_before['show_onboarding_notice']  = false;
+		update_option( 'wpseo', $option_before );
+
+		// Turn them around and see if they still return the correct value
+		WPSEO_Options::set( 'keyword_analysis_active', false );
+		WPSEO_Options::set( 'show_onboarding_notice', true );
+
+		$result = WPSEO_Options::get( 'keyword_analysis_active' );
+		$this->assertFalse( $result );
+
+		$result = WPSEO_Options::get( 'show_onboarding_notice' );
+		$this->assertTrue( $result );
+	}
 }

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -10,7 +10,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 
 
 	/**
-	 * @covers WPSEO_Options::grant_access
+	 * @covers WPSEO_Utils::grant_access
 	 */
 	public function test_grant_access() {
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Introduces a new `WPSEO_Options::get` and `WPSEO_Options::set` function that only require the key.

## Relevant technical choices:

* Created a `get_lookup_table` function in the `WPSEO_Options` class to make `set` work easily.

## Test instructions

This PR can be tested by following these steps:

* Use it :)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended