### PR TITLE
Fetch `wpseo_titles` from database as well

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -444,6 +444,7 @@ class WPSEO_Upgrade {
 		$wpseo_rss           = $this->get_option_from_database( 'wpseo_rss' );
 		$wpseo               = $this->get_option_from_database( 'wpseo' );
 		$wpseo_internallinks = $this->get_option_from_database( 'wpseo_internallinks' );
+		$wpseo_titles        = $this->get_option_from_database( 'wpseo_titles' );
 
 		// Move some permalink settings, then delete the option.
 		$this->save_option_setting( $wpseo_permalinks, 'redirectattachment', 'disable-attachment' );
@@ -471,9 +472,7 @@ class WPSEO_Upgrade {
 		}
 
 		// Convert hidden metabox options to display metabox options.
-		$title_options = get_option( 'wpseo_titles' );
-
-		foreach ( $title_options as $key => $value ) {
+		foreach ( $wpseo_titles as $key => $value ) {
 			if ( strpos( $key, 'hideeditbox-tax-' ) === 0 ) {
 				$taxonomy = substr( $key, strlen( 'hideeditbox-tax-' ) );
 				WPSEO_Options::set( 'display-metabox-tax-' . $taxonomy, ! $value );


### PR DESCRIPTION
## Test instructions

Test instructions:

My approach to test different versions:
- Install 6.3.1 in `wordpress-seo-6.3.1` folder
- Install this branch in `wordpress-seo`
- Remove all `wpseo*` settings in the database
- Activate `6.3.1` branch and save the settings you want to test/see
- Deactivate `6.3.1`
- Activate the Yoast SEO with this branch
- See the changes being shown as expected

Set all `metaboxes` to 'disabled' in Post types and Taxonomies and expect them to be disabled after upgrading as well.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9190
