### PR TITLE
Check if properties exists instead of forcing a specific object

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -479,7 +479,12 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * @return string Score markup, or empty string if none available.
 	 */
-	protected function get_post_score( WP_Post $post ) {
+	protected function get_post_score( $post ) {
+		if ( ! is_object( $post ) || ! property_exists( $post, 'ID' ) ) {
+			return '';
+		}
+
+
 		if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
 			return '';
 		}
@@ -528,7 +533,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * @return string Score markup, or empty string if none available.
 	 */
-	protected function get_term_score( WP_Term $term ) {
+	protected function get_term_score( $term ) {
+		if ( ! is_object( $term ) || ! property_exists( $term, 'term_id' ) || property_exists( $term, 'taxonomy' ) ) {
+			return '';
+		}
+
 		$analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -484,7 +484,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			return '';
 		}
 
-
 		if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
 			return '';
 		}
@@ -534,7 +533,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Score markup, or empty string if none available.
 	 */
 	protected function get_term_score( $term ) {
-		if ( ! is_object( $term ) || ! property_exists( $term, 'term_id' ) || property_exists( $term, 'taxonomy' ) ) {
+		if ( ! is_object( $term ) || ! property_exists( $term, 'term_id' ) || ! property_exists( $term, 'taxonomy' ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a type error is thrown when the passed score for terms and posts isn't of the type `WP_Post` as this can collide with third-party plugins.

## Relevant technical choices:

* Instead of forcing the object type I just check if argument is an object and if it contains the needed properties.

## Test instructions

This PR can be tested by following these steps:

* Check if the bullet still works on the adminbar in the frontend when viewing a post and term page.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10646
