### PR TITLE
Moved `Stable Tag` to it's own Grunt update-version command:

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -65,12 +65,25 @@ check:
   - 'update-version:readme'
   - 'update-version:beta'
 
-artifact:
+'artifact:trunk':
   - 'shell:production-composer-install'
   # Update the version numbers in the relevant files
-  - 'update-version'
+  - 'update-version:beta'
   # Build like we normally would
   - 'release'
+  # Copy files and create a zip file
+  - 'create-artifact'
+
+'artifact:master':
+  - 'shell:production-composer-install'
+  # Update the version numbers in the relevant files
+  - 'update-version:release'
+  # Build like we normally would
+  - 'release'
+  # Copy files and create a zip file
+  - 'create-artifact'
+
+'create-artifact':
   # Remove build folder
   - 'clean:artifact'
   # Copy only the relevant files to the folder

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -57,33 +57,17 @@ check:
 'check:i18n':
   - 'checktextdomain'
 
-'update-version:beta':
+# Update all versions except the stable tag
+'update-version-trunk':
   - 'update-version:pluginFile'
   - 'update-version:initializer'
 
-'update-version:release':
-  - 'update-version:readme'
-  - 'update-version:beta'
-
-'artifact:trunk':
+'artifact':
   - 'shell:production-composer-install'
-  # Update the version numbers in the relevant files
-  - 'update-version:beta'
   # Build like we normally would
   - 'release'
   # Copy files and create a zip file
   - 'create-artifact'
-
-'artifact:master':
-  - 'shell:production-composer-install'
-  # Update the version numbers in the relevant files
-  - 'update-version:release'
-  # Build like we normally would
-  - 'release'
-  # Copy files and create a zip file
-  - 'create-artifact'
-
-'create-artifact':
   # Remove build folder
   - 'clean:artifact'
   # Copy only the relevant files to the folder
@@ -108,13 +92,15 @@ release:
   - 'webpack:buildProd'
 
 'deploy:trunk':
-  - artifact
-  - wp_deploy:trunk
+  - 'update-version-trunk'
+  - 'artifact'
+  - 'wp_deploy:trunk'
 
 'deploy:master':
-  - artifact
-  - wp_deploy:master
+  - 'update-version'
+  - 'artifact'
+  - 'wp_deploy:master'
 
 # Default task
 default:
-  - build
+  - 'build'

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -57,6 +57,14 @@ check:
 'check:i18n':
   - 'checktextdomain'
 
+'update-version:beta':
+  - 'update-version:pluginFile'
+  - 'update-version:initializer'
+
+'update-version:release':
+  - 'update-version:readme'
+  - 'update-version:beta'
+
 artifact:
   - 'shell:production-composer-install'
   # Update the version numbers in the relevant files

--- a/grunt/config/update-version.js
+++ b/grunt/config/update-version.js
@@ -11,6 +11,8 @@ module.exports = {
 		},
 		src: "readme.txt",
 	},
+
+	// When changing or adding entries, make sure to update `aliases.yml` for "update-version-trunk".
 	pluginFile: {
 		options: {
 			regEx: /(\* Version: )(\d+(\.\d+){0,3})([^\n^\.\d]?.*?)(\n)/,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* we now have 2 seperate update-version commands
grunt update-version:beta
grunt update-version:release
This commit does not break the original update-version command

## Relevant technical choices:

* Creating extra grunt aliases

## Test instructions

This PR can be tested by following these steps:

1. Ensure you have all development dependency's for the project
2. Execute the new commands:
`grunt update-version:beta`
`grunt update-version:release`
3. Check if the command did what it was supposed to do.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8955