### PR TITLE
Adapt i18n helper to be able to specify the namespace

### DIFF
--- a/js/src/helpers/i18n.js
+++ b/js/src/helpers/i18n.js
@@ -18,7 +18,6 @@ export function setTextdomainL10n( textdomain, l10nNamespace = "wpseoYoastJSL10n
 
 	if ( currentTranslations === false ) {
 		const translations = get( window, [ l10nNamespace, textdomain, "locale_data", textdomain ], false );
-		console.log( textdomain, l10nNamespace, translations );
 
 		if ( translations === false ) {
 			// Jed needs to have meta information in the object keyed by an empty string.

--- a/js/src/helpers/i18n.js
+++ b/js/src/helpers/i18n.js
@@ -4,17 +4,21 @@ import get from "lodash/get";
 /**
  * Sets the l10n for the given textdomain in Jed.
  *
- * All the locale data should be available in wpseoYoastComponentsL10n
+ * All the locale data should be available in the l10nNamespace.
  *
- * @param {string} textdomain The textdomain to set the locale data for.
+ * @param {string} textdomain      The textdomain to set the locale data for.
+ * @param {string} [l10nNamespace] The global namespace to get the localization
+ *                                 data from.
+ *
  * @returns {void}
  */
-export function setTextdomainL10n( textdomain ) {
+export function setTextdomainL10n( textdomain, l10nNamespace = "wpseoYoastJSL10n" ) {
 	const jed = getI18n();
 	const currentTranslations = get( jed, [ "options", "locale_data", textdomain ], false );
 
 	if ( currentTranslations === false ) {
-		const translations = get( window, [ "wpseoYoastJSL10n", textdomain, "locale_data", textdomain ], false );
+		const translations = get( window, [ l10nNamespace, textdomain, "locale_data", textdomain ], false );
+		console.log( textdomain, l10nNamespace, translations );
 
 		if ( translations === false ) {
 			// Jed needs to have meta information in the object keyed by an empty string.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Adapt the i18n helper to be able to specify the namespace. This is used in premium for the JS translations.

## Test instructions

This PR can be tested by following these steps:

* Check if the default still works: the `window.wpseoYoastJSL10n` object should fill with translations.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1828