### PR TITLE
Gutenberg: Remove grey dots in content analysis

### DIFF
--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -369,7 +369,7 @@ td.column-wpseo-linked {
 	margin-top: 0.5em;
 }
 
-.wpseo-premium-advantages-list {
+.yoast.wpseo-metabox .wpseo-premium-description .wpseo-premium-advantages-list {
 	list-style: disc;
 	padding-left: 1.5em;
 }

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -320,20 +320,6 @@ ul.wpseo-metabox-tabs li {
 	background-color: lightyellow;
 }
 
-#focuskwresults ul {
-	margin: 0;
-}
-
-#focuskwresults p,
-#focuskwresults li {
-	font-size: 13px;
-}
-
-#focuskwresults li {
-	margin: 0 0 0 20px;
-	list-style-type: disc;
-}
-
 .wpseo_hidden {
 	display: none;
 }

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -45,9 +45,8 @@ ul.wpseo-metabox-tabs:after {
 	clear: both;
 }
 
-#wpseo_meta.wpseo-metabox .wpseo-metabox-content ul {
+.yoast.wpseo-metabox .wpseo-metabox-content ul {
 	list-style: none;
-	list-style-type: none;
 }
 
 ul.wpseo-metabox-tabs li.active {

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -45,8 +45,9 @@ ul.wpseo-metabox-tabs:after {
 	clear: both;
 }
 
-.wpseo-metabox-tabs-div ul {
+#wpseo_meta.wpseo-metabox .wpseo-metabox-content ul {
 	list-style: none;
+	list-style-type: none;
 }
 
 ul.wpseo-metabox-tabs li.active {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Gutenberg: Remove grey dots in content analysis.

## Relevant technical choices:

* Made the CSS rule more specific to override the Gutenberg one.
* There are 2 UL's that I combined with this 1 CSS rule. If the css in Gutenberg is made to be less specific the traffic light UL CSS rule would probably still need to be more specific.

## Test instructions

This PR can be tested by following these steps:

1. Activate Gutenberg.
2. Go to a post.
3. Confirm it no longer has these circles:
<img width="554" alt="36780333-f694b15e-1c72-11e8-86d1-15a9f38f8b5d" src="https://user-images.githubusercontent.com/35524806/36796703-7a5ba050-1ca6-11e8-943d-6f77fbb0334e.png">
4. Deactivate Gutenberg and check if it still looks good there too.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/gutenberg/issues/25
