### PR TITLE
Use ThemeProvider as wrapper for Sidebar and Metabox

### DIFF
--- a/js/src/components/Metabox.js
+++ b/js/src/components/Metabox.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Provider as StoreProvider } from "react-redux";
 import { ThemeProvider } from "styled-components";
+import { Fragment } from "@wordpress/element";
 import { Fill } from "@wordpress/components";
 
 import SidebarItem from "./SidebarItem";
@@ -23,38 +24,40 @@ import CollapsibleCornerstone from "../containers/CollapsibleCornerstone";
 export default function Metabox( { settings, store, theme } ) {
 	return (
 		<Fill name="YoastMetabox">
-			<SidebarItem renderPriority={ 9 }>
-				<StoreProvider store={ store }>
-					<ThemeProvider theme={ theme }>
-						<SnippetEditor hasPaperStyle={ false }/>
-					</ThemeProvider>
-				</StoreProvider>
-			</SidebarItem>
-			{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
-				<StoreProvider store={ store } >
-					<ReadabilityAnalysis />
-				</StoreProvider>
-			</SidebarItem> }
-			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
-				<StoreProvider store={ store } >
-					<SeoAnalysis
-					shouldUpsell={ settings.shouldUpsell }
-					keywordUpsell={ keywordUpsellProps }
-					/>
-				</StoreProvider>
-			</SidebarItem> }
-			{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
-				<StoreProvider store={ store }>
-					<CollapsibleCornerstone />
-				</StoreProvider>
-			</SidebarItem>
-			}
+			<ThemeProvider theme={ theme }>
+				<Fragment>
+					<SidebarItem renderPriority={ 9 }>
+						<StoreProvider store={ store }>
+							<SnippetEditor hasPaperStyle={ false }/>
+						</StoreProvider>
+					</SidebarItem>
+					{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+						<StoreProvider store={ store }>
+							<ReadabilityAnalysis />
+						</StoreProvider>
+					</SidebarItem> }
+					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+						<StoreProvider store={ store }>
+							<SeoAnalysis
+								shouldUpsell={ settings.shouldUpsell }
+								keywordUpsell={ keywordUpsellProps }
+							/>
+						</StoreProvider>
+					</SidebarItem> }
+					{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+						<StoreProvider store={ store }>
+							<CollapsibleCornerstone />
+						</StoreProvider>
+					</SidebarItem>
+					}
+				</Fragment>
+			</ThemeProvider>
 		</Fill>
 	);
 }
 
 Metabox.propTypes = {
 	settings: PropTypes.object,
-	theme: PropTypes.object,
 	store: PropTypes.object,
+	theme: PropTypes.object,
 };

--- a/js/src/components/Sidebar.js
+++ b/js/src/components/Sidebar.js
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Provider as StoreProvider } from "react-redux";
+import { ThemeProvider } from "styled-components";
+import { Fragment } from "@wordpress/element";
 import { Fill } from "@wordpress/components";
 
 import SidebarItem from "./SidebarItem";
@@ -13,34 +15,39 @@ import SeoAnalysis from "./contentAnalysis/SeoAnalysis";
  * Creates the Sidebar component.
  *
  * @param {Object} settings The feature toggles.
- * @param {Object} store The Redux store.
+ * @param {Object} store    The Redux store.
+ * @param {Object} theme    The theme to use.
  *
  * @returns {ReactElement} The Sidebar component.
  *
  * @constructor
  */
-export default function Sidebar( { settings, store } ) {
+export default function Sidebar( { settings, store, theme } ) {
 	return (
 		<Fill name="YoastSidebar">
-			{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
-				<StoreProvider store={ store } >
-					<ReadabilityAnalysis />
-				</StoreProvider>
-			</SidebarItem> }
-			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
-				<StoreProvider store={ store } >
-					<SeoAnalysis
-					shouldUpsell={ settings.shouldUpsell }
-					keywordUpsell={ keywordUpsellProps }
-					/>
-				</StoreProvider>
-			</SidebarItem> }
-			{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
-				<StoreProvider store={ store }>
-					<CollapsibleCornerstone />
-				</StoreProvider>
-			</SidebarItem>
-			}
+			<ThemeProvider theme={ theme }>
+				<Fragment>
+					{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+						<StoreProvider store={ store }>
+							<ReadabilityAnalysis />
+						</StoreProvider>
+					</SidebarItem> }
+					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+						<StoreProvider store={ store }>
+							<SeoAnalysis
+								shouldUpsell={ settings.shouldUpsell }
+								keywordUpsell={ keywordUpsellProps }
+							/>
+						</StoreProvider>
+					</SidebarItem> }
+					{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+						<StoreProvider store={ store }>
+							<CollapsibleCornerstone />
+						</StoreProvider>
+					</SidebarItem>
+					}
+				</Fragment>
+			</ThemeProvider>
 		</Fill>
 	);
 }
@@ -48,4 +55,5 @@ export default function Sidebar( { settings, store } ) {
 Sidebar.propTypes = {
 	settings: PropTypes.object,
 	store: PropTypes.object,
+	theme: PropTypes.object,
 };

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -84,7 +84,7 @@ function registerPlugin( store ) {
 
 			<Provider store={ store } >
 				<Fragment>
-					<Sidebar store={ store } />
+					<Sidebar store={ store } theme={ theme } />
 					<MetaboxPortal target="wpseo-metabox-root" store={ store } theme={ theme } />
 				</Fragment>
 			</Provider>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds ThemeProvider to wrap the whole Sidebar and Metabox to make RTL styles work properly

## Relevant technical choices:

This PR aims to fix a first part of #10493. As mentioned in https://github.com/Yoast/wordpress-seo/issues/10493#issuecomment-409942486 all the yoast-components in both the Sidebar and the Metabox need a `theme.isRtl` prop to correctly render RTL styles.

## Test instructions

There's no easy way to test this for now, as it needs actual fixes in the yoast components RTL styles; first pending one is https://github.com/Yoast/yoast-components/pull/685 
