### PR TITLE
Subscribe to Gutenberg's data API

### DIFF
--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -1,5 +1,4 @@
 /* global jQuery, YoastSEO, wpseoPostScraperL10n */
-import isEmpty from "lodash/isEmpty";
 
 import isKeywordAnalysisActive from "./isKeywordAnalysisActive";
 import removeMarks from "yoastseo/js/markers/removeMarks";
@@ -10,9 +9,8 @@ import getIndicatorForScore from "./getIndicatorForScore";
 import { update as updateTrafficLight } from "../ui/trafficLight";
 import { update as updateAdminBar }from "../ui/adminBar";
 
-import { getData } from  "./data";
-
 import publishBox from "../ui/publishBox";
+import isGutenbergDataAvailable from "../helpers/isGutenbergDataAvailable";
 
 let $ = jQuery;
 let currentKeyword = "";
@@ -21,6 +19,7 @@ let currentKeyword = "";
  * Show warning in console when the unsupported CkEditor is used
  *
  * @param {Object} args The arguments for the post scraper.
+ * @param {Object} args.data The data.
  * @param {TabManager} args.tabManager The tab manager for this post.
  *
  * @constructor
@@ -30,6 +29,7 @@ let PostDataCollector = function( args ) {
 		console.warn( "YoastSEO currently doesn't support ckEditor. The content analysis currently only works with the HTML editor or TinyMCE." );
 	}
 
+	this._data = args.data;
 	this._tabManager = args.tabManager;
 };
 
@@ -42,9 +42,9 @@ let PostDataCollector = function( args ) {
 PostDataCollector.prototype.getData = function() {
 	let gutenbergData;
 
-	// Only use data from Gutenberg if the Gutenberg data object isn't empty.
-	if( ! isEmpty( getData() ) ) {
-		gutenbergData = getData();
+	// Only use data from Gutenberg if Gutenberg is available.
+	if ( isGutenbergDataAvailable() ) {
+		gutenbergData = this._data.getData();
 	}
 
 	return {

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -54,7 +54,7 @@ PostDataCollector.prototype.getData = function() {
 		text: gutenbergData && gutenbergData.content ? gutenbergData.content : text,
 		title: gutenbergData && gutenbergData.title ? gutenbergData.title : this.getTitle(),
 		url: gutenbergData && gutenbergData.slug ? gutenbergData.slug : this.getUrl(),
-		excerpt: this.getExcerpt(),
+		excerpt: gutenbergData && gutenbergData.excerpt ? gutenbergData.excerpt : this.getExcerpt(),
 		snippetTitle: this.getSnippetTitle(),
 		snippetMeta: this.getSnippetMeta(),
 		snippetCite: this.getSnippetCite(),

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -1,4 +1,6 @@
 /* global jQuery, YoastSEO, wpseoPostScraperL10n */
+import isEmpty from "lodash/isEmpty";
+
 
 import isKeywordAnalysisActive from "./isKeywordAnalysisActive";
 import removeMarks from "yoastseo/js/markers/removeMarks";
@@ -40,26 +42,12 @@ let PostDataCollector = function( args ) {
  */
 PostDataCollector.prototype.getData = function() {
 	let gutenbergData;
-	if( getData() && getData().isDirty ) {
-		gutenbergData = getData().data;
+
+	// Only use data from Gutenberg if the Gutenberg data object isn't empty.
+	if( ! isEmpty( getData() ) ) {
+		gutenbergData = getData();
 	}
 	let text = this.getText();
-
-	console.log( {
-		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",
-		meta: this.getMeta(),
-		text: gutenbergData && gutenbergData.content ? gutenbergData.content : text,
-		title: gutenbergData && gutenbergData.title ? gutenbergData.title : this.getTitle(),
-		url: gutenbergData && gutenbergData.slug ? gutenbergData.slug : this.getUrl(),
-		excerpt: this.getExcerpt(),
-		snippetTitle: this.getSnippetTitle(),
-		snippetMeta: this.getSnippetMeta(),
-		snippetCite: this.getSnippetCite(),
-		primaryCategory: this.getPrimaryCategory(),
-		searchUrl: this.getSearchUrl(),
-		postUrl: this.getPostUrl(),
-		permalink: this.getPermalink(),
-	} );
 
 	return {
 		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -46,12 +46,11 @@ PostDataCollector.prototype.getData = function() {
 	if( ! isEmpty( getData() ) ) {
 		gutenbergData = getData();
 	}
-	let text = this.getText();
 
 	return {
 		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",
 		meta: this.getMeta(),
-		text: gutenbergData && gutenbergData.content ? gutenbergData.content : text,
+		text: gutenbergData && gutenbergData.content ? gutenbergData.content : this.getText(),
 		title: gutenbergData && gutenbergData.title ? gutenbergData.title : this.getTitle(),
 		url: gutenbergData && gutenbergData.slug ? gutenbergData.slug : this.getUrl(),
 		excerpt: gutenbergData && gutenbergData.excerpt ? gutenbergData.excerpt : this.getExcerpt(),

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -1,7 +1,6 @@
 /* global jQuery, YoastSEO, wpseoPostScraperL10n */
 import isEmpty from "lodash/isEmpty";
 
-
 import isKeywordAnalysisActive from "./isKeywordAnalysisActive";
 import removeMarks from "yoastseo/js/markers/removeMarks";
 import tmceHelper from "../wp-seo-tinymce";

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -9,8 +9,9 @@ import getIndicatorForScore from "./getIndicatorForScore";
 import { update as updateTrafficLight } from "../ui/trafficLight";
 import { update as updateAdminBar }from "../ui/adminBar";
 
+import { getData } from  "./data";
+
 import publishBox from "../ui/publishBox";
-import _get from "lodash/get";
 
 let $ = jQuery;
 let currentKeyword = "";
@@ -33,28 +34,39 @@ let PostDataCollector = function( args ) {
 
 /**
  * Get data from input fields and store them in an analyzerData object. This object will be used to fill
- * the analyzer and the snippet preview.
+ * the analyzer and the snippet preview. If Gutenberg data is available, use it.
  *
- * @returns {void}
+ * @returns {Object} The data.
  */
 PostDataCollector.prototype.getData = function() {
+	let gutenbergData;
+	if( getData() && getData().isDirty ) {
+		gutenbergData = getData().data;
+	}
 	let text = this.getText();
 
-	/*
-	 * Gutenberg exposes a global on the window. Which is `_wpGutenbergPost`. The post has two content
-	 * properties: `rendered` and `raw`. For the content analysis we are interested in the rendered content.
-	 */
-	let gutenbergContent = _get( window, "_wpGutenbergPost.content.rendered", "" );
-	if ( gutenbergContent !== "" ) {
-		text = gutenbergContent;
-	}
+	console.log( {
+		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",
+		meta: this.getMeta(),
+		text: gutenbergData && gutenbergData.content ? gutenbergData.content : text,
+		title: gutenbergData && gutenbergData.title ? gutenbergData.title : this.getTitle(),
+		url: gutenbergData && gutenbergData.slug ? gutenbergData.slug : this.getUrl(),
+		excerpt: this.getExcerpt(),
+		snippetTitle: this.getSnippetTitle(),
+		snippetMeta: this.getSnippetMeta(),
+		snippetCite: this.getSnippetCite(),
+		primaryCategory: this.getPrimaryCategory(),
+		searchUrl: this.getSearchUrl(),
+		postUrl: this.getPostUrl(),
+		permalink: this.getPermalink(),
+	} );
 
 	return {
 		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",
 		meta: this.getMeta(),
-		text,
-		title: this.getTitle(),
-		url: this.getUrl(),
+		text: gutenbergData && gutenbergData.content ? gutenbergData.content : text,
+		title: gutenbergData && gutenbergData.title ? gutenbergData.title : this.getTitle(),
+		url: gutenbergData && gutenbergData.slug ? gutenbergData.slug : this.getUrl(),
 		excerpt: this.getExcerpt(),
 		snippetTitle: this.getSnippetTitle(),
 		snippetMeta: this.getSnippetMeta(),

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,4 +1,4 @@
-/* global wp */
+/* global wp YoastSEO */
 import debounce from "lodash/debounce";
 
 let data = {};
@@ -42,14 +42,11 @@ const isShallowEqual = ( currentData, gutenbergData ) => {
  * @returns {Object} The data.
  */
 const updateData = ( data, gutenbergData ) => {
-	isDirty = false;
-	if ( ! data ) {
-		data = gutenbergData;
-		isDirty = true;
-	}
 	// Set isDirty to false if the current data and Gutenberg data are unequal.
 	isDirty = ! isShallowEqual( data, gutenbergData );
-	if ( data && isDirty ) {
+
+	// If there is new data from Gutenberg, overwrite the data object with the new data.
+	if ( isDirty ) {
 		data = gutenbergData;
 	}
 	return data;
@@ -67,7 +64,12 @@ const getGutenbergData = () => {
 		title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
 		slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
 	};
-	updateData( data, gutenbergData );
+	data = updateData( data, gutenbergData );
+
+	if ( isDirty ) {
+		YoastSEO.app.refresh();
+	}
+	isDirty = false;
 };
 
 const subscriber = debounce( getGutenbergData, 500 );
@@ -83,15 +85,11 @@ export const subscribeToGutenberg = function() {
 	);
 };
 
-// Todo: Single responsibility.
 /**
  * Returns the data and whether the data is dirty.
  *
  * @returns {Object} The data and whether the data is dirty.
  */
 export const getData = () => {
-	return {
-		data: data,
-		isDirty: isDirty,
-	};
+	return data;
 };

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -2,7 +2,6 @@
 import debounce from "lodash/debounce";
 
 let data = {};
-let isDirty;
 
 /**
  * Checks whether the current data and the Gutenberg data are the same.
@@ -19,32 +18,7 @@ const isShallowEqual = ( currentData, gutenbergData ) => {
 			}
 		}
 	}
-	for( let dataPoint in gutenbergData ) {
-		if ( gutenbergData.hasOwnProperty( dataPoint ) ) {
-			if( ! ( dataPoint in currentData ) || currentData[ dataPoint ] !== gutenbergData[ dataPoint ] ) {
-				return false;
-			}
-		}
-	}
 	return true;
-};
-
-/**
- * Updates the data object.
- *
- * @param {Object} data The current data.
- * @param {Object} gutenbergData The data from Gutenberg.
- * @returns {Object} The data.
- */
-const updateData = ( data, gutenbergData ) => {
-	// Set isDirty to false if the current data and Gutenberg data are unequal.
-	isDirty = ! isShallowEqual( data, gutenbergData );
-
-	// If there is new data from Gutenberg, overwrite the data object with the new data.
-	if ( isDirty ) {
-		data = gutenbergData;
-	}
-	return data;
 };
 
 /**
@@ -68,12 +42,14 @@ const collectGutenbergData =  () => {
  */
 const refreshYoastSEO = () => {
 	let gutenbergData = collectGutenbergData();
-	data = updateData( data, gutenbergData );
+
+	// Set isDirty to false if the current data and Gutenberg data are unequal.
+	let isDirty = ! isShallowEqual( data, gutenbergData );
 
 	if ( isDirty ) {
+		data = gutenbergData;
 		YoastSEO.app.refresh();
 	}
-	isDirty = false;
 };
 
 const subscriber = debounce( refreshYoastSEO, 500 );

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -85,7 +85,7 @@ class Data {
 	refreshYoastSEO() {
 		let gutenbergData = this.collectGutenbergData( this.getPostAttribute );
 
-		// Set isDirty to false if the current data and Gutenberg data are unequal.
+		// Set isDirty to true if the current data and Gutenberg data are unequal.
 		let isDirty = ! this.isShallowEqual( this.data, gutenbergData );
 
 		if ( isDirty ) {

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -16,6 +16,18 @@ class Data {
 		this._refresh = refresh;
 		this.data = {};
 		this.getPostAttribute = this.getPostAttribute.bind( this );
+		this.refreshYoastSEO = this.refreshYoastSEO.bind( this );
+	}
+
+	/**
+	 * Sets the refresh function.
+	 *
+	 * @param {Function} refresh The refresh function.
+	 *
+	 * @returns {void}
+	 */
+	setRefresh( refresh ) {
+		this._refresh = refresh;
 	}
 
 	/**
@@ -75,6 +87,8 @@ class Data {
 
 		// Set isDirty to false if the current data and Gutenberg data are unequal.
 		let isDirty = ! this.isShallowEqual( this.data, gutenbergData );
+		console.log( "isDirty", isDirty );
+		console.log( "refresh", this._refresh );
 
 		if ( isDirty ) {
 			this.data = gutenbergData;
@@ -102,7 +116,6 @@ class Data {
 	 * @returns {Object} The data and whether the data is dirty.
 	 */
 	getData() {
-		console.log( this.data );
 		return this.data;
 	}
 }

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -57,6 +57,7 @@ const getGutenbergData = () => {
 		content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
 		title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
 		slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
+		excerpt: wp.data.select( "core/editor" ).getEditedPostAttribute( "excerpt" ),
 	};
 	data = updateData( data, gutenbergData );
 
@@ -81,6 +82,7 @@ export const subscribeToGutenberg = function() {
 			content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
 			title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
 			slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
+			excerpt: wp.data.select( "core/editor" ).getEditedPostAttribute( "excerpt" ),
 		};
 		wp.data.subscribe(
 			subscriber

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,80 +1,109 @@
 /* global wp YoastSEO */
 import debounce from "lodash/debounce";
 
-let data = {};
-
 /**
- * Checks whether the current data and the Gutenberg data are the same.
- *
- * @param {Object} currentData The current data.
- * @param {Object} gutenbergData The data from Gutenberg.
- * @returns {boolean} Whether the current data and the gutenbergData is the same.
+ * Represents the data.
  */
-const isShallowEqual = ( currentData, gutenbergData ) => {
-	for( let dataPoint in currentData ) {
-		if ( currentData.hasOwnProperty( dataPoint ) ) {
-			if( ! ( dataPoint in gutenbergData ) || currentData[ dataPoint ] !== gutenbergData[ dataPoint ] ) {
-				return false;
+class data {
+	/**
+	 *
+	 *
+	 * @param {object}
+	 * @returns {void}
+	 */
+	constructor( wp.data, YoastSEO.app ) {
+		super();
+		this._wpData = wp.data;
+		this._yoastSEOApp = YoastSEO.app;
+		this.data = {};
+	}
+
+	/**
+	 * Checks whether the current data and the Gutenberg data are the same.
+	 *
+	 * @param {Object} currentData The current data.
+	 * @param {Object} gutenbergData The data from Gutenberg.
+	 * @returns {boolean} Whether the current data and the gutenbergData is the same.
+	 */
+	isShallowEqual = ( currentData, gutenbergData ) => {
+		if ( Object.keys( currentData ).length !== Object.keys( gutenbergData ).length ) {
+			return false;
+		}
+
+		for( let dataPoint in currentData ) {
+			if ( currentData.hasOwnProperty( dataPoint ) ) {
+				if( ! ( dataPoint in gutenbergData ) || currentData[ dataPoint ] !== gutenbergData[ dataPoint ] ) {
+					return false;
+				}
 			}
 		}
-	}
-	return true;
-};
-
-/**
- * Collects the content, title, slug and excerpt of a post from Gutenberg.
- *
- * @returns {{content: string, title: string, slug: string, excerpt: string}} The content, title, slug and excerpt.
- */
-const collectGutenbergData =  () => {
-	return {
-		content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
-		title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
-		slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
-		excerpt: wp.data.select( "core/editor" ).getEditedPostAttribute( "excerpt" ),
+		return true;
 	};
-};
 
-/**
- * Refreshes YoastSEO's app when the Gutenberg data is dirty.
- *
- * @returns {void}
- */
-const refreshYoastSEO = () => {
-	let gutenbergData = collectGutenbergData();
+	/**
+	 * Retrieves the Gutenberg data for the passed post attribute.
+	 *
+	 * @param {string} attribute The post attribute you'd like to retrieve.
+	 * @returns {string} The post attribute .
+	 */
+	getPostAttribute = ( attribute ) => {
+		return this._wpData.select( "core/editor" ).getEditedPostAttribute( attribute );
+	};
 
-	// Set isDirty to false if the current data and Gutenberg data are unequal.
-	let isDirty = ! isShallowEqual( data, gutenbergData );
+	/**
+	 * Collects the content, title, slug and excerpt of a post from Gutenberg.
+	 *
+	 * @returns {{content: string, title: string, slug: string, excerpt: string}} The content, title, slug and excerpt.
+	 */
+	collectGutenbergData =  ( retriever ) => {
+		return {
+			content: retriever( "content" ),
+			title: retriever( "title" ),
+			slug: retriever( "slug" ),
+			excerpt: retriever( "excerpt" ),
+		};
+	};
 
-	if ( isDirty ) {
-		data = gutenbergData;
-		YoastSEO.app.refresh();
-	}
-};
+	/**
+	 * Refreshes YoastSEO's app when the Gutenberg data is dirty.
+	 *
+	 * @returns {void}
+	 */
+	refreshYoastSEO = () => {
+		let gutenbergData = collectGutenbergData( getPostAttribute );
 
-const subscriber = debounce( refreshYoastSEO, 500 );
+		// Set isDirty to false if the current data and Gutenberg data are unequal.
+		let isDirty = ! isShallowEqual( data, gutenbergData );
 
-/**
- * Listens to the Gutenberg data.
- *
- * @returns {void}
- */
-export const subscribeToGutenberg = function() {
-	// Only subscribe when Gutenberg's data API is available.
-	if ( wp && wp.data ) {
+		if ( isDirty ) {
+			data = gutenbergData;
+			YoastSEO.app.refresh();
+		}
+	};
+
+	subscriber = debounce( refreshYoastSEO, 500 );
+
+	/**
+	 * Listens to the Gutenberg data.
+	 *
+	 * @returns {void}
+	 */
+	subscribeToGutenberg = () => {
 		// Fill data object on page load.
-		data = collectGutenbergData();
+		data = collectGutenbergData( getPostAttribute );
 		wp.data.subscribe(
 			subscriber
 		);
-	}
-};
+	};
 
-/**
- * Returns the data and whether the data is dirty.
- *
- * @returns {Object} The data and whether the data is dirty.
- */
-export const getData = () => {
-	return data;
-};
+	/**
+	 * Returns the data and whether the data is dirty.
+	 *
+	 * @returns {Object} The data and whether the data is dirty.
+	 */
+	getData = () => {
+		console.log( data )
+		return data;
+	};
+}
+module.exports = data;

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -5,17 +5,17 @@ import debounce from "lodash/debounce";
  */
 class Data {
 	/**
-	 *
+	 * Sets the wp data, Yoast SEO refresh function and data object.
 	 *
 	 * @param {Object} wpData The Gutenberg data API.
-	 * @param {Object} YoastSEOApp The app of YoastSEO.
+	 * @param {Function} refresh The YoastSEO refresh function.
 	 * @returns {void}
 	 */
-	constructor( wpData, YoastSEOApp ) {
+	constructor( wpData, refresh ) {
 		this._wpData = wpData;
-		this._yoastSEOApp = YoastSEOApp;
+		this._refresh = refresh;
 		this.data = {};
-		this.subscriber = debounce( this.refreshYoastSEO, 500 );
+		this.getPostAttribute = this.getPostAttribute.bind( this );
 	}
 
 	/**
@@ -53,15 +53,15 @@ class Data {
 	/**
 	 * Collects the content, title, slug and excerpt of a post from Gutenberg.
 	 *
-	 * @param {Function} retriever The data retriever function.
+	 * @param {Function} getPostAttribute The post attribute retrieval function.
 	 * @returns {{content: string, title: string, slug: string, excerpt: string}} The content, title, slug and excerpt.
 	 */
-	collectGutenbergData( retriever ) {
+	collectGutenbergData( getPostAttribute ) {
 		return {
-			content: retriever( "content" ),
-			title: retriever( "title" ),
-			slug: retriever( "slug" ),
-			excerpt: retriever( "excerpt" ),
+			content: getPostAttribute( "content" ),
+			title: getPostAttribute( "title" ),
+			slug: getPostAttribute( "slug" ),
+			excerpt: getPostAttribute( "excerpt" ),
 		};
 	}
 
@@ -78,7 +78,7 @@ class Data {
 
 		if ( isDirty ) {
 			this.data = gutenbergData;
-			this._yoastSEOApp.refresh();
+			this._refresh();
 		}
 	}
 
@@ -90,6 +90,7 @@ class Data {
 	subscribeToGutenberg() {
 		// Fill data object on page load.
 		this.data = this.collectGutenbergData( this.getPostAttribute );
+		this.subscriber = debounce( this.refreshYoastSEO, 500 );
 		this._wpData.subscribe(
 			this.subscriber
 		);

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -75,7 +75,7 @@ const subscriber = debounce( getGutenbergData, 500 );
  */
 export const subscribeToGutenberg = function() {
 	// Only subscribe when Gutenberg's data API is available.
-	if ( wp.data ) {
+	if ( wp && wp.data ) {
 		// Fill data object on page load.
 		data = {
 			content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -4,10 +4,6 @@ import debounce from "lodash/debounce";
 let data = {};
 let isDirty;
 
-// Todo: tests
-
-// Todo: algemener maken qua argument naming etc?
-// Todo: complexity
 /**
  * Checks whether the current data and the Gutenberg data are the same.
  *
@@ -33,7 +29,6 @@ const isShallowEqual = ( currentData, gutenbergData ) => {
 	return true;
 };
 
-// Todo: naming & single responsibility
 /**
  * Updates the data object.
  *
@@ -52,7 +47,6 @@ const updateData = ( data, gutenbergData ) => {
 	return data;
 };
 
-// Todo: naming & single responsibility.
 /**
  * Gets the Gutenberg data.
  *
@@ -82,6 +76,12 @@ const subscriber = debounce( getGutenbergData, 500 );
 export const subscribeToGutenberg = function() {
 	// Only subscribe when Gutenberg's data API is available.
 	if ( wp.data ) {
+		// Fill data object on page load.
+		data = {
+			content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
+			title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
+			slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
+		};
 		wp.data.subscribe(
 			subscriber
 		);

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -4,29 +4,70 @@ import debounce from "lodash/debounce";
 let data = {};
 let isDirty;
 
-// todo: naming + isDirty per data point?
-const setDataPoint = ( dataPoint, data, gutenbergData ) => {
+// Todo: tests
+
+// Todo: algemener maken qua argument naming etc?
+// Todo: complexity
+/**
+ * Checks whether the current data and the Gutenberg data are the same.
+ *
+ * @param {Object} currentData The current data.
+ * @param {Object} gutenbergData The data from Gutenberg.
+ * @returns {boolean} Whether the current data and the gutenbergData is the same.
+ */
+const isShallowEqual = ( currentData, gutenbergData ) => {
+	for( let dataPoint in currentData ) {
+		if ( currentData.hasOwnProperty( dataPoint ) ) {
+			if( ! ( dataPoint in gutenbergData ) || currentData[ dataPoint ] !== gutenbergData[ dataPoint ] ) {
+				return false;
+			}
+		}
+	}
+	for( let dataPoint in gutenbergData ) {
+		if ( gutenbergData.hasOwnProperty( dataPoint ) ) {
+			if( ! ( dataPoint in currentData ) || currentData[ dataPoint ] !== gutenbergData[ dataPoint ] ) {
+				return false;
+			}
+		}
+	}
+	return true;
+};
+
+// Todo: naming & single responsibility
+/**
+ * Updates the data object.
+ *
+ * @param {Object} data The current data.
+ * @param {Object} gutenbergData The data from Gutenberg.
+ * @returns {Object} The data.
+ */
+const updateData = ( data, gutenbergData ) => {
 	isDirty = false;
-	if ( ! data[ dataPoint ] ) {
-		data[ dataPoint ] = gutenbergData[ dataPoint ];
+	if ( ! data ) {
+		data = gutenbergData;
 		isDirty = true;
 	}
-	if ( data[ dataPoint ] !== gutenbergData[ dataPoint ] ) {
-		data[ dataPoint ] = gutenbergData[ dataPoint ];
-		isDirty = true;
+	// Set isDirty to false if the current data and Gutenberg data are unequal.
+	isDirty = ! isShallowEqual( data, gutenbergData );
+	if ( data && isDirty ) {
+		data = gutenbergData;
 	}
 	return data;
 };
 
+// Todo: naming & single responsibility.
+/**
+ * Gets the Gutenberg data.
+ *
+ * @returns {void}
+ */
 const getGutenbergData = () => {
 	let gutenbergData = {
 		content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
 		title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
 		slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
 	};
-	setDataPoint( "content", data, gutenbergData );
-	setDataPoint( "title", data, gutenbergData );
-	setDataPoint( "slug", data, gutenbergData );
+	updateData( data, gutenbergData );
 };
 
 const subscriber = debounce( getGutenbergData, 500 );
@@ -34,7 +75,7 @@ const subscriber = debounce( getGutenbergData, 500 );
 /**
  * Listens to the Gutenberg data.
  *
- * @returns {Object} A data object containing content, title and url from Gutenberg.
+ * @returns {void}
  */
 export const subscribeToGutenberg = function() {
 	wp.data.subscribe(
@@ -42,6 +83,12 @@ export const subscribeToGutenberg = function() {
 	);
 };
 
+// Todo: Single responsibility.
+/**
+ * Returns the data and whether the data is dirty.
+ *
+ * @returns {Object} The data and whether the data is dirty.
+ */
 export const getData = () => {
 	return {
 		data: data,

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,0 +1,66 @@
+/* global wp */
+import debounce from "lodash/debounce";
+let GutenbergDataCollector = {};
+
+/**
+ * Gets data from Gutenberg and stores them in an analyzerData object. This object will be used to fill
+ * the analyzer and the snippet preview.
+ *
+ * @returns {Object} The data object.
+ */
+GutenbergDataCollector.prototype.getData = function() {
+	return {
+		content: this.getContent(),
+		title: this.getTitle(),
+		slug: this.getUrl(),
+	};
+};
+
+/**
+ * Returns the Gutenberg content.
+ *
+ * @returns {string} The content.
+ */
+GutenbergDataCollector.prototype.getContent = function() {
+};
+
+let gutenbergData;
+let data = {};
+
+/**
+ * Listens to the Gutenberg data.
+ *
+ * @returns {Object} A data object containing content, title and url from Gutenberg.
+ */
+const unsubscribe = debounce(
+	wp.data.subscribe( () => {
+		gutenbergData = {
+			content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
+			title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
+			url: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
+		};
+		// Todo: use less if statements.
+		if ( ! data.title ) {
+			data.title = gutenbergData.title;
+		}
+		if ( data.title !== gutenbergData.title ) {
+			data.title = gutenbergData.title;
+			console.log( data.title );
+		}
+		if ( ! data.content ) {
+			data.content = gutenbergData.content;
+		}
+		if ( data.content !== gutenbergData.content ) {
+			data.content = gutenbergData.content;
+			console.log( data.content );
+		}
+		if ( ! data.slug ) {
+			data.slug = gutenbergData.slug;
+		}
+		if ( data.slug !== gutenbergData.slug ) {
+			data.slug = gutenbergData.slug;
+			console.log( data.slug );
+		}
+	} )
+, 500 );
+

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -87,8 +87,6 @@ class Data {
 
 		// Set isDirty to false if the current data and Gutenberg data are unequal.
 		let isDirty = ! this.isShallowEqual( this.data, gutenbergData );
-		console.log( "isDirty", isDirty );
-		console.log( "refresh", this._refresh );
 
 		if ( isDirty ) {
 			this.data = gutenbergData;

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -48,17 +48,26 @@ const updateData = ( data, gutenbergData ) => {
 };
 
 /**
- * Gets the Gutenberg data.
+ * Collects the content, title, slug and excerpt of a post from Gutenberg.
  *
- * @returns {void}
+ * @returns {{content: string, title: string, slug: string, excerpt: string}} The content, title, slug and excerpt.
  */
-const getGutenbergData = () => {
-	let gutenbergData = {
+const collectGutenbergData =  () => {
+	return {
 		content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
 		title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
 		slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
 		excerpt: wp.data.select( "core/editor" ).getEditedPostAttribute( "excerpt" ),
 	};
+};
+
+/**
+ * Refreshes YoastSEO's app when the Gutenberg data is dirty.
+ *
+ * @returns {void}
+ */
+const refreshYoastSEO = () => {
+	let gutenbergData = collectGutenbergData();
 	data = updateData( data, gutenbergData );
 
 	if ( isDirty ) {
@@ -67,7 +76,7 @@ const getGutenbergData = () => {
 	isDirty = false;
 };
 
-const subscriber = debounce( getGutenbergData, 500 );
+const subscriber = debounce( refreshYoastSEO, 500 );
 
 /**
  * Listens to the Gutenberg data.
@@ -78,12 +87,7 @@ export const subscribeToGutenberg = function() {
 	// Only subscribe when Gutenberg's data API is available.
 	if ( wp && wp.data ) {
 		// Fill data object on page load.
-		data = {
-			content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
-			title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
-			slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
-			excerpt: wp.data.select( "core/editor" ).getEditedPostAttribute( "excerpt" ),
-		};
+		data = collectGutenbergData();
 		wp.data.subscribe(
 			subscriber
 		);

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -27,6 +27,17 @@ GutenbergDataCollector.prototype.getContent = function() {
 let gutenbergData;
 let data = {};
 
+// todo: naming
+let setDataPoint = ( dataPoint, data, gutenbergData ) => {
+	if ( ! data[ dataPoint ] ) {
+		data[ dataPoint ] = gutenbergData[ dataPoint ];
+	}
+	if ( data[ dataPoint ] !== gutenbergData[ dataPoint ] ) {
+		data[ dataPoint ] = gutenbergData[ dataPoint ];
+		console.log( data[ dataPoint ] );
+	}
+};
+
 /**
  * Listens to the Gutenberg data.
  *
@@ -37,30 +48,11 @@ const unsubscribe = debounce(
 		gutenbergData = {
 			content: wp.data.select( "core/editor" ).getEditedPostAttribute( "content" ),
 			title: wp.data.select( "core/editor" ).getEditedPostAttribute( "title" ),
-			url: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
+			slug: wp.data.select( "core/editor" ).getEditedPostAttribute( "slug" ),
 		};
-		// Todo: use less if statements.
-		if ( ! data.title ) {
-			data.title = gutenbergData.title;
-		}
-		if ( data.title !== gutenbergData.title ) {
-			data.title = gutenbergData.title;
-			console.log( data.title );
-		}
-		if ( ! data.content ) {
-			data.content = gutenbergData.content;
-		}
-		if ( data.content !== gutenbergData.content ) {
-			data.content = gutenbergData.content;
-			console.log( data.content );
-		}
-		if ( ! data.slug ) {
-			data.slug = gutenbergData.slug;
-		}
-		if ( data.slug !== gutenbergData.slug ) {
-			data.slug = gutenbergData.slug;
-			console.log( data.slug );
-		}
+		setDataPoint( "content", data, gutenbergData );
+		setDataPoint( "title", data, gutenbergData );
+		setDataPoint( "slug", data, gutenbergData );
 	} )
 , 500 );
 

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -80,9 +80,12 @@ const subscriber = debounce( getGutenbergData, 500 );
  * @returns {void}
  */
 export const subscribeToGutenberg = function() {
-	wp.data.subscribe(
-		subscriber
-	);
+	// Only subscribe when Gutenberg's data API is available.
+	if ( wp.data ) {
+		wp.data.subscribe(
+			subscriber
+		);
+	}
 };
 
 /**

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -127,7 +127,6 @@ export function initialize( args ) {
 	if ( isGutenbergDataAvailable() ) {
 		const gutenbergData = new Data( wp.data, args.onRefreshRequest );
 		gutenbergData.subscribeToGutenberg();
-		gutenbergData.setRefresh( () => {} );
 		data = gutenbergData;
 	}
 

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -115,8 +115,9 @@ function renderReactApps( store, args ) {
  * @param {Object} args Edit initialize arguments.
  * @param {string} args.seoTarget Target to render the seo analysis.
  * @param {string} args.readabilityTarget Target to render the readability analysis.
+ * @param {Function} args.onRefreshRequest The function to refresh the analysis.
  *
- * @returns {Object} Things that need to be exposed, such as the store.
+ * @returns {Object} The store and the data.
  */
 export function initialize( args ) {
 	const store = configureStore();
@@ -126,6 +127,7 @@ export function initialize( args ) {
 	if ( isGutenbergDataAvailable() ) {
 		const gutenbergData = new Data( wp.data, args.onRefreshRequest );
 		gutenbergData.subscribeToGutenberg();
+		gutenbergData.setRefresh( () => {} );
 		data = gutenbergData;
 	}
 

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -15,6 +15,7 @@ import activeKeyword from "./redux/reducers/activeKeyword";
 import ContentAnalysis from "./components/contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "./components/contentAnalysis/SeoAnalysis";
 import { subscribeToGutenberg } from "./analysis/data.js";
+import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
 let localizedData = { intl: {} };
@@ -120,7 +121,11 @@ function renderReactApps( store, args ) {
 export function initialize( args ) {
 	const store = configureStore();
 
-	subscribeToGutenberg();
+	// Only subscribe if Gutenberg's data API is available.
+	if ( isGutenbergDataAvailable() ) {
+		subscribeToGutenberg();
+	}
+
 	renderReactApps( store, args );
 
 	return {

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -14,6 +14,7 @@ import analysis from "yoast-components/composites/Plugin/ContentAnalysis/reducer
 import activeKeyword from "./redux/reducers/activeKeyword";
 import ContentAnalysis from "./components/contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "./components/contentAnalysis/SeoAnalysis";
+import { subscribeToGutenberg } from "./analysis/data.js";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
 let localizedData = { intl: {} };
@@ -119,6 +120,7 @@ function renderReactApps( store, args ) {
 export function initialize( args ) {
 	const store = configureStore();
 
+	subscribeToGutenberg();
 	renderReactApps( store, args );
 
 	return {

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -120,17 +120,20 @@ function renderReactApps( store, args ) {
  */
 export function initialize( args ) {
 	const store = configureStore();
+	let data = {};
 
-	// Only subscribe if Gutenberg's data API is available.
+	// Only use Gutenberg's data if Gutenberg is available.
 	if ( isGutenbergDataAvailable() ) {
-		const gutenbergData = new Data( wp.data, YoastSEO.app );
+		const gutenbergData = new Data( wp.data, args.onRefreshRequest );
 		gutenbergData.subscribeToGutenberg();
+		data = gutenbergData;
 	}
 
 	renderReactApps( store, args );
 
 	return {
 		store,
+		data,
 	};
 }
 

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -1,4 +1,4 @@
-/* global window wpseoPostScraperL10n wpseoTermScraperL10n process wp YoastSEO */
+/* global window wpseoPostScraperL10n wpseoTermScraperL10n process wp */
 
 import { createStore, applyMiddleware, combineReducers } from "redux";
 import thunk from "redux-thunk";

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -1,4 +1,4 @@
-/* global window wpseoPostScraperL10n wpseoTermScraperL10n process */
+/* global window wpseoPostScraperL10n wpseoTermScraperL10n process wp YoastSEO */
 
 import { createStore, applyMiddleware, combineReducers } from "redux";
 import thunk from "redux-thunk";
@@ -14,7 +14,7 @@ import analysis from "yoast-components/composites/Plugin/ContentAnalysis/reducer
 import activeKeyword from "./redux/reducers/activeKeyword";
 import ContentAnalysis from "./components/contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "./components/contentAnalysis/SeoAnalysis";
-import { subscribeToGutenberg } from "./analysis/data.js";
+import Data from "./analysis/data.js";
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
@@ -123,7 +123,8 @@ export function initialize( args ) {
 
 	// Only subscribe if Gutenberg's data API is available.
 	if ( isGutenbergDataAvailable() ) {
-		subscribeToGutenberg();
+		const gutenbergData = new Data( wp.data, YoastSEO.app );
+		gutenbergData.subscribeToGutenberg();
 	}
 
 	renderReactApps( store, args );

--- a/js/src/helpers/isGutenbergDataAvailable.js
+++ b/js/src/helpers/isGutenbergDataAvailable.js
@@ -1,0 +1,14 @@
+/* global wp */
+
+import isUndefined from "lodash/isUndefined";
+
+/**
+ * Checks if the data API from Gutenberg is available.
+ *
+ * @returns {boolean} True if the data API is available.
+ */
+const isGutenbergDataAvailable = () => {
+	return ( ! isUndefined( wp ) && ! isUndefined( wp.data ) );
+};
+
+export default isGutenbergDataAvailable;

--- a/js/src/helpers/isGutenbergDataAvailable.js
+++ b/js/src/helpers/isGutenbergDataAvailable.js
@@ -8,7 +8,7 @@ import isUndefined from "lodash/isUndefined";
  * @returns {boolean} True if the data API is available.
  */
 const isGutenbergDataAvailable = () => {
-	return ( ! isUndefined( wp ) && ! isUndefined( wp.data ) );
+	return ( ! isUndefined( window.wp ) && ! isUndefined( wp.data ) );
 };
 
 export default isGutenbergDataAvailable;

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -254,9 +254,11 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 	/**
 	 * Returns the arguments necessary to initialize the app.
 	 *
+	 * @param {Object} store The store.
+	 *
 	 * @returns {Object} The arguments to initialize the app
 	 */
-	function getAppArgs() {
+	function getAppArgs( store ) {
 		const args = {
 			// ID's of elements that need to trigger updating the analyzer.
 			elementTarget: [
@@ -385,7 +387,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 			seoTarget: "wpseo-pageanalysis",
 			onRefreshRequest: () => {},
 		};
-		const { store, data } =  initializeEdit( editArgs );
+		const { store, data } = initializeEdit( editArgs );
 
 		snippetContainer = $( "#wpseosnippet" );
 
@@ -399,7 +401,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		publishBox.initalise();
 		snippetPreview = initSnippetPreview( postDataCollector );
 
-		let appArgs = getAppArgs();
+		let appArgs = getAppArgs( store );
 		app = new App( appArgs );
 
 		postDataCollector.app = app;
@@ -459,7 +461,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		store.dispatch( setActiveKeyword( tabManager.getKeywordTab().getKeyWord() ) );
 
 		// Set refresh function.
-		editArgs.onRefreshRequest = app.refresh();
+		data.setRefresh( app.refresh );
 	}
 
 	jQuery( document ).ready( initializePostAnalysis );

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -237,11 +237,14 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 	/**
 	 * Initializes post data collector.
 	 *
+	 * @param {Object} data The data.
+	 *
 	 * @returns {PostDataCollector} The initialized post data collector.
 	 */
-	function initializePostDataCollector() {
+	function initializePostDataCollector( data ) {
 		let postDataCollector = new PostDataCollector( {
 			tabManager,
+			data,
 		} );
 		postDataCollector.leavePostNameUntouched = false;
 
@@ -380,8 +383,9 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		const editArgs = {
 			readabilityTarget: "yoast-seo-content-analysis",
 			seoTarget: "wpseo-pageanalysis",
+			onRefreshRequest: () => {},
 		};
-		store = initializeEdit( editArgs ).store;
+		const { store, data } =  initializeEdit( editArgs );
 
 		snippetContainer = $( "#wpseosnippet" );
 
@@ -391,7 +395,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		}
 
 		tabManager = initializeTabManager();
-		postDataCollector = initializePostDataCollector();
+		postDataCollector = initializePostDataCollector( data );
 		publishBox.initalise();
 		snippetPreview = initSnippetPreview( postDataCollector );
 
@@ -453,6 +457,9 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 
 		// Set initial keyword.
 		store.dispatch( setActiveKeyword( tabManager.getKeywordTab().getKeyWord() ) );
+
+		// Set refresh function.
+		editArgs.onRefreshRequest = app.refresh();
 	}
 
 	jQuery( document ).ready( initializePostAnalysis );

--- a/js/tests/data.test.js
+++ b/js/tests/data.test.js
@@ -1,8 +1,33 @@
 import Data from "../src/analysis/data.js";
 
 let wpData = {};
-let YoastSEOApp = {};
-let gutenbergData = new Data( wpData, YoastSEOApp );
+let refresh =  () => {
+	return true;
+};
+let data = new Data( wpData, refresh );
+
+// Mocks the select function and .
+const mockSelect = jest.fn();
+
+// Mocks the getEditedPostAttribute function.
+const mockGetEditedPostAttribute = jest.fn();
+
+// Ensures mockSelect.getEditedPostAttribute is a function.
+mockSelect.mockReturnValue( { getEditedPostAttribute: mockGetEditedPostAttribute } );
+
+data._wpData.select = mockSelect;
+
+describe( 'setRefresh', () => {
+	it( 'sets the refresh function', () => {
+		const expected = () => {
+			return "refresh";
+		};
+		data.setRefresh( expected );
+
+		const actual = data._refresh;
+		expect( actual ).toBe( expected );
+	} );
+} );
 
 describe( 'isShallowEqual', () => {
 	it( 'returns true if two objects contain the same key value pairs', () => {
@@ -14,7 +39,7 @@ describe( 'isShallowEqual', () => {
 			key2: "value2",
 			key1: "value1",
 		};
-		const actual = gutenbergData.isShallowEqual( object1, object2 );
+		const actual = data.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( true );
 	} );
 	it( 'returns false if two objects contain the same keys but 1 value differs', () => {
@@ -26,7 +51,7 @@ describe( 'isShallowEqual', () => {
 			key2: "value2b",
 			key1: "value1",
 		};
-		const actual = gutenbergData.isShallowEqual( object1, object2 );
+		const actual = data.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( false );
 	} );
 	it( 'returns false if two objects don\'t contain the same keys value pairs', () => {
@@ -38,7 +63,64 @@ describe( 'isShallowEqual', () => {
 			key3: "value2",
 			key1: "value1",
 		};
-		const actual = gutenbergData.isShallowEqual( object1, object2 );
+		const actual = data.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( false );
+	} );
+} );
+
+describe( 'getPostAttribute', () => {
+	it( 'gets the post attribute', () => {
+		data.getPostAttribute( "content" );
+		expect( mockGetEditedPostAttribute ).toBeCalledWith( "content" );
+	} );
+} );
+
+describe( 'collectGutenbergData', () => {
+	it( 'collects the GutenbergData', () => {
+		const retriever = ( attribute ) => {
+			return attribute;
+		};
+		const expected = {
+			content: "content",
+			title: "title",
+			slug: "slug",
+			excerpt: "excerpt",
+		};
+
+		const actual = data.collectGutenbergData( retriever );
+		expect( actual ).toEqual( expected );
+	} );
+} );
+
+describe( 'refreshYoastSEO', () => {
+	/*
+		After the first call of collectGutenbergData in refreshYoastSEO, the Gutenberg data is always dirty,
+		because data is initially an empty object.
+	*/
+	it( 'refreshes YoastSEO when the Gutenberg data is dirty', () => {
+		const mockRefresh = jest.fn();
+		data._refresh = mockRefresh;
+		data.refreshYoastSEO();
+		expect( mockRefresh ).toBeCalled();
+	} );
+
+	/*
+		After collectGutenbergData is called a second time, and nothing has changed,
+		the data isn't dirty and the refresh function shouldn't be called.
+	*/
+	it( 'doesn\'t refresh YoastSEO when the Gutenberg data is not dirty', () => {
+		const mockRefresh2 = jest.fn();
+		data._refresh = mockRefresh2;
+		data.refreshYoastSEO();
+		expect( mockRefresh2 ).not.toBeCalled();
+	} );
+} );
+
+describe( 'getData', () => {
+	it( 'returns the data', () => {
+		data.data = { content: "this is the content" };
+		const actual = data.getData();
+		const expected = { content: "this is the content" };
+		expect( actual ).toEqual( expected );
 	} );
 } );

--- a/js/tests/data.test.js
+++ b/js/tests/data.test.js
@@ -1,4 +1,8 @@
-import { isShallowEqual } from "../src/analysis/data.js";
+import Data from "../src/analysis/data.js";
+
+let wpData = {};
+let YoastSEOApp = {};
+let gutenbergData = new Data( wpData, YoastSEOApp );
 
 describe( 'isShallowEqual', () => {
 	it( 'returns true if two objects contain the same key value pairs', () => {
@@ -10,7 +14,7 @@ describe( 'isShallowEqual', () => {
 			key2: "value2",
 			key1: "value1",
 		};
-		const actual = isShallowEqual( object1, object2 );
+		const actual = gutenbergData.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( true );
 	} );
 	it( 'returns false if two objects contain the same keys but 1 value differs', () => {
@@ -22,7 +26,7 @@ describe( 'isShallowEqual', () => {
 			key2: "value2b",
 			key1: "value1",
 		};
-		const actual = isShallowEqual( object1, object2 );
+		const actual = gutenbergData.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( false );
 	} );
 	it( 'returns false if two objects don\'t contain the same keys value pairs', () => {
@@ -34,7 +38,7 @@ describe( 'isShallowEqual', () => {
 			key3: "value2",
 			key1: "value1",
 		};
-		const actual = isShallowEqual( object1, object2 );
+		const actual = gutenbergData.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( false );
 	} );
 } );

--- a/js/tests/data.test.js
+++ b/js/tests/data.test.js
@@ -1,0 +1,40 @@
+import { isShallowEqual } from "../src/analysis/data.js";
+
+describe( 'isShallowEqual', () => {
+	it( 'returns true if two objects contain the same key value pairs', () => {
+		const object1 = {
+			key1: "value1",
+			key2: "value2",
+		};
+		const object2 = {
+			key2: "value2",
+			key1: "value1",
+		};
+		const actual = isShallowEqual( object1, object2 );
+		expect( actual ).toBe( true );
+	} );
+	it( 'returns false if two objects contain the same keys but 1 value differs', () => {
+		const object1 = {
+			key1: "value1",
+			key2: "value2",
+		};
+		const object2 = {
+			key2: "value2b",
+			key1: "value1",
+		};
+		const actual = isShallowEqual( object1, object2 );
+		expect( actual ).toBe( false );
+	} );
+	it( 'returns false if two objects don\'t contain the same keys value pairs', () => {
+		const object1 = {
+			key1: "value1",
+			key2: "value2",
+		};
+		const object2 = {
+			key3: "value2",
+			key1: "value1",
+		};
+		const actual = isShallowEqual( object1, object2 );
+		expect( actual ).toBe( false );
+	} );
+} );

--- a/js/tests/edit.test.js
+++ b/js/tests/edit.test.js
@@ -9,7 +9,6 @@ describe( 'initialize', () => {
 				locale: "en_EN",
 			},
 		};
-		window.wp = {};
 		const actual = initialize( {} );
 		expect( actual.store ).toBeDefined();
 	} );

--- a/js/tests/edit.test.js
+++ b/js/tests/edit.test.js
@@ -9,6 +9,7 @@ describe( 'initialize', () => {
 				locale: "en_EN",
 			},
 		};
+		window.wp = {};
 		const actual = initialize( {} );
 		expect( actual.store ).toBeDefined();
 	} );

--- a/js/tests/isGutenbergDataAvailable.test.js
+++ b/js/tests/isGutenbergDataAvailable.test.js
@@ -1,0 +1,19 @@
+import isGutenbergDataAvailable from "../src/helpers/isGutenbergDataAvailable.js";
+
+describe( 'isGutenbergDataAvailable', () => {
+	it( 'returns true if both wp and wp.data are defined', () => {
+		window.wp = { data: true };
+		const actual = isGutenbergDataAvailable();
+		expect( actual ).toBe( true );
+	} );
+	it( 'returns false if wp.data is not defined', () => {
+		window.wp = { something: true };
+		const actual = isGutenbergDataAvailable();
+		expect( actual ).toBe( false );
+	} );
+	it( 'returns false if wp is not defined', () => {
+		window.wp = undefined;
+		const actual = isGutenbergDataAvailable();
+		expect( actual ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry: 

* Makes it possible to use the content, slug, title and excerpt from Gutenberg posts in the SEO and readability analysis.

## Relevant technical choices:

* This is a prototype. Architecture and naming might change in the future.

## Test instructions

This PR can be tested by following these steps:

* Create a post in Gutenberg.
* Make sure all SEO and readability assessments that use the content, slug and/or title work correctly.
* Also make sure all assessments still work correctly in the classic editor.
* Write an excerpt in the document sidebar. Use the %%excerpt%% and %%title%% replace var in the snippet preview.

**Important**: Currently, Gutenberg only saves a slug after publishing the post.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9019
