### PR TITLE
Fixed incorrect import

### DIFF
--- a/js/src/components/Metabox.js
+++ b/js/src/components/Metabox.js
@@ -11,7 +11,7 @@ import keywordUpsellProps from "../values/keywordUpsellProps";
 import SeoAnalysis from "./contentAnalysis/SeoAnalysis";
 import ReadabilityAnalysis from "./contentAnalysis/ReadabilityAnalysis";
 import CollapsibleCornerstone from "../containers/CollapsibleCornerstone";
-import { __ } from "@wordpress/i18n/build/index";
+import { __ } from "@wordpress/i18n";
 import Collapsible from "./SidebarCollapsible";
 
 /**

--- a/js/src/components/SnippetPreviewModal.js
+++ b/js/src/components/SnippetPreviewModal.js
@@ -25,6 +25,7 @@ class SnippetPreviewModal extends React.Component {
 	}
 
 	render() {
+		console.log( this.props );
 		return (
 			<React.Fragment>
 				<ButtonSection

--- a/js/src/components/SnippetPreviewModal.js
+++ b/js/src/components/SnippetPreviewModal.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { ButtonSection } from "yoast-components";
 import { Button, Modal } from "@wordpress/components";
-import { __ } from "@wordpress/i18n/build/index";
+import { __ } from "@wordpress/i18n";
 import SnippetEditorWrapper from "../containers/SnippetEditor";
 
 class SnippetPreviewModal extends React.Component {
@@ -25,7 +25,6 @@ class SnippetPreviewModal extends React.Component {
 	}
 
 	render() {
-		console.log( this.props );
 		return (
 			<React.Fragment>
 				<ButtonSection

--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -1,8 +1,10 @@
+/* External dependencies */
 import React from "react";
+import { __ } from "@wordpress/i18n";
 
+/* Internal dependencies */
 import FAQ from "./components/FAQ";
 
-const { __ } = window.wp.i18n;
 const { registerBlockType } = window.wp.blocks;
 
 export default () => {

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -1,10 +1,13 @@
+/* External dependencies */
 import React from "react";
 import PropTypes from "prop-types";
+import isUndefined from "lodash/isUndefined";
+import { __ } from "@wordpress/i18n";
+
+/* Internal dependencies */
 import Question from "./Question";
 import { stripHTML } from "../../../helpers/stringHelpers";
-import isUndefined from "lodash/isUndefined";
 
-const { __ } = window.wp.i18n;
 const { RichText } = window.wp.editor;
 const { IconButton } = window.wp.components;
 const { Component, renderToString } = window.wp.element;

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -1,7 +1,8 @@
+/* External dependencies */
 import PropTypes from "prop-types";
+import { __ } from "@wordpress/i18n";
 
 const { Component } = window.wp.element;
-const { __ } = window.wp.i18n;
 const { IconButton } = window.wp.components;
 const { RichText, MediaUpload } = window.wp.editor;
 

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -1,6 +1,9 @@
+/* External dependencies */
+import { __ } from "@wordpress/i18n";
+
+/* Internal dependencies */
 import HowTo from "./components/HowTo";
 
-const { __ } = window.wp.i18n;
 const { registerBlockType } = window.wp.blocks;
 
 const attributes = {

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -1,11 +1,13 @@
+/* External dependencies */
 import PropTypes from "prop-types";
-
 import HowToStep from "./HowToStep";
-import { stripHTML } from "../../../helpers/stringHelpers";
 import isUndefined from "lodash/isUndefined";
 import moment from "moment";
+import { __ } from "@wordpress/i18n";
 
-const { __ } = window.wp.i18n;
+/* Internal dependencies */
+import { stripHTML } from "../../../helpers/stringHelpers";
+
 const { RichText, InspectorControls } = window.wp.editor;
 const { IconButton, PanelBody, TextControl, ToggleControl } = window.wp.components;
 const { Component, renderToString } = window.wp.element;

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -1,7 +1,8 @@
+/* External dependencies */
 import PropTypes from "prop-types";
+import { __ } from "@wordpress/i18n";
 
 const { Component } = window.wp.element;
-const { __ } = window.wp.i18n;
 const { IconButton } = window.wp.components;
 const { RichText, MediaUpload } = window.wp.editor;
 const { getBlockContent } = window.wp.blocks;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes incorrect import of `@wordpress/i18n`.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Make sure the jed localization error is no longer preset when loading gutenberg.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10673 
