### PR TITLE
Prevent duplicate key errors

### DIFF
--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -94,13 +94,16 @@ class WPSEO_Database_Proxy {
 	 * Performs an insert into and if key is duplicate it will update the existing record.
 	 *
 	 * @param array $data         Data to update on the table.
-	 * @param array $where        Where condition as key => value array.
-	 * @param null  $format       Optional. data prepare format.
-	 * @param null  $where_format Optional. Where prepare format.
+	 * @param array $where        Optional. Unused. Where condition as key => value array.
+	 * @param null  $format       Optional. Data prepare format.
+	 * @param null  $where_format Deprecated. Where prepare format.
 	 *
 	 * @return false|int False when the upsert request is invalid, int on number of rows changed.
 	 */
-	public function upsert( array $data, array $where, $format = null, $where_format = null ) {
+	public function upsert( array $data, array $where = null, $format = null, $where_format = null ) {
+		if ( $where_format !== null ) {
+			_deprecated_argument( __METHOD__, '7.7.0', 'The where_format argument is deprecated' );
+		}
 
 		$this->pre_execution();
 

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -91,7 +91,7 @@ class WPSEO_Database_Proxy {
 	/**
 	 * Upserts data in the database.
 	 *
-	 * Tries to insert the data first, if this fails an update is attempted.
+	 * Performs an insert into and if key is duplicate it will update the existing record.
 	 *
 	 * @param array $data         Data to update on the table.
 	 * @param array $where        Where condition as key => value array.
@@ -101,11 +101,33 @@ class WPSEO_Database_Proxy {
 	 * @return false|int False when the upsert request is invalid, int on number of rows changed.
 	 */
 	public function upsert( array $data, array $where, $format = null, $where_format = null ) {
-		$result = $this->insert( $data, $format );
 
-		if ( false === $result ) {
-			$result = $this->update( $data, $where, $format, $where_format );
+		$this->pre_execution();
+
+		$update  = array();
+		$keys    = array();
+		$columns = array_keys( $data );
+		foreach ( $columns as $column ) {
+			$keys[]   = '`' . $column . '`';
+			$update[] = sprintf( '%1$s = VALUES(%1$s)', '`' . $column . '`' );
 		}
+
+		$query = sprintf(
+			'INSERT INTO `%1$s` (%2$s) VALUES ( %3$s ) ON DUPLICATE KEY UPDATE %4$s',
+			$this->get_table_name(),
+			implode( ', ', $keys ),
+			implode( ', ', array_fill( 0, count( $data ), '%s' ) ),
+			implode( ', ', $update )
+		);
+
+		$result = $this->database->query(
+			$this->database->prepare(
+				$query,
+				array_values( $data )
+			)
+		);
+
+		$this->post_execution();
 
 		return $result;
 	}

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -94,7 +94,7 @@ class WPSEO_Database_Proxy {
 	 * Performs an insert into and if key is duplicate it will update the existing record.
 	 *
 	 * @param array $data         Data to update on the table.
-	 * @param array $where        Optional. Unused. Where condition as key => value array.
+	 * @param array $where        Unused. Where condition as key => value array.
 	 * @param null  $format       Optional. Data prepare format.
 	 * @param null  $where_format Deprecated. Where prepare format.
 	 *
@@ -112,7 +112,7 @@ class WPSEO_Database_Proxy {
 		$columns = array_keys( $data );
 		foreach ( $columns as $column ) {
 			$keys[]   = '`' . $column . '`';
-			$update[] = sprintf( '%1$s = VALUES(%1$s)', '`' . $column . '`' );
+			$update[] = sprintf( '`%1$s` = VALUES(`%1$s`)', $column );
 		}
 
 		$query = sprintf(

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -187,8 +187,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 			array(
 				'id' => 2,
 			),
-			array( '%d', '%s', '%s' ),
-			array( '%d' )
+			array( '%d', '%s', '%s' )
 		);
 
 		$this->assertSame( 1, $result );
@@ -209,8 +208,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 			array(
 				'id' => 1,
 			),
-			array( '%d', '%s', '%s' ),
-			array( '%d' )
+			array( '%d', '%s', '%s' )
 		);
 
 		/**

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -41,6 +41,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$installer->install();
 	}
 
+	/**
+	 * Truncates the table before each test.
+	 *
+	 * @return void
+	 */
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -213,7 +213,12 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 			array( '%d' )
 		);
 
-		$this->assertSame( 1, $result );
+		/**
+		 * You would think the expected result will be 1, but it will be 2. For more context:
+		 * @see https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+		 * "With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if the row is inserted as a new row and 2 if an existing row is updated."
+		 */
+		$this->assertSame( 2, $result );
 	}
 
 	/**

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -91,6 +91,14 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Database_Proxy::insert()
 	 */
 	public function test_insert_exists() {
+		self::$proxy->insert(
+			array(
+				'testkey' => 'key2',
+				'testval' => 'value2',
+			),
+			array( '%s', '%s' )
+		);
+
 		$result = self::$proxy->insert(
 			array(
 				'id'      => 1,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where suppressed MySQL errors are logged when 'upserting' a record to our Yoast meta table.

## Test instructions

This PR can be tested by following these steps:

* Have the query monitor active.
* Save a post to the database and MySQL errors are given (on trunk)
* Checkout this branch and see no MySQL errors are given.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #8650
