### PR TITLE
Only add basedir if it does not already exists

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -128,8 +128,9 @@ class WPSEO_Image_Utils {
 			$uploads = wp_get_upload_dir();
 		}
 
-		if ( empty( $uploads['error'] ) ) {
-			return $uploads['basedir'] . "/$path";
+		// Only add basedir if it does not already exist in the path.
+		if ( empty( $uploads['error'] ) && strpos( $path, $uploads['basedir'] . DIRECTORY_SEPARATOR ) !== 0 ) {
+			return $uploads['basedir'] . DIRECTORY_SEPARATOR . $path;
 		}
 
 		return $path;

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -128,7 +128,7 @@ class WPSEO_Image_Utils {
 			$uploads = wp_get_upload_dir();
 		}
 
-		// Only add basedir if it does not already exist in the path.
+		// Add the uploads basedir if the path does not start with it.
 		if ( empty( $uploads['error'] ) && strpos( $path, $uploads['basedir'] . DIRECTORY_SEPARATOR ) !== 0 ) {
 			return $uploads['basedir'] . DIRECTORY_SEPARATOR . ltrim( $path, DIRECTORY_SEPARATOR );
 		}

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -130,7 +130,7 @@ class WPSEO_Image_Utils {
 
 		// Only add basedir if it does not already exist in the path.
 		if ( empty( $uploads['error'] ) && strpos( $path, $uploads['basedir'] . DIRECTORY_SEPARATOR ) !== 0 ) {
-			return $uploads['basedir'] . DIRECTORY_SEPARATOR . $path;
+			return $uploads['basedir'] . DIRECTORY_SEPARATOR . ltrim( $path, DIRECTORY_SEPARATOR );
 		}
 
 		return $path;

--- a/tests/frontend/test-class-wpseo-image-utils.php
+++ b/tests/frontend/test-class-wpseo-image-utils.php
@@ -71,7 +71,7 @@ final class WPSEO_Image_Utils_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Tests if the absolute path is working as expected
+	 * Tests if the absolute path is working as expected.
 	 *
 	 * @param string $input    Data to use in execution.
 	 * @param string $expected Expected result.
@@ -98,11 +98,15 @@ final class WPSEO_Image_Utils_Test extends PHPUnit_Framework_TestCase {
 				'/a',
 				$uploads['basedir'] . '/a',
 				'Relative path should receive basedir as prefix.',
-				$uploads['basedir'] . '/a',
-				$uploads['basedir'] . '/a',
+			),
+			array(
+				$uploads['basedir'] . '/b',
+				$uploads['basedir'] . '/b',
 				'Absolute path should be returned as is.',
-				'/b' . $uploads['basedir'] . '/a',
-				$uploads['basedir'] . '/b' . $uploads['basedir'] . '/a',
+			),
+			array(
+				'/c' . $uploads['basedir'] . '/d',
+				$uploads['basedir'] . '/c' . $uploads['basedir'] . '/d',
 				'Relative path with absolute path inside should be prefixed with basedir.',
 			)
 		);

--- a/tests/frontend/test-class-wpseo-image-utils.php
+++ b/tests/frontend/test-class-wpseo-image-utils.php
@@ -75,14 +75,14 @@ final class WPSEO_Image_Utils_Test extends PHPUnit_Framework_TestCase {
 	 *
 	 * @param string $input    Data to use in execution.
 	 * @param string $expected Expected result.
-	 * @param string $reason   Description of the tested data.
+	 * @param string $message  Description of the tested data.
 	 *
 	 * @dataProvider data_get_absolute_path
 	 */
-	public function test_absolute_path( $input, $expected, $reason = '' ) {
+	public function test_absolute_path( $input, $expected, $message = '' ) {
 		$result = WPSEO_Image_Utils::get_absolute_path( $input );
 
-		$this->assertEquals( $expected, $result, $reason );
+		$this->assertEquals( $expected, $result, $message );
 	}
 
 	/**

--- a/tests/frontend/test-class-wpseo-image-utils.php
+++ b/tests/frontend/test-class-wpseo-image-utils.php
@@ -10,22 +10,31 @@
  */
 final class WPSEO_Image_Utils_Test extends PHPUnit_Framework_TestCase {
 	/**
+	 * Tests the usable dimensions method.
+	 *
 	 * @dataProvider data_get_usable_dimensions
+	 *
+	 * @param int     $width       Width of the image.
+	 * @param int     $height      Height of the image.
+	 * @param boolean $is_usable   If these dimensions are usable or not.
+	 * @param string  $description Description for the data being tested.
 	 */
-	public function test_get_usable_dimensions( $width, $height, $inside, $msg = '' ) {
+	public function test_get_usable_dimensions( $width, $height, $is_usable, $description = '' ) {
 		$expected = array();
-		if ( $inside ) {
+		if ( $is_usable ) {
 			$expected[] = array(
-				'width' => $width,
+				'width'  => $width,
 				'height' => $height,
 			);
 		}
+
 		$input = array(
 			array(
-				'width' => $width,
+				'width'  => $width,
 				'height' => $height,
 			),
 		);
+
 		$requirements = array(
 			'min_width'  => 200,
 			'max_width'  => 2000,
@@ -37,9 +46,14 @@ final class WPSEO_Image_Utils_Test extends PHPUnit_Framework_TestCase {
 
 		$actual = WPSEO_Image_Utils::filter_usable_dimensions( $requirements, $input );
 
-		$this->assertEquals( $expected, $actual, $msg );
+		$this->assertEquals( $expected, $actual, $description );
 	}
 
+	/**
+	 * Provides data for the usable dimensions test.
+	 *
+	 * @return array Data.
+	 */
 	public function data_get_usable_dimensions() {
 		return array(
 			array( 200, 200, true ),
@@ -53,6 +67,44 @@ final class WPSEO_Image_Utils_Test extends PHPUnit_Framework_TestCase {
 			array( 2000, 2001, false ),
 			array( 2001, 2000, false ),
 			array( 1000, 1000, true ),
+		);
+	}
+
+	/**
+	 * Tests if the absolute path is working as expected
+	 *
+	 * @param string $input    Data to use in execution.
+	 * @param string $expected Expected result.
+	 * @param string $reason   Description of the tested data.
+	 *
+	 * @dataProvider data_get_absolute_path
+	 */
+	public function test_absolute_path( $input, $expected, $reason = '' ) {
+		$result = WPSEO_Image_Utils::get_absolute_path( $input );
+
+		$this->assertEquals( $expected, $result, $reason );
+	}
+
+	/**
+	 * Provides data for the absolute path test.
+	 *
+	 * @return array Data.
+	 */
+	public function data_get_absolute_path() {
+		$uploads = wp_get_upload_dir();
+
+		return array(
+			array(
+				'/a',
+				$uploads['basedir'] . '/a',
+				'Relative path should receive basedir as prefix.',
+				$uploads['basedir'] . '/a',
+				$uploads['basedir'] . '/a',
+				'Absolute path should be returned as is.',
+				'/b' . $uploads['basedir'] . '/a',
+				$uploads['basedir'] . '/b' . $uploads['basedir'] . '/a',
+				'Relative path with absolute path inside should be prefixed with basedir.',
+			)
 		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the filesize could not be determined due to invalid absolute path determination.

## Relevant technical choices:

* Prefix the basedir only if it is not already present at the start of the path.

## Test instructions

This PR can be tested by following these steps:

* Have an image with an absolute path (this is default behaviour in my test environment when uploading an image)
* Make sure the path is correct after running through the absolute path method
* Query Monitor gives a notification of a suppressed warning if it occured before, even with the muted filesize check

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/9682
