### PR TITLE
Use cached analysis results

### DIFF
--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 
 import mapResults from "./mapResults";
 import ContentAnalysis from "yoast-components/composites/Plugin/ContentAnalysis/components/ContentAnalysis";
-import Loader from "yoast-components/composites/basic/Loader";
 
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.
@@ -64,7 +63,7 @@ class Results extends React.Component {
 	 * @returns {ReactElement} The react element.
 	 */
 	render() {
-		const { analysisIsLoading, mappedResults } = this.state;
+		const { mappedResults } = this.state;
 		const {
 			errorsResults,
 			improvementsResults,

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -12,7 +12,6 @@ class Results extends React.Component {
 		super( props );
 
 		this.state = {
-			analysisIsLoading: false,
 			mappedResults: mapResults( this.props.results ),
 		};
 	}

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -3,11 +3,34 @@ import PropTypes from "prop-types";
 
 import mapResults from "./mapResults";
 import ContentAnalysis from "yoast-components/composites/Plugin/ContentAnalysis/components/ContentAnalysis";
+import Loader from "yoast-components/composites/basic/Loader";
 
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.
  */
 class Results extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			analysisIsLoading: false,
+			mappedResults: mapResults( this.props.results ),
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		/*
+		 * Check if there are new results.
+		 * When the new results are null, we presume we are loading the analysis.
+		 * Only update the mappedResults when we have new and non-null results.
+		 */
+		if ( nextProps.results !== null && nextProps.results !== this.props.results ) {
+			this.setState( {
+				mappedResults: mapResults( nextProps.results ),
+			} );
+		}
+	}
+
 	/**
 	 * Handles a click on a marker button, to mark the text in the editor.
 	 *
@@ -41,7 +64,7 @@ class Results extends React.Component {
 	 * @returns {ReactElement} The react element.
 	 */
 	render() {
-		const mappedResults = mapResults( this.props.results );
+		const { analysisIsLoading, mappedResults } = this.state;
 		const {
 			errorsResults,
 			improvementsResults,
@@ -49,21 +72,23 @@ class Results extends React.Component {
 			considerationsResults,
 			problemsResults,
 		} = mappedResults;
-		return(
-			<ContentAnalysis
-				errorsResults={ errorsResults }
-				problemsResults={ problemsResults }
-				improvementsResults={ improvementsResults }
-				considerationsResults={ considerationsResults }
-				goodResults={ goodResults }
-				changeLanguageLink={ this.props.changeLanguageLink }
-				language={ this.props.language }
-				showLanguageNotice={ this.props.showLanguageNotice }
-				canChangeLanguage={ this.props.canChangeLanguage }
-				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
-				marksButtonClassName={ this.props.marksButtonClassName }
-				marksButtonStatus={ this.props.marksButtonStatus }
-			/>
+		return (
+			<React.Fragment>
+				<ContentAnalysis
+					errorsResults={ errorsResults }
+					problemsResults={ problemsResults }
+					improvementsResults={ improvementsResults }
+					considerationsResults={ considerationsResults }
+					goodResults={ goodResults }
+					changeLanguageLink={ this.props.changeLanguageLink }
+					language={ this.props.language }
+					showLanguageNotice={ this.props.showLanguageNotice }
+					canChangeLanguage={ this.props.canChangeLanguage }
+					onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
+					marksButtonClassName={ this.props.marksButtonClassName }
+					marksButtonStatus={ this.props.marksButtonStatus }
+				/>
+			</React.Fragment>
 		);
 	}
 }

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -72,22 +72,20 @@ class Results extends React.Component {
 			problemsResults,
 		} = mappedResults;
 		return (
-			<React.Fragment>
-				<ContentAnalysis
-					errorsResults={ errorsResults }
-					problemsResults={ problemsResults }
-					improvementsResults={ improvementsResults }
-					considerationsResults={ considerationsResults }
-					goodResults={ goodResults }
-					changeLanguageLink={ this.props.changeLanguageLink }
-					language={ this.props.language }
-					showLanguageNotice={ this.props.showLanguageNotice }
-					canChangeLanguage={ this.props.canChangeLanguage }
-					onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
-					marksButtonClassName={ this.props.marksButtonClassName }
-					marksButtonStatus={ this.props.marksButtonStatus }
-				/>
-			</React.Fragment>
+			<ContentAnalysis
+				errorsResults={ errorsResults }
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				considerationsResults={ considerationsResults }
+				goodResults={ goodResults }
+				changeLanguageLink={ this.props.changeLanguageLink }
+				language={ this.props.language }
+				showLanguageNotice={ this.props.showLanguageNotice }
+				canChangeLanguage={ this.props.canChangeLanguage }
+				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
+				marksButtonClassName={ this.props.marksButtonClassName }
+				marksButtonStatus={ this.props.marksButtonStatus }
+			/>
 		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where the analysis results where being hidden while updating.

## Relevant technical choices:

* Use cached analysis results when the new results are equal to `null`.

## Test instructions

This PR can be tested by following these steps:

Check the following steps in both free and premium:

1. Go to Post
2. Scroll to Focus keyword
3. Enter "test"
4. Check that Analysis is updated (Problems with something like "The focus keyword 'test' does not appear in the SEO title.")
5. Change Focus keyword to "testtest"
6. Observe the delay in updating the Analysis

To make it possible to test in premium:

1. Ensure you are in the latest `release/7.7` branch of premium: `git checkout release/7.7 && git pull`.
2. Add free as a remote: `git remote add free https://github.com/Yoast/wordpress-seo.git`.
3. Pull the changes from free: `git fetch --all`.
4. Pull this branch from free: `git pull free stories/use-cached-analysis-results`.
5. Normal build steps.
* To revert premium back after testing: `git reset --hard origin/release/7.7`.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1774
