### PR TITLE
Removes hard define in the bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_script:
 - if [[ "$COVERAGE" == "1" ]]; then ./cc-test-reporter before-build; fi
 
 script:
-- if [[ "$PHPLINT" == "1" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+- if [[ "$PHPLINT" == "1" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l -d error_reporting=22527; fi
 - if [[ "$PHPCS" == "1" ]]; then vendor/bin/phpcs -v --runtime-set ignore_warnings_on_exit 1; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check:js; fi
 - if [[ -z "$CODECLIMATE_REPO_TOKEN" ]]; then COVERAGE="0"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_script:
 - if [[ "$COVERAGE" == "1" ]]; then ./cc-test-reporter before-build; fi
 
 script:
-- if [[ "$PHPLINT" == "1" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l -d error_reporting=22527; fi
+- if [[ "$PHPLINT" == "1" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
 - if [[ "$PHPCS" == "1" ]]; then vendor/bin/phpcs -v --runtime-set ignore_warnings_on_exit 1; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check:js; fi
 - if [[ -z "$CODECLIMATE_REPO_TOKEN" ]]; then COVERAGE="0"; fi

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,9 +15,6 @@ if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
 
-define( 'YOAST_ENVIRONMENT', 'production' );
-
-
 $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'wordpress-seo/wp-seo.php' ),
 );
@@ -29,6 +26,9 @@ else {
 	require_once '../../../../tests/phpunit/includes/bootstrap.php';
 }
 
+if ( defined( 'WPSEO_TESTS_PATH' ) && WPSEO_TESTS_PATH !== dirname( __FILE__ ) . '/' ) {
+	die( 'WPSEO_TESTS_PATH is already defined and does not match expected path.' );
+}
 define( 'WPSEO_TESTS_PATH', dirname( __FILE__ ) . '/' );
 
 // Load autoloader.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,7 +27,8 @@ else {
 }
 
 if ( defined( 'WPSEO_TESTS_PATH' ) && WPSEO_TESTS_PATH !== dirname( __FILE__ ) . '/' ) {
-	die( 'WPSEO_TESTS_PATH is already defined and does not match expected path.' );
+	echo 'WPSEO_TESTS_PATH is already defined and does not match expected path.';
+	exit( 1 ); // Exit with error code, to make the build fail.
 }
 define( 'WPSEO_TESTS_PATH', dirname( __FILE__ ) . '/' );
 


### PR DESCRIPTION
This is defaulted in the plugin already.
As the travis build is using `--dev` it is already set for these builds and triggers an already set warning.

Added a condition around WPSEO_TESTS_PATH to check for existing value if already defined.

Removes `create_function` message from linting results.