### PR TITLE
Don't separately replace term_title before redux replacevars are used

### DIFF
--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -81,7 +81,7 @@ import {
 		} ) );
 
 		this.addReplacement( new ReplaceVar( "%%term_title%%", "term_title", {
-			scope: [ "post", "term" ],
+			scope: [ "term" ],
 		} ) );
 
 		this.addReplacement( new ReplaceVar( "%%title%%", "title", {
@@ -169,8 +169,6 @@ import {
 	 */
 	YoastReplaceVarPlugin.prototype.replaceVariables = function( data ) {
 		if ( ! isUndefined( data ) ) {
-			data = this.termtitleReplace( data );
-
 			// This order currently needs to be maintained until we can figure out a nicer way to replace this.
 			data = this.parentReplace( data );
 			data = this.replaceCustomTaxonomy( data );
@@ -499,20 +497,6 @@ import {
 	/*
 	 * SPECIALIZED REPLACES
 	 */
-
-	/**
-	 * Replaces %%term_title%% with the title of the term.
-	 *
-	 * @param {string} data The data that needs its placeholders replaced.
-	 * @returns {string} The data with all its placeholders replaced by actual values.
-	 */
-	YoastReplaceVarPlugin.prototype.termtitleReplace = function( data ) {
-		var termTitle = this._app.rawData.name;
-
-		data = data.replace( /%%term_title%%/g, termTitle );
-
-		return data;
-	};
 
 	/**
 	 * Replaces %%parent_title%% with the selected value from selectbox (if available on pages only).


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the term title snippet variable would be replaced by 'undefined' instead of an empty string on posts and pages.

## Relevant technical choices:

* Before, term_title would be separately replaced by the termtitleReplace function before all other replacevars would be replaced via redux or the replacevar plugin. It was being replaced by `this._app.rawData.name`, which is undefined for posts and pages. I've removed the termtitleReplace function, because %%term_title%% can be replaced in the same way as all/most other replacevars.

## Test instructions

This PR can be tested by following these steps:

* Test the %%term_title%% replacevar on posts, custom posttypes, and pages. It should be replaced by an empty string. NB: term_title is not in the suggestions, so you should type %%term_title%% yourself.
* Test the %%term_title%% replacevar on categories, tags, and custom taxonomies. It should be replaced by the term title.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/10052
