### PR TITLE
Make sure $term->taxonomy is set before using it, fixes #10143

### DIFF
--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -448,10 +448,10 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 */
 	public static function get_meta_without_term( $meta ) {
 		$term = $GLOBALS['wp_query']->get_queried_object();
-		if ( $term && isset( $term->taxonomy ) ) {
-			return self::get_term_meta( $term, $term->taxonomy, $meta );
+		if ( ! $term || empty( $term->taxonomy ) ) {
+			return false;
 		}
-		return false;
+		return self::get_term_meta( $term, $term->taxonomy, $meta );
 	}
 
 	/**

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -448,9 +448,10 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 */
 	public static function get_meta_without_term( $meta ) {
 		$term = $GLOBALS['wp_query']->get_queried_object();
-
-		return self::get_term_meta( $term, $term->taxonomy, $meta );
-
+		if ( $term && isset( $term->taxonomy ) ) {
+			return self::get_term_meta( $term, $term->taxonomy, $meta );
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

*  Fixes a bug where a notice ("Notice: Trying to get property of non-object") is given when the `$term->taxonomy` isn't set before it is used.` Props to [bainternet](https://github.com/bainternet)
## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10143
