### PR TITLE
Change structure of results to enable overall scores to be added

### DIFF
--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -3,6 +3,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import isUndefined from "lodash/isUndefined";
 
 import Results from "./Results";
 
@@ -49,7 +50,7 @@ ReadabilityAnalysis.propTypes = {
 function mapStateToProps( state, ownProps ) {
 	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
 	let results = null;
-	if ( typeof( state.analysis.readability ) !== "undefined" ) {
+	if ( ! isUndefined( state.analysis.readability ) ) {
 		results = state.analysis.readability.results;
 	}
 

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -49,7 +49,7 @@ ReadabilityAnalysis.propTypes = {
 function mapStateToProps( state, ownProps ) {
 	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
 	let results = null;
-	if (typeof( state.analysis.readability ) !== "undefined" ){
+	if ( typeof( state.analysis.readability ) !== "undefined" ){
 		results = state.analysis.readability.results;
 	}
 

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -49,7 +49,7 @@ ReadabilityAnalysis.propTypes = {
 function mapStateToProps( state, ownProps ) {
 	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
 	let results = null;
-	if ( typeof( state.analysis.readability ) !== "undefined" ){
+	if ( typeof( state.analysis.readability ) !== "undefined" ) {
 		results = state.analysis.readability.results;
 	}
 

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -48,9 +48,13 @@ ReadabilityAnalysis.propTypes = {
  */
 function mapStateToProps( state, ownProps ) {
 	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
+	let results = null;
+	if (typeof( state.analysis.readability ) !== "undefined" ){
+		results = state.analysis.readability.results;
+	}
 
 	return {
-		results: state.analysis.readability,
+		results: results,
 		marksButtonStatus: marksButtonStatus,
 	};
 }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -20,7 +20,7 @@ class SeoAnalysis extends React.Component {
 }
 
 SeoAnalysis.propTypes = {
-	results: PropTypes.array,
+	results: PropTypes.object,
 	marksButtonStatus: PropTypes.string,
 	hideMarksButtons: PropTypes.bool,
 };
@@ -35,9 +35,12 @@ SeoAnalysis.propTypes = {
  */
 function mapStateToProps( state, ownProps ) {
 	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
-
+	let results = null;
+	if ( typeof( state.analysis.seo[ state.activeKeyword ] ) !== "undefined" ) {
+		results = state.analysis.seo[ state.activeKeyword ].results;
+	}
 	return {
-		results: state.analysis.seo[ state.activeKeyword ] || null,
+		results: results,
 		marksButtonStatus: marksButtonStatus,
 	};
 }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -20,7 +20,7 @@ class SeoAnalysis extends React.Component {
 }
 
 SeoAnalysis.propTypes = {
-	results: PropTypes.object,
+	results: PropTypes.array,
 	marksButtonStatus: PropTypes.string,
 	hideMarksButtons: PropTypes.bool,
 };

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import isUndefined from "lodash/isUndefined";
 
 import Results from "./Results";
 
@@ -36,7 +37,7 @@ SeoAnalysis.propTypes = {
 function mapStateToProps( state, ownProps ) {
 	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
 	let results = null;
-	if ( typeof( state.analysis.seo[ state.activeKeyword ] ) !== "undefined" ) {
+	if ( ! isUndefined( state.analysis.seo[ state.activeKeyword ] ) ) {
 		results = state.analysis.seo[ state.activeKeyword ].results;
 	}
 	return {

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -7,7 +7,7 @@ import YoastMarkdownPlugin from "./wp-seo-markdown-plugin";
 
 import initializeEdit from "./edit";
 import { setActiveKeyword } from "./redux/actions/activeKeyword";
-import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
+import { setReadabilityResults, setSeoResultsForKeyword, setOverallReadabilityScore, setOverallSeoScore } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
 import tinyMCEHelper from "./wp-seo-tinymce";
 import { tinyMCEDecorator } from "./decorator/tinyMCE";
 
@@ -282,6 +282,7 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 
 		if ( isKeywordAnalysisActive() ) {
 			args.callbacks.saveScores = postDataCollector.saveScores.bind( postDataCollector );
+			let savedKeywordScore = $( "#yoast_wpseo_linkdex" ).val();
 			args.callbacks.updatedKeywordsResults = function( results ) {
 				let keyword = tabManager.getKeywordTab().getKeyWord();
 
@@ -292,14 +293,17 @@ import { setMarkerStatus } from "./redux/actions/markerButtons";
 				 */
 				if ( tabManager.isMainKeyword( keyword ) ) {
 					store.dispatch( setSeoResultsForKeyword( keyword, results ) );
+					store.dispatch( setOverallSeoScore( savedKeywordScore, keyword ) );
 				}
 			};
 		}
 
 		if ( isContentAnalysisActive() ) {
 			args.callbacks.saveContentScore = postDataCollector.saveContentScore.bind( postDataCollector );
+			let savedContentScore = $( "#yoast_wpseo_content_score" ).val();
 			args.callbacks.updatedContentResults = function( results ) {
 				store.dispatch( setReadabilityResults( results ) );
+				store.dispatch( setOverallReadabilityScore( savedContentScore ) );
 			};
 		}
 

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -21,7 +21,7 @@ import TermDataCollector from "./analysis/TermDataCollector";
 import { termsTmceId as tmceId } from "./wp-seo-tinymce";
 import initializeEdit from "./edit";
 import { setActiveKeyword } from "./redux/actions/activeKeyword";
-import { setReadabilityResults, setSeoResultsForKeyword, setOverallScoreReadability, setOverallScoreSeo } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
+import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
 
 window.yoastHideMarkers = true;
 
@@ -235,10 +235,8 @@ window.yoastHideMarkers = true;
 
 		if ( isContentAnalysisActive() ) {
 			args.callbacks.saveContentScore = termScraper.saveContentScore.bind( termScraper );
-			let savedContentScore = $( "#yoast_wpseo_content_score" ).val();
 			args.callbacks.updatedContentResults = function( results ) {
 				store.dispatch( setReadabilityResults( results ) );
-				store.dispatch( setOverallScoreReadability( savedContentScore ) );
 			};
 		}
 

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -21,7 +21,7 @@ import TermDataCollector from "./analysis/TermDataCollector";
 import { termsTmceId as tmceId } from "./wp-seo-tinymce";
 import initializeEdit from "./edit";
 import { setActiveKeyword } from "./redux/actions/activeKeyword";
-import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
+import { setReadabilityResults, setSeoResultsForKeyword, setOverallScoreReadability, setOverallScoreSeo } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
 
 window.yoastHideMarkers = true;
 
@@ -235,8 +235,10 @@ window.yoastHideMarkers = true;
 
 		if ( isContentAnalysisActive() ) {
 			args.callbacks.saveContentScore = termScraper.saveContentScore.bind( termScraper );
+			let savedContentScore = $( "#yoast_wpseo_content_score" ).val();
 			args.callbacks.updatedContentResults = function( results ) {
 				store.dispatch( setReadabilityResults( results ) );
+				store.dispatch( setOverallScoreReadability( savedContentScore ) );
 			};
 		}
 


### PR DESCRIPTION
> Blocked for now. We will pick this up when feature/content-analysis-in-sidebar gets merged.

## Summary

This PR can be summarized in the following changelog entry:

* Adds the overall score for each type of analysis to the redux state

## Relevant technical choices:

* Added an intermediate level in the result structure where overall score for an analysis is added

## Test instructions

This PR can be tested by following these steps:

* Check that the new structure looks like the following:

```
{
	activeKeyword: "string",
	analysis:
		{ 
			readability: {
				results: [],
				overallScore: "string"
			}
			seo: { 
				keyword: { 
					results: [],
					overallScore: "string"
				} 
			} ,
		},
	marksButtonStatus: "string",
}
```

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/9308
