### PR TITLE
Add Google Search Console to translate

### DIFF
--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -20,5 +20,5 @@ printf(
 );
 
 $yform->textinput( 'msverify', '<a target="_blank" href="' . esc_url( 'http://www.bing.com/webmaster/?rfp=1#/Dashboard/?url=' . urlencode( str_replace( 'http://', '', get_bloginfo( 'url' ) ) ) ) . '">' . __( 'Bing Webmaster Tools', 'wordpress-seo' ) . '</a>' );
-$yform->textinput( 'googleverify', '<a target="_blank" href="' . esc_url( 'https://www.google.com/webmasters/verification/verification?hl=en&siteUrl=' . urlencode( get_bloginfo( 'url' ) ) . '/' ) . '">Google Search Console</a>' );
+$yform->textinput( 'googleverify', '<a target="_blank" href="' . esc_url( 'https://www.google.com/webmasters/verification/verification?hl=en&siteUrl=' . urlencode( get_bloginfo( 'url' ) ) . '/' ) . '">' . __( 'Google Search Console', 'wordpress-seo' ) . '</a>' );
 $yform->textinput( 'yandexverify', '<a target="_blank" href="http://help.yandex.com/webmaster/service/rights.xml#how-to">' . __( 'Yandex Webmaster Tools', 'wordpress-seo' ) . '</a>' );

--- a/languages/wordpress-seo.pot
+++ b/languages/wordpress-seo.pot
@@ -1393,6 +1393,7 @@ msgstr ""
 
 #: admin/config-ui/class-configuration-structure.php:52
 #: admin/google_search_console/views/gsc-display.php:33
+#: admin/views/tabs/dashboard/webmaster-tools.php:23
 msgid "Google Search Console"
 msgstr ""
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The Google Search Console in the webmaster tools section translation was missing.

## Quality assurance

* [x] I have tested this code to the best of my abilities