### PR TITLE
Add missing heading in network admin edit files page

### DIFF
--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -11,6 +11,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
+$yform = Yoast_Form::get_instance();
 $robots_file    = get_home_path() . 'robots.txt';
 $ht_access_file = get_home_path() . '.htaccess';
 
@@ -84,18 +85,18 @@ if ( isset( $_POST['submithtaccess'] ) ) {
 	}
 }
 
-if ( isset( $msg ) && ! empty( $msg ) ) {
-	echo '<div id="message" class="updated fade"><p>', esc_html( $msg ), '</p></div>';
-}
-
 if ( is_multisite() ) {
 	$action_url = network_admin_url( 'admin.php?page=wpseo_files' );
+	$yform->admin_header( false, 'wpseo_ms' );
 }
 else {
 	$action_url = admin_url( 'admin.php?page=wpseo_tools&tool=file-editor' );
 }
 
-echo '<br><br>';
+if ( isset( $msg ) && ! empty( $msg ) ) {
+	echo '<div id="message" class="notice notice-success"><p>', esc_html( $msg ), '</p></div>';
+}
+
 $helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', __( 'Bulk editor', 'wordpress-seo' ),
 	array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-file-editor' ) ) );
 
@@ -238,4 +239,8 @@ if ( ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWAR
 		);
 		echo '</p>';
 	}
+}
+
+if ( is_multisite() ) {
+	$yform->admin_footer( false );
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add a missing H1 heading to the Network Admin > SEO > Edit Files page

I see the standard way in the plugin to output the heading (and footer) is by using `Yoast_Form->admin_header()` and `Yoast_Form->admin_footer()`. This also adds the Sidebar, which appears also on Premium, but this seems to be the current standard behavior. For example, the same thing already happens in the MultiSite Settings page.

## Test instructions
- test in a multisite install
- go to Network Admin > SEO > Edit Files
- verify there's a main H1 heading "Yoast SEO: Edit Files"
- create a robots.txt file and edit the form
- submit and verify the "success" notice appears nicely and everything works
- test on a single site install
- go to SEO > Tools > File editor
- verify there are no visual and functional changes

Fixes #10403 
