### PR TITLE
Fix JS error in the post scraper

### DIFF
--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -75,7 +75,7 @@ class ClassicEditorData {
 		let newPostSlug = document.getElementById( "new-post-slug" );
 
 		if ( newPostSlug ) {
-			slug = newPostSlug.val();
+			slug = newPostSlug.value;
 		} else if ( document.getElementById( "editable-post-name-full" ) !== null ) {
 			slug = document.getElementById( "editable-post-name-full" ).textContent;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a JS error in the post scraper that occurred when the hidden slug input would be there on page load.

## Props

Thanks @moorscode for spotting the error ! 

## Relevant technical choices:

* Fixes jQuery call to fetch the value to default JS.

## Test instructions

This PR can be tested by following these steps:

* Multiple plugins where reported to trigger this error:
  - [Shortcodes Ultimate 5.0.4](https://wordpress.org/plugins/shortcodes-ultimate/)
  - [Custom Permalinks 1.2.24](https://wordpress.org/plugins/custom-permalinks/)
  - [Permalink Customizer 1.3.9](https://wordpress.org/plugins/permalinks-customizer/)
* Install and activate a plugin from the above list.
* Open the JS console.
* Create a page or post and publish it.
* There should no longer be a JS error.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Multiple issues found for this PR:
- https://github.com/Yoast/wordpress-seo/issues/9957
- https://github.com/Yoast/wordpress-seo/issues/9964
- Possibly: https://github.com/Yoast/wordpress-seo/issues/9965
- https://github.com/Yoast/wordpress-seo/issues/9966
- https://github.com/Yoast/wordpress-seo/issues/9967
- https://github.com/Yoast/wordpress-seo/issues/9968

Fixes #9968 
