### PR TITLE
Reintroduce structured data blocks feature flag

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -306,7 +306,10 @@ function wpseo_init() {
 
 	$integrations   = array();
 	$integrations[] = new WPSEO_Slug_Change_Watcher();
-	$integrations[] = new WPSEO_Structured_Data_Blocks();
+
+	if ( defined( 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' ) ) {
+		$integrations[] = new WPSEO_Structured_Data_Blocks();
+	}
 
 	foreach ( $integrations as $integration ) {
 		$integration->register_hooks();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* On release/8.1, make sure the How To and FAQ gutenblock are visible without the 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' feature flag in your wp-config.php.
* Check out this branch. Add 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' to your wp-config.php. Make sure the How To and FAQ Gutenblocks are visible in the menu (and is functional, of course)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
