### PR TITLE
Bump to 1.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
     "sassdash": "^0.8.1",
     "svg-react-loader": "^0.4.5",
     "time-grunt": "^1.0.0",
-    "webpack-dev-server": "^2.11.0",
     "unminified-webpack-plugin": "^1.4.2",
-    "webpack": "^3.4.1"
+    "webpack": "^3.4.1",
+    "webpack-dev-server": "^2.11.0"
   },
   "optionalDependencies": {
     "grunt-contrib-imagemin": "^2.0.1"
@@ -103,7 +103,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "yoast-components": "^3.1.0",
-    "yoastseo": "^1.30"
+    "yoastseo": "^1.30.1"
   },
   "yoast": {
     "pluginVersion": "7.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9975,9 +9975,9 @@ yoast-components@^3.1.0:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.30:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.30.0.tgz#9bd482097ad4aa0e48a74af2c2b5484e70e51fba"
+yoastseo@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.30.1.tgz#56ae066ede0009d840debaf3f129c130433b363a"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug that broke a filter which marks Spanish and French sentences as non-passive when certain exception words occur between the auxiliary and the participle.

## Test instructions

This PR can be tested by following these steps:

* Test whether the functionality above is present and nothing else breaks.
