### PR TITLE
Setup webpack config for the snippet editor

### DIFF
--- a/webpack/webpack.config.default.js
+++ b/webpack/webpack.config.default.js
@@ -19,12 +19,13 @@ const defaultWebpackConfig = {
 		jsonpFunction: "yoastWebpackJsonp",
 	},
 	resolve: {
-		extensions: [ ".js", ".jsx" ],
+		extensions: [ ".json", ".js", ".jsx" ],
 	},
 	module: {
 		rules: [
 			{
 				test: /.jsx?$/,
+				exclude: /node_modules\/(?!(yoast-components)\/).*/,
 				use: [
 					{
 						loader: "babel-loader",
@@ -38,6 +39,10 @@ const defaultWebpackConfig = {
 						loader: "svg-react-loader",
 					},
 				],
+			},
+			{
+				test: /\.json$/,
+				use: [ "json-loader" ],
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _not applicable_

## Relevant technical choices:

This excludes all packages from babel parsing except yoast-components. That makes the build faster and also prevents DraftJS from including a bunch of packages for which we don't have the correct babel plugins and presets.

I also included JSON files in the webpack config, because we need that in yoast-components. And it is just nice to be able to load json files.

## Test instructions

This PR can be tested by following these steps:

* Make sure all the JavaScript still compiles as expected.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended