### PR TITLE
Add days active to short links

### DIFF
--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -111,6 +111,6 @@ class WPSEO_Shortlinker {
 		$date_activated = WPSEO_Options::get( 'first_activated_on' );
 		$datediff       = ( time() - $date_activated );
 
-		return (int) round( $datediff / ( 60 * 60 * 24 ) );
+		return (int) round( $datediff / DAY_IN_SECONDS );
 	}
 }

--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -25,6 +25,7 @@ class WPSEO_Shortlinker {
 				'software'         => $this->get_software(),
 				'software_version' => WPSEO_VERSION,
 				'role'             => $this->get_filtered_user_role(),
+				'days_active'      => $this->get_days_active(),
 			),
 			$url
 		);
@@ -99,5 +100,17 @@ class WPSEO_Shortlinker {
 			$role = 'unknown';
 		}
 		return $role;
+	}
+
+	/**
+	 * Gets the number of days the plugin has been active.
+	 *
+	 * @return int The number of days the plugin is active.
+	 */
+	private function get_days_active() {
+		$date_activated = WPSEO_Options::get( 'first_activated_on' );
+		$datediff       = ( time() - $date_activated );
+
+		return (int) round( $datediff / ( 60 * 60 * 24 ) );
 	}
 }


### PR DESCRIPTION
Adds the number of days the plugin has been active to the data we sent along when clicking on shortlinks.

## Summary

This PR can be summarized in the following changelog entry:

* none needed

