### PR TITLE
Readme/Changelog: make a link clickable

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -169,4 +169,4 @@ Other:
 
 = Earlier versions =
 
-For the changelog of earlier versions, please refer to https://yoa.st/yoast-seo-changelog
+For the changelog of earlier versions, please refer to [https://yoa.st/yoast-seo-changelog](https://yoa.st/yoast-seo-changelog).


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _The link to the changelog for older versions is now clickable._

## Relevant technical choices:

For whatever reason, this URL is not automatically made clickable, so let's make sure it's clickable.

This can be seen/experienced on:
* https://wordpress.org/plugins/wordpress-seo/#developers
    ![wpseo-changlog-not-linked-1](https://user-images.githubusercontent.com/663378/40536731-5f369cb2-600d-11e8-81c1-52390d857259.png)
* When clicking on the "_View version x.x.x details._" link on the `Updates` page from within a WP install.

If someone has a better suggestion for link text, please let me know.

## Test instructions

* Not testable until the next release has been posted on wp.org.
