### PR TITLE
Fix filter inconsistency (#10695)

### DIFF
--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -159,7 +159,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$offset = ( $current_page > 1 ) ? ( ( $current_page - 1 ) * $max_entries ) : 0;
 
 		/** This filter is documented in inc/sitemaps/class-taxonomy-sitemap-provider.php */
-		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, $taxonomy );
+		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, array( $taxonomy->name ) );
 		$terms      = get_terms( $taxonomy->name, array( 'hide_empty' => $hide_empty ) );
 		$terms      = array_splice( $terms, $offset, $steps );
 


### PR DESCRIPTION
Use of filter 'wpseo_sitemap_exclude_empty_terms' didn't match it's own documentation

## Summary

This PR can be summarized in the following changelog entry:

* Updated `inc/sitemaps/class-taxonomy-sitemap-provider.php` according to the issue

## Relevant technical choices:

* Just followed the filter documentation (lines 53-60, same file)

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10695
