### PR TITLE
Implemented react replace var editor for Custom Content Type Archives

### DIFF
--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -72,8 +72,8 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 			$custom_post_type_archive_help->get_button_html() . $custom_post_type_archive_help->get_panel_html()
 		);
 
-		$yform->textinput( 'title-ptarchive-' . $name, __( 'Title', 'wordpress-seo' ), 'template posttype-template' );
-		$yform->textarea( 'metadesc-ptarchive-' . $name, __( 'Meta description', 'wordpress-seo' ), array( 'class' => 'template posttype-template' ) );
+		$editor = new WPSEO_Replacevar_Editor( $yform, 'title-ptarchive-' . $name, 'metadesc-ptarchive-' . $name );
+		$editor->render();
 		if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
 			$yform->textinput( 'bctitle-ptarchive-' . $name, __( 'Breadcrumbs title', 'wordpress-seo' ) );
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Custom Content Type Archives post type replacement variable editors have been switched to the new react snippet editor.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10001 
