### PR TITLE
Made styled components a global dependency

### DIFF
--- a/js/src/wp-seo-wp-globals-backport.js
+++ b/js/src/wp-seo-wp-globals-backport.js
@@ -1,6 +1,8 @@
 import * as importedData from "@wordpress/data";
 import * as importedElement from "@wordpress/element";
 import * as importedComponents from "@wordpress/components";
+import * as styledComponents from "styled-components";
+
 import get from "lodash/get";
 
 /*
@@ -20,6 +22,8 @@ yoast._wp = {
 	data,
 	components,
 };
+
+yoast.styledComponents = styledComponents;
 
 // Put it all actually on the global.
 window.yoast = yoast;

--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -10,7 +10,6 @@ const entry = {
 	vendor: [
 		"react",
 		"react-dom",
-		"styled-components",
 		"babel-polyfill",
 	],
 	"configuration-wizard": "./configuration-wizard.js",

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -117,6 +117,8 @@ module.exports = function( env = { environment: "production" } ) {
 				"@wordpress/element": "window.yoast._wp.element",
 				"@wordpress/data": "window.yoast._wp.data",
 				"@wordpress/components": "window.yoast._wp.components",
+
+				"styled-components": "window.yoast.styledComponents",
 			},
 			plugins: [
 				...plugins,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Exposes `styled-components` on `window.yoast.styledComponents` to be used in premium.

## Test instructions

This PR can be tested by following these steps:

* Test in conjunction with `stories/react-multi-keywork` on premium to verify `styled-components` works as expected. The warning thrown in the console should be gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
