### PR TITLE
Add ESLinting to tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,9 @@ module.exports = function( grunt ) {
 			js: [
 				"js/src/**/*.js",
 			],
+			jsTests: [
+				"js/tests/**/*.js",
+			],
 			php: [
 				"*.php",
 				"admin/**/*.php",

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -6,6 +6,12 @@ module.exports = {
 			maxWarnings: 100,
 		},
 	},
+	tests: {
+		src: [ "<%= files.jsTests %>" ],
+		options: {
+			fix: true,
+		}
+	},
 	grunt: {
 		src: [ "<%= files.grunt %>", "<%= files.config %>" ],
 		options: {

--- a/js/tests/.eslintrc
+++ b/js/tests/.eslintrc
@@ -1,0 +1,6 @@
+env:
+  jest: true
+
+rules:
+  react/display-name: 0
+  no-undefined: 0

--- a/js/tests/data.test.js
+++ b/js/tests/data.test.js
@@ -17,8 +17,8 @@ mockSelect.mockReturnValue( { getEditedPostAttribute: mockGetEditedPostAttribute
 
 data._wpData.select = mockSelect;
 
-describe( 'setRefresh', () => {
-	it( 'sets the refresh function', () => {
+describe( "setRefresh", () => {
+	it( "sets the refresh function", () => {
 		const expected = () => {
 			return "refresh";
 		};
@@ -29,8 +29,8 @@ describe( 'setRefresh', () => {
 	} );
 } );
 
-describe( 'isShallowEqual', () => {
-	it( 'returns true if two objects contain the same key value pairs', () => {
+describe( "isShallowEqual", () => {
+	it( "returns true if two objects contain the same key value pairs", () => {
 		const object1 = {
 			key1: "value1",
 			key2: "value2",
@@ -42,7 +42,7 @@ describe( 'isShallowEqual', () => {
 		const actual = data.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( true );
 	} );
-	it( 'returns false if two objects contain the same keys but 1 value differs', () => {
+	it( "returns false if two objects contain the same keys but 1 value differs", () => {
 		const object1 = {
 			key1: "value1",
 			key2: "value2",
@@ -54,7 +54,7 @@ describe( 'isShallowEqual', () => {
 		const actual = data.isShallowEqual( object1, object2 );
 		expect( actual ).toBe( false );
 	} );
-	it( 'returns false if two objects don\'t contain the same keys value pairs', () => {
+	it( "returns false if two objects don't contain the same keys value pairs", () => {
 		const object1 = {
 			key1: "value1",
 			key2: "value2",
@@ -68,15 +68,15 @@ describe( 'isShallowEqual', () => {
 	} );
 } );
 
-describe( 'getPostAttribute', () => {
-	it( 'gets the post attribute', () => {
+describe( "getPostAttribute", () => {
+	it( "gets the post attribute", () => {
 		data.getPostAttribute( "content" );
 		expect( mockGetEditedPostAttribute ).toBeCalledWith( "content" );
 	} );
 } );
 
-describe( 'collectGutenbergData', () => {
-	it( 'collects the GutenbergData', () => {
+describe( "collectGutenbergData", () => {
+	it( "collects the GutenbergData", () => {
 		const retriever = ( attribute ) => {
 			return attribute;
 		};
@@ -92,12 +92,12 @@ describe( 'collectGutenbergData', () => {
 	} );
 } );
 
-describe( 'refreshYoastSEO', () => {
+describe( "refreshYoastSEO", () => {
 	/*
 		After the first call of collectGutenbergData in refreshYoastSEO, the Gutenberg data is always dirty,
 		because data is initially an empty object.
 	*/
-	it( 'refreshes YoastSEO when the Gutenberg data is dirty', () => {
+	it( "refreshes YoastSEO when the Gutenberg data is dirty", () => {
 		const mockRefresh = jest.fn();
 		data._refresh = mockRefresh;
 		data.refreshYoastSEO();
@@ -108,7 +108,7 @@ describe( 'refreshYoastSEO', () => {
 		After collectGutenbergData is called a second time, and nothing has changed,
 		the data isn't dirty and the refresh function shouldn't be called.
 	*/
-	it( 'doesn\'t refresh YoastSEO when the Gutenberg data is not dirty', () => {
+	it( "doesn't refresh YoastSEO when the Gutenberg data is not dirty", () => {
 		const mockRefresh2 = jest.fn();
 		data._refresh = mockRefresh2;
 		data.refreshYoastSEO();
@@ -116,8 +116,8 @@ describe( 'refreshYoastSEO', () => {
 	} );
 } );
 
-describe( 'getData', () => {
-	it( 'returns the data', () => {
+describe( "getData", () => {
+	it( "returns the data", () => {
 		data.data = { content: "this is the content" };
 		const actual = data.getData();
 		const expected = { content: "this is the content" };

--- a/js/tests/edit.test.js
+++ b/js/tests/edit.test.js
@@ -2,8 +2,8 @@ import initialize from "../src/edit.js";
 
 jest.mock( "react-dom" );
 
-describe( 'initialize', () => {
-	it( 'initializes all functionality on the edit screen', () => {
+describe( "initialize", () => {
+	it( "initializes all functionality on the edit screen", () => {
 		window.wpseoPostScraperL10n = {
 			intl: {
 				locale: "en_EN",

--- a/js/tests/isGutenbergDataAvailable.test.js
+++ b/js/tests/isGutenbergDataAvailable.test.js
@@ -1,17 +1,17 @@
 import isGutenbergDataAvailable from "../src/helpers/isGutenbergDataAvailable.js";
 
-describe( 'isGutenbergDataAvailable', () => {
-	it( 'returns true if both wp and wp.data are defined', () => {
+describe( "isGutenbergDataAvailable", () => {
+	it( "returns true if both wp and wp.data are defined", () => {
 		window.wp = { data: true };
 		const actual = isGutenbergDataAvailable();
 		expect( actual ).toBe( true );
 	} );
-	it( 'returns false if wp.data is not defined', () => {
+	it( "returns false if wp.data is not defined", () => {
 		window.wp = { something: true };
 		const actual = isGutenbergDataAvailable();
 		expect( actual ).toBe( false );
 	} );
-	it( 'returns false if wp is not defined', () => {
+	it( "returns false if wp is not defined", () => {
 		window.wp = undefined;
 		const actual = isGutenbergDataAvailable();
 		expect( actual ).toBe( false );

--- a/js/tests/shortcode-plugin.test.js
+++ b/js/tests/shortcode-plugin.test.js
@@ -1,10 +1,10 @@
-import shortCodePlugin from "../src/wp-seo-shortcode-plugin";
+import "../src/wp-seo-shortcode-plugin";
 
 const { YoastShortcodePlugin } = window;
 const { removeUnknownShortCodes } = YoastShortcodePlugin.prototype;
 
-describe( 'removeUnknownShortcodes', () => {
-	it( 'filters undefined shortcodes', () => {
+describe( "removeUnknownShortcodes", () => {
+	it( "filters undefined shortcodes", () => {
 		const input = "[shortcode]Hello[/shortcode]";
 		const expected = "Hello";
 
@@ -13,12 +13,23 @@ describe( 'removeUnknownShortcodes', () => {
 		expect( actual ).toBe( expected );
 	} );
 
-	it( 'filters shortcodes with special characters', () => {
-		const input = '<p>[vc_row][vc_column][vc_column_text css_animation="bounceInLeft" el_class="tøüst123" css=".vc_custom_1482153765626{margin-right: 4px !important;border-right-width: 2px !important;padding-right: 1px !important;background-color: #777777 !important;border-right-style: dashed !important;border-radius: 10px !important;}"]I am text blöck. Click edit button to change this text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.[/vc_column_text][/vc_column][/vc_row]</p>';
-		const expected = "<p>I am text blöck. Click edit button to change this text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.</p>";
+	it( "filters shortcodes with special characters", () => {
+		const input = "<p>" +
+			"[vc_row]" +
+				"[vc_column]" +
+					"[vc_column_text" +
+						' css_animation="bounceInLeft"' +
+						' el_class="tøüst123"' +
+						' css=".vc_custom_1482153765626{margin-right: 4px !important;}"]' +
+						"This is the text that needs to be preserved." +
+					"[/vc_column_text]" +
+				"[/vc_column]" +
+			"[/vc_row]" +
+		"</p>";
+		const expected = "<p>This is the text that needs to be preserved.</p>";
 
 		const actual = removeUnknownShortCodes( input );
 
 		expect( actual ).toBe( expected );
 	} );
-});
+} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _not applicable_

## Relevant technical choices:

* Enabled Jest environment in the tests, for obvious reasons.
* Using `undefined` in tests is really useful, so disabling the rule that disallows it.
* Having anonymous React components is useful during mocking, so disabling the rule that requires a display name in the tests.

## Test instructions

This PR can be tested by following these steps:

Scenario 1

* Run `grunt check` and see that the JS tests are now linted.

Scenario 2

* Change something in the tests so it violates our linting rules.
* Run `grunt check` and see that it fails.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended