### PR TITLE
Remove style overwrite

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -625,6 +625,7 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 .yoast-section {
 	box-shadow: 0 1px 2px rgba( 0, 0, 0, .2 );
 	position: relative;
+	background-color: #fff;
 	padding: 0 20px 15px;
 
 	&__heading {

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -625,12 +625,11 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 .yoast-section {
 	box-shadow: 0 1px 2px rgba( 0, 0, 0, .2 );
 	position: relative;
-	background-color: #fff;
 	padding: 0 20px 15px;
 
 	&__heading {
 		padding: 8px 20px;
-		font-size: 0.9rem;
+		font-size: 1rem;
 		margin: 0 -20px 15px;
 		font-family: "Open Sans", sans-serif;
 		font-weight: 300;

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -13,7 +13,6 @@ const Section = styled( StyledSection )`
 		padding-right: 0;
 
 		& ${ StyledHeading } {
-			font-size: 14.4px;
 			${ getRtlStyle( "padding-left", "padding-right" ) }: 20px;
 			margin-left: ${ getRtlStyle( "0", "20px" ) };
 		}

--- a/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
+++ b/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
@@ -15,7 +15,7 @@ exports[`SnippetPreviewSection RTL renders the snippet editor inside of it 1`] =
     headingLevel={3}
     headingText="Snippet editor">
     <StyledSection
-      className="SnippetPreviewSection__Section-kWfIbs hPjctU"
+      className="SnippetPreviewSection__Section-kWfIbs LsuOf"
       hasPaperStyle={true}
       headingIcon="eye"
       headingIconColor="#555"
@@ -46,7 +46,7 @@ exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
     headingLevel={3}
     headingText="Snippet editor">
     <StyledSection
-      className="SnippetPreviewSection__Section-kWfIbs hPjctU"
+      className="SnippetPreviewSection__Section-kWfIbs LsuOf"
       hasPaperStyle={true}
       headingIcon="eye"
       headingIconColor="#555"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

The font-size of the sections are not the same. After this `Focus keyword` is the only one not the same, but this is going to get Reactified at some point.

* Removed the heading font size overwrite.

## Test instructions

This PR can be tested by following these steps:

* Check if the heading font-size of the snippet editor is now 16px.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
