### PR TITLE
Change schema.org to https

### DIFF
--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -75,7 +75,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 			return;
 		}
 		$this->data = array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@type'    => 'WebSite',
 			'@id'      => '#website',
 			'url'      => $this->get_home_url(),
@@ -149,7 +149,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 		$this->fetch_social_profiles();
 
 		$this->data = array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@type'    => '',
 			'url'      => $this->get_home_url(),
 			'sameAs'   => $this->profiles,

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -39,7 +39,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$home_url   = WPSEO_Utils::home_url();
 		$search_url = $home_url . '?s={search_term_string}';
 		$json       = wp_json_encode( array(
-			'@context'        => 'http://schema.org',
+			'@context'        => 'htts://schema.org',
 			'@type'           => 'WebSite',
 			'@id'             => '#website',
 			'url'             => $home_url,
@@ -70,7 +70,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 
 		$home_url = WPSEO_Utils::home_url();
 		$json     = wp_json_encode( array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@type'    => 'Person',
 			'url'      => $home_url,
 			'sameAs'   => array( $instagram ),
@@ -96,7 +96,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'instagram_url', 'http://instagram.com:8080/{}yoast' );
 
 		$json = wp_json_encode( array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@type'    => 'Person',
 			'url'      => $home_url,
 			'sameAs'   => array( 'http://instagram.com:8080/yoast' ), // The {} will be stripped out by saving the option.
@@ -126,7 +126,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 
 		$home_url = WPSEO_Utils::home_url();
 		$json     = wp_json_encode( array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@type'    => 'Organization',
 			'url'      => $home_url,
 			'sameAs'   => array( $facebook, $instagram ),

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -39,7 +39,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$home_url   = WPSEO_Utils::home_url();
 		$search_url = $home_url . '?s={search_term_string}';
 		$json       = wp_json_encode( array(
-			'@context'        => 'htts://schema.org',
+			'@context'        => 'https://schema.org',
 			'@type'           => 'WebSite',
 			'@id'             => '#website',
 			'url'             => $home_url,


### PR DESCRIPTION
Replaces #8550 

## Summary

This PR can be summarized in the following changelog entry:

* Changed schema.org output to link to https://schema.org instead of http://, props @vladiiancu, @mariusghitulescu 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #7849, #8550 