### PR TITLE
Don't show time needed if human readable string is empty

### DIFF
--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -314,7 +314,7 @@ export default class HowTo extends Component {
 					value={ title }
 					id={ stripHTML( renderToString( title ) ).toLowerCase().replace( /\s+/g, "-" ) }
 				/>
-				{ ( hasDuration ) &&
+				{ ( hasDuration && timeString.length > 0 ) &&
 					<p className="schema-how-to-total-time">
 						{ __( "Time needed:", "wordpress-seo" ) }
 						&nbsp;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Add a how-to block
* Add a time duration
* Enter 0 for hours and minutes
* Publish post, and view it in the frontend: should not show "Time needed: .".
* Go back to editor, enter a non zero number of minutes or hours.
* Update post.
* Verify that it now does show the time needed.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10664 
