### PR TITLE
Remove 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' feature flag 

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -306,10 +306,7 @@ function wpseo_init() {
 
 	$integrations   = array();
 	$integrations[] = new WPSEO_Slug_Change_Watcher();
-
-	if ( defined( 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' ) ) {
-		$integrations[] = new WPSEO_Structured_Data_Blocks();
-	}
+	$integrations[] = new WPSEO_Structured_Data_Blocks();
 
 	foreach ( $integrations as $integration ) {
 		$integration->register_hooks();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* On trunk, make sure the How To gutenblock is only visible when you have the 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' feature flag in your wp-config.php, and not when .
* Check out this branch. Remove 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' from your wp-config.php. Make sure the How To Gutenblock is still visible in the menu (and is functional, of course)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10633
