### PR TITLE
Wraps generic styles in the class wpseo_content_wrapper

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -42,36 +42,40 @@ tr.yst_row.even {
 	margin: 10px 10px 0 0;
 }
 
-/* Forms. */
-label.textinput,
-label.select {
-	float: left;
-	width: 200px;
-	margin: 5px 0;
-}
+.wpseo_content_wrapper {
 
-.yoast-inline-label {
-	float: none;
-	margin: 0;
-}
+	/* Forms. */
+	label.textinput,
+	label.select {
+		float:  left;
+		width:  200px;
+		margin: 5px 0;
+	}
 
-input.textinput,
-textarea,
-select {
-	width: 400px;
-}
+	.yoast-inline-label {
+		float:  none;
+		margin: 0;
+	}
 
-input.textinput,
-textarea.textinput,
-select.select {
-	margin: 0 0 15px 0;
-}
+	input.textinput,
+	textarea,
+	select {
+		width: 400px;
+	}
 
-/* @todo: check if the .double class is still used. */
-input.radio,
-input.checkbox,
-input.checkbox.double {
-	margin: 6px 10px 6px 0;
+	input.textinput,
+	textarea.textinput,
+	select.select {
+		margin: 0 0 15px 0;
+	}
+
+	/* @todo: check if the .double class is still used. */
+	input.radio,
+	input.checkbox,
+	input.checkbox.double {
+		margin: 6px 10px 6px 0;
+	}
+
 }
 
 /* @todo: check this. */

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -20,12 +20,6 @@
 	width: 100%;
 }
 
-#sidebar-container {
-	/* For historical reasons banner images have a 261px width. */
-	width: 261px;
-	padding: 0 0 0 19px;
-}
-
 /* @todo: check this. */
 tr.yst_row {
 	margin: 5px 0 0 0;
@@ -37,8 +31,13 @@ tr.yst_row.even {
 	background-color: #f6f6f6;
 }
 
-
 .wpseo_content_wrapper {
+	#sidebar-container {
+		/* For historical reasons banner images have a 261px width. */
+		width: 261px;
+		padding: 0 0 0 19px;
+	}
+
 	/* Forms. */
 	label.textinput,
 	label.select {

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -380,25 +380,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	box-shadow: none;
 }
 
-/* @todo: remove this, see #6380. */
-.nav-tab .dashicons {
-	width: 18px;
-	height: 18px;
-	font-size: 18px;
-	line-height: 24px;
-}
-
-/* @todo: remove this, see #6380. */
-.nav-tab .pinteresticon {
-	width: 12px;
-	height: 24px;
-	margin-right: 2px;
-	background-image: url(../../images/pinterest-23x30.png);
-	background-repeat: no-repeat;
-	background-position: center center;
-	background-size: contain;
-}
-
 /* Recalculate score progress bar. Note: currently not used. */
 #wpseo_progressbar {
 	height: 25px;

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -43,7 +43,6 @@ tr.yst_row.even {
 }
 
 .wpseo_content_wrapper {
-
 	/* Forms. */
 	label.textinput,
 	label.select {
@@ -76,28 +75,125 @@ tr.yst_row.even {
 		margin: 6px 10px 6px 0;
 	}
 
-}
+	/* @todo: check this. */
+	.textinput.metadesc {
+		height: 50px;
+	}
 
-/* @todo: check this. */
-.textinput.metadesc {
-	height: 50px;
-}
+	/* @todo: check this. Couldn't find any textarea with class 'import'. */
+	textarea.import {
+		width: 500px;
+		height: 100px;
+	}
 
-/* @todo: check this. Couldn't find any textarea with class 'import'. */
-textarea.import {
-	width: 500px;
-	height: 100px;
-}
+	p.desc {
+		margin: 6px 0 10px 0;
+		padding: 0 0 8px 25px;
+	}
 
-p.desc {
-	margin: 6px 0 10px 0;
-	padding: 0 0 8px 25px;
-}
+	p.desc.label,
+	div.desc.label {
+		margin: 0 0 20px;
+		padding: 0 0 10px 200px;
+	}
 
-p.desc.label,
-div.desc.label {
-	margin: 0 0 20px;
-	padding: 0 0 10px 200px;
+	h4 {
+		clear: both;
+		margin: 1.2em 0 0.5em 0;
+	}
+
+	/* @todo: check this. */
+	.postbox form {
+		line-height: 150%;
+	}
+
+	/* @todo: check this. */
+	.text {
+		width: 250px;
+	}
+
+	/* @todo: check this. */
+	.correct {
+		padding: 5px;
+		color: white;
+		background-color: green;
+	}
+
+	/* @todo: check this. */
+	.wrong {
+		padding: 5px;
+		color: white;
+		background-color: #dc3232;
+	}
+
+	/* @todo: check this. */
+	.wrong code {
+		padding: 3px 8px;
+		color: #000;
+	}
+
+	/* @todo: check this. */
+	.button.fixit {
+		float: right;
+		margin: 0 5px;
+	}
+
+	/* @todo: check this. */
+	.button.checkit {
+		float: right;
+		margin: 0 5px;
+		padding: 5px 8px;
+	}
+
+	/* Search Appearance: title separator. */
+	#separator {
+		margin: 1.5em 0 0.5em;
+	}
+
+	#separator input.radio {
+		/* visually hide the radio buttons but keep them accessible */
+		position: absolute;
+		left: -9999em;
+		width: 1px;
+		height: 1px;
+	}
+
+	#separator input.radio + label {
+		float: left;
+		width: 30px !important;
+		margin: 0 5px 0.5em 0 !important;
+		padding: 9px 6px;
+		border: 1px solid #ccc;
+		/* Don't change: these mimic Google's font and font size for titles */
+		font-family: Arial, Helvetica, sans-serif !important;
+		font-size: 18px !important;
+		line-height: 24px;
+		text-align: center;
+		cursor: pointer;
+	}
+
+	#separator input.radio:checked + label {
+		border: 1px solid #a4286a;
+		background-color: #fff;
+		box-shadow: inset 0 0 0 2px #a4286a;
+	}
+
+	#separator input.radio:focus + label {
+		border-radius: 10px;
+		border-bottom-right-radius: 0;
+	}
+
+	/* @todo: check this. */
+	.svg-container {
+		text-align: center;
+	}
+
+	/* @todo: check this. */
+	.svg-container .dashicons {
+		width: 200px;
+		height: 100px;
+		font-size: 100px;
+	}
 }
 
 /* Google Search Console: Reload crawl issues form. */
@@ -114,11 +210,6 @@ div.desc.label {
 .wpseo_content_wrapper h3 {
 	font-size: 1.15em;
 	margin: 1em 0 0.5em 0;
-}
-
-h4 {
-	clear: both;
-	margin: 1.2em 0 0.5em 0;
 }
 
 .wpseo_content_wrapper p,
@@ -169,16 +260,6 @@ table.wpseo th {
 	font-size: 1.3em;
 }
 
-/* @todo: check this. */
-.postbox form {
-	line-height: 150%;
-}
-
-/* @todo: check this. */
-.text {
-	width: 250px;
-}
-
 /* Template variables table. */
 table.yoast_help {
 	border-collapse: collapse;
@@ -225,26 +306,6 @@ table.yoast_help .yoast-variable-desc {
 	min-width: 300px;
 }
 
-/* @todo: check this. */
-.correct {
-	padding: 5px;
-	color: white;
-	background-color: green;
-}
-
-/* @todo: check this. */
-.wrong {
-	padding: 5px;
-	color: white;
-	background-color: #dc3232;
-}
-
-/* @todo: check this. */
-.wrong code {
-	padding: 3px 8px;
-	color: #000;
-}
-
 .yoast-notice-blocking-files code {
 	line-height: 2;
 	color: #000;
@@ -256,19 +317,6 @@ table.yoast_help .yoast-variable-desc {
 
 .wpseo_content_wrapper .yoast-blocking-files-error p {
 	max-width: none;
-}
-
-/* @todo: check this. */
-.button.fixit {
-	float: right;
-	margin: 0 5px;
-}
-
-/* @todo: check this. */
-.button.checkit {
-	float: right;
-	margin: 0 5px;
-	padding: 5px 8px;
 }
 
 /* Tabs. */
@@ -323,56 +371,6 @@ input.wpseo-new-title,
 textarea.wpseo-new-metadesc {
 	width: 100%;
 	max-width: 100%;
-}
-
-/* Search Appearance: title separator. */
-#separator {
-	margin: 1.5em 0 0.5em;
-}
-
-#separator input.radio {
-	/* visually hide the radio buttons but keep them accessible */
-	position: absolute;
-	left: -9999em;
-	width: 1px;
-	height: 1px;
-}
-
-#separator input.radio + label {
-	float: left;
-	width: 30px !important;
-	margin: 0 5px 0.5em 0 !important;
-	padding: 9px 6px;
-	border: 1px solid #ccc;
-	/* Don't change: these mimic Google's font and font size for titles */
-	font-family: Arial, Helvetica, sans-serif !important;
-	font-size: 18px !important;
-	line-height: 24px;
-	text-align: center;
-	cursor: pointer;
-}
-
-#separator input.radio:checked + label {
-	border: 1px solid #a4286a;
-	background-color: #fff;
-	box-shadow: inset 0 0 0 2px #a4286a;
-}
-
-#separator input.radio:focus + label {
-	border-radius: 10px;
-	border-bottom-right-radius: 0;
-}
-
-/* @todo: check this. */
-.svg-container {
-	text-align: center;
-}
-
-/* @todo: check this. */
-.svg-container .dashicons {
-	width: 200px;
-	height: 100px;
-	font-size: 100px;
 }
 
 /* Yoast SEO credits page. */
@@ -671,32 +669,34 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 
 @media screen and ( max-width: 782px ) {
-	/* Forms. */
-	label.textinput,
-	label.select {
-		display: inline-block;
-		float: none;
-		width: auto;
-	}
+	.wpseo_content_wrapper {
+		/* Forms. */
+		label.textinput,
+		label.select {
+			display: inline-block;
+			float: none;
+			width: auto;
+		}
 
-	input.textinput,
-	textarea,
-	textarea.textinput {
-		display: block;
-		width: 100%;
-	}
+		input.textinput,
+		textarea,
+		textarea.textinput {
+			display: block;
+			width: 100%;
+		}
 
-	select,
-	select.select,
-	.select2-container {
-		display: block;
-		max-width: 100%;
-		margin: 0 0 5px 0;
-	}
+		select,
+		select.select,
+		.select2-container {
+			display: block;
+			max-width: 100%;
+			margin: 0 0 5px 0;
+		}
 
-	p.desc.label,
-	div.desc.label {
-		padding-left: 0;
+		p.desc.label,
+		div.desc.label {
+			padding-left: 0;
+		}
 	}
 
 	.wp-core-ui .button.wpseo-gsc-save-profile {

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -41,13 +41,13 @@ tr.yst_row.even {
 	/* Forms. */
 	label.textinput,
 	label.select {
-		float:  left;
-		width:  200px;
+		float: left;
+		width: 200px;
 		margin: 5px 0;
 	}
 
 	.yoast-inline-label {
-		float:  none;
+		float: none;
 		margin: 0;
 	}
 

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -37,10 +37,6 @@ tr.yst_row.even {
 	background-color: #f6f6f6;
 }
 
-/* @todo: check this. */
-.postbox {
-	margin: 10px 10px 0 0;
-}
 
 .wpseo_content_wrapper {
 	/* Forms. */
@@ -100,6 +96,11 @@ tr.yst_row.even {
 	h4 {
 		clear: both;
 		margin: 1.2em 0 0.5em 0;
+	}
+
+	/* @todo: check this. */
+	.postbox {
+		margin: 10px 10px 0 0;
 	}
 
 	/* @todo: check this. */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where generic css styling has been applied on non Yoast form fields.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Follow the steps in the issue to make sure this pull fixes that issue.
* Make sure nothing has been changed in the styling for the Yoast Settings.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9954
Fixes #9969
Fixes #9955 