### PR TITLE
Removed gutenberg sidebar feature flag

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -66,7 +66,6 @@ class WPSEO_Metabox_Formatter {
 			'cornerstoneActive' 	=> WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
 			'intl'                  => $this->get_content_analysis_component_translations(),
 			'isRtl'                 => is_rtl(),
-			'gutenbergSidebar'      => defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR' ) && YOAST_FEATURE_GUTENBERG_SIDEBAR,
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -353,7 +353,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return bool Whether the React section should be rendered.
 	 */
 	private function should_load_react_section( $section_name ) {
-		return $section_name === 'content' && ( defined( 'YOAST_FEATURE_GUTENBERG_SIDEBAR' ) && YOAST_FEATURE_GUTENBERG_SIDEBAR );
+		return $section_name === 'content';
 	}
 
 	/**

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -56,46 +56,48 @@ function registerStoreInGutenberg() {
  * @returns {void}
  **/
 function registerPlugin( store ) {
-	if ( isGutenbergDataAvailable() ) {
-		const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
-		const { registerPlugin } = wp.plugins;
-		const theme = {
-			isRtl: localizedData.isRtl,
-		};
-
-		const YoastSidebar = () => (
-			<Fragment>
-				<PluginSidebarMoreMenuItem
-					target="seo-sidebar"
-					icon={ <PluginIcon/> }
-				>
-					Yoast SEO
-				</PluginSidebarMoreMenuItem>
-				<PluginSidebar
-					name="seo-sidebar"
-					title="Yoast SEO"
-				>
-					<Slot name="YoastSidebar">
-						{ ( fills ) => {
-							return sortComponentsByRenderPriority( fills );
-						} }
-					</Slot>
-				</PluginSidebar>
-
-				<Provider store={ store } >
-					<Fragment>
-						<Sidebar store={ store } />
-						<MetaboxPortal target="wpseo-meta-section-react" store={ store } theme={ theme } />
-					</Fragment>
-				</Provider>
-			</Fragment>
-		);
-
-		registerPlugin( "yoast-seo", {
-			render: YoastSidebar,
-			icon: <PinnedPluginIcon />,
-		} );
+	if ( ! isGutenbergDataAvailable() )  {
+		return;
 	}
+
+	const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
+	const { registerPlugin } = wp.plugins;
+	const theme = {
+		isRtl: localizedData.isRtl,
+	};
+
+	const YoastSidebar = () => (
+		<Fragment>
+			<PluginSidebarMoreMenuItem
+				target="seo-sidebar"
+				icon={ <PluginIcon/> }
+			>
+				Yoast SEO
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar
+				name="seo-sidebar"
+				title="Yoast SEO"
+			>
+				<Slot name="YoastSidebar">
+					{ ( fills ) => {
+						return sortComponentsByRenderPriority( fills );
+					} }
+				</Slot>
+			</PluginSidebar>
+
+			<Provider store={ store } >
+				<Fragment>
+					<Sidebar store={ store } />
+					<MetaboxPortal target="wpseo-meta-section-react" store={ store } theme={ theme } />
+				</Fragment>
+			</Provider>
+		</Fragment>
+	);
+
+	registerPlugin( "yoast-seo", {
+		render: YoastSidebar,
+		icon: <PinnedPluginIcon />,
+	} );
 }
 
 /**
@@ -200,9 +202,7 @@ export function initializeData( data, args, store ) {
 export function initialize( args ) {
 	const store = registerStoreInGutenberg();
 
-	if ( args.shouldRenderGutenbergSidebar ) {
-		registerPlugin( store );
-	}
+	registerPlugin( store );
 
 	const data = initializeData( wp.data, args, store );
 

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -443,12 +443,10 @@ setWordPressSeoL10n();
 		const editArgs = {
 			analysisSection: "pageanalysis",
 			onRefreshRequest: () => {},
-			shouldRenderSnippetPreview: true,
 			snippetEditorBaseUrl: wpseoPostScraperL10n.base_url,
 			snippetEditorDate: wpseoPostScraperL10n.metaDescriptionDate,
 			replaceVars: wpseoReplaceVarsL10n.replace_vars,
 			recommendedReplaceVars: wpseoReplaceVarsL10n.recommended_replace_vars,
-			shouldRenderGutenbergSidebar: !! wpseoPostScraperL10n.gutenbergSidebar,
 		};
 		const { store, data } = initializeEdit( editArgs );
 		editStore = store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3073,10 +3073,10 @@ draft-js-plugins-editor@^2.0.4:
     union-class-names "^1.0.0"
 
 draft-js-single-line-plugin@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/draft-js-single-line-plugin/-/draft-js-single-line-plugin-2.0.1.tgz#3aea1b100b1562d7ef3d5d02e73190da12953857"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/draft-js-single-line-plugin/-/draft-js-single-line-plugin-2.0.2.tgz#b0a63b19f70a76bfc496db7cd621cf504a10a675"
   dependencies:
-    immutable "^3.8.1"
+    immutable "~3.7.4"
 
 draft-js@^0.10.5:
   version "0.10.5"
@@ -5219,10 +5219,6 @@ imagemin@^5.3.1:
     p-pipe "^1.1.0"
     pify "^2.3.0"
     replace-ext "^1.0.0"
-
-immutable@^3.8.1:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
 immutable@~3.7.4:
   version "3.7.6"
@@ -10951,7 +10947,7 @@ yauzl@^2.2.1:
 
 "yoast-components@git+https://github.com/Yoast/yoast-components.git#develop":
   version "4.8.0"
-  resolved "git+https://github.com/Yoast/yoast-components.git#358f419e243971c148dc3fbf148788146d4deb56"
+  resolved "git+https://github.com/Yoast/yoast-components.git#99300f768de1827e329393663a38133229a2b75c"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Make sure the `define( 'YOAST_FEATURE_GUTENBERG_SIDEBAR', true );` is removed from your `wp-config.php` file.
* Make sure the sidebar and new metabox are still being rendered in gutenberg and the new metabox is still being rendered in the classic editor.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10373 
