### PR TITLE
Fix OpenGraph image output for homepage

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -200,18 +200,14 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	private function set_front_page_image() {
-		$this->set_user_defined_image();
+		if ( get_option( 'show_on_front' ) === 'page' ) {
+			$this->set_user_defined_image();
 
-		if ( $this->has_images() ) {
+			// Don't fall back to the frontpage image below, as that's not set for this situation, so we should fall back to the default image.
 			return;
 		}
 
-		// If no frontpage image is found, don't add anything.
-		if ( WPSEO_Options::get( 'og_frontpage_image', '' ) === '' ) {
-			return;
-		}
-
-		$this->add_image_by_url( WPSEO_Options::get( 'og_frontpage_image' ) );
+		$this->add_image_by_url( WPSEO_Options::get( 'og_frontpage_image', '' ) );
 	}
 
 	/**

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -181,7 +181,8 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_OpenGraph_Image::set_front_page_image
 	 */
 	public function test_frontpage_image() {
-		WPSEO_Options::set( 'og_frontpage_image', '/test.png' );
+		WPSEO_Options::set( 'og_frontpage_image', '/frontpage.png' );
+		WPSEO_Options::set( 'og_default_image', '/test.png' );
 
 		$current_page_on_front = get_option( 'page_on_front' );
 		$current_show_on_front = get_option( 'show_on_front' );
@@ -195,6 +196,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = $this->setup_class();
 
+		// With a static frontpage, the image should be the default image, or the image from the static front page itself, not the frontpage image.
 		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
 
 		update_option( 'show_on_front', $current_show_on_front );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the OpenGraph image wouldn't show correctly for the frontpage in a few situations. Props @mt8 for the solution direction.

## Test instructions

This PR can be tested by following these steps:

1. Set an image in SEO → Social → Facebook → Frontpage settings.
2. Set a different image for your latest post.
3. Set the homepage to show the latest posts in Settings → Reading.
4. Check the source of the homepage, it will show the image you set in step 1, instead of the one in step 2.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10391 
