### PR TITLE
Add WP-CLI commands to manage redirects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,10 @@ script:
 - |
   if [[ "$PHPLINT" == "1" ]]; then
     travis_fold start "PHP.check" && travis_time_start
-    find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then
+      SKIP_CLI="-o -path ./cli -prune"
+    fi
+    find -L . -path ./vendor -prune -o -path ./node_modules -prune $SKIP_CLI -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     travis_time_finish && travis_fold end "PHP.check"
   fi
 # PHP CS

--- a/cli/class-cli-premium-requirement.php
+++ b/cli/class-cli-premium-requirement.php
@@ -4,6 +4,10 @@
  *
  * @package WPSEO\CLI
  */
+
+/**
+ * Enforce premium version requirement on commands covering premium features.
+ */
 final class WPSEO_CLI_Premium_Requirement {
 
 	/**

--- a/cli/class-cli-premium-requirement.php
+++ b/cli/class-cli-premium-requirement.php
@@ -13,6 +13,8 @@ final class WPSEO_CLI_Premium_Requirement {
 	/**
 	 * Enforces license requirements for commands representing premium
 	 * functionality.
+	 *
+	 * @return void
 	 */
 	public static function enforce() {
 		if ( WPSEO_Utils::is_yoast_seo_premium() ) {

--- a/cli/class-cli-premium-requirement.php
+++ b/cli/class-cli-premium-requirement.php
@@ -11,7 +11,7 @@
 final class WPSEO_CLI_Premium_Requirement {
 
 	/**
-	 * Enforce license requirements for commands representing premium
+	 * Enforces license requirements for commands representing premium
 	 * functionality.
 	 */
 	public static function enforce() {

--- a/cli/class-cli-premium-requirement.php
+++ b/cli/class-cli-premium-requirement.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+final class WPSEO_CLI_Premium_Requirement {
+
+	/**
+	 * Enforce license requirements for commands representing premium
+	 * functionality.
+	 */
+	public static function enforce() {
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			return;
+		}
+
+		// No premium commands allowed.
+		WP_CLI::error(
+			'This command can only be run with an active Yoast SEO Premium license.'
+		);
+	}
+}

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -91,7 +91,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	 * @return bool Whether a redirect for the given origin was found.
 	 */
 	protected function has_redirect( $origin ) {
-		return false !== $this->get_redirect( $origin );
+		return $this->get_redirect( $origin ) !== false;
 	}
 
 	/**
@@ -107,7 +107,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	 */
 	protected function validate( $new_origin, $target, $type, $format, $old_origin = null ) {
 		$new_redirect = new WPSEO_Redirect( $new_origin, $target, $type, $format );
-		$old_redirect = ( null !== $old_origin ) ? $this->get_redirect( $old_origin ) : null;
+		$old_redirect = ( $old_origin !== null ) ? $this->get_redirect( $old_origin ) : null;
 
 		$validator = new WPSEO_Redirect_Validator();
 

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -109,6 +109,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 		$new_redirect = new WPSEO_Redirect( $new_origin, $target, $type, $format );
 
 		$old_redirect = null;
+
 		if ( $old_origin !== null ) {
 			$old_redirect = $this->get_redirect( $old_origin );
 		}

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -18,7 +18,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	protected $redirect_manager;
 
 	/**
-	 * Instantiate a WPSEO_CLI_Redirect_Create_Command object.
+	 * Instantiates a WPSEO_CLI_Redirect_Create_Command object.
 	 */
 	public function __construct() {
 		// This could potentially have the Redirect Manager injected.
@@ -26,7 +26,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Create a new redirect.
+	 * Creates a new redirect.
 	 *
 	 * @param string $origin Origin of the redirect.
 	 * @param string $target Target of the redirect.
@@ -42,7 +42,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Update an existing redirect.
+	 * Updates an existing redirect.
 	 *
 	 * @param string $old_origin Origin of the redirect.
 	 * @param string $new_origin Origin of the redirect.
@@ -60,7 +60,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete an existing redirect.
+	 * Deletes an existing redirect.
 	 *
 	 * @param string $origin Origin of the redirect.
 	 *
@@ -73,7 +73,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the redirect for a given origin.
+	 * Gets the redirect for a given origin.
 	 *
 	 * @param string $origin Origin to check for.
 	 *
@@ -84,7 +84,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check whether a redirect for a given origin already exists.
+	 * Checks whether a redirect for a given origin already exists.
 	 *
 	 * @param string $origin Origin to check for.
 	 *
@@ -95,7 +95,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check whether a given redirect is valid.
+	 * Checks whether a given redirect is valid.
 	 *
 	 * @param string      $new_origin New origin of the redirect.
 	 * @param string      $target     Target of the redirect.
@@ -132,7 +132,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Reformat error messages by removing excessive whitespace.
+	 * Reformats error messages by removing excessive whitespace.
 	 *
 	 * @param string $message Error message to reformat.
 	 *

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -107,7 +107,11 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	 */
 	protected function validate( $new_origin, $target, $type, $format, $old_origin = null ) {
 		$new_redirect = new WPSEO_Redirect( $new_origin, $target, $type, $format );
-		$old_redirect = ( $old_origin !== null ) ? $this->get_redirect( $old_origin ) : null;
+
+		$old_redirect = null;
+		if ( $old_origin !== null ) {
+			$old_redirect = $this->get_redirect( $old_origin );
+		}
 
 		$validator = new WPSEO_Redirect_Validator();
 

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -102,6 +102,8 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	 * @param int         $type       Type of the redirect.
 	 * @param string      $format     Format of the redirect.
 	 * @param string|null $old_origin Optional. Old origin of the redirect to update.
+	 *
+	 * @return void
 	 */
 	protected function validate( $new_origin, $target, $type, $format, $old_origin = null ) {
 		$new_redirect = new WPSEO_Redirect( $new_origin, $target, $type, $format );

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -19,7 +19,6 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 
 	/**
 	 * Instantiate a WPSEO_CLI_Redirect_Create_Command object.
-	 *
 	 */
 	public function __construct() {
 		// This could potentially have the Redirect Manager injected.
@@ -98,15 +97,15 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	/**
 	 * Check whether a given redirect is valid.
 	 *
-	 * @param string $new_origin
-	 * @param string $target
-	 * @param  int   $type
-	 * @param string $format
-	 * @param null   $old_origin
+	 * @param string      $new_origin New origin of the redirect.
+	 * @param string      $target     Target of the redirect.
+	 * @param int         $type       Type of the redirect.
+	 * @param string      $format     Format of the redirect.
+	 * @param string|null $old_origin Optional. Old origin of the redirect to update.
 	 */
 	protected function validate( $new_origin, $target, $type, $format, $old_origin = null ) {
 		$new_redirect = new WPSEO_Redirect( $new_origin, $target, $type, $format );
-		$old_redirect = null !== $old_origin ? $this->get_redirect( $old_origin ) : null;
+		$old_redirect = ( null !== $old_origin ) ? $this->get_redirect( $old_origin ) : null;
 
 		$validator = new WPSEO_Redirect_Validator();
 
@@ -140,7 +139,7 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	 * @return string Reformatted error message.
 	 */
 	protected function reformat_error( $message ) {
-		$message = preg_replace('/\s+/', ' ', $message );
+		$message = preg_replace( '/\s+/', ' ', $message );
 		return trim( $message );
 	}
 }

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -98,4 +98,49 @@ class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
 	protected function has_redirect( $origin ) {
 		return false !== $this->get_redirect( $origin );
 	}
+
+	/**
+	 * Check whether a given redirect is valid.
+	 *
+	 * @param WPSEO_Redirect $redirect       Redirect to validate.
+	 * @param bool           $ignore_warning Ignore warnings.
+	 * @param bool           $ignore_error   Ignore errors.
+	 */
+	protected function validate( $origin, $target, $type, $format, $ignore_warning = false, $ignore_error = false ) {
+		$redirect  = new WPSEO_Redirect( $origin, $target, $type, $format );
+		$validator = new WPSEO_Redirect_Validator();
+
+		if ( $validator->validate( $redirect ) === true ) {
+			return;
+		}
+
+		$error = $validator->get_error();
+
+		$message = sprintf(
+			'Failed to validate redirect \'%s\' => \'%s\': %s',
+			$redirect->get_origin(),
+			$redirect->get_target(),
+			$this->reformat_error( $error->get_message() )
+		);
+
+		if ( ! $ignore_warning && $error->get_type() === 'warning' ) {
+			WP_CLI::warning( $message );
+		}
+
+		if ( ! $ignore_error && $error->get_type() === 'error' ) {
+			WP_CLI::error( $message );
+		}
+	}
+
+	/**
+	 * Reformat error messages by removing excessive whitespace.
+	 *
+	 * @param string $message Error message to reformat.
+	 *
+	 * @return string Reformatted error message.
+	 */
+	protected function reformat_error( $message ) {
+		$message = preg_replace('/\s+/', ' ', $message );
+		return trim( $message );
+	}
 }

--- a/cli/class-cli-redirect-base-command.php
+++ b/cli/class-cli-redirect-base-command.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+/**
+ * Base class for the redirect commands.
+ */
+class WPSEO_CLI_Redirect_Base_Command extends WP_CLI_Command {
+
+	/**
+	 * Redirect Manager instance to use.
+	 *
+	 * @var WPSEO_Redirect_Manager
+	 */
+	protected $redirect_manager;
+
+	/**
+	 * Instantiate a WPSEO_CLI_Redirect_Create_Command object.
+	 *
+	 */
+	public function __construct() {
+		// This could potentially have the Redirect Manager injected.
+		$this->redirect_manager = new WPSEO_Redirect_Manager();
+	}
+
+	/**
+	 * Create a new redirect.
+	 *
+	 * @param string $origin Origin of the redirect.
+	 * @param string $target Target of the redirect.
+	 * @param string $type   Type of the redirect.
+	 * @param string $format Format of the redirect.
+	 *
+	 * @return bool Whether creation was successful.
+	 */
+	protected function create_redirect( $origin, $target, $type, $format ) {
+		$redirect = new WPSEO_Redirect( $origin, $target, $type, $format );
+
+		return $this->redirect_manager->create_redirect( $redirect );
+	}
+
+	/**
+	 * Update an existing redirect.
+	 *
+	 * @param string $origin Origin of the redirect.
+	 * @param string $target Target of the redirect.
+	 * @param string $type   Type of the redirect.
+	 * @param string $format Format of the redirect.
+	 *
+	 * @return bool Whether updating was successful.
+	 */
+	protected function update_redirect( $origin, $target, $type, $format ) {
+		$redirect = new WPSEO_Redirect( $origin, $target, $type, $format );
+
+		/*
+		 * The update_redirect method takes two redirect objects, a current one
+		 * and the planned new one. However, the $origin is used as ID and is
+		 * the only value that is retrieved from the current redirect, so
+		 * there's effectively no point in having two different objects.
+		 */
+		return $this->redirect_manager->update_redirect( $redirect, $redirect );
+	}
+
+	/**
+	 * Delete an existing redirect.
+	 *
+	 * @param string $origin Origin of the redirect.
+	 *
+	 * @return bool Whether deletion was successful.
+	 */
+	protected function delete_redirect( $origin ) {
+		$redirect = new WPSEO_Redirect( $origin );
+
+		return $this->redirect_manager->delete_redirects( array( $redirect ) );
+	}
+
+	/**
+	 * Get the redirect for a given origin.
+	 *
+	 * @param string $origin Origin to check for.
+	 *
+	 * @return WPSEO_Redirect|false Redirect value object, or false if not found.
+	 */
+	protected function get_redirect( $origin ) {
+		return $this->redirect_manager->get_redirect( $origin );
+	}
+
+	/**
+	 * Check whether a redirect for a given origin already exists.
+	 *
+	 * @param string $origin Origin to check for.
+	 *
+	 * @return bool Whether a redirect for the given origin was found.
+	 */
+	protected function has_redirect( $origin ) {
+		return false !== $this->get_redirect( $origin );
+	}
+}

--- a/cli/class-cli-redirect-command-namespace.php
+++ b/cli/class-cli-redirect-command-namespace.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+use WP_CLI\Dispatcher\CommandNamespace;
+
+/**
+ * Lists, creates, updates, deletes and follows Yoast SEO redirects.
+ */
+final class WPSEO_CLI_Redirect_Command_Namespace extends CommandNamespace {
+	// Intentionally left empty.
+}

--- a/cli/class-cli-redirect-create-command.php
+++ b/cli/class-cli-redirect-create-command.php
@@ -47,6 +47,9 @@ final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * ---
 	 * default: false
 	 * ---
+	 *
+	 * @param array $args Array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin, $target ) = $args;
@@ -63,9 +66,13 @@ final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Co
 
 		$force || $this->validate( $origin, $target, $type, $format );
 
-		$success = $exists
-			? $this->update_redirect( $origin, $origin, $target, $type, $format )
-			: $this->create_redirect( $origin, $target, $type, $format );
+		if ( $exists ) {
+			$success = $this->update_redirect( $origin, $origin, $target, $type, $format );
+		}
+
+		if ( ! $exists ) {
+			$success = $this->create_redirect( $origin, $target, $type, $format );
+		}
 
 		if ( ! $success ) {
 			WP_CLI::error( "Could not create redirect: '{$origin}' => '{$target}'." );

--- a/cli/class-cli-redirect-create-command.php
+++ b/cli/class-cli-redirect-create-command.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+/**
+ * Implementation of the 'redirect create' WP-CLI command.
+ */
+final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Command {
+
+	/**
+	 * Creates a new Yoast SEO redirect.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <origin>
+	 * : Origin of the redirect.
+	 *
+	 * <target>
+	 * : Target of the redirect.
+	 *
+	 * [--type=<type>]
+	 * : Type of the redirect.
+	 * ---
+	 * default: 301
+	 * options:
+	 *  - 301
+	 *  - 302
+	 *  - 307
+	 *  - 410
+	 *  - 451
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Format of the redirect.
+	 * ---
+	 * default: plain
+	 * options:
+	 *  - plain
+	 *  - regex
+	 * ---
+	 *
+	 * [--force]
+	 * : Force creation of the redirect, so an existing redirect will be overwritten.
+	 * ---
+	 * default: false
+	 * ---
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		list( $origin, $target ) = $args;
+
+		$type   = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'type', '301' );
+		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'plain' );
+		$force  = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+
+		if ( $this->has_redirect( $origin ) ) {
+			if ( ! $force ) {
+				WP_CLI::error( "Redirect already exists for '{$origin}'." );
+			}
+			$success = $this->update_redirect( $origin, $target, $type, $format );
+		} else {
+			$success = $this->create_redirect( $origin, $target, $type, $format );
+		}
+
+		if ( ! $success ) {
+			WP_CLI::error( "Could not create redirect: '{$origin}' => '{$target}'." );
+		}
+
+		WP_CLI::success( "Redirect created: '{$origin}' => '{$target}'." );
+	}
+}

--- a/cli/class-cli-redirect-create-command.php
+++ b/cli/class-cli-redirect-create-command.php
@@ -43,7 +43,7 @@ final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * ---
 	 *
 	 * [--force]
-	 * : Force creation of the redirect, so an existing redirect will be overwritten.
+	 * : Force creation of the redirect, bypassing any validation.
 	 * ---
 	 * default: false
 	 * ---
@@ -61,10 +61,10 @@ final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Co
 			WP_CLI::error( "Redirect already exists for '{$origin}'." );
 		}
 
-		$this->validate( $origin, $target, $type, $format, $force, $force );
+		$force || $this->validate( $origin, $target, $type, $format );
 
 		$success = $exists
-			? $this->update_redirect( $origin, $target, $type, $format )
+			? $this->update_redirect( $origin, $origin, $target, $type, $format )
 			: $this->create_redirect( $origin, $target, $type, $format );
 
 		if ( ! $success ) {

--- a/cli/class-cli-redirect-create-command.php
+++ b/cli/class-cli-redirect-create-command.php
@@ -66,7 +66,9 @@ final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Co
 			WP_CLI::error( "Redirect already exists for '{$origin}'." );
 		}
 
-		$force || $this->validate( $origin, $target, $type, $format );
+		if ( ! $force ) {
+			$this->validate( $origin, $target, $type, $format );
+		}
 
 		if ( $exists ) {
 			$success = $this->update_redirect( $origin, $origin, $target, $type, $format );

--- a/cli/class-cli-redirect-create-command.php
+++ b/cli/class-cli-redirect-create-command.php
@@ -55,14 +55,17 @@ final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Co
 		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'plain' );
 		$force  = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
-		if ( $this->has_redirect( $origin ) ) {
-			if ( ! $force ) {
-				WP_CLI::error( "Redirect already exists for '{$origin}'." );
-			}
-			$success = $this->update_redirect( $origin, $target, $type, $format );
-		} else {
-			$success = $this->create_redirect( $origin, $target, $type, $format );
+		$exists = $this->has_redirect( $origin );
+
+		if ( $exists && ! $force ) {
+			WP_CLI::error( "Redirect already exists for '{$origin}'." );
 		}
+
+		$this->validate( $origin, $target, $type, $format, $force, $force );
+
+		$success = $exists
+			? $this->update_redirect( $origin, $target, $type, $format )
+			: $this->create_redirect( $origin, $target, $type, $format );
 
 		if ( ! $success ) {
 			WP_CLI::error( "Could not create redirect: '{$origin}' => '{$target}'." );

--- a/cli/class-cli-redirect-create-command.php
+++ b/cli/class-cli-redirect-create-command.php
@@ -50,6 +50,8 @@ final class WPSEO_CLI_Redirect_Create_Command extends WPSEO_CLI_Redirect_Base_Co
 	 *
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
+	 *
+	 * @return void
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin, $target ) = $args;

--- a/cli/class-cli-redirect-delete-command.php
+++ b/cli/class-cli-redirect-delete-command.php
@@ -23,9 +23,9 @@ final class WPSEO_CLI_Redirect_Delete_Command extends WPSEO_CLI_Redirect_Base_Co
 
 		if ( ! $this->has_redirect( $origin ) ) {
 			WP_CLI::error( "Redirect does not exist for '{$origin}'." );
-		} else {
-			$success = $this->delete_redirect( $origin );
 		}
+
+		$success = $this->delete_redirect( $origin );
 
 		if ( ! $success ) {
 			WP_CLI::error( "Could not delete redirect: '{$origin}'." );

--- a/cli/class-cli-redirect-delete-command.php
+++ b/cli/class-cli-redirect-delete-command.php
@@ -17,6 +17,9 @@ final class WPSEO_CLI_Redirect_Delete_Command extends WPSEO_CLI_Redirect_Base_Co
 	 *
 	 * <origin>
 	 * : Origin of the redirect.
+	 *
+	 * @param array $args Array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin ) = $args;

--- a/cli/class-cli-redirect-delete-command.php
+++ b/cli/class-cli-redirect-delete-command.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+/**
+ * Implementation of the 'redirect delete' WP-CLI command.
+ */
+final class WPSEO_CLI_Redirect_Delete_Command extends WPSEO_CLI_Redirect_Base_Command {
+
+	/**
+	 * Deletes an existing Yoast SEO redirect.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <origin>
+	 * : Origin of the redirect.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		list( $origin ) = $args;
+
+		if ( ! $this->has_redirect( $origin ) ) {
+			WP_CLI::error( "Redirect does not exist for '{$origin}'." );
+		} else {
+			$success = $this->delete_redirect( $origin );
+		}
+
+		if ( ! $success ) {
+			WP_CLI::error( "Could not delete redirect: '{$origin}'." );
+		}
+
+		WP_CLI::success( "Redirect delete: '{$origin}'." );
+	}
+}

--- a/cli/class-cli-redirect-delete-command.php
+++ b/cli/class-cli-redirect-delete-command.php
@@ -20,6 +20,8 @@ final class WPSEO_CLI_Redirect_Delete_Command extends WPSEO_CLI_Redirect_Base_Co
 	 *
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
+	 *
+	 * @return void
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin ) = $args;

--- a/cli/class-cli-redirect-follow-command.php
+++ b/cli/class-cli-redirect-follow-command.php
@@ -67,7 +67,7 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 	}
 
 	/**
-	 * Get the stack of redirect targets for a given starting redirect.
+	 * Gets the stack of redirect targets for a given starting redirect.
 	 *
 	 * @param WPSEO_Redirect $redirect Redirect to get the stack for.
 	 * @param int            $limit    Number of steps to limit the stack to.
@@ -94,7 +94,7 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 	}
 
 	/**
-	 * Add a new target to the stack.
+	 * Adds a new target to the stack.
 	 *
 	 * @param string $target Target to add to the stack.
 	 */

--- a/cli/class-cli-redirect-follow-command.php
+++ b/cli/class-cli-redirect-follow-command.php
@@ -76,7 +76,7 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * @param WPSEO_Redirect $redirect Redirect to get the stack for.
 	 * @param int            $limit    Number of steps to limit the stack to.
 	 *
-	 * @return array<string> Array of target URL steps.
+	 * @return array Array of target URL steps.
 	 */
 	private function get_stack( WPSEO_Redirect $redirect, $limit ) {
 		$steps = 0;

--- a/cli/class-cli-redirect-follow-command.php
+++ b/cli/class-cli-redirect-follow-command.php
@@ -53,7 +53,7 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 
 		$redirect = $this->get_redirect( $origin );
 
-		if ( false === $redirect ) {
+		if ( $redirect === false ) {
 			WP_CLI::error( "Redirect does not exist for '{$origin}'." );
 		}
 
@@ -79,7 +79,7 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 	private function get_stack( WPSEO_Redirect $redirect, $limit ) {
 		$steps = 0;
 
-		while ( ! $this->detected_loop && false !== $redirect ) {
+		while ( ! $this->detected_loop && $redirect !== false ) {
 			$steps++;
 			if ( $limit > 0 && $steps >= $limit ) {
 				break;

--- a/cli/class-cli-redirect-follow-command.php
+++ b/cli/class-cli-redirect-follow-command.php
@@ -33,6 +33,9 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * ---
 	 * default: 0
 	 * ---
+	 *
+	 * @param array $args Array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin ) = $args;
@@ -46,10 +49,10 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 		}
 
 		$stack = $this->get_stack( $redirect, $limit );
-
-		foreach ( $trace ? $stack : (array) array_pop( $stack ) as $target ) {
-			WP_CLI::line( $target );
+		if ( $trace ) {
+			$stack = (array) array_pop( $stack );
 		}
+		array_map( 'WP_CLI::line', $stack );
 
 		if ( $this->detected_loop ) {
 			WP_CLI::error( "Detected redirect loop for redirect: '{$origin}'." );

--- a/cli/class-cli-redirect-follow-command.php
+++ b/cli/class-cli-redirect-follow-command.php
@@ -58,9 +58,11 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 		}
 
 		$stack = $this->get_stack( $redirect, $limit );
+
 		if ( ! $trace ) {
 			$stack = (array) array_pop( $stack );
 		}
+
 		array_map( 'WP_CLI::line', $stack );
 
 		if ( $this->detected_loop ) {

--- a/cli/class-cli-redirect-follow-command.php
+++ b/cli/class-cli-redirect-follow-command.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+/**
+ * Implementation of the 'redirect follow' WP-CLI command.
+ */
+final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Command {
+
+	/**
+	 * Follows a Yoast SEO redirect chain to get the final target it resolves to.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <origin>
+	 * : Origin of the redirect.
+	 *
+	 * [--trace]
+	 * : Show a trace of all intermediary steps.
+	 *
+	 * [--limit=<limit>]
+	 * : Limit the number of jumps to follow the redirect chain. '0' means unlimited.
+	 * ---
+	 * default: 0
+	 * ---
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		list( $origin ) = $args;
+		$trace = (bool) WP_CLI\Utils\get_flag_value( $assoc_args, 'trace', false );
+		$limit = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'limit', '0' );
+
+		$redirect = $this->get_redirect( $origin );
+
+		if ( false === $redirect ) {
+			WP_CLI::error( "Redirect does not exist for '{$origin}'." );
+		}
+
+		$steps = 0;
+		$stack = array();
+		$loop  = false;
+
+		while ( false !== $redirect ) {
+			$steps++;
+			if ( $limit > 0 && $steps >= $limit ) {
+				break;
+			}
+
+			$target = $redirect->get_target();
+
+			if ( array_key_exists( $target, $stack ) ) {
+				$loop = true;
+				break;
+			}
+
+			$stack[ $target ] = true;
+
+			$target_redirect = $this->get_redirect( $target );
+
+			if ( false === $target_redirect ) {
+				break;
+			}
+
+			$redirect = $target_redirect;
+		}
+
+		$stack = array_keys( $stack );
+
+		foreach ( $trace ? $stack : (array) array_pop( $stack ) as $target ) {
+			WP_CLI::line( $target );
+		}
+
+		if ( $loop ) {
+			WP_CLI::error( "Detected redirect loop for redirect: '{$origin}'." );
+		}
+	}
+}

--- a/cli/class-cli-redirect-follow-command.php
+++ b/cli/class-cli-redirect-follow-command.php
@@ -43,6 +43,8 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 	 *
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
+	 *
+	 * @return void
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin ) = $args;
@@ -97,6 +99,8 @@ final class WPSEO_CLI_Redirect_Follow_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * Adds a new target to the stack.
 	 *
 	 * @param string $target Target to add to the stack.
+	 *
+	 * @return void
 	 */
 	private function add_to_stack( $target ) {
 		if ( array_key_exists( $target, $this->stack ) ) {

--- a/cli/class-cli-redirect-has-command.php
+++ b/cli/class-cli-redirect-has-command.php
@@ -17,6 +17,9 @@ final class WPSEO_CLI_Redirect_Has_Command extends WPSEO_CLI_Redirect_Base_Comma
 	 *
 	 * <origin>
 	 * : Origin of the redirect.
+	 *
+	 * @param array $args Array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin ) = $args;

--- a/cli/class-cli-redirect-has-command.php
+++ b/cli/class-cli-redirect-has-command.php
@@ -20,6 +20,8 @@ final class WPSEO_CLI_Redirect_Has_Command extends WPSEO_CLI_Redirect_Base_Comma
 	 *
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
+	 *
+	 * @return void
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin ) = $args;

--- a/cli/class-cli-redirect-has-command.php
+++ b/cli/class-cli-redirect-has-command.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+/**
+ * Implementation of the 'redirect has' WP-CLI command.
+ */
+final class WPSEO_CLI_Redirect_Has_Command extends WPSEO_CLI_Redirect_Base_Command {
+
+	/**
+	 * Checks whether a given Yoast SEO redirect exists.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <origin>
+	 * : Origin of the redirect.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		list( $origin ) = $args;
+
+		exit( $this->has_redirect( $origin ) ? 0 : 1 );
+	}
+}

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -103,7 +103,8 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	}
 
 	/**
-	 * Callback function to filter the redirects.
+	 * Filters the redirects based on whether they match the provided filter
+	 * array.
 	 *
 	 * @param array $redirect Array data for an individual redirect.
 	 *
@@ -111,7 +112,8 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	 */
 	private function filter_redirect( $redirect ) {
 		foreach ( $this->filter as $key => $value ) {
-			// Loose comparison to ignore type.
+			// Loose comparison to ignore type, as CLI arguments are always
+			// strings.
 			if ( $value != $redirect[ $key ] ) {
 				return false;
 			}
@@ -138,7 +140,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	}
 
 	/**
-	 * Get the array of field names to use for formatting the table columns.
+	 * Gets the array of field names to use for formatting the table columns.
 	 *
 	 * @param array $assoc_args Parameters passed to command. Determines
 	 *                          formatting.

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -138,7 +138,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	}
 
 	/**
-	 * Gets Formatter object based on supplied parameters.
+	 * Get the array of field names to use for formatting the table columns.
 	 *
 	 * @param array $assoc_args Parameters passed to command. Determines
 	 *                          formatting.

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -108,7 +108,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	 *
 	 * @param array $redirect Array data for an individual redirect.
 	 *
-	 * @return bool
+	 * @return bool Whether to include the redirect or not.
 	 */
 	private function filter_redirect( $redirect ) {
 		foreach ( $this->filter as $key => $value ) {

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -52,6 +52,8 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	 *
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
+	 *
+	 * @return void
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$filter = $this->get_filter( $assoc_args );

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -13,6 +13,13 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	const ALL_FIELDS = 'origin,target,type,format';
 
 	/**
+	 * Filter to use for filtering the list of redirects.
+	 *
+	 * @var array
+	 */
+	private $filter;
+
+	/**
 	 * Lists Yoast SEO redirects.
 	 *
 	 * ## OPTIONS
@@ -56,7 +63,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	 * @return void
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		$filter = $this->get_filter( $assoc_args );
+		$this->filter = $this->get_filter( $assoc_args );
 
 		/*
 		 * By default, WP-CLI uses `--format=<format>` to define the output
@@ -75,16 +82,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 
 		$redirects = array_filter(
 			$this->get_redirects(),
-			function ( $redirect ) use ( $filter ) {
-				foreach ( $filter as $key => $value ) {
-					// Loose comparison to ignore type.
-					if ( $value != $redirect[ $key ] ) {
-						return false;
-					}
-				}
-
-				return true;
-			}
+			array( $this, 'filter_redirect' )
 		);
 
 		$formatter->display_items( $redirects );
@@ -102,6 +100,24 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 			array( $this, 'adapt_redirect_data' ),
 			$redirect_objects
 		);
+	}
+
+	/**
+	 * Callback function to filter the redirects.
+	 *
+	 * @param array $redirect Array data for an individual redirect.
+	 *
+	 * @return bool
+	 */
+	private function filter_redirect( $redirect ) {
+		foreach ( $this->filter as $key => $value ) {
+			// Loose comparison to ignore type.
+			if ( $value != $redirect[ $key ] ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -89,7 +89,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	}
 
 	/**
-	 * Get the filtered list of redirects.
+	 * Gets the filtered list of redirects.
 	 *
 	 * @return array Associative array of redirects.
 	 */
@@ -103,7 +103,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	}
 
 	/**
-	 * Adapt redirect data fetched from the redirect manager to fit WP_CLI
+	 * Adapts redirect data fetched from the redirect manager to fit WP_CLI
 	 * requirements.
 	 *
 	 * @param WPSEO_Redirect $redirect Redirection value object.
@@ -120,7 +120,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	}
 
 	/**
-	 * Get Formatter object based on supplied parameters.
+	 * Gets Formatter object based on supplied parameters.
 	 *
 	 * @param array $assoc_args Parameters passed to command. Determines
 	 *                          formatting.
@@ -140,7 +140,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	}
 
 	/**
-	 * Get the filter array to filter values against.
+	 * Gets the filter array to filter values against.
 	 *
 	 * @param array $assoc_args Parameters passed to command. Determines
 	 *                          formatting.

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -49,6 +49,9 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	 * * target
 	 * * type
 	 * * format
+	 *
+	 * @param array $args Array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$filter = $this->get_filter( $assoc_args );
@@ -71,7 +74,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 		$redirects = array_filter(
 			$this->get_redirects(),
 			function ( $redirect ) use ( $filter ) {
-				foreach( $filter as $key => $value ) {
+				foreach ( $filter as $key => $value ) {
 					// Loose comparison to ignore type.
 					if ( $value != $redirect[ $key ] ) {
 						return false;
@@ -90,7 +93,7 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	 *
 	 * @return array Associative array of redirects.
 	 */
-	private function get_redirects(  ) {
+	private function get_redirects() {
 		$redirect_objects = $this->redirect_manager->get_all_redirects();
 
 		return array_map(

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -112,8 +112,10 @@ final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Comm
 	 */
 	private function filter_redirect( $redirect ) {
 		foreach ( $this->filter as $key => $value ) {
-			// Loose comparison to ignore type, as CLI arguments are always
-			// strings.
+			/*
+			 * Loose comparison to ignore type, as CLI arguments are always
+			 * strings.
+			 */
 			if ( $value != $redirect[ $key ] ) {
 				return false;
 			}

--- a/cli/class-cli-redirect-list-command.php
+++ b/cli/class-cli-redirect-list-command.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+/**
+ * Implementation of the 'redirect list' WP-CLI command.
+ */
+final class WPSEO_CLI_Redirect_List_Command extends WPSEO_CLI_Redirect_Base_Command {
+
+	const ALL_FIELDS = 'origin,target,type,format';
+
+	/**
+	 * Lists Yoast SEO redirects.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--<field>=<value>]
+	 * : Filter the list to only show specific values for a given field.
+	 *
+	 * [--field=<field>]
+	 * : Prints the value of a single field for each redirect.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific object fields.
+	 * ---
+	 * default: origin,target,type,format
+	 * ---
+	 *
+	 * [--output=<output>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *  - table
+	 *  - csv
+	 *  - json
+	 *  - yaml
+	 *  - count
+	 * ---
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for each redirect:
+	 *
+	 * * origin
+	 * * target
+	 * * type
+	 * * format
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$filter = $this->get_filter( $assoc_args );
+
+		/*
+		 * By default, WP-CLI uses `--format=<format>` to define the output
+		 * format for lists. As we also have a `format` field here and want to
+		 * be able to easily filter the list by a given format, we use
+		 * `--output=<output>` to define the format.
+		 * We need to rename it back again here to be able to use the default
+		 * format handling provided by WP-CLI.
+		 */
+		$assoc_args['format'] = $assoc_args['output'];
+
+		$formatter = new WP_CLI\Formatter(
+			$assoc_args,
+			$this->get_fields( $assoc_args )
+		);
+
+		$redirects = array_filter(
+			$this->get_redirects(),
+			function ( $redirect ) use ( $filter ) {
+				foreach( $filter as $key => $value ) {
+					// Loose comparison to ignore type.
+					if ( $value != $redirect[ $key ] ) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+		);
+
+		$formatter->display_items( $redirects );
+	}
+
+	/**
+	 * Get the filtered list of redirects.
+	 *
+	 * @return array Associative array of redirects.
+	 */
+	private function get_redirects(  ) {
+		$redirect_objects = $this->redirect_manager->get_all_redirects();
+
+		return array_map(
+			array( $this, 'adapt_redirect_data' ),
+			$redirect_objects
+		);
+	}
+
+	/**
+	 * Adapt redirect data fetched from the redirect manager to fit WP_CLI
+	 * requirements.
+	 *
+	 * @param WPSEO_Redirect $redirect Redirection value object.
+	 *
+	 * @return array Associative array of redirects.
+	 */
+	private function adapt_redirect_data( $redirect ) {
+		return array(
+			'origin' => $redirect->get_origin(),
+			'target' => $redirect->get_target(),
+			'type'   => $redirect->get_type(),
+			'format' => $redirect->get_format(),
+		);
+	}
+
+	/**
+	 * Get Formatter object based on supplied parameters.
+	 *
+	 * @param array $assoc_args Parameters passed to command. Determines
+	 *                          formatting.
+	 *
+	 * @return array Array of fields to use.
+	 */
+	private function get_fields( $assoc_args ) {
+		if ( empty( $assoc_args['fields'] ) ) {
+			return explode( ',', self::ALL_FIELDS );
+		}
+
+		if ( is_string( $assoc_args['fields'] ) ) {
+			return explode( ',', $assoc_args['fields'] );
+		}
+
+		return $assoc_args['fields'];
+	}
+
+	/**
+	 * Get the filter array to filter values against.
+	 *
+	 * @param array $assoc_args Parameters passed to command. Determines
+	 *                          formatting.
+	 *
+	 * @return array Associative array of filter values.
+	 */
+	private function get_filter( $assoc_args ) {
+		$filter = array();
+
+		foreach ( array( 'origin', 'target', 'type', 'format' ) as $type ) {
+			if ( isset( $assoc_args[ $type ] ) ) {
+				$filter[ $type ] = $assoc_args[ $type ];
+			}
+		}
+
+		return $filter;
+	}
+}

--- a/cli/class-cli-redirect-update-command.php
+++ b/cli/class-cli-redirect-update-command.php
@@ -53,6 +53,8 @@ final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Co
 	 *
 	 * @param array $args Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
+	 *
+	 * @return void
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin, $new_origin, $target ) = $args;

--- a/cli/class-cli-redirect-update-command.php
+++ b/cli/class-cli-redirect-update-command.php
@@ -69,7 +69,9 @@ final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Co
 			WP_CLI::error( "Redirect does not exist for '{$origin}'." );
 		}
 
-		$force || $this->validate( $new_origin, $target, $type, $format, $origin );
+		if ( ! $force ) {
+			$this->validate( $new_origin, $target, $type, $format, $origin );
+		}
 
 		$success = $this->update_redirect( $origin, $new_origin, $target, $type, $format );
 

--- a/cli/class-cli-redirect-update-command.php
+++ b/cli/class-cli-redirect-update-command.php
@@ -50,6 +50,9 @@ final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * ---
 	 * default: false
 	 * ---
+	 *
+	 * @param array $args Array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		list( $origin, $new_origin, $target ) = $args;

--- a/cli/class-cli-redirect-update-command.php
+++ b/cli/class-cli-redirect-update-command.php
@@ -16,8 +16,11 @@ final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * ## OPTIONS
 	 *
 	 * <origin>
-	 * : Origin of the redirect.
+	 * : Origin of the redirect to update.
 	 *
+	 * <new-origin>
+	 * : New origin of the redirect.
+
 	 * <target>
 	 * : Target of the redirect.
 	 *
@@ -43,13 +46,13 @@ final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Co
 	 * ---
 	 *
 	 * [--force]
-	 * : Force updating of a redirect, so an missing redirect will be created.
+	 * : Force updating of the redirect, bypassing any validation.
 	 * ---
 	 * default: false
 	 * ---
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		list( $origin, $target ) = $args;
+		list( $origin, $new_origin, $target ) = $args;
 
 		$type   = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'type', '301' );
 		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'plain' );
@@ -61,16 +64,14 @@ final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Co
 			WP_CLI::error( "Redirect does not exist for '{$origin}'." );
 		}
 
-		$this->validate( $origin, $target, $type, $format, $force, $force );
+		$force || $this->validate( $new_origin, $target, $type, $format, $origin );
 
-		$success = $exists
-			? $this->update_redirect( $origin, $target, $type, $format )
-			: $this->create_redirect( $origin, $target, $type, $format );
+		$success = $this->update_redirect( $origin, $new_origin, $target, $type, $format );
 
 		if ( ! $success ) {
-			WP_CLI::error( "Could not update redirect: '{$origin}' => '{$target}'." );
+			WP_CLI::error( "Could not update redirect: '{$new_origin}' => '{$target}'." );
 		}
 
-		WP_CLI::success( "Redirect updated: '{$origin}' => '{$target}'." );
+		WP_CLI::success( "Redirect updated: '{$new_origin}' => '{$target}'." );
 	}
 }

--- a/cli/class-cli-redirect-update-command.php
+++ b/cli/class-cli-redirect-update-command.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\CLI
+ */
+
+/**
+ * Implementation of the 'redirect create' WP-CLI command.
+ */
+final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Command {
+
+	/**
+	 * Updates an existing Yoast SEO redirect.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <origin>
+	 * : Origin of the redirect.
+	 *
+	 * <target>
+	 * : Target of the redirect.
+	 *
+	 * [--type=<type>]
+	 * : Type of the redirect.
+	 * ---
+	 * default: 301
+	 * options:
+	 *  - 301
+	 *  - 302
+	 *  - 307
+	 *  - 410
+	 *  - 451
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Format of the redirect.
+	 * ---
+	 * default: plain
+	 * options:
+	 *  - plain
+	 *  - regex
+	 * ---
+	 *
+	 * [--force]
+	 * : Force updating of a redirect, so an missing redirect will be created.
+	 * ---
+	 * default: false
+	 * ---
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		list( $origin, $target ) = $args;
+
+		$type   = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'type', '301' );
+		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'plain' );
+		$force  = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+
+		if ( ! $this->has_redirect( $origin ) ) {
+			if ( ! $force ) {
+				WP_CLI::error( "Redirect does not exist for '{$origin}'." );
+			}
+			$success = $this->create_redirect( $origin, $target, $type, $format );
+		} else {
+			$success = $this->update_redirect( $origin, $target, $type, $format );
+		}
+
+		if ( ! $success ) {
+			WP_CLI::error( "Could not update redirect: '{$origin}' => '{$target}'." );
+		}
+
+		WP_CLI::success( "Redirect updated: '{$origin}' => '{$target}'." );
+	}
+}

--- a/cli/class-cli-redirect-update-command.php
+++ b/cli/class-cli-redirect-update-command.php
@@ -55,14 +55,17 @@ final class WPSEO_CLI_Redirect_Update_Command extends WPSEO_CLI_Redirect_Base_Co
 		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'plain' );
 		$force  = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
-		if ( ! $this->has_redirect( $origin ) ) {
-			if ( ! $force ) {
-				WP_CLI::error( "Redirect does not exist for '{$origin}'." );
-			}
-			$success = $this->create_redirect( $origin, $target, $type, $format );
-		} else {
-			$success = $this->update_redirect( $origin, $target, $type, $format );
+		$exists = $this->has_redirect( $origin );
+
+		if ( ! $exists && ! $force ) {
+			WP_CLI::error( "Redirect does not exist for '{$origin}'." );
 		}
+
+		$this->validate( $origin, $target, $type, $format, $force, $force );
+
+		$success = $exists
+			? $this->update_redirect( $origin, $target, $type, $format )
+			: $this->create_redirect( $origin, $target, $type, $format );
 
 		if ( ! $success ) {
 			WP_CLI::error( "Could not update redirect: '{$origin}' => '{$target}'." );

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
 			"admin/",
 			"frontend/",
 			"inc/",
-			"deprecated/"
+			"deprecated/",
+			"cli/"
 		]
 	},
 	"autoload-dev": {

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -374,6 +374,45 @@ function wpseo_admin_init() {
 	new WPSEO_Admin_Init();
 }
 
+/**
+ * Initialize the WP-CLI integration.
+ *
+ * The WP-CLI integration needs PHP 5.3 support, which should be automatically
+ * enforced by the check for the WP_CLI constant. As WP-CLI itself only runs
+ * on PHP 5.3+, the constant should only be set when requirements are met.
+ */
+function wpseo_cli_init() {
+	WP_CLI::add_command( 'redirect list', 'WPSEO_CLI_Redirect_List_Command', array(
+		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
+	) );
+
+	WP_CLI::add_command( 'redirect create', 'WPSEO_CLI_Redirect_Create_Command', array(
+		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
+	) );
+
+	WP_CLI::add_command( 'redirect update', 'WPSEO_CLI_Redirect_Update_Command', array(
+		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
+	) );
+
+	WP_CLI::add_command( 'redirect delete', 'WPSEO_CLI_Redirect_Delete_Command', array(
+		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
+	) );
+
+	WP_CLI::add_command( 'redirect has', 'WPSEO_CLI_Redirect_Has_Command', array(
+		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
+	) );
+
+	WP_CLI::add_command( 'redirect follow', 'WPSEO_CLI_Redirect_Follow_Command', array(
+		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
+	) );
+
+	// Only add the namespace if the required base class exists (WP-CLI 1.5.0+).
+	// This is optional and only adds the description of the root `redirect`
+	// command.
+	if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {
+		WP_CLI::add_command( 'redirect', 'WPSEO_CLI_Redirect_Command_Namespace' );
+	}
+}
 
 /* ***************************** BOOTSTRAP / HOOK INTO WP *************************** */
 $spl_autoload_exists = function_exists( 'spl_autoload_register' );
@@ -414,6 +453,10 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 	}
 
 	add_action( 'plugins_loaded', 'load_yoast_notifications' );
+
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		add_action( 'plugins_loaded', 'wpseo_cli_init', 20 );
+	}
 }
 
 // Activation and deactivation hook.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds WP-CLI commands to manage redirects.

## Relevant technical choices:

* The following subcommands are implemented under the `redirect` command root:
    `redirect create` - Creates a new Yoast SEO redirect.
    `redirect delete` - Deletes an existing Yoast SEO redirect.
    `redirect follow` - Follows a Yoast SEO redirect chain to get the final target it resolves to.
    `redirect has` - Checks whether a given Yoast SEO redirect exists.
    `redirect list` - Lists Yoast SEO redirects.
    `redirect update` - Updates an existing Yoast SEO redirect.
* The check for premium has been moved out of the individual commands and will bew processed on the `before_invoke` hook for each premium command. The code can be deployed with the free codebase, as the logic is not contained within the commands, and a meaningful error message is produced for premium commands run on the free version.
* The parameter to select the output rendering format does not use the convention set by the bundled WP-CLI commands (`--format=<format>`). Instead, I opted to keep the `--format` for easy filtering of the redirect "format", and moved the output rendering flag to `--output=<output>` instead.
* The commands are built for convenient scripting. Here are a few examples of how that works:
    ```
    # redirect has will return an exit code, so that it can be directly used in shell conditionals:
    $ URL="<some-url>"; if wp redirect has $URL; then
        echo "Yes, the redirect for $URL exists."
      else
        echo "No, the redirect for $URL does not exist."
      fi
    No, the redirect for <some-url> does not exist.

    # redirect list output can be filtered and shaped so that it can be fed into other commands.
    # As an example, here's how to delete all 307 redirects:
    wp redirect list --type=307 --field=origin | xargs -I {} wp redirect delete {}
* As unit tests are mostly worthless for commands (as the logic is found elsewhere), and as we don't have an integration test infrastructure yet, this pull request does not contain any automated tests. I suggest creating a new issue for tests and implement them as soon as an integration testing infrastructure is available.

## Test instructions

This PR can be tested by following these steps:

* Enter the shell terminal.
* Ensure you have installed a working version of WP-CLI by running `wp cli info` ([Installation instructions](https://make.wordpress.org/cli/handbook/installing/#recommended-installation)).
* Change into the root folder of the development site where you are running Yoast SEO with this pull request.
* Running `wp help redirect` should now show an overview of the available redirect subcommands.
* Running `wp help redirect <subcommand>` will produce a help screen for that given subcommand.
* Using a subcommand should be explained on the respective help screens.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1566