### PR TITLE
Update yoast components to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
-    "yoast-components": "^3.0.2",
+    "yoast-components": "^3.1.0",
     "yoastseo": "^1.29"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9768,9 +9768,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yoast-components@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-3.0.2.tgz#96662e12948127518179fafc1782e40988a6d8fe"
+yoast-components@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-3.1.0.tgz#f218ffea942d11d6c1cc4f01ed90a6d9a2caa24e"
   dependencies:
     a11y-speak "git+https://github.com/Yoast/a11y-speak.git#master"
     algoliasearch "^3.22.3"
@@ -9780,7 +9780,6 @@ yoast-components@^3.0.2:
     jed "^1.1.1"
     lodash "^4.17.4"
     prop-types "^15.6.0"
-    react-intl "^2.4.0"
     react-redux "^5.0.6"
     react-tabs "^2.2.1"
     redux "^3.7.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Content analysis headers are all expanded by default.

This PR can be tested by following these steps:

* Create a new post or open an existing post.
* Notice all content analysis headers are expanded.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #8882 
