### PR TITLE
Add Support for Baidu Webmaster Tools Verification

### DIFF
--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -40,10 +40,10 @@ $googleverify_link = add_query_arg(
 $yform->textinput( 'baiduverify', __( 'Baidu verification code', 'wordpress-seo' ) );
 echo '<p class="desc label">';
 printf(
-	/* translators: 1: link open tag; 2: link close tag. */
+	/* translators: %1$s expands to a link start tag to the Baidu Webmaster Tools site add page, %2$s is the link closing tag */
 	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress-seo' ),
 	/**
-	 * Got the Baidu Webmaster Tools site add link from this 3rd party article
+	 * Get the Baidu Webmaster Tools site add link from this 3rd party article
 	 * http://www.dragonmetrics.com/how-to-optimize-your-site-with-baidu-webmaster-tools/.
 	 * We are unable to create a Baidu Webmaster Tools account due to the Chinese phone number verification.
 	 */

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -40,7 +40,7 @@ $googleverify_link = add_query_arg(
 $yform->textinput( 'baiduverify', __( 'Baidu verification code', 'wordpress-seo' ) );
 echo '<p class="desc label">';
 printf(
-	/* translators: %1$s expands to a link start tag to the Baidu Webmaster Tools site add page, %2$s is the link closing tag */
+	/* translators: %1$s expands to a link start tag to the Baidu Webmaster Tools site add page, %2$s is the link closing tag. */
 	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress-seo' ),
 	/**
 	 * Get the Baidu Webmaster Tools site add link from this 3rd party article

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -37,6 +37,15 @@ $googleverify_link = add_query_arg(
 	'https://www.google.com/webmasters/verification/verification'
 );
 
+$yform->textinput( 'baiduverify', __( 'Baidu verification code', 'wordpress-seo' ) );
+echo '<p class="desc label">';
+printf(
+	/* translators: 1: link open tag; 2: link close tag. */
+	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress' ),
+	'<a target="_blank" href="' . esc_url( 'https://ziyuan.baidu.com/site/siteadd' ) . '" rel="noopener noreferrer">',
+	'</a>'
+);
+echo '</p>';
 
 $yform->textinput( 'msverify', __( 'Bing verification code', 'wordpress-seo' ) );
 echo '<p class="desc label">';

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -41,7 +41,13 @@ $yform->textinput( 'baiduverify', __( 'Baidu verification code', 'wordpress-seo'
 echo '<p class="desc label">';
 printf(
 	/* translators: 1: link open tag; 2: link close tag. */
-	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress' ),
+	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress-seo' ),
+
+	/**
+	 * Got the Baidu Webmaster Tools site add link from this 3rd party article
+	 * http://www.dragonmetrics.com/how-to-optimize-your-site-with-baidu-webmaster-tools/.
+	 * We are unable to create a Baidu Webmaster Tools account due to the Chinese phone number verification.
+	 */
 	'<a target="_blank" href="' . esc_url( 'https://ziyuan.baidu.com/site/siteadd' ) . '" rel="noopener noreferrer">',
 	'</a>'
 );

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -42,7 +42,6 @@ echo '<p class="desc label">';
 printf(
 	/* translators: 1: link open tag; 2: link close tag. */
 	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress-seo' ),
-
 	/**
 	 * Got the Baidu Webmaster Tools site add link from this 3rd party article
 	 * http://www.dragonmetrics.com/how-to-optimize-your-site-with-baidu-webmaster-tools/.

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -632,7 +632,7 @@ class WPSEO_Frontend {
 	 * Output Webmaster Tools authentication strings.
 	 */
 	public function webmaster_tools_authentication() {
-		// Baidu
+		// Baidu.
 		$this->webmaster_tools_helper( 'baiduverify', 'baidu-site-verification' );
 
 		// Bing.

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -632,6 +632,9 @@ class WPSEO_Frontend {
 	 * Output Webmaster Tools authentication strings.
 	 */
 	public function webmaster_tools_authentication() {
+		// Baidu
+		$this->webmaster_tools_helper( 'baiduverify', 'baidu-site-verification' );
+
 		// Bing.
 		$this->webmaster_tools_helper( 'msverify', 'msvalidate.01' );
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -28,7 +28,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		// Form fields.
 		'disableadvanced_meta'            => true,
 		'onpage_indexability'             => true,
-		'baiduverify'                     => '',
+		'baiduverify'                     => '', // Text field.
 		'googleverify'                    => '', // Text field.
 		'msverify'                        => '', // Text field.
 		'yandexverify'                    => '',

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -28,6 +28,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		// Form fields.
 		'disableadvanced_meta'            => true,
 		'onpage_indexability'             => true,
+		'baiduverify'                     => '',
 		'googleverify'                    => '', // Text field.
 		'msverify'                        => '', // Text field.
 		'yandexverify'                    => '',
@@ -49,6 +50,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	 */
 	public $ms_exclude = array(
 		/* Privacy. */
+		'baiduverify',
 		'googleverify',
 		'msverify',
 		'yandexverify',
@@ -137,6 +139,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					break;
 
 				/* Verification strings. */
+				case 'baiduverify':
 				case 'googleverify':
 				case 'msverify':
 				case 'yandexverify':

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -242,6 +242,11 @@ abstract class WPSEO_Option {
 				$service = '';
 
 				switch ( $key ) {
+					case 'baiduverify':
+						$regex   = '`^[A-Za-z0-9_-]+$`';
+						$service = 'Baidu Webmaster tools';
+						break;
+
 					case 'googleverify':
 						$regex   = '`^[A-Za-z0-9_-]+$`';
 						$service = 'Google Webmaster tools';

--- a/tests/frontend/test-class-wpseo-frontend.php
+++ b/tests/frontend/test-class-wpseo-frontend.php
@@ -151,7 +151,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 
 		$this->go_to_home();
 
-		$this->run_webmaster_tools_authentication_option_test( 'baiduverify', 'h95vqTAZZq', '<meta name="baidu-site-verification", content="h95vqTAZZq" />' . "\n" );
+		$this->run_webmaster_tools_authentication_option_test( 'baiduverify', 'h95vqTAZZq', '<meta name="baidu-site-verification" content="h95vqTAZZq" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'googleverify', 'googleverify', '<meta name="google-site-verification" content="googleverify" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'msverify', 'acfacfacf', '<meta name="msvalidate.01" content="acfacfacf" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'yandexverify', 'defdefdef', '<meta name="yandex-verification" content="defdefdef" />' . "\n" );

--- a/tests/frontend/test-class-wpseo-frontend.php
+++ b/tests/frontend/test-class-wpseo-frontend.php
@@ -151,6 +151,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 
 		$this->go_to_home();
 
+		$this->run_webmaster_tools_authentication_option_test( 'baiduverify', 'h95vqTAZZq', '<meta name="baidu-site-verification", content="h95vqTAZZq" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'googleverify', 'googleverify', '<meta name="google-site-verification" content="googleverify" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'msverify', 'acfacfacf', '<meta name="msvalidate.01" content="acfacfacf" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'yandexverify', 'defdefdef', '<meta name="yandex-verification" content="defdefdef" />' . "\n" );

--- a/tests/frontend/test-class-wpseo-frontend.php
+++ b/tests/frontend/test-class-wpseo-frontend.php
@@ -151,7 +151,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 
 		$this->go_to_home();
 
-		$this->run_webmaster_tools_authentication_option_test( 'baiduverify', 'h95vqTAZZq', '<meta name="baidu-site-verification" content="h95vqTAZZq" />' . "\n" );
+		$this->run_webmaster_tools_authentication_option_test( 'baiduverify', 'hasdfa34ds', '<meta name="baidu-site-verification" content="hasdfa34ds" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'googleverify', 'googleverify', '<meta name="google-site-verification" content="googleverify" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'msverify', 'acfacfacf', '<meta name="msvalidate.01" content="acfacfacf" />' . "\n" );
 		$this->run_webmaster_tools_authentication_option_test( 'yandexverify', 'defdefdef', '<meta name="yandex-verification" content="defdefdef" />' . "\n" );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add Baidu Webmaster Tools verification support

## Relevant technical choices:

* An example Baidu webmaster tools verification can be found on the relevant unit test method.

## Test instructions

This PR can be tested by following these steps:

* Go to Yoast SEO -> Webmaster Tools (tab).
* Add a Baidu webmaster tools verification code.
* Check the homepage source code for the verification meta.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #5409