### PR TITLE
Implemented a rough version of the PHP 5.2 check

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -417,11 +417,11 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	public function unsupported_php_notice() {
-
-		$info_message = '<strong>' . __( 'Action is needed', 'wordpress-seo' ) . '</strong>' . ': ';
-		$info_message .= sprintf(
-			/* translators: 1: the Yoast SEO version that is dropping support; 2: The release date of the version of Yoast SEO that is dropping support; 3: The PHP version no longer being supported; */
-			__( 'As of version %1$s, due to be released on %2$s, Yoast SEO will no longer work with PHP %3$s. Unfortunately, your site is running on PHP %3$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
+		$info_message = sprintf(
+			/* translators: 1: The strong opening tag; 2: The strong closing tag; 3: the Yoast SEO version that is dropping support; 4: The release date of the version of Yoast SEO that is dropping support; 5: The PHP version no longer being supported; */
+			__( '%1$sAction is needed%2$s: As of version %3$s, due to be released on %4$s, Yoast SEO will no longer work with PHP %5$s. Unfortunately, your site is running on PHP %5$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
+			'<strong>',
+			'</strong>',
 			'7.5',
 			date_i18n( get_option( 'date_format' ), strtotime( '15-05-2018' ) ),
 			'5.2'

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -423,7 +423,7 @@ class WPSEO_Admin_Init {
 			/* translators: 1: the Yoast SEO version that is dropping support; 2: The release date of the version of Yoast SEO that is dropping support; 3: The PHP version no longer being supported; */
 			__( 'As of version %1$s, due to be released on %2$s, Yoast SEO will no longer work with PHP %3$s. Unfortunately, your site is running on PHP %3$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
 			'7.5',
-			'15-05-2018',
+			date_i18n( get_option( 'date_format' ), strtotime( '15-05-2018' ) ),
 			'5.2'
 		);
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -417,13 +417,14 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	public function unsupported_php_notice() {
-		$info_message = sprintf(
-			/* translators: 1: the Yoast SEO version that is dropping support; 2: The PHP version no longer being supported; 3: The link tag to the information page; 4: The link closing tag. */
-			__( 'As of version %1$s, Yoast SEO is going to stop supporting PHP %2$s, which is the PHP version your site is running on. You can %3$sfind instructions here%4$s on how to update your PHP version quickly and safely.', 'wordpress-seo' ),
-			'7.3',
-			'5.2',
-			'<a href="' . esc_attr( 'https://wordpress.org/support/upgrade-php/' ) . '" target="_blank" rel="noopener noreferrer">',
-			'</a>'
+
+		$info_message = '<strong>' . __( 'Action is needed', 'wordpress-seo' ) . '</strong>' . ': ';
+		$info_message .= sprintf(
+			/* translators: 1: the Yoast SEO version that is dropping support; 2: The release date of the version of Yoast SEO that is dropping support; 3: The PHP version no longer being supported; */
+			__( 'As of version %1$s, due to be released on %2$s, Yoast SEO will no longer work with PHP %3$s. Unfortunately, your site is running on PHP %3$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
+			'7.5',
+			'15-05-2018',
+			'5.2'
 		);
 
 		$unsupported_php_notification = new Yoast_Notification(

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -417,10 +417,6 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	public function unsupported_php_notice() {
-		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) || $this->is_site_notice_dismissed( 'wpseo_dismiss_unsupported_php' ) ) {
-			return;
-		}
-
 		$info_message = sprintf(
 			/* translators: 1: the Yoast SEO version that is dropping support; 2: The PHP version no longer being supported; 3: The link tag to the information page; 4: The link closing tag. */
 			__( 'As of version %1$s, Yoast SEO is going to stop supporting PHP %2$s, which is the PHP version your site is running on. You can %3$sfind instructions here%4$s on how to update your PHP version quickly and safely.', 'wordpress-seo' ),

--- a/admin/class-admin-utils.php
+++ b/admin/class-admin-utils.php
@@ -67,4 +67,18 @@ class WPSEO_Admin_Utils {
 		);
 
 	}
+
+	/**
+	 * Determines whether or not the user has an invalid version of PHP installed.
+	 *
+	 * @return bool Whether or not PHP 5.2 or lower is installed
+	 */
+	public static function is_supported_php_version_installed() {
+		$checker = new Whip_RequirementsChecker( array( 'php' => PHP_VERSION ) );
+
+		$checker->addRequirement( Whip_VersionRequirement::fromCompareString( 'php', '>=5.3' ) );
+		$checker->check();
+
+		return $checker->hasMessages() === false;
+	}
 }

--- a/admin/class-admin-utils.php
+++ b/admin/class-admin-utils.php
@@ -71,7 +71,7 @@ class WPSEO_Admin_Utils {
 	/**
 	 * Determines whether or not the user has an invalid version of PHP installed.
 	 *
-	 * @return bool Whether or not PHP 5.2 or lower is installed
+	 * @return bool Whether or not PHP 5.2 or lower is installed.
 	 */
 	public static function is_supported_php_version_installed() {
 		$checker = new Whip_RequirementsChecker( array( 'php' => PHP_VERSION ) );

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -324,7 +324,7 @@ class WPSEO_Admin {
 			return;
 		}
 
-		// Check if the user is running PHP 5.2
+		// Check if the user is running PHP 5.2.
 		if ( WPSEO_Admin_Utils::is_supported_php_version_installed() === false ) {
 			$this->show_unsupported_php_message();
 
@@ -358,8 +358,8 @@ class WPSEO_Admin {
 	protected function show_unsupported_php_message() {
 		$presenter = new Whip_WPMessagePresenter(
 			new WPSEO_Unsupported_PHP_Message(),
-			new Whip_MessageDismisser( time(), WEEK_IN_SECONDS * 4, new Whip_WPDismissOption() ),
-			__( 'Remind me again in 4 weeks.', 'wordpress' )
+			new Whip_MessageDismisser( time(), ( WEEK_IN_SECONDS * 4 ), new Whip_WPDismissOption() ),
+			__( 'Remind me again in 4 weeks.', 'wordpress-seo' )
 		);
 
 		$presenter->register_hooks();

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -318,7 +318,6 @@ class WPSEO_Admin {
 	 * @return void
 	 */
 	protected function check_php_version() {
-
 		// If the user isn't an admin, don't display anything.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -318,8 +318,14 @@ class WPSEO_Admin {
 	 * @return void
 	 */
 	protected function check_php_version() {
+
+		// If the user isn't an admin, don't display anything.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		// Check if the user is running PHP 5.2
-		if ( $this->has_invalid_php_installed() ) {
+		if ( WPSEO_Admin_Utils::is_supported_php_version_installed() === false ) {
 			$this->show_unsupported_php_message();
 
 			return;
@@ -335,10 +341,6 @@ class WPSEO_Admin {
 			return;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
 		if ( ! $this->on_dashboard_page() ) {
 			return;
 		}
@@ -349,28 +351,14 @@ class WPSEO_Admin {
 	}
 
 	/**
-	 * Determines whether or not the user has an invalid version of PHP installed.
-	 *
-	 * @return bool Whether or not PHP 5.2 or lower is installed
-	 */
-	protected function has_invalid_php_installed() {
-		$checker = new Whip_RequirementsChecker( array( 'php' => '5.0' ) );
-
-		$checker->addRequirement( Whip_VersionRequirement::fromCompareString( 'php', '>=5.3' ) );
-		$checker->check();
-
-		return $checker->hasMessages();
-	}
-
-	/**
 	 * Creates a new message to display regarding the usage of PHP 5.2 (or lower).
 	 *
 	 * @return void
 	 */
 	protected function show_unsupported_php_message() {
 		$presenter = new Whip_WPMessagePresenter(
-			new WPSEO_Unsupported_PHP_Message( 'wordpress-seo' ),
-			new Whip_MessageDismisser( time(), WEEK_IN_SECONDS * 4, new Whip_WPDismissOption( 'wordpress-seo-52' ) ),
+			new WPSEO_Unsupported_PHP_Message(),
+			new Whip_MessageDismisser( time(), WEEK_IN_SECONDS * 4, new Whip_WPDismissOption() ),
 			__( 'Remind me again in 4 weeks.', 'wordpress' )
 		);
 

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -20,10 +20,11 @@ class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'PHP update required.', 'wordpress-seo' ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph(
-				'<strong>' . __( 'Action is needed', 'wordpress-seo' ) . '</strong>' . ': ' .
 				sprintf(
-				/* translators: 1: the Yoast SEO version that is dropping support; 2: The release date of the version of Yoast SEO that is dropping support; 3: The PHP version no longer being supported; */
-					__( 'As of version %1$s, due to be released on %2$s, Yoast SEO will no longer work with PHP %3$s. Unfortunately, your site is running on PHP %3$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
+					/* translators: 1: The strong opening tag; 2: The strong closing tag; 3: the Yoast SEO version that is dropping support; 4: The release date of the version of Yoast SEO that is dropping support; 5: The PHP version no longer being supported; */
+					__( '%1$sAction is needed%2$s: As of version %3$s, due to be released on %4$s, Yoast SEO will no longer work with PHP %5$s. Unfortunately, your site is running on PHP %5$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
+					'<strong>',
+					'</strong>',
 					'7.5',
 					date_i18n( get_option( 'date_format' ), strtotime( '15-05-2018' ) ),
 					'5.2'

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -1,19 +1,15 @@
 <?php
 
-class WPSEO_Unsupported_PHP_Message implements Whip_Message {
-	/**
-	 * @var string
-	 */
-	private $textdomain;
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
 
-	/**
-	 * Whip_UpgradePhpMessage constructor.
-	 *
-	 * @param string $textdomain The text domain to use for the translations.
-	 */
-	public function __construct( $textdomain ) {
-		$this->textdomain = $textdomain;
-	}
+/**
+ * Class that creates the PHP 5.2 support message.
+ */
+class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 
 	/**
 	 * Composes the body of the message to display.
@@ -21,17 +17,17 @@ class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 	 * @return string The message to display.
 	 */
 	public function body() {
-		$textdomain = $this->textdomain;
-
 		$message = array();
 
-		$message[] = Whip_MessageFormatter::strongParagraph( __( 'PHP update required.', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'As of version 7.3, Yoast SEO is going to stop supporting PHP 5.2, which is the PHP version your site is running on. Thankfully, you can update your PHP yourself.', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::strongParagraph( __( 'Why?', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'PHP is the programming language WordPress runs on. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site. Plus, it it enables our developers to use the latest technologies to make Yoast SEO even better.', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::strongParagraph( __( 'How?', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'For any questions you may have about updating your PHP version, WordPress has a great page with instructions here. We recommend going up to version 7.2. Not all plugins may be ready for PHP7 though, so we wrote an article on how to test them before you update here.', $textdomain ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'If you cannot update your PHP yourself, you can send an email to your host. We have examples here. If they don\'t want to upgrade your PHP version, we recommend switching hosts. Take a look at our list of recommended WordPress hosting partners, they\'ve been vetted by the Yoast support team and offer all the features a modern host should have.', $textdomain ) ) . '<br />';
+		$upgrade_page_url = esc_attr( 'https://wordpress.org/support/upgrade-php/' );
+
+		$message[] = Whip_MessageFormatter::strongParagraph( __( 'PHP update required.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'As of version 7.3, Yoast SEO is going to stop supporting PHP 5.2, which is the PHP version your site is running on. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::strongParagraph( __( 'Why?', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'PHP is the programming language WordPress runs on. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site. Plus, it it enables our developers to use the latest technologies to make Yoast SEO even better.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::strongParagraph( __( 'How?', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'For any questions you may have about updating your PHP version, WordPress <a href="' . $upgrade_page_url . '" target="_blank" rel="noopener noreferrer">has a great page with instructions here</a>. We recommend going up to version 7.2. Not all plugins may be ready for PHP 7 though, so we wrote an article on how to test them before you update here.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'If you cannot update your PHP yourself, you can send an email to your host. We have examples here. If they don\'t want to upgrade your PHP version, we recommend switching hosts. Take a look at our list of recommended WordPress hosting partners, they\'ve been vetted by the Yoast support team and offer all the features a modern host should have.', 'wordpress-seo' ) ) . '<br />';
 
 		return implode( $message, "\n" );
 	}

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -1,0 +1,38 @@
+<?php
+
+class WPSEO_Unsupported_PHP_Message implements Whip_Message {
+	/**
+	 * @var string
+	 */
+	private $textdomain;
+
+	/**
+	 * Whip_UpgradePhpMessage constructor.
+	 *
+	 * @param string $textdomain The text domain to use for the translations.
+	 */
+	public function __construct( $textdomain ) {
+		$this->textdomain = $textdomain;
+	}
+
+	/**
+	 * Composes the body of the message to display.
+	 *
+	 * @return string The message to display.
+	 */
+	public function body() {
+		$textdomain = $this->textdomain;
+
+		$message = array();
+
+		$message[] = Whip_MessageFormatter::strongParagraph( __( 'PHP update required.', $textdomain ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'As of version 7.3, Yoast SEO is going to stop supporting PHP 5.2, which is the PHP version your site is running on. Thankfully, you can update your PHP yourself.', $textdomain ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::strongParagraph( __( 'Why?', $textdomain ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'PHP is the programming language WordPress runs on. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site. Plus, it it enables our developers to use the latest technologies to make Yoast SEO even better.', $textdomain ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::strongParagraph( __( 'How?', $textdomain ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'For any questions you may have about updating your PHP version, WordPress has a great page with instructions here. We recommend going up to version 7.2. Not all plugins may be ready for PHP7 though, so we wrote an article on how to test them before you update here.', $textdomain ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'If you cannot update your PHP yourself, you can send an email to your host. We have examples here. If they don\'t want to upgrade your PHP version, we recommend switching hosts. Take a look at our list of recommended WordPress hosting partners, they\'ve been vetted by the Yoast support team and offer all the features a modern host should have.', $textdomain ) ) . '<br />';
+
+		return implode( $message, "\n" );
+	}
+}

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -19,12 +19,48 @@ class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 		$message = array();
 
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'PHP update required.', 'wordpress-seo' ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'As of version 7.3, Yoast SEO is going to stop supporting PHP 5.2, which is the PHP version your site is running on. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph(
+				'<strong>' . __( 'Action is needed', 'wordpress-seo' ) . '</strong>' . ': ' .
+				sprintf(
+				/* translators: 1: the Yoast SEO version that is dropping support; 2: The release date of the version of Yoast SEO that is dropping support; 3: The PHP version no longer being supported; */
+					__( 'As of version %1$s, due to be released on %2$s, Yoast SEO will no longer work with PHP %3$s. Unfortunately, your site is running on PHP %3$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
+					'7.5',
+					'15-05-2018',
+					'5.2'
+				)
+			) . '<br />';
+
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'Why?', 'wordpress-seo' ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'PHP is the programming language WordPress runs on. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site. Plus, it it enables our developers to use the latest technologies to make Yoast SEO even better.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph(
+			sprintf(
+				/* translators: 1: the PHP version that will no longer be supported; 2: The year the unsupported PHP version was released; 3: The minimal PHP version that will be supported; 4: The year the minimally supported version of PHP was released; */
+				__( 'PHP is the programming language WordPress is developed in and your site runs on. PHP %1$s was released in %2$s and was replaced by PHP %3$s in %4$s. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site. Plus, it it enables our developers to use the latest technologies to make Yoast SEO even better.', 'wordpress-seo' ),
+				'5.2',
+				'2006',
+				'5.3',
+				'2009'
+			)
+		) . '<br />';
+
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'How?', 'wordpress-seo' ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'For any questions you may have about updating your PHP version, WordPress <a href="https://wordpress.org/support/upgrade-php/" target="_blank" rel="noopener noreferrer">has a great page with instructions here</a>. We recommend going up to version 7.2. Not all plugins may be ready for PHP 7 though, so we wrote an article on how to test them before you update here.', 'wordpress-seo' ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'If you cannot update your PHP yourself, you can send an email to your host. We have examples here. If they don\'t want to upgrade your PHP version, we recommend switching hosts. Take a look at our list of recommended WordPress hosting partners, they\'ve been vetted by the Yoast support team and offer all the features a modern host should have.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph(
+			sprintf(
+				/* translators: 1: The link tag to the  WordPress instructions page for upgrading to newer versions of PHP; 2: The link closing tag; 3: The recommended PHP version; 4: The Yoast article about testing plugin compatibility with newer PHP versions; */
+				__( 'For any questions you may have about updating your PHP version, WordPress %1$shas a great page with instructions here%2$s. We recommend going up to version %3$s. Not all plugins may be ready for PHP 7 though, so %4$swe wrote an article on how to test them before you update here%2$s.', 'wordpress-seo' ),
+				'<a href="https://wordpress.org/support/upgrade-php/" target="_blank" rel="noopener noreferrer">',
+				'</a>',
+				'7.2',
+				'<a href="https://yoa.st/wg" target="_blank">'
+			) ) . '<br />';
+
+		$message[] = Whip_MessageFormatter::paragraph(
+			sprintf(
+				/* translators: 1: The link tag to email examples page; 2: The link closing tag; 3: The link tag for the list of recommended WordPress hosting partners; */
+				__( 'If you cannot update your PHP yourself, you can send an email to your host. We have %1$sexamples%2$s here. If they don\'t want to upgrade your PHP version, we recommend switching hosts. Take a look at our list of %3$srecommended WordPress hosting partners%2$s, they\'ve been vetted by the Yoast support team and offer all the features a modern host should have.', 'wordpress-seo' ),
+				'<a href="https://yoa.st/wh" target="_blank">',
+				'</a>',
+				sprintf( '<a href="%1$s" target="_blank">', esc_url( Whip_Host::hostingPageUrl() ) )
+				) ) . '<br />';
 
 		return implode( $message, "\n" );
 	}

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -51,14 +51,14 @@ class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 				'<a href="https://wordpress.org/support/upgrade-php/" target="_blank" rel="noopener noreferrer">',
 				'</a>',
 				'7.2',
-				'<a href="https://yoa.st/wg" target="_blank">'
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/wg' ) . '" target="_blank">'
 			) ) . '<br />';
 
 		$message[] = Whip_MessageFormatter::paragraph(
 			sprintf(
 				/* translators: 1: The link tag to email examples page; 2: The link closing tag; 3: The link tag for the list of recommended WordPress hosting partners; */
 				__( 'If you cannot update your PHP yourself, you can send an email to your host. We have %1$sexamples%2$s here. If they don\'t want to upgrade your PHP version, we recommend switching hosts. Take a look at our list of %3$srecommended WordPress hosting partners%2$s, they\'ve been vetted by the Yoast support team and offer all the features a modern host should have.', 'wordpress-seo' ),
-				'<a href="https://yoa.st/wh" target="_blank">',
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/wh' ) . '" target="_blank">',
 				'</a>',
 				sprintf( '<a href="%1$s" target="_blank">', esc_url( Whip_Host::hostingPageUrl() ) )
 				) ) . '<br />';

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -25,7 +25,7 @@ class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 				/* translators: 1: the Yoast SEO version that is dropping support; 2: The release date of the version of Yoast SEO that is dropping support; 3: The PHP version no longer being supported; */
 					__( 'As of version %1$s, due to be released on %2$s, Yoast SEO will no longer work with PHP %3$s. Unfortunately, your site is running on PHP %3$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
 					'7.5',
-					'15-05-2018',
+					date_i18n( get_option( 'date_format' ), strtotime( '15-05-2018' ) ),
 					'5.2'
 				)
 			) . '<br />';

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * WPSEO plugin file.
  *
@@ -19,14 +18,12 @@ class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 	public function body() {
 		$message = array();
 
-		$upgrade_page_url = esc_attr( 'https://wordpress.org/support/upgrade-php/' );
-
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'PHP update required.', 'wordpress-seo' ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph( __( 'As of version 7.3, Yoast SEO is going to stop supporting PHP 5.2, which is the PHP version your site is running on. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'Why?', 'wordpress-seo' ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph( __( 'PHP is the programming language WordPress runs on. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site. Plus, it it enables our developers to use the latest technologies to make Yoast SEO even better.', 'wordpress-seo' ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::strongParagraph( __( 'How?', 'wordpress-seo' ) ) . '<br />';
-		$message[] = Whip_MessageFormatter::paragraph( __( 'For any questions you may have about updating your PHP version, WordPress <a href="' . $upgrade_page_url . '" target="_blank" rel="noopener noreferrer">has a great page with instructions here</a>. We recommend going up to version 7.2. Not all plugins may be ready for PHP 7 though, so we wrote an article on how to test them before you update here.', 'wordpress-seo' ) ) . '<br />';
+		$message[] = Whip_MessageFormatter::paragraph( __( 'For any questions you may have about updating your PHP version, WordPress <a href="https://wordpress.org/support/upgrade-php/" target="_blank" rel="noopener noreferrer">has a great page with instructions here</a>. We recommend going up to version 7.2. Not all plugins may be ready for PHP 7 though, so we wrote an article on how to test them before you update here.', 'wordpress-seo' ) ) . '<br />';
 		$message[] = Whip_MessageFormatter::paragraph( __( 'If you cannot update your PHP yourself, you can send an email to your host. We have examples here. If they don\'t want to upgrade your PHP version, we recommend switching hosts. Take a look at our list of recommended WordPress hosting partners, they\'ve been vetted by the Yoast support team and offer all the features a modern host should have.', 'wordpress-seo' ) ) . '<br />';
 
 		return implode( $message, "\n" );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -538,6 +538,9 @@ class WPSEO_Upgrade {
 		global $wpdb;
 		// We've moved the cornerstone checkbox to our proper namespace.
 		$wpdb->query( "UPDATE $wpdb->postmeta SET meta_key = '_yoast_wpseo_is_cornerstone' WHERE meta_key = '_yst_is_cornerstone'" );
+
+		// Remove the previous Whip dismissed message, as this is a new one regarding PHP 5.2.
+		delete_option( 'whip_dismiss_timestamp' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds messages to the admin regarding our ongoing policy in terms of PHP 5.2 support.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch on a system running PHP 5.2 or lower.
* Login to the admin and see that there's a notification at the top of the screen.
* Navigate to SEO -> Dashboard and see an additional message in the Notification Center.

If you cannot run a version of PHP that is old enough, you can alter your currently running version on line 77 of `class-admin-utils.php` by altering the following:

```
$checker = new Whip_RequirementsChecker( array( 'php' => PHP_VERSION ) );
```
to
```
$checker = new Whip_RequirementsChecker( array( 'php' => '5.2' ) );
```


## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9466 
