### PR TITLE
Ignore custom fields without an id

### DIFF
--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -449,7 +449,7 @@ import {
 		// Remove all the custom fields prior. This ensures that deleted fields don't show up anymore.
 		this.removeCustomFields();
 
-		var textFields = jQuery( targetMetaBox ).find( "#the-list > tr:visible" );
+		var textFields = jQuery( targetMetaBox ).find( "#the-list > tr:visible[id]" );
 
 		if ( textFields.length > 0 ) {
 			this.parseFields( textFields );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where custom fields rows without an id would cause errors.

## Relevant technical choices:

* Ignore those fields.

## Test instructions

This PR can be tested by following these steps:

* In the standalone app, it should no longer crash immediately after changing the title.
* In combination with the Yoast SEO plugin:
  - Test if you no longer see the JS Error (did not occur always like in the standalone).
  - When you add, update or remove a custom field in a post you should see this reflected in the 
 replacement variables in the Snippet Editor right away. Where removing the custom field if you have it in the title you should see the `%%cf_<name_of_custom_field>%%` instead.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
