### PR TITLE
Only add Go Premium video description if user is using Free

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -106,18 +106,24 @@ class WPSEO_Help_Center {
 
 		$formatted_data['videoDescriptions'] = array(
 			array(
-				'title'       => __( 'Need some help?', 'wordpress-seo' ),
-				'description' => __( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ),
-				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/seo-premium-vt' ),
-				'linkText'    => __( 'Get Yoast SEO Premium now »', 'wordpress-seo' ),
-			),
-			array(
 				'title'       => __( 'Want to be a Yoast SEO Expert?', 'wordpress-seo' ),
 				'description' => __( 'Follow our Yoast SEO for WordPress training and become a certified Yoast SEO Expert!', 'wordpress-seo' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/wordpress-training-vt' ),
 				'linkText'    => __( 'Enroll in the Yoast SEO for WordPress training »', 'wordpress-seo' ),
 			),
 		);
+
+		if ( $is_premium === false ) {
+			array_unshift(
+				$formatted_data['videoDescriptions'],
+				array(
+					'title'       => __( 'Need some help?', 'wordpress-seo' ),
+					'description' => __( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ),
+					'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/seo-premium-vt' ),
+					'linkText'    => __( 'Get Yoast SEO Premium now »', 'wordpress-seo' ),
+				)
+			);
+		}
 
 		$formatted_data['contactSupportParagraphs'] = array(
 			array(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a check to only display the Get Premium message next to video tutorials if the user is not running Yoast SEO Premium.

## Relevant technical choices:

* As the logic for these video descriptions is implemented in the Free version, I decided to add the logic here. Please note that this will also have to be tested in Premium via a separate branch (see test instructions).

## Test instructions

This PR can be tested by following these steps:

**Free**

* After checking out this branch, go to SEO -> General
* Click on the 'Need help?' button.
* Notice the following scenario:

<img width="1477" alt="general_-_yoast_seo_ _acceptance_test_ _wordpress" src="https://user-images.githubusercontent.com/4181340/41460420-f034489c-708c-11e8-95e3-ec00acfeecec.png">

**Premium**

* After checking out the `1696-testing-only` branch in Premium, go to SEO -> General
* Click on the 'Need help?' button.
* Notice the following scenario:

<img width="1483" alt="general_-_yoast_seo_ _local_wordpress_dev_ _wordpress" src="https://user-images.githubusercontent.com/4181340/41460612-a0dc851a-708d-11e8-8400-407277dda603.png">

**NOTE: Please delete the `1696-testing-only` branch after successfully testing.**

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1696
