### PR TITLE
Improve cornerstone collapsible l10n and a11y.

### DIFF
--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { __, sprintf } from "@wordpress/i18n";
+import { utils } from "yoast-components";
 
 import Collapsible from "./SidebarCollapsible";
 import CornerstoneToggle from "yoast-components/composites/Plugin/CornerstoneContent/components/CornerstoneToggle";
@@ -12,13 +13,17 @@ import CornerstoneToggle from "yoast-components/composites/Plugin/CornerstoneCon
  * @constructor
  */
 export default function CollapsibleCornerstone( { isCornerstone, onChange, postTypeName } ) {
+	const { makeOutboundLink } = utils;
+	const LearnMoreLink = makeOutboundLink();
+
 	return (
-		<Collapsible title="Cornerstone content">
-			<p> { sprintf(
-				__( "Mark the most important %1$s as 'cornerstone content' to improve your site structure. ", "wordpress-seo" ),
+		<Collapsible title={ __( "Cornerstone content", "wordpress-seo" ) }>
+			<p>{ sprintf(
+				__( "Mark the most important %1$s as 'cornerstone content' to improve your site structure.", "wordpress-seo" ),
 				postTypeName.toLowerCase()
-			) }
-				<a href='https://yoa.st/1i9' target="_blank"> { __( "Learn more about cornerstone content.", "wordpress-seo" ) } </a>
+			) } <LearnMoreLink href={ "https://yoa.st/1i9" } rel={ null }>
+					{ __( "Learn more about cornerstone content.", "wordpress-seo" ) }
+				</LearnMoreLink>
 			</p>
 			<CornerstoneToggle
 				isEnabled={ isCornerstone }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the cornerstone collapsible l10n and a11y.

## Relevant technical choices:

- makes the collapsible title translatable
- better solution for spacing between the string and the link
- uses `makeOutboundLink()` with a prop `rel={ null }`: this way, the default attribute `rel="noopener noreferrer"` is omitted as advised by @jono-alderson and the a11y message is still rendered

## Test instructions

This PR can be tested by following these steps:

- check in the metabox and sidebar the cornerstone collapsible title and text render correctly
- check the link has `target="_blank"`, the visually hidden a11y message and no `rel="noopener noreferrer"`

Fixes #10524 
