### PR TITLE
Only show public taxonomies 

### DIFF
--- a/admin/views/tabs/metas/breadcrumbs.php
+++ b/admin/views/tabs/metas/breadcrumbs.php
@@ -56,6 +56,9 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 		if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 			$values = array( 0 => __( 'None', 'wordpress-seo' ) );
 			foreach ( $taxonomies as $tax ) {
+				if ( ! $tax->public  ) {
+					continue;
+				}
 				$values[ $tax->name ] = $tax->labels->singular_name;
 			}
 			$label = $pt->labels->name . ' (<code>' . $pt->name . '</code>)';

--- a/admin/views/tabs/metas/breadcrumbs.php
+++ b/admin/views/tabs/metas/breadcrumbs.php
@@ -59,6 +59,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 				if ( ! $tax->public ) {
 					continue;
 				}
+
 				$values[ $tax->name ] = $tax->labels->singular_name;
 			}
 			$label = $pt->labels->name . ' (<code>' . $pt->name . '</code>)';

--- a/admin/views/tabs/metas/breadcrumbs.php
+++ b/admin/views/tabs/metas/breadcrumbs.php
@@ -56,7 +56,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 		if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
 			$values = array( 0 => __( 'None', 'wordpress-seo' ) );
 			foreach ( $taxonomies as $tax ) {
-				if ( ! $tax->public  ) {
+				if ( ! $tax->public ) {
 					continue;
 				}
 				$values[ $tax->name ] = $tax->labels->singular_name;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where non-public taxonomies are settable in the breadcrumbs.


## Test instructions

This PR can be tested by following these steps:

* This fix is made for premium (https://github.com/Yoast/wordpress-seo-premium/issues/1648). It is possible to set prominents words for posttypes in the breadcrumbs.
* Howto test: Merge this branch in a local branch of wordpress-seo-premium. 
* Verify that the prominent words are not visible in the dropdowns under `Taxonomy to show in breadcrumbs for content types`

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1648
