### PR TITLE
Corrected business logic for og-image on frontpage

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -64,7 +64,7 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Constructor.
 	 *
-	 * @param null|string     $image     Optional. The Image to use.
+	 * @param null|string     $image Optional. The Image to use.
 	 * @param WPSEO_OpenGraph $opengraph Optional. The OpenGraph object.
 	 */
 	public function __construct( $image = null, WPSEO_OpenGraph $opengraph = null ) {
@@ -196,21 +196,22 @@ class WPSEO_OpenGraph_Image {
 	 * If the frontpage image exists, call add_image.
 	 */
 	private function set_front_page_image() {
-	    
-        $show_on_front = get_option( 'show_on_front' );
-        
-        // if frontpage is a simple page, call the set_singular_image function
-        if( $show_on_front !== 'posts' ){
-            $this->set_singular_image();
-            return;
-        }
-        
+
+		$show_on_front = get_option( 'show_on_front' );
+
+		// If frontpage is a simple page, call the set_singular_image function.
+		if ( $show_on_front !== 'posts' ) {
+			$this->set_singular_image();
+
+			return;
+		}
+
 		// If no frontpage image is found, don't add anything.
 		if ( WPSEO_Options::get( 'og_frontpage_image', '' ) === '' ) {
 			return;
 		}
-        
-        // if posts are showing in frontpage, add image set in options
+
+		// If posts are showing in frontpage, add image set in options.
 		$this->add_image_by_url( WPSEO_Options::get( 'og_frontpage_image' ) );
 	}
 
@@ -357,6 +358,7 @@ class WPSEO_OpenGraph_Image {
 		$attachment_id = WPSEO_Image_Utils::get_attachment_by_url( $url );
 		if ( $attachment_id > 0 ) {
 			$this->add_image_by_id( $attachment_id );
+
 			return;
 		}
 
@@ -425,6 +427,7 @@ class WPSEO_OpenGraph_Image {
 
 		if ( $this->is_size_overridden() ) {
 			$this->get_overridden_image( $attachment_id );
+
 			return;
 		}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -64,7 +64,7 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Constructor.
 	 *
-	 * @param null|string     $image Optional. The Image to use.
+	 * @param null|string     $image     Optional. The Image to use.
 	 * @param WPSEO_OpenGraph $opengraph Optional. The OpenGraph object.
 	 */
 	public function __construct( $image = null, WPSEO_OpenGraph $opengraph = null ) {

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -196,11 +196,21 @@ class WPSEO_OpenGraph_Image {
 	 * If the frontpage image exists, call add_image.
 	 */
 	private function set_front_page_image() {
+	    
+        $show_on_front = get_option( 'show_on_front' );
+        
+        // if frontpage is a simple page, call the set_singular_image function
+        if( $show_on_front !== 'posts' ){
+            $this->set_singular_image();
+            return;
+        }
+        
 		// If no frontpage image is found, don't add anything.
 		if ( WPSEO_Options::get( 'og_frontpage_image', '' ) === '' ) {
 			return;
 		}
-
+        
+        // if posts are showing in frontpage, add image set in options
 		$this->add_image_by_url( WPSEO_Options::get( 'og_frontpage_image' ) );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* From latest versions of Yoast, i have nomore og-image metatag on frontpage
* After inspecting for a while, i realized you are showing (and i don't know why precisely) the og-image meta only if the frontpage is showing the posts archive. Please take a look where the option `og_frontpage_image` can be set (/admin/views/tabs/social/facebook.php, from row 33):
```php
if ( 'posts' === get_option( 'show_on_front' ) ) {
	$social_facebook_frontpage_help = new WPSEO_Admin_Help_Panel(
		'social-facebook-frontpage',
		esc_html__( 'Learn more about the title separator setting', 'wordpress-seo' ),
		esc_html__( 'These are the title, description and image used in the Open Graph meta tags on the front page of your site.', 'wordpress-seo' ),
		'has-wrapper'
	);
	echo '<h2 class="help-button-inline">' . esc_html__( 'Frontpage settings', 'wordpress-seo' ) . $social_facebook_frontpage_help->get_button_html() . '</h2>';
	echo $social_facebook_frontpage_help->get_panel_html();

	$yform->media_input( 'og_frontpage_image', __( 'Image URL', 'wordpress-seo' ) );
	$yform->textinput( 'og_frontpage_title', __( 'Title', 'wordpress-seo' ) );
	$yform->textinput( 'og_frontpage_desc', __( 'Description', 'wordpress-seo' ) );

	//...........
}
```
* As a frontpage could also be a simple page, i added the possibility to have the Yoast SEO metabox where i can select the og-image working again as expected

## Relevant technical choices:

* I preferred to call directly the set_singular_image instead of rewriting an already done business logic for a single page

## Test instructions

This PR can be tested by following these steps:

* select a single front page and add the og-image using Yoast metabox in backend 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
