### PR TITLE
Remove image cache on post save

### DIFF
--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -8,13 +8,33 @@
 /**
  * WPSEO_Content_Images
  */
-class WPSEO_Content_Images {
+class WPSEO_Content_Images implements WPSEO_WordPress_Integration {
 	/**
 	 * The key used to store our image cache.
 	 *
 	 * @var string
 	 */
 	private $cache_meta_key = '_yoast_wpseo_post_image_cache';
+
+	/**
+	 * Registers the hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'save_post', array( $this, 'clear_cached_images' ) );
+	}
+
+	/**
+	 * Removes the cached images on post save.
+	 *
+	 * @param int $post_id The post id to remove the images from.
+	 *
+	 * @return void
+	 */
+	public function clear_cached_images( $post_id ) {
+		delete_post_meta( $post_id, $this->cache_meta_key );
+	}
 
 	/**
 	 * Retrieves images from the post content.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -306,6 +306,9 @@ function wpseo_init() {
 	// Loading Ryte integration.
 	$wpseo_onpage = new WPSEO_OnPage();
 	$wpseo_onpage->register_hooks();
+
+	$wpseo_content_images = new WPSEO_Content_Images();
+	$wpseo_content_images->register_hooks();
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* On post save, just remove the cached images for that post.

## Test instructions

This PR can be tested by following these steps:

* Have images in your content
* View the source of the post page.
* Change the images
* See the OG-tags being changed.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
