### PR TITLE
Fix regression for post type archives

### DIFF
--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -25,7 +25,7 @@ if ( $wpseo_post_type->name === 'product' && WPSEO_Utils::is_woocommerce_active(
 	return;
 }
 
-if ( $wpseo_post_type->has_archive === true ) {
+if ( $wpseo_post_type->has_archive !== false ) {
 	$plural_label = $wpseo_post_type->labels->name;
 
 	// translators: %s is the plural version of the post type's name.


### PR DESCRIPTION
When a post type archive is set to a specific slug, instead of just true, this code fails. Just reversing the check to `!== false` fixes this.

## Summary

This PR can be summarized in the following changelog entry:

* Show post type archive search appearance settings for post types that have a specific slug set for their archive instead of just true.

## Test instructions

This PR can be tested by following these steps:

* Register a custom post type archive with a specific slug, like [so](https://github.com/Yoast/yoast.com/blob/master/site/core-yoastcom/WordPress/Integration/Data.php#L135).

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10351 