### PR TITLE
Don't resolve symlinks in webpack

### DIFF
--- a/webpack/webpack.config.default.js
+++ b/webpack/webpack.config.default.js
@@ -54,6 +54,7 @@ const defaultWebpackConfig = {
 	resolve: {
 		extensions: [ ".json", ".js", ".jsx" ],
 		alias,
+		symlinks: false,
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _not applicable_

## Relevant technical choices:

* This makes building YoastSEO.js work when it is linked using `yarn link`.

## Test instructions

This PR can be tested by following these steps:

* Does @afercia's build work?

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended