### PR TITLE
Move babel-polyfill to be the first thing in Webpack's entry

### DIFF
--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -8,9 +8,9 @@ const cssDistPath = path.resolve( "css", "dist" );
 // Output filename: Entry file (relative to jsSrcPath)
 const entry = {
 	vendor: [
+		"babel-polyfill",
 		"react",
 		"react-dom",
-		"babel-polyfill",
 	],
 	"configuration-wizard": "./configuration-wizard.js",
 	"search-appearance": "./search-appearance.js",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* moves `babel-polyfill` as first thing in the Webpack's entry.

## Relevant technical choices:

Ensuring the transformations made by babel-polyfill happen first, makes Internet Explorer a bit more happy. Inspired by this comment and following ones: https://github.com/facebook/react/issues/8379#issuecomment-264641700

## Test instructions

This PR should be carefully tested on a Windows machine with IE11 and also on mac with other browsers to make sure there are no regressions.

- set up a dev environment on a Windows machine ( 😬)
- switch to this branch
- build the JS: building on Windows you will probably get the error mentioned in https://github.com/Yoast/wordpress-seo/issues/10539#issuecomment-411034485 and you need to manually install `yarn add babel-preset-stage-0`
- edit a post using Internet Explorer 11
- verify the metabox renders and works correctly, both in the Classic Editor and in Gutenberg
- try the two analysis to check they work
- disable / enable features to see the metabox content changes
- etc.

**Important notes:**

- in the Classic Editor, with IE11 TinyMCE is just a blank area; seems unrelated and will open a separate issue
- in Gutenberg, with IE11 the metabox position is broken and covers the top part of the post content; this must be reported upstream
- with IE11, especially when the browser console is open, I've got a few browser crashes with no apparent JS errors; it's just my personal opinion but seems to me there's just too much JavaScript to process for IE

Fixes #10539
