### PR TITLE
Fix bug where switching to readability didn't work

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -37,7 +37,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 	let decorator = null;
 	let tabManager, postDataCollector;
 
-	let store;
+	let editStore;
 
 	/**
 	 * Retrieves either a generated slug or the page title as slug for the preview.
@@ -108,8 +108,8 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		// Only add markers when tinyMCE is loaded and show_markers is enabled (can be disabled by a WordPress hook).
 		// Only check for the tinyMCE object because the actual editor isn't loaded at this moment yet.
 		if ( typeof tinyMCE === "undefined" || ! displayMarkers() ) {
-			if ( ! isUndefined( store ) ) {
-				store.dispatch( setMarkerStatus( "hidden" ) );
+			if ( ! isUndefined( editStore ) ) {
+				editStore.dispatch( setMarkerStatus( "hidden" ) );
 			}
 			return false;
 		}
@@ -333,7 +333,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 		window.YoastSEO.wp._tabManager = tabManager;
 		window.YoastSEO.wp._tinyMCEHelper = tinyMCEHelper;
 
-		window.YoastSEO.store = store;
+		window.YoastSEO.store = editStore;
 	}
 
 	/**
@@ -388,6 +388,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 			shouldRenderSnippetPreview: !! wpseoPostScraperL10n.reactSnippetPreview,
 		};
 		const { store, data } = initializeEdit( editArgs );
+		editStore = store;
 
 		snippetContainer = $( "#wpseosnippet" );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Not applicable

## Relevant technical choices:

* Because the store was set to a new const the 'global' store wasn't set. Solve this by renaming the 'global' store.

## Test instructions

This PR can be tested by following these steps:

* Switching to the readability tab and seeing that the readability results are shown.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9325