### PR TITLE
Create UpsellBox component and test

### DIFF
--- a/js/src/components/UpsellBox.js
+++ b/js/src/components/UpsellBox.js
@@ -1,0 +1,130 @@
+/* External dependencies */
+import React from "react";
+import interpolateComponents from "interpolate-components";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { utils } from "yoast-components";
+
+const { makeOutboundLink } = utils;
+
+const StyledList = styled.ul`
+	list-style: none;
+	margin: 0 0 16px;
+	padding: 0;
+
+	li {
+		margin: 5px 0 0 0;
+		padding-left: 16px;
+	}
+
+	span[aria-hidden="true"]:before {
+		margin: 0 8px 0 -16px;
+		font-weight: bold;
+		content: "+";
+	}
+`;
+
+const ButtonLabel = styled.small`
+	display: block;
+`;
+
+const UpsellButton = makeOutboundLink();
+
+/**
+ * Returns the UpsellBox component.
+ *
+ * @returns {ReactElement} The UpsellBox component.
+ */
+class UpsellBox extends React.Component {
+	/**
+	 * The constructor.
+	 *
+	 * @param {object} props The component props.
+	 *
+	 * @returns {void}
+	 */
+	constructor( props ) {
+		super( props );
+	}
+
+	/**
+	 * Creates the HTML for the benefits list.
+	 *
+	 * @param {array} benefits The list of benefits to be rendered.
+	 *
+	 * @returns {*} HTML for the list of benefits.
+	 */
+	createBenefitsList( benefits ) {
+		return (
+			benefits.length > 0 &&
+			<StyledList role="list">
+				{ benefits.map( ( benefit, index ) => {
+					return <li key={ index }>
+						<span aria-hidden="true"></span>
+						{ interpolateComponents( {
+							mixedString: benefit.replace( "<strong>", "{{strong}}" ).replace( "</strong>", "{{/strong}}" ),
+							components: { strong: <strong /> },
+						} ) }
+					</li>;
+				} ) }
+			</StyledList>
+		);
+	}
+
+	/**
+	 * Creates the HTML for the info paragraphs.
+	 *
+	 * @param {array} paragraphs The paragraphs to be rendered.
+	 *
+	 * @returns {*} The HTML for the info paragraphs.
+	 */
+	createInfoParagraphs( paragraphs ) {
+		return(
+			paragraphs.map( ( paragraph, index ) => {
+				return <p key={ index } >{ paragraph }</p>;
+			} )
+		);
+	}
+
+	/**
+	 * Renders a UpsellBox component.
+	 *
+	 * @returns {ReactElement} The rendered UpsellBox component.
+	 */
+	render() {
+		return (
+			<div>
+				{ this.createInfoParagraphs( this.props.infoParagraphs ) }
+				{ this.createBenefitsList( this.props.benefits ) }
+				<UpsellButton
+					{ ...this.props.upsellButton }
+				>
+					{ this.props.upsellButtonText }
+				</UpsellButton>
+				<ButtonLabel id={ this.props.upsellButton[ "aria-describedby" ] }>
+					{ this.props.upsellButtonLabel }
+				</ButtonLabel>
+			</div>
+		);
+	}
+}
+
+UpsellBox.propTypes = {
+	benefits: PropTypes.array,
+	infoParagraphs: PropTypes.array,
+	upsellButton: PropTypes.object,
+	upsellButtonText: PropTypes.string.isRequired,
+	upsellButtonLabel: PropTypes.string,
+};
+
+UpsellBox.defaultProps = {
+	infoParagraphs: [],
+	benefits: [],
+	upsellButton: {
+		href: "",
+		className: "button button-primary",
+	},
+	upsellButtonLabel: ""
+};
+
+export default UpsellBox;

--- a/js/tests/components/UpsellBox.test.js
+++ b/js/tests/components/UpsellBox.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { mount } from "enzyme";
+import UpsellBox from "../../src/components/UpsellBox";
+
+describe( "UpsellBox", () => {
+	it( "renders the snippet editor inside of it", () => {
+		const tree = mount(
+			<UpsellBox
+				benefits={ [
+					"<strong>Strong text</strong> and not so strong text",
+					"<strong>Strong text two</strong>",
+				] }
+				infoParagraphs={ [
+					"Text",
+					[ "Array with ", <a key="1" href="#">links</a>, " test" ],
+				] }
+				upsellButtonText="A button"
+				upsellButton={ {
+					href: "#",
+					className: "class name",
+					"aria-labelledby": "label-id",
+				} }
+				buttonLabel="Small text below button"
+			/>
+		);
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/js/tests/components/__snapshots__/UpsellBox.test.js.snap
+++ b/js/tests/components/__snapshots__/UpsellBox.test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpsellBox renders the snippet editor inside of it 1`] = `
+<UpsellBox
+  benefits={
+    Array [
+      "<strong>Strong text</strong> and not so strong text",
+      "<strong>Strong text two</strong>",
+    ]
+  }
+  buttonLabel="Small text below button"
+  infoParagraphs={
+    Array [
+      "Text",
+      Array [
+        "Array with ",
+        <a
+          href="#"
+        >
+          links
+        </a>,
+        " test",
+      ],
+    ]
+  }
+  upsellButton={
+    Object {
+      "aria-labelledby": "label-id",
+      "className": "class name",
+      "href": "#",
+    }
+  }
+  upsellButtonLabel=""
+  upsellButtonText="A button"
+>
+  <div>
+    <p
+      key="0"
+    >
+      Text
+    </p>
+    <p
+      key="1"
+    >
+      Array with 
+      <a
+        href="#"
+        key="1"
+      >
+        links
+      </a>
+       test
+    </p>
+    <UpsellBox__StyledList
+      role="list"
+    >
+      <ul
+        className="UpsellBox__StyledList-fkmvyw eKxmfa"
+        role="list"
+      >
+        <li
+          key="0"
+        >
+          <span
+            aria-hidden="true"
+          />
+          <strong
+            key="interpolation-child-1/.0"
+          >
+            Strong text
+          </strong>
+           and not so strong text
+        </li>
+        <li
+          key="1"
+        >
+          <span
+            aria-hidden="true"
+          />
+          <strong
+            key="interpolation-child-1/.0"
+          >
+            Strong text two
+          </strong>
+        </li>
+      </ul>
+    </UpsellBox__StyledList>
+    <OutboundLink
+      aria-labelledby="label-id"
+      className="class name"
+      href="#"
+    >
+      <a
+        aria-labelledby="label-id"
+        className="class name"
+        href="#"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        A button
+        <A11yNotice>
+          <span
+            className="A11yNotice-cySKx gKxLLd"
+          >
+            (Opens in a new browser tab)
+          </span>
+        </A11yNotice>
+      </a>
+    </OutboundLink>
+    <UpsellBox__ButtonLabel>
+      <small
+        className="UpsellBox__ButtonLabel-kkHBve effcmu"
+      />
+    </UpsellBox__ButtonLabel>
+  </div>
+</UpsellBox>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Created an UpsellBox React component. We decided to not create it in yoast-components, since we are moving to a mono-repo anyways.

## Test instructions

This PR can be tested by following these steps:

* Check out the [sibling branch in yoast-components](https://github.com/Yoast/yoast-components/pull/672), and link it to wordpress-seo with `yarn link`.
* Place this code somewhere you can find it (in the DOM), for example on line 42 in `SnippetPreviewSection.js`:
```
			<UpsellBox
				benefits={ [
					"<strong>Strong text</strong> and not so strong text",
					"<strong>Strong text two</strong>",
				] }
				infoParagraphs={ [
					"Text",
					[ "Array with ", <a key="1" href="#">links</a>, " test" ],
				] }
				upsellButtonText="A button"
				upsellButton={ {
					href: "#",
					className: "button button-primary",
					"aria-labelledby": "label-id",
				} }
				upsellButtonLabel="Small text below button"
			/>
```
* Verify that it looks as described in the issue (in essence), and whether the functionality is there.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/yoast-components/issues/661
