### PR TITLE
Fixes a problem where multiple keywords would only show results for the main keyword.

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -294,7 +294,8 @@ setYoastComponentsI18n();
 		if ( isKeywordAnalysisActive() ) {
 			args.callbacks.saveScores = postDataCollector.saveScores.bind( postDataCollector );
 			args.callbacks.updatedKeywordsResults = function( results ) {
-				let keyword = tabManager.getKeywordTab().getKeyWord();
+				const keyword = $( "#yoast_wpseo_focuskw_text_input" ).val();
+				store.dispatch( setActiveKeyword( keyword ) );
 
 				/*
 				 * The results from the main App callback are always for the first keyword. So

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -295,7 +295,6 @@ setYoastComponentsI18n();
 			args.callbacks.saveScores = postDataCollector.saveScores.bind( postDataCollector );
 			args.callbacks.updatedKeywordsResults = function( results ) {
 				let keyword = tabManager.getKeywordTab().getKeyWord();
-				store.dispatch( setActiveKeyword( keyword ) );
 
 				/*
 				 * The results from the main App callback are always for the first keyword. So


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a problem where multiple keywords would only show results for the main keyword.

## Relevant technical choices:

* Removed the dispatcher for the set_active_keyword action from getAppArgs. 

This was originally added to make sure the assessment results updated when the keyword was updated. It had the unintended side-effect of resetting the active keyword to the first keyword, regardless of keyword tab. 

After removing this dispatch, all seems fixed, even the original issue doesn't seem present, but please test to make sure the SEO results are updated when you change the focus keyword.

## Test instructions

This PR can be tested by following these steps:
- for wpseo-free:
Checkout this branch.
Change the focus keyword a couple of times
Check if the SEO results keep updating with the focus keyword changes.

- for wpseo premium.
Checkout the release branch.
Merge this free branch into the premium branch. https://github.com/Yoast/Wiki/wiki/Merging-Free-into-Premium explains how this is done. set the remote and merge this branch (free/1532-....) DO NOT perform the last step (push to trunk). 
Visit a post with multiple keywords.
Check if the assessments results change per keyword tab.
Check if the title length assessment is consistent ( check if it fixes https://github.com/Yoast/YoastSEO.js/issues/1532)
Looks like it fixes https://github.com/Yoast/wordpress-seo-premium/issues/1782 as well for me. double check please.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/YoastSEO.js/issues/1532 
Fixes https://github.com/Yoast/YoastSEO.js/issues/1333
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1782
