### PR TITLE
When the given argument is not an array, just make it an array

### DIFF
--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -104,9 +104,9 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 */
 	public function add_weekly_schedule( $schedules ) {
 		if ( ! is_array( $schedules ) ) {
-			return $schedules;
+			$schedules = array();
 		}
-		
+
 		$schedules['weekly'] = array(
 			'interval' => WEEK_IN_SECONDS,
 			'display'  => __( 'Once Weekly', 'wordpress-seo' ),

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -102,7 +102,11 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 *
 	 * @return array Enriched list of schedules.
 	 */
-	public function add_weekly_schedule( array $schedules ) {
+	public function add_weekly_schedule( $schedules ) {
+		if ( ! is_array( $schedules ) ) {
+			return $schedules;
+		}
+		
 		$schedules['weekly'] = array(
 			'interval' => WEEK_IN_SECONDS,
 			'display'  => __( 'Once Weekly', 'wordpress-seo' ),

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -49,8 +49,18 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( array_key_exists( 'weekly', $schedules ) );
 		$this->assertEquals( $schedules['weekly']['interval'], WEEK_IN_SECONDS );
 		$this->assertEquals( $schedules['weekly']['display'], __( 'Once Weekly', 'wordpress-seo' ) );
+	}
+	/**
+	 * Test if the weekly schedule is added to wp_get_schedules.
+	 *
+	 * @see https://github.com/Yoast/wordpress-seo/issues/9450
+	 * @see https://github.com/Yoast/wordpress-seo/issues/9475
+	 *
+	 * @covers WPSEO_OnPage::add_weekly_schedule
+	 */
+	public function test_add_weekly_schedule_with_invalid_filter_input() {
+		$this->class_instance->register_hooks();
 
-		// Test with invalid filter output.
 		add_filter( 'cron_schedules', '__return_false', 1 );
 
 		$schedules = wp_get_schedules();

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -49,6 +49,17 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( array_key_exists( 'weekly', $schedules ) );
 		$this->assertEquals( $schedules['weekly']['interval'], WEEK_IN_SECONDS );
 		$this->assertEquals( $schedules['weekly']['display'], __( 'Once Weekly', 'wordpress-seo' ) );
+
+		// Test with invalid filter output.
+		add_filter( 'cron_schedules', '__return_false', 1 );
+
+		$schedules = wp_get_schedules();
+
+		$this->assertTrue( array_key_exists( 'weekly', $schedules ) );
+		$this->assertEquals( $schedules['weekly']['interval'], WEEK_IN_SECONDS );
+		$this->assertEquals( $schedules['weekly']['display'], __( 'Once Weekly', 'wordpress-seo' ) );
+
+		remove_filter( 'cron_schedules', '__return_false', 1 );
 	}
 
 	/**

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -50,6 +50,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $schedules['weekly']['interval'], WEEK_IN_SECONDS );
 		$this->assertEquals( $schedules['weekly']['display'], __( 'Once Weekly', 'wordpress-seo' ) );
 	}
+
 	/**
 	 * Test if the weekly schedule is added to wp_get_schedules.
 	 *


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a non-array value causes a fatal error when `cron_schedules` filter has been executed.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk
* Add a filter `cron_schedules` with high prio that returns an boolean.
```php
add_filter( 'cron_schedules', '__return_false', 1 );
```
* Call the method `wp_get_schedules();`
```php
add_action( 'admin_init', function() {
    print_r( wp_get_schedules() );
   exit;
} );
```
* See a fatal error being shown.
* Checkout this branch and follow the steps mentioned before. The error should be gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9450
Fixes #9475