### PR TITLE
Improve version upgrade scripts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,6 @@ var loadGruntConfig = require( "load-grunt-config" );
 const { flattenVersionForFile } = require( "./webpack/paths" );
 
 module.exports = function( grunt ) {
-	"use strict";
 
 	timeGrunt( grunt );
 

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -147,7 +147,7 @@ class WPSEO_Admin_Asset_Manager {
 	public function flatten_version( $version ) {
 		$parts = explode( '.', $version );
 
-		if ( count( $parts ) === 2 ) {
+		if ( count( $parts ) === 2 && preg_match( '/^\d+$/', $parts[1] ) === 1 ) {
 			$parts[] = '0';
 		}
 

--- a/grunt/config/addtextdomain.js
+++ b/grunt/config/addtextdomain.js
@@ -1,4 +1,4 @@
-// https://github.com/blazersix/grunt-wp-i18n
+// See https://github.com/blazersix/grunt-wp-i18n for details.
 module.exports = {
 	options: {
 		textdomain: "<%= pkg.plugin.textdomain %>",

--- a/grunt/config/checktextdomain.js
+++ b/grunt/config/checktextdomain.js
@@ -1,4 +1,4 @@
-// https://github.com/stephenharris/grunt-checktextdomain
+// See https://github.com/stephenharris/grunt-checktextdomain for details.
 module.exports = {
 	options: {
 		text_domain: "<%= pkg.plugin.textdomain %>",

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -1,4 +1,4 @@
-// https://github.com/gruntjs/grunt-contrib-clean
+// See https://github.com/gruntjs/grunt-contrib-clean for details.
 module.exports = {
 	"po-files": [
 		"<%= paths.languages %>*.po",

--- a/grunt/config/cssmin.js
+++ b/grunt/config/cssmin.js
@@ -1,4 +1,4 @@
-// https://github.com/gruntjs/grunt-contrib-cssmin
+// See https://github.com/gruntjs/grunt-contrib-cssmin for details.
 module.exports = {
 	options: {
 		report: "gzip",

--- a/grunt/config/imagemin.js
+++ b/grunt/config/imagemin.js
@@ -1,10 +1,9 @@
-// https://github.com/gruntjs/grunt-contrib-imagemin
+// See https://github.com/gruntjs/grunt-contrib-imagemin for details.
 module.exports = {
 	plugin: {
 		files: [ {
 			expand: true,
-			// this would require the addition of a assets folder from which the images are
-			// processed and put inside the images folder
+			// This would require the addition of a assets folder from which the images are processed and put inside the images folder.
 			cwd: "<%= paths.images %>",
 			src: [ "*.*" ],
 			dest: "<%= paths.images %>",

--- a/grunt/config/set-version.js
+++ b/grunt/config/set-version.js
@@ -1,0 +1,10 @@
+// Custom task
+module.exports = {
+	packageJSON: {
+		options: {
+			base: "yoast",
+			target: "pluginVersion"
+		},
+		src: "package.json",
+	}
+};

--- a/grunt/config/set-version.js
+++ b/grunt/config/set-version.js
@@ -3,8 +3,8 @@ module.exports = {
 	packageJSON: {
 		options: {
 			base: "yoast",
-			target: "pluginVersion"
+			target: "pluginVersion",
 		},
 		src: "package.json",
-	}
+	},
 };

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -1,7 +1,5 @@
 // See https://github.com/sindresorhus/grunt-shell
 module.exports = function( grunt ) {
-	"use strict";
-
 	return {
 		"combine-pot-files": {
 			fromFiles: [

--- a/grunt/config/update-version.js
+++ b/grunt/config/update-version.js
@@ -5,7 +5,7 @@ module.exports = {
 	},
 	readme: {
 		options: {
-			regEx: /(Stable tag: )(\d+(\.\d+){0,3})([^\.\d]?.*?)(\n)/,
+			regEx: /(Stable tag: )(\d+(\.\d+){0,3})([^\n^\.\d]?.*?)(\n)/,
 			preVersionMatch: "$1",
 			postVersionMatch: "$5",
 		},
@@ -13,7 +13,7 @@ module.exports = {
 	},
 	pluginFile: {
 		options: {
-			regEx: /(\* Version: )(\d+(\.\d+){0,3})([^\.\d]?.*?)(\n)/,
+			regEx: /(\* Version: )(\d+(\.\d+){0,3})([^\n^\.\d]?.*?)(\n)/,
 			preVersionMatch: "$1",
 			postVersionMatch: "$5",
 		},

--- a/grunt/config/update-version.js
+++ b/grunt/config/update-version.js
@@ -5,25 +5,25 @@ module.exports = {
 	},
 	readme: {
 		options: {
-			regEx: /(Stable tag: )(\d\d?(\.\d\d?){0,3})([^\.\d]?.*?\n)/,
+			regEx: /(Stable tag: )(\d+(\.\d+){0,3})([^\.\d]?.*?)(\n)/,
 			preVersionMatch: "$1",
-			postVersionMatch: "$4",
+			postVersionMatch: "$5",
 		},
 		src: "readme.txt",
 	},
 	pluginFile: {
 		options: {
-			regEx: /(\* Version: )(\d\d?(\.\d\d?){0,3})([^\.\d]?.*?\n)/,
+			regEx: /(\* Version: )(\d+(\.\d+){0,3})([^\.\d]?.*?)(\n)/,
 			preVersionMatch: "$1",
-			postVersionMatch: "$4",
+			postVersionMatch: "$5",
 		},
 		src: "wp-seo.php",
 	},
 	initializer: {
 		options: {
-			regEx: /(define\( \'WPSEO_VERSION\'\, \')(\d\d?(\.\d\d?){0,3})(\'.*?\n)/,
+			regEx: /(define\( \'WPSEO_VERSION\'\, \')(\d+(\.\d+){0,3})([^\.^\'\d]?.*?)(\' \);\n)/,
 			preVersionMatch: "$1",
-			postVersionMatch: "$4",
+			postVersionMatch: "$5",
 		},
 		src: "wp-seo-main.php",
 	},

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -1,4 +1,4 @@
-// https://github.com/gruntjs/grunt-contrib-watch
+// See https://github.com/gruntjs/grunt-contrib-watch for details.
 module.exports = {
 	options: {
 		livereload: true,

--- a/grunt/config/wp_deploy.js
+++ b/grunt/config/wp_deploy.js
@@ -1,4 +1,4 @@
-// See: https://github.com/stephenharris/grunt-wp-deploy
+// See: https://github.com/stephenharris/grunt-wp-deploy for details.
 /* eslint camelcase: 0 */
 module.exports = {
 	trunk: {

--- a/grunt/config/wpcss.js
+++ b/grunt/config/wpcss.js
@@ -1,4 +1,4 @@
-// https://github.com/cedaro/grunt-wp-css
+// See https://github.com/cedaro/grunt-wp-css for details.
 module.exports = {
 	css: {
 		expand: true,

--- a/grunt/custom/set-version.js
+++ b/grunt/custom/set-version.js
@@ -1,0 +1,34 @@
+/**
+ * A task that updates version numbers in project files in accordance with
+ * build config.
+ *
+ * @param {Object} grunt The grunt helper object.
+ * @returns {void}
+ */
+module.exports = function( grunt ) {
+	grunt.registerMultiTask(
+		"set-version",
+		"Configures a new version number.",
+		function() {
+			let options = this.options(
+				{
+					base: "Option to use as a base",
+					target: "Target value to set"
+				}
+			);
+
+			var version = grunt.option( "new-version" ) || '';
+			if ( version.trim().length === 0 ) {
+				grunt.fail.fatal( 'Missing --new-version argument' );
+			}
+
+			this.files.forEach( (file) => {
+				file.src.forEach( (path) => {
+					let contents = grunt.file.readJSON( path );
+					contents[ options.base ][ options.target ] = version;
+					grunt.file.write( path, JSON.stringify( contents, null, '  ' ) + "\n" );
+				} );
+			} );
+		}
+	);
+}

--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -51,7 +51,7 @@ const entry = {
  */
 function flattenVersionForFile( version ) {
 	let versionParts = version.split( "." );
-	if ( versionParts.length === 2 ) {
+	if ( versionParts.length === 2 && /^\d+$/.test( versionParts[ 1 ] ) ) {
 		versionParts.push( 0 );
 	}
 


### PR DESCRIPTION
This PR allows Release Candidate versions to be set via the `grunt update-version` command.
It also introduces a grunt command to update the version to a new one.

Test instructions:

Run the following commands:
- `grunt set-version --new-version=7.0-RC1`
- `grunt update-version`

After this, `grunt build:js build:css` should be run to make sure the assets have the correct version and will be loaded.

See https://github.com/Yoast/wordpress-seo/issues/8885