### PR TITLE
Added words to improve how to resolve a comment notification 

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -150,7 +150,7 @@ class WPSEO_Admin_Init {
 
 		$info_message .= sprintf(
 			/* translators: %1$s resolves to the opening tag of the link to the comment setting page, %2$s resolves to the closing tag of the link */
-			__( 'Simply uncheck the box before "Break comments into pages..." on the %1$sComment settings page%2$s.', 'wordpress-seo' ),
+			__( 'To fix this uncheck the box in front of the "Break comments into pages..." on the %1$sComment settings page%2$s.', 'wordpress-seo' ),
 			'<a href="' . esc_url( admin_url( 'options-discussion.php' ) ) . '">',
 			'</a>'
 		);

--- a/languages/wordpress-seo.pot
+++ b/languages/wordpress-seo.pot
@@ -268,7 +268,7 @@ msgstr ""
 #. setting page, %2$s resolves to the closing tag of the link
 #: admin/class-admin-init.php:151
 msgid ""
-"Simply uncheck the box before \"Break comments into pages...\" on the "
+"To fix this uncheck the box in front of the \"Break comments into pages...\" on the "
 "%1$sComment settings page%2$s."
 msgstr ""
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*Added words to improve how to resolve a comment notification 

## Relevant technical choices:

*n/a

## Test instructions

This PR can be tested by following these steps:

*1. Install plugin
 2. Visit comments settings section and click the box in front of  "Break Comments into pages". This will then trigger the new notification 
3. See new notification 

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/wordpress-seo/issues/8876
