### PR TITLE
Delete potfile from copy.js

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -66,7 +66,6 @@ module.exports = {
 					"wp-seo.php",
 					"wp-seo-main.php",
 					"wpml-config.xml",
-					"!languages/wordpress-seo.pot",
 					"!vendor/bin",
 					"!vendor/composer/installed.json",
 					"!vendor/composer/installers/**",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Delete "!languages/wordpress-seo.pot" from copy.js because that file no longer exists in the repo.