### PR TITLE
Rename Dashboard to General

### DIFF
--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -207,7 +207,7 @@ class WPSEO_Admin_Menu implements WPSEO_WordPress_Integration {
 		// Use WordPress global $submenu to directly access it's properties.
 		global $submenu;
 		if ( isset( $submenu[ $this->menu->get_page_identifier() ] ) && WPSEO_Capability_Utils::current_user_can( $this->get_manage_capability() ) ) {
-			$submenu[ $this->menu->get_page_identifier() ][0][0] = __( 'Dashboard', 'wordpress-seo' );
+			$submenu[ $this->menu->get_page_identifier() ][0][0] = __( 'General', 'wordpress-seo' );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Renames the Dashboard menu item to General

## Test instructions

This PR can be tested by following these steps:

* Look at the sidebar menu and see the first submenu change to General.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9033 
Fixes https://github.com/Yoast/wordpress-seo/issues/8989