### PR TITLE
Fixed broken version compare checks

### DIFF
--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -51,15 +51,6 @@ class WPSEO_Gutenberg_Compatibility {
 	}
 
 	/**
-	 * Determines whether or not the currently installed version of Gutenberg is the latest known version.
-	 *
-	 * @return bool True if the currently installed version is the latest known version. False otherwise.
-	 */
-	public function is_latest_version() {
-		return version_compare( $this->current_version, $this->get_latest_release(), '==' );
-	}
-
-	/**
 	 * Gets the currently installed version.
 	 *
 	 * @return string The currently installed version.

--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -13,7 +13,7 @@ class WPSEO_Gutenberg_Compatibility {
 	/**
 	 * The currently released version of Gutenberg.
 	 */
-	const CURRENT_RELEASE = '3.4.0';
+	const CURRENT_RELEASE = '3.5.0';
 
 	/**
 	 * The minimally supported version of Gutenberg by the plugin.
@@ -47,7 +47,7 @@ class WPSEO_Gutenberg_Compatibility {
 	 * @return bool True if the currently installed version is below the minimum supported version. False otherwise.
 	 */
 	public function is_below_minimum() {
-		return $this->get_major_minor_version( $this->current_version ) < $this->get_major_minor_version( $this->get_minimum_supported_version() );
+		return version_compare( $this->current_version, $this->get_minimum_supported_version(), '<' );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class WPSEO_Gutenberg_Compatibility {
 	 * @return bool True if the currently installed version is the latest known version. False otherwise.
 	 */
 	public function is_latest_version() {
-		return $this->get_major_minor_version( $this->current_version ) === $this->get_major_minor_version( $this->get_latest_release() );
+		return version_compare( $this->current_version, $this->get_latest_release(), '==' );
 	}
 
 	/**
@@ -74,7 +74,7 @@ class WPSEO_Gutenberg_Compatibility {
 	 * @return bool Whether or not the currently installed version is fully compatible.
 	 */
 	public function is_fully_compatible() {
-		return ! $this->is_below_minimum() && $this->is_latest_version();
+		return version_compare( $this->current_version, $this->get_latest_release(), '>=' );
 	}
 
 	/**
@@ -93,19 +93,6 @@ class WPSEO_Gutenberg_Compatibility {
 	 */
 	protected function get_minimum_supported_version() {
 		return self::MINIMUM_SUPPORTED;
-	}
-
-	/**
-	 * Gets the major/minor version of the plugin for easier comparing.
-	 *
-	 * @param string $version The version to trim.
-	 *
-	 * @return string The major/minor version of the plugin.
-	 */
-	protected function get_major_minor_version( $version ) {
-		$version_numbers = explode( '.', $version );
-
-		return implode( '.', array_slice( $version_numbers, 0, 2 ) );
 	}
 
 	/**

--- a/tests/admin/test-class-gutenberg-compatibility.php
+++ b/tests/admin/test-class-gutenberg-compatibility.php
@@ -82,38 +82,6 @@ class WPSEO_Gutenberg_Compatibility_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the installed Gutenberg version is the latest one.
-	 *
-	 * @covers WPSEO_Gutenberg_Compatibility::is_latest_version
-	 */
-	public function test_gutenberg_version_is_latest() {
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_latest_release' )
-			->will( $this->returnValue( '3.3.0' ) );
-
-		$this->default_mock->set_installed_gutenberg_version( '3.3.0' );
-
-		$this->assertEquals( $this->default_mock->is_latest_version(), true );
-	}
-
-	/**
-	 * Tests that the installed Gutenberg version is not the latest one.
-	 *
-	 * @covers WPSEO_Gutenberg_Compatibility::is_latest_version
-	 */
-	public function test_gutenberg_version_is_not_latest() {
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_latest_release' )
-			->will( $this->returnValue( '3.4.0' ) );
-
-		$this->default_mock->set_installed_gutenberg_version( '3.3.0' );
-
-		$this->assertEquals( $this->default_mock->is_latest_version(), false );
-	}
-
-	/**
 	 * Tests that the installed Gutenberg version is considered fully compatible.
 	 *
 	 * @covers WPSEO_Gutenberg_Compatibility::is_fully_compatible


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the Gutenberg compatibility checks to work via `version_compare`.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:
**Acceptance test only**
* Checkout this branch, make sure you have run `composer install`. 
* If you're running an environment with `YOAST_SEO_DEV_SERVER` set to true, ensure you also run `yarn`, `yarn upgrade yoast-components` and `yarn start`. Otherwise, you can skip this step.

**Testing steps**
* Ensure you have the latest version (https://downloads.wordpress.org/plugin/gutenberg.3.5.0.zip) of Gutenberg installed and activated.
* Go into SEO -> General and check that **no** notifications are being shown in regards to Gutenberg incompatibility.
* Uninstall Gutenberg and install an older version (https://downloads.wordpress.org/plugin/gutenberg.3.4.0.zip).
* Go back into SEO -> General and see that a notification has been added in regards to Gutenberg incompatibility under the Notifications header.
* Uninstall Gutenberg and install an _even older_ version (https://downloads.wordpress.org/plugin/gutenberg.2.2.0.zip).
* Go back into SEO -> General and see that a notification has been added in regards to Gutenberg incompatibility under the Problems header.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

