### PR TITLE
Check for empty post_password

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Yoast SEO
 ======================
 
-[![Build Status](https://api.travis-ci.org/Yoast/wordpress-seo.png?branch=master)](https://travis-ci.org/Yoast/wordpress-seo)
+[![Build Status](https://api.travis-ci.org/Yoast/wordpress-seo.svg?branch=master)](https://travis-ci.org/Yoast/wordpress-seo)
 [![Stable Version](https://poser.pugx.org/yoast/wordpress-seo/v/stable.svg)](https://packagist.org/packages/yoast/wordpress-seo)
 [![License](https://poser.pugx.org/yoast/wordpress-seo/license.svg)](https://packagist.org/packages/yoast/wordpress-seo)
 [![Maintainability](https://api.codeclimate.com/v1/badges/9f5d48fd95e3ab3d8472/maintainability)](https://codeclimate.com/repos/54523c9069568068a70b3279/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Yoast SEO
 ======================
 
-[![Build Status](https://api.travis-ci.org/Yoast/wordpress-seo.svg?branch=master)](https://travis-ci.org/Yoast/wordpress-seo)
+[![Build Status](https://api.travis-ci.org/Yoast/wordpress-seo.png?branch=master)](https://travis-ci.org/Yoast/wordpress-seo)
 [![Stable Version](https://poser.pugx.org/yoast/wordpress-seo/v/stable.svg)](https://packagist.org/packages/yoast/wordpress-seo)
 [![License](https://poser.pugx.org/yoast/wordpress-seo/license.svg)](https://packagist.org/packages/yoast/wordpress-seo)
 [![Maintainability](https://api.codeclimate.com/v1/badges/9f5d48fd95e3ab3d8472/maintainability)](https://codeclimate.com/repos/54523c9069568068a70b3279/maintainability)

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -569,7 +569,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		// Based on WP_Query->get_posts(). R.
 		if ( 'attachment' === $post_type ) {
 			$join   = " LEFT JOIN {$wpdb->posts} AS p2 ON ({$wpdb->posts}.post_parent = p2.ID) ";
-			$status = "p2.post_status = 'publish'";
+			$status = "p2.post_status = 'publish' AND p2.post_password = ''";
 		}
 
 		$where_clause = "


### PR DESCRIPTION
⚠️ **SHOULD PROBABLY GO INTO RELEASE BRANCH** ⚠️ 

## Summary

This PR can be summarized in the following changelog entry:

* Prevent attachments of password protected posts from showing up in XML sitemaps.

## Relevant technical choices:

* Added check for `post_password = ''` because the `post_status` for a private post _can_ be 'publish', as core checks `post_password`. 

## Test instructions

This PR can be tested by following these steps:

* See #9194, with this patch you should no longer be able to reproduce.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9194 
