### PR TITLE
Added backwards compatibility to opengraph image class

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -143,6 +143,12 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	public function add_image( $attachment ) {
+
+		// Don't break backwards compatibility.
+		if ( is_string( $attachment ) ) {
+			$attachment = array( 'url' => $attachment );
+		}
+
 		/**
 		 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph image.
 		 *

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -157,7 +157,6 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	public function add_image( $attachment ) {
-
 		 // In the past `add_image` accepted an image url, so leave this for backwards compatibility.
 		if ( is_string( $attachment ) ) {
 			$attachment = array( 'url' => $attachment );
@@ -458,7 +457,7 @@ class WPSEO_OpenGraph_Image {
 	 * @return string The path of the image URL. Returns an empty string if URL parsing fails.
 	 */
 	protected function get_image_url_path( $url ) {
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		if ( $parsed_url === false ) {
 			return '';

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -56,6 +56,12 @@ class WPSEO_OpenGraph_Image {
 	 */
 	private $valid_image_types = array( 'image/jpeg', 'image/gif', 'image/png' );
 
+	/**
+	 * Image extensions that are supported by OpenGraph.
+	 *
+	 * @var array
+	 */
+	private $valid_image_extensions = array( 'jpeg', 'jpg', 'gif', 'png' );
 
 	/**
 	 * Constructor.
@@ -429,19 +435,59 @@ class WPSEO_OpenGraph_Image {
 
 	/**
 	 * Determines whether the passed URL is considered valid.
-	 * In this case, this means it doesn't end in .svg.
 	 *
 	 * @param string $url The URL to check.
 	 *
-	 * @return bool Whether or not the URL is an SVG.
+	 * @return bool Whether or not the URL is a valid image.
 	 */
 	protected function is_valid_image_url( $url ) {
 		if ( ! is_string( $url ) ) {
 			return false;
 		}
 
+		$image_extension = $this->get_extension_from_url( $url );
+
+		return in_array( $image_extension, $this->valid_image_extensions, true );
+	}
+
+	/**
+	 * Gets the image path from the passed URL.
+	 *
+	 * @param string $url The URL to get the path from.
+	 *
+	 * @return string The path of the image URL. Returns an empty string if URL parsing fails.
+	 */
+	protected function get_image_url_path( $url ) {
 		$parsed_url = parse_url( $url );
 
-		return substr( $parsed_url['path'], -4 ) !== '.svg';
+		if ( $parsed_url === false ) {
+			return '';
+		}
+
+		return $parsed_url['path'];
+	}
+
+	/**
+	 * Determines the file extension of the passed URL.
+	 *
+	 * @param string $url The URL.
+	 *
+	 * @return string The extension.
+	 */
+	protected function get_extension_from_url( $url ) {
+		$extension = '';
+		$path = $this->get_image_url_path( $url );
+
+		if ( $path === '' ) {
+			return $extension;
+		}
+
+		$parts = explode( '.', $path );
+
+		if ( ! empty( $parts ) ) {
+			$extension = end( $parts );
+		}
+
+		return $extension;
 	}
 }

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -118,6 +118,16 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests whether has images is false by default.
+	 */
+	public function test_add_image_as_string() {
+		$class_instance = $this->setup_class();
+		$class_instance->add_image( '/test.png' );
+
+		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
+	}
+
+	/**
 	 * Test setting the front page image.
 	 */
 	public function test_frontpage_image() {

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -118,13 +118,23 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether has images is false by default.
+	 * Tests whether passing an image string and not an array, works.
 	 */
 	public function test_add_image_as_string() {
 		$class_instance = $this->setup_class();
 		$class_instance->add_image( '/test.png' );
 
 		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
+	}
+
+	/**
+	 * Tests whether adding SVGs results in no og:image being created.
+	 */
+	public function test_add_svg_image() {
+		$class_instance = $this->setup_class();
+		$class_instance->add_image( array( 'url' => 'http://example.org/test.svg' ) );
+
+		$this->assertEmpty( $class_instance->get_images() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds backwards compatibility for the `add_image` function in `WPSEO_OpenGraph_Image`.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Check that the test passes.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9609 
