### PR TITLE
10203 show notification once

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -325,6 +325,7 @@ class Yoast_Notification_Center {
 
 		$sorted_notifications = $this->get_sorted_notifications();
 		$notifications        = array_filter( $sorted_notifications, array( $this, 'is_notification_persistent' ) );
+		$notifications        = array_unique( $notifications );
 
 		if ( empty( $notifications ) ) {
 			return;

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -82,7 +82,7 @@ class Yoast_Notification_Center {
 			) );
 		}
 
-		if ( $notification_center->maybe_dismiss_notification( $notification ) ) {
+		if ( self::maybe_dismiss_notification( $notification ) ) {
 			die( '1' );
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the same notification is shown multiple times when trashing multiple posts.

## Test instructions

This PR can be tested by following these steps:

* Have some posts you can trash (don't worry - you can restore them if necessary)
* Select multiple posts and remove them via bulk actions - move to trash
* Only one notification should be shown.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10203
