### PR TITLE
Added title for Breadcrumb title field to better describe its goal

### DIFF
--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -82,10 +82,12 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 			$recommended_replace_vars = new WPSEO_Admin_Recommended_Replace_Vars();
 			$page_type                = $recommended_replace_vars->determine_for_archive( $post_type->name );
 
-			$editor = new WPSEO_Replacevar_Editor( $yform, 'title-ptarchive-' . $post_type->name, 'metadesc-ptarchive-' . $post_type->name, $page_type );
+			$editor = new WPSEO_Replacevar_Editor( $yform, 'title-ptarchive-' . $post_type->name, 'metadesc-ptarchive-' . $post_type->name, $page_type, false );
 			$editor->render();
 
 			if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
+				// translators: %s is the plural version of the post type's name.
+				echo '<h4>' . esc_html( sprintf( __( 'Breadcrumb settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h4>';
 				$yform->textinput( 'bctitle-ptarchive-' . $post_type->name, __( 'Breadcrumbs title', 'wordpress-seo' ) );
 			}
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Removed paper style and added a header to more clearly describe what the Breadcrumb title is used for. This combination should fix any margin issues that may have been present.

## Test instructions

This PR can be tested by following these steps:

* Ensure you've ran `yarn`, `grunt build:css` and `grunt build:js`.
* Ensure you have the Yoast Test Plugin installed and have activated the custom post types.
* Go to SEO -> Search Appearance
* Toggle open one of the two custom post types.
* Determine that there's a nice amount of margin + a title present.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10132 
