### PR TITLE
HowTo block fix classes

### DIFF
--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -74,8 +74,8 @@ export default () => {
 		 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
 		 * @returns {Component} The display component.
 		 */
-		save: function( { attributes, className } ) {
-			return HowTo.getContent( attributes, className );
+		save: function( { attributes } ) {
+			return HowTo.getContent( attributes );
 		},
 	} );
 };

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -290,21 +290,23 @@ export default class HowTo extends Component {
 	 * the How-to block on Wordpress (e.g. not in the editor).
 	 *
 	 * @param {object} attributes the attributes of the How-to block
-	 * @param {string} className  the class to apply to the root component.
 	 *
 	 * @returns {Component} the component representing a How-to block
 	 */
-	static getContent( attributes, className ) {
-		let { steps, title, hours, minutes, description, unorderedList, additionalListCssClasses } = attributes;
+	static getContent( attributes ) {
+		let { steps, title, hours, minutes, description, unorderedList, className, additionalListCssClasses } = attributes;
 
 		steps = steps ? steps.map( ( step ) =>
 			HowToStep.getContent( step )
 		) : null;
 
+		const classNames = [ "schema-how-to", className ].filter( ( i ) => i ).join( " " );
+		const listClassNames = [ "schema-how-to-steps", additionalListCssClasses ].filter( ( i ) => i ).join( " " );
+
 		return (
 			<Fragment>
 				{ this.renderJSONLD( attributes ) }
-				<div className={ `schema-how-to ${ className }` }>
+				<div className={ classNames }>
 					<RichText.Content
 						tagName="h2"
 						className="schema-how-to-title"
@@ -324,8 +326,8 @@ export default class HowTo extends Component {
 						value={ description }
 					/>
 					{ unorderedList
-						? <ul className={ `schema-how-to-steps ${ additionalListCssClasses }` }>{ steps }</ul>
-						: <ol className={ `schema-how-to-steps ${ additionalListCssClasses }` }>{ steps }</ol>
+						? <ul className={ listClassNames }>{ steps }</ul>
+						: <ol className={ listClassNames }>{ steps }</ol>
 					}
 				</div>
 			</Fragment>


### PR DESCRIPTION
## Summary

Fixes the classes that are being output by the HowTo block.

This PR can be summarized in the following changelog entry:

* Fixes the HowTo block receiving the `undefined` class if no additional class is set.

## Test instructions

This PR can be tested by following these steps:

* Add a HowTo Block.
* Don't give it a class name.
* Check the HTML output, it should not receive an `undefined` class.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10558.
