### PR TITLE
Fix WooCommerce replacement variables

### DIFF
--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -32,7 +32,7 @@ const Section = styled( StyledSection )`
  * @param {string} data.url         The snippet preview url: baseUrl with the slug.
  * @param {string} data.description The snippet preview description.
  *
- * @returns {Object} Returns the data object win which the placeholders have been replaced.
+ * @returns {Object} Returns the data object in which the placeholders have been replaced.
  */
 const legacyReplaceUsingPlugin = function( data ) {
 	const replaceVariables = get( window, [ "YoastSEO", "wp", "replaceVarsPlugin", "replaceVariables" ], identity );
@@ -52,7 +52,7 @@ const legacyReplaceUsingPlugin = function( data ) {
  * @param {string} data.url         The snippet preview url: baseUrl with the slug.
  * @param {string} data.description The snippet preview description.
  *
- * @returns {Object} Returns the data object win which the placeholders have been replaced.
+ * @returns {Object} Returns the data object in which the placeholders have been replaced.
  */
 const applyReplaceUsingPlugin = function( data ) {
 	// If we do not have pluggable loaded, apply just our own replace variables.

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -35,12 +35,38 @@ const Section = styled( StyledSection )`
  * @returns {Object} Returns the data object win which the placeholders have been replaced.
  */
 const legacyReplaceUsingPlugin = function( data ) {
-	let replaceVariables = get( window, [ "YoastSEO", "wp", "replaceVarsPlugin", "replaceVariables" ], identity );
+	const replaceVariables = get( window, [ "YoastSEO", "wp", "replaceVarsPlugin", "replaceVariables" ], identity );
 
-	return  {
+	return {
 		url: data.url,
 		title: stripFullTags( replaceVariables( data.title ) ),
 		description: stripFullTags( replaceVariables( data.description ) ),
+	};
+};
+
+/**
+ * Apply replaceVariables function on the data in the snippet preview.
+ *
+ * @param {Object} data             The snippet preview data object.
+ * @param {string} data.title       The snippet preview title.
+ * @param {string} data.url         The snippet preview url: baseUrl with the slug.
+ * @param {string} data.description The snippet preview description.
+ *
+ * @returns {Object} Returns the data object win which the placeholders have been replaced.
+ */
+const applyReplaceUsingPlugin = function( data ) {
+	// If we do not have pluggable loaded, apply just our own replace variables.
+	const pluggable = get( window, [ "YoastSEO", "app", "pluggable" ], false );
+	if ( ! pluggable || ! get( window, [ "YoastSEO", "app", "pluggable", "loaded" ], false ) ) {
+		return legacyReplaceUsingPlugin( data );
+	}
+
+	const applyModifications = pluggable._applyModifications.bind( pluggable );
+
+	return  {
+		url: data.url,
+		title: stripFullTags( applyModifications( "data_page_title", data.title ) ),
+		description: stripFullTags( applyModifications( "data_meta_desc", data.description ) ),
 	};
 };
 
@@ -58,7 +84,7 @@ const mapEditorDataToPreview = function( data ) {
 	// Replace whitespaces in the url with dashes.
 	data.url = data.url.replace( /\s/g, "-" );
 
-	return legacyReplaceUsingPlugin( data );
+	return applyReplaceUsingPlugin( data );
 };
 
 /**

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -4,10 +4,11 @@ import filter from "lodash/filter";
 import trim from "lodash/trim";
 import isUndefined from "lodash/isUndefined";
 
-var ReplaceVar = require( "./values/replaceVar" );
+import ReplaceVar from "./values/replaceVar";
 import {
 	removeReplacementVariable,
 	updateReplacementVariable,
+	refreshSnippetEditor,
 } from "./redux/actions/snippetEditor";
 
 ( function() {
@@ -240,7 +241,7 @@ import {
 	 */
 	YoastReplaceVarPlugin.prototype.declareReloaded = function() {
 		this._app.pluginReloaded( "replaceVariablePlugin" );
-		this._store.dispatch( { type: "REFRESH_SNIPPET_EDITOR" } );
+		this._store.dispatch( refreshSnippetEditor() );
 	};
 
 	/*


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Remarks

This solution does not fix the extra replace vars described in the issue.

- `%%ct_product_tag%%`
- `%%ct_pa_product-attribute-slug%%`


## Relevant technical choices:

* Use the pluggable modifications where plugins can hook into the replacement variables.

## Test instructions

This PR can be tested by following these steps:

* Install the plugins: `WooCommerce`, `Yoast SEO: WooCommerce`, and `Perfect WooCommerce Brands`.
* Create some data: a brand and a product with: short description, sku, price and brand.
* Test if these work in the Snippet Editor.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9773 
