### PR TITLE
Change max meta description length

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -339,7 +339,7 @@ class WPSEO_Replace_Vars {
 				$replacement = wp_strip_all_tags( $this->args->post_excerpt );
 			}
 			elseif ( $this->args->post_content !== '' ) {
-				$replacement = wp_html_excerpt( strip_shortcodes( $this->args->post_content ), 320 );
+				$replacement = wp_html_excerpt( strip_shortcodes( $this->args->post_content ), 156 );
 				// Trim the auto-generated string to a word boundary.
 				$replacement = substr( $replacement, 0, strrpos( $replacement, ' ' ) );
 			}

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -7,48 +7,8 @@ import {
 import { measureTextWidth } from "yoastseo/js/helpers/createMeasurementElement";
 import MetaDescriptionLengthAssessment from "yoastseo/js/assessments/seo/metaDescriptionLengthAssessment";
 import PageTitleWidthAssesment from "yoastseo/js/assessments/seo/pageTitleWidthAssessment";
-import isUndefined from "lodash/isUndefined";
 import get from "lodash/get";
 import identity from "lodash/identity";
-import { getResultsForKeyword, getActiveKeyword } from "../redux/selectors/results";
-
-/**
- * Returns true for the title length result.
- *
- * @param {array} results The SEO results.
- * @returns {boolean} True if it's the title length result.
- */
-function isTitleLengthResult( results ) {
-	return results._identifier === "titleWidth";
-}
-
-/**
- * Returns true for the description length result.
- *
- * @param {array} results The SEO results.
- * @returns {boolean} True if it's the description length result.
- */
-function isDescriptionLengthResult( results ) {
-	return results._identifier === "metaDescriptionLength";
-}
-
-/**
- *	Gets the data needed for calculating the length progress.
- *
- * @param {Object} result The assessment result.
- * @returns {Object} The data needed for calculating the length progress.
- */
-function getProgress( result ) {
-	let progress = {};
-	if ( ! isUndefined( result ) ) {
-		progress = {
-			max: result.max,
-			actual: result.actual,
-			score: result.score,
-		};
-	}
-	return progress;
-}
 
 /**
  * Gets the title progress.

--- a/js/tests/containers/SnippetEditor.test.js
+++ b/js/tests/containers/SnippetEditor.test.js
@@ -12,8 +12,8 @@ describe( "SnippetEditor container", () => {
 			analysis: {
 				seo: {
 					active: [
-						{ _identifier: "metaDescriptionLength", max: 320, actual: 153, score: 7 },
-						{ _identifier: "titleWidth", max: 600, actual: 400, score: 7 } ],
+						{ _identifier: "metaDescriptionLength", max: 156, actual: 11, score: 6 },
+						{ _identifier: "titleWidth", max: 600, actual: 400, score: 6 } ],
 				},
 			},
 			snippetEditor: {
@@ -35,14 +35,14 @@ describe( "SnippetEditor container", () => {
 			mode: "desktop",
 			keyword: "active",
 			descriptionLengthProgress: {
-				max: 320,
-				actual: 153,
-				score: 7,
+				max: 156,
+				actual: 11,
+				score: 6,
 			},
 			titleLengthProgress: {
 				max: 600,
-				actual: 400,
-				score: 7,
+				actual: 0,
+				score: 1,
 			},
 			data: {
 				title: "Title",

--- a/package.json
+++ b/package.json
@@ -123,8 +123,8 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "^4.0.2",
-    "yoastseo": "^1.32.0"
+    "yoast-components": "^4.1.0",
+    "yoastseo": "^1.33.0"
   },
   "yoast": {
     "pluginVersion": "7.6-RC1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11256,9 +11256,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yoast-components@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.0.2.tgz#d3a184cfc9afb4c6097bbd6540c41b9a4d1c1f63"
+yoast-components@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.1.0.tgz#200057113e4885678e13ec81aa5fabaafdccb0f1"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -11279,13 +11279,13 @@ yoast-components@^4.0.2:
     striptags "^3.1.0"
     styled-components "^2.1.2"
     whatwg-fetch "^1.0.0"
-    yoastseo "^1.32.0"
+    yoastseo "^1.33.0"
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.32.0.tgz#d15982118849c3d5ba2438776b49bfc83cb1d53a"
+yoastseo@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.33.0.tgz#9cea8af7fea97c382e2ef0317133dacc51f11237"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the maximum length of the the meta description assessment from 320 to 156.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

Please look at https://github.com/Yoast/YoastSEO.js/pull/1497 and https://github.com/Yoast/yoast-components/pull/547 first.

* Please test in the classic editor.
* Use define( 'YOAST_FEATURE_SNIPPET_PREVIEW', true ); to see the react snippet editor (for example on line 46 in `class-metabox-formatter.php`, or in your `wp-config.php`).
* Link the branches from https://github.com/Yoast/YoastSEO.js/pull/1497 and https://github.com/Yoast/yoast-components/pull/547.
   * Link `yoastseo.js` and `yoast-components` to `wordpress-seo`. 
   * Link `yoastseo` to `yoast-components` using `ln -s [path to your local yoastseo folder] node_modules/yoastseo` in `yoast-components` + remove `.babelrc` from yoastseo to avoid build errors. (It's ugly, I know)
   * Don't forget to run `yarn install` afterwards.

### Metadescription progress bar
* Both in the desktop view and mobile view, write some meta descriptions in the react snippet editor and see the progress bar reflecting the length, both by progress and color (with a delay, see 'Known issues that don't block merging' below). 0-120 and >156 characters = orange bar, 121-156 characters = green bar.
* NB: in the 'old' snippet preview, the meta description turns red when it's too long. We don't want that anymore (as discussed with @jdevalk and @jono-alderson)

### Other
* Look if nothing else breaks, especially in the content analysis.

## Important for merging
- First merge https://github.com/Yoast/YoastSEO.js/pull/1497 and https://github.com/Yoast/yoast-components/pull/547 first.
- Release yoast-components and yoastseo.js (please discuss yoastseo.js release with team frontend).
- Change the versions of yoast-components and yoastseo.js in the package.json in this branch. Also commit the new yarn.lock.
- Merge this PR

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes Yoast/YoastSEO.js#1496
