### PR TITLE
Non-public post types shouldn't show in post type archives overview

### DIFF
--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -44,6 +44,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 
 $post_types = get_post_types(
 	array(
+		'public' => true,
 		'_builtin'    => false,
 		'has_archive' => true,
 	),

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -44,7 +44,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 
 $post_types = get_post_types(
 	array(
-		'public' => true,
+		'public'      => true,
 		'_builtin'    => false,
 		'has_archive' => true,
 	),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* No longer show non-public post types in the Post type archives list on the Content Types tab under Search Appearance.

## Test instructions

This PR can be tested by following these steps:

* Create a non-public post type with a post type archive. See the difference.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended

Fixes #9058