### PR TITLE
Bring currentyear back as a replacevar

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -983,6 +983,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'sitedesc',
 			'sep',
 			'page',
+			'currentyear',
 		);
 
 		foreach ( $vars_to_cache as $var ) {

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -323,6 +323,7 @@ class WPSEO_Taxonomy {
 			'category_description',
 			'tag_description',
 			'searchphrase',
+			'currentyear',
 		);
 
 		foreach ( $vars_to_cache as $var ) {

--- a/js/src/values/defaultReplaceVariables.js
+++ b/js/src/values/defaultReplaceVariables.js
@@ -95,5 +95,10 @@ export default function getDefaultReplacementVariables() {
 			label: __( "Term description", "wordpress-seo" ),
 			value: "",
 		},
+		{
+			name: "currentyear",
+			label: __( "Current year", "wordpress-seo" ),
+			value: "",
+		},
 	];
 }

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,9 @@ Bugfixes:
 * Fixes a bug where disabling the post_format archive would result in it actually being enabled and vice versa.
 * Fixes an issue where more all replacement variables were being displayed instead of the recommended ones.
 
+Other:
+* Restores `currentyear` as a snippet variable.
+
 = 7.7.0 =
 Release Date: June 26th, 2018
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Restores `currentyear` as a snippet variable.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Go to a post. Type %c in a title or description field. 'Current year' should show up. The snippet preview should shoe 2018, and the progress bars should respond to this addition.
* Go to Search Appearance. Type %c in a title or description field. 'Current year' should show up.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
