### PR TITLE
Fix post format toggle

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -597,6 +597,20 @@ class WPSEO_Upgrade {
 	}
 
 	/**
+	 * Performs the 7.7.1 upgrade.
+	 *
+	 * @return void
+	 */
+	private function upgrade_771() {
+		// Check if WPSEO titles is set. If so, lets not touch it.
+
+		// format archives default to 0 if untouched.
+
+
+
+	}
+
+	/**
 	 * Removes all sitemap validators.
 	 *
 	 * This should be executed on every upgrade routine until we have removed the sitemap caching in the database.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -597,20 +597,6 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 7.7.1 upgrade.
-	 *
-	 * @return void
-	 */
-	private function upgrade_771() {
-		// Check if WPSEO titles is set. If so, lets not touch it.
-
-		// format archives default to 0 if untouched.
-
-
-
-	}
-
-	/**
 	 * Removes all sitemap validators.
 	 *
 	 * This should be executed on every upgrade routine until we have removed the sitemap caching in the database.

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -232,7 +232,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return false;
 		}
 
-		if ( 'post_format' === $taxonomy_name && ! WPSEO_Options::get( 'disable-post_format', false ) ) {
+		if ( 'post_format' === $taxonomy_name && WPSEO_Options::get( 'disable-post_format', false ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where disabling the `post_format` archive would result in it actually being enabled and vice versa.

## Relevant technical choices:

* No upgrade routine was introduced because we cannot determine if someone deliberately turned the option on or off. The option itself hasn't changed either.

## Test instructions

This PR can be tested by following these steps:

* Add a new post and set the Post Format to something like Quote. Save the post.
* Go to SEO -> Search Appearance -> Taxonomies -> Format
* Under the Format section, set `Format-based archives` to Enabled and `Show Format in search results?` to Yes.
* Open the sitemap and determine that there's a `post_format-sitemap` entry.
* Click the entry and see that the Post Format you applied to your post, is also listed.
* Click that entry again and determine that you reach a Post Format archive page.
* Check the source and determine that there's no `noindex` value present.
* Go back to the Format section, set `Show Format in search results?` to No.
* Check the source and determine that there's a `noindex` value present.
* Go back to the Format section, set `Format-based archives` to Disabled.
* Open the sitemap and determine that there's **no** `post_format-sitemap` entry.
* Also determine that the archive page for the Post Format no longer exists.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10119 
