### PR TITLE
moved seperator decoding logic from yoast components to wpseo

### DIFF
--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -7,6 +7,7 @@ import {
 	fillReplacementVariables,
 	mapCustomFields,
 	mapCustomTaxonomies,
+	decodeSeparatorVariable,
 } from "../helpers/replacementVariableHelpers";
 import tmceHelper, { tmceId } from "../wp-seo-tinymce";
 import debounce from "lodash/debounce";
@@ -41,7 +42,7 @@ class ClassicEditorData {
 	 */
 	initialize( replaceVars ) {
 		this._data = this.getInitialData( replaceVars );
-		fillReplacementVariables( this._data, this._store );
+		fillReplacementVariables( decodeSeparatorVariable( this._data ), this._store );
 		this.subscribeToElements();
 		this.subscribeToStore();
 	}

--- a/js/src/helpers/replacementVariableHelpers.js
+++ b/js/src/helpers/replacementVariableHelpers.js
@@ -1,6 +1,10 @@
+/* External dependencies */
 import forEach from "lodash/forEach";
-import { updateReplacementVariable } from "../redux/actions/snippetEditor";
 import omit from "lodash/omit";
+
+/* Internal dependencies */
+import { updateReplacementVariable } from "../redux/actions/snippetEditor";
+import decodeHTML from "yoast-components/composites/OnboardingWizard/helpers/htmlDecoder";
 
 export const nonReplaceVars = [ "slug", "content" ];
 
@@ -19,6 +23,21 @@ export function fillReplacementVariables( data, store ) {
 		}
 		store.dispatch( updateReplacementVariable( name, value ) );
 	} );
+}
+
+/**
+ * Decodes the separator replacement variable to a displayable symbol.
+ *
+ * @param {array} replacementVariables   The array of replacement variable objects.
+ *
+ * @returns {array} replacementVariables The array of replacement variable objects with the updated separator variable.
+ */
+export function decodeSeparatorVariable( replacementVariables ) {
+	if( replacementVariables[ "sep" ] ) {
+		replacementVariables[ "sep" ] = decodeHTML( replacementVariables[ "sep" ] );
+	}
+
+	return replacementVariables;
 }
 
 /**

--- a/js/src/helpers/replacementVariableHelpers.js
+++ b/js/src/helpers/replacementVariableHelpers.js
@@ -28,9 +28,9 @@ export function fillReplacementVariables( data, store ) {
 /**
  * Decodes the separator replacement variable to a displayable symbol.
  *
- * @param {array} replacementVariables   The array of replacement variable objects.
+ * @param {Object} replacementVariables   The object with replacement variables.
  *
- * @returns {array} replacementVariables The array of replacement variable objects with the updated separator variable.
+ * @returns {Object} replacementVariables The object with replacement variables with a decoded separator.
  */
 export function decodeSeparatorVariable( replacementVariables ) {
 	if( replacementVariables[ "sep" ] ) {

--- a/js/tests/helpers/replacementVariableHelpers.test.js
+++ b/js/tests/helpers/replacementVariableHelpers.test.js
@@ -1,0 +1,51 @@
+import {
+	decodeSeparatorVariable,
+} from "../../src/helpers/replacementVariableHelpers";
+
+describe( "decodeSeparatorVariable", () => {
+	it( "decodes &ndashes from the replacementvariables object from a code to a symbol.", () => {
+		const replacementVariables = {
+			date: "May 15, 2018",
+			sep: "&ndash;",
+		};
+
+		const expected = {
+			date: "May 15, 2018",
+			sep: "–",
+		};
+
+		const actual = decodeSeparatorVariable( replacementVariables );
+
+		expect( expected ).toEqual( actual );
+	} );
+
+	it( "decodes the seperator from the replacementvariables object from a code to a symbol.", () => {
+		const replacementVariables = {
+			date: "May 15, 2018",
+			sep: "&#8902;",
+		};
+
+		const expected = {
+			date: "May 15, 2018",
+			sep: "⋆",
+		};
+
+		const actual = decodeSeparatorVariable( replacementVariables );
+
+		expect( expected ).toEqual( actual );
+	} );
+
+	it( "returns the passed object when no sep variable was present in the replacement variables object", () => {
+		const replacementVariables = {
+			date: "May 15, 2018",
+		};
+
+		const expected = {
+			date: "May 15, 2018",
+		};
+
+		const actual = decodeSeparatorVariable( replacementVariables );
+
+		expect( expected ).toEqual( actual );
+	} );
+} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*N/A

## Relevant technical choices:

* moved seperator decoding logic from yoast components to wpseo. It was an array in yoast components, but is an object here, so adapted the logic to the new situation.

## Test instructions

This PR can be tested by following these steps:

* With wordpress-seo and yoast-components linked, check if all seperators show up as symbols, rather than as codes.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/yoast-components/issues/550
