### PR TITLE
Restore notification unhook

### DIFF
--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -88,6 +88,8 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	public function activate_hooks() {
 		if ( $this->get_option()->is_enabled() ) {
 			$this->schedule_cron();
+
+			return;
 		}
 
 		$this->unschedule_cron();

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -154,9 +154,9 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Builds the indexability notification
+	 * Builds the indexability notification.
 	 *
-	 * @return Yoast_Notification
+	 * @return Yoast_Notification The notification.
 	 */
 	private function get_indexability_notification() {
 		$notice = sprintf(
@@ -179,7 +179,7 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	/**
 	 * Sends a request to Ryte to get the indexability.
 	 *
-	 * @return int(0)|int(1)|false
+	 * @return int|bool The indexability value.
 	 */
 	protected function request_indexability() {
 		$parameters = array();
@@ -230,6 +230,8 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Schedules the cronjob to get the new indexibility status.
+	 *
+	 * @return void
 	 */
 	private function schedule_cron() {
 		if ( wp_next_scheduled( 'wpseo_onpage_fetch' ) ) {
@@ -241,6 +243,8 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Unschedules the cronjob to get the new indexibility status.
+	 *
+	 * @return void
 	 */
 	private function unschedule_cron() {
 		if ( ! wp_next_scheduled( 'wpseo_onpage_fetch' ) ) {
@@ -252,6 +256,8 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Redo the fetch request for Ryte.
+	 *
+	 * @return void
 	 */
 	private function catch_redo_listener() {
 		if ( ! self::is_active() ) {
@@ -268,7 +274,7 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	/**
 	 * Checks if WordFence protects the site against 'fake' Google crawlers.
 	 *
-	 * @return boolean
+	 * @return boolean True if WordFence protects the site.
 	 */
 	private function wordfence_protection_enabled() {
 		if ( ! class_exists( 'wfConfig' ) ) {

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -33,15 +33,15 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		if ( ! $this->is_active() ) {
+		// Adds admin notice if necessary.
+		add_filter( 'admin_init', array( $this, 'show_notice' ) );
+
+		if ( ! self::is_active() ) {
 			return;
 		}
 
 		// Adds weekly schedule to the cron job schedules.
 		add_filter( 'cron_schedules', array( $this, 'add_weekly_schedule' ) );
-
-		// Adds admin notice if necessary.
-		add_filter( 'admin_init', array( $this, 'show_notice' ) );
 
 		// Sets the action for the Ryte fetch.
 		add_action( 'wpseo_onpage_fetch', array( $this, 'fetch_from_onpage' ) );
@@ -70,8 +70,12 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 *
 	 * @return bool True if this functionality can be used.
 	 */
-	protected function is_active() {
+	public static function is_active() {
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX === true ) {
+			return false;
+		}
+
+		if ( ! WPSEO_Options::get( 'onpage_indexability' ) ) {
 			return false;
 		}
 
@@ -231,7 +235,7 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 * Redo the fetch request for Ryte.
 	 */
 	private function catch_redo_listener() {
-		if ( ! $this->is_active() ) {
+		if ( ! self::is_active() ) {
 			return;
 		}
 

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -86,7 +86,11 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 * Hooks to run on plugin activation.
 	 */
 	public function activate_hooks() {
-		$this->set_cron();
+		if ( $this->get_option()->is_enabled() ) {
+			$this->schedule_cron();
+		}
+
+		$this->unschedule_cron();
 	}
 
 	/**
@@ -223,12 +227,25 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Sets up the cronjob to get the new indexibility status.
+	 * Schedules the cronjob to get the new indexibility status.
 	 */
-	private function set_cron() {
-		if ( ! wp_next_scheduled( 'wpseo_onpage_fetch' ) ) {
-			wp_schedule_event( time(), 'weekly', 'wpseo_onpage_fetch' );
+	private function schedule_cron() {
+		if ( wp_next_scheduled( 'wpseo_onpage_fetch' ) ) {
+			return;
 		}
+
+		wp_schedule_event( time(), 'weekly', 'wpseo_onpage_fetch' );
+	}
+
+	/**
+	 * Unschedules the cronjob to get the new indexibility status.
+	 */
+	private function unschedule_cron() {
+		if ( ! wp_next_scheduled( 'wpseo_onpage_fetch' ) ) {
+			return;
+		}
+
+		wp_unschedule_event( time(), 'wpseo_onpage_fetch' );
 	}
 
 	/**

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -161,4 +161,38 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 
 		$this->assertTrue( $instance->should_show_notice() );
 	}
+
+	/**
+	 * Tests whether OnPage is not indexable and enabled, the notice should be shown.
+	 *
+	 * @covers WPSEO_OnPage::__construct
+	 * @covers WPSEO_OnPage::should_show_notice
+	 */
+	public function test_should_not_show_notice() {
+		// Disable OnPage.
+		$option = new OnPage_Option_Mock( false, WPSEO_OnPage_Option::IS_NOT_INDEXABLE, true );
+
+		// Set blog to public.
+		update_option( 'blog_public', 1 );
+
+		$instance = $this->getMockBuilder( 'WPSEO_OnPage_Double' )
+						 ->setMethods( array( 'get_option' ) )
+						 ->getMock();
+
+		$instance->expects( $this->atLeastOnce() )
+				 ->method( 'get_option' )
+				 ->will( $this->returnValue( $option ) );
+
+		$this->assertFalse( $instance->should_show_notice(), 'The notice should not be shown when disabled.' );
+	}
+
+	/**
+	 * Tests if the notice constrol is hooked.
+	 */
+	public function test_notification_hooks_should_be_hooked() {
+		$onpage = new WPSEO_OnPage();
+		$onpage->register_hooks();
+
+		$this->assertNotFalse( has_action( 'admin_init', array( $onpage, 'show_notice' ) ) );
+	}
 }

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -207,10 +207,38 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if active is baed on the option.
+	 *
+	 * @covers WPSEO_OnPage::is_active()
 	 */
 	public function test_is_active() {
 		WPSEO_Options::set( 'onpage_indexability', true );
 
 		$this->assertTrue( WPSEO_OnPage::is_active() );
+	}
+
+	/**
+	 * Tests if the cronjob is scheduled when enabled.
+	 *
+	 * @covers WPSEO_OnPage::activate_hooks()
+	 * @covers WPSEO_OnPage::schedule_cron()
+	 * @covers WPSEO_OnPage::unschedule_cron()
+	 */
+	public function test_cron_scheduling() {
+		WPSEO_Options::set( 'onpage_indexability', true );
+
+		$this->assertFalse( wp_next_scheduled( 'wpseo_onpage_fetch' ) );
+
+		$instance = new WPSEO_OnPage();
+		$instance->activate_hooks();
+
+		$this->assertNotFalse( wp_next_scheduled( 'wpseo_onpage_fetch' ) );
+
+		// Disable the option.
+		WPSEO_Options::set( 'onpage_indexability', false );
+
+		$instance->activate_hooks();
+
+		// The cron should be removed.
+		$this->assertFalse( wp_next_scheduled( 'wpseo_onpage_fetch' ) );
 	}
 }

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -195,4 +195,22 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 
 		$this->assertNotFalse( has_action( 'admin_init', array( $onpage, 'show_notice' ) ) );
 	}
+
+	/**
+	 * Tests if not active is based on the option.
+	 */
+	public function test_is_not_active() {
+		WPSEO_Options::set( 'onpage_indexability', false );
+
+		$this->assertFalse( WPSEO_OnPage::is_active() );
+	}
+
+	/**
+	 * Tests if active is baed on the option.
+	 */
+	public function test_is_active() {
+		WPSEO_Options::set( 'onpage_indexability', true );
+
+		$this->assertTrue( WPSEO_OnPage::is_active() );
+	}
 }

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -309,23 +309,25 @@ function wpseo_init() {
  */
 function wpseo_init_rest_api() {
 	// We can't do anything when requirements are not met.
-	if ( WPSEO_Utils::is_api_available() ) {
-		// Boot up REST API.
-		$configuration_service = new WPSEO_Configuration_Service();
-		$configuration_service->initialize();
+	if ( ! WPSEO_Utils::is_api_available() ) {
+		return;
+	}
 
-		$link_reindex_endpoint = new WPSEO_Link_Reindex_Post_Endpoint( new WPSEO_Link_Reindex_Post_Service() );
-		$link_reindex_endpoint->register();
+	// Boot up REST API.
+	$configuration_service = new WPSEO_Configuration_Service();
+	$configuration_service->initialize();
 
-		$statistics_service  = new WPSEO_Statistics_Service( new WPSEO_Statistics() );
-		$statistics_endpoint = new WPSEO_Endpoint_Statistics( $statistics_service );
-		$statistics_endpoint->register();
+	$link_reindex_endpoint = new WPSEO_Link_Reindex_Post_Endpoint( new WPSEO_Link_Reindex_Post_Service() );
+	$link_reindex_endpoint->register();
 
-		if ( WPSEO_OnPage::is_active() ) {
-			$ryte_endpoint_service = new WPSEO_Ryte_Service( new WPSEO_OnPage_Option() );
-			$ryte_endpoint         = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
-			$ryte_endpoint->register();
-		}
+	$statistics_service  = new WPSEO_Statistics_Service( new WPSEO_Statistics() );
+	$statistics_endpoint = new WPSEO_Endpoint_Statistics( $statistics_service );
+	$statistics_endpoint->register();
+
+	if ( WPSEO_OnPage::is_active() ) {
+		$ryte_endpoint_service = new WPSEO_Ryte_Service( new WPSEO_OnPage_Option() );
+		$ryte_endpoint         = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
+		$ryte_endpoint->register();
 	}
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -300,10 +300,8 @@ function wpseo_init() {
 	$link_watcher->load();
 
 	// Loading Ryte integration.
-	if ( WPSEO_Options::get( 'onpage_indexability' ) ) {
-		$wpseo_onpage = new WPSEO_OnPage();
-		$wpseo_onpage->register_hooks();
-	}
+	$wpseo_onpage = new WPSEO_OnPage();
+	$wpseo_onpage->register_hooks();
 }
 
 /**
@@ -323,9 +321,11 @@ function wpseo_init_rest_api() {
 		$statistics_endpoint = new WPSEO_Endpoint_Statistics( $statistics_service );
 		$statistics_endpoint->register();
 
-		$ryte_endpoint_service = new WPSEO_Ryte_Service( new WPSEO_OnPage_Option() );
-		$ryte_endpoint         = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
-		$ryte_endpoint->register();
+		if ( WPSEO_OnPage::is_active() ) {
+			$ryte_endpoint_service = new WPSEO_Ryte_Service( new WPSEO_OnPage_Option() );
+			$ryte_endpoint         = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
+			$ryte_endpoint->register();
+		}
 	}
 }
 


### PR DESCRIPTION
Due to merge conflicts this was broken.
The notification needs to be removed when the service is inactive.

Also doesnt register the REST endpoint when Ryte is disabled.

## Summary

This PR can be summarized in the following changelog entry:

* _Not applicable_

## Relevant technical choices:

* Also disabled REST API when feature is disabled.

## Test instructions

This PR can be tested by following these steps:

* See issue.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9371
