### PR TITLE
Add filter for viewable posttypes

### DIFF
--- a/inc/class-post-type.php
+++ b/inc/class-post-type.php
@@ -19,6 +19,7 @@ class WPSEO_Post_Type {
 	 */
 	public static function get_accessible_post_types() {
 		$post_types = get_post_types( array( 'public' => true ) );
+		$post_types = array_filter( $post_types, 'is_post_type_viewable' );
 
 		/**
 		 * Filter: 'wpseo_accessible_post_types' - Allow changing the accessible post types.

--- a/tests/inc/test-class-post-type.php
+++ b/tests/inc/test-class-post-type.php
@@ -45,6 +45,17 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the situation with a custom public post type that is not publicly queryable.
+	 *
+	 * @covers WPSEO_Post_Type::get_accessible_post_types()
+	 */
+	public function test_get_accessible_post_types_with_a_custom_post_type_that_is_noy_publicly_queryable() {
+		register_post_type( 'hidden-post-type', array( 'public' => true, 'publicly_queryable' => false ) );
+
+		$this->assertNotContains( 'hidden-post-type', WPSEO_Post_Type::get_accessible_post_types() );
+	}
+
+	/**
 	 * Tests the situation with a custom private post post type
 	 *
 	 * @covers WPSEO_Post_Type::get_accessible_post_types()


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Apply features on real publicly queryable post types only.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch
* Create a post type by pasting the next code in de wp-seo-main.php file
```php
// Alert: this is modern php xD
add_action( 'admin_init', function() { 
    register_post_type( 'hidden-post-type', [ 'public' => true, 'publicly_queryable' => false ] );
} )
```
* For example: the cornerstone feature still works. But it shouldn't work. Checkout this branch.
* It will be solved now.



## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9085 