### PR TITLE
Added to documentation of getColorFromScore() 

### DIFF
--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -31,7 +31,7 @@ class DashboardWidget extends React.Component {
 	/**
 	 * Returns a color to be used for a given score.
 	 *
-	 * @param {string} score The score, expected to be 'na', 'bad', 'ok', 'good'.
+	 * @param {string} score The score, expected to be 'na', 'bad', 'ok', 'good' or 'noindex'.
 	 *
 	 * @returns {string} The color to use for this score. Defaults to grey if no such color exists.
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds to the documentation of `getColorFromScore()` that `noindex` is also an expected outcome.

Fixes https://github.com/Yoast/yoast-components/issues/446
