### PR TITLE
Re-adds `wpseo_opengraph_image_size` filter.

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -318,6 +318,54 @@ class WPSEO_OpenGraph_Image {
 	}
 
 	/**
+	 * Returns the overridden image size if it has been overridden.
+	 *
+	 * @return null|string The overridden image size or null.
+	 */
+	protected function get_overridden_image_size() {
+		/**
+		 * Filter: 'wpseo_opengraph_image_size' - Allow overriding the image size used
+		 * for OpenGraph sharing. If this filter is used, the defined size will always be
+		 * used for the og:image. The image will still be rejected if it is too small.
+		 *
+		 * Only use this filter if you manually want to determine the best image size
+		 * for the `og:image` tag.
+		 *
+		 * Use the `wpseo_image_sizes` filter if you want to use our logic. That filter
+		 * can be used to add an image size that needs to be taken into consideration
+		 * within our own logic
+		 *
+		 * @api string $size Size string.
+		 */
+		return apply_filters( 'wpseo_opengraph_image_size', null );
+	}
+
+	/**
+	 * Determines if the og image size should overridden.
+	 *
+	 * @return bool Whether the size should be overridden.
+	 */
+	protected function is_size_overridden() {
+		return $this->get_overridden_image_size() !== null;
+	}
+
+	/**
+	 * Adds the possibility to short-circuit all the optimal variation logic with
+	 * your own size.
+	 *
+	 * @param int $attachment_id The attachment ID that is used.
+	 *
+	 * @return void
+	 */
+	protected function get_overridden_image( $attachment_id ) {
+		$attachment = WPSEO_Image_Utils::get_image( $attachment_id, $this->get_overridden_image_size() );
+
+		if ( $attachment ) {
+			$this->add_image( $attachment );
+		}
+	}
+
+	/**
 	 * Adds an image to the list by attachment ID.
 	 *
 	 * @param int $attachment_id The attachment ID to add.
@@ -325,6 +373,11 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	protected function add_image_by_id( $attachment_id ) {
+		if ( $this->is_size_overridden() ) {
+			$this->get_overridden_image( $attachment_id );
+			return;
+		}
+
 		if ( ! WPSEO_Image_Utils::has_usable_dimensions( $attachment_id, $this->image_params ) ) {
 			return;
 		}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -341,7 +341,7 @@ class WPSEO_OpenGraph_Image {
 	}
 
 	/**
-	 * Determines if the og image size should overridden.
+	 * Determines if the OpenGraph image size should overridden.
 	 *
 	 * @return bool Whether the size should be overridden.
 	 */

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -141,7 +141,7 @@ class WPSEO_Image_Utils {
 	 *
 	 * @return array|false Returns an array with image data on success, false on failure.
 	 */
-	private static function get_image( $attachment_id, $size ) {
+	public static function get_image( $attachment_id, $size ) {
 		if ( $size === 'full' ) {
 			$image         = wp_get_attachment_metadata( $attachment_id );
 			$image['url']  = wp_get_attachment_image_url( $attachment_id, 'full' );

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,12 @@ You'll find answers to many of your questions on [kb.yoast.com](https://yoa.st/1
 
 == Changelog ==
 
+= 7.4.1 =
+Release Date: May 2nd, 2018
+
+Bugfixes:
+* Re-adds `wpseo_opengraph_image_size` filter. This will completely override any automatic size determination our code does. This filter now also applies to all ways an `og:image` can be determined: In the content, as a featured image or as set in our Facebook image setting.
+
 = 7.4.0 =
 Release Date: May 1st, 2018
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Re-adds `wpseo_opengraph_image_size` filter. This will completely override any automatic size determination our code does. This filter now also applies to all ways an `og:image` can be determined: In the content, as a featured image or as set in our Facebook image setting.

## Relevant technical choices:

* This will completely override any automatic size determination our code does. This filter now also applies to all ways an `og:image` can be determined: In the content, as a featured image or as set in our Facebook image setting.

## Test instructions

This PR can be tested by following these steps:

* Add this filter in your code an set the size to 'large' for example.
* Check the `og:image` tag and see that the 'large' size is used.

* Set the size that is too small.
* Check that the `og:image` tag is still not output.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9606