### PR TITLE
Sanitize the saved cornerstone value

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -467,7 +467,8 @@ class WPSEO_Meta {
 				break;
 
 			case ( $field_def['type'] === 'hidden' && $meta_key === self::$meta_prefix . 'is_cornerstone' ):
-				if ( $meta_value === 'true') {
+				// This used to be a checkbox, then became a hidden input. To make sure the value remains consistent, we cast 'true' to '1'.
+				if ( $meta_value === 'true' ) {
 					$clean = '1';
 				}
 				break;

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -466,6 +466,11 @@ class WPSEO_Meta {
 				}
 				break;
 
+			case ( $field_def['type'] === 'hidden' && $meta_key === self::$meta_prefix . 'is_cornerstone' ):
+				if ( $meta_value === 'true') {
+					$clean = '1';
+				}
+				break;
 
 			case ( $field_def['type'] === 'textarea' ):
 				if ( is_string( $meta_value ) ) {

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -467,6 +467,8 @@ class WPSEO_Meta {
 				break;
 
 			case ( $field_def['type'] === 'hidden' && $meta_key === self::$meta_prefix . 'is_cornerstone' ):
+				$clean = $meta_value;
+
 				// This used to be a checkbox, then became a hidden input. To make sure the value remains consistent, we cast 'true' to '1'.
 				if ( $meta_value === 'true' ) {
 					$clean = '1';

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -454,7 +454,7 @@ setWordPressSeoL10n();
 
 		// Set the initial snippet editor data.
 		editStore.dispatch( updateData( snippetEditorData ) );
-		editStore.dispatch( setCornerstoneContent( document.getElementById( "yoast_wpseo_is_cornerstone" ).value === "true" ) );
+		editStore.dispatch( setCornerstoneContent( document.getElementById( "yoast_wpseo_is_cornerstone" ).value === "1" ) );
 
 		// Save the keyword, in order to compare it to store changes.
 		let focusKeyword = editStore.getState().focusKeyword;

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -454,6 +454,7 @@ setWordPressSeoL10n();
 
 		// Set the initial snippet editor data.
 		editStore.dispatch( updateData( snippetEditorData ) );
+		// This used to be a checkbox, then became a hidden input. For consistency, we set the value to '1'.
 		editStore.dispatch( setCornerstoneContent( document.getElementById( "yoast_wpseo_is_cornerstone" ).value === "1" ) );
 
 		// Save the keyword, in order to compare it to store changes.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Makes sure the right cornerstone value is saved.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch
* Save a post as cornerstone
* Refresh the page, the cornerstone flag is true

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #[1928](https://github.com/Yoast/wordpress-seo-premium/issues/1928)
