### PR TITLE
Simplify copy in cornerstone component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ test.sh
 /coverage
 /gettext.pot
 /.wordpress-svn
+/webpack-stats.json

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -15,7 +15,7 @@ export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {
 	return (
 		<Collapsible title="Cornerstone content">
 			<p> { __( "Cornerstone content should be the most important and extensive articles on your site. ", "wordpress-seo" ) }
-				<a href='https://yoa.st/1i9' target="_blank"> { __( "Learn more about cornerstone content.", "wordpress-seo" ) } </a>
+				<a href='https://yoa.st/1i9' target="_blank"> { __( "Learn more about Cornerstone Content.", "wordpress-seo" ) } </a>
 			</p>
 			<CornerstoneToggle
 				isEnabled={ isCornerstone }

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 
 import Collapsible from "./SidebarCollapsible";
 import CornerstoneToggle from "yoast-components/composites/Plugin/CornerstoneContent/components/CornerstoneToggle";
@@ -11,13 +11,10 @@ import CornerstoneToggle from "yoast-components/composites/Plugin/CornerstoneCon
  * @returns {ReactElement} The collapsible cornerstone toggle component.
  * @constructor
  */
-export default function CollapsibleCornerstone( { isCornerstone, onChange, postTypeName } ) {
+export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {
 	return (
 		<Collapsible title="Cornerstone content">
-			<p> { sprintf(
-				__( "Mark the most important %1$s as 'cornerstone content' to improve your site structure. ", "wordpress-seo" ),
-				postTypeName.toLowerCase()
-			) }
+			<p> { __( "Cornerstone content should be the most important and extensive articles on your site. ", "wordpress-seo" ) }
 				<a href='https://yoa.st/1i9' target="_blank"> { __( "Learn more about cornerstone content.", "wordpress-seo" ) } </a>
 			</p>
 			<CornerstoneToggle
@@ -31,5 +28,4 @@ export default function CollapsibleCornerstone( { isCornerstone, onChange, postT
 CollapsibleCornerstone.propTypes = {
 	isCornerstone: PropTypes.bool,
 	onChange: PropTypes.func,
-	postTypeName: PropTypes.string,
 };

--- a/js/src/containers/CollapsibleCornerstone.js
+++ b/js/src/containers/CollapsibleCornerstone.js
@@ -1,8 +1,5 @@
 /* External dependencies */
 import { connect } from "react-redux";
-import flowRight from "lodash/flowRight";
-import get from "lodash/get";
-import { withSelect } from "@wordpress/data";
 
 /* Internal dependencies */
 import CollapsibleCornerstone from "../components/CollapsibleCornerstone";
@@ -36,22 +33,4 @@ function mapDispatchToProps( dispatch ) {
 	};
 }
 
-export default flowRight( [
-	connect( mapStateToProps, mapDispatchToProps ),
-	withSelect( ( select ) => {
-		let postTypeName;
-
-		try {
-			const postTypeSlug = select( "core/editor" ).getEditedPostAttribute( "type" );
-			const postType = select( "core" ).getPostType( postTypeSlug );
-			postTypeName = get( postType, [ "labels", "name" ], "NOT YET RECEIVED" );
-		} catch ( error ) {
-			postTypeName = "COULDN'T GET POST TYPE NAME";
-		}
-
-		return {
-			postTypeName,
-		};
-
-	} ),
-] )( CollapsibleCornerstone );
+export default connect( mapStateToProps, mapDispatchToProps )( CollapsibleCornerstone );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the post type was not available in the copy of the cornerstone content description

## Relevant technical choices:

* As the the post type was not really relevant in the copy, The copy was changed to be in line with the [original design](https://user-images.githubusercontent.com/6073772/40122626-87e97e26-5924-11e8-8c82-ac5a7ead9b00.png).
* Dependencies to make the post type accessible were removed. 

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and build by running in the following order: 
-Composer, 
-Yarn upgrade yoast-components, 
-Grunt. 
* Look at the text under Cornerstone content, either in the sidebar or metabox. It should be exactly the same as in the design. Also, it should work under all 3 testing conditions: 
-With Gutenberg active using Gutenberg
-With Gutenberg active using the classic editor
-Without Gutenberg active using the classic editor

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10525 
