### PR TITLE
CS/I18n: correct placement of a translation comment and add a missing one

### DIFF
--- a/admin/notifiers/class-post-type-archive-notification-handler.php
+++ b/admin/notifiers/class-post-type-archive-notification-handler.php
@@ -95,8 +95,8 @@ class WPSEO_Post_Type_Archive_Notification_Handler implements WPSEO_Listener, WP
 		);
 		$message .= PHP_EOL . PHP_EOL;
 		$message .= sprintf(
+			/* translators: %1$s is the archive template link start tag, %2$s is the link closing tag, %3$s is a comma separated string with content types. */
 			_n(
-				/* translators: %1$s is the archive template link start tag, %2$s is the link closing tag, %3$s is a comma separated string with content types. */
 				'Please check the %1$sarchive template%2$s for the following content type: %3$s.',
 				' Please check the %1$sarchive templates%2$s for the following content types: %3$s.',
 				count( $post_types ),

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -28,7 +28,7 @@ if ( $wpseo_post_type->name === 'product' && WPSEO_Utils::is_woocommerce_active(
 if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	$plural_label = $wpseo_post_type->labels->name;
 
-	// translators: %s is the plural version of the post type's name.
+	/* translators: %s is the plural version of the post type's name. */
 	echo '<h3>' . esc_html( sprintf( __( 'Settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h3>';
 
 	$custom_post_type_archive_help = $view_utils->search_results_setting_help( $wpseo_post_type, 'archive' );

--- a/admin/views/tabs/metas/paper-content/post_type/woocommerce-shop-page.php
+++ b/admin/views/tabs/metas/paper-content/post_type/woocommerce-shop-page.php
@@ -19,5 +19,6 @@ if ( $woocommerce_shop_page->get_shop_page_id() !== -1 ) {
 	);
 }
 
+/* translators: %s expands to the post type name. */
 echo '<h3>' . esc_html( sprintf( __( 'Settings for %s archive', 'wordpress-seo' ), $wpseo_post_type->labels->name ) ) . '</h3>';
 echo '<p>' . $description . '</p>';


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Correct the placement of a translation comment, add a missing translation comment and fix the comment style for a third one.



## Test instructions
_N/A_