### PR TITLE
Restore variable_warning and use onInput.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -280,6 +280,8 @@ class WPSEO_Admin {
 	 */
 	private function localize_admin_global_script() {
 		return array(
+			/* translators: %s: '%%term_title%%' variable used in titles and meta's template that's not compatible with the given template */
+			'variable_warning'        => sprintf( __( 'Warning: the variable %s cannot be used in this template. See the help center for more info.', 'wordpress-seo' ), '<code>%s</code>' ),
 			'dismiss_about_url'       => $this->get_dismiss_url( 'wpseo-dismiss-about' ),
 			'dismiss_tagline_url'     => $this->get_dismiss_url( 'wpseo-dismiss-tagline-notice' ),
 			'help_video_iframe_title' => __( 'Yoast SEO video tutorial', 'wordpress-seo' ),

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -1,4 +1,4 @@
-/* global wpseoAdminL10n, ajaxurl, wpseoSelect2Locale */
+/* global wpseoAdminGlobalL10n, ajaxurl, wpseoSelect2Locale */
 
 import a11ySpeak from "a11y-speak";
 
@@ -47,7 +47,7 @@ import a11ySpeak from "a11y-speak";
 			errorId = e.attr( "id" ) + "-" + variable + "-warning";
 			if ( e.val().search( "%%" + variable + "%%" ) !== -1 ) {
 				e.addClass( "wpseo-variable-warning-element" );
-				var msg = wpseoAdminL10n.variable_warning.replace( "%s", "%%" + variable + "%%" );
+				var msg = wpseoAdminGlobalL10n.variable_warning.replace( "%s", "%%" + variable + "%%" );
 				if ( jQuery( "#" + errorId ).length ) {
 					jQuery( "#" + errorId ).html( msg );
 				}
@@ -55,7 +55,7 @@ import a11ySpeak from "a11y-speak";
 					e.after( ' <div id="' + errorId + '" class="wpseo-variable-warning">' + msg + "</div>" );
 				}
 
-				a11ySpeak( wpseoAdminL10n.variable_warning.replace( "%s", variable ), "assertive" );
+				a11ySpeak( wpseoAdminGlobalL10n.variable_warning.replace( "%s", variable ), "assertive" );
 
 				warn = true;
 			}
@@ -267,9 +267,9 @@ import a11ySpeak from "a11y-speak";
 		} ).change();
 
 		// Check correct variables usage in title and description templates.
-		jQuery( ".template" ).change( function() {
+		jQuery( ".template" ).on( "input", function() {
 			wpseoDetectWrongVariables( jQuery( this ) );
-		} ).change();
+		} );
 
 		// Prevent form submission when pressing Enter on the switch-toggles.
 		jQuery( ".switch-yoast-seo input" ).on( "keydown", function( event ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Restores the missing warning for wrong replacement variables.

## Note

This is a copy of @afercia 's [PR](https://github.com/Yoast/wordpress-seo/pull/9869) just to branch it from release/7.6 without taking trunk commits with it.

## Relevant technical choices:

* the translation string `variable_warning` used to be localised in the `wpseoAdminL10n` script
* after the Help Center refactoring `wpseoAdminL10n` is now enqueued only in the post and term pages
* this PR restores the missing string putting it in the `wpseoAdminGlobalL10n` localized script
* also, changes the `change` that triggered the check to `input` event:
  - modern browsers support the `input` event 
  - this way, the warning is displayed as soon as users finish typing a wrong variable, and also on paste
  - previously, the warning was displayed only when the field was blurred 

## Test instructions

This PR can be tested by following these steps:

- on current trunk, go in Search Appearance > Taxonomies > Categories
- enter `%%searchphrase%%` in the Categories Meta description template
- observe the JS error in your browser's console and no warning appearing
- switch to this branch, build the JS
- repeat the steps above
- check the warning appears correctly and no JS errors occur


Note 1: the warning copy could be improved

Note 2: the warning doesn't appear on page load (same also before these changes). Say users enter a wrong variable and submit anyway. After the page reload, or at a subsequent visit of the same page, no warning is displayed. Maybe this could be improved a bit.

Fixes #9866 