### PR TITLE
Deprecate userid in snippet editors

### DIFF
--- a/js/src/values/defaultReplaceVariables.js
+++ b/js/src/values/defaultReplaceVariables.js
@@ -87,11 +87,6 @@ const defaultReplaceVariables = [
 		label: __( "Term description", "wordpress-seo" ),
 		value: "",
 	},
-	{
-		name: "userid",
-		label: __( "User ID", "wordpress-seo" ),
-		value: "",
-	},
 ];
 
 export default defaultReplaceVariables;

--- a/js/src/values/defaultReplaceVariables.js
+++ b/js/src/values/defaultReplaceVariables.js
@@ -87,6 +87,11 @@ const defaultReplaceVariables = [
 		label: __( "Term description", "wordpress-seo" ),
 		value: "",
 	},
+	{
+		name: "userid",
+		label: __( "User ID", "wordpress-seo" ),
+		value: "",
+	},
 ];
 
 export default defaultReplaceVariables;

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -62,6 +62,7 @@ import {
 		this.addReplacement( new ReplaceVar( "%%currenttime%%",     "currenttime" ) );
 		this.addReplacement( new ReplaceVar( "%%currentyear%%",     "currentyear" ) );
 		this.addReplacement( new ReplaceVar( "%%date%%",            "date" ) );
+		this.addReplacement( new ReplaceVar( "%%userid%%",          "userid" ) );
 		this.addReplacement( new ReplaceVar( "%%id%%",              "id" ) );
 		this.addReplacement( new ReplaceVar( "%%page%%",            "page" ) );
 		this.addReplacement( new ReplaceVar( "%%searchphrase%%",    "searchphrase" ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A (fix for new thing in 7.7 changelog)

## Relevant technical choices:

* Adds the userid as replacevar in JS.

## Test instructions

This PR can be tested by following these steps:

* Add %%userid%% in posts, pages, custom stuff.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10038
