### PR TITLE
Prefix CLI command with `yoast`

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -389,27 +389,27 @@ function wpseo_admin_init() {
  * on PHP 5.3+, the constant should only be set when requirements are met.
  */
 function wpseo_cli_init() {
-	WP_CLI::add_command( 'redirect list', 'WPSEO_CLI_Redirect_List_Command', array(
+	WP_CLI::add_command( 'yoast redirect list', 'WPSEO_CLI_Redirect_List_Command', array(
 		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
 	) );
 
-	WP_CLI::add_command( 'redirect create', 'WPSEO_CLI_Redirect_Create_Command', array(
+	WP_CLI::add_command( 'yoast redirect create', 'WPSEO_CLI_Redirect_Create_Command', array(
 		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
 	) );
 
-	WP_CLI::add_command( 'redirect update', 'WPSEO_CLI_Redirect_Update_Command', array(
+	WP_CLI::add_command( 'yoast redirect update', 'WPSEO_CLI_Redirect_Update_Command', array(
 		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
 	) );
 
-	WP_CLI::add_command( 'redirect delete', 'WPSEO_CLI_Redirect_Delete_Command', array(
+	WP_CLI::add_command( 'yoast redirect delete', 'WPSEO_CLI_Redirect_Delete_Command', array(
 		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
 	) );
 
-	WP_CLI::add_command( 'redirect has', 'WPSEO_CLI_Redirect_Has_Command', array(
+	WP_CLI::add_command( 'yoast redirect has', 'WPSEO_CLI_Redirect_Has_Command', array(
 		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
 	) );
 
-	WP_CLI::add_command( 'redirect follow', 'WPSEO_CLI_Redirect_Follow_Command', array(
+	WP_CLI::add_command( 'yoast redirect follow', 'WPSEO_CLI_Redirect_Follow_Command', array(
 		'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
 	) );
 
@@ -417,7 +417,7 @@ function wpseo_cli_init() {
 	// This is optional and only adds the description of the root `redirect`
 	// command.
 	if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {
-		WP_CLI::add_command( 'redirect', 'WPSEO_CLI_Redirect_Command_Namespace' );
+		WP_CLI::add_command( 'yoast', 'WPSEO_CLI_Redirect_Command_Namespace' );
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds WP-CLI commands to manage redirects, use `wp yoast redirect` to see the list of commands available.

## Relevant technical choices:

* Added `yoast` as command prefix for the CLI commands.

## Test instructions

This PR can be tested by following these steps:

* Enter your Vagrant
* Go to the root of the WordPress installation you have checked out this branch
* Run `wp help yoast` or `wp yoast redirect` to see that the command can be executed and provides information about the commands that can be run.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #9763 
