### PR TITLE
Fix error when $terms[0] does not exist in open-graph

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -683,7 +683,8 @@ class WPSEO_OpenGraph {
 
 		if ( ! is_wp_error( $terms ) && is_array( $terms ) && ! empty( $terms ) ) {
 			// We can only show one section here, so we take the first one.
-			$this->og_tag( 'article:section', reset( $terms )->name );
+			$term = reset( $terms );
+			$this->og_tag( 'article:section', $term->name );
 			return true;
 		}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -681,10 +681,9 @@ class WPSEO_OpenGraph {
 
 		$terms = get_the_category();
 
-		if ( ! is_wp_error( $terms ) && ( is_array( $terms ) && $terms !== array() ) ) {
+		if ( ! is_wp_error( $terms ) && is_array( $terms ) && ! empty( $terms ) ) {
 			// We can only show one section here, so we take the first one.
-			$this->og_tag( 'article:section', $terms[0]->name );
-
+			$this->og_tag( 'article:section', reset( $terms )->name );
 			return true;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix error when $terms[0] does not exist (such as when there is only $terms[1].)

## Relevant technical choices:

* Use `reset($terms)->name` instead of `$terms[0]->name` because the first element may be `$terms[1]`.
* Use `!empty($terms)` instead of `$terms !== array()` because it is clearer.

## Test instructions

This PR can be tested by following these steps:

* Select more than more category.  
* Do NOT set a Primary category
* Add `'get_the_categories'` filter that unsets `$term[0]` _(as a commercial theme a client was using does. It removes parent categories if child categories are selected.)_

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
