### PR TITLE
Improvements to JSON+LD

### DIFF
--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -13,11 +13,6 @@
 class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 
 	/**
-	 * @var array Holds the plugins options.
-	 */
-	public $options = array();
-
-	/**
 	 * @var array Holds the social profiles for the entity
 	 */
 	private $profiles = array();
@@ -26,13 +21,6 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * @var array Holds the data to put out
 	 */
 	private $data = array();
-
-	/**
-	 * Class constructor.
-	 */
-	public function __construct() {
-		$this->options = WPSEO_Options::get_options( array( 'wpseo', 'wpseo_social' ) );
-	}
 
 	/**
 	 * Registers the hooks.
@@ -58,13 +46,14 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * @since 1.8
 	 */
 	public function organization_or_person() {
-		if ( '' === $this->options['company_or_person'] ) {
+		$company_or_person = WPSEO_Options::get( 'company_or_person', '' );
+		if ( '' ===  $company_or_person ) {
 			return;
 		}
 
 		$this->prepare_organization_person_markup();
 
-		switch ( $this->options['company_or_person'] ) {
+		switch ( $company_or_person ) {
 			case 'company':
 				$this->organization();
 				break;
@@ -73,7 +62,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 				break;
 		}
 
-		$this->output( $this->options['company_or_person'] );
+		$this->output( $company_or_person );
 	}
 
 	/**
@@ -127,11 +116,11 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * Schema for Organization.
 	 */
 	private function organization() {
-		if ( '' !== $this->options['company_name'] ) {
+		if ( '' !== WPSEO_Options::get( 'company_name', '' ) ) {
 			$this->data['@type'] = 'Organization';
 			$this->data['@id']   = '#organization';
-			$this->data['name']  = $this->options['company_name'];
-			$this->data['logo']  = $this->options['company_logo'];
+			$this->data['name']  = WPSEO_Options::get( 'company_name' );
+			$this->data['logo']  = WPSEO_Options::get( 'company_logo' );
 			return;
 		}
 		$this->data = false;
@@ -141,10 +130,10 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * Schema for Person.
 	 */
 	private function person() {
-		if ( '' !== $this->options['person_name'] ) {
+		if ( '' !== WPSEO_Options::get( 'person_name', '' ) ) {
 			$this->data['@type'] = 'Person';
 			$this->data['@id']   = '#person';
-			$this->data['name']  = $this->options['person_name'];
+			$this->data['name']  = WPSEO_Options::get( 'person_name' );
 			return;
 		}
 		$this->data = false;
@@ -182,13 +171,13 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 			'pinterest_url',
 		);
 		foreach ( $social_profiles as $profile ) {
-			if ( $this->options[ $profile ] !== '' ) {
-				$this->profiles[] = $this->options[ $profile ];
+			if ( WPSEO_Options::get( $profile, '' ) !== '' ) {
+				$this->profiles[] = WPSEO_Options::get( $profile );
 			}
 		}
 
-		if ( ! empty( $this->options['twitter_site'] ) ) {
-			$this->profiles[] = 'https://twitter.com/' . $this->options['twitter_site'];
+		if ( WPSEO_Options::get( 'twitter_site', false ) ) {
+			$this->profiles[] = 'https://twitter.com/' . WPSEO_Options::get( 'twitter_site' );
 		}
 	}
 
@@ -210,17 +199,22 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * Returns an alternate name if one was specified in the Yoast SEO settings.
 	 */
 	private function add_alternate_name() {
-		if ( '' !== $this->options['alternate_website_name'] ) {
-			$this->data['alternateName'] = $this->options['alternate_website_name'];
+		if ( '' !== WPSEO_Options::get( 'alternate_website_name', '' ) ) {
+			$this->data['alternateName'] = WPSEO_Options::get( 'alternate_website_name' );
 		}
 	}
 
 	/**
-	 * Adds the internal search JSON LD code if it's not disabled.
+	 * Adds the internal search JSON LD code to the homepage if it's not disabled.
 	 *
 	 * @link https://developers.google.com/structured-data/slsb-overview
+	 *       
+	 * @return void
 	 */
 	private function internal_search_section() {
+		if ( ! is_front_page() ) {
+			return;
+		}
 		/**
 		 * Filter: 'disable_wpseo_json_ld_search' - Allow disabling of the json+ld output.
 		 *
@@ -250,8 +244,8 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * @return string
 	 */
 	private function get_website_name() {
-		if ( '' !== $this->options['website_name'] ) {
-			return $this->options['website_name'];
+		if ( '' !== WPSEO_Options::get( 'website_name', '' ) ) {
+			return WPSEO_Options::get( 'website_name' );
 		}
 
 		return get_bloginfo( 'name' );

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -148,7 +148,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 		$this->data = array(
 			'@context' => 'http://schema.org',
 			'@type'    => '',
-			'url'      => WPSEO_Frontend::get_instance()->canonical( false, true ),
+			'url'      => $this->get_home_url(),
 			'sameAs'   => $this->profiles,
 		);
 	}

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -73,6 +73,9 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * @link  https://developers.google.com/structured-data/site-name
 	 */
 	public function website() {
+		if ( ! is_front_page() ) {
+			return;
+		}
 		$this->data = array(
 			'@context' => 'http://schema.org',
 			'@type'    => 'WebSite',
@@ -212,9 +215,6 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	private function internal_search_section() {
-		if ( ! is_front_page() ) {
-			return;
-		}
 		/**
 		 * Filter: 'disable_wpseo_json_ld_search' - Allow disabling of the json+ld output.
 		 *

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -11,12 +11,10 @@
  * @since 1.8
  */
 class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
-
 	/**
 	 * @var array Holds the social profiles for the entity
 	 */
 	private $profiles = array();
-
 	/**
 	 * @var array Holds the data to put out
 	 */
@@ -47,7 +45,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 */
 	public function organization_or_person() {
 		$company_or_person = WPSEO_Options::get( 'company_or_person', '' );
-		if ( '' ===  $company_or_person ) {
+		if ( '' === $company_or_person ) {
 			return;
 		}
 
@@ -124,6 +122,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 			$this->data['@id']   = '#organization';
 			$this->data['name']  = WPSEO_Options::get( 'company_name' );
 			$this->data['logo']  = WPSEO_Options::get( 'company_logo' );
+
 			return;
 		}
 		$this->data = false;
@@ -137,6 +136,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 			$this->data['@type'] = 'Person';
 			$this->data['@id']   = '#person';
 			$this->data['name']  = WPSEO_Options::get( 'person_name' );
+
 			return;
 		}
 		$this->data = false;
@@ -211,7 +211,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * Adds the internal search JSON LD code to the homepage if it's not disabled.
 	 *
 	 * @link https://developers.google.com/structured-data/slsb-overview
-	 *       
+	 *
 	 * @return void
 	 */
 	private function internal_search_section() {
@@ -256,7 +256,6 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 *
 	 * @deprecated 2.1
 	 * @deprecated use WPSEO_JSON_LD::website()
-
 	 * @codeCoverageIgnore
 	 */
 	public function internal_search() {

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -53,9 +53,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 	public function test_person() {
 		$name      = 'Joost de Valk';
 		$instagram = 'http://instagram.com/yoast';
-		self::$class_instance->options['company_or_person'] = 'person';
-		self::$class_instance->options['person_name']       = $name;
-		self::$class_instance->options['instagram_url']     = $instagram;
+		WPSEO_Options::set( 'company_or_person', 'person' );
+		WPSEO_Options::set( 'person_name', $name );
+		WPSEO_Options::set( 'instagram_url', $instagram );
 
 		$this->go_to_home();
 
@@ -81,10 +81,10 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$name      = 'Yoast';
 		$facebook  = 'https://www.facebook.com/Yoast';
 		$instagram = 'http://instagram.com/yoast';
-		self::$class_instance->options['company_or_person'] = 'company';
-		self::$class_instance->options['company_name']      = $name;
-		self::$class_instance->options['facebook_site']     = $facebook;
-		self::$class_instance->options['instagram_url']     = $instagram;
+		WPSEO_Options::set( 'company_or_person', 'company' );
+		WPSEO_Options::set( 'company_name', $name );
+		WPSEO_Options::set( 'facebook_site', $facebook );
+		WPSEO_Options::set( 'instagram_url', $instagram );
 
 		$this->go_to_home();
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Only show JSON+LD markup for website + search on the front page.
* Make sure JSON+LD organization markup links to the frontpage. 

## Relevant technical choices:

* Use `home_url` instead of current page's canonical.
* Removed the use of `$this->options` in favor of `WPSEO_Option::get()`

## Test instructions

This PR can be tested by following these steps:

* Open the homepage, see the search markup.
* Open a single page, see the search markup is gone and see the organization markup points to the homepage.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #7827 
