### PR TITLE
API function/method: Get all WPSEO related capabilities

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -250,7 +250,7 @@ add_action( 'split_shared_term', 'wpseo_split_shared_term', 10, 4 );
 /**
  * Get all WPSEO related capabilities.
  *
- * @since 7.2.x
+ * @since 8.3
  * @return array
  */
 function wpseo_get_capabilities() {

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -246,3 +246,14 @@ function wpseo_split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id,
 }
 
 add_action( 'split_shared_term', 'wpseo_split_shared_term', 10, 4 );
+
+/**
+ * Get all WPSEO related capabilities.
+ *
+ * @since 7.1.x
+ * @return array
+ */
+function wpseo_get_capabilities() {
+	$capability_manager = WPSEO_Capability_Manager_Factory::get();
+	return $capability_manager->get_capabilities();
+}

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -250,13 +250,12 @@ add_action( 'split_shared_term', 'wpseo_split_shared_term', 10, 4 );
 /**
  * Get all WPSEO related capabilities.
  *
- * @since 7.1.x
+ * @since 7.2.x
  * @return array
  */
 function wpseo_get_capabilities() {
-	$capability_manager = WPSEO_Capability_Manager_Factory::get();
 	if ( ! did_action( 'wpseo_register_capabilities' ) ) {
 		do_action( 'wpseo_register_capabilities' );
 	}
-	return $capability_manager->get_capabilities();
+	return WPSEO_Capability_Manager_Factory::get()->get_capabilities();
 }

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -255,5 +255,8 @@ add_action( 'split_shared_term', 'wpseo_split_shared_term', 10, 4 );
  */
 function wpseo_get_capabilities() {
 	$capability_manager = WPSEO_Capability_Manager_Factory::get();
+	if ( ! did_action( 'wpseo_register_capabilities' ) ) {
+		do_action( 'wpseo_register_capabilities' );
+	}
 	return $capability_manager->get_capabilities();
 }

--- a/tests/test-wpseo-functions.php
+++ b/tests/test-wpseo-functions.php
@@ -55,4 +55,12 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 		 *  - Test all Advanced Variables.
 		 */
 	}
+
+	/**
+	 * @covers wpseo_get_capabilities()
+	 */
+	public function test_wpseo_get_capabilities() {
+		// No need for assertions. The function shouldn't trigger any errors.
+		$caps = wpseo_get_capabilities();
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Add API function to get all WPSEO related capabilities.

## Relevant technical choices:

Used the capability manager class instance.

## Test instructions

This PR can be tested by following these steps:

Call the function. It should return the following:
`Array ( [0] => wpseo_bulk_edit [1] => wpseo_edit_advanced_metadata [2] => wpseo_manage_options )`

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9300