### PR TITLE
Remove Unnecessary Alexa Verification Related Code

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -51,7 +51,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	 */
 	public $ms_exclude = array(
 		/* Privacy. */
-		'alexaverify',
 		'googleverify',
 		'msverify',
 		'yandexverify',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Alexa verification has been removed from Yoast SEO a long way back. So, we don't want to have the Alexa verification related code in Yoast SEO anymore.

## Quality assurance

* [x] I have tested this code to the best of my abilities