### PR TITLE
Structured data blocks feature flag

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -49,7 +49,9 @@ class WPSEO_Admin {
 
 		if ( WPSEO_Metabox::is_post_overview( $pagenow ) || WPSEO_Metabox::is_post_edit( $pagenow ) ) {
 			$this->admin_features['primary_category']       = new WPSEO_Primary_Term_Admin();
-			$this->admin_features['structured_data_blocks'] = new WPSEO_Structured_Data_Blocks();
+			if ( defined( 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' ) ) {
+				$this->admin_features['structured_data_blocks'] = new WPSEO_Structured_Data_Blocks();
+			}
 		}
 
 		if ( filter_input( INPUT_GET, 'page' ) === 'wpseo_tools' && filter_input( INPUT_GET, 'tool' ) === null ) {

--- a/tests/admin/test-class-admin.php
+++ b/tests/admin/test-class-admin.php
@@ -25,7 +25,6 @@ class WPSEO_Admin_Test extends WPSEO_UnitTestCase {
 			'google_search_console'  => new WPSEO_GSC(),
 			'primary_category'       => new WPSEO_Primary_Term_Admin(),
 			'dashboard_widget'       => new Yoast_Dashboard_Widget(),
-			'structured_data_blocks' => new WPSEO_Structured_Data_Blocks(),
 		);
 
 		$this->assertEquals( $admin_features, $class_instance->get_admin_features() );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Make sure the structured data how-to block is removed from the changelog for 8.0.

## Test instructions

This PR can be tested by following these steps:

* Add the feature flag `define( 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS', true);` to `wp-config.php.
* Make sure the "How to" block is available in Gutenberg.
* Remove the feature flag and make sure it's not available anymore.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10501
