### PR TITLE
Ensure notification nonces are not stored in the database

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -641,7 +641,13 @@ class Yoast_Notification_Center {
 	 */
 	private function notification_to_array( Yoast_Notification $notification ) {
 
-		return $notification->to_array();
+		$notification_data = $notification->to_array();
+
+		if ( isset( $notification_data['nonce'] ) ) {
+			unset( $notification_data['nonce'] );
+		}
+
+		return $notification_data;
 	}
 
 	/**
@@ -652,6 +658,10 @@ class Yoast_Notification_Center {
 	 * @return Yoast_Notification
 	 */
 	private function array_to_notification( $notification_data ) {
+
+		if ( isset( $notification_data['options']['nonce'] ) ) {
+			unset( $notification_data['options']['nonce'] );
+		}
 
 		return new Yoast_Notification(
 			$notification_data['message'],

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -591,6 +591,79 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests that nonces are stripped when notifications are fetched from the database.
+	 *
+	 * @covers Yoast_Notification_Center::retrieve_notifications_from_storage()
+	 */
+	public function test_retrieve_notifications_from_storage_strips_nonces() {
+		$notification_center = Yoast_Notification_Center::get();
+
+		$storage_data         = array();
+		$expected             = array();
+		$sample_notifications = $this->get_sample_notifications();
+		foreach ( $sample_notifications as $sample_notification ) {
+
+			// Ensure nonces are present.
+			$sample_notification->get_nonce();
+
+			$storage_data[] = $sample_notification->to_array();
+
+			$expected[ $sample_notification->get_id() ] = null;
+		}
+
+		update_user_option( get_current_user_id(), Yoast_Notification_Center::STORAGE_KEY, $storage_data );
+
+		$notification_center->setup_current_notifications();
+
+		$stored_notifications = $notification_center->get_notifications();
+		foreach ( $stored_notifications as $index => $stored_notification ) {
+			$stored_notifications[ $index ] = $stored_notification->to_array();
+		}
+
+		$this->assertSame( $expected, wp_list_pluck( wp_list_pluck( $stored_notifications, 'options' ), 'nonce', 'id' ) );
+	}
+
+	/**
+	 * Tests that nonces are not stored in the database when persisting notifications.
+	 *
+	 * @covers Yoast_Notification_Center::update_storage()
+	 */
+	public function test_update_storage_strips_nonces() {
+		$notification_center = Yoast_Notification_Center::get();
+
+		add_filter( 'yoast_notifications_before_storage', array( $this, 'get_sample_notifications' ) );
+		$notification_center->update_storage();
+
+		$stored_notifications = get_user_option( Yoast_Notification_Center::STORAGE_KEY, get_current_user_id() );
+
+		$expected             = array();
+		$sample_notifications = $this->get_sample_notifications();
+		foreach ( $sample_notifications as $sample_notification ) {
+			$expected[ $sample_notification->get_id() ] = null;
+		}
+
+		$this->assertSame( $expected, wp_list_pluck( wp_list_pluck( $stored_notifications, 'options' ), 'nonce', 'id' ) );
+	}
+
+	/**
+	 * Gets some notification objects.
+	 *
+	 * This method is used as a filter to override notifications.
+	 *
+	 * @return array List of notification objects.
+	 */
+	public function get_sample_notifications() {
+		return array(
+			new Yoast_Notification( 'notification', array(
+				'id' => 'some_id',
+			) ),
+			new Yoast_Notification( 'notification', array(
+				'id' => 'another_id',
+			) ),
+		);
+	}
+
+	/**
 	 * Gets the initialized notification center.
 	 *
 	 * @return Yoast_Notification_Center Notification center instance.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Ensure old notifications can still be dismissed and restored as expected.

## Relevant technical choices:

* Currently, it can happen that notifications that have been around for some time can no longer be dismissed or restored. That happens because their nonces are stored in the database.
* Nonces become out-of-date and invalid after some time, they should never be stored anywhere persistently, such as in the database. However this is currently the case, where the entire notification object gets turned into an array with that entire array being persisted.
* This PR ensures that when updating the notification storage, nonces are stripped from each notification.
* It also ensures that nonces are stripped from notification data when fetching it from the storage. This ensures that existing data is fixed as well, it's something that we should be able to remove some time in the future.

## Test instructions

This PR can be tested by following these steps:

* Use a site where there have been several notifications present for a while (for example yoast.com appears to be such a case).
* Log in to the admin and go to the plugin's settings screen.
* See that some old notifications (such as the "Count links" warning) cannot be dismissed/restored anymore.
* Apply this PR.
* See that now dismissing/restoring notifications works correctly.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10033 
