### PR TITLE
Add X-Redirect-By header to all redirects

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1339,6 +1339,7 @@ class WPSEO_Frontend {
 
 			$redir = $this->get_seo_meta_value( 'redirect', $post->ID );
 			if ( $redir !== '' ) {
+				header( 'X-Redirect-By: Yoast SEO' );
 				wp_redirect( $redir, 301 );
 				exit;
 			}
@@ -1675,6 +1676,7 @@ class WPSEO_Frontend {
 	 * @param int    $status   Status code to use.
 	 */
 	public function redirect( $location, $status = 302 ) {
+		header( 'X-Redirect-By: Yoast SEO' );
 		wp_safe_redirect( $location, $status );
 		exit;
 	}

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -103,6 +103,7 @@ class WPSEO_Rewrite {
 		if ( isset( $query_vars['wpseo_category_redirect'] ) ) {
 			$catlink = trailingslashit( get_option( 'home' ) ) . user_trailingslashit( $query_vars['wpseo_category_redirect'], 'category' );
 
+			header( 'X-Redirect-By: Yoast SEO' );
 			wp_redirect( $catlink, 301 );
 			exit;
 		}

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -69,6 +69,7 @@ class WPSEO_Sitemaps_Router {
 		$current_url .= sanitize_text_field( $_SERVER['REQUEST_URI'] );
 
 		if ( home_url( '/sitemap.xml' ) === $current_url && $wp_query->is_404 ) {
+			header( 'X-Redirect-By: Yoast SEO' );
 			wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
 			exit;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds X-Redirect-By header to all redirects. Making the origin of redirects much easier to debug.

## Relevant technical choices:

* Because redirects are not abstracted I just added the `header` call before every redirect.

## Test instructions

This PR can be tested by following these steps:

* Test a redirect using a tool such as `curl -I` and see the X-Redirect-By header

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended