### PR TITLE
Fix faulty noindex in post, page, category and tag overview

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -542,11 +542,11 @@ class WPSEO_Meta_Columns {
 	 * @return bool Whether or not it is indexable.
 	 */
 	protected function is_indexable( $post_id ) {
-		if ( WPSEO_Meta::get_value( 'meta-robots-noindex', $post_id ) === '1' ) {
-			return false;
-		}
-
 		$post = get_post( $post_id );
+
+		if ( ! $this->uses_default_indexing( $post_id ) ) {
+			return WPSEO_Meta::get_value( 'meta-robots-noindex', $post_id ) === '2';
+		}
 
 		if ( is_object( $post ) ) {
 			// If the option is false, this means we want to index it.
@@ -554,6 +554,17 @@ class WPSEO_Meta_Columns {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Determines whether the given post ID uses the default indexing settings.
+	 *
+	 * @param integer $post_id The post ID to check.
+	 *
+	 * @return bool Whether or not the default indexing is being used for the post.
+	 */
+	protected function uses_default_indexing( $post_id ) {
+		return WPSEO_Meta::get_value( 'meta-robots-noindex', $post_id ) === '0';
 	}
 	
 	/**

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -535,6 +535,28 @@ class WPSEO_Meta_Columns {
 	}
 
 	/**
+	 * Determines whether a particular post_id is of an indexable post type.
+	 *
+	 * @param string $post_id The post ID to check.
+	 *
+	 * @return bool Whether or not it is indexable.
+	 */
+	protected function is_indexable( $post_id ) {
+		if ( WPSEO_Meta::get_value( 'meta-robots-noindex', $post_id ) === '1' ) {
+			return false;
+		}
+
+		$post = get_post( $post_id );
+
+		if ( is_object( $post ) ) {
+			// If the option is false, this means we want to index it.
+			return WPSEO_Options::get( 'noindex-' . $post->post_type, false ) === false;
+		}
+
+		return true;
+	}
+	
+	/**
 	 * Returns filters when $order_by is matched in the if-statement.
 	 *
 	 * @param string $order_by The ID of the column by which to order the posts.
@@ -567,7 +589,7 @@ class WPSEO_Meta_Columns {
 	 * @return string The HTML for the SEO score indicator.
 	 */
 	private function parse_column_score( $post_id ) {
-		if ( WPSEO_Meta::get_value( 'meta-robots-noindex', $post_id ) === '1' ) {
+		if ( ! $this->is_indexable( $post_id ) ) {
 			$rank  = new WPSEO_Rank( WPSEO_Rank::NO_INDEX );
 			$title = __( 'Post is set to noindex.', 'wordpress-seo' );
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -566,7 +566,7 @@ class WPSEO_Meta_Columns {
 	protected function uses_default_indexing( $post_id ) {
 		return WPSEO_Meta::get_value( 'meta-robots-noindex', $post_id ) === '0';
 	}
-	
+
 	/**
 	 * Returns filters when $order_by is matched in the if-statement.
 	 *

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -542,11 +542,11 @@ class WPSEO_Meta_Columns {
 	 * @return bool Whether or not it is indexable.
 	 */
 	protected function is_indexable( $post_id ) {
-		$post = get_post( $post_id );
-
-		if ( ! $this->uses_default_indexing( $post_id ) ) {
+		if ( ! empty( $post_id ) && ! $this->uses_default_indexing( $post_id ) ) {
 			return WPSEO_Meta::get_value( 'meta-robots-noindex', $post_id ) === '2';
 		}
+
+		$post = get_post( $post_id );
 
 		if ( is_object( $post ) ) {
 			// If the option is false, this means we want to index it.

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -173,19 +173,22 @@ class WPSEO_Taxonomy_Columns {
 	 *
 	 * @param mixed $term The current term.
 	 *
-	 * @return bool
+	 * @return bool Whether or not the term is indexable.
 	 */
 	private function is_indexable( $term ) {
 		// When the no_index value is not empty and not default, check if its value is index.
 		$no_index = WPSEO_Taxonomy_Meta::get_term_meta( $term->term_id, $this->taxonomy, 'noindex' );
+
+		// Check if the default for taxonomy is empty (this will be index).
 		if ( ! empty( $no_index ) && $no_index !== 'default' ) {
 			return ( $no_index === 'index' );
 		}
 
-		// Check if the default for taxonomy is empty (this will be index).
-		$no_index_key = 'noindex-tax-' . $term->taxonomy;
 		if ( is_object( $term ) ) {
-			return WPSEO_Options::get( $no_index_key, false );
+			$no_index_key = 'noindex-tax-' . $term->taxonomy;
+
+			// If the option is false, this means we want to index it.
+			return WPSEO_Options::get( $no_index_key, false ) === false;
 		}
 
 		return true;

--- a/tests/doubles/wpseo-meta-columns-double.php
+++ b/tests/doubles/wpseo-meta-columns-double.php
@@ -9,27 +9,59 @@
 class WPSEO_Meta_Columns_Double extends WPSEO_Meta_Columns {
 	private $current_post_type;
 
+	/**
+	 * @inheritdoc
+	 */
 	public function determine_seo_filters( $seo_filter ) {
 		return parent::determine_seo_filters( $seo_filter );
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	public function determine_readability_filters( $readability_filter ) {
 		return parent::determine_readability_filters( $readability_filter );
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	public function is_valid_filter( $filter ) {
 		return parent::is_valid_filter( $filter );
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	public function build_filter_query( $vars, $filter ) {
 		return parent::build_filter_query( $vars, $filter );
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	public function set_current_post_type( $post_type ) {
 		$this->current_post_type = $post_type;
 	}
-	
+
+	/**
+	 * @inheritdoc
+	 */
 	public function get_current_post_type() {
 		return $this->current_post_type;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function is_indexable( $post_id ) {
+		return parent::is_indexable( $post_id );
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function uses_default_indexing( $post_id ) {
+		return parent::uses_default_indexing( $post_id );
 	}
 }

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -22,6 +22,11 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 		self::$class_instance = new WPSEO_Meta_Columns_Double();
 	}
 
+	/**
+	 * Determines what dataprovider to use for SEO filters.
+	 *
+	 * @return array The SEO filters dataprovider.
+	 */
 	public function determine_seo_filters_dataprovider() {
 		return array(
 			array(
@@ -134,6 +139,11 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Determines what dataprovider to use for Readability filters.
+	 *
+	 * @return array The Readability filters dataprovider.
+	 */
 	public function build_filter_query_dataprovider() {
 		return array(
 			array(
@@ -396,5 +406,99 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 		$result = self::$class_instance->build_filter_query( $vars, $filters );
 
 		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Tests whether the default indexing is being used.
+	 *
+	 * @covers WPSEO_Meta_Columns::uses_default_indexing()
+	 */
+	public function test_is_using_default_indexing() {
+		$post = $this->factory()->post->create_and_get( array() );
+
+		// Set metavalue
+		WPSEO_Meta::set_value( 'meta-robots-noindex', '0', $post->ID );
+
+		$uses_default_indexing = self::$class_instance->uses_default_indexing( $post->ID );
+
+		$this->assertTrue( $uses_default_indexing );
+	}
+
+	/**
+	 * Tests whether the default indexing is not being used.
+	 *
+	 * @covers WPSEO_Meta_Columns::uses_default_indexing()
+	 */
+	public function test_is_not_using_default_indexing() {
+		$post = $this->factory()->post->create_and_get( array() );
+
+		// Set metavalue
+		WPSEO_Meta::set_value( 'meta-robots-noindex', '1', $post->ID );
+
+		$uses_default_indexing = self::$class_instance->uses_default_indexing( $post->ID );
+
+		$this->assertFalse( $uses_default_indexing );
+	}
+
+	/**
+	 * Tests whether a hard set indexing value on a post, is considered indexable.
+	 *
+	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 */
+	public function test_is_indexable_when_set_on_post() {
+		$post = $this->factory()->post->create_and_get( array() );
+
+		// Set metavalue
+		WPSEO_Meta::set_value( 'meta-robots-noindex', '2', $post->ID );
+
+		$is_indexable = self::$class_instance->is_indexable( $post->ID );
+
+		$this->assertTrue( $is_indexable );
+	}
+
+	/**
+	 * Tests whether a not hard set indexing value on a post, is considered indexable based on the default setting.
+	 *
+	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 */
+	public function test_is_indexable_when_using_default() {
+		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+
+		// Set metavalue
+		WPSEO_Meta::set_value( 'meta-robots-noindex', '0', $post->ID );
+		WPSEO_Options::set( 'noindex-post', false );
+
+		$is_indexable = self::$class_instance->is_indexable( $post->ID );
+
+		$this->assertTrue( $is_indexable );
+	}
+
+	/**
+	 * Tests whether a not hard set indexing value on a post, is considered not indexable based on the default setting.
+	 *
+	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 */
+	public function test_is_not_indexable_when_using_default() {
+		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+
+		// Set metavalue
+		WPSEO_Meta::set_value( 'meta-robots-noindex', '0', $post->ID );
+		WPSEO_Options::set( 'noindex-post', true );
+
+		$is_indexable = self::$class_instance->is_indexable( $post->ID );
+
+		$this->assertFalse( $is_indexable );
+	}
+
+	/**
+	 * Tests whether a malformed post object defaults to true.
+	 *
+	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 */
+	public function test_is_indexable_when_using_malformed_post_object() {
+		$post         = '';
+		$is_indexable = self::$class_instance->is_indexable( $post );
+
+		$this->assertTrue( $is_indexable );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where the overview pages were incorrectly showing categories / tags marked as `noindex` when in reality they weren't set to `noindex` (and vice versa). This meant that blue bullets were being shown incorrectly.
* Fixes an issue where setting posts and pages to `noindex` didn't change the overview.

## Relevant technical choices:

* Individually setting a post to `index` when the post type is set to `noindex`, overrules the parent setting for that specific post/page/category/tag.

## Test instructions

This PR can be tested by following these steps:

* Set `Show Posts in search results?` to "No" in SEO -> Search Appearance -> Content Types.
* Check that the SEO column in the Posts overview only displays blue bullets.
* Override the index setting for a single post (set it to "Yes").
* Check that the SEO column in the Posts overview, displays the proper bullet for that specific post.
* Set `Show Posts in search results?` to "Yes" in SEO -> Search Appearance -> Content Types.
* Check that the SEO column in the Posts overview displays the various, colored bullets.
* Override the index setting for a single post (set it to "No").
* Check that the SEO column in the Posts overview, displays the proper bullet for that specific post.

**Optional**
* Replicate this behavior for Pages, Categories and Tags.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9022 
