### PR TITLE
Bumped version of YoastSEO to 1.37, components to 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,8 +133,8 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components.git#develop",
-    "yoastseo": "^1.36.1"
+    "yoast-components": "^4.9.0",
+    "yoastseo": "^1.37"
   },
   "yoast": {
     "pluginVersion": "8.0-RC3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10941,9 +10941,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-"yoast-components@git+https://github.com/Yoast/yoast-components.git#develop":
-  version "4.8.0"
-  resolved "git+https://github.com/Yoast/yoast-components.git#6c78af9426cbc69b4fe0b76d0482290506f1a41b"
+yoast-components@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.9.0.tgz#2349624903186c8690407966016d7b2197e16245"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -10966,13 +10966,13 @@ yauzl@^2.2.1:
     striptags "^3.1.0"
     styled-components "^2.1.2"
     whatwg-fetch "^1.0.0"
-    yoastseo "^1.36.0"
+    yoastseo "^1.37.0"
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.36.0, yoastseo@^1.36.1:
-  version "1.36.1"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.36.1.tgz#264be38517d1c293fbd93b8b8fc9dd12bc8a941f"
+yoastseo@^1.37, yoastseo@^1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.37.0.tgz#257b3dfe3e764ccd5e8dd444987eb88d68c4e969"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Bumped YoastSEO.js to v1.37
* Bumped Yoast Components to 4.9.0

## Test instructions

This PR can be tested by following these steps:

* N/A.

