### PR TITLE
Fix error when async or defer is added to scripts

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -217,8 +217,8 @@ class WPSEO_Admin_Asset_Manager {
 			}
 			else {
 				if ( ! wp_script_is( self::PREFIX . 'lodash', 'registered' ) ) {
-					wp_register_script( self::PREFIX . 'lodash', plugins_url( 'js/vendor/lodash.min.js', WPSEO_FILE ) );
-					wp_add_inline_script( self::PREFIX . 'lodash', 'window.lodash = _.noConflict();', 'after' );
+					wp_register_script( self::PREFIX . 'lodash-base', plugins_url( 'js/vendor/lodash.min.js', WPSEO_FILE ), array(), false, true );
+					wp_register_script( self::PREFIX . 'lodash', plugins_url( 'js/vendor/lodash-noconflict.js', WPSEO_FILE ), array( self::PREFIX . 'lodash-base' ), false, true );
 				}
 				$backport_wp_dependencies[] = self::PREFIX . 'lodash';
 			}

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -56,7 +56,7 @@ module.exports = {
 					"images/**",
 					"inc/**",
 					"cli/**",
-					"js/vendor/**/*.min.js",
+					"js/vendor/**/*.js",
 					"js/dist/**/*.min.js",
 					"js/dist/select2/i18n/*.js",
 					"languages/**",

--- a/js/vendor/lodash-noconflict.js
+++ b/js/vendor/lodash-noconflict.js
@@ -1,0 +1,1 @@
+window.lodash = _.noConflict();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where adding the `defer` or `async` attributes to our script handles would result in an error.

## Relevant technical choices:

* When a plugin or code-snippet would add sync or defer to the lodash script the inline script would refer to `_` even though this wasn't available yet because the `lodash` script was not loaded yet. This PR fixes that by moving the noConflict to a file and enqueuing that file instead.

## Test instructions

This PR can be tested by following these steps:

* Before applying this PR, add this code snippet to your theme's `functions.php`:

```
function defer_parsing_of_js ( $url ) {
	if ( FALSE === strpos( $url, '.js' ) ) return $url;
	if ( strpos( $url, 'jquery.js' ) ) return $url;
	return "$url' defer ";
}
add_filter( 'clean_url', 'defer_parsing_of_js', 11, 1 );
```

* Observe that Yoast SEO breaks in the classic editor in all scenarios
* Apply this PR.
* Test in the classic editor without Gutenberg available, observe our plugin works.
* Test in the classic editor with the classic editor plugin activated, observe our plugin works.
* Test in the classic editor with the classic editor plugin activated and Gutenberg activated, observe our plugin works, but you see `Uncaught TypeError: Cannot read property 'editor' of undefined` which is caused by Gutenberg.
* Test in the classic editor without the classic editor plugin and Gutenberg activated, observe our plugin works, but you see `Uncaught TypeError: Cannot read property 'editor' of undefined` which is caused by Gutenberg.

Note: This doesn't fix it for Gutenberg, because Gutenberg itself has the exact same code snippet that broke our code.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10696