### PR TITLE
Change OK score icon color.

### DIFF
--- a/js/src/components/contentAnalysis/mapResults.js
+++ b/js/src/components/contentAnalysis/mapResults.js
@@ -94,7 +94,7 @@ export function getIconForScore( score ) {
 			icon = { icon: "seo-score-good", color: colors.$color_green_medium };
 			break;
 		case "ok":
-			icon = { icon: "seo-score-ok", color: colors.$color_yellow_score };
+			icon = { icon: "seo-score-ok", color: colors.$color_ok };
 			break;
 		case "bad":
 			icon = { icon: "seo-score-bad", color: colors.$color_red };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Change the fill color of the OK SEO score icon to orange

## Relevant technical choices:

- see related yoast-components PR https://github.com/Yoast/yoast-components/pull/704

## Test instructions

- build the JS
- verify the OK icon background color has changed from yellow `#f5c819` to orange `#ee7c1b`
- to see the black eyes / mouth you need to test with the yoast-components PR from https://github.com/Yoast/yoast-components/pull/704

Fixes https://github.com/Yoast/yoast-components/issues/702
