### PR TITLE
Show the facebook app id

### DIFF
--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -27,6 +27,9 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 	</p>
 
 <?php
+
+$yform->textinput( 'fbadminapp', __( 'Facebook App ID', 'wordpress-seo' ) );
+
 if ( 'posts' === get_option( 'show_on_front' ) ) {
 	$social_facebook_frontpage_help = new WPSEO_Admin_Help_Panel(
 		'social-facebook-frontpage',

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -26,6 +26,7 @@ class WPSEO_OpenGraph {
 			add_action( 'wpseo_opengraph', array( $this, 'locale' ), 1 );
 			add_action( 'wpseo_opengraph', array( $this, 'type' ), 5 );
 			add_action( 'wpseo_opengraph', array( $this, 'og_title' ), 10 );
+			add_action( 'wpseo_opengraph', array( $this, 'app_id' ), 20 );
 			add_action( 'wpseo_opengraph', array( $this, 'description' ), 11 );
 			add_action( 'wpseo_opengraph', array( $this, 'url' ), 12 );
 			add_action( 'wpseo_opengraph', array( $this, 'site_name' ), 13 );

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -749,6 +749,21 @@ class WPSEO_OpenGraph {
 	}
 
 	/**
+	 * Outputs the Facebook app_id.
+	 *
+	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
+	 *
+	 * @return void
+	 */
+	public function app_id() {
+		$app_id = WPSEO_Options::get( 'fbadminapp', '' );
+		if ( $app_id !== '' ) {
+			$this->og_tag( 'fb:app_id', $app_id );
+		}
+	}
+
+
+	/**
 	 * Outputs the site owner.
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -39,6 +39,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 		'youtube_url'        => '',
 		'google_plus_url'    => '',
 		// Form field, but not always available.
+		'fbadminapp'         => '', // Facebook app ID.
 	);
 
 	/**
@@ -47,6 +48,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	public $ms_exclude = array(
 		/* Privacy. */
 		'pinterestverify',
+		'fbadminapp',
 	);
 
 
@@ -186,6 +188,12 @@ class WPSEO_Option_Social extends WPSEO_Option {
 				case 'opengraph':
 				case 'twitter':
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );
+					break;
+
+				case 'fbadminapp' :
+					if ( isset( $dirty[ $key ] ) && ! empty( $dirty[ $key ] ) ) {
+						$clean[ $key ] = $dirty[ $key ];
+					}
 					break;
 			}
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Bring back the Facebook app_id in the settings and as a metatag

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk
* On the frontend: view the source of a post, page or what you want 
* No app_id is present
* Checkout this branch and go to the Facebook settings: social > facebook
* Set an app id
* Again view the source of post, page on the frontend
* See the app_id being present as a metatag.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9323
