### PR TITLE
Remove the whip notification

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -314,7 +314,7 @@ class WPSEO_Admin {
 	 * Initializes Whip to show a notice for outdated PHP versions.
 	 *
 	 *
-	 * @todo Deprecate this method when WordPress 5.1 is our supported version.
+	 * @todo Deprecate this method when WordPress 5.1 is our currently minimal supported version.
 	 *
 	 * @return void
 	 */
@@ -323,7 +323,8 @@ class WPSEO_Admin {
 		 * The Whip message shouldn't be shown from WordPress 4.9.5 and higher because
 		 * that version introduces Serve Happy which is almost similar to Whip.
 		 */
-		if ( version_compare( $GLOBALS['wp_version'], '4.9.5', '>=' ) ) {
+		$minimal_required_wordpress_version = '4.9.5';
+		if ( version_compare( $GLOBALS['wp_version'], $minimal_required_wordpress_version, '>=' ) ) {
 			return;
 		}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -312,8 +312,17 @@ class WPSEO_Admin {
 
 	/**
 	 * Initializes Whip to show a notice for outdated PHP versions.
+	 *
+	 *
+	 * @todo Deprecate this method when WordPress 5.1 is our supported version.
+	 *
+	 * @return void
 	 */
 	protected function check_php_version() {
+		/*
+		 * The Whip message shouldn't be shown from WordPress 4.9.5 and higher because
+		 * that version introduces Serve Happy which is almost similar to Whip.
+		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.9.5', '>=' ) ) {
 			return;
 		}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -314,6 +314,10 @@ class WPSEO_Admin {
 	 * Initializes Whip to show a notice for outdated PHP versions.
 	 */
 	protected function check_php_version() {
+		if ( version_compare( $GLOBALS['wp_version'], '4.9.5', '>=' ) ) {
+			return;
+		}
+
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -313,7 +313,6 @@ class WPSEO_Admin {
 	/**
 	 * Initializes Whip to show a notice for outdated PHP versions.
 	 *
-	 *
 	 * @todo Deprecate this method when WordPress 5.1 is our currently minimal supported version.
 	 *
 	 * @return void

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -322,8 +322,8 @@ class WPSEO_Admin {
 		 * The Whip message shouldn't be shown from WordPress 4.9.5 and higher because
 		 * that version introduces Serve Happy which is almost similar to Whip.
 		 */
-		$minimal_required_wordpress_version = '4.9.5';
-		if ( version_compare( $GLOBALS['wp_version'], $minimal_required_wordpress_version, '>=' ) ) {
+		$minimal_wp_version = '4.9.5';
+		if ( version_compare( $GLOBALS['wp_version'], $minimal_wp_version, '>=' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the Whip notification for WordPress versions starting from 4.9.5

## Test instructions

This PR can be tested by following these steps:

* Change `>=5.4` in the `whip_wp_check_versions` function call to `>=7.3`. This fakes the minimal required PHP version. You can test with a version below 5.4 if you want, will do the same.
* Go to the WordPress dashboard. 
* A notification will be shown.
* Change the 4.9.5 in the version compare to the current WordPress version (4.9.4?). This fakes the minimal required WordPress version to a version that has been released already.
* The notification should be hidden now.

## Quality assurance

* [x] I have tested this code to the best of my abilities


Fixes #9220
