### PR TITLE
Use tabbed layout in the network settings screen

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -89,9 +89,7 @@ class WPSEO_Admin {
 		$this->check_php_version();
 		$this->initialize_cornerstone_content();
 
-		if ( Yoast_Network_Admin::meets_requirements() ) {
-			Yoast_Network_Admin::get()->register_hooks();
-		}
+		Yoast_Network_Admin::get()->register_hooks();
 
 		new Yoast_Modal();
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -89,10 +89,9 @@ class WPSEO_Admin {
 		$this->check_php_version();
 		$this->initialize_cornerstone_content();
 
-		Yoast_Network_Admin::get()->register_hooks();
-
 		new Yoast_Modal();
 
+		$integrations[] = new Yoast_Network_Admin();
 		$integrations[] = new WPSEO_Yoast_Columns();
 		$integrations[] = new WPSEO_License_Page_Manager();
 		$integrations[] = new WPSEO_Statistic_Integration();

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -93,6 +93,10 @@ class WPSEO_Admin {
 			Yoast_Network_Settings_API::get()->register_hooks();
 		}
 
+		if ( Yoast_Network_Admin::meets_requirements() ) {
+			Yoast_Network_Admin::get()->register_hooks();
+		}
+
 		new Yoast_Modal();
 
 		$integrations[] = new WPSEO_Yoast_Columns();

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -89,10 +89,6 @@ class WPSEO_Admin {
 		$this->check_php_version();
 		$this->initialize_cornerstone_content();
 
-		if ( Yoast_Network_Settings_API::meets_requirements() ) {
-			Yoast_Network_Settings_API::get()->register_hooks();
-		}
-
 		if ( Yoast_Network_Admin::meets_requirements() ) {
 			Yoast_Network_Admin::get()->register_hooks();
 		}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -77,7 +77,7 @@ class Yoast_Form {
 		if ( $form === true ) {
 			$enctype = ( $contains_files ) ? ' enctype="multipart/form-data"' : '';
 
-			$network_admin = Yoast_Network_Admin::get();
+			$network_admin = new Yoast_Network_Admin();
 			if ( $network_admin->meets_requirements() ) {
 				$action_url       = network_admin_url( 'settings.php' );
 				$hidden_fields_cb = array( $network_admin, 'settings_fields' );

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -77,10 +77,12 @@ class Yoast_Form {
 		if ( $form === true ) {
 			$enctype = ( $contains_files ) ? ' enctype="multipart/form-data"' : '';
 
-			if ( Yoast_Network_Admin::meets_requirements() ) {
+			$network_admin = Yoast_Network_Admin::get();
+			if ( $network_admin->meets_requirements() ) {
 				$action_url       = network_admin_url( 'settings.php' );
-				$hidden_fields_cb = array( Yoast_Network_Admin::get(), 'settings_fields' );
-			} else {
+				$hidden_fields_cb = array( $network_admin, 'settings_fields' );
+			}
+			else {
 				$action_url       = admin_url( 'options.php' );
 				$hidden_fields_cb = 'settings_fields';
 			}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -77,9 +77,9 @@ class Yoast_Form {
 		if ( $form === true ) {
 			$enctype = ( $contains_files ) ? ' enctype="multipart/form-data"' : '';
 
-			if ( Yoast_Network_Settings_API::meets_requirements() ) {
+			if ( Yoast_Network_Admin::meets_requirements() ) {
 				$action_url       = network_admin_url( 'settings.php' );
-				$hidden_fields_cb = array( Yoast_Network_Settings_API::get(), 'settings_fields' );
+				$hidden_fields_cb = array( Yoast_Network_Admin::get(), 'settings_fields' );
 			} else {
 				$action_url       = admin_url( 'options.php' );
 				$hidden_fields_cb = 'settings_fields';

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -21,11 +21,6 @@ class Yoast_Network_Admin {
 	const RESTORE_SITE_ACTION = 'yoast_restore_site';
 
 	/**
-	 * @var bool Internal flag for whether the necessary hooks have been added.
-	 */
-	private $hooks_registered = false;
-
-	/**
 	 * @var Yoast_Network_Admin The singleton instance of this class.
 	 */
 	private static $instance = null;
@@ -195,12 +190,6 @@ class Yoast_Network_Admin {
 	 * @return void
 	 */
 	public function register_hooks() {
-
-		if ( $this->hooks_registered ) {
-			return;
-		}
-
-		$this->hooks_registered = true;
 
 		add_action( 'admin_action_' . self::UPDATE_OPTIONS_ACTION, array( $this, 'handle_update_options_request' ) );
 		add_action( 'admin_action_' . self::RESTORE_SITE_ACTION, array( $this, 'handle_restore_site_request' ) );

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -120,7 +120,7 @@ class Yoast_Network_Admin {
 
 		$option_group = 'wpseo_ms';
 
-		$site_id = (int) filter_input( INPUT_POST, 'site_id', FILTER_SANITIZE_NUMBER_INT );
+		$site_id = ! empty( $_POST[ $option_group ]['site_id'] ) ? (int) $_POST[ $option_group ]['site_id'] : 0;
 		if ( ! $site_id ) {
 			add_settings_error( $option_group, 'settings_updated', __( 'No site has been selected to restore.', 'wordpress-seo' ), 'error' );
 		}
@@ -177,12 +177,11 @@ class Yoast_Network_Admin {
 			$yform->select(
 				'site_id',
 				__( 'Site ID', 'wordpress-seo' ),
-				$this->get_site_choices(),
-				'wpseo_ms'
+				$this->get_site_choices()
 			);
 		}
 		else {
-			$yform->textinput( 'site_id', __( 'Blog ID', 'wordpress-seo' ), 'wpseo_ms' );
+			$yform->textinput( 'site_id', __( 'Blog ID', 'wordpress-seo' ) );
 		}
 
 		echo '<input type="hidden" name="action" value="' . esc_attr( self::RESTORE_SITE_ACTION ) . '" />';

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -36,7 +36,7 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 
 		$sites = get_sites( array( 'deleted' => 0 ) );
 		foreach ( $sites as $site ) {
-			$choices[ $site->blog_id ] = $site->blog_id . ': ' . $site->domain;
+			$choices[ $site->blog_id ] = $site->blog_id . ': ' . $site->domain . $site->path;
 
 			$site_states = $this->get_site_states( $site );
 			if ( ! empty( $site_states ) ) {

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -181,7 +181,7 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 			);
 		}
 		else {
-			$yform->textinput( 'site_id', __( 'Blog ID', 'wordpress-seo' ) );
+			$yform->textinput( 'site_id', __( 'Site ID', 'wordpress-seo' ) );
 		}
 
 		echo '<input type="hidden" name="action" value="' . esc_attr( self::RESTORE_SITE_ACTION ) . '" />';

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -74,7 +74,7 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Handles a request in which plugin network options should be updated.
+	 * Handles a request to update plugin network options.
 	 *
 	 * This method works similar to how option updates are handled in `wp-admin/options.php` and
 	 * `wp-admin/network/settings.php`.
@@ -114,7 +114,7 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Handles a request in which a site's default settings should be restored.
+	 * Handles a request to restore a site's default settings.
 	 *
 	 * @return void
 	 */
@@ -227,9 +227,11 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 	 */
 	private function persist_settings_errors() {
 
-		// Use a regular transient here, since it is automatically cleared right after the redirect.
-		// A network transient would be cleaner, but would require a lot of copied code from core for
-		// just a minor adjustment when displaying settings errors.
+		/*
+		 * A regular transient is used here, since it is automatically cleared right after the redirect.
+		 * A network transient would be cleaner, but would require a lot of copied code from core for
+		 * just a minor adjustment when displaying settings errors.
+		 */
 		set_transient( 'settings_errors', get_settings_errors(), 30 );
 	}
 }

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -8,7 +8,7 @@
 /**
  * Multisite utility class for network admin functionality.
  */
-class Yoast_Network_Admin {
+class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Action identifier for updating plugin network options.

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Internals
+ */
+
+/**
+ * Multisite utility class for network admin functionality.
+ */
+class Yoast_Network_Admin {
+
+	/**
+	 * Action identifier for restoring a site.
+	 */
+	const RESTORE_SITE_ACTION = 'yoast_restore_site';
+
+	/**
+	 * @var bool Internal flag for whether the necessary hooks have been added.
+	 */
+	private $hooks_registered = false;
+
+	/**
+	 * @var Yoast_Network_Admin The singleton instance of this class.
+	 */
+	private static $instance = null;
+
+	/**
+	 * Gets the available sites as choices, e.g. for a dropdown.
+	 *
+	 * @param bool $include_empty Optional. Whether to include an initial placeholder choice.
+	 *
+	 * @return array Choices as $site_id => $site_label pairs.
+	 */
+	public function get_site_choices( $include_empty = false ) {
+		$choices = array();
+
+		if ( $include_empty ) {
+			$choices['-'] = __( 'None', 'wordpress-seo' );
+		}
+
+		$available_states = array(
+			'public'   => __( 'public', 'wordpress-seo' ),
+			'archived' => __( 'archived', 'wordpress-seo' ),
+			'mature'   => __( 'mature', 'wordpress-seo' ),
+			'spam'     => __( 'spam', 'wordpress-seo' ),
+		);
+
+		$sites = get_sites( array( 'deleted' => 0 ) );
+		foreach ( $sites as $site ) {
+			$choices[ $site->blog_id ] = $site->blog_id . ': ' . $site->domain;
+
+			$site_states = array();
+			foreach ( $available_states as $state_slug => $state_label ) {
+				if ( $site->$state_slug === '1' ) {
+					$site_states[] = $state_label;
+				}
+			}
+
+			if ( ! empty( $site_states ) ) {
+				$choices[ $site->blog_id ] .= ' [' . implode( ', ', $site_states ) . ']';
+			}
+		}
+
+		return $choices;
+	}
+
+	/**
+	 * Handles a request in which a site's default settings should be restored.
+	 *
+	 * @return void
+	 */
+	public function handle_restore_site_request() {
+		check_admin_referer( 'wpseo-network-restore' );
+
+		$option_group = 'wpseo_ms';
+
+		$site_id = (int) filter_input( INPUT_POST, 'site_id', FILTER_SANITIZE_NUMBER_INT );
+		if ( ! $site_id ) {
+			add_settings_error( $option_group, 'settings_updated', __( 'No site has been selected to restore.', 'wordpress-seo' ), 'error' );
+			return;
+		}
+
+		$site = get_site( $site_id );
+		if ( ! $site ) {
+			/* translators: %s expands to the ID of a site within a multisite network. */
+			add_settings_error( $option_group, 'settings_updated', sprintf( __( 'Site %d not found.', 'wordpress-seo' ), $site_id ), 'error' );
+			return;
+		}
+
+		WPSEO_Options::reset_ms_blog( $site_id );
+
+		/* translators: %s expands to the name of a site within a multisite network. */
+		add_settings_error( $option_group, 'settings_updated', sprintf( __( '%s restored to default SEO settings.', 'wordpress-seo' ), esc_html( $site->blogname ) ), 'updated' );
+	}
+
+	/**
+	 * Prints the form for restoring a site with its default settings.
+	 *
+	 * @return void
+	 */
+	public function print_restore_form() {
+		$yform = Yoast_Form::get_instance();
+
+		echo '<h2>' . esc_html__( 'Restore site to default settings', 'wordpress-seo' ) . '</h2>';
+		echo '<form method="post" accept-charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
+		wp_nonce_field( 'wpseo-network-restore' );
+		echo '<p>' . esc_html__( 'Using this form you can reset a site to the default SEO settings.', 'wordpress-seo' ) . '</p>';
+
+		if ( get_blog_count() <= 100 ) {
+			$yform->select(
+				'site_id',
+				__( 'Site ID', 'wordpress-seo' ),
+				$this->get_site_choices(),
+				'wpseo_ms'
+			);
+		}
+		else {
+			$yform->textinput( 'site_id', __( 'Blog ID', 'wordpress-seo' ), 'wpseo_ms' );
+		}
+
+		echo '<input type="hidden" name="action" value="' . esc_attr( self::RESTORE_SITE_ACTION ) . '" />';
+		echo '<input type="submit" name="wpseo_restore_blog" value="' . esc_attr__( 'Restore site to defaults', 'wordpress-seo' ) . '" class="button"/>';
+		echo '</form>';
+	}
+
+	/**
+	 * Hooks in the necessary actions and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+
+		if ( $this->hooks_registered ) {
+			return;
+		}
+
+		$this->hooks_registered = true;
+
+		add_action( 'admin_action_' . self::RESTORE_SITE_ACTION, array( $this, 'handle_restore_site_request' ) );
+		add_action( 'wpseo_admin_footer', array( $this, 'print_restore_form' ) );
+	}
+
+	/**
+	 * Gets the singleton instance of this class.
+	 *
+	 * @return Yoast_Network_Admin The singleton instance.
+	 */
+	public static function get() {
+
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Checks whether the requirements to use this class are met.
+	 *
+	 * @return bool True if requirements are met, false otherwise.
+	 */
+	public static function meets_requirements() {
+		return is_multisite() && is_network_admin();
+	}
+}

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -34,30 +34,43 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 			$choices['-'] = __( 'None', 'wordpress-seo' );
 		}
 
-		$available_states = array(
-			'public'   => __( 'public', 'wordpress-seo' ),
-			'archived' => __( 'archived', 'wordpress-seo' ),
-			'mature'   => __( 'mature', 'wordpress-seo' ),
-			'spam'     => __( 'spam', 'wordpress-seo' ),
-		);
-
 		$sites = get_sites( array( 'deleted' => 0 ) );
 		foreach ( $sites as $site ) {
 			$choices[ $site->blog_id ] = $site->blog_id . ': ' . $site->domain;
 
-			$site_states = array();
-			foreach ( $available_states as $state_slug => $state_label ) {
-				if ( $site->$state_slug === '1' ) {
-					$site_states[] = $state_label;
-				}
-			}
-
+			$site_states = $this->get_site_states( $site );
 			if ( ! empty( $site_states ) ) {
 				$choices[ $site->blog_id ] .= ' [' . implode( ', ', $site_states ) . ']';
 			}
 		}
 
 		return $choices;
+	}
+
+	/**
+	 * Gets the states of a site.
+	 *
+	 * @param WP_Site $site Site object.
+	 *
+	 * @return array Array of $state_slug => $state_label pairs.
+	 */
+	public function get_site_states( $site ) {
+		$available_states = array(
+			'public'   => __( 'public', 'wordpress-seo' ),
+			'archived' => __( 'archived', 'wordpress-seo' ),
+			'mature'   => __( 'mature', 'wordpress-seo' ),
+			'spam'     => __( 'spam', 'wordpress-seo' ),
+			'deleted'  => __( 'deleted', 'wordpress-seo' ),
+		);
+
+		$site_states = array();
+		foreach ( $available_states as $state_slug => $state_label ) {
+			if ( $site->$state_slug === '1' ) {
+				$site_states[ $state_slug ] = $state_label;
+			}
+		}
+
+		return $site_states;
 	}
 
 	/**

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -21,11 +21,6 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 	const RESTORE_SITE_ACTION = 'yoast_restore_site';
 
 	/**
-	 * @var Yoast_Network_Admin The singleton instance of this class.
-	 */
-	private static $instance = null;
-
-	/**
 	 * Gets the available sites as choices, e.g. for a dropdown.
 	 *
 	 * @param bool $include_empty Optional. Whether to include an initial placeholder choice.
@@ -223,19 +218,5 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 		// A network transient would be cleaner, but would require a lot of copied code from core for
 		// just a minor adjustment when displaying settings errors.
 		set_transient( 'settings_errors', get_settings_errors(), 30 );
-	}
-
-	/**
-	 * Gets the singleton instance of this class.
-	 *
-	 * @return Yoast_Network_Admin The singleton instance.
-	 */
-	public static function get() {
-
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
 	}
 }

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -191,9 +191,22 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 	 */
 	public function register_hooks() {
 
+		if ( ! $this->meets_requirements() ) {
+			return;
+		}
+
 		add_action( 'admin_action_' . self::UPDATE_OPTIONS_ACTION, array( $this, 'handle_update_options_request' ) );
 		add_action( 'admin_action_' . self::RESTORE_SITE_ACTION, array( $this, 'handle_restore_site_request' ) );
 		add_action( 'wpseo_admin_footer', array( $this, 'print_restore_form' ) );
+	}
+
+	/**
+	 * Checks whether the requirements to use this class are met.
+	 *
+	 * @return bool True if requirements are met, false otherwise.
+	 */
+	public function meets_requirements() {
+		return is_multisite() && is_network_admin();
 	}
 
 	/**
@@ -224,14 +237,5 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * Checks whether the requirements to use this class are met.
-	 *
-	 * @return bool True if requirements are met, false otherwise.
-	 */
-	public static function meets_requirements() {
-		return is_multisite() && is_network_admin();
 	}
 }

--- a/admin/class-yoast-network-settings-api.php
+++ b/admin/class-yoast-network-settings-api.php
@@ -11,11 +11,6 @@
 class Yoast_Network_Settings_API {
 
 	/**
-	 * Action identifier for updating plugin network options.
-	 */
-	const UPDATE_ACTION = 'yoast_handle_network_options';
-
-	/**
 	 * @var array Registered network settings.
 	 */
 	private $registered_settings = array();
@@ -26,29 +21,9 @@ class Yoast_Network_Settings_API {
 	private $whitelist_options = array();
 
 	/**
-	 * @var bool Internal flag for whether the necessary hooks have been added.
-	 */
-	private $hooks_registered = false;
-
-	/**
 	 * @var Yoast_Network_Settings_API The singleton instance of this class.
 	 */
 	private static $instance = null;
-
-	/**
-	 * Outputs nonce, action and option group fields for a network settings page in the plugin.
-	 *
-	 * @param string $option_group Option group name for the current page.
-	 *
-	 * @return void
-	 */
-	public function settings_fields( $option_group ) {
-		?>
-		<input type="hidden" name="network_option_group" value="<?php echo esc_attr( $option_group ); ?>" />
-		<input type="hidden" name="action" value="<?php echo esc_attr( self::UPDATE_ACTION ); ?>" />
-		<?php
-		wp_nonce_field( "$option_group-network-options" );
-	}
 
 	/**
 	 * Registers a network setting and its data.
@@ -89,44 +64,27 @@ class Yoast_Network_Settings_API {
 	}
 
 	/**
-	 * Handles a request in which plugin network options should be updated.
+	 * Gets the registered settings and their data.
 	 *
-	 * This method works similar to how option updates are handled in `wp-admin/options.php` and
-	 * `wp-admin/network/settings.php`.
-	 *
-	 * @return void
+	 * @return array Array of $option_name => $data pairs.
 	 */
-	public function handle_update_options_request() {
-		$option_group = filter_input( INPUT_POST, 'network_option_group', FILTER_SANITIZE_STRING );
+	public function get_registered_settings() {
+		return $this->registered_settings;
+	}
 
-		check_admin_referer( "$option_group-network-options" );
-
+	/**
+	 * Gets the whitelisted options for a given option group.
+	 *
+	 * @param string $option_group Option group.
+	 *
+	 * @return array List of option names, or empty array if unknown option group.
+	 */
+	public function get_whitelist_options( $option_group ) {
 		if ( ! isset( $this->whitelist_options[ $option_group ] ) ) {
-			wp_die( __( 'Sorry, you are not allowed to modify unregistered network settings.', 'wordpress-seo' ), '', 403 );
+			return array();
 		}
 
-		foreach ( $this->whitelist_options[ $option_group ] as $option_name ) {
-			$value = null;
-			if ( isset( $_POST[ $option_name ] ) ) {
-				$value = wp_unslash( $_POST[ $option_name ] );
-			}
-
-			WPSEO_Options::update_site_option( $option_name, $value );
-		}
-
-		$settings_errors = get_settings_errors();
-		if ( empty( $settings_errors ) ) {
-			add_settings_error( $option_group, 'settings_updated', __( 'Settings Updated.', 'wordpress-seo' ), 'updated' );
-		}
-
-		// Use a regular transient here, since it is automatically cleared right after the redirect.
-		// A network transient would be cleaner, but would require a lot of copied code from core for
-		// just a minor adjustment when displaying settings errors.
-		set_transient( 'settings_errors', get_settings_errors(), 30 );
-
-		$sendback = add_query_arg( 'settings-updated', 'true', wp_get_referer() );
-		wp_safe_redirect( $sendback );
-		exit;
+		return $this->whitelist_options[ $option_group ];
 	}
 
 	/**
@@ -175,22 +133,6 @@ class Yoast_Network_Settings_API {
 	}
 
 	/**
-	 * Hooks in the necessary actions and filters.
-	 *
-	 * @return void
-	 */
-	public function register_hooks() {
-
-		if ( $this->hooks_registered ) {
-			return;
-		}
-
-		$this->hooks_registered = true;
-
-		add_action( 'admin_action_' . self::UPDATE_ACTION, array( $this, 'handle_update_options_request' ) );
-	}
-
-	/**
 	 * Gets the singleton instance of this class.
 	 *
 	 * @return Yoast_Network_Settings_API The singleton instance.
@@ -210,6 +152,6 @@ class Yoast_Network_Settings_API {
 	 * @return bool True if requirements are met, false otherwise.
 	 */
 	public static function meets_requirements() {
-		return is_multisite() && is_network_admin();
+		return is_multisite();
 	}
 }

--- a/admin/class-yoast-network-settings-api.php
+++ b/admin/class-yoast-network-settings-api.php
@@ -133,6 +133,15 @@ class Yoast_Network_Settings_API {
 	}
 
 	/**
+	 * Checks whether the requirements to use this class are met.
+	 *
+	 * @return bool True if requirements are met, false otherwise.
+	 */
+	public function meets_requirements() {
+		return is_multisite();
+	}
+
+	/**
 	 * Gets the singleton instance of this class.
 	 *
 	 * @return Yoast_Network_Settings_API The singleton instance.
@@ -144,14 +153,5 @@ class Yoast_Network_Settings_API {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * Checks whether the requirements to use this class are met.
-	 *
-	 * @return bool True if requirements are met, false otherwise.
-	 */
-	public static function meets_requirements() {
-		return is_multisite();
 	}
 }

--- a/admin/class-yoast-network-settings-api.php
+++ b/admin/class-yoast-network-settings-api.php
@@ -104,7 +104,7 @@ class Yoast_Network_Settings_API {
 			return $value;
 		}
 
-		return call_user_func( $this->registered_settings[ $option ]['santize_callback'], $value );
+		return call_user_func( $this->registered_settings[ $option ]['sanitize_callback'], $value );
 	}
 
 	/**

--- a/admin/menu/class-network-admin-menu.php
+++ b/admin/menu/class-network-admin-menu.php
@@ -44,9 +44,9 @@ class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
 		$page_callback = array( $this->menu, 'load_page' );
 
 		add_menu_page(
-			'Yoast SEO: ' . __( 'MultiSite Settings', 'wordpress-seo' ),
+			__( 'Network Settings', 'wordpress-seo' ) . ' - Yoast SEO',
 			__( 'SEO', 'wordpress-seo' ),
-			'delete_users',
+			'wpseo_manage_network_options',
 			$this->menu->get_page_identifier(),
 			array( $this, 'network_config_page' ),
 			WPSEO_Utils::get_icon_svg()
@@ -55,9 +55,10 @@ class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
 		if ( WPSEO_Utils::allow_system_file_edit() === true ) {
 			add_submenu_page(
 				$this->menu->get_page_identifier(),
-				'Yoast SEO: ' . __( 'Edit Files', 'wordpress-seo' ),
+				__( 'Edit Files', 'wordpress-seo' ) . ' - Yoast SEO',
 				__( 'Edit Files', 'wordpress-seo' ),
-				'delete_users', 'wpseo_files',
+				'wpseo_manage_network_options',
+				'wpseo_files',
 				$page_callback
 			);
 		}
@@ -65,12 +66,18 @@ class WPSEO_Network_Admin_Menu implements WPSEO_WordPress_Integration {
 		// Add Extension submenu page.
 		add_submenu_page(
 			$this->menu->get_page_identifier(),
-			'Yoast SEO: ' . __( 'Extensions', 'wordpress-seo' ),
+			__( 'Extensions', 'wordpress-seo' ) . ' - Yoast SEO',
 			__( 'Extensions', 'wordpress-seo' ),
-			'delete_users',
+			'wpseo_manage_network_options',
 			'wpseo_licenses',
 			$page_callback
 		);
+
+		// Use WordPress global $submenu to directly access its properties.
+		global $submenu;
+		if ( isset( $submenu[ $this->menu->get_page_identifier() ] ) ) {
+			$submenu[ $this->menu->get_page_identifier() ][0][0] = __( 'General', 'wordpress-seo' );
+		}
 	}
 
 	/**

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -14,39 +14,8 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_ms' );
 
-/* {@internal Important: Make sure the options added to the array here are in line with the options set in the WPSEO_Option_MS::$allowed_access_options property.}} */
-$yform->select(
-	'access',
-	/* translators: %1$s expands to Yoast SEO */
-	sprintf( __( 'Who should have access to the %1$s settings', 'wordpress-seo' ), 'Yoast SEO' ),
-	array(
-		'admin'      => __( 'Site Admins (default)', 'wordpress-seo' ),
-		'superadmin' => __( 'Super Admins only', 'wordpress-seo' ),
-	),
-	'wpseo_ms'
-);
+$tabs = new WPSEO_Option_Tabs( 'network' );
+$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );
+$tabs->display( $yform );
 
-if ( get_blog_count() <= 100 ) {
-	$yform->select(
-		'defaultblog',
-		__( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ),
-		Yoast_Network_Admin::get()->get_site_choices( true ),
-		'wpseo_ms'
-	);
-	echo '<p>' . esc_html__( 'Choose the site whose settings you want to use as default for all sites that are added to your network. If you choose \'None\', the normal plugin defaults will be used.', 'wordpress-seo' ) . '</p>';
-}
-else {
-	$yform->textinput( 'defaultblog', __( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ), 'wpseo_ms' );
-	echo '<p>';
-	printf(
-		/* translators: 1: link open tag; 2: link close tag. */
-		esc_html__( 'Enter the %1$sSite ID%2$s for the site whose settings you want to use as default for all sites that are added to your network. Leave empty for none (i.e. the normal plugin defaults will be used).', 'wordpress-seo' ),
-		'<a href="' . esc_url( network_admin_url( 'sites.php' ) ) . '">',
-		'</a>'
-	);
-	echo '</p>';
-}
-
-echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';
-
-$yform->admin_footer( true );
+$yform->admin_footer();

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -11,108 +11,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-/**
- * Gets the available sites as choices for a dropdown.
- *
- * @param bool $include_empty Optional. Whether to include an initial placeholder choice.
- *
- * @return array Choices as $site_id => $site_label pairs.
- */
-function wpseo_ms_get_site_dropdown_choices( $include_empty = false ) {
-	$choices = array();
-
-	if ( $include_empty ) {
-		$choices['-'] = __( 'None', 'wordpress-seo' );
-	}
-
-	$available_states = array(
-		'public'   => __( 'public', 'wordpress-seo' ),
-		'archived' => __( 'archived', 'wordpress-seo' ),
-		'mature'   => __( 'mature', 'wordpress-seo' ),
-		'spam'     => __( 'spam', 'wordpress-seo' ),
-	);
-
-	$sites = get_sites( array( 'deleted' => 0 ) );
-	foreach ( $sites as $site ) {
-		$choices[ $site->blog_id ] = $site->blog_id . ': ' . $site->domain;
-
-		$site_states = array();
-		foreach ( $available_states as $state_slug => $state_label ) {
-			if ( $site->$state_slug === '1' ) {
-				$site_states[] = $state_label;
-			}
-		}
-
-		if ( ! empty( $site_states ) ) {
-			$choices[ $site->blog_id ] .= ' [' . implode( ', ', $site_states ) . ']';
-		}
-	}
-
-	return $choices;
-}
-
-/**
- * Restores a site with its default settings.
- *
- * @return void
- */
-function wpseo_ms_maybe_restore_site() {
-	if ( ! isset( $_POST['wpseo_restore_blog'] ) ) {
-		return;
-	}
-
-	check_admin_referer( 'wpseo-network-restore' );
-
-	if ( ! isset( $_POST['wpseo_ms']['restoreblog'] ) || ! is_numeric( $_POST['wpseo_ms']['restoreblog'] ) ) {
-		return;
-	}
-
-	$restoreblog = (int) WPSEO_Utils::validate_int( $_POST['wpseo_ms']['restoreblog'] );
-	$blog        = get_blog_details( $restoreblog );
-
-	if ( $blog ) {
-		WPSEO_Options::reset_ms_blog( $restoreblog );
-		/* translators: %s expands to the name of a blog within a multi-site network. */
-		add_settings_error( 'wpseo_ms', 'settings_updated', sprintf( __( '%s restored to default SEO settings.', 'wordpress-seo' ), esc_html( $blog->blogname ) ), 'updated' );
-	}
-	else {
-		/* translators: %s expands to the ID of a blog within a multi-site network. */
-		add_settings_error( 'wpseo_ms', 'settings_updated', sprintf( __( 'Blog %s not found.', 'wordpress-seo' ), esc_html( $restoreblog ) ), 'error' );
-	}
-}
-
-/**
- * Prints the form for restoring a site with its default settings.
- *
- * @return void
- */
-function wpseo_ms_print_restore_form() {
-	$yform = Yoast_Form::get_instance();
-
-	echo '<h2>' . esc_html__( 'Restore site to default settings', 'wordpress-seo' ) . '</h2>';
-	echo '<form method="post" accept-charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
-	wp_nonce_field( 'wpseo-network-restore', '_wpnonce', true, true );
-	echo '<p>' . esc_html__( 'Using this form you can reset a site to the default SEO settings.', 'wordpress-seo' ) . '</p>';
-
-	if ( get_blog_count() <= 100 ) {
-		$yform->select(
-			'restoreblog',
-			__( 'Site ID', 'wordpress-seo' ),
-			wpseo_ms_get_site_dropdown_choices(),
-			'wpseo_ms'
-		);
-	}
-	else {
-		$yform->textinput( 'restoreblog', __( 'Blog ID', 'wordpress-seo' ), 'wpseo_ms' );
-	}
-
-	echo '<input type="submit" name="wpseo_restore_blog" value="' . esc_attr__( 'Restore site to defaults', 'wordpress-seo' ) . '" class="button"/>';
-	echo '</form>';
-}
-
-wpseo_ms_maybe_restore_site();
-add_action( 'wpseo_admin_footer', 'wpseo_ms_print_restore_form' );
-
 $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_ms' );
 
@@ -132,7 +30,7 @@ if ( get_blog_count() <= 100 ) {
 	$yform->select(
 		'defaultblog',
 		__( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ),
-		wpseo_ms_get_site_dropdown_choices( true ),
+		Yoast_Network_Admin::get()->get_site_choices( true ),
 		'wpseo_ms'
 	);
 	echo '<p>' . esc_html__( 'Choose the site whose settings you want to use as default for all sites that are added to your network. If you choose \'None\', the normal plugin defaults will be used.', 'wordpress-seo' ) . '</p>';
@@ -148,6 +46,7 @@ else {
 	);
 	echo '</p>';
 }
-	echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';
+
+echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';
 
 $yform->admin_footer( true );

--- a/admin/views/tabs/network/general.php
+++ b/admin/views/tabs/network/general.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Views
+ */
+
+/**
+ * @var Yoast_Form $yform
+ */
+
+if ( ! defined( 'WPSEO_VERSION' ) ) {
+	header( 'Status: 403 Forbidden' );
+	header( 'HTTP/1.1 403 Forbidden' );
+	exit();
+}
+
+/* {@internal Important: Make sure the options added to the array here are in line with the options set in the WPSEO_Option_MS::$allowed_access_options property.}} */
+$yform->select(
+	'access',
+	/* translators: %1$s expands to Yoast SEO */
+	sprintf( __( 'Who should have access to the %1$s settings', 'wordpress-seo' ), 'Yoast SEO' ),
+	array(
+		'admin'      => __( 'Site Admins (default)', 'wordpress-seo' ),
+		'superadmin' => __( 'Super Admins only', 'wordpress-seo' ),
+	)
+);
+
+if ( get_blog_count() <= 100 ) {
+	$yform->select(
+		'defaultblog',
+		__( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ),
+		Yoast_Network_Admin::get()->get_site_choices( true )
+	);
+	echo '<p>' . esc_html__( 'Choose the site whose settings you want to use as default for all sites that are added to your network. If you choose \'None\', the normal plugin defaults will be used.', 'wordpress-seo' ) . '</p>';
+}
+else {
+	$yform->textinput( 'defaultblog', __( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ) );
+	echo '<p>';
+	printf(
+		/* translators: 1: link open tag; 2: link close tag. */
+		esc_html__( 'Enter the %1$sSite ID%2$s for the site whose settings you want to use as default for all sites that are added to your network. Leave empty for none (i.e. the normal plugin defaults will be used).', 'wordpress-seo' ),
+		'<a href="' . esc_url( network_admin_url( 'sites.php' ) ) . '">',
+		'</a>'
+	);
+	echo '</p>';
+}
+
+echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';

--- a/admin/views/tabs/network/general.php
+++ b/admin/views/tabs/network/general.php
@@ -48,4 +48,4 @@ else {
 	echo '</p>';
 }
 
-echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new blogs.', 'wordpress-seo' ) . '</p>';
+echo '<p><strong>' . esc_html__( 'Take note:', 'wordpress-seo' ) . '</strong> ' . esc_html__( 'Privacy sensitive (FB admins and such), theme specific (title rewrite) and a few very site specific settings will not be imported to new sites.', 'wordpress-seo' ) . '</p>';

--- a/admin/views/tabs/network/general.php
+++ b/admin/views/tabs/network/general.php
@@ -27,10 +27,12 @@ $yform->select(
 );
 
 if ( get_blog_count() <= 100 ) {
+	$network_admin = new Yoast_Network_Admin();
+
 	$yform->select(
 		'defaultblog',
 		__( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ),
-		Yoast_Network_Admin::get()->get_site_choices( true )
+		$network_admin->get_site_choices( true )
 	);
 	echo '<p>' . esc_html__( 'Choose the site whose settings you want to use as default for all sites that are added to your network. If you choose \'None\', the normal plugin defaults will be used.', 'wordpress-seo' ) . '</p>';
 }

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -416,17 +416,19 @@ abstract class WPSEO_Option {
 	 * @return void
 	 */
 	public function register_setting() {
-		if ( WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
-			if ( $this->multisite_only === true ) {
-				$network_settings_api = Yoast_Network_Settings_API::get();
-				if ( $network_settings_api->meets_requirements() ) {
-					$network_settings_api->register_setting( $this->group_name, $this->option_name );
-				}
-				return;
-			}
-
-			register_setting( $this->group_name, $this->option_name );
+		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
+			return;
 		}
+
+		if ( $this->multisite_only === true ) {
+			$network_settings_api = Yoast_Network_Settings_API::get();
+			if ( $network_settings_api->meets_requirements() ) {
+				$network_settings_api->register_setting( $this->group_name, $this->option_name );
+			}
+			return;
+		}
+
+		register_setting( $this->group_name, $this->option_name );
 	}
 
 

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -418,7 +418,10 @@ abstract class WPSEO_Option {
 	public function register_setting() {
 		if ( WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
 			if ( $this->multisite_only === true ) {
-				Yoast_Network_Settings_API::get()->register_setting( $this->group_name, $this->option_name );
+				$network_settings_api = Yoast_Network_Settings_API::get();
+				if ( $network_settings_api->meets_requirements() ) {
+					$network_settings_api->register_setting( $this->group_name, $this->option_name );
+				}
 				return;
 			}
 

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -58,19 +58,9 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	public function test_register_hooks() {
 		$admin = new Yoast_Network_Admin();
 
-		// Hooks should be present after first call.
 		$admin->register_hooks();
 		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) ) );
 		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) ) );
-
-		// Remove the hooks again manually.
-		remove_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) );
-		remove_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) );
-
-		// Hooks should not be added again because of restriction.
-		$admin->register_hooks();
-		$this->assertFalse( has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) ) );
-		$this->assertFalse( has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) ) );
 	}
 
 	/**

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -46,8 +46,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 		$this->assertTrue( (bool) strpos( $output, 'name="network_option_group" value="' . $group . '"' ) );
 		$this->assertTrue( (bool) strpos( $output, 'name="action" value="' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION . '"' ) );
-		$this->assertTrue( preg_match( '/name="_wpnonce" value="([a-z0-9]+)"/', $output, $matches ) );
-		$this->assertTrue( wp_verify_nonce( $matches[1], $group . '-network-options' ) );
+		$this->assertTrue( (bool) preg_match( '/name="_wpnonce" value="([a-z0-9]+)"/', $output, $matches ) );
+		$this->assertTrue( (bool) wp_verify_nonce( $matches[1], $group . '-network-options' ) );
 	}
 
 	/**

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -71,15 +71,6 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests the singleton getter.
-	 *
-	 * @covers Yoast_Network_Admin::get()
-	 */
-	public function test_get() {
-		$this->assertInstanceOf( 'Yoast_Network_Admin', Yoast_Network_Admin::get() );
-	}
-
-	/**
 	 * Tests checking requirements for the network settings API.
 	 *
 	 * @covers Yoast_Network_Admin::meets_requirements()

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -31,6 +31,28 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests getting a site's states.
+	 *
+	 * @group ms-required
+	 * @covers Yoast_Network_Admin::get_site_states()
+	 */
+	public function test_get_site_states() {
+		$admin = new Yoast_Network_Admin();
+
+		$active_states = array(
+			'public' => '1',
+			'mature' => '1',
+			'spam'   => '1',
+		);
+
+		$site_id = self::factory()->blog->create();
+		update_blog_details( $site_id, $active_states );
+
+		$site_states = $admin->get_site_states( get_site( $site_id ) );
+		$this->assertSame( array_keys( $active_states ), array_keys( $site_states ) );
+	}
+
+	/**
 	 * Tests output for hidden settings fields.
 	 *
 	 * @covers Yoast_Network_Admin::settings_fields()

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -56,7 +56,14 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Admin::register_hooks()
 	 */
 	public function test_register_hooks() {
-		$admin = new Yoast_Network_Admin();
+		$admin = $this->getMockBuilder( 'Yoast_Network_Admin' )
+			->setMethods( array( 'meets_requirements' ) )
+			->getMock();
+
+		$admin
+			->expects( $this->once() )
+			->method( 'meets_requirements' )
+			->willReturn( true );
 
 		$admin->register_hooks();
 		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) ) );
@@ -78,8 +85,9 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Admin::meets_requirements()
 	 */
 	public function test_meets_requirements() {
+		$admin = new Yoast_Network_Admin();
 
 		// It's impossible to simulate `is_network_admin()` to be true in tests.
-		$this->assertFalse( Yoast_Network_Admin::meets_requirements() );
+		$this->assertFalse( $admin->meets_requirements() );
 	}
 }

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin
+ */
+
+/**
+ * Unit Test Class.
+ */
+class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Tests getting site choices.
+	 *
+	 * @covers Yoast_Network_Admin::get_site_choices()
+	 */
+	public function test_get_site_choices() {
+		$admin = new Yoast_Network_Admin();
+
+		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );
+
+		$choices = $admin->get_site_choices();
+		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
+
+		array_unshift( $site_ids, '-' );
+
+		$choices = $admin->get_site_choices( true );
+		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
+	}
+
+	/**
+	 * Tests output for hidden settings fields.
+	 *
+	 * @covers Yoast_Network_Admin::settings_fields()
+	 */
+	public function test_settings_fields() {
+		$admin = new Yoast_Network_Admin();
+
+		$group = 'yst_ms_group';
+
+		ob_start();
+		$admin->settings_fields( $group );
+		$output = ob_get_clean();
+
+		$this->assertTrue( (bool) strpos( $output, 'name="network_option_group" value="' . $group . '"' ) );
+		$this->assertTrue( (bool) strpos( $output, 'name="action" value="' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION . '"' ) );
+		$this->assertTrue( preg_match( '/name="_wpnonce" value="([a-z0-9]+)"/', $output, $matches ) );
+		$this->assertTrue( wp_verify_nonce( $matches[1], $group . '-network-options' ) );
+	}
+
+	/**
+	 * Tests registering main hooks.
+	 *
+	 * @covers Yoast_Network_Admin::register_hooks()
+	 */
+	public function test_register_hooks() {
+		$admin = new Yoast_Network_Admin();
+
+		// Hooks should be present after first call.
+		$admin->register_hooks();
+		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) ) );
+		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) ) );
+
+		// Remove the hooks again manually.
+		remove_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) );
+		remove_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) );
+
+		// Hooks should not be added again because of restriction.
+		$admin->register_hooks();
+		$this->assertFalse( has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) ) );
+		$this->assertFalse( has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) ) );
+	}
+
+	/**
+	 * Tests the singleton getter.
+	 *
+	 * @covers Yoast_Network_Admin::get()
+	 */
+	public function test_get() {
+		$this->assertInstanceOf( 'Yoast_Network_Admin', Yoast_Network_Admin::get() );
+	}
+
+	/**
+	 * Tests checking requirements for the network settings API.
+	 *
+	 * @covers Yoast_Network_Admin::meets_requirements()
+	 */
+	public function test_meets_requirements() {
+
+		// It's impossible to simulate `is_network_admin()` to be true in tests.
+		$this->assertFalse( Yoast_Network_Admin::meets_requirements() );
+	}
+}

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -13,6 +13,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting site choices.
 	 *
+	 * @group ms-required
 	 * @covers Yoast_Network_Admin::get_site_choices()
 	 */
 	public function test_get_site_choices() {

--- a/tests/admin/test-class-yoast-network-settings-api.php
+++ b/tests/admin/test-class-yoast-network-settings-api.php
@@ -19,8 +19,8 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 		$api = new Yoast_Network_Settings_API();
 
 		$api->register_setting( 'yst_ms_group', 'yst_ms_option', array(
-			'santize_callback' => 'absint',
-			'default'          => 1,
+			'sanitize_callback' => 'absint',
+			'default'           => 1,
 		) );
 
 		$this->assertInternalType( 'int', has_filter( 'sanitize_option_yst_ms_option', array( $api, 'filter_sanitize_option' ) ) );
@@ -36,15 +36,15 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 		$group = 'yst_ms_group';
 		$name  = 'yst_ms_option';
 		$args  = array(
-			'santize_callback' => 'absint',
-			'default'          => 1,
+			'sanitize_callback' => 'absint',
+			'default'           => 1,
 		);
 
 		$api = new Yoast_Network_Settings_API();
 		$api->register_setting( $group, $name, $args );
 
-		$args['group'] = $group;
-		$expected      = array( $name => $args );
+		$args     = array_merge( array( 'group' => $group ), $args );
+		$expected = array( $name => $args );
 
 		$this->assertSame( $expected, $api->get_registered_settings() );
 	}
@@ -81,7 +81,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( '2', $api->filter_sanitize_option( '2', 'yst_ms_unregistered_option' ) );
 
 		// Option registered.
-		$api->register_setting( 'yst_ms_group', 'yst_ms_option', array( 'santize_callback' => 'absint' ) );
+		$api->register_setting( 'yst_ms_group', 'yst_ms_option', array( 'sanitize_callback' => 'absint' ) );
 		$this->assertSame( 2, $api->filter_sanitize_option( '2', 'yst_ms_option' ) );
 	}
 

--- a/tests/admin/test-class-yoast-network-settings-api.php
+++ b/tests/admin/test-class-yoast-network-settings-api.php
@@ -119,6 +119,8 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Settings_API::meets_requirements()
 	 */
 	public function test_meets_requirements() {
-		$this->assertSame( is_multisite(), Yoast_Network_Settings_API::meets_requirements() );
+		$api = new Yoast_Network_Settings_API();
+
+		$this->assertSame( is_multisite(), $api->meets_requirements() );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Implements the same tabbed layout in the plugin's network settings screen that is also used in the plugin's site settings screens.

## Relevant technical choices:

* This is the follow-up PR to #9690. It should be merged into the feature branch for #9447.
* A new `Yoast_Network_Admin` class is introduced that contains network-admin specific hooks and utility methods. It holds for example the method for getting a list of site choices (e.g. for dropdowns), and it also takes care of the restoring site functionality (both of which were previously "inline functions" in the `network.php` screen template file. This class is only initialized if the current context is a multisite and we're currently in the network admin.
* A few improvements over the original introduction of the network settings API in #9690 needed to be made: The network settings API is not only scoped to the network admin screens, it might also be used in other areas, for example the REST API or WP-CLI. Therefore the network admin-specific parts of `Yoast_Network_Settings_API` were relocated to the new `Yoast_Network_Admin` class. This is in line with how core now allows registering settings from anywhere in the codebase, while the admin parts of the settings API are only available in the admin context. Two simple getter methods have been added to `Yoast_Network_Settings_API` to have access to the registered and whitelisted settings from the outside.
* The `WPSEO_Option_Tabs` class is now used to power the network settings screen, and a single "General" tab has been added for now, holding the existing settings. As a result, there's now a separate template file for that tab. This now opens up flexibility, and more tabs will be added in the future as part of other enhancement issues.
* The page titles in the network admin have been adjusted to follow the same format as the page titles in the site admin ("Page Title - Yoast SEO" instead of "Yoast SEO: Page Title"). In addition, the term "MultiSite" has been replaced with "Network", similar how other core pages do use the latter term in favor of "multisite".
* The network admin pages have been adjusted to use a new `wpseo_manage_network_options` capability as requirement, which allows for more granular access management than with reusing an arbitrary core capability (previously `delete_users` was used). This is fully backward-compatible since a network administrator has all capabilities by default anyway.

## Test instructions

This PR can be tested by following these steps:

* Set up a multisite and activate the plugin network-wide.
* Go into the network admin.
* Ensure that you can access the plugin's three network admin pages.
* Ensure that the "General" settings page in the network admin uses a tabbed layout and looks in line with the site admin screens' appearance.
* Ensure that when you change the two available network settings, the values you set persist correctly.
* Ensure that the "Restore site to default settings" form still works correctly:
    * Go to the site admin and change some of the plugin's settings.
    * Go back to the network admin, select the site where you changed the settings, and submit the form.
    * After submitting, you should receive a success feedback message at the top of the screen.
    * Go back to the site admin and verify that the settings you changed are back to their defaults.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9688 
