### PR TITLE
Add data equality checks for the snippet editor data

### DIFF
--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -3,7 +3,6 @@
 // External dependencies.
 import { App } from "yoastseo";
 import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
-import isEqual from "lodash/isEqual";
 import isFunction from "lodash/isFunction";
 import isUndefined from "lodash/isUndefined";
 

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -73,7 +73,7 @@ window.yoastHideMarkers = true;
 		 */
 		descriptionTd.append( newEditor ).append( text );
 
-		// Populate the editor textarea with the original content,
+		// Populate the editor textarea with the original content.
 		document.getElementById( "description" ).value = textNode;
 
 		// Make the description textarea label plain text removing the label tag.

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -389,18 +389,25 @@ window.yoastHideMarkers = true;
 		// Subscribe to the store to save the snippet editor data.
 		store.subscribe( () => {
 			const data = snippetEditorHelpers.getDataFromStore( store );
+			const dataWithoutTemplates = snippetEditorHelpers.getDataWithoutTemplates( data, snippetEditorTemplates );
 
-			if ( ! isEqual( snippetEditorData, data ) ) {
-				snippetEditorData = data;
-				const dataWithoutTemplates = snippetEditorHelpers.getDataWithoutTemplates( data, snippetEditorTemplates );
-				termScraper.saveSnippetData( {
-					title: dataWithoutTemplates.title,
-					urlPath: dataWithoutTemplates.slug,
-					metaDesc: dataWithoutTemplates.description,
-				} );
-
-				updateLegacySnippetEditor( data );
+			if ( snippetEditorData.title !== data.title ) {
+				termScraper.setDataFromSnippet( dataWithoutTemplates.title, "snippet_title" );
 			}
+
+			if ( snippetEditorData.slug !== data.slug ) {
+				termScraper.setDataFromSnippet( dataWithoutTemplates.slug, "snippet_cite" );
+			}
+
+			if ( snippetEditorData.description !== data.description ) {
+				termScraper.setDataFromSnippet( dataWithoutTemplates.description, "snippet_meta" );
+			}
+
+			snippetEditorData.title = data.title;
+			snippetEditorData.slug = data.slug;
+			snippetEditorData.description = data.description;
+
+			updateLegacySnippetEditor( data );
 		} );
 	} );
 }( jQuery, window ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Add data equality checks for the snippet editor data to the term scraper.

## Test instructions

This PR can be tested by following these steps:

* Check if the snippet editor data updates correctly on terms.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Based on https://github.com/Yoast/wordpress-seo/pull/9738
Fixes #
