### PR TITLE
Render yoast app in both Gutenberg sidebar and metabox

### DIFF
--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
+/**
+ * Generates and displays the React root element for a metabox section.
+ */
+class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
+	/**
+	 * Name of the section, used as an identifier in the HTML.
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * Content to use before the React root node.
+	 *
+	 * @var string
+	 */
+	public $content;
+
+	/**
+	 * Content to use to display the button to open this content block.
+	 *
+	 * @var string
+	 */
+	private $link_content;
+
+	/**
+	 * Class to add to the link.
+	 *
+	 * @var string
+	 */
+	private $link_class;
+
+	/**
+	 * Aria label to use for the link.
+	 *
+	 * @var string
+	 */
+	private $link_aria_label;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name         The name of the section, used as an identifier in the html. Can only contain URL safe characters.
+	 * @param string $link_content The text content of the section link.
+	 * @param string $content      Optional. Content to use above the React root element.
+	 * @param array  $options      Optional link attributes.
+	 */
+	public function __construct( $name, $link_content, $content = '', array $options = array() ) {
+		$this->name = $name;
+		$this->content = $content;
+		$default_options = array(
+			'link_class'      => '',
+			'link_aria_label' => '',
+		);
+		$options = array_merge( $default_options, $options );
+		$this->link_content    = $link_content;
+		$this->link_class      = $options['link_class'];
+		$this->link_aria_label = $options['link_aria_label'];
+	}
+
+	/**
+	 * Outputs the section link.
+	 *
+	 * @return void
+	 */
+	public function display_link() {
+		printf(
+			'<li><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link %2$s"%3$s>%4$s</a></li>',
+			esc_attr( $this->name ),
+			esc_attr( $this->link_class ),
+			( '' !== $this->link_aria_label ) ? ' aria-label="' . esc_attr( $this->link_aria_label ) . '"' : '',
+			$this->link_content
+		);
+	}
+
+	/**
+	 * Outputs the section content.
+	 *
+	 * @return void
+	 */
+	public function display_content() {
+		$html  = '<div id="%1$s" class="wpseo-meta-section">';
+		$html .= $this->content;
+		$html .= '<div id="wpseo-metabox-root" class="wpseo-metabox-root"></div>';
+		$html .= '</div>';
+		printf(
+			$html,
+			esc_attr( 'wpseo-meta-section-' . $this->name )
+		);
+	}
+}

--- a/admin/metabox/class-metabox-tab-section.php
+++ b/admin/metabox/class-metabox-tab-section.php
@@ -165,4 +165,13 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 		}
 		return $content;
 	}
+
+	/**
+	 * Gets the name of the tab section.
+	 *
+	 * @return string The name of the tab section.
+	 */
+	public function get_name() {
+		return $this->name;
+	}
 }

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -336,9 +336,24 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		foreach ( $content_sections as $content_section ) {
 			$content_section->display_content();
+
+			if ( $this->should_load_react_section( $content_section->get_name() ) ) {
+				echo '<div id="wpseo-meta-section-react" class="wpseo-meta-section-react"></div>';
+			}
 		}
 
 		echo '</div>';
+	}
+
+	/**
+	 * Determines whether the React section should be rendered.
+	 *
+	 * @param string $section_name The name of the section.
+	 *
+	 * @return bool Whether the React section should be rendered.
+	 */
+	private function should_load_react_section( $section_name ) {
+		return $section_name === 'content' && ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR' ) && YOAST_FEATURE_GUTENBERG_SIDEBAR );
 	}
 
 	/**
@@ -369,6 +384,34 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		return $content_sections;
+	}
+
+	/**
+	* Returns the metabox content for React to hook into.
+	*
+	* @return WPSEO_Metabox_Section
+	*/
+	private function get_content_meta_section_react() {
+		$fields = $this->get_hidden_tab_fields( 'general' );
+
+		// Add fields that weren't hidden, as hidden fields.
+		$fields .= $this->do_meta_box(
+			array(
+				'type'  => 'hidden',
+				'title' => '',
+			),
+			'is_cornerstone'
+		);
+
+		return new WPSEO_Metabox_Section_React(
+			'content',
+			'<span class="screen-reader-text">' . __( 'Content optimization', 'wordpress-seo' ) . '</span><span class="yst-traffic-light-container">' . WPSEO_Utils::traffic_light_svg() . '</span>',
+			$fields,
+			array(
+				'link_aria_label' => __( 'Content optimization', 'wordpress-seo' ),
+				'link_class'      => 'yoast-tooltip yoast-tooltip-e',
+			)
+		);
 	}
 
 	/**

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -65,7 +65,7 @@ ul.wpseo-metabox-tabs li.active {
 	background-color: #fdfdfd;
 }
 
-.wpseo-meta-section {
+.wpseo-meta-section, .wpseo-meta-section-react {
 	display: none;
 	width: 100%;
 	max-width: calc( 100% - 50px );
@@ -74,6 +74,11 @@ ul.wpseo-metabox-tabs li.active {
 
 .wpseo-meta-section.active {
 	display: inline-block;
+}
+
+.wpseo-meta-section-react.active {
+	display: block;
+	margin-left: 50px;
 }
 
 .wpseo-metabox-sidebar {

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -6,6 +6,7 @@ import { Provider } from "react-redux";
 import flatten from "lodash/flatten";
 import { ThemeProvider } from "styled-components";
 import styled from "styled-components";
+import { Slot, Fill } from "@wordpress/components/slot-fill";
 
 /* Internal dependencies */
 import IntlProvider from "./components/IntlProvider";
@@ -69,6 +70,27 @@ function sortComponentsByPosition( components ) {
 }
 
 /**
+ * Render the metabox portal.
+ *
+ * @returns {null|ReactElement} The element.
+ */
+function renderMetaboxPortal() {
+	const metaboxElement = document.getElementById( "wpseo-meta-section-react" );
+
+	if ( metaboxElement ) {
+		return yoast._wp.element.createPortal(
+			<Slot name="YoastSidebar">
+				{ ( fills ) => {
+					return sortComponentsByPosition( fills );
+				} }
+			</Slot>,
+			metaboxElement
+		);
+	}
+	return null;
+}
+
+/**
  * Registers the plugin into the gutenberg editor, creates a sidebar entry for the plugin,
  * and creates that sidebar's content.
  *
@@ -79,7 +101,6 @@ function registerPlugin() {
 		const { Fragment } = yoast._wp.element;
 		const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
 		const { registerPlugin } = wp.plugins;
-		const { Slot, Fill } = wp.components;
 
 		const YoastSidebar = () => (
 			<Fragment>
@@ -103,6 +124,7 @@ function registerPlugin() {
 					<SidebarItem renderPriority={ 10 }>Readability analysis</SidebarItem>
 					<SidebarItem renderPriority={ 20 }>SEO analysis</SidebarItem>
 				</Fill>
+				{ renderMetaboxPortal() }
 			</Fragment>
 		);
 

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -36,7 +36,8 @@
 		}
 
 		if ( jQuery( ".wpseo-meta-section" ).length > 0 ) {
-			jQuery( "#wpseo-meta-section-content" ).addClass( "active" );
+			jQuery( "#wpseo-meta-section-content, .wpseo-meta-section-react" ).addClass( "active" );
+
 			jQuery( ".wpseo-metabox-sidebar li" ).filter( function() {
 				return jQuery( this ).find( ".wpseo-meta-section-link" ).attr( "href" ) === "#wpseo-meta-section-content";
 			} ).addClass( "active" );
@@ -51,9 +52,13 @@
 
 					jQuery( ".wpseo-metabox-sidebar li" ).removeClass( "active" );
 					jQuery( ".wpseo-meta-section" ).removeClass( "active" );
+					jQuery( ".wpseo-meta-section-react.active" ).removeClass( "active" );
 
 					// Hide the Yoast tooltip when the element gets clicked.
 					jQuery( this ).addClass( "yoast-tooltip-hidden" );
+					if ( targetTab === "#wpseo-meta-section-content" ) {
+						jQuery( ".wpseo-meta-section-react" ).addClass( "active" );
+					}
 
 					targetTabElement.addClass( "active" );
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "grunt-contrib-imagemin": "^2.0.1"
   },
   "dependencies": {
+    "@wordpress/components": "^1.0.1",
     "@wordpress/i18n": "^1.1.1",
     "@wordpress/is-shallow-equal": "^1.0.2",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.0.0-beta.52":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.54.tgz#39ebb42723fe7ca4b3e1b00e967e80138d47cadf"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.36":
   version "7.0.0-beta.36"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.36.tgz#02e903de5d68bd7899bce3c5b5447e59529abb00"
@@ -98,6 +105,21 @@
   dependencies:
     "@wordpress/dom-ready" "^1.0.4"
 
+"@wordpress/a11y@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-1.1.1.tgz#83104d69aa90043554e4b387993ab78f5e51e3fc"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    "@wordpress/dom-ready" "^1.1.1"
+
+"@wordpress/api-fetch@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-1.0.1.tgz#05b0a6a123d4519e4343e7d44a0f1374a3033408"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    "@wordpress/i18n" "^1.2.1"
+    jquery "^3.3.1"
+
 "@wordpress/autop@1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-1.0.4.tgz#a1c39f0d0af0ed8d38bcc0a0b60b8d56c0233091"
@@ -124,13 +146,90 @@
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.1.3.tgz#3224c58f8bbec9d9fd88079c6ed31947080e6c57"
 
+"@wordpress/components@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-1.0.1.tgz#a0492541398b75a5ab2b3e8680f121a183e206b1"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    "@wordpress/a11y" "^1.1.1"
+    "@wordpress/api-fetch" "^1.0.1"
+    "@wordpress/compose" "^1.0.1"
+    "@wordpress/deprecated" "^1.0.1"
+    "@wordpress/dom" "^1.0.1"
+    "@wordpress/element" "^1.0.1"
+    "@wordpress/hooks" "^1.3.1"
+    "@wordpress/i18n" "^1.2.1"
+    "@wordpress/is-shallow-equal" "^1.1.1"
+    "@wordpress/keycodes" "^1.0.1"
+    classnames "^2.2.5"
+    clipboard "^1.7.1"
+    dom-scroll-into-view "^1.2.1"
+    element-closest "^2.0.2"
+    http-build-query "^0.7.0"
+    lodash "^4.17.10"
+    memize "^1.0.5"
+    moment "^2.22.1"
+    mousetrap "^1.6.2"
+    react-click-outside "^2.3.1"
+    react-color "^2.13.4"
+    react-datepicker "^1.4.1"
+    rememo "^3.0.0"
+    uuid "^3.1.0"
+
+"@wordpress/compose@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-1.0.1.tgz#fdfb24b27390ca97db432108c47188b4fc96dea8"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    "@wordpress/element" "^1.0.1"
+    "@wordpress/is-shallow-equal" "^1.1.1"
+    lodash "^4.17.10"
+
+"@wordpress/deprecated@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-1.0.1.tgz#8769d791b228022caef156dbbff0f21eb2b21f3e"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+
 "@wordpress/dom-ready@^1.0.3", "@wordpress/dom-ready@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-1.0.4.tgz#626648e83529de2243009ff04c12aeb9a949e333"
 
+"@wordpress/dom-ready@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-1.1.1.tgz#68d9124035682db2fc37d7de7f92a7a95816ed23"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+
+"@wordpress/dom@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-1.0.1.tgz#95ed56a9ea0740d304f4037378725af8acf6bbb2"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    element-closest "^2.0.2"
+    lodash "^4.17.10"
+    tinymce "^4.7.2"
+
+"@wordpress/element@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-1.0.1.tgz#d9e31e437793655556816e6328bc67bfbecc4a27"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    "@wordpress/deprecated" "^1.0.1"
+    "@wordpress/is-shallow-equal" "^1.1.1"
+    lodash "^4.17.10"
+    react "^16.4.1"
+    react-dom "^16.4.1"
+
 "@wordpress/hooks@1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-1.1.6.tgz#13ad11592648d6941301a72d2a92470b8a92cda5"
+
+"@wordpress/hooks@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-1.3.1.tgz#1ee50c777938060a96b202e22ca2e902eacce335"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
 
 "@wordpress/i18n@1.0.0":
   version "1.0.0"
@@ -150,9 +249,32 @@
     lodash "^4.17.5"
     memize "^1.0.5"
 
+"@wordpress/i18n@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-1.2.1.tgz#b5c7c52065db9fa13a3d1872ddb9a198bc8ea29a"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    gettext-parser "^1.3.1"
+    jed "^1.1.1"
+    lodash "^4.17.10"
+    memize "^1.0.5"
+
 "@wordpress/is-shallow-equal@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.0.2.tgz#9368bedc69d5ec08f46ff7b188a0d48c6499818c"
+
+"@wordpress/is-shallow-equal@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.1.1.tgz#377db18206afe2a6e787862106c3ff5c27d65e36"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+
+"@wordpress/keycodes@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-1.0.1.tgz#f70518e8c45e86abe90872e3f6d9ec62e4245d71"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    lodash "^4.17.10"
 
 "@wordpress/url@1.0.3":
   version "1.0.3"
@@ -2162,7 +2284,7 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
-clipboard@1.7.1:
+clipboard@1.7.1, clipboard@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
   dependencies:
@@ -2457,7 +2579,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -3016,7 +3138,7 @@ dom-react@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dom-react/-/dom-react-2.2.0.tgz#dc6270608ed56cbdf90c9a3ec3553f9b5a0bd7b3"
 
-dom-scroll-into-view@1.2.1:
+dom-scroll-into-view@1.2.1, dom-scroll-into-view@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz#e8f36732dd089b0201a88d7815dc3f88e6d66c7e"
 
@@ -3191,7 +3313,7 @@ electron-to-chromium@^1.3.30:
   version "1.3.31"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz#00d832cba9fe2358652b0c48a8816c8e3a037e9f"
 
-element-closest@2.0.2:
+element-closest@2.0.2, element-closest@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-2.0.2.tgz#72a740a107453382e28df9ce5dbb5a8df0f966ec"
 
@@ -5116,6 +5238,10 @@ htmlparser2@^3.9.1, htmlparser2@^3.9.2:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
+http-build-query@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/http-build-query/-/http-build-query-0.7.0.tgz#f2add22b42ea5b08dacbe5ea6cac1775c9a067f2"
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -6481,6 +6607,10 @@ jquery@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
+jquery@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+
 js-base64@^2.1.8:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
@@ -7381,9 +7511,17 @@ moment@2.21.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
+moment@^2.22.1:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 mousetrap@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.1.tgz#2a085f5c751294c75e7e81f6ec2545b29cbf42d9"
+
+mousetrap@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.2.tgz#caadd9cf886db0986fb2fee59a82f6bd37527587"
 
 ms@0.7.1:
   version "0.7.1"
@@ -8235,7 +8373,7 @@ po2json@*:
     gettext-parser "1.1.0"
     nomnom "1.8.1"
 
-popper.js@^1.12.5:
+popper.js@^1.12.5, popper.js@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
 
@@ -8593,7 +8731,7 @@ react-autosize-textarea@3.0.2:
     line-height "^0.3.1"
     prop-types "^15.5.6"
 
-react-click-outside@2.3.1:
+react-click-outside@2.3.1, react-click-outside@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-2.3.1.tgz#318737ebdf081a4a3bcd46825663674cbe9836eb"
   dependencies:
@@ -8609,6 +8747,16 @@ react-color@2.13.4:
     reactcss "^1.2.0"
     tinycolor2 "^1.1.2"
 
+react-color@^2.13.4:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.14.1.tgz#db8ad4f45d81e74896fc2e1c99508927c6d084e0"
+  dependencies:
+    lodash "^4.0.1"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
+
 react-datepicker@0.61.0:
   version "0.61.0"
   resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-0.61.0.tgz#ac1e7bf18bf88bdf22548a3c4e13a35710bb40eb"
@@ -8620,6 +8768,15 @@ react-datepicker@0.61.0:
     prop-types "^15.6.0"
     react-onclickoutside "^6.6.3"
     react-popper "^0.7.4"
+
+react-datepicker@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-1.5.0.tgz#7eacd9609313189c84a21bb7421486054939a4b2"
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+    react-onclickoutside "^6.7.1"
+    react-popper "^0.9.1"
 
 react-dom@16.2.0, "react-dom@^0.14.3 || ^15.1.0 || ^16.0.0":
   version "16.2.0"
@@ -8633,6 +8790,15 @@ react-dom@16.2.0, "react-dom@^0.14.3 || ^15.1.0 || ^16.0.0":
 react-dom@16.3.0:
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.0.tgz#b318e52184188ecb5c3e81117420cca40618643e"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-dom@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -8674,7 +8840,7 @@ react-modal@^3.1.10:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-onclickoutside@^6.6.3:
+react-onclickoutside@^6.6.3, react-onclickoutside@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
@@ -8684,6 +8850,13 @@ react-popper@^0.7.4:
   dependencies:
     popper.js "^1.12.5"
     prop-types "^15.5.10"
+
+react-popper@^0.9.1:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.9.5.tgz#02a24ef3eec33af9e54e8358ab70eb0e331edd05"
+  dependencies:
+    popper.js "^1.14.1"
+    prop-types "^15.6.1"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -8757,6 +8930,15 @@ react-transition-group@^2.3.1:
 react@16.3.0:
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.3.0.tgz#fc5a01c68f91e9b38e92cf83f7b795ebdca8ddff"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -8968,6 +9150,10 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz#8052ac952d85b10f3425192cd0c53f45cf65c6cb"
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -9012,6 +9198,10 @@ rememo@2.4.0:
   resolved "https://registry.yarnpkg.com/rememo/-/rememo-2.4.0.tgz#b75028851435ce704a01fe24429c74022f869987"
   dependencies:
     shallow-equal "^1.0.0"
+
+rememo@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rememo/-/rememo-3.0.0.tgz#06e8e76e108865cc1e9b73329db49f844eaf8392"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -10288,9 +10478,13 @@ tiny-lr@^0.2.1:
     parseurl "~1.3.0"
     qs "~5.1.0"
 
-tinycolor2@1.4.1, tinycolor2@^1.1.2:
+tinycolor2@1.4.1, tinycolor2@^1.1.2, tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
+
+tinymce@^4.7.2:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-4.8.0.tgz#3c4c88701d0526374efb45bafbb820c7715e2356"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Creates a cloned application that is rendered in both the sidebar and the metabox.

## Relevant technical choices:

* This PR needs to be iterated on to make sure the new metabox is also rendered in the classic editor.

## Test instructions

This PR can be tested by following these steps:

* Make sure the `define( 'YOAST_FEATURE_GUTENBERG_SIDEBAR', true );` constant is defined.
* Make sure duplicate content is rendered both below the (old) metabox and in the yoast sidebar.
* You can verify this by altering the components being rendered in the `YoastSidebar` Fill on line 123 in `edit.js`

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10427 
