### PR TITLE
Fixes backwards compatibility for WPSEO_Opengraph_Image class

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1243,7 +1243,10 @@ class WPSEO_Frontend {
 				$template = WPSEO_Options::get( 'metadesc-' . $post_type );
 				$term     = $post;
 			}
-			$metadesc_override = $this->get_seo_meta_value( 'metadesc', $post->ID );
+
+			if ( is_object( $post ) ) {
+				$metadesc_override = $this->get_seo_meta_value( 'metadesc', $post->ID );
+			}
 		}
 		else {
 			if ( is_search() ) {

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -53,9 +53,9 @@ class WPSEO_OpenGraph_Image {
 	 * Constructor.
 	 *
 	 * @param null|string     $image           Optional. The Image to use.
-	 * @param WPSEO_Opengraph $wpseo_opengraph Optional. The OpenGraph object.
+	 * @param WPSEO_OpenGraph $wpseo_opengraph Optional. The OpenGraph object.
 	 */
-	public function __construct( $image = null, WPSEO_Opengraph $wpseo_opengraph = null ) {
+	public function __construct( $image = null, WPSEO_OpenGraph $wpseo_opengraph = null ) {
 		if ( $wpseo_opengraph === null ) {
 			$wpseo_opengraph = new WPSEO_OpenGraph();
 		}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -52,14 +52,21 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Constructor.
 	 *
-	 * @param mixed $wpseo_opengraph Optional. The OpenGraph object.
+	 * @param null|string     $image           Optional. The Image to use.
+	 * @param WPSEO_Opengraph $wpseo_opengraph Optional. The OpenGraph object.
 	 */
-	public function __construct( $wpseo_opengraph = null ) {
-		if ( $wpseo_opengraph instanceof WPSEO_Opengraph === false ) {
+	public function __construct( $image = null, WPSEO_Opengraph $wpseo_opengraph = null ) {
+		if ( $wpseo_opengraph === null ) {
 			$wpseo_opengraph = new WPSEO_OpenGraph();
 		}
 
 		$this->opengraph = $wpseo_opengraph;
+
+
+		if ( ! empty( $image ) && is_string( $image ) ) {
+			$this->add_image_by_url( $image );
+		}
+
 
 		$this->set_images();
 	}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -52,21 +52,26 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Constructor.
 	 *
-	 * @param null|string     $image           Optional. The Image to use.
-	 * @param WPSEO_OpenGraph $wpseo_opengraph Optional. The OpenGraph object.
+	 * @param null|string     $image     Optional. The Image to use.
+	 * @param WPSEO_OpenGraph $opengraph Optional. The OpenGraph object.
 	 */
-	public function __construct( $image = null, WPSEO_OpenGraph $wpseo_opengraph = null ) {
-		if ( $wpseo_opengraph === null ) {
-			$wpseo_opengraph = new WPSEO_OpenGraph();
+	public function __construct( $image = null, WPSEO_OpenGraph $opengraph = null ) {
+		if ( $opengraph === null ) {
+			global $wpseo_og;
+
+			// Use the global if available.
+			if ( empty( $wpseo_og ) ) {
+				$wpseo_og = new WPSEO_OpenGraph();
+			}
+
+			$opengraph = $wpseo_og;
 		}
 
-		$this->opengraph = $wpseo_opengraph;
-
+		$this->opengraph = $opengraph;
 
 		if ( ! empty( $image ) && is_string( $image ) ) {
 			$this->add_image_by_url( $image );
 		}
-
 
 		$this->set_images();
 	}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -52,9 +52,13 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Constructor.
 	 *
-	 * @param WPSEO_OpenGraph $wpseo_opengraph The OpenGraph object.
+	 * @param mixed $wpseo_opengraph Optional. The OpenGraph object.
 	 */
-	public function __construct( WPSEO_OpenGraph $wpseo_opengraph ) {
+	public function __construct( $wpseo_opengraph = null ) {
+		if ( $wpseo_opengraph instanceof WPSEO_Opengraph === false ) {
+			$wpseo_opengraph = new WPSEO_OpenGraph();
+		}
+
 		$this->opengraph = $wpseo_opengraph;
 
 		$this->set_images();

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -531,9 +531,15 @@ class WPSEO_OpenGraph {
 	/**
 	 * Create new WPSEO_OpenGraph_Image class and get the images to set the og:image.
 	 *
+	 * @param string|bool $image Optional. Image URL.
+	 *
 	 * @return void
 	 */
-	public function image() {
+	public function image( $image = false ) {
+		if ( empty( $image ) === false ) {
+			_deprecated_argument( __METHOD__, 'WPSEO 7.4' );
+		}
+
 		$opengraph_image = new WPSEO_OpenGraph_Image( $this );
 		$opengraph_image->show();
 	}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -765,7 +765,8 @@ class WPSEO_OpenGraph {
 	 */
 	public function image_output( $image = false ) {
 		_deprecated_function( 'WPSEO_OpenGraph::image_output', '7.4', 'WPSEO_OpenGraph::image' );
-		$this->image();
+
+		$this->image( $image );
 	}
 
 } /* End of class */

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -536,11 +536,7 @@ class WPSEO_OpenGraph {
 	 * @return void
 	 */
 	public function image( $image = false ) {
-		if ( empty( $image ) === false ) {
-			_deprecated_argument( __METHOD__, 'WPSEO 7.4' );
-		}
-
-		$opengraph_image = new WPSEO_OpenGraph_Image( $this );
+		$opengraph_image = new WPSEO_OpenGraph_Image( $image, $this );
 		$opengraph_image->show();
 	}
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -621,7 +621,12 @@ class WPSEO_Twitter {
 	 * Displays the authors Twitter account.
 	 */
 	protected function author() {
-		$twitter = ltrim( trim( get_the_author_meta( 'twitter', get_post()->post_author ) ), '@' );
+		$post = get_post();
+
+		$twitter = null;
+		if ( is_object( $post ) ) {
+			$twitter = ltrim( trim( get_the_author_meta( 'twitter', $post->post_author ) ), '@' );
+		}
 		/**
 		 * Filter: 'wpseo_twitter_creator_account' - Allow changing the Twitter account as output in the Twitter card by Yoast SEO
 		 *

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -40,6 +40,28 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests instantiating of the object with no argument.
+	 *
+	 * @covers WPSEO_OpenGraph_Image::__construct
+	 */
+	public function test_constructor_with_no_argument() {
+		$class_instance = new WPSEO_OpenGraph_Image();
+
+		$this->assertAttributeInstanceOf( 'WPSEO_OpenGraph', 'opengraph', $class_instance );
+	}
+
+	/**
+	 * Tests instantiating of the object with a string argument.
+	 *
+	 * @covers WPSEO_OpenGraph_Image::__construct
+	 */
+	public function test_constructor_with_string_argument() {
+		$class_instance = new WPSEO_OpenGraph_Image( 'image.jpg' );
+
+		$this->assertAttributeInstanceOf( 'WPSEO_OpenGraph', 'opengraph', $class_instance );
+	}
+
+	/**
 	 * Tests whether has images is false by default.
 	 */
 	public function test_has_images_is_FALSE() {

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -334,7 +334,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	 * @return WPSEO_OpenGraph_Image
 	 */
 	private function setup_class() {
-		return new WPSEO_OpenGraph_Image( new WPSEO_OpenGraph() );
+		return new WPSEO_OpenGraph_Image( null, new WPSEO_OpenGraph() );
 	}
 
 	/**

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -61,6 +61,23 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$this->assertAttributeInstanceOf( 'WPSEO_OpenGraph', 'opengraph', $class_instance );
 	}
 
+
+	/**
+	 * Tests instantiating of the object OpenGraph 'not being set'.
+	 *
+	 * @covers WPSEO_OpenGraph_Image::__construct
+	 */
+	public function test_constructor_with_no_global_wpseo_og_object() {
+		$old_og = $GLOBALS['wpseo_og'];
+		$GLOBALS['wpseo_og'] = false;
+		$class_instance = new WPSEO_OpenGraph_Image( 'image.jpg' );
+
+		$GLOBALS['wpseo_og'] = $old_og;
+
+		$this->assertAttributeInstanceOf( 'WPSEO_OpenGraph', 'opengraph', $class_instance );
+
+	}
+
 	/**
 	 * Tests whether has images is false by default.
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Create instance of `WPSEO_Opengraph_Image` with in the constructor a string argument and an instance with no argument.
* This should work now.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
