### PR TITLE
Fix hard cast to array

### DIFF
--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -167,7 +167,10 @@ class WPSEO_Link_Columns {
 	 *
 	 * @return array The extended array with columns.
 	 */
-	public function add_post_columns( array $columns ) {
+	public function add_post_columns( $columns ) {
+		if ( ! is_array( $columns ) ) {
+			return $columns;
+		}
 		$columns[ 'wpseo-' . self::COLUMN_LINKS ] = '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-label="' . esc_attr__( 'Number of internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( '# links in post', 'wordpress-seo' ) . '</span></span>';
 
 		if ( ! WPSEO_Link_Query::has_unprocessed_posts( $this->public_post_types ) ) {

--- a/tests/admin/links/test-class-link-columns.php
+++ b/tests/admin/links/test-class-link-columns.php
@@ -96,6 +96,15 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the addition of post columns with a non-array value.
+	 */
+	public function test_add_faulty_post_columns() {
+		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
+
+		$this->assertTrue( $link_columns->add_post_columns( true ) );
+	}
+
+	/**
 	 * Test set_count_objects to set the object correctly.
 	 */
 	public function test_set_count_objects() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Prevent hard casting to array on WP internal filter.

## Relevant technical choices:

* Returned `$columns` when it's not an array.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9403 
