### PR TITLE
Fix OpenGraph image detection

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -406,11 +406,17 @@ class WPSEO_OpenGraph_Image {
 			return;
 		}
 
-		if ( ! WPSEO_Image_Utils::has_usable_dimensions( $attachment_id, $this->image_params ) ) {
+		$variations = WPSEO_Image_Utils::get_variations( $attachment_id );
+		$variations = WPSEO_Image_Utils::filter_usable_dimensions( $this->image_params, $variations );
+		$variations = WPSEO_Image_Utils::filter_usable_file_size( $variations );
+
+		// If we are left without variations, there is no valid variation for this attachment.
+		if ( empty( $variations ) ) {
 			return;
 		}
 
-		$attachment = WPSEO_Image_Utils::get_optimal_variation( $attachment_id );
+		// The variations are ordered so the first variations is by definition the best one.
+		$attachment = $variations[0];
 
 		if ( $attachment ) {
 			$this->add_image( $attachment );

--- a/tests/frontend/test-class-wpseo-image-utils.php
+++ b/tests/frontend/test-class-wpseo-image-utils.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Frontend
+ */
+
+/**
+ * Tests WPSEO_Image_Utils
+ */
+final class WPSEO_Image_Utils_Test extends PHPUnit_Framework_TestCase {
+	/**
+	 * @dataProvider data_get_usable_dimensions
+	 */
+	public function test_get_usable_dimensions( $width, $height, $inside, $msg = '' ) {
+		$expected = array();
+		if ( $inside ) {
+			$expected[] = array(
+				'width' => $width,
+				'height' => $height,
+			);
+		}
+		$input = array(
+			array(
+				'width' => $width,
+				'height' => $height,
+			),
+		);
+		$requirements = array(
+			'min_width'  => 200,
+			'max_width'  => 2000,
+			'min_height' => 200,
+			'max_height' => 2000,
+			'min_ratio'  => 0.333,
+			'max_ratio'  => 3,
+		);
+
+		$actual = WPSEO_Image_Utils::filter_usable_dimensions( $requirements, $input );
+
+		$this->assertEquals( $expected, $actual, $msg );
+	}
+
+	public function data_get_usable_dimensions() {
+		return array(
+			array( 200, 200, true ),
+			array( 200, 199, false ),
+			array( 199, 200, false ),
+			array( 600, 200, true ),
+			array( 601, 200, false, 'Outside ratio' ),
+			array( 200, 600, true ),
+			array( 200, 601, false, 'Outside ratio' ),
+			array( 2000, 2000, true ),
+			array( 2000, 2001, false ),
+			array( 2001, 2000, false ),
+			array( 1000, 1000, true ),
+		);
+	}
+}


### PR DESCRIPTION
When an image was used that didn't meet the image requirements we
didn't try different image sizes. This change makes sure that we
always try the image sizes that are specified in the
`wpseo_image_sizes` filter. Even if the original image is too big.

Fixes #9627