### PR TITLE
Make sure self::$backfill is instantiated.

### DIFF
--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -225,6 +225,9 @@ class WPSEO_Options {
 	 * @return mixed|null Returns value if found, $default if not.
 	 */
 	public static function get( $key, $default = null ) {
+		if ( ! self::$backfill ) {
+			self::get_instance();
+		}
 		self::$backfill->remove_hooks();
 
 		$option = self::get_all();
@@ -459,6 +462,9 @@ class WPSEO_Options {
 	 * @return array The lookup table.
 	 */
 	private static function get_lookup_table() {
+		if ( ! self::$backfill ) {
+			self::get_instance();
+		}
 		$lookup_table = array();
 
 		self::$backfill->remove_hooks();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

```
Fatal error: Uncaught Error: Call to a member function remove_hooks() on null in /wp-content/plugins/wordpress-seo/inc/options/class-wpseo-options.php:226
Stack trace:
#0 /wp-content/plugins/wordpress-seo/admin/capabilities/class-register-capabilities.php(36): WPSEO_Options::get('access')
#1 /wp-includes/class-wp-hook.php(286): WPSEO_Register_Capabilities->register('')
#2 /wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)
#3 /wp-includes/plugin.php(465): WP_Hook->do_action(Array)
#4 /wp-content/plugins/wordpress-seo/admin/capabilities/class-capability-manager-integration.php(48): do_action('wpseo_register_...')
#5 /wp-includes/class-wp-hook.php(286): WPSEO_Ca in /wp-content/plugins/wordpress-seo/inc/options/class-wpseo-options.php on line 226
```

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #
