### PR TITLE
Render json-ld server side to circumvent tags being stripped from post_content.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -49,9 +49,6 @@ class WPSEO_Admin {
 
 		if ( WPSEO_Metabox::is_post_overview( $pagenow ) || WPSEO_Metabox::is_post_edit( $pagenow ) ) {
 			$this->admin_features['primary_category']       = new WPSEO_Primary_Term_Admin();
-			if ( defined( 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' ) ) {
-				$this->admin_features['structured_data_blocks'] = new WPSEO_Structured_Data_Blocks();
-			}
 		}
 
 		if ( filter_input( INPUT_GET, 'page' ) === 'wpseo_tools' && filter_input( INPUT_GET, 'tool' ) === null ) {

--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -18,7 +18,7 @@ class WPSEO_Gutenberg_Compatibility {
 	/**
 	 * The minimally supported version of Gutenberg by the plugin.
 	 */
-	const MINIMUM_SUPPORTED = '2.8.0';
+	const MINIMUM_SUPPORTED = '3.4.0';
 
 	/**
 	 * @var string

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -8,7 +8,7 @@
 /**
  * Class to load assets required for structured data blocks.
  */
-class WPSEO_Structured_Data_Blocks {
+class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 	/**
 	 * @var WPSEO_Admin_Asset_Manager
 	 */
@@ -19,9 +19,13 @@ class WPSEO_Structured_Data_Blocks {
 	 */
 	public function __construct() {
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
+	}
 
+	public function register_hooks() {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_categories', array( $this, 'add_block_category' ) );
+
+		WPSEO_How_To_Block::register();
 	}
 
 	/**

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -21,6 +21,9 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 	}
 
+	/**
+	 * Registers hooks for Structured Data Blocks with WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_categories', array( $this, 'add_block_category' ) );

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -28,7 +28,13 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_categories', array( $this, 'add_block_category' ) );
 
-		WPSEO_How_To_Block::register();
+		$integrations = array(
+			new WPSEO_How_To_Block(),
+		);
+
+		foreach ( $integrations as $integration ) {
+			$integration->register_hooks();
+		}
 	}
 
 	/**

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -28,12 +28,12 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_categories', array( $this, 'add_block_category' ) );
 
-		$integrations = array(
+		$block_integrations = array(
 			new WPSEO_How_To_Block(),
 		);
 
-		foreach ( $integrations as $integration ) {
-			$integration->register_hooks();
+		foreach ( $block_integrations as $block_integration ) {
+			$block_integration->register_hooks();
 		}
 	}
 

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -32,7 +32,7 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	 * @param array  $attributes The attributes of the block.
 	 * @param string $content    The HTML content of the block.
 	 *
-	 * @return string The block preceded by it's JSON LD script.
+	 * @return string The block preceded by its JSON LD script.
 	 */
 	public function render( $attributes, $content ) {
 		if ( ! is_array( $attributes ) ) {
@@ -65,7 +65,9 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 			$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];
 			$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
 
-			$json_ld['totalTime'] = 'PT' . $hours . 'H' . $minutes . 'M';
+			if ( $hours !== 0 || $minutes !== 0 ) {
+				$json_ld['totalTime'] = 'PT' . $hours . 'H' . $minutes . 'M';
+			}
 		}
 
 		if ( ! empty( $attributes['jsonDescription'] ) ) {

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -8,16 +8,16 @@
 /**
  * Class WPSEO_How_To_Block
  */
-class WPSEO_How_To_Block {
+class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	/**
 	 * Registers the how-to block as a server-side rendered block.
 	 *
 	 * @return void
 	 */
-	public static function register() {
+	public function register_hooks() {
 		if ( function_exists( 'register_block_type' ) ) {
 			register_block_type( 'yoast/how-to-block', array(
-				'render_callback' => 'WPSEO_How_To_Block::render',
+				'render_callback' => array( $this, 'render' ),
 			) );
 		}
 	}
@@ -32,8 +32,8 @@ class WPSEO_How_To_Block {
 	 *
 	 * @return string The block preceded by it's JSON LD script.
 	 */
-	public static function render( $attributes, $content ) {
-		$json_ld = self::get_json_ld( $attributes );
+	public function render( $attributes, $content ) {
+		$json_ld = $this->get_json_ld( $attributes );
 
 		return '<script type="application/ld+json">' . wp_json_encode( $json_ld ) . '</script>' . $content;
 	}
@@ -45,7 +45,7 @@ class WPSEO_How_To_Block {
 	 *
 	 * @return array The JSON LD representation of the how-to block in array form.
 	 */
-	protected static function get_json_ld( $attributes ) {
+	protected function get_json_ld( $attributes ) {
 		$json_ld = array(
 			'@context' => 'http://schema.org',
 			'@type' => 'HowTo',
@@ -69,7 +69,7 @@ class WPSEO_How_To_Block {
 		if ( ! empty( $attributes['steps'] ) && is_array( $attributes['steps'] ) ) {
 			$json_ld['step'] = array();
 			foreach ( $attributes['steps'] as $index => $step ) {
-				$json_ld['step'][] = self::get_step_json_ld( $step, $index );
+				$json_ld['step'][] = $this->get_step_json_ld( $step, $index );
 			}
 		}
 
@@ -84,7 +84,7 @@ class WPSEO_How_To_Block {
 	 *
 	 * @return array The JSON LD representation of the step in a how-to block in array form.
 	 */
-	protected static function get_step_json_ld( $step, $index ) {
+	protected function get_step_json_ld( $step, $index ) {
 		$step_json_ld = array(
 			'@type' => 'HowToStep',
 			'position' => $index + 1,

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -66,7 +66,7 @@ class WPSEO_How_To_Block {
 			$json_ld['description'] = $attributes['jsonDescription'];
 		}
 
-		if ( ! empty( $attributes['steps'] && is_array( $attributes['steps'] ) ) ) {
+		if ( ! empty( $attributes['steps'] ) && is_array( $attributes['steps'] ) ) {
 			$json_ld['step'] = array();
 			foreach ( $attributes['steps'] as $index => $step ) {
 				$json_ld['step'][] = self::get_step_json_ld( $step, $index );

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -76,10 +76,9 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 
 		if ( ! empty( $attributes['steps'] ) && is_array( $attributes['steps'] ) ) {
 			$json_ld['step'] = array();
-			foreach ( $attributes['steps'] as $index => $step ) {
-				if ( is_array( $step ) ) {
-					$json_ld['step'][] = $this->get_step_json_ld( $step, $index );
-				}
+			$steps = array_filter( $attributes['steps'], 'is_array' );
+			foreach ( $steps as $index => $step ) {
+				$json_ld['step'][] = $this->get_step_json_ld( $step, $index );
 			}
 		}
 

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Structured_Data_Blocks
+ */
+
+class WPSEO_How_To_Block {
+	/**
+	 * Registers the how-to block as a server-side rendered block.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		if ( function_exists( 'register_block_type' ) ) {
+			register_block_type( 'yoast/how-to-block', array(
+				'render_callback' => 'WPSEO_How_To_Block::render',
+			) );
+		}
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * Because we can't save script tags in Gutenberg without sufficient user permissions we render these server-side.
+	 *
+	 * @param array  $attributes The attributes of the block.
+	 * @param string $content    The HTML content of the block.
+	 *
+	 * @return string
+	 */
+	public static function render( $attributes, $content ) {
+		$json_ld = array(
+			"@context" => "http://schema.org",
+			"@type" => "HowTo",
+		);
+
+		if ( ! empty( $attributes['jsonTitle'] ) ) {
+			$json_ld['name'] = $attributes['jsonTitle'];
+		}
+
+		if( ! empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] === true ) {
+			$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];
+			$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
+
+			$json_ld['totalTime'] = 'PT' . $hours . 'H' . $minutes . 'M';
+		}
+
+		if ( ! empty( $attributes['jsonDescription'] ) ) {
+			$json_ld['description'] = $attributes['jsonDescription'];
+		}
+
+		if ( ! empty( $attributes['steps'] && is_array( $attributes['steps' ] ) ) ) {
+			$json_ld['step'] = array();
+			foreach( $attributes['steps'] as $index => $step ) {
+				$step_json_ld = array(
+					"@type" => "HowToStep",
+					"position" => $index + 1,
+					"text" => $step['jsonContents'],
+				);
+
+				if ( ! empty( $step['jsonImageSrc'] ) ) {
+					$step_json_ld['associatedMedia'] = array(
+						"@type" => "ImageObject",
+						"contentUrl" => $step['jsonImageSrc'],
+					);
+				}
+
+				$json_ld['step'][] = $step_json_ld;
+			}
+		}
+
+		return '<script type="application/ld+json">' .  json_encode( $json_ld ) . '</script>' . $content;
+	}
+}

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -15,11 +15,13 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		if ( function_exists( 'register_block_type' ) ) {
-			register_block_type( 'yoast/how-to-block', array(
-				'render_callback' => array( $this, 'render' ),
-			) );
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
 		}
+
+		register_block_type( 'yoast/how-to-block', array(
+			'render_callback' => array( $this, 'render' ),
+		) );
 	}
 
 	/**
@@ -33,6 +35,10 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	 * @return string The block preceded by it's JSON LD script.
 	 */
 	public function render( $attributes, $content ) {
+		if ( ! is_array( $attributes ) ) {
+			return $content;
+		}
+
 		$json_ld = $this->get_json_ld( $attributes );
 
 		return '<script type="application/ld+json">' . wp_json_encode( $json_ld ) . '</script>' . $content;
@@ -45,10 +51,10 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	 *
 	 * @return array The JSON LD representation of the how-to block in array form.
 	 */
-	protected function get_json_ld( $attributes ) {
+	protected function get_json_ld( array $attributes ) {
 		$json_ld = array(
 			'@context' => 'http://schema.org',
-			'@type' => 'HowTo',
+			'@type'    => 'HowTo',
 		);
 
 		if ( ! empty( $attributes['jsonTitle'] ) ) {
@@ -69,7 +75,9 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 		if ( ! empty( $attributes['steps'] ) && is_array( $attributes['steps'] ) ) {
 			$json_ld['step'] = array();
 			foreach ( $attributes['steps'] as $index => $step ) {
-				$json_ld['step'][] = $this->get_step_json_ld( $step, $index );
+				if ( is_array( $step ) ) {
+					$json_ld['step'][] = $this->get_step_json_ld( $step, $index );
+				}
 			}
 		}
 
@@ -84,11 +92,11 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	 *
 	 * @return array The JSON LD representation of the step in a how-to block in array form.
 	 */
-	protected function get_step_json_ld( $step, $index ) {
+	protected function get_step_json_ld( array $step, $index ) {
 		$step_json_ld = array(
-			'@type' => 'HowToStep',
+			'@type'    => 'HowToStep',
 			'position' => $index + 1,
-			'text' => $step['jsonContents'],
+			'text'     => $step['jsonContents'],
 		);
 
 		if ( ! empty( $step['jsonImageSrc'] ) ) {

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -101,7 +101,7 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 
 		if ( ! empty( $step['jsonImageSrc'] ) ) {
 			$step_json_ld['associatedMedia'] = array(
-				'@type' => 'ImageObject',
+				'@type'      => 'ImageObject',
 				'contentUrl' => $step['jsonImageSrc'],
 			);
 		}

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Structured_Data_Blocks
  */
 
+/**
+ * Class WPSEO_How_To_Block
+ */
 class WPSEO_How_To_Block {
 	/**
 	 * Registers the how-to block as a server-side rendered block.
@@ -32,7 +35,7 @@ class WPSEO_How_To_Block {
 	public static function render( $attributes, $content ) {
 		$json_ld = self::get_json_ld( $attributes );
 
-		return '<script type="application/ld+json">' .  json_encode( $json_ld ) . '</script>' . $content;
+		return '<script type="application/ld+json">' . wp_json_encode( $json_ld ) . '</script>' . $content;
 	}
 
 	/**
@@ -44,15 +47,15 @@ class WPSEO_How_To_Block {
 	 */
 	protected static function get_json_ld( $attributes ) {
 		$json_ld = array(
-			"@context" => "http://schema.org",
-			"@type" => "HowTo",
+			'@context' => 'http://schema.org',
+			'@type' => 'HowTo',
 		);
 
 		if ( ! empty( $attributes['jsonTitle'] ) ) {
 			$json_ld['name'] = $attributes['jsonTitle'];
 		}
 
-		if( ! empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] === true ) {
+		if ( ! empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] === true ) {
 			$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];
 			$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
 
@@ -65,7 +68,7 @@ class WPSEO_How_To_Block {
 
 		if ( ! empty( $attributes['steps'] && is_array( $attributes['steps' ] ) ) ) {
 			$json_ld['step'] = array();
-			foreach( $attributes['steps'] as $index => $step ) {
+			foreach ( $attributes['steps'] as $index => $step ) {
 				$json_ld['step'][] = self::get_step_json_ld( $step, $index );
 			}
 		}
@@ -83,15 +86,15 @@ class WPSEO_How_To_Block {
 	 */
 	protected static function get_step_json_ld( $step, $index ) {
 		$step_json_ld = array(
-			"@type" => "HowToStep",
-			"position" => $index + 1,
-			"text" => $step['jsonContents'],
+			'@type' => 'HowToStep',
+			'position' => $index + 1,
+			'text' => $step['jsonContents'],
 		);
 
 		if ( ! empty( $step['jsonImageSrc'] ) ) {
 			$step_json_ld['associatedMedia'] = array(
-				"@type" => "ImageObject",
-				"contentUrl" => $step['jsonImageSrc'],
+				'@type' => 'ImageObject',
+				'contentUrl' => $step['jsonImageSrc'],
 			);
 		}
 

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -66,7 +66,7 @@ class WPSEO_How_To_Block {
 			$json_ld['description'] = $attributes['jsonDescription'];
 		}
 
-		if ( ! empty( $attributes['steps'] && is_array( $attributes['steps' ] ) ) ) {
+		if ( ! empty( $attributes['steps'] && is_array( $attributes['steps'] ) ) ) {
 			$json_ld['step'] = array();
 			foreach ( $attributes['steps'] as $index => $step ) {
 				$json_ld['step'][] = self::get_step_json_ld( $step, $index );

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -27,9 +27,22 @@ class WPSEO_How_To_Block {
 	 * @param array  $attributes The attributes of the block.
 	 * @param string $content    The HTML content of the block.
 	 *
-	 * @return string
+	 * @return string The block preceded by it's JSON LD script.
 	 */
 	public static function render( $attributes, $content ) {
+		$json_ld = self::get_json_ld( $attributes );
+
+		return '<script type="application/ld+json">' .  json_encode( $json_ld ) . '</script>' . $content;
+	}
+
+	/**
+	 * Returns the JSON LD for a how-to block in array form.
+	 *
+	 * @param array $attributes The attributes of the how-to block.
+	 *
+	 * @return array The JSON LD representation of the how-to block in array form.
+	 */
+	protected static function get_json_ld( $attributes ) {
 		$json_ld = array(
 			"@context" => "http://schema.org",
 			"@type" => "HowTo",
@@ -53,23 +66,35 @@ class WPSEO_How_To_Block {
 		if ( ! empty( $attributes['steps'] && is_array( $attributes['steps' ] ) ) ) {
 			$json_ld['step'] = array();
 			foreach( $attributes['steps'] as $index => $step ) {
-				$step_json_ld = array(
-					"@type" => "HowToStep",
-					"position" => $index + 1,
-					"text" => $step['jsonContents'],
-				);
-
-				if ( ! empty( $step['jsonImageSrc'] ) ) {
-					$step_json_ld['associatedMedia'] = array(
-						"@type" => "ImageObject",
-						"contentUrl" => $step['jsonImageSrc'],
-					);
-				}
-
-				$json_ld['step'][] = $step_json_ld;
+				$json_ld['step'][] = self::get_step_json_ld( $step, $index );
 			}
 		}
 
-		return '<script type="application/ld+json">' .  json_encode( $json_ld ) . '</script>' . $content;
+		return $json_ld;
+	}
+
+	/**
+	 * Returns the JSON LD for a step in a how-to block in array form.
+	 *
+	 * @param array $step  The attributes of a step in the how-to block.
+	 * @param int   $index The index of the step in the how-to block.
+	 *
+	 * @return array The JSON LD representation of the step in a how-to block in array form.
+	 */
+	protected static function get_step_json_ld( $step, $index ) {
+		$step_json_ld = array(
+			"@type" => "HowToStep",
+			"position" => $index + 1,
+			"text" => $step['jsonContents'],
+		);
+
+		if ( ! empty( $step['jsonImageSrc'] ) ) {
+			$step_json_ld['associatedMedia'] = array(
+				"@type" => "ImageObject",
+				"contentUrl" => $step['jsonImageSrc'],
+			);
+		}
+
+		return $step_json_ld;
 	}
 }

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import HowTo from "./components/HowTo";
 
 const { __ } = window.wp.i18n;
@@ -22,6 +20,9 @@ export default () => {
 				source: "children",
 				selector: ".schema-how-to-title",
 			},
+			jsonTitle: {
+				type: "string",
+			},
 			hasDuration: {
 				type: "boolean",
 			},
@@ -35,6 +36,9 @@ export default () => {
 				type: "array",
 				source: "children",
 				selector: ".schema-how-to-description",
+			},
+			jsonDescription: {
+				type: "string",
 			},
 			steps: {
 				type: "array",
@@ -75,7 +79,7 @@ export default () => {
 		 * @returns {Component} The display component.
 		 */
 		save: function( { attributes } ) {
-			return HowTo.getContent( attributes );
+			return <HowTo.Content { ...attributes }/>;
 		},
 	} );
 };

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -78,7 +78,7 @@ export default () => {
 		 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
 		 * @returns {Component} The display component.
 		 */
-		// eslint-disable-next-line
+		// eslint-disable-next-line react/display-name
 		save: function( { attributes } ) {
 			return <HowTo.Content { ...attributes }/>;
 		},

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -78,6 +78,7 @@ export default () => {
 		 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
 		 * @returns {Component} The display component.
 		 */
+		// eslint-disable-next-line
 		save: function( { attributes } ) {
 			return <HowTo.Content { ...attributes }/>;
 		},

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -259,7 +259,7 @@ export default class HowTo extends Component {
 		const listClassNames = [ "schema-how-to-steps", additionalListCssClasses ].filter( ( i ) => i ).join( " " );
 
 		return (
-			<div className={ `schema-how-to ${ className }` }>
+			<div className={ classNames }>
 				<RichText.Content
 					tagName="h2"
 					className="schema-how-to-title"
@@ -279,8 +279,8 @@ export default class HowTo extends Component {
 					value={ description }
 				/>
 				{ unorderedList
-					? <ul className={ `schema-how-to-steps ${ additionalListCssClasses }` }>{ steps }</ul>
-					: <ol className={ `schema-how-to-steps ${ additionalListCssClasses }` }>{ steps }</ol>
+					? <ul className={ listClassNames }>{ steps }</ul>
+					: <ol className={ listClassNames }>{ steps }</ol>
 				}
 			</div>
 		);

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -8,7 +8,6 @@ const { __ } = window.wp.i18n;
 const { RichText, InspectorControls } = window.wp.editor;
 const { IconButton, PanelBody, TextControl, ToggleControl } = window.wp.components;
 const { Component, renderToString } = window.wp.element;
-const { Fragment } = window.wp.element;
 
 /**
  * A How-to block component.
@@ -65,7 +64,15 @@ export default class HowTo extends Component {
 			return;
 		}
 
-		steps[ index ].contents = newContents;
+		steps[ index ].contents     = newContents;
+		steps[ index ].jsonContents = stripHTML( renderToString( newContents ) );
+
+		let imageSrc = HowToStep.getImageSrc( newContents );
+
+		if ( imageSrc ) {
+			steps[ index ].jsonImageSrc = imageSrc;
+		}
+
 		this.props.setAttributes( { steps } );
 	}
 
@@ -237,100 +244,46 @@ export default class HowTo extends Component {
 	}
 
 	/**
-	 * Serializes a How-to block into a JSON-LD representation.
-	 *
-	 * @param {object} attributes the attributes of the How-to block.
-	 *
-	 * @returns {object} the JSON-LD representation of this How-to block.
-	 */
-	static toJSONLD( attributes ) {
-		let jsonLD = {
-			"@context": "http://schema.org",
-			"@type": "HowTo",
-			name: stripHTML( renderToString( attributes.title ) ),
-		};
-
-		if( attributes.hasDuration ) {
-			jsonLD.totalTime = `PT${ attributes.hours || 0 }H${ attributes.minutes || 0 }M`;
-		}
-		if( attributes.description && attributes.description.length > 0 ) {
-			jsonLD.description = stripHTML( renderToString( attributes.description ) );
-		}
-		if( attributes.steps && attributes.steps.length > 0 ) {
-			jsonLD.step = attributes.steps.map( ( step, index ) => HowToStep.toJSONLD( step, index ) );
-		}
-
-		return jsonLD;
-	}
-
-	/**
-	 * Renders a JSON-LD representation of this How-to block.
-	 *
-	 * @param {object} attributes the attributes of the How-to block.
-	 *
-	 * @returns {Component} the JSON-LD representation, wrapped in a script tag of type "application/ld+json".
-	 */
-	static renderJSONLD( attributes ) {
-		let stringified = JSON.stringify( this.toJSONLD( attributes ), null, 3 );
-
-		/*
-		 * Gutenberg uses a slightly different JSON stringifier,
-		 * Combined with the fact that Gutenberg compares the stringified JSONs
-		 * By replacing all subsequent whitespaces with one space means that
-		 * Everything breaks when encountering "[ {" instead of "[{" etc.
-		 */
-		stringified = stringified.replace( /\[[\s]+\{/g, "[{" );
-
-		return <script type="application/ld+json">{ stringified }</script>;
-	}
-
-
-	/**
 	 * Returns the component to be used to render
 	 * the How-to block on Wordpress (e.g. not in the editor).
 	 *
-	 * @param {object} attributes the attributes of the How-to block
+	 * @param {object} props the attributes of the How-to block
 	 *
 	 * @returns {Component} the component representing a How-to block
 	 */
-	static getContent( attributes ) {
-		let { steps, title, hours, minutes, description, unorderedList, className, additionalListCssClasses } = attributes;
+	static Content( props ) {
+		let { steps, title, hasDuration, hours, minutes, description, unorderedList, additionalListCssClasses, className } = props;
 
-		steps = steps ? steps.map( ( step ) =>
-			HowToStep.getContent( step )
-		) : null;
+		steps = steps ? steps.map( ( step ) => <HowToStep.Content { ...step }/> ) : null;
 
 		const classNames = [ "schema-how-to", className ].filter( ( i ) => i ).join( " " );
 		const listClassNames = [ "schema-how-to-steps", additionalListCssClasses ].filter( ( i ) => i ).join( " " );
 
 		return (
-			<Fragment>
-				{ this.renderJSONLD( attributes ) }
-				<div className={ classNames }>
-					<RichText.Content
-						tagName="h2"
-						className="schema-how-to-title"
-						value={ title }
-						id={ stripHTML( renderToString( title ) ).toLowerCase().replace( /\s+/g, "-" ) }
-					/>
-					{ ( attributes.hasDuration ) &&
-						<p className="schema-how-to-total-time">
-							{ __( "Total time:", "wordpress-seo" ) }
-							&nbsp;
-							{ hours || 0 }:{ ( "00" + ( minutes || 0 ) ).slice( -2 ) }
-						</p>
-					}
-					<RichText.Content
-						tagName="p"
-						className="schema-how-to-description"
-						value={ description }
-					/>
-					{ unorderedList
-						? <ul className={ listClassNames }>{ steps }</ul>
-						: <ol className={ listClassNames }>{ steps }</ol>
-					}
-				</div>
-			</Fragment>
+			<div className={ `schema-how-to ${ className }` }>
+				<RichText.Content
+					tagName="h2"
+					className="schema-how-to-title"
+					value={ title }
+					id={ stripHTML( renderToString( title ) ).toLowerCase().replace( /\s+/g, "-" ) }
+				/>
+				{ ( hasDuration ) &&
+					<p className="schema-how-to-total-time">
+						{ __( "Total time:", "wordpress-seo" ) }
+						&nbsp;
+						{ hours || 0 }:{ ( "00" + ( minutes || 0 ) ).slice( -2 ) }
+					</p>
+				}
+				<RichText.Content
+					tagName="p"
+					className="schema-how-to-description"
+					value={ description }
+				/>
+				{ unorderedList
+					? <ul className={ `schema-how-to-steps ${ additionalListCssClasses }` }>{ steps }</ul>
+					: <ol className={ `schema-how-to-steps ${ additionalListCssClasses }` }>{ steps }</ol>
+				}
+			</div>
 		);
 	}
 
@@ -427,7 +380,7 @@ export default class HowTo extends Component {
 					value={ attributes.title }
 					isSelected={ this.state.focus === "title" }
 					setFocusedElement={ () => this.setFocus( "title" ) }
-					onChange={ ( title ) => setAttributes( { title } ) }
+					onChange={ ( title ) => setAttributes( { title, jsonTitle: stripHTML( renderToString( title ) ) } ) }
 					onSetup={ ( ref ) => {
 						this.editorRefs.title = ref;
 					} }
@@ -441,7 +394,7 @@ export default class HowTo extends Component {
 					value={ attributes.description }
 					isSelected={ this.state.focus === "description" }
 					setFocusedElement={ () => this.setFocus( "description" ) }
-					onChange={ ( description ) => setAttributes( { description } ) }
+					onChange={ ( description ) => setAttributes( { description, jsonDescription: stripHTML( renderToString( description ) ) } ) }
 					onSetup={ ( ref ) => {
 						this.editorRefs.description = ref;
 					} }

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -243,9 +243,9 @@ export default class HowTo extends Component {
 	 * Returns the component to be used to render
 	 * the How-to block on Wordpress (e.g. not in the editor).
 	 *
-	 * @param {object} props the attributes of the How-to block
+	 * @param {object} props the attributes of the How-to block.
 	 *
-	 * @returns {Component} the component representing a How-to block
+	 * @returns {Component} The component representing a How-to block.
 	 */
 	static Content( props ) {
 		let { steps, title, hasDuration, hours, minutes, description, unorderedList, additionalListCssClasses, className } = props;

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 
 import HowToStep from "./HowToStep";

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -218,19 +218,16 @@ export default class HowTo extends Component {
 					className="schema-how-to-duration-input"
 					type="number"
 					value={ attributes.hours }
-					min="0"
 					onFocus={ () => this.setFocus( "hours" ) }
-					onChange={ ( event ) => setAttributes( { hours: event.target.value } ) }
+					onChange={ ( event ) => setAttributes( { hours: Math.max( 0, event.target.value ) } ) }
 					placeholder="HH"/>
 				<span>:</span>
 				<input
 					className="schema-how-to-duration-input"
 					type="number"
-					min="0"
-					max="59"
 					value={ attributes.minutes }
 					onFocus={ () => this.setFocus( "minutes" ) }
-					onChange={ ( event ) => setAttributes( { minutes: event.target.value } ) }
+					onChange={ ( event ) => setAttributes( { minutes: Math.min( Math.max( 0, event.target.value ), 60 ) } ) }
 					placeholder="MM" />
 				<IconButton
 					className="schema-how-to-duration-button editor-inserter__toggle"

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -1,7 +1,4 @@
-import React from "react";
 import PropTypes from "prop-types";
-
-import { stripHTML } from "../../../helpers/stringHelpers";
 
 const { Component } = window.wp.element;
 const { __ } = window.wp.i18n;

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { stripHTML } from "../../../helpers/stringHelpers";
 
-const { Component, renderToString } = window.wp.element;
+const { Component } = window.wp.element;
 const { __ } = window.wp.i18n;
 const { IconButton } = window.wp.components;
 const { RichText, MediaUpload } = window.wp.editor;
@@ -181,46 +181,19 @@ export default class HowToStep extends Component {
 	}
 
 	/**
-	 * Generates a JSON-LD representation of the given How-to step.
-	 *
-	 * @param {object} step          The how-to step.
-	 * @param {string} step.contents The text of the How-to step.
-	 * @param {number} index         The index of the step in the How-to block (or section).
-	 *
-	 * @returns {Object} the JSON-LD representation of the given step.
-	 */
-	static toJSONLD( step, index ) {
-		let jsonLD = {
-			"@type": "HowToStep",
-			position: ( index + 1 ).toString(),
-			text: stripHTML( renderToString( step.contents ) ),
-		};
-		let imageSrc = HowToStep.getImageSrc( step.contents );
-
-		if ( imageSrc ) {
-			jsonLD.associatedMedia = {
-				"@type": "ImageObject",
-				contentUrl: imageSrc,
-			};
-		}
-
-		return jsonLD;
-	}
-
-	/**
 	 * Returns the component of the given How-to step to be rendered in a WordPress post
 	 * (e.g. not in the editor).
 	 *
-	 * @param {object} step The how-to step.
+	 * @param {object} props The props of the how-to step.
 	 *
 	 * @returns {Component} the component to be rendered.
 	 */
-	static getContent( step ) {
+	static Content( props ) {
 		return <RichText.Content
 			tagName="li"
 			className="schema-how-to-step"
-			key={ step.id }
-			value={ step.contents }
+			key={ props.id }
+			value={ props.contents }
 		/>;
 	}
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -307,6 +307,10 @@ function wpseo_init() {
 	$integrations   = array();
 	$integrations[] = new WPSEO_Slug_Change_Watcher();
 
+	if ( defined( 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' ) ) {
+		$integrations[] = new WPSEO_Structured_Data_Blocks();
+	}
+
 	foreach ( $integrations as $integration ) {
 		$integration->register_hooks();
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the HowTo block outputting JSON directly to the front-end instead of in the appropriate tags when used by authors.

## Relevant technical choices:

* The json-ld scripts are now rendered server-side, I deemed this the most reliable and secure method of adding the script tags without any risk of code being injected.
* This does mean that the Structured Data Blocks integration needs to be active on both the front-end and the admin and as such I've moved it to `wpseo-main.php`.

## Test instructions

This PR can be tested by following these steps:

* Build the JS.
* Enable the `YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS` feature flag.
* Log in as an author.
* Create a HowTo block.
* It should output the correct json-ld inside the appropriate script tag.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
