### PR TITLE
Added a password check to the og image output

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -85,7 +85,10 @@ class WPSEO_OpenGraph_Image {
 			$this->add_image_by_url( $image );
 		}
 
-		$this->set_images();
+		if( ! post_password_required() ){
+			$this->set_images();
+		}
+
 	}
 
 	/**

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -85,7 +85,7 @@ class WPSEO_OpenGraph_Image {
 			$this->add_image_by_url( $image );
 		}
 
-		if( ! post_password_required() ){
+		if ( ! post_password_required() ) {
 			$this->set_images();
 		}
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -68,7 +68,7 @@ class WPSEO_Twitter {
 		$this->title();
 		$this->site_twitter();
 
-		if( ! post_password_required() ){
+		if ( ! post_password_required() ) {
 			$this->image();
 		}
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -67,7 +67,11 @@ class WPSEO_Twitter {
 		$this->description();
 		$this->title();
 		$this->site_twitter();
-		$this->image();
+
+		if( ! post_password_required() ){
+			$this->image();
+		}
+
 		if ( is_singular() ) {
 			$this->author();
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where images from password protected posts could end up in OG image tags. 

## Test instructions

This PR can be tested by following these steps:

* Create a post and insert a couple of images.
* Password protect the post.
* View the source code of the post and verify that, while the post is password protected, there are OG links to some images. You can recognise these by their `meta property="og:image"` and `meta name="twitter:image"` tags. 
* Switch to this branch and reload the page: The tags should be gone, there should be no links to images in the pw protected post anymore.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9988 
