### PR TITLE
set box-sizing for yoast_meta class and force all children to inherit

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -13,6 +13,14 @@
 	@return inline-svg('<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path fill="#{$color}" d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z" /></svg>');
 }
 
+#wpseo_meta {
+	box-sizing: border-box;
+
+	*, *:before, *:after {
+		box-sizing: inherit;
+	}
+}
+
 /* Hide the taxonomy metabox rich editor when it's first inserted in the form. */
 #edittag > #wp-description-wrap {
 	display: none;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Set box-sizing to border-box on the highest yoast metabox class, and set all children to inherit that box-sizing.

## Relevant technical choices:

* In keeping with the decision by the Gutenberg team to only set border-box inside Gutenberg, and keep content-box in the metaboxes, we now override that setting in the Yoast SEO plugin.

## Test instructions

This PR can be tested by following these steps:

* In the content analysis metabox, verify that all sections have a width of 640 and are similarly aligned. Appearance in Gutenberg should match that of the classic editor.
* Do some tests to check whether the new inheritance is probably set throughout our plugin, and that there are no conflicts between any box-sizing settings further down the hierarchy.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/gutenberg/issues/46
Fixes https://github.com/Yoast/gutenberg/issues/47
Fixes https://github.com/Yoast/gutenberg/issues/48