### PR TITLE
Fix the fact that author with no posts don't show up in sitemap

### DIFF
--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -115,7 +115,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			),
 		);
 
-		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', false ) ) {
+		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {
 			// $defaults['who']                 = ''; // Otherwise it cancels out next argument.
 			$defaults['has_published_posts'] = true;
 		}

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * @package WPSEO\Tests\Sitemaps.
+ * @package WPSEO\Tests\Sitemaps
  */
 
 /**
- * Class Test_WPSEO_Author_Sitemap_Provider.
+ * Class Test_WPSEO_Author_Sitemap_Provider
  */
 class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var WPSEO_Author_Sitemap_Provider.
+	 * @var WPSEO_Author_Sitemap_Provider
 	 */
 	private static $class_instance;
 

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -93,6 +93,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		// Create a user with 3 posts.
 		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
 		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
+
+		// Exclude the user from the sitemaps.
 		update_user_meta( $user_id, 'wpseo_noindex_author', 'on' );
 
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -81,9 +81,10 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		// We should now have three in the XML sitemap.
 		$this->assertCount( 3, $sitemap_links );
 
-		$this->assertContains( get_author_posts_url( $author_id ), wp_list_pluck( $sitemap_links, 'loc' ) );
-		$this->assertContains( get_author_posts_url( $admin_id ), wp_list_pluck( $sitemap_links, 'loc' ) );
-		$this->assertContains( get_author_posts_url( $editor_id ), wp_list_pluck( $sitemap_links, 'loc' ) );
+		$sitemap_urls = wp_list_pluck( $sitemap_links, 'loc' );
+		$this->assertContains( get_author_posts_url( $author_id ), $sitemap_urls );
+		$this->assertContains( get_author_posts_url( $admin_id ), $sitemap_urls );
+		$this->assertContains( get_author_posts_url( $editor_id ), $sitemap_urls );
 	}
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -1,20 +1,20 @@
 <?php
 /**
- * @package WPSEO\Tests\Sitemaps
+ * @package WPSEO\Tests\Sitemaps.
  */
 
 /**
- * Class Test_WPSEO_Author_Sitemap_Provider
+ * Class Test_WPSEO_Author_Sitemap_Provider.
  */
 class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var WPSEO_Author_Sitemap_Provider
+	 * @var WPSEO_Author_Sitemap_Provider.
 	 */
 	private static $class_instance;
 
 	/**
-	 * Set up our double class
+	 * Set up our double class.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -26,7 +26,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test if a user is excluded from the sitemap when there are no posts
+	 * Test if a user is excluded from the sitemap when there are no posts.
 	 */
 	public function test_author_excluded_from_sitemap_by_zero_posts() {
 		// Remove authors with no posts.
@@ -43,7 +43,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests if a user is NOT excluded from the sitemap when there are posts
+	 * Tests if a user is NOT excluded from the sitemap when there are posts.
 	 */
 	public function test_author_not_excluded_from_sitemap_non_zero_posts() {
 		// Remove authors with no posts.
@@ -65,7 +65,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test if a user is NOT excluded from the sitemap when there are no posts
+	 * Test if a user is NOT excluded from the sitemap when there are no posts.
 	 */
 	public function test_author_not_excluded_from_sitemap_by_zero_posts() {
 		// Don't remove authors with no posts.

--- a/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -19,6 +19,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
+		WPSEO_Options::set( 'disable-author', false );
+		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
 		self::$class_instance = new WPSEO_Author_Sitemap_Provider();
 	}
 
@@ -27,11 +29,6 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-
-		remove_filter( 'get_usernumposts', array( $this, 'filter_user_has_no_posts' ) );
-		remove_filter( 'get_usernumposts', array( $this, 'filter_user_has_posts' ) );
-
-		remove_filter( 'get_the_author_wpseo_excludeauthorsitemap', array( $this, 'filter_user_meta_exclude_author_from_sitemap' ) );
 	}
 
 	/**
@@ -53,24 +50,52 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 * Test if a user is excluded from the sitemap when there are no posts
 	 */
 	public function test_author_excluded_from_sitemap_by_zero_posts() {
-		// Make the user have -no- posts.
-		add_filter( 'get_usernumposts', array( $this, 'filter_user_has_no_posts' ) );
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
 
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 
-		// User should be removed.
+		// User should not be seen.
 		$this->assertEmpty( $sitemap_links );
+
+		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
+
+		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+
+		// User should now be in the XML sitemap as user now has 3 posts.
+		$this->assertCount( 1, $sitemap_links );
+
 	}
 
 	/**
-	 * Exclude author by profile setting
-	 *
-	 * @param mixed $value Value.
-	 *
-	 * @return string
+	 * Test if a user is NOT excluded from the sitemap when there are no posts
 	 */
-	public function filter_user_meta_exclude_author_from_sitemap( $value ) {
-		return 'on';
+	public function test_author_not_excluded_from_sitemap_by_zero_posts() {
+		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
+
+		// Add three more users (of different types) without posts.
+		$this->factory->user->create( array( 'role' => 'author' ) );
+		$this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->factory->user->create( array( 'role' => 'editor' ) );
+
+		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+
+		// We should now have three in the XML sitemap.
+		$this->assertCount( 3, $sitemap_links );
+	}
+
+	/**
+	 * Test whether setting a user to not be visible in search results excludes user from XML sitemap.
+	 */
+	public function test_author_exclusion() {
+		// Create a user with 3 posts.
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
+		update_user_meta( $user_id, 'wpseo_noindex_author', 'on' );
+
+		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+
+		// User should not be in the XML sitemap.
+		$this->assertEmpty( $sitemap_links );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This is a regression from 6.3, so no need for a changelog entry. Added tests to make sure we don't break this again.

## Test instructions

This PR can be tested by following these steps:

* Create author without posts, toggle setting, check XML sitemap.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended

Fixes #9029 