### PR TITLE
Allow accessing multisite options via `WPSEO_Options::get()`

### DIFF
--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -228,6 +228,7 @@ class WPSEO_Options {
 		self::$backfill->remove_hooks();
 
 		$option = self::get_all();
+		$option = self::add_ms_option( $option );
 
 		self::$backfill->register_hooks();
 
@@ -451,6 +452,22 @@ class WPSEO_Options {
 		$saved_option = self::get_option( $wpseo_options_group_name );
 
 		return $saved_option[ $option_name ] === $options[ $option_name ];
+	}
+
+	/**
+	 * Adds the multisite options to the option stack if relevant.
+	 *
+	 * @param array $option The currently present options settings.
+	 *
+	 * @return array Options possible including multisite.
+	 */
+	protected static function add_ms_option( $option ) {
+		if ( ! is_multisite() ) {
+			return $option;
+		}
+
+		$ms_option = self::get_option( 'wpseo_ms' );
+		return array_merge( $option, $ms_option );
 	}
 
 	/**

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -459,7 +459,7 @@ class WPSEO_Options {
 	 *
 	 * @param array $option The currently present options settings.
 	 *
-	 * @return array Options possible including multisite.
+	 * @return array Options possibly including multisite.
 	 */
 	protected static function add_ms_option( $option ) {
 		if ( ! is_multisite() ) {
@@ -467,6 +467,7 @@ class WPSEO_Options {
 		}
 
 		$ms_option = self::get_option( 'wpseo_ms' );
+
 		return array_merge( $option, $ms_option );
 	}
 

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -181,4 +181,36 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 			$keys = array_merge( $keys, $option_keys );
 		}
 	}
+
+	/**
+	 * Tests that multisite options are available via WPSEO_Options::get() in multisite.
+	 *
+	 * @group ms-required
+	 *
+	 * @covers WPSEO_Options::get()
+	 * @covers WPSEO_Options::add_ms_option()
+	 */
+	public function test_ms_options_included_in_get_in_multisite() {
+		$ms_options = WPSEO_Options::get_option( 'wpseo_ms' );
+
+		foreach ( $ms_options as $key => $value ) {
+			$this->assertEquals( $value, WPSEO_Options::get( $key ) );
+		}
+	}
+
+	/**
+	 * Tests that multisite options are not available via WPSEO_Options::get() in non-multisite.
+	 *
+	 * @group ms-excluded
+	 *
+	 * @covers WPSEO_Options::get()
+	 * @covers WPSEO_Options::add_ms_option()
+	 */
+	public function test_ms_options_excluded_in_get_non_multisite() {
+		$ms_option_keys = array_keys( WPSEO_Options::get_option( 'wpseo_ms' ) );
+
+		foreach ( $ms_option_keys as $key ) {
+			$this->assertNull( WPSEO_Options::get( $key ) );
+		}
+	}
 }

--- a/tests/inc/options/test-class-wpseo-options.php
+++ b/tests/inc/options/test-class-wpseo-options.php
@@ -191,10 +191,10 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::add_ms_option()
 	 */
 	public function test_ms_options_included_in_get_in_multisite() {
-		$ms_options = WPSEO_Options::get_option( 'wpseo_ms' );
+		$ms_option_keys = array( 'access', 'defaultblog' );
 
-		foreach ( $ms_options as $key => $value ) {
-			$this->assertEquals( $value, WPSEO_Options::get( $key ) );
+		foreach ( $ms_option_keys as $key ) {
+			$this->assertNotNull( WPSEO_Options::get( $key ) );
 		}
 	}
 
@@ -207,7 +207,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::add_ms_option()
 	 */
 	public function test_ms_options_excluded_in_get_non_multisite() {
-		$ms_option_keys = array_keys( WPSEO_Options::get_option( 'wpseo_ms' ) );
+		$ms_option_keys = array( 'access', 'defaultblog' );
 
 		foreach ( $ms_option_keys as $key ) {
 			$this->assertNull( WPSEO_Options::get( $key ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Ensures that multisite options can be retrieved via `WPSEO_Options::get()` in a multisite.

## Relevant technical choices:

* Since the methods called by `WPSEO_Options::get()` are deeply integrated with other functionality, the most risk-free approach was to manually make the changes in there.

## Test instructions

This PR can be tested by following these steps:

* In a multisite, call `WPSEO_Options::get( 'access' )` or `WPSEO_Options::get( 'defaultblog' )` in `functions.php` or similar, and verify that you get a possible value for the option back (i.e. not NULL).
* Do the same in a non-multisite, to make sure that those calls then return NULL and don't cause unexpected issues (like possibly calling multisite functions in a non-multisite context).

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9453 
