### PR TITLE
Pass along focus keyword in wpseo

### DIFF
--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -14,7 +14,10 @@ import {
  * @returns {Object} Data for the `SnippetEditor` component.
  */
 export function mapStateToProps( state ) {
-	return state.snippetEditor;
+	return {
+		...state.snippetEditor,
+		keyword: state.activeKeyword,
+	};
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*N/A

## Relevant technical choices:

* See sibling Pr: https://github.com/Yoast/yoast-components/pull/522

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch in wpseo, and it's sibling branch in Yoast-components.
* link yoast components to wpseo.
* build yoast components and wpseo.
* start watchers for yoast components and wpseo.
* Open a post, choose a focus keyword, put the focus keyword in the meta description. 
     * Check if the focus keyword is highlighted in the meta description.
     * Don't worry about the fact the highlighting doesn't update when the keyword is updated. This is because the active keyword is not updated when you change it in the metabox. And is not a regression caused by this pull.


## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/yoast-components/issues/516
