### PR TITLE
fix og: image Front page setting ignored

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -200,11 +200,6 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	private function set_front_page_image() {
-		$this->set_user_defined_image();
-
-		if ( $this->has_images() ) {
-			return;
-		}
 
 		// If no frontpage image is found, don't add anything.
 		if ( WPSEO_Options::get( 'og_frontpage_image', '' ) === '' ) {


### PR DESCRIPTION
## Summary

Frontpage og:image picked correctly when using Latest Posts as Homepage.
Related #10391

## Relevant technical choices:

* Social

## Test instructions

* Social -> Facobook
* Add Open Graph meta data -> Enabled
* Frontpage settings -> Some Images
* Visit HomePage
* The image set here is output as og: image

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #

This bug is caused by the following code cleanup.
https://github.com/Yoast/wordpress-seo/commit/7ab3718f327078218b1aa2658689003cdb3c24d0#diff-5c8bfdd787da54de896d0e47fe56f892L198