### PR TITLE
Ryte endpoint should be avaible to check for enabled status

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -328,11 +328,9 @@ function wpseo_init_rest_api() {
 	$statistics_endpoint = new WPSEO_Endpoint_Statistics( $statistics_service );
 	$statistics_endpoint->register();
 
-	if ( WPSEO_OnPage::is_active() ) {
-		$ryte_endpoint_service = new WPSEO_Ryte_Service( new WPSEO_OnPage_Option() );
-		$ryte_endpoint         = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
-		$ryte_endpoint->register();
-	}
+	$ryte_endpoint_service = new WPSEO_Ryte_Service( new WPSEO_OnPage_Option() );
+	$ryte_endpoint         = new WPSEO_Endpoint_Ryte( $ryte_endpoint_service );
+	$ryte_endpoint->register();
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Ryte endpoint is not available to check the Ryte active status

## Relevant technical choices:

* Just renabled the endpoint again

## Test instructions

This PR can be tested by following these steps:

* Disable the Ryte feature in the Features tab on the General settings page
* Open the dashboard
* See the Ryte request being done to the REST endpoint
* See the Ryte request serving a `ryte: false` response to notify that the service is disabled

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #8698
