### PR TITLE
Checked code for all soft-deprecated methods, actions, hooks or filters to add messages. 

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -245,7 +245,7 @@ class WPSEO_Help_Center {
 	/**
 	 * Outputs the help center.
 	 *
-	 * @deprecated
+	 * @deprecated 5.6
 	 */
 	public function output_help_center() {
 		_deprecated_function( 'WPSEO_Help_Center::output_help_center', 'WPSEO 5.6.0', 'WPSEO_Help_Center::mount()' );

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -360,7 +360,7 @@ class WPSEO_Meta {
 				 *
 				 * @return     array
 				 */
-				$field_defs = apply_filters( 'wpseo_metabox_entries', $field_defs );
+				$field_defs = apply_filters_deprecated( 'wpseo_metabox_entries', array($field_defs), 'WPSEO 7.0','wpseo_metabox_entries_general' );
 				break;
 
 

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -360,7 +360,7 @@ class WPSEO_Meta {
 				 *
 				 * @return     array
 				 */
-				$field_defs = apply_filters_deprecated( 'wpseo_metabox_entries', array($field_defs), 'WPSEO 7.0','wpseo_metabox_entries_general' );
+				$field_defs = apply_filters_deprecated( 'wpseo_metabox_entries', array( $field_defs ), 'WPSEO 7.0','wpseo_metabox_entries_general' );
 				break;
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*Checked code for all soft-deprecated methods, actions, hooks or filters to add messages to them. Found one filter and added a deprecation message.  

## Test instructions

This PR can be tested by following these steps:
* There should be no change in behavior of the plugin.  
* Use a plugin like Query Monitor to see debug messages. 
* When the filter 'wpseo_metabox_entries' is applied there should be a deprecation warning. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [#8800](https://github.com/Yoast/wordpress-seo/issues/8800)