### PR TITLE
Strip multiple whitespaces in slug

### DIFF
--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -56,7 +56,7 @@ const legacyReplaceUsingPlugin = function( data ) {
  */
 const mapEditorDataToPreview = function( data ) {
 	// Replace whitespaces in the url with dashes.
-	data.url = data.url.replace( /\s/g, "-" );
+	data.url = data.url.replace( /\s+/g, "-" );
 
 	return legacyReplaceUsingPlugin( data );
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* I'm very proud of my one-character fix 🤓 

## Test instructions

This PR can be tested by following these steps:

* Add multiple spaces to the slug field in the snippet editor.
* Those spaces should be changed into a single dash in the slug in the preview.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/wordpress-seo/issues/9795
