### PR TITLE
Implement working category replacevar for posts

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -490,7 +490,7 @@ import { updateData } from "./redux/actions/snippetEditor";
 
 		postDataCollector.app = app;
 
-		const replaceVarsPlugin = new YoastReplaceVarPlugin( app );
+		const replaceVarsPlugin = new YoastReplaceVarPlugin( app, store );
 		const shortcodePlugin = new YoastShortcodePlugin( app );
 
 		if ( wpseoPostScraperL10n.markdownEnabled ) {

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -289,6 +289,11 @@ var ReplaceVar = require( "./values/replaceVar" );
 			}
 		}.bind( this ) );
 
+		// Custom taxonomies (ie. taxonomies that are not "category") should be prefixed with ct_.
+		if ( taxonomyName !== "category" ) {
+			taxonomyName = "ct_" + taxonomyName;
+		}
+
 		this._store.dispatch( updateReplacementVariable( taxonomyName, checkedCategories.join( ", " ) ) );
 	};
 

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -278,19 +278,16 @@ var ReplaceVar = require( "./values/replaceVar" );
 			var taxonomyID = checkbox.val();
 
 			let categoryName = this.getCategoryName( checkbox );
+			let isChecked = checkbox.prop( "checked" );
 			taxonomyElements[ taxonomyName ][ taxonomyID ] = {
 				label: categoryName,
-				checked: checkbox.prop( "checked" ),
+				checked: isChecked,
 			};
+			if( isChecked && checkedCategories.indexOf( categoryName ) === -1 ) {
+				// Only push the categoryName to the checkedCategories array if it's not already in there.
+				checkedCategories.push( categoryName );
+			}
 		}.bind( this ) );
-
-		forEach( taxonomyElements, ( taxonomyElement ) => {
-			forEach( taxonomyElement, ( checkbox ) => {
-				if ( checkbox.checked ) {
-					checkedCategories.push( checkbox.label );
-				}
-			} );
-		} );
 
 		this._store.dispatch( updateReplacementVariable( taxonomyName, checkedCategories.join( ", " ) ) );
 	};

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -271,21 +271,21 @@ var ReplaceVar = require( "./values/replaceVar" );
 			taxonomyElements[ taxonomyName ] = {};
 		}
 
-		let checkedCategories = [];
+		const checkHierarchicalTerm = [];
 
 		forEach( checkboxes, function( checkbox ) {
 			checkbox = jQuery( checkbox );
-			var taxonomyID = checkbox.val();
+			const taxonomyID = checkbox.val();
 
-			let categoryName = this.getCategoryName( checkbox );
-			let isChecked = checkbox.prop( "checked" );
+			const hierarchicalTermName = this.getCategoryName( checkbox );
+			const isChecked = checkbox.prop( "checked" );
 			taxonomyElements[ taxonomyName ][ taxonomyID ] = {
-				label: categoryName,
+				label: hierarchicalTermName,
 				checked: isChecked,
 			};
-			if( isChecked && checkedCategories.indexOf( categoryName ) === -1 ) {
+			if( isChecked && checkHierarchicalTerm.indexOf( hierarchicalTermName ) === -1 ) {
 				// Only push the categoryName to the checkedCategories array if it's not already in there.
-				checkedCategories.push( categoryName );
+				checkHierarchicalTerm.push( hierarchicalTermName );
 			}
 		}.bind( this ) );
 
@@ -294,7 +294,7 @@ var ReplaceVar = require( "./values/replaceVar" );
 			taxonomyName = "ct_" + taxonomyName;
 		}
 
-		this._store.dispatch( updateReplacementVariable( taxonomyName, checkedCategories.join( ", " ) ) );
+		this._store.dispatch( updateReplacementVariable( taxonomyName, checkHierarchicalTerm.join( ", " ) ) );
 	};
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Because we need category replacevars quickly, we decided to add the store to the replacevar plugin and dispatch the data to the store on the spot.
* Custom taxonomies _should_ also work. If the taxonomyName is not `"category"`, we prefix it with `ct_`, and it should be replaceable in the snippet preview. 

## Test instructions

This PR can be tested by following these steps:

* Use the %%category%% replacement in the Snippet Editors, and create some categories on your post. %%category%% should be replaced by all the **checked** variables, separated by a comma (and a space).
* To test the custom taxonomies, make a custom taxonomy (for example "chapter"), and call `%%ct_chapter%%` in the snippet preview. It should be replaced by the chapter title if that's checked. See https://github.com/Yoast/gutenberg/issues/20#issuecomment-372335370 (If this is unclear, pm me or Irene).

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Partial fix for #9531 
