### PR TITLE
Fix translations for YoastSEO.js

### DIFF
--- a/grunt/custom/i18n-clean-json.js
+++ b/grunt/custom/i18n-clean-json.js
@@ -79,7 +79,7 @@ module.exports = function( grunt ) {
 	 * @returns {void}
 	 */
 	function cleanJSONFiles() {
-		cleanJSON( "languages/yoast-seo-js.json", "languages/wordpress-seo-*.json", "wordpress-seo", "messages" );
+		cleanJSON( "languages/yoast-seo-js.json", "languages/wordpress-seo-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 		cleanJSON( "languages/yoast-components.json", "languages/yoast-components-*.json", "wordpress-seo", "messages", "yoast-components" );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _not applicable_

## Relevant technical choices:

Because of the translation toolchain changes the textdomain wasn't set correctly in the JSON files. This change fixes that.

## Test instructions

This PR can be tested by following these steps:

* Build the translation files using `grunt build:i18n`.
* Make sure that the translations for YoastSEO.js (content analysis results) work. I've tested it with Dutch.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9766 