### PR TITLE
CS: clean up after latest merges - prevent fatal error/security hardening

### DIFF
--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -31,13 +31,17 @@ elseif ( filter_input( INPUT_POST, 'import_external' ) ) {
 	check_admin_referer( 'wpseo-import-plugins' );
 
 	$class = filter_input( INPUT_POST, 'import_external_plugin' );
-	$import = new WPSEO_Import_Plugin( new $class, 'import' );
+	if ( class_exists( $class ) ) {
+		$import = new WPSEO_Import_Plugin( new $class(), 'import' );
+	}
 }
 elseif ( filter_input( INPUT_POST, 'clean_external' ) ) {
 	check_admin_referer( 'wpseo-clean-plugins' );
 
 	$class = filter_input( INPUT_POST, 'clean_external_plugin' );
-	$import = new WPSEO_Import_Plugin( new $class, 'cleanup' );
+	if ( class_exists( $class ) ) {
+		$import = new WPSEO_Import_Plugin( new $class(), 'cleanup' );
+	}
 }
 elseif ( isset( $_FILES['settings_import_file'] ) ) {
 	check_admin_referer( 'wpseo-import-file' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _Security hardening_

## Relevant technical choices:

Only try and instantiate the class provided via `$_POST` if the class exists.
Prevents a potential fatal error if - for whatever reason/hack or otherwise -, the query argument in the URL does not correspond to one of the WPSEO import classes.

Also: always use parentheses when instantiating an object.


## Test instructions

This PR can be tested by following these steps:

* Using `trunk` - open the import page, edit the HTML so an invalid class is used for `import_external_plugin`/`clean_external_plugin` and see what happens.
* Do the same using this branch.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

