### PR TITLE
Fix styling of snippet editor and preview for RTL

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -84,6 +84,7 @@ class WPSEO_Admin_Pages {
 
 		if ( $page === 'wpseo_titles' ) {
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'search-appearance', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'search-appearance', 'wpseoSearchAppearance', array( 'isRtl' => is_rtl() ) );
 			$this->asset_manager->enqueue_script( 'search-appearance' );
 			$this->asset_manager->enqueue_style( 'search-appearance' );
 

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -64,6 +64,7 @@ class WPSEO_Metabox_Formatter {
 			'contentAnalysisActive' => $analysis_readability->is_enabled() ? 1 : 0,
 			'keywordAnalysisActive' => $analysis_seo->is_enabled() ? 1 : 0,
 			'intl'                  => $this->get_content_analysis_component_translations(),
+			'isRtl'                 => is_rtl(),
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -14,7 +14,6 @@ const Section = styled( StyledSection )`
 
 		& ${ StyledHeading } {
 			font-size: 14.4px;
-			
 			${ getRtlStyle( "padding-left", "padding-right" ) }: 20px;
 			margin-left: ${ getRtlStyle( "0", "20px" ) };
 		}

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -3,6 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { StyledSection, StyledHeading, StyledSectionBase } from "yoast-components";
+import { getRtlStyle } from "yoast-components";
 
 const Section = styled( StyledSection )`
 	max-width: 640px;
@@ -12,8 +13,10 @@ const Section = styled( StyledSection )`
 		padding-right: 0;
 
 		& ${ StyledHeading } {
-			padding-left: 20px;
 			font-size: 14.4px;
+			
+			${ getRtlStyle( "padding-left", "padding-right" ) }: 20px;
+			margin-left: ${ getRtlStyle( "0", "20px" ) };
 		}
 	}
 `;

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -74,7 +74,6 @@ function wrapInTopLevelComponents( Component, store, props ) {
 	);
 }
 
-
 /**
  * Render a react app to a target element.
  *

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -18,9 +18,10 @@ import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
 import SnippetEditor from "./containers/SnippetEditor";
 import configureEnhancers from "./redux/utils/configureEnhancers";
 import analysisDataReducer from "./redux/reducers/analysisData";
+import { ThemeProvider } from "styled-components";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
-let localizedData = { intl: {} };
+let localizedData = { intl: {}, isRtl: false };
 if( window.wpseoPostScraperL10n ) {
 	localizedData = wpseoPostScraperL10n;
 } else if ( window.wpseoTermScraperL10n ) {
@@ -57,15 +58,22 @@ function configureStore() {
  * @returns {ReactElement} The wrapped component.
  */
 function wrapInTopLevelComponents( Component, store, props ) {
+	const theme = {
+		isRtl: localizedData.isRtl,
+	};
+
 	return (
 		<IntlProvider
 			messages={ localizedData.intl } >
 			<Provider store={ store } >
-				<Component { ...props } />
+				<ThemeProvider theme={ theme }>
+					<Component { ...props } />
+				</ThemeProvider>
 			</Provider>
 		</IntlProvider>
 	);
 }
+
 
 /**
  * Render a react app to a target element.

--- a/js/src/search-appearance.js
+++ b/js/src/search-appearance.js
@@ -1,4 +1,4 @@
-/* global wpseoReplaceVarsL10n */
+/* global wpseoReplaceVarsL10n, wpseoSearchAppearance */
 
 /* External dependencies */
 import ReactDOM from "react-dom";
@@ -14,6 +14,7 @@ import configureEnhancers from "./redux/utils/configureEnhancers";
 import getDefaultReplacementVariables from "./values/defaultReplaceVariables";
 import { updateReplacementVariable } from "./redux/actions/snippetEditor";
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
+import { ThemeProvider } from "styled-components";
 
 setYoastComponentsL10n();
 setWordPressSeoL10n();
@@ -56,12 +57,18 @@ if( editorElements.length ) {
 
 	const store = configureStore();
 
+	const theme = {
+		isRtl: wpseoSearchAppearance.isRtl,
+	};
+
 	ReactDOM.render(
 		<Provider store={ store }>
-			<SettingsReplacementVariableEditors
-				singleFieldElements={ singleFieldElements }
-				editorElements={ editorElements }
-			/>
+			<ThemeProvider theme={ theme }>
+				<SettingsReplacementVariableEditors
+					singleFieldElements={ singleFieldElements }
+					editorElements={ editorElements }
+				/>
+			</ThemeProvider>
 		</Provider>,
 		element
 	);

--- a/js/tests/components/SnippetPreviewSection.test.js
+++ b/js/tests/components/SnippetPreviewSection.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { mount } from "enzyme";
-
 import SnippetPreviewSection from "../../src/components/SnippetPreviewSection";
 
 jest.mock( "../../src/containers/SnippetEditor", () => {
@@ -9,8 +8,13 @@ jest.mock( "../../src/containers/SnippetEditor", () => {
 	};
 } );
 
+
 jest.mock( "yoast-components", () => {
-	return { StyledSection: () => <span>yoast-components StyledSection</span> };
+	const yoastComponents = require.requireActual( "yoast-components" );
+	return {
+		...yoastComponents,
+		StyledSection: () => <span>yoast-components StyledSection</span>,
+	};
 } );
 
 describe( "SnippetPreviewSection", () => {
@@ -18,9 +22,23 @@ describe( "SnippetPreviewSection", () => {
 		const tree = mount(
 			<SnippetPreviewSection
 				title="Snippet editor"
-				icon="eye" />
+				icon="eye"
+				theme={ { isRtl: false } }
+			/>
 		);
+		expect( tree ).toMatchSnapshot();
+	} );
+} );
 
+describe( "SnippetPreviewSection RTL", () => {
+	it( "renders the snippet editor inside of it", () => {
+		const tree = mount(
+			<SnippetPreviewSection
+				title="Snippet editor"
+				icon="eye"
+				theme={ { isRtl: true } }
+			/>
+		);
 		expect( tree ).toMatchSnapshot();
 	} );
 } );

--- a/js/tests/components/SnippetPreviewSection.test.js
+++ b/js/tests/components/SnippetPreviewSection.test.js
@@ -8,7 +8,6 @@ jest.mock( "../../src/containers/SnippetEditor", () => {
 	};
 } );
 
-
 jest.mock( "yoast-components", () => {
 	const yoastComponents = require.requireActual( "yoast-components" );
 	return {

--- a/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
+++ b/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
@@ -1,7 +1,12 @@
-exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
+exports[`SnippetPreviewSection RTL renders the snippet editor inside of it 1`] = `
 <SnippetPreviewSection
   hasPaperStyle={true}
   icon="eye"
+  theme={
+    Object {
+      "isRtl": true,
+    }
+  }
   title="Snippet editor">
   <SnippetPreviewSection__Section
     hasPaperStyle={true}
@@ -10,7 +15,38 @@ exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
     headingLevel={3}
     headingText="Snippet editor">
     <StyledSection
-      className="SnippetPreviewSection__Section-kWfIbs iPXqmw"
+      className="SnippetPreviewSection__Section-kWfIbs hPjctU"
+      hasPaperStyle={true}
+      headingIcon="eye"
+      headingIconColor="#555"
+      headingLevel={3}
+      headingText="Snippet editor">
+      <span>
+        yoast-components StyledSection
+      </span>
+    </StyledSection>
+  </SnippetPreviewSection__Section>
+</SnippetPreviewSection>
+`;
+
+exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
+<SnippetPreviewSection
+  hasPaperStyle={true}
+  icon="eye"
+  theme={
+    Object {
+      "isRtl": false,
+    }
+  }
+  title="Snippet editor">
+  <SnippetPreviewSection__Section
+    hasPaperStyle={true}
+    headingIcon="eye"
+    headingIconColor="#555"
+    headingLevel={3}
+    headingText="Snippet editor">
+    <StyledSection
+      className="SnippetPreviewSection__Section-kWfIbs hPjctU"
       hasPaperStyle={true}
       headingIcon="eye"
       headingIconColor="#555"

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "^4.4.0",
+    "yoast-components": "^4.5.0",
     "yoastseo": "^1.34.0"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11297,9 +11297,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yoast-components@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.4.0.tgz#825bba1790908b80da616b82691b2bbd8ae8276c"
+yoast-components@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.5.0.tgz#298c3d0334646835c260f56ff1a5f6f01fddc50c"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
**Cannot be merged before https://github.com/Yoast/yoast-components/pull/629 has been merged and yoast-components has been released**

## Summary

This PR can be summarized in the following changelog entry:

* Fixes the styling of the snippet editor and snippet preview for right-to-left languages in both the metabox and in the Search Appearance settings.

## Relevant technical choices:

* Uses `is_rtl()` in the php to determine whether we're dealing with an RTL or LTR language. 
* Adds a ThemeProvider that passes the language direction to the components.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/17744553/42048290-2379c030-7b03-11e8-9181-9c8d402e0045.png)
![image](https://user-images.githubusercontent.com/17744553/42048296-266413d6-7b03-11e8-8cdd-29805c01570b.png)



### After
![image](https://user-images.githubusercontent.com/17744553/42048274-11f941dc-7b03-11e8-8b94-f50fc2c84586.png)
![image](https://user-images.githubusercontent.com/17744553/42048281-1ab2e224-7b03-11e8-99b4-322ccab55958.png)
![image](https://user-images.githubusercontent.com/17744553/42048285-1ff00924-7b03-11e8-9d9e-133da207ab7b.png)



## Test instructions

This PR can be tested by following these steps:

* Link https://github.com/Yoast/yoast-components/pull/629
* Set your language to Hebrew, or another RTL language which is translated.
* Go to the metabox and look at the styling of all components in the snippet preview section. Don't forget to click the 'edit snippet' button.
* Go to Search Appearance and look at the styling of all components.
* Set your language to English.
* Check if nothing breaks in the metabox or in Search Appearance.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10174 