### PR TITLE
Bump YoastSEO.js to 1.30.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "yoast-components": "^3.2.1",
-    "yoastseo": "^1.30.1"
+    "yoastseo": "^1.30.2"
   },
   "yoast": {
     "pluginVersion": "7.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9825,9 +9825,9 @@ yoast-components@^3.2.1:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.30.1.tgz#56ae066ede0009d840debaf3f129c130433b363a"
+yoastseo@^1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.30.2.tgz#857a622593c8d67784e83748b6a3da9ec0c7dd98"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Reverts the default view of the snippet preview to desktop.

## Test instructions

This PR can be tested by following these steps:

* Test whether the functionality above is present and nothing else breaks.
