### PR TITLE
Bump YoastSEO version to 1.36.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "git+https://github.com/Yoast/yoast-components.git#develop",
-    "yoastseo": "^1.36.0"
+    "yoastseo": "^1.36.1"
   },
   "yoast": {
     "pluginVersion": "8.0-RC1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11002,6 +11002,18 @@ yoastseo@^1.36.0:
     sassdash "0.9.0"
     tokenizer2 "^2.0.0"
 
+yoastseo@^1.36.1:
+  version "1.36.1"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.36.1.tgz#264be38517d1c293fbd93b8b8fc9dd12bc8a941f"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    jest "^23.0.0"
+    lodash "^4.14.1"
+    node-sass "^4.7.2"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.0"
+
 zip-stream@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-1.2.0.tgz#a8bc45f4c1b49699c6b90198baacaacdbcd4ba04"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Bumped YoastSEO.js to v1.36.1

## Test instructions

This PR can be tested by following these steps:

* N/A

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10543 
