### PR TITLE
Remove cache validators on upgrade routine

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -103,6 +103,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_73();
 		}
 
+		if ( version_compare( $version, '7.4-RC0', '<' ) ) {
+			$this->upgrade_74();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -541,6 +545,29 @@ class WPSEO_Upgrade {
 
 		// Remove the previous Whip dismissed message, as this is a new one regarding PHP 5.2.
 		delete_option( 'whip_dismiss_timestamp' );
+	}
+
+	/**
+	 * Performs the 7.4 upgrade.
+	 *
+	 * @return void
+	 */
+	private function upgrade_74() {
+		$this->remove_sitemap_validators();
+	}
+
+	/**
+	 * Removes all sitemap validators.
+	 *
+	 * This should be executed on every upgrade routine until we have removed the sitemap caching in the database.
+	 *
+	 * @return void
+	 */
+	private function remove_sitemap_validators() {
+		global $wpdb;
+
+		// Remove all sitemap validators.
+		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'wpseo_sitemap%validator%'" );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Clears all existing cache validator entries from the database. This is a small step towards removing the cache from the database entirely.

## Relevant technical choices:

* Created a separate method, to use on the following release as well if the caching has not be removed at the moment of the upcoming RC.

## Test instructions

This PR can be tested by following these steps:

* Before checking out the branch
* Visit the sitemaps
* Open the database and go to the `wp_options` table
* Search for `option_name LIKE 'wpseo_sitemap%validator%'`
* See entries being present
* Check out the branch
* Reload a page, to make sure the upgrade routine has been triggered
* Reload the database, see the entries being removed or updated

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #9491 
