### PR TITLE
Used the same sanitizing method for RSS, as was being used in 6.3

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -395,7 +395,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				case 'rssbefore':
 				case 'rssafter':
 					if ( isset( $dirty[ $key ] ) ) {
-						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
+						$clean[ $key ] = wp_kses_post( $dirty[ $key ] );
 					}
 					break;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses the old sanitizing method that was present in 6.3. to sanitize the RSS before and RSS after fields.

## Test instructions

This PR can be tested by following these steps:

* Add a link to the RSS before field in `Search Appearance > RSS`.
* Add `<script>alert('')</script>` to the RSS after field.
* Save the settings.
* Ensure that the link remains, but the `<script>` tag is stripped.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9129 
