### PR TITLE
Refactor database proxy class to handle table prefix and register table with WordPress

### DIFF
--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -230,10 +230,10 @@ class WPSEO_Database_Proxy {
 
 		if ( $this->is_global ) {
 			$this->database->ms_global_tables[] = $table_name;
+			return;
 		}
-		else {
-			$this->database->tables[] = $table_name;
-		}
+
+		$this->database->tables[] = $table_name;
 	}
 
 	/**

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -17,7 +17,7 @@ class WPSEO_Database_Proxy {
 	protected $suppress_errors = true;
 
 	/** @var bool */
-	protected $is_global = false;
+	protected $is_multisite_table = false;
 
 	/** @var bool */
 	protected $last_suppressed_state;
@@ -28,16 +28,16 @@ class WPSEO_Database_Proxy {
 	/**
 	 * Sets the class attributes and registers the table.
 	 *
-	 * @param wpdb   $database        The database object.
-	 * @param string $table_name      The table name that is represented.
-	 * @param bool   $suppress_errors Should the errors be suppressed.
-	 * @param bool   $is_global       Should the table be global in multisite.
+	 * @param wpdb   $database           The database object.
+	 * @param string $table_name         The table name that is represented.
+	 * @param bool   $suppress_errors    Should the errors be suppressed.
+	 * @param bool   $is_multisite_table Should the table be global in multisite.
 	 */
-	public function __construct( $database, $table_name, $suppress_errors = true, $is_global = false ) {
-		$this->table_name      = $table_name;
-		$this->suppress_errors = (bool) $suppress_errors;
-		$this->is_global       = (bool) $is_global;
-		$this->database        = $database;
+	public function __construct( $database, $table_name, $suppress_errors = true, $is_multisite_table = false ) {
+		$this->table_name         = $table_name;
+		$this->suppress_errors    = (bool) $suppress_errors;
+		$this->is_multisite_table = (bool) $is_multisite_table;
+		$this->database           = $database;
 
 		// If the table prefix was provided, strip it as it's handled automatically.
 		$table_prefix = $this->get_table_prefix();
@@ -212,7 +212,7 @@ class WPSEO_Database_Proxy {
 	 * @return string Table prefix.
 	 */
 	protected function get_table_prefix() {
-		if ( $this->is_global ) {
+		if ( $this->is_multisite_table ) {
 			return $this->database->base_prefix;
 		}
 
@@ -228,7 +228,7 @@ class WPSEO_Database_Proxy {
 
 		$this->database->$table_name = $full_table_name;
 
-		if ( $this->is_global ) {
+		if ( $this->is_multisite_table ) {
 			$this->database->ms_global_tables[] = $table_name;
 			return;
 		}
@@ -242,7 +242,7 @@ class WPSEO_Database_Proxy {
 	 * @return bool True if the table is registered, false otherwise.
 	 */
 	protected function is_table_registered() {
-		if ( $this->is_global ) {
+		if ( $this->is_multisite_table ) {
 			return in_array( $this->table_name, $this->database->ms_global_tables, true );
 		}
 

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -41,7 +41,7 @@ class WPSEO_Database_Proxy {
 
 		// If the table prefix was provided, strip it as it's handled automatically.
 		$table_prefix = $this->get_table_prefix();
-		if ( 0 === strpos( $this->table_name, $table_prefix ) ) {
+		if ( strpos( $this->table_name, $table_prefix ) === 0 ) {
 			$this->table_prefix = substr( $this->table_name, strlen( $table_prefix ) );
 		}
 
@@ -200,7 +200,7 @@ class WPSEO_Database_Proxy {
 	/**
 	 * Returns the full table name.
 	 *
-	 * @return string
+	 * @return string Full table name including prefix.
 	 */
 	public function get_table_name() {
 		return $this->get_table_prefix() . $this->table_name;
@@ -209,7 +209,7 @@ class WPSEO_Database_Proxy {
 	/**
 	 * Returns the prefix to use for the table.
 	 *
-	 * @return string Table prefix.
+	 * @return string The table prefix depending on the database context.
 	 */
 	protected function get_table_prefix() {
 		if ( $this->is_multisite_table ) {
@@ -221,6 +221,8 @@ class WPSEO_Database_Proxy {
 
 	/**
 	 * Registers the table with WordPress.
+	 *
+	 * @return void
 	 */
 	protected function register_table() {
 		$table_name      = $this->table_name;

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -15,21 +15,20 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 	/** @var WPSEO_Database_Proxy */
 	protected $database_proxy;
 
-	/** @var null|string */
+	/** @var null|string Deprecated. */
 	protected $table_prefix;
 
 	/**
-	 * Sets the table prefix.
+	 * Initializes the database table.
 	 *
-	 * @param string $table_prefix Optional. The prefix to use for the table.
+	 * @param string $table_prefix Optional. Deprecated argument.
 	 */
 	public function __construct( $table_prefix = null ) {
-		if ( null === $table_prefix ) {
-			$table_prefix = $GLOBALS['wpdb']->get_blog_prefix();
+		if ( null !== $table_prefix ) {
+			_deprecated_argument( __METHOD__, 'WPSEO 7.4' );
 		}
 
-		$this->table_prefix   = $table_prefix;
-		$this->database_proxy = new WPSEO_Database_Proxy( $GLOBALS['wpdb'], $this->get_table_name(), true );
+		$this->database_proxy = new WPSEO_Database_Proxy( $GLOBALS['wpdb'], self::TABLE_NAME, true );
 	}
 
 	/**
@@ -38,7 +37,7 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 	 * @return string The table name.
 	 */
 	public function get_table_name() {
-		return $this->table_prefix . self::TABLE_NAME;
+		return $this->database_proxy->get_table_name();
 	}
 
 	/**

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -24,7 +24,7 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 	 * @param string $table_prefix Optional. Deprecated argument.
 	 */
 	public function __construct( $table_prefix = null ) {
-		if ( null !== $table_prefix ) {
+		if ( $table_prefix !== null ) {
 			_deprecated_argument( __METHOD__, 'WPSEO 7.4' );
 		}
 

--- a/admin/links/class-link-storage.php
+++ b/admin/links/class-link-storage.php
@@ -24,7 +24,7 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 	 * @param string $table_prefix Optional. Deprecated argument.
 	 */
 	public function __construct( $table_prefix = null ) {
-		if ( null !== $table_prefix ) {
+		if ( $table_prefix !== null ) {
 			_deprecated_argument( __METHOD__, 'WPSEO 7.4' );
 		}
 

--- a/admin/links/class-link-storage.php
+++ b/admin/links/class-link-storage.php
@@ -15,21 +15,20 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 	/** @var WPSEO_Database_Proxy */
 	protected $database_proxy;
 
-	/** @var null|string */
+	/** @var null|string Deprecated. */
 	protected $table_prefix;
 
 	/**
-	 * Sets the table prefix.
+	 * Initializes the database table.
 	 *
-	 * @param string $table_prefix Optional. The prefix to use for the table.
+	 * @param string $table_prefix Optional. Deprecated argument.
 	 */
 	public function __construct( $table_prefix = null ) {
-		if ( null === $table_prefix ) {
-			$table_prefix = $GLOBALS['wpdb']->get_blog_prefix();
+		if ( null !== $table_prefix ) {
+			_deprecated_argument( __METHOD__, 'WPSEO 7.4' );
 		}
 
-		$this->table_prefix   = $table_prefix;
-		$this->database_proxy = new WPSEO_Database_Proxy( $GLOBALS['wpdb'], $this->get_table_name(), true );
+		$this->database_proxy = new WPSEO_Database_Proxy( $GLOBALS['wpdb'], self::TABLE_NAME, true );
 	}
 
 	/**
@@ -38,7 +37,7 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 	 * @return string The table name.
 	 */
 	public function get_table_name() {
-		return $this->table_prefix . self::TABLE_NAME;
+		return $this->database_proxy->get_table_name();
 	}
 
 	/**

--- a/tests/admin/links/test-class-link-storage.php
+++ b/tests/admin/links/test-class-link-storage.php
@@ -39,15 +39,6 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests the usage of a custom table prefix.
-	 */
-	public function test_table_prefix() {
-		$storage = new WPSEO_Link_Storage( 'custom_prefix_' );
-
-		$this->assertEquals( 'custom_prefix_yoast_seo_links', $storage->get_table_name() );
-	}
-
-	/**
 	 * Tests the creation of the table.
 	 *
 	 * @todo make this test having sense

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -61,6 +61,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$wpdb->query( "DROP TABLE {$full_table_name}" );
 	}
 
+	/**
+	 * Tests inserting a valid dataset into the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::insert()
+	 */
 	public function test_insert() {
 		$result = self::$proxy->insert(
 			array(
@@ -73,6 +78,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( 1, $result );
 	}
 
+	/**
+	 * Tests inserting a dataset with an existing ID into the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::insert()
+	 */
 	public function test_insert_exists() {
 		$result = self::$proxy->insert(
 			array(
@@ -86,6 +96,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	/**
+	 * Tests inserting an invalid dataset into the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::insert()
+	 */
 	public function test_insert_invalid() {
 		$result = self::$proxy->insert(
 			array(
@@ -97,6 +112,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	/**
+	 * Tests updating a valid dataset in the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::update()
+	 */
 	public function test_update() {
 		$result = self::$proxy->update(
 			array(
@@ -112,6 +132,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( 1, $result );
 	}
 
+	/**
+	 * Tests updating a not existing dataset in the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::update()
+	 */
 	public function test_update_not_exists() {
 		$result = self::$proxy->update(
 			array(
@@ -127,6 +152,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( 0, $result );
 	}
 
+	/**
+	 * Tests updating an invalid dataset in the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::update()
+	 */
 	public function test_update_invalid() {
 		$result = self::$proxy->update(
 			array(
@@ -142,6 +172,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	/**
+	 * Tests inserting or otherwise updating a valid dataset in the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::upsert()
+	 */
 	public function test_upsert_new() {
 		$result = self::$proxy->upsert(
 			array(
@@ -159,6 +194,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( 1, $result );
 	}
 
+	/**
+	 * Tests inserting or otherwise updating an existing dataset in the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::upsert()
+	 */
 	public function test_upsert_existing() {
 		$result = self::$proxy->upsert(
 			array(
@@ -176,6 +216,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( 1, $result );
 	}
 
+	/**
+	 * Tests deleting a valid dataset from the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::delete()
+	 */
 	public function test_delete() {
 		$result = self::$proxy->delete(
 			array(
@@ -187,6 +232,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( 1, $result );
 	}
 
+	/**
+	 * Tests deleting a not existing dataset from the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::delete()
+	 */
 	public function test_delete_not_exists() {
 		$result = self::$proxy->delete(
 			array(
@@ -198,6 +248,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( 0, $result );
 	}
 
+	/**
+	 * Tests deleting an invalid dataset from the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::delete()
+	 */
 	public function test_delete_invalid() {
 		$result = self::$proxy->delete(
 			array(
@@ -209,6 +264,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	/**
+	 * Tests querying results from the database.
+	 *
+	 * @covers WPSEO_Database_Proxy::get_results()
+	 */
 	public function test_get_results() {
 		$table_name = self::$proxy->get_table_name();
 
@@ -225,6 +285,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
+	/**
+	 * Tests creating a table in the database from columns definition.
+	 *
+	 * @covers WPSEO_Database_Proxy::create_table()
+	 */
 	public function test_create_table() {
 		global $wpdb;
 
@@ -245,10 +310,20 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * Tests checking whether the last database request resulted in an error.
+	 *
+	 * @covers WPSEO_Database_Proxy::has_error()
+	 */
 	public function test_has_error() {
 		$this->assertFalse( self::$proxy->has_error() );
 	}
 
+	/**
+	 * Tests correctness of the full prefixed table name for a regular table.
+	 *
+	 * @covers WPSEO_Database_Proxy::get_table_name()
+	 */
 	public function test_get_table_name() {
 		global $wpdb;
 
@@ -258,6 +333,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	/**
+	 * Tests correctness of the full prefixed table name for a global table.
+	 *
+	 * @covers WPSEO_Database_Proxy::get_table_name()
+	 */
 	public function test_get_table_name_global() {
 		global $wpdb;
 
@@ -270,6 +350,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	/**
+	 * Tests correct registration of a regular table with WordPress.
+	 *
+	 * @covers WPSEO_Database_Proxy::register_table()
+	 */
 	public function test_register_table() {
 		global $wpdb;
 
@@ -279,6 +364,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( in_array( $proxy_table_name, $wpdb->tables, true ) );
 	}
 
+	/**
+	 * Tests correct registration of a global table with WordPress.
+	 *
+	 * @covers WPSEO_Database_Proxy::register_table()
+	 */
 	public function test_register_table_global() {
 		global $wpdb;
 

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin
+ */
+
+/**
+ * Unit Test Class.
+ */
+class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
+
+	/** @var string */
+	private static $proxy_table_name;
+
+	/** @var WPSEO_Database_Proxy */
+	private static $proxy;
+
+	/**
+	 * Instantiates a reusable table proxy and creates the table.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		global $wpdb;
+
+		self::$proxy_table_name = 'yoast_seo_test_table';
+		self::$proxy = new WPSEO_Database_Proxy( $wpdb, self::$proxy_table_name, true );
+		self::$proxy->create_table(
+			array(
+				'id bigint(20) unsigned NOT NULL AUTO_INCREMENT',
+				'testkey varchar(255) NOT NULL',
+				'testval longtext NOT NULL',
+			),
+			array(
+				'PRIMARY KEY (id)',
+			)
+		);
+		self::$proxy->insert(
+			array(
+				'testkey' => 'key1',
+				'testval' => 'value1',
+			),
+			array( '%s', '%s' )
+		);
+
+		$installer = new WPSEO_Link_Installer();
+		$installer->install();
+	}
+
+	/**
+	 * Drops the table from the proxy.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		global $wpdb;
+
+		$full_table_name = self::$proxy->get_table_name();
+
+		$wpdb->query( "DROP TABLE {$full_table_name}" );
+	}
+
+	public function test_insert() {
+		$result = self::$proxy->insert(
+			array(
+				'testkey' => 'key2',
+				'testval' => 'value2',
+			),
+			array( '%s', '%s' )
+		);
+
+		$this->assertSame( 1, $result );
+	}
+
+	public function test_insert_exists() {
+		$result = self::$proxy->insert(
+			array(
+				'id'      => 1,
+				'testkey' => 'key2',
+				'testval' => 'value2',
+			),
+			array( '%d', '%s', '%s' )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_insert_invalid() {
+		$result = self::$proxy->insert(
+			array(
+				'testvalue' => 'value2',
+			),
+			array( '%s' )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_update() {
+		$result = self::$proxy->update(
+			array(
+				'testval' => 'value2',
+			),
+			array(
+				'testkey' => 'key1',
+			),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		$this->assertSame( 1, $result );
+	}
+
+	public function test_update_not_exists() {
+		$result = self::$proxy->update(
+			array(
+				'testval' => 'value2',
+			),
+			array(
+				'testkey' => 'key2',
+			),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		$this->assertSame( 0, $result );
+	}
+
+	public function test_update_invalid() {
+		$result = self::$proxy->update(
+			array(
+				'testvalue' => 'value2',
+			),
+			array(
+				'testkey' => 'key1',
+			),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_upsert_new() {
+		$result = self::$proxy->upsert(
+			array(
+				'id'      => 2,
+				'testkey' => 'key2',
+				'testval' => 'value2',
+			),
+			array(
+				'id' => 2,
+			),
+			array( '%d', '%s', '%s' ),
+			array( '%d' )
+		);
+
+		$this->assertSame( 1, $result );
+	}
+
+	public function test_upsert_existing() {
+		$result = self::$proxy->upsert(
+			array(
+				'id'      => 1,
+				'testkey' => 'key2',
+				'testval' => 'value2',
+			),
+			array(
+				'id' => 1,
+			),
+			array( '%d', '%s', '%s' ),
+			array( '%d' )
+		);
+
+		$this->assertSame( 1, $result );
+	}
+
+	public function test_delete() {
+		$result = self::$proxy->delete(
+			array(
+				'testkey' => 'key1',
+			),
+			array( '%s' )
+		);
+
+		$this->assertSame( 1, $result );
+	}
+
+	public function test_delete_not_exists() {
+		$result = self::$proxy->delete(
+			array(
+				'testkey' => 'key2',
+			),
+			array( '%s' )
+		);
+
+		$this->assertSame( 0, $result );
+	}
+
+	public function test_delete_invalid() {
+		$result = self::$proxy->delete(
+			array(
+				'testvalue' => 'key1',
+			),
+			array( '%s' )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_get_results() {
+		$table_name = self::$proxy->get_table_name();
+
+		$result = self::$proxy->get_results( "SELECT * FROM $table_name WHERE testkey = 'key1'" );
+
+		$expected = array(
+			(object) array(
+				'id'      => 1,
+				'testkey' => 'key1',
+				'testval' => 'value1',
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	public function test_create_table() {
+		global $wpdb;
+
+		$proxy_table_name = self::$proxy_table_name . '_duplicate';
+		$proxy            = new WPSEO_Database_Proxy( $wpdb, $proxy_table_name, true );
+
+		$result = $proxy->create_table(
+			array(
+				'id bigint(20) unsigned NOT NULL AUTO_INCREMENT',
+				'testkey varchar(255) NOT NULL',
+				'testval longtext NOT NULL',
+			),
+			array(
+				'PRIMARY KEY (id)',
+			)
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_has_error() {
+		$this->assertFalse( self::$proxy->has_error() );
+	}
+
+	public function test_get_table_name() {
+		global $wpdb;
+
+		$expected = $wpdb->get_blog_prefix() . self::$proxy_table_name;
+		$result   = self::$proxy->get_table_name();
+
+		$this->assertSame( $expected, $result );
+	}
+
+	public function test_get_table_name_global() {
+		global $wpdb;
+
+		$proxy_table_name = self::$proxy_table_name . '_duplicate';
+		$proxy            = new WPSEO_Database_Proxy( $wpdb, $proxy_table_name, true, true );
+
+		$expected = $wpdb->base_prefix . $proxy_table_name;
+		$result   = $proxy->get_table_name();
+
+		$this->assertSame( $expected, $result );
+	}
+
+	public function test_register_table() {
+		global $wpdb;
+
+		$proxy_table_name = self::$proxy_table_name . '_duplicate';
+		$proxy            = new WPSEO_Database_Proxy( $wpdb, $proxy_table_name, true );
+
+		$this->assertTrue( in_array( $proxy_table_name, $wpdb->tables, true ) );
+	}
+
+	public function test_register_table_global() {
+		global $wpdb;
+
+		$proxy_table_name = self::$proxy_table_name . '_duplicate';
+		$proxy            = new WPSEO_Database_Proxy( $wpdb, $proxy_table_name, true, true );
+
+		$this->assertTrue( in_array( $proxy_table_name, $wpdb->ms_global_tables, true ) );
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Handles the database table prefix flexibly in the `WPSEO_Database_Proxy` class instead of relying on a passed hard-coded table name that includes it. This makes the class behave correctly when switching sites in multisite.
* Registers the database table with the WordPress database object (`$wpdb`). This makes WordPress aware and ensures that it automatically drops them for example when a site is deleted. It also standardizes behavior as other developers often rely on all database tables being present in the WordPress object.

## Relevant technical choices:

* Store only the unprefixed database table name in the internal property `$table_name` and get the current prefix to use from the database object (`$wpdb`). To be backward-compatible, if a fully qualified table name is passed to the constructor, the prefix will be stripped initially.
* The table is automatically registered in the constructor. This happens however only if it isn't registered already, which may be the case since the database proxy objects are initialized in multiple locations.
* The `get_table_name()` method has been made public. It still returns the full table name as before, and since the prefixes are handled internally, it is useful to have this method publicly available. For example when writing manual SQL queries to pass to the `get_results()` method.
* While the changes in the class keep backward-compatibility in themselves, the classes currently using it are still doing it wrong essentially (for the new behavior). Therefore in `WPSEO_Meta_Storage` and `WPSEO_Link_Storage`, the `$table_prefix` parameter in the constructor is no longer used and has been deprecated.
* I added unit tests for the entire `WPSEO_Database_Proxy` class, since none were present before.

## Test instructions

This PR can be tested by following these steps:

* Create a new sub-site in a multisite, activate the plugin and make sure the database tables are present. Delete the sub-site, and make sure the database tables are deleted.
* Make sure relevant unit tests (still) pass.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8609 
