### PR TITLE
Introduces a React root element when feature is enabled

### DIFF
--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -11,21 +11,21 @@
 class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 
 	/**
-	 * Name of the section.
+	 * Name of the section, used as an identifier in the HTML.
 	 *
 	 * @var string
 	 */
 	public $name;
 
 	/**
-	 * Content to use above the React root node.
+	 * Content to use before the React root node.
 	 *
 	 * @var string
 	 */
 	public $content;
 
 	/**
-	 * Content to use for the link.
+	 * Content to use to display the button to open this content block.
 	 *
 	 * @var string
 	 */

--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -98,7 +98,7 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	public function display_content() {
 		$html  = '<div id="%1$s" class="wpseo-meta-section">';
 		$html .= $this->content;
-		$html .= '<div id="wpseosnippet" class="wpseosnippet"></div>';
+		$html .= '<div id="wpseo-metabox-root" class="wpseo-metabox-root"></div>';
 		$html .= '</div>';
 
 		printf(

--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -11,26 +11,43 @@
 class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 
 	/**
+	 * Name of the section.
+	 *
 	 * @var string
 	 */
 	public $name;
 
 	/**
+	 * Content to use above the React root node.
+	 *
+	 * @var string
+	 */
+	public $content;
+
+	/**
+	 * Content to use for the link.
+	 *
 	 * @var string
 	 */
 	private $link_content;
 
 	/**
+	 * Link title to use.
+	 *
 	 * @var string
 	 */
 	private $link_title;
 
 	/**
+	 * Class to add to the link.
+	 *
 	 * @var string
 	 */
 	private $link_class;
 
 	/**
+	 * Aria label to use for the link.
+	 *
 	 * @var string
 	 */
 	private $link_aria_label;
@@ -40,9 +57,10 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	 *
 	 * @param string $name         The name of the section, used as an identifier in the html. Can only contain URL safe characters.
 	 * @param string $link_content The text content of the section link.
+	 * @param string $content      Optional. Content to use above the React root element.
 	 * @param array  $options      Optional link attributes.
 	 */
-	public function __construct( $name, $link_content, $content, array $options = array() ) {
+	public function __construct( $name, $link_content, $content = '', array $options = array() ) {
 		$this->name = $name;
 		$this->content = $content;
 

--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -74,7 +74,7 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	 */
 	public function display_link() {
 		printf(
-			'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link %2$s"%3$s%4$s>%5$s</a></li>',
+			'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link %2$s"%3$s>%4$s</a></li>',
 			esc_attr( $this->name ),
 			esc_attr( $this->link_class ),
 			( '' !== $this->link_aria_label ) ? ' aria-label="' . esc_attr( $this->link_aria_label ) . '"' : '',

--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -32,13 +32,6 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	private $link_content;
 
 	/**
-	 * Link title to use.
-	 *
-	 * @var string
-	 */
-	private $link_title;
-
-	/**
 	 * Class to add to the link.
 	 *
 	 * @var string
@@ -65,7 +58,6 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 		$this->content = $content;
 
 		$default_options = array(
-			'link_title'      => '',
 			'link_class'      => '',
 			'link_aria_label' => '',
 		);
@@ -73,7 +65,6 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 		$options = array_merge( $default_options, $options );
 
 		$this->link_content    = $link_content;
-		$this->link_title      = $options['link_title'];
 		$this->link_class      = $options['link_class'];
 		$this->link_aria_label = $options['link_aria_label'];
 	}
@@ -86,7 +77,6 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 			'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link %2$s"%3$s%4$s>%5$s</a></li>',
 			esc_attr( $this->name ),
 			esc_attr( $this->link_class ),
-			( '' !== $this->link_title ) ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
 			( '' !== $this->link_aria_label ) ? ' aria-label="' . esc_attr( $this->link_aria_label ) . '"' : '',
 			$this->link_content
 		);

--- a/admin/metabox/class-metabox-section-reaction.php
+++ b/admin/metabox/class-metabox-section-reaction.php
@@ -42,8 +42,9 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	 * @param string $link_content The text content of the section link.
 	 * @param array  $options      Optional link attributes.
 	 */
-	public function __construct( $name, $link_content, array $options = array() ) {
+	public function __construct( $name, $link_content, $content, array $options = array() ) {
 		$this->name = $name;
+		$this->content = $content;
 
 		$default_options = array(
 			'link_title'      => '',
@@ -78,6 +79,7 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	 */
 	public function display_content() {
 		$html  = '<div id="%1$s" class="wpseo-meta-section">';
+		$html .= $this->content;
 		$html .= '<div id="wpseosnippet" class="wpseosnippet"></div>';
 		$html .= '</div>';
 

--- a/admin/metabox/class-metabox-section-reaction.php
+++ b/admin/metabox/class-metabox-section-reaction.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Generates and displays the React root element for a metabox section.
+ */
+class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
+
+	/**
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * @var string
+	 */
+	private $link_content;
+
+	/**
+	 * @var string
+	 */
+	private $link_title;
+
+	/**
+	 * @var string
+	 */
+	private $link_class;
+
+	/**
+	 * @var string
+	 */
+	private $link_aria_label;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name         The name of the section, used as an identifier in the html. Can only contain URL safe characters.
+	 * @param string $link_content The text content of the section link.
+	 * @param array  $options      Optional link attributes.
+	 */
+	public function __construct( $name, $link_content, array $options = array() ) {
+		$this->name = $name;
+
+		$default_options = array(
+			'link_title'      => '',
+			'link_class'      => '',
+			'link_aria_label' => '',
+		);
+
+		$options = array_merge( $default_options, $options );
+
+		$this->link_content    = $link_content;
+		$this->link_title      = $options['link_title'];
+		$this->link_class      = $options['link_class'];
+		$this->link_aria_label = $options['link_aria_label'];
+	}
+
+	/**
+	 * Outputs the section link.
+	 */
+	public function display_link() {
+		printf(
+			'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link %2$s"%3$s%4$s>%5$s</a></li>',
+			esc_attr( $this->name ),
+			esc_attr( $this->link_class ),
+			( '' !== $this->link_title ) ? ' title="' . esc_attr( $this->link_title ) . '"' : '',
+			( '' !== $this->link_aria_label ) ? ' aria-label="' . esc_attr( $this->link_aria_label ) . '"' : '',
+			$this->link_content
+		);
+	}
+
+	/**
+	 * Outputs the section content.
+	 */
+	public function display_content() {
+		$html  = '<div id="%1$s" class="wpseo-meta-section">';
+		$html .= '<div id="wpseosnippet" class="wpseosnippet"></div>';
+		$html .= '</div>';
+
+		printf(
+			$html,
+			esc_attr( 'wpseo-meta-section-' . $this->name )
+		);
+	}
+}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -382,10 +382,21 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return WPSEO_Metabox_Section
 	 */
 	private function get_content_meta_section_react() {
+		$fields = $this->get_hidden_tab_fields( 'general' );
+
+		// Add fields that weren't hidden, as hidden fields.
+		$fields .= $this->do_meta_box(
+			array(
+				'type'  => 'hidden',
+				'title' => '',
+			),
+			'is_cornerstone'
+		);
+
 		return new WPSEO_Metabox_Section_React(
 			'content',
 			'<span class="screen-reader-text">' . __( 'Content optimization', 'wordpress-seo' ) . '</span><span class="yst-traffic-light-container">' . WPSEO_Utils::traffic_light_svg() . '</span>',
-			$this->get_hidden_tab_fields( 'general' ),
+			$fields,
 			array(
 				'link_aria_label' => __( 'Content optimization', 'wordpress-seo' ),
 				'link_class'      => 'yoast-tooltip yoast-tooltip-e',

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -349,9 +349,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	private function get_content_sections() {
 		$content_sections = array();
 
-		if ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR') && YOAST_FEATURE_GUTENBERG_SIDEBAR ) {
-            $content_sections[] = $this->get_content_meta_section_react();
-		} else {
+		if ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR' ) && YOAST_FEATURE_GUTENBERG_SIDEBAR ) {
+			$content_sections[] = $this->get_content_meta_section_react();
+		}
+		else {
 			$content_sections[] = $this->get_content_meta_section();
 		}
 
@@ -576,8 +577,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$content = '';
 		foreach ( $this->get_meta_field_defs( $tab_name ) as $key => $meta_field ) {
 			if ( $meta_field['type'] !== 'hidden' ) {
-			    continue;
-            }
+				continue;
+			}
+
 			$content .= $this->do_meta_box( $meta_field, $key );
 		}
 		unset( $key, $meta_field );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -347,7 +347,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return WPSEO_Metabox_Section[]
 	 */
 	private function get_content_sections() {
-		$content_sections = array( $this->get_content_meta_section() );
+		$content_sections = array();
+
+		if ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR') && YOAST_FEATURE_GUTENBERG_SIDEBAR ) {
+            $content_sections[] = $this->get_content_meta_section_react();
+		} else {
+			$content_sections[] = $this->get_content_meta_section();
+		}
 
 		// Check if social_admin is an instance of WPSEO_Social_Admin.
 		if ( $this->social_admin instanceof WPSEO_Social_Admin ) {
@@ -367,6 +373,23 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		return $content_sections;
+	}
+
+	/**
+	 * Returns the metabox content for React to hook into.
+	 *
+	 * @return WPSEO_Metabox_Section
+	 */
+	private function get_content_meta_section_react() {
+		return new WPSEO_Metabox_Section_React(
+			'content',
+			'<span class="screen-reader-text">' . __( 'Content optimization', 'wordpress-seo' ) . '</span><span class="yst-traffic-light-container">' . WPSEO_Utils::traffic_light_svg() . '</span>',
+			array(),
+			array(
+				'link_aria_label' => __( 'Content optimization', 'wordpress-seo' ),
+				'link_class'      => 'yoast-tooltip yoast-tooltip-e',
+			)
+		);
 	}
 
 	/**

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -384,7 +384,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		return new WPSEO_Metabox_Section_React(
 			'content',
 			'<span class="screen-reader-text">' . __( 'Content optimization', 'wordpress-seo' ) . '</span><span class="yst-traffic-light-container">' . WPSEO_Utils::traffic_light_svg() . '</span>',
-			array(),
+			$this->get_hidden_tab_fields( 'general' ),
 			array(
 				'link_aria_label' => __( 'Content optimization', 'wordpress-seo' ),
 				'link_class'      => 'yoast-tooltip yoast-tooltip-e',
@@ -558,6 +558,26 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	private function get_tab_content( $tab_name ) {
 		$content = '';
 		foreach ( $this->get_meta_field_defs( $tab_name ) as $key => $meta_field ) {
+			$content .= $this->do_meta_box( $meta_field, $key );
+		}
+		unset( $key, $meta_field );
+
+		return $content;
+	}
+
+	/**
+	 * Gets the contents for the metabox tab.
+	 *
+	 * @param string $tab_name Tab for which to retrieve the field definitions.
+	 *
+	 * @return string
+	 */
+	private function get_hidden_tab_fields( $tab_name ) {
+		$content = '';
+		foreach ( $this->get_meta_field_defs( $tab_name ) as $key => $meta_field ) {
+			if ( $meta_field['type'] !== 'hidden' ) {
+			    continue;
+            }
 			$content .= $this->do_meta_box( $meta_field, $key );
 		}
 		unset( $key, $meta_field );

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -130,15 +130,32 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return WPSEO_Metabox_Section
 	 */
 	private function get_content_meta_section_react() {
+		$taxonomy_content_fields = new WPSEO_Taxonomy_Content_Fields( $this->term );
+
+		$fields  = $taxonomy_content_fields->get( $this->term );
+		$fields  = array_filter( $fields, array( $this, 'filter_hidden_fields' ) );
+		$content = $this->taxonomy_tab_content->html( $fields );
+
 		return new WPSEO_Metabox_Section_React(
 			'content',
 			'<span class="screen-reader-text">' . __( 'Content optimization', 'wordpress-seo' ) . '</span><span class="yst-traffic-light-container">' . WPSEO_Utils::traffic_light_svg() . '</span>',
-			array(),
+			$content,
 			array(
 				'link_aria_label' => __( 'Content optimization', 'wordpress-seo' ),
 				'link_class'      => 'yoast-tooltip yoast-tooltip-e',
 			)
 		);
+	}
+
+	/**
+	 * Filters out non-hidden fields.
+	 *
+	 * @param array $field Content field to check.
+	 *
+	 * @return bool True if the field is a hidden field.
+	 */
+	private function filter_hidden_fields( $field ) {
+		return $field['type'] === 'hidden';
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -108,9 +108,10 @@ class WPSEO_Taxonomy_Metabox {
 	private function get_content_sections() {
 		$content_sections = array();
 
-		if ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR') && YOAST_FEATURE_GUTENBERG_SIDEBAR ) {
+		if ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR' ) && YOAST_FEATURE_GUTENBERG_SIDEBAR ) {
 			$content_sections[] = $this->get_content_meta_section_react();
-		} else {
+		}
+		else {
 			$content_sections[] = $this->get_content_meta_section();
 		}
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -133,8 +133,20 @@ class WPSEO_Taxonomy_Metabox {
 	private function get_content_meta_section_react() {
 		$taxonomy_content_fields = new WPSEO_Taxonomy_Content_Fields( $this->term );
 
-		$fields  = $taxonomy_content_fields->get( $this->term );
-		$fields  = array_filter( $fields, array( $this, 'filter_hidden_fields' ) );
+		$fields = $taxonomy_content_fields->get( $this->term );
+		$fields = array_filter( $fields, array( $this, 'filter_hidden_fields' ) );
+
+		$fields += array(
+			'focuskw' =>
+				array(
+					'label'       => '',
+					'description' => '',
+					'type'        => 'hidden',
+					'options'     => '',
+					'hide'        => '',
+				),
+		);
+
 		$content = $this->taxonomy_tab_content->html( $fields );
 
 		return new WPSEO_Metabox_Section_React(

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -106,17 +106,39 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return WPSEO_Metabox_Section[]
 	 */
 	private function get_content_sections() {
-		$content_sections = array(
-			$this->get_content_meta_section(),
-			$this->get_social_meta_section(),
-			$this->get_settings_meta_section(),
-		);
+		$content_sections = array();
+
+		if ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR') && YOAST_FEATURE_GUTENBERG_SIDEBAR ) {
+			$content_sections[] = $this->get_content_meta_section_react();
+		} else {
+			$content_sections[] = $this->get_content_meta_section();
+		}
+
+		$content_sections[] = $this->get_social_meta_section();
+		$content_sections[] = $this->get_settings_meta_section();
 
 		if ( ! defined( 'WPSEO_PREMIUM_FILE' ) ) {
 			$content_sections[] = $this->get_buy_premium_section();
 		}
 
 		return $content_sections;
+	}
+
+	/**
+	 * Returns the metabox content for React to hook into.
+	 *
+	 * @return WPSEO_Metabox_Section
+	 */
+	private function get_content_meta_section_react() {
+		return new WPSEO_Metabox_Section_React(
+			'content',
+			'<span class="screen-reader-text">' . __( 'Content optimization', 'wordpress-seo' ) . '</span><span class="yst-traffic-light-container">' . WPSEO_Utils::traffic_light_svg() . '</span>',
+			array(),
+			array(
+				'link_aria_label' => __( 'Content optimization', 'wordpress-seo' ),
+				'link_class'      => 'yoast-tooltip yoast-tooltip-e',
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Introduced a class which can be used on multiple spots, to render the React root node.
* ~This root node has the same name used in the Snippet Preview, the name could be changed later, but for now it already shows the Snippet Editor on the location it is expected.~
* The root node has been renamed to make sure the Snippet Preview can still be used without the feature flag. This means that no components are shown when checking out this branch.
    * There should be a `<div id="wpseo-metabox-root" class="wpseo-metabox-root"></div>` in the pages
* Ignored the JavaScript errors relating to the focus keyword not being an element on the pages anymore
* Filtered the Form elements that were registered for the sections by "hidden" status, to make sure the hidden fields remain present on the specific pages

## Test instructions

This PR can be tested by following these steps:

* Set `define( 'YOAST_FEATURE_GUTENBERG_SIDEBAR', true );` to enable the feature flag
* Check the post-edit page to see the Snippet Editor as only element in the "Content" tab in the metabox
* Check the Taxonomy-edit page to see the Snippet Editor as the only element in the "Content" tab
* The other tabs should be usable as expected

Hidden fields
* There are a couple of hidden fields that we use to store data
* Post-edit:
    * yoast_wpseo_title
    * yoast_wpseo_metadesc
     * yoast_wpseo_linkdex
     * yoast_wpseo_content_score
* Term-edit:
     * #hidden_wpseo_title
     * #hidden_wpseo_desc
     * wpseo_linkdex (#hidden_wpseo_linkdex)
     * wpseo_content_score (#hidden_wpseo_content_score)
* These fields need to be present on the page when the feature flag is enabled
* These fields need to maintain their values if set with the feature flag disabled

JavaScript errors:
* ~Post edit page:~
    * ~`addEventListener` - this tries to connect to the `focus keyword` input, which needs to be build~
    * ~`Given action "WPSEO_SET_ACTIVE_KEYWORD", reducer "activeKeyword" returned undefined.` - this also tries to connect to the `focus keyword` input.~
* Taxonomy edit page:
    * `Cannot read property 'value' of null` x2 - these try to connect to the `wpseo_focuskw` element which does not exist in the page at this point

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10364
