### PR TITLE
Implement templates in the React Snippet Editor

### DIFF
--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -7,7 +7,7 @@ import { tmceId } from "../wp-seo-tinymce";
 import getIndicatorForScore from "./getIndicatorForScore";
 
 import { update as updateTrafficLight } from "../ui/trafficLight";
-import { update as updateAdminBar }from "../ui/adminBar";
+import { update as updateAdminBar } from "../ui/adminBar";
 
 import publishBox from "../ui/publishBox";
 import isGutenbergDataAvailable from "../helpers/isGutenbergDataAvailable";

--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -17,7 +17,7 @@ function getDataFromCollector( collector ) {
 }
 
 /**
- * Gets the snippet editor data from a data collector.
+ * Gets the snippet editor data from the redux store.
  *
  * @param {Object} store The redux store to get the data from.
  *

--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -1,4 +1,3 @@
-import get from "lodash/get";
 import isEmpty from "lodash/isEmpty";
 import isUndefined from "lodash/isUndefined";
 
@@ -53,7 +52,11 @@ function getTemplatesFromL10n( l10nObject ) {
 	if ( isEmpty( templates.title ) ) {
 		templates.title = "%%title%% - %%sitename%%";
 	}
-	templates.description = get( l10nObject, "metadesc_template", "" );
+
+	const description = l10nObject.metadesc_template;
+	if ( ! isEmpty( description ) ) {
+		templates.description = description;
+	}
 
 	return templates;
 }

--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -72,13 +72,11 @@ function getTemplatesFromL10n( l10nObject ) {
  * @returns {Object} A copy of the data with the templates applied.
  */
 function getDataWithTemplates( data, templates ) {
-	const dataWithTemplates = {};
+	const dataWithTemplates = { ...data };
 
 	forEach( templates, ( template, key ) => {
 		if ( has( data, key ) && data[ key ] === "" ) {
 			dataWithTemplates[ key ] = template;
-		} else {
-			dataWithTemplates[ key ] = data[ key ];
 		}
 	} );
 
@@ -94,13 +92,11 @@ function getDataWithTemplates( data, templates ) {
  * @returns {Object} A copy of the data without the templates.
  */
 function getDataWithoutTemplates( data, templates ) {
-	const dataWithoutTemplates = {};
+	const dataWithoutTemplates = { ...data };
 
 	forEach( templates, ( template, key ) => {
 		if ( has( data, key ) && data[ key ] === template ) {
 			dataWithoutTemplates[ key ] = "";
-		} else {
-			dataWithoutTemplates[ key ] = data[ key ];
 		}
 	} );
 

--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -1,0 +1,65 @@
+import get from "lodash/get";
+import isEmpty from "lodash/isEmpty";
+import isUndefined from "lodash/isUndefined";
+
+/**
+ * Gets the snippet editor data from a data collector.
+ *
+ * @param {PostDataCollector|TermDataCollector} collector The collector to get the data from.
+ *
+ * @returns {Object} The snippet editor data object.
+ */
+function getDataFromCollector( collector ) {
+	return {
+		title: collector.getSnippetTitle(),
+		slug: collector.getSnippetCite(),
+		description: collector.getSnippetMeta(),
+	};
+}
+
+/**
+ * Gets the snippet editor data from a data collector.
+ *
+ * @param {Object} store The redux store to get the data from.
+ *
+ * @returns {Object} The snippet editor data object.
+ */
+function getDataFromStore( store ) {
+	const state = store.getState();
+	const data = state.snippetEditor.data;
+
+	return {
+		title: data.title,
+		slug: data.slug,
+		description: data.description,
+	};
+}
+
+/**
+ * Gets the templates from the localization object.
+ *
+ * @param {Object} l10nObject The localization object.
+ *
+ * @returns {Object} The templates object.
+ */
+function getTemplatesFromL10n( l10nObject ) {
+	const templates = {};
+
+	if ( isUndefined( l10nObject ) ) {
+		return templates;
+	}
+
+	templates.title = l10nObject.title_template;
+	if ( isEmpty( templates.title ) ) {
+		templates.title = "%%title%% - %%sitename%%";
+	}
+	templates.description = get( l10nObject, "metadesc_template", "" );
+
+	return templates;
+}
+
+export default {
+	getDataFromCollector,
+	getDataFromStore,
+	getTemplatesFromL10n,
+};

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -1,8 +1,11 @@
+// External dependencies.
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import { StyledSection, StyledHeading, StyledSectionBase } from "yoast-components";
+
+// Internal dependencies.
 import SnippetEditor from "../containers/SnippetEditor";
-import PropTypes from "prop-types";
 
 const Section = styled( StyledSection )`
 	margin-bottom: 2em;
@@ -20,9 +23,9 @@ const Section = styled( StyledSection )`
 /**
  * Process the snippet editor form data before it's being displayed in the snippet preview.
  *
- * @param {Object} data The snippet preview data object.
- * @param {string} data.title The snippet preview title.
- * @param {string} data.url The snippet preview url: baseUrl with the slug.
+ * @param {Object} data             The snippet preview data object.
+ * @param {string} data.title       The snippet preview title.
+ * @param {string} data.url         The snippet preview url: baseUrl with the slug.
  * @param {string} data.description The snippet preview description.
  *
  * @returns {Object} The snippet preview data object.
@@ -37,7 +40,9 @@ const mapEditorDataToPreview = function( data ) {
 /**
  * Creates the Snippet Preview Section.
  *
- * @param {Object} props The component props.
+ * @param {Object} props         The component props.
+ * @param {string} props.baseUrl The base url that the preview uses for the slug.
+ * @param {string} props.date    The date that can get prefixed to the meta description.
  *
  * @returns {ReactElement} Snippet Preview Section.
  */

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -557,9 +557,12 @@ import { updateData } from "./redux/actions/snippetEditor";
 
 			if ( ! isEqual( snippetEditorData, data ) ) {
 				snippetEditorData = data;
-				postDataCollector.saveSnippetData(
-					snippetEditorHelpers.getDataWithoutTemplates( data, snippetEditorTemplates )
-				);
+				const dataWithoutTemplates = snippetEditorHelpers.getDataWithoutTemplates( data, snippetEditorTemplates );
+				postDataCollector.saveSnippetData( {
+					title: dataWithoutTemplates.title,
+					urlPath: dataWithoutTemplates.slug,
+					metaDesc: dataWithoutTemplates.description,
+				} );
 
 				updateLegacySnippetEditor( data );
 			}

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -386,9 +386,12 @@ window.yoastHideMarkers = true;
 
 			if ( ! isEqual( snippetEditorData, data ) ) {
 				snippetEditorData = data;
-				termScraper.saveSnippetData(
-					snippetEditorHelpers.getDataWithoutTemplates( data, snippetEditorTemplates )
-				);
+				const dataWithoutTemplates = snippetEditorHelpers.getDataWithoutTemplates( data, snippetEditorTemplates );
+				termScraper.saveSnippetData( {
+					title: dataWithoutTemplates.title,
+					urlPath: dataWithoutTemplates.slug,
+					metaDesc: dataWithoutTemplates.description,
+				} );
 
 				updateLegacySnippetEditor( data );
 			}

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -1,9 +1,13 @@
 /* global YoastSEO: true, wpseoTermScraperL10n, YoastReplaceVarPlugin, console, require */
+
+// External dependencies.
 import { App } from "yoastseo";
 import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
-import isUndefined from "lodash/isUndefined";
+import isEqual from "lodash/isEqual";
 import isFunction from "lodash/isFunction";
+import isUndefined from "lodash/isUndefined";
 
+// Internal dependencies.
 import initializeEdit from "./edit";
 import { termsTmceId as tmceId } from "./wp-seo-tinymce";
 import { update as updateTrafficLight } from "./ui/trafficLight";
@@ -14,6 +18,7 @@ import getTranslations from "./analysis/getTranslations";
 import isKeywordAnalysisActive from "./analysis/isKeywordAnalysisActive";
 import isContentAnalysisActive from "./analysis/isContentAnalysisActive";
 import snippetPreviewHelpers from "./analysis/snippetPreview";
+import snippetEditorHelpers from "./analysis/snippetEditor";
 import TermDataCollector from "./analysis/TermDataCollector";
 import UsedKeywords from "./analysis/usedKeywords";
 import TaxonomyAssessor from "./assessors/taxonomyAssessor";
@@ -138,13 +143,13 @@ window.yoastHideMarkers = true;
 	 * @returns {SnippetPreview} Instance of snippetpreview.
 	 */
 	function initSnippetPreview( termScraper ) {
+		const snippetEditorData = snippetEditorHelpers.getDataFromCollector( termScraper );
 		return snippetPreviewHelpers.create( snippetContainer, {
-			title: termScraper.getSnippetTitle(),
-			urlPath: termScraper.getSnippetCite(),
-			metaDesc: termScraper.getSnippetMeta(),
+			title: snippetEditorData.title,
+			urlPath: snippetEditorData.slug,
+			metaDesc: snippetEditorData.description,
 		}, ( data ) => {
-			const state = store.getState();
-			const previousData = state.snippetEditor.data;
+			const previousData = snippetEditorHelpers.getDataFromStore( store );
 
 			if (
 				previousData.title !== data.title ||
@@ -367,25 +372,20 @@ window.yoastHideMarkers = true;
 			app.snippetPreview.handleWindowResizing();
 		} );
 
-		const snippetEditorData = {
-			title: termScraper.getSnippetTitle(),
-			slug: termScraper.getSnippetCite(),
-			description: termScraper.getSnippetMeta(),
-		};
-
+		// Set the initial snippet editor data.
+		let snippetEditorData = snippetEditorHelpers.getDataFromCollector( termScraper );
 		store.dispatch( updateData( snippetEditorData ) );
 
+		// Subscribe to the store to save the snippet editor data.
 		store.subscribe( () => {
-			const state = store.getState();
-			const data = state.snippetEditor.data;
+			const data = snippetEditorHelpers.getDataFromStore( store );
 
-			termScraper.saveSnippetData( {
-				title: data.title,
-				urlPath: data.slug,
-				metaDesc: data.description,
-			} );
+			if ( ! isEqual( snippetEditorData, data ) ) {
+				snippetEditorData = data;
+				termScraper.saveSnippetData( data );
 
-			updateLegacySnippetEditor( data );
+				updateLegacySnippetEditor( data );
+			}
 		} );
 	} );
 }( jQuery, window ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## What this should do

* Add the title & description templates that exist in classic to the React version.
* Apply a template if the variable is empty on load.
* If a value equals a template, use an empty value to send to the server (hidden input).

## Relevant technical choices:

* Use the initial data set to apply templates.
* Use the store subscribe hook to keep the data free of templates.
* Extract this logic into a separate file.

## Test instructions

This PR can be tested by following these steps:

* Checkout branch & build.
* Use `define( 'YOAST_FEATURE_SNIPPET_PREVIEW', true );` in your `wp-config.php` to enable the React snippet preview.
* Edit the title & description in the snippet editor on posts & pages as well as the taxonomies.
* You should see the initial value in the store after refresh.
* You should see the save value on the hidden inputs: 
  - On posts: `#yoast_wpseo_title` & `#yoast_wpseo_metadesc`.
  - On taxonomies: `#hidden_wpseo_title` & `#hidden_wpseo_desc`.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9532 
