### PR TITLE
Fix sitemap.xml not redirecting to sitemap_index.xml.

### DIFF
--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -65,7 +65,12 @@ class WPSEO_Sitemaps_Router {
 			$current_url = 'https://';
 		}
 
-		$current_url .= sanitize_text_field( $_SERVER['SERVER_NAME'] );
+		$domain = $_SERVER['SERVER_NAME'];
+		if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
+			$domain = $_SERVER['HTTP_HOST'];
+		}
+
+		$current_url .= sanitize_text_field( $domain );
 		$current_url .= sanitize_text_field( $_SERVER['REQUEST_URI'] );
 
 		if ( home_url( '/sitemap.xml' ) === $current_url && $wp_query->is_404 ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix a bug where `/sitemap.xml` would not correctly redirect to `/sitemap_index.xml` in some environments.

## Relevant technical choices:

* `$_SERVER['SERVER_NAME']` possibly does not contain the full host used in the current request. `$_SERVER['HTTP_HOST']` should be used instead if available.

## Test instructions

This PR can be tested by following these steps:

* In VVV, set up a subdomain multisite environment similar like this (via `vvv-custom.yml`):
```yml
  network-revolution:
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    hosts:
      - network-revolution.test
      - subsite1.network-revolution.test
      - subsite2.network-revolution.test
      - network-revolution2.test
      - subsite1.network-revolution2.test
      - subsite2.network-revolution2.test
    custom:
      db_name: network_revolution
      wp_type: subdomain
      site_title: 'Network Revolution'
```
* You can provision that site quickly with `vagrant provision --provision-with site-network-revolution`.
* Create at least one secondary site on the network, using one of the subdomains included in the `hosts` list in the YML file.
* Pull Yoast SEO into that installation (first without this PR) and activate it network-wide.
* When you go to the site with that subdomain, specifically to `subsite1.network-revolution.test/sitemap.xml`, the redirect to `/sitemap_index.xml` should not work and you should get a 404.
* Update your Yoast SEO with this PR. Afterwards do the same as before, and the redirect should work.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (not applicable)

Fixes #10353 
