### PR TITLE
Replace the function wp_safe_redirect by wp_redirect

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1705,7 +1705,7 @@ class WPSEO_Frontend {
 	 */
 	public function redirect( $location, $status = 302 ) {
 		header( 'X-Redirect-By: Yoast SEO' );
-		wp_redirect( $location, $status );
+		wp_safe_redirect( $location, $status );
 		exit;
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -101,7 +101,6 @@ class WPSEO_Frontend {
 			add_action( 'wp', array( $this, 'archive_redirect' ) );
 		}
 		add_action( 'template_redirect', array( $this, 'attachment_redirect' ), 1 );
-		add_filter( 'allowed_redirect_hosts' , array( $this, 'add_attachment_host' ) );
 
 		add_filter( 'the_content_feed', array( $this, 'embed_rssfooter' ) );
 		add_filter( 'the_excerpt_rss', array( $this, 'embed_rssfooter_excerpt' ) );
@@ -1431,7 +1430,7 @@ class WPSEO_Frontend {
 		$url = apply_filters( 'wpseo_attachment_redirect_url', wp_get_attachment_url( get_queried_object_id() ), get_queried_object() );
 
 		if ( ! empty( $url ) ) {
-			$this->redirect( $url, 301 );
+			$this->do_attachment_redirect( $url );
 
 			return true;
 		}
@@ -1440,30 +1439,16 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * Adds the upload directory host to the allowed redirect hosts to make sure
-	 * wp_safe_redirect works well with a set external url. This is intended
-	 * when a CDN is used.
+	 * Performs the redirect from the attachment page to the image file itself.
 	 *
-	 * @param array $allowed_redirect_hosts Array with allowed redirect hosts.
+	 * @param string $attachment_url The attachment image url.
 	 *
-	 * @return array Modified redirect hosts.
+	 * @return void
 	 */
-	public function add_attachment_host( $allowed_redirect_hosts ) {
-		$site_host   = wp_parse_url( home_url(), PHP_URL_HOST );
-		$upload_dir  = wp_get_upload_dir();
-		$upload_host = wp_parse_url( $upload_dir['baseurl'], PHP_URL_HOST );
-
-		if ( $site_host === $upload_host ) {
-			return $allowed_redirect_hosts;
-		}
-
-		if ( in_array( $upload_host, $allowed_redirect_hosts, true ) ) {
-			return $allowed_redirect_hosts;
-		}
-
-		$allowed_redirect_hosts[] = $upload_host;
-
-		return $allowed_redirect_hosts;
+	public function do_attachment_redirect( $attachment_url ) {
+		header( 'X-Redirect-By: Yoast SEO' );
+		wp_safe_redirect( $attachment_url, 301 );
+		exit;
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1447,7 +1447,7 @@ class WPSEO_Frontend {
 	 */
 	public function do_attachment_redirect( $attachment_url ) {
 		header( 'X-Redirect-By: Yoast SEO' );
-		wp_safe_redirect( $attachment_url, 301 );
+		wp_redirect( $attachment_url, 301 );
 		exit;
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1675,7 +1675,7 @@ class WPSEO_Frontend {
 	 * @param int    $status   Status code to use.
 	 */
 	public function redirect( $location, $status = 302 ) {
-		wp_safe_redirect( $location, $status );
+		wp_redirect( $location, $status );
 		exit;
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -101,6 +101,7 @@ class WPSEO_Frontend {
 			add_action( 'wp', array( $this, 'archive_redirect' ) );
 		}
 		add_action( 'template_redirect', array( $this, 'attachment_redirect' ), 1 );
+		add_filter( 'allowed_redirect_hosts' , array( $this, 'add_attachment_host' ) );
 
 		add_filter( 'the_content_feed', array( $this, 'embed_rssfooter' ) );
 		add_filter( 'the_excerpt_rss', array( $this, 'embed_rssfooter_excerpt' ) );
@@ -1436,6 +1437,33 @@ class WPSEO_Frontend {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Adds the upload directory host to the allowed redirect hosts to make sure
+	 * wp_safe_redirect works well with a set external url. This is intended
+	 * when a CDN is used.
+	 *
+	 * @param array $allowed_redirect_hosts Array with allowed redirect hosts.
+	 *
+	 * @return array Modified redirect hosts.
+	 */
+	public function add_attachment_host( $allowed_redirect_hosts ) {
+		$site_host   = wp_parse_url( home_url(), PHP_URL_HOST );
+		$upload_dir  = wp_get_upload_dir();
+		$upload_host = wp_parse_url( $upload_dir['baseurl'], PHP_URL_HOST );
+
+		if ( $site_host === $upload_host ) {
+			return $allowed_redirect_hosts;
+		}
+
+		if ( in_array( $upload_host, $allowed_redirect_hosts, true ) ) {
+			return $allowed_redirect_hosts;
+		}
+
+		$allowed_redirect_hosts[] = $upload_host;
+
+		return $allowed_redirect_hosts;
 	}
 
 	/**

--- a/tests/doubles/frontend-double.php
+++ b/tests/doubles/frontend-double.php
@@ -54,6 +54,13 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	/**
 	 * @inheritdoc
 	 */
+	public function do_attachment_redirect( $attachment_url ) {
+		// Intentionally left empty to remove actual redirection code to be able to test it.
+	}
+
+	/**
+	 * @inheritdoc
+	 */
 	public function get_queried_post_type() {
 		return parent::get_queried_post_type();
 	}

--- a/tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -150,4 +150,33 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 
 		$this->assertFalse( self::$class_instance->attachment_redirect() );
 	}
+
+	/**
+	 * Tests if do_attachment_redirect has been called.
+	 *
+	 * @covers WPSEO_Frontend::attachment_redirect
+	 */
+	public function test_do_attachment_redirect() {
+		WPSEO_Options::set( 'disable-attachment', true );
+		$class_instance = $this
+			->getMockBuilder( 'WPSEO_Frontend_Double' )
+			->setMethods( array( 'do_attachment_redirect' ) )
+			->getMock();
+
+
+		$class_instance
+			->expects( $this->once() )
+			->method( 'do_attachment_redirect' );
+
+		// Create an attachment with parent.
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'attachment',
+			)
+		);
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Make sure the redirect is applied.
+		$class_instance->attachment_redirect();
+	}
 }

--- a/tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -150,36 +150,4 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 
 		$this->assertFalse( self::$class_instance->attachment_redirect() );
 	}
-
-
-	/**
-	 * Tests the situation where the upload directory refers to an external host. This
-	 * is mostly the case when a CDN is used.
-	 */
-	public function test_attachment_redirect_on_cdn() {
-		// By adding the filter where a faking the CDN.
-		add_filter ( 'upload_dir', array( $this, 'set_cdn_upload_dir' ) );
-		
-		$id = self::factory()->attachment->create_object( 'image.jpg', 0, array(
-			'post_mime_type' => 'image/jpeg',
-			'post_type'      => 'attachment',
-		) );
-
-		$attachment_url = wp_get_attachment_url( $id, get_post( $id ) );
-
-		$this->assertEquals( 'https://cdn.com/uploads/image.jpg', wp_validate_redirect( $attachment_url ) );
-	}
-
-	/**
-	 * Sets a CDN baseurl in the upload directory config.
-	 *
-	 * @param array $upload_directory The upload dir settings.
-	 *
-	 * @return array The modified upload dir settings.
-	 */
-	public function set_cdn_upload_dir( $upload_directory ) {
-		$upload_directory['baseurl'] = 'https://cdn.com/uploads';
-
-		return $upload_directory;
-	}
 }

--- a/tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -150,4 +150,36 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 
 		$this->assertFalse( self::$class_instance->attachment_redirect() );
 	}
+
+
+	/**
+	 * Tests the situation where the upload directory refers to an external host. This
+	 * is mostly the case when a CDN is used.
+	 */
+	public function test_attachment_redirect_on_cdn() {
+		// By adding the filter where a faking the CDN.
+		add_filter ( 'upload_dir', array( $this, 'set_cdn_upload_dir' ) );
+		
+		$id = self::factory()->attachment->create_object( 'image.jpg', 0, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_type'      => 'attachment',
+		) );
+
+		$attachment_url = wp_get_attachment_url( $id, get_post( $id ) );
+
+		$this->assertEquals( 'https://cdn.com/uploads/image.jpg', wp_validate_redirect( $attachment_url ) );
+	}
+
+	/**
+	 * Sets a CDN baseurl in the upload directory config.
+	 *
+	 * @param array $upload_directory The upload dir settings.
+	 *
+	 * @return array The modified upload dir settings.
+	 */
+	public function set_cdn_upload_dir( $upload_directory ) {
+		$upload_directory['baseurl'] = 'https://cdn.com/uploads';
+
+		return $upload_directory;
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the attachment url was redirected to `wp-admin` when the attachment is not located on the Site URL domain.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* This pull request is pretty hard to test. I've seen this happening on my personal blog where I am using a CDN (Amazon). This is causing wrong redirects in combination with the Offload S3 plugin.
* Please verify if the old situation still works. This means that attachment url will be redirect to the attachment image itself (when the option has been enabled under search appearance - media.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9880
