### PR TITLE
Stop enqueueing jQuery UI autocomplete.

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -250,8 +250,6 @@ class WPSEO_Admin_Asset_Manager {
 				'src'       => 'wp-seo-metabox-' . $flat_version,
 				'deps'      => array(
 					'jquery',
-					'jquery-ui-core',
-					'jquery-ui-autocomplete',
 					self::PREFIX . 'select2',
 					self::PREFIX . 'select2-translations',
 					self::PREFIX . 'react-dependencies',

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -901,8 +901,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$asset_manager->enqueue_script( 'replacevar-plugin' );
 			$asset_manager->enqueue_script( 'shortcode-plugin' );
 
-			wp_enqueue_script( 'jquery-ui-autocomplete' );
-
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-media', 'wpseoMediaL10n', $this->localize_media_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'wpseoPostScraperL10n', $this->localize_post_scraper_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes jQuery UI autocomplete from the enqueued scripts.

## Test instructions

This PR can be tested by following these steps:

On the plugin version 2.3 autocomplete was used on the focus keyword field and invoked this way:
`jQuery( '#' + wpseoMetaboxL10n.field_prefix + 'focuskw' ).autocomplete( {`

so typically this jQuery UI widgets is invoked on a form field with `.autocomplete()`
- I've searched through the codebase for occurrences of `.autocomplete` and haven't found any
- I've searched also through all the add-ons I could think of
- to test: enable all add-ons, check all the pages: edit post, edit terms, settings, user profile, dashboard
- be sure there are no JS errors

Fixes #6598 
