### PR TITLE
Fixes Search Appearance templates

### DIFF
--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -35,10 +35,10 @@ $yform->show_hide_switch(
 $editor = new WPSEO_Replacevar_Editor(
 	$yform,
 	array(
-		'title'                 => 'title-ptarchive-' . $wpseo_post_type->name,
-		'description'           => 'metadesc-ptarchive-' . $wpseo_post_type->name,
-		'page_type_recommended' => $recommended_replace_vars->determine_for_archive( $wpseo_post_type->name ),
-		'page_type_specific'    => $editor_specific_replace_vars->determine_for_archive( $wpseo_post_type->name ),
+		'title'                 => 'title-' . $wpseo_post_type->name,
+		'description'           => 'metadesc-' . $wpseo_post_type->name,
+		'page_type_recommended' => $recommended_replace_vars->determine_for_post_type( $wpseo_post_type->name ),
+		'page_type_specific'    => $editor_specific_replace_vars->determine_for_post_type( $wpseo_post_type->name ),
 		'paper_style'           => false,
 	)
 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where saved templates in Search Appearance would be saved incorrectly into the database, resulting in them never being loaded when editing a post, page, etc. and thus displaying the wrong template.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Prior to checking out this branch, create a custom template for posts in the Search Appearance tab.
* Go to add a new post. Notice that the snippet editor does not display the template you set.
* Checkout this branch.
* Go back into Search Appearance and change the template for posts.
* Go to add a new post and verify that your custom template is now properly being used.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10320 
