### PR TITLE
Loading spinner for term pages

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -103,6 +103,7 @@ class WPSEO_Taxonomy {
 			$asset_manager->enqueue_style( 'scoring' );
 			$asset_manager->enqueue_script( 'metabox' );
 			$asset_manager->enqueue_script( 'term-scraper' );
+			$asset_manager->enqueue_style( 'yoast-components' );
 
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper', 'wpseoTermScraperL10n', $this->localize_term_scraper_script() );
 			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();

--- a/js/src/analysis/getIndicatorForScore.js
+++ b/js/src/analysis/getIndicatorForScore.js
@@ -2,6 +2,7 @@
 
 import isUndefined  from "lodash/isUndefined";
 import { helpers } from "yoastseo";
+import isNil from "lodash/isNil";
 const { scoreToRating } = helpers;
 
 /**
@@ -39,10 +40,6 @@ var getPresenter = function() {
  * @returns {Object} The indicator for the given score.
  */
 function getIndicatorForScore( score ) {
-	// Scale because scoreToRating works from 0 to 10.
-	score /= 10;
-
-
 	var indicator = {
 		className: "",
 		screenReaderText: "",
@@ -50,11 +47,20 @@ function getIndicatorForScore( score ) {
 		screenReaderReadabilityText: "",
 	};
 
-	var presenter = getPresenter();
-
 	if ( ! hasPresenter() ) {
 		return indicator;
 	}
+
+	if ( isNil( score ) ) {
+		indicator.className = "loading";
+
+		return indicator;
+	}
+
+	// Scale because scoreToRating works from 0 to 10.
+	score /= 10;
+
+	var presenter = getPresenter();
 
 	return presenter.getIndicator( scoreToRating( score ) );
 }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -13,7 +13,6 @@ import { setFocusKeyword } from "../../redux/actions/focusKeyword";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
 import { getIconForScore } from "./mapResults";
 import { utils } from "yoast-components";
-import isNil from "lodash/isNil";
 import KeywordSynonyms from "../modals/KeywordSynonyms";
 import Modal from "../modals/Modal";
 import MultipleKeywords from "../modals/MultipleKeywords";
@@ -205,13 +204,9 @@ class SeoAnalysis extends React.Component {
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );
 
-		if ( this.props.keyword === "" ) {
+		if ( score.className !== "loading" && this.props.keyword === "" ) {
 			score.className = "na";
 			score.screenReaderReadabilityText = __( "Enter a focus keyword to calculate the SEO score", "wordpress-seo" );
-		}
-
-		if ( isNil( this.props.overallScore ) ) {
-			score.className = "loading";
 		}
 
 		return (


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where loading spinners wouldn't show up on term pages.

## Relevant technical choices:

* Also optimized some of the indicator's code as it was overriding / checking things at weird times throughout the code.

## Test instructions

This PR can be tested by following these steps:

* Ensure that you now see spinner icons when a term is still loading the analysis.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10720 
