### PR TITLE
Removes the backfill hooks when calling `WPSEO_Options::get` to improve performance

### DIFF
--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -14,11 +14,6 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	const USER_META_KEY = 'wpseo_dismiss_onpage';
 
 	/**
-	 * @var WPSEO_OnPage_Option The Ryte option class.
-	 */
-	private $onpage_option;
-
-	/**
 	 * @var boolean Is the request started by pressing the fetch button.
 	 */
 	private $is_manual_request = false;

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Handle the request for getting the Ryte status.
+ * Handles the request for getting the Ryte status.
  */
 class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 
@@ -22,30 +22,33 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 * Constructs the object.
 	 */
 	public function __construct() {
-		// We never want to fetch on AJAX request because doing a remote request is really slow.
 		$this->catch_redo_listener();
 	}
 
 	/**
 	 * Sets up the hooks.
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		if ( ! $this->is_active() ) {
 			return;
 		}
 
-		// Add weekly schedule to the cron job schedules.
+		// Adds weekly schedule to the cron job schedules.
 		add_filter( 'cron_schedules', array( $this, 'add_weekly_schedule' ) );
 
-		// Adding admin notice if necessary.
+		// Adds admin notice if necessary.
 		add_filter( 'admin_init', array( $this, 'show_notice' ) );
 
-		// Setting the action for the Ryte fetch.
+		// Sets the action for the Ryte fetch.
 		add_action( 'wpseo_onpage_fetch', array( $this, 'fetch_from_onpage' ) );
 	}
 
 	/**
-	 * Show a notice when the website is not indexable
+	 * Shows a notice when the website is not indexable.
+	 *
+	 * @return void
 	 */
 	public function show_notice() {
 		$notification        = $this->get_indexability_notification();
@@ -61,9 +64,9 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Determines if we can run OnPage functionality.
+	 * Determines if we can use the functionality.
 	 *
-	 * @return bool True if OnPage can be used.
+	 * @return bool True if this functionality can be used.
 	 */
 	protected function is_active() {
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX === true ) {
@@ -118,10 +121,7 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 		// The currently indexability status.
 		$old_status = $onpage_option->get_status();
 
-		// Saving the new status.
 		$onpage_option->set_status( $new_status );
-
-		// Saving the option.
 		$onpage_option->save_option();
 
 		// Check if the status has been changed.
@@ -200,7 +200,7 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Notifies the admins
+	 * Notifies the admins.
 	 *
 	 * @return void
 	 */

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -223,7 +223,13 @@ class WPSEO_Options {
 	 * @return mixed|null Returns value if found, $default if not.
 	 */
 	public static function get( $key, $default = null ) {
+		self::get_instance();
+		self::$backfill->remove_hooks();
+
 		$option = self::get_all();
+
+		self::$backfill->register_hooks();
+
 		if ( isset( $option[ $key ] ) ) {
 			return $option[ $key ];
 		}

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -223,7 +223,6 @@ class WPSEO_Options {
 	 * @return mixed|null Returns value if found, $default if not.
 	 */
 	public static function get( $key, $default = null ) {
-		self::get_instance();
 		self::$backfill->remove_hooks();
 
 		$option = self::get_all();

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -36,6 +36,12 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	public function test_add_weekly_schedule() {
 		$this->class_instance->register_hooks();
 
+		$schedules = $this->class_instance->add_weekly_schedule( array() );
+
+		$this->assertTrue( array_key_exists( 'weekly', $schedules ) );
+		$this->assertEquals( $schedules['weekly']['interval'], WEEK_IN_SECONDS );
+		$this->assertEquals( $schedules['weekly']['display'], __( 'Once Weekly', 'wordpress-seo' ) );
+
 		$schedules = wp_get_schedules();
 
 		$this->assertTrue( array_key_exists( 'weekly', $schedules ) );

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -34,6 +34,8 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_OnPage::add_weekly_schedule
 	 */
 	public function test_add_weekly_schedule() {
+		$this->class_instance->register_hooks();
+
 		$schedules = wp_get_schedules();
 
 		$this->assertTrue( array_key_exists( 'weekly', $schedules ) );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -182,6 +182,10 @@ function _wpseo_activate() {
 	$notifier = new WPSEO_Link_Notifier();
 	$notifier->manage_notification();
 
+	// Schedule cronjob when it doesn't exists on activation.
+	$wpseo_onpage = new WPSEO_OnPage();
+	$wpseo_onpage->activate_hooks();
+
 	do_action( 'wpseo_activate' );
 }
 /**
@@ -292,6 +296,12 @@ function wpseo_init() {
 	 */
 	$link_watcher = new WPSEO_Link_Watcher_Loader();
 	$link_watcher->load();
+
+	// Loading Ryte integration.
+	if ( WPSEO_Options::get( 'onpage_indexability' ) ) {
+		$wpseo_onpage = new WPSEO_OnPage();
+		$wpseo_onpage->register_hooks();
+	}
 }
 
 /**
@@ -405,9 +415,6 @@ register_activation_hook( WPSEO_FILE, 'wpseo_activate' );
 register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
 add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );
-
-// Loading Ryte integration.
-new WPSEO_OnPage();
 
 // Registers SEO capabilities.
 $wpseo_register_capabilities = new WPSEO_Register_Capabilities();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the backfill hooks when calling `WPSEO_Options::get()` to improve performance.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Determine that the current release (`7.0.3`) has a significant increase in the loading time (in some cases 2x) as per described in the issue.
* Checkout this branch, run the same tests and determine that the loading time decreases.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9170 
