### PR TITLE
Stories/9718 change meta description keyword taxonomy assessor specs

### DIFF
--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -48,6 +48,7 @@ describe( "running assessments in the assessor", function() {
 
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
+			"keyphraseLength",
 			"metaDescriptionLength",
 			"titleWidth",
 			"textLength",
@@ -82,38 +83,6 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
-	it( "additionally runs assessments that require a url and a keyword", function() {
-		assessor.assess( new Paper( "text", { url: "sample url", keyword: "keyword" } ) );
-		let AssessmentResults = assessor.getValidResults();
-		let assessments = getResults( AssessmentResults );
-
-		expect( assessments ).toEqual( [
-			"introductionKeyword",
-			"keyphraseLength",
-			"metaDescriptionLength",
-			"titleWidth",
-			"urlKeyword",
-			"textLength",
-		] );
-	} );
-
-	it( "additionally runs assessments that require a meta description and a keyword", function() {
-		assessor.assess( new Paper( "text", { keyword: "keyword", description: "meta description" } ) );
-		let assessments = getResults( assessor.getValidResults() );
-
-		expect( assessments ).toEqual( [
-			"introductionKeyword",
-			"keyphraseLength",
-			"metaDescriptionKeyword",
-			"metaDescriptionLength",
-			"textImages",
-			"textLength",
-			"externalLinks",
-			"internalLinks",
-			"titleWidth",
-		] );
-	} );
-
 	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
 		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id. Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas. Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
 		let AssessmentResults = assessor.getValidResults();
@@ -137,6 +106,7 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
+			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleWidth",
 			"textLength",

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -83,6 +83,21 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 
+	it( "additionally runs assessments that require a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { url: "sample url", keyword: "keyword" } ) );
+		let AssessmentResults = assessor.getValidResults();
+		let assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"titleWidth",
+			"urlKeyword",
+			"textLength",
+		] );
+	} );
+
 	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
 		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id. Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas. Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
 		let AssessmentResults = assessor.getValidResults();

--- a/js/tests/taxonomyAssessor.test.js
+++ b/js/tests/taxonomyAssessor.test.js
@@ -48,7 +48,6 @@ describe( "running assessments in the assessor", function() {
 
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleWidth",
 			"textLength",
@@ -63,7 +62,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleKeyword",
 			"titleWidth",
@@ -92,11 +90,27 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleWidth",
 			"urlKeyword",
 			"textLength",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a meta description and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "meta description" } ) );
+		let assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"externalLinks",
+			"internalLinks",
+			"titleWidth",
 		] );
 	} );
 
@@ -109,7 +123,6 @@ describe( "running assessments in the assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"keywordDensity",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleWidth",
 			"textLength",
@@ -124,7 +137,6 @@ describe( "running assessments in the assessor", function() {
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"metaDescriptionKeyword",
 			"metaDescriptionLength",
 			"titleWidth",
 			"textLength",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

n/a

## Relevant technical choices:

* Updates the taxonomy assessor spec files to match the new behavior of the meta description keyword assessment.
* Also adds the keyphraseLength assessment in a spec where it was missing.

## Test instructions

This PR can be tested by following these steps:

- Check out the branch and run `yarn install`.
- Run `yarn add` "git+https://github.com/Yoast/yoastseo.js#stories/1478-improve-meta-description-keyword-feedback" in the plugin's directory. (If that branch has already been merged, use "git+https://github.com/Yoast/yoastseo.js#feature/recalibration")
– Run `yarn install`
- Navigate to `node_modules/yoastseo` and run `yarn install` and `grunt build:js`.
- Navigate back to the plugin's directory and run `grunt build:js`.
– Run `yarn test` and make sure all the tests pass.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9718 
