### PR TITLE
Skip fallback for empty title and excerpt

### DIFF
--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -121,6 +121,7 @@ class Data {
 		// Handle excerpt change
 		if ( this._data.excerpt !== newData.excerpt ) {
 			this._store.dispatch( updateReplacementVariable( "excerpt", newData.excerpt ) );
+			this._store.dispatch( updateReplacementVariable( "excerpt_only", newData.excerpt ) );
 		}
 	}
 

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -116,7 +116,7 @@ export function mapStateToProps( state ) {
 
 	// Replace all empty values with %%replaceVarName%% so the replacement variables plugin can do its job.
 	replacementVariables.forEach( ( replaceVariable ) => {
-		if( replaceVariable.value === "" ) {
+		if( replaceVariable.value === "" && ! [ "title", "excerpt", "excerpt_only" ].includes( replaceVariable.name ) ) {
 			replaceVariable.value = "%%" + replaceVariable.name + "%%";
 		}
 	} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* The replacevar plugin was quite slow in updating the rawData when title and excerpt became empty. On our end (in the redux store) we replaced the empty values with `%%title%%` and `%%excerpt%%` etc., as a fallback for certain replacement variables that weren't filled via React. This caused the title to be replaced with the slow rawData when it was emptied. Now, we do not fallback for fields to which we are subscribed via React.

## Test instructions

This PR can be tested by following these steps:

* Put `%%title%%` in the title snippet editor field.
* Put `%%excerpt%%` and `%%excerpt_only%%` only in the description.
* Put a large title in the editor title.
* Put a large excerpt in the excerpt (excerptception :trollface: )
* Select all in the title, delete or cut, and see that the title progress bar is immediately emptied, as opposed to state on the release branch.
* Do the same for excerpt.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/yoast-components/issues/617
