### PR TITLE
Added separate slot, container and component for Metabox

### DIFF
--- a/js/src/components/Metabox.js
+++ b/js/src/components/Metabox.js
@@ -8,8 +8,8 @@ import SidebarItem from "./SidebarItem";
 /**
  * Creates the Metabox component.
  *
- * @param {bool} isContentAnalysisActive Whether or not the readability analysis is active or not.
- * @param {bool} isKeywordAnalysisActive Whether or not the readability analysis is active or not.
+ * @param {bool} isContentAnalysisActive Whether or not the readability analysis is active.
+ * @param {bool} isKeywordAnalysisActive Whether or not the SEO analysis is active.
  *
  * @returns {ReactElement} The Metabox component.
  */

--- a/js/src/components/Metabox.js
+++ b/js/src/components/Metabox.js
@@ -6,25 +6,25 @@ import PropTypes from "prop-types";
 import SidebarItem from "./SidebarItem";
 
 /**
- * Creates the Sidebar component.
+ * Creates the Metabox component.
  *
  * @param {bool} isContentAnalysisActive Whether or not the readability analysis is active or not.
  * @param {bool} isKeywordAnalysisActive Whether or not the readability analysis is active or not.
  *
- * @returns {ReactElement} The Sidebar component.
+ * @returns {ReactElement} The Metabox component.
  */
-export default function Sidebar( { isContentAnalysisActive, isKeywordAnalysisActive } ) {
+export default function Metabox( { isContentAnalysisActive, isKeywordAnalysisActive } ) {
 	const { Fill } = wp.components;
 
 	return (
-		<Fill name="YoastSidebar">
+		<Fill name="YoastMetabox">
 			{ isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>Readability analysis</SidebarItem> }
 			{ isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>SEO analysis</SidebarItem> }
 		</Fill>
 	);
 }
 
-Sidebar.propTypes = {
+Metabox.propTypes = {
 	isContentAnalysisActive: PropTypes.bool,
 	isKeywordAnalysisActive: PropTypes.bool,
 };

--- a/js/src/components/Sidebar.js
+++ b/js/src/components/Sidebar.js
@@ -8,8 +8,8 @@ import SidebarItem from "./SidebarItem";
 /**
  * Creates the Sidebar component.
  *
- * @param {bool} isContentAnalysisActive Whether or not the readability analysis is active or not.
- * @param {bool} isKeywordAnalysisActive Whether or not the readability analysis is active or not.
+ * @param {bool} isContentAnalysisActive Whether or not the readability analysis is active.
+ * @param {bool} isKeywordAnalysisActive Whether or not the SEO analysis is active.
  *
  * @returns {ReactElement} The Sidebar component.
  */

--- a/js/src/containers/Metabox.js
+++ b/js/src/containers/Metabox.js
@@ -1,0 +1,18 @@
+import Metabox from "../components/Metabox";
+import { connect } from "react-redux";
+
+/**
+ * Maps the state to props.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {Object} The props for the Metabox component.
+ */
+function mapStateToProps( state ) {
+	return {
+		isContentAnalysisActive: state.preferences.isContentAnalysisActive,
+		isKeywordAnalysisActive: state.preferences.isKeywordAnalysisActive,
+	};
+}
+
+export default connect( mapStateToProps )( Metabox );

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -8,7 +8,6 @@ import { ThemeProvider } from "styled-components";
 import styled from "styled-components";
 
 /* Internal dependencies */
-import IntlProvider from "./components/IntlProvider";
 import AnalysisSection from "./components/contentAnalysis/AnalysisSection";
 import Data from "./analysis/data.js";
 import reducers from "./redux/reducers";

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -17,6 +17,7 @@ import ClassicEditorData from "./analysis/classicEditorData.js";
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
 import SnippetEditor from "./containers/SnippetEditor";
 import Sidebar from "./containers/Sidebar";
+import Metabox from "./containers/Metabox";
 
 // This should be the entry point for all the edit screens. Because of backwards compatibility we can't change this at once.
 let localizedData = { intl: {}, isRtl: false };
@@ -82,7 +83,7 @@ function renderMetaboxPortal() {
 
 	const { Slot } = wp.components;
 	return yoast._wp.element.createPortal(
-		<Slot name="YoastSidebar">
+		<Slot name="YoastMetabox">
 			{ ( fills ) => {
 				return sortComponentsByPosition( fills );
 			} }
@@ -125,7 +126,10 @@ function registerPlugin( store ) {
 					</Slot>
 				</PluginSidebar>
 				<Provider store={ store } >
-					<Sidebar />
+					<Fragment>
+						<Sidebar />
+						<Metabox />
+					</Fragment>
 				</Provider>
 				{ renderMetaboxPortal() }
 			</Fragment>
@@ -153,14 +157,11 @@ function wrapInTopLevelComponents( Component, store, props ) {
 	};
 
 	return (
-		<IntlProvider
-			messages={ localizedData.intl } >
-			<Provider store={ store } >
-				<ThemeProvider theme={ theme }>
-					<Component { ...props } />
-				</ThemeProvider>
-			</Provider>
-		</IntlProvider>
+		<Provider store={ store } >
+			<ThemeProvider theme={ theme }>
+				<Component { ...props } />
+			</ThemeProvider>
+		</Provider>
 	);
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Creates a separate slot for the metabox, besides the already existing sidebar slot.
* Also removes `IntlProvider` from react applications on post pages (HelpCenter, Snippet Preview and Content analysis results).

## Test instructions

This PR can be tested by following these steps:

* There are two components: `js/src/components/Metabox.js` and `js/src/components/Sidebar.js`. Give both different contents and make sure the Sidebar and Metabox show the correct content.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10454 
