### PR TITLE
Always refresh previously used keywords.

### DIFF
--- a/js/src/analysis/usedKeywords.js
+++ b/js/src/analysis/usedKeywords.js
@@ -53,10 +53,13 @@ UsedKeywords.prototype.init = function() {
 		.then( () => {
 			this._initialized = true;
 
-			if ( ! isEqual( this._options.usedKeywords, this._keywordUsage ) ) {
-				worker.sendMessage( "updateKeywordUsage", this._keywordUsage, "used-keywords-assessment" )
-					.then( () => this._app.refresh() );
+			if ( isEqual( this._options.usedKeywords, this._keywordUsage ) ) {
+				this._app.refresh();
+				return;
 			}
+
+			worker.sendMessage( "updateKeywordUsage", this._keywordUsage, "used-keywords-assessment" )
+				.then( () => this._app.refresh() );
 		} )
 		.catch( error => console.error( error ) );
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N.A.

## Relevant technical choices:

* Sets the previously used keywords assessment to run when it's loaded not just when keywords have been changed while loading.

## Test instructions

This PR can be tested by following these steps:

* Have a post with a keyword that you've used before.
* Load the post edit.
* You should immediately see the assessment that you've used this keyword before.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/10741
