### PR TITLE
Revert "Merge pull request #9720 from Yoast/stories/remove-old-snippet-editor"

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -64,6 +64,7 @@ class WPSEO_Metabox_Formatter {
 			'contentAnalysisActive' => $analysis_readability->is_enabled() ? 1 : 0,
 			'keywordAnalysisActive' => $analysis_seo->is_enabled() ? 1 : 0,
 			'intl'                  => $this->get_content_analysis_component_translations(),
+			'reactSnippetPreview'   => defined( 'YOAST_FEATURE_SNIPPET_PREVIEW' ) && YOAST_FEATURE_SNIPPET_PREVIEW,
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -60,6 +60,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	public static function translate_meta_boxes() {
 		self::$meta_fields['general']['snippetpreview']['title'] = __( 'Snippet editor', 'wordpress-seo' );
+		/* translators: 1: link open tag; 2: link close tag. */
+		self::$meta_fields['general']['snippetpreview']['help']        = sprintf( __( 'This is a rendering of what this post might look like in Google\'s search results. %1$sLearn more about the Snippet Preview%2$s.', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/snippet-preview' ) . '">', '</a>' );
+		self::$meta_fields['general']['snippetpreview']['help-button'] = __( 'Show information about the snippet editor', 'wordpress-seo' );
 
 		self::$meta_fields['general']['pageanalysis']['title'] = __( 'Analysis', 'wordpress-seo' );
 		/* translators: 1: link open tag; 2: link close tag. */

--- a/admin/taxonomy/class-taxonomy-content-fields.php
+++ b/admin/taxonomy/class-taxonomy-content-fields.php
@@ -20,7 +20,12 @@ class WPSEO_Taxonomy_Content_Fields extends WPSEO_Taxonomy_Fields {
 			'snippet' => $this->get_field_config(
 				__( 'Snippet editor', 'wordpress-seo' ),
 				'',
-				'snippetpreview'
+				'snippetpreview',
+				array(
+					'help-button' => __( 'Show information about the snippet editor', 'wordpress-seo' ),
+					/* translators: 1: link open tag; 2: link close tag. */
+					'help'        => sprintf( __( 'This is a rendering of what this post might look like in Google\'s search results. %1$sLearn more about the Snippet Preview%2$s.', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/snippet-preview' ) . '">', '</a>' ),
+				)
 			),
 			'focuskw' => $this->get_field_config(
 				__( 'Focus keyword', 'wordpress-seo' ),

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -1,17 +1,14 @@
 /* global jQuery, YoastSEO, wpseoPostScraperL10n */
 
-/* External dependencies */
-import removeMarks from "yoastseo/js/markers/removeMarks";
-import get from "lodash/get";
-import { measureTextWidth } from "yoastseo/js/helpers/createMeasurementElement";
-
-/* Internal dependencies */
 import isKeywordAnalysisActive from "./isKeywordAnalysisActive";
+import removeMarks from "yoastseo/js/markers/removeMarks";
 import tmceHelper from "../wp-seo-tinymce";
 import { tmceId } from "../wp-seo-tinymce";
 import getIndicatorForScore from "./getIndicatorForScore";
+
 import { update as updateTrafficLight } from "../ui/trafficLight";
 import { update as updateAdminBar } from "../ui/adminBar";
+
 import publishBox from "../ui/publishBox";
 
 let $ = jQuery;
@@ -33,7 +30,6 @@ let PostDataCollector = function( args ) {
 
 	this._data = args.data;
 	this._tabManager = args.tabManager;
-	this._store = args.store;
 };
 
 /**
@@ -45,7 +41,7 @@ let PostDataCollector = function( args ) {
 PostDataCollector.prototype.getData = function() {
 	const data = this._data.getData();
 
-	const otherData = {
+	return {
 		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",
 		meta: this.getMeta(),
 		text: data.content,
@@ -59,19 +55,6 @@ PostDataCollector.prototype.getData = function() {
 		searchUrl: this.getSearchUrl(),
 		postUrl: this.getPostUrl(),
 		permalink: this.getPermalink(),
-		titleWidth: measureTextWidth( this.getSnippetTitle() ),
-	};
-
-	const state = this._store.getState();
-	const snippetData = {
-		metaTitle: get( state, [ "snippetEditor", "data", "title" ], "" ),
-		url: get( state, [ "snippetEditor", "data", "slug" ], "" ),
-		meta: get( state, [ "snippetEditor", "data", "description" ], "" ),
-	};
-
-	return {
-		...otherData,
-		...snippetData,
 	};
 };
 

--- a/js/src/analysis/TermDataCollector.js
+++ b/js/src/analysis/TermDataCollector.js
@@ -6,8 +6,6 @@ import { update as updateTrafficLight } from "../ui/trafficLight";
 import { update as updateAdminBar } from "../ui/adminBar";
 import isKeywordAnalysisActive from "../analysis/isKeywordAnalysisActive";
 import { termsTmceId as tmceId } from "../wp-seo-tinymce";
-import get from "lodash/get";
-import { measureTextWidth } from "yoastseo/js/helpers/createMeasurementElement";
 
 let $ = jQuery;
 
@@ -25,7 +23,6 @@ var TermDataCollector = function( args ) {
 	}
 
 	this._tabManager = args.tabManager;
-	this._store = args.store;
 };
 
 /**
@@ -34,7 +31,7 @@ var TermDataCollector = function( args ) {
  * @returns {{keyword: *, meta: *, text: *, pageTitle: *, title: *, url: *, baseUrl: *, snippetTitle: *, snippetMeta: *, snippetCite: *}} The object with data.
  */
 TermDataCollector.prototype.getData = function() {
-	const otherData = {
+	return {
 		title: this.getTitle(),
 		keyword: isKeywordAnalysisActive() ? this.getKeyword() : "",
 		text: this.getText(),
@@ -47,19 +44,6 @@ TermDataCollector.prototype.getData = function() {
 		name: this.getName(),
 		baseUrl: this.getBaseUrl(),
 		pageTitle: this.getPageTitle(),
-		titleWidth: measureTextWidth( this.getTitle() ),
-	};
-
-	const state = this._store.getState();
-	const snippetData = {
-		metaTitle: get( state, [ "snippetEditor", "data", "title" ], "" ),
-		url: get( state, [ "snippetEditor", "data", "slug" ], "" ),
-		meta: get( state, [ "snippetEditor", "data", "description" ], "" ),
-	};
-
-	return {
-		...otherData,
-		...snippetData,
 	};
 };
 

--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -1,5 +1,8 @@
 /* External dependencies */
 import removeMarks from "yoastseo/js/markers/removeMarks";
+import debounce from "lodash/debounce";
+import omit from "lodash/omit";
+import forEach from "lodash/forEach";
 
 /* Internal dependencies */
 import { updateReplacementVariable } from "../redux/actions/snippetEditor";
@@ -9,7 +12,6 @@ import {
 	mapCustomTaxonomies,
 } from "../helpers/replacementVariableHelpers";
 import tmceHelper, { tmceId } from "../wp-seo-tinymce";
-import debounce from "lodash/debounce";
 
 /**
  * Represents the classic editor data.
@@ -26,10 +28,7 @@ class ClassicEditorData {
 		this._refresh = refresh;
 		this._store = store;
 		this._data = {};
-		// This will be used for the comparison whether the title, description and slug are dirty.
-		this._previousData = {};
 		this.updateData = this.updateData.bind( this );
-		this.refreshYoastSEO = this.refreshYoastSEO.bind( this );
 	}
 
 	/**
@@ -43,7 +42,6 @@ class ClassicEditorData {
 		this._data = this.getInitialData( replaceVars );
 		fillReplacementVariables( this._data, this._store );
 		this.subscribeToElements();
-		this.subscribeToStore();
 	}
 
 	/**
@@ -194,6 +192,52 @@ class ClassicEditorData {
 		this._store.subscribe(
 			this.subscriber
 		);
+	}
+	/**
+	 * Map the custom_fields field in the replacevars to a format suited for redux.
+	 *
+	 * @param {Object} replaceVars       The original replacevars.
+	 *
+	 * @returns {Object}                 The restructured replacevars object without custom_fields.
+	 */
+	mapCustomFields( replaceVars ) {
+		if( ! replaceVars.custom_fields ) {
+			return replaceVars;
+		}
+
+		let customFieldReplaceVars = {};
+		forEach( replaceVars.custom_fields, ( value, key ) => {
+			customFieldReplaceVars[ `cf_${ key }` ] = value;
+		} );
+
+		return omit( {
+			...replaceVars,
+			...customFieldReplaceVars,
+		}, "custom_fields" );
+	}
+
+	/**
+	 * Map the custom_taxonomies field in the replacevars to a format suited for redux.
+	 *
+	 * @param {Object} replaceVars       The original replacevars.
+	 *
+	 * @returns {Object}                 The restructured replacevars object without custom_taxonomies.
+	 */
+	mapCustomTaxonomies( replaceVars ) {
+		if( ! replaceVars.custom_taxonomies ) {
+			return replaceVars;
+		}
+
+		let customTaxonomyReplaceVars = {};
+		forEach( replaceVars.custom_taxonomies, ( value, key ) => {
+			customTaxonomyReplaceVars[ `ct_${ key }` ] = value.name;
+			customTaxonomyReplaceVars[ `ct_desc_${ key }` ] = value.description;
+		} );
+
+		return omit( {
+			...replaceVars,
+			...customTaxonomyReplaceVars,
+		}, "custom_taxonomies" );
 	}
 
 	/**

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -99,7 +99,7 @@ const mapEditorDataToPreview = function( data ) {
 const SnippetPreviewSection = ( { baseUrl, date } ) => {
 	return <Section
 		headingLevel={ 3 }
-		headingText="Snippet preview"
+		headingText="React snippet preview"
 		headingIcon="eye"
 		headingIconColor="#555"
 	>

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -121,9 +121,12 @@ function renderSnippetPreview( store, props ) {
 		return;
 	}
 
+	const container = document.createElement( "div" );
+	targetElement.parentNode.insertBefore( container, targetElement );
+
 	ReactDOM.render(
 		wrapInTopLevelComponents( SnippetPreviewSection, store, props ),
-		targetElement,
+		container,
 	);
 }
 
@@ -184,10 +187,12 @@ export function initialize( args ) {
 
 	renderReactApps( store, args );
 
-	renderSnippetPreview( store, {
-		baseUrl: args.snippetEditorBaseUrl,
-		date: args.snippetEditorDate,
-	} );
+	if ( args.shouldRenderSnippetPreview ) {
+		renderSnippetPreview( store, {
+			baseUrl: args.snippetEditorBaseUrl,
+			date: args.snippetEditorDate,
+		} );
+	}
 
 	return {
 		store,

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -170,6 +170,10 @@
 		jQuery( "#pageanalysis > section.yoast-section" ).find( "h3" ).after(
 			jQuery( "#help-yoast-pageanalysis" ).detach().removeClass( "wpseo_hidden" )
 		);
+
+		var snippetHelp = jQuery( "#help-yoast-snippetpreview" ).detach().removeClass( "wpseo_hidden" );
+		// Post/taxonomy/media meta box.
+		jQuery( "#wpseosnippet" ).find( "h3" ).after( snippetHelp );
 	}
 
 	jQuery( document ).ready( function() {

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -2,6 +2,7 @@
 
 // External dependencies.
 import { App } from "yoastseo";
+import isFunction from "lodash/isFunction";
 import isUndefined from "lodash/isUndefined";
 import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
 import { refreshSnippetEditor } from "./redux/actions/snippetEditor.js";
@@ -34,6 +35,7 @@ import { setYoastComponentsI18n } from "./helpers/i18n";
 
 setYoastComponentsI18n();
 
+
 ( function( $ ) {
 	"use strict"; // eslint-disable-line
 	if ( typeof wpseoPostScraperL10n === "undefined" ) {
@@ -42,7 +44,7 @@ setYoastComponentsI18n();
 
 	let snippetContainer;
 	let titleElement;
-	let app;
+	let app, snippetPreview;
 	let decorator = null;
 	let tabManager, postDataCollector;
 
@@ -90,6 +92,51 @@ setYoastComponentsI18n();
 		}
 	} );
 
+	/**
+	 * Dispatches an action to the store that updates the snippet editor.
+	 *
+	 * @param {Object} data The data from the legacy snippet editor.
+	 *
+	 * @returns {void}
+	 */
+	const dispatchUpdateSnippetEditor = function( data ) {
+		/*
+		 * The setTimeout makes sure the React component is only rendered on the next
+		 * frame.
+		 */
+		setTimeout( () => {
+			editStore.dispatch( updateData( {
+				title: data.title,
+				slug: data.urlPath,
+				description: data.metaDesc,
+			} ) );
+		}, 0 );
+	};
+
+	/**
+	 * Initializes the snippet preview.
+	 *
+	 * @param {Object} snippetEditorData The snippet editor data.
+	 *
+	 * @returns {SnippetPreview} The created snippetpreview element.
+	 */
+	function initSnippetPreview( snippetEditorData ) {
+		return snippetPreviewHelpers.create( snippetContainer, {
+			title: snippetEditorData.title,
+			urlPath: snippetEditorData.slug,
+			metaDesc: snippetEditorData.description,
+		}, ( data ) => {
+			const previousData = snippetEditorHelpers.getDataFromStore( editStore );
+
+			if (
+				previousData.title !== data.title ||
+				previousData.description !== data.metaDesc ||
+				previousData.slug !== data.urlPath
+			) {
+				dispatchUpdateSnippetEditor( data );
+			}
+		} );
+	}
 	/**
 	 * Determines if markers should be shown.
 	 *
@@ -245,7 +292,6 @@ setYoastComponentsI18n();
 		let postDataCollector = new PostDataCollector( {
 			tabManager,
 			data,
-			store: editStore,
 		} );
 
 		/*
@@ -287,7 +333,7 @@ setYoastComponentsI18n();
 			marker: getMarker(),
 			contentAnalysisActive: isContentAnalysisActive(),
 			keywordAnalysisActive: isKeywordAnalysisActive(),
-			hasSnippetPreview: false,
+			snippetPreview: snippetPreview,
 		};
 
 		if ( isKeywordAnalysisActive() ) {
@@ -390,15 +436,51 @@ setYoastComponentsI18n();
 	}
 
 	/**
+	 * Update the legacy snippet preview based on the passed data from the redux
+	 * store.
+	 *
+	 * @param {Object} data The data from the store.
+	 *
+	 * @returns {void}
+	 */
+	function updateLegacySnippetEditor( data ) {
+		if ( isFunction( snippetPreview.refresh ) ) {
+			let isDataChanged = false;
+
+			if ( snippetPreview.data.title !== data.title ) {
+				snippetPreview.element.input.title.value = data.title;
+
+				isDataChanged = true;
+			}
+
+			if ( snippetPreview.data.urlPath !== data.slug ) {
+				snippetPreview.element.input.urlPath.value = data.slug;
+
+				isDataChanged = true;
+			}
+
+			if ( snippetPreview.data.metaDesc !== data.description ) {
+				snippetPreview.element.input.metaDesc.value = data.description;
+
+				isDataChanged = true;
+			}
+
+			if ( isDataChanged ) {
+				snippetPreview.changedInput();
+			}
+		}
+	}
+
+	/**
 	 * Initializes analysis for the post edit screen.
 	 *
 	 * @returns {void}
 	 */
-	 function initializePostAnalysis() {
+	function initializePostAnalysis() {
 		const editArgs = {
 			analysisSection: "pageanalysis",
 			onRefreshRequest: () => {},
-			shouldRenderSnippetPreview: true,
+			shouldRenderSnippetPreview: !! wpseoPostScraperL10n.reactSnippetPreview,
 			snippetEditorBaseUrl: wpseoPostScraperL10n.base_url,
 			snippetEditorDate: wpseoPostScraperL10n.metaDescriptionDate,
 			replaceVars: wpseoReplaceVarsL10n.replace_vars,
@@ -416,6 +498,13 @@ setYoastComponentsI18n();
 		tabManager = initializeTabManager();
 		postDataCollector = initializePostDataCollector( data );
 		publishBox.initalise();
+
+		// Initialize the snippet editor data.
+		let snippetEditorData = snippetEditorHelpers.getDataFromCollector( postDataCollector );
+		const snippetEditorTemplates = snippetEditorHelpers.getTemplatesFromL10n( wpseoPostScraperL10n );
+		snippetEditorData = snippetEditorHelpers.getDataWithTemplates( snippetEditorData, snippetEditorTemplates );
+
+		snippetPreview = initSnippetPreview( snippetEditorData );
 
 		const appArgs = getAppArgs( store );
 		app = new App( appArgs );
@@ -438,6 +527,15 @@ setYoastComponentsI18n();
 		activateEnabledAnalysis( tabManager );
 
 		jQuery( window ).trigger( "YoastSEO:ready" );
+
+		/*
+		 * Checks the snippet preview size and toggles views when the WP admin menu state changes.
+		 * In WordPress, `wp-collapse-menu` fires when clicking on the Collapse/expand button.
+		 * `wp-menu-state-set` fires also when the window gets resized and the menu can be folded/auto-folded/collapsed/expanded/responsive.
+		 */
+		jQuery( document ).on( "wp-collapse-menu wp-menu-state-set", function() {
+			app.snippetPreview.handleWindowResizing();
+		} );
 
 		// Backwards compatibility.
 		YoastSEO.analyzerArgs = appArgs;
@@ -472,11 +570,6 @@ setYoastComponentsI18n();
 			data.setRefresh( app.refresh );
 		}
 
-		// Initialize the snippet editor data.
-		let snippetEditorData = snippetEditorHelpers.getDataFromCollector( postDataCollector );
-		const snippetEditorTemplates = snippetEditorHelpers.getTemplatesFromL10n( wpseoPostScraperL10n );
-		snippetEditorData = snippetEditorHelpers.getDataWithTemplates( snippetEditorData, snippetEditorTemplates );
-
 		// Set the initial snippet editor data.
 		store.dispatch( updateData( snippetEditorData ) );
 
@@ -499,6 +592,8 @@ setYoastComponentsI18n();
 			snippetEditorData.title = data.title;
 			snippetEditorData.slug = data.slug;
 			snippetEditorData.description = data.description;
+
+			updateLegacySnippetEditor( data );
 		} );
 	}
 

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -3,6 +3,7 @@
 // External dependencies.
 import { App } from "yoastseo";
 import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
+import isFunction from "lodash/isFunction";
 import isUndefined from "lodash/isUndefined";
 
 // Internal dependencies.
@@ -78,6 +79,88 @@ window.yoastHideMarkers = true;
 		// Make the description textarea label plain text removing the label tag.
 		descriptionLabel.replaceWith( descriptionLabel.html() );
 	};
+
+	/**
+	 * Dispatches an action to the store that updates the snippet editor.
+	 *
+	 * @param {Object} data The data from the legacy snippet editor.
+	 *
+	 * @returns {void}
+	 */
+	const dispatchUpdateSnippetEditor = function( data ) {
+		/*
+		 * The setTimeout makes sure the React component is only updated on the next
+		 * frame. This is to prevent input lag.
+		 */
+		setTimeout( () => {
+			store.dispatch( updateData( {
+				title: data.title,
+				slug: data.urlPath,
+				description: data.metaDesc,
+			} ) );
+		}, 0 );
+	};
+
+	/**
+	 * Update the legacy snippet preview based on the passed data from the redux
+	 * store.
+	 *
+	 * @param {Object} data The data from the store.
+	 *
+	 * @returns {void}
+	 */
+	function updateLegacySnippetEditor( data ) {
+		if ( isFunction( snippetPreview.refresh ) ) {
+			let isDataChanged = false;
+
+			if ( snippetPreview.data.title !== data.title ) {
+				snippetPreview.element.input.title.value = data.title;
+
+				isDataChanged = true;
+			}
+
+			if ( snippetPreview.data.urlPath !== data.slug ) {
+				snippetPreview.element.input.urlPath.value = data.slug;
+
+				isDataChanged = true;
+			}
+
+			if ( snippetPreview.data.metaDesc !== data.description ) {
+				snippetPreview.element.input.metaDesc.value = data.description;
+
+				isDataChanged = true;
+			}
+
+			if ( isDataChanged ) {
+				snippetPreview.changedInput();
+			}
+		}
+	}
+
+	/**
+	 * Initializes the snippet preview.
+	 *
+	 * @param {Object} snippetEditorData The snippet editor data.
+	 *
+	 * @returns {SnippetPreview} Instance of snippetpreview.
+	 */
+	function initSnippetPreview( snippetEditorData ) {
+		return snippetPreviewHelpers.create( snippetContainer, {
+			title: snippetEditorData.title,
+			urlPath: snippetEditorData.slug,
+			metaDesc: snippetEditorData.description,
+		}, ( data ) => {
+			const previousData = snippetEditorHelpers.getDataFromStore( store );
+
+			if (
+				previousData.title !== data.title ||
+				previousData.description !== data.metaDesc ||
+				previousData.slug !== data.urlPath
+			) {
+				dispatchUpdateSnippetEditor( data );
+			}
+		} );
+	}
 
 	/**
 	 * Function to handle when the user updates the term slug
@@ -178,6 +261,7 @@ window.yoastHideMarkers = true;
 
 		const editArgs = {
 			analysisSection: "pageanalysis",
+			shouldRenderSnippetPreview: !! wpseoTermScraperL10n.reactSnippetPreview,
 			snippetEditorBaseUrl: wpseoTermScraperL10n.base_url,
 			replaceVars: wpseoReplaceVarsL10n.replace_vars,
 		};
@@ -196,7 +280,14 @@ window.yoastHideMarkers = true;
 
 		tabManager.init();
 
-		termScraper = new TermDataCollector( { tabManager, store } );
+		termScraper = new TermDataCollector( { tabManager } );
+
+		// Initialize the snippet editor data.
+		let snippetEditorData = snippetEditorHelpers.getDataFromCollector( termScraper );
+		const snippetEditorTemplates = snippetEditorHelpers.getTemplatesFromL10n( wpseoTermScraperL10n );
+		snippetEditorData = snippetEditorHelpers.getDataWithTemplates( snippetEditorData, snippetEditorTemplates );
+
+		snippetPreview = initSnippetPreview( snippetEditorData );
 
 		args = {
 			// ID's of elements that need to trigger updating the analyzer.
@@ -208,7 +299,7 @@ window.yoastHideMarkers = true;
 			locale: wpseoTermScraperL10n.contentLocale,
 			contentAnalysisActive: isContentAnalysisActive(),
 			keywordAnalysisActive: isKeywordAnalysisActive(),
-			hasSnippetPreview: false,
+			snippetPreview: snippetPreview,
 		};
 
 		if ( isKeywordAnalysisActive() ) {
@@ -286,10 +377,14 @@ window.yoastHideMarkers = true;
 			disableYoastSEORenderers( app );
 		};
 
-		// Initialize the snippet editor data.
-		let snippetEditorData = snippetEditorHelpers.getDataFromCollector( termScraper );
-		const snippetEditorTemplates = snippetEditorHelpers.getTemplatesFromL10n( wpseoTermScraperL10n );
-		snippetEditorData = snippetEditorHelpers.getDataWithTemplates( snippetEditorData, snippetEditorTemplates );
+		/*
+		 * Checks the snippet preview size and toggles views when the WP admin menu state changes.
+		 * In WordPress, `wp-collapse-menu` fires when clicking on the Collapse/expand button.
+		 * `wp-menu-state-set` fires also when the window gets resized and the menu can be folded/auto-folded/collapsed/expanded/responsive.
+		 */
+		jQuery( document ).on( "wp-collapse-menu wp-menu-state-set", function() {
+			app.snippetPreview.handleWindowResizing();
+		} );
 
 		// Set the initial snippet editor data.
 		store.dispatch( updateData( snippetEditorData ) );
@@ -314,6 +409,8 @@ window.yoastHideMarkers = true;
 			snippetEditorData.title = data.title;
 			snippetEditorData.slug = data.slug;
 			snippetEditorData.description = data.description;
+
+			updateLegacySnippetEditor( data );
 		} );
 	} );
 }( jQuery, window ) );

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -40,6 +40,8 @@ window.yoastHideMarkers = true;
 
 	let store;
 
+	let snippetPreview;
+
 	/**
 	 * Get the editor created via wp_editor() and append it to the term-description-wrap
 	 * table cell. This way we can use the wp tinyMCE editor on the description field.

--- a/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
+++ b/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
@@ -6,13 +6,13 @@ exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
     headingIcon="eye"
     headingIconColor="#555"
     headingLevel={3}
-    headingText="Snippet preview">
+    headingText="React snippet preview">
     <StyledSection
       className="SnippetPreviewSection__Section-kWfIbs cakLAM"
       headingIcon="eye"
       headingIconColor="#555"
       headingLevel={3}
-      headingText="Snippet preview">
+      headingText="React snippet preview">
       <span>
         yoast-components StyledSection
       </span>

--- a/js/tests/containers/SnippetEditor.test.js
+++ b/js/tests/containers/SnippetEditor.test.js
@@ -13,7 +13,8 @@ describe( "SnippetEditor container", () => {
 				seo: {
 					active: [
 						{ _identifier: "metaDescriptionLength", max: 156, actual: 11, score: 6 },
-						{ _identifier: "titleWidth", max: 600, actual: 400, score: 6 } ],
+						{ _identifier: "titleWidth", max: 600, actual: 400, score: 6 },
+					],
 				},
 			},
 			snippetEditor: {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Hides the React Snippet Editor under a feature flag and restores the old snippet editor.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Make sure the classic snippet editor works as expected.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
