### PR TITLE
Move title fallback from js to PHP

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -153,10 +153,16 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	/**
 	 * Retrieves the title template.
 	 *
-	 * @return string
+	 * @return string The title template.
 	 */
 	private function get_title_template() {
-		return $this->get_template( 'title' );
+		$title = $this->get_template( 'title' );
+
+		if ( $title === '' ) {
+			return '%%title%% %%sep%% %%sitename%%';
+		}
+
+		return $title;
 	}
 
 	/**

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -109,10 +109,16 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	/**
 	 * Retrieves the title template.
 	 *
-	 * @return string
+	 * @return string The title template.
 	 */
 	private function get_title_template() {
-		return $this->get_template( 'title' );
+		$title = $this->get_template( 'title' );
+
+		if ( $title === '' ) {
+			return '%%title%% %%sep%% %%sitename%%';
+		}
+
+		return $title;
 	}
 
 	/**

--- a/js/src/analysis/getTitlePlaceholder.js
+++ b/js/src/analysis/getTitlePlaceholder.js
@@ -13,10 +13,6 @@ function getTitlePlaceholder() {
 		titlePlaceholder = l10nObject.title_template;
 	}
 
-	if ( titlePlaceholder === "" ) {
-		titlePlaceholder = "%%title%% - %%sitename%%";
-	}
-
 	return titlePlaceholder;
 }
 

--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -51,9 +51,6 @@ function getTemplatesFromL10n( l10nObject ) {
 	}
 
 	templates.title = l10nObject.title_template;
-	if ( isEmpty( templates.title ) ) {
-		templates.title = "%%title%% - %%sitename%%";
-	}
 
 	const description = l10nObject.metadesc_template;
 	if ( ! isEmpty( description ) ) {

--- a/tests/formatter/test-post-metabox-formatter.php
+++ b/tests/formatter/test-post-metabox-formatter.php
@@ -59,9 +59,9 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, array(), '' );
 		$result   = $instance->get_values();
 
-		$this->assertEquals( $result['keyword_usage'], array( '' => array() ) );
-		$this->assertEquals( $result['title_template'], '' );
-		$this->assertEquals( $result['metadesc_template'], '' );
+		$this->assertEquals( array( '' => array() ), $result['keyword_usage'] );
+		$this->assertEquals( '%%title%% %%sep%% %%sitename%%', $result['title_template'] );
+		$this->assertEquals( '', $result['metadesc_template'] );
 	}
 
 	/**

--- a/tests/formatter/test-term-metabox-formatter.php
+++ b/tests/formatter/test-term-metabox-formatter.php
@@ -74,10 +74,10 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $result['search_url'], admin_url( 'edit-tags.php?taxonomy=' . $this->term->taxonomy . '&seo_kw_filter={keyword}' ) );
 		$this->assertEquals( $result['post_edit_url'], admin_url( 'edit-tags.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' ) );
 
-		$this->assertEquals( $result['base_url'], trailingslashit( home_url( 'tag' ) ) );
-		$this->assertEquals( $result['keyword_usage'], array( '' => array() ) );
-		$this->assertEquals( $result['title_template'], '' );
-		$this->assertEquals( $result['metadesc_template'], '' );
+		$this->assertEquals( trailingslashit( home_url( 'tag' ) ), $result['base_url'] );
+		$this->assertEquals( array( '' => array() ), $result['keyword_usage'] );
+		$this->assertEquals( '%%title%% %%sep%% %%sitename%%', $result['title_template'] );
+		$this->assertEquals( '', $result['metadesc_template'] );
 	}
 
 	/**
@@ -131,8 +131,8 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		$instance = new WPSEO_Term_Metabox_Formatter( $this->taxonomy, $this->term );
 		$result   = $instance->get_values();
 
-		$this->assertEquals( $result['title_template'], '' );
-		$this->assertEquals( $result['metadesc_template'], 'This is a meta description' );
+		$this->assertEquals( '%%title%% %%sep%% %%sitename%%', $result['title_template'] );
+		$this->assertEquals( 'This is a meta description', $result['metadesc_template'] );
 	}
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Stops `-` being hardcoded in the title template for the snippeteditor.

## Test instructions

This PR can be tested by following these steps:

* Change the separator on Search Appearance
* Removes the template for a post
* Adds a new post and see the right template is used.
* Do the same for the term.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9912
