### PR TITLE
Alter configuration service text if the user is already using Premium

### DIFF
--- a/admin/config-ui/components/class-component-configuration-choices.php
+++ b/admin/config-ui/components/class-component-configuration-choices.php
@@ -63,9 +63,9 @@ class WPSEO_Config_Component_Configuration_Choices implements WPSEO_Config_Compo
 
 		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
 			$configuration_service_text = sprintf(
-				/* translators: %1$s expands to 'Yoast SEO'. */
+				/* translators: %1$s expands to 'Yoast SEO Premium'. */
 				__( 'While we strive to make setting up %1$s as easy as possible, we understand it can still be daunting. If you would rather have us set up %1$s for you, order a %1$s configuration service and sit back while we configure your site.', 'wordpress-seo' ),
-				'Yoast SEO'
+				'Yoast SEO Premium'
 			);
 		}
 

--- a/admin/config-ui/components/class-component-configuration-choices.php
+++ b/admin/config-ui/components/class-component-configuration-choices.php
@@ -53,17 +53,28 @@ class WPSEO_Config_Component_Configuration_Choices implements WPSEO_Config_Compo
 			),
 			plugin_dir_url( WPSEO_FILE ) . '/images/Yoast_SEO_Icon.svg'
 		);
+
+		$configuration_service_text = sprintf(
+			/* translators: %1$s expands to 'Yoast SEO', %2$s expands to 'Yoast SEO Premium'. */
+			__( 'While we strive to make setting up %1$s as easy as possible, we understand it can still be daunting. If you would rather have us set up %1$s for you (and get a copy of %2$s in the process), order a %1$s configuration service and sit back while we configure your site.', 'wordpress-seo' ),
+			'Yoast SEO',
+			'Yoast SEO Premium'
+		);
+
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			$configuration_service_text = sprintf(
+				/* translators: %1$s expands to 'Yoast SEO'. */
+				__( 'While we strive to make setting up %1$s as easy as possible, we understand it can still be daunting. If you would rather have us set up %1$s for you, order a %1$s configuration service and sit back while we configure your site.', 'wordpress-seo' ),
+				'Yoast SEO'
+			);
+		}
+
 		$field->add_choice(
 			sprintf(
 				/* translators: %s expands to 'Yoast SEO'. */
 				__( 'Let us set up %s for you', 'wordpress-seo' ), 'Yoast SEO'
 			),
-			sprintf(
-				/* translators: %1$s expands to 'Yoast SEO', %2$s expands to 'Yoast SEO Premium'. */
-				__( 'While we strive to make setting up %1$s as easy as possible, we understand it can still be daunting. If you would rather have us set up %1$s for you (and get a copy of %2$s in the process), order a %1$s configuration service and sit back while we configure your site.', 'wordpress-seo' ),
-				'Yoast SEO',
-				'Yoast SEO Premium'
-			),
+			$configuration_service_text,
 			array(
 				'type'   => 'secondary',
 				'label'  => __( 'Configuration service', 'wordpress-seo' ),


### PR DESCRIPTION
# Summary

This PR can be summarized in the following changelog entry:

* Alters the configuration service text in the Configuration Wizard when a user is already running Yoast SEO Premium. Previously the text contained a reference to getting a bundled copy of Premium, even if the user was already running Premium.

## Relevant technical choices:

* Added the logic to Free, as the text is being generated there.

## Test instructions

This PR can be tested by following these steps:

**Free**
* Checkout this branch
* Run `composer install`, `yarn` and `grunt build` prior to testing.
* Start the Configuration Wizard (`SEO -> General`)
* Notice the block on the right of the welcome page of the Configuration Wizard. Please note that the old text (with a reference to a copy of Premium) is still there.

**Premium**
* Pull this branch into a test branch within your Premium testing environment (i.e. `git pull free 335-fix-copy-configuration-wizard`)
* Run `composer install`, `yarn` and `grunt build`.
* Navigate to the `premium` directory.
* Run `yarn` and `grunt build` prior to testing.
* Start the Configuration Wizard (`SEO -> General`)
* Notice the block on the right of the welcome page of the Configuration Wizard. Please note that text no longer contains a reference to a copy of Premium when purchasing the Configuration Service.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/335
