### PR TITLE
Fix title and description template saving

### DIFF
--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -88,12 +88,16 @@ function getDataWithTemplates( data, templates ) {
 
  * @returns {Object} A copy of the data without the templates.
  */
-function getDataWithoutTemplates( data, templates ) {
+export function getDataWithoutTemplates( data, templates ) {
 	const dataWithoutTemplates = { ...data };
 
 	forEach( templates, ( template, key ) => {
-		if ( has( data, key ) && data[ key ] === template ) {
-			dataWithoutTemplates[ key ] = "";
+		if ( has( data, key ) ) {
+			// Trim spaces from the beginning and end of the data to make a fair comparison with the template.
+			const trimmedData = data[ key ].replace( /^\s+|\s+$/g, "" );
+			if ( trimmedData === template ) {
+				dataWithoutTemplates[ key ] = "";
+			}
 		}
 	} );
 

--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -92,12 +92,15 @@ export function getDataWithoutTemplates( data, templates ) {
 	const dataWithoutTemplates = { ...data };
 
 	forEach( templates, ( template, key ) => {
-		if ( has( data, key ) ) {
-			// Trim spaces from the beginning and end of the data to make a fair comparison with the template.
-			const trimmedData = data[ key ].replace( /^\s+|\s+$/g, "" );
-			if ( trimmedData === template ) {
-				dataWithoutTemplates[ key ] = "";
-			}
+		if ( ! has( data, key ) ) {
+			return;
+		}
+
+		// Trim spaces from the beginning and end of the data to make a fair comparison with the template.
+		const trimmedData = data[ key ].trim();
+
+		if ( trimmedData === template ) {
+			dataWithoutTemplates[ key ] = "";
 		}
 	} );
 

--- a/js/tests/analysis/snippetEditor.test.js
+++ b/js/tests/analysis/snippetEditor.test.js
@@ -1,0 +1,67 @@
+import { getDataWithoutTemplates } from "../../src/analysis/snippetEditor";
+
+describe( "getDataWithoutTemplates", () => {
+	it( "returns an empty title and description when the data and templates are exactly the same", () => {
+		const templates = {
+			title: "%%title%% %%sep%% %%sitename%%",
+			slug: "",
+			description: "%%excerpt%%",
+		};
+
+		const data = {
+			title: "%%title%% %%sep%% %%sitename%%",
+			description: "%%excerpt%%",
+		};
+
+		const expected = {
+			title: "",
+			description: "",
+		};
+
+		const actual = getDataWithoutTemplates( data, templates );
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "returns an empty title and description when the data and templates only differ regarding leading and trailing spaces", () => {
+		const templates = {
+			title: "%%title%% %%sep%% %%sitename%%",
+			slug: "",
+			description: "%%excerpt%%",
+		};
+
+		const data = {
+			title: "  %%title%% %%sep%% %%sitename%%  ",
+			description: "%%excerpt%%",
+		};
+
+		const expected = {
+			title: "",
+			description: "",
+		};
+
+		const actual = getDataWithoutTemplates( data, templates );
+		expect( actual ).toEqual( expected );
+	} );
+
+
+	it( "returns the title and description from the data when the data and templates differ from each other", () => {
+		const templates = {
+			title: "%%title%% %%sep%% %%sitename%%",
+			slug: "",
+			description: "%%excerpt%%",
+		};
+
+		const data = {
+			title: "%%title%% %%sep%% %%sitename%% changes are cool",
+			description: "%%excerpt%% with more text",
+		};
+
+		const expected = {
+			title: "%%title%% %%sep%% %%sitename%% changes are cool",
+			description: "%%excerpt%% with more text",
+		};
+
+		const actual = getDataWithoutTemplates( data, templates );
+		expect( actual ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where title and description templates were saved to the database.

## Relevant technical choices:
* This bug was caused by adding spaces after each replace var, which meant that the template was compared to the template + a space at the end. Those two values were different, which meant the template + space was saved to the database.
* Solution: Trim title and description data before comparing it to the template.

## Test instructions

This PR can be tested by following these steps:

* Look for the hidden input fields `yoast_wpseo_title` and `yoast_wpseo_metadesc` in the html inspector. It's value should be empty when creating a new post, and stay empty when you open the snippet editor. If you change the title and meta description in the editor, the hidden input field value should change to the title/description you just changed.
* In the database, the hidden input field values shouldn't be saved when you didn't touch the title and description.
* The same goes for pages/taxonomies/tags/etc.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10192 
