### PR TITLE
Link to the Customizer control for the tagline directly when highlighting it should be changed

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -83,7 +83,8 @@ class WPSEO_Admin_Init {
 		$current_url   = ( is_ssl() ? 'https://' : 'http://' );
 		$current_url  .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
 		$customize_url = add_query_arg( array(
-			'url' => urlencode( $current_url ),
+			'autofocus[control]' => 'blogdescription',
+			'url'                => urlencode( $current_url ),
 		), wp_customize_url() );
 
 		$info_message = sprintf(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Link to the Customizer control for the tagline directly when highlighting it should be changed.

## Relevant technical choices:

* When you provide a query argument like `autofocus[panel]`, `autofocus[section]` or `autofocus[control]` to the Customizer, the respective panel/section/control will be initially focused. This can be used here to point the user directly to the correct control for the tagline (the setting is internally called `blogdescription`).

## Test instructions

This PR can be tested by following these steps:

* Ensure that the tagline for your site is set to the default WordPress tagline ("Just another WordPress site" in English).
* Go to the Yoast SEO dashboard, and see the notification that reminds you that you still use the default tagline.
* Click the link and verify that the Customizer automatically takes you to the control where you can change the tagline.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (unit tests are not applicable here)

Fixes #9743 
