### PR TITLE
Recreate getMarker function after worker is done

### DIFF
--- a/js/src/analysis/getMarker.js
+++ b/js/src/analysis/getMarker.js
@@ -1,0 +1,30 @@
+/* global tinyMCE */
+
+import noop from "lodash/noop";
+
+import tinyMCEHelper from "../wp-seo-tinymce";
+import { tinyMCEDecorator } from "../decorator/tinyMCE";
+
+let decorator = null;
+
+/**
+ * Gets the marker function.
+ *
+ * @param {boolean} [showMarkers=true] Whether to return the marker function or not.
+ *
+ * @returns {Function} The marker function or an empty function.
+ */
+export default function getMarker( showMarkers = true ) {
+	if ( ! showMarkers ) {
+		return noop;
+	}
+	return ( paper, marks ) => {
+		if ( tinyMCEHelper.isTinyMCEAvailable( tinyMCEHelper.tmceId ) ) {
+			if ( null === decorator ) {
+				decorator = tinyMCEDecorator( tinyMCE.get( tinyMCEHelper.tmceId ) );
+			}
+
+			decorator( paper, marks );
+		}
+	};
+}

--- a/js/src/analysis/refreshAnalysis.js
+++ b/js/src/analysis/refreshAnalysis.js
@@ -1,9 +1,12 @@
 import {
 	setOverallReadabilityScore,
 	setOverallSeoScore, setReadabilityResults,
-	setSeoResultsForKeyword
+	setSeoResultsForKeyword,
 } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
+import { Paper } from "yoastseo";
+
 import getAnalysisData from "./getAnalysisData";
+import getMarker from "./getMarker";
 
 /**
  * Refreshes the analysis.
@@ -24,10 +27,33 @@ export default function refreshAnalysis( edit, analysisWorker, store, customAnal
 	analysisWorker.analyze( data )
 		.then( ( { result: { seo, readability } } ) => {
 			if ( seo ) {
+				// Recreate the getMarker function after the worker is done.
+				seo.results.map( function( result ) {
+					result.getMarker = () => {
+						const { marksButtonStatus } = store.getState();
+						const showMarkers = marksButtonStatus === "enabled";
+						return () => {
+							const marker = getMarker( showMarkers );
+							marker( Paper.parse( data ), result.marks );
+						};
+					};
+				}
+			);
 				store.dispatch( setSeoResultsForKeyword( data.keyword, seo.results ) );
 				store.dispatch( setOverallSeoScore( seo.score, data.keyword ) );
 			}
 			if ( readability ) {
+				readability.results.map( function( result ) {
+					result.getMarker = () => {
+						const { marksButtonStatus } = store.getState();
+						const showMarkers = marksButtonStatus === "enabled";
+						return () => {
+							const marker = getMarker( showMarkers );
+							marker( Paper.parse( data ), result.marks );
+						};
+					};
+				}
+			);
 				store.dispatch( setReadabilityResults( readability.results ) );
 				store.dispatch( setOverallReadabilityScore( readability.score ) );
 			}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Recreates the getMarker function after the web worker is done with the analyses.
* Moves the marker function to a separate file so that it can be used in different locations (e.g., the term scraper once we're able to use marking there).

## Test instructions

This PR can be tested by following these steps:

* Check whether the markings still work.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/YoastSEO.js/issues/1692
