### PR TITLE
Renames breadcrumbs-blog-remove to breadcrumbs-display-blog-page

### DIFF
--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -71,7 +71,7 @@ class WPSEO_Customizer {
 	 */
 	private function breadcrumbs_blog_remove_setting() {
 		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-blog-remove]', array(
+			'wpseo_titles[breadcrumbs-display-blog-page]', array(
 				'default'   => '',
 				'type'      => 'option',
 				'transport' => 'refresh',
@@ -80,11 +80,11 @@ class WPSEO_Customizer {
 
 		$this->wp_customize->add_control(
 			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-blog-remove', array(
+				$this->wp_customize, 'wpseo-breadcrumbs-display-blog-page', array(
 					'label'           => __( 'Remove blog page from breadcrumbs', 'wordpress-seo' ),
 					'type'            => 'checkbox',
 					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_titles[breadcrumbs-blog-remove]',
+					'settings'        => 'wpseo_titles[breadcrumbs-display-blog-page]',
 					'context'         => '',
 					'active_callback' => array( $this, 'breadcrumbs_blog_remove_active_cb' ),
 				)

--- a/admin/views/tabs/metas/breadcrumbs.php
+++ b/admin/views/tabs/metas/breadcrumbs.php
@@ -32,7 +32,7 @@ $yform->textinput( 'breadcrumbs-404crumb', __( 'Breadcrumb for 404 Page', 'wordp
 echo '<br/>';
 
 if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) > 0 ) {
-	$yform->show_hide_switch( 'breadcrumbs-blog-remove', __( 'Show Blog page', 'wordpress-seo' ) );
+	$yform->show_hide_switch( 'breadcrumbs-display-blog-page', __( 'Show Blog page', 'wordpress-seo' ) );
 }
 
 $yform->toggle_switch( 'breadcrumbs-boldlast', array(

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -486,7 +486,7 @@ class WPSEO_Breadcrumbs {
 	 */
 	private function maybe_add_blog_crumb() {
 		if ( ( 'page' === $this->show_on_front && 'post' === get_post_type() ) && ( ! is_home() && ! is_search() ) ) {
-			if ( $this->page_for_posts && WPSEO_Options::get( 'breadcrumbs-blog-remove' ) === false ) {
+			if ( $this->page_for_posts && WPSEO_Options::get( 'breadcrumbs-display-blog-page' ) === true ) {
 				$this->add_blog_crumb();
 			}
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -511,6 +511,15 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_71() {
 		$this->cleanup_option_data( 'wpseo_social' );
+
+		// Move the breadcrumbs setting and invert it.
+		$title_options = $this->get_option_from_database( 'wpseo_titles' );
+
+		if ( array_key_exists( 'breadcrumbs-blog-remove', $title_options ) ) {
+			WPSEO_Options::set( 'breadcrumbs-display-blog-page', ! $title_options['breadcrumbs-blog-remove'] );
+
+			$this->cleanup_option_data( 'wpseo_titles' );
+		}
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -47,7 +47,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'disable-attachment'           => true,
 
 		'breadcrumbs-404crumb'         => '', // Text field.
-		'breadcrumbs-blog-remove'      => false,
+		'breadcrumbs-display-blog-page' => true,
 		'breadcrumbs-boldlast'         => false,
 		'breadcrumbs-archiveprefix'    => '', // Text field.
 		'breadcrumbs-enable'           => false,
@@ -528,7 +528,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				 *  'display-metabox-pt-'. $pt->name
 				 *  'display-metabox-tax-'
 				 *  'display-metabox-tax-' . $tax->name
-				 *  'breadcrumbs-blog-remove'
+				 *  'breadcrumbs-display-blog-page'
 				 *  'breadcrumbs-boldlast'
 				 *  'breadcrumbs-enable'
 				 *  'stripcategorybase'

--- a/inc/options/class-wpseo-options-backfill.php
+++ b/inc/options/class-wpseo-options-backfill.php
@@ -93,7 +93,7 @@ class WPSEO_Options_Backfill implements WPSEO_WordPress_Integration {
 			'wpseo_internallinks' =>
 				array(
 					'breadcrumbs-404crumb'      => 'breadcrumbs-404crumb',
-					'breadcrumbs-blog-remove'   => 'breadcrumbs-blog-remove',
+					'breadcrumbs-blog-remove'   => 'breadcrumbs-display-blog-page',
 					'breadcrumbs-boldlast'      => 'breadcrumbs-boldlast',
 					'breadcrumbs-archiveprefix' => 'breadcrumbs-archiveprefix',
 					'breadcrumbs-enable'        => 'breadcrumbs-enable',
@@ -166,6 +166,19 @@ class WPSEO_Options_Backfill implements WPSEO_WordPress_Integration {
 	 * @return array Extended data.
 	 */
 	public function extend_wpseo_titles( $data ) {
+		// Make sure we don't get stuck in an infinite loop.
+		static $running = false;
+
+		// If we are already running, don't run again.
+		if ( $running ) {
+			return $data;
+		}
+		$running = true;
+
+		$data['breadcrumbs-blog-remove'] = ! WPSEO_Options::get( 'breadcrumbs-display-blog-page' );
+
+		$running = false;
+
 		$data = $this->add_hideeditbox( $data );
 
 		return $data;

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,7 @@ Release Date: March 20th, 2018
 * Fixes a bug where the `page` and `paged` values could cause errors if they weren't properly handled as integers.
 * Fixes a bug where division by zero errors in the passive voice assessment would cause `NaN%` to show up in the feedback.
 * Fixes a bug where multiple `rel` arguments prevented correct `nofollow` detection.
+* Fixes a bug where enabling the Show blog page in the breadcrumb settings had the inverse effect. Internally renamed `breadcrumbs-blog-remove` to `breadcrumbs-display-blog-page` to fix logic issues.
 
 = 7.0.3 =
 Release Date: March 12th, 2018


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Renames `breadcrumbs-blog-remove` to `breadcrumbs-display-blog-page` to fix logic issues. Previously when you enabled the `Show blog page` in the breadcrumb settings, it'd be disabled and vice versa.

## Relevant technical choices:

*

## Test instructions

(Credits to @CarolineGeven for these detailed instructions)

This PR can be tested by following these steps:

**IMPORTANT: Prior to testing, ensure that the `version` property in your database is set to a value lower than `7.1.0`. The property can be found under the `wpseo` option name in the `wp_options` database table.**

* Go to Settings -> Reading.
* Set a static page for posts page. (Leaving the option unset is fine)
* Create a blog post and insert the `[wpseo_breadcrumb]` shortcode.
* Go to SEO -> Search Appearance -> Breadcrumbs.
* Set `Show blog page` to `Hide`.
* Go to your post with the shortcode and see that the blog page is no longer shown in the breadcrumbs. For example, if your blog page title you've set in step 2, is called sample page, you will no longer see `home >> sample page >> post title`
* Set `Show blog page` to `Show` in SEO -> Search Appearance -> Breadcrumbs
* Go to your post with the shortcode and see that the blog page is now shown. 
## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9174 
