### PR TITLE
Move ThemeProvider inside SidebarItem

### DIFF
--- a/js/src/components/Metabox.js
+++ b/js/src/components/Metabox.js
@@ -24,34 +24,40 @@ import CollapsibleCornerstone from "../containers/CollapsibleCornerstone";
 export default function Metabox( { settings, store, theme } ) {
 	return (
 		<Fill name="YoastMetabox">
-			<ThemeProvider theme={ theme }>
-				<Fragment>
-					<SidebarItem renderPriority={ 9 }>
+			<Fragment>
+				<SidebarItem renderPriority={ 9 }>
+					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
 							<SnippetEditor hasPaperStyle={ false }/>
 						</StoreProvider>
-					</SidebarItem>
-					{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+					</ThemeProvider>
+				</SidebarItem>
+				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
 							<ReadabilityAnalysis />
 						</StoreProvider>
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+					</ThemeProvider>
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
 							<SeoAnalysis
 								shouldUpsell={ settings.shouldUpsell }
 								keywordUpsell={ keywordUpsellProps }
 							/>
 						</StoreProvider>
-					</SidebarItem> }
-					{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+					</ThemeProvider>
+				</SidebarItem> }
+				{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
 							<CollapsibleCornerstone />
 						</StoreProvider>
-					</SidebarItem>
-					}
-				</Fragment>
-			</ThemeProvider>
+					</ThemeProvider>
+				</SidebarItem>
+				}
+			</Fragment>
 		</Fill>
 	);
 }

--- a/js/src/components/Metabox.js
+++ b/js/src/components/Metabox.js
@@ -23,8 +23,8 @@ import CollapsibleCornerstone from "../containers/CollapsibleCornerstone";
  */
 export default function Metabox( { settings, store, theme } ) {
 	return (
-		<Fill name="YoastMetabox">
-			<Fragment>
+		<Fragment>
+			<Fill name="YoastMetabox">
 				<SidebarItem renderPriority={ 9 }>
 					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
@@ -57,8 +57,8 @@ export default function Metabox( { settings, store, theme } ) {
 					</ThemeProvider>
 				</SidebarItem>
 				}
-			</Fragment>
-		</Fill>
+			</Fill>
+		</Fragment>
 	);
 }
 

--- a/js/src/components/Sidebar.js
+++ b/js/src/components/Sidebar.js
@@ -25,29 +25,33 @@ import SeoAnalysis from "./contentAnalysis/SeoAnalysis";
 export default function Sidebar( { settings, store, theme } ) {
 	return (
 		<Fill name="YoastSidebar">
-			<ThemeProvider theme={ theme }>
-				<Fragment>
-					{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+			<Fragment>
+				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
 							<ReadabilityAnalysis />
 						</StoreProvider>
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+					</ThemeProvider>
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
 							<SeoAnalysis
 								shouldUpsell={ settings.shouldUpsell }
 								keywordUpsell={ keywordUpsellProps }
 							/>
 						</StoreProvider>
-					</SidebarItem> }
-					{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+					</ThemeProvider>
+				</SidebarItem> }
+				{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
 							<CollapsibleCornerstone />
 						</StoreProvider>
-					</SidebarItem>
-					}
-				</Fragment>
-			</ThemeProvider>
+					</ThemeProvider>
+				</SidebarItem>
+				}
+			</Fragment>
 		</Fill>
 	);
 }

--- a/js/src/components/Sidebar.js
+++ b/js/src/components/Sidebar.js
@@ -24,8 +24,8 @@ import SeoAnalysis from "./contentAnalysis/SeoAnalysis";
  */
 export default function Sidebar( { settings, store, theme } ) {
 	return (
-		<Fill name="YoastSidebar">
-			<Fragment>
+		<Fragment>
+			<Fill name="YoastSidebar">
 				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
 					<ThemeProvider theme={ theme }>
 						<StoreProvider store={ store }>
@@ -51,8 +51,8 @@ export default function Sidebar( { settings, store, theme } ) {
 					</ThemeProvider>
 				</SidebarItem>
 				}
-			</Fragment>
-		</Fill>
+			</Fill>
+		</Fragment>
 	);
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Move ThemeProvider inside SidebarItem.

## Test instructions

This PR can be tested by following these steps:

- check the order of the components in the sidebar in free and premium is correct /Cc @moorscode 

Fixes #10513 
