### PR TITLE
Improve the Webmaster tools page labels, links, and help text.

### DIFF
--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -15,14 +15,51 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 $webmaster_tools_help = new WPSEO_Admin_Help_Panel(
 	'dashboard-webmaster-tools',
-	__( 'Learn more about the Webmaster Tools verification', 'wordpress-seo' ),
-	__( 'You can use the boxes below to verify with the different Webmaster Tools, if your site is already verified, you can just forget about these.', 'wordpress-seo' ),
+	esc_html__( 'Learn more about the Webmaster Tools verification', 'wordpress-seo' ),
+	esc_html__( 'You can use the boxes below to verify with the different Webmaster Tools. This feature will add a verification meta tag on your home page. Follow the links to the different Webmaster Tools and look for instructions for the meta tag verification method to get the verification code. If your site is already verified, you can just forget about these.', 'wordpress-seo' ),
 	'has-wrapper'
 );
 
 echo '<h2 class="help-button-inline">' . esc_html__( 'Webmaster Tools verification', 'wordpress-seo' ) . $webmaster_tools_help->get_button_html() . '</h2>';
 echo $webmaster_tools_help->get_panel_html();
 
-$yform->textinput( 'msverify', '<a target="_blank" href="' . esc_url( 'http://www.bing.com/webmaster/?rfp=1#/Dashboard/?url=' . urlencode( str_replace( 'http://', '', get_bloginfo( 'url' ) ) ) ) . '">' . __( 'Bing Webmaster Tools', 'wordpress-seo' ) . '</a>' );
-$yform->textinput( 'googleverify', '<a target="_blank" href="' . esc_url( 'https://www.google.com/webmasters/verification/verification?hl=en&siteUrl=' . urlencode( get_bloginfo( 'url' ) ) . '/' ) . '">Google Search Console</a>' );
-$yform->textinput( 'yandexverify', '<a target="_blank" href="http://help.yandex.com/webmaster/service/rights.xml#how-to">' . __( 'Yandex Webmaster Tools', 'wordpress-seo' ) . '</a>' );
+$msverify_link = add_query_arg( array(
+	'rfp' => '1#/Dashboard/?url=' . rawurlencode( str_replace( 'http://', '', get_bloginfo( 'url' ) ) ),
+), esc_url( 'http://www.bing.com/webmaster/' ) );
+
+$googleverify_link = add_query_arg( array(
+	'hl' => 'en',
+	'tid' => 'alternate',
+	'siteUrl' => rawurlencode( get_bloginfo( 'url' ) ) . '/',
+), esc_url( 'https://www.google.com/webmasters/verification/verification' ) );
+
+
+$yform->textinput( 'msverify', __( 'Bing verification code', 'wordpress-seo' ) );
+echo '<p class="desc label">';
+printf(
+	/* translators: 1: link open tag; 2: link close tag. */
+	esc_html__( 'Get your Bing verification code in %1$sBing Webmaster Tools%2$s.', 'wordpress-seo' ),
+	'<a target="_blank" href="' . $msverify_link . '" rel="noopener noreferrer">',
+	'</a>'
+);
+echo '</p>';
+
+$yform->textinput( 'googleverify', __( 'Google verification code', 'wordpress-seo' ) );
+echo '<p class="desc label">';
+printf(
+	/* translators: 1: link open tag; 2: link close tag. */
+	esc_html__( 'Get your Google verification code in %1$sGoogle Search Console%2$s.', 'wordpress-seo' ),
+	'<a target="_blank" href="' . $googleverify_link . '" rel="noopener noreferrer">',
+	'</a>'
+);
+echo '</p>';
+
+$yform->textinput( 'yandexverify', __( 'Yandex verification code', 'wordpress-seo' ) );
+echo '<p class="desc label">';
+printf(
+	/* translators: 1: link open tag; 2: link close tag. */
+	esc_html__( 'Get your Yandex verification code in %1$sYandex Webmaster Tools%2$s.', 'wordpress-seo' ),
+	'<a target="_blank" href="' . esc_url( 'http://help.yandex.com/webmaster/service/rights.xml#how-to' ) . '" rel="noopener noreferrer">',
+	'</a>'
+);
+echo '</p>';

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -25,7 +25,7 @@ echo $webmaster_tools_help->get_panel_html();
 
 $msverify_link = add_query_arg( array(
 	'rfp' => '1#/Dashboard/?url=' . rawurlencode( str_replace( 'http://', '', get_bloginfo( 'url' ) ) ),
-), esc_url( 'http://www.bing.com/webmaster/' ) );
+), esc_url( 'https://www.bing.com/webmaster/' ) );
 
 $googleverify_link = add_query_arg( array(
 	'hl' => 'en',
@@ -59,7 +59,7 @@ echo '<p class="desc label">';
 printf(
 	/* translators: 1: link open tag; 2: link close tag. */
 	esc_html__( 'Get your Yandex verification code in %1$sYandex Webmaster Tools%2$s.', 'wordpress-seo' ),
-	'<a target="_blank" href="' . esc_url( 'http://help.yandex.com/webmaster/service/rights.xml#how-to' ) . '" rel="noopener noreferrer">',
+	'<a target="_blank" href="' . esc_url( 'https://webmaster.yandex.com/sites/add/' ) . '" rel="noopener noreferrer">',
 	'</a>'
 );
 echo '</p>';


### PR DESCRIPTION
This PR is a first pass to improve the labels, links, and help text on teh Webmaster tools page. Any feedback welcome.

## Summary

This PR can be summarized in the following changelog entry:

* Improved accessibility and inline Help for the Webmaster Tools settings page.

## Relevant technical choices:

- removes links from the labels
- makes the labels text a bit more meaningful
- moves the various Webmaster Tools sites links below the fields
- uses `add_query_arg()` for the links, where applicable
- adds a parameter `tid=alternate` to the Google Webmaster Central link to let users land on the right "tab" (see screenshot on the issue)
- uses `rawurlencode()` instead of `urlencode()` to avoid Coding Standards warnings, but please double check this
- tries to improve the text on the top of the page. Note: this text will be hidden in 7.0 which uses a question mark + collapsible help panel

## Test instructions

This PR can be tested by following these steps:

- please verify all the links to the various sites work correctly
- please verify the new copy is correct from a SEO perspective

Fixes #8920
