### PR TITLE
Implements translations for wordpress-seo JS textdomain

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,10 +52,12 @@ module.exports = function( grunt ) {
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",
 				yoastComponentsConfigurationWizard: "<%= paths.languages %>yoast-components1.pot",
 				yoastComponentsRemaining: "gettext.pot",
+				wordpressSeoJs: "<%= paths.languages %>wordpress-seo-js.pot",
 
 				php: {
 					yoastseojs: "<%= paths.languages %>yoast-seo-js.php",
 					yoastComponents: "<%= paths.languages %>yoast-components.php",
+					wordpressSeoJs: "<%= paths.languages %>wordpress-seo-js.php",
 				},
 			},
 			phptests: "tests/**/*.php",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,12 +52,12 @@ module.exports = function( grunt ) {
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",
 				yoastComponentsConfigurationWizard: "<%= paths.languages %>yoast-components1.pot",
 				yoastComponentsRemaining: "gettext.pot",
-				wordpressSeoJs: "<%= paths.languages %>wordpress-seo-js.pot",
+				wordpressSeoJs: "<%= paths.languages %>wordpress-seojs.pot",
 
 				php: {
 					yoastseojs: "<%= paths.languages %>yoast-seo-js.php",
 					yoastComponents: "<%= paths.languages %>yoast-components.php",
-					wordpressSeoJs: "<%= paths.languages %>wordpress-seo-js.php",
+					wordpressSeoJs: "<%= paths.languages %>wordpress-seojs.php",
 				},
 			},
 			phptests: "tests/**/*.php",

--- a/admin/class-admin-asset-yoast-components-l10n.php
+++ b/admin/class-admin-asset-yoast-components-l10n.php
@@ -4,29 +4,33 @@
  */
 
 /**
- * Localizes yoast-components.
+ * Localizes JavaScript files.
  */
 final class WPSEO_Admin_Asset_Yoast_Components_l10n {
 	/**
-	 * Localizes the given script with the yoast-components translations.
+	 * Localizes the given script with the JavaScript translations.
 	 *
 	 * @param string $script_handle The script handle to localize for.
 	 *
 	 * @return void
 	 */
 	public function localize_script( $script_handle ) {
-		wp_localize_script( $script_handle, 'wpseoYoastComponentsL10n', $this->get_translations() );
+		wp_localize_script( $script_handle, 'wpseoYoastJSL10n', array(
+			'yoast-components' => $this->get_translations( 'yoast-components' ),
+			'wordpress-seo' => $this->get_translations( 'wordpress-seojs' ),
+		) );
 	}
 
 	/**
-	 * Returns translations necessary for yoast-components.
+	 * Returns translations necessary for JS files.
 	 *
-	 * @return object The translations in a Jed format for yoast-components.
+	 * @param string $component The component to retrieve the translations for.
+	 * @return object The translations in a Jed format for JS files.
 	 */
-	protected function get_translations() {
+	protected function get_translations( $component ) {
 		$locale = WPSEO_Utils::get_user_locale();
 
-		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/yoast-components-' . $locale . '.json';
+		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/' . $component . '-' . $locale . '.json';
 		if ( file_exists( $file ) ) {
 			$file = file_get_contents( $file );
 			if ( is_string( $file ) && $file !== '' ) {

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -86,6 +86,9 @@ class WPSEO_Admin_Pages {
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'search-appearance', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
 			$this->asset_manager->enqueue_script( 'search-appearance' );
 			$this->asset_manager->enqueue_style( 'search-appearance' );
+
+			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_l10n();
+			$yoast_components_l10n->localize_script( 'search-appearance' );
 		}
 
 		wp_enqueue_script( 'dashboard' );

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -34,6 +34,8 @@ build:
 'build:i18n:potFiles':
   - 'makepot'
   - 'shell:makepot-yoast-components-configuration-wizard'
+  - 'shell:makepot-wordpress-seo'
+  - 'copy:makepot-wordpress-seo'
   - 'shell:makepot-yoast-components-remaining'
   - 'shell:combine-pots-yoast-components'
   - 'shell:makepot-yoastseojs'

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -28,6 +28,7 @@ build:
 
 # Build internationalisation features
 'build:i18n':
+  - 'clean:language-files'
   - 'build:i18n:potFiles'
   - 'build:i18n:translations'
 # Create the relevant POT files

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -2,7 +2,7 @@
 module.exports = {
 	"language-files": [
 		"<%= paths.languages %>*",
-		"!<%= paths.languages %>index.js",
+		"!<%= paths.languages %>index.php",
 	],
 	"po-files": [
 		"<%= paths.languages %>*.po",

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -8,6 +8,7 @@ module.exports = {
 		"<%= files.pot.yoastComponents %>",
 		"<%= files.pot.yoastComponentsConfigurationWizard %>",
 		"<%= files.pot.yoastComponentsRemaining %>",
+		"<%= files.pot.wordpressSeoJs %>",
 		"<%= paths.languages %>yoast-components.pot",
 		"<%= paths.languages %>yoast-components.json",
 

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -1,5 +1,9 @@
 // See https://github.com/gruntjs/grunt-contrib-clean for details.
 module.exports = {
+	"language-files": [
+		"<%= paths.languages %>*",
+		"!<%= paths.languages %>index.js",
+	],
 	"po-files": [
 		"<%= paths.languages %>*.po",
 		"<%= paths.languages %><%= pkg.plugin.textdomain %>-temp.pot",

--- a/grunt/config/convert-pot-to-wp.js
+++ b/grunt/config/convert-pot-to-wp.js
@@ -11,4 +11,8 @@ module.exports = {
 		src: "<%= files.pot.yoastseojs %>",
 		dest: "<%= files.pot.php.yoastseojs %>",
 	},
+	wordpressSeoJs: {
+		src: "<%= files.pot.wordpressSeoJs %>",
+		dest: "<%= files.pot.php.wordpressSeoJs %>",
+	},
 };

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -27,6 +27,15 @@ module.exports = {
 					return dest + src.replace( "wordpress-seo", "yoast-components" );
 				},
 			},
+			{
+				expand: true,
+				cwd: "languages/",
+				src: [ "wordpress-seo-*.json" ],
+				dest: "languages/",
+				rename: ( dest, src ) => {
+					return dest + src.replace( "wordpress-seo", "wordpress-seojs" );
+				},
+			},
 		],
 	},
 	"makepot-wordpress-seo": {

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -29,6 +29,10 @@ module.exports = {
 			},
 		],
 	},
+	"makepot-wordpress-seo": {
+		src: "gettext.pot",
+		dest: "<%= files.pot.wordpressSeoJs %>",
+	},
 	artifact: {
 		files: [
 			{

--- a/grunt/config/po2json.js
+++ b/grunt/config/po2json.js
@@ -8,6 +8,7 @@ module.exports = {
 		src: [
 			"<%= files.pot.yoastseojs %>",
 			"<%= files.pot.yoastComponents %>",
+			"<%= files.pot.wordpressSeoJs %>",
 		],
 		dest: "languages",
 	},

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -65,6 +65,10 @@ module.exports = function( grunt ) {
 			command: "yarn i18n-yoast-components",
 		},
 
+		"makepot-wordpress-seo": {
+			command: "yarn i18n-wordpress-seo",
+		},
+
 		"makepot-yoastseojs": {
 			potFile: "languages/yoast-seo-js.pot",
 			textdomain: "js-text-analysis",

--- a/grunt/custom/i18n-clean-json.js
+++ b/grunt/custom/i18n-clean-json.js
@@ -81,6 +81,7 @@ module.exports = function( grunt ) {
 	function cleanJSONFiles() {
 		cleanJSON( "languages/yoast-seo-js.json", "languages/wordpress-seo-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 		cleanJSON( "languages/yoast-components.json", "languages/yoast-components-*.json", "wordpress-seo", "messages", "yoast-components" );
+		cleanJSON( "languages/wordpress-seojs.json", "languages/wordpress-seojs-*.json", "wordpress-seo", "messages" );
 	}
 
 	grunt.registerTask( "i18n-clean-json", "Cleans JSON files", cleanJSONFiles );

--- a/grunt/custom/i18n-clean-json.js
+++ b/grunt/custom/i18n-clean-json.js
@@ -81,7 +81,7 @@ module.exports = function( grunt ) {
 	function cleanJSONFiles() {
 		cleanJSON( "languages/yoast-seo-js.json", "languages/wordpress-seo-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 		cleanJSON( "languages/yoast-components.json", "languages/yoast-components-*.json", "wordpress-seo", "messages", "yoast-components" );
-		cleanJSON( "languages/wordpress-seojs.json", "languages/wordpress-seojs-*.json", "wordpress-seo", "messages" );
+		cleanJSON( "languages/wordpress-seojs.json", "languages/wordpress-seojs-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 	}
 
 	grunt.registerTask( "i18n-clean-json", "Cleans JSON files", cleanJSONFiles );

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -19,7 +19,7 @@ import isUndefined from "lodash/isUndefined";
 
 import YoastIcon from "../../images/Yoast_SEO_Icon.svg";
 
-import { setYoastComponentsI18n } from "./helpers/i18n";
+import { setYoastComponentsL10n } from "./helpers/i18n";
 
 injectTapEventPlugin();
 
@@ -152,6 +152,6 @@ class App extends React.Component {
 	}
 }
 
-setYoastComponentsI18n();
+setYoastComponentsL10n();
 
 ReactDOM.render( <App/>, document.getElementById( "wizard" ) );

--- a/js/src/helpers/i18n.js
+++ b/js/src/helpers/i18n.js
@@ -2,6 +2,30 @@ import { setLocaleData, getI18n } from "@wordpress/i18n";
 import get from "lodash/get";
 
 /**
+ * Sets the l10n for the given textdomain in Jed.
+ *
+ * All the locale data should be available in wpseoYoastComponentsL10n
+ *
+ * @param {string} textdomain The textdomain to set the locale data for.
+ * @returns {void}
+ */
+function setTextdomainL10n( textdomain ) {
+	const jed = getI18n();
+	const currentTranslations = get( jed, [ "options", "locale_data", textdomain ], false );
+
+	if ( currentTranslations === false ) {
+		const translations = get( window, [ "wpseoYoastJSL10n", textdomain, "locale_data", textdomain ], false );
+
+		if ( translations === false ) {
+			// Jed needs to have meta information in the object keyed by an empty string.
+			setLocaleData( { "": {} }, textdomain );
+		} else {
+			setLocaleData( translations, textdomain );
+		}
+	}
+}
+
+/**
  * Configures the i18n for yoast-components.
  *
  * We call translation functions using `@wordpress/i18n` so we need to register
@@ -9,18 +33,18 @@ import get from "lodash/get";
  *
  * @returns {void}
  */
-export function setYoastComponentsI18n() {
-	const jed = getI18n();
-	const currentTranslations = get( jed, [ "options", "locale_data", "yoast-components" ], false );
+export function setYoastComponentsL10n() {
+	setTextdomainL10n( "yoast-components" );
+}
 
-	if ( currentTranslations === false ) {
-		const translations = get( window, [ "wpseoYoastComponentsL10n", "locale_data", "yoast-components" ], false );
-
-		if ( translations === false ) {
-			// Jed needs to have meta information in the object keyed by an empty string.
-			setLocaleData( { "": {} }, "yoast-components" );
-		} else {
-			setLocaleData( translations, "yoast-components" );
-		}
-	}
+/**
+ * Configures the l10n for wordpress-seo-js.
+ *
+ * We call translation functions using `@wordpress/i18n` so we need to register
+ * all our strings there too. This function does that.
+ *
+ * @returns {void}
+ */
+export function setWordPressSeoL10n() {
+	setTextdomainL10n( "wordpress-seo" );
 }

--- a/js/src/redux/reducers/snippetEditor.js
+++ b/js/src/redux/reducers/snippetEditor.js
@@ -1,5 +1,5 @@
 import { DEFAULT_MODE } from "yoast-components";
-import defaultReplaceVariables from "../../values/defaultReplaceVariables";
+import getDefaultReplacementVariables from "../../values/defaultReplaceVariables";
 import {
 	SWITCH_MODE,
 	UPDATE_DATA,
@@ -9,16 +9,23 @@ import {
 } from "../actions/snippetEditor";
 import { createLabelFromName } from "../../helpers/replacementVariableHelpers";
 
-const INITIAL_STATE = {
-	mode: DEFAULT_MODE,
-	data: {
-		title: "",
-		slug: "",
-		description: "",
-	},
-	replacementVariables: defaultReplaceVariables,
-	uniqueRefreshValue: "",
-};
+/**
+ * Returns the initial state for the snippetEditorReducer.
+ *
+ * @returns {Object} The initial state.
+ */
+function getInitialState() {
+	return {
+		mode: DEFAULT_MODE,
+		data: {
+			title: "",
+			slug: "",
+			description: "",
+		},
+		replacementVariables: getDefaultReplacementVariables(),
+		uniqueRefreshValue: "",
+	};
+}
 
 /**
  * Reduces the dispatched action for the snippet editor state.
@@ -28,7 +35,7 @@ const INITIAL_STATE = {
  *
  * @returns {Object} The new state.
  */
-function snippetEditorReducer( state = INITIAL_STATE, action ) {
+function snippetEditorReducer( state = getInitialState(), action ) {
 	switch ( action.type ) {
 		case SWITCH_MODE:
 			return {

--- a/js/src/search-appearance.js
+++ b/js/src/search-appearance.js
@@ -11,8 +11,12 @@ import { createStore, combineReducers } from "redux";
 import SettingsReplacementVariableEditors from "./components/SettingsReplacementVariableEditors";
 import snippetEditorReducer from "./redux/reducers/snippetEditor";
 import configureEnhancers from "./redux/utils/configureEnhancers";
-import defaultReplacementVariables from "./values/defaultReplaceVariables";
+import getDefaultReplacementVariables from "./values/defaultReplaceVariables";
 import { updateReplacementVariable } from "./redux/actions/snippetEditor";
+import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
+
+setYoastComponentsL10n();
+setWordPressSeoL10n();
 
 /**
  * Create a shared store for all snippet editors in the search appearance pages.
@@ -26,7 +30,7 @@ function configureStore() {
 		} ),
 		{
 			snippetEditor: {
-				replacementVariables: defaultReplacementVariables,
+				replacementVariables: getDefaultReplacementVariables(),
 				recommendedReplacementVariables: wpseoReplaceVarsL10n.recommended_replace_vars,
 			},
 		},

--- a/js/src/values/defaultReplaceVariables.js
+++ b/js/src/values/defaultReplaceVariables.js
@@ -1,92 +1,99 @@
 import { __ } from "@wordpress/i18n";
 
-// This const was created to populate the redux store with the default replace variables, while keeping the reducer clean.
-const defaultReplaceVariables = [
-	{
-		name: "date",
-		label: __( "Date", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "id",
-		label: __( "ID", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "page",
-		label: __( "Page number", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "searchphrase",
-		label: __( "Search phrase", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "sitedesc",
-		label: __( "Tagline", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "sitename",
-		label: __( "Site title", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "category",
-		label: __( "Category", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "focuskw",
-		label: __( "Focus keyword", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "title",
-		label: __( "Title", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "parent_title",
-		label: __( "Parent title", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "excerpt",
-		label: __( "Excerpt", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "primary_category",
-		label: __( "Primary category", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "sep",
-		label: __( "Separator", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "excerpt_only",
-		label: __( "Excerpt only", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "category_description",
-		label: __( "Category description", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "tag_description",
-		label: __( "Tag description", "wordpress-seo" ),
-		value: "",
-	},
-	{
-		name: "term_description",
-		label: __( "Term description", "wordpress-seo" ),
-		value: "",
-	},
-];
-
-export default defaultReplaceVariables;
+/**
+ * Returns the default replacement variables.
+ *
+ * This const was created to populate the redux store with the default replace
+ * variables, while keeping the reducer clean.
+ *
+ * @returns {Object[]} The default replacement variables.
+ */
+export default function getDefaultReplacementVariables() {
+	return [
+		{
+			name: "date",
+			label: __( "Date", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "id",
+			label: __( "ID", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "page",
+			label: __( "Page number", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "searchphrase",
+			label: __( "Search phrase", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "sitedesc",
+			label: __( "Tagline", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "sitename",
+			label: __( "Site title", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "category",
+			label: __( "Category", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "focuskw",
+			label: __( "Focus keyword", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "title",
+			label: __( "Title", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "parent_title",
+			label: __( "Parent title", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "excerpt",
+			label: __( "Excerpt", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "primary_category",
+			label: __( "Primary category", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "sep",
+			label: __( "Separator", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "excerpt_only",
+			label: __( "Excerpt only", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "category_description",
+			label: __( "Category description", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "tag_description",
+			label: __( "Tag description", "wordpress-seo" ),
+			value: "",
+		},
+		{
+			name: "term_description",
+			label: __( "Term description", "wordpress-seo" ),
+			value: "",
+		},
+	];
+}

--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -8,7 +8,7 @@ import ScoreAssessments from "yoast-components/composites/Plugin/Shared/componen
 import getFeed from "yoast-components/utils/getFeed";
 import WordpressFeed from "yoast-components/composites/Plugin/DashboardWidget/components/WordpressFeed";
 import colors from "yoast-components/style-guide/colors.json";
-import { setYoastComponentsI18n } from "./helpers/i18n";
+import { setYoastComponentsL10n } from "./helpers/i18n";
 
 
 class DashboardWidget extends React.Component {
@@ -191,7 +191,7 @@ class DashboardWidget extends React.Component {
 const element = document.getElementById( "yoast-seo-dashboard-widget" );
 
 if( element ) {
-	setYoastComponentsI18n();
+	setYoastComponentsL10n();
 
 	ReactDOM.render( <DashboardWidget/>, element );
 }

--- a/js/src/wp-seo-help-center.js
+++ b/js/src/wp-seo-help-center.js
@@ -7,7 +7,7 @@ import ReactDOM from "react-dom";
 import get from "lodash/get";
 import { injectIntl, intlShape } from "react-intl";
 import IntlProvider from "./components/IntlProvider";
-import { setYoastComponentsI18n } from "./helpers/i18n";
+import { setYoastComponentsL10n } from "./helpers/i18n";
 
 /* Internal dependencies */
 import VideoTutorial from "yoast-components/composites/HelpCenter/views/VideoTutorial";
@@ -279,7 +279,7 @@ function handleTabSelect() {
 }
 
 if ( window.wpseoHelpCenterData ) {
-	setYoastComponentsI18n();
+	setYoastComponentsL10n();
 
 	ReactDOM.render(
 		<IntlProvider

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -31,9 +31,10 @@ import UsedKeywords from "./analysis/usedKeywords";
 import { setActiveKeyword } from "./redux/actions/activeKeyword";
 import { setMarkerStatus } from "./redux/actions/markerButtons";
 import { updateData } from "./redux/actions/snippetEditor";
-import { setYoastComponentsI18n } from "./helpers/i18n";
+import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 
-setYoastComponentsI18n();
+setYoastComponentsL10n();
+setWordPressSeoL10n();
 
 ( function( $ ) {
 	"use strict"; // eslint-disable-line

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -23,9 +23,10 @@ import UsedKeywords from "./analysis/usedKeywords";
 import TaxonomyAssessor from "./assessors/taxonomyAssessor";
 import { setActiveKeyword } from "./redux/actions/activeKeyword";
 import { refreshSnippetEditor, updateData } from "./redux/actions/snippetEditor";
-import { setYoastComponentsI18n } from "./helpers/i18n";
+import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 
-setYoastComponentsI18n();
+setYoastComponentsL10n();
+setWordPressSeoL10n();
 
 window.yoastHideMarkers = true;
 

--- a/js/tests/redux/reducers/snippetEditor.test.js
+++ b/js/tests/redux/reducers/snippetEditor.test.js
@@ -6,7 +6,7 @@ import {
 } from "../../../src/redux/actions/snippetEditor";
 import snippetEditorReducer from "../../../src/redux/reducers/snippetEditor";
 import { DEFAULT_MODE } from "yoast-components";
-import defaultReplaceVariables from "../../../src/values/defaultReplaceVariables";
+import getDefaultReplaceVariables from "../../../src/values/defaultReplaceVariables";
 
 describe( "snippet editor reducers", () => {
 	describe( "snippetEditorReducer", () => {
@@ -20,7 +20,7 @@ describe( "snippet editor reducers", () => {
 					slug: "",
 					description: "",
 				},
-				replacementVariables: defaultReplaceVariables,
+				replacementVariables: getDefaultReplaceVariables(),
 				uniqueRefreshValue: "",
 			} );
 		} );

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "jest",
     "build": "NODE_ENV=production webpack --config ./webpack/webpack.config.prod.js",
     "i18n-yoast-components": "NODE_ENV=production babel node_modules/yoast-components --ignore node_modules/yoast-components/node_modules,tests/*Test.js --plugins=@wordpress/babel-plugin-makepot > /dev/null",
+    "i18n-wordpress-seo": "NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot > /dev/null",
     "start": "webpack-dev-server --config ./webpack/webpack.config.dev.js --progress"
   },
   "jest": {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _Not applicable_

## Relevant technical choices:

* Copied most of the `yoast-components` translation pipeline.

## Test instructions

This PR can be tested by following these steps:

* Run `grunt build:i18n`.
* Set your installation to Dutch
* You should now see 'Snippetvoorvertooning' in your snippet editor.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10010