### PR TITLE
Just return `free` or `premium`

### DIFF
--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -69,23 +69,11 @@ class WPSEO_Shortlinker {
 	 * @return string The software name + activation state.
 	 */
 	private function get_software() {
-		if ( ! class_exists( 'WPSEO_Product_Premium' ) ) {
-			return 'free';
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			return 'premium';
 		}
 
-		static $software;
-
-		if ( $software === null ) {
-			$software          = 'premium-inactive';
-			$product_premium   = new WPSEO_Product_Premium();
-			$extension_manager = new WPSEO_Extension_Manager();
-
-			if ( $extension_manager->is_activated( $product_premium->get_slug() ) ) {
-				$software = 'premium-activated';
-			}
-		}
-
-		return $software;
+		return 'free';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _Not applicable: Regression_

## Relevant technical choices:

* Just return `free` or `premium` instead of trying to do `license active` logic.

## Test instructions

This PR can be tested by following these steps:

* Merge this into Premium and verify that there are no fatal errors on the `License` or settings-pages.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #9400 
