### PR TITLE
Disables markers in Gutenberg

### DIFF
--- a/js/src/compatibility/compatibilityHelper.js
+++ b/js/src/compatibility/compatibilityHelper.js
@@ -63,7 +63,7 @@ class CompatibilityHelper {
 	 * @returns {boolean} Whether the classic editor is hidden.
 	 */
 	isClassicEditorHidden() {
-		return ( this.diviActive && DiviHelper.isTinyMCEHidden() );
+		return !! ( this.diviActive && DiviHelper.isTinyMCEHidden() );
 	}
 }
 

--- a/js/src/helpers/isGutenbergAvailable.js
+++ b/js/src/helpers/isGutenbergAvailable.js
@@ -17,15 +17,3 @@ export const isGutenbergDataAvailable = () => {
 	);
 };
 
-/**
- * Checks if the Gutenberg editor is being used.
- *
- * Gutenberg uses wp_add_inline_script to pass along the initial post data.
- * Therefor we can test if this variable exists to know if the Gutenberg editor is being used.
- * see: https://github.com/WordPress/gutenberg/blob/master/lib/client-assets.php#L853
- *
- * @returns {boolean} True if the Gutenberg editor is being used.
- */
-export const isGutenbergPostAvailable = () => {
-	return ! isUndefined( window._wpGutenbergPost );
-};

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -30,7 +30,6 @@ import UsedKeywords from "./analysis/usedKeywords";
 
 import { setFocusKeyword } from "./redux/actions/focusKeyword";
 import { setMarkerStatus } from "./redux/actions/markerButtons";
-import { isGutenbergPostAvailable } from "./helpers/isGutenbergAvailable";
 import { updateData } from "./redux/actions/snippetEditor";
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 import { setCornerstoneContent } from "./redux/actions/cornerstoneContent";
@@ -105,7 +104,7 @@ setWordPressSeoL10n();
 	 * @returns {boolean} True when markers should be shown.
 	 */
 	function displayMarkers() {
-		return ! isGutenbergPostAvailable() && wpseoPostScraperL10n.show_markers === "1";
+		return ! isGutenbergDataAvailable() && wpseoPostScraperL10n.show_markers === "1";
 	}
 
 	/**
@@ -363,7 +362,7 @@ setWordPressSeoL10n();
 			tinyMCEHelper.disableMarkerButtons();
 		}
 
-		if( compatibilityHelper.vcActive ) {
+		if ( compatibilityHelper.vcActive ) {
 			tinyMCEHelper.disableMarkerButtons();
 		} else {
 			compatibilityHelper.listen( {

--- a/js/tests/isGutenbergAvailable.test.js
+++ b/js/tests/isGutenbergAvailable.test.js
@@ -1,4 +1,4 @@
-import { isGutenbergDataAvailable, isGutenbergPostAvailable } from "../src/helpers/isGutenbergAvailable.js";
+import { isGutenbergDataAvailable } from "../src/helpers/isGutenbergAvailable.js";
 
 describe( "isGutenbergDataAvailable", () => {
 	it( "returns true if both wp and wp.data are defined", () => {
@@ -25,18 +25,5 @@ describe( "isGutenbergDataAvailable", () => {
 		window.wp = undefined;
 		const actual = isGutenbergDataAvailable();
 		expect( actual ).toBe( false );
-	} );
-} );
-
-describe( "isGutenbergPostAvailable", () => {
-	it( "returns true if _wpGutenbergPost is defined", () => {
-		window._wpGutenbergPost = { id: 1234 };
-		const actual = isGutenbergPostAvailable();
-		expect( actual ).toBe( true );
-	} );
-	it( "returns false if _wpGutenbergPost is not defined", () => {
-		delete window._wpGutenbergPost;
-		const actual = isGutenbergPostAvailable();
-		expect( actual ).toEqual( false );
 	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a non-existing global was being checked against to determine whether markers should be displayed is Gutenberg, resulting in markers displaying in Gutenberg.

## Relevant technical choices:

* Additionally to fixing the marker issue, a small change was made to the Compatibility Helper so that `isClassicEditorHidden` always returns a boolean. 

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch.
* Ensure you run `composer du`, `yarn` and `yarn start`.
* Create a post in the Classic Editor that triggers a marker.
* Save the post and switch to the Gutenberg editor.
* Determine that the marker isn't shown for any of the assessments.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10505 
