### PR TITLE
Avoid ini value parsing

### DIFF
--- a/admin/class-import.php
+++ b/admin/class-import.php
@@ -142,6 +142,11 @@ class WPSEO_Import {
 	 * Parse the option file
 	 */
 	private function parse_options() {
+		/*
+		 * Implemented INI_SCANNER_RAW to make sure variables aren't parsed.
+		 *
+		 * http://php.net/manual/en/function.parse-ini-file.php#99943
+		 */
 		$options = parse_ini_file( $this->filename, true, INI_SCANNER_RAW );
 
 		if ( is_array( $options ) && $options !== array() ) {

--- a/admin/class-import.php
+++ b/admin/class-import.php
@@ -142,7 +142,7 @@ class WPSEO_Import {
 	 * Parse the option file
 	 */
 	private function parse_options() {
-		$options = parse_ini_file( $this->filename, true );
+		$options = parse_ini_file( $this->filename, true, INI_SCANNER_RAW );
 
 		if ( is_array( $options ) && $options !== array() ) {
 			if ( isset( $options['wpseo']['version'] ) && $options['wpseo']['version'] !== '' ) {


### PR DESCRIPTION
Related: http://php.net/manual/en/function.parse-ini-file.php#99943

By using the `INI_SCANNER_RAW` argument, script variables will not be parsed and just used raw as input.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where importing of the values of ini files are being parsed for dynamic content.

## Relevant technical choices:

* Implement the available argument to not parse dynamic values.

## Test instructions

This PR can be tested by following these steps:

* See #dev-plugin for context