### PR TITLE
Prevent console error in classic editor

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -461,7 +461,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		store.dispatch( setActiveKeyword( tabManager.getKeywordTab().getKeyWord() ) );
 
 		// Set refresh function. data.setRefresh is only defined when Gutenberg is available.
-		if( data.setRefresh ) {
+		if ( data.setRefresh ) {
 			data.setRefresh( app.refresh );
 		}
 	}

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -460,8 +460,10 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		// Set initial keyword.
 		store.dispatch( setActiveKeyword( tabManager.getKeywordTab().getKeyWord() ) );
 
-		// Set refresh function.
-		data.setRefresh( app.refresh );
+		// Set refresh function. data.setRefresh is only defined when Gutenberg is available.
+		if( data.setRefresh ) {
+			data.setRefresh( app.refresh );
+		}
 	}
 
 	jQuery( document ).ready( initializePostAnalysis );


### PR DESCRIPTION
Fixes a console error in the classic editor that states that `data.setRefresh` is not defined/not a function.

## Testing
1. On master, open a post in the classic editor.
2. Check your console and see the error.
3. Check out this branch. Don't forget to build etc.
4. Open a post in the classic editor.
5. The error is gone