### PR TITLE
Added notifications that trigger when a post is trashed or deleted

### DIFF
--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -34,61 +34,6 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Shows an message when a post is about to get trashed.
-	 *
-	 * @param integer $post_id The current post ID.
-	 *
-	 * @return void
-	 */
-	public function detect_post_trash( $post_id ) {
-		$post_type_label = $this->get_post_type_label( get_post_type( $post_id ) );
-
-		$message = sprintf(
-			/* translators: %1$s expands to the translated name of the post type, %2$s expands to the anchor opening tag, %3$s to the anchor closing tag. */
-			__(
-				'You just trashed this %1$s. To ensure your visitors do not see a 404 on the old URL, you should create a redirect. %2$sLearn how to create redirects here.%3$s',
-				'wordpress-seo'
-			),
-			$post_type_label,
-			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">',
-			'</a>'
-		);
-
-		$this->add_notification( $message );
-	}
-
-	/**
-	 * Shows an message when a post is about to get trashed.
-	 *
-	 * @param integer $post_id The current post ID.
-	 *
-	 * @return void
-	 */
-	public function detect_post_delete( $post_id ) {
-		// We don't want to redirect menu items.
-		if ( is_nav_menu_item( $post_id ) ) {
-			return;
-		}
-		// When the post comes from the trash or if the post is a revision then skip further execution.
-		if ( get_post_status( $post_id ) === 'trash' || wp_is_post_revision( $post_id ) ) {
-			return;
-		}
-
-		$message = sprintf(
-			/* translators: %1$s expands to the translated name of the post type, %2$s expands to the anchor opening tag, %3$s to the anchor closing tag. */
-			__(
-				'You just DELETED this %1$s. To ensure your visitors do not see a 404 on the old URL, you should create a redirect. %2$sLearn how to create redirects here.%3$s',
-				'wordpress-seo'
-			),
-			$this->get_post_type_label( get_post_type( $post_id ) ),
-			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">',
-			'</a>'
-		);
-
-		$this->add_notification( $message );
-	}
-
-	/**
 	 * Enqueues the quick edit handler.
 	 *
 	 * @return void
@@ -136,6 +81,61 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 				'wordpress-seo'
 			),
 			$this->get_post_type_label( $post->post_type ),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">',
+			'</a>'
+		);
+
+		$this->add_notification( $message );
+	}
+
+	/**
+	 * Shows an message when a post is about to get trashed.
+	 *
+	 * @param integer $post_id The current post ID.
+	 *
+	 * @return void
+	 */
+	public function detect_post_trash( $post_id ) {
+		$post_type_label = $this->get_post_type_label( get_post_type( $post_id ) );
+
+		$message = sprintf(
+		/* translators: %1$s expands to the translated name of the post type, %2$s expands to the anchor opening tag, %3$s to the anchor closing tag. */
+			__(
+				'You just trashed this %1$s. To ensure your visitors do not see a 404 on the old URL, you should create a redirect. %2$sLearn how to create redirects here.%3$s',
+				'wordpress-seo'
+			),
+			$post_type_label,
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">',
+			'</a>'
+		);
+
+		$this->add_notification( $message );
+	}
+
+	/**
+	 * Shows an message when a post is about to get trashed.
+	 *
+	 * @param integer $post_id The current post ID.
+	 *
+	 * @return void
+	 */
+	public function detect_post_delete( $post_id ) {
+		// We don't want to redirect menu items.
+		if ( is_nav_menu_item( $post_id ) ) {
+			return;
+		}
+		// When the post comes from the trash or if the post is a revision then skip further execution.
+		if ( get_post_status( $post_id ) === 'trash' || wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		$message = sprintf(
+		/* translators: %1$s expands to the translated name of the post type, %2$s expands to the anchor opening tag, %3$s to the anchor closing tag. */
+			__(
+				'You just deleted this %1$s. To ensure your visitors do not see a 404 on the old URL, you should create a redirect. %2$sLearn how to create redirects here.%3$s',
+				'wordpress-seo'
+			),
+			$this->get_post_type_label( get_post_type( $post_id ) ),
 			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">',
 			'</a>'
 		);

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -96,6 +96,12 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function detect_post_trash( $post_id ) {
+
+		$post_status = get_post_status( $post_id );
+		if ( ! $this->check_visible_post_status( $post_status ) ) {
+			return;
+		}
+
 		$post_type_label = $this->get_post_type_label( get_post_type( $post_id ) );
 
 		$message = sprintf(
@@ -124,8 +130,15 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		if ( is_nav_menu_item( $post_id ) ) {
 			return;
 		}
+
+		$post_status = get_post_status( $post_id );
+
 		// When the post comes from the trash or if the post is a revision then skip further execution.
-		if ( get_post_status( $post_id ) === 'trash' || wp_is_post_revision( $post_id ) ) {
+		if ( $post_status === 'trash' || wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		if ( ! $this->check_visible_post_status( $post_status ) ) {
 			return;
 		}
 

--- a/tests/admin/watchers/test-class-slug-change-watcher.php
+++ b/tests/admin/watchers/test-class-slug-change-watcher.php
@@ -187,6 +187,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 		wp_trash_post( $post->ID );
 	}
 
+	// Happy path: expects notification to be triggered when post is deleted.
 	public function test_detect_post_delete() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
@@ -210,4 +211,104 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 		wp_delete_post( $post->ID );
 	}
 
+	// Tests if we correctly don't show the notification when we delete a menu item.
+	public function test_detect_post_delete_menu_item() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+					'post_type' => 'nav_menu_item',
+				)
+			);
+
+		wp_delete_post( $post->ID );
+	}
+
+	// Tests if we correctly don't show the notification when a post is trashed.
+	public function test_detect_post_delete_trashed_post() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+					'post_status' => 'trash',
+				)
+			);
+
+		wp_delete_post( $post->ID );
+	}
+
+	// Tests if we correctly don't show the notification when a post is a revision.
+	public function test_detect_post_delete_revision() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+				)
+			);
+
+		$revision_id         = wp_save_post_revision( $post->ID );
+
+		wp_delete_post( $revision_id );
+	}
+
+	// Tests if we correctly don't show the notification when a post is not visible.
+	public function test_detect_post_delete_when_not_visible() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name'     => 'new_post',
+					'post_status'   => 'pending',
+				)
+			);
+
+		wp_delete_post( $post->ID );
+	}
 }

--- a/tests/admin/watchers/test-class-slug-change-watcher.php
+++ b/tests/admin/watchers/test-class-slug-change-watcher.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin\Watchers
+ */
+
+/**
+ * Unit Test Class.
+ *
+ * @group test
+ */
+class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
+
+	public function test_detect_slug_change() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+				)
+			);
+
+		$post->post_name = 'altered_post';
+
+		wp_update_post( $post );
+	}
+
+	public function test_detect_slug_change_for_revision() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+				)
+			);
+
+		$revision_id         = wp_save_post_revision( $post->ID );
+		$revision            = get_post( $revision_id );
+		$revision->post_name = 'revision';
+
+		$instance->register_hooks();
+
+		wp_update_post( $revision );
+	}
+
+	public function test_detect_slug_change_no_slug_change() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+				)
+			);
+
+		wp_update_post( $post );
+	}
+
+	public function test_detect_slug_change_no_visible_post_status() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name'   => 'new_post',
+					'post_status' => 'draft',
+				)
+			);
+
+		$post->post_name = 'altered_post';
+
+		wp_update_post( $post );
+	}
+
+	public function test_detect_slug_change_public_becomes_draft() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name'   => 'new_post',
+					'post_status' => 'public',
+				)
+			);
+
+		$post->post_status = 'draft';
+		$post->post_name   = 'altered_post';
+
+		wp_update_post( $post );
+	}
+
+	public function test_detect_post_trash() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+				)
+			);
+
+		wp_trash_post( $post->ID );
+	}
+
+	public function test_detect_post_trash_no_visible_post_status() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name'   => 'new_post',
+					'post_status' => 'draft',
+				)
+			);
+
+		wp_trash_post( $post->ID );
+	}
+
+	public function test_detect_post_delete() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'add_notification' );
+
+		$instance->register_hooks();
+
+		$post = self::factory()
+			->post
+			->create_and_get(
+				array(
+					'post_name' => 'new_post',
+				)
+			);
+
+		wp_delete_post( $post->ID );
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a notification when a post is trashed or deleted. 

## Relevant technical choices:

* Uses the WPSEO_Slug_Change_Watcher, as the logic is closely related. 

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch. 
* Go to Posts. You will see the post overview. Hover over a post title and click `Trash` or open a post and click `Move to trash` on the right side. 
* You should see a message at the top of the screen starting with "You just trashed this Post..."
* To test the delete functionality: enter `define('EMPTY_TRASH_DAYS', 0);` under "// ** MySQL settings ** //" in your `wp-config.php` file, it's in your `public_html` folder.
* Reload your website: `Trash` should now be replaced with `Delete Permanently`. When clicked there should be a message at the top starting with "You just deleted this Post..."
* Don't forget to set your settings back in your `wp-config` file. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #[1798(premium)](https://github.com/Yoast/wordpress-seo-premium/issues/1798)