### PR TITLE
Output home URL before #organization

### DIFF
--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -121,7 +121,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	private function organization() {
 		if ( '' !== WPSEO_Options::get( 'company_name', '' ) ) {
 			$this->data['@type'] = 'Organization';
-			$this->data['@id']   = '#organization';
+			$this->data['@id']   = $this->get_home_url() . '#organization';
 			$this->data['name']  = WPSEO_Options::get( 'company_name' );
 			$this->data['logo']  = WPSEO_Options::get( 'company_logo', '' );
 

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -132,7 +132,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 			'@type'    => 'Organization',
 			'url'      => $home_url,
 			'sameAs'   => array( $facebook, $instagram ),
-			'@id'      => '#organization',
+			'@id'      => $home_url . '#organization',
 			'name'     => $name,
 			'logo'     => '',
 		) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changed JSON+LD organization output to always point to `#organization` on the homepage instead of the current page.

## Test instructions

This PR can be tested by following these steps:

* See any page's JSON+LD #organization section.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended

Fixes #9228 
