### PR TITLE
Only load dashboard on admin_init

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -353,8 +353,6 @@ new WPSEO_GSC_Ajax();
 // SEO Score Recalculations.
 new WPSEO_Recalculate_Scores_Ajax();
 
-new Yoast_Dashboard_Widget();
-
 new Yoast_OnPage_Ajax();
 
 new WPSEO_Shortcode_Filter();

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -32,7 +32,15 @@ class Yoast_Dashboard_Widget {
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_assets' ) );
+		add_action( 'admin_init', array( $this, 'queue_dashboard_widget' ) );
+	}
 
+	/**
+	 * Adds the dashboard widget if it should be shown.
+	 *
+	 * @return void
+	 */
+	public function queue_dashboard_widget() {
 		if ( $this->show_widget() ) {
 			add_action( 'wp_dashboard_setup', array( $this, 'add_dashboard_widget' ) );
 		}


### PR DESCRIPTION
## Summary

* Regression

## Relevant technical choices:

* Only load the dashboard widget on admin_init

## Test instructions

This PR can be tested by following these steps:

* See no AJAX request have 500 errors anymore.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #8901 
