### PR TITLE
Set SC_ATTR when building to prevent conflicts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
       env: WP_VERSION=master
     - stage: 🚀 deployment
       if: branch = deploy # Only build when on the `deploy` branch, this functionality is not used yet and is taking a long time to complete.
+      env: SC_ATTR=wordpress-seo
       before_script: skip
       script: grunt artifact
       before_install: skip


### PR DESCRIPTION
I noticed some odd behaviour when running Yoast SEO alongside another plugin I'd written that uses styled components. In newer version their rehydration step will cause other instances of styled components stylesheets to be wiped out which isn't ideal.

The `SC_ATTR` environment variables allows you to scope the attribute of the generated stylesheet to avoid these conflicts. See the pertinent changelog here: https://github.com/styled-components/styled-components/releases/tag/v3.2.4

It might be good to incorporate this into the npm or grunt script somehow for local builds too but I couldn't work out the best place in relation to grunt and webpack.

## Summary

This PR can be summarized in the following changelog entry:

* n/a
