### PR TITLE
Adjust the Help Panel to be used anywhere.

### DIFF
--- a/admin/class-admin-help-panel.php
+++ b/admin/class-admin-help-panel.php
@@ -56,9 +56,9 @@ class WPSEO_Admin_Help_Panel {
 		}
 
 		return sprintf(
-			' <button type="button" class="yoast_help yoast-help-button dashicons" id="%1$s-help-toggle" aria-expanded="false" aria-controls="%1$s-help"><span class="screen-reader-text">%2$s</span></button>',
+			' <button type="button" class="yoast_help yoast-help-button dashicons" id="%1$s-help-toggle" aria-expanded="false" aria-controls="%1$s-help"><span class="yoast-help-icon" aria-hidden="true"></span><span class="screen-reader-text">%2$s</span></button>',
 			esc_attr( $this->id ),
-			$this->help_button_text
+			esc_html( $this->help_button_text )
 		);
 	}
 

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $webmaster_tools_help = new WPSEO_Admin_Help_Panel(
-	'search-appearance-webmaster-tools',
+	'dashboard-webmaster-tools',
 	__( 'Learn more about the Webmaster Tools verification', 'wordpress-seo' ),
 	__( 'You can use the boxes below to verify with the different Webmaster Tools, if your site is already verified, you can just forget about these.', 'wordpress-seo' ),
 	'has-wrapper'

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -13,11 +13,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-echo '<h2>' . esc_html__( 'Webmaster Tools verification', 'wordpress-seo' ) . '</h2>';
-printf(
-	'<p>%s</p>',
-	esc_html__( 'You can use the boxes below to verify with the different Webmaster Tools, if your site is already verified, you can just forget about these. Enter the verify meta values for:', 'wordpress-seo' )
+$webmaster_tools_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-webmaster-tools',
+	__( 'Learn more about the Webmaster Tools verification', 'wordpress-seo' ),
+	__( 'You can use the boxes below to verify with the different Webmaster Tools, if your site is already verified, you can just forget about these.', 'wordpress-seo' ),
+	'has-wrapper'
 );
+
+echo '<h2 class="help-button-inline">' . esc_html__( 'Webmaster Tools verification', 'wordpress-seo' ) . $webmaster_tools_help->get_button_html() . '</h2>';
+echo $webmaster_tools_help->get_panel_html();
 
 $yform->textinput( 'msverify', '<a target="_blank" href="' . esc_url( 'http://www.bing.com/webmaster/?rfp=1#/Dashboard/?url=' . urlencode( str_replace( 'http://', '', get_bloginfo( 'url' ) ) ) ) . '">' . __( 'Bing Webmaster Tools', 'wordpress-seo' ) . '</a>' );
 $yform->textinput( 'googleverify', '<a target="_blank" href="' . esc_url( 'https://www.google.com/webmasters/verification/verification?hl=en&siteUrl=' . urlencode( get_bloginfo( 'url' ) ) . '/' ) . '">Google Search Console</a>' );

--- a/admin/views/tabs/metas/archives.php
+++ b/admin/views/tabs/metas/archives.php
@@ -13,24 +13,32 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-echo '<p>';
-printf(
+$archives_help_01 = sprintf(
 	/* translators: %1$s / %2$s: links to an article about duplicate content on yoast.com */
 	esc_html__( 'If you\'re running a one author blog, the author archive will be exactly the same as your homepage. This is what\'s called a %1$sduplicate content problem%2$s.', 'wordpress-seo' ),
 	'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/duplicate-content' ) ) . '">',
 	'</a>'
 );
-echo ' ';
-printf(
+
+$archives_help_02 = sprintf(
 	/* translators: %s expands to <code>noindex, follow</code> */
 	esc_html__( 'If this is the case on your site, you can choose to either disable it (which makes it redirect to the homepage), or to add %s to it so it doesn\'t show up in the search results.', 'wordpress-seo' ),
 	'<code>noindex,follow</code>'
 );
-echo ' ';
-echo esc_html__( 'Note that links to archives might be still output by your theme and you would need to remove them separately.', 'wordpress-seo' );
-echo ' ';
-esc_html_e( 'Date-based archives could in some cases also be seen as duplicate content.', 'wordpress-seo' );
-echo '</p>';
+
+$archives_help_03 = esc_html__( 'Note that links to archives might be still output by your theme and you would need to remove them separately.', 'wordpress-seo' );
+
+$archives_help_04 = esc_html__( 'Date-based archives could in some cases also be seen as duplicate content.', 'wordpress-seo' );
+
+$archives_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-archives',
+	__( 'Learn more about the archives setting', 'wordpress-seo' ),
+	$archives_help_01 . ' ' . $archives_help_02 . ' ' . $archives_help_03 . ' ' . $archives_help_04,
+	'has-wrapper'
+);
+
+echo '<p class="help-button-inline"><strong>' . esc_html__( 'Archives settings help', 'wordpress-sep' ) . $archives_help->get_button_html() . '</strong><p>';
+echo $archives_help->get_panel_html();
 
 echo '<div class="tab-block" id="author-archives-titles-metas">';
 echo '<h2>' . esc_html__( 'Author archives settings', 'wordpress-seo' ) . '</h2>';
@@ -61,15 +69,21 @@ $yform->textarea( 'metadesc-archive-wpseo', __( 'Meta description template', 'wo
 echo '</div>';
 echo '</div>';
 
-echo '<div class="tab-block" id="special-pages-titles-metas">';
-echo '<h2>' . esc_html__( 'Special Pages', 'wordpress-seo' ) . '</h2>';
-echo '<p>';
-printf(
-	/* translators: %s expands to <code>noindex, follow</code> */
-	esc_html__( 'These pages will be %s by default, so they will never show up in search results.', 'wordpress-seo' ),
-	'<code>noindex, follow</code>'
+$spcia_pages_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-special-pages',
+	__( 'Learn more about the special pages setting', 'wordpress-seo' ),
+	sprintf(
+		/* translators: %s expands to <code>noindex, follow</code>. */
+		__( 'These pages will be %s by default, so they will never show up in search results.', 'wordpress-seo' ),
+		'<code>noindex, follow</code>'
+	),
+	'has-wrapper'
 );
-echo '</p>';
+
+echo '<div class="tab-block" id="special-pages-titles-metas">';
+echo '<h2 class="help-button-inline">' . esc_html__( 'Special Pages', 'wordpress-seo' ) . $spcia_pages_help->get_button_html() . '</h2>';
+echo $spcia_pages_help->get_panel_html();
+
 echo '<p><strong>' . esc_html__( 'Search pages', 'wordpress-seo' ) . '</strong><br/>';
 $yform->textinput( 'title-search-wpseo', __( 'Title template', 'wordpress-seo' ), 'template search-template' );
 echo '</p>';

--- a/admin/views/tabs/metas/archives.php
+++ b/admin/views/tabs/metas/archives.php
@@ -37,7 +37,7 @@ $archives_help = new WPSEO_Admin_Help_Panel(
 	'has-wrapper'
 );
 
-echo '<p class="help-button-inline"><strong>' . esc_html__( 'Archives settings help', 'wordpress-sep' ) . $archives_help->get_button_html() . '</strong><p>';
+echo '<p class="help-button-inline"><strong>' . esc_html__( 'Archives settings help', 'wordpress-seo' ) . $archives_help->get_button_html() . '</strong><p>';
 echo $archives_help->get_panel_html();
 
 echo '<div class="tab-block" id="author-archives-titles-metas">';

--- a/admin/views/tabs/metas/general/homepage.php
+++ b/admin/views/tabs/metas/general/homepage.php
@@ -9,14 +9,21 @@
 <div class="tab-block">
 	<?php
 	if ( 'posts' === get_option( 'show_on_front' ) ) {
-		echo '<h2>', esc_html__( 'Homepage', 'wordpress-seo' ), '</h2>';
-		echo '<p class="description">' . __( 'This is what shows in the search results when people find your homepage. This means this is probably what they see when they search for your brand name.', 'wordpress-seo' ) . '</p>';
+		$homepage_help = new WPSEO_Admin_Help_Panel(
+			'search-appearance-homepage',
+			__( 'Learn more about the homepage setting', 'wordpress-seo' ),
+			__( 'This is what shows in the search results when people find your homepage. This means this is probably what they see when they search for your brand name.', 'wordpress-seo' ),
+			'has-wrapper'
+		);
+
+		echo '<h2 class="help-button-inline">', esc_html__( 'Homepage', 'wordpress-seo' ), $homepage_help->get_button_html(), '</h2>';
+		echo $homepage_help->get_panel_html();
 		$yform->textinput( 'title-home-wpseo', __( 'Title', 'wordpress-seo' ), 'template homepage-template' );
 		$yform->textarea( 'metadesc-home-wpseo', __( 'Meta description', 'wordpress-seo' ), array( 'class' => 'template homepage-template' ) );
 	}
 	else {
 		echo '<h2>', esc_html__( 'Homepage &amp; Front page', 'wordpress-seo' ), '</h2>';
-		echo '<p class="description">';
+		echo '<p>';
 		printf(
 		/* translators: 1: link open tag; 2: link close tag. */
 			esc_html__( 'You can determine the title and description for the front page by %1$sediting the front page itself &raquo;%2$s', 'wordpress-seo' ),

--- a/admin/views/tabs/metas/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/general/knowledge-graph.php
@@ -18,10 +18,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 );
 ?>
 <div class="tab-block">
-	<h2 class="help-button-inline"><?php
-		esc_html_e( 'Knowledge Graph', 'wordpress-seo' );
-		echo $knowledge_graph_help->get_button_html();
-	?></h2>
+	<h2 class="help-button-inline"><?php echo esc_html__( 'Knowledge Graph', 'wordpress-seo' ) . $knowledge_graph_help->get_button_html(); ?></h2>
 	<?php
 	echo $knowledge_graph_help->get_panel_html();
 	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), array(

--- a/admin/views/tabs/metas/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/general/knowledge-graph.php
@@ -18,10 +18,12 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 );
 ?>
 <div class="tab-block">
-	<h2 class="help-button-inline"><?php esc_html_e( 'Knowledge Graph', 'wordpress-seo' ); echo $knowledge_graph_help->get_button_html(); ?></h2>
-	<?php echo $knowledge_graph_help->get_panel_html(); ?>
+	<h2 class="help-button-inline"><?php
+		esc_html_e( 'Knowledge Graph', 'wordpress-seo' );
+		echo $knowledge_graph_help->get_button_html();
+	?></h2>
 	<?php
-
+	echo $knowledge_graph_help->get_panel_html();
 	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), array(
 		''        => __( 'Choose whether you\'re a company or person', 'wordpress-seo' ),
 		'company' => __( 'Company', 'wordpress-seo' ),

--- a/admin/views/tabs/metas/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/general/knowledge-graph.php
@@ -5,19 +5,21 @@
  * @var Yoast_Form $yform
  */
 
+$knowledge_graph_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-knowledge-graph',
+	__( 'Learn more about the knowledge graph setting', 'wordpress-seo' ),
+	sprintf(
+		/* translators: %1$s opens the link to the Yoast.com article about Google's Knowledge Graph, %2$s closes the link, */
+		__( 'This data is shown as metadata in your site. It is intended to appear in %1$sGoogle\'s Knowledge Graph%2$s. You can be either a company, or a person.', 'wordpress-seo' ),
+		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1-p' ) ) . '" target="_blank" rel="noopener noreferer">',
+		'</a>'
+	),
+	'has-wrapper'
+);
 ?>
 <div class="tab-block">
-	<h2><?php esc_html_e( 'Knowledge Graph', 'wordpress-seo' ); ?></h2>
-	<p class="description">
-		<?php
-		printf(
-		/* translators: %1$s opens the link to the Yoast.com article about Google's Knowledge Graph, %2$s closes the link */
-			esc_html__( 'This data is shown as metadata in your site. It is intended to appear in %1$sGoogle\'s Knowledge Graph%2$s. You can be either a company, or a person, choose either:', 'wordpress-seo' ),
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1-p' ) ) . '" target="_blank" rel="noopener noreferer">',
-			'</a>'
-		);
-		?>
-	</p>
+	<h2 class="help-button-inline"><?php esc_html_e( 'Knowledge Graph', 'wordpress-seo' ); echo $knowledge_graph_help->get_button_html(); ?></h2>
+	<?php echo $knowledge_graph_help->get_panel_html(); ?>
 	<?php
 
 	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), array(

--- a/admin/views/tabs/metas/general/title-separator.php
+++ b/admin/views/tabs/metas/general/title-separator.php
@@ -5,16 +5,17 @@
  * @var Yoast_Form $yform
  */
 
+$title_separator_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-title-separator',
+	__( 'Learn more about the title separator setting', 'wordpress-seo' ),
+	__( 'Choose the symbol to use as your title separator. This will display, for instance, between your post title and site name. Symbols are shown in the size they\'ll appear in the search results.', 'wordpress-seo' ),
+	'has-wrapper'
+);
 ?>
 <div class="tab-block">
-	<h2><?php esc_html_e( 'Title Separator', 'wordpress-seo' ); ?></h2>
-	<p class="description">
-		<?php
-		esc_html_e( 'Choose the symbol to use as your title separator. This will display, for instance, between your post title and site name.', 'wordpress-seo' );
-		esc_html_e( 'Symbols are shown in the size they\'ll appear in the search results.', 'wordpress-seo' );
-		?>
-	</p>
+	<h2 class="help-button-inline"><?php esc_html_e( 'Title Separator', 'wordpress-seo' ); echo $title_separator_help->get_button_html(); ?></h2>
 	<?php
+	echo $title_separator_help->get_panel_html();
 	$legend      = __( 'Title separator symbol', 'wordpress-seo' );
 	$legend_attr = array( 'class' => 'radiogroup screen-reader-text' );
 	$yform->radio( 'separator', WPSEO_Option_Titles::get_instance()->get_separator_options(), $legend, $legend_attr );

--- a/admin/views/tabs/metas/general/title-separator.php
+++ b/admin/views/tabs/metas/general/title-separator.php
@@ -13,7 +13,10 @@ $title_separator_help = new WPSEO_Admin_Help_Panel(
 );
 ?>
 <div class="tab-block">
-	<h2 class="help-button-inline"><?php esc_html_e( 'Title Separator', 'wordpress-seo' ); echo $title_separator_help->get_button_html(); ?></h2>
+	<h2 class="help-button-inline"><?php
+		esc_html_e( 'Title Separator', 'wordpress-seo' );
+		echo $title_separator_help->get_button_html();
+	?></h2>
 	<?php
 	echo $title_separator_help->get_panel_html();
 	$legend      = __( 'Title separator symbol', 'wordpress-seo' );

--- a/admin/views/tabs/metas/general/title-separator.php
+++ b/admin/views/tabs/metas/general/title-separator.php
@@ -13,10 +13,7 @@ $title_separator_help = new WPSEO_Admin_Help_Panel(
 );
 ?>
 <div class="tab-block">
-	<h2 class="help-button-inline"><?php
-		esc_html_e( 'Title Separator', 'wordpress-seo' );
-		echo $title_separator_help->get_button_html();
-	?></h2>
+	<h2 class="help-button-inline"><?php echo esc_html__( 'Title Separator', 'wordpress-seo' ) . $title_separator_help->get_button_html(); ?></h2>
 	<?php
 	echo $title_separator_help->get_panel_html();
 	$legend      = __( 'Title separator symbol', 'wordpress-seo' );

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -12,13 +12,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'HTTP/1.1 403 Forbidden' );
 	exit();
 }
+
+$media_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-media',
+	__( 'Learn more about the Media and attachment URLs setting', 'wordpress-seo' ),
+	__( 'When you upload media (an image or video for example) to WordPress, it doesn\'t just save the media, it creates an attachment URL for it. These attachment pages are quite empty: they contain the media item and maybe a title if you entered one. Because of that, if you never use these attachment URLs, it\'s better to disable them, and redirect them to the media item itself.', 'wordpress-seo' ),
+	'has-wrapper'
+);
 ?>
-	<h2><?php esc_html_e( 'Media & attachment URLs', 'wordpress-seo' ); ?></h2>
-	<p>
-		<?php esc_html_e( 'When you upload media (an image or video for example) to WordPress, it doesn\'t just save the media, it creates an attachment URL for it.', 'wordpress-seo' ); ?>
-		<?php esc_html_e( 'These attachment pages are quite empty: they contain the media item and maybe a title if you entered one.', 'wordpress-seo' ); ?>
-		<?php esc_html_e( 'Because of that, if you never use these attachment URLs, it\'s better to disable them, and redirect them to the media item itself.', 'wordpress-seo' ); ?>
-	</p>
+	<h2 class="help-button-inline"><?php esc_html_e( 'Media & attachment URLs', 'wordpress-seo' ); echo $media_help->get_button_html(); ?></h2>
+	<?php echo $media_help->get_panel_html(); ?>
 	<p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
 <?php
 

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -20,7 +20,10 @@ $media_help = new WPSEO_Admin_Help_Panel(
 	'has-wrapper'
 );
 ?>
-	<h2 class="help-button-inline"><?php esc_html_e( 'Media & attachment URLs', 'wordpress-seo' ); echo $media_help->get_button_html(); ?></h2>
+	<h2 class="help-button-inline"><?php
+		esc_html_e( 'Media & attachment URLs', 'wordpress-seo' );
+		echo $media_help->get_button_html();
+	?></h2>
 	<?php echo $media_help->get_panel_html(); ?>
 	<p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
 <?php

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -20,10 +20,7 @@ $media_help = new WPSEO_Admin_Help_Panel(
 	'has-wrapper'
 );
 ?>
-	<h2 class="help-button-inline"><?php
-		esc_html_e( 'Media & attachment URLs', 'wordpress-seo' );
-		echo $media_help->get_button_html();
-	?></h2>
+	<h2 class="help-button-inline"><?php echo esc_html__( 'Media & attachment URLs', 'wordpress-seo' ) . $media_help->get_button_html(); ?></h2>
 	<?php echo $media_help->get_panel_html(); ?>
 	<p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
 <?php

--- a/admin/views/tabs/metas/rss.php
+++ b/admin/views/tabs/metas/rss.php
@@ -13,9 +13,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-echo '<h2>' . esc_html__( 'RSS feed settings', 'wordpress-seo' ) . '</h2>';
+$rss_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-rss',
+	__( 'Learn more about the RSS feed setting', 'wordpress-seo' ),
+	__( 'This feature is used to automatically add content to your RSS, more specifically, it\'s meant to add links back to your blog and your blog posts, so dumb scrapers will automatically add these links too, helping search engines identify you as the original source of the content.', 'wordpress-seo' ),
+	'has-wrapper'
+);
 
-echo '<p>' . esc_html__( "This feature is used to automatically add content to your RSS, more specifically, it's meant to add links back to your blog and your blog posts, so dumb scrapers will automatically add these links too, helping search engines identify you as the original source of the content.", 'wordpress-seo' ) . '</p>';
+echo '<h2 class="help-button-inline">' . esc_html__( 'RSS feed settings', 'wordpress-seo' ) . $rss_help->get_button_html() . '</h2>';
+
+echo $rss_help->get_panel_html();
 
 $textarea_atts = array(
 	'cols' => '50',
@@ -24,10 +31,16 @@ $textarea_atts = array(
 $yform->textarea( 'rssbefore', __( 'Content to put before each post in the feed', 'wordpress-seo' ), '', $textarea_atts );
 $yform->textarea( 'rssafter', __( 'Content to put after each post in the feed', 'wordpress-seo' ), '', $textarea_atts );
 
-echo '<h2>' . esc_html__( 'Available variables', 'wordpress-seo' ) . '</h2>';
-?>
+$rss_variables_help = new WPSEO_Admin_Help_Panel(
+	'search-appearance-rss-variables',
+	__( 'Learn more about the available variables', 'wordpress-seo' ),
+	__( 'You can use the following variables within the content, they will be replaced by the value on the right.', 'wordpress-seo' ),
+	'has-wrapper'
+);
 
-<p><?php esc_html_e( 'You can use the following variables within the content, they will be replaced by the value on the right.', 'wordpress-seo' ); ?></p>
+echo '<h2 class="help-button-inline">' . esc_html__( 'Available variables', 'wordpress-seo' ) . $rss_variables_help->get_button_html() . '</h2>';
+echo $rss_variables_help->get_panel_html();
+?>
 <table class="wpseo yoast_help yoast-table-scrollable">
 <thead>
 	<tr>

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -13,11 +13,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-echo '<h2>' . esc_html__( 'Your social profiles', 'wordpress-seo' ) . '</h2>';
+$social_profiles_help = new WPSEO_Admin_Help_Panel(
+	'social-accounts',
+	__( 'Learn more about your social profiles settings', 'wordpress-seo' ),
+	__( 'To let search engines know which social profiles are associated to this site, enter your site social profiles data below.', 'wordpress-seo' ),
+	'has-wrapper'
+);
 
-echo '<p>';
-esc_html_e( 'To let search engines know which social profiles are associated to this site, enter them below:', 'wordpress-seo' );
-echo '</p>';
+echo '<h2 class="help-button-inline">' . esc_html__( 'Your social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
+echo $social_profiles_help->get_panel_html();
 
 $yform = Yoast_Form::get_instance();
 $yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ) );

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -26,8 +26,14 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 
 <?php
 if ( 'posts' === get_option( 'show_on_front' ) ) {
-	echo '<h2>' . esc_html__( 'Frontpage settings', 'wordpress-seo' ) . '</h2>';
-	echo '<p>' . esc_html__( 'These are the title, description and image used in the Open Graph meta tags on the front page of your site.', 'wordpress-seo' ) . '</p>';
+	$social_facebook_frontpage_help = new WPSEO_Admin_Help_Panel(
+		'social-facebook-frontpage',
+		__( 'Learn more about the title separator setting', 'wordpress-seo' ),
+		__( 'These are the title, description and image used in the Open Graph meta tags on the front page of your site.', 'wordpress-seo' ),
+		'has-wrapper'
+	);
+	echo '<h2 class="help-button-inline">' . esc_html__( 'Frontpage settings', 'wordpress-seo' ) . $social_facebook_frontpage_help->get_button_html() . '</h2>';
+	echo $social_facebook_frontpage_help->get_panel_html();
 
 	$yform->media_input( 'og_frontpage_image', __( 'Image URL', 'wordpress-seo' ) );
 	$yform->textinput( 'og_frontpage_title', __( 'Title', 'wordpress-seo' ) );

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -383,7 +383,7 @@ td.column-wpseo-linked {
 	padding: 0;
 	border: 0;
 	outline: none;
-	color: #a4286a;
+	color: #72777c;
 	background: transparent;
 	box-shadow: none;
 	vertical-align: top;
@@ -417,7 +417,7 @@ td.column-wpseo-linked {
 
 .yoast_help.yoast-help-button:hover,
 .yoast_help.yoast-help-button:focus {
-	color: #832055;
+	color: #0073aa;
 }
 
 .yoast_help.yoast-help-button:focus .yoast-help-icon::before,
@@ -433,4 +433,8 @@ td.column-wpseo-linked {
 	padding: 0 0 1em;
 	font-weight: normal;
 	white-space: normal;
+}
+
+.wpseo-admin-page .yoast-help-panel {
+	max-width: 600px !important;
 }

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -373,3 +373,64 @@ td.column-wpseo-linked {
 	list-style: disc;
 	padding-left: 1.5em;
 }
+
+.yoast_help.yoast-help-button {
+	overflow: visible;
+	position: relative;
+	width: 20px;
+	height: 20px;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	outline: none;
+	color: #a4286a;
+	background: transparent;
+	box-shadow: none;
+	vertical-align: top;
+	/* IE 11 */
+	cursor: pointer;
+}
+
+.yoast-section .yoast_help.yoast-help-button {
+	float: right;
+}
+
+.help-button-inline .yoast_help.yoast-help-button {
+	margin-top: -4px;
+}
+
+.yoast-section .yoast_help.yoast-help-button {
+	margin-top: -44px;
+}
+
+.wpseo-admin-page .yoast_help.yoast-help-button {
+	margin-right: 6px;
+}
+
+.yoast_help .yoast-help-icon::before {
+	position: absolute;
+	top: 0;
+	left: 0;
+	padding: 4px;
+	content: "\f223";
+}
+
+.yoast_help.yoast-help-button:hover,
+.yoast_help.yoast-help-button:focus {
+	color: #832055;
+}
+
+.yoast_help.yoast-help-button:focus .yoast-help-icon::before,
+.assessment-results__mark:focus {
+	border-radius: 100%;
+	box-shadow: 0 0 0 1px #5b9dd9,
+	0 0 2px 1px rgba(30, 140, 190, 0.8);
+}
+
+.yoast-help-panel {
+	display: none;
+	max-width: 30em !important;
+	padding: 0 0 1em;
+	font-weight: normal;
+	white-space: normal;
+}

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -396,63 +396,6 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
 }
 
-.yoast_help.yoast-help-button {
-	overflow: visible;
-	position: relative;
-	width: 20px;
-	height: 20px;
-	margin: 0;
-	padding: 0;
-	border: 0;
-	outline: none;
-	color: #72777c;
-	background: transparent;
-	box-shadow: none;
-	vertical-align: top;
-	/* IE 11 */
-	cursor: pointer;
-}
-
-.wpseotab .yoast_help.yoast-help-button {
-	float: right;
-}
-
-.wpseotab.content .yoast_help.yoast-help-button {
-	margin-top: -47px;
-}
-
-.wpseo-admin-page .yoast_help.yoast-help-button {
-	margin-right: 6px;
-}
-
-.yoast_help.yoast-help-button:before {
-	position: absolute;
-	top: 0;
-	left: 0;
-	padding: 4px;
-	content: "\f223";
-}
-
-.yoast_help.yoast-help-button:hover,
-.yoast_help.yoast-help-button:focus {
-	color: #0073aa;
-}
-
-.yoast_help.yoast-help-button:focus:before,
-.assessment-results__mark:focus {
-	border-radius: 100%;
-	box-shadow: 0 0 0 1px #5b9dd9,
-	0 0 2px 1px rgba(30, 140, 190, 0.8);
-}
-
-.yoast-help-panel {
-	display: none;
-	max-width: 30em !important;
-	padding: 0 0 1em;
-	font-weight: normal;
-	white-space: normal;
-}
-
 .wpseo-admin-page .subsubsub li {
 	display: inline;
 	max-width: none;


### PR DESCRIPTION
 ## Summary

This PR can be summarized in the following changelog entry:

* Update the Admin Help Panel classo to be used in the settings pages too

## Relevant technical choices:

- moved the CSS to admin global scss
- changed the button color globally so it will be purple also in the metabox and in the search console
- kept the class untouched, but it could probably benefit from a small refactoring to pass an $args array to be used, for example, for the optional wrapper and additional CSS classes; I'd like to review this part later if no objections
- considered a small helper function to print out the help button and content but then decided to not do that as the current class allows to print out them separately, and that's nice
- the styling could be improved, open to suggestions

## Test instructions

This PR can be tested by following these steps:

- build the CSS
- see usage example in `admin/views/tabs/metas/general.php`, the class needs:
  - an id
  - the visually hidden button text
  - the help text

Fixes #8886

Screenshots:

![screen shot 2018-02-09 at 15 14 18](https://user-images.githubusercontent.com/1682452/36032238-a8755880-0dad-11e8-98bc-403e2885f154.png)

![screen shot 2018-02-09 at 15 14 24](https://user-images.githubusercontent.com/1682452/36032239-a88e5c04-0dad-11e8-92d1-8e7000d21330.png)

