### PR TITLE
Include editor affected checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,6 +23,11 @@
 ### Technical info
 * WordPress version:
 * Yoast SEO version:
+<!-- You can check these boxes once you've created the issue. -->
+* If relevant, which editor is affected (or editors): 
+- [ ] Classic Editor
+- [ ] Gutenberg
+- [ ] Classic Editor plugin
 * Relevant plugins in case of a bug:
 <!-- Please make sure you can reproduce this bug with a default theme such as Twenty Seventeen. Sometimes issues may occur due to theme conflicts. -->
 * Tested with theme:


### PR DESCRIPTION
Adds "editor affected" checkboxes. Choose from Classic editor, Gutenberg or the Classic editor plugin.

## Summary

This PR can be summarized in the following changelog entry:

* Not applicable

## Relevant technical choices:

* Not applicable

## Test instructions

This PR can be tested by following these steps:

* Not applicable

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
