### PR TITLE
Remove the Microsoft Edge Site scan link

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -242,13 +242,6 @@ function wpseo_admin_bar_menu() {
 			) );
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'wpseo-analysis',
-				'id'     => 'wpseo-microsoftedge',
-				'title'  => __( 'Microsoft Edge Site Scan', 'wordpress-seo' ),
-				'href'   => 'https://developer.microsoft.com/en-us/microsoft-edge/tools/staticscan/?url=' . urlencode( $url ),
-				'meta'   => array( 'target' => '_blank' ),
-			) );
-			$wp_admin_bar->add_menu( array(
-				'parent' => 'wpseo-analysis',
 				'id'     => 'wpseo-google-mobile-friendly',
 				'title'  => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
 				'href'   => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . urlencode( $url ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove the Microsoft Edge Site scan link as the tool is no longer functional.

## Test instructions

This PR can be tested by following these steps:

* See the Microsoft Edge Site Scan link in the toolbar. 
* Apply this PR. 
* See it's gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #8908 

Props to @iamazik for initial patch.