### PR TITLE
Relevancy check tighten up

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -563,14 +563,23 @@ class WPSEO_Upgrade {
 	/**
 	 * Performs the 7.5.3 upgrade.
 	 *
+	 * When upgrading purging media is potentially relevant.
+	 *
 	 * @return void
 	 */
 	private function upgrade_753() {
-		// Only when upgrading potentially purging media is relevant.
-		if ( WPSEO_Options::get( 'disable-attachment' ) === false ) {
-			// Only when attachments are not disabled.
-			WPSEO_Options::set( 'is-media-purge-relevant', true );
+		// Only when attachments are not disabled.
+		if ( WPSEO_Options::get( 'disable-attachment' ) === true ) {
+			return;
 		}
+
+		// Only when attachments are not no-indexed.
+		if ( WPSEO_Options::get( 'noindex-attachment' ) === true ) {
+			return;
+		}
+
+		// Set purging relevancy.
+		WPSEO_Options::set( 'is-media-purge-relevant', true );
 	}
 
 	/**


### PR DESCRIPTION
Only when all conditions are met the purge is relevant.
If the attachments are no-index'd, the purge is less relevant and we dont want to show any message.

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Made the checks the same as for the Dashboard notification
* This will not show when `attachments` are set to `noindex`

## Test instructions

This PR can be tested by following these steps:

* Set the media settings to "No", "No"
* Set the version of Yoast SEO back to 7.4 (using the Test Helper plugin)
* Refresh the page
* Set the media settings to "No", "Yes"
* Don't see the yellow message (which is shown without this patch)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
