### PR TITLE
Fix logic for removing canonical when noindexing

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -789,7 +789,7 @@ class WPSEO_Frontend {
 		}
 
 		// If a page has a noindex, it should _not_ have a canonical, as these are opposing indexing directives.
-		if ( $robots['index'] === 'noindex' ) {
+		if ( strpos( $robotsstr, 'noindex' ) !== false ) {
 			remove_action( 'wpseo_head', array( $this, 'canonical' ), 20 );
 		}
 
@@ -1337,6 +1337,7 @@ class WPSEO_Frontend {
 	 * Outputs noindex values for the current page.
 	 */
 	public function noindex_page() {
+		remove_action( 'wpseo_head', array( $this, 'canonical' ), 20 );
 		echo '<meta name="robots" content="noindex" />', "\n";
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* When setting a page to `noindex` through the `wpseo_robots` filter we now properly remove the `canonical` element.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended

Fixes #9132
