### PR TITLE
Add support for multisite-only or single site-only unit tests

### DIFF
--- a/tests/framework/class-wpseo-unit-test-case.php
+++ b/tests/framework/class-wpseo-unit-test-case.php
@@ -72,7 +72,6 @@ abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 	 * This is a custom extension of the PHPUnit and WordPress requirements handling.
 	 */
 	protected function checkRequirements() {
-
 		parent::checkRequirements();
 
 		$annotations = $this->getAnnotations();

--- a/tests/framework/class-wpseo-unit-test-case.php
+++ b/tests/framework/class-wpseo-unit-test-case.php
@@ -80,17 +80,21 @@ abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 		if ( ! empty( $annotations['class']['group'] ) ) {
 			$groups = array_merge( $groups, $annotations['class']['group'] );
 		}
+
 		if ( ! empty( $annotations['method']['group'] ) ) {
 			$groups = array_merge( $groups, $annotations['method']['group'] );
 		}
 
-		if ( ! empty( $groups ) ) {
-			if ( in_array( 'ms-required', $groups, true ) ) {
-				$this->skipWithoutMultisite();
-			}
-			if ( in_array( 'ms-excluded', $groups, true ) ) {
-				$this->skipWithMultisite();
-			}
+		if ( empty( $groups ) ) {
+			return;
+		}
+
+		if ( in_array( 'ms-required', $groups, true ) ) {
+			$this->skipWithoutMultisite();
+		}
+
+		if ( in_array( 'ms-excluded', $groups, true ) ) {
+			$this->skipWithMultisite();
 		}
 	}
 }

--- a/tests/framework/class-wpseo-unit-test-case.php
+++ b/tests/framework/class-wpseo-unit-test-case.php
@@ -65,4 +65,33 @@ abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 			$this->assertTrue( $found !== false, sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
 		}
 	}
+
+	/**
+	 * Allows tests to be skipped on single or multisite installs by using @group annotations.
+	 *
+	 * This is a custom extension of the PHPUnit and WordPress requirements handling.
+	 */
+	protected function checkRequirements() {
+
+		parent::checkRequirements();
+
+		$annotations = $this->getAnnotations();
+
+		$groups = array();
+		if ( ! empty( $annotations['class']['group'] ) ) {
+			$groups = array_merge( $groups, $annotations['class']['group'] );
+		}
+		if ( ! empty( $annotations['method']['group'] ) ) {
+			$groups = array_merge( $groups, $annotations['method']['group'] );
+		}
+
+		if ( ! empty( $groups ) ) {
+			if ( in_array( 'ms-required', $groups, true ) ) {
+				$this->skipWithoutMultisite();
+			}
+			if ( in_array( 'ms-excluded', $groups, true ) ) {
+				$this->skipWithMultisite();
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* This change allows unit tests to use `ms-required` or `ms-excluded` as group annotations, with the effect that the test will only be executed with or without multisite respectively. Otherwise, the test will be marked as skipped. That is an established pattern core uses for their multisite tests.

## Relevant technical choices:

* While core performs these checks, they are depending on other environments and PHPUnit versions than we are, so the `checkRequirements()` method used by PHPUnit and core needs to be overridden. PHPUnit's `Testcase::getAnnotations()` method returns an array with `class` and `method` keys, where both have a `group` key. If any of those groups contain one of the two groups we're looking for here, the test is skipped accordingly if necessary.

## Test instructions

This PR can be tested by following these steps:

* #9538 contains the first multisite-only tests for the plugin and uses those annotations. However, the multisite-only tests are still executed on non-multisite environments. When merging this PR into that PR, those tests should be skipped correctly.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9544 
