### PR TITLE
Remove ending space from string

### DIFF
--- a/admin/config-ui/fields/class-field-post-type-visibility.php
+++ b/admin/config-ui/fields/class-field-post-type-visibility.php
@@ -16,7 +16,7 @@ class WPSEO_Config_Field_Post_Type_Visibility extends WPSEO_Config_Field {
 
 		$copy = __( 'Please specify what content types you would like to appear in search engines.
  If you do not know the differences between these, it\'s best to choose the
- default settings. ', 'wordpress-seo' );
+ default settings.', 'wordpress-seo' );
 
 		$html = '<p>' . esc_html( $copy ) . '</p><br/>';
 


### PR DESCRIPTION
As requested in https://github.com/Yoast/wordpress-seo/pull/8969#issuecomment-366676748.

Removes an ending space from a string, thus preventing a warning for translators.

## Summary

This PR can be summarized in the following changelog entry:

* Optimizes a string for translation

## Test instructions

This PR can be tested by following these steps:

* See if the string still displays correctly.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
