### PR TITLE
9059 sitemap error with different wp content url

### DIFF
--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -339,7 +339,7 @@ class WPSEO_Sitemaps_Renderer {
 			return home_url( 'main-sitemap.xsl' );
 		}
 
-		//Check if plugin url is not loaded from a different domain.
+		//Fallback in case the plugin url is on a different (sub)domain.
 		if ( strpos( plugins_url(), home_url() ) !== 0 ) {
 			return home_url( 'main-sitemap.xsl' );
 		}

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -339,7 +339,7 @@ class WPSEO_Sitemaps_Renderer {
 			return home_url( 'main-sitemap.xsl' );
 		}
 
-		//Fallback in case the plugin url is on a different (sub)domain.
+		// Fallback in case the plugin url is on a different (sub)domain.
 		if ( strpos( plugins_url(), home_url() ) !== 0 ) {
 			return home_url( 'main-sitemap.xsl' );
 		}

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -339,6 +339,11 @@ class WPSEO_Sitemaps_Renderer {
 			return home_url( 'main-sitemap.xsl' );
 		}
 
+		//Check if plugin url is not loaded from a different domain.
+		if ( strpos( plugins_url(), home_url() ) !== 0 ) {
+			return home_url( 'main-sitemap.xsl' );
+		}
+
 		return plugin_dir_url( WPSEO_FILE ) . 'css/main-sitemap.xsl';
 	}
 }

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -339,7 +339,7 @@ class WPSEO_Sitemaps_Renderer {
 			return home_url( 'main-sitemap.xsl' );
 		}
 
-		// Fallback in case the plugin url is on a different (sub)domain.
+		// Fallback to circumvent a cross-domain security problem when the XLS file is loaded from a different (sub)domain.
 		if ( strpos( plugins_url(), home_url() ) !== 0 ) {
 			return home_url( 'main-sitemap.xsl' );
 		}

--- a/tests/doubles/class-sitemaps-renderer-double.php
+++ b/tests/doubles/class-sitemaps-renderer-double.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Sitemaps_Renderer_Double extends WPSEO_Sitemaps_Renderer {
+
+	/**
+	 * Returns the XSL URL
+	 *
+	 * @return string
+	 */
+	public function get_xsl_url() {
+		return parent::get_xsl_url();
+	}
+}

--- a/tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -76,6 +76,23 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 		$this->assertContains( "<image:title><![CDATA[{$title}]]></image:title>", $index );
 		$this->assertContains( "<image:caption><![CDATA[{$alt}]]></image:caption>", $index );
 	}
+
+	/**
+	 * Tests getting the fallback url if the plugin is loaded from a different domain.
+	 *
+	 * @covers WPSEO_Sitemaps_Renderer_Double::get_xsl_url()
+	 */
+	public function test_is_home_url_returned_correctly() {
+		$class_instance = new WPSEO_Sitemaps_Renderer_Double();
+
+		function change_plugin_url() {
+			return 'http://test.com/wp-content/plugins';
+		}
+
+		add_filter( 'plugins_url', 'change_plugin_url' );
+
+		$this->assertEquals( 'http://example.org/main-sitemap.xsl', $class_instance->get_xsl_url() );
+	}
 }
 
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -78,6 +78,13 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Helper function to set plugin url to a different domain.
+	 */
+	public function change_plugin_url() {
+		return 'http://test.com/wp-content/plugins';
+	}
+
+	/**
 	 * Tests getting the fallback url if the plugin is loaded from a different domain.
 	 *
 	 * @covers WPSEO_Sitemaps_Renderer_Double::get_xsl_url()
@@ -85,14 +92,12 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 	public function test_is_home_url_returned_correctly() {
 		$class_instance = new WPSEO_Sitemaps_Renderer_Double();
 
-		function change_plugin_url() {
-			return 'http://test.com/wp-content/plugins';
-		}
-
-		add_filter( 'plugins_url', 'change_plugin_url' );
-
+		add_filter( 'plugins_url', array ($this, 'change_plugin_url') );
 		$this->assertEquals( 'http://example.org/main-sitemap.xsl', $class_instance->get_xsl_url() );
+		remove_filter('plugins_url', array ($this, 'change_plugin_url'));
 	}
+
+
 }
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where loading the WordPress content directory from a different domain blocked the XML sitemap from loading. 

## Relevant technical choices:

* Added an additional check in the fallback. 

## Test instructions

This PR can be tested by following these steps:

* Reproduce the original issue by:
Changing your WP content dir in wp-config.php. This can be done by adding the following line:
`define( 'WP_CONTENT_URL',   'http://example.test/wp-content' );`
It's important this is a different site than the one you're testing from. If you get errors loading the plugin make sure both sites have the same version of the plugin installed. 
* Go to your XML sitemap and see the page in blank with a 'Unsafe attempt to load URL' message in the console.
* Switch to the fixed version and the XML sitemap should load correctly.  

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9059 
