### PR TITLE
Restricts loading of backports if classic editor is currently being used

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -579,11 +579,12 @@ class WPSEO_Admin_Asset_Manager {
 			return false;
 		}
 
+		// When working in the classic editor shipped with Gutenberg, the assets shouldn't be loaded. Fixes IE11 bug.
 		if ( isset( $_GET['classic-editor'] ) ) {
 			return false;
 		}
 
-		// When classic editor plugin and Gutenberg are active the Gutenberg assets shouldn't be loaded.
+		// When classic editor plugin and Gutenberg are active, the Gutenberg assets shouldn't be loaded.
 		if ( function_exists( 'classic_editor_is_gutenberg_active' ) && classic_editor_is_gutenberg_active() ) {
 			return false;
 		}

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -579,6 +579,10 @@ class WPSEO_Admin_Asset_Manager {
 			return false;
 		}
 
+		if ( isset( $_GET['classic-editor'] ) ) {
+			return false;
+		}
+
 		// When classic editor plugin and Gutenberg are active the Gutenberg assets shouldn't be loaded.
 		if ( function_exists( 'classic_editor_is_gutenberg_active' ) && classic_editor_is_gutenberg_active() ) {
 			return false;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where Gutenberg backports were being loaded in the Classical editor, leading to errors in IE11.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Determine that the Classic editor now loads properly in IE11.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10571 
