### PR TITLE
Add support for the WP_TESTS_DIR environment variable to the test suite

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,7 +21,10 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'wordpress-seo/wp-seo.php' ),
 );
 
-if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
+if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
+	require_once getenv( 'WP_TESTS_DIR' ) . 'includes/bootstrap.php';
+}
+elseif ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	require_once getenv( 'WP_DEVELOP_DIR' ) . 'tests/phpunit/includes/bootstrap.php';
 }
 else {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add support for the WP_TESTS_DIR environment variable to the test suite.

## Relevant technical choices:

* VVV sets `WP_TESTS_DIR` by default, pointing to the core test suite.
* The plugin only uses `WP_DEVELOP_DIR` which needs to be manually set. At least for VVV, having support for `WP_TESTS_DIR` would help a lot for local testing.

## Test instructions

This PR can be tested by following these steps:

* Use the plugin on VVV.
* SSH into your VVV and move to the plugin directory.
* Run `vendor/bin/phpunit` without manually specifying any `WP_DEVELOP_DIR` or `WP_TESTS_DIR` environment variables.
* Ensure it works.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (not applicable)

Fixes #10355 
