### PR TITLE
Implement stale content notification

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -386,7 +386,7 @@ class WPSEO_Admin {
 		return array(
 			'cornerstone'          => new WPSEO_Cornerstone(),
 			'cornerstone_filter'   => new WPSEO_Cornerstone_Filter(),
-			'stale_content_filter' => new WPSEO_Stale_Content_Filter(),
+			'stale_cornerstone_content_filter' => new WPSEO_Stale_Cornerstone_Content_Filter(),
 		);
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -87,7 +87,6 @@ class WPSEO_Admin {
 		$this->set_upsell_notice();
 
 		$this->check_php_version();
-		$this->initialize_cornerstone_content();
 
 		new Yoast_Modal();
 
@@ -96,7 +95,7 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_Statistic_Integration();
 		$integrations[] = new WPSEO_Slug_Change_Watcher();
 		$integrations[] = new WPSEO_Capability_Manager_Integration( WPSEO_Capability_Manager_Factory::get() );
-		$integrations   = array_merge( $integrations, $this->initialize_seo_links() );
+		$integrations   = array_merge( $integrations, $this->initialize_seo_links(), $this->initialize_cornerstone_content() );
 
 		/** @var WPSEO_WordPress_Integration $integration */
 		foreach ( $integrations as $integration ) {
@@ -376,17 +375,19 @@ class WPSEO_Admin {
 
 	/**
 	 * Loads the cornerstone filter.
+	 *
+	 * @return WPSEO_WordPress_Integration[] The integrations to initialize.
 	 */
 	protected function initialize_cornerstone_content() {
 		if ( ! WPSEO_Options::get( 'enable_cornerstone_content' ) ) {
-			return;
+			return array();
 		}
 
-		$cornerstone = new WPSEO_Cornerstone();
-		$cornerstone->register_hooks();
-
-		$cornerstone_filter = new WPSEO_Cornerstone_Filter();
-		$cornerstone_filter->register_hooks();
+		return array(
+			'cornerstone'          => new WPSEO_Cornerstone(),
+			'cornerstone_filter'   => new WPSEO_Cornerstone_Filter(),
+			'stale_content_filter' => new WPSEO_Stale_Content_Filter(),
+		);
 	}
 
 	/**

--- a/admin/class-cornerstone.php
+++ b/admin/class-cornerstone.php
@@ -8,7 +8,7 @@
 /**
  * Represents the yoast cornerstone content.
  */
-class WPSEO_Cornerstone {
+class WPSEO_Cornerstone implements WPSEO_WordPress_Integration  {
 
 	const META_NAME = 'is_cornerstone';
 

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -13,7 +13,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 	/**
 	 * Returns the query value this filter uses.
 	 *
-	 * @return {string} The query value this filter uses.
+	 * @return string The query value this filter uses.
 	 */
 	public function get_query_val() {
 		return 'cornerstone';

--- a/admin/filters/class-stale-content-filter.php
+++ b/admin/filters/class-stale-content-filter.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Registers the filter for filtering stale content.
+ */
+class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
+
+	/**
+	 * Returns the query value this filter uses.
+	 *
+	 * @return string The query value this filter uses.
+	 */
+	public function get_query_val() {
+		return 'stale-content';
+	}
+
+	/**
+	 * Modify the query based on the seo_filter variable in $_GET
+	 *
+	 * @param string $where Query variables.
+	 *
+	 * @return string The modified query.
+	 */
+	public function filter_posts( $where ) {
+		if ( ! $this->is_filter_active() ) {
+			return $where;
+		}
+
+		global $wpdb;
+
+		$where .= sprintf( ' AND ' . $wpdb->posts . '.post_modified < "%s" ', $this->date_threshold() );
+		$where .= sprintf(
+			' AND ' . $wpdb->posts . '.ID IN( SELECT post_id FROM ' . $wpdb->postmeta . ' WHERE meta_key = "%s" AND meta_value = "1" ) ',
+			WPSEO_Meta::$meta_prefix . WPSEO_Cornerstone::META_NAME
+		);
+
+		return $where;
+	}
+
+	/**
+	 * Returns the label for this filter.
+	 *
+	 * @return string The label for this filter.
+	 */
+	protected function get_label() {
+		return __( 'Stale content', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns a text explaining this filter.
+	 *
+	 * @return string The explanation.
+	 */
+	protected function get_explanation() {
+		$post_type_object = get_post_type_object( $this->get_current_post_type() );
+
+		if ( $post_type_object === null ) {
+			return null;
+		}
+
+		return sprintf(
+		/* translators: %1$s expands to the posttype label, %2$s expands anchor to blog post about cornerstone content, %3$s expands to </a> */
+			__( 'Stale content refers to cornerstone content that hasn’t been updated in the last 6 months. Make sure to keep these %s up-to-date. %2$sLearn more about cornerstone content%3$s.', 'wordpress-seo' ),
+			strtolower( $post_type_object->labels->name ),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1i9' ) . '" target="_blank">',
+			'</a>'
+		);
+	}
+
+	/**
+	 * Returns the total amount of stale content.
+	 *
+	 * @return integer The total amount.
+	 */
+	protected function get_post_total() {
+		global $wpdb;
+
+		return (int) $wpdb->get_var(
+			$wpdb->prepare( '
+				SELECT COUNT( 1 )
+				FROM ' . $wpdb->postmeta . '
+				WHERE post_id IN( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = %s && post_modified < %s ) &&
+				meta_value = "1" AND meta_key = %s
+				',
+				$this->get_current_post_type(),
+				$this->date_threshold(),
+				WPSEO_Meta::$meta_prefix . WPSEO_Cornerstone::META_NAME
+			)
+		);
+	}
+
+	/**
+	 * Returns the post types to which this filter should be added.
+	 *
+	 * @return array The post types to which this filter should be added.
+	 */
+	protected function get_post_types() {
+		$post_types = apply_filters( 'wpseo_cornerstone_post_types', parent::get_post_types() );
+		if ( ! is_array( $post_types ) ) {
+			return array();
+		}
+
+		return $post_types;
+	}
+
+	/**
+	 * Returns the date 6 months ago.
+	 *
+	 * @return string The formatted date.
+	 */
+	protected function date_threshold() {
+		$timestamp = strtotime( '-6months' );
+		$formatted_date_gmt = gmdate( 'Y-m-d', $timestamp );
+		if ( $formatted_date_gmt ) {
+			return $formatted_date_gmt;
+		}
+
+		return date( 'Y-m-d', $timestamp );
+	}
+}

--- a/admin/filters/class-stale-content-filter.php
+++ b/admin/filters/class-stale-content-filter.php
@@ -20,7 +20,7 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	}
 
 	/**
-	 * Modify the query based on the seo_filter variable in $_GET.
+	 * Modifies the query based on the seo_filter variable in $_GET.
 	 *
 	 * @param string $where The where statement.
 	 *

--- a/admin/filters/class-stale-content-filter.php
+++ b/admin/filters/class-stale-content-filter.php
@@ -20,9 +20,9 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	}
 
 	/**
-	 * Modify the query based on the seo_filter variable in $_GET
+	 * Modify the query based on the seo_filter variable in $_GET.
 	 *
-	 * @param string $where Query variables.
+	 * @param string $where The where statement.
 	 *
 	 * @return string The modified query.
 	 */
@@ -33,10 +33,10 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 
 		global $wpdb;
 
-		$where .= sprintf( ' AND ' . $wpdb->posts . '.post_modified < "%s" ', $this->date_threshold() );
 		$where .= sprintf(
-			' AND ' . $wpdb->posts . '.ID IN( SELECT post_id FROM ' . $wpdb->postmeta . ' WHERE meta_key = "%s" AND meta_value = "1" ) ',
-			WPSEO_Meta::$meta_prefix . WPSEO_Cornerstone::META_NAME
+			' AND ' . $wpdb->posts . '.ID IN( SELECT post_id FROM ' . $wpdb->postmeta . ' WHERE meta_key = "%s" AND meta_value = "1" ) AND ' . $wpdb->posts . '.post_modified < "%s" ',
+			WPSEO_Meta::$meta_prefix . WPSEO_Cornerstone::META_NAME,
+			$this->date_threshold()
 		);
 
 		return $where;
@@ -54,7 +54,7 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	/**
 	 * Returns a text explaining this filter.
 	 *
-	 * @return string The explanation.
+	 * @return string The explanation for this filter.
 	 */
 	protected function get_explanation() {
 		$post_type_object = get_post_type_object( $this->get_current_post_type() );
@@ -75,7 +75,7 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	/**
 	 * Returns the total amount of stale content.
 	 *
-	 * @return integer The total amount.
+	 * @return integer The total amount of stale content.
 	 */
 	protected function get_post_total() {
 		global $wpdb;
@@ -114,12 +114,6 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	 * @return string The formatted date.
 	 */
 	protected function date_threshold() {
-		$timestamp = strtotime( '-6months' );
-		$formatted_date_gmt = gmdate( 'Y-m-d', $timestamp );
-		if ( $formatted_date_gmt ) {
-			return $formatted_date_gmt;
-		}
-
-		return date( 'Y-m-d', $timestamp );
+		return gmdate( 'Y-m-d', strtotime( '-6months' ) );
 	}
 }

--- a/admin/filters/class-stale-cornerstone-content-filter.php
+++ b/admin/filters/class-stale-cornerstone-content-filter.php
@@ -6,9 +6,9 @@
  */
 
 /**
- * Registers the filter for filtering stale content.
+ * Registers the filter for filtering stale cornerstone content.
  */
-class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
+class WPSEO_Stale_Cornerstone_Content_Filter extends WPSEO_Abstract_Post_Filter {
 
 	/**
 	 * Returns the query value this filter uses.
@@ -16,7 +16,7 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	 * @return string The query value this filter uses.
 	 */
 	public function get_query_val() {
-		return 'stale-content';
+		return 'stale-cornerstone-content';
 	}
 
 	/**
@@ -48,7 +48,7 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	 * @return string The label for this filter.
 	 */
 	protected function get_label() {
-		return __( 'Stale content', 'wordpress-seo' );
+		return __( 'Stale cornerstone content', 'wordpress-seo' );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 
 		return sprintf(
 		/* translators: %1$s expands to the posttype label, %2$s expands anchor to blog post about cornerstone content, %3$s expands to </a> */
-			__( 'Stale content refers to cornerstone content that hasn’t been updated in the last 6 months. Make sure to keep these %s up-to-date. %2$sLearn more about cornerstone content%3$s.', 'wordpress-seo' ),
+			__( 'Stale cornerstone content refers to cornerstone content that hasn’t been updated in the last 6 months. Make sure to keep these %s up-to-date. %2$sLearn more about cornerstone content%3$s.', 'wordpress-seo' ),
 			strtolower( $post_type_object->labels->name ),
 			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1i9' ) . '" target="_blank">',
 			'</a>'
@@ -73,9 +73,9 @@ class WPSEO_Stale_Content_Filter extends WPSEO_Abstract_Post_Filter {
 	}
 
 	/**
-	 * Returns the total amount of stale content.
+	 * Returns the total amount of stale cornerstone content.
 	 *
-	 * @return integer The total amount of stale content.
+	 * @return integer The total amount of stale cornerstone content.
 	 */
 	protected function get_post_total() {
 		global $wpdb;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a filter for stale content (cornerstone content which hasn't been updated in the last 6 months).

## Test instructions

This PR can be tested by following these steps:

* Mark some content as cornerstone content
* Modify the 'post_modified' column for one item in the database (phpmyadmin) with a date set more than 6 months ago.
* The post should be visible in the post overview when using the cornerstone filter and will also be visible with the stale content filter.
* When setting the post_modified date within that last 6 months, the post will be hidden in the stale content filter.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #8309
