### PR TITLE
Removed old command from grunt aliases

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -66,8 +66,6 @@ check:
   - 'shell:production-composer-install'
   # Build like we normally would
   - 'release'
-  # Copy files and create a zip file
-  - 'create-artifact'
   # Remove build folder
   - 'clean:artifact'
   # Copy only the relevant files to the folder


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where an old alias was still present in the aliases file which lead to `grunt artifact` to fail.

## Test instructions

This PR can be tested by following these steps:

* Run `grunt artifact` and ensure that it completes successfully.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
