### PR TITLE
9063 remove intl dependency

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -85,17 +85,6 @@ class WPSEO_Admin_Asset_Manager {
 	 * Calls the functions that register scripts and styles with the scripts and styles to be registered as arguments.
 	 */
 	public function register_assets() {
-
-		$user_locale = WPSEO_Utils::get_user_locale();
-		$language    = WPSEO_Utils::get_language( $user_locale );
-
-		wp_register_script(
-			self::PREFIX . 'intl-polyfill',
-			sprintf( 'https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.%s', $language ),
-			array(),
-			WPSEO_VERSION
-		);
-
 		$this->register_scripts( $this->scripts_to_be_registered() );
 		$this->register_styles( $this->styles_to_be_registered() );
 	}
@@ -199,7 +188,6 @@ class WPSEO_Admin_Asset_Manager {
 				// Load webpack-commons for bundle support.
 				'src'  => 'commons-' . $flat_version,
 				'deps' => array(
-					self::PREFIX . 'intl-polyfill',
 					self::PREFIX . 'babel-polyfill',
 				),
 			),

--- a/js/src/components/IntlProvider.js
+++ b/js/src/components/IntlProvider.js
@@ -8,7 +8,21 @@ import { IntlProvider as IntlProviderOriginal } from "react-intl";
  * This component will render an IntlProvider when the locale-data promise is resolved.
  */
 class IntlProvider extends React.Component {
+
+	/**
+	 * Renders the provider component.
+	 *
+	 * @returns {IntlProviderOriginal|string} String if Intl is missing, IntlProviderOriginal if not.
+	 */
 	render() {
+		if ( typeof window.Intl === "undefined" ) {
+			return (
+				<div className="notice notice-error">
+					<p>Yoast SEO detected that you are using a browser that doesn't support all the features we require. Please try using another browser.</p>
+				</div>
+			);
+		}
+
 		return (
 			<IntlProviderOriginal
 				locale="en"

--- a/js/src/components/IntlProvider.js
+++ b/js/src/components/IntlProvider.js
@@ -18,7 +18,7 @@ class IntlProvider extends React.Component {
 		if ( typeof window.Intl === "undefined" ) {
 			return (
 				<div className="notice notice-error">
-					<p>Yoast SEO detected that you are using a browser that doesn't support all the features we require. Please try using another browser.</p>
+					<p>Yoast SEO detected that you are using a browser that doesn't support all the features we require. Please try using a different browser.</p>
 				</div>
 			);
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the intl polyfill and show message on browsers that doesn't support intl.


## Test instructions

This PR can be tested by following these steps:

* Checkout this branch.
* Add `window.Intl = undefined` somewhere in the code. For example in the `js/src/components/IntlProvider.js` in the `render` function before the `if` statement.
* Do a `grunt build:js`
* See an error message is given in the Yoast SEO metabox, but also in the admin pages where you can expect the help-center box.
* Remove the `window.Intl = undefined` and do a `grunt build:js`
* Everything should work correctly: Yoast SEO metabox, help-center box on the admin pages. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9063 
