### PR TITLE
Changed 'Dashboard' into 'General' in Admin menu

### DIFF
--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -262,7 +262,7 @@ function wpseo_admin_bar_menu() {
 		$wp_admin_bar->add_menu( array(
 			'parent' => 'wpseo-settings',
 			'id'     => 'wpseo-general',
-			'title'  => __( 'Dashboard', 'wordpress-seo' ),
+			'title'  => __( 'General', 'wordpress-seo' ),
 			'href'   => admin_url( 'admin.php?page=wpseo_dashboard' ),
 		) );
 		$wp_admin_bar->add_menu( array(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Renamed 'Dashboard' to 'General' in admin bar to match naming in side bar. 

## Test instructions

This PR can be tested by following these steps:

* Look under 'SEO Settings' in the admin bar (top of the screen) and see that 'Dashboard' is now named 'General'

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9543 
