### PR TITLE
Check for empty post_password

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -569,7 +569,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		// Based on WP_Query->get_posts(). R.
 		if ( 'attachment' === $post_type ) {
 			$join   = " LEFT JOIN {$wpdb->posts} AS p2 ON ({$wpdb->posts}.post_parent = p2.ID) ";
-			$status = "p2.post_status = 'publish'";
+			$status = "p2.post_status = 'publish' AND p2.post_password = ''";
 		}
 
 		$where_clause = "

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -213,6 +213,9 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	 * Related: https://github.com/Yoast/wordpress-seo/issues/9194
 	 */
 	public function test_password_protected_post_parent_attachment() {
+		// Enable attachments in the sitemap.
+		WPSEO_Options::set( 'disable-attachment', false );
+
 		// Create password protected post.
 		$post_id = $this->factory->post->create(
 			array(

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -123,9 +123,10 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_url
 	 */
 	public function test_get_url() {
-		$instance = $this->getMockBuilder( 'WPSEO_Post_Type_Sitemap_Provider_Double' )
-						 ->setMethods( array( 'get_home_url' ) )
-						 ->getMock();
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Post_Type_Sitemap_Provider_Double' )
+			->setMethods( array( 'get_home_url' ) )
+			->getMock();
 
 		$instance
 			->expects( $this->once() )

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -153,13 +153,19 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that password protected posts are not included in the sitemap.
+	 * Tests a regular post is added to the sitemap.
 	 */
-	public function test_password_protected_post() {
+	public function test_regular_post() {
 		$this->factory->post->create();
 
+		// Expect the created post to be in the sitemap list.
 		$this->assertCount( 1, self::$class_instance->get_sitemap_links( 'post', 100, 0 ) );
+	}
 
+	/**
+	 * Tests to make sure password protected posts are not in the sitemap.
+	 */
+	public function test_password_protected_post() {
 		// Create password protected post.
 		$this->factory->post->create(
 			array(
@@ -167,15 +173,19 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 			)
 		);
 
-		$this->assertCount( 1, self::$class_instance->get_sitemap_links( 'post', 100, 0 ) );
+		// Expect the protected post should not be added.
+		$this->assertCount(
+			0,
+			self::$class_instance->get_sitemap_links( 'post', 100, 0 ),
+			'Password protected posts should not be in the sitemap'
+		);
 	}
 
 	/**
-	 * Tests to make sure attachment is not added when parent is a protected post.
-	 *
-	 * Related: https://github.com/Yoast/wordpress-seo/issues/9194
+	 * Tests to make sure a regular attachment is include in the sitemap.
 	 */
-	public function test_password_protected_post_parent_media() {
+	public function test_regular_attachment() {
+		// Enable attachments in the sitemap.
 		WPSEO_Options::set( 'disable-attachment', false );
 
 		// Create non-password-protected post.
@@ -195,7 +205,14 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 		// Expect the attchment to be in the list.
 		$this->assertCount( 1, self::$class_instance->get_sitemap_links( 'attachment', 100, 0 ) );
+	}
 
+	/**
+	 * Tests to make sure attachment is not added when parent is a protected post.
+	 *
+	 * Related: https://github.com/Yoast/wordpress-seo/issues/9194
+	 */
+	public function test_password_protected_post_parent_attachment() {
 		// Create password protected post.
 		$post_id = $this->factory->post->create(
 			array(
@@ -212,6 +229,6 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		);
 
 		// Expect the attachment not to be added to the list.
-		$this->assertCount( 1, self::$class_instance->get_sitemap_links( 'attachment', 100, 0 ) );
+		$this->assertCount( 0, self::$class_instance->get_sitemap_links( 'attachment', 100, 0 ) );
 	}
 }

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -7,11 +7,13 @@
 
 /**
  * Class WPSEO_Sitemaps_Test
+ *
+ * @group sitemaps
  */
 class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var WPSEO_Sitemaps
+	 * @var WPSEO_Sitemaps_Double
 	 */
 	private static $class_instance;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Prevent attachments of password protected posts from showing up in XML sitemaps.

## Relevant technical choices:

* Added check for `post_password = ''` because the `post_status` for a private post _can_ be 'publish', as core checks `post_password`. 

## Test instructions

This PR can be tested by following these steps:

* See #9194, with this patch you should no longer be able to reproduce.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9194