### PR TITLE
Mute the call to opcache_reset() to prevent notices when opcache.restrict_api is set

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -274,7 +274,7 @@ function wpseo_init() {
 
 	if ( version_compare( WPSEO_Options::get( 'version', 1 ), WPSEO_VERSION, '<' ) ) {
 		if ( function_exists( 'opcache_reset' ) ) {
-			opcache_reset();
+			@opcache_reset();
 		}
 
 		new WPSEO_Upgrade();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix a PHP notice that could be triggered when the `opcache.restrict_api` directive was enabled.

## Relevant technical choices:

* As decided on the issue, the most straightforward way to fix this is to mute the call to the function. This is safer than trying to read the configuration value directly via `ini_get()` or another way.

## Test instructions

This PR can be tested by following these steps:

* Install an older version of Yoast SEO on your WordPress site via Composer.
* Set the `opcache.restrict_api` directive to '1' in the `php.ini` configuration for the server.
* Update to the version from this PR via Composer.
* Access the WordPress site again, and ensure no notice `Zend OPcache API is restricted by "restrict_api" configuration directive` is thrown.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (unit tests are not applicable for this)

Fixes #9800 
