### PR TITLE
Replaced all shortlinks to use the expose shortlinks class

### DIFF
--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -23,7 +23,10 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 	 * @return array
 	 */
 	public function expose_shortlinks( $input ) {
-		$input['shortlinks.focus_keyword_info'] = WPSEO_Shortlinker::get( 'https://yoa.st/focus-keyword' );
+		$input['shortlinks.focus_keyword_info']            = WPSEO_Shortlinker::get( 'https://yoa.st/focus-keyword' );
+		$input['shortlinks.snippet_preview_info']          = WPSEO_Shortlinker::get( 'https://yoa.st/snippet-preview' );
+		$input['shortlinks.cornerstone_content_info']      = WPSEO_Shortlinker::get( 'https://yoa.st/1i9' );
+		$input['shortlinks.configuration_wizard_conflict'] = WPSEO_Shortlinker::get( 'https://yoa.st/configuration-wizard-error-plugin-conflict' );
 
 		return $input;
 	}

--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -26,7 +26,6 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		$input['shortlinks.focus_keyword_info']            = WPSEO_Shortlinker::get( 'https://yoa.st/focus-keyword' );
 		$input['shortlinks.snippet_preview_info']          = WPSEO_Shortlinker::get( 'https://yoa.st/snippet-preview' );
 		$input['shortlinks.cornerstone_content_info']      = WPSEO_Shortlinker::get( 'https://yoa.st/1i9' );
-		$input['shortlinks.configuration_wizard_conflict'] = WPSEO_Shortlinker::get( 'https://yoa.st/configuration-wizard-error-plugin-conflict' );
 
 		return $input;
 	}

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -1,3 +1,4 @@
+/* globals wpseoAdminL10n */
 import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
@@ -19,7 +20,7 @@ export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {
 	return (
 		<Collapsible title={ __( "Cornerstone content", "wordpress-seo" ) }>
 			<p>{ __( "Cornerstone content should be the most important and extensive articles on your site. ", "wordpress-seo" ) }
-				<LearnMoreLink href={ "https://yoa.st/1i9" } rel={ null }>
+				<LearnMoreLink href={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] } rel={ null }>
 					{ __( "Learn more about Cornerstone Content.", "wordpress-seo" ) }
 				</LearnMoreLink>
 			</p>

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -1,4 +1,4 @@
-/* global yoastWizardConfig */
+/* global yoastWizardConfig, wpseoAdminL10n */
 import React from "react";
 import ReactDOM from "react-dom";
 import "./helpers/babel-polyfill";
@@ -142,7 +142,7 @@ class App extends React.Component {
 			mixedString:
 			"The configuration wizard could not be started." +
 			" The likely cause is an interfering plugin. Please {{link}}check for plugin conflicts{{/link}} to solve this problem. ",
-			components: { link: <a href="https://yoa.st/configuration-wizard-error-plugin-conflict" target="_blank" /> },
+			components: { link: <a href={ wpseoAdminL10n[ "shortlinks.configuration_wizard_conflict" ] } target="_blank" /> },
 		};
 
 		return (

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -1,4 +1,4 @@
-/* global yoastWizardConfig, wpseoAdminL10n */
+/* global yoastWizardConfig */
 import React from "react";
 import ReactDOM from "react-dom";
 import "./helpers/babel-polyfill";
@@ -142,7 +142,7 @@ class App extends React.Component {
 			mixedString:
 			"The configuration wizard could not be started." +
 			" The likely cause is an interfering plugin. Please {{link}}check for plugin conflicts{{/link}} to solve this problem. ",
-			components: { link: <a href={ wpseoAdminL10n[ "shortlinks.configuration_wizard_conflict" ] } target="_blank" /> },
+			components: { link: <a href="https://yoa.st/configuration-wizard-error-plugin-conflict" target="_blank" /> },
 		};
 
 		return (

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -1,3 +1,4 @@
+/* globals wpseoAdminL10n */
 import React from "react";
 import { connect } from "react-redux";
 import { SnippetEditor } from "yoast-components";
@@ -102,7 +103,7 @@ const SnippetEditorWrapper = ( props ) => (
 	<Collapsible title={ __( "Snippet Preview", "wordpress-seo" ) } initialIsOpen={ true }>
 		<p>
 			{ __( "This is a rendering of what this post might look like in Google's search results.", "wordpress-seo" ) + " " }
-			<ExplanationLink href="https://yoa.st/snippet-preview">
+			<ExplanationLink href={ wpseoAdminL10n[ "shortlinks.snippet_preview_info" ] }>
 				{ __( "Learn more about the Snippet Preview.", "wordpress-seo" ) }
 			</ExplanationLink>
 		</p>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaces all shortlinks used in the React components to be parsed by the `WPSEO_Expose_Shortlinks` class.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and ensure you've properly run `composer install`, `yarn`, `grunt build` and `yarn start` (if applicable).
* Go to Posts -> Add new.
* Ensure that the "Learn more about the Snippet Preview." link in the Snippet Editor, now also contains information about the PHP version that's being used.
* Ensure that the "Learn more about Cornerstone Content." link in the Cornerstone Content component, now also contains information about the PHP version that's being used.
* Ensure that both links work.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10535 
