### PR TITLE
Moved language notice props to seperate component

### DIFF
--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 import mapResults from "./mapResults";
 import ContentAnalysis from "yoast-components/composites/Plugin/ContentAnalysis/components/ContentAnalysis";
+import LanguageNotice from "yoast-components/composites/Plugin/Shared/components/LanguageNotice.js";
 
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.
@@ -71,20 +72,24 @@ class Results extends React.Component {
 			problemsResults,
 		} = mappedResults;
 		return (
-			<ContentAnalysis
-				errorsResults={ errorsResults }
-				problemsResults={ problemsResults }
-				improvementsResults={ improvementsResults }
-				considerationsResults={ considerationsResults }
-				goodResults={ goodResults }
-				changeLanguageLink={ this.props.changeLanguageLink }
-				language={ this.props.language }
-				showLanguageNotice={ this.props.showLanguageNotice }
-				canChangeLanguage={ this.props.canChangeLanguage }
-				onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
-				marksButtonClassName={ this.props.marksButtonClassName }
-				marksButtonStatus={ this.props.marksButtonStatus }
-			/>
+			<React.Fragment>
+				<LanguageNotice
+					changeLanguageLink={ this.props.changeLanguageLink }
+					language={ this.props.language }
+					showLanguageNotice={ this.props.showLanguageNotice }
+					canChangeLanguage={ this.props.canChangeLanguage }
+				/>
+				<ContentAnalysis
+					errorsResults={ errorsResults }
+					problemsResults={ problemsResults }
+					improvementsResults={ improvementsResults }
+					considerationsResults={ considerationsResults }
+					goodResults={ goodResults }
+					onMarkButtonClick={ this.handleMarkButtonClick.bind( this ) }
+					marksButtonClassName={ this.props.marksButtonClassName }
+					marksButtonStatus={ this.props.marksButtonStatus }
+				/>
+			</React.Fragment>
 		);
 	}
 }

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -2,8 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import mapResults from "./mapResults";
-import ContentAnalysis from "yoast-components/composites/Plugin/ContentAnalysis/components/ContentAnalysis";
-import { LanguageNotice } from "yoast-components";
+import { LanguageNotice, ContentAnalysis } from "yoast-components";
 
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import mapResults from "./mapResults";
 import ContentAnalysis from "yoast-components/composites/Plugin/ContentAnalysis/components/ContentAnalysis";
-import LanguageNotice from "yoast-components/composites/Plugin/Shared/components/LanguageNotice";
+import { LanguageNotice } from "yoast-components";
 
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import mapResults from "./mapResults";
 import ContentAnalysis from "yoast-components/composites/Plugin/ContentAnalysis/components/ContentAnalysis";
-import LanguageNotice from "yoast-components/composites/Plugin/Shared/components/LanguageNotice.js";
+import LanguageNotice from "yoast-components/composites/Plugin/Shared/components/LanguageNotice";
 
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Moved language notice props to seperate component

## Relevant technical choices:

* Done to work together properly with its sibling pr: https://github.com/Yoast/yoast-components/pull/492/files

## Test instructions

This PR can be tested by following these steps:

* Only test in combination with its sibling pr: https://github.com/Yoast/yoast-components/pull/492/files
* Check the sibling pr for test instructions.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/yoast-components/issues/475
