### PR TITLE
Retrieve parent page type using the rest api in gutenberg

### DIFF
--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -1,4 +1,4 @@
-/* global wpseoReplaceVarsL10n, require */
+/* global wpseoReplaceVarsL10n, require, wp, wpApiSettings */
 import forEach from "lodash/forEach";
 import filter from "lodash/filter";
 import trim from "lodash/trim";
@@ -10,6 +10,8 @@ import {
 	refreshSnippetEditor,
 } from "./redux/actions/snippetEditor";
 import "./helpers/babel-polyfill";
+import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
+import {debounce} from "lodash";
 
 ( function() {
 	var modifiableFields = [
@@ -44,6 +46,7 @@ import "./helpers/babel-polyfill";
 		this.registerReplacements();
 		this.registerModifications();
 		this.registerEvents();
+		this.subscribeToGutenberg();
 	};
 
 	/*
@@ -114,7 +117,7 @@ import "./helpers/babel-polyfill";
 	 * @returns {void}
 	 */
 	YoastReplaceVarPlugin.prototype.registerEvents = function() {
-		var currentScope = wpseoReplaceVarsL10n.scope;
+		const currentScope = wpseoReplaceVarsL10n.scope;
 
 		if ( currentScope === "post" ) {
 			// Set events for each taxonomy box.
@@ -125,6 +128,60 @@ import "./helpers/babel-polyfill";
 			// Add support for custom fields as well.
 			jQuery( "#postcustomstuff > #list-table" ).each( this.bindFieldEvents.bind( this ) );
 		}
+	};
+
+	/**
+	 * Subscribes to Gutenberg to watch a possible parent page change.
+	 *
+	 * @return {void}
+	 */
+	YoastReplaceVarPlugin.prototype.subscribeToGutenberg = function() {
+		if ( ! isGutenbergDataAvailable() ) {
+			return;
+		}
+
+		let fetchedParents = { 0: "" };
+		let currentParent  = null;
+		const wpData       = wp.data;
+		wpData.subscribe(
+			function() {
+				let newParent = wpData.select( "core/editor" ).getEditedPostAttribute( "parent" );
+
+				if ( typeof newParent === "undefined" || currentParent === newParent ) {
+					return;
+				}
+
+				currentParent = newParent;
+
+				if ( newParent < 1 ) {
+					this._currentParentPageTitle = "";
+
+					this.declareReloaded();
+
+					return;
+				}
+
+				if ( ! isUndefined( fetchedParents[ newParent ] ) ) {
+					this._currentParentPageTitle = fetchedParents[ newParent ];
+
+					return;
+				}
+
+				jQuery.ajax(
+					{
+						url: wpApiSettings.root + "wp/v2/pages/" + newParent,
+						method: "GET",
+						beforeSend: function( xhr ) {
+							xhr.setRequestHeader( "X-WP-Nonce", wpApiSettings.nonce );
+						},
+					}
+				).done( function( response ) {
+					this._currentParentPageTitle = response.title.rendered;
+					fetchedParents[ newParent ]  = this._currentParentPageTitle;
+
+					this.declareReloaded();
+				}.bind( this ) );
+			}.bind( this ), 800 );
 	};
 
 	/**
@@ -509,10 +566,14 @@ import "./helpers/babel-polyfill";
 	 * @returns {string} The data with all its placeholders replaced by actual values.
 	 */
 	YoastReplaceVarPlugin.prototype.parentReplace = function( data ) {
-		var parent = jQuery( "#parent_id, #parent" ).eq( 0 );
+		let parent = jQuery( "#parent_id, #parent" ).eq( 0 );
 
 		if ( this.hasParentTitle( parent ) ) {
 			data = data.replace( /%%parent_title%%/, this.getParentTitleReplacement( parent ) );
+		}
+
+		if ( isGutenbergDataAvailable() && ! isUndefined( this._currentParentPageTitle ) ) {
+			data = data.replace( /%%parent_title%%/, this._currentParentPageTitle );
 		}
 
 		return data;

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -167,10 +167,15 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
 			const page = new wp.api.models.Page( { id: newParent } );
 			page.fetch().then(
-				( response ) => {
+				response => {
 					this._currentParentPageTitle = response.title.rendered;
 					fetchedParents[ newParent ]  = this._currentParentPageTitle;
 
+					this.declareReloaded();
+				}
+			).fail(
+				() => {
+					this._currentParentPageTitle = "";
 					this.declareReloaded();
 				}
 			);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Retrieves the parent page title via the REST API when using Gutenberg

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Add or edit a page in Gutenberg mode
* In the snippet preview use `%%parent_title%%` in the template
* Select a parent page and see the preview showing it's title

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9263 
