### PR TITLE
Prevent error on PHP 5.2

### DIFF
--- a/admin/import/class-import-settings.php
+++ b/admin/import/class-import-settings.php
@@ -139,12 +139,16 @@ class WPSEO_Import_Settings {
 	 * Parse the option file
 	 */
 	private function parse_options() {
-		/*
-		 * Implemented INI_SCANNER_RAW to make sure variables aren't parsed.
-		 *
-		 * http://php.net/manual/en/function.parse-ini-file.php#99943
-		 */
-		$options = parse_ini_file( $this->filename, true, INI_SCANNER_RAW );
+		if ( defined( 'INI_SCANNER_RAW' ) ) {
+			/*
+			 * Implemented INI_SCANNER_RAW to make sure variables aren't parsed.
+			 *
+			 * http://php.net/manual/en/function.parse-ini-file.php#99943
+			 */
+			$options = parse_ini_file( $this->filename, true, INI_SCANNER_RAW );
+		} else {
+			$options = parse_ini_file( $this->filename, true );
+		}
 
 		if ( is_array( $options ) && $options !== array() ) {
 			$this->import_options( $options );

--- a/admin/import/class-import-settings.php
+++ b/admin/import/class-import-settings.php
@@ -146,7 +146,9 @@ class WPSEO_Import_Settings {
 			 * http://php.net/manual/en/function.parse-ini-file.php#99943
 			 */
 			$options = parse_ini_file( $this->filename, true, INI_SCANNER_RAW );
-		} else {
+		}
+		else {
+			// PHP 5.2 does not implement the 3rd argument, this is a fallback.
 			$options = parse_ini_file( $this->filename, true );
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* No changelog needed.

## Relevant technical choices:

* Prevents an error on 5.2 (where the third parameter doesn't work anyway) while providing max security on higher PHP versions.

Fixes #9234 
