### PR TITLE
Replaced info on copywriting training with basic seo

### DIFF
--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -44,15 +44,15 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 		}
 
 		$field->add_suggestion(
-			__( 'Learn how to write copy that ranks', 'wordpress-seo' ),
+			__( 'Learn all about SEO with our Basic SEO course', 'wordpress-seo' ),
 			/* translators: %1$s resolves to SEO copywriting training */
-			sprintf( __( 'Do you want to learn how to write content that generates traffic? Check out our %1$s. We will help you to write awesome copy that will rank in the search engines. The %1$s covers all the main steps in SEO copywriting: from keyword research to publishing.', 'wordpress-seo' ), 'SEO copywriting training' ),
+			sprintf( __( 'Do you want to learn how you can improve your SEO yourself? In our %1$s you\'ll learn practical SEO skills from keyword research and copywriting to technical SEO and off-page SEO. Using the Yoast SEO plugin is one thing. Doing good SEO day-to-day is another. You simply won\'t get the results you want without putting in work yourself. The %1$s teaches you how.', 'wordpress-seo' ), 'Basic SEO training' ),
 			array(
-				'label' => 'SEO copywriting training',
+				'label' => 'Basic SEO training',
 				'type'  => 'link',
-				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/configuration-wizard-copywrite-course-link' ),
+				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/2up' ),
 			),
-			WPSEO_Shortlinker::get( 'https://yoa.st/video-course-copywriting' )
+			WPSEO_Shortlinker::get( 'https://www.youtube.com/embed/0jo-g9uSoZc' )
 		);
 
 		$field->add_suggestion(

--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -52,7 +52,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 				'type'  => 'link',
 				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/2up' ),
 			),
-			WPSEO_Shortlinker::get( 'https://www.youtube.com/embed/0jo-g9uSoZc' )
+			WPSEO_Shortlinker::get( 'https://yoa.st/2v0' )
 		);
 
 		$field->add_suggestion(

--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -44,9 +44,17 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 		}
 
 		$field->add_suggestion(
-			__( 'Learn all about SEO with our Basic SEO course', 'wordpress-seo' ),
-			/* translators: %1$s resolves to SEO copywriting training */
-			sprintf( __( 'Do you want to learn how you can improve your SEO yourself? In our %1$s you\'ll learn practical SEO skills from keyword research and copywriting to technical SEO and off-page SEO. Using the Yoast SEO plugin is one thing. Doing good SEO day-to-day is another. You simply won\'t get the results you want without putting in work yourself. The %1$s teaches you how.', 'wordpress-seo' ), 'Basic SEO training' ),
+			sprintf(
+				/* translators: %1$s resolves to Basic SEO training */
+				__( 'Learn all about SEO with our %1$s', 'wordpress-seo' ),
+				'Basic SEO training'
+			),
+			sprintf(
+				/* translators: %1$s resolves to Basic SEO training, 2: Yoast SEO */
+				__( 'Do you want to learn how you can improve your SEO yourself? In our %1$s you\'ll learn practical SEO skills from keyword research and copywriting to technical SEO and off-page SEO. Using the %2$s plugin is one thing. Doing good SEO day-to-day is another. You simply won\'t get the results you want without putting in work yourself. The %1$s teaches you how.', 'wordpress-seo' ),
+				'Basic SEO training',
+				'Yoast SEO'
+			),
 			array(
 				'label' => 'Basic SEO training',
 				'type'  => 'link',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch. 
* Go to page 11 of the configuration wizard, see block about the basic SEO training instead of the copywriting block. The text, title, video, and link should be replaced. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10086 
