### PR TITLE
Move out options debug code

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -117,7 +117,7 @@ class Yoast_Form {
 	 *
 	 * @return array
 	 */
-	private function get_option() {
+	public function get_option() {
 		if ( is_network_admin() ) {
 			return get_site_option( $this->option_name );
 		}
@@ -160,22 +160,7 @@ class Yoast_Form {
 
 		echo '</div><!-- end of div wpseo_content_wrapper -->';
 
-
-		if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) ) {
-			$xdebug = ( extension_loaded( 'xdebug' ) ? true : false );
-			echo '
-			<div id="wpseo-debug-info" class="yoast-container">
-
-				<h2>' . esc_html__( 'Debug Information', 'wordpress-seo' ) . '</h2>
-				<div>
-					<h3 class="wpseo-debug-heading">' . esc_html__( 'Current option:', 'wordpress-seo' ) . ' <span class="wpseo-debug">' . esc_html( $this->option_name ) . '</span></h3>
-					' . ( ( $xdebug ) ? '' : '<pre>' );
-			var_dump( $this->get_option() );
-			echo '
-					' . ( ( $xdebug ) ? '' : '</pre>' ) . '
-				</div>
-			</div>';
-		}
+		do_action( 'wpseo_admin_below_content', $this );
 
 		echo '
 			</div><!-- end of wrap -->';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Showing the options below the admin pages has been moved to the Yoast Test helper plugin.

## Relevant technical choices:

* Made `get_option` public to be able to access it from the Yoast test helper.

## Test instructions

This PR can be tested by following these steps:

* See any admin page, see the options block is gone when `WP_DEBUG` is on.

## Quality assurance

* [x] I have tested this code to the best of my abilities
