### PR TITLE
Bumped version for the PHP 5.2 support drop to 7.7

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -422,8 +422,8 @@ class WPSEO_Admin_Init {
 			__( '%1$sAction is needed%2$s: As of version %3$s, due to be released on %4$s, Yoast SEO will no longer work with PHP %5$s. Unfortunately, your site is running on PHP %5$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
 			'<strong>',
 			'</strong>',
-			'7.5',
-			date_i18n( get_option( 'date_format' ), strtotime( '15-05-2018' ) ),
+			'7.7',
+			date_i18n( get_option( 'date_format' ), strtotime( '11-06-2018' ) ),
 			'5.2'
 		);
 

--- a/admin/class-unsupported-php-message.php
+++ b/admin/class-unsupported-php-message.php
@@ -25,8 +25,8 @@ class WPSEO_Unsupported_PHP_Message implements Whip_Message {
 					__( '%1$sAction is needed%2$s: As of version %3$s, due to be released on %4$s, Yoast SEO will no longer work with PHP %5$s. Unfortunately, your site is running on PHP %5$s right now, so action is needed. Thankfully, you can update your PHP yourself.', 'wordpress-seo' ),
 					'<strong>',
 					'</strong>',
-					'7.5',
-					date_i18n( get_option( 'date_format' ), strtotime( '15-05-2018' ) ),
+					'7.7',
+					date_i18n( get_option( 'date_format' ), strtotime( '11-06-2018' ) ),
 					'5.2'
 				)
 			) . '<br />';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Alters the copy for the PHP 5.2 support message from 7.5, to 7.7. Additionally, the dates in the copy have been altered as well.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Trigger the PHP upgrade notice (as per instructions in https://github.com/Yoast/wordpress-seo/pull/9467).
* Notice the copy has been altered.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9515 
