### PR TITLE
Fixed the broken webpack config by adding YoastSEO.js

### DIFF
--- a/webpack/webpack.config.default.js
+++ b/webpack/webpack.config.default.js
@@ -59,7 +59,7 @@ const defaultWebpackConfig = {
 		rules: [
 			{
 				test: /.jsx?$/,
-				exclude: /node_modules\/(?!(yoast-components|gutenberg)\/).*/,
+				exclude: /node_modules\/(?!(yoast-components|gutenberg|yoastseo)\/).*/,
 				use: [
 					{
 						loader: "babel-loader",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Attempt to build WordPress SEO with a custom YoastSEO.js branch. Webpack should now succeed.
