### PR TITLE
Fixed the analysis failing on numbers only keyword

### DIFF
--- a/js/src/analysis/keywordTab.js
+++ b/js/src/analysis/keywordTab.js
@@ -126,10 +126,10 @@ module.exports = ( function() {
 	/**
 	 * Returns the keyword for this keyword tab
 	 *
-	 * @returns {void}
+	 * @returns {string} The keyword
 	 */
 	KeywordTab.prototype.getKeywordFromElement = function() {
-		return this.element.find( ".wpseo_tablink" ).data( "keyword" );
+		return String( this.element.find( ".wpseo_tablink" ).data( "keyword" ) );
 	};
 
 	return KeywordTab;


### PR DESCRIPTION
## Summary

Because we only want the CONTENT_ANALYSIS_SET_SEO_RESULTS_FOR_KEYWORD action to dispatch when you have the analysis open, we check for that. 

But when you keyword consists only of numbers ( an unlikely use case, but still ), the check retrieves the keyword from the tab as a number instead of as a string. 

Because of that the strict check fails, the action isn't dispatched, en the entire analysis section collapses. which you can see in the screenshot below.

<img width="661" alt="issues_with_the_gutenberg_editor___ _wordpress_develop_ _wordpress-3" src="https://user-images.githubusercontent.com/11849359/40229742-7a93c700-5a95-11e8-84e7-d1e0393419ad.png">


This PR can be summarized in the following changelog entry:

* Fixed numbers-only keywords causing the analysis to fail.



## Relevant technical choices:

* Ensured the function fetching the keyword from the tab returns a string. If there's a better way to cast to string, or if it's better to cast only in the function checking if the keyword matches the keyword in the tab. Or if it's better to change the strict check to a more loose check, I'm open for suggestions on either area.

## Test instructions

This PR can be tested by following these steps:

* Create a post.
* use only numbers as keyword. (123 for instance)
* Check if the analysis can deal with the keyword. (compare with the previous release, or with the current trunk, to see if the behaviour has improved. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
