### PR TITLE
Exclude CSS dist directory

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,3 +27,4 @@ exclude_paths:
 - grunt/**/*
 - inc/wpseo-functions-deprecated.php
 - js/dist/*
+- css/dist/*


### PR DESCRIPTION
No reason for CodeClimate to check our parsed files, I'd prefer it checks our `scss` files...

## Relevant technical choices:

* Excluded the CSS dist dir.

