### PR TITLE
Show more details in multisite site lists

### DIFF
--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -39,7 +39,10 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 			$choices['-'] = __( 'None', 'wordpress-seo' );
 		}
 
-		$sites = get_sites( array( 'deleted' => 0 ) );
+		$sites = get_sites( array(
+			'deleted'    => 0,
+			'network_id' => get_current_network_id(),
+		) );
 		foreach ( $sites as $site ) {
 			$site_name = $site->domain . $site->path;
 			if ( $show_title ) {

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -24,10 +24,15 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 	 * Gets the available sites as choices, e.g. for a dropdown.
 	 *
 	 * @param bool $include_empty Optional. Whether to include an initial placeholder choice.
+	 *                            Default false.
+	 * @param bool $show_title    Optional. Whether to show the title for each site. This requires
+	 *                            switching through the sites, so has performance implications for
+	 *                            sites that do not use a persistent cache.
+	 *                            Default false.
 	 *
 	 * @return array Choices as $site_id => $site_label pairs.
 	 */
-	public function get_site_choices( $include_empty = false ) {
+	public function get_site_choices( $include_empty = false, $show_title = false ) {
 		$choices = array();
 
 		if ( $include_empty ) {
@@ -36,7 +41,11 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 
 		$sites = get_sites( array( 'deleted' => 0 ) );
 		foreach ( $sites as $site ) {
-			$choices[ $site->blog_id ] = $site->blog_id . ': ' . $site->domain . $site->path;
+			$site_name = $site->domain . $site->path;
+			if ( $show_title ) {
+				$site_name = $site->blogname . ' (' . $site->domain . $site->path . ')';
+			}
+			$choices[ $site->blog_id ] = $site->blog_id . ': ' . $site_name;
 
 			$site_states = $this->get_site_states( $site );
 			if ( ! empty( $site_states ) ) {

--- a/admin/views/tabs/network/general.php
+++ b/admin/views/tabs/network/general.php
@@ -32,7 +32,7 @@ if ( get_blog_count() <= 100 ) {
 	$yform->select(
 		'defaultblog',
 		__( 'New sites in the network inherit their SEO settings from this site', 'wordpress-seo' ),
-		$network_admin->get_site_choices( true )
+		$network_admin->get_site_choices( true, true )
 	);
 	echo '<p>' . esc_html__( 'Choose the site whose settings you want to use as default for all sites that are added to your network. If you choose \'None\', the normal plugin defaults will be used.', 'wordpress-seo' ) . '</p>';
 }

--- a/admin/views/tabs/network/restore-site.php
+++ b/admin/views/tabs/network/restore-site.php
@@ -23,7 +23,7 @@ if ( get_blog_count() <= 100 ) {
 	$yform->select(
 		'site_id',
 		__( 'Site ID', 'wordpress-seo' ),
-		$network_admin->get_site_choices()
+		$network_admin->get_site_choices( false, true )
 	);
 }
 else {

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -68,6 +68,31 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests getting site choices output.
+	 *
+	 * @group yoastnetwork
+	 *
+	 * @group ms-required
+	 * @covers Yoast_Network_Admin::get_site_choices()
+	 */
+	public function test_get_site_choices_output() {
+		$admin = new Yoast_Network_Admin();
+
+		$site = get_site();
+
+		$choices = $admin->get_site_choices();
+		$this->assertSame( $site->id, (int) key( $choices ) );
+		$this->assertContains( (string) $site->id, $choices[ $site->id ] );
+		$this->assertContains( $site->domain . $site->path, $choices[ $site->id ] );
+
+		$choices = $admin->get_site_choices( false, true );
+		$this->assertSame( $site->id, (int) key( $choices ) );
+		$this->assertContains( (string) $site->id, $choices[ $site->id ] );
+		$this->assertContains( $site->blogname, $choices[ $site->id ] );
+		$this->assertContains( $site->domain . $site->path, $choices[ $site->id ] );
+	}
+
+	/**
 	 * Tests getting a site's states.
 	 *
 	 * @group ms-required


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Shows the title of each site in network site dropdowns, as well as domain and path.

## Relevant technical choices:

* `Yoast_Network_Admin::get_sites()` now accepts a second parameter to enable showing the title for each site. It is false by default since there may be performance implications for large setups or relatively big setups without a persistent object cache (to retrieve the site title, sites need to be switched).
* Yoast SEO is only using the function for a maximum of 100 sites though, and WordPress core has been doing similar, so we should be fine. Therefore in the two calls of that method, the second parameter is passed as `true`.
* The format of each entry is the following:
    * `{$id}: {$domain}{$path} [{$states}]` if `$show_title` is false
    * `{$id}: {$title} ({$domain}{$path}) [{$states}]` if `$show_title` is true
* A minor bug with multi-network environments has been fixed in the surrounding code, to ensure that only sites from the current network are present in the list.

## Test instructions

This PR can be tested by following these steps:

* Setup a multisite.
* Activate the plugin network-wide.
* Go to the plugin's network settings screen.
* Verify that all site dropdowns in all tabs show the site ID, the site title, the site domain and path (plus the site states if any are present).

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #4445 