### PR TITLE
Remove obsolete assessments from taxonomy assessor

### DIFF
--- a/js/src/assessors/taxonomyAssessor.js
+++ b/js/src/assessors/taxonomyAssessor.js
@@ -3,14 +3,11 @@ var Assessor = require( "yoastseo/js/assessor.js" );
 var introductionKeyword = require( "yoastseo/js/assessments/seo/introductionKeywordAssessment.js" );
 var keyphraseLength = require( "yoastseo/js/assessments/seo/keyphraseLengthAssessment.js" );
 var keywordDensity = require( "yoastseo/js/assessments/seo/keywordDensityAssessment.js" );
-var keywordStopWords = require( "yoastseo/js/assessments/seo/keywordStopWordsAssessment.js" );
 var metaDescriptionKeyword = require( "yoastseo/js/assessments/seo/metaDescriptionKeywordAssessment.js" );
 var MetaDescriptionLength = require( "yoastseo/js/assessments/seo/metaDescriptionLengthAssessment.js" );
 var titleKeyword = require( "yoastseo/js/assessments/seo/titleKeywordAssessment.js" );
 var TitleWidth = require( "yoastseo/js/assessments/seo/pageTitleWidthAssessment.js" );
 var UrlKeyword = require( "yoastseo/js/assessments/seo/urlKeywordAssessment.js" );
-var UrlLength = require( "yoastseo/js/assessments/seo/urlLengthAssessment.js" );
-var urlStopWords = require( "yoastseo/js/assessments/seo/urlStopWordsAssessment.js" );
 var TextLength = require( "yoastseo/js/assessments/seo/textLengthAssessment.js" );
 
 /**
@@ -26,14 +23,11 @@ var TaxonomyAssessor = function( i18n ) {
 		introductionKeyword,
 		keyphraseLength,
 		keywordDensity,
-		keywordStopWords,
 		metaDescriptionKeyword,
 		new MetaDescriptionLength(),
 		titleKeyword,
 		new TitleWidth(),
 		new UrlKeyword(),
-		new UrlLength(),
-		urlStopWords,
 		new TextLength( {
 			recommendedMinimum: 250,
 			slightlyBelowMinimum: 200,

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -55,21 +55,6 @@ describe ( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a keyword with a stopword", function() {
-		assessor.assess( new Paper( "text", { keyword: "the keyword" } ) );
-		let AssessmentResults = assessor.getValidResults();
-		let assessments = getResults( AssessmentResults );
-
-		expect( assessments ).toEqual( [
-			"introductionKeyword",
-			"keywordStopWords",
-			"metaDescriptionLength",
-			"titleKeyword",
-			"titleWidth",
-			"textLength"
-		] );
-	} );
-
 	it( "additionally runs assessments that require a url", function() {
 		assessor.assess( new Paper( "text", { url: "sample url" } ) );
 		let AssessmentResults = assessor.getValidResults();
@@ -79,34 +64,6 @@ describe ( "running assessments in the assessor", function() {
 			"keyphraseLength",
 			"metaDescriptionLength",
 			"titleWidth",
-			"textLength"
-		] );
-	} );
-
-	it( "additionally runs assessments that require a url that is too long", function() {
-		assessor.assess( new Paper( "text", { url: "12345678901234567890123456789012345678901" } ) );
-		let AssessmentResults = assessor.getValidResults();
-		let assessments = getResults( AssessmentResults );
-
-		expect( assessments ).toEqual( [
-			"keyphraseLength",
-			"metaDescriptionLength",
-			"titleWidth",
-			"urlLength",
-			"textLength"
-		] );
-	} );
-
-	it( "additionally runs assessments that require a url with a stopword", function() {
-		assessor.assess( new Paper( "text", { url: "the sample url" } ) );
-		let AssessmentResults = assessor.getValidResults();
-		let assessments = getResults( AssessmentResults );
-
-		expect( assessments ).toEqual( [
-			"keyphraseLength",
-			"metaDescriptionLength",
-			"titleWidth",
-			"urlStopWords",
 			"textLength"
 		] );
 	} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the URL length assessment, the stopword in URL assessment, and the stopword in keyword assessment from the taxonomy assessor. These assessments have become obsolete.

## Test instructions

This PR can be tested by following these steps:

* Check out the branch. Don't forget to run `grunt build:js`.
* Add a new category in `Posts > Categories`.
* Make your slug very long, e.g. `new-very-very-very-very-very-very-lengthy-url`. Make sure no feedback is triggered.
* Add a stopword (e.g. `the`) in your slug. Make sure no feedback is triggered.
* Add a stopword (e.g. `the`) in your focus keyword. Make sure no feedback is triggered.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended - N.A. – only removed code

Fixes #9512 
