### PR TITLE
Use a loader icon when a score is not yet present

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -774,6 +774,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager->enqueue_style( 'metabox-css' );
 		$asset_manager->enqueue_style( 'scoring' );
 		$asset_manager->enqueue_style( 'select2' );
+		$asset_manager->enqueue_style( 'yoast-components' );
 
 		$asset_manager->enqueue_script( 'metabox' );
 		$asset_manager->enqueue_script( 'help-center' );

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
+import isNil from "lodash/isNil";
 
 import Results from "./Results";
 import Collapsible from "../SidebarCollapsible";
@@ -31,6 +32,11 @@ if( window.wpseoPostScraperL10n ) {
 class ReadabilityAnalysis extends React.Component {
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );
+
+		if ( isNil( this.props.overallScore ) ) {
+			score.className = "loading";
+		}
+
 		return (
 			<Collapsible
 				title={ __( "Readability", "wordpress-seo" ) }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -15,6 +15,7 @@ import ModalButtonContainer from "../ModalButtonContainer";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
 import { getIconForScore } from "./mapResults";
 import { utils } from "yoast-components";
+import isNil from "lodash/isNil";
 
 const AnalysisHeader = styled.span`
 	font-size: 1em;
@@ -107,6 +108,10 @@ class SeoAnalysis extends React.Component {
 		if( this.props.keyword === "" ) {
 			score.className = "na";
 			score.screenReaderReadabilityText = __( "Enter a focus keyword to calculate the SEO score", "wordpress-seo" );
+		}
+
+		if ( isNil( this.props.overallScore ) ) {
+			score.className = "loading";
 		}
 
 		return (

--- a/js/src/components/contentAnalysis/mapResults.js
+++ b/js/src/components/contentAnalysis/mapResults.js
@@ -90,6 +90,9 @@ export function getIconForScore( score ) {
 	let icon = { icon: "seo-score-none", color: colors.$color_grey_disabled };
 
 	switch( score ) {
+		case "loading":
+			icon = { icon: "loading-spinner", color: colors.$color_green_medium_light };
+			break;
 		case "good":
 			icon = { icon: "seo-score-good", color: colors.$color_green_medium };
 			break;


### PR DESCRIPTION
## Summary

Originally intended to address the score that changes during the initialisation of a category page.

The issue is that, when opening a category-edit page. The overall SEO score in the metabox is set multiple times. Once it's set to undefined, at this point the overall score is still unknown. Once it's calculated wrongly, giving a wrong score as a result. Only the final score is correct. 

The intention of this PR was originally to try and remove the wrong score that is set in the store at some point in time. That goal hasn't been reached yet.

What this PR does do is that, during the time when the SEO/Readability score is unknown, it replaces the grey analysis result with a spinner showing that it's still being loaded.

This PR can be summarized in the following changelog entry:

* Changes the overall analysis scores to a loader icon when the analysis results are still being calculated. 

## Relevant technical choices:

* Used the same CSS approach as used by the loader.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and its sibling PR: https://github.com/Yoast/yoast-components/pull/709
* In the sibling pr: `yarn link`
* on this branch: `yarn && yarn link yoast-components && grunt && yarn start`
* Open a post-edit and/or term-edit page
* Check if, while the analysis is still being loaded, the icon appears as a spinner.


is a partially fix: https://github.com/Yoast/YoastSEO.js/issues/1688 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/10612
