### PR TITLE
Update Draft.js mention plugin to match yoast-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
     "draft-js": "^0.10.5",
-    "draft-js-mention-plugin": "^2.0.1",
+    "draft-js-mention-plugin": "^3.0.4",
     "find-with-regex": "~1.0.2",
     "grunt-wp-deploy": "^1.2.1",
     "gutenberg": "Wordpress/gutenberg",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3073,17 +3073,6 @@ download@^4.0.0, download@^4.1.2:
     vinyl-fs "^2.2.0"
     ware "^1.2.0"
 
-draft-js-mention-plugin@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/draft-js-mention-plugin/-/draft-js-mention-plugin-2.0.1.tgz#388e39861df25d61c3de577799a69c92374e206a"
-  dependencies:
-    decorate-component-with-props "^1.0.2"
-    find-with-regex "^1.0.2"
-    immutable "~3.7.4"
-    lodash.escaperegexp "^4.1.2"
-    prop-types "^15.5.8"
-    union-class-names "^1.0.0"
-
 draft-js-mention-plugin@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/draft-js-mention-plugin/-/draft-js-mention-plugin-3.0.4.tgz#e8530b7c16f23ce5b980515458418b5e24376f4a"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Updated Draft.js mention plugin to match yoast-components.

## Test instructions

This PR can be tested by following these steps:

* Draft-js and the mention plugin are only used for styling. I updated this because it had a larger margin-top of the snippet editor suggestions popover. And now it has a smaller margin-top.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9604 