### PR TITLE
Reintroduce parent title code for gutenberg

### DIFF
--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -1,4 +1,4 @@
-/* global wpseoReplaceVarsL10n, require */
+/* global wpseoReplaceVarsL10n, require, wp */
 import forEach from "lodash/forEach";
 import filter from "lodash/filter";
 import trim from "lodash/trim";
@@ -10,6 +10,8 @@ import {
 	refreshSnippetEditor,
 } from "./redux/actions/snippetEditor";
 import "./helpers/babel-polyfill";
+
+import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
 ( function() {
 	var modifiableFields = [
@@ -44,6 +46,7 @@ import "./helpers/babel-polyfill";
 		this.registerReplacements();
 		this.registerModifications();
 		this.registerEvents();
+		this.subscribeToGutenberg();
 	};
 
 	/*
@@ -114,7 +117,7 @@ import "./helpers/babel-polyfill";
 	 * @returns {void}
 	 */
 	YoastReplaceVarPlugin.prototype.registerEvents = function() {
-		var currentScope = wpseoReplaceVarsL10n.scope;
+		const currentScope = wpseoReplaceVarsL10n.scope;
 
 		if ( currentScope === "post" ) {
 			// Set events for each taxonomy box.
@@ -125,6 +128,49 @@ import "./helpers/babel-polyfill";
 			// Add support for custom fields as well.
 			jQuery( "#postcustomstuff > #list-table" ).each( this.bindFieldEvents.bind( this ) );
 		}
+	};
+
+	/**
+	 * Subscribes to Gutenberg to watch a possible parent page change.
+	 *
+	 * @returns {void}
+	 */
+	YoastReplaceVarPlugin.prototype.subscribeToGutenberg = function() {
+		if ( ! isGutenbergDataAvailable() ) {
+			return;
+		}
+		let fetchedParents = { 0: "" };
+		let currentParent  = null;
+		const wpData       = window.wp.data;
+		wpData.subscribe( () => {
+			let newParent = wpData.select( "core/editor" ).getEditedPostAttribute( "parent" );
+			if ( typeof newParent === "undefined" || currentParent === newParent ) {
+				return;
+			}
+			currentParent = newParent;
+			if ( newParent < 1 ) {
+				this._currentParentPageTitle = "";
+				this.declareReloaded();
+				return;
+			}
+			if ( ! isUndefined( fetchedParents[ newParent ] ) ) {
+				this._currentParentPageTitle = fetchedParents[ newParent ];
+				return;
+			}
+			const page = new wp.api.models.Page( { id: newParent } );
+			page.fetch().then(
+				response => {
+					this._currentParentPageTitle = response.title.rendered;
+					fetchedParents[ newParent ]  = this._currentParentPageTitle;
+					this.declareReloaded();
+				}
+			).fail(
+				() => {
+					this._currentParentPageTitle = "";
+					this.declareReloaded();
+				}
+			);
+		} );
 	};
 
 	/**
@@ -509,10 +555,14 @@ import "./helpers/babel-polyfill";
 	 * @returns {string} The data with all its placeholders replaced by actual values.
 	 */
 	YoastReplaceVarPlugin.prototype.parentReplace = function( data ) {
-		var parent = jQuery( "#parent_id, #parent" ).eq( 0 );
+		let parent = jQuery( "#parent_id, #parent" ).eq( 0 );
 
 		if ( this.hasParentTitle( parent ) ) {
 			data = data.replace( /%%parent_title%%/, this.getParentTitleReplacement( parent ) );
+		}
+
+		if ( isGutenbergDataAvailable() && ! isUndefined( this._currentParentPageTitle ) ) {
+			data = data.replace( /%%parent_title%%/, this._currentParentPageTitle );
 		}
 
 		return data;

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -155,6 +155,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 			}
 			if ( ! isUndefined( fetchedParents[ newParent ] ) ) {
 				this._currentParentPageTitle = fetchedParents[ newParent ];
+				this.declareReloaded();
 				return;
 			}
 			const page = new wp.api.models.Page( { id: newParent } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:
* Reintroduced the code from https://github.com/Yoast/wordpress-seo/pull/10587/files that was lost during a merge conflict. 
* I've added a `this.declareReloaded();` within `if ( ! isUndefined( fetchedParents[ newParent ] ) ) {`.
 Without that, the replacevar doesn't update when a previously selected (and thus previously fetched) parent is reselected again. 

## Test instructions

This PR can be tested by following these steps:

* Add or edit a page in Gutenberg mode
* In the snippet preview use %%parent_title%% in the template
* Select a parent page and see the preview showing its title. Switch between different parent pages. Also, make sure to reselect a parent page that has been selected before, because that was broken in the previous implementation.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9263 
Fixes #10724