### PR TITLE
Fix Jest security error: localStorage is not available for opaque origins at Window.get localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     },
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
-    ]
+    ],
+    "testURL": "http://localhost/"
   },
   "devDependencies": {
     "@wordpress/babel-plugin-makepot": "^1.0.0",


### PR DESCRIPTION
## Summary

Fixes the following Jest error:
```
FAIL
● Test suite failed to run

SecurityError: localStorage is not available for opaque origins at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
      at Array.forEach (<anonymous>)
```

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Run `npm run test` or `yarn test`.

## Quality assurance

* [x] I have tested this code to the best of my abilities