### PR TITLE
Changed wording on index-toggle in advanced metabox

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -83,10 +83,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			self::$meta_fields['advanced']['meta-robots-noindex']['description'] = '<p class="error-message">' . __( 'Warning: even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, so these settings won\'t have an effect.', 'wordpress-seo' ) . '</p>';
 		}
 		/* translators: %1$s expands to Yes or No,  %2$s expands to the post type name.*/
-		self::$meta_fields['advanced']['meta-robots-noindex']['options']['0'] = __( '%1$s (default for %2$s)', 'wordpress-seo' );
+		self::$meta_fields['advanced']['meta-robots-noindex']['options']['0'] = __( 'Default setting for %2$s, currently: %1$s', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-noindex']['options']['2'] = __( 'Yes', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-noindex']['options']['1'] = __( 'No', 'wordpress-seo' );
-
+		
 		/* translators: %1$s expands to the post type name.*/
 		self::$meta_fields['advanced']['meta-robots-nofollow']['title']        = __( 'Should search engines follow links on this %1$s?', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-nofollow']['options']['0'] = __( 'Yes', 'wordpress-seo' );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -83,10 +83,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			self::$meta_fields['advanced']['meta-robots-noindex']['description'] = '<p class="error-message">' . __( 'Warning: even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, so these settings won\'t have an effect.', 'wordpress-seo' ) . '</p>';
 		}
 		/* translators: %1$s expands to Yes or No,  %2$s expands to the post type name.*/
-		self::$meta_fields['advanced']['meta-robots-noindex']['options']['0'] = __( 'Default setting for %2$s, currently: %1$s', 'wordpress-seo' );
+		self::$meta_fields['advanced']['meta-robots-noindex']['options']['0'] = __( 'Default for %2$s, currently: %1$s', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-noindex']['options']['2'] = __( 'Yes', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-noindex']['options']['1'] = __( 'No', 'wordpress-seo' );
-		
+
 		/* translators: %1$s expands to the post type name.*/
 		self::$meta_fields['advanced']['meta-robots-nofollow']['title']        = __( 'Should search engines follow links on this %1$s?', 'wordpress-seo' );
 		self::$meta_fields['advanced']['meta-robots-nofollow']['options']['0'] = __( 'Yes', 'wordpress-seo' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the wording on the drop down menu in the advanced tab of the metabox. It changed from Yes (Default for Posts) / Yes / No, to:
Default for Posts, currently: Yes / Yes / No

## Test instructions

This PR can be tested by following these steps:

* Make sure the advanced tab is enabled. Go to the metabox under a page or post and check the dropdown menu under "Allow search engines to show this Page in search results?". The naming should have changed according to the description above. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #8949 
