### PR TITLE
Expose mark button status as a selector

### DIFF
--- a/js/src/redux/selectors/results.js
+++ b/js/src/redux/selectors/results.js
@@ -23,4 +23,14 @@ export function getResultsForKeyword( state, keyword ) {
 	return get( seoResults, keyword, [] );
 }
 
+/**
+ * Returns the marks button status.
+ *
+ * @param {object} state The state.
+ *
+ * @returns {string} The status of the mark buttons.
+ */
+export function getMarkButtonStatus( state ) {
+	return state.marksButtonStatus;
+}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _not applicable_

## Relevant technical choices:

* This selector is automatically exposed to `wp.data.select( "yoast-seo/editor" )` which we can use in premium.

## Test instructions

This PR can be tested by following these steps:

* Run `wp.data.select( "yoast-seo/editor" )` in the console and see that you see the status of the mark buttons.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Relates to https://github.com/Yoast/YoastSEO.js/issues/1723