### PR TITLE
Harden sitemap.xml redirect and add tests

### DIFF
--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -56,28 +56,38 @@ class WPSEO_Sitemaps_Router {
 	 * Redirects sitemap.xml to sitemap_index.xml.
 	 */
 	public function template_redirect() {
-
-		global $wp_query;
-
-		$current_url = 'http://';
-
-		if ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ) {
-			$current_url = 'https://';
-		}
-
-		$domain = $_SERVER['SERVER_NAME'];
-		if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
-			$domain = $_SERVER['HTTP_HOST'];
-		}
-
-		$current_url .= sanitize_text_field( $domain );
-		$current_url .= sanitize_text_field( $_SERVER['REQUEST_URI'] );
-
-		if ( home_url( '/sitemap.xml' ) === $current_url && $wp_query->is_404 ) {
+		if ( $this->needs_sitemap_index_redirect() ) {
 			header( 'X-Redirect-By: Yoast SEO' );
 			wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
 			exit;
 		}
+	}
+
+	/**
+	 * Checks whether the current request needs to be redirected to sitemap_index.xml.
+	 *
+	 * @global WP_Query $wp_query Current query.
+	 *
+	 * @return bool True if redirect is needed, false otherwise.
+	 */
+	public function needs_sitemap_index_redirect() {
+		global $wp_query;
+
+		$protocol = 'http://';
+		if ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ) {
+			$protocol = 'https://';
+		}
+
+		$domain = sanitize_text_field( $_SERVER['SERVER_NAME'] );
+		$path   = sanitize_text_field( $_SERVER['REQUEST_URI'] );
+
+		// Due to different environment configurations, we need to check both SERVER_NAME and HTTP_HOST.
+		$check_urls = array( $protocol . $domain . $path );
+		if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
+			$check_urls[] = $protocol . sanitize_text_field( $_SERVER['HTTP_HOST'] ) . $path;
+		}
+
+		return $wp_query->is_404 && in_array( home_url( '/sitemap.xml' ), $check_urls, true );
 	}
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -10,6 +10,9 @@
  */
 class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 
+	/** @var string Temporary home URL storage. */
+	private $home_url = '';
+
 	/** @var WPSEO_Sitemaps_Router */
 	private static $class_instance;
 
@@ -52,5 +55,124 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 		update_option( 'home', 'https://example.org' );
 		$this->assertEquals( 'https://example.org/sitemap.xml', WPSEO_Sitemaps_Router::get_base_url( 'sitemap.xml' ) );
 		$this->assertNotEquals( 'http://example.org/sitemap.xml', WPSEO_Sitemaps_Router::get_base_url( 'sitemap.xml' ) );
+	}
+
+	/**
+	 * Tests whether the current request should be redirected to sitemap_index.xml.
+	 *
+	 * @covers WPSEO_Sitemaps_Router::needs_sitemap_index_redirect()
+	 * @dataProvider data_needs_sitemap_index_redirect
+	 *
+	 * @param array    $server_vars Associative array of `$_SERVER` vars to set.
+	 * @param string   $home_url    The home URL to set.
+	 * @param WP_Query $wp_query    WP_Query instance to set.
+	 * @param bool     $expected    The expected test result.
+	 */
+	public function test_needs_sitemap_index_redirect( $server_vars, $home_url, $wp_query, $expected ) {
+		$server_orig   = $_SERVER;
+		$wp_query_orig = $GLOBALS['wp_query'];
+
+		$_SERVER             = array_merge( $_SERVER, $server_vars );
+		$this->home_url      = $home_url;
+		$GLOBALS['wp_query'] = $wp_query;
+
+		add_filter( 'home_url', array( $this, 'filter_home_url' ), 100, 2 );
+		$result = self::$class_instance->needs_sitemap_index_redirect();
+		remove_filter( 'home_url', array( $this, 'filter_home_url' ), 100 );
+
+		$GLOBALS['wp_query'] = $wp_query_orig;
+		$this->home_url      = '';
+		$_SERVER             = $server_orig;
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Filters the home URL.
+	 *
+	 * @param string $home_url Original home URL.
+	 * @return string Home URL to override, or value of $home_url.
+	 */
+	public function filter_home_url( $home_url, $path ) {
+		if ( ! empty( $this->home_url ) ) {
+			if ( ! empty( $path ) ) {
+				return $this->home_url . '/' . ltrim( $path, '/' );
+			}
+			return $this->home_url;
+		}
+
+		return $home_url;
+	}
+
+	/**
+	 * Provides test data for the `test_needs_sitemap_index_redirect()` test.
+	 *
+	 * The format for each record is:
+	 * [0] array:    Associative array of `$_SERVER` vars to set.
+	 * [1] string:   The home URL to set.
+	 * [2] WP_Query: WP_Query instance to set.
+	 * [3] bool:     The expected test result.
+	 *
+	 * @return array The test data.
+	 */
+	public function data_needs_sitemap_index_redirect() {
+		$server_vars_sets = array(
+			array(
+				'SERVER_NAME' => 'testsite.org',
+				'REQUEST_URI' => '/sitemap.xml',
+			),
+			array(
+				'HTTP_HOST' => 'testsite.org',
+				'REQUEST_URI' => '/sitemap.xml',
+			),
+			array(
+				'SERVER_NAME' => 'testsite.org',
+				'REQUEST_URI' => '/sitemap_index.xml',
+			),
+			array(
+				'HTTP_HOST' => 'other-testsite.org',
+				'REQUEST_URI' => '/sitemap_index.xml',
+			),
+			array(
+				'SERVER_NAME' => 'other-testsite.org',
+				'REQUEST_URI' => '/sitemap.xml',
+			),
+			array(
+				'HTTP_HOST' => 'other-testsite.org',
+				'REQUEST_URI' => '/sitemap.xml',
+			),
+		);
+
+		$home_urls = array(
+			'http://testsite.org',
+			'http://other-testsite.org',
+			'https://testsite.org',
+			'https://other-testsite.org',
+		);
+
+		$wp_queries = array(
+			new WP_Query(),
+			new WP_Query(),
+		);
+		$wp_queries[1]->is_404 = true;
+
+		// Create test data from all possible combinations, plus HTTP vs HTTPS.
+		$testdata = array();
+		foreach ( $server_vars_sets as $server_vars ) {
+			foreach ( $home_urls as $home_url ) {
+				foreach ( $wp_queries as $wp_query ) {
+					$domain = ! empty( $server_vars['HTTP_HOST'] ) ? $server_vars['HTTP_HOST'] : $server_vars['SERVER_NAME'];
+					$path   = $server_vars['REQUEST_URI'];
+
+					$expected   = $home_url === 'http://' . $domain && $path === '/sitemap.xml' && $wp_query->is_404;
+					$testdata[] = array( $server_vars, $home_url, $wp_query, $expected );
+
+					$expected   = $home_url === 'https://' . $domain && $path === '/sitemap.xml' && $wp_query->is_404;
+					$testdata[] = array( array_merge( $server_vars, array( 'HTTPS' => 'on' ) ), $home_url, $wp_query, $expected );
+				}
+			}
+		}
+
+		return $testdata;
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Handles sitemap redirects better accounting for different environments and improves test coverage for them.

## Relevant technical choices:

* This is a follow-up to #10353 which didn't fix this bug for _all_ environments.
* Both the `HTTP_HOST` and `SERVER_NAME` server vars should be considered when detecting the current URL, as different environments use those variables differently.
* A test with comprehensive test data has been added to check all different possibilities for the method.

## Test instructions

This PR can be tested by following these steps:

* Use a server where the `$_SERVER['SERVER_NAME']` is set to the domain of your WordPress site. At the same time, also ensure that `$_SERVER['HTTP_HOST']` is set, but to another domain.
* Granted, this is an edge-case and thus hard to test. You can set those variables temporarily in your `wp-config.php` to simulate it.
* Activate the plugin.
* With those variables set, ensure that `sitemap.xml` is redirected to `sitemap_index.xml` properly.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10661