### PR TITLE
Export text domain helper

### DIFF
--- a/js/src/helpers/i18n.js
+++ b/js/src/helpers/i18n.js
@@ -9,7 +9,7 @@ import get from "lodash/get";
  * @param {string} textdomain The textdomain to set the locale data for.
  * @returns {void}
  */
-function setTextdomainL10n( textdomain ) {
+export function setTextdomainL10n( textdomain ) {
 	const jed = getI18n();
 	const currentTranslations = get( jed, [ "options", "locale_data", textdomain ], false );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Export the `setTextdomainL10n` helper to enable setting a domain in premium.

## Test instructions

This PR can be tested by following these steps:

* Not really needed. Does it still build?
* No Jed error in combination with the fixes issue.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/yoast-components/issues/622
