### PR TITLE
Change Pinterest claim site links

### DIFF
--- a/admin/views/tabs/social/pinterest.php
+++ b/admin/views/tabs/social/pinterest.php
@@ -30,7 +30,7 @@ echo '<p>';
 printf(
 	/* translators: %1$s / %2$s expands to a link to pinterest.com's help page. */
 	esc_html__( 'To %1$sconfirm your site with Pinterest%2$s, add the meta tag here:', 'wordpress-seo' ),
-	'<a target="_blank" href="https://help.pinterest.com/en/articles/confirm-your-website#meta_tag">',
+	'<a target="_blank" href="https://pinterest.com/settings/#claimWebsite">',
 	'</a>'
 );
 echo '</p>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changed the link to claim your website on Pinterest to push you to the right location more easily.

## Quality assurance

* [x] I have tested this code to the best of my abilities
