### PR TITLE
Bump WHIP WordPress version conditional

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -333,10 +333,10 @@ class WPSEO_Admin {
 		}
 
 		/*
-		 * The Whip message shouldn't be shown from WordPress 4.9.5 and higher because
+		 * The Whip message shouldn't be shown from WordPress 5.0.0 and higher because
 		 * that version introduces Serve Happy which is almost similar to Whip.
 		 */
-		$minimal_wp_version = '4.9.7';
+		$minimal_wp_version = '5.0.0';
 		if ( version_compare( $GLOBALS['wp_version'], $minimal_wp_version, '>=' ) ) {
 			return;
 		}


### PR DESCRIPTION
As the ServeHappy dashboard message has not been implemented in the WordPress version we expected it to be in, we need to bump the version which hides the WHIP message.

The changelog for 4.9.6 has just been released and the ServeHappy code is not referenced in that one, bumping the version check to ~4.9.7~ 5.0.0 for now.
See https://core.trac.wordpress.org/ticket/41191#comment:115

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [] ~I have added unittests to verify the code works as intended~

Fixes #
