### PR TITLE
Get parent title via WordPress REST API for replacevars in Gutenberg

### DIFF
--- a/admin/class-admin-asset-dev-server-location.php
+++ b/admin/class-admin-asset-dev-server-location.php
@@ -22,6 +22,7 @@ final class WPSEO_Admin_Asset_Dev_Server_Location implements WPSEO_Admin_Asset_L
 		'wp-seo-metabox',
 		'wp-seo-post-scraper',
 		'wp-seo-term-scraper',
+		'wp-seo-replacevar-plugin',
 	);
 
 	/**

--- a/js/src/replacevar/data.js
+++ b/js/src/replacevar/data.js
@@ -1,0 +1,109 @@
+/* global wp wpseoReplaceVarsL10n */
+import isUndefined from "lodash/isUndefined";
+import get from "lodash/get";
+import noop from "lodash/noop";
+import isGutenbergDataAvailable from "../helpers/isGutenbergDataAvailable";
+
+class GutenbergDataCollector {
+	constructor( refresh ) {
+		console.log( refresh );
+		this.refresh = refresh || noop;
+		this.parentTitles = {};
+	}
+
+	/**
+	 * Gets the parent title.
+	 *
+	 * Gets the parent title via the WordPress REST API, and caches the result,
+	 * and calls the refresh callback once the parent title has been cached.
+	 *
+	 * @returns {string} Parent title.
+	 */
+	getParentTitle() {
+		const parentId = wp.data.select( "core/editor" ).getEditedPostAttribute( "parent" );
+		if ( parentId === 0 ) {
+			return "";
+		}
+		const cachedParentTitle = get( this.parentTitles, parentId );
+		if( cachedParentTitle ) {
+			return cachedParentTitle;
+		}
+		const model = new wp.api.models.Page( { id: parentId } );
+		model.fetch().done( data => {
+			this.parentTitles[ parentId ] = data.title.rendered;
+			this.refresh();
+		} ).fail( () => {} );
+	}
+}
+
+
+class TinyMceDataCollector {
+	/**
+	 * Gets the parent title from the select box.
+	 *
+	 * @returns {string} Parent title.
+	 */
+	getParentTitle() {
+		const select = jQuery( "#parent_id, #parent" ).eq( 0 );
+
+		if ( ! this.hasParentTitle( select ) ) {
+			return "";
+		}
+
+		return this.getParentTitleReplacement( select );
+	}
+
+	/**
+	 * Checks whether or not there's a parent title available.
+	 *
+	 * @param {Object} parent The parent element.
+	 *
+	 * @returns {boolean} Whether or not there is a parent title present.
+	 */
+	hasParentTitle( parent ) {
+		return ( ! isUndefined( parent ) && ! isUndefined( parent.prop( "options" ) ) );
+	}
+
+	/**
+	 * Gets the replacement for the parent title.
+	 *
+	 * @param {Object} parent The parent object to use to look for the selected option.
+	 * @returns {string} The string to replace the placeholder with.
+	 */
+	getParentTitleReplacement( parent ) {
+		const parentText = parent.find( "option:selected" ).text();
+
+		if ( parentText === wpseoReplaceVarsL10n.no_parent_text ) {
+			return "";
+		}
+
+		return parentText;
+	}
+}
+
+/**
+ * Adapter for retrieving the replacevars in either the classic editor or TinyMCE.
+ */
+class ReplacevarData {
+	/**
+	 * @param {function} refresh Callback to be called when data has changed.
+	 */
+	constructor( refresh ) {
+		if ( isGutenbergDataAvailable() ) {
+			this.dataCollector = new GutenbergDataCollector( refresh );
+		} else {
+			this.dataCollector = new TinyMceDataCollector();
+		}
+	}
+
+	/**
+	 * Gets the parent title from the select box.
+	 *
+	 * @returns {string} Parent title.
+	 */
+	getParentTitle() {
+		return this.dataCollector.getParentTitle();
+	}
+}
+
+export default ReplacevarData;

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -3,6 +3,7 @@ var forEach = require( "lodash/forEach" );
 var filter = require( "lodash/filter" );
 var isUndefined = require( "lodash/isUndefined" );
 var ReplaceVar = require( "./values/replaceVar" );
+import ReplaceVarData from "./replacevar/data";
 
 ( function() {
 	var modifiableFields = [
@@ -23,11 +24,13 @@ var ReplaceVar = require( "./values/replaceVar" );
 	 *
 	 * @param {app} app The app object.
 	 *
-	 * @returns {void}
+	 * @returns {void }
 	 */
 	var YoastReplaceVarPlugin = function( app ) {
 		this._app = app;
 		this._app.registerPlugin( "replaceVariablePlugin", { status: "ready" } );
+
+		this._data = new ReplaceVarData( app.refresh );
 
 		this.registerReplacements();
 		this.registerModifications();
@@ -491,40 +494,17 @@ var ReplaceVar = require( "./values/replaceVar" );
 	 * @returns {string} The data with all its placeholders replaced by actual values.
 	 */
 	YoastReplaceVarPlugin.prototype.parentReplace = function( data ) {
-		var parent = jQuery( "#parent_id, #parent" ).eq( 0 );
+		if( ! data.match( /%%parent_title%%/ ) ) {
+			return data;
+		}
 
-		if ( this.hasParentTitle( parent ) ) {
-			data = data.replace( /%%parent_title%%/, this.getParentTitleReplacement( parent ) );
+		const parentTitle = this._data.getParentTitle();
+
+		if ( parentTitle ) {
+			data = data.replace( /%%parent_title%%/, parentTitle );
 		}
 
 		return data;
-	};
-
-	/**
-	 * Checks whether or not there's a parent title available.
-	 *
-	 * @param {Object} parent The parent element.
- 	 *
-	 * @returns {boolean} Whether or not there is a parent title present.
-	 */
-	YoastReplaceVarPlugin.prototype.hasParentTitle = function( parent ) {
-		return ( ! isUndefined( parent ) && ! isUndefined( parent.prop( "options" ) ) );
-	};
-
-	/**
-	 * Gets the replacement for the parent title.
-	 *
-	 * @param {Object} parent The parent object to use to look for the selected option.
-	 * @returns {string} The string to replace the placeholder with.
-	 */
-	YoastReplaceVarPlugin.prototype.getParentTitleReplacement = function( parent ) {
-		var parentText = parent.find( "option:selected" ).text();
-
-		if ( parentText === wpseoReplaceVarsL10n.no_parent_text ) {
-			return "";
-		}
-
-		return parentText;
 	};
 
 	/*

--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -20,7 +20,6 @@ const entryAll = {
 	"wp-seo-metabox": "./wp-seo-metabox.js",
 	"wp-seo-recalculate": "./wp-seo-recalculate.js",
 	"wp-seo-reindex-links": "./wp-seo-reindex-links.js",
-	"wp-seo-replacevar-plugin": "./wp-seo-replacevar-plugin.js",
 	"wp-seo-shortcode-plugin": "./wp-seo-shortcode-plugin.js",
 	"wp-seo-api": "./wp-seo-api.js",
 	"wp-seo-dashboard-widget": "./wp-seo-dashboard-widget.js",
@@ -40,6 +39,7 @@ const entry = {
 	"wp-seo-metabox": "./wp-seo-metabox.js",
 	"wp-seo-post-scraper": "./wp-seo-post-scraper.js",
 	"wp-seo-term-scraper": "./wp-seo-term-scraper.js",
+	"wp-seo-replacevar-plugin": "./wp-seo-replacevar-plugin.js",
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Gets the `%%parent_title%%` replacevar in Gutenberg.

## Relevant technical choices:

* Introduces a replacevar data adapter, retrieving the parent title based on the editor you are using.

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9263 
