### PR TITLE
Use generated_slug when slug is empty

### DIFF
--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -104,7 +104,8 @@ class Data {
 		return {
 			content: getPostAttribute( "content" ),
 			title: getPostAttribute( "title" ),
-			slug: getPostAttribute( "slug" ),
+			/* Use the generated slug when the slug is empty */
+			slug: getPostAttribute( "slug" ) || getPostAttribute( "generated_slug" ),
 			excerpt: getPostAttribute( "excerpt" ),
 		};
 	}
@@ -139,6 +140,7 @@ class Data {
 	 */
 	refreshYoastSEO() {
 		let gutenbergData = this.collectGutenbergData( this.getPostAttribute );
+		console.log( gutenbergData );
 
 		// Set isDirty to true if the current data and Gutenberg data are unequal.
 		let isDirty = ! this.isShallowEqual( this._data, gutenbergData );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* When `slug` is not available in the gutenberg post, we now use `generated_slug`.

## Test instructions

This PR can be tested by following these steps:

* Repeat the steps in https://github.com/Yoast/wordpress-seo/issues/10573.
* Make sure the slug works and the snippet editor and preview are updated.
* Change the slug in the gutenberg editor.
* Make sure the gutenberg editor, the snippet editor and preview are updated.
* Change the slug in the snippet editor.
* Make sure the gutenberg editor, the snippet editor and preview are updated.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10573 
