### PR TITLE
Changed padding to margin for the icon in the Go Premium link

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -427,7 +427,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return string
 	 */
 	private function get_buy_premium_link() {
-		return sprintf( "<div class='%s'><a href='#wpseo-meta-section-premium' class='wpseo-meta-section-link'><span class='dashicons dashicons-star-filled wpseo-buy-premium' style='box-sizing: content-box'></span>%s</a></div>",
+		return sprintf( "<div class='%s'><a href='#wpseo-meta-section-premium' class='wpseo-meta-section-link'><span class='dashicons dashicons-star-filled wpseo-buy-premium'></span>%s</a></div>",
 			'wpseo-metabox-buy-premium',
 			__( 'Go Premium', 'wordpress-seo' )
 		);

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -427,7 +427,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return string
 	 */
 	private function get_buy_premium_link() {
-		return sprintf( "<div class='%s'><a href='#wpseo-meta-section-premium' class='wpseo-meta-section-link'><span class='dashicons dashicons-star-filled wpseo-buy-premium'></span>%s</a></div>",
+		return sprintf( "<div class='%s'><a href='#wpseo-meta-section-premium' class='wpseo-meta-section-link'><span class='dashicons dashicons-star-filled wpseo-buy-premium' style='box-sizing: content-box'></span>%s</a></div>",
 			'wpseo-metabox-buy-premium',
 			__( 'Go Premium', 'wordpress-seo' )
 		);

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -725,7 +725,8 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 		display: inline-block;
 		width: 20px;
 		height: 20px;
-		padding: 0 5px 0;
+		margin-right: 5px;
+		padding: 0;
 	}
 
 	.yoast-help-panel {

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -535,7 +535,7 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 
 .wpseo-buy-premium {
 	color: #A4286A;
-	padding-right: 5px;
+	margin-right: 5px;
 }
 
 .wpseo-metabox-go-to {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Change the padding to margin to keep the same spacing between the icon and the text on a wide screen.
* Change the smaller screen media style to margin-right and overwrite the padding to zero again to keep the same spacing between the icon and the text.

## Relevant technical choices:

* Keep the `box-sizing` as `border-box`.

## Test instructions

This PR can be tested by following these steps:

* Inspect the 'Go Premium' link and make sure there is space between the star icon and the link text. Just like it was before we introduced `box-sizing: border-box;` See issue for screenshot comparison.
![image](https://user-images.githubusercontent.com/7872022/37708823-5d00f89e-2d08-11e8-910b-9020495149d4.png)
* Also adjust screen width to smaller and check the same.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/gutenberg/issues/51
