### PR TITLE
Implement logic for labels

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1146,13 +1146,83 @@ class WPSEO_Replace_Vars {
 	 *
 	 * @param string $replacement_variable The replacement variable.
 	 *
-	 * @return bool True when the replacement variable contains a
+	 * @return bool True when the replacement variable is not prefixed.
 	 */
 	private function is_not_prefixed( $replacement_variable ) {
-		$prefixes = array( 'cf_', 'ct_' );
-		$prefix   = substr( $replacement_variable, 0, 3 );
+		$prefixes = array( 'cf_', 'ct_', 'pt_' );
+		$prefix   = $this->get_prefix( $replacement_variable );
 
 		return ! in_array( $prefix, $prefixes );
+	}
+
+	/**
+	 * Strip the prefix from a replacement variable name.
+	 *
+	 * @param string $replacement_variable The replacement variable.
+	 *
+	 * @return string The replacement variable name without the prefix.
+	 */
+	private function strip_prefix( $replacement_variable ) {
+		return substr( $replacement_variable, 3 );
+	}
+
+	/**
+	 * Gets the prefix from a replacement variable name.
+	 *
+	 * @param string $replacement_variable The replacement variable.
+	 *
+	 * @return string The prefix of the replacement variable.
+	 */
+	private function get_prefix( $replacement_variable ) {
+		return substr( $replacement_variable, 0, 3 );
+	}
+
+	/**
+	 * Strips 'desc_' if present, and appends '(description)' at the end.
+	 *
+	 * @param string $label The replacement variable.
+	 *
+	 * @return string The altered replacement variable name.
+	 */
+	private function handle_description( $label ) {
+		if ( substr( $label, 0, 5 ) === 'desc_' ) {
+			return substr( $label, 5 ) . ' description';
+		}
+		return $label;
+	}
+
+	/**
+	 * Creates a label for prefixed replacement variables that matches the format in the editors.
+	 *
+	 * @param string $replacement_variable The replacement variable.
+	 *
+	 * @return string The replacement variable label.
+	 */
+	private function get_prefix_label( $replacement_variable ) {
+		$label = '';
+		$prefix = $this->get_prefix( $replacement_variable );
+		switch ( $prefix ) {
+			case 'cf_':
+				$label = $this->strip_prefix( $replacement_variable ) . ' (custom field)';
+				break;
+			case 'ct_':
+				$label = $this->strip_prefix( $replacement_variable );
+				$label = $this->handle_description( $label );
+				$label .= ' (custom taxonomy)';
+				break;
+			case 'pt_':
+				if ( $replacement_variable = 'pt_single' ) {
+					$label = 'Post type (singular)';
+					break;
+				}
+				else {
+					$label = 'Post type (plural)';
+					break;
+				}
+			default:
+				break;
+		}
+		return $label;
 	}
 
 	/**
@@ -1163,7 +1233,11 @@ class WPSEO_Replace_Vars {
 	 * @return array The formatted replacement variable.
 	 */
 	private function format_replacement_variable( $replacement_variable ) {
-		return array( 'name' => $replacement_variable, 'value' => '' );
+		$label = '';
+		if ( ! $this->is_not_prefixed( $replacement_variable ) ) {
+			$label = $this->get_prefix_label( $replacement_variable );
+		}
+		return array( 'name' => $replacement_variable, 'value' => '', 'label' => $label );
 	}
 
 	/**

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1178,7 +1178,7 @@ class WPSEO_Replace_Vars {
 	}
 
 	/**
-	 * Strips 'desc_' if present, and appends '(description)' at the end.
+	 * Strips 'desc_' if present, and appends ' description' at the end.
 	 *
 	 * @param string $label The replacement variable.
 	 *

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1152,7 +1152,7 @@ class WPSEO_Replace_Vars {
 		$prefixes = array( 'cf_', 'ct_', 'pt_' );
 		$prefix   = $this->get_prefix( $replacement_variable );
 
-		return ! in_array( $prefix, $prefixes );
+		return ! in_array( $prefix, $prefixes, true );
 	}
 
 	/**
@@ -1185,9 +1185,10 @@ class WPSEO_Replace_Vars {
 	 * @return string The altered replacement variable name.
 	 */
 	private function handle_description( $label ) {
-		if ( substr( $label, 0, 5 ) === 'desc_' ) {
+		if ( strpos( $label, 'desc_' ) === 0 ) {
 			return substr( $label, 5 ) . ' description';
 		}
+
 		return $label;
 	}
 
@@ -1198,31 +1199,27 @@ class WPSEO_Replace_Vars {
 	 *
 	 * @return string The replacement variable label.
 	 */
-	private function get_prefix_label( $replacement_variable ) {
-		$label = '';
+	private function get_label( $replacement_variable ) {
 		$prefix = $this->get_prefix( $replacement_variable );
-		switch ( $prefix ) {
-			case 'cf_':
-				$label = $this->strip_prefix( $replacement_variable ) . ' (custom field)';
-				break;
-			case 'ct_':
-				$label = $this->strip_prefix( $replacement_variable );
-				$label = $this->handle_description( $label );
-				$label .= ' (custom taxonomy)';
-				break;
-			case 'pt_':
-				if ( $replacement_variable = 'pt_single' ) {
-					$label = 'Post type (singular)';
-					break;
-				}
-				else {
-					$label = 'Post type (plural)';
-					break;
-				}
-			default:
-				break;
+		if ( $prefix === 'cf_' ) {
+			return $this->strip_prefix( $replacement_variable ) . ' (custom field)';
 		}
-		return $label;
+
+		if ( $prefix === 'ct_' ) {
+			$label = $this->strip_prefix( $replacement_variable );
+			$label = $this->handle_description( $label );
+			return $label . ' (custom taxonomy)';
+		}
+
+		if ( $prefix === 'pt_' ) {
+			if ( $replacement_variable === 'pt_single' ) {
+				return 'Post type (singular)';
+			}
+
+			return 'Post type (plural)';
+		}
+
+		return '';
 	}
 
 	/**
@@ -1233,11 +1230,11 @@ class WPSEO_Replace_Vars {
 	 * @return array The formatted replacement variable.
 	 */
 	private function format_replacement_variable( $replacement_variable ) {
-		$label = '';
-		if ( ! $this->is_not_prefixed( $replacement_variable ) ) {
-			$label = $this->get_prefix_label( $replacement_variable );
-		}
-		return array( 'name' => $replacement_variable, 'value' => '', 'label' => $label );
+		return array(
+			'name'  => $replacement_variable,
+			'value' => '',
+			'label' => $this->get_label( $replacement_variable ),
+		);
 	}
 
 	/**

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1142,14 +1142,14 @@ class WPSEO_Replace_Vars {
 	}
 
 	/**
-	 * Checks if the replacement variable contains a prefix.
+	 * Checks whether the replacement variable contains a `ct_` or `cf_` prefix, because they follow different logic.
 	 *
 	 * @param string $replacement_variable The replacement variable.
 	 *
 	 * @return bool True when the replacement variable is not prefixed.
 	 */
 	private function is_not_prefixed( $replacement_variable ) {
-		$prefixes = array( 'cf_', 'ct_', 'pt_' );
+		$prefixes = array( 'cf_', 'ct_' );
 		$prefix   = $this->get_prefix( $replacement_variable );
 
 		return ! in_array( $prefix, $prefixes, true );
@@ -1208,7 +1208,7 @@ class WPSEO_Replace_Vars {
 		if ( $prefix === 'ct_' ) {
 			$label = $this->strip_prefix( $replacement_variable );
 			$label = $this->handle_description( $label );
-			return $label . ' (custom taxonomy)';
+			return ucfirst( $label . ' (custom taxonomy)' );
 		}
 
 		if ( $prefix === 'pt_' ) {

--- a/js/src/search-appearance.js
+++ b/js/src/search-appearance.js
@@ -42,6 +42,7 @@ function configureStore() {
 		store.dispatch( updateReplacementVariable(
 			name,
 			replacementVariable.value,
+			replacementVariable.label,
 		) );
 	} );
 	return store;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Label creation logic for prefixed replacement variables is now identical to the editor's snippet editor redux store's logic.

## Test instructions

This PR can be tested by following these steps:

* Have custom fields with spaces and without spaces. Also, custom taxonomies if you want/can. Tip: use `yoast-test-helper`.
* See how the labels look in the redux store on a post.
* Verify that they look the same on the search-appearance page.
* Look specifically for the replacevars that have `ct_` (and `ct_desc_`), `cf_`, and `pt_` prefixes.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10098 
