### PR TITLE
Implement templates in the React Snippet Editor

### DIFF
--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -1,8 +1,11 @@
+// External dependencies.
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import { StyledSection, StyledHeading, StyledSectionBase } from "yoast-components";
+
+// Internal dependencies.
 import SnippetEditor from "../containers/SnippetEditor";
-import PropTypes from "prop-types";
 
 const Section = styled( StyledSection )`
 	margin-bottom: 2em;
@@ -37,11 +40,15 @@ const mapEditorDataToPreview = function( data ) {
 /**
  * Creates the Snippet Preview Section.
  *
- * @param {Object} props The component props.
+ * @param {Object} props           The component props.
+ * @param {string} props.baseUrl   The base url that the preview uses for the slug.
+ * @param {string} props.date      The date that can get prefixed to the meta description.
+ * @param {Object} props.templates Can contain templates for the title and/or the description.
+ *                                 Which will then be used if they are empty.
  *
  * @returns {ReactElement} Snippet Preview Section.
  */
-const SnippetPreviewSection = ( { baseUrl, date } ) => {
+const SnippetPreviewSection = ( { baseUrl, date, templates } ) => {
 	return <Section
 		headingLevel={ 3 }
 		headingText="React snippet preview"
@@ -52,6 +59,7 @@ const SnippetPreviewSection = ( { baseUrl, date } ) => {
 			baseUrl={ baseUrl }
 			mapDataToPreview={ mapEditorDataToPreview }
 			date={ date }
+			templates={ templates }
 		/>
 	</Section>;
 };
@@ -59,6 +67,7 @@ const SnippetPreviewSection = ( { baseUrl, date } ) => {
 SnippetPreviewSection.propTypes = {
 	baseUrl: PropTypes.string.isRequired,
 	date: PropTypes.string,
+	templates: PropTypes.object,
 };
 
 SnippetPreviewSection.defaultProps = {

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -1,32 +1,71 @@
+// External dependencies.
 import { connect } from "react-redux";
 import { SnippetEditor } from "yoast-components";
+import isEmpty from "lodash/isEmpty";
+import forEach from "lodash/forEach";
+import cloneDeep from "lodash/cloneDeep";
+
+// Internal dependencies.
 import {
 	switchMode,
 	updateData,
 } from "../redux/actions/snippetEditor";
 
 /**
+ * Applies the template to the data in the state.
+ *
+ * @param {Object} data     Scoped part of the redux state.
+ * @param {string} key      The key of the data.
+ * @param {string} template The value of the template.
+ *
+ * @returns {Object} The Redux state.
+ */
+function applyDataTemplate( data, key, template ) {
+	if ( isEmpty( data[ key ] ) ) {
+		data[ key ] = template;
+	}
+	return data;
+}
+
+/**
  * Maps the redux state to the snippet editor component.
  *
  * @param {Object} state The current state.
  * @param {Object} state.snippetEditor The state for the snippet editor.
+ * @param {Object} ownProps The properties for the snippet editor.
  *
  * @returns {Object} Data for the `SnippetEditor` component.
  */
-export function mapStateToProps( state ) {
-	return state.snippetEditor;
+export function mapStateToProps( state, ownProps ) {
+	const newState = cloneDeep( state.snippetEditor );
+	forEach( ownProps.templates, ( template, key ) => {
+		newState.data = applyDataTemplate( newState.data, key, template );
+	} );
+	return newState;
 }
 
 /**
  * Maps dispatch function to props for the snippet editor component.
  *
  * @param {Function} dispatch The dispatch function that will dispatch a redux action.
+ * @param {Object}   ownProps The properties for the snippet editor.
  *
  * @returns {Object} Props for the `SnippetEditor` component.
  */
-export function mapDispatchToProps( dispatch ) {
+export function mapDispatchToProps( dispatch, ownProps ) {
 	return {
 		onChange: ( key, value ) => {
+			// Check if we are updating something that contains a template.
+			forEach( ownProps.templates, ( template, templateKey ) => {
+				if ( key === templateKey ) {
+					// If the value is the same as the template, pretend it is empty.
+					if ( value === template ) {
+						console.log( "clearing", key, value, template );
+						value = "";
+					}
+				}
+			} );
+
 			let action = updateData( {
 				[ key ]: value,
 			} );

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -18,6 +18,8 @@ import AnalysisSection from "./components/contentAnalysis/AnalysisSection";
 import Data from "./analysis/data.js";
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
 import SnippetPreviewSection from "./components/SnippetPreviewSection";
+import getTitlePlaceholder from "./analysis/getTitlePlaceholder";
+import getDescriptionPlaceholder from "./analysis/getDescriptionPlaceholder";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
 let localizedData = { intl: {} };
@@ -171,6 +173,10 @@ export function initialize( args ) {
 		renderSnippetPreview( store, {
 			baseUrl: args.snippetEditorBaseUrl,
 			date: args.snippetEditorDate,
+			templates: {
+				title: getTitlePlaceholder(),
+				description: getDescriptionPlaceholder(),
+			},
 		} );
 	}
 

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -1,6 +1,7 @@
 /* global YoastSEO: true, tinyMCE, wpseoPostScraperL10n, YoastShortcodePlugin, YoastReplaceVarPlugin, console, require */
 import { App } from "yoastseo";
 import isUndefined from "lodash/isUndefined";
+import isFunction from "lodash/isFunction";
 
 import { tmceId, setStore } from "./wp-seo-tinymce";
 import YoastMarkdownPlugin from "./wp-seo-markdown-plugin";
@@ -25,7 +26,6 @@ import snippetPreviewHelpers from "./analysis/snippetPreview";
 import UsedKeywords from "./analysis/usedKeywords";
 import { setMarkerStatus } from "./redux/actions/markerButtons";
 import { updateData } from "./redux/actions/snippetEditor";
-import isFunction from "lodash/isFunction";
 
 ( function( $ ) {
 	"use strict"; // eslint-disable-line


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Uses the container's mapStateToProps to copy the templates to the component state.
* Uses the container's mapDispatchToProps to remove the templates before a dispatch.

## TODO

* Add a flag to only apply the templates on page load. So we don't get into the situation that when you remove the whole title for example that you then instantly get the template again.

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9532 
