### PR TITLE
Do not run ‘Link Watcher’ on trash posts

### DIFF
--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -55,6 +55,11 @@ class WPSEO_Link_Watcher {
 			return;
 		}
 
+		// When trashing a post
+		if ( $post->post_status === 'trash' ) {
+			return ;
+		}
+
 		// When the post isn't processable, just remove the saved links.
 		if ( ! $this->is_processable( $post_id ) ) {
 			return;

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -61,6 +61,30 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Don't process trash posts
+	 */
+	public function test_skip_trash_posts() {
+
+		$post = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		wp_delete_post( $post );
+
+		$post = get_post($post);
+
+		$processor = $this->get_processor();
+		$processor
+			->expects( $this->never() )
+			->method( 'process' );
+
+		$watcher = new WPSEO_Link_Watcher( $processor );
+		$watcher->save_post( $post->ID, $post );
+	}
+
+	/**
 	 * Test with a draft post.
 	 *
 	 * This should be processed, but will not be displayed.


### PR DESCRIPTION
When Deleting multiple posts, the process method fire 'the_content' filter and this may cause performance issue in some cases.