### PR TITLE
Fixed logic bug so breadcrumb ancestors are properly displayed

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -332,7 +332,7 @@ class WPSEO_Breadcrumbs {
 			if ( isset( $this->post->post_parent ) && 0 === $this->post->post_parent ) {
 				$this->maybe_add_taxonomy_crumbs_for_post();
 			}
-			if ( ! isset( $this->post->post_parent ) || 0 === $this->post->post_parent ) {
+			if ( isset( $this->post->post_parent ) && $this->post->post_parent !== 0 ) {
 				$this->add_post_ancestor_crumbs();
 			}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where breadcrumb ancestors wouldn't be displayed for nested pages.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Implement breadcrumbs in your theme.
* Create a new page.
* Create another page and set its parent to the previously made page.
* Visit the newest page and observe that the parent page is properly displayed in the breadcrumbs.

## Quality assurance

* [X] I have tested this code to the best of my abilities

Fixes #9128 
