### PR TITLE
Give access to image functions for use in extensions

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -372,7 +372,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @return void
 	 */
-	protected function add_image_by_url( $url ) {
+	public function add_image_by_url( $url ) {
 		if ( empty( $url ) ) {
 			return;
 		}
@@ -442,7 +442,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @return void
 	 */
-	protected function add_image_by_id( $attachment_id ) {
+	public function add_image_by_id( $attachment_id ) {
 		if ( ! $this->is_valid_attachment( $attachment_id ) ) {
 			return;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* None needed.

## Relevant technical choices:

* Made access to `add_image_by_id` and `add_image_by_url` public so it could be properly used in extensions.

