### PR TITLE
Remove header footer plugin conflict notice

### DIFF
--- a/admin/class-plugin-conflict.php
+++ b/admin/class-plugin-conflict.php
@@ -35,7 +35,6 @@ class WPSEO_Plugin_Conflict extends Yoast_Plugin_Conflict {
 			'facebook-thumb-fixer/_facebook-thumb-fixer.php',        // Facebook Thumb Fixer.
 			'facebook-and-digg-thumbnail-generator/facebook-and-digg-thumbnail-generator.php',
 			// Fedmich's Facebook Open Graph Meta.
-			'header-footer/plugin.php',                              // Header and Footer.
 			'network-publisher/networkpub.php',                      // Network Publisher.
 			'nextgen-facebook/nextgen-facebook.php',                 // NextGEN Facebook OG.
 			'opengraph/opengraph.php',                               // Open Graph.

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -222,7 +222,7 @@ class Yoast_Plugin_Conflict {
 	 *
 	 * @param string $plugin_file Clear the optional notification for this plugin.
 	 */
-	protected function clear_error( $plugin_file ) {
+	public function clear_error( $plugin_file ) {
 		$identifier = $this->get_notification_identifier( $plugin_file );
 
 		$notification_center = Yoast_Notification_Center::get();

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -516,7 +516,7 @@ class WPSEO_Upgrade {
 
 		// Remove possibly present plugin conflict notice for plugin that was removed from the list of conflicting plugins.
 		$yoast_plugin_conflict = WPSEO_Plugin_Conflict::get_instance();
-		$yoast_plugin_conflict->clear_error('header-footer/plugin.php');
+		$yoast_plugin_conflict->clear_error( 'header-footer/plugin.php' );
 
 		// Moves the user meta for excluding from the XML sitemap to a noindex.
 		global $wpdb;

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -514,6 +514,10 @@ class WPSEO_Upgrade {
 		}
 		delete_option( 'wpseo_internallinks' );
 
+		// Remove possibly present plugin conflict notice for plugin that was removed from the list of conflicting plugins.
+		$yoast_plugin_conflict = WPSEO_Plugin_Conflict::get_instance();
+		$yoast_plugin_conflict->clear_error('header-footer/plugin.php');
+
 		// Moves the user meta for excluding from the XML sitemap to a noindex.
 		global $wpdb;
 		$wpdb->query( "UPDATE $wpdb->usermeta SET meta_key = 'wpseo_noindex_author' WHERE meta_key = 'wpseo_excludeauthorsitemap'" );

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ Release Date: March 6th, 2018
     * Removes the clean permalinks feature, as it was created before canonical was introduced and is no longer needed.
     * Fixes a reference to the ACF Content Analysis for Yoast SEO plugin
     * Removes all functions, methods and files that were deprecated since before version 4.0 and were showing a deprecation warning.
+    * Removes the plugin conflict check for the `Head, Footer and Post Injections`-plugin as it no longer manages OpenGraph tags.
 
 ## Bugs:
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removed the plugin conflict notice for the Head, Footer and Post Injections plugin as it no longer manages OpenGraph tags.

## Test instructions

This PR can be tested by following these steps:

#### New notice is not being created
* Install plugin, see notice.
* Apply PR, see notice doesn't show.

#### Old notice is being removed
* With the notice active
* Reduce the version in the option: `wpseo` to below 7.0
* Make sure the notice is removed after reloading (the upgrade script will be triggered)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8951 