### PR TITLE
Set yoast-components dependency to develop branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "^4.7",
+    "yoast-components": "git+https://github.com/Yoast/yoast-components.git#develop",
     "yoastseo": "^1.35.3"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11160,9 +11160,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yoast-components@^4.7:
+"yoast-components@git+https://github.com/Yoast/yoast-components.git#develop":
   version "4.7.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.7.0.tgz#58ab1df09d72a53330d9bfeae2b9878279978079"
+  resolved "git+https://github.com/Yoast/yoast-components.git#0a7177a75a7d206675f6df522c2905cf446e9707"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Wordpress-seo is now dependent on the yoast-components develop branch, rather than a built version.

This PR can be tested by following these steps:

* Run `yarn install`, verify that your `yarn.lock` has the develop dependency, and see that yoast-component related things still work (think Snippet Preview etc).

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

