### PR TITLE
7812 pass args to replacement filter

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -168,11 +168,12 @@ class WPSEO_Replace_Vars {
 		/**
 		 * Filter: 'wpseo_replacements' - Allow customization of the replacements before they are applied.
 		 *
-		 * @api array $replacements The replacements.
+		 * @api     array   $replacements The replacements.
 		 *
-		 * @param object $args Optional argument which can be a post or term instance.
+		 * @param   array   $args The object some of the replacement values might come from,
+		 *                       could be a post, taxonomy or term.
 		 */
-		$replacements = apply_filters( 'wpseo_replacements', $replacements, $args );
+		$replacements = apply_filters( 'wpseo_replacements', $replacements, $this->args );
 
 		// Do the actual replacements.
 		if ( is_array( $replacements ) && $replacements !== array() ) {

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -171,7 +171,6 @@ class WPSEO_Replace_Vars {
 		 * @api array $replacements The replacements.
 		 *
 		 * @param object $args Optional argument which can be a post or term instance.
-		 *
 		 */
 		$replacements = apply_filters( 'wpseo_replacements', $replacements, $args );
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -170,7 +170,7 @@ class WPSEO_Replace_Vars {
 		 *
 		 * @api array $replacements The replacements.
 		 */
-		$replacements = apply_filters( 'wpseo_replacements', $replacements );
+		$replacements = apply_filters( 'wpseo_replacements', $replacements, $args );
 
 		// Do the actual replacements.
 		if ( is_array( $replacements ) && $replacements !== array() ) {

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -169,6 +169,9 @@ class WPSEO_Replace_Vars {
 		 * Filter: 'wpseo_replacements' - Allow customization of the replacements before they are applied.
 		 *
 		 * @api array $replacements The replacements.
+		 *
+		 * @param object $args Optional argument which can be a post or term instance.
+		 *
 		 */
 		$replacements = apply_filters( 'wpseo_replacements', $replacements, $args );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds an extra argument to `wpseo_replacements` filter. This makes it possible to access post, taxonomy or term instances when applying the filter.

## Test instructions

This PR can be tested by following these steps:
* This PR can be tested by adding a filter manually and calling it. For example in the functions.php file which can be found in the wp-admin panel by go to Appearance->Editor. 
* Example code that should now work and would not have worked before:

```
function do_something_with_replacements( $replacements, $args ) {
	$replacements['%%my_custom_replacement%%'] = get_post_meta($args->ID, 'my_meta', true);
	return $replacements;
};

add_filter( 'wpseo_replacements', 'do_something_with_replacements', 10, 2 );
```

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #7812 
