### PR TITLE
Check for truthy has_archive values

### DIFF
--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -25,7 +25,7 @@ if ( $wpseo_post_type->name === 'product' && WPSEO_Utils::is_woocommerce_active(
 	return;
 }
 
-if ( $wpseo_post_type->has_archive === true ) {
+if ( $wpseo_post_type->has_archive ) {
 	$plural_label = $wpseo_post_type->labels->name;
 
 	// translators: %s is the plural version of the post type's name.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where archive settings for post types aren't shown on the search appearance page when the has_archive for that post type contains an archive slug. Props to [nesinervink](https://github.com/nesinervink)


## Relevant technical choices:

* Wordpress `register_post_type` accepts both _boolean_ and _string_ `has_archive` values to enable post type archive pages: https://codex.wordpress.org/Function_Reference/register_post_type#has_archive

## Test instructions

This PR can be tested by following these steps:

* Test with both _string_ and _boolean_ `has_archive` values when creating custom post type. "Settings for `post type name` archive" in SEO > Search appearance > Content type menu relevant post type section should be visible.

## Quality 

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
