### PR TITLE
Reverts the wpseo_focuskw_strippable_chars filter

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -511,19 +511,16 @@ class WPSEO_Meta {
 				}
 
 				if ( $meta_key === self::$meta_prefix . 'focuskw' ) {
-
-					/**
-					 * Filter: 'wpseo_focuskw_strippable_chars' - Allows customization of the strippable characters
-					 * in the focus keyword field.
-					 *
-					 * @api array $strippable_chars The characters to strip from the focus keyword.
-					 */
-					$strippable_chars = apply_filters(
-						'wpseo_focuskw_strippable_chars',
-						array( '&lt;', '&gt;', '&quot', '&#96', '<', '>', '"', '`' )
-					);
-
-					$clean = str_replace( $strippable_chars, '', $clean );
+					$clean = str_replace( array(
+						'&lt;',
+						'&gt;',
+						'&quot',
+						'&#96',
+						'<',
+						'>',
+						'"',
+						'`',
+					), '', $clean );
 				}
 
 				break;

--- a/readme.txt
+++ b/readme.txt
@@ -114,7 +114,6 @@ Enhancements:
 * Adds caching for images found in a post to reduce load.
 * Adds image alt tag to the OpenGraph output, using the meta tag `og:image:alt`.
 * Adds the `is_post_type_viewable` WordPress function to improve support for the `wpseo_accessible_post_types` filters.
-* Adds the ability to filter our strippable characters from the keyword. Allowing keywords such as `21" OLED television` to be used without the `"` character being stripped out. This can be done via the `wpseo_focuskw_strippable_chars` filter. Props to [Bryan Headrick](https://github.com/bheadrick).
 
 Bugfixes:
 * Fixes a bug where a non-array value causes a fatal error when `cron_schedules` filter has been executed.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Reverts the `wpseo_focuskw_strippable_chars` filter as there is some breakage that needs further investigation.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Determine that the filter is no longer being executed when added.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Reverts #9415 
Fixes https://github.com/Yoast/wordpress-seo/issues/9561