### PR TITLE
Fix php notice on pt_??? replace vars

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -617,7 +617,7 @@ class WPSEO_Replace_Vars {
 		global $wp_query;
 		$pt_single = null;
 		$pt_plural = null;
-		$post_type = null;
+		$post_type = '';
 
 		if ( isset( $wp_query->query_vars['post_type'] ) && ( ( is_string( $wp_query->query_vars['post_type'] ) && $wp_query->query_vars['post_type'] !== '' ) || ( is_array( $wp_query->query_vars['post_type'] ) && $wp_query->query_vars['post_type'] !== array() ) ) ) {
 			$post_type = $wp_query->query_vars['post_type'];

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -617,6 +617,7 @@ class WPSEO_Replace_Vars {
 		global $wp_query;
 		$pt_single = null;
 		$pt_plural = null;
+		$post_type = null;
 
 		if ( isset( $wp_query->query_vars['post_type'] ) && ( ( is_string( $wp_query->query_vars['post_type'] ) && $wp_query->query_vars['post_type'] !== '' ) || ( is_array( $wp_query->query_vars['post_type'] ) && $wp_query->query_vars['post_type'] !== array() ) ) ) {
 			$post_type = $wp_query->query_vars['post_type'];
@@ -626,7 +627,11 @@ class WPSEO_Replace_Vars {
 		}
 		else {
 			// Make it work in preview mode.
-			$post_type = $wp_query->get_queried_object()->post_type;
+			$post = $wp_query->get_queried_object();
+			if ( $post instanceof WP_Post ) {
+				$post_type = $post->post_type;
+			}
+
 		}
 
 		if ( is_array( $post_type ) ) {

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -631,7 +631,6 @@ class WPSEO_Replace_Vars {
 			if ( $post instanceof WP_Post ) {
 				$post_type = $post->post_type;
 			}
-
 		}
 
 		if ( is_array( $post_type ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where PHP notices got triggered on archive page when `%%pt_single%%` and/or `%%pt_plural%%` are used as a template.

## Test instructions

This PR can be tested by following these steps:

* Follow the steps mentioned in the issue and see it is solved.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10083 
