### PR TITLE
Delete alloptions cache when clearing sitemap cache transients

### DIFF
--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -179,6 +179,8 @@ class WPSEO_Sitemaps_Cache_Validator {
 		// Delete transients.
 		$query = sprintf( 'DELETE FROM %1$s WHERE %2$s', $wpdb->options, implode( ' OR ', $where ) );
 		$wpdb->query( $query );
+
+		wp_cache_delete( 'alloptions', 'options' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix a bug where sitemap cache transients would not be correctly cleared.

## Relevant technical choices:

* As described in the issue, clearing the transients from the database in `WPSEO_Sitemaps_Cache_Validator::cleanup_database()` is not enough. Transients without expiration date are also stored in WordPress's internal alloptions cache, so that needs to be cleared. Otherwise, these transients are still available if being retrieved within the same request.

## Test instructions

This PR can be tested by following these steps:

* It's impossible to acceptance-test this PR. The unit test working correctly is a confirmation that it solves the issue.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended (failing unit test already present)

Fixes #10396 
