### PR TITLE
Move restore default settings

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -36,7 +36,7 @@ class WPSEO_Admin_Pages {
 	public function init() {
 		if ( filter_input( INPUT_GET, 'wpseo_reset_defaults' ) && wp_verify_nonce( filter_input( INPUT_GET, 'nonce' ), 'wpseo_reset_defaults' ) && current_user_can( 'manage_options' ) ) {
 			WPSEO_Options::reset();
-			wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ) );
+			wp_redirect( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) );
 		}
 
 		add_action( 'admin_init', array( $this, 'admin_init' ) );

--- a/admin/views/tabs/dashboard/general.php
+++ b/admin/views/tabs/dashboard/general.php
@@ -22,8 +22,11 @@ if ( WPSEO_Utils::is_api_available() && current_user_can( WPSEO_Configuration_En
 		?>
 	</p>
 <p>
-	<a class="button"
+	<a class="button button-primary"
 		href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ); ?>"><?php esc_html_e( 'Open the configuration wizard', 'wordpress-seo' ); ?></a>
+	<a onclick='if ( !confirm( <?php echo esc_attr( wp_json_encode( __( 'Are you sure you want to reset your SEO settings?', 'wordpress-seo' ) . "\n\n" . __( 'This will automatically start the configuration wizard to make sure you get the correct settings for your site.', 'wordpress-seo' ) ) ); ?> ) ) return false;'
+	   class="button"
+	   href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php esc_html_e( 'Restore default settings', 'wordpress-seo' ); ?></a>
 </p>
 
 	<br/>
@@ -52,23 +55,4 @@ echo '<h2>' . esc_html__( 'Credits', 'wordpress-seo' ) . '</h2>';
 <p>
 	<a class="button"
 		href="<?php echo esc_url( admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&intro=1' ) ); ?>"><?php esc_html_e( 'View credits', 'wordpress-seo' ); ?></a>
-</p>
-<br/>
-<?php
-echo '<h2>' . esc_html__( 'Restore default settings', 'wordpress-seo' ) . '</h2>';
-?>
-<p>
-	<?php
-	printf(
-		/* translators: %s expands to Yoast SEO. */
-		esc_html__( 'If you want to restore a site to the default %s settings, press this button.', 'wordpress-seo' ),
-		'Yoast SEO'
-	);
-	?>
-</p>
-
-<p>
-	<a onclick='if ( !confirm( <?php echo esc_attr( wp_json_encode( __( 'Are you sure you want to reset your SEO settings?', 'wordpress-seo' ) ) ); ?> ) ) return false;'
-		class="button"
-		href="<?php echo esc_url( add_query_arg( array( 'nonce' => wp_create_nonce( 'wpseo_reset_defaults' ) ), admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&wpseo_reset_defaults=1' ) ) ); ?>"><?php esc_html_e( 'Restore default settings', 'wordpress-seo' ); ?></a>
 </p>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Restoring the default settings now automatically opens the configuration wizard.

General tab looks like this after this change:

![general-tab](https://user-images.githubusercontent.com/487629/36377345-292ba350-1577-11e8-9e3f-49f705134055.jpg)

## Relevant technical choices:

* Made the configuration wizard the primary button, as that is now the primary button on the page.

## Test instructions

This PR can be tested by following these steps:

* Open General tab, see restore button has been moved.
* Click restore button, see question has added remark about opening the configuration wizard.
* Confirm default settings have been restored, and that configuration wizard automatically opens.

## Quality assurance

* [x] I have tested this code to the best of my abilities
