### PR TITLE
CS: clean up after latest merges - add missing translators comment

### DIFF
--- a/admin/taxonomy/class-taxonomy-settings-fields.php
+++ b/admin/taxonomy/class-taxonomy-settings-fields.php
@@ -31,6 +31,7 @@ class WPSEO_Taxonomy_Settings_Fields extends WPSEO_Taxonomy_Fields {
 		$labels = $this->get_taxonomy_labels();
 		$fields = array(
 			'noindex'   => $this->get_field_config(
+				/* translators: %s = taxonomy name. */
 				esc_html( sprintf( __( 'Allow search engines to show this %s in search results?', 'wordpress-seo' ), $labels->singular_name ) ),
 				'',
 				'select',

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -6,8 +6,12 @@
  */
 
 /* translators: %1$s expands to Yoast SEO */
-$wpseo_up_settings_header = sprintf( __( '%1$s settings', 'wordpress-seo' ), 'Yoast SEO' );
-
+$wpseo_up_settings_header    = sprintf( __( '%1$s settings', 'wordpress-seo' ), 'Yoast SEO' );
+$wpseo_no_index_author_label = sprintf(
+	/* translators: %s expands to "this author's archives". */
+	__( 'Do not allow search engines to show %s in search results.', 'wordpress-seo' ),
+	__( 'this author\'s archives', 'wordpress-seo' )
+);
 ?>
 
 <div class="yoast yoast-settings">
@@ -27,7 +31,7 @@ $wpseo_up_settings_header = sprintf( __( '%1$s settings', 'wordpress-seo' ), 'Yo
 		name="wpseo_noindex_author"
 		value="on" <?php echo ( get_the_author_meta( 'wpseo_noindex_author', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
 	<label class="yoast-label-strong"
-		for="wpseo_noindex_author"><?php printf( esc_html__( 'Do not allow search engines to show %s in search results.', 'wordpress-seo' ), __( 'this author\'s archives', 'wordpress-seo' ) ); ?></label><br>
+		for="wpseo_noindex_author"><?php echo esc_html( $wpseo_no_index_author_label ); ?></label><br>
 
 	<?php if ( WPSEO_Options::get( 'keyword_analysis_active', false ) ) : ?>
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_keyword_analysis_disable"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _Minor I18n improvements_

## Relevant technical choices:

Regarding the second one (in `user-profile.php`):
PHP open/close tags for multi-line snippets should be on their own line, but this can cause layout issues when the output is directly embedded in certain HTML tags.
By creating a variable beforehand and passing that in, we create a stable result.

Includes some improved output escaping.


## Test instructions

This PR can be tested by following these steps:
* _N/A_

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

