### PR TITLE
Add a sorted YoastSidebar slot.

### DIFF
--- a/js/src/components/SidebarItem.js
+++ b/js/src/components/SidebarItem.js
@@ -1,0 +1,11 @@
+/* External dependencies */
+import React from "react";
+
+/* Internal dependencies */
+import withYoastSidebarPriority from "./higherorder/withYoastSidebarPriority";
+
+const SidebarItem = withYoastSidebarPriority( ( { children } ) => {
+	return <div>{ children }</div>;
+} );
+
+export default SidebarItem;

--- a/js/src/components/higherorder/withYoastSidebarPriority.js
+++ b/js/src/components/higherorder/withYoastSidebarPriority.js
@@ -9,7 +9,7 @@ const withYoastSidebarPriority = ( WrappedComponent ) => {
 			renderPriority,
 			...otherProps
 		} = props;
-		return <WrappedComponent { ...otherProps } />
+		return <WrappedComponent { ...otherProps } />;
 	};
 	YoastSidebarPriority.propTypes = {
 		renderPriority: PropTypes.number,

--- a/js/src/components/higherorder/withYoastSidebarPriority.js
+++ b/js/src/components/higherorder/withYoastSidebarPriority.js
@@ -7,7 +7,7 @@ const withYoastSidebarPriority = ( WrappedComponent ) => {
 		const {
 			// eslint-disable-next-line
 			sequence,
-			...otherProps,
+			...otherProps
 		} = props;
 		return <WrappedComponent { ...otherProps } />
 	};

--- a/js/src/components/higherorder/withYoastSidebarPriority.js
+++ b/js/src/components/higherorder/withYoastSidebarPriority.js
@@ -1,0 +1,20 @@
+/* External dependencies */
+import React from "react";
+import PropTypes from "prop-types";
+
+const withYoastSidebarPriority = ( WrappedComponent ) => {
+	const YoastSidebarPriority = ( props ) => {
+		const {
+			// eslint-disable-next-line
+			sequence,
+			...otherProps,
+		} = props;
+		return <WrappedComponent { ...otherProps } />
+	};
+	YoastSidebarPriority.propTypes = {
+		sequence: PropTypes.number,
+	};
+	return YoastSidebarPriority;
+};
+
+export default withYoastSidebarPriority;

--- a/js/src/components/higherorder/withYoastSidebarPriority.js
+++ b/js/src/components/higherorder/withYoastSidebarPriority.js
@@ -6,13 +6,13 @@ const withYoastSidebarPriority = ( WrappedComponent ) => {
 	const YoastSidebarPriority = ( props ) => {
 		const {
 			// eslint-disable-next-line
-			sequence,
+			renderPriority,
 			...otherProps
 		} = props;
 		return <WrappedComponent { ...otherProps } />
 	};
 	YoastSidebarPriority.propTypes = {
-		sequence: PropTypes.number,
+		renderPriority: PropTypes.number,
 	};
 	return YoastSidebarPriority;
 };

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -1,10 +1,12 @@
 /* global window wpseoPostScraperL10n wpseoTermScraperL10n process wp yoast */
-
+/* External dependencies */
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
-import _flatten from "lodash/flatten";
+import flatten from "lodash/flatten";
+import { ThemeProvider } from "styled-components";
 
+/* Internal dependencies */
 import IntlProvider from "./components/IntlProvider";
 import AnalysisSection from "./components/contentAnalysis/AnalysisSection";
 import Data from "./analysis/data.js";
@@ -13,7 +15,7 @@ import PluginIcon from "../../images/Yoast_icon_kader.svg";
 import ClassicEditorData from "./analysis/classicEditorData.js";
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
 import SnippetEditor from "./containers/SnippetEditor";
-import { ThemeProvider } from "styled-components";
+import SidebarItem from "./components/SidebarItem";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
 let localizedData = { intl: {}, isRtl: false };
@@ -34,6 +36,29 @@ function registerStoreInGutenberg() {
 	return registerStore( "yoast-seo/editor", {
 		reducer: combineReducers( reducers ),
 	} );
+}
+
+/**
+ * Sorts components by a prop `position`.
+ *
+ * The array is flattened before sorting to make sure that components inside of
+ * a collection are also included. This is to allow sorting multiple fills of
+ * which at least one includes an array of components.
+ *
+ * @param {ReactElement|array} components The component(s) to be sorted.
+ *
+ * @returns {ReactElement|array} The sorted component(s).
+ */
+function sortComponentsByPosition( components ) {
+	if ( typeof components.length !== "undefined" ) {
+		return flatten( components ).sort( ( a, b ) => {
+			if ( typeof a.props.sequence === "undefined" ) {
+				return 1;
+			}
+			return a.props.sequence - b.props.sequence;
+		} );
+	}
+	return components;
 }
 
 /**
@@ -63,17 +88,13 @@ function registerPlugin() {
 				>
 					<Slot name="YoastSidebar">
 						{ ( fills ) => {
-							return SortComponentsByPosition( fills );
+							return sortComponentsByPosition( fills );
 						} }
 					</Slot>
 				</PluginSidebar>
-				<Fill name="YoastSidebar"> // Free fill
-					<div position={10}>Readability analysis</div>
-					<div position={20}>SEO analysis</div>
-					<div position={30}>Cornerstone content</div>
-					<div position={40}>Snippet editor</div>
-					<div position={50}>Social</div>
-					<div position={60}>Robots</div>
+				<Fill name="YoastSidebar">
+					<SidebarItem sequence={ 10 }>Readability analysis</SidebarItem>
+					<SidebarItem sequence={ 20 }>SEO analysis</SidebarItem>
 				</Fill>
 			</Fragment>
 		);
@@ -82,26 +103,6 @@ function registerPlugin() {
 			render: YoastSidebar,
 		} );
 	}
-}
-
-/**
- * Sorts components by a prop `position`.
- *
- * The array is flattened before sorting to make sure that components inside of
- * a collection are also included. This is to allow sorting multiple fills of
- * which at least one includes an array of components.
- *
- * @param {Object|array} components The component(s) to be sorted.
- *
- * @returns {Object|array} The sorted component(s).
- */
-const SortComponentsByPosition = function( components ) {
-	if ( typeof components.length  !== "undefined" ) {
-		return _flatten( components ).sort( ( a, b ) => {
-			return a.props.position - b.props.position;
-		} );
-	}
-	return components;
 }
 
 /**

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -3,6 +3,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
+import _flatten from "lodash/flatten";
 
 import IntlProvider from "./components/IntlProvider";
 import AnalysisSection from "./components/contentAnalysis/AnalysisSection";
@@ -46,6 +47,7 @@ function registerPlugin() {
 		const { Fragment } = yoast._wp.element;
 		const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
 		const { registerPlugin } = wp.plugins;
+		const { Slot, Fill } = wp.components;
 
 		const YoastSidebar = () => (
 			<Fragment>
@@ -59,8 +61,20 @@ function registerPlugin() {
 					name="seo-sidebar"
 					title="Yoast SEO"
 				>
-					<p> Contents of the sidebar </p>
+					<Slot name="YoastSidebar">
+						{ ( fills ) => {
+							return SortComponentsByPosition( fills );
+						} }
+					</Slot>
 				</PluginSidebar>
+				<Fill name="YoastSidebar"> // Free fill
+					<div position={10}>Readability analysis</div>
+					<div position={20}>SEO analysis</div>
+					<div position={30}>Cornerstone content</div>
+					<div position={40}>Snippet editor</div>
+					<div position={50}>Social</div>
+					<div position={60}>Robots</div>
+				</Fill>
 			</Fragment>
 		);
 
@@ -68,6 +82,26 @@ function registerPlugin() {
 			render: YoastSidebar,
 		} );
 	}
+}
+
+/**
+ * Sorts components by a prop `position`.
+ *
+ * The array is flattened before sorting to make sure that components inside of
+ * a collection are also included. This is to allow sorting multiple fills of
+ * which at least one includes an array of components.
+ *
+ * @param {Object|array} components The component(s) to be sorted.
+ *
+ * @returns {Object|array} The sorted component(s).
+ */
+const SortComponentsByPosition = function( components ) {
+	if ( typeof components.length  !== "undefined" ) {
+		return _flatten( components ).sort( ( a, b ) => {
+			return a.props.position - b.props.position;
+		} );
+	}
+	return components;
 }
 
 /**

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -39,7 +39,7 @@ function registerStoreInGutenberg() {
 }
 
 /**
- * Sorts components by a prop `position`.
+ * Sorts components by a prop `sequence`.
  *
  * The array is flattened before sorting to make sure that components inside of
  * a collection are also included. This is to allow sorting multiple fills of
@@ -50,15 +50,16 @@ function registerStoreInGutenberg() {
  * @returns {ReactElement|array} The sorted component(s).
  */
 function sortComponentsByPosition( components ) {
-	if ( typeof components.length !== "undefined" ) {
-		return flatten( components ).sort( ( a, b ) => {
-			if ( typeof a.props.sequence === "undefined" ) {
-				return 1;
-			}
-			return a.props.sequence - b.props.sequence;
-		} );
+	if ( typeof components.length === "undefined" ) {
+		return components;
 	}
-	return components;
+
+	return flatten( components ).sort( ( a, b ) => {
+		if ( typeof a.props.sequence === "undefined" ) {
+			return 1;
+		}
+		return a.props.sequence - b.props.sequence;
+	} );
 }
 
 /**

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -39,7 +39,7 @@ function registerStoreInGutenberg() {
 }
 
 /**
- * Sorts components by a prop `sequence`.
+ * Sorts components by a prop `renderPriority`.
  *
  * The array is flattened before sorting to make sure that components inside of
  * a collection are also included. This is to allow sorting multiple fills of
@@ -55,10 +55,10 @@ function sortComponentsByPosition( components ) {
 	}
 
 	return flatten( components ).sort( ( a, b ) => {
-		if ( typeof a.props.sequence === "undefined" ) {
+		if ( typeof a.props.renderPriority === "undefined" ) {
 			return 1;
 		}
-		return a.props.sequence - b.props.sequence;
+		return a.props.renderPriority - b.props.renderPriority;
 	} );
 }
 
@@ -94,8 +94,8 @@ function registerPlugin() {
 					</Slot>
 				</PluginSidebar>
 				<Fill name="YoastSidebar">
-					<SidebarItem sequence={ 10 }>Readability analysis</SidebarItem>
-					<SidebarItem sequence={ 20 }>SEO analysis</SidebarItem>
+					<SidebarItem renderPriority={ 10 }>Readability analysis</SidebarItem>
+					<SidebarItem renderPriority={ 20 }>SEO analysis</SidebarItem>
 				</Fill>
 			</Fragment>
 		);


### PR DESCRIPTION
## Summary

Unit tests are currently missing but can be added later to not block other work from being merged.

This PR can be summarized in the following changelog entry:

* Adds a sorted sidebar slot to allow mixing free and premium components

## Relevant technical choices:

* I decided to make our sidebar flexibly extensible from the start.

## Test instructions

This PR can be tested by following these steps:

* build and run

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
