### PR TITLE
Add premium upsell for synonyms

### DIFF
--- a/admin/class-add-keyword-modal.php
+++ b/admin/class-add-keyword-modal.php
@@ -18,7 +18,7 @@ class WPSEO_Add_Keyword_Modal {
 	 */
 	public function get_translations() {
 		return array(
-			'title'                    => __( 'Want to add more than one keyword?', 'wordpress-seo' ),
+			'title'                    => __( 'Would you like to add more than one keyword?', 'wordpress-seo' ),
 			'intro'                    => sprintf(
 				/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
 				__( 'Great news: you can, with %1$s!', 'wordpress-seo' ),

--- a/admin/class-add-keyword-modal.php
+++ b/admin/class-add-keyword-modal.php
@@ -40,7 +40,7 @@ class WPSEO_Add_Keyword_Modal {
 	}
 
 	/**
-	 * Pass tanslations to JS for the Add Keyword modal component.
+	 * Passes translations to JS for the Add Keyword modal component.
 	 *
 	 * @return array Translated text strings for the Add Keyword modal component.
 	 */

--- a/admin/class-keyword-synonyms-modal.php
+++ b/admin/class-keyword-synonyms-modal.php
@@ -40,7 +40,7 @@ class WPSEO_Keyword_Synonyms_Modal {
 	}
 
 	/**
-	 * Pass tanslations to JS for the Keyword Synonyms modal component.
+	 * Passes translations to JS for the Keyword Synonyms modal component.
 	 *
 	 * @return array Translated text strings for the Keyword Synonyms modal component.
 	 */

--- a/admin/class-keyword-synonyms-modal.php
+++ b/admin/class-keyword-synonyms-modal.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Class to print out the translatable strings for the Keyword Synonyms modal.
+ */
+class WPSEO_Keyword_Synonyms_Modal {
+
+	/**
+	 * Returns the translations for the Keyword Synonyms modal.
+	 *
+	 * These strings are not escaped because they're meant to be used with React
+	 * which already takes care of that. If used in PHP, they should be escaped.
+	 *
+	 * @return array Translated text strings for the Keyword Synonyms modal.
+	 */
+	public function get_translations() {
+		return array(
+			'title'                    => __( 'Want to add keyword synonyms?', 'wordpress-seo' ),
+			'intro'                    => sprintf(
+				/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
+				__( 'Great news: you can, with %1$s!', 'wordpress-seo' ),
+				'{{link}}Yoast SEO Premium{{/link}}'
+			),
+			'link'                     => WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ),
+			'other'                    => sprintf(
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				__( 'Other benefits of %s for you:', 'wordpress-seo' ), 'Yoast SEO Premium'
+			),
+			'buylink'                  => WPSEO_Shortlinker::get( 'https://yoa.st/keyword-synonyms-popup' ),
+			'buy'                      => sprintf(
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				__( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium'
+			),
+			'small'                    => __( '1 year free updates and upgrades included!', 'wordpress-seo' ),
+			'a11yNotice.opensInNewTab' => __( '(Opens in a new browser tab)', 'wordpress-seo' ),
+		);
+	}
+
+	/**
+	 * Pass tanslations to JS for the Keyword Synonyms modal component.
+	 *
+	 * @return array Translated text strings for the Keyword Synonyms modal component.
+	 */
+	public function get_translations_for_js() {
+		$translations = $this->get_translations();
+		return array(
+			'locale' => WPSEO_Utils::get_user_locale(),
+			'intl'   => $translations,
+		);
+	}
+
+	/**
+	 * Prints the localized Keyword Synonyms modal translations for JS.
+	 */
+	public function enqueue_translations() {
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-global-script', 'yoastKeywordSynonymsModalL10n', $this->get_translations_for_js() );
+	}
+}

--- a/admin/class-keyword-synonyms-modal.php
+++ b/admin/class-keyword-synonyms-modal.php
@@ -18,7 +18,7 @@ class WPSEO_Keyword_Synonyms_Modal {
 	 */
 	public function get_translations() {
 		return array(
-			'title'                    => __( 'Want to add keyword synonyms?', 'wordpress-seo' ),
+			'title'                    => __( 'Would you like to add keyword synonyms?', 'wordpress-seo' ),
 			'intro'                    => sprintf(
 				/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
 				__( 'Great news: you can, with %1$s!', 'wordpress-seo' ),

--- a/admin/class-premium-benefits-for-synonyms-list.php
+++ b/admin/class-premium-benefits-for-synonyms-list.php
@@ -33,7 +33,7 @@ class WPSEO_Premium_Benefits_For_Synonyms_List {
 	}
 
 	/**
-	 * Pass translations to JS for the Add Keyword JS component Premium benefits list.
+	 * Passes translations to JS for the Add Keyword JS component Premium benefits list.
 	 *
 	 * @return array Translated text strings for the Premium benefits list component.
 	 */

--- a/admin/class-premium-benefits-for-synonyms-list.php
+++ b/admin/class-premium-benefits-for-synonyms-list.php
@@ -33,7 +33,7 @@ class WPSEO_Premium_Benefits_For_Synonyms_List {
 	}
 
 	/**
-	 * Pass tanslations to JS for the Add Keyword JS component Premium benefits list.
+	 * Pass translations to JS for the Add Keyword JS component Premium benefits list.
 	 *
 	 * @return array Translated text strings for the Premium benefits list component.
 	 */

--- a/admin/class-premium-benefits-for-synonyms-list.php
+++ b/admin/class-premium-benefits-for-synonyms-list.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Class to print out a list of Premium benefits specific for the keyword synonyms.
+ */
+class WPSEO_Premium_Benefits_For_Synonyms_List {
+
+	/**
+	 * Returns the translations for the Premium benefits list.
+	 *
+	 * @return array Translated text strings for the Premium benefits list.
+	 */
+	public function get_translations() {
+		return array(
+			'<strong>' . __( 'Rank for up to 5 focus keywords per page', 'wordpress-seo' ) . '</strong>',
+			sprintf(
+				/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+				__( '%1$sNo more dead links%2$s: easy redirect manager', 'wordpress-seo' ),
+				'<strong>', '</strong>'
+			),
+			'<strong>' . __( 'Superfast internal links suggestions', 'wordpress-seo' ) . '</strong>',
+			sprintf(
+				/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
+				__( '%1$sSocial media preview%2$s: Facebook & Twitter', 'wordpress-seo' ),
+				'<strong>', '</strong>'
+			),
+			'<strong>' . __( '24/7 support', 'wordpress-seo' ) . '</strong>',
+			'<strong>' . __( 'No ads!', 'wordpress-seo' ) . '</strong>',
+		);
+	}
+
+	/**
+	 * Pass tanslations to JS for the Add Keyword JS component Premium benefits list.
+	 *
+	 * @return array Translated text strings for the Premium benefits list component.
+	 */
+	public function get_translations_for_js() {
+		$translations = $this->get_translations();
+		return array(
+			'locale' => WPSEO_Utils::get_user_locale(),
+			'intl'   => $translations,
+		);
+	}
+
+	/**
+	 * Prints the localized Premium benefits translations for JS.
+	 */
+	public function enqueue_translations() {
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-global-script', 'yoastPremiumBenefitsForSynonymsL10n', $this->get_translations_for_js() );
+	}
+}

--- a/admin/metabox/class-metabox-keyword-synonyms-button.php
+++ b/admin/metabox/class-metabox-keyword-synonyms-button.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Metabox
+ */
+
+/**
+ * Button to show the premium upsell.
+ */
+class WPSEO_Metabox_Keyword_Synonyms_Button {
+
+	/**
+	 * Returns a button because a link is inappropriate here.
+	 *
+	 * @return string
+	 */
+	public function get_link() {
+
+		if ( WPSEO_UTILS::is_yoast_seo_premium() ) {
+			return '';
+		}
+
+		$keyword_synonyms_modal_config = array(
+			'mountHook'      => '.wpseo-button-keyword-synonyms',
+			'openButtonIcon' => '',
+			'intl'           => array(
+				'open'           => __( 'Want to add keyword synonyms?', 'wordpress-seo' ),
+				'modalAriaLabel' => sprintf(
+					/* translators: %s expands to 'Yoast SEO Premium'. */
+					__( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium'
+				),
+				'heading'        => sprintf(
+					/* translators: %s expands to 'Yoast SEO Premium'. */
+					__( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium'
+				),
+			),
+			'classes'        => array(
+				'openButton' => 'wpseo-keyword-synonyms button-link',
+			),
+			'content'        => 'KeywordSynonyms',
+		);
+
+		$translations = new WPSEO_Keyword_Synonyms_Modal();
+		$translations->enqueue_translations();
+
+		$benefits = new WPSEO_Premium_Benefits_List();
+		$benefits->enqueue_translations();
+
+		Yoast_Modal::add( $keyword_synonyms_modal_config );
+
+		return '<div class="wpseo-button-keyword-synonyms"></div>';
+	}
+}

--- a/admin/metabox/class-metabox-keyword-synonyms-button.php
+++ b/admin/metabox/class-metabox-keyword-synonyms-button.php
@@ -17,10 +17,6 @@ class WPSEO_Metabox_Keyword_Synonyms_Button {
 	 */
 	public function get_link() {
 
-		if ( WPSEO_UTILS::is_yoast_seo_premium() ) {
-			return '';
-		}
-
 		$keyword_synonyms_modal_config = array(
 			'mountHook'      => '.wpseo-button-keyword-synonyms',
 			'openButtonIcon' => '',

--- a/admin/metabox/class-metabox-keyword-synonyms-button.php
+++ b/admin/metabox/class-metabox-keyword-synonyms-button.php
@@ -40,7 +40,7 @@ class WPSEO_Metabox_Keyword_Synonyms_Button {
 		$translations = new WPSEO_Keyword_Synonyms_Modal();
 		$translations->enqueue_translations();
 
-		$benefits = new WPSEO_Premium_Benefits_List();
+		$benefits = new WPSEO_Premium_Benefits_For_Synonyms_List();
 		$benefits->enqueue_translations();
 
 		Yoast_Modal::add( $keyword_synonyms_modal_config );

--- a/admin/metabox/class-metabox-keyword-synonyms-button.php
+++ b/admin/metabox/class-metabox-keyword-synonyms-button.php
@@ -25,7 +25,7 @@ class WPSEO_Metabox_Keyword_Synonyms_Button {
 			'mountHook'      => '.wpseo-button-keyword-synonyms',
 			'openButtonIcon' => '',
 			'intl'           => array(
-				'open'           => __( 'Want to add keyword synonyms?', 'wordpress-seo' ),
+				'open'           => __( '+ Add synonyms', 'wordpress-seo' ),
 				'modalAriaLabel' => sprintf(
 					/* translators: %s expands to 'Yoast SEO Premium'. */
 					__( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium'

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -596,8 +596,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				$content .= '<label for="' . $esc_form_key . '" class="screen-reader-text">' . esc_html( $meta_field_def['label'] ) . '</label>';
 				$content .= '<input type="text"' . $placeholder . ' id="' . $esc_form_key . '" autocomplete="off" name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '" class="large-text' . $class . '"/>';
 
-				$button = new WPSEO_Metabox_Keyword_Synonyms_Button();
-				$content .= $button->get_link();
+				if ( WPSEO_UTILS::is_yoast_seo_premium() === false ) {
+					$button = new WPSEO_Metabox_Keyword_Synonyms_Button();
+					$content .= $button->get_link();
+				}
 
 				if ( WPSEO_Options::get( 'enable_cornerstone_content', false ) ) {
 					$cornerstone_field = new WPSEO_Cornerstone_Field();

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -596,6 +596,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				$content .= '<label for="' . $esc_form_key . '" class="screen-reader-text">' . esc_html( $meta_field_def['label'] ) . '</label>';
 				$content .= '<input type="text"' . $placeholder . ' id="' . $esc_form_key . '" autocomplete="off" name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '" class="large-text' . $class . '"/>';
 
+				$button = new WPSEO_Metabox_Keyword_Synonyms_Button();
+				$content .= $button->get_link();
+
 				if ( WPSEO_Options::get( 'enable_cornerstone_content', false ) ) {
 					$cornerstone_field = new WPSEO_Cornerstone_Field();
 

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -178,6 +178,10 @@ ul.wpseo-metabox-tabs li {
 	margin-bottom: 2em;
 }
 
+#wpseo-focuskeyword-section .wpseo-keyword-synonyms {
+	margin-top: 16px;
+}
+
 /* Tab links. */
 .wpseo-metabox-tabs .wpseo_tablink {
 	display: inline-block;

--- a/js/src/components/PremiumBenefitsForSynonymsList.js
+++ b/js/src/components/PremiumBenefitsForSynonymsList.js
@@ -1,0 +1,44 @@
+/* global yoastPremiumBenefitsForSynonymsL10n */
+import React from "react";
+import styled from "styled-components";
+import interpolateComponents from "interpolate-components";
+
+let localizedData = null;
+if ( window.yoastPremiumBenefitsForSynonymsL10n ) {
+	localizedData = yoastPremiumBenefitsForSynonymsL10n;
+}
+
+const StyledList = styled.ul`
+	list-style: none;
+	margin: 0 0 16px;
+
+	li {
+		margin: 5px 0 0 0;
+		padding-left: 16px;
+	}
+
+	span[aria-hidden="true"]:before {
+		margin: 0 8px 0 -16px;
+		font-weight: bold;
+		content: "+";
+	}
+`;
+
+const PremiumBenefitsForSynonymsList = () => {
+	return (
+		localizedData &&
+			<StyledList role="list">
+				{ localizedData.intl.map( ( benefit, index ) => {
+					return <li key={ index }>
+						<span aria-hidden="true"></span>
+						{ interpolateComponents( {
+							mixedString: benefit.replace( "<strong>", "{{strong}}" ).replace( "</strong>", "{{/strong}}" ),
+							components: { strong: <strong /> },
+						} ) }
+					</li>;
+				} ) }
+			</StyledList>
+	);
+};
+
+export default PremiumBenefitsForSynonymsList;

--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -1,0 +1,65 @@
+/* global yoastKeywordSynonymsModalL10n */
+import React from "react";
+import styled from "styled-components";
+import interpolateComponents from "interpolate-components";
+
+import IntlProvider from "../IntlProvider";
+import Icon from "yoast-components/composites/Plugin/Shared/components/Icon";
+import YoastSeoIcon from "yoast-components/composites/basic/YoastSeoIcon";
+import { makeOutboundLink } from "yoast-components/utils/makeOutboundLink";
+import PremiumBenefitsList from "../PremiumBenefitsList";
+
+let localizedData = null;
+if ( window.yoastKeywordSynonymsModalL10n ) {
+	localizedData = yoastKeywordSynonymsModalL10n;
+}
+
+const YesYouCanLink = makeOutboundLink();
+const BuyButtonLink = makeOutboundLink();
+
+const StyledContainer = styled.div`
+	min-width: 600px;
+
+	@media screen and ( max-width: 680px ) {
+		min-width: 0;
+		width: 86vw;
+	}
+`;
+
+const StyledIcon = styled( Icon )`
+	float: right;
+	margin: 0 0 16px 16px;
+
+	&& {
+		@media screen and ( max-width: 680px ) {
+			width: 80px;
+			height: 80px;
+		}
+	}
+`;
+
+const KeywordSynonyms = () => {
+	return (
+		localizedData && <IntlProvider messages={ localizedData.intl }>
+			<StyledContainer>
+				<StyledIcon icon={ YoastSeoIcon } width="150px" height="150px" />
+				<h2>{ localizedData.intl.title }</h2>
+				<p>
+					{ interpolateComponents( {
+						mixedString: localizedData.intl.intro,
+						components: { link: <YesYouCanLink href={ localizedData.intl.link } /> },
+					} ) }
+				</p>
+				<p>{ localizedData.intl.other }</p>
+				<PremiumBenefitsList />
+				<BuyButtonLink href={ localizedData.intl.buylink } className="button button-primary">
+					{ localizedData.intl.buy }
+				</BuyButtonLink>
+				<br/>
+				<small>{ localizedData.intl.small }</small>
+			</StyledContainer>
+		</IntlProvider>
+	);
+};
+
+export default KeywordSynonyms;

--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -7,7 +7,7 @@ import IntlProvider from "../IntlProvider";
 import Icon from "yoast-components/composites/Plugin/Shared/components/Icon";
 import YoastSeoIcon from "yoast-components/composites/basic/YoastSeoIcon";
 import { makeOutboundLink } from "yoast-components/utils/makeOutboundLink";
-import PremiumBenefitsList from "../PremiumBenefitsList";
+import PremiumBenefitsForSynonymsList from "../PremiumBenefitsForSynonymsList";
 
 let localizedData = null;
 if ( window.yoastKeywordSynonymsModalL10n ) {
@@ -51,7 +51,7 @@ const KeywordSynonyms = () => {
 					} ) }
 				</p>
 				<p>{ localizedData.intl.other }</p>
-				<PremiumBenefitsList />
+				<PremiumBenefitsForSynonymsList />
 				<BuyButtonLink href={ localizedData.intl.buylink } className="button button-primary">
 					{ localizedData.intl.buy }
 				</BuyButtonLink>

--- a/js/src/components/modals/index.js
+++ b/js/src/components/modals/index.js
@@ -1,7 +1,9 @@
 import AddKeyword from "./AddKeyword";
+import KeywordSynonyms from "./KeywordSynonyms";
 
 const modals = {
 	AddKeyword: AddKeyword,
+	KeywordSynonyms: KeywordSynonyms,
 };
 
 export default modals;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Add a modal just like add keywords: https://github.com/Yoast/wordpress-seo/pull/9231
* The buy link uses a newly generated shortcode: https://yoa.st/keyword-synonyms-popup/

## Screenshots
<img width="660" alt="link" src="https://user-images.githubusercontent.com/35524806/42317114-d258ffa6-804b-11e8-88ba-9b9e29f69556.png">
<img width="662" alt="modal" src="https://user-images.githubusercontent.com/35524806/42317118-d4f558e0-804b-11e8-99f6-791fb8a14510.png">


## Test instructions

This PR can be tested by following these steps:

* Test if the add keyword modal still functions like before.
* Test if modal functions properly:
  * Text matches.
  * Links to correct url.
  * Looks the same as add keyword.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10263
