### PR TITLE
Flushes the rewrite rules after option update

### DIFF
--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -147,6 +147,9 @@ abstract class WPSEO_Option {
 		*/
 		add_filter( 'sanitize_option_' . $this->option_name, array( $this, 'validate' ) );
 
+		// Flushes the rewrite rules when option is updated.
+		add_action( 'update_option_' . $this->option_name, array( 'WPSEO_Utils', 'clear_rewrites' ) );
+
 		/* Register our option for the admin pages */
 		add_action( 'admin_init', array( $this, 'register_setting' ) );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the rewrite rules aren't removed after stripping the category base. This resulted in an unaccessible page.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch
* Strip the category base
* See the category page is working.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9196
