### PR TITLE
Ensure notification nonces are not stored in the database or stripped…

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -641,7 +641,13 @@ class Yoast_Notification_Center {
 	 */
 	private function notification_to_array( Yoast_Notification $notification ) {
 
-		return $notification->to_array();
+		$notification_data = $notification->to_array();
+
+		if ( isset( $notification_data['nonce'] ) ) {
+			unset( $notification_data['nonce'] );
+		}
+
+		return $notification_data;
 	}
 
 	/**
@@ -652,6 +658,10 @@ class Yoast_Notification_Center {
 	 * @return Yoast_Notification
 	 */
 	private function array_to_notification( $notification_data ) {
+
+		if ( isset( $notification_data['options']['nonce'] ) ) {
+			unset( $notification_data['options']['nonce'] );
+		}
 
 		return new Yoast_Notification(
 			$notification_data['message'],

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -591,6 +591,79 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests that nonces are stripped when notifications are fetched from the database.
+	 *
+	 * @covers Yoast_Notification_Center::retrieve_notifications_from_storage()
+	 */
+	public function test_retrieve_notifications_from_storage_strips_nonces() {
+		$notification_center = Yoast_Notification_Center::get();
+
+		$storage_data         = array();
+		$expected             = array();
+		$sample_notifications = $this->get_sample_notifications();
+		foreach ( $sample_notifications as $sample_notification ) {
+
+			// Ensure nonces are present.
+			$sample_notification->get_nonce();
+
+			$storage_data[] = $sample_notification->to_array();
+
+			$expected[ $sample_notification->get_id() ] = null;
+		}
+
+		update_user_option( get_current_user_id(), Yoast_Notification_Center::STORAGE_KEY, $storage_data );
+
+		$notification_center->setup_current_notifications();
+
+		$stored_notifications = $notification_center->get_notifications();
+		foreach ( $stored_notifications as $index => $stored_notification ) {
+			$stored_notifications[ $index ] = $stored_notification->to_array();
+		}
+
+		$this->assertSame( $expected, wp_list_pluck( wp_list_pluck( $stored_notifications, 'options' ), 'nonce', 'id' ) );
+	}
+
+	/**
+	 * Tests that nonces are not stored in the database when persisting notifications.
+	 *
+	 * @covers Yoast_Notification_Center::update_storage()
+	 */
+	public function test_update_storage_strips_nonces() {
+		$notification_center = Yoast_Notification_Center::get();
+
+		add_filter( 'yoast_notifications_before_storage', array( $this, 'get_sample_notifications' ) );
+		$notification_center->update_storage();
+
+		$stored_notifications = get_user_option( Yoast_Notification_Center::STORAGE_KEY, get_current_user_id() );
+
+		$expected             = array();
+		$sample_notifications = $this->get_sample_notifications();
+		foreach ( $sample_notifications as $sample_notification ) {
+			$expected[ $sample_notification->get_id() ] = null;
+		}
+
+		$this->assertSame( $expected, wp_list_pluck( wp_list_pluck( $stored_notifications, 'options' ), 'nonce', 'id' ) );
+	}
+
+	/**
+	 * Gets some notification objects.
+	 *
+	 * This method is used as a filter to override notifications.
+	 *
+	 * @return array List of notification objects.
+	 */
+	public function get_sample_notifications() {
+		return array(
+			new Yoast_Notification( 'notification', array(
+				'id' => 'some_id',
+			) ),
+			new Yoast_Notification( 'notification', array(
+				'id' => 'another_id',
+			) ),
+		);
+	}
+
+	/**
 	 * Gets the initialized notification center.
 	 *
 	 * @return Yoast_Notification_Center Notification center instance.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where very old notifications could not be be dismissed or restored.

This is a copy of [https://github.com/Yoast/wordpress-seo/pull/10085](https://github.com/Yoast/wordpress-seo/pull/10085), which was merged in the wrong branch and reverted. 

Fixes #10033 
