### PR TITLE
Add routine for deleting postmeta by key.

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -621,7 +621,11 @@ class WPSEO_Upgrade {
 	private function delete_post_meta( $meta_key ) {
 		global $wpdb;
 
-		$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $meta_key ), array( '%s' ) );
+		$deleted = $wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $meta_key ), array( '%s' ) );
+
+		if ( $deleted ) {
+			wp_cache_set( 'last_changed', microtime(), 'posts' );
+		}
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -597,7 +597,7 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_77() {
 		// Remove all OpenGraph content image cache.
-		delete_post_meta_by_key( '_yoast_wpseo_post_image_cache' );
+		$this->delete_post_meta( '_yoast_wpseo_post_image_cache' );
 	}
 
 	/**
@@ -609,6 +609,19 @@ class WPSEO_Upgrade {
 		if ( WPSEO_Utils::is_woocommerce_active() ) {
 			$this->migrate_woocommerce_archive_setting_to_shop_page();
 		}
+	}
+
+	/**
+	 * Removes the post meta fields for a given meta key.
+	 *
+	 * @param string $meta_key The meta key.
+	 *
+	 * @return void
+	 */
+	private function delete_post_meta( $meta_key ) {
+		global $wpdb;
+
+		$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $meta_key ), array( '%s' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the upgrade routing for 7.7 gave performance issues on larger databases.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch.
* Have posts with postmetas for the key `_yoast_wpseo_post_image_cache` - adding these manually. Perhaps the CLI can create large datasets for it (I don't know, it's just an idea)
* Install the Yoast test helper and sets the version to 7.6
* By setting the value, the version will updated directly
* Go to the database and verify that the postmetas for the key `_yoast_wpseo_post_image_cache` are deleted.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10209