### PR TITLE
Replace ExplanationTexts with yoast-component HelpText

### DIFF
--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -2,10 +2,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import { utils } from "yoast-components";
+import {
+	utils,
+	HelpText
+} from "yoast-components";
 
 import Collapsible from "./SidebarCollapsible";
 import CornerstoneToggle from "yoast-components/composites/Plugin/CornerstoneContent/components/CornerstoneToggle";
+const LearnMoreLink = utils.makeOutboundLink();
 
 /**
  * Renders the collapsible cornerstone toggle.
@@ -14,16 +18,14 @@ import CornerstoneToggle from "yoast-components/composites/Plugin/CornerstoneCon
  * @constructor
  */
 export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {
-	const { makeOutboundLink } = utils;
-	const LearnMoreLink = makeOutboundLink();
-
 	return (
 		<Collapsible title={ __( "Cornerstone content", "wordpress-seo" ) }>
-			<p>{ __( "Cornerstone content should be the most important and extensive articles on your site. ", "wordpress-seo" ) }
+			<HelpText>
+				{ __( "Cornerstone content should be the most important and extensive articles on your site. ", "wordpress-seo" ) }
 				<LearnMoreLink href={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] } rel={ null }>
 					{ __( "Learn more about Cornerstone Content.", "wordpress-seo" ) }
 				</LearnMoreLink>
-			</p>
+			</HelpText>
 			<CornerstoneToggle
 				isEnabled={ isCornerstone }
 				onToggle={ onChange }

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -21,7 +21,7 @@ export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {
 	return (
 		<Collapsible title={ __( "Cornerstone content", "wordpress-seo" ) }>
 			<HelpText>
-				{ __( "Cornerstone content should be the most important and extensive articles on your site. ", "wordpress-seo" ) }
+				{ __( "Cornerstone content should be the most important and extensive articles on your site.", "wordpress-seo" ) + " " }
 				<LearnMoreLink href={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] } rel={ null }>
 					{ __( "Learn more about Cornerstone Content.", "wordpress-seo" ) }
 				</LearnMoreLink>

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import {
 	utils,
-	HelpText
+	HelpText,
 } from "yoast-components";
 
 import Collapsible from "./SidebarCollapsible";

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -75,9 +75,9 @@ class SeoAnalysis extends React.Component {
 		const upsell = this.props.keywordUpsell;
 		return (
 			<Collapsible
-			prefixIcon={ { icon: "plus", color: colors.$color_grey_medium_dark } }
-			prefixIconCollapsed={ { icon: "plus", color: colors.$color_grey_medium_dark } }
-			title={ __( "Add additional keyword", "wordpress-seo" ) }
+				prefixIcon={ { icon: "plus", color: colors.$color_grey_medium_dark } }
+				prefixIconCollapsed={ { icon: "plus", color: colors.$color_grey_medium_dark } }
+				title={ __( "Add additional keyword", "wordpress-seo" ) }
 			>
 				<UpsellBox
 					benefits={ upsell.benefits }
@@ -86,7 +86,7 @@ class SeoAnalysis extends React.Component {
 					upsellButton={ {
 						href: upsell.buttonLink,
 						className: "button button-primary",
-						"aria-labelledby": "label-id",
+						rel: null,
 					} }
 					upsellButtonLabel={ upsell.buttonLabel }
 				/>
@@ -102,7 +102,7 @@ class SeoAnalysis extends React.Component {
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );
 
-		if( this.props.keyword === "" ) {
+		if ( this.props.keyword === "" ) {
 			score.className = "na";
 			score.screenReaderReadabilityText = __( "Enter a focus keyword to calculate the SEO score", "wordpress-seo" );
 		}
@@ -119,8 +119,8 @@ class SeoAnalysis extends React.Component {
 					<HelpText>
 						{ __( "A focus keyword is the term (or phrase) you'd like to be found with, in search engines. " +
 							"Enter it below to see how you can improve your text for this term.", "wordpress-seo" ) + " " }
-						<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] }>
-							{ __( "Learn more about the Keyword Analysis", "wordpress-seo" ) }
+						<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
+							{ __( "Learn more about the Keyword Analysis.", "wordpress-seo" ) }
 						</FocusKeywordLink>
 					</HelpText>
 					<KeywordInput
@@ -132,7 +132,7 @@ class SeoAnalysis extends React.Component {
 					{ this.props.shouldUpsell && this.renderSynonymsUpsell() }
 					{ this.props.shouldUpsell && this.renderMultipleKeywordsUpsell() }
 					<AnalysisHeader>
-						Analysis results:
+						{ __( "Analysis results:", "wordpress-seo" ) }
 					</AnalysisHeader>
 					<Results
 						showLanguageNotice={ false }
@@ -179,7 +179,7 @@ function mapStateToProps( state, ownProps ) {
 
 	let results = null;
 	let overallScore = null;
-	if( state.analysis.seo[ keyword ] ) {
+	if ( state.analysis.seo[ keyword ] ) {
 		results = state.analysis.seo[ keyword ].results;
 		overallScore = state.analysis.seo[ keyword ].overallScore;
 	}

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import { Slot } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
 import colors from "yoast-components/style-guide/colors.json";
+import { HelpText } from "yoast-components";
 import Collapsible from "../SidebarCollapsible";
 import KeywordInput from "yoast-components/composites/Plugin/Shared/components/KeywordInput";
 import Results from "./Results";
@@ -21,9 +22,6 @@ const AnalysisHeader = styled.span`
 	font-weight: bold;
 	margin: 1.5em 0 1em;
 	display: block;
-`;
-
-const ExplanationText = styled.p`
 `;
 
 const FocusKeywordLink = utils.makeOutboundLink();
@@ -118,13 +116,13 @@ class SeoAnalysis extends React.Component {
 					prefixIconCollapsed={ getIconForScore( score.className ) }
 					subTitle={ this.props.keyword }
 				>
-					<ExplanationText>
+					<HelpText>
 						{ __( "A focus keyword is the term (or phrase) you'd like to be found with, in search engines. " +
 							"Enter it below to see how you can improve your text for this term.", "wordpress-seo" ) + " " }
 						<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] }>
 							{ __( "Learn more about the Keyword Analysis", "wordpress-seo" ) }
 						</FocusKeywordLink>
-					</ExplanationText>
+					</HelpText>
 					<KeywordInput
 						id="focus-keyword-input"
 						onChange={ this.props.onFocusKeywordChange }

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -62,7 +62,7 @@ const applyReplaceUsingPlugin = function( data ) {
 
 	const applyModifications = pluggable._applyModifications.bind( pluggable );
 
-	return  {
+	return {
 		url: data.url,
 		title: stripFullTags( applyModifications( "data_page_title", data.title ) ),
 		description: stripFullTags( applyModifications( "data_meta_desc", data.description ) ),
@@ -84,7 +84,7 @@ const applyReplaceUsingPlugin = function( data ) {
 export const mapEditorDataToPreview = function( data, context ) {
 	let baseUrlLength = 0;
 
-	if( context.shortenedBaseUrl && typeof( context.shortenedBaseUrl ) === "string" ) {
+	if ( context.shortenedBaseUrl && typeof( context.shortenedBaseUrl ) === "string" ) {
 		baseUrlLength = context.shortenedBaseUrl.length;
 	}
 
@@ -106,7 +106,7 @@ const SnippetEditorWrapper = ( props ) => (
 	<Collapsible title={ __( "Snippet Preview", "wordpress-seo" ) } initialIsOpen={ true }>
 		<HelpText>
 			{ __( "This is a rendering of what this post might look like in Google's search results.", "wordpress-seo" ) + " " }
-			<ExplanationLink href={ wpseoAdminL10n[ "shortlinks.snippet_preview_info" ] }>
+			<ExplanationLink href={ wpseoAdminL10n[ "shortlinks.snippet_preview_info" ] } rel={ null }>
 				{ __( "Learn more about the Snippet Preview.", "wordpress-seo" ) }
 			</ExplanationLink>
 		</HelpText>

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -1,7 +1,10 @@
 /* globals wpseoAdminL10n */
 import React from "react";
 import { connect } from "react-redux";
-import { SnippetEditor } from "yoast-components";
+import {
+	SnippetEditor,
+	HelpText,
+} from "yoast-components";
 import identity from "lodash/identity";
 import get from "lodash/get";
 import { __ } from "@wordpress/i18n";
@@ -101,12 +104,12 @@ export const mapEditorDataToPreview = function( data, context ) {
 
 const SnippetEditorWrapper = ( props ) => (
 	<Collapsible title={ __( "Snippet Preview", "wordpress-seo" ) } initialIsOpen={ true }>
-		<p>
+		<HelpText>
 			{ __( "This is a rendering of what this post might look like in Google's search results.", "wordpress-seo" ) + " " }
 			<ExplanationLink href={ wpseoAdminL10n[ "shortlinks.snippet_preview_info" ] }>
 				{ __( "Learn more about the Snippet Preview.", "wordpress-seo" ) }
 			</ExplanationLink>
-		</p>
+		</HelpText>
 		<SnippetPreviewSection
 			icon="eye"
 			hasPaperStyle={ props.hasPaperStyle }

--- a/js/src/values/keywordUpsellProps.js
+++ b/js/src/values/keywordUpsellProps.js
@@ -21,7 +21,7 @@ export default {
 	infoParagraphs: [
 		interpolateComponents( {
 			mixedString: upsellIntro.intro,
-			components: { link: <YesYouCanLink href={ upsellIntro.link } /> },
+			components: { link: <YesYouCanLink href={ upsellIntro.link } rel={ null } /> },
 		} ),
 		upsellIntro.other,
 	],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaces all explanation texts with `HelpText` from `yoast-component`.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* Test in combination with https://github.com/Yoast/yoast-components/pull/700 using `yarn-link`.
* Make sure all explanation texts in the metabox and sidebar have color `#767676`.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes Yoast/yoast-components#694
