### PR TITLE
Update class-wpseo-image-utils.php

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -18,7 +18,7 @@ class WPSEO_Image_Utils {
 	 */
 	public static function get_attachment_by_url( $url ) {
 		// Because get_attachment_by_url won't work on resized versions of images, we strip out the size part of an image URL.
-		$url = preg_replace( '/(.*)-\d+x\d+\.(jpg|png|gif)$/', '$1.$2', $url );
+		$url = preg_replace( '/(.*)(-\d+x\d+)?\.(jpg|png|gif)$/U', '$1.$3', $url );
 
 		if ( function_exists( 'wpcom_vip_attachment_url_to_postid' ) ) {
 			// @codeCoverageIgnoreStart -- we can't test this properly.
@@ -40,7 +40,7 @@ class WPSEO_Image_Utils {
 		$cache_key = sprintf( 'yoast_attachment_url_post_id_%s', md5( $url ) );
 
 		// Set the ID based on the hashed url in the cache.
-		$id = wp_cache_get( $cache_key );
+		$id = get_transient($cache_key);
 
 		if ( $id === 'not_found' ) {
 			return 0;
@@ -60,7 +60,7 @@ class WPSEO_Image_Utils {
 		}
 
 		// We have the Post ID, but it's not in the cache yet. We do that here and return.
-		wp_cache_set( $cache_key, $id, '', ( 24 * HOUR_IN_SECONDS + mt_rand( 0, ( 12 * HOUR_IN_SECONDS ) ) ) );
+		set_transient( $cache_key, $id,  24 * HOUR_IN_SECONDS );
 		return $id;
 
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changed the regex for attachment url that will be search for post id
* use transient instead of wp_cache

## Relevant technical choices:

* use persistent transient cache so the very expensive meta value search query will only be fired once

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10195 
