### PR TITLE
Removed a margin and disabled paper styling in Search Appearance

### DIFF
--- a/admin/views/class-view-utils.php
+++ b/admin/views/class-view-utils.php
@@ -108,7 +108,7 @@ you want more information about the impact of showing media in search results.',
 			sprintf( __( '%1$s Meta Box', 'wordpress-seo' ), 'Yoast SEO' )
 		);
 
-		$editor = new WPSEO_Replacevar_Editor( $this->form, 'title-' . $post_type->name, 'metadesc-' . $post_type->name );
+		$editor = new WPSEO_Replacevar_Editor( $this->form, 'title-' . $post_type->name, 'metadesc-' . $post_type->name, false );
 		$editor->render();
 
 	}

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -79,7 +79,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 				$custom_post_type_archive_help->get_button_html() . $custom_post_type_archive_help->get_panel_html()
 			);
 
-			$editor = new WPSEO_Replacevar_Editor( $yform, 'title-ptarchive-' . $post_type->name, 'metadesc-ptarchive-' . $post_type->name );
+			$editor = new WPSEO_Replacevar_Editor( $yform, 'title-ptarchive-' . $post_type->name, 'metadesc-ptarchive-' . $post_type->name, false );
 			$editor->render();
 
 			if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import { StyledSection, StyledHeading, StyledSectionBase } from "yoast-components";
 
 const Section = styled( StyledSection )`
-	margin-bottom: 2em;
 	max-width: 640px;
 	
 	&${ StyledSectionBase } {

--- a/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
+++ b/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
@@ -10,7 +10,7 @@ exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
     headingLevel={3}
     headingText="Snippet editor">
     <StyledSection
-      className="SnippetPreviewSection__Section-kWfIbs DsgBW"
+      className="SnippetPreviewSection__Section-kWfIbs iPXqmw"
       hasPaperStyle={true}
       headingIcon="eye"
       headingIconColor="#555"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11299,7 +11299,7 @@ yauzl@^2.2.1:
 
 "yoast-components@git+https://github.com/Yoast/yoast-components#develop":
   version "4.2.0"
-  resolved "git+https://github.com/Yoast/yoast-components#7db9dd87fda4a1d3469f06ce73e8fc9570d6b7cc"
+  resolved "git+https://github.com/Yoast/yoast-components#3c656048d0c77f3584a79603f6e1f2caa279765f"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Disables the Paper styling in Search Appearance and removes a margin that caused for some odd styling.

## Relevant technical choices:

* Please note that this PR depends on an update from Yoast Components.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and ensure the latest **develop** version of Yoast Components is properly installed.
* Navigate to SEO -> Search Appearance and note that there's no Paper style surrounding the Snippet Editor anymore.
* Navigate to Posts -> Add New and ensure the Snippet Editor looks the same way as it used to.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Depends on https://github.com/Yoast/yoast-components/pull/615
