### PR TITLE
Fix option settings migration

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -145,7 +145,7 @@ class WPSEO_Upgrade {
 		$this->save_option_setting( $wpseo, 'pinterestverify' );
 
 		// Re-save option to trigger sanitization.
-		$this->refresh_option_content( 'wpseo' );
+		$this->cleanup_option_data( 'wpseo' );
 	}
 
 	/**
@@ -178,7 +178,7 @@ class WPSEO_Upgrade {
 		// Unschedule our tracking.
 		wp_clear_scheduled_hook( 'yoast_tracking' );
 
-		$this->refresh_option_content( 'wpseo' );
+		$this->cleanup_option_data( 'wpseo' );
 	}
 
 	/**
@@ -268,7 +268,7 @@ class WPSEO_Upgrade {
 		$this->save_option_setting( $wpseo_titles, 'keyword-analysis-active', 'keyword_analysis_active' );
 
 		// Remove irrelevant content from the option.
-		$this->refresh_option_content( 'wpseo_titles' );
+		$this->cleanup_option_data( 'wpseo_titles' );
 	}
 
 	/**
@@ -429,7 +429,7 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_63() {
-		$this->refresh_option_content( 'wpseo_titles' );
+		$this->cleanup_option_data( 'wpseo_titles' );
 	}
 
 	/**
@@ -463,7 +463,7 @@ class WPSEO_Upgrade {
 		$this->save_option_setting( $wpseo, 'person_name' );
 
 		// Remove the website name and altername name as we no longer need them.
-		$this->refresh_option_content( 'wpseo' );
+		$this->cleanup_option_data( 'wpseo' );
 
 		// All the breadcrumbs settings have moved to the search appearance settings.
 		foreach ( array_keys( $wpseo_internallinks ) as $key ) {
@@ -523,18 +523,24 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Re-save the option to make sure only the expected values are there.
+	 * Cleans the option to make sure only relevant settings are there.
 	 *
-	 * @param string $option_name Option name to sanitize.
+	 * @param string $option_name Option name save.
 	 *
 	 * @return void
 	 */
-	protected function refresh_option_content( $option_name ) {
+	protected function cleanup_option_data( $option_name ) {
 		$data = get_option( $option_name, array() );
 		if ( ! is_array( $data ) || $data === array() ) {
 			return;
 		}
 
+		/*
+		 * Clean up the option by re-saving it.
+		 *
+		 * The option framework will remove any settings that are not configure
+		 * for this option, removing any migrated settings.
+		 */
 		update_option( $option_name, $data );
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -538,7 +538,7 @@ class WPSEO_Upgrade {
 		/*
 		 * Clean up the option by re-saving it.
 		 *
-		 * The option framework will remove any settings that are not configure
+		 * The option framework will remove any settings that are not configured
 		 * for this option, removing any migrated settings.
 		 */
 		update_option( $option_name, $data );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -141,7 +141,7 @@ class WPSEO_Upgrade {
 		 */
 		delete_option( 'wpseo_ms' );
 
-		$wpseo = $this->get_option_raw( 'wpseo' );
+		$wpseo = $this->get_option_from_database( 'wpseo' );
 		$this->save_option_setting( $wpseo, 'pinterestverify' );
 
 		// Re-save option to trigger sanitization.
@@ -262,7 +262,7 @@ class WPSEO_Upgrade {
 	 * Moves the content-analysis-active and keyword-analysis-acive options from wpseo-titles to wpseo.
 	 */
 	private function upgrade_44() {
-		$wpseo_titles = $this->get_option_raw( 'wpseo_titles' );
+		$wpseo_titles = $this->get_option_from_database( 'wpseo_titles' );
 
 		$this->save_option_setting( $wpseo_titles, 'content-analysis-active', 'content_analysis_active' );
 		$this->save_option_setting( $wpseo_titles, 'keyword-analysis-active', 'keyword_analysis_active' );
@@ -439,11 +439,11 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_70() {
 
-		$wpseo_permalinks    = $this->get_option_raw( 'wpseo_permalinks' );
-		$wpseo_xml           = $this->get_option_raw( 'wpseo_xml' );
-		$wpseo_rss           = $this->get_option_raw( 'wpseo_rss' );
-		$wpseo               = $this->get_option_raw( 'wpseo' );
-		$wpseo_internallinks = $this->get_option_raw( 'wpseo_internallinks' );
+		$wpseo_permalinks    = $this->get_option_from_database( 'wpseo_permalinks' );
+		$wpseo_xml           = $this->get_option_from_database( 'wpseo_xml' );
+		$wpseo_rss           = $this->get_option_from_database( 'wpseo_rss' );
+		$wpseo               = $this->get_option_from_database( 'wpseo' );
+		$wpseo_internallinks = $this->get_option_from_database( 'wpseo_internallinks' );
 
 		// Move some permalink settings, then delete the option.
 		$this->save_option_setting( $wpseo_permalinks, 'redirectattachment', 'disable-attachment' );
@@ -509,7 +509,7 @@ class WPSEO_Upgrade {
 	 *
 	 * @return array|mixed The content of the option if exists, otherwise an empty array.
 	 */
-	protected function get_option_raw( $option_name ) {
+	protected function get_option_from_database( $option_name ) {
 		global $wpdb;
 
 		// Load option directly from the database, to avoid filtering and sanitization.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -109,25 +109,6 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Helper function to remove keys from options.
-	 *
-	 * @param string       $option The option to remove the keys from.
-	 * @param string|array $keys   The key or keys to remove.
-	 */
-	private function remove_key_from_option( $option, $keys ) {
-		$options = WPSEO_Options::get_option( $option );
-
-		if ( ! is_array( $keys ) ) {
-			$keys = array( $keys );
-		}
-		foreach ( $keys as $key ) {
-			unset( $options[ $key ] );
-		}
-
-		update_option( $option, $options );
-	}
-
-	/**
 	 * Helper function to move a key from one option to another.
 	 *
 	 * @param array       $old_options The option containing the value to be migrated.
@@ -215,13 +196,7 @@ class WPSEO_Upgrade {
 		// Unschedule our tracking.
 		wp_clear_scheduled_hook( 'yoast_tracking' );
 
-		// Clear the tracking settings, the seen about setting and the ignore tour setting.
-		$this->remove_key_from_option( 'wpseo', array(
-			'tracking_popup_done',
-			'yoast_tracking',
-			'seen_about',
-			'ignore_tour',
-		) );
+		$this->refresh_option_content( 'wpseo' );
 	}
 
 	/**
@@ -467,16 +442,7 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_63() {
-		$this->remove_key_from_option( 'wpseo_titles', array( 'noindex-subpages-wpseo', 'usemetakeywords' ) );
-
-		// Remove all the meta keyword template options we've stored.
-		$option_titles = WPSEO_Options::get_option( 'wpseo_titles' );
-		foreach ( array_keys( $option_titles ) as $key ) {
-			if ( strpos( $key, 'metakey' ) === 0 ) {
-				unset( $option_titles[ $key ] );
-			}
-		}
-		update_option( 'wpseo_titles', $option_titles );
+		$this->refresh_option_content( 'wpseo_titles' );
 	}
 
 	/**
@@ -509,7 +475,7 @@ class WPSEO_Upgrade {
 		$this->move_key_to_other_option( $wpseo, 'wpseo_titles', 'person_name' );
 
 		// Remove the website name and altername name as we no longer need them.
-		$this->remove_key_from_option( 'wpseo', array( 'website_name', 'alternate_website_name', 'company_logo', 'company_name', 'company_or_person', 'person_name' ) );
+		$this->refresh_option_content( 'wpseo' );
 
 		// All the breadcrumbs settings have moved to the search appearance settings.
 		foreach ( array_keys( $wpseo_internallinks ) as $key ) {

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -484,11 +484,11 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_70() {
 
-		$wpseo_permalinks    = get_option( 'wpseo_permalinks' );
-		$wpseo_xml           = get_option( 'wpseo_xml' );
-		$wpseo_rss           = get_option( 'wpseo_rss' );
-		$wpseo               = get_option( 'wpseo' );
-		$wpseo_internallinks = (array) get_option( 'wpseo_internallinks' );
+		$wpseo_permalinks    = $this->get_option_raw( 'wpseo_permalinks' );
+		$wpseo_xml           = $this->get_option_raw( 'wpseo_xml' );
+		$wpseo_rss           = $this->get_option_raw( 'wpseo_rss' );
+		$wpseo               = $this->get_option_raw( 'wpseo' );
+		$wpseo_internallinks = $this->get_option_raw( 'wpseo_internallinks' );
 
 		// Move some permalink settings, then delete the option.
 		$this->move_key_to_other_option( $wpseo_permalinks, 'wpseo_titles', 'redirectattachment', 'disable-attachment' );
@@ -546,5 +546,21 @@ class WPSEO_Upgrade {
 		// Moves the user meta for excluding from the XML sitemap to a noindex.
 		global $wpdb;
 		$wpdb->query( "UPDATE $wpdb->usermeta SET meta_key = 'wpseo_noindex_author' WHERE meta_key = 'wpseo_excludeauthorsitemap'" );
+	}
+
+	/**
+	 * Retrieves the option value directly from the database.
+	 *
+	 * @param string $option_name Option to retrieve.
+	 *
+	 * @return array|mixed
+	 */
+	private function get_option_raw( $option_name ) {
+		global $wpdb;
+
+		$sql = $wpdb->prepare( 'SELECT option_value FROM ' . $wpdb->options . ' WHERE option_name = %s', $option_name );
+		$result = $wpdb->get_row( $sql, ARRAY_N );
+
+		return maybe_unserialize( $result );
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -109,25 +109,6 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Saves an option setting to where it should be stored.
-	 *
-	 * @param array       $source_data    The option containing the value to be migrated.
-	 * @param string      $source_setting Name of the key in the "from" option.
-	 * @param string|null $target_setting Name of the key in the "to" option.
-	 *
-	 * @return void
-	 */
-	private function save_option_setting( $source_data, $source_setting, $target_setting = null ) {
-		if ( $target_setting === null ) {
-			$target_setting = $source_setting;
-		}
-
-		if ( isset( $source_data[ $source_setting ] ) ) {
-			WPSEO_Options::set( $target_setting, $source_data[ $source_setting ] );
-		}
-	}
-
-	/**
 	 * Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
 	 */
 	private function finish_up() {
@@ -555,5 +536,24 @@ class WPSEO_Upgrade {
 		}
 
 		update_option( $option_name, $data );
+	}
+
+	/**
+	 * Saves an option setting to where it should be stored.
+	 *
+	 * @param array       $source_data    The option containing the value to be migrated.
+	 * @param string      $source_setting Name of the key in the "from" option.
+	 * @param string|null $target_setting Name of the key in the "to" option.
+	 *
+	 * @return void
+	 */
+	protected function save_option_setting( $source_data, $source_setting, $target_setting = null ) {
+		if ( $target_setting === null ) {
+			$target_setting = $source_setting;
+		}
+
+		if ( isset( $source_data[ $source_setting ] ) ) {
+			WPSEO_Options::set( $target_setting, $source_data[ $source_setting ] );
+		}
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -69,7 +69,7 @@ class WPSEO_Upgrade {
 		}
 
 		if ( version_compare( $version, '5.0', '>=' )
-			&& version_compare( $version, '5.1', '<' )
+			 && version_compare( $version, '5.1', '<' )
 		) {
 			$this->upgrade_50_51();
 		}

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -114,9 +114,8 @@ class WPSEO_Options {
 		if ( is_network_admin() && isset( self::$option_instances[ $option_name ] ) ) {
 			return self::$option_instances[ $option_name ]->update_site_option( $value );
 		}
-		else {
-			return false;
-		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Because we have introduced the backfilling of the options, these are also being backfilled during the Upgrade routine.
This results in the empty values of the -not yet- migrated options.

By loading the options directly from the database, the settings can be loaded as they exist during the upgrade.

Also, saving the new options directly via `WPSEO_Options::set` provides a simpler way of storing the settings to be migrated.

Removing irrelevant keys can be done more easily, by re-saving the option, which is picked up by the Options framework, which in turn makes sure only valid settings are stored in the database.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the option settings that need to be migrated are backfilled prematurely.

## Relevant technical choices:

* `save_option_setting` still accepts the original setting and the key that should be extracted from there, to have to `isset` check being done internally and having better readability
* Removed the `remove_key_from_option` in favor of `refresh_option_content` which is removing all irrelevant settings from the option
* Uses `WPSEO_Options::set` in `save_option_setting` which removes the need for the `target` option name.
* Renamed `move_key_to_other_option ` to `save_option_setting`, as it is now just a 'resave' of a specific setting, the target is irrelevant.

## Test instructions

This PR can be tested by following these steps:

My approach to test different versions:
- Install 6.3.1 in `wordpress-seo-6.3.1` folder
- Install this branch in `wordpress-seo`
- Remove all `wpseo*` settings in the database
- Activate `6.3.1` branch and save the settings you want to test/see
- Deactivate `6.3.1`
- Activate the Yoast SEO with this branch
- See the changes being shown as expected

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9180 