### PR TITLE
Add optional paper style for snippet editors

### DIFF
--- a/admin/menu/class-replacevar-editor.php
+++ b/admin/menu/class-replacevar-editor.php
@@ -25,16 +25,23 @@ class WPSEO_Replacevar_Editor {
 	private $description;
 
 	/**
+	 * @var bool Whether the editor has paper style.
+	 */
+	private $paper_style;
+
+	/**
 	 * Constructs the object.
 	 *
 	 * @param Yoast_Form $yform       Yoast forms.
 	 * @param string     $title       The title field id.
 	 * @param string     $description The description field id.
+	 * @param bool       $paper_style Whether the editor has paper style.
 	 */
-	public function __construct( Yoast_Form $yform, $title, $description ) {
+	public function __construct( Yoast_Form $yform, $title, $description, $paper_style = true ) {
 		$this->yform       = $yform;
 		$this->title       = $title;
 		$this->description = $description;
+		$this->paper_style = $paper_style;
 	}
 
 	/**
@@ -51,9 +58,11 @@ class WPSEO_Replacevar_Editor {
 		printf( '<div
 				data-react-replacevar-editor
 				data-react-replacevar-title-field-id="%1$s"
-				data-react-replacevar-metadesc-field-id="%2$s"></div>',
+				data-react-replacevar-metadesc-field-id="%2$s"
+				data-react-replacevar-paper-style="%3$s"></div>',
 			esc_attr( $this->title ),
-			esc_attr( $this->description )
+			esc_attr( $this->description ),
+			esc_attr( $this->paper_style )
 		);
 	}
 }

--- a/js/src/components/SettingsReplacementVariableEditor.js
+++ b/js/src/components/SettingsReplacementVariableEditor.js
@@ -1,5 +1,6 @@
 /* External dependencies */
 import React from "react";
+import PropTypes from "prop-types";
 import { SettingsSnippetEditor } from "yoast-components";
 import { __ } from "@wordpress/i18n";
 import { replacementVariablesShape } from "yoast-components/composites/Plugin/SnippetEditor/constants";
@@ -15,7 +16,9 @@ class SettingsReplacementVariableEditor extends React.Component {
 
 	render() {
 		return (
-			<SnippetPreviewSection>
+			<SnippetPreviewSection
+				hasPaperStyle={ this.props.hasPaperStyle }
+			>
 				<SettingsSnippetEditor
 					descriptionEditorFieldPlaceholder={ __( "Modify your meta description by editing it right here", "wordpress-seo" ) }
 					onChange={ ( field, value ) => {
@@ -32,7 +35,9 @@ class SettingsReplacementVariableEditor extends React.Component {
 					data={ {
 						title: this.props.title.value,
 						description: this.props.description.value,
-					} } />
+					} }
+					hasPaperStyle={ this.props.hasPaperStyle }
+				/>
 			</SnippetPreviewSection>
 		);
 	}
@@ -42,6 +47,11 @@ SettingsReplacementVariableEditor.propTypes = {
 	replacementVariables: replacementVariablesShape,
 	title: linkFieldsShape,
 	description: linkFieldsShape,
+	hasPaperStyle: PropTypes.bool,
+};
+
+SettingsReplacementVariableEditor.defaultProps = {
+	hasPaperStyle: true,
 };
 
 export default linkHiddenFields( props => {

--- a/js/src/components/SettingsReplacementVariableEditors.js
+++ b/js/src/components/SettingsReplacementVariableEditors.js
@@ -39,12 +39,15 @@ class SettingsReplacementVariableEditors extends React.Component {
 			const {
 				reactReplacevarTitleFieldId,
 				reactReplacevarMetadescFieldId,
+				reactReplacevarPaperStyle,
 			} = targetElement.dataset;
 			return ReactDOM.createPortal(
 				<SettingsReplacementVariableEditor
 					replacementVariables={ this.props.replacementVariables }
 					titleTarget={ reactReplacevarTitleFieldId }
-					descriptionTarget={ reactReplacevarMetadescFieldId } />,
+					descriptionTarget={ reactReplacevarMetadescFieldId }
+					hasPaperStyle={ reactReplacevarPaperStyle === "1" }
+				/>,
 				targetElement
 			);
 		} );

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -9,8 +9,6 @@ const Section = styled( StyledSection )`
 	max-width: 640px;
 	
 	&${ StyledSectionBase } {
-		padding: 0 0 15px;
-
 		& ${ StyledHeading } {
 			padding-left: 20px;
 			font-size: 14.4px;
@@ -21,25 +19,37 @@ const Section = styled( StyledSection )`
 /**
  * Creates the Snippet Preview Section.
  *
- * @param {Object} props                  The component props.
- * @param {ReactComponent} props.children The component's children
+ * @param {Object}         props               The component props.
+ * @param {ReactComponent} props.children      The component's children.
+ * @param {string}         props.title         The heading title.
+ * @param {string}         props.icon          The heading icon.
+ * @param {bool}           props.hasPaperStyle Whether the section should have a paper style.
  *
  * @returns {ReactElement} Snippet Preview Section.
  */
-const SnippetPreviewSection = ( { children, title, icon } ) => {
-	return <Section
-		headingLevel={ 3 }
-		headingText={ title }
-		headingIcon={ icon }
-		headingIconColor="#555" >
-		{ children }
-	</Section>;
+const SnippetPreviewSection = ( { children, title, icon, hasPaperStyle } ) => {
+	return (
+		<Section
+			headingLevel={ 3 }
+			headingText={ title }
+			headingIcon={ icon }
+			headingIconColor="#555"
+			hasPaperStyle={ hasPaperStyle }
+		>
+			{ children }
+		</Section>
+	);
 };
 
 SnippetPreviewSection.propTypes = {
 	children: PropTypes.element,
 	title: PropTypes.string,
 	icon: PropTypes.string,
+	hasPaperStyle: PropTypes.bool,
+};
+
+SnippetPreviewSection.defaultProps = {
+	hasPaperStyle: true,
 };
 
 export default SnippetPreviewSection;

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -95,11 +95,14 @@ export const mapEditorDataToPreview = function( data, context ) {
 const SnippetEditorWrapper = ( props ) => (
 	<SnippetPreviewSection
 		title={ __( "Snippet preview", "wordpress-seo" ) }
-		icon="eye">
+		icon="eye"
+		hasPaperStyle={ props.hasPaperStyle }
+	>
 		<SnippetEditor
 			{ ...props }
 			descriptionPlaceholder={ __( "Please provide a meta description by editing the snippet below." ) }
-			mapEditorDataToPreview={ mapEditorDataToPreview } />
+			mapEditorDataToPreview={ mapEditorDataToPreview }
+		/>
 	</SnippetPreviewSection>
 );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*  Add paper style to `WPSEO_Replacevar_Editor`. Which passes it to JS: `SettingsReplacementVariableEditors`.
* SettingsReplacementVariableEditors converts the data property to `hasPaperStyle` boolean prop and passes it to: 
  - SnippetPreviewSection
  - SettingsSnippetEditor
* Which both pass it along to `yoast-components`'s `StyledSection` and `SnippetPreviewSection` respectively. 

## Test instructions

This PR can be tested by following these steps:

* Switch between paper style and not through the WPSEO_Replacevar_Editor paper_style option.
* Without paper style there should:
  - No longer be padding on the StyledSection.
  - No more `box-shadow` and a transparent `background-color` on the SnippetPreviewSection. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/yoast-components/issues/609
