### PR TITLE
Register store to Gutenberg if available

### DIFF
--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -9,17 +9,11 @@ import { Provider } from "react-redux";
 import flowRight from "lodash/flowRight";
 
 import IntlProvider from "./components/IntlProvider";
-import markerStatusReducer from "./redux/reducers/markerButtons";
-import keywordsReducer from "./redux/reducers/keywords";
-import analysisReducer from "yoast-components/composites/Plugin/ContentAnalysis/reducers/contentAnalysisReducer";
-import activeKeywordReducer from "./redux/reducers/activeKeyword";
-import activeTab from "./redux/reducers/activeTab";
 import AnalysisSection from "./components/contentAnalysis/AnalysisSection";
 import Data from "./analysis/data.js";
 import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 import SnippetPreviewSection from "./components/SnippetPreviewSection";
-import openSidebarSectionsReducer from "./redux/reducers/openSidebarSections";
-import cornerstoneContentReducer from "./redux/reducers/cornerstoneContent";
+import reducers from "./redux/reducers";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
 let localizedData = { intl: {} };
@@ -27,6 +21,19 @@ if( window.wpseoPostScraperL10n ) {
 	localizedData = wpseoPostScraperL10n;
 } else if ( window.wpseoTermScraperL10n ) {
 	localizedData = wpseoTermScraperL10n;
+}
+
+/**
+ * Registers a redux store to Gutenberg.
+ *
+ * @returns {store} The store.
+ */
+function registerStore() {
+	const { combineReducers, registerStore } = wp.data;
+
+	return registerStore( "yoast-seo/editor", {
+		reducer: combineReducers( reducers ),
+	} );
 }
 
 /**
@@ -51,17 +58,11 @@ function configureStore() {
 		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
 	}
 
-	const rootReducer = combineReducers( {
-		marksButtonStatus: markerStatusReducer,
-		keywords: keywordsReducer,
-		openSidebarSections: openSidebarSectionsReducer,
-		analysis: analysisReducer,
-		activeKeyword: activeKeywordReducer,
-		isCornerstone: cornerstoneContentReducer,
-		activeTab,
-	} );
+	if ( isGutenbergDataAvailable() ) {
+		return registerStore();
+	}
 
-	return createStore( rootReducer, {}, flowRight( enhancers ) );
+	return createStore( combineReducers( reducers ), {}, flowRight( enhancers ) );
 }
 
 /**

--- a/js/src/redux/actions/index.js
+++ b/js/src/redux/actions/index.js
@@ -1,0 +1,15 @@
+import * as activeKeyword from "./activeKeyword";
+import * as activeTab from "./activeTab";
+import * as cornerstoneContent from "./cornerstoneContent";
+import * as keywords from "./keywords";
+import * as markerButtons from "./markerButtons";
+import * as openSidebarSections from "./openSidebarSections";
+
+export default {
+	activeKeyword,
+	activeTab,
+	cornerstoneContent,
+	keywords,
+	markerButtons,
+	openSidebarSections,
+};

--- a/js/src/redux/reducers/index.js
+++ b/js/src/redux/reducers/index.js
@@ -1,0 +1,18 @@
+import analysis from "yoast-components/composites/Plugin/ContentAnalysis/reducers/contentAnalysisReducer";
+
+import activeKeyword from "./activeKeyword";
+import activeTab from "./activeTab";
+import isCornerstone from "./cornerstoneContent";
+import keywords from "./keywords";
+import marksButtonStatus from "./markerButtons";
+import openSidebarSections from "./openSidebarSections";
+
+export default {
+	analysis,
+	activeKeyword,
+	activeTab,
+	isCornerstone,
+	keywords,
+	marksButtonStatus,
+	openSidebarSections,
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Use Gutenberg to register the store, if the Gutenberg data is available.
* Added an index file to the redux actions & reducers for easy importing.
* For the actions we would need to determine which actions should be exposed to plugins. At this time I did not add any.

## Test instructions

This PR can be tested by following these steps:

* Go to a post in the classic editor and test if the store still functions as normal.
* Go to a post in the Gutenberg editor and test if the store still functions as normal.

## Quality assurance

* [x] I have tested this code to the best of my abilities
~~* [ ] I have added unittests to verify the code works as intended~~

Fixes #9496
