### PR TITLE
Add notification when conditions are met

### DIFF
--- a/admin/class-admin-media-purge-notification.php
+++ b/admin/class-admin-media-purge-notification.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Handles the media purge notification showing and hiding.
+ */
+class WPSEO_Admin_Media_Purge_Notification implements WPSEO_WordPress_Integration {
+
+	/**
+	 * Notification ID to use.
+	 *
+	 * @var string
+	 */
+	private $notification_id = 'wpseo_media_purge';
+
+	/**
+	 * Registers all hooks to WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'admin_init', array( $this, 'manage_notification' ) );
+		add_filter( 'wpseo_option_tab-metas_media', array( $this, 'output_hidden_setting' ) );
+
+		// Dismissing is just setting the relevancy to false, which cancels out any functionality.
+		if ( WPSEO_Utils::is_yoast_seo_page() && filter_input( INPUT_GET, 'dismiss' ) === $this->notification_id ) {
+			WPSEO_Options::set( 'is-media-purge-relevant', false );
+		}
+	}
+
+	/**
+	 * Adds a hidden setting to the media tab.
+	 *
+	 * To make sure the setting is not reverted to the default when -anything-
+	 * is saved on the entire page (not just the media tab).
+	 *
+	 * @return void
+	 */
+	public function output_hidden_setting() {
+		$form = Yoast_Form::get_instance();
+		$form->hidden( 'is-media-purge-relevant' );
+	}
+
+	/**
+	 * Manages if the notification should be shown or removed.
+	 *
+	 * @return void
+	 */
+	public function manage_notification() {
+		if ( ! WPSEO_Options::get( 'is-media-purge-relevant' ) ) {
+			$this->remove_notification();
+
+			return;
+		}
+
+		// This is the desired behaviour, remove any notifications and carry on.
+		if ( WPSEO_Options::get( 'disable-attachment' ) === true ) {
+			$this->remove_notification();
+
+			return;
+		}
+
+		// When the attachments are no-indexed, this is acceptable.
+		if ( WPSEO_Options::get( 'noindex-attachment' ) === true ) {
+			$this->remove_notification();
+
+			return;
+		}
+
+		$this->add_notification();
+	}
+
+	/**
+	 * Retrieves the notification that should be shown or removed.
+	 *
+	 * @return Yoast_Notification The notification to use.
+	 */
+	private function get_notification() {
+		$content = sprintf(
+		/* translators: %1$s expands to the link to the article, %2$s closes the link tag. */
+			__( 'Your site\'s settings currently allow attachment URLs on your site to exist. Please read %1$sthis post about a potential issue%2$s with attachment URLs and check whether you have the correct setting for your site.', 'wordpress-seo' ),
+			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="nofollow noreferer" target="_blank">',
+			'</a>'
+		);
+
+		$content .= '<br><br>';
+		$content .= sprintf(
+			__( 'If you know what this means and you do not want to see this message anymore, you can %1$sdismiss this message%2$s.', 'wordpress-seo' ),
+			'<a href="' . admin_url( 'admin.php?page=wpseo_dashboard&dismiss=' . $this->notification_id ) . '">',
+			'</a>'
+		);
+
+		return new Yoast_Notification(
+			$content,
+			array(
+				'type'         => Yoast_Notification::ERROR,
+				'id'           => $this->notification_id,
+				'capabilities' => 'wpseo_manage_options',
+				'priority'     => 1,
+			)
+		);
+	}
+
+	/**
+	 * Adds the notification to the notificaton center.
+	 *
+	 * @return void
+	 */
+	private function add_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->add_notification( $this->get_notification() );
+	}
+
+	/**
+	 * Removes the notification from the notification center.
+	 *
+	 * @return void
+	 */
+	private function remove_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->remove_notification( $this->get_notification() );
+	}
+}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -96,6 +96,7 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_Statistic_Integration();
 		$integrations[] = new WPSEO_Slug_Change_Watcher();
 		$integrations[] = new WPSEO_Capability_Manager_Integration( WPSEO_Capability_Manager_Factory::get() );
+		$integrations[] = new WPSEO_Admin_Media_Purge_Notification();
 		$integrations   = array_merge( $integrations, $this->initialize_seo_links() );
 
 		/** @var WPSEO_WordPress_Integration $integration */


### PR DESCRIPTION
Conditions:
- attachments are not redirect to the file
- attachments are not "noindexed"

Dismissed by setting the option "is-media-purge-relevant" to `false`
Bypassing any introduced functionality

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Added a hidden field on the newly introduced filter (not returning anything, so not affecting the content)
* Introduced conditions to the manage_notification method

## Test instructions

This PR can be tested by following these steps:

* Have the `is-media-purge-relevant` set to `true` (in `wpseo_titles`, either via Upgrade routine or directly in the database)
* Have the Media settings: 
<img width="360" alt="search_appearance_-_yoast_seo_ _local_wordpress_ _wordpress" src="https://user-images.githubusercontent.com/2005352/40666537-4378a6fe-6360-11e8-8413-8a194313ed97.png">

* See the notification being added to the notification center
* Using the dismiss link will reload the page and the notification should be gone

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/search-index-purge/issues/22
