### PR TITLE
Create a container for the (one) keyword analysis

### DIFF
--- a/js/src/components/UpsellBox.js
+++ b/js/src/components/UpsellBox.js
@@ -1,0 +1,130 @@
+/* External dependencies */
+import React from "react";
+import interpolateComponents from "interpolate-components";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { utils } from "yoast-components";
+
+const { makeOutboundLink } = utils;
+
+const StyledList = styled.ul`
+	list-style: none;
+	margin: 0 0 16px;
+	padding: 0;
+
+	li {
+		margin: 5px 0 0 0;
+		padding-left: 16px;
+	}
+
+	span[aria-hidden="true"]:before {
+		margin: 0 8px 0 -16px;
+		font-weight: bold;
+		content: "+";
+	}
+`;
+
+const ButtonLabel = styled.small`
+	display: block;
+`;
+
+const UpsellButton = makeOutboundLink();
+
+/**
+ * Returns the UpsellBox component.
+ *
+ * @returns {ReactElement} The UpsellBox component.
+ */
+class UpsellBox extends React.Component {
+	/**
+	 * The constructor.
+	 *
+	 * @param {object} props The component props.
+	 *
+	 * @returns {void}
+	 */
+	constructor( props ) {
+		super( props );
+	}
+
+	/**
+	 * Creates the HTML for the benefits list.
+	 *
+	 * @param {array} benefits The list of benefits to be rendered.
+	 *
+	 * @returns {*} HTML for the list of benefits.
+	 */
+	createBenefitsList( benefits ) {
+		return (
+			benefits.length > 0 &&
+			<StyledList role="list">
+				{ benefits.map( ( benefit, index ) => {
+					return <li key={ index }>
+						<span aria-hidden="true"></span>
+						{ interpolateComponents( {
+							mixedString: benefit.replace( "<strong>", "{{strong}}" ).replace( "</strong>", "{{/strong}}" ),
+							components: { strong: <strong /> },
+						} ) }
+					</li>;
+				} ) }
+			</StyledList>
+		);
+	}
+
+	/**
+	 * Creates the HTML for the info paragraphs.
+	 *
+	 * @param {array} paragraphs The paragraphs to be rendered.
+	 *
+	 * @returns {*} The HTML for the info paragraphs.
+	 */
+	createInfoParagraphs( paragraphs ) {
+		return(
+			paragraphs.map( ( paragraph, index ) => {
+				return <p key={ index } >{ paragraph }</p>;
+			} )
+		);
+	}
+
+	/**
+	 * Renders a UpsellBox component.
+	 *
+	 * @returns {ReactElement} The rendered UpsellBox component.
+	 */
+	render() {
+		return (
+			<div>
+				{ this.createInfoParagraphs( this.props.infoParagraphs ) }
+				{ this.createBenefitsList( this.props.benefits ) }
+				<UpsellButton
+					{ ...this.props.upsellButton }
+				>
+					{ this.props.upsellButtonText }
+				</UpsellButton>
+				<ButtonLabel id={ this.props.upsellButton[ "aria-describedby" ] }>
+					{ this.props.upsellButtonLabel }
+				</ButtonLabel>
+			</div>
+		);
+	}
+}
+
+UpsellBox.propTypes = {
+	benefits: PropTypes.array,
+	infoParagraphs: PropTypes.array,
+	upsellButton: PropTypes.object,
+	upsellButtonText: PropTypes.string.isRequired,
+	upsellButtonLabel: PropTypes.string,
+};
+
+UpsellBox.defaultProps = {
+	infoParagraphs: [],
+	benefits: [],
+	upsellButton: {
+		href: "",
+		className: "button button-primary",
+	},
+	upsellButtonLabel: ""
+};
+
+export default UpsellBox;

--- a/js/src/components/contentAnalysis/AnalysisSection.js
+++ b/js/src/components/contentAnalysis/AnalysisSection.js
@@ -5,7 +5,7 @@ import StyledSection from "yoast-components/forms/StyledSection/StyledSection";
 import colors from "yoast-components/style-guide/colors.json";
 
 import ReadabilityAnalysis from "./ReadabilityAnalysis";
-import SeoAnalysis from "./SeoAnalysis";
+import SeoAnalysisLegacy from "./SeoAnalysisLegacy";
 
 /**
  * Redux container for the Seo & Readability analysis.
@@ -24,7 +24,7 @@ class AnalysisSection extends React.Component {
 				headingIconSize="16px"
 				className={ className }
 			>
-				{ activeTab === "keyword" ? <SeoAnalysis/> : null }
+				{ activeTab === "keyword" ? <SeoAnalysisLegacy/> : null }
 				{ activeTab === "readability" ? <ReadabilityAnalysis/> : null }
 			</StyledSection>
 		);

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -3,6 +3,10 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import Results from "./Results";
+import UpsellBox from "../UpsellBox";
+import { Collapsible } from "yoast-components/composites/Plugin/Shared/components/Collapsible";
+import KeywordInput from "yoast-components/composites/Plugin/Shared/components/KeywordInput";
+import { setActiveKeyword } from "../../redux/actions/activeKeyword";
 
 /**
  * Redux container for the seo analysis.
@@ -10,11 +14,39 @@ import Results from "./Results";
 class SeoAnalysis extends React.Component {
 	render() {
 		return (
-			<Results
-				showLanguageNotice={ false }
-				results={ this.props.results }
-				marksButtonClassName="yoast-tooltip yoast-tooltip-s"
-				marksButtonStatus={ this.props.marksButtonStatus } />
+			<React.Fragment>
+				<Collapsible
+					title="Focus keyword analysis"
+				>
+					<KeywordInput
+						id="focus-keyword-input"
+						label="Focus keyword"
+						keyword={ this.props.keyword }
+						onChange={ this.props.onKeywordChange }
+					/>
+					<Results
+						showLanguageNotice={ false }
+						results={ this.props.results }
+						marksButtonClassName="yoast-tooltip yoast-tooltip-s"
+						marksButtonStatus={ this.props.marksButtonStatus }
+					/>
+				</Collapsible>
+				<Collapsible
+					title="Add another keyword"
+				>
+					<UpsellBox
+						benefits={ this.props.upsell.benefits }
+						infoParagraphs={ this.props.upsell.infoParagraphs }
+						upsellButtonText={ this.props.upsell.buttonText }
+						upsellButton={ {
+							href: this.props.upsell.buttonLink,
+							className: "button button-primary",
+							"aria-labelledby": "label-id",
+						} }
+						upsellButtonLabel={ this.props.upsell.buttonLabel }
+					/>
+				</Collapsible>
+			</React.Fragment>
 		);
 	}
 }
@@ -23,6 +55,13 @@ SeoAnalysis.propTypes = {
 	results: PropTypes.array,
 	marksButtonStatus: PropTypes.string,
 	hideMarksButtons: PropTypes.bool,
+	upsell: PropTypes.shape( {
+		benefits: PropTypes.array,
+		infoParagraphs: PropTypes.array,
+		buttonLink: PropTypes.string,
+		buttonText: PropTypes.string,
+		buttonLabel: PropTypes.string,
+	} ),
 };
 
 /**
@@ -37,14 +76,24 @@ function mapStateToProps( state, ownProps ) {
 	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
 
 	let results = null;
+	let keyword = state.activeKeyword;
 	if( state.analysis.seo[ state.activeKeyword ] ) {
 		results = state.analysis.seo[ state.activeKeyword ].results;
 	}
 
 	return {
 		results,
+		keyword,
 		marksButtonStatus: marksButtonStatus,
 	};
 }
 
-export default connect( mapStateToProps )( SeoAnalysis );
+function mapDispatchToProps( dispatch ) {
+	return {
+		onKeywordChange: ( value ) => {
+			dispatch( setActiveKeyword( value ) );
+		},
+	};
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( SeoAnalysis );

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -1,12 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import styled from "styled-components";
 
 import Results from "./Results";
 import UpsellBox from "../UpsellBox";
 import { Collapsible } from "yoast-components/composites/Plugin/Shared/components/Collapsible";
 import KeywordInput from "yoast-components/composites/Plugin/Shared/components/KeywordInput";
 import { setActiveKeyword } from "../../redux/actions/activeKeyword";
+
+const AnalysisHeader = styled.span`
+	font-size: 1em;
+	font-weight: bold;
+	margin: 1.5em 0 1em;
+	display: block;
+`;
+
+const ExplanationText = styled.p`
+`;
+
+const AddSynonyms = styled.a`
+`;
 
 /**
  * Redux container for the seo analysis.
@@ -18,12 +32,23 @@ class SeoAnalysis extends React.Component {
 				<Collapsible
 					title="Focus keyword analysis"
 				>
+					<ExplanationText>
+						A focus keyword is the term (or phrase) you'd like to be found with in search engines.
+						Enter it below to see how you can improve your text for this term. <a href="#">Learn more about the Keyword Analysis</a>
+					</ExplanationText>
 					<KeywordInput
 						id="focus-keyword-input"
-						label="Focus keyword"
 						keyword={ this.props.keyword }
 						onChange={ this.props.onKeywordChange }
 					/>
+					<AddSynonyms
+						href="#"
+					>
+						+ Add synonyms
+					</AddSynonyms>
+					<AnalysisHeader>
+						Analysis results:
+					</AnalysisHeader>
 					<Results
 						showLanguageNotice={ false }
 						results={ this.props.results }
@@ -84,7 +109,7 @@ function mapStateToProps( state, ownProps ) {
 	return {
 		results,
 		keyword,
-		marksButtonStatus: marksButtonStatus,
+		marksButtonStatus,
 	};
 }
 

--- a/js/src/components/contentAnalysis/SeoAnalysisLegacy.js
+++ b/js/src/components/contentAnalysis/SeoAnalysisLegacy.js
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+import Results from "./Results";
+
+/**
+ * Redux container for the seo analysis.
+ */
+class SeoAnalysisLegacy extends React.Component {
+	render() {
+		return (
+			<Results
+				showLanguageNotice={ false }
+				results={ this.props.results }
+				marksButtonClassName="yoast-tooltip yoast-tooltip-s"
+				marksButtonStatus={ this.props.marksButtonStatus }
+			/>
+		);
+	}
+}
+
+SeoAnalysisLegacy.propTypes = {
+	results: PropTypes.array,
+	marksButtonStatus: PropTypes.string,
+	hideMarksButtons: PropTypes.bool,
+};
+
+/**
+ * Maps redux state to SeoAnalysisLegacy props.
+ *
+ * @param {Object} state The redux state.
+ * @param {Object} ownProps The component's props.
+ *
+ * @returns {Object} Props that should be passed to SeoAnalysisLegacy.
+ */
+function mapStateToProps( state, ownProps ) {
+	const marksButtonStatus = ownProps.hideMarksButtons ? "disabled" : state.marksButtonStatus;
+
+	let results = null;
+	if( state.analysis.seo[ state.activeKeyword ] ) {
+		results = state.analysis.seo[ state.activeKeyword ].results;
+	}
+
+	return {
+		results,
+		marksButtonStatus: marksButtonStatus,
+	};
+}
+
+export default connect( mapStateToProps )( SeoAnalysisLegacy );

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -1,4 +1,4 @@
-/* global window wpseoPostScraperL10n wpseoTermScraperL10n process wp yoast */
+/* global window, wpseoPostScraperL10n, wpseoTermScraperL10n, yoastPremiumBenefitsL10n, process, wp, yoast */
 /* External dependencies */
 import React from "react";
 import ReactDOM from "react-dom";
@@ -17,6 +17,8 @@ import ClassicEditorData from "./analysis/classicEditorData.js";
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
 import SnippetEditor from "./containers/SnippetEditor";
 import SidebarItem from "./components/SidebarItem";
+import SeoAnalysis from "./components/contentAnalysis/SeoAnalysis";
+import keywordUpsellProps from "./values/keywordUpsellProps";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
 let localizedData = { intl: {}, isRtl: false };
@@ -74,7 +76,7 @@ function sortComponentsByPosition( components ) {
  *
  * @returns {void}
  **/
-function registerPlugin() {
+function registerPlugin( store ) {
 	if ( isGutenbergDataAvailable() ) {
 		const { Fragment } = yoast._wp.element;
 		const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
@@ -101,7 +103,11 @@ function registerPlugin() {
 				</PluginSidebar>
 				<Fill name="YoastSidebar">
 					<SidebarItem renderPriority={ 10 }>Readability analysis</SidebarItem>
-					<SidebarItem renderPriority={ 20 }>SEO analysis</SidebarItem>
+					<SidebarItem renderPriority={ 20 }>
+						{ wrapInTopLevelComponents( SeoAnalysis, store, {
+							upsell: keywordUpsellProps,
+						} ) }
+					</SidebarItem>
 				</Fill>
 			</Fragment>
 		);
@@ -251,7 +257,7 @@ export function initializeData( data, args, store ) {
 export function initialize( args ) {
 	const store = registerStoreInGutenberg();
 	if( args.shouldRenderGutenbergSidebar ) {
-		registerPlugin();
+		registerPlugin( store );
 	}
 
 	const data = initializeData( wp.data, args, store );

--- a/js/src/values/keywordUpsellProps.js
+++ b/js/src/values/keywordUpsellProps.js
@@ -1,0 +1,32 @@
+/* global window, yoastPremiumBenefitsL10n, yoastAddKeywordModalL10n */
+import React from "react";
+import interpolateComponents from "interpolate-components";
+
+import { utils } from "yoast-components";
+
+const { makeOutboundLink } = utils;
+const YesYouCanLink = makeOutboundLink();
+
+let benefits = null;
+if ( window.yoastPremiumBenefitsL10n ) {
+	benefits = yoastPremiumBenefitsL10n.intl;
+}
+
+let upsellIntro = null;
+if ( window.yoastAddKeywordModalL10n ) {
+	upsellIntro = yoastAddKeywordModalL10n.intl;
+}
+
+export default {
+	benefits,
+	infoParagraphs: [
+		interpolateComponents( {
+			mixedString: upsellIntro.intro,
+			components: { link: <YesYouCanLink href={ upsellIntro.link } /> },
+		} ),
+		upsellIntro.other
+	],
+	buttonLink: upsellIntro.buylink,
+	buttonText: upsellIntro.buy,
+	buttonLabel: upsellIntro.small,
+};

--- a/js/src/values/keywordUpsellProps.js
+++ b/js/src/values/keywordUpsellProps.js
@@ -12,7 +12,7 @@ if ( window.yoastPremiumBenefitsL10n ) {
 	benefits = yoastPremiumBenefitsL10n.intl;
 }
 
-let upsellIntro = null;
+let upsellIntro = { intro: "" };
 if ( window.yoastAddKeywordModalL10n ) {
 	upsellIntro = yoastAddKeywordModalL10n.intl;
 }

--- a/js/tests/components/UpsellBox.test.js
+++ b/js/tests/components/UpsellBox.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { mount } from "enzyme";
+import UpsellBox from "../../src/components/UpsellBox";
+
+describe( "UpsellBox", () => {
+	it( "renders the snippet editor inside of it", () => {
+		const tree = mount(
+			<UpsellBox
+				benefits={ [
+					"<strong>Strong text</strong> and not so strong text",
+					"<strong>Strong text two</strong>",
+				] }
+				infoParagraphs={ [
+					"Text",
+					[ "Array with ", <a key="1" href="#">links</a>, " test" ],
+				] }
+				upsellButtonText="A button"
+				upsellButton={ {
+					href: "#",
+					className: "class name",
+					"aria-labelledby": "label-id",
+				} }
+				buttonLabel="Small text below button"
+			/>
+		);
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/js/tests/components/__snapshots__/UpsellBox.test.js.snap
+++ b/js/tests/components/__snapshots__/UpsellBox.test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpsellBox renders the snippet editor inside of it 1`] = `
+<UpsellBox
+  benefits={
+    Array [
+      "<strong>Strong text</strong> and not so strong text",
+      "<strong>Strong text two</strong>",
+    ]
+  }
+  buttonLabel="Small text below button"
+  infoParagraphs={
+    Array [
+      "Text",
+      Array [
+        "Array with ",
+        <a
+          href="#"
+        >
+          links
+        </a>,
+        " test",
+      ],
+    ]
+  }
+  upsellButton={
+    Object {
+      "aria-labelledby": "label-id",
+      "className": "class name",
+      "href": "#",
+    }
+  }
+  upsellButtonLabel=""
+  upsellButtonText="A button"
+>
+  <div>
+    <p
+      key="0"
+    >
+      Text
+    </p>
+    <p
+      key="1"
+    >
+      Array with 
+      <a
+        href="#"
+        key="1"
+      >
+        links
+      </a>
+       test
+    </p>
+    <UpsellBox__StyledList
+      role="list"
+    >
+      <ul
+        className="UpsellBox__StyledList-fkmvyw eKxmfa"
+        role="list"
+      >
+        <li
+          key="0"
+        >
+          <span
+            aria-hidden="true"
+          />
+          <strong
+            key="interpolation-child-1/.0"
+          >
+            Strong text
+          </strong>
+           and not so strong text
+        </li>
+        <li
+          key="1"
+        >
+          <span
+            aria-hidden="true"
+          />
+          <strong
+            key="interpolation-child-1/.0"
+          >
+            Strong text two
+          </strong>
+        </li>
+      </ul>
+    </UpsellBox__StyledList>
+    <OutboundLink
+      aria-labelledby="label-id"
+      className="class name"
+      href="#"
+    >
+      <a
+        aria-labelledby="label-id"
+        className="class name"
+        href="#"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        A button
+        <A11yNotice>
+          <span
+            className="A11yNotice-cySKx gKxLLd"
+          >
+            (Opens in a new browser tab)
+          </span>
+        </A11yNotice>
+      </a>
+    </OutboundLink>
+    <UpsellBox__ButtonLabel>
+      <small
+        className="UpsellBox__ButtonLabel-kkHBve effcmu"
+      />
+    </UpsellBox__ButtonLabel>
+  </div>
+</UpsellBox>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Focus keyword analysis is now visible in the Gutenberg Sidebar, when the Yoast Sidebar is enabled.

## Relevant technical choices:

* Created a component that always consists of two collapsible headers: One for the Focus Keyword input, followed by the results... and one for the "additional keyword", filled with the `UpsellBox`.

## Test instructions

This PR can be tested by following these steps:

* Checkout branch and remember to run `yarn upgrade yoast-components`, to get the latest version of yoast-components.
* Make sure the feature flag `define('YOAST_FEATURE_GUTENBERG_SIDEBAR', true );` is set to true.
* Open the Yoast Plugin in the sidebar, and verify that the components there *APPROXIMATE* the look required in the issue. Styling will be finalized a later point.
* Note that the focus keyword inputfield will already show the keyword, and will send redux action when it is altered, but the analysis results are not yet updated accordingly. These things should all be connected in a separate issue.
* Furthermore, the Add Synonyms button does not yet open the modal, as we were unsure about how to open the PHP modal without polluting the react component with globals.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/yoast-components/issues/662
