### PR TITLE
Change boundaries of taxonomy text length assessment

### DIFF
--- a/js/src/assessors/taxonomyAssessor.js
+++ b/js/src/assessors/taxonomyAssessor.js
@@ -11,7 +11,7 @@ var TitleWidth = require( "yoastseo/js/assessments/seo/pageTitleWidthAssessment.
 var UrlKeyword = require( "yoastseo/js/assessments/seo/urlKeywordAssessment.js" );
 var UrlLength = require( "yoastseo/js/assessments/seo/urlLengthAssessment.js" );
 var urlStopWords = require( "yoastseo/js/assessments/seo/urlStopWordsAssessment.js" );
-var taxonomyTextLength = require( "yoastseo/js/assessments/seo/taxonomyTextLengthAssessment" );
+var TextLength = require( "yoastseo/js/assessments/seo/textLengthAssessment.js" );
 
 /**
  * Creates the Assessor
@@ -29,12 +29,17 @@ var TaxonomyAssessor = function( i18n ) {
 		keywordStopWords,
 		metaDescriptionKeyword,
 		new MetaDescriptionLength(),
-		taxonomyTextLength,
 		titleKeyword,
 		new TitleWidth(),
 		new UrlKeyword(),
 		new UrlLength(),
 		urlStopWords,
+		new TextLength( {
+			recommendedMinimum: 250,
+			slightlyBelowMinimum: 200,
+			belowMinimum: 150,
+			veryFarBelowMinimum: 100,
+		} ),
 	];
 };
 

--- a/js/src/assessors/taxonomyAssessor.js
+++ b/js/src/assessors/taxonomyAssessor.js
@@ -46,4 +46,3 @@ var TaxonomyAssessor = function( i18n ) {
 module.exports = TaxonomyAssessor;
 
 require( "util" ).inherits( module.exports, Assessor );
-

--- a/js/tests/helpers/factory.js
+++ b/js/tests/helpers/factory.js
@@ -1,0 +1,19 @@
+// Make sure the Jed object is globally available
+let Jed = require('jed');
+
+let FactoryProto = function(){};
+
+FactoryProto.prototype.buildJed = function() {
+	return new Jed({
+		"domain": "js-text-analysis",
+		"locale_data": {
+			"js-text-analysis": {
+				"": {}
+			}
+		}
+	});
+};
+
+let Factory = new FactoryProto();
+
+module.exports = Factory;

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -1,0 +1,163 @@
+let Assessor = require( "../src/assessors/taxonomyAssessor.js" );
+let Paper = require("yoastseo/js/values/Paper.js");
+let factory = require( "yoastseo/spec/helpers/factory.js" );
+let i18n = factory.buildJed();
+let assessor = new Assessor( i18n );
+
+describe ( "running assessments in the assessor", function() {
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * keyphraseLength
+	 * MetaDescriptionLength
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		expect( assessor.getValidResults().length ).toBe( 4 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * keyphraseLength
+	 * MetaDescriptionLength
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "additionally runs assessments that only require a text", function() {
+		assessor.assess( new Paper( "text" ) );
+		expect( assessor.getValidResults().length ).toBe( 4 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * introductionKeyword
+	 * MetaDescriptionLength
+	 * titleKeyword
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		expect( assessor.getValidResults().length ).toBe( 5 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * introductionKeyword
+	 * MetaDescriptionLength
+	 * titleKeyword
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		expect( assessor.getValidResults().length ).toBe( 5 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * introductionKeyword
+	 * keywordStopWords
+	 * MetaDescriptionLength
+	 * titleKeyword
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require text and a keyword with a stopword", function() {
+		assessor.assess( new Paper( "text", { keyword: "the keyword" } ) );
+		expect( assessor.getValidResults().length ).toBe( 6 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * keyphraseLength
+	 * MetaDescriptionLength
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require a url", function() {
+		assessor.assess( new Paper( "text", { url: "sample url" } ) );
+		expect( assessor.getValidResults().length ).toBe( 4 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * keyphraseLength
+	 * MetaDescriptionLength
+	 * TitleWidth
+	 * UrlLength
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require a url that is too long", function() {
+		assessor.assess( new Paper( "text", { url: "12345678901234567890123456789012345678901" } ) );
+		expect( assessor.getValidResults().length ).toBe( 5 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * keyphraseLength
+	 * MetaDescriptionLength
+	 * TitleWidth
+	 * urlStopWords
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require a url with a stopword", function() {
+		assessor.assess( new Paper( "text", { url: "the sample url" } ) );
+		expect( assessor.getValidResults().length ).toBe( 5 );
+	} );
+
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * introductionKeyword
+	 * MetaDescriptionLength
+	 * titleKeyword
+	 * TitleWidth
+	 * UrlKeyword
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { url: "sample url", keyword: "keyword" } ) );
+		expect( assessor.getValidResults().length ).toBe( 6 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * introductionKeyword
+	 * keywordDensity
+	 * MetaDescriptionLength
+	 * titleKeyword
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
+		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id. Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas. Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		expect( assessor.getValidResults().length ).toBe( 6 );
+	} );
+
+	/*
+	 * Triggers the following assessments:
+	 *
+	 * introductionKeyword
+	 * metaDescriptionKeyword
+	 * MetaDescriptionLength
+	 * titleKeyword
+	 * TitleWidth
+	 * TextLength
+	 */
+	it( "additionally runs assessments that require a keyword and a meta description", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "description" } ) );
+		expect( assessor.getValidResults().length ).toBe( 6 );
+	} );
+} );

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -4,160 +4,169 @@ let factory = require( "yoastseo/spec/helpers/factory.js" );
 let i18n = factory.buildJed();
 let assessor = new Assessor( i18n );
 
+let getResults = function ( Results ) {
+	let assessments = [];
+
+	for ( let Result of Results ) {
+		assessments.push( Result._identifier );
+	}
+
+	return assessments;
+};
+
 describe ( "running assessments in the assessor", function() {
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * keyphraseLength
-	 * MetaDescriptionLength
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "runs assessments without any specific requirements", function() {
 		assessor.assess( new Paper( "" ) );
-		expect( assessor.getValidResults().length ).toBe( 4 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * keyphraseLength
-	 * MetaDescriptionLength
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "additionally runs assessments that only require a text", function() {
 		assessor.assess( new Paper( "text" ) );
-		expect( assessor.getValidResults().length ).toBe( 4 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * introductionKeyword
-	 * MetaDescriptionLength
-	 * titleKeyword
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 5 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"titleKeyword",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * introductionKeyword
-	 * MetaDescriptionLength
-	 * titleKeyword
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require text and a keyword", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 5 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"titleKeyword",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * introductionKeyword
-	 * keywordStopWords
-	 * MetaDescriptionLength
-	 * titleKeyword
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require text and a keyword with a stopword", function() {
 		assessor.assess( new Paper( "text", { keyword: "the keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 6 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordStopWords",
+			"metaDescriptionLength",
+			"titleKeyword",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * keyphraseLength
-	 * MetaDescriptionLength
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require a url", function() {
 		assessor.assess( new Paper( "text", { url: "sample url" } ) );
-		expect( assessor.getValidResults().length ).toBe( 4 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * keyphraseLength
-	 * MetaDescriptionLength
-	 * TitleWidth
-	 * UrlLength
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require a url that is too long", function() {
 		assessor.assess( new Paper( "text", { url: "12345678901234567890123456789012345678901" } ) );
-		expect( assessor.getValidResults().length ).toBe( 5 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"titleWidth",
+			"urlLength",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * keyphraseLength
-	 * MetaDescriptionLength
-	 * TitleWidth
-	 * urlStopWords
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require a url with a stopword", function() {
 		assessor.assess( new Paper( "text", { url: "the sample url" } ) );
-		expect( assessor.getValidResults().length ).toBe( 5 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"titleWidth",
+			"urlStopWords",
+			"textLength"
+		] );
 	} );
 
-
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * introductionKeyword
-	 * MetaDescriptionLength
-	 * titleKeyword
-	 * TitleWidth
-	 * UrlKeyword
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require a url and a keyword", function() {
 		assessor.assess( new Paper( "text", { url: "sample url", keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 6 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionLength",
+			"titleKeyword",
+			"titleWidth",
+			"urlKeyword",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * introductionKeyword
-	 * keywordDensity
-	 * MetaDescriptionLength
-	 * titleKeyword
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
 		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id. Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas. Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
-		expect( assessor.getValidResults().length ).toBe( 6 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"titleKeyword",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 
-	/*
-	 * Triggers the following assessments:
-	 *
-	 * introductionKeyword
-	 * metaDescriptionKeyword
-	 * MetaDescriptionLength
-	 * titleKeyword
-	 * TitleWidth
-	 * TextLength
-	 */
 	it( "additionally runs assessments that require a keyword and a meta description", function() {
 		assessor.assess( new Paper( "text", { keyword: "keyword", description: "description" } ) );
-		expect( assessor.getValidResults().length ).toBe( 6 );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"metaDescriptionKeyword",
+			"metaDescriptionLength",
+			"titleKeyword",
+			"titleWidth",
+			"textLength"
+		] );
 	} );
 } );

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -1,5 +1,5 @@
 let Assessor = require( "../src/assessors/taxonomyAssessor.js" );
-let Paper = require("yoastseo/js/values/Paper.js");
+let Paper = require( "yoastseo/js/values/Paper.js" );
 let factory = require( "./helpers/factory.js" );
 let i18n = factory.buildJed();
 let assessor = new Assessor( i18n );
@@ -55,21 +55,7 @@ describe ( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require text and a keyword", function() {
-		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		let AssessmentResults = assessor.getValidResults();
-		let assessments = getResults( AssessmentResults );
-
-		expect( assessments ).toEqual( [
-			"introductionKeyword",
-			"metaDescriptionLength",
-			"titleKeyword",
-			"titleWidth",
-			"textLength"
-		] );
-	} );
-
-	it( "additionally runs assessments that require text and a keyword with a stopword", function() {
+	it( "additionally runs assessments that require a keyword with a stopword", function() {
 		assessor.assess( new Paper( "text", { keyword: "the keyword" } ) );
 		let AssessmentResults = assessor.getValidResults();
 		let assessments = getResults( AssessmentResults );

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -1,6 +1,6 @@
 let Assessor = require( "../src/assessors/taxonomyAssessor.js" );
 let Paper = require("yoastseo/js/values/Paper.js");
-let factory = require( "yoastseo/spec/helpers/factory.js" );
+let factory = require( "./helpers/factory.js" );
 let i18n = factory.buildJed();
 let assessor = new Assessor( i18n );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the boundaries of the taxonomy text length assessment to the following values:
  * Red: 0-200 words (slightly below minimum: 200-250, below minimum: 150-200,  far below minimum: 100-150, very far below minimum: under 100)
  * Orange: 200-250 words
  * Green: 250+ words

## Relevant technical choices:

* Makes use of the `TextLength` assessment, passing along the appropriate values instead of making use of the separate `taxonomyTextLength` assessment. (The  `taxonomyTextLength` assessment will subsequently be deleted from yoastseo.js).
* Adds unit tests for the taxonomy assessor.

## Test instructions

This PR can be tested by following these steps:

* Check out the branch. Don't forget to run `grunt build:js`.
* Add a new category in `Posts > Categories`. Add a description.
* Vary the length of the description. Make sure there are appropriate feedback messages according to the new boundaries.

Fixes #8986