### PR TITLE
Unescape HTML entities in replacement variable value strings

### DIFF
--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -42,7 +42,7 @@ class ClassicEditorData {
 	 */
 	initialize( replaceVars ) {
 		this._data = this.getInitialData( replaceVars );
-		fillReplacementVariables( decodeSeparatorVariable( this._data ), this._store );
+		fillReplacementVariables( this._data, this._store );
 		this.subscribeToElements();
 		this.subscribeToStore();
 	}

--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -7,7 +7,6 @@ import {
 	fillReplacementVariables,
 	mapCustomFields,
 	mapCustomTaxonomies,
-	decodeSeparatorVariable,
 } from "../helpers/replacementVariableHelpers";
 import tmceHelper, { tmceId } from "../wp-seo-tinymce";
 import debounce from "lodash/debounce";

--- a/js/src/helpers/replacementVariableHelpers.js
+++ b/js/src/helpers/replacementVariableHelpers.js
@@ -4,7 +4,6 @@ import omit from "lodash/omit";
 
 /* Internal dependencies */
 import { updateReplacementVariable } from "../redux/actions/snippetEditor";
-import decodeHTML from "yoast-components/composites/OnboardingWizard/helpers/htmlDecoder";
 import { firstToUpperCase } from "./stringHelpers";
 
 
@@ -102,21 +101,6 @@ export function pushNewReplaceVar( replacementVariables, action ) {
 		label: action.label || createLabelFromName( action.name ),
 		value: action.value,
 	} );
-	return replacementVariables;
-}
-
-/**
- * Decodes the separator replacement variable to a displayable symbol.
- *
- * @param   {Object} replacementVariables   The object with replacement variables.
- *
- * @returns {Object} The object with replacement variables with a decoded separator.
- */
-export function decodeSeparatorVariable( replacementVariables ) {
-	if( replacementVariables[ "sep" ] ) {
-		replacementVariables[ "sep" ] = decodeHTML( replacementVariables[ "sep" ] );
-	}
-
 	return replacementVariables;
 }
 

--- a/js/src/helpers/stringHelpers.js
+++ b/js/src/helpers/stringHelpers.js
@@ -1,17 +1,3 @@
-import unescape from "lodash/unescape";
-
-/**
- * Wraps Lodash's unescape function to deal with PHP's escaping of the apostrophe, which is &#039; in PHP.
- * Converts &amp;, &lt;, &gt;, &quot;, and &#39; in escapedString to their corresponding characters.
- *
- * @param {string}   escapedString         The string that is to be escaped.
- * @returns {string} The unescaped string.
-  */
-export function unescapeString( escapedString ) {
-	escapedString = escapedString.replace( /&#0*39;/g, "&#39;" );
-	return unescape( escapedString );
-}
-
 /**
  * Capitalize the first letter of a string.
  *

--- a/js/src/redux/actions/snippetEditor.js
+++ b/js/src/redux/actions/snippetEditor.js
@@ -1,4 +1,4 @@
-import { unescapeString } from "../../helpers/stringHelpers";
+import decodeHTML from "yoast-components/composites/OnboardingWizard/helpers/htmlDecoder";
 
 export const SWITCH_MODE = "SNIPPET_EDITOR_SWITCH_MODE";
 export const UPDATE_DATA = "SNIPPET_EDITOR_UPDATE_DATA";
@@ -48,7 +48,7 @@ export function updateData( data ) {
  */
 export function updateReplacementVariable( name, value, label = "" ) {
 	const unescapedValue = ( typeof value === "string" )
-		? unescapeString( value )
+		? decodeHTML( value )
 		: value;
 	return {
 		type: UPDATE_REPLACEMENT_VARIABLE,

--- a/js/tests/helpers/replacementVariableHelpers.test.js
+++ b/js/tests/helpers/replacementVariableHelpers.test.js
@@ -1,57 +1,9 @@
 import {
-	pushNewReplaceVar, decodeSeparatorVariable, mapCustomFields, mapCustomTaxonomies, prepareCustomFieldForDispatch,
+	pushNewReplaceVar, mapCustomFields, mapCustomTaxonomies, prepareCustomFieldForDispatch,
 	prepareCustomTaxonomyForDispatch,
 	replaceSpaces,
 } from "../../src/helpers/replacementVariableHelpers";
 import { UPDATE_REPLACEMENT_VARIABLE } from "../../src/redux/actions/snippetEditor";
-
-describe( "decodeSeparatorVariable", () => {
-	it( "decodes &ndashes from the replacementvariables object from a code to a symbol.", () => {
-		const replacementVariables = {
-			date: "May 15, 2018",
-			sep: "&ndash;",
-		};
-
-		const expected = {
-			date: "May 15, 2018",
-			sep: "–",
-		};
-
-		const actual = decodeSeparatorVariable( replacementVariables );
-
-		expect( actual ).toEqual( expected );
-	} );
-
-	it( "decodes the seperator from the replacementvariables object from a code to a symbol.", () => {
-		const replacementVariables = {
-			date: "May 15, 2018",
-			sep: "&#8902;",
-		};
-
-		const expected = {
-			date: "May 15, 2018",
-			sep: "⋆",
-		};
-
-		const actual = decodeSeparatorVariable( replacementVariables );
-
-		expect( actual ).toEqual( expected );
-	} );
-
-	it( "returns the passed object when no sep variable was present in the replacement variables object", () => {
-		const replacementVariables = {
-			date: "May 15, 2018",
-		};
-
-		const expected = {
-			date: "May 15, 2018",
-		};
-
-		const actual = decodeSeparatorVariable( replacementVariables );
-
-		expect( actual ).toEqual( expected );
-	} );
-} );
 
 describe( "replaceSpaces", () => {
 	it( "replaces single spaces in a string with underscores", () => {

--- a/js/tests/helpers/stringHelpers.test.js
+++ b/js/tests/helpers/stringHelpers.test.js
@@ -1,24 +1,14 @@
 import {
-	unescapeString,
+	firstToUpperCase,
 } from "../../src/helpers/stringHelpers";
 
-describe( "unescapeString", () => {
-	it( "decodes &#39; from the string to an apostrophe.", () => {
-		const escapedString = "I have apostrophe&#39;s!";
+describe( "firstToUpperCase", () => {
+	it( "sets the first character of a string to uppercase", () => {
+		const escapedString = "i should know better and be capitalized";
 
-		const expected = "I have apostrophe's!";
+		const expected = "I should know better and be capitalized";
 
-		const actual = unescapeString( escapedString );
-
-		expect( actual ).toEqual( expected );
-	} );
-
-	it( "decodes &#039; (with a zero) from the string to an apostrophe.", () => {
-		const escapedString = "I have apostrophe&#039;s!";
-
-		const expected = "I have apostrophe's!";
-
-		const actual = unescapeString( escapedString );
+		const actual = firstToUpperCase( escapedString );
 
 		expect( actual ).toEqual( expected );
 	} );

--- a/js/tests/helpers/stringHelpers.test.js
+++ b/js/tests/helpers/stringHelpers.test.js
@@ -4,11 +4,11 @@ import {
 
 describe( "firstToUpperCase", () => {
 	it( "sets the first character of a string to uppercase", () => {
-		const escapedString = "i should know better and be capitalized";
+		const uncapitalizedString = "i should know better and be capitalized";
 
 		const expected = "I should know better and be capitalized";
 
-		const actual = firstToUpperCase( escapedString );
+		const actual = firstToUpperCase( uncapitalizedString );
 
 		expect( actual ).toEqual( expected );
 	} );

--- a/js/tests/redux/reducers/snippetEditor.test.js
+++ b/js/tests/redux/reducers/snippetEditor.test.js
@@ -60,6 +60,20 @@ describe( "snippet editor reducers", () => {
 			expect( result ).toEqual( expected );
 		} );
 
+		it( "unescapes/decodes strings in replacement variable values, including variants of the apostrophe", () => {
+			// Value parameter contains all the necessary html entities for the separator. Separators such as |, *, ~ etc. don't need to be escaped in the first place.
+			const action = updateReplacementVariable(
+				"title",
+				"&ndash;&mdash;&middot;&bull;&Star;&laquo;&raquo;&lt;&gt;&quot;&grave;&apos;&#039;&#39;",
+				"New label"
+			);
+			const expected = { replacementVariables: [ { name: "title", value: "–—·•⋆«»<>\"`'''", label: "New label" } ] };
+
+			const result = snippetEditorReducer( { replacementVariables: [ { name: "title", value: "Old title", label: "Old label" } ] }, action );
+
+			expect( result ).toEqual( expected );
+		} );
+
 		it( "updates replacement variables without a new label, keeps the old label", () => {
 			const action = updateReplacementVariable( "title", "New title" );
 			const expected = { replacementVariables: [ { name: "title", value: "New title", label: "Old label" } ] };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where HTML entities were not always decoded in the Snippet Variables.

## Relevant technical choices:

* Decided to use a yoast-components helper function rather than lodash, because it works more generally.
* decodeSeparatorVariable became obsolete, as we now decode any replacement variable value anyways (provided it's a string).

## Test instructions

This PR can be tested by following these steps:

* Verify that HTML entities in replacement variables are correctly decoded.
* Specifically, verify that the bullet separator now works in both the classic editor and in the Gutenberg editor.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10279 
