### PR TITLE
Used the yoast plugin icon as pinned plugin icon for gutenberg

### DIFF
--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import flatten from "lodash/flatten";
 import { ThemeProvider } from "styled-components";
+import styled from "styled-components";
 
 /* Internal dependencies */
 import IntlProvider from "./components/IntlProvider";
@@ -24,6 +25,11 @@ if( window.wpseoPostScraperL10n ) {
 } else if ( window.wpseoTermScraperL10n ) {
 	localizedData = wpseoTermScraperL10n;
 }
+
+const PinnedPluginIcon = styled( PluginIcon )`
+	width: 20px;
+	height: 20px;
+`;
 
 /**
  * Registers a redux store in Gutenberg.
@@ -102,6 +108,7 @@ function registerPlugin() {
 
 		registerPlugin( "yoast-seo", {
 			render: YoastSidebar,
+			icon: <PinnedPluginIcon />,
 		} );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added the Yoast icon as pinned plugin icon in Gutenberg.

## Relevant technical choices:

* Kept the styled component in `edit.js` because it's only a resize, which isn't used anywhere else.
* Set the size of the icon at 20x20px to match the other icons in the bar.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch.
* Make sure the following flag is set : `define( 'YOAST_FEATURE_GUTENBERG_SIDEBAR', true );`
* Open a post-edit page.
* Make sure the yoast-sidebar is pinned ( open the yoast sidebar -> click on the star at the top ).
* Check if the icon added in the header toolbar by pinning yoast-seo is the yoast icon ( you can check the issue how it used to look for comparision ). 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10295 
