### PR TITLE
Apply post scraper snippet preview things to term scraper

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -1,6 +1,7 @@
 /* global YoastSEO: true, tinyMCE, wpseoPostScraperL10n, YoastShortcodePlugin, YoastReplaceVarPlugin, console, require */
 import { App } from "yoastseo";
 import isUndefined from "lodash/isUndefined";
+import isFunction from "lodash/isFunction";
 
 import { tmceId, setStore } from "./wp-seo-tinymce";
 import YoastMarkdownPlugin from "./wp-seo-markdown-plugin";
@@ -25,7 +26,6 @@ import snippetPreviewHelpers from "./analysis/snippetPreview";
 import UsedKeywords from "./analysis/usedKeywords";
 import { setMarkerStatus } from "./redux/actions/markerButtons";
 import { updateData } from "./redux/actions/snippetEditor";
-import isFunction from "lodash/isFunction";
 
 ( function( $ ) {
 	"use strict"; // eslint-disable-line

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -82,8 +82,8 @@ window.yoastHideMarkers = true;
 	 */
 	const dispatchUpdateSnippetEditor = function( data ) {
 		/*
-		 * The setTimeout makes sure the React component is only rendered on the next
-		 * frame.
+		 * The setTimeout makes sure the React component is only updated on the next
+		 * frame. This is to prevent input lag.
 		 */
 		setTimeout( () => {
 			store.dispatch( updateData( {

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -95,14 +95,14 @@ window.yoastHideMarkers = true;
 	};
 
 	/**
-	 * Renders the legacy snippet preview based on the passed data from the redux
+	 * Update the legacy snippet preview based on the passed data from the redux
 	 * store.
 	 *
 	 * @param {Object} data The data from the store.
 	 *
 	 * @returns {void}
 	 */
-	function renderLegacySnippetEditor( data ) {
+	function updateLegacySnippetEditor( data ) {
 		if ( isFunction( snippetPreview.refresh ) ) {
 			let isDataChanged = false;
 
@@ -385,7 +385,7 @@ window.yoastHideMarkers = true;
 				metaDesc: data.description,
 			} );
 
-			renderLegacySnippetEditor( data );
+			updateLegacySnippetEditor( data );
 		} );
 	} );
 }( jQuery, window ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* The solutions from https://github.com/Yoast/wordpress-seo/pull/9527 to implement the react snippet preview into the term scraper.
* Update `require` to `import` and reorder them a bit to at least have a division of external & internal.

## Test instructions

This PR can be tested by following these steps:

* Use `define( 'YOAST_FEATURE_SNIPPET_PREVIEW', true );` in `wp-config.php` to display the React version.
* Go to a term edit page.
* Check if the snippet editor behaves the same as the old one.
* Check if the old snippet editor still behaves the same like it did before this.

## Quality assurance

* [x] I have tested this code to the best of my abilities
~~* [ ] I have added unittests to verify the code works as intended~~

Fixes #9536 
