### PR TITLE
Removed filter that runs do_shortcode on category descriptions in admin

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -56,7 +56,7 @@ class WPSEO_Taxonomy {
 		}
 
 		$this->insert_description_field_editor();
-		
+
 		add_action( sanitize_text_field( $this->taxonomy ) . '_edit_form', array( $this, 'term_metabox' ), 90, 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 	}
@@ -197,11 +197,15 @@ class WPSEO_Taxonomy {
 	/**
 	 * Adds shortcode support to category descriptions.
 	 *
+	 * @deprecated 7.6.0
+	 *
 	 * @param string $desc String to add shortcodes in.
 	 *
 	 * @return string
 	 */
 	public function custom_category_descriptions_add_shortcode_support( $desc ) {
+		_deprecated_function( __FUNCTION__, 'WPSEO 7.8.0' );
+
 		// Wrap in output buffering to prevent shortcodes that echo stuff instead of return from breaking things.
 		ob_start();
 		$desc = do_shortcode( $desc );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -56,9 +56,7 @@ class WPSEO_Taxonomy {
 		}
 
 		$this->insert_description_field_editor();
-
-		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
-
+		
 		add_action( sanitize_text_field( $this->taxonomy ) . '_edit_form', array( $this, 'term_metabox' ), 90, 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 	}
@@ -208,7 +206,6 @@ class WPSEO_Taxonomy {
 		ob_start();
 		$desc = do_shortcode( $desc );
 		ob_end_clean();
-
 		return $desc;
 	}
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -197,7 +197,7 @@ class WPSEO_Taxonomy {
 	/**
 	 * Adds shortcode support to category descriptions.
 	 *
-	 * @deprecated 7.6.0
+	 * @deprecated 7.8.0
 	 *
 	 * @param string $desc String to add shortcodes in.
 	 *

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -91,6 +91,9 @@ class WPSEO_Frontend {
 		add_filter( 'loginout', array( $this, 'nofollow_link' ) );
 		add_filter( 'register', array( $this, 'nofollow_link' ) );
 
+		// Add support for shortcodes to category descriptions.
+		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
+
 		// Fix the WooThemes woo_title() output.
 		add_filter( 'woo_title', array( $this, 'fix_woo_title' ), 99 );
 
@@ -1790,6 +1793,21 @@ class WPSEO_Frontend {
 		$replacer = new WPSEO_Replace_Vars();
 
 		return $replacer->replace( $string, $args, $omit );
+	}
+
+	/**
+	 * Adds shortcode support to category descriptions.
+	 *
+	 * @param string $desc String to add shortcodes in.
+	 *
+	 * @return string
+	 */
+	public function custom_category_descriptions_add_shortcode_support( $desc ) {
+		// Wrap in output buffering to prevent shortcodes that echo stuff instead of return from breaking things.
+		ob_start();
+		$desc = do_shortcode( $desc );
+		ob_end_clean();
+		return $desc;
 	}
 
 	/** Deprecated functions */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes UI issue that happend when do_shortcode was run on category descriptions in the admin list. Additionally, fixed rendering of shortcodes in category descriptions on the frontend. 

## Relevant technical choices:

* Moved both the method and the filter calling `custom_category_descriptions_add_shortcode_support` from from the admin to the frontend, so it's called in the right place. 
* Deprecated `custom_category_descriptions_add_shortcode_support` in `class-taxonomy.php` instead of removing it since it is public. 

## Test instructions

This PR can be tested by following these steps:

* Go to Posts->Categories, see the category descriptions on the right side. 
* Add a category with shortcodes in the description, for example a [gallery], and note how this results in images in the description fields.
* Make sure you assign this category to at least one post. 
* Click "View" under your category with shortcodes and see the shortcodes shown as plain text on the front page. 
* Check out this branch and see the the images/videos disappear and the shortcodes are shown as plain text in the admin. When you visit the category page on the front end the shortcodes are rendered instead of shown as plain text. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #8262 
