### PR TITLE
Adds logic to check if a post type is viewable

### DIFF
--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -54,8 +54,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function detect_post_trash( $post_id ) {
-		$post_status = get_post_status( $post_id );
-		if ( ! $this->check_visible_post_status( $post_status ) ) {
+		if ( ! $this->is_post_accessible( $post_id ) ) {
 			return;
 		}
 
@@ -74,13 +73,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function detect_post_delete( $post_id ) {
-		// We don't want to redirect menu items.
-		if ( is_nav_menu_item( $post_id ) ) {
-			return;
-		}
-
-		$post_status = get_post_status( $post_id );
-		if ( ! $this->check_visible_post_status( $post_status ) ) {
+		if ( ! $this->is_post_accessible( $post_id ) ) {
 			return;
 		}
 
@@ -89,6 +82,31 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		$message        = $this->get_message( $first_sentence );
 
 		$this->add_notification( $message );
+	}
+
+	/**
+	 * Checks if the post is accesible.
+	 *
+	 * This method will check:
+	 * 1. Is the post type for the given post viewable
+	 * 2. Is the post status is publically visible.
+	 *
+	 * @param string $post_id The post id to check.
+	 *
+	 * @return bool Whether the post is accessible or not.
+	 */
+	protected function is_post_accessible( $post_id ) {
+		$post_type = get_post_type( $post_id );
+		if ( ! is_post_type_viewable( $post_type ) ) {
+			return false;
+		}
+
+		$post_status = get_post_status( $post_id );
+		if ( ! $this->check_visible_post_status( $post_status ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -85,15 +85,11 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Checks if the post is accesible.
-	 *
-	 * This method will check:
-	 * 1. Is the post type for the given post viewable.
-	 * 2. Is the post status is publically visible.
+	 * Checks if the post is viewable.
 	 *
 	 * @param string $post_id The post id to check.
 	 *
-	 * @return bool Whether the post is accessible or not.
+	 * @return bool Whether the post is viewable or not.
 	 */
 	protected function is_post_viewable( $post_id ) {
 		$post_type = get_post_type( $post_id );

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -54,7 +54,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function detect_post_trash( $post_id ) {
-		if ( ! $this->is_post_accessible( $post_id ) ) {
+		if ( ! $this->is_post_viewable( $post_id ) ) {
 			return;
 		}
 
@@ -73,7 +73,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function detect_post_delete( $post_id ) {
-		if ( ! $this->is_post_accessible( $post_id ) ) {
+		if ( ! $this->is_post_viewable( $post_id ) ) {
 			return;
 		}
 
@@ -88,16 +88,16 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 * Checks if the post is accesible.
 	 *
 	 * This method will check:
-	 * 1. Is the post type for the given post viewable
+	 * 1. Is the post type for the given post viewable.
 	 * 2. Is the post status is publically visible.
 	 *
 	 * @param string $post_id The post id to check.
 	 *
 	 * @return bool Whether the post is accessible or not.
 	 */
-	protected function is_post_accessible( $post_id ) {
+	protected function is_post_viewable( $post_id ) {
 		$post_type = get_post_type( $post_id );
-		if ( ! is_post_type_viewable( $post_type ) ) {
+		if ( ! WPSEO_Post_Type::is_post_type_accessible( $post_type ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* I've use `is_post_type_viewable` which checks if the post type is publicly queryable or has public access.

## Test instructions

This PR can be tested by following these steps:

* Follow the steps in #10125
* I've change some piece of code (simplified) that needs some verification. Create a menu under appearance and add some menu items to it. Remove a menu item. The notification shouldn't be visible.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10125
