### PR TITLE
Move reindex tool to tools tab

### DIFF
--- a/admin/links/class-link-query.php
+++ b/admin/links/class-link-query.php
@@ -139,9 +139,7 @@ class WPSEO_Link_Query {
 	 */
 	protected static function get_count_table_name() {
 		$storage     = new WPSEO_Meta_Storage();
-		$count_table = $storage->get_table_name();
-
-		return $count_table;
+		return $storage->get_table_name();
 	}
 
 	/**
@@ -149,7 +147,7 @@ class WPSEO_Link_Query {
 	 *
 	 * @param array $post_types The post types to format.
 	 *
-	 * @return array|string
+	 * @return string Post types formatted for use in SQL statement.
 	 */
 	protected static function format_post_types( array $post_types ) {
 		$sanitized_post_types = array_map( 'esc_sql', $post_types );

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -11,7 +11,7 @@ class WPSEO_Link_Reindex_Dashboard {
 	protected $public_post_types = array();
 
 	/** @var int Number of unprocessed items */
-	protected static $unprocessed = 0;
+	protected $unprocessed = 0;
 
 	/**
 	 * Registers all hooks to WordPress.
@@ -40,7 +40,7 @@ class WPSEO_Link_Reindex_Dashboard {
 		$this->public_post_types = apply_filters( 'wpseo_link_count_post_types', WPSEO_Post_Type::get_accessible_post_types() );
 
 		if ( is_array( $this->public_post_types ) && $this->public_post_types !== array() ) {
-			self::$unprocessed = WPSEO_Link_Query::get_unprocessed_count( $this->public_post_types );
+			$this->unprocessed = WPSEO_Link_Query::get_unprocessed_count( $this->public_post_types );
 		}
 	}
 
@@ -123,7 +123,7 @@ class WPSEO_Link_Reindex_Dashboard {
 				/* translators: 1: expands to a <span> containing the number of items recalculated. 2: expands to a <strong> containing the total number of items. */
 				__( 'Text %1$s of %2$s processed.', 'wordpress-seo' ),
 				'<span id="wpseo_count_index_links">0</span>',
-				sprintf( '<strong id="wpseo_count_total">%d</strong>', self::$unprocessed )
+				sprintf( '<strong id="wpseo_count_total">%d</strong>', $this->unprocessed )
 			);
 
 			$inner_text  = '<div id="wpseo_index_links_progressbar" class="wpseo-progressbar"></div>';
@@ -153,7 +153,7 @@ class WPSEO_Link_Reindex_Dashboard {
 		$asset_manager->enqueue_script( 'reindex-links' );
 
 		$data = array(
-			'amount'  => self::$unprocessed,
+			'amount'  => $this->unprocessed,
 			'restApi' => array(
 				'root'     => esc_url_raw( rest_url() ),
 				'endpoint' => WPSEO_Link_Reindex_Post_Endpoint::REST_NAMESPACE . '/' . WPSEO_Link_Reindex_Post_Endpoint::ENDPOINT_QUERY,
@@ -195,7 +195,7 @@ class WPSEO_Link_Reindex_Dashboard {
 	 * @return bool True if there are unprocessed items.
 	 */
 	public function has_unprocessed() {
-		return self::$unprocessed > 0;
+		return $this->unprocessed > 0;
 	}
 
 	/**
@@ -204,13 +204,13 @@ class WPSEO_Link_Reindex_Dashboard {
 	 * @return int Number of unprocessed items.
 	 */
 	public function get_unprocessed_count() {
-		return self::$unprocessed;
+		return $this->unprocessed;
 	}
 
 	/**
-	 * @param $html
+	 * Retrieves the message to show starting indexation.
 	 *
-	 * @return string
+	 * @return string The message.
 	 */
 	public function message_start_indexing() {
 		return sprintf(

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -11,10 +11,12 @@ class WPSEO_Link_Reindex_Dashboard {
 	protected $public_post_types = array();
 
 	/** @var int Number of unprocessed items */
-	protected $unprocessed = 0;
+	protected static $unprocessed = 0;
 
 	/**
 	 * Registers all hooks to WordPress.
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		if ( ! $this->is_dashboard_page() ) {
@@ -25,7 +27,8 @@ class WPSEO_Link_Reindex_Dashboard {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ), 10 );
 
 		add_action( 'admin_footer', array( $this, 'modal_box' ), 20 );
-		add_action( 'wpseo_internal_linking', array( $this, 'add_link_index_interface' ) );
+
+		add_action( 'wpseo_tools_overview_list_items', array( $this, 'show_tools_overview_item' ), 10 );
 	}
 
 	/**
@@ -37,14 +40,40 @@ class WPSEO_Link_Reindex_Dashboard {
 		$this->public_post_types = apply_filters( 'wpseo_link_count_post_types', WPSEO_Post_Type::get_accessible_post_types() );
 
 		if ( is_array( $this->public_post_types ) && $this->public_post_types !== array() ) {
-			$this->unprocessed = WPSEO_Link_Query::get_unprocessed_count( $this->public_post_types );
+			self::$unprocessed = WPSEO_Link_Query::get_unprocessed_count( $this->public_post_types );
 		}
 	}
 
 	/**
+	 * Adds an item to the tools page overview list.
+	 *
+	 * @return void
+	 */
+	public function show_tools_overview_item() {
+		echo '<li>';
+		echo '<strong>' . esc_html__( 'Text link counter', 'wordpress-seo' ) . '</strong><br/>';
+
+		if ( ! $this->has_unprocessed() ) {
+			echo $this->message_already_indexed();
+		}
+
+		if ( $this->has_unprocessed() ) {
+			printf( '<span id="reindexLinks">%s</span>', $this->message_start_indexing() );
+		}
+
+		echo '</li>';
+	}
+
+	/**
 	 * Add the indexing interface for links to the dashboard.
+	 *
+	 * @deprecated 7.0
+	 *
+	 * @return void
 	 */
 	public function add_link_index_interface() {
+		_deprecated_function( __METHOD__, 'WPSEO 7.0' );
+
 		$html  = '';
 		$html .= '<h2>' . esc_html__( 'Text link counter', 'wordpress-seo' ) . '</h2>';
 		$html .= '<p>' . sprintf(
@@ -55,19 +84,12 @@ class WPSEO_Link_Reindex_Dashboard {
 				'</a>'
 		) . '</p>';
 
-
-		if ( $this->unprocessed === 0 ) {
+		if ( ! $this->has_unprocessed() ) {
 			$html .= '<p>' . $this->message_already_indexed() . '</p>';
 		}
 
-		if ( $this->unprocessed > 0 ) {
-			$html .= '<p id="reindexLinks">';
-			$html .= sprintf(
-				'<a id="openLinkIndexing" href="#TB_inline?width=600&height=%1$s&inlineId=wpseo_index_links_wrapper" title="%2$s" class="btn button yoast-js-index-links yoast-js-calculate-index-links--all thickbox">%2$s</a>',
-				175,
-				esc_attr__( 'Count links in your texts', 'wordpress-seo' )
-			);
-			$html .= '</p>';
+		if ( $this->has_unprocessed() ) {
+			$html .= '<p id="reindexLinks">' . $this->message_start_indexing() . '</p>';
 		}
 
 		$html .= '<br />';
@@ -77,6 +99,8 @@ class WPSEO_Link_Reindex_Dashboard {
 
 	/**
 	 * Generates the model box.
+	 *
+	 * @return void
 	 */
 	public function modal_box() {
 		if ( ! $this->is_dashboard_page() ) {
@@ -88,18 +112,18 @@ class WPSEO_Link_Reindex_Dashboard {
 
 		$blocks = array();
 
-		if ( $this->unprocessed === 0 ) {
+		if ( ! $this->has_unprocessed() ) {
 			$inner_text = sprintf( '<p>%s</p>',
 				esc_html__( 'All your texts are already counted, there is no need to count them again.', 'wordpress-seo' )
 			);
 		}
 
-		if ( $this->unprocessed > 0 ) {
+		if ( $this->has_unprocessed() ) {
 			$progress = sprintf(
 				/* translators: 1: expands to a <span> containing the number of items recalculated. 2: expands to a <strong> containing the total number of items. */
 				__( 'Text %1$s of %2$s processed.', 'wordpress-seo' ),
 				'<span id="wpseo_count_index_links">0</span>',
-				sprintf( '<strong id="wpseo_count_total">%d</strong>', $this->unprocessed )
+				sprintf( '<strong id="wpseo_count_total">%d</strong>', self::$unprocessed )
 			);
 
 			$inner_text  = '<div id="wpseo_index_links_progressbar" class="wpseo-progressbar"></div>';
@@ -121,13 +145,15 @@ class WPSEO_Link_Reindex_Dashboard {
 
 	/**
 	 * Enqueues site wide analysis script
+	 *
+	 * @return void
 	 */
 	public function enqueue() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'reindex-links' );
 
 		$data = array(
-			'amount'  => $this->unprocessed,
+			'amount'  => self::$unprocessed,
 			'restApi' => array(
 				'root'     => esc_url_raw( rest_url() ),
 				'endpoint' => WPSEO_Link_Reindex_Post_Endpoint::REST_NAMESPACE . '/' . WPSEO_Link_Reindex_Post_Endpoint::ENDPOINT_QUERY,
@@ -145,22 +171,52 @@ class WPSEO_Link_Reindex_Dashboard {
 		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'reindex-links', 'yoastReindexLinksData', array( 'data' => $data ) );
 	}
 
-
 	/**
 	 * Checks if the current page is the dashboard page.
 	 *
 	 * @return bool True when current page is the dashboard page.
 	 */
 	protected function is_dashboard_page() {
-		return ( filter_input( INPUT_GET, 'page' ) === 'wpseo_dashboard' );
+		return ( filter_input( INPUT_GET, 'page' ) === 'wpseo_tools' );
 	}
 
 	/**
-	 * When everything has been indexed already.
+	 * Retrieves the string to display when everything has been indexed.
+	 *
+	 * @return string The message to show when everything has been indexed.
+	 */
+	public function message_already_indexed() {
+		return '<span class="wpseo-checkmark-ok-icon"></span>' . esc_html__( 'Good job! All the links in your texts have been counted.', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns if there are unprocessed items
+	 *
+	 * @return bool True if there are unprocessed items.
+	 */
+	public function has_unprocessed() {
+		return self::$unprocessed > 0;
+	}
+
+	/**
+	 * Returns the number of unprocessed items.
+	 *
+	 * @return int Number of unprocessed items.
+	 */
+	public function get_unprocessed_count() {
+		return self::$unprocessed;
+	}
+
+	/**
+	 * @param $html
 	 *
 	 * @return string
 	 */
-	protected function message_already_indexed() {
-		return '<span class="wpseo-checkmark-ok-icon"></span>' . esc_html__( 'Good job! All the links in your texts have been counted.', 'wordpress-seo' );
+	public function message_start_indexing() {
+		return sprintf(
+			'<a id="openLinkIndexing" href="#TB_inline?width=600&height=%1$s&inlineId=wpseo_index_links_wrapper" title="%2$s" class="btn button yoast-js-index-links yoast-js-calculate-index-links--all thickbox">%2$s</a>',
+			175,
+			esc_attr__( 'Count links in your texts', 'wordpress-seo' )
+		);
 	}
 }

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -123,7 +123,7 @@ class WPSEO_Link_Reindex_Dashboard {
 				/* translators: 1: expands to a <span> containing the number of items recalculated. 2: expands to a <strong> containing the total number of items. */
 				__( 'Text %1$s of %2$s processed.', 'wordpress-seo' ),
 				'<span id="wpseo_count_index_links">0</span>',
-				sprintf( '<strong id="wpseo_count_total">%d</strong>', $this->unprocessed )
+				sprintf( '<strong id="wpseo_count_total">%d</strong>', $this->get_unprocessed_count() )
 			);
 
 			$inner_text  = '<div id="wpseo_index_links_progressbar" class="wpseo-progressbar"></div>';
@@ -153,7 +153,7 @@ class WPSEO_Link_Reindex_Dashboard {
 		$asset_manager->enqueue_script( 'reindex-links' );
 
 		$data = array(
-			'amount'  => $this->unprocessed,
+			'amount'  => $this->get_unprocessed_count(),
 			'restApi' => array(
 				'root'     => esc_url_raw( rest_url() ),
 				'endpoint' => WPSEO_Link_Reindex_Post_Endpoint::REST_NAMESPACE . '/' . WPSEO_Link_Reindex_Post_Endpoint::ENDPOINT_QUERY,

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -23,17 +23,17 @@ if ( '' === $tool_page ) {
 		'desc'  => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) blog.', 'wordpress-seo' ),
 	);
 
-	$tools['bulk-editor'] = array(
-		'title' => __( 'Bulk editor', 'wordpress-seo' ),
-		'desc'  => __( 'This tool allows you to quickly change titles and descriptions of your posts and pages without having to go into the editor for each page.', 'wordpress-seo' ),
-	);
-
 	if ( WPSEO_Utils::allow_system_file_edit() === true && ! is_multisite() ) {
 		$tools['file-editor'] = array(
 			'title' => __( 'File editor', 'wordpress-seo' ),
 			'desc'  => __( 'This tool allows you to quickly change important files for your SEO, like your robots.txt and, if you have one, your .htaccess file.', 'wordpress-seo' ),
 		);
 	}
+
+	$tools['bulk-editor'] = array(
+		'title' => __( 'Bulk editor', 'wordpress-seo' ),
+		'desc'  => __( 'This tool allows you to quickly change titles and descriptions of your posts and pages without having to go into the editor for each page.', 'wordpress-seo' ),
+	);
 
 	echo '<p>';
 	printf(

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -16,37 +16,24 @@ $yform->admin_header( false );
 
 if ( '' === $tool_page ) {
 
-	$tools = array(
-		'bulk-editor' => array(
-			'title' => __( 'Bulk editor', 'wordpress-seo' ),
-			'desc'  => __( 'This tool allows you to quickly change titles and descriptions of your posts and pages without having to go into the editor for each page.', 'wordpress-seo' ),
-		),
-		'import-export' => array(
-			'title' => __( 'Import and Export', 'wordpress-seo' ),
-			'desc'  => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) blog.', 'wordpress-seo' ),
-		),
+	$tools = array();
+
+	$tools['import-export'] = array(
+		'title' => __( 'Import and Export', 'wordpress-seo' ),
+		'desc'  => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) blog.', 'wordpress-seo' ),
 	);
+
+	$tools['bulk-editor'] = array(
+		'title' => __( 'Bulk editor', 'wordpress-seo' ),
+		'desc'  => __( 'This tool allows you to quickly change titles and descriptions of your posts and pages without having to go into the editor for each page.', 'wordpress-seo' ),
+	);
+
 	if ( WPSEO_Utils::allow_system_file_edit() === true && ! is_multisite() ) {
 		$tools['file-editor'] = array(
 			'title' => __( 'File editor', 'wordpress-seo' ),
 			'desc'  => __( 'This tool allows you to quickly change important files for your SEO, like your robots.txt and, if you have one, your .htaccess file.', 'wordpress-seo' ),
 		);
 	}
-
-	/*
-		Temporary disabled. See: https://github.com/Yoast/wordpress-seo/issues/4532
-
-		$tools['recalculate'] = array(
-			'href'    => '#TB_inline?width=300&height=150&inlineId=wpseo_recalculate',
-			'attr'    => "id='wpseo_recalculate_link' class='thickbox'",
-			'title'   => __( 'Recalculate SEO scores', 'wordpress-seo' ),
-			'desc'    => __( 'Recalculate SEO scores for all pieces of content with a focus keyword.', 'wordpress-seo' ),
-		);
-
-		if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
-			$tools['recalculate']['attr'] .= "data-open='open'";
-		}
-	*/
 
 	echo '<p>';
 	printf(
@@ -55,8 +42,6 @@ if ( '' === $tool_page ) {
 		'Yoast SEO'
 	);
 	echo '</p>';
-
-	asort( $tools );
 
 	echo '<ul class="ul-disc">';
 
@@ -71,6 +56,12 @@ if ( '' === $tool_page ) {
 		echo $tool['desc'];
 		echo '</li>';
 	}
+
+	/**
+	 * Action: 'wpseo_tools_overview_list_items' - Hook to add additional tools to the overview.
+	 */
+	do_action( 'wpseo_tools_overview_list_items' );
+
 	echo '</ul>';
 
 	echo '<input type="hidden" id="wpseo_recalculate_nonce" name="wpseo_recalculate_nonce" value="' . esc_attr( wp_create_nonce( 'wpseo_recalculate' ) ) . '" />';

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -32,8 +32,10 @@ endif;
 
 /**
  * Action: 'wpseo_internal_linking' - Hook to add the internal linking analyze interface to the interface.
+ *
+ * @deprecated 7.0
  */
-do_action( 'wpseo_internal_linking' );
+do_action_deprecated( 'wpseo_internal_linking', array(), 'WPSEO 7.0' );
 
 echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 ?>

--- a/tests/admin/links/test-class-link_reindex_dashboard.php
+++ b/tests/admin/links/test-class-link_reindex_dashboard.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package WPSEO\Tests\Admin\Links
+ */
+
+/**
+ * Tests for the reindex dashboard.
+ */
+class WPSEO_Link_Reindex_Dashboard_Test extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Tests if unprocessed works as expected.
+	 */
+	public function test_unprocessed() {
+		$instance = new WPSEO_Link_Reindex_Dashboard_Double();
+		$instance->set_unprocessed( 1 );
+
+		$this->assertTrue( $instance->has_unprocessed() );
+
+		$instance->set_unprocessed( 0 );
+
+		$this->assertFalse( $instance->has_unprocessed() );
+	}
+
+	/**
+	 * Tests if the unprocessed count is presented as expected.
+	 */
+	public function test_get_unprocessed_count() {
+		$instance = new WPSEO_Link_Reindex_Dashboard_Double();
+		$instance->set_unprocessed( 1 );
+
+		$this->assertEquals( 1, $instance->get_unprocessed_count() );
+	}
+}

--- a/tests/doubles/wpseo-link-reindex-dashboard-double.php
+++ b/tests/doubles/wpseo-link-reindex-dashboard-double.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Double for the WPSEO_Link_Reindex_Dashboard class
+ */
+class WPSEO_Link_Reindex_Dashboard_Double extends WPSEO_Link_Reindex_Dashboard {
+	/**
+	 * Sets the unprocessed count to test other methods.
+	 *
+	 * @param mixed $unprocessed
+	 *
+	 * @return void
+	 */
+	public function set_unprocessed( $unprocessed ) {
+		$this->unprocessed = $unprocessed;
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Moves the `Text link counter calculation` to the `tools` submenu.

## Relevant technical choices:

* Introduced a new action to hook into to add more tool entries in the list.

## Test instructions

This PR can be tested by following these steps:

* Go to the Tools submenu and see the `Text link counter` section.
* Go to the General tab on the dashboard submenu and see the `Text link counter` being removed.
* Test if the functionality still works.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8840