### PR TITLE
Replace append by appendChild

### DIFF
--- a/js/src/search-appearance.js
+++ b/js/src/search-appearance.js
@@ -52,7 +52,7 @@ const singleFieldElements = document.querySelectorAll( "[data-react-replacevar-f
 
 if( editorElements.length ) {
 	const element = document.createElement( "div" );
-	document.body.append( element );
+	document.body.appendChild( element );
 
 	const store = configureStore();
 


### PR DESCRIPTION
`append` is not supported by IE and Edge. We should use `appendChild` instead.

Fixes an issue where the snippet editors were not shown in IE and Edge. 
![image 1](https://user-images.githubusercontent.com/17744553/41855532-2988dc6c-7893-11e8-8ea0-586cee2d8986.png)
