### PR TITLE
Fix classic editor plugin conflict

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -193,7 +193,7 @@ class WPSEO_Admin_Asset_Manager {
 		$backport_wp_dependencies = array( self::PREFIX . 'react-dependencies' );
 
 		// If Gutenberg is present we can borrow their globals for our own.
-		if ( function_exists( 'gutenberg_register_scripts_and_styles' ) ) {
+		if ( $this->load_gutenberg_assets() ) {
 			$backport_wp_dependencies[] = 'wp-element';
 			$backport_wp_dependencies[] = 'wp-data';
 			$backport_wp_dependencies[] = 'wp-components';
@@ -566,5 +566,24 @@ class WPSEO_Admin_Asset_Manager {
 				'deps' => array( 'wp-edit-blocks' ),
 			),
 		);
+	}
+
+	/**
+	 * Checks if the Gutenberg assets must be loaded.
+	 *
+	 * @return bool True wheter Gutenberg assets must be loaded.
+	 */
+	protected function load_gutenberg_assets() {
+		// When Gutenberg is not active, just return false.
+		if ( ! function_exists( 'gutenberg_register_scripts_and_styles' ) ) {
+			return false;
+		}
+
+		// When classic editor plugin and Gutenberg are active the Gutenberg assets shouldn't be loaded.
+		if ( function_exists( 'classic_editor_is_gutenberg_active' ) && classic_editor_is_gutenberg_active() ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -193,7 +193,7 @@ class WPSEO_Admin_Asset_Manager {
 		$backport_wp_dependencies = array( self::PREFIX . 'react-dependencies' );
 
 		// If Gutenberg is present we can borrow their globals for our own.
-		if ( $this->load_gutenberg_assets() ) {
+		if ( $this->should_load_gutenberg_assets() ) {
 			$backport_wp_dependencies[] = 'wp-element';
 			$backport_wp_dependencies[] = 'wp-data';
 			$backport_wp_dependencies[] = 'wp-components';
@@ -573,7 +573,7 @@ class WPSEO_Admin_Asset_Manager {
 	 *
 	 * @return bool True wheter Gutenberg assets must be loaded.
 	 */
-	protected function load_gutenberg_assets() {
+	protected function should_load_gutenberg_assets() {
 		// When Gutenberg is not active, just return false.
 		if ( ! function_exists( 'gutenberg_register_scripts_and_styles' ) ) {
 			return false;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the metabox isn't loaded correctly when the Classic Editor plugin is active. 

## Test instructions

This PR can be tested by following these steps:

* Install the classic editor plugin
* Have Gutenberg active
* Create a new post and see the metabox isn't loaded correctly.
* Checkout this branche
* Create a branch and see that the metabox is fixed.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9991
