### PR TITLE
Disable media by default

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -44,7 +44,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'disable-author'         => false,
 		'disable-date'           => false,
 		'disable-post_format'    => false,
-		'disable-attachment'     => false,
+		'disable-attachment'     => true,
 
 		'breadcrumbs-404crumb'      => '', // Text field.
 		'breadcrumbs-blog-remove'   => false,

--- a/tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -136,8 +136,7 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 	 * @covers WPSEO_Frontend::attachment_redirect
 	 */
 	public function test_attachment_redirect_not_enabled() {
-		$frontend = self::$class_instance;
-		$frontend->options['disable-attachment'] = false;
+		WPSEO_Options::set( 'disable-attachment', false );
 
 		// Create and go to post.
 		$post_id = $this->factory->post->create(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Our new feature to disable attachment URLs entirely is on by default for new sites.

