### PR TITLE
Handle editor changes via Redux: implement title

### DIFF
--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,4 +1,5 @@
 import debounce from "lodash/debounce";
+import { updateReplacementVariable } from "../redux/actions/snippetEditor";
 
 /**
  * Represents the data.
@@ -7,13 +8,15 @@ class Data {
 	/**
 	 * Sets the wp data, Yoast SEO refresh function and data object.
 	 *
-	 * @param {Object} wpData The Gutenberg data API.
+	 * @param {Object} wpData    The Gutenberg data API.
 	 * @param {Function} refresh The YoastSEO refresh function.
+	 * @param {Object} store     The YoastSEO Redux store.
 	 * @returns {void}
 	 */
-	constructor( wpData, refresh ) {
+	constructor( wpData, refresh, store ) {
 		this._wpData = wpData;
 		this._refresh = refresh;
+		this.store = store;
 		this.data = {};
 		this.getPostAttribute = this.getPostAttribute.bind( this );
 		this.refreshYoastSEO = this.refreshYoastSEO.bind( this );
@@ -77,6 +80,26 @@ class Data {
 		};
 	}
 
+	handleEditorChange( newData ) {
+		// // Handle content change
+		// if( this.data.content !== newData.content ) {
+		// }
+
+		// Handle title change
+		if( this.data.title !== newData.title ) {
+			this.store.dispatch( updateReplacementVariable( "title", newData.title ) );
+		}
+
+		// // Handle slug change
+		// if( this.data.slug !== newData.slug ) {
+		// }
+
+		// Handle excerpt change
+		if( this.data.excerpt !== newData.excerpt ) {
+			this.store.dispatch( updateReplacementVariable( "excerpt", newData.excerpt ) );
+		}
+	}
+
 	/**
 	 * Refreshes YoastSEO's app when the Gutenberg data is dirty.
 	 *
@@ -89,6 +112,7 @@ class Data {
 		let isDirty = ! this.isShallowEqual( this.data, gutenbergData );
 
 		if ( isDirty ) {
+			this.handleEditorChange( gutenbergData );
 			this.data = gutenbergData;
 			this._refresh();
 		}

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -162,7 +162,7 @@ export function initialize( args ) {
 
 	// Only use Gutenberg's data if Gutenberg is available.
 	if ( isGutenbergDataAvailable() ) {
-		const gutenbergData = new Data( wp.data, args.onRefreshRequest );
+		const gutenbergData = new Data( wp.data, args.onRefreshRequest, store );
 		gutenbergData.subscribeToGutenberg();
 		data = gutenbergData;
 	}

--- a/js/src/redux/actions/snippetEditor.js
+++ b/js/src/redux/actions/snippetEditor.js
@@ -1,6 +1,7 @@
 export const SWITCH_MODE = "SNIPPET_EDITOR_SWITCH_MODE";
 export const UPDATE_DATA = "SNIPPET_EDITOR_UPDATE_DATA";
 export const UPDATE_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_UPDATE_REPLACEMENT_VARIABLE";
+export const INSERT_REPLACEMENT_VARIABLE = "SNIPPET_EDITOR_INSERT_REPLACEMENT_VARIABLE";
 
 /**
  * Switches mode of the snippet editor.
@@ -44,6 +45,22 @@ export function updateData( data ) {
 export function updateReplacementVariable( name, value ) {
 	return {
 		type: UPDATE_REPLACEMENT_VARIABLE,
+		name,
+		value,
+	};
+}
+
+/**
+ * Inserts replacement variables in redux.
+ *
+ * @param {string} name  The name of the replacement variable.
+ * @param {string} value The value of the replacement variable.
+ *
+ * @returns {Object} An action for redux.
+ */
+export function insertReplacementVariable( name, value ) {
+	return {
+		type: INSERT_REPLACEMENT_VARIABLE,
 		name,
 		value,
 	};

--- a/js/src/redux/reducers/snippetEditor.js
+++ b/js/src/redux/reducers/snippetEditor.js
@@ -3,6 +3,7 @@ import {
 	SWITCH_MODE,
 	UPDATE_DATA,
 	UPDATE_REPLACEMENT_VARIABLE,
+	INSERT_REPLACEMENT_VARIABLE,
 } from "../actions/snippetEditor";
 
 const INITIAL_STATE = {
@@ -41,6 +42,21 @@ function snippetEditorReducer( state = INITIAL_STATE, action ) {
 			};
 
 		case UPDATE_REPLACEMENT_VARIABLE:
+			let newReplacementVariables = state.replacementVariables.map( ( replaceVar ) => {
+				if( replaceVar.name === action.name ) {
+					return {
+						name: action.name,
+						value: action.value,
+					}
+				}
+				return replaceVar;
+			} );
+			return {
+				...state,
+				replacementVariables: newReplacementVariables,
+			};
+
+		case INSERT_REPLACEMENT_VARIABLE:
 			return {
 				...state,
 				replacementVariables: [

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -1,5 +1,5 @@
 /* global wpseoReplaceVarsL10n, require */
-import { updateReplacementVariable } from "./redux/actions/snippetEditor";
+import { insertReplacementVariable } from "./redux/actions/snippetEditor";
 
 var forEach = require( "lodash/forEach" );
 var filter = require( "lodash/filter" );
@@ -127,7 +127,10 @@ var ReplaceVar = require( "./values/replaceVar" );
 	 */
 	YoastReplaceVarPlugin.prototype.addReplacement = function( replacement ) {
 		placeholders[ replacement.placeholder ] = replacement;
-		this._store.dispatch( updateReplacementVariable( replacement.replacement, "" ) );
+
+		// Stripping percentage signs to have clean names in the Redux store.
+		let strippedPlaceholder = replacement.placeholder.replace( "(\\s*%%sep%%)*", "" ).replace( /%%/g, "" );
+		this._store.dispatch( insertReplacementVariable( strippedPlaceholder, "" ) );
 	};
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* There was already a shallow comparison between gutenberg data and our redux data in `refreshYoastSEO()` in `data.js`. I passed the store to the data class, and made a change handler function that can dispatch relevant actions to the store.
* There was a bug in the snippetEditorReducer for the update_replacement_variable action, in that it would simply append all new replacevars at the end of the array, leading to duplicates. I've now changed that to return a new array with the updated value. I also created an insertReplacementVariable action to load the array initially.
* We are now stripping the `%%`'s from the placeholder names in Redux, because the new editor takes care of that, and the autocompletion looks better without the `%%`'s. So does the store, for that matter.

## Test instructions

This PR can be tested by following these steps:

* Go to Gutenberg, and edit the title of the post. The redux logger should show `SNIPPET_EDITOR_UPDATE_REPLACEMENT_VARIABLE` with an object containing the name 'title', and the title you just entered under value.
* If you have the new snippet editor (place `define( 'YOAST_FEATURE_SNIPPET_PREVIEW', true );` in your `wp-config.php` ), you can enter `%%title%%` (or use the autocomplete) and the title will appear in the snippet editor, and change on updates. This was not the case before.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


