### PR TITLE
Standardize the switch toggles text to be not bold

### DIFF
--- a/css/src/toggle-switch.scss
+++ b/css/src/toggle-switch.scss
@@ -268,10 +268,6 @@
 		vertical-align: middle;
 	}
 
-	.switch-light.switch-yoast-seo > strong {
-		font-weight: 600;
-	}
-
 	.switch-toggle.switch-yoast-seo,
 	.switch-light.switch-yoast-seo > span {
 		width: 250px;
@@ -374,7 +370,7 @@
 	.switch-container .label-text {
 		display: block;
 		margin: 0.5em 0;
-		font-weight: 600;
+		font-weight: 400;
 	}
 
 	.switch-container {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Standardizes the Switch Toggle controls to use not bold text

## Relevant technical choices:

- set the `<b>` element printed out by `light_switch()` to a font-weight 400
- removed a CSS rule for a strong element that's actually not used by `light_switch()`

## Test instructions

- build hte CSS
- verify `light_switch()`, `toggle_switch()` and their helper functions, always print out a default text that is not bold

Fixes #8919
