### PR TITLE
Hide notification for premium users

### DIFF
--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -60,7 +60,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 			$dependency_names = $checker->get_dependency_names( $plugin );
 			$notification     = $this->get_yoast_seo_suggested_plugins_notification( $plugin_name, $plugin, $dependency_names[0] );
 
-			if ( ! $checker->is_installed( $plugin ) || ! $checker->is_active( $plugin['slug'] ) ) {
+			if ( ! WPSEO_Utils::is_yoast_seo_premium() && ( ! $checker->is_installed( $plugin ) || ! $checker->is_active( $plugin['slug'] ) ) ) {
 				$this->notification_center->add_notification( $notification );
 
 				continue;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Hide suggestions for plugins on the dashboard if Premium plugin is active

## Test instructions

This PR can be tested by following these steps:

* Have ACF, WooCommerce or AMP for WordPress installed. 
* Checkout trunk on this repo.
* Go to the dashboard and see some suggestions.
* Checkout premium trunk
* See the notifications still being present.
* Create a temporary branch on premium and merge this branch into that branch.
* Refresh the dashboard and see the notifications being removed. 

An unfair test is to change the implementation of WPSEO_Utils:: is_yoast_seo_premium by returning that method true. This fakes the premium situation. Or you can define a constant named `WPSEO_PREMIUM_PLUGIN_FILE`

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1632
