### PR TITLE
Removed trailing spaces changing to dashes

### DIFF
--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -80,9 +80,12 @@ const applyReplaceUsingPlugin = function( data ) {
  *
  * @returns {Object} The snippet preview data object.
  */
-const mapEditorDataToPreview = function( data ) {
+export const mapEditorDataToPreview = function( data ) {
 	// Replace whitespaces in the url with dashes.
 	data.url = data.url.replace( /\s+/g, "-" );
+	if ( data.url[ data.url.length - 1 ] === "-" ) {
+		data.url = data.url.substring( 0, data.url.length - 1 );
+	}
 
 	return applyReplaceUsingPlugin( data );
 };

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -84,7 +84,7 @@ export const mapEditorDataToPreview = function( data ) {
 	// Replace whitespaces in the url with dashes.
 	data.url = data.url.replace( /\s+/g, "-" );
 	if ( data.url[ data.url.length - 1 ] === "-" ) {
-		data.url = data.url.substring( 0, data.url.length - 1 );
+		data.url = data.url.slice( 0, -1 );
 	}
 
 	return applyReplaceUsingPlugin( data );

--- a/js/tests/components/SnippetPreviewSection.test.js
+++ b/js/tests/components/SnippetPreviewSection.test.js
@@ -1,7 +1,6 @@
 import { mount } from "enzyme";
-import SnippetPreviewSection from "../../src/components/SnippetPreviewSection";
+import SnippetPreviewSection, { mapEditorDataToPreview } from "../../src/components/SnippetPreviewSection";
 import React from "react";
-import { mapEditorDataToPreview } from "../../src/components/SnippetPreviewSection";
 
 jest.mock( "../../src/containers/SnippetEditor", () => {
 	return () => {

--- a/js/tests/components/SnippetPreviewSection.test.js
+++ b/js/tests/components/SnippetPreviewSection.test.js
@@ -21,7 +21,7 @@ describe( "SnippetPreviewSection", () => {
 } );
 
 describe( "mapEditorDataToPreview", () => {
-	it( "hyphenates a space in the URL", () => {
+	it( "Hyphenates a space in the URL.", () => {
 		const exampleURL = "my URL";
 		const expected = "my-URL";
 
@@ -36,7 +36,7 @@ describe( "mapEditorDataToPreview", () => {
 		expect( actual.url ).toEqual( expected );
 	} );
 
-	it( "hyphenates all spaces in the URL", () => {
+	it( "Hyphenates all spaces in the URL.", () => {
 		const exampleURL = "my URL is awesome";
 		const expected = "my-URL-is-awesome";
 
@@ -51,7 +51,7 @@ describe( "mapEditorDataToPreview", () => {
 		expect( actual.url ).toEqual( expected );
 	} );
 
-	it( "Doesn't hyphenate a trailing space", () => {
+	it( "Doesn't hyphenate a trailing space.", () => {
 		const exampleURL = "my URL is awesome ";
 		const expected = "my-URL-is-awesome";
 
@@ -66,7 +66,7 @@ describe( "mapEditorDataToPreview", () => {
 		expect( actual.url ).toEqual( expected );
 	} );
 
-	it( "Doesn't hyphenate trailing spaces", () => {
+	it( "Doesn't hyphenate trailing spaces.", () => {
 		const exampleURL = "my URL is awesome    ";
 		const expected = "my-URL-is-awesome";
 

--- a/js/tests/components/SnippetPreviewSection.test.js
+++ b/js/tests/components/SnippetPreviewSection.test.js
@@ -21,38 +21,8 @@ describe( "SnippetPreviewSection", () => {
 } );
 
 describe( "mapEditorDataToPreview", () => {
-	it( "Hyphenates a space in the URL.", () => {
-		const exampleURL = "my URL";
-		const expected = "my-URL";
-
-		const dataObject = {
-			title: "",
-			url: exampleURL,
-			description: "",
-		};
-
-		const actual = mapEditorDataToPreview( dataObject );
-
-		expect( actual.url ).toEqual( expected );
-	} );
-
-	it( "Hyphenates all spaces in the URL.", () => {
+	it( "Hyphenates spaces between words of the URL.", () => {
 		const exampleURL = "my URL is awesome";
-		const expected = "my-URL-is-awesome";
-
-		const dataObject = {
-			title: "",
-			url: exampleURL,
-			description: "",
-		};
-
-		const actual = mapEditorDataToPreview( dataObject );
-
-		expect( actual.url ).toEqual( expected );
-	} );
-
-	it( "Doesn't hyphenate a trailing space.", () => {
-		const exampleURL = "my URL is awesome ";
 		const expected = "my-URL-is-awesome";
 
 		const dataObject = {

--- a/js/tests/components/SnippetPreviewSection.test.js
+++ b/js/tests/components/SnippetPreviewSection.test.js
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import SnippetPreviewSection from "../../src/components/SnippetPreviewSection";
 import React from "react";
+import { mapEditorDataToPreview } from "../../src/components/SnippetPreviewSection";
 
 jest.mock( "../../src/containers/SnippetEditor", () => {
 	return () => {
@@ -17,5 +18,67 @@ describe( "SnippetPreviewSection", () => {
 		const tree = mount( <SnippetPreviewSection baseUrl="http://example.org" /> );
 
 		expect( tree ).toMatchSnapshot();
+	} );
+} );
+
+describe( "mapEditorDataToPreview", () => {
+	it( "hyphenates a space in the URL", () => {
+		const exampleURL = "my URL";
+		const expected = "my-URL";
+
+		const dataObject = {
+			title: "",
+			url: exampleURL,
+			description: "",
+		};
+
+		const actual = mapEditorDataToPreview( dataObject );
+
+		expect( actual.url ).toEqual( expected );
+	} );
+
+	it( "hyphenates all spaces in the URL", () => {
+		const exampleURL = "my URL is awesome";
+		const expected = "my-URL-is-awesome";
+
+		const dataObject = {
+			title: "",
+			url: exampleURL,
+			description: "",
+		};
+
+		const actual = mapEditorDataToPreview( dataObject );
+
+		expect( actual.url ).toEqual( expected );
+	} );
+
+	it( "Doesn't hyphenate a trailing space", () => {
+		const exampleURL = "my URL is awesome ";
+		const expected = "my-URL-is-awesome";
+
+		const dataObject = {
+			title: "",
+			url: exampleURL,
+			description: "",
+		};
+
+		const actual = mapEditorDataToPreview( dataObject );
+
+		expect( actual.url ).toEqual( expected );
+	} );
+
+	it( "Doesn't hyphenate trailing spaces", () => {
+		const exampleURL = "my URL is awesome    ";
+		const expected = "my-URL-is-awesome";
+
+		const dataObject = {
+			title: "",
+			url: exampleURL,
+			description: "",
+		};
+
+		const actual = mapEditorDataToPreview( dataObject );
+
+		expect( actual.url ).toEqual( expected );
 	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Caught them in an if-statement. Tried to do it in the regex at first, but it wouldn't cooperate.

## Test instructions

This PR can be tested by following these steps:

* run the tests.
* Visit the react snippet editor in a post
* write a slug ending in a space, and observe the dash not showing in the snippet preview.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #9868
