### PR TITLE
Update the active keyword in the state when it has been changed.

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -322,6 +322,7 @@ import { updateData } from "./redux/actions/snippetEditor";
 			args.callbacks.saveScores = postDataCollector.saveScores.bind( postDataCollector );
 			args.callbacks.updatedKeywordsResults = function( results ) {
 				let keyword = tabManager.getKeywordTab().getKeyWord();
+				store.dispatch( setActiveKeyword( keyword ) );
 
 				/*
 				 * The results from the main App callback are always for the first keyword. So


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updates the active keyword in the state whenever changes are made in the keyword field 

## Relevant technical choices:

* Adds the store dispatch call to the updatedKeyword callback function, which now correctly sets the new keyword before updating the analyses.

## Test instructions

This PR can be tested by following these steps:

* Go to the snippet editor and change the keyword
* The `WPSEO_SET_ACTIVE_KEYWORD` action should be fired
* The `activeKeyword` in the state should be set to the new keyword

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9704
