### PR TITLE
Change quotes in SHOW TABLES queries

### DIFF
--- a/admin/class-accessible-table.php
+++ b/admin/class-accessible-table.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Links
+ */
+
+/**
+ * Represents the state of a table being accessible.
+ */
+abstract class WPSEO_Accessible_Table {
+
+	const ACCESSIBLE   = '0';
+	const INACCESSBILE = '1';
+
+	/**
+	 * The storage class used to check the accessible table.
+	 *
+	 * @var string
+	 */
+	public static $storage_class = 'WPSEO_Link_Storage';
+
+	/**
+	 * The transient used to store the accessible state.
+	 *
+	 * @var string
+	 */
+	public static $transient_name = 'wpseo_link_table_inaccessible';
+
+	/**
+	 * Checks if the given table name exists.
+	 *
+	 * @return bool True when table is accessible.
+	 */
+	public static function is_accessible() {
+		$value = get_transient( self::transient_name() );
+
+		// If the value is not set, check the table.
+		if ( false === $value ) {
+			return self::check_table();
+		}
+
+		return $value === self::ACCESSIBLE;
+	}
+
+	/**
+	 * Sets the transient value to 1, to indicate the table is not accessible.
+	 *
+	 * @return void
+	 */
+	public static function set_inaccessible() {
+		set_transient( self::transient_name(), self::INACCESSBILE, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Removes the transient.
+	 *
+	 * @return void
+	 */
+	public static function cleanup() {
+		delete_transient( self::transient_name() );
+	}
+
+	/**
+	 * Sets the transient value to 0, to indicate the table is accessible.
+	 *
+	 * @return void
+	 */
+	protected static function set_accessible() {
+		/*
+		 * Prefer to set a 0 timeout, but if the timeout was set before WordPress will not delete the transient
+		 * correctly when overridden with a zero value.
+		 *
+		 * Setting a YEAR_IN_SECONDS instead.
+		 */
+		set_transient( self::transient_name(), self::ACCESSIBLE, YEAR_IN_SECONDS );
+	}
+
+	/**
+	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @return bool True if table is accessible.
+	 */
+	protected static function check_table() {
+		global $wpdb;
+
+		$storage = new self::$storage_class();
+		$query   = $wpdb->prepare( "SHOW TABLES LIKE %s", $storage->get_table_name() );
+		if ( $wpdb->get_var( $query ) !== $storage->get_table_name() ) {
+			self::set_inaccessible();
+			return false;
+		}
+
+		self::set_accessible();
+		return true;
+	}
+
+	/**
+	 * Returns the name of the transient.
+	 *
+	 * @return string The name of the transient to use.
+	 */
+	protected static function transient_name() {
+		return self::$transient_name;
+	}
+
+	/**
+	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
+	 *
+	 * @deprecated 6.0
+	 *
+	 * @return bool True if table is accessible.
+	 */
+	public static function check_table_is_accessible() {
+		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
+		return self::is_accessible();
+	}
+}

--- a/admin/class-accessible-table.php
+++ b/admin/class-accessible-table.php
@@ -85,7 +85,7 @@ abstract class WPSEO_Accessible_Table {
 		global $wpdb;
 
 		$storage = new self::$storage_class();
-		$query   = $wpdb->prepare( "SHOW TABLES LIKE %s", $storage->get_table_name() );
+		$query   = $wpdb->prepare( 'SHOW TABLES LIKE %s', $storage->get_table_name() );
 		if ( $wpdb->get_var( $query ) !== $storage->get_table_name() ) {
 			self::set_inaccessible();
 			return false;

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -8,96 +8,18 @@
 /**
  * Represents the state of the table being accessible.
  */
-class WPSEO_Meta_Table_Accessible {
-
-	const ACCESSIBLE   = '0';
-	const INACCESSBILE = '1';
+class WPSEO_Meta_Table_Accessible extends WPSEO_Accessible_Table {
+	/**
+	 * The storage class used to check the accessible table.
+	 *
+	 * @var string
+	 */
+	public static $storage_class = 'WPSEO_Meta_Storage';
 
 	/**
-	 * Checks if the given table name exists.
+	 * The transient used to store the accessible state.
 	 *
-	 * @return bool True when table is accessible.
+	 * @var string
 	 */
-	public static function is_accessible() {
-		$value = get_transient( self::transient_name() );
-
-		// If the value is not set, check the table.
-		if ( false === $value ) {
-			return self::check_table();
-		}
-
-		return $value === self::ACCESSIBLE;
-	}
-
-	/**
-	 * Sets the transient value to 1, to indicate the table is not accessible.
-	 *
-	 * @return void
-	 */
-	public static function set_inaccessible() {
-		set_transient( self::transient_name(), self::INACCESSBILE, HOUR_IN_SECONDS );
-	}
-
-	/**
-	 * Removes the transient.
-	 *
-	 * @return void
-	 */
-	public static function cleanup() {
-		delete_transient( self::transient_name() );
-	}
-
-	/**
-	 * Sets the transient value to 0, to indicate the table is accessible.
-	 *
-	 * @return void
-	 */
-	protected static function set_accessible() {
-		/*
-		 * Prefer to set a 0 timeout, but if the timeout was set before WordPress will not delete the transient
-		 * correctly when overridden with a zero value.
-		 *
-		 * Setting a YEAR_IN_SECONDS instead.
-		 */
-		set_transient( self::transient_name(), self::ACCESSIBLE, YEAR_IN_SECONDS );
-	}
-
-	/**
-	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
-	 *
-	 * @return bool True if table is accessible.
-	 */
-	protected static function check_table() {
-		global $wpdb;
-
-		$storage = new WPSEO_Meta_Storage();
-		if ( $wpdb->get_var( 'SHOW TABLES LIKE \'' . $storage->get_table_name() . '\'' ) !== $storage->get_table_name() ) {
-			self::set_inaccessible();
-			return false;
-		}
-
-		self::set_accessible();
-		return true;
-	}
-
-	/**
-	 * Returns the name of the transient.
-	 *
-	 * @return string The name of the transient to use.
-	 */
-	protected static function transient_name() {
-		return 'wpseo_meta_table_inaccessible';
-	}
-
-	/**
-	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
-	 *
-	 * @deprecated 6.0
-	 *
-	 * @return bool True if table is accessible.
-	 */
-	public static function check_table_is_accessible() {
-		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
-		return self::is_accessible();
-	}
+	public static $transient_name = 'wpseo_meta_table_inaccessible';
 }

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -71,7 +71,7 @@ class WPSEO_Meta_Table_Accessible {
 		global $wpdb;
 
 		$storage = new WPSEO_Meta_Storage();
-		if ( $wpdb->get_var( 'SHOW TABLES LIKE "' . $storage->get_table_name() . '"' ) !== $storage->get_table_name() ) {
+		if ( $wpdb->get_var( 'SHOW TABLES LIKE \'' . $storage->get_table_name() . '\'' ) !== $storage->get_table_name() ) {
 			self::set_inaccessible();
 			return false;
 		}

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -71,7 +71,7 @@ class WPSEO_Link_Table_Accessible {
 		global $wpdb;
 
 		$storage = new WPSEO_Link_Storage();
-		if ( $wpdb->get_var( 'SHOW TABLES LIKE "' . $storage->get_table_name() . '"' ) !== $storage->get_table_name() ) {
+		if ( $wpdb->get_var( 'SHOW TABLES LIKE \'' . $storage->get_table_name() . '\'' ) !== $storage->get_table_name() ) {
 			self::set_inaccessible();
 			return false;
 		}

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -8,96 +8,18 @@
 /**
  * Represents the state of the table being accessible.
  */
-class WPSEO_Link_Table_Accessible {
-
-	const ACCESSIBLE   = '0';
-	const INACCESSBILE = '1';
+class WPSEO_Link_Table_Accessible extends WPSEO_Accessible_Table {
+	/**
+	 * The storage class used to check the accessible table.
+	 *
+	 * @var string
+	 */
+	public static $storage_class = 'WPSEO_Link_Storage';
 
 	/**
-	 * Checks if the given table name exists.
+	 * The transient used to store the accessible state.
 	 *
-	 * @return bool True when table is accessible.
+	 * @var string
 	 */
-	public static function is_accessible() {
-		$value = get_transient( self::transient_name() );
-
-		// If the value is not set, check the table.
-		if ( false === $value ) {
-			return self::check_table();
-		}
-
-		return $value === self::ACCESSIBLE;
-	}
-
-	/**
-	 * Sets the transient value to 1, to indicate the table is not accessible.
-	 *
-	 * @return void
-	 */
-	public static function set_inaccessible() {
-		set_transient( self::transient_name(), self::INACCESSBILE, HOUR_IN_SECONDS );
-	}
-
-	/**
-	 * Removes the transient.
-	 *
-	 * @return void
-	 */
-	public static function cleanup() {
-		delete_transient( self::transient_name() );
-	}
-
-	/**
-	 * Sets the transient value to 0, to indicate the table is accessible.
-	 *
-	 * @return void
-	 */
-	protected static function set_accessible() {
-		/*
-		 * Prefer to set a 0 timeout, but if the timeout was set before WordPress will not delete the transient
-		 * correctly when overridden with a zero value.
-		 *
-		 * Setting a YEAR_IN_SECONDS instead.
-		 */
-		set_transient( self::transient_name(), self::ACCESSIBLE, YEAR_IN_SECONDS );
-	}
-
-	/**
-	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
-	 *
-	 * @return bool True if table is accessible.
-	 */
-	protected static function check_table() {
-		global $wpdb;
-
-		$storage = new WPSEO_Link_Storage();
-		if ( $wpdb->get_var( 'SHOW TABLES LIKE \'' . $storage->get_table_name() . '\'' ) !== $storage->get_table_name() ) {
-			self::set_inaccessible();
-			return false;
-		}
-
-		self::set_accessible();
-		return true;
-	}
-
-	/**
-	 * Returns the name of the transient.
-	 *
-	 * @return string The name of the transient to use.
-	 */
-	protected static function transient_name() {
-		return 'wpseo_link_table_inaccessible';
-	}
-
-	/**
-	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
-	 *
-	 * @deprecated 6.0
-	 *
-	 * @return bool True if table is accessible.
-	 */
-	public static function check_table_is_accessible() {
-		_deprecated_function( __FUNCTION__, '6.0', __CLASS__ . '::is_accessible' );
-		return self::is_accessible();
-	}
+	public static $transient_name = 'wpseo_link_table_inaccessible';
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* No mention needed.

## Relevant technical choices:

* Decided to make one abstract class `WPSEO_Accessible_Table` and make `WPSEO_Link_Table_Accessible` and `WPSEO_Meta_Table_Accessible` extend as the functionality was a one-on-one copy.
* Switched the quotes in `SHOW TABLES` queries to `'` instead of `"`. Discussed in `#devchat` with @schlessera, doesn't seem to be problematic.
* After that made a change to use `$wpdb->prepare` properly which foregoes the whole problem above.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9237 