### PR TITLE
Replaced Microsoft Edge Site Scan to Sonarwhal

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -242,16 +242,16 @@ function wpseo_admin_bar_menu() {
 			) );
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'wpseo-analysis',
-				'id'     => 'wpseo-microsoftedge',
-				'title'  => __( 'Microsoft Edge Site Scan', 'wordpress-seo' ),
-				'href'   => 'https://developer.microsoft.com/en-us/microsoft-edge/tools/staticscan/?url=' . urlencode( $url ),
+				'id'     => 'wpseo-google-mobile-friendly',
+				'title'  => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
+				'href'   => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . urlencode( $url ),
 				'meta'   => array( 'target' => '_blank' ),
 			) );
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'wpseo-analysis',
-				'id'     => 'wpseo-google-mobile-friendly',
-				'title'  => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
-				'href'   => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . urlencode( $url ),
+				'id'     => 'wpseo-sonarwhal',
+				'title'  => __( 'Sonarwhal Site Scan', 'wordpress-seo' ),
+				'href'   => 'https://sonarwhal.com/scanner/',
 				'meta'   => array( 'target' => '_blank' ),
 			) );
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The Microsoft Edge Site Scan tool is no longer available and the team introduced a new site scan tool called **[Sonarwhal](https://sonarwhal.com/)**.
* So, replaced the Microsoft Edge Site Scan tool to [Sonarwhal Site Scan](https://sonarwhal.com/scanner/) tool.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #8908 