### PR TITLE
Improve the Search Appearance - Content Types collapsible sections a11y

### DIFF
--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -41,19 +41,22 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 		echo '<div class="paper tab-block" id="' . esc_attr( $post_type->name . '-titles-metas' ) . '">';
 
 		$toggle_icon = 'dashicons-arrow-up-alt2';
-		$class 		 = 'toggleable-container';
+		$class       = 'toggleable-container';
+		$expanded    = 'true';
 
 		if ( $id !== 'post' ) {
 			$toggle_icon = 'dashicons-arrow-down-alt2';
 			$class .= ' toggleable-container-hidden';
+			$expanded = 'false';
 		}
 
 		printf(
-			'<h2 id="%s">%s (<code>%s</code>) <button class="toggleable-container-trigger"><span class="toggleable-container-icon dashicons %s"></span></button></h2>',
+			'<h2 id="%1$s"><button type="button" class="toggleable-container-trigger" aria-expanded="%5$s">%2$s (<code>%3$s</code>) <span class="toggleable-container-icon dashicons %4$s" aria-hidden="true"></span></button></h2>',
 			esc_attr( $post_type->name ),
 			esc_html( $plural_label ),
 			esc_html( $post_type->name ),
-			$toggle_icon
+			$toggle_icon,
+			$expanded
 		);
 
 		echo '<div class="' . $class . '">';

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -216,6 +216,7 @@ tr.yst_row.even {
 		width: 100%;
 		padding: 0;
 		text-align: left;
+		overflow: visible; // IE11 clips the icon focus style
 	}
 
 	.toggleable-container-icon {

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -209,13 +209,40 @@ tr.yst_row.even {
 	}
 
 	.toggleable-container-trigger {
-		float: right;
 		border: 0;
 		background: none;
 		cursor: pointer;
 		height: 20px;
-		width: 20px;
+		width: 100%;
 		padding: 0;
+		text-align: left;
+	}
+
+	.toggleable-container-icon {
+		float: right;
+		width: 20px;
+		height: 20px;
+		position: relative;
+	}
+
+
+	.toggleable-container-trigger .toggleable-container-icon::after {
+		content: "";
+		display: block;
+		padding: 14px; // will make the total width 28px
+		position: absolute;
+		top: -4px; // total width - toggleable-container-icon width / 2
+		left: -4px;
+	}
+
+	.toggleable-container-trigger:focus {
+		outline: none;
+
+		.toggleable-container-icon::after {
+			border-radius: 100%;
+			box-shadow: 0 0 0 1px #5b9dd9,
+			0 0 2px 1px rgba(30, 140, 190, 0.8);
+		}
 	}
 
 	.toggleable-container-hidden {

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -280,12 +280,13 @@ import a11ySpeak from "a11y-speak";
 
 		// Allow collapsing of the content types sections.
 		jQuery( "body" ).on( "click", "button.toggleable-container-trigger", ( event ) => {
-			event.preventDefault();
-
 			let target = jQuery( event.currentTarget );
+			let toggleableContainer = target.parent().siblings( ".toggleable-container" );
 
-			target.find( "span" ).toggleClass( "dashicons-arrow-up-alt2 dashicons-arrow-down-alt2" );
-			target.parent().siblings( ".toggleable-container" ).toggleClass( "toggleable-container-hidden" );
+			toggleableContainer.toggleClass( "toggleable-container-hidden" );
+			target
+				.attr( "aria-expanded", ! toggleableContainer.hasClass( "toggleable-container-hidden" ) )
+				.find( "span" ).toggleClass( "dashicons-arrow-up-alt2 dashicons-arrow-down-alt2" );
 		} );
 
 		wpseoCopyHomeMeta();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

- Improved accessibility of the collapsible sections in Search Appearance > Content Types

## Relevant technical choices:

- moves the text inside the button to avoid an empty interactive element
- uses `aria-expanded` to give feedback about the toggled state
- completely hides the icon from assistive technologies using `aria-hidden="true"`
- uses the same "circular focus style" used in other places, for example on the Help button

## Test instructions

This PR can be tested by following these steps:

- using a screen reader, go to one of the expandable section headings
- check it's announced with the content type name and the toggled state
- check the toggled state change is announced when toggling the panel
- check the focus style is rendered nicely in all browsers

Re: the focus style, I've opted to make it look like the one used in other places, e.g. for the Help Button:

<img width="692" alt="screen shot 2018-06-28 at 15 35 13" src="https://user-images.githubusercontent.com/1682452/42039295-57bff3de-7aed-11e8-889a-87d785f4572d.png">

Note: actually, the whole width is clickable but I'm fine to show the focus style only on the icon.

Tested also on Windows and IE 11 but at the moment I can't test on Edge (sorry)

Fixes #10183 
