### PR TITLE
Add template variable tab to Term Help Center

### DIFF
--- a/admin/help_center/class-template-variables-tab.php
+++ b/admin/help_center/class-template-variables-tab.php
@@ -33,7 +33,7 @@ class WPSEO_Help_Center_Template_Variables_Tab implements WPSEO_WordPress_Integr
 	 */
 	public function register_hooks() {
 		add_filter( 'wpseo_help_center_items', array( $this, 'add_meta_options_help_center_tabs' ), $this->priority );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 	}
 
 	/**
@@ -41,7 +41,7 @@ class WPSEO_Help_Center_Template_Variables_Tab implements WPSEO_WordPress_Integr
 	 *
 	 * @return void
 	 */
-	public function enqueue() {
+	public function enqueue_assets() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_style( 'admin-css' );
 	}

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -69,6 +69,9 @@ class WPSEO_Taxonomy {
 	 * @param stdClass|WP_Term $term Term to show the edit boxes for.
 	 */
 	public function term_metabox( $term ) {
+		$tab = new WPSEO_Help_Center_Template_Variables_Tab();
+		$tab->register_hooks();
+
 		$metabox = new WPSEO_Taxonomy_Metabox( $this->taxonomy, $term );
 		$metabox->display();
 	}
@@ -88,6 +91,8 @@ class WPSEO_Taxonomy {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_style( 'scoring' );
 
+		$tab = new WPSEO_Help_Center_Template_Variables_Tab();
+		$tab->enqueue_assets();
 
 		$tag_id = filter_input( INPUT_GET, 'tag_ID' );
 		if (

--- a/tests/admin/help_center/test-class-help-center-template-variables-tab.php
+++ b/tests/admin/help_center/test-class-help-center-template-variables-tab.php
@@ -20,7 +20,7 @@ class WPSEO_Help_Center_Template_Variables_Tab_Test extends WPSEO_UnitTestCase {
 			$instance,
 			'add_meta_options_help_center_tabs'
 		) ) );
-		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_assets' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds "Template explanation" tab to the Help Center of the Term edit page.

## Relevant technical choices:

* As on the Post edit pages, the Help Tab also needs to be present on the term-edit page.

## Test instructions

This PR can be tested by following these steps:

* Go to a term and edit it
* Open the Help Center and see the "Template explanation" tab present.
* The styling of the content should be zebra-striped table rows.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

