### PR TITLE
Change direct call of the analyzer to refresh

### DIFF
--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -362,18 +362,7 @@ PostDataCollector.prototype.inputElementEventBinder = function( app ) {
 
 	tmceHelper.tinyMceEventBinder( app, tmceId );
 
-	document.getElementById( "yoast_wpseo_focuskw_text_input" ).addEventListener( "blur", this.resetQueue.bind( this ) );
-};
-
-/**
- * Resets the current queue if focus keyword is changed and not empty.
- *
- * @returns {void}
- */
-PostDataCollector.prototype.resetQueue = function() {
-	if ( this.app.rawData.keyword !== "" ) {
-		this.app.runAnalyzer( this.rawData );
-	}
+	document.getElementById( "yoast_wpseo_focuskw_text_input" ).addEventListener( "blur", app.refresh.bind( app ) );
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

While debugging something else, came across this direct call of `runAnalyzer`. Changed to call `app.refresh` on blur instead. Going through the debounce.

## Test instructions

This PR can be tested by following these steps:

* Check that the assessments still properly update after blurring the focus keyword fields.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
