### PR TITLE
Always run Travis tests against the latest WordPress version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ install:
   fi
 
 before_script:
+# Careful: The HTTPS version of the following URL is different, therefore we need to use HTTP.
 - |
   if [[ "$WP_VERSION" == "latest" ]]; then
     curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,6 @@ before_script:
 - |
   if [[ "$WP_VERSION" == "latest" ]]; then
     curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
-    grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
     WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
   fi
 - PLUGIN_SLUG=$(basename $(pwd))

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ jobs:
   fast_finish: true
   include:
     - php: 7.2
-      env: WP_VERSION=4.9 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
+      env: WP_VERSION=latest WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
     - php: 7.2
-      env: WP_VERSION=4.9 WP_MULTISITE=1 COVERAGE=1
+      env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
@@ -24,12 +24,11 @@ jobs:
     - php: 5.3
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
-      env: WP_VERSION=4.9
+      env: WP_VERSION=latest
     - php: 5.6
-      env: WP_VERSION=4.9
-    # WP >= 4.8 is needed for PHP 7.1
+      env: WP_VERSION=latest
     - php: 7.0
-      env: WP_VERSION=4.9
+      env: WP_VERSION=latest
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
@@ -94,6 +93,12 @@ install:
   fi
 
 before_script:
+- |
+  if [[ "$WP_VERSION" == "latest" ]]; then
+    curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
+    grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+    WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+  fi
 - PLUGIN_SLUG=$(basename $(pwd))
 - export WP_DEVELOP_DIR=/tmp/wordpress/
 - git clone --depth=50 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Always run Travis tests against the latest WordPress version instead of hard-coding the latest major release.

## Relevant technical choices:

* I added a new instruction in the travis script that, if "latest" is specified for `WP_VERSION`, fetches the latest version number from the wordpress.org API.
* Everywhere we currently hard-code "4.9", I changed it to "latest", so that we don't need to worry about it anymore and always test against the actual latest release. This allows to spot bugs that would be specific to 4.9.6 as well for example.

## Test instructions

This PR can be tested by following these steps:

* Not really acceptance-testable. By looking at the Travis test logs for the PR we should be able to determine whether the correct latest WordPress version is fetched where desired.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (not applicable)

Fixes #9881 
