### PR TITLE
Update slug in snippet preview when the slug has been changed in WP

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -81,7 +81,12 @@ setYoastComponentsI18n();
 			 */
 			postDataCollector.leavePostNameUntouched = true;
 
-			app.snippetPreview.setUrlPath( getUrlPathFromResponse( response ) );
+
+			const snippetEditorData = {
+				slug: getUrlPathFromResponse( response ),
+			};
+
+			editStore.dispatch( updateData( snippetEditorData ) );
 		}
 	} );
 

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -31,7 +31,7 @@ window.yoastHideMarkers = true;
 ( function( $, window ) {
 	var snippetContainer;
 
-	var app, snippetPreview;
+	var app;
 
 	var termSlugInput;
 
@@ -85,7 +85,11 @@ window.yoastHideMarkers = true;
 	 * @returns {void}
 	 */
 	function updatedTermSlug() {
-		snippetPreview.setUrlPath( termSlugInput.val() );
+		const snippetEditorData = {
+			slug: termSlugInput.val(),
+		};
+
+		store.dispatch( updateData( snippetEditorData ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

* When the slug in changed in WP (right under the title), the slug in the snippet preview should be updated as well.

## Relevant technical choices:

* sent an action updateData to the store, with the new slug. Removed the old method, which uses a function that does not exist anymore.

## Test instructions

This PR can be tested by following these steps:

* Visit a post page. (make sure the permalink structure is post).
* Change the slug (right below the title).
* Check if the slug is also changed in the snippet preview.
* Check console for errors.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9771 
Fixes #9767 
