### PR TITLE
Backfill changeAssessorOptions

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -4,6 +4,7 @@
 import { App } from "yoastseo";
 import isUndefined from "lodash/isUndefined";
 import debounce from "lodash/debounce";
+import merge from "lodash/merge";
 import {
 	setReadabilityResults,
 	setSeoResultsForKeyword,
@@ -438,6 +439,10 @@ setWordPressSeoL10n();
 					YoastSEO.app.pluggable._registerAssessment( YoastSEO.app.cornerStoneSeoAssessor, name, assessment, pluginName );
 			}
 		};
+		YoastSEO.app.changeAssessorOptions = function( assessorOptions ) {
+			YoastSEO.analysisWorker.initialize( assessorOptions );
+			YoastSEO.app.refresh();
+		};
 
 		edit.initializeUsedKeywords( app, "get_focus_keyword_usage" );
 
@@ -537,7 +542,7 @@ setWordPressSeoL10n();
 				document.getElementById( "yoast_wpseo_is_cornerstone" ).value = currentState.isCornerstone;
 
 				app.changeAssessorOptions( {
-					useCornerStone: currentState.isCornerstone,
+					useCornerstone: currentState.isCornerstone,
 				} );
 			}
 

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -4,7 +4,6 @@
 import { App } from "yoastseo";
 import isUndefined from "lodash/isUndefined";
 import debounce from "lodash/debounce";
-import merge from "lodash/merge";
 import {
 	setReadabilityResults,
 	setSeoResultsForKeyword,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Backfills `YoastSEO.app.changeAssessorOptions`

## Test instructions

This PR can be tested by following these steps:

* Check whether the cornerstone toggle still works (when it's switched on, the text length assessment should prompt you to write at least 900 words; when it's switched off, that value is 300 words).
* For `useKeywordDistribution` you can manually set `window.YoastSEO.app.changeAssessorOptions( { useKeywordDistribution: true } );`. Usually this option is set in Premium (in `metabox.js`). I'm not sure how we can best test that. 

Fixes https://github.com/Yoast/YoastSEO.js/issues/1708