### PR TITLE
Bump yoast-components to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "^4.3.0",
+    "yoast-components": "^4.4.0",
     "yoastseo": "^1.34.0"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11297,9 +11297,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yoast-components@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.3.0.tgz#9e3f38e6d9d5b36878dd9bf1ec603fed19847f1f"
+yoast-components@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.4.0.tgz#825bba1790908b80da616b82691b2bbd8ae8276c"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Bumps yoast-components to 4.4.0

## Test instructions

This PR can be tested by following these steps:

* Check whether nothing breaks.