### PR TITLE
Fix search appearance RSS textarea size

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -353,9 +353,9 @@ class Yoast_Form {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $var   The variable within the option to create the textarea for.
-	 * @param string $label The label to show for the variable.
-	 * @param array  $attr  The CSS class to assign to the textarea.
+	 * @param string       $var   The variable within the option to create the textarea for.
+	 * @param string       $label The label to show for the variable.
+	 * @param string|array $attr  The CSS class or an array of attributes to assign to the textarea.
 	 */
 	public function textarea( $var, $label, $attr = array() ) {
 		if ( ! is_array( $attr ) ) {

--- a/admin/views/tabs/metas/paper-content/rss-content.php
+++ b/admin/views/tabs/metas/paper-content/rss-content.php
@@ -11,8 +11,8 @@ $textarea_atts = array(
 	'cols' => '50',
 	'rows' => '5',
 );
-$yform->textarea( 'rssbefore', __( 'Content to put before each post in the feed', 'wordpress-seo' ), '', $textarea_atts );
-$yform->textarea( 'rssafter', __( 'Content to put after each post in the feed', 'wordpress-seo' ), '', $textarea_atts );
+$yform->textarea( 'rssbefore', __( 'Content to put before each post in the feed', 'wordpress-seo' ), $textarea_atts );
+$yform->textarea( 'rssafter', __( 'Content to put after each post in the feed', 'wordpress-seo' ), $textarea_atts );
 
 $rss_variables_help = new WPSEO_Admin_Help_Panel(
 	'search-appearance-rss-variables',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the textareas size in the Search Appearance -> RSS tab

## Relevant technical choices:

- the `Yoast_Form->textarea()` method accepts 3 arguments but we were passing 4 parameters, the third one was an empty string, thus no attributes were passed

## Test instructions

This PR can be tested by following these steps:

* check the `rows` and `cols` HTML attributes of the two textareas aren't empty and do have the passed values

Screenshot before:

<img width="691" alt="screen shot 2018-07-11 at 14 38 09" src="https://user-images.githubusercontent.com/1682452/42572536-f12bc0f8-8519-11e8-8779-7245fc582e15.png">

After:

<img width="686" alt="screen shot 2018-07-11 at 14 38 31" src="https://user-images.githubusercontent.com/1682452/42572519-ec7cbcec-8519-11e8-925c-8f4efb77c680.png">



