### PR TITLE
Add ability to filter out strippable characters from the focus keyword

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -511,19 +511,21 @@ class WPSEO_Meta {
 				}
 
 				if ( $meta_key === self::$meta_prefix . 'focuskw' ) {
-					$clean = str_replace(
-					    apply_filters('wpseo_focuskw_strip_chars',
-					    array(
-						'&lt;',
-						'&gt;',
-						'&quot',
-						'&#96',
-						'<',
-						'>',
-						'"',
-						'`',
-					)), '', $clean );
+
+					/**
+					 * Filter: 'wpseo_focuskw_strippable_chars' - Allows customization of the strippable characters
+					 * in the focus keyword field.
+					 *
+					 * @api array $strippable_chars The characters to strip from the focus keyword.
+					 */
+					$strippable_chars = apply_filters(
+						'wpseo_focuskw_strippable_chars',
+						array( '&lt;', '&gt;', '&quot', '&#96', '<', '>', '"', '`' )
+					);
+
+					$clean = str_replace( $strippable_chars, '', $clean );
 				}
+
 				break;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the ability to filter out strippable characters from the focus keyword so they don't get removed on save. Props to @BHEADRICK.

## Relevant technical choices:

* Refrained from adding unit tests in this PR due to the complexity of the sanitation function. Will create a new issue for this, as some refactoring might be necessary.

## Test instructions

This PR can be tested by following these steps:

* Create a new post and add a keyword that contains the `"` character in it (i.e. `21" television`).
* Save the post and note that the `"` is stripped from the keyword.
* Checkout this branch.
* Add a call to the newly added filter (i.e. `add_filter( 'wpseo_focuskw_strippable_chars', 'function_to_call' );`). Make sure the function you call returns an array _without_ the `"` in it.
A potential file to implement this filter in, is in the `wp-seo-main.php` file.
* Create a new post and add a `"` to your keyword. Notice that the character is not stripped after you save the post.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #8476 
