### PR TITLE
fix Undefined index:

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -566,7 +566,7 @@ class WPSEO_OpenGraph_Image {
 	protected function get_image_url_path( $url ) {
 		$parsed_url = wp_parse_url( $url );
 
-		if ( $parsed_url === false ) {
+		if ( $parsed_url === false && !isset( $parsed_url['path'] ) ) {
 			return '';
 		}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -563,9 +563,9 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @return string The path of the image URL. Returns an empty string if URL parsing fails.
 	 */
-	 protected function get_image_url_path( $url ) {
-		 return (string) wp_parse_url( $url, PHP_URL_PATH );
-	 }
+	protected function get_image_url_path( $url ) {
+		return (string) wp_parse_url( $url, PHP_URL_PATH );
+	}
 
 	/**
 	 * Determines the file extension of the passed URL.

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -570,7 +570,7 @@ class WPSEO_OpenGraph_Image {
 			return '';
 		}
 
-		return $parsed_url['path'];
+		return $parsed_url;
 	}
 
 	/**

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -564,9 +564,9 @@ class WPSEO_OpenGraph_Image {
 	 * @return string The path of the image URL. Returns an empty string if URL parsing fails.
 	 */
 	protected function get_image_url_path( $url ) {
-		$parsed_url = wp_parse_url( $url );
+		$parsed_url = wp_parse_url( $url, PHP_URL_PATH );
 
-		if ( $parsed_url === false || !isset( $parsed_url['path'] ) ) {
+		if ( empty($parsed_url) ) {
 			return '';
 		}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -563,15 +563,9 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @return string The path of the image URL. Returns an empty string if URL parsing fails.
 	 */
-	protected function get_image_url_path( $url ) {
-		$parsed_url = wp_parse_url( $url, PHP_URL_PATH );
-
-		if ( empty($parsed_url) ) {
-			return '';
-		}
-
-		return $parsed_url;
-	}
+	 protected function get_image_url_path( $url ) {
+ 		return (string) wp_parse_url( $url, PHP_URL_PATH );
+ 	 }
 
 	/**
 	 * Determines the file extension of the passed URL.

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -566,7 +566,7 @@ class WPSEO_OpenGraph_Image {
 	protected function get_image_url_path( $url ) {
 		$parsed_url = wp_parse_url( $url );
 
-		if ( $parsed_url === false && !isset( $parsed_url['path'] ) ) {
+		if ( $parsed_url === false || !isset( $parsed_url['path'] ) ) {
 			return '';
 		}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -564,8 +564,8 @@ class WPSEO_OpenGraph_Image {
 	 * @return string The path of the image URL. Returns an empty string if URL parsing fails.
 	 */
 	 protected function get_image_url_path( $url ) {
- 		return (string) wp_parse_url( $url, PHP_URL_PATH );
- 	 }
+		 return (string) wp_parse_url( $url, PHP_URL_PATH );
+	 }
 
 	/**
 	 * Determines the file extension of the passed URL.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a `undefined index` notice is given when an OG image url doesn't have a correct path. Props to @Julian-B90 

## Test instructions
* To reproduce this issue create a new post and go to the Yoast Seo social tab, under "Facebook Image" enter ```http://063540.jpfdsfdsfsdg``` or any other broken url. After saving and opening the post you should see an error: ` Notice: Undefined index: path in /srv/www/wordpress-default/public_html/wp-content/plugins/wordpress-seo/frontend/class-opengraph-image.php on line 569`
* Checkout this branch, build, and reload the page. The error should be gone and the page should function normally. 

## Quality assurance
* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10715 
