### PR TITLE
Add option to determine Media Purge message on

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -107,6 +107,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_74();
 		}
 
+		if ( version_compare( $version, '7.5.3', '<' ) ) {
+			$this->upgrade_753();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -554,6 +558,19 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_74() {
 		$this->remove_sitemap_validators();
+	}
+
+	/**
+	 * Performs the 7.5.3 upgrade.
+	 *
+	 * @return void
+	 */
+	private function upgrade_753() {
+		// Only when upgrading potentially purging media is relevant.
+		if ( WPSEO_Options::get( 'disable-attachment' ) === false ) {
+			// Only when attachments are not disabled.
+			WPSEO_Options::set( 'is-media-purge-relevant', true );
+		}
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -47,6 +47,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'disable-date'                  => false,
 		'disable-post_format'           => false,
 		'disable-attachment'            => true,
+		'is-media-purge-relevant'       => false,
 
 		'breadcrumbs-404crumb'          => '', // Text field.
 		'breadcrumbs-display-blog-page' => true,
@@ -532,6 +533,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				 *  'breadcrumbs-boldlast'
 				 *  'breadcrumbs-enable'
 				 *  'stripcategorybase'
+				 *  'is-media-purge-relevant'
 				 */
 				default:
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );


### PR DESCRIPTION
Set option value on upgrade routine
Use default "false" for new installs

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/search-index-purge/issues/21
