### PR TITLE
Add event listener for text editor which is without TinyMCE

### DIFF
--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -107,10 +107,13 @@ class ClassicEditorData {
 		this.subscribeToInputElement( "excerpt", "excerpt" );
 		this.subscribeToInputElement( "excerpt", "excerpt_only" );
 
+		// Register a listener for content changes in the "text" editor.
+		this.subscribeToInputElement( "content", "content" );
+
+		// Register a listener for content changes in the "visual" (TinyMCE) editor.
 		let dispatchContentToStore = () => {
 			this._store.dispatch( setDocumentContent( this.getContent() ) );
 		};
-
 		tmceHelper.addEventHandler( tmceId, [ "input", "change", "cut", "paste" ], dispatchContentToStore );
 	}
 
@@ -133,7 +136,7 @@ class ClassicEditorData {
 			return;
 		}
 
-		// Title and excerpt also need to be sent to the DocumentData in the Redux store.
+		// Title, content, and excerpt also need to be sent to the DocumentData in the Redux store.
 		switch ( targetField ) {
 			case "excerpt":
 				element.addEventListener( "input", ( event ) => {
@@ -145,6 +148,11 @@ class ClassicEditorData {
 				element.addEventListener( "input", ( event ) => {
 					this._store.dispatch( setDocumentTitle( event.target.value ) );
 					this.updateReplacementData( event, targetField );
+				} );
+				break;
+			case "content":
+				element.addEventListener( "input", ( event ) => {
+					this._store.dispatch( setDocumentContent( event.target.value ) );
 				} );
 				break;
 			default:


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Also added a listener to the id `content`, which is only present when the "text" editor tab is activated. This is not a TinyMCE editor, so no need for the tmce helpers.

## Test instructions

This PR can be tested by following these steps:

* Verify that on the feature branch, typing in the `visual` editor will dispatch `SET_DOCUMENT_DATA` actions and update the Snippet Preview, whereas typing in the `text` editor will not do so.
* Verify that on this branch, that is the case.
* Do your best to break the listener by cutting, pasting etc...

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [] I have added unittests to verify the code works as intended

Fixes #9904 
