### PR TITLE
Move the Gutenberg register to the configuration page class

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -197,10 +197,6 @@ class WPSEO_Admin_Asset_Manager {
 			$backport_wp_dependencies[] = 'wp-element';
 			$backport_wp_dependencies[] = 'wp-data';
 
-			if ( ! wp_script_is( 'wp-element', 'registered' ) ) {
-				gutenberg_register_scripts_and_styles();
-			}
-
 			/*
 			 * The version of TinyMCE that Gutenberg uses is incompatible with
 			 * the one core uses. So we need to make sure that the core version

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -70,6 +70,10 @@ class WPSEO_Configuration_Page {
 	public function enqueue_assets() {
 		wp_enqueue_media();
 
+		if ( ! wp_script_is( 'wp-element', 'registered' ) ) {
+			gutenberg_register_scripts_and_styles();
+		}
+
 		/*
 		 * Print the `forms.css` WP stylesheet before any Yoast style, this way
 		 * it's easier to override selectors with the same specificity later.

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -70,7 +70,7 @@ class WPSEO_Configuration_Page {
 	public function enqueue_assets() {
 		wp_enqueue_media();
 
-		if ( ! wp_script_is( 'wp-element', 'registered' ) ) {
+		if ( ! wp_script_is( 'wp-element', 'registered' ) && function_exists( 'gutenberg_register_scripts_and_styles' ) ) {
 			gutenberg_register_scripts_and_styles();
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Move the Gutenberg register to fix them being loaded twice when not on the Configuration Wizard and using Gutenberg.

## Test instructions

This PR can be tested by following these steps:

* Check the Configuration Wizard!

## Quality assurance

* [x] I have tested this code to the best of my abilities
~~* [ ] I have added unittests to verify the code works as intended~~
