### PR TITLE
Refactor how we handle OpenGraph images

### DIFF
--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -251,7 +251,7 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		wp_unschedule_event( time(), 'wpseo_onpage_fetch' );
+		wp_clear_scheduled_hook( 'wpseo_onpage_fetch' );
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1237,7 +1237,7 @@ class WPSEO_Frontend {
 		}
 		elseif ( $this->frontend_page_type->is_simple_page() ) {
 			$post      = get_post( $this->frontend_page_type->get_simple_page_id() );
-			$post_type = $post->post_type;
+			$post_type = isset( $post->post_type ) ? $post->post_type : '';
 
 			if ( ( $metadesc === '' && $post_type !== '' ) && WPSEO_Options::get( 'metadesc-' . $post_type, '' ) !== '' ) {
 				$template = WPSEO_Options::get( 'metadesc-' . $post_type );

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -58,20 +58,17 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Display an OpenGraph image tag.
 	 *
-	 * @param string $img      Source URL to the image.
-	 * @param int    $width    The image width.
-	 * @param int    $height   The image height.
-	 * @param string $alt_text The image alt text.
+	 * @param array $attachment Attachment array.
 	 *
 	 * @return void
 	 */
-	public function add_image( $img, $width = null, $height = null, $alt_text = '' ) {
+	public function add_image( $attachment ) {
 		/**
 		 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph image.
 		 *
 		 * @api string - The URL of the OpenGraph image.
 		 */
-		$img = trim( apply_filters( 'wpseo_opengraph_image', $img ) );
+		$img = trim( apply_filters( 'wpseo_opengraph_image', $attachment['url'] ) );
 
 		if ( empty( $img ) ) {
 			return;
@@ -86,9 +83,10 @@ class WPSEO_OpenGraph_Image {
 		}
 
 		$this->images[ $img ] = array(
-			'width'  => $width,
-			'height' => $height,
-			'alt'    => $alt_text,
+			'width'  => $attachment['width'],
+			'height' => $attachment['height'],
+			'alt'    => $attachment['alt-text'],
+			'type'   => $attachment['mime-type'],
 		);
 	}
 
@@ -279,13 +277,22 @@ class WPSEO_OpenGraph_Image {
 		$alt_text   = WPSEO_Image_Utils::get_image_alt_tag( $attachment_id );
 
 		if ( $attachment ) {
-			$this->add_image( $attachment['url'], $attachment['width'], $attachment['height'], $alt_text );
+			$attachment['alt-text'] = $alt_text;
+			$this->add_image( $attachment );
+
 			return;
 		}
 
 		$image = wp_get_attachment_image_src( $attachment_id, 'full' );
 		if ( $image ) {
-			$this->add_image( $image[0], $image[1], $image[2], $alt_text );
+			$attachment = array(
+				'url'       => $image[0],
+				'width'     => $image[1],
+				'height'    => $image[2],
+				'alt-text'  => $alt_text,
+				'mime-type' => get_post_mime_type( $attachment_id ),
+			);
+			$this->add_image( $attachment );
 		}
 	}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -222,17 +222,7 @@ class WPSEO_OpenGraph_Image {
 	private function set_featured_image( $post_id ) {
 		if ( has_post_thumbnail( $post_id ) ) {
 			$attachment_id = get_post_thumbnail_id( $post_id );
-			/**
-			 * Filter: 'wpseo_opengraph_image_size' - Allow changing the image size used for OpenGraph sharing.
-			 *
-			 * @api string $unsigned Size string.
-			 */
-			$thumb = wp_get_attachment_image_src( $attachment_id, apply_filters( 'wpseo_opengraph_image_size', 'original' ) );
-
-			if ( $this->check_featured_image_size( $thumb ) ) {
-				$this->add_image_by_id( $attachment_id );
-				return;
-			}
+			$this->add_image_by_id( $attachment_id );
 		}
 	}
 
@@ -301,26 +291,6 @@ class WPSEO_OpenGraph_Image {
 	}
 
 	/**
-	 * Check size of featured image. If image is too small, return false, else return true.
-	 *
-	 * @param array $img_data Image info from wp_get_attachment_image_src: url, width, height, icon.
-	 *
-	 * @return bool Whether an image is fit for OpenGraph display or not.
-	 */
-	protected function check_featured_image_size( $img_data ) {
-		if ( ! is_array( $img_data ) ) {
-			return false;
-		}
-
-		// Get the width and height of the image.
-		if ( $img_data[1] < 200 || $img_data[2] < 200 ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Adds an image to the list by attachment ID.
 	 *
 	 * @param int $attachment_id The attachment ID to add.
@@ -328,25 +298,12 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	protected function add_image_by_id( $attachment_id ) {
-		$attachment = WPSEO_Image_Utils::find_correct_image_size( $attachment_id );
-		$alt_text   = WPSEO_Image_Utils::get_image_alt_tag( $attachment_id );
-
-		if ( $attachment ) {
-			$attachment['alt'] = $alt_text;
-			$this->add_image( $attachment );
-
+		if ( ! WPSEO_Image_Utils::check_original_image_size( $attachment_id ) ) {
 			return;
 		}
+		$attachment = WPSEO_Image_Utils::find_correct_image_size( $attachment_id );
 
-		$image = wp_get_attachment_image_src( $attachment_id, 'full' );
-		if ( $image ) {
-			$attachment = array(
-				'url'    => $image[0],
-				'width'  => $image[1],
-				'height' => $image[2],
-				'alt'    => $alt_text,
-				'type'   => get_post_mime_type( $attachment_id ),
-			);
+		if ( $attachment ) {
 			$this->add_image( $attachment );
 		}
 	}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -316,7 +316,7 @@ class WPSEO_OpenGraph_Image {
 		if ( ! WPSEO_Image_Utils::has_usable_dimensions( $attachment_id, $this->image_params ) ) {
 			return;
 		}
-		$attachment = WPSEO_Image_Utils::find_correct_image_size( $attachment_id );
+		$attachment = WPSEO_Image_Utils::get_optimal_variation( $attachment_id );
 
 		if ( $attachment ) {
 			$this->add_image( $attachment );

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -84,6 +84,7 @@ class WPSEO_OpenGraph_Image {
 			}
 		}
 	}
+
 	/**
 	 * Outputs an image tag based on whether it's https or not.
 	 *

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -27,21 +27,7 @@ class WPSEO_OpenGraph_Image {
 		 */
 		do_action( 'wpseo_add_opengraph_images', $this );
 
-		if ( is_front_page() ) {
-			$this->set_front_page_image();
-		}
-		elseif ( is_home() ) {
-			$this->set_posts_page_image();
-		}
-		elseif ( is_attachment() ) {
-			$this->set_attachment_page_image();
-		}
-		elseif ( is_single() || is_singular() ) {
-			$this->set_singular_image();
-		}
-		elseif ( is_category() || is_tax() || is_tag() ) {
-			$this->set_taxonomy_image();
-		}
+		$this->set_images();
 
 		if ( ! $this->has_images() ) {
 			$this->set_default_image();
@@ -303,4 +289,24 @@ class WPSEO_OpenGraph_Image {
 		}
 	}
 
+	/**
+	 * Sets the images based on the page type.
+	 */
+	private function set_images() {
+		if ( is_front_page() ) {
+			$this->set_front_page_image();
+		}
+		elseif ( is_home() ) {
+			$this->set_posts_page_image();
+		}
+		elseif ( is_attachment() ) {
+			$this->set_attachment_page_image();
+		}
+		elseif ( is_single() || is_singular() ) {
+			$this->set_singular_image();
+		}
+		elseif ( is_category() || is_tax() || is_tag() ) {
+			$this->set_taxonomy_image();
+		}
+	}
 }

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -312,8 +312,8 @@ class WPSEO_OpenGraph_Image {
 		if ( ! WPSEO_Image_Utils::has_usable_dimensions( $attachment_id, $this->image_params ) ) {
 			return;
 		}
-		$attachment = WPSEO_Image_Utils::get_optimal_variation( $attachment_id );
 
+		$attachment = WPSEO_Image_Utils::get_optimal_variation( $attachment_id );
 		if ( $attachment ) {
 			$this->add_image( $attachment );
 		}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -36,6 +36,20 @@ class WPSEO_OpenGraph_Image {
 	);
 
 	/**
+	 * The parameters we have for Facebook images.
+	 *
+	 * @var array
+	 */
+	private $image_params = array(
+		'min_width'  => 200,
+		'max_width'  => 2000,
+		'min_height' => 200,
+		'max_height' => 2000,
+		'min_ratio'  => 1,
+		'max_ratio'  => 3,
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WPSEO_OpenGraph $wpseo_opengraph The OpenGraph object.
@@ -298,7 +312,7 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	protected function add_image_by_id( $attachment_id ) {
-		if ( ! WPSEO_Image_Utils::check_original_image_size( $attachment_id ) ) {
+		if ( ! WPSEO_Image_Utils::check_image_measurements( $attachment_id, $this->image_params ) ) {
 			return;
 		}
 		$attachment = WPSEO_Image_Utils::find_correct_image_size( $attachment_id );

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -72,13 +72,14 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Display an OpenGraph image tag.
 	 *
-	 * @param string $img    Source URL to the image.
-	 * @param int    $width  The image width.
-	 * @param int    $height The image height.
+	 * @param string $img      Source URL to the image.
+	 * @param int    $width    The image width.
+	 * @param int    $height   The image height.
+	 * @param string $alt_text The image alt text.
 	 *
 	 * @return void
 	 */
-	public function add_image( $img, $width = null, $height = null ) {
+	public function add_image( $img, $width = null, $height = null, $alt_text = '' ) {
 		/**
 		 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph image.
 		 *
@@ -101,6 +102,7 @@ class WPSEO_OpenGraph_Image {
 		$this->images[ $img ] = array(
 			'width'  => $width,
 			'height' => $height,
+			'alt'    => $alt_text,
 		);
 	}
 
@@ -121,7 +123,7 @@ class WPSEO_OpenGraph_Image {
 	private function set_posts_page_image() {
 		$post_id = get_option( 'page_for_posts' );
 
-		$this->set_image_post( $post_id );
+		$this->set_image_post_meta( $post_id );
 		if ( $this->has_images() ) {
 			return;
 		}
@@ -141,7 +143,7 @@ class WPSEO_OpenGraph_Image {
 			$post_id = get_the_ID();
 		}
 
-		$this->set_image_post( $post_id );
+		$this->set_image_post_meta( $post_id );
 		if ( $this->has_images() ) {
 			return;
 		}
@@ -168,7 +170,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @param int $post_id Optional post ID to use.
 	 */
-	private function set_image_post( $post_id = 0 ) {
+	private function set_image_post_meta( $post_id = 0 ) {
 		$image_url = WPSEO_Meta::get_value( 'opengraph-image', $post_id );
 		$this->add_image_by_url( $image_url );
 	}
@@ -232,8 +234,12 @@ class WPSEO_OpenGraph_Image {
 			return;
 		}
 
-		foreach ( $images as $image ) {
-			$this->add_image_by_url( $image );
+		foreach ( $images as $image_url => $attachment_id ) {
+			if ( $attachment_id !== 0 ) {
+				$this->add_image_by_id( $attachment_id );
+				continue;
+			}
+			$this->add_image_by_url( $image_url );
 		}
 	}
 
@@ -284,14 +290,16 @@ class WPSEO_OpenGraph_Image {
 	 */
 	protected function add_image_by_id( $attachment_id ) {
 		$attachment = WPSEO_Image_Utils::find_correct_image_size( $attachment_id );
+		$alt_text   = WPSEO_Image_Utils::get_image_alt_tag( $attachment_id );
+
 		if ( $attachment ) {
-			$this->add_image( $attachment['url'], $attachment['width'], $attachment['height'] );
+			$this->add_image( $attachment['url'], $attachment['width'], $attachment['height'], $alt_text );
 			return;
 		}
 
 		$image = wp_get_attachment_image_src( $attachment_id, 'full' );
 		if ( $image ) {
-			$this->add_image( $image[0], $image[1], $image[2] );
+			$this->add_image( $image[0], $image[1], $image[2], $alt_text );
 		}
 	}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -9,26 +9,21 @@
  * Class WPSEO_OpenGraph_Image
  */
 class WPSEO_OpenGraph_Image {
-
 	/**
-	 * @var array $images Holds the images that have been put out as OG image.
+	 * Holds the images that have been put out as OG image.
+	 *
+	 * @var array
 	 */
-	private $images = array();
-
-	/**
-	 * @todo This needs to be refactored since we only hold one set of dimensions for multiple images. R.
-	 * @var array $dimensions Holds image dimensions, if determined.
-	 */
-	protected $dimensions = array();
+	protected $images = array();
 
 	/**
 	 * Constructor.
 	 *
-	 * @param string|boolean $image   Optional image URL.
+	 * @param string|boolean $image Optional image URL.
 	 */
 	public function __construct( $image = false ) {
 		// If an image was not supplied or could not be added.
-		if ( empty( $image ) || ! $this->add_image( $image ) ) {
+		if ( empty( $image ) || ! $this->add_image_by_url( $image ) ) {
 			$this->set_images();
 		}
 	}
@@ -43,53 +38,48 @@ class WPSEO_OpenGraph_Image {
 	}
 
 	/**
-	 * Return the dimensions array.
-	 *
-	 * @return array
-	 */
-	public function get_dimensions() {
-		return $this->dimensions;
-	}
-
-	/**
 	 * Display an OpenGraph image tag.
 	 *
-	 * @param string $img Source URL to the image.
+	 * @param string $img    Source URL to the image.
+	 * @param int    $width  The image width.
+	 * @param int    $height The image height.
 	 *
-	 * @return bool
+	 * @return bool Whether we were succesful or not.
 	 */
-	public function add_image( $img ) {
-
-		$original = trim( $img );
-
-		// Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph image.
+	public function add_image( $img, $width = null, $height = null ) {
+		/**
+		 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph image.
+		 *
+		 * @api string - The URL of the OpenGraph image.
+		 */
 		$img = trim( apply_filters( 'wpseo_opengraph_image', $img ) );
-
-		if ( $original !== $img ) {
-			$this->dimensions = array();
-		}
 
 		if ( empty( $img ) ) {
 			return false;
 		}
 
 		if ( WPSEO_Utils::is_url_relative( $img ) === true ) {
-			$img = $this->get_relative_path( $img );
+			$img = WPSEO_Image_Utils::get_relative_path( $img );
 		}
 
-		if ( in_array( $img, $this->images, true ) ) {
+		if ( array_key_exists( $img, $this->images ) ) {
 			return false;
 		}
-		array_push( $this->images, $img );
+
+		$this->images[ $img ] = array(
+			'width'  => $width,
+			'height' => $height,
+		);
 
 		return true;
 	}
 
 	/**
-	 * Check if page is front page or singular and call the corresponding functions. If not, call get_default_image.
+	 * Find the correct image for the current page type.
+	 *
+	 * @return bool Whether we added an image or not.
 	 */
-	private function set_images() {
-
+	protected function set_images() {
 		/**
 		 * Filter: wpseo_add_opengraph_images - Allow developers to add images to the OpenGraph tags.
 		 *
@@ -98,102 +88,46 @@ class WPSEO_OpenGraph_Image {
 		do_action( 'wpseo_add_opengraph_images', $this );
 
 		if ( is_front_page() ) {
-			$this->get_front_page_image();
+			return $this->get_front_page_image();
 		}
-		elseif ( is_home() ) { // Posts page, which won't be caught by is_singular() below.
-			$this->get_posts_page_image();
+		if ( is_home() ) { // Posts page, which won't be caught by is_singular() below.
+			return $this->get_posts_page_image();
 		}
-
-		$frontend_page_type = new WPSEO_Frontend_Page_Type();
-		if ( $frontend_page_type->is_simple_page() ) {
-			$this->get_singular_image( $frontend_page_type->get_simple_page_id() );
+		if ( is_singular() ) {
+			return $this->get_singular_image();
 		}
-
 		if ( is_category() || is_tax() || is_tag() ) {
-			$this->get_opengraph_image_taxonomy();
+			return $this->get_opengraph_image_taxonomy();
 		}
 
-		/**
-		 * Filter: wpseo_add_opengraph_additional_images - Allows to add additional images to the OpenGraph tags.
-		 *
-		 * @api WPSEO_OpenGraph_Image The current object.
-		 */
-		do_action( 'wpseo_add_opengraph_additional_images', $this );
-
-		$this->get_default_image();
+		return $this->get_default_image();
 	}
 
 	/**
 	 * If the frontpage image exists, call add_image.
+	 *
+	 * @return bool Whether we added an image or not.
 	 */
 	private function get_front_page_image() {
 		if ( WPSEO_Options::get( 'og_frontpage_image', '' ) !== '' ) {
-			$this->add_image( WPSEO_Options::get( 'og_frontpage_image' ) );
+			return $this->add_image_by_url( WPSEO_Options::get( 'og_frontpage_image' ) );
 		}
+		return false;
 	}
 
 	/**
 	 * Get the images of the posts page.
+	 *
+	 * @return bool Whether we added an image or not.
 	 */
 	private function get_posts_page_image() {
-
 		$post_id = get_option( 'page_for_posts' );
 
 		if ( $this->get_opengraph_image_post( $post_id ) ) {
-			return;
+			return true;
 		}
 
 		if ( $this->get_featured_image( $post_id ) ) {
-			return;
-		}
-	}
-
-	/**
-	 * Get the images of the singular post.
-	 *
-	 * @param null|int $post_id The post id to get the images for.
-	 */
-	private function get_singular_image( $post_id = null ) {
-		if ( $post_id === null ) {
-			$post_id = get_the_ID();
-		}
-
-		if ( $this->get_opengraph_image_post( $post_id ) ) {
-			return;
-		}
-
-		if ( $this->get_attachment_page_image( $post_id ) ) {
-			return;
-		}
-
-		if ( $this->get_featured_image( $post_id ) ) {
-			return;
-		}
-
-		$this->get_content_images( get_post( $post_id ) );
-	}
-
-	/**
-	 * Get default image and call add_image.
-	 */
-	private function get_default_image() {
-		if ( count( $this->images ) === 0 && WPSEO_Options::get( 'og_default_image', '' ) !== '' ) {
-			$this->add_image( WPSEO_Options::get( 'og_default_image' ) );
-		}
-	}
-
-	/**
-	 * If opengraph-image is set, call add_image and return true.
-	 *
-	 * @param int $post_id Optional post ID to use.
-	 *
-	 * @return bool
-	 */
-	private function get_opengraph_image_post( $post_id = 0 ) {
-		$ogimg = WPSEO_Meta::get_value( 'opengraph-image', $post_id );
-		if ( $ogimg !== '' ) {
-			$this->add_image( $ogimg );
-
 			return true;
 		}
 
@@ -201,13 +135,64 @@ class WPSEO_OpenGraph_Image {
 	}
 
 	/**
+	 * Get the images of the singular post.
+	 *
+	 * @param null|int $post_id The post id to get the images for.
+	 *
+	 * @return bool Whether we added an image or not.
+	 */
+	private function get_singular_image( $post_id = null ) {
+		if ( $post_id === null ) {
+			$post_id = get_the_ID();
+		}
+
+		if ( $this->get_opengraph_image_post( $post_id ) ) {
+			return true;
+		}
+
+		if ( $this->get_attachment_page_image( $post_id ) ) {
+			return true;
+		}
+
+		if ( $this->get_featured_image( $post_id ) ) {
+			return true;
+		}
+
+		return $this->get_content_images( get_post( $post_id ) );
+	}
+
+	/**
+	 * Get default image and call add_image.
+	 *
+	 * @return bool Whether we added an image or not.
+	 */
+	private function get_default_image() {
+		if ( count( $this->images ) === 0 && WPSEO_Options::get( 'og_default_image', '' ) !== '' ) {
+			return $this->add_image_by_url( WPSEO_Options::get( 'og_default_image' ) );
+		}
+		return false;
+	}
+
+	/**
+	 * If opengraph-image is set, call add_image and return true.
+	 *
+	 * @param int $post_id Optional post ID to use.
+	 *
+	 * @return bool Whether we added an image or not.
+	 */
+	private function get_opengraph_image_post( $post_id = 0 ) {
+		$image_url = WPSEO_Meta::get_value( 'opengraph-image', $post_id );
+		return $this->add_image_by_url( $image_url );
+	}
+
+	/**
 	 * Check if taxonomy has an image and add this image.
+	 *
+	 * @return bool Whether we added an image or not.
 	 */
 	private function get_opengraph_image_taxonomy() {
-		$ogimg = WPSEO_Taxonomy_Meta::get_meta_without_term( 'opengraph-image' );
-		if ( $ogimg !== '' ) {
-			$this->add_image( $ogimg );
-		}
+		$image_url = WPSEO_Taxonomy_Meta::get_meta_without_term( 'opengraph-image' );
+		return $this->add_image_by_url( $image_url );
 	}
 
 	/**
@@ -215,24 +200,21 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @param int $post_id The post ID.
 	 *
-	 * @return bool
+	 * @return bool Whether we added an image or not.
 	 */
 	private function get_featured_image( $post_id ) {
-
 		if ( has_post_thumbnail( $post_id ) ) {
+			$attachment_id = get_post_thumbnail_id( $post_id );
 			/**
 			 * Filter: 'wpseo_opengraph_image_size' - Allow changing the image size used for OpenGraph sharing.
 			 *
 			 * @api string $unsigned Size string.
 			 */
-			$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), apply_filters( 'wpseo_opengraph_image_size', 'original' ) );
+			$thumb = wp_get_attachment_image_src( $attachment_id, apply_filters( 'wpseo_opengraph_image_size', 'original' ) );
 
 			if ( $this->check_featured_image_size( $thumb ) ) {
-
-				$this->dimensions['width']  = $thumb[1];
-				$this->dimensions['height'] = $thumb[2];
-
-				return $this->add_image( $thumb[0] );
+				$return = $this->add_image_by_id( $attachment_id );
+				return $return;
 			}
 		}
 
@@ -244,39 +226,59 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @param int $post_id The post ID.
 	 *
-	 * @return bool
+	 * @return bool Whether we added an image or not.
 	 */
 	private function get_attachment_page_image( $post_id ) {
-		if ( get_post_type( $post_id ) === 'attachment' ) {
-			$mime_type = get_post_mime_type( $post_id );
-			switch ( $mime_type ) {
-				case 'image/jpeg':
-				case 'image/png':
-				case 'image/gif':
-					return $this->add_image( wp_get_attachment_url( $post_id ) );
-			}
+		if ( get_post_type( $post_id ) === 'attachment' && wp_attachment_is_image( $post_id ) ) {
+			return $this->add_image_by_id( $post_id );
 		}
 
 		return false;
 	}
 
 	/**
-	 * Filter: 'wpseo_pre_analysis_post_content' - Allow filtering the content before analysis.
-	 *
-	 * @api string $post_content The Post content string.
+	 * Retrieve images from the post content.
 	 *
 	 * @param object $post The post object.
+	 *
+	 * @return bool Whether we added an image or not.
 	 */
 	private function get_content_images( $post ) {
-		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
+		$status       = false;
+		$image_finder = new WPSEO_Content_Images();
+		$images       = $image_finder->get_content_images( $post->ID, $post );
 
-		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
-			foreach ( $matches[0] as $img ) {
-				if ( preg_match( '`src=(["\'])(.*?)\1`', $img, $match ) ) {
-					$this->add_image( $match[2] );
-				}
+		if ( ! is_array( $images ) || $images === array() ) {
+			return false;
+		}
+
+		foreach ( $images as $image ) {
+			$return = $this->add_image_by_url( $image );
+			if ( $return ) {
+				$status = true;
 			}
 		}
+
+		return $status;
+	}
+
+	/**
+	 * Adds an image based on a given URL, and attempts to be smart about it.
+	 *
+	 * @param string $url The given URL.
+	 *
+	 * @return bool Whether we were successful or not.
+	 */
+	protected function add_image_by_url( $url ) {
+		if ( $url !== '' ) {
+			$attachment_id = WPSEO_Image_Utils::get_attachment_by_url( $url );
+			if ( $attachment_id > 0 ) {
+				return $this->add_image_by_id( $attachment_id );
+			}
+			return $this->add_image( $url );
+		}
+
+		return false;
 	}
 
 	/**
@@ -284,10 +286,9 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @param array $img_data Image info from wp_get_attachment_image_src: url, width, height, icon.
 	 *
-	 * @return bool
+	 * @return bool Whether an image is fit for OpenGraph display or not.
 	 */
-	private function check_featured_image_size( $img_data ) {
-
+	protected function check_featured_image_size( $img_data ) {
 		if ( ! is_array( $img_data ) ) {
 			return false;
 		}
@@ -301,22 +302,24 @@ class WPSEO_OpenGraph_Image {
 	}
 
 	/**
-	 * Get the relative path of the image.
+	 * Adds an image to the list by attachment ID.
 	 *
-	 * @param array $img Image data array.
+	 * @param int $attachment_id The attachment ID to add.
 	 *
-	 * @return bool|string
+	 * @return bool Whether we were successful or not.
 	 */
-	private function get_relative_path( $img ) {
-		if ( $img[0] !== '/' ) {
-			return false;
+	protected function add_image_by_id( $attachment_id ) {
+		$attachment = WPSEO_Image_Utils::find_correct_image_size( $attachment_id );
+		if ( $attachment ) {
+			return $this->add_image( $attachment['url'], $attachment['width'], $attachment['height'] );
 		}
 
-		// If it's a relative URL, it's relative to the domain, not necessarily to the WordPress install, we
-		// want to preserve domain name and URL scheme (http / https) though.
-		$parsed_url = wp_parse_url( home_url() );
-		$img        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $img;
+		$image = wp_get_attachment_image_src( $attachment_id, 'full' );
+		if ( $image ) {
+			return $this->add_image( $image[0], $image[1], $image[2] );
+		}
 
-		return $img;
+		return false;
 	}
+
 }

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -132,21 +132,20 @@ class WPSEO_OpenGraph_Image {
 		 *
 		 * @api string - The URL of the OpenGraph image.
 		 */
-		$img = trim( apply_filters( 'wpseo_opengraph_image', $attachment['url'] ) );
-
-		if ( empty( $img ) ) {
+		$image_url = trim( apply_filters( 'wpseo_opengraph_image', $attachment['url'] ) );
+		if ( empty( $image_url ) ) {
 			return;
 		}
 
-		if ( WPSEO_Utils::is_url_relative( $img ) === true ) {
-			$img = WPSEO_Image_Utils::get_relative_path( $img );
+		if ( WPSEO_Utils::is_url_relative( $image_url ) === true ) {
+			$image_url = WPSEO_Image_Utils::get_relative_path( $image_url );
 		}
 
-		if ( array_key_exists( $img, $this->images ) ) {
+		if ( array_key_exists( $image_url, $this->images ) ) {
 			return;
 		}
 
-		$this->images[ $img ] = $attachment;
+		$this->images[ $image_url ] = $attachment;
 	}
 
 	/**

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -69,12 +69,10 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	private function og_image_tag( $img ) {
-		// @todo verify we can output only one of these.
-		$tag = 'og:image';
+		$this->opengraph->og_tag( 'og:image', esc_url( $img ) );
 		if ( 0 === strpos( $img, 'https://' ) ) {
-			$tag = 'og:image:secure_url';
+			$this->opengraph->og_tag( 'og:image:secure_url', esc_url( $img ) );
 		}
-		$this->opengraph->og_tag( $tag, esc_url( $img ) );
 	}
 
 	/**
@@ -162,7 +160,7 @@ class WPSEO_OpenGraph_Image {
 	 */
 	private function set_singular_image( $post_id = null ) {
 		if ( $post_id === null ) {
-			$post_id = get_the_ID();
+			$post_id = get_queried_object_id();
 		}
 
 		$this->set_image_post_meta( $post_id );

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -262,7 +262,7 @@ class WPSEO_OpenGraph_Image {
 	 */
 	private function add_content_images( $post ) {
 		$image_finder = new WPSEO_Content_Images();
-		$images       = $image_finder->get_content_images( $post->ID, $post );
+		$images       = $image_finder->get_images( $post->ID, $post );
 
 		if ( ! is_array( $images ) || $images === array() ) {
 			return;
@@ -313,7 +313,7 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	protected function add_image_by_id( $attachment_id ) {
-		if ( ! WPSEO_Image_Utils::check_image_measurements( $attachment_id, $this->image_params ) ) {
+		if ( ! WPSEO_Image_Utils::has_usable_dimensions( $attachment_id, $this->image_params ) ) {
 			return;
 		}
 		$attachment = WPSEO_Image_Utils::find_correct_image_size( $attachment_id );

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -54,7 +54,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @param WPSEO_OpenGraph $wpseo_opengraph The OpenGraph object.
 	 */
-	public function __construct( $wpseo_opengraph ) {
+	public function __construct( WPSEO_OpenGraph $wpseo_opengraph ) {
 		$this->opengraph = $wpseo_opengraph;
 
 		$this->set_images();

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -539,9 +539,9 @@ class WPSEO_OpenGraph {
 		foreach ( $opengraph_images->get_images() as $img => $image_meta ) {
 			$this->og_image_tag( $img );
 
-			foreach ( array( 'width', 'height', 'alt' ) as $key ) {
-				if ( ! empty( $image_meta[ $key ] ) ) {
-					$this->og_tag( 'og:image:' . $key, $image_meta['key'] );
+			foreach ( array( 'width', 'height', 'alt', 'type' ) as $key ) {
+				if ( isset( $image_meta[ $key ] ) && ! empty( $image_meta[ $key ] ) ) {
+					$this->og_tag( 'og:image:' . $key, $image_meta[ $key ] );
 				}
 			}
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -537,24 +537,29 @@ class WPSEO_OpenGraph {
 		$opengraph_images = new WPSEO_OpenGraph_Image();
 
 		foreach ( $opengraph_images->get_images() as $img => $image_meta ) {
-			$tag = 'og:image';
-			if ( 0 === strpos( $img, 'https://' ) ) {
-				$tag = 'og:image:secure_url';
-			}
-			$this->og_tag( $tag, esc_url( $img ) );
+			$this->og_image_tag( $img );
 
-			if ( ! empty( $image_meta['width'] ) ) {
-				$this->og_tag( 'og:image:width', (int) $image_meta['width'] );
-			}
-
-			if ( ! empty( $image_meta['height'] ) ) {
-				$this->og_tag( 'og:image:height', (int) $image_meta['height'] );
-			}
-
-			if ( ! empty( $image_meta['alt'] ) ) {
-				$this->og_tag( 'og:image:alt', $image_meta['alt'] );
+			foreach ( array( 'width', 'height', 'alt' ) as $key ) {
+				if ( ! empty( $image_meta[ $key ] ) ) {
+					$this->og_tag( 'og:image:' . $key, $image_meta['key'] );
+				}
 			}
 		}
+	}
+
+	/**
+	 * Outputs an image tag based on whether it's https or not.
+	 *
+	 * @param string $img The image URL.
+	 *
+	 * @return void
+	 */
+	private function og_image_tag( $img ) {
+		$tag = 'og:image';
+		if ( 0 === strpos( $img, 'https://' ) ) {
+			$tag = 'og:image:secure_url';
+		}
+		$this->og_tag( $tag, esc_url( $img ) );
 	}
 
 	/**

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -536,19 +536,23 @@ class WPSEO_OpenGraph {
 	public function image() {
 		$opengraph_images = new WPSEO_OpenGraph_Image();
 
-		foreach ( $opengraph_images->get_images() as $img => $dimensions ) {
+		foreach ( $opengraph_images->get_images() as $img => $image_meta ) {
 			$tag = 'og:image';
 			if ( 0 === strpos( $img, 'https://' ) ) {
 				$tag = 'og:image:secure_url';
 			}
 			$this->og_tag( $tag, esc_url( $img ) );
 
-			if ( ! empty( $dimensions['width'] ) ) {
-				$this->og_tag( 'og:image:width', (int) $dimensions['width'] );
+			if ( ! empty( $image_meta['width'] ) ) {
+				$this->og_tag( 'og:image:width', (int) $image_meta['width'] );
 			}
 
-			if ( ! empty( $dimensions['height'] ) ) {
-				$this->og_tag( 'og:image:height', (int) $dimensions['height'] );
+			if ( ! empty( $image_meta['height'] ) ) {
+				$this->og_tag( 'og:image:height', (int) $image_meta['height'] );
+			}
+
+			if ( ! empty( $image_meta['alt'] ) ) {
+				$this->og_tag( 'og:image:alt', $image_meta['alt'] );
 			}
 		}
 	}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -762,9 +762,7 @@ class WPSEO_OpenGraph {
 	 * @codeCoverageIgnore
 	 */
 	public function image_output( $image = false ) {
-		if ( $image !== false ) {
-			_deprecated_argument( 'WPSEO_OpenGraph::image_output', '7.4', 'WPSEO_OpenGraph_Image::show' );
-		}
+		_deprecated_function( 'WPSEO_OpenGraph::image_output', '7.4', 'WPSEO_OpenGraph::image' );
 		$this->image();
 	}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -536,22 +536,20 @@ class WPSEO_OpenGraph {
 	public function image( $image = false ) {
 		$opengraph_images = new WPSEO_OpenGraph_Image( $image );
 
-		foreach ( $opengraph_images->get_images() as $img ) {
-			$this->og_tag( 'og:image', esc_url( $img ) );
-
+		foreach ( $opengraph_images->get_images() as $img => $dimensions ) {
+			$tag = 'og:image';
 			if ( 0 === strpos( $img, 'https://' ) ) {
-				$this->og_tag( 'og:image:secure_url', esc_url( $img ) );
+				$tag = 'og:image:secure_url';
 			}
-		}
+			$this->og_tag( $tag, esc_url( $img ) );
 
-		$dimensions = $opengraph_images->get_dimensions();
+			if ( ! empty( $dimensions['width'] ) ) {
+				$this->og_tag( 'og:image:width', (int) $dimensions['width'] );
+			}
 
-		if ( ! empty( $dimensions['width'] ) ) {
-			$this->og_tag( 'og:image:width', absint( $dimensions['width'] ) );
-		}
-
-		if ( ! empty( $dimensions['height'] ) ) {
-			$this->og_tag( 'og:image:height', absint( $dimensions['height'] ) );
+			if ( ! empty( $dimensions['height'] ) ) {
+				$this->og_tag( 'og:image:height', (int) $dimensions['height'] );
+			}
 		}
 	}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -534,41 +534,8 @@ class WPSEO_OpenGraph {
 	 * @return void
 	 */
 	public function image() {
-		$opengraph_images = new WPSEO_OpenGraph_Image();
-
-		foreach ( $opengraph_images->get_images() as $img => $image_meta ) {
-			$this->og_image_tag( $img );
-
-			foreach ( array( 'width', 'height', 'alt', 'type' ) as $key ) {
-				if ( isset( $image_meta[ $key ] ) && ! empty( $image_meta[ $key ] ) ) {
-					$this->og_tag( 'og:image:' . $key, $image_meta[ $key ] );
-				}
-			}
-		}
-	}
-
-	/**
-	 * Outputs an image tag based on whether it's https or not.
-	 *
-	 * @param string $img The image URL.
-	 *
-	 * @return void
-	 */
-	private function og_image_tag( $img ) {
-		$tag = 'og:image';
-		if ( 0 === strpos( $img, 'https://' ) ) {
-			$tag = 'og:image:secure_url';
-		}
-		$this->og_tag( $tag, esc_url( $img ) );
-	}
-
-	/**
-	 * Fallback method for plugins using image_output.
-	 *
-	 * @param string $image Image URL.
-	 */
-	public function image_output( $image ) {
-		$this->image( $image );
+		$opengraph_image = new WPSEO_OpenGraph_Image( $this );
+		$opengraph_image->show();
 	}
 
 	/**
@@ -784,6 +751,21 @@ class WPSEO_OpenGraph {
 		if ( function_exists( 'wp_get_current_user' ) && current_user_can( 'manage_options' ) ) {
 			_deprecated_function( 'WPSEO_OpenGraph::site_owner', '7.1', null );
 		}
+	}
+
+	/**
+	 * Fallback method for plugins using image_output.
+	 *
+	 * @param string|bool $image Image URL.
+	 *
+	 * @deprecated 7.4
+	 * @codeCoverageIgnore
+	 */
+	public function image_output( $image = false ) {
+		if ( $image !== false ) {
+			_deprecated_argument( 'WPSEO_OpenGraph::image_output', '7.4', 'WPSEO_OpenGraph_Image::show' );
+		}
+		$this->image();
 	}
 
 } /* End of class */

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -531,10 +531,10 @@ class WPSEO_OpenGraph {
 	/**
 	 * Create new WPSEO_OpenGraph_Image class and get the images to set the og:image.
 	 *
-	 * @param string|boolean $image Optional image URL.
+	 * @return void
 	 */
-	public function image( $image = false ) {
-		$opengraph_images = new WPSEO_OpenGraph_Image( $image );
+	public function image() {
+		$opengraph_images = new WPSEO_OpenGraph_Image();
 
 		foreach ( $opengraph_images->get_images() as $img => $dimensions ) {
 			$tag = 'og:image';

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -14,7 +14,7 @@ class WPSEO_Content_Images {
 	 *
 	 * @var string
 	 */
-	private $key_name = 'wpseo_post_image_cache';
+	private $key_name = '_wpseo_post_image_cache';
 
 	/**
 	 * Retrieve images from the post content.
@@ -61,19 +61,45 @@ class WPSEO_Content_Images {
 	 *
 	 * @param string $content The post content string.
 	 *
-	 * @return array
+	 * @return array An array of image URLs as keys and ID's as values.
 	 */
 	private function get_images_from_content( $content ) {
 		$images = array();
-		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
-			foreach ( $matches[0] as $img ) {
-				if ( preg_match( '`src=(["\'])(.*?)\1`', $img, $match ) ) {
-					$attachment_id       = WPSEO_Image_Utils::get_attachment_by_url( $match[2] );
-					$images[ $match[2] ] = $attachment_id;
-				}
+		foreach ( $this->get_img_tags_from_content( $content ) as $img ) {
+			$url = $this->get_image_url_from_img( $img );
+			if ( $url ) {
+				$attachment_id  = WPSEO_Image_Utils::get_attachment_by_url( $url );
+				$images[ $url ] = $attachment_id;
 			}
 		}
 
 		return $images;
+	}
+
+	/**
+	 * Gets the image tags from a given content string.
+	 *
+	 * @param string $content The content to search for image tags.
+	 *
+	 * @return array An array of `<img>` tags.
+	 */
+	private function get_img_tags_from_content( $content ) {
+		preg_match_all( '`<img [^>]+>`', $content, $matches, PREG_SET_ORDER );
+		return $matches[0];
+	}
+
+	/**
+	 * Retrieves the image URL from an image tag.
+	 *
+	 * @param string $image Image HTML element.
+	 *
+	 * @return string
+	 */
+	private function get_image_url_from_img( $image ) {
+		preg_match( '`src=(["\'])(.*?)\1`', $image, $matches );
+		if ( isset( $matches[2] ) ) {
+			return $matches[2];
+		}
+		return false;
 	}
 }

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -25,7 +25,7 @@ class WPSEO_Content_Images {
 	 * @return array An array of images found in this post.
 	 */
 	public function get_content_images( $post_id, $post = null ) {
-		$post_image_cache = false; // get_post_meta( $post_id, $this->key_name, true );
+		$post_image_cache = get_post_meta( $post_id, $this->key_name, true );
 		if ( is_array( $post_image_cache ) ) {
 			return $post_image_cache;
 		}

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -25,7 +25,7 @@ class WPSEO_Content_Images {
 	 * @return array An array of images found in this post.
 	 */
 	public function get_content_images( $post_id, $post = null ) {
-		$post_image_cache = get_post_meta( $post_id, $this->key_name, true );
+		$post_image_cache = false; // get_post_meta( $post_id, $this->key_name, true );
 		if ( is_array( $post_image_cache ) ) {
 			return $post_image_cache;
 		}
@@ -84,7 +84,7 @@ class WPSEO_Content_Images {
 	 * @return array An array of `<img>` tags.
 	 */
 	private function get_img_tags_from_content( $content ) {
-		preg_match_all( '`<img [^>]+>`', $content, $matches, PREG_SET_ORDER );
+		preg_match_all( '`<img [^>]+>`', $content, $matches );
 		if ( isset( $matches[0] ) ) {
 			return $matches[0];
 		}

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -85,7 +85,10 @@ class WPSEO_Content_Images {
 	 */
 	private function get_img_tags_from_content( $content ) {
 		preg_match_all( '`<img [^>]+>`', $content, $matches, PREG_SET_ORDER );
-		return $matches[0];
+		if ( isset( $matches[0] ) ) {
+			return $matches[0];
+		}
+		return array();
 	}
 
 	/**

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -54,7 +54,8 @@ class WPSEO_Content_Images {
 		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
 			foreach ( $matches[0] as $img ) {
 				if ( preg_match( '`src=(["\'])(.*?)\1`', $img, $match ) ) {
-					$images[] = $match[2];
+					$attachment_id       = WPSEO_Image_Utils::get_attachment_by_url( $match[2] );
+					$images[ $match[2] ] = $attachment_id;
 				}
 			}
 		}

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO
+ */
+
+/**
+ * WPSEO_Content_Images
+ */
+class WPSEO_Content_Images {
+	/**
+	 * The key used to store our image cache.
+	 *
+	 * @var string
+	 */
+	private $key_name = 'wpseo_post_image_cache';
+
+	/**
+	 * Retrieve images from the post content.
+	 *
+	 * @param int      $post_id The post ID.
+	 * @param \WP_Post $post    The post object.
+	 *
+	 * @return array An array of images found in this post.
+	 */
+	public function get_content_images( $post_id, $post = null ) {
+		$post_image_cache = get_post_meta( $post_id, $this->key_name, true );
+		if ( is_array( $post_image_cache ) ) {
+			return $post_image_cache;
+		}
+		if ( is_null( $post ) ) {
+			$post = get_post( $post_id );
+		}
+		return $this->heat_content_image_cache( $post );
+	}
+
+	/**
+	 * Heat the content image cache so we can retrieve it everywhere.
+	 *
+	 * @param \WP_Post $post The post object.
+	 *
+	 * @return array $images An array of images found in the post, empty if none found.
+	 */
+	private function heat_content_image_cache( $post ) {
+		/**
+		 * Filter: 'wpseo_pre_analysis_post_content' - Allow filtering the content before analysis.
+		 *
+		 * @api string $post_content The Post content string.
+		 */
+		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
+
+		$images = array();
+		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
+			foreach ( $matches[0] as $img ) {
+				if ( preg_match( '`src=(["\'])(.*?)\1`', $img, $match ) ) {
+					$images[] = $match[2];
+				}
+			}
+		}
+		update_post_meta( $post->ID, $this->key_name, $images );
+
+		return $images;
+	}
+}

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -14,10 +14,10 @@ class WPSEO_Content_Images {
 	 *
 	 * @var string
 	 */
-	private $key_name = '_wpseo_post_image_cache';
+	private $cache_meta_key = '_wpseo_post_image_cache';
 
 	/**
-	 * Retrieve images from the post content.
+	 * Retrieves images from the post content.
 	 *
 	 * @param int      $post_id The post ID.
 	 * @param \WP_Post $post    The post object.
@@ -25,7 +25,7 @@ class WPSEO_Content_Images {
 	 * @return array An array of images found in this post.
 	 */
 	public function get_content_images( $post_id, $post = null ) {
-		$post_image_cache = get_post_meta( $post_id, $this->key_name, true );
+		$post_image_cache = get_post_meta( $post_id, $this->cache_meta_key, true );
 		if ( is_array( $post_image_cache ) ) {
 			return $post_image_cache;
 		}
@@ -51,7 +51,7 @@ class WPSEO_Content_Images {
 		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
 
 		$images = $this->get_images_from_content( $content );
-		update_post_meta( $post->ID, $this->key_name, $images );
+		update_post_meta( $post->ID, $this->cache_meta_key, $images );
 
 		return $images;
 	}
@@ -96,7 +96,7 @@ class WPSEO_Content_Images {
 	 *
 	 * @param string $image Image HTML element.
 	 *
-	 * @return string
+	 * @return string|bool The image URL on success, false on failure.
 	 */
 	private function get_image_url_from_img( $image ) {
 		preg_match( '`src=(["\'])(.*?)\1`', $image, $matches );

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -50,6 +50,20 @@ class WPSEO_Content_Images {
 		 */
 		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
 
+		$images = $this->get_images_from_content( $content );
+		update_post_meta( $post->ID, $this->key_name, $images );
+
+		return $images;
+	}
+
+	/**
+	 * Grabs the images from the content.
+	 *
+	 * @param string $content The post content string.
+	 *
+	 * @return array
+	 */
+	private function get_images_from_content( $content ) {
 		$images = array();
 		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
 			foreach ( $matches[0] as $img ) {
@@ -59,7 +73,6 @@ class WPSEO_Content_Images {
 				}
 			}
 		}
-		update_post_meta( $post->ID, $this->key_name, $images );
 
 		return $images;
 	}

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -98,16 +98,8 @@ class WPSEO_Image_Utils {
 		}
 
 		$img_data['ratio'] = ( $img_data['width'] / $img_data['height'] );
-		foreach ( array( 'width', 'height', 'ratio' ) as $param ) {
-			if (
-				( $img_data[ $param ] < $params[ 'min_' . $param ] ) ||
-				( $img_data[ $param ] > $params[ 'max_' . $param ] )
-			) {
-				return false;
-			}
-		}
 
-		return true;
+		return self::check_image_measurement_params( $params, $img_data );
 	}
 
 	/**
@@ -238,5 +230,26 @@ class WPSEO_Image_Utils {
 	 */
 	public static function get_image_alt_tag( $attachment_id ) {
 		return (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+	}
+
+	/**
+	 * Checks whether an img sizes up to the parameters.
+	 *
+	 * @param array $params   The parameters to check against.
+	 * @param array $img_data The image values.
+	 *
+	 * @return bool
+	 */
+	private static function check_image_measurement_params( $params, $img_data ) {
+		foreach ( array( 'width', 'height', 'ratio' ) as $param ) {
+			if (
+				( $img_data[ $param ] < $params[ 'min_' . $param ] ) ||
+				( $img_data[ $param ] > $params[ 'max_' . $param ] )
+			) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -37,6 +37,25 @@ class WPSEO_Image_Utils {
 	 * @return array|false
 	 */
 	public static function find_correct_image_size( $attachment_id ) {
+		foreach ( self::get_image_sizes() as $size ) {
+			$image = self::check_image_by_size( $attachment_id, $size );
+			if ( $image !== false ) {
+				return $image;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks a size version of an image to see if it's not too heavy.
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $size          Size name.
+	 *
+	 * @return array|false Image array with metadata on success, false on failure.
+	 */
+	public static function check_image_by_size( $attachment_id, $size ) {
 		/**
 		 * Filter: 'wpseo_image_image_weight_limit' - Determines what the maximum weight (in bytes) of an image is allowed to be, default is 2 MB.
 		 *
@@ -44,19 +63,16 @@ class WPSEO_Image_Utils {
 		 */
 		$max_size = apply_filters( 'wpseo_image_image_weight_limit', ( 2 * 1024 * 1024 ) );
 
-		foreach ( self::get_image_sizes() as $size ) {
-			// @todo fix how this is tested in test-class-opengraph as that test now doesn't work.
-			$image = image_get_intermediate_size( $attachment_id, $size );
-			if ( $image === false ) {
-				continue;
-			}
-			$file_size = self::get_image_file_size( $image );
-			if ( $file_size === false || $file_size < $max_size ) {
-				return $image;
-			}
+		$image = image_get_intermediate_size( $attachment_id, $size );
+		if ( $image === false ) {
+			return false;
+		}
+		$file_size = self::get_image_file_size( $image );
+		if ( $file_size > $max_size ) {
+			return false;
 		}
 
-		return false;
+		return $image;
 	}
 
 	/**

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -64,6 +64,7 @@ class WPSEO_Image_Utils {
 		$max_size = apply_filters( 'wpseo_image_image_weight_limit', ( 2 * 1024 * 1024 ) );
 
 		$image = image_get_intermediate_size( $attachment_id, $size );
+
 		if ( $image === false ) {
 			return false;
 		}

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -37,7 +37,7 @@ class WPSEO_Image_Utils {
 	 *
 	 * @return array|false Image array on success, false on failure.
 	 */
-	public static function find_correct_image_size( $attachment_id ) {
+	public static function get_optimal_variation( $attachment_id ) {
 		foreach ( self::get_sizes() as $size ) {
 			$image = self::has_usable_file_size( $attachment_id, $size );
 			if ( $image !== false ) {

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -93,16 +93,17 @@ class WPSEO_Image_Utils {
 	 */
 	public static function check_image_measurements( $attachment_id, $params ) {
 		$img_data = wp_get_attachment_metadata( $attachment_id );
-		// Get the width and height of the image.
-		if ( isset( $img_data['width'] ) && isset( $img_data['height'] ) ) {
-			$img_data['ratio'] = ( $img_data['width'] / $img_data['height'] );
-			foreach ( array( 'width', 'height', 'ratio' ) as $param ) {
-				if ( $img_data[ $param ] < $params[ 'min_' . $param ] ) {
-					return false;
-				}
-				if ( $img_data[ $param ] > $params[ 'max_' . $param ] ) {
-					return false;
-				}
+		if ( ! isset( $img_data['width'] ) || ! isset( $img_data['height'] ) ) {
+			return true;
+		}
+
+		$img_data['ratio'] = ( $img_data['width'] / $img_data['height'] );
+		foreach ( array( 'width', 'height', 'ratio' ) as $param ) {
+			if ( $img_data[ $param ] < $params[ 'min_' . $param ] ) {
+				return false;
+			}
+			if ( $img_data[ $param ] > $params[ 'max_' . $param ] ) {
+				return false;
 			}
 		}
 
@@ -225,8 +226,7 @@ class WPSEO_Image_Utils {
 		 *
 		 * @api array - The array of image sizes to loop through.
 		 */
-		$image_sizes = apply_filters( 'wpseo_image_sizes', array( 'full', 'large', 'medium_large' ) );
-		return $image_sizes;
+		return apply_filters( 'wpseo_image_sizes', array( 'full', 'large', 'medium_large' ) );
 	}
 
 	/**

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO
+ */
+
+/**
+ * WPSEO_Image_Utils
+ */
+class WPSEO_Image_Utils {
+	/**
+	 * Find an attachment ID for a given URL.
+	 *
+	 * @param string $url The URL to find the attachment for.
+	 *
+	 * @return int The found attachment ID, or 0 if none was found.
+	 */
+	public static function get_attachment_by_url( $url ) {
+		// Because get_attachment_by_url won't work on resized versions of images, we strip out the size part of an image URL.
+		$url = preg_replace( '/(.*)-\d+x\d+\.(jpg|png|gif)$/', '$1.$2', $url );
+
+		if ( function_exists( 'wpcom_vip_attachment_url_to_postid' ) ) {
+			return wpcom_vip_attachment_url_to_postid( $url );
+		}
+
+		// We use the WP COM version if we can, see above.
+		// phpcs:ignore WordPress.VIP.RestrictedFunctions
+		return attachment_url_to_postid( $url );
+	}
+
+	/**
+	 * Finds an image size that is under 1 MB and thus viable to use for social sharing.
+	 *
+	 * @param int $attachment_id The attachment ID.
+	 *
+	 * @return array|false
+	 */
+	public static function find_correct_image_size( $attachment_id ) {
+		/**
+		 * Filter: 'wpseo_image_image_weight_limit' - Determines what the maximum weight (in bytes) of an image is allowed to be, default is 5 MB.
+		 *
+		 * @api int - The maximum weight (in bytes) of an image.
+		 */
+		$max_size = apply_filters( 'wpseo_image_image_weight_limit', ( 5 * 1024 * 1024 ) );
+
+		/**
+		 * Filter: 'wpseo_opengraph_image_sizes' - Determines which image sizes we'll loop through to get an appropriate image.
+		 *
+		 * @api array - The array of image sizes to loop through.
+		 */
+		$image_sizes = apply_filters( 'wpseo_opengraph_image_sizes', array( 'full', 'large', 'medium_large' ) );
+		foreach ( $image_sizes as $size ) {
+			// @todo fix how this is tested in test-class-opengraph as that test now doesn't work.
+			$image = image_get_intermediate_size( $attachment_id, $size );
+			if ( $image === false ) {
+				continue;
+			}
+			// If the file size for the file is over our limit, we're going to go for a smaller version.
+			// phpcs:ignore -- If file size doesn't properly return, we'll not fail.
+			$file_size = filesize( self::get_full_file_path( $image['path'] ) );
+			if ( $file_size === false ) {
+				return $image;
+			}
+			if ( $file_size < $max_size ) {
+				return $image;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Finds the full file path for a given image file.
+	 *
+	 * @param string $path The relative file path.
+	 *
+	 * @return string
+	 */
+	public static function get_full_file_path( $path ) {
+		static $uploads;
+
+		if ( ! isset( $uploads ) ) {
+			$uploads = wp_get_upload_dir();
+		}
+
+		if ( false !== $uploads['error'] ) {
+			return $uploads['basedir'] . "/$path";
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Get the relative path of the image.
+	 *
+	 * @param string $img Image URL.
+	 *
+	 * @return string The expanded image URL.
+	 */
+	public static function get_relative_path( $img ) {
+		if ( $img[0] !== '/' ) {
+			return $img;
+		}
+
+		// If it's a relative URL, it's relative to the domain, not necessarily to the WordPress install, we
+		// want to preserve domain name and URL scheme (http / https) though.
+		$parsed_url = wp_parse_url( home_url() );
+		$img        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $img;
+
+		return $img;
+	}
+
+}

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -24,8 +24,7 @@ class WPSEO_Image_Utils {
 			return wpcom_vip_attachment_url_to_postid( $url );
 		}
 
-		// We use the WP COM version if we can, see above.
-		// phpcs:ignore WordPress.VIP.RestrictedFunctions
+		// phpcs:ignore WordPress.VIP.RestrictedFunctions -- We use the WP COM version if we can, see above.
 		return attachment_url_to_postid( $url );
 	}
 

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -99,10 +99,10 @@ class WPSEO_Image_Utils {
 
 		$img_data['ratio'] = ( $img_data['width'] / $img_data['height'] );
 		foreach ( array( 'width', 'height', 'ratio' ) as $param ) {
-			if ( $img_data[ $param ] < $params[ 'min_' . $param ] ) {
-				return false;
-			}
-			if ( $img_data[ $param ] > $params[ 'max_' . $param ] ) {
+			if (
+				( $img_data[ $param ] < $params[ 'min_' . $param ] ) ||
+				( $img_data[ $param ] > $params[ 'max_' . $param ] )
+			) {
 				return false;
 			}
 		}

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -38,11 +38,11 @@ class WPSEO_Image_Utils {
 	 */
 	public static function find_correct_image_size( $attachment_id ) {
 		/**
-		 * Filter: 'wpseo_image_image_weight_limit' - Determines what the maximum weight (in bytes) of an image is allowed to be, default is 5 MB.
+		 * Filter: 'wpseo_image_image_weight_limit' - Determines what the maximum weight (in bytes) of an image is allowed to be, default is 2 MB.
 		 *
 		 * @api int - The maximum weight (in bytes) of an image.
 		 */
-		$max_size = apply_filters( 'wpseo_image_image_weight_limit', ( 5 * 1024 * 1024 ) );
+		$max_size = apply_filters( 'wpseo_image_image_weight_limit', ( 2 * 1024 * 1024 ) );
 
 		/**
 		 * Filter: 'wpseo_opengraph_image_sizes' - Determines which image sizes we'll loop through to get an appropriate image.

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -64,7 +64,7 @@ class WPSEO_Sitemap_Image_Parser {
 		if ( $thumbnail_id ) {
 
 			$src      = $this->get_absolute_url( $this->image_url( $thumbnail_id ) );
-			$alt      = get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true );
+			$alt      = WPSEO_Image_Utils::get_image_alt_tag( $thumbnail_id );
 			$title    = get_post_field( 'post_title', $thumbnail_id );
 			$images[] = $this->get_image_item( $post, $src, $title, $alt );
 		}
@@ -86,7 +86,7 @@ class WPSEO_Sitemap_Image_Parser {
 		foreach ( $this->parse_galleries( $post->post_content, $post->ID ) as $attachment ) {
 
 			$src = $this->get_absolute_url( $this->image_url( $attachment->ID ) );
-			$alt = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
+			$alt = WPSEO_Image_Utils::get_image_alt_tag( $attachment->ID );
 
 			$images[] = $this->get_image_item( $post, $src, $attachment->post_title, $alt );
 		}
@@ -94,7 +94,7 @@ class WPSEO_Sitemap_Image_Parser {
 		if ( 'attachment' === $post->post_type && wp_attachment_is_image( $post ) ) {
 
 			$src = $this->get_absolute_url( $this->image_url( $post->ID ) );
-			$alt = get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
+			$alt = WPSEO_Image_Utils::get_image_alt_tag( $post->ID );
 
 			$images[] = $this->get_image_item( $post, $src, $post->post_title, $alt );
 		}
@@ -131,7 +131,7 @@ class WPSEO_Sitemap_Image_Parser {
 			$images[] = array(
 				'src'   => $this->get_absolute_url( $this->image_url( $attachment->ID ) ),
 				'title' => $attachment->post_title,
-				'alt'   => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
+				'alt'   => WPSEO_Image_Utils::get_image_alt_tag( $attachment->ID ),
 			);
 		}
 

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -64,7 +64,7 @@ class WPSEO_Sitemap_Image_Parser {
 		if ( $thumbnail_id ) {
 
 			$src      = $this->get_absolute_url( $this->image_url( $thumbnail_id ) );
-			$alt      = WPSEO_Image_Utils::get_image_alt_tag( $thumbnail_id );
+			$alt      = WPSEO_Image_Utils::get_alt_tag( $thumbnail_id );
 			$title    = get_post_field( 'post_title', $thumbnail_id );
 			$images[] = $this->get_image_item( $post, $src, $title, $alt );
 		}
@@ -86,7 +86,7 @@ class WPSEO_Sitemap_Image_Parser {
 		foreach ( $this->parse_galleries( $post->post_content, $post->ID ) as $attachment ) {
 
 			$src = $this->get_absolute_url( $this->image_url( $attachment->ID ) );
-			$alt = WPSEO_Image_Utils::get_image_alt_tag( $attachment->ID );
+			$alt = WPSEO_Image_Utils::get_alt_tag( $attachment->ID );
 
 			$images[] = $this->get_image_item( $post, $src, $attachment->post_title, $alt );
 		}
@@ -94,7 +94,7 @@ class WPSEO_Sitemap_Image_Parser {
 		if ( 'attachment' === $post->post_type && wp_attachment_is_image( $post ) ) {
 
 			$src = $this->get_absolute_url( $this->image_url( $post->ID ) );
-			$alt = WPSEO_Image_Utils::get_image_alt_tag( $post->ID );
+			$alt = WPSEO_Image_Utils::get_alt_tag( $post->ID );
 
 			$images[] = $this->get_image_item( $post, $src, $post->post_title, $alt );
 		}
@@ -131,7 +131,7 @@ class WPSEO_Sitemap_Image_Parser {
 			$images[] = array(
 				'src'   => $this->get_absolute_url( $this->image_url( $attachment->ID ) ),
 				'title' => $attachment->post_title,
-				'alt'   => WPSEO_Image_Utils::get_image_alt_tag( $attachment->ID ),
+				'alt'   => WPSEO_Image_Utils::get_alt_tag( $attachment->ID ),
 			);
 		}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -35,4 +35,8 @@
         <exclude-pattern>inc/class-wpseo-replace-vars.php</exclude-pattern>
     </rule>
 
+    <!-- TEMPORARY exclusion! Because we're not on 0.5 yet -->
+    <rule ref="WordPress.VIP.RestrictedFunctions">
+        <exclude-pattern>inc/class-wpseo-image-utils.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,7 @@
     <exclude-pattern>node_modules/*</exclude-pattern>
     <exclude-pattern>deprecated/*</exclude-pattern>
     <exclude-pattern>languages/*</exclude-pattern>
+    <exclude-pattern>artifact/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>
     <arg value="sp"/>

--- a/tests/frontend/test-class-opengraph.php
+++ b/tests/frontend/test-class-opengraph.php
@@ -387,7 +387,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	public function test_image_get_content_image() {
 		$post_id = $this->factory->post->create(
 			array(
-				'post_content' => '<img class="alignnone size-medium wp-image-490" src="' . get_site_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />',
+				'post_content' => '<img class="alignnone size-medium wp-image-490" src="' . get_home_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />',
 			)
 		);
 
@@ -396,12 +396,10 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$class_instance = new WPSEO_OpenGraph();
 
 		ob_start();
-
 		$class_instance->opengraph();
-
 		$output = ob_get_clean();
 
-		$expected_output = '<meta property="og:image" content="' . get_site_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />';
+		$expected_output = '<meta property="og:image" content="' . get_home_url() . '/wp-content/plugins/wordpress-seo/tests/yoast.png" />';
 
 		$this->assertContains( $expected_output, $output );
 	}

--- a/tests/frontend/test-class-opengraph.php
+++ b/tests/frontend/test-class-opengraph.php
@@ -492,6 +492,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 
 		$image_url       = 'https://example.com/image.png';
 		$expected_output = <<<EXPECTED
+<meta property="og:image" content="{$image_url}" />
 <meta property="og:image:secure_url" content="{$image_url}" />
 EXPECTED;
 		WPSEO_Meta::set_value( 'opengraph-image', $image_url, $post_id );
@@ -726,7 +727,7 @@ EXPECTED;
 
 		$basename       = basename( $image );
 		$upload_dir     = wp_upload_dir();
-		$source_image   = dirname( __FILE__ ) . $image;
+		$source_image   = dirname( __FILE__ ) . '/..' . $image;
 		$featured_image = $upload_dir['path'] . '/' . $basename;
 
 		copy( $source_image, $featured_image ); // Prevent original from deletion.

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -158,7 +158,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test get singular false
+	 * Test get singular post with featured image.
 	 */
 	public function test_set_singular_image_featured() {
 		$post_id = $this->create_post();
@@ -169,6 +169,20 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$class_instance = $this->setup_class();
 
 		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+	}
+
+	/**
+	 * Test get singular with too small featured image.
+	 */
+	public function test_set_singular_image_featured_TOO_SMALL() {
+		$post_id = $this->create_post();
+		$this->create_featured_image( '/assets/small.png', $post_id );
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( array(), $class_instance->get_images() );
 	}
 
 	/**
@@ -227,6 +241,9 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
 	}
 
+	/**
+	 * Test getting the image from post content.
+	 */
 	public function test_get_images_from_content() {
 		// Create our post.
 		$post_id        = $this->create_post();
@@ -270,6 +287,9 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, $class_instance->get_images() );
 	}
 
+	/**
+	 * Test using an image that's already uploaded to another post as OG setting.
+	 */
 	public function test_uploaded_image_added_by_id() {
 		// We create a post, and upload an image to it.
 		$post_id = $this->create_post();
@@ -330,10 +350,10 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 			'tmp_name' => $featured_image,
 		);
 		$attach_id  = media_handle_sideload( $file_array, $post_id );
-
+		$file       = get_attached_file( $attach_id );
+		wp_generate_attachment_metadata( $attach_id, $file );
 		update_post_meta( $post_id, '_thumbnail_id', $attach_id );
 
-		$file = get_attached_file( $attach_id );
 
 		return array(
 			'path' => $file,

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests
+ */
+
+/**
+ * OpenGraph tests
+ *
+ * @group OpenGraph
+ */
+class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Set up class instance.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+	}
+
+	/**
+	 * Provision tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+		WPSEO_Frontend::get_instance()->reset();
+		remove_all_actions( 'wpseo_opengraph' );
+	}
+
+	/**
+	 * Clean output buffer after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		WPSEO_Options::set( 'og_default_image', false );
+		WPSEO_Options::set( 'og_frontpage_image', false );
+
+		ob_clean();
+	}
+
+	/**
+	 * Tests whether has images is false by default.
+	 */
+	public function test_has_images_is_FALSE() {
+		$class_instance = $this->setup_class();
+
+		$this->assertFalse( $class_instance->has_images() );
+	}
+
+	/**
+	 * Tests whether has images is false by default.
+	 */
+	public function test_add_image_empty() {
+		$class_instance = $this->setup_class();
+
+		$this->assertEmpty( $class_instance->add_image( array( 'url' => '' ) ) );
+	}
+
+	/**
+	 * Tests whether has images is false by default.
+	 */
+	public function test_add_image_relative() {
+		$class_instance = $this->setup_class();
+
+		$class_instance->add_image( array( 'url' => '/test.png' ) );
+		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
+	}
+
+	/**
+	 * Tests whether has images is false by default.
+	 */
+	public function test_add_image_twice() {
+		$class_instance = $this->setup_class();
+
+		$class_instance->add_image( array( 'url' => 'http://example.org/test.png' ) );
+		$class_instance->add_image( array( 'url' => '/test.png' ) );
+		$this->assertEquals( $this->sample_array( false ), $class_instance->get_images() );
+	}
+
+	/**
+	 * Test setting the front page image.
+	 */
+	public function test_frontpage_image() {
+		WPSEO_Options::set( 'og_frontpage_image', '/test.png' );
+
+		$current_page_on_front = get_option( 'page_on_front' );
+		$current_show_on_front = get_option( 'show_on_front' );
+
+		// Create and go to a static front page.
+		$page_on_front = $this->create_post( 'page' );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $page_on_front );
+
+		$this->go_to( '/' );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
+
+		update_option( 'show_on_front', $current_show_on_front );
+		update_option( 'page_on_front', $current_page_on_front );
+	}
+
+	/**
+	 * Test attachment pages.
+	 */
+	public function test_set_attachment_page_image() {
+		$post_id         = $this->create_post();
+		$image           = '/assets/yoast.png';
+		$rand            = rand( 1000, 9999 );
+		$basename        = str_replace( '.png', '-attachment-test-' . $rand . '.png', basename( $image ) );
+		$upload_dir      = wp_upload_dir();
+		$source_image    = dirname( __FILE__ ) . '/..' . $image;
+		$full_image_path = $upload_dir['path'] . '/' . $basename;
+
+		copy( $source_image, $full_image_path ); // Prevent original from deletion.
+
+		$file_array = array(
+			'name'     => $basename,
+			'tmp_name' => $full_image_path,
+		);
+		$attach_id  = media_handle_sideload( $file_array, $post_id );
+		$filename   = basename( get_attached_file( $attach_id ) );
+
+		$this->go_to( get_permalink( $attach_id ) );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_full_file_array( $upload_dir['url'] . '/' . $filename ), $class_instance->get_images() );
+
+		wp_delete_file( get_attached_file( $attach_id ) );
+	}
+
+	/**
+	 * Test get singular false
+	 */
+	public function test_set_singular_image_FALSE() {
+		$post_id = $this->create_post();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertFalse( $class_instance->has_images() );
+	}
+
+	/**
+	 * Test get singular false
+	 */
+	public function test_set_singular_image_post_meta() {
+		$post_id = $this->create_post();
+		WPSEO_Meta::set_value( 'opengraph-image', '/test.png', $post_id );
+		$this->go_to( get_permalink( $post_id ) );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
+	}
+
+	/**
+	 * Test get singular false
+	 */
+	public function test_set_singular_image_featured() {
+		$post_id = $this->create_post();
+		$image   = $this->create_featured_image( '/assets/yoast.png', $post_id );
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+	}
+
+	/**
+	 * Test our default image fallback.
+	 */
+	public function test_set_images_default() {
+		WPSEO_Options::set( 'og_default_image', '/test.png' );
+		$this->go_to_home();
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
+	}
+
+	/**
+	 * Test the featured image for the posts page.
+	 */
+	public function test_set_posts_page_image() {
+		$frontpage = $this->create_post( 'page' );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $frontpage );
+
+		$post_id = $this->create_post( 'page' );
+		$image   = $this->create_featured_image( '/assets/yoast.png', $post_id );
+		update_option( 'page_for_posts', $post_id );
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+	}
+
+	/**
+	 * Test setting the opengraph image for a taxonomy term.
+	 */
+	public function test_set_taxonomy_image() {
+		$post_id = $this->create_post( 'post' );
+		$term_id = $this->factory()->category->create( array(
+				'name' => 'Test Category 1',
+				'slug' => 'test1',
+			)
+		);
+		wp_set_object_terms( $post_id, $term_id, 'category' );
+		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-image', '/test.png' );
+
+		$url = add_query_arg(
+			array(
+				'cat' => $term_id,
+			), '/'
+		);
+		$this->go_to( $url );
+
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
+	}
+
+	public function test_get_images_from_content() {
+		// Create our post.
+		$post_id        = $this->create_post();
+
+		// Upload an image to it.
+		$image          = '/assets/yoast.png';
+		$upload_dir     = wp_upload_dir();
+		$basename       = basename( $image );
+		$source_image   = dirname( __FILE__ ) . '/..' . $image;
+		$featured_image = $upload_dir['path'] . '/' . $basename;
+		copy( $source_image, $featured_image ); // Prevent original from deletion.
+
+		$file_array     = array(
+			'name'     => $basename,
+			'tmp_name' => $featured_image,
+		);
+		$attach_id      = media_handle_sideload( $file_array, $post_id );
+
+		// Get the image URL so we can add it in the post content.
+		$file           = get_attached_file( $attach_id );
+		$attached_image = $upload_dir['url'] . '/' . basename( $file );
+		$image2_url     = 'https://cdn.yoast.com/app/uploads/2018/03/Caroline_Blog_SEO_FI-600x314.jpg';
+
+		// Update the post content.
+		$post_content = '<p>This is a post. It has an image:</p>
+<img src="' . $attached_image . '"/>
+<p>It also has an image that is not attached to this post:</p>
+<img src="' . $image2_url . '"/>
+<p>End of post</p>';
+		wp_update_post( array( 'ID' => $post_id, 'post_content' => $post_content ) );
+
+		// Run our test.
+		$this->go_to( get_permalink( $post_id ) );
+		$class_instance = $this->setup_class();
+
+		$expected = $this->sample_full_file_array( $attached_image );
+		$expected['https://cdn.yoast.com/app/uploads/2018/03/Caroline_Blog_SEO_FI-600x314.jpg'] = array(
+			'url' => 'https://cdn.yoast.com/app/uploads/2018/03/Caroline_Blog_SEO_FI-600x314.jpg'
+		);
+
+		$this->assertEquals( $expected, $class_instance->get_images() );
+	}
+
+//	public function test_uploaded_image_added_by_id() {
+//		// We create a post, and upload an image to it.
+//		$post_id = $this->create_post();
+//		$image   = $this->create_featured_image( '/assets/yoast.png', $post_id );
+//
+//		// We create another post and use the image, attached to the _other_ post, as its OpenGraph image.
+//		$post2_id = $this->create_post();
+//		WPSEO_Meta::set_value( 'opengraph-image', $image['url'], $post2_id );
+//
+//		$class_instance = $this->setup_class();
+//
+////		$this->assertEquals( $image['url'], get_post_meta( $post2_id, '_yoast_wpseo_opengraph-image', true ) );
+//		$this->assertEquals( $image['url'], WPSEO_Meta::get_value( 'opengraph-image', $post_id ) );
+//		$this->go_to( get_permalink( $post2_id ) );
+//		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+//	}
+
+	/**
+	 * Sets up our test class
+	 * @return WPSEO_OpenGraph_Image
+	 */
+	private function setup_class() {
+		return new WPSEO_OpenGraph_Image( new WPSEO_OpenGraph() );
+	}
+
+	/**
+	 * Creates a post for testing.
+	 *
+	 * @param string $post_type The post type to create a post of.
+	 *
+	 * @return int $post_id Post ID.
+	 */
+	private function create_post( $post_type = 'post' ) {
+		return self::factory()->post->create(
+			array(
+				'post_type' => $post_type,
+			)
+		);
+	}
+
+	/**
+	 * @param string  $image   Path.
+	 * @param integer $post_id Post ID.
+	 *
+	 * @return array
+	 */
+	private function create_featured_image( $image, $post_id ) {
+
+		$basename       = basename( $image );
+		$upload_dir     = wp_upload_dir();
+		$source_image   = dirname( __FILE__ ) . '/..' . $image;
+		$featured_image = $upload_dir['path'] . '/' . $basename;
+
+		copy( $source_image, $featured_image ); // Prevent original from deletion.
+
+		$file_array = array(
+			'name'     => $basename,
+			'tmp_name' => $featured_image,
+		);
+		$attach_id  = media_handle_sideload( $file_array, $post_id );
+
+		update_post_meta( $post_id, '_thumbnail_id', $attach_id );
+
+		$file = get_attached_file( $attach_id );
+
+		return array(
+			'path' => $file,
+			'url'  => $upload_dir['url'] . '/' . basename( $file ),
+		);
+	}
+
+	/**
+	 * Returns a sample test array.
+	 *
+	 * @param bool $relative Whether the URL was passed in relative or not.
+	 *
+	 * @return array
+	 */
+	private function sample_array( $relative = true ) {
+		return array(
+			'http://example.org/test.png' => array(
+				'url' => ( ( $relative ) ? '/test.png' : 'http://example.org/test.png' ),
+			),
+		);
+	}
+
+	/**
+	 * Returns a sample test array.
+	 *
+	 * @param string $url The URL for the file
+	 *
+	 * @return array
+	 */
+	private function sample_full_file_array( $url ) {
+		return array(
+			$url => array(
+				'url'    => $url,
+				'width'  => 500,
+				'height' => 500,
+				'alt'    => '',
+				'type'   => 'image/png',
+			),
+		);
+	}
+}

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -270,22 +270,22 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, $class_instance->get_images() );
 	}
 
-//	public function test_uploaded_image_added_by_id() {
-//		// We create a post, and upload an image to it.
-//		$post_id = $this->create_post();
-//		$image   = $this->create_featured_image( '/assets/yoast.png', $post_id );
-//
-//		// We create another post and use the image, attached to the _other_ post, as its OpenGraph image.
-//		$post2_id = $this->create_post();
-//		WPSEO_Meta::set_value( 'opengraph-image', $image['url'], $post2_id );
-//
-//		$class_instance = $this->setup_class();
-//
-////		$this->assertEquals( $image['url'], get_post_meta( $post2_id, '_yoast_wpseo_opengraph-image', true ) );
-//		$this->assertEquals( $image['url'], WPSEO_Meta::get_value( 'opengraph-image', $post_id ) );
-//		$this->go_to( get_permalink( $post2_id ) );
-//		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
-//	}
+	public function test_uploaded_image_added_by_id() {
+		// We create a post, and upload an image to it.
+		$post_id = $this->create_post();
+		$image   = $this->create_featured_image( '/assets/yoast.png', $post_id );
+
+		// We create another post and use the image, attached to the _other_ post, as its OpenGraph image.
+		$post2_id = $this->create_post();
+		WPSEO_Meta::set_value( 'opengraph-image', $image['url'], $post2_id );
+
+		//		$this->assertEquals( '1', get_post_meta( $post2_id, '_yoast_wpseo_opengraph-image', true ) );
+		$this->assertEquals( $image['url'], WPSEO_Meta::get_value( 'opengraph-image', $post2_id ) );
+		$this->go_to( get_permalink( $post2_id ) );
+		$class_instance = $this->setup_class();
+
+		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+	}
 
 	/**
 	 * Sets up our test class

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -127,7 +127,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = $this->setup_class();
 
-		$this->assertEquals( $this->sample_full_file_array( $upload_dir['url'] . '/' . $filename ), $class_instance->get_images() );
+		$this->assertEquals( $this->sample_full_file_array( $upload_dir['url'] . '/' . $filename, $attach_id ), $class_instance->get_images() );
 
 		wp_delete_file( get_attached_file( $attach_id ) );
 	}
@@ -168,7 +168,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = $this->setup_class();
 
-		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+		$this->assertEquals( $this->sample_full_file_array( $image['url'], $image['id'] ), $class_instance->get_images() );
 	}
 
 	/**
@@ -213,7 +213,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = $this->setup_class();
 
-		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+		$this->assertEquals( $this->sample_full_file_array( $image['url'], $image['id'] ), $class_instance->get_images() );
 	}
 
 	/**
@@ -279,7 +279,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 		$class_instance = $this->setup_class();
 
-		$expected = $this->sample_full_file_array( $attached_image );
+		$expected = $this->sample_full_file_array( $attached_image, $attach_id );
 		$expected['https://cdn.yoast.com/app/uploads/2018/03/Caroline_Blog_SEO_FI-600x314.jpg'] = array(
 			'url' => 'https://cdn.yoast.com/app/uploads/2018/03/Caroline_Blog_SEO_FI-600x314.jpg'
 		);
@@ -304,7 +304,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$this->go_to( get_permalink( $post2_id ) );
 		$class_instance = $this->setup_class();
 
-		$this->assertEquals( $this->sample_full_file_array( $image['url'] ), $class_instance->get_images() );
+		$this->assertEquals( $this->sample_full_file_array( $image['url'], $image['id'] ), $class_instance->get_images() );
 	}
 
 	/**
@@ -356,6 +356,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 
 		return array(
+			'id'   => $attach_id,
 			'path' => $file,
 			'url'  => $upload_dir['url'] . '/' . basename( $file ),
 		);
@@ -379,11 +380,12 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Returns a sample test array.
 	 *
-	 * @param string $url The URL for the file
+	 * @param string $url The URL for the file.
+	 * @param int    $id  Attached file ID.
 	 *
-	 * @return array
+	 * @return array An array for our default file.
 	 */
-	private function sample_full_file_array( $url ) {
+	private function sample_full_file_array( $url, $id ) {
 		return array(
 			$url => array(
 				'url'    => $url,
@@ -391,6 +393,10 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 				'height' => 500,
 				'alt'    => '',
 				'type'   => 'image/png',
+				'path'   => get_attached_file( $id ),
+				'size'   => 'full',
+				'id' 	 => $id,
+				'pixels' => 250000,
 			),
 		);
 	}

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -412,47 +412,6 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$this->assertContains( $expected_output, $output );
 	}
 
-
-
-	/**
-	 * Tests whether the correct OG tag for an image via HTTP is generated.
-	 *
-	 * @group test
-	 */
-	public function test_image_insecure_url() {
-		$stub = $this
-			->getMockBuilder( 'WPSEO_OpenGraph' )
-			->setMethods( array( 'og_tag' ) )
-			->getMock();
-
-		$stub
-			->expects( $this->once() )
-			->method( 'og_tag' )
-			->with( 'og:image' );
-
-		$stub->image( 'http://example.org/test.png' );
-	}
-
-
-
-	/**
-	 * Tests whether the correct OG tag for an image via HTTPS is generated.
-	 */
-	public function test_image_secure_url() {
-		$stub = $this
-			->getMockBuilder( 'WPSEO_OpenGraph' )
-			->setMethods( array( 'og_tag' ) )
-			->getMock();
-
-		$stub
-			->expects( $this->exactly( 2 ) )
-			->method( 'og_tag' )
-			->with( $this->logicalOr( 'og:image', 'og:image:secure_url' ) );
-
-		$stub->image( 'https://example.org/test.png' );
-	}
-
-
 	/**
 	 * @covers WPSEO_OpenGraph::description
 	 */

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -7,6 +7,8 @@
 
 /**
  * OpenGraph tests
+ *
+ * @group OpenGraph
  */
 class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -265,6 +265,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if the opengraph-image (Facebook Image) is added to opengraph.
 	 *
 	 * @covers WPSEO_OpenGraph::image
+	 *
+	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_and_HAS_open_graph_image() {
 		$post_id = $this->factory->post->create();
@@ -291,6 +293,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if the content image does not get added to opengraph when there is an opengraph-image (Facebook Image).
 	 *
 	 * @covers WPSEO_OpenGraph::image
+	 *
+	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_and_HAS_open_graph_image_AND_HAS_content_images() {
 		$post_id = $this->factory->post->create(
@@ -322,6 +326,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if featured image does not get added to opengraph when the image is too small.
 	 *
 	 * @covers WPSEO_OpenGraph::image
+	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_AND_HAS_featured_image_AND_HAS_WRONG_size() {
 		$post_id   = $this->factory->post->create();
@@ -351,6 +356,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test if featured image gets added to opengraph when it is the correct size.
 	 * @covers WPSEO_OpenGraph::image
+	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_AND_HAS_featured_image_AND_HAS_RIGHT_size() {
 		$post_id   = $this->factory->post->create();
@@ -381,6 +387,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if image in content is added to open graph.
 	 *
 	 * @covers WPSEO_OpenGraph::image
+	 *
+	 * @group test
 	 */
 	public function test_image_get_content_image() {
 		$post_id = $this->factory->post->create(
@@ -408,6 +416,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests whether the correct OG tag for an image via HTTP is generated.
+	 *
+	 * @group test
 	 */
 	public function test_image_insecure_url() {
 		$stub = $this
@@ -529,7 +539,6 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 
 		$image_url       = 'https://example.com/image.png';
 		$expected_output = <<<EXPECTED
-<meta property="og:image" content="{$image_url}" />
 <meta property="og:image:secure_url" content="{$image_url}" />
 EXPECTED;
 		WPSEO_Meta::set_value( 'opengraph-image', $image_url, $post_id );

--- a/tests/test-class-opengraph.php
+++ b/tests/test-class-opengraph.php
@@ -265,8 +265,6 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if the opengraph-image (Facebook Image) is added to opengraph.
 	 *
 	 * @covers WPSEO_OpenGraph::image
-	 *
-	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_and_HAS_open_graph_image() {
 		$post_id = $this->factory->post->create();
@@ -293,8 +291,6 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if the content image does not get added to opengraph when there is an opengraph-image (Facebook Image).
 	 *
 	 * @covers WPSEO_OpenGraph::image
-	 *
-	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_and_HAS_open_graph_image_AND_HAS_content_images() {
 		$post_id = $this->factory->post->create(
@@ -326,7 +322,6 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if featured image does not get added to opengraph when the image is too small.
 	 *
 	 * @covers WPSEO_OpenGraph::image
-	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_AND_HAS_featured_image_AND_HAS_WRONG_size() {
 		$post_id   = $this->factory->post->create();
@@ -356,7 +351,6 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test if featured image gets added to opengraph when it is the correct size.
 	 * @covers WPSEO_OpenGraph::image
-	 * @group test
 	 */
 	public function test_image_IS_SINGULAR_AND_HAS_featured_image_AND_HAS_RIGHT_size() {
 		$post_id   = $this->factory->post->create();
@@ -387,8 +381,6 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 * Test if image in content is added to open graph.
 	 *
 	 * @covers WPSEO_OpenGraph::image
-	 *
-	 * @group test
 	 */
 	public function test_image_get_content_image() {
 		$post_id = $this->factory->post->create(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Output width and height in OpenGraph meta tags way more often.
* When an image found for OpenGraph is larger than 2MB, choose a smaller version.
* Cache images found in a post so we don't need to do this on every page load.
* When an image has an alt tag, output it as `og:image:alt`.

## Relevant technical choices:

* Factored out two new classes, `WPSEO_Image_Utils` and `WPSEO_Content_Images`. The former to find attachment ID's from image URLs, find correct image paths and find image file sizes. The latter to find and cache images in post content.

## Test instructions

This PR can be tested by following these steps:

* Play with images in post content, as featured image, specifically set as Facebook image and make sure it all still works as expected, and has width and height output everywhere.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended

Fixes #9409
Fixes #9370 
Fixes #8054 
Fixes #4400 
Fixes #5541 
Fixes #8342