### PR TITLE
Introduce Template Variables Help Center tab

### DIFF
--- a/admin/help_center/class-template-variables-tab.php
+++ b/admin/help_center/class-template-variables-tab.php
@@ -66,7 +66,7 @@ class WPSEO_Help_Center_Template_Variables_Tab implements WPSEO_WordPress_Integr
 	 */
 	private function get_content() {
 		$explanation = sprintf(
-		/* translators: %1$s expands to Yoast SEO. */
+			/* translators: %1$s expands to Yoast SEO. */
 			__( 'The search appearance settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The table below contains a list of the available variables.', 'wordpress-seo' ),
 			'Yoast SEO'
 		);

--- a/admin/help_center/class-template-variables-tab.php
+++ b/admin/help_center/class-template-variables-tab.php
@@ -27,7 +27,9 @@ class WPSEO_Help_Center_Template_Variables_Tab implements WPSEO_WordPress_Integr
 	}
 
 	/**
-	 * Registers all hooks to WordPress
+	 * Registers all hooks to WordPress.
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		add_filter( 'wpseo_help_center_items', array( $this, 'add_meta_options_help_center_tabs' ), $this->priority );
@@ -36,6 +38,8 @@ class WPSEO_Help_Center_Template_Variables_Tab implements WPSEO_WordPress_Integr
 
 	/**
 	 * Enqueues the styles needed in the Help Center tab.
+	 *
+	 * @return void
 	 */
 	public function enqueue() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();

--- a/admin/help_center/template-variables-tab.php
+++ b/admin/help_center/template-variables-tab.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Class that adds a template variables explanation tab to the Help Center.
+ */
+class WPSEO_Help_Center_Template_Variables_Tab implements WPSEO_WordPress_Integration {
+
+	/**
+	 * Priority to hook into the tab filter.
+	 *
+	 * @var int
+	 */
+	private $priority;
+
+	/**
+	 * Tab constructor.
+	 *
+	 * @param int $priority The priority to add the filter on, allows for ordering.
+	 */
+	public function __construct( $priority = 10 ) {
+		$this->priority = $priority;
+	}
+
+	/**
+	 * Registers all hooks to WordPress
+	 */
+	public function register_hooks() {
+		add_filter( 'wpseo_help_center_items', array( $this, 'add_meta_options_help_center_tabs' ), $this->priority );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
+	}
+
+	/**
+	 * Enqueues the styles needed in the Help Center tab.
+	 */
+	public function enqueue() {
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		$asset_manager->enqueue_style( 'admin-css' );
+	}
+
+	/**
+	 * Adds help tabs.
+	 *
+	 * @param array $tabs Current help center tabs.
+	 *
+	 * @return array List containing all the additional tabs.
+	 */
+	public function add_meta_options_help_center_tabs( $tabs ) {
+		$tabs[] = new WPSEO_Help_Center_Item(
+			'template-variables',
+			__( 'Template explanation', 'wordpress-seo' ),
+			array( 'content' => $this->get_content() )
+		);
+
+		return $tabs;
+	}
+
+	/**
+	 * Adds template variables to the help center.
+	 *
+	 * @return string The content for the template variables tab.
+	 */
+	private function get_content() {
+		$explanation = sprintf(
+		/* translators: %1$s expands to Yoast SEO. */
+			__( 'The search appearance settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The table below contains a list of the available variables.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
+
+		$output_explanation = sprintf(
+			'<h2>%s</h2><p>%s</p><p>%s</p>',
+			esc_html( __( 'Template explanation', 'wordpress-seo' ) ),
+			esc_html( $explanation ),
+			esc_html( __( 'Note that not all variables can be used in every template.', 'wordpress-seo' ) )
+		);
+
+		$output_basic = sprintf(
+			'<h2>%s</h2>%s',
+			esc_html( __( 'Basic Variables', 'wordpress-seo' ) ),
+			WPSEO_Replace_Vars::get_basic_help_texts()
+		);
+
+		$output_advanced = sprintf(
+			'<h2>%s</h2>%s',
+			esc_html( __( 'Advanced Variables', 'wordpress-seo' ) ),
+			WPSEO_Replace_Vars::get_advanced_help_texts()
+		);
+
+		return $output_explanation . $output_basic . $output_advanced;
+	}
+}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -182,6 +182,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			return;
 		}
 
+		$tab_registered = false;
+
 		foreach ( $post_types as $post_type ) {
 			if ( $this->display_metabox( $post_type ) === false ) {
 				continue;
@@ -196,6 +198,14 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			if ( get_current_screen() !== null ) {
 				$screen_id = get_current_screen()->id;
 				add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
+			}
+
+			if ( ! $tab_registered ) {
+				// Add template variables tab to the Help Center.
+				$tab = new WPSEO_Help_Center_Template_Variables_Tab();
+				$tab->register_hooks();
+
+				$tab_registered = true;
 			}
 
 			add_meta_box( 'wpseo_meta', $product_title, array(
@@ -864,45 +874,45 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		if ( self::is_post_overview( $pagenow ) ) {
 			$asset_manager->enqueue_style( 'edit-page' );
 			$asset_manager->enqueue_script( 'edit-page-script' );
+
+			return;
 		}
-		else {
 
-			if ( get_queried_object_id() !== 0 ) {
-				wp_enqueue_media( array( 'post' => get_queried_object_id() ) ); // Enqueue files needed for upload functionality.
-			}
+		if ( get_queried_object_id() !== 0 ) {
+			wp_enqueue_media( array( 'post' => get_queried_object_id() ) ); // Enqueue files needed for upload functionality.
+		}
 
-			$asset_manager->enqueue_style( 'metabox-css' );
-			$asset_manager->enqueue_style( 'scoring' );
-			$asset_manager->enqueue_style( 'snippet' );
-			$asset_manager->enqueue_style( 'select2' );
+		$asset_manager->enqueue_style( 'metabox-css' );
+		$asset_manager->enqueue_style( 'scoring' );
+		$asset_manager->enqueue_style( 'snippet' );
+		$asset_manager->enqueue_style( 'select2' );
 
-			$asset_manager->enqueue_script( 'metabox' );
-			$asset_manager->enqueue_script( 'help-center' );
-			$asset_manager->enqueue_script( 'admin-media' );
+		$asset_manager->enqueue_script( 'metabox' );
+		$asset_manager->enqueue_script( 'help-center' );
+		$asset_manager->enqueue_script( 'admin-media' );
 
-			$asset_manager->enqueue_script( 'post-scraper' );
-			$asset_manager->enqueue_script( 'replacevar-plugin' );
-			$asset_manager->enqueue_script( 'shortcode-plugin' );
+		$asset_manager->enqueue_script( 'post-scraper' );
+		$asset_manager->enqueue_script( 'replacevar-plugin' );
+		$asset_manager->enqueue_script( 'shortcode-plugin' );
 
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-media', 'wpseoMediaL10n', $this->localize_media_script() );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'wpseoPostScraperL10n', $this->localize_post_scraper_script() );
-			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_l10n();
-			$yoast_components_l10n->localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper' );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-media', 'wpseoMediaL10n', $this->localize_media_script() );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'wpseoPostScraperL10n', $this->localize_post_scraper_script() );
+		$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_l10n();
+		$yoast_components_l10n->localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper' );
 
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'shortcode-plugin', 'wpseoShortcodePluginL10n', $this->localize_shortcode_plugin_script() );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'shortcode-plugin', 'wpseoShortcodePluginL10n', $this->localize_shortcode_plugin_script() );
 
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Help_Center::get_translated_texts() );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
 
-			if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
-				$asset_manager->enqueue_style( 'featured-image' );
+		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
+			$asset_manager->enqueue_style( 'featured-image' );
 
-				$asset_manager->enqueue_script( 'featured-image' );
+			$asset_manager->enqueue_script( 'featured-image' );
 
-				$featured_image_l10 = array( 'featured_image_notice' => __( 'SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.', 'wordpress-seo' ) );
-				wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoFeaturedImageL10n', $featured_image_l10 );
-			}
+			$featured_image_l10 = array( 'featured_image_notice' => __( 'SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.', 'wordpress-seo' ) );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoFeaturedImageL10n', $featured_image_l10 );
 		}
 	}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -879,7 +879,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		if ( get_queried_object_id() !== 0 ) {
-			wp_enqueue_media( array( 'post' => get_queried_object_id() ) ); // Enqueue files needed for upload functionality.
+			// Enqueue files needed for upload functionality.
+			wp_enqueue_media( array( 'post' => get_queried_object_id() ) );
 		}
 
 		$asset_manager->enqueue_style( 'metabox-css' );

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -11,8 +11,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-add_filter( 'wpseo_help_center_items', 'yoast_add_meta_options_help_center_tabs' );
-
 $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_titles' );
 
@@ -28,54 +26,5 @@ $tabs->display( $yform );
 
 $yform->admin_footer();
 
-/**
- * Adds help tabs.
- *
- * @param array $tabs Current help center tabs.
- *
- * @return array List containing all the additional tabs.
- */
-function yoast_add_meta_options_help_center_tabs( $tabs ) {
-
-	$tabs[] = new WPSEO_Help_Center_Item(
-		'template-variables',
-		__( 'Template explanation', 'wordpress-seo' ),
-		array( 'content' => wpseo_add_template_variables_helpcenter() )
-	);
-
-	return $tabs;
-}
-
-/**
- * Adds template variables to the help center.
- *
- * @return string The content for the template variables tab.
- */
-function wpseo_add_template_variables_helpcenter() {
-	$explanation = sprintf(
-		/* translators: %1$s expands to Yoast SEO. */
-		__( 'The search appearance settings for %1$s are made up of variables that are replaced by specific values from the page when the page is displayed. The table below contains a list of the available variables.', 'wordpress-seo' ),
-		'Yoast SEO'
-	);
-
-	$output_explanation = sprintf(
-		'<h2>%s</h2><p>%s</p><p>%s</p>',
-		esc_html( __( 'Template explanation', 'wordpress-seo' ) ),
-		esc_html( $explanation ),
-		esc_html( __( 'Note that not all variables can be used in every template.', 'wordpress-seo' ) )
-	);
-
-	$output_basic = sprintf(
-		'<h2>%s</h2>%s',
-		esc_html( __( 'Basic Variables', 'wordpress-seo' ) ),
-		WPSEO_Replace_Vars::get_basic_help_texts()
-	);
-
-	$output_advanced = sprintf(
-		'<h2>%s</h2>%s',
-		esc_html( __( 'Advanced Variables', 'wordpress-seo' ) ),
-		WPSEO_Replace_Vars::get_advanced_help_texts()
-	);
-
-	return $output_explanation . $output_basic . $output_advanced;
-}
+$tab = new WPSEO_Help_Center_Template_Variables_Tab();
+$tab->register_hooks();

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -11,6 +11,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
+$tab = new WPSEO_Help_Center_Template_Variables_Tab();
+$tab->register_hooks();
+
 $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_titles' );
 
@@ -25,6 +28,3 @@ $tabs->add_tab( new WPSEO_Option_Tab( 'rss', __( 'RSS', 'wordpress-seo' ), array
 $tabs->display( $yform );
 
 $yform->admin_footer();
-
-$tab = new WPSEO_Help_Center_Template_Variables_Tab();
-$tab->register_hooks();

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -28,3 +28,31 @@ function wpseo_add_capabilities() {
 
 	WPSEO_Capability_Manager_Factory::get()->add();
 }
+
+/**
+ * Adds help tabs.
+ *
+ * @deprecated 7.6.0
+ *
+ * @param array $tabs Current help center tabs.
+ *
+ * @return array List containing all the additional tabs.
+ */
+function yoast_add_meta_options_help_center_tabs( $tabs ) {
+	_deprecated_function( __FUNCTION__, 'WPSEO 7.6.0', 'WPSEO_Help_Center_Template_Variables_Tab::add_meta_options_help_center_tabs' );
+
+	return $tabs;
+}
+
+/**
+ * Adds template variables to the help center.
+ *
+ * @deprecated 7.6.0
+ *
+ * @return string The content for the template variables tab.
+ */
+function wpseo_add_template_variables_helpcenter() {
+	_deprecated_function( __FUNCTION__, 'WPSEO 7.6.0' );
+
+	return '';
+}

--- a/tests/admin/help_center/test-class-help-center-template-variables-tab.php
+++ b/tests/admin/help_center/test-class-help-center-template-variables-tab.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Class WPSEO_Help_Center_Template_Variables_Tab_Test
+ *
+ * @group help-center
+ */
+class WPSEO_Help_Center_Template_Variables_Tab_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Tests expected hooks and filters being added.
+	 */
+	public function test_register_hooks() {
+		$instance = new WPSEO_Help_Center_Template_Variables_Tab();
+		$instance->register_hooks();
+
+		$this->assertEquals( 10, has_filter( 'wpseo_help_center_items', array(
+			$instance,
+			'add_meta_options_help_center_tabs'
+		) ) );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue' ) ) );
+	}
+
+	/**
+	 * Tests priority application on filter.
+	 */
+	public function test_register_hooks_priority() {
+		$instance = new WPSEO_Help_Center_Template_Variables_Tab( 20 );
+		$instance->register_hooks();
+
+		$this->assertEquals( 20, has_filter( 'wpseo_help_center_items', array(
+			$instance,
+			'add_meta_options_help_center_tabs'
+		) ) );
+	}
+
+	/**
+	 * Tests the addition of the tab to the list.
+	 */
+	public function test_add_meta_options_help_center_tabs() {
+		$instance = new WPSEO_Help_Center_Template_Variables_Tab();
+		$tabs     = $instance->add_meta_options_help_center_tabs( array() );
+
+		$this->assertInstanceOf( 'WPSEO_Help_Center_Item', $tabs[0] );
+		$this->assertEquals( 'template-variables', $tabs[0]->get_identifier() );
+	}
+}

--- a/tests/admin/help_center/test-class-help-center-template-variables-tab.php
+++ b/tests/admin/help_center/test-class-help-center-template-variables-tab.php
@@ -9,6 +9,8 @@ class WPSEO_Help_Center_Template_Variables_Tab_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests expected hooks and filters being added.
+	 *
+	 * @covers WPSEO_Help_Center_Template_Variables_Tab::register_hooks
 	 */
 	public function test_register_hooks() {
 		$instance = new WPSEO_Help_Center_Template_Variables_Tab();
@@ -23,6 +25,9 @@ class WPSEO_Help_Center_Template_Variables_Tab_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests priority application on filter.
+	 *
+	 * @covers WPSEO_Help_Center_Template_Variables_Tab::__construct
+	 * @covers WPSEO_Help_Center_Template_Variables_Tab::register_hooks
 	 */
 	public function test_register_hooks_priority() {
 		$instance = new WPSEO_Help_Center_Template_Variables_Tab( 20 );
@@ -36,6 +41,8 @@ class WPSEO_Help_Center_Template_Variables_Tab_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests the addition of the tab to the list.
+	 *
+	 * @covers WPSEO_Help_Center_Template_Variables_Tab::add_meta_options_help_center_tabs
 	 */
 	public function test_add_meta_options_help_center_tabs() {
 		$instance = new WPSEO_Help_Center_Template_Variables_Tab();

--- a/tests/admin/links/test-class-link-watcher.php
+++ b/tests/admin/links/test-class-link-watcher.php
@@ -64,8 +64,6 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	 * Don't process trash posts.
 	 *
 	 * @covers WPSEO_Link_Watcher::save_post()
-	 *
-	 * @group test
 	 */
 	public function test_skip_trash_posts() {
 


### PR DESCRIPTION
Class that adds the Template Variables Help Center tab.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a tab to the Help Center on posts/pages and custom post types which explains which template variables can be used in the Snippet Preview.

## Relevant technical choices:

* Moved all functionality to a class
* Added ability to provide priority for placement-control
* Added registration of required stylesheet in the same class

## Test instructions

This PR can be tested by following these steps:

* Go to a Post/Page edit page
* Open the Help Center
* See the Tab being introduced
* Open the tab
* See the styling of the table being similar as on the Search Appearance Help Center tab

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9804 
