### PR TITLE
Prevent cornerstone info box overlapping

### DIFF
--- a/admin/class-cornerstone-field.php
+++ b/admin/class-cornerstone-field.php
@@ -31,7 +31,7 @@ class WPSEO_Cornerstone_Field {
 			checked( $this->get_meta_value( $post->ID ), '1', false )
 		);
 
-		$return .= sprintf( '<label for="%1$s">', WPSEO_Cornerstone::META_NAME );
+		$return .= sprintf( '<label for="%1$s">', WPSEO_Cornerstone::FIELD_NAME );
 
 		$return .= sprintf(
 			/* translators: 1: link open tag; 2: link close tag. */

--- a/css/src/filter-explanation.scss
+++ b/css/src/filter-explanation.scss
@@ -1,3 +1,4 @@
 #posts-filter .wpseo-filter-explanation {
   margin: 10px 1px 5px;
+  clear: both;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the pagination overlaps the cornerstone info block on lower resolutions

## Test instructions

This PR can be tested by following these steps:

* Have at least 1 cornerstone post present.
* Checkout `trunk`
* Resize the windows, till you get to this point:
![posts_ _local_wordpress_dev_ _wordpress](https://user-images.githubusercontent.com/325040/37965302-e91dd2f0-31c4-11e8-8df5-21061bac621a.png)

* Checkout this branch and run `grunt build:css`
* It should be fixed now. **Note:** there might be an issue with a top margin, this is not the scope if this issue.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9293
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1664