### PR TITLE
8923 replace titles and metas in help center

### DIFF
--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -52,7 +52,7 @@ function yoast_add_meta_options_help_center_tabs( $tabs ) {
 function wpseo_add_template_variables_helpcenter() {
 	$explanation = sprintf(
 		/* translators: %1$s expands to Yoast SEO. */
-		__( 'The title &amp; metas settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The table below contains a list of the available variables.', 'wordpress-seo' ),
+		__( 'The search appearance settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The table below contains a list of the available variables.', 'wordpress-seo' ),
 		'Yoast SEO'
 	);
 

--- a/languages/wordpress-seo.pot
+++ b/languages/wordpress-seo.pot
@@ -375,7 +375,7 @@ msgstr ""
 #. translators: %1$s expands to Yoast SEO.
 #: admin/class-admin.php:618
 msgid ""
-"The search appearance settings for %1$s are made up of variables that are "
+"The title &amp; metas settings for %1$s are made up of variables that are "
 "replaced by specific values from the page when the page is displayed. The "
 "tabs on the left explain the available variables."
 msgstr ""
@@ -2781,7 +2781,7 @@ msgstr ""
 #. translators: %1$s expands to Yoast SEO.
 #: admin/pages/metas.php:55
 msgid ""
-"The search appearance settings for %1$s are made up of variables that are "
+"The title &amp; metas settings for %1$s are made up of variables that are "
 "replaced by specific values from the page when the page is displayed. The "
 "table below contains a list of the available variables."
 msgstr ""

--- a/languages/wordpress-seo.pot
+++ b/languages/wordpress-seo.pot
@@ -375,7 +375,7 @@ msgstr ""
 #. translators: %1$s expands to Yoast SEO.
 #: admin/class-admin.php:618
 msgid ""
-"The title &amp; metas settings for %1$s are made up of variables that are "
+"The search appearance settings for %1$s are made up of variables that are "
 "replaced by specific values from the page when the page is displayed. The "
 "tabs on the left explain the available variables."
 msgstr ""
@@ -2781,7 +2781,7 @@ msgstr ""
 #. translators: %1$s expands to Yoast SEO.
 #: admin/pages/metas.php:55
 msgid ""
-"The title &amp; metas settings for %1$s are made up of variables that are "
+"The search appearance settings for %1$s are made up of variables that are "
 "replaced by specific values from the page when the page is displayed. The "
 "table below contains a list of the available variables."
 msgstr ""


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*Changed 'titles & meta settings' on the templates variables tab in the help center to 'search appearance settings' to correspond to new naming. 

## Test instructions

This PR can be tested by following these steps:

*Go to Search Appearance, click 'need help?'. The first sentence below 'Template Explanation' should start with 'The search appearance...'

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8923 