### PR TITLE
Consistency in capitalization

### DIFF
--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -53,7 +53,7 @@ $tabs->add_tab(
 $tabs->add_tab(
 	new WPSEO_Option_Tab(
 		'webmaster-tools',
-		__( 'Webmaster tools', 'wordpress-seo' ),
+		__( 'Webmaster Tools', 'wordpress-seo' ),
 		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-general-search-console' ) )
 	)
 );

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -53,7 +53,7 @@ $feature_toggles = array(
 		'order'           => 40,
 	),
 	(object) array(
-		'name'            => __( 'XML Sitemaps', 'wordpress-seo' ),
+		'name'            => __( 'XML sitemaps', 'wordpress-seo' ),
 		'setting'         => 'enable_xml_sitemap',
 		/* translators: %s expands to Yoast SEO */
 		'label'           => sprintf( __( 'Enable the XML sitemaps that %s generates.', 'wordpress-seo' ), 'Yoast SEO' ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The second letter in settings and tabs is not consistently capitalized. The capitalization is the norm (Search Appearance, Search Console, Regex Redirects, Content Types), but tools in _Webmaster tools_ is not capitalized.

## Test instructions

This PR can be tested by following these steps:

* Go to General -> Features (tab) and check the capitalization on XML Sitemaps toggle and other toggles.
* Go to General -> Webmaster tools (tab) to check the tab title.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #8993 