### PR TITLE
Add paper to the media templates

### DIFF
--- a/admin/views/class-view-utils.php
+++ b/admin/views/class-view-utils.php
@@ -62,11 +62,12 @@ class Yoast_View_Utils {
 	/**
 	 * Shows the search appearance settings for a post type.
 	 *
-	 * @param string|object $post_type The post type to show the search appearance settings for.
+	 * @param string|object $post_type   The post type to show the search appearance settings for.
+	 * @param bool          $paper_style Whether or not the paper style should be shown.
 	 *
 	 * @return void
 	 */
-	public function show_post_type_settings( $post_type ) {
+	public function show_post_type_settings( $post_type, $paper_style = false ) {
 		if ( ! is_object( $post_type ) ) {
 			$post_type = get_post_type_object( $post_type );
 		}
@@ -111,7 +112,7 @@ you want more information about the impact of showing media in search results.',
 		$recommended_replace_vars = new WPSEO_Admin_Recommended_Replace_Vars();
 		$page_type                = $recommended_replace_vars->determine_for_post_type( $post_type->name );
 
-		$editor = new WPSEO_Replacevar_Editor( $this->form, 'title-' . $post_type->name, 'metadesc-' . $post_type->name, $page_type, false );
+		$editor = new WPSEO_Replacevar_Editor( $this->form, 'title-' . $post_type->name, 'metadesc-' . $post_type->name, $page_type, $paper_style );
 		$editor->render();
 	}
 }

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -43,6 +43,6 @@ $yform->toggle_switch(
 
 		<?php
 		$view_utils = new Yoast_View_Utils();
-		$view_utils->show_post_type_settings( 'attachment' );
+		$view_utils->show_post_type_settings( 'attachment', true );
 		?>
 	</div>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the white background to the template of media on the search appearance page.

## Relevant technical choices:

* Added a `paper style` parameter to show-post-type-settings (used by media), false by default, as it used to be. Set it to true where media calls it.

## Test instructions

This PR can be tested by following these steps:

* Visit search appearance > media. Set the toggle to no, check if the seo_title/meda desc have the paper style.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10148 
