### PR TITLE
Change label to the front end one

### DIFF
--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -250,7 +250,7 @@ export default class HowTo extends Component {
 
 		return (
 			<div className="schema-how-to-duration">
-				<span>{ __( "Total time:", "wordpress-seo" ) }&nbsp;</span>
+				<span>{  __( "Time needed:", "wordpress-seo" ) }&nbsp;</span>
 				<input
 					className="schema-how-to-duration-input"
 					type="number"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where 'Time needed:' was displayed as 'total time:' in the editor

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Build this branch and verify if you add a how to block in the gutenberg editor the text displays "Time needed:"

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10666 
