### PR TITLE
Add keyword length assessment to taxonomy assessor test

### DIFF
--- a/js/src/assessors/taxonomyAssessor.js
+++ b/js/src/assessors/taxonomyAssessor.js
@@ -22,8 +22,8 @@ var TaxonomyAssessor = function( i18n ) {
 	this._assessments = [
 		introductionKeyword,
 		keyphraseLength,
-		keywordDensity,
-		metaDescriptionKeyword,
+		new keywordDensity(),
+		new metaDescriptionKeyword(),
 		new MetaDescriptionLength(),
 		titleKeyword,
 		new TitleWidth(),

--- a/js/src/assessors/taxonomyAssessor.js
+++ b/js/src/assessors/taxonomyAssessor.js
@@ -1,7 +1,7 @@
 var Assessor = require( "yoastseo/js/assessor.js" );
 
 var introductionKeyword = require( "yoastseo/js/assessments/seo/introductionKeywordAssessment.js" );
-var keyphraseLength = require( "yoastseo/js/assessments/seo/keyphraseLengthAssessment.js" );
+var KeyphraseLength = require( "yoastseo/js/assessments/seo/keyphraseLengthAssessment.js" );
 var keywordDensity = require( "yoastseo/js/assessments/seo/keywordDensityAssessment.js" );
 var metaDescriptionKeyword = require( "yoastseo/js/assessments/seo/metaDescriptionKeywordAssessment.js" );
 var MetaDescriptionLength = require( "yoastseo/js/assessments/seo/metaDescriptionLengthAssessment.js" );
@@ -21,7 +21,7 @@ var TaxonomyAssessor = function( i18n ) {
 
 	this._assessments = [
 		introductionKeyword,
-		keyphraseLength,
+		new KeyphraseLength(),
 		new keywordDensity(),
 		new metaDescriptionKeyword(),
 		new MetaDescriptionLength(),

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -47,6 +47,7 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
+			"keyphraseLength",
 			"introductionKeyword",
 			"metaDescriptionLength",
 			"titleKeyword",
@@ -74,6 +75,7 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
+			"keyphraseLength",
 			"introductionKeyword",
 			"metaDescriptionLength",
 			"titleKeyword",
@@ -89,6 +91,7 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
+			"keyphraseLength",
 			"introductionKeyword",
 			"keywordDensity",
 			"metaDescriptionLength",
@@ -104,6 +107,7 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
+			"keyphraseLength",
 			"introductionKeyword",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -47,8 +47,9 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
-			"keyphraseLength",
 			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleKeyword",
 			"titleWidth",
@@ -75,8 +76,9 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
-			"keyphraseLength",
 			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleKeyword",
 			"titleWidth",
@@ -91,9 +93,10 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
-			"keyphraseLength",
 			"introductionKeyword",
+			"keyphraseLength",
 			"keywordDensity",
+			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleKeyword",
 			"titleWidth",
@@ -107,8 +110,8 @@ describe ( "running assessments in the assessor", function() {
 		let assessments = getResults( AssessmentResults );
 
 		expect( assessments ).toEqual( [
-			"keyphraseLength",
 			"introductionKeyword",
+			"keyphraseLength",
 			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleKeyword",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Keyword length assessment was added to taxonomy assessor test.

## Test instructions

This PR can be tested by following these steps:

### Browserified

- Check out the branch.
- Use the browserified example. Don't forget to run a grunt build:js.
- Add a text
- Keep the keyword empty - you should receive feedback that keyword was not entered
- Enter a keyword - you should receive feedback concerning length of your keyword length.
- Make sure this functionality also works when cornerstone is switched on.

### WordPress

- Check out this in wordpress-seo.
- Run yarn install in the plugin's directory.
- Run yarn add "git+https://github.com/Yoast/yoastseo.js#stories/1312-improve-keyword-length-assessment" in the plugin's directory.
- Navigate to node_modules/yoastseo and run yarn install and grunt build:js.
- Navigate back to the plugin's directory and run grunt build:js.
- Test the same functionality as described in the test instructions for the browserified example.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (not relevant)

Fixes #9558
