### PR TITLE
Fix noreferer - noreferrer typos and a few missing ones

### DIFF
--- a/admin/class-admin-media-purge-notification.php
+++ b/admin/class-admin-media-purge-notification.php
@@ -67,7 +67,7 @@ class WPSEO_Admin_Media_Purge_Notification implements WPSEO_WordPress_Integratio
 		$content = sprintf(
 			/* translators: %1$s expands to the link to the article, %2$s closes the link tag. */
 			__( 'Your site\'s settings currently allow attachment URLs on your site to exist. Please read %1$sthis post about a potential issue%2$s with attachment URLs and check whether you have the correct setting for your site.', 'wordpress-seo' ),
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="nofollow noreferer" target="_blank">',
+			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="nofollow noreferrer" target="_blank">',
 			'</a>'
 		);
 

--- a/admin/class-admin-media-purge-notification.php
+++ b/admin/class-admin-media-purge-notification.php
@@ -67,7 +67,7 @@ class WPSEO_Admin_Media_Purge_Notification implements WPSEO_WordPress_Integratio
 		$content = sprintf(
 			/* translators: %1$s expands to the link to the article, %2$s closes the link tag. */
 			__( 'Your site\'s settings currently allow attachment URLs on your site to exist. Please read %1$sthis post about a potential issue%2$s with attachment URLs and check whether you have the correct setting for your site.', 'wordpress-seo' ),
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="nofollow noreferrer" target="_blank">',
+			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="noopener noreferrer" target="_blank">',
 			'</a>'
 		);
 

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -13,7 +13,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	sprintf(
 		/* translators: %1$s opens the link to the Yoast.com article about Google's Knowledge Graph, %2$s closes the link, */
 		__( 'This data is shown as metadata in your site. It is intended to appear in %1$sGoogle\'s Knowledge Graph%2$s. You can be either a company, or a person.', 'wordpress-seo' ),
-		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1-p' ) ) . '" target="_blank" rel="noopener noreferer">',
+		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1-p' ) ) . '" target="_blank" rel="noopener noreferrer">',
 		'</a>'
 	),
 	'has-wrapper'

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -40,7 +40,7 @@ $yform->toggle_switch(
 				negative impact on your ranking. Please carefully consider this and %1$sread this post%2$s if
 				you want more information about the impact of showing media in search results.', 'wordpress-seo'
 			) ),
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="noopener nofollow" target="_blank">',
+			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="noopener noreferrer" target="_blank">',
 			'</a>'
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a few occurrences of wrong values for the attribute `rel="noopener noreferrer"`

## Relevant technical choices:

- fixes two typos `referer` vs. `referrer`
- removes two `nofollow` which don't make much sense, as they're used in the admin, and uses proper values `noopener noreferrer`

## Test instructions

N/A

Fixes #10327
