### PR TITLE
Add filter for option tab content

### DIFF
--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -46,11 +46,19 @@ class WPSEO_Option_Tabs_Formatter {
 			$class = 'wpseotab ' . ( $tab->has_save_button() ? 'save' : 'nosave' );
 			printf( '<div id="%1$s" class="%2$s">', esc_attr( $identifier ), esc_attr( $class ) );
 
-			// Output the settings view for all tabs.
-			$tab_view = $this->get_tab_view( $option_tabs, $tab );
-			if ( is_file( $tab_view ) ) {
-				$yform = Yoast_Form::get_instance();
-				require_once $tab_view;
+			$tab_filter_name    = sprintf( '%s_%s', $option_tabs->get_base(), $tab->get_name() );
+			$option_tab_content = apply_filters( 'wpseo_option_tab-' . $tab_filter_name, null );
+			if ( ! empty( $option_tab_content ) ) {
+				echo $option_tab_content;
+			}
+
+			if ( empty( $option_tab_content ) ) {
+				// Output the settings view for all tabs.
+				$tab_view = $this->get_tab_view( $option_tabs, $tab );
+				if ( is_file( $tab_view ) ) {
+					$yform = Yoast_Form::get_instance();
+					require_once $tab_view;
+				}
 			}
 
 			echo '</div>';

--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -47,7 +47,18 @@ class WPSEO_Option_Tabs_Formatter {
 			printf( '<div id="%1$s" class="%2$s">', esc_attr( $identifier ), esc_attr( $class ) );
 
 			$tab_filter_name    = sprintf( '%s_%s', $option_tabs->get_base(), $tab->get_name() );
-			$option_tab_content = apply_filters( 'wpseo_option_tab-' . $tab_filter_name, null );
+
+			/**
+			 * Allows to override the content that is display on the specific option tab.
+			 *
+			 * @internal For internal Yoast SEO use only.
+			 *
+			 * @api      string|null The content that should be displayed for this tab. Leave empty for default behaviour.
+			 *
+			 * @param WPSEO_Option_Tabs $option_tabs The registered option tabs.
+			 * @param WPSEO_Option_Tab  $tab         The tab that is being displayed.
+			 */
+			$option_tab_content = apply_filters( 'wpseo_option_tab-' . $tab_filter_name, null, $option_tabs, $tab );
 			if ( ! empty( $option_tab_content ) ) {
 				echo $option_tab_content;
 			}

--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -46,7 +46,7 @@ class WPSEO_Option_Tabs_Formatter {
 			$class = 'wpseotab ' . ( $tab->has_save_button() ? 'save' : 'nosave' );
 			printf( '<div id="%1$s" class="%2$s">', esc_attr( $identifier ), esc_attr( $class ) );
 
-			$tab_filter_name    = sprintf( '%s_%s', $option_tabs->get_base(), $tab->get_name() );
+			$tab_filter_name = sprintf( '%s_%s', $option_tabs->get_base(), $tab->get_name() );
 
 			/**
 			 * Allows to override the content that is display on the specific option tab.


### PR DESCRIPTION
This allows to hook into `wpseo_option_tab-metas_media` to override the media config data.

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Add a general filter for tab content

## Test instructions

This PR can be tested by following these steps:

* Add a filter:
```
add_filter( 'wpseo_option_tab-metas_media', function() {
	return 'hoi';
});
```
* See the content being displayed on http://local.wordpress.test/wp-admin/admin.php?page=wpseo_titles#top#media

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes https://github.com/Yoast/search-index-purge/issues/7
