### PR TITLE
Add fr_BE as a locale

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -365,6 +365,7 @@ class WPSEO_OpenGraph {
 			'ff_NG', // Fulah.
 			'fi_FI', // Finnish.
 			'fo_FO', // Faroese.
+			'fr_BE', // French (Belgium).
 			'fr_CA', // French (Canada).
 			'fr_FR', // French (France).
 			'fy_NL', // Frisian.

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -413,7 +413,7 @@ class WPSEO_OpenGraph {
 			'nb_NO', // Norwegian (bokmal).
 			'nd_ZW', // Ndebele.
 			'ne_NP', // Nepali.
-			'nl_BE', // Dutch (Belgie).
+			'nl_BE', // Dutch (Belgium).
 			'nl_NL', // Dutch.
 			'nn_NO', // Norwegian (nynorsk).
 			'ny_MW', // Chewa.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed fr_BE being turned into fr_FR in og:locale meta tag

## Test instructions

This PR can be tested by following these steps:

* Set fr-BE as WordPress language.
* Check og:locale metatag content.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9655
