### PR TITLE
Disable marker buttons when tinyMCE is not available

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -9,9 +9,8 @@ import isShallowEqualObjects from "@wordpress/is-shallow-equal/objects";
 
 // Internal dependencies.
 import initializeEdit from "./edit";
-import { tmceId, setStore } from "./wp-seo-tinymce";
+import tinyMCEHelper, { tmceId, setStore } from "./wp-seo-tinymce";
 import YoastMarkdownPlugin from "./wp-seo-markdown-plugin";
-import tinyMCEHelper from "./wp-seo-tinymce";
 import { tinyMCEDecorator } from "./decorator/tinyMCE";
 
 import publishBox from "./ui/publishBox";
@@ -30,7 +29,6 @@ import UsedKeywords from "./analysis/usedKeywords";
 
 import { setActiveKeyword } from "./redux/actions/activeKeyword";
 import { setMarkerStatus } from "./redux/actions/markerButtons";
-import { isGutenbergPostAvailable } from "./helpers/isGutenbergAvailable";
 import { updateData } from "./redux/actions/snippetEditor";
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 
@@ -99,7 +97,7 @@ setWordPressSeoL10n();
 	 * @returns {boolean} True when markers should be shown.
 	 */
 	function displayMarkers() {
-		return ! isGutenbergPostAvailable() && wpseoPostScraperL10n.show_markers === "1";
+		return window.wpseoPostScraperL10n.show_markers === "1";
 	}
 
 	/**
@@ -110,7 +108,7 @@ setWordPressSeoL10n();
 	function getMarker() {
 		// Only add markers when tinyMCE is loaded and show_markers is enabled (can be disabled by a WordPress hook).
 		// Only check for the tinyMCE object because the actual editor isn't loaded at this moment yet.
-		if ( typeof tinyMCE === "undefined" || ! displayMarkers() ) {
+		if ( ! tinyMCEHelper.isTinyMCEAvailable( tmceId ) || ! displayMarkers() ) {
 			if ( ! isUndefined( editStore ) ) {
 				editStore.dispatch( setMarkerStatus( "hidden" ) );
 			}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Disable Yoast SEO markers outside of TinyMCE.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Test whether the markers are disabled in Gutenberg.
* Test whether the markers are still available in TinyMCE.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10347 
