### PR TITLE
Fix keyboard trap on the How-to block steps

### DIFF
--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -195,17 +195,22 @@ export default class HowTo extends Component {
 	}
 
 	/**
-	 * Sets the focus to a specific step in the How-to block.
+	 * Sets the focus to a specific element in the How-to block.
 	 *
-	 * @param {number|string} focus the element to focus, either the index of the step that should be in focus or name of the input.
+	 * @param {number|string} elementToFocus The element to focus: either the index of
+	 *                                       a step or a focusable element ref name.
 	 *
 	 * @returns {void}
 	 */
-	setFocus( focus ) {
-		this.setState( { focus } );
+	setFocus( elementToFocus ) {
+		if ( elementToFocus === this.state.focus ) {
+			return;
+		}
 
-		if ( this.editorRefs[ focus ] ) {
-			this.editorRefs[ focus ].focus();
+		this.setState( { focus: elementToFocus } );
+
+		if ( this.editorRefs[ elementToFocus ] ) {
+			this.editorRefs[ elementToFocus ].focus();
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves focus management in the How-to block to avoid a keyboard trap

## Relevant technical choices:

Inspired by what is already implemented in the `faq` component, avoids to continuously set focus on a step field when pressing the Tab key. In other words, when a step field is already focused, there's no need to set focus on it again and again.

## Test instructions

- build the JS
- add a How-to block with some steps
- using only the keyboard, verify there are no keyboard traps and you can Tab through all the block's UI elements, for example the add image, delete, add buttons:

<img width="721" alt="screen shot 2018-08-23 at 18 05 47" src="https://user-images.githubusercontent.com/1682452/44537701-c2cebc80-a6ff-11e8-9b1b-eff1a7f7aaa4.png">

- verify all the previous behaviors work correctly, for example:
  - when adding a step, focus is moved to the new step field
  - when removing a step, focus is moved to the previous step field
  - when removing the first step, focus is moved to the how-to description field
  - when moving a step up or down, focus is moved to its step field 
  - when splitting a step (press Enter while cursor is within the step), focus is moved to the splitted, new, step

Fixes #10752
