### PR TITLE
Removed unused ref to avoid error crashing the configuration wizard

### DIFF
--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -24,6 +24,7 @@ class MediaUpload extends React.Component {
 
 		this.state.mediaUpload.on( "select", this.selectUpload.bind( this ) );
 	}
+
 	/**
 	 * Sends the change event, because the component is updated.
 	 *
@@ -86,6 +87,7 @@ class MediaUpload extends React.Component {
 		if ( ! this.state.currentUpload ) {
 			return null;
 		}
+
 		return (
 			<RaisedButton
 				label={ this.props.translate( "Remove the image" ) }
@@ -104,6 +106,7 @@ class MediaUpload extends React.Component {
 		if ( ! this.state.currentUpload ) {
 			return null;
 		}
+
 		return (
 			<img
 				className="yoast-wizard-image-upload-container__image"

--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -78,37 +78,59 @@ class MediaUpload extends React.Component {
 	}
 
 	/**
+	 * Renders a remove button when a company image is set.
+	 *
+	 * @returns {ReactElement} The button element.
+	 */
+	renderRemoveButton() {
+		if ( ! this.state.currentUpload ) {
+			return null;
+		}
+		return (
+			<RaisedButton
+				label={ this.props.translate( "Remove the image" ) }
+				onClick={ this.removeUpload.bind( this ) }
+				className="yoast-wizard-image-upload-container-buttons__remove"
+				type="button" />
+		);
+	}
+
+	/**
+	 * Renders the company image when available.
+	 *
+	 * @returns {ReactElement} The image element.
+	 */
+	renderImage() {
+		if ( ! this.state.currentUpload ) {
+			return null;
+		}
+		return (
+			<img
+				className="yoast-wizard-image-upload-container__image"
+				src={ this.state.currentUpload }
+				alt={ this.props.translate( "company logo image preview" ) } />
+		);
+	}
+
+	/**
 	 * Renders the output.
 	 *
 	 * @returns {JSX.Element} The rendered HTML.
 	 */
 	render() {
-		let removeButton;
-		let image;
-		if( this.state.currentUpload !== "" ) {
-			removeButton = <RaisedButton
-				label={this.props.translate( "Remove the image" )}
-				onClick={ this.removeUpload.bind( this ) }
-				className="yoast-wizard-image-upload-container-buttons__remove"
-				type="button"/>;
-			image = <img className="yoast-wizard-image-upload-container__image"
-						ref="companyImage"
-						src={this.state.currentUpload}
-						alt={this.props.translate( "company logo image preview" )}/>;
-		}
 
 		return (
 			<div className="yoast-wizard-image-upload-container">
 				<p className="yoast-wizard-image-upload-container-description">
 					{this.props.properties.label}
 				</p>
-				{image}
+				{ this.renderImage() }
 				<div className="yoast-wizard-image-upload-container-buttons">
 					<RaisedButton label={this.props.translate( "Choose image" )}
 						onClick={ this.chooseUpload.bind( this ) }
 						type="button"
 						className="yoast-wizard-image-upload-container-buttons__choose"/>
-					{removeButton}
+					{ this.renderRemoveButton() }
 				</div>
 			</div>
 		);

--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -78,7 +78,7 @@ class MediaUpload extends React.Component {
 	}
 
 	/**
-	 * Renders a remove button when a company image is set.
+	 * Renders a remove button when an image is set.
 	 *
 	 * @returns {ReactElement} The button element.
 	 */
@@ -96,7 +96,7 @@ class MediaUpload extends React.Component {
 	}
 
 	/**
-	 * Renders the company image when available.
+	 * Renders the image when available.
 	 *
 	 * @returns {ReactElement} The image element.
 	 */
@@ -108,7 +108,7 @@ class MediaUpload extends React.Component {
 			<img
 				className="yoast-wizard-image-upload-container__image"
 				src={ this.state.currentUpload }
-				alt={ this.props.translate( "company logo image preview" ) } />
+				alt={ this.props.translate( "image preview" ) } />
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where adding a company image in step 4 of the configuration wizard, would make the wizard crash.

## Relevant technical choices:

* This issue was fixed by removing an unused string ref, this does not solve the underlying issue of multiple react instances conflicting on the page.

## Test instructions

This PR can be tested by following these steps:

* Go to step 4 of the configuration wizard and set the radio button to company.
* Upload or select an image and make sure the configuration wizard doesn't crash.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10123
