### PR TITLE
Set option to use the taxonomy assessor in the term scraper

### DIFF
--- a/js/src/analysis/worker.js
+++ b/js/src/analysis/worker.js
@@ -2,6 +2,7 @@
 import { AnalysisWorkerWrapper, createWorker } from "yoastseo";
 import get from "lodash/get";
 import isUndefined from "lodash/isUndefined";
+import merge from "lodash/merge";
 
 // Internal dependencies.
 import getContentLocale from "./getContentLocale";
@@ -22,14 +23,18 @@ export function createAnalysisWorker() {
 /**
  * Retrieves the analysis configuration for the worker.
  *
+ * @param {Object} [customConfiguration] The custom configuration to use.
+ *
  * @returns {Object} The analysis configuration.
  */
-export function getAnalysisConfiguration() {
-	const configuration = {
+export function getAnalysisConfiguration( customConfiguration = {}) {
+	let configuration = {
 		locale: getContentLocale(),
 		contentAnalysisActive: isContentAnalysisActive(),
 		keywordAnalysisActive: isKeywordAnalysisActive(),
 	};
+
+	configuration = merge( configuration, customConfiguration );
 
 	const translations = getTranslations();
 	if ( ! isUndefined( translations ) && ! isUndefined( translations.domain ) ) {

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -326,7 +326,7 @@ window.yoastHideMarkers = true;
 		}
 
 		// Initialize the analysis worker.
-		YoastSEO.analysisWorker.initialize( getAnalysisConfiguration() )
+		YoastSEO.analysisWorker.initialize( getAnalysisConfiguration( { useTaxonomy: true } ) )
 			.then( () => {
 				jQuery( window ).trigger( "YoastSEO:ready" );
 			} )


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Sets the option to use the taxonomy assessor in the term scraper.

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/YoastSEO.js/pull/1707

Fixes https://github.com/Yoast/YoastSEO.js/issues/1706
