### PR TITLE
Make entire button clickable

### DIFF
--- a/js/src/components/SnippetPreviewModal.js
+++ b/js/src/components/SnippetPreviewModal.js
@@ -31,7 +31,7 @@ class SnippetPreviewModal extends React.Component {
 					title={ __( "Snippet preview", "wordpress-seo" ) }
 					suffixIcon={ { size: "20px", icon: "pencil-square" } }
 					hasSeparator={ true }
-					onTitleClick={ this.openModal }
+					onClick={ this.openModal }
 					{ ...this.props }
 				/>
 				{ this.state.isOpen && <Modal


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Link `yoast-components` branch `10680-make-entire-button-clickable` to `wordpress-seo`. [#714](https://github.com/Yoast/yoast-components/pull/714)
* Make sure the entire `Snippet Editor` button in the Yoast SEO sidebar is clickable.
* **Make sure it works in firefox aswell, because this PR attempts to fix #10682 aswell!**

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10680 
Fixes #10682 
