### PR TITLE
Adds functionality to invert logic for displaying the metabox

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -634,8 +634,8 @@ class Yoast_Form {
 	 * @return void
 	 */
 	public function show_hide_switch( $var, $label, $inverse_keys = false ) {
-		$on_key   = ( $inverse_keys ) ? 'off' : 'on';
-		$off_key  = ( $inverse_keys ) ? 'on' : 'off';
+		$on_key  = ( $inverse_keys ) ? 'off' : 'on';
+		$off_key = ( $inverse_keys ) ? 'on' : 'off';
 
 		$show_hide_switch = array(
 			$on_key  => __( 'Show', 'wordpress-seo' ),

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -627,15 +627,19 @@ class Yoast_Form {
 	/**
 	 * Creates a toggle switch to show hide certain options.
 	 *
-	 * @param string $var    The variable within the option to create the radio buttons for.
-	 * @param string $label  The visual label for the radio buttons group, used as the fieldset legend.
+	 * @param string $var           The variable within the option to create the radio buttons for.
+	 * @param string $label         The visual label for the radio buttons group, used as the fieldset legend.
+	 * @param bool   $inverse_keys  Whether or not the option keys need to be inverted to support older functions.
 	 *
 	 * @return void
 	 */
-	public function show_hide_switch( $var, $label ) {
+	public function show_hide_switch( $var, $label, $inverse_keys = false ) {
+		$on_key   = ( $inverse_keys ) ? 'off' : 'on';
+		$off_key  = ( $inverse_keys ) ? 'on' : 'off';
+
 		$show_hide_switch = array(
-			'on'  => __( 'Show', 'wordpress-seo' ),
-			'off' => __( 'Hide', 'wordpress-seo' ),
+			$on_key  => __( 'Show', 'wordpress-seo' ),
+			$off_key => __( 'Hide', 'wordpress-seo' ),
 		);
 
 		$this->toggle_switch( $var, $show_hide_switch, $label );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -122,7 +122,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @param  string $post_type Optional. The post type to test, defaults to the current post post_type.
 	 *
-	 * @return  bool        Whether or not the meta box (and associated columns etc) should be hidden.
+	 * @return  bool Whether or not the meta box (and associated columns etc) should be hidden.
 	 */
 	public function is_metabox_hidden( $post_type = null ) {
 		if ( ! isset( $post_type ) && ( isset( $GLOBALS['post'] ) && ( is_object( $GLOBALS['post'] ) && isset( $GLOBALS['post']->post_type ) ) ) ) {
@@ -135,7 +135,21 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 			return ( WPSEO_Options::get( 'hideeditbox-' . $post_type, false ) || in_array( $post_type, $post_types, true ) === false );
 		}
+
 		return false;
+	}
+
+	/**
+     * Wraps the is_metabox_hidden method to make the logic a bit more readable in the code.
+     *
+     * This is due to a change the interface, but not the option, making flipping logic necessary.
+     *
+	 * @param null|string $post_type    Optional. The post type to test, defaults to the current post post_type.
+	 *
+	 * @return bool Whether or not the metabox should be displayed.
+	 */
+	public function should_display_metabox( $post_type = null ) {
+        return $this->is_metabox_hidden( $post_type ) === true;
 	}
 
 	/**
@@ -151,7 +165,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * Outputs the page analysis score in the Publish Box.
 	 */
 	public function publish_box() {
-		if ( $this->is_metabox_hidden() === true ) {
+        if ( $this->should_display_metabox() === false ) {
 			return;
 		}
 
@@ -187,7 +201,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		if ( is_array( $post_types ) && $post_types !== array() ) {
 			foreach ( $post_types as $post_type ) {
-				if ( $this->is_metabox_hidden( $post_type ) === false ) {
+				if ( $this->should_display_metabox( $post_type ) !== false ) {
 					$product_title = 'Yoast SEO';
 					if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
 						$product_title .= ' Premium';
@@ -862,7 +876,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$is_editor = self::is_post_overview( $pagenow ) || self::is_post_edit( $pagenow );
 
 		/* Filter 'wpseo_always_register_metaboxes_on_admin' documented in wpseo-main.php */
-		if ( ( ! $is_editor && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->is_metabox_hidden() === true
+		if ( ( ! $is_editor && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->should_display_metabox() === false
 		) {
 			return;
 		}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -115,12 +115,12 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
-     * Checks whether `post` is set in GLOBALS and whether it's an object.
-     *
+	 * Checks whether `post` is set in GLOBALS and whether it's an object.
+	 *
 	 * @return bool Returns false if not set or if it's not an object.
 	 */
 	private function has_globally_set_post_object() {
-        return isset( $GLOBALS['post'] ) && is_object( $GLOBALS['post'] );
+		return isset( $GLOBALS['post'] ) && is_object( $GLOBALS['post'] );
 	}
 
 	/**
@@ -139,14 +139,14 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		if ( ! isset( $post_type ) ) {
-		    return false;
+			return false;
 		}
 
-        if ( ! in_array( $post_type, WPSEO_Post_Type::get_accessible_post_types(), true ) ) {
-            return true;
-        }
+		if ( ! in_array( $post_type, WPSEO_Post_Type::get_accessible_post_types(), true ) ) {
+			return true;
+		}
 
-        return WPSEO_Options::get( 'hideeditbox-' . $post_type, false );
+		return WPSEO_Options::get( 'hideeditbox-' . $post_type, false );
 	}
 
 	/**
@@ -192,37 +192,37 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	/**
 	 * Adds the Yoast SEO meta box to the edit boxes in the edit post, page,
 	 * attachment, and custom post types pages.
-     *
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function add_meta_box() {
 		$post_types = WPSEO_Post_Type::get_accessible_post_types();
 
 		if ( ! is_array( $post_types ) || $post_types === array() ) {
-		    return;
+			return;
 		}
 
-        foreach ( $post_types as $post_type ) {
-		    if ( $this->is_metabox_hidden( $post_type ) ) {
-		        continue;
-            }
+		foreach ( $post_types as $post_type ) {
+			if ( $this->is_metabox_hidden( $post_type ) ) {
+				continue;
+			}
 
-            $product_title = 'Yoast SEO';
+			$product_title = 'Yoast SEO';
 
-            if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
-                $product_title .= ' Premium';
-            }
+			if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
+				$product_title .= ' Premium';
+			}
 
-            if ( get_current_screen() !== null ) {
-                $screen_id = get_current_screen()->id;
-                add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
-            }
+			if ( get_current_screen() !== null ) {
+				$screen_id = get_current_screen()->id;
+				add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
+			}
 
-            add_meta_box( 'wpseo_meta', $product_title, array(
-                $this,
-                'meta_box',
-            ), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ) );
-        }
+			add_meta_box( 'wpseo_meta', $product_title, array(
+				$this,
+				'meta_box',
+			), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ) );
+		}
 	}
 
 	/**

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -115,6 +115,15 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
+     * Checks whether `post` is set in GLOBALS and whether it's an object.
+     *
+	 * @return bool Returns false if not set or if it's not an object.
+	 */
+	private function has_globally_set_post_object() {
+        return isset( $GLOBALS['post'] ) && is_object( $GLOBALS['post'] );
+	}
+
+	/**
 	 * Test whether the metabox should be hidden either by choice of the admin or because
 	 * the post type is not a public post type.
 	 *
@@ -125,31 +134,19 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return  bool Whether or not the meta box (and associated columns etc) should be hidden.
 	 */
 	public function is_metabox_hidden( $post_type = null ) {
-		if ( ! isset( $post_type ) && ( isset( $GLOBALS['post'] ) && ( is_object( $GLOBALS['post'] ) && isset( $GLOBALS['post']->post_type ) ) ) ) {
+		if ( ! isset( $post_type ) && ( $this->has_globally_set_post_object() ) && isset( $GLOBALS['post']->post_type ) ) {
 			$post_type = $GLOBALS['post']->post_type;
 		}
 
-		if ( isset( $post_type ) ) {
-			// Don't make static as post_types may still be added during the run.
-			$post_types = WPSEO_Post_Type::get_accessible_post_types();
-
-			return ( WPSEO_Options::get( 'hideeditbox-' . $post_type, false ) || in_array( $post_type, $post_types, true ) === false );
+		if ( ! isset( $post_type ) ) {
+		    return false;
 		}
 
-		return false;
-	}
+        if ( ! in_array( $post_type, WPSEO_Post_Type::get_accessible_post_types(), true ) ) {
+            return true;
+        }
 
-	/**
-	 * Wraps the is_metabox_hidden method to make the logic a bit more readable in the code.
-	 *
-	 * This is due to a change the interface, but not the option, making flipping logic necessary.
-	 *
-	 * @param null|string $post_type    Optional. The post type to test, defaults to the current post post_type.
-	 *
-	 * @return bool Whether or not the metabox should be displayed.
-	 */
-	public function should_display_metabox( $post_type = null ) {
-		return $this->is_metabox_hidden( $post_type ) === true;
+        return WPSEO_Options::get( 'hideeditbox-' . $post_type, false );
 	}
 
 	/**
@@ -165,7 +162,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * Outputs the page analysis score in the Publish Box.
 	 */
 	public function publish_box() {
-		if ( $this->should_display_metabox() === false ) {
+		if ( $this->is_metabox_hidden() === true ) {
 			return;
 		}
 
@@ -195,30 +192,37 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	/**
 	 * Adds the Yoast SEO meta box to the edit boxes in the edit post, page,
 	 * attachment, and custom post types pages.
+     *
+     * @return void
 	 */
 	public function add_meta_box() {
 		$post_types = WPSEO_Post_Type::get_accessible_post_types();
 
-		if ( is_array( $post_types ) && $post_types !== array() ) {
-			foreach ( $post_types as $post_type ) {
-				if ( $this->should_display_metabox( $post_type ) === true ) {
-					$product_title = 'Yoast SEO';
-					if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
-						$product_title .= ' Premium';
-					}
-
-					if ( null !== get_current_screen() ) {
-						$screen_id = get_current_screen()->id;
-						add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
-					}
-
-					add_meta_box( 'wpseo_meta', $product_title, array(
-						$this,
-						'meta_box',
-					), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ) );
-				}
-			}
+		if ( ! is_array( $post_types ) || $post_types === array() ) {
+		    return;
 		}
+
+        foreach ( $post_types as $post_type ) {
+		    if ( $this->is_metabox_hidden( $post_type ) ) {
+		        continue;
+            }
+
+            $product_title = 'Yoast SEO';
+
+            if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
+                $product_title .= ' Premium';
+            }
+
+            if ( get_current_screen() !== null ) {
+                $screen_id = get_current_screen()->id;
+                add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
+            }
+
+            add_meta_box( 'wpseo_meta', $product_title, array(
+                $this,
+                'meta_box',
+            ), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ) );
+        }
 	}
 
 	/**
@@ -876,8 +880,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$is_editor = self::is_post_overview( $pagenow ) || self::is_post_edit( $pagenow );
 
 		/* Filter 'wpseo_always_register_metaboxes_on_admin' documented in wpseo-main.php */
-		if ( ( ! $is_editor && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->should_display_metabox() === false
-		) {
+		if ( ( ! $is_editor && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->is_metabox_hidden() === true ) {
 			return;
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -201,7 +201,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		if ( is_array( $post_types ) && $post_types !== array() ) {
 			foreach ( $post_types as $post_type ) {
-				if ( $this->should_display_metabox( $post_type ) !== false ) {
+				if ( $this->should_display_metabox( $post_type ) === true ) {
 					$product_title = 'Yoast SEO';
 					if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
 						$product_title .= ' Premium';

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -140,16 +140,16 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
-     * Wraps the is_metabox_hidden method to make the logic a bit more readable in the code.
-     *
-     * This is due to a change the interface, but not the option, making flipping logic necessary.
-     *
+	 * Wraps the is_metabox_hidden method to make the logic a bit more readable in the code.
+	 *
+	 * This is due to a change the interface, but not the option, making flipping logic necessary.
+	 *
 	 * @param null|string $post_type    Optional. The post type to test, defaults to the current post post_type.
 	 *
 	 * @return bool Whether or not the metabox should be displayed.
 	 */
 	public function should_display_metabox( $post_type = null ) {
-        return $this->is_metabox_hidden( $post_type ) === true;
+		return $this->is_metabox_hidden( $post_type ) === true;
 	}
 
 	/**
@@ -165,7 +165,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * Outputs the page analysis score in the Publish Box.
 	 */
 	public function publish_box() {
-        if ( $this->should_display_metabox() === false ) {
+		if ( $this->should_display_metabox() === false ) {
 			return;
 		}
 

--- a/admin/views/class-view-utils.php
+++ b/admin/views/class-view-utils.php
@@ -54,7 +54,8 @@ class Yoast_View_Utils {
 		$this->form->show_hide_switch(
 			'hideeditbox-' . $post_type->name,
 			/* translators: %1$s expands to Yoast SEO */
-			sprintf( __( '%1$s Meta Box', 'wordpress-seo' ), 'Yoast SEO' )
+			sprintf( __( '%1$s Meta Box', 'wordpress-seo' ), 'Yoast SEO' ),
+			true
 		);
 	}
 }

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -74,6 +74,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 			->getMock();
 
 		$stub
+			->expects( $this->any() )
 			->method( 'is_metabox_hidden' )
 			->will( $this->returnValue( true ) );
 

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -18,10 +18,13 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
+
 		self::$class_instance = new WPSEO_Metabox();
 	}
 
 	/**
+	 * Tests that on certain pages, assets are not enqueued.
+	 *
 	 * @covers WPSEO_Metabox::enqueue()
 	 */
 	public function test_enqueue_not_firing_on_options_page() {
@@ -36,6 +39,8 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests that enqueuing the necessary assets, works.
+	 *
 	 * @covers WPSEO_Metabox::enqueue()
 	 */
 	public function test_enqueue_firing_on_new_post_page() {
@@ -55,10 +60,24 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( $enqueued );
 	}
 
+	/**
+	 * Tests that adding of valid metaboxes works properly.
+	 *
+	 * @covers WPSEO_Meta::add_metabox
+	 */
 	public function test_add_metabox() {
 		global $wp_meta_boxes;
 
-		self::$class_instance->add_meta_box();
+		$stub = $this
+			->getMockBuilder( 'WPSEO_Metabox' )
+			->setMethods( array( 'is_metabox_hidden' ) )
+			->getMock();
+
+		$stub
+			->method( 'is_metabox_hidden' )
+			->will( $this->returnValue( true ) );
+
+		$stub->add_meta_box();
 
 		$post_types = WPSEO_Post_Type::get_accessible_post_types();
 
@@ -68,6 +87,11 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Tests that saving postdata works properly.
+	 *
+	 * @covers WPSEO_Meta::save_postdata
+	 */
 	public function test_save_postdata() {
 
 		// Create and go to post.
@@ -120,5 +144,43 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 				$this->assertEquals( $value, 'on' );
 			}
 		}
+	}
+
+	/**
+	 * Tests that the should_display_metabox method returns true.
+	 *
+	 * @covers WPSEO_Metabox::should_display_metabox
+	 */
+	public function test_should_display_metabox_is_true() {
+		$stub = $this
+			->getMockBuilder( 'WPSEO_Metabox' )
+			->setMethods( array( 'is_metabox_hidden' ) )
+			->getMock();
+
+		$stub
+			->expects( $this->once() )
+			->method( 'is_metabox_hidden' )
+			->will( $this->returnValue( true ) );
+
+		$this->assertTrue( $stub->should_display_metabox() );
+	}
+
+	/**
+	 * Tests that the should_display_metabox method returns false.
+	 *
+	 * @covers WPSEO_Metabox::should_display_metabox
+	 */
+	public function test_should_display_metabox_is_false() {
+		$stub = $this
+			->getMockBuilder( 'WPSEO_Metabox' )
+			->setMethods( array( 'is_metabox_hidden' ) )
+			->getMock();
+
+		$stub
+			->expects( $this->once() )
+			->method( 'is_metabox_hidden' )
+			->will( $this->returnValue( false ) );
+
+		$this->assertFalse( $stub->should_display_metabox() );
 	}
 }

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -76,7 +76,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		$stub
 			->expects( $this->any() )
 			->method( 'is_metabox_hidden' )
-			->will( $this->returnValue( true ) );
+			->will( $this->returnValue( false ) );
 
 		$stub->add_meta_box();
 
@@ -145,43 +145,5 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 				$this->assertEquals( $value, 'on' );
 			}
 		}
-	}
-
-	/**
-	 * Tests that the should_display_metabox method returns true.
-	 *
-	 * @covers WPSEO_Metabox::should_display_metabox
-	 */
-	public function test_should_display_metabox_is_true() {
-		$stub = $this
-			->getMockBuilder( 'WPSEO_Metabox' )
-			->setMethods( array( 'is_metabox_hidden' ) )
-			->getMock();
-
-		$stub
-			->expects( $this->once() )
-			->method( 'is_metabox_hidden' )
-			->will( $this->returnValue( true ) );
-
-		$this->assertTrue( $stub->should_display_metabox() );
-	}
-
-	/**
-	 * Tests that the should_display_metabox method returns false.
-	 *
-	 * @covers WPSEO_Metabox::should_display_metabox
-	 */
-	public function test_should_display_metabox_is_false() {
-		$stub = $this
-			->getMockBuilder( 'WPSEO_Metabox' )
-			->setMethods( array( 'is_metabox_hidden' ) )
-			->getMock();
-
-		$stub
-			->expects( $this->once() )
-			->method( 'is_metabox_hidden' )
-			->will( $this->returnValue( false ) );
-
-		$this->assertFalse( $stub->should_display_metabox() );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where setting the Yoast SEO Metabox to Show for a particular post type in the Settings, resulted in it being hidden (and vice versa).

## Relevant technical choices:

* This PR purely wraps `is_metabox_hidden` and checks if the value returned is `true`. Due to the large overhaul in the Settings pages, the old logic of being able to set the Yoast SEO Metabox to hidden went from a 'Do you want to hide the Yoast SEO Metabox? (Yes/No)', to a 'Yoast SEO Metabox (Show/Hide)'. This means the old logic where you answered 'Yes' was being mapped to 'Show', where in reality it's 'Hide'. If anything, this 'fix' is more  cognitive change and not a functional one.
* I'm considering this a temporary fix. It'd be much better to do a (minor) options overhaul to transfer this option over.

## Test instructions

This PR can be tested by following these steps:

* Test the original issue.
* Notice that setting the Yoast SEO Metabox for a particular post type to Show, results in it being hidden and vice versa.
* Checkout this PR.
* Change the setting again.
* Notice that when you set it to Show, the Metabox is properly displayed for the post type.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8909 
