### PR TITLE
Resets the opcache when function exists

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -273,6 +273,10 @@ function wpseo_init() {
 	WPSEO_Meta::init();
 
 	if ( version_compare( WPSEO_Options::get( 'version', 1 ), WPSEO_VERSION, '<' ) ) {
+		if ( function_exists( 'opcache_reset' ) ) {
+			opcache_reset();
+		}
+
 		new WPSEO_Upgrade();
 		// Get a cleaned up version of the $options.
 	}


### PR DESCRIPTION
This reset will be done when there is a difference between the existing and the new version of Yoast SEO.

## Summary

This PR can be summarized in the following changelog entry:

* Resets the opcode cache when an update has been done.


## Test instructions

This PR can be tested by following these steps:

* I've no clue what opcode cache does and how it works. I've only checked for existence of the function and I called it.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9315 
