### PR TITLE
Add wpseo_attachment_redirect filter

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1404,7 +1404,7 @@ class WPSEO_Frontend {
 			return false;
 		}
 
-		$url = apply_filters( 'wpseo_attachment_redirect_url', wp_get_attachment_url( get_queried_object_id() ) );
+		$url = apply_filters( 'wpseo_attachment_redirect_url', wp_get_attachment_url( get_queried_object_id() ), get_queried_object() );
 
 		if ( ! empty( $url ) ) {
 			$this->redirect( $url, 301 );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1404,7 +1404,7 @@ class WPSEO_Frontend {
 			return false;
 		}
 
-		$url = apply_filters( 'wpseo_attachment_redirect', wp_get_attachment_url( get_queried_object_id() ) );
+		$url = apply_filters( 'wpseo_attachment_redirect_url', wp_get_attachment_url( get_queried_object_id() ) );
 
 		if ( ! empty( $url ) ) {
 			$this->redirect( $url, 301 );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1404,7 +1404,7 @@ class WPSEO_Frontend {
 			return false;
 		}
 
-    $url = apply_filters( 'wpseo_attachment_redirect', wp_get_attachment_url( get_queried_object_id() ) );
+		$url = apply_filters( 'wpseo_attachment_redirect', wp_get_attachment_url( get_queried_object_id() ) );
 
 		if ( ! empty( $url ) ) {
 			$this->redirect( $url, 301 );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1404,7 +1404,7 @@ class WPSEO_Frontend {
 			return false;
 		}
 
-		$url = wp_get_attachment_url( get_queried_object_id() );
+    $url = apply_filters( 'wpseo_attachment_redirect', wp_get_attachment_url( get_queried_object_id() ) );
 
 		if ( ! empty( $url ) ) {
 			$this->redirect( $url, 301 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the `wpseo_attachment_redirect_url` filter to allow changing of the target redirection URL for attachments. This may be necessary to restore the redirect to the parent post. Props to @cawa-93.
