### PR TITLE
Added notification when attachment url redirects are set to no

### DIFF
--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -39,7 +39,7 @@ $yform->toggle_switch(
 
 if ( $yform->options['disable-attachment'] === 'off' ) {
 	?>
-	<div class="notice error is-dismissible" >
+	<div class="notice notice-warning is-dismissible" >
 		<p><?php _e( 'Your website is configured to show \'attachment\' pages for the images and media you\'ve uploaded. In most cases, this can be harmful to your SEO. We generally recommend hiding these pages by enabling the "Redirect attachment URLs to the attachment itself" option in our \'Media\' settings tab.', 'wordpress-seo' ); ?></p>
 	</div>
 	<?php

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -37,21 +37,12 @@ $yform->toggle_switch(
 	__( 'Redirect attachment URLs to the attachment itself?', 'wordpress-seo' )
 );
 
-/**
- * Contains the output for the warning shown when attachment redirects are turned off.
- *
- * @return void
- */
-function show_attachment_warning() {
+if ( $yform->options['disable-attachment'] === 'off' ) {
 	?>
 	<div class="notice error is-dismissible" >
 		<p><?php _e( 'Your website is configured to show \'attachment\' pages for the images and media you\'ve uploaded. In most cases, this can be harmful to your SEO. We generally recommend hiding these pages by enabling the "Redirect attachment URLs to the attachment itself" option in our \'Media\' settings tab.', 'wordpress-seo' ); ?></p>
 	</div>
 	<?php
-}
-
-if ( $yform->options['disable-attachment'] === 'off' ) {
-	show_attachment_warning();
 }
 
 ?>

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -39,16 +39,18 @@ $yform->toggle_switch(
 
 /**
  * Contains the output for the warning shown when attachment redirects are turned off.
+ *
+ * @return void
  */
-function show_attachment_warning(){
+function show_attachment_warning() {
 	?>
-    <div class="notice error is-dismissible" >
-        <p><?php _e( 'Your website is configured to show \'attachment\' pages for the images and media you\'ve uploaded. In most cases, this can be harmful to your SEO. We generally recommend hiding these pages by enabling the "Redirect attachment URLs to the attachment itself" option in our \'Media\' settings tab.', 'wordpress-seo' ); ?></p>
-    </div>
+	<div class="notice error is-dismissible" >
+		<p><?php _e( 'Your website is configured to show \'attachment\' pages for the images and media you\'ve uploaded. In most cases, this can be harmful to your SEO. We generally recommend hiding these pages by enabling the "Redirect attachment URLs to the attachment itself" option in our \'Media\' settings tab.', 'wordpress-seo' ); ?></p>
+	</div>
 	<?php
 }
 
-if ($yform->options['disable-attachment'] === 'off'){
+if ( $yform->options['disable-attachment'] === 'off' ) {
 	show_attachment_warning();
 }
 

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -25,6 +25,7 @@ $media_help = new WPSEO_Admin_Help_Panel(
 	<h2 class="help-button-inline"><?php echo esc_html__( 'Media & attachment URLs', 'wordpress-seo' ) . $media_help->get_button_html(); ?></h2>
 	<?php echo $media_help->get_panel_html(); ?>
 	<p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
+
 <?php
 
 $yform->toggle_switch(
@@ -35,6 +36,21 @@ $yform->toggle_switch(
 	),
 	__( 'Redirect attachment URLs to the attachment itself?', 'wordpress-seo' )
 );
+
+/**
+ * Contains the output for the warning shown when attachment redirects are turned off.
+ */
+function show_attachment_warning(){
+	?>
+    <div class="notice error is-dismissible" >
+        <p><?php _e( 'Your website is configured to show \'attachment\' pages for the images and media you\'ve uploaded. In most cases, this can be harmful to your SEO. We generally recommend hiding these pages by enabling the "Redirect attachment URLs to the attachment itself" option in our \'Media\' settings tab.', 'wordpress-seo' ); ?></p>
+    </div>
+	<?php
+}
+
+if ($yform->options['disable-attachment'] === 'off'){
+	show_attachment_warning();
+}
 
 ?>
 	<div id="media_settings">


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added a warning notification for users who have Attachment pages enabled. 

## Relevant technical choices:

* Used a WordPress default message instead of the notification center.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch. Go to SEO->Search Appearance->Media.
* Set "Redirect attachment URLs to the attachment itself?" to "No". Save the settings. 
* A warning saying "'Your website is configured to show..." should show at the top of the page. This message should be dismissable.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9793 
