### PR TITLE
Apply filter just-in-time

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -22,9 +22,6 @@ class WPSEO_Sitemaps {
 	/** @var bool $transient Whether or not the XML sitemap was served from a transient or not. */
 	private $transient = false;
 
-	/** @var int $max_entries The maximum number of entries per sitemap page. */
-	private $max_entries;
-
 	/**
 	 * @var string $http_protocol HTTP protocol to use in headers.
 	 * @since 3.2
@@ -72,7 +69,6 @@ class WPSEO_Sitemaps {
 		add_action( 'wpseo_hit_sitemap_index', array( $this, 'hit_sitemap_index' ) );
 		add_action( 'wpseo_ping_search_engines', array( __CLASS__, 'ping_search_engines' ) );
 
-		$this->max_entries = $this->get_entries_per_page();
 		$this->timezone    = new WPSEO_Sitemap_Timezone();
 		$this->router      = new WPSEO_Sitemaps_Router();
 		$this->renderer    = new WPSEO_Sitemaps_Renderer();
@@ -323,7 +319,7 @@ class WPSEO_Sitemaps {
 				continue;
 			}
 
-			$links = $provider->get_sitemap_links( $type, $this->max_entries, $this->current_page );
+			$links = $provider->get_sitemap_links( $type, $this->get_entries_per_page(), $this->current_page );
 
 			if ( empty( $links ) ) {
 				$this->bad_sitemap = true;
@@ -356,7 +352,7 @@ class WPSEO_Sitemaps {
 		$links = array();
 
 		foreach ( $this->providers as $provider ) {
-			$links = array_merge( $links, $provider->get_index_links( $this->max_entries ) );
+			$links = array_merge( $links, $provider->get_index_links( $this->get_entries_per_page() ) );
 		}
 
 		if ( empty( $links ) ) {
@@ -536,6 +532,9 @@ class WPSEO_Sitemaps {
 	protected function get_entries_per_page() {
 		/**
 		 * Filter the maximum number of entries per XML sitemap.
+		 *
+		 * After changing the output of the filter, make sure that you disable and enable the
+		 * sitemaps to make sure the value is picked up for the sitemap cache.
 		 *
 		 * @param int $entries The maximum number of entries per XML sitemap.
 		 */

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -314,12 +314,14 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
+		$entries_per_page = $this->get_entries_per_page();
+
 		foreach ( $this->providers as $provider ) {
 			if ( ! $provider->handles_type( $type ) ) {
 				continue;
 			}
 
-			$links = $provider->get_sitemap_links( $type, $this->get_entries_per_page(), $this->current_page );
+			$links = $provider->get_sitemap_links( $type, $entries_per_page, $this->current_page );
 
 			if ( empty( $links ) ) {
 				$this->bad_sitemap = true;
@@ -350,9 +352,10 @@ class WPSEO_Sitemaps {
 	public function build_root_map() {
 
 		$links = array();
+		$entries_per_page = $this->get_entries_per_page();
 
 		foreach ( $this->providers as $provider ) {
-			$links = array_merge( $links, $provider->get_index_links( $this->get_entries_per_page() ) );
+			$links = array_merge( $links, $provider->get_index_links( $entries_per_page ) );
 		}
 
 		if ( empty( $links ) ) {


### PR DESCRIPTION
Instead of triggering it in the constructor, which is being called on `plugins_loaded`, excluding theme's from ever being able to use it.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where adding a `wpseo_sitemap_entries_per_page` which is not being used in rendering the sitemaps. 

## Relevant technical choices:

* Using the filter just in time.

## Test instructions

This PR can be tested by following these steps:

* Add the following filter in your theme (functions.php):
 ```
add_filter( 'wpseo_sitemap_entries_per_page', function() {
	return 5;
});
```
* Disable the Sitemap feature
* Enable the Sitemap feature (this will reset the cache buster)
* Visit a sitemap post type page and verify the max entries is being respected

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9166
