### PR TITLE
Add initial scale for viewport meta tag for the onboarding wizard

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -106,7 +106,7 @@ class WPSEO_Configuration_Page {
 		<html <?php language_attributes(); ?>>
 		<!--<![endif]-->
 		<head>
-			<meta name="viewport" content="width=device-width"/>
+			<meta name="viewport" content="width=device-width", initial-scale=1/>
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 			<title><?php
 				printf(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes incorrect zooming on older iPhones for the installation wizard

## Relevant technical choices:

* Not applicable

## Test instructions

This PR can be tested by following these steps:

* To test it, you should check the configuration wizard page on a an old iPhone (or maybe the Chrome emulator, worth trying) and change device orientation. After the orientation change, iPhones used to incorrectly zoom the page, and the `initial-scale=1` should fix that.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
#5597 