### PR TITLE
Remove term_title and category replacement variable defaults

### DIFF
--- a/js/src/values/defaultReplaceVariables.js
+++ b/js/src/values/defaultReplaceVariables.js
@@ -112,16 +112,6 @@ const defaultReplaceVariables = [
 		label: __( "Term description", "wordpress-seo" ),
 		value: "",
 	},
-	{
-		name: "term_title",
-		label: __( "Term title", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "category",
-		label: __( "Category", "wordpress-seo" ),
-		value: "",
-	},
 ];
 
 export default defaultReplaceVariables;


### PR DESCRIPTION
## Remove term_title replacement variable default.
When it had a default, it also (unwantedly) showed up in the list of suggestions where it didn't belong. For example, term_title would show up in the suggestions on a post, and would be replaced by 'undefined'. This is bad UX.

## Remove category replacement variable default.
Category was dynamically added and added through the defaults. This resulted in an errror nabout duplicate IDs.

## Testing
- Go to a post. Type '%t'. `term_title` shouldn't show up in the suggestions.
- Go to a tag. Type '%t'. `term_title` should show up in the suggestions.
- Go to a category. Type '%t'. `term_title` should show up in the suggestions.
- Go to a post. Use %%category%%. No console errors should be thrown about duplicate IDs.