### PR TITLE
[FIX] Fix display of post type archive settings

### DIFF
--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -84,7 +84,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 			continue;
 		}
 
-		if ( $post_type->has_archive == true ) {
+		if ( ! empty( $post_type->has_archive ) ) {
 			// translators: %s is the plural version of the post type's name.
 			echo '<h3>' . esc_html( sprintf( __( 'Settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h3>';
 

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -84,7 +84,7 @@ if ( is_array( $post_types ) && $post_types !== array() ) {
 			continue;
 		}
 
-		if ( $post_type->has_archive === true ) {
+		if ( $post_type->has_archive == true ) {
 			// translators: %s is the plural version of the post type's name.
 			echo '<h3>' . esc_html( sprintf( __( 'Settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h3>';
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where archive settings for post types aren't shown on the search appearance page when the `has_archive` for that post type contains an archive slug. Props to [schurig](https://github.com/schurig)

## Relevant technical choices:

`$post_type->has_archive` can also be a string. So here we shouldn't match for the type. We just want to know if the value is truthy or not.

## Test instructions

This PR can be tested by following these steps:

* Create a post type with a custom archive name so that `has_archive` is a string
* go on `/wp-admin/admin.php?page=wpseo_titles#top#post-types` and it should show the archive options too (before it didn't)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (didn't find any specs related to that, also the last time I worked with PHP was at least 5 years ago)

Fixes #10211
