### PR TITLE
Gutenberg: Extend CSS specificity for input max-width

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -221,13 +221,15 @@ ul.wpseo-metabox-tabs li {
 }
 
 /* Basic styling for social, advanced, and add-ons tabs content. */
-.wpseotab input,
-.wpseotab label,
-.wpseotab textarea,
-.wpseotab .select2-container,
-.yoast-metabox__description,
-.wpseotab p.error-message {
-	max-width: 600px;
+.yoast {
+	.wpseotab input,
+	.wpseotab label,
+	.wpseotab textarea,
+	.wpseotab .select2-container,
+	.yoast-metabox__description,
+	.wpseotab p.error-message {
+		max-width: 600px;
+	}
 }
 
 .wpseotab fieldset {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Gutenberg: Extend CSS specificity for input max-width.

## Relevant technical choices:

* Fix it in this repo instead of Gutenberg.

## Test instructions

This PR can be tested by following these steps:

* Activate Gutenberg.
* Under a post -> in the keyword tab -> in the focus keyword section.
* Check if the checkbox is under the input correctly.
* Check if other things with inputs still look correct.
* Disable Gutenberg and check the same things.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/gutenberg/issues/27
