### PR TITLE
Add ability to register components

### DIFF
--- a/js/src/helpers/classicEditor.js
+++ b/js/src/helpers/classicEditor.js
@@ -49,8 +49,8 @@ class RegisteredComponentsContainer extends Component {
 	 * @returns {React.Element[]} The rendered components in an array.
 	 */
 	render() {
-		return this.state.registeredComponents.map( ( registered ) => {
-			return <registered.Component key={ registered.key } />;
+		return this.state.registeredComponents.map( ( { Components, key } ) => {
+			return <Component key={ key } />;
 		} );
 	}
 }

--- a/js/src/helpers/classicEditor.js
+++ b/js/src/helpers/classicEditor.js
@@ -1,0 +1,108 @@
+import { render, Component, createRef } from "@wordpress/element";
+import { SlotFillProvider } from "@wordpress/components";
+import MetaboxPortal from "../components/MetaboxPortal";
+import getL10nObject from "../analysis/getL10nObject";
+
+const registeredComponents = [];
+let containerRef = null;
+
+class RegisteredComponentsContainer extends Component {
+
+	/**
+	 * Constructs a container for registered components.
+	 *
+	 * @param {Object} props Props for this component.
+	 */
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			registeredComponents: [],
+		};
+	}
+
+	/**
+	 * Registers a react component to be rendered within the metabox slot-fill
+	 * provider.
+	 *
+	 * @param {string}          key       Unique key to give to React to render
+	 *                                    within a list of components.
+	 * @param {React.Component} Component A valid React component to render.
+	 *
+	 * @returns {void}
+	 */
+	registerComponent( key, Component ) {
+		this.setState( {
+			registerComponent: [
+				...this.state.registeredComponents,
+				{
+					key,
+					Component,
+				},
+			],
+		} );
+	}
+
+	/**
+	 * Renders all the registered components.
+	 *
+	 * @returns {React.Element[]} The rendered components in an array.
+	 */
+	render() {
+		return this.state.registeredComponents.map( ( registered ) => {
+			return <registered.Component key={ registered.key } />;
+		} );
+	}
+}
+
+/**
+ * Renders a React tree for the classic editor.
+ *
+ * @param {Object} store The active redux store.
+ *
+ * @returns {void}
+ */
+export function renderClassicEditorMetabox( store ) {
+	const localizedData = getL10nObject();
+	containerRef = createRef();
+
+	const theme = {
+		isRtl: localizedData.isRtl,
+	};
+
+	render(
+		(
+			<SlotFillProvider>
+				<MetaboxPortal
+					target="wpseo-meta-section-react"
+					store={store}
+					theme={theme}
+				/>
+				<RegisteredComponentsContainer ref={containerRef}/>
+			</SlotFillProvider>
+		),
+		document.getElementById( "wpseo-meta-section-react" )
+	);
+
+	registeredComponents.forEach( ( registered ) => {
+		containerRef.current.registerComponent( registered.key, registered.Component );
+	} );
+}
+
+/**
+ * Registers a react component to be rendered within the metabox slot-fill
+ * provider.
+ *
+ * @param {string}          key       Unique key to give to React to render
+ *                                    within a list of components.
+ * @param {React.Component} Component A valid React component to render.
+ *
+ * @returns {void}
+ */
+export function registerReactComponent( key, Component ) {
+	if ( containerRef === null || containerRef.current === null ) {
+		registeredComponents.push( { key, Component } );
+	} else {
+		containerRef.current.registerComponent( key, Component );
+	}
+}

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -413,10 +413,6 @@ setWordPressSeoL10n();
 		}
 	}
 
-	function registerReactTree( key, Component ) {
-
-	}
-
 	/**
 	 * Initializes analysis for the post edit screen.
 	 *

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -472,7 +472,6 @@ setWordPressSeoL10n();
 		// Backwards compatibility.
 		YoastSEO.analyzerArgs = appArgs;
 
-
 		keywordElementSubmitHandler();
 		postDataCollector.bindElementEvents( app );
 

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -7,8 +7,6 @@ import debounce from "lodash/debounce";
 import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
 import { refreshSnippetEditor } from "./redux/actions/snippetEditor.js";
 import isShallowEqualObjects from "@wordpress/is-shallow-equal/objects";
-import { render } from "@wordpress/element";
-import { SlotFillProvider } from "@wordpress/components";
 
 // Internal dependencies.
 import "./helpers/babel-polyfill";
@@ -38,8 +36,11 @@ import { isGutenbergPostAvailable } from "./helpers/isGutenbergAvailable";
 import { updateData } from "./redux/actions/snippetEditor";
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 import { setCornerstoneContent } from "./redux/actions/cornerstoneContent";
-import MetaboxPortal from "./components/MetaboxPortal";
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
+import {
+	registerReactComponent,
+	renderClassicEditorMetabox,
+} from "./helpers/classicEditor";
 
 setYoastComponentsL10n();
 setWordPressSeoL10n();
@@ -412,26 +413,8 @@ setWordPressSeoL10n();
 		}
 	}
 
-	/**
-	 * Renders a React tree for the classic editor.
-	 *
-	 * @param {Object} store The active redux store.
-	 *
-	 * @returns {void}
-	 */
-	function renderClassicEditorMetabox( store ) {
-		const theme = {
-			isRtl: wpseoPostScraperL10n.isRtl,
-		};
+	function registerReactTree( key, Component ) {
 
-		render(
-			(
-				<SlotFillProvider>
-					<MetaboxPortal target="wpseo-meta-section-react" store={ store } theme={ theme } />
-				</SlotFillProvider>
-			),
-			document.getElementById( "wpseo-meta-section-react" )
-		);
 	}
 
 	/**
@@ -486,10 +469,13 @@ setWordPressSeoL10n();
 
 		activateEnabledAnalysis( tabManager );
 
+		YoastSEO._registerReactComponent = registerReactComponent;
+
 		jQuery( window ).trigger( "YoastSEO:ready" );
 
 		// Backwards compatibility.
 		YoastSEO.analyzerArgs = appArgs;
+
 
 		keywordElementSubmitHandler();
 		postDataCollector.bindElementEvents( app );

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -5,8 +5,6 @@ import { App } from "yoastseo";
 import { setReadabilityResults, setSeoResultsForKeyword } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
 import isUndefined from "lodash/isUndefined";
 import isShallowEqualObjects from "@wordpress/is-shallow-equal/objects";
-import { render } from "@wordpress/element";
-import { SlotFillProvider } from "@wordpress/components";
 
 // Internal dependencies.
 import "./helpers/babel-polyfill";
@@ -28,7 +26,10 @@ import { refreshSnippetEditor, updateData } from "./redux/actions/snippetEditor"
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 import { setFocusKeyword } from "./redux/actions/focusKeyword";
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
-import MetaboxPortal from "./components/MetaboxPortal";
+import {
+	registerReactComponent,
+	renderClassicEditorMetabox
+} from "./helpers/classicEditor";
 
 setYoastComponentsL10n();
 setWordPressSeoL10n();
@@ -201,28 +202,6 @@ window.yoastHideMarkers = true;
 	}
 
 	/**
-	 * Renders a React tree for the classic editor.
-	 *
-	 * @param {Object} store The active redux store.
-	 *
-	 * @returns {void}
-	 */
-	function renderClassicEditorMetabox( store ) {
-		const theme = {
-			isRtl: wpseoTermScraperL10n.isRtl,
-		};
-
-		render(
-			(
-				<SlotFillProvider>
-					<MetaboxPortal target="wpseo-meta-section-react" store={ store } theme={ theme } />
-				</SlotFillProvider>
-			),
-			document.getElementById( "wpseo-meta-section-react" )
-		);
-	}
-
-	/**
 	 * Initializes analysis for the term edit screen.
 	 *
 	 * @returns {void}
@@ -317,6 +296,8 @@ window.yoastHideMarkers = true;
 
 		// For backwards compatibility.
 		YoastSEO.analyzerArgs = args;
+
+		YoastSEO._registerReactComponent = registerReactComponent;
 
 		initTermSlugWatcher();
 		termScraper.bindElementEvents( app );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _not applicable_

This allows us to get Fill's inside the tree outside of Gutenberg.