### PR TITLE
Remove remaining ads from premium

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -104,20 +104,23 @@ class WPSEO_Help_Center {
 
 		$formatted_data['translations'] = self::get_translated_texts();
 
-		$formatted_data['videoDescriptions'] = array(
-			array(
+		$formatted_data['videoDescriptions'] = array();
+
+		if ( $is_premium === false ) {
+			$formatted_data['videoDescriptions'][] = array(
 				'title'       => __( 'Need some help?', 'wordpress-seo' ),
 				'description' => __( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/seo-premium-vt' ),
 				'linkText'    => __( 'Get Yoast SEO Premium now »', 'wordpress-seo' ),
-			),
-			array(
+			);
+
+			$formatted_data['videoDescriptions'][] = array(
 				'title'       => __( 'Want to be a Yoast SEO Expert?', 'wordpress-seo' ),
 				'description' => __( 'Follow our Yoast SEO for WordPress training and become a certified Yoast SEO Expert!', 'wordpress-seo' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/wordpress-training-vt' ),
 				'linkText'    => __( 'Enroll in the Yoast SEO for WordPress training »', 'wordpress-seo' ),
-			),
-		);
+			);
+		}
 
 		$formatted_data['contactSupportParagraphs'] = array(
 			array(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _In premium: Removes remaining advertisements in Premium from the Help Center tabs._

## Relevant technical choices:

* Only add video descriptions when `premium` is true.

## Test instructions

This PR can be tested by following these steps:

* Fake being in the premium plugin
Adjust https://github.com/Yoast/wordpress-seo/blob/c4dc5a69bad90a2c6b78f46a3ffbac0652d9560b/inc/class-wpseo-utils.php#L847
```
public static function is_yoast_seo_premium() {
return true;
}
```
or `define( 'WPSEO_PREMIUM_PLUGIN_FILE', true );`


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1806
