### PR TITLE
Add descriptions to the How-to and FAQ blocks

### DIFF
--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -10,6 +10,7 @@ const { registerBlockType } = window.wp.blocks;
 export default () => {
 	registerBlockType( "yoast/faq-block", {
 		title: __( "FAQ", "wordpress-seo" ),
+		description: __( "List your Frequently Asked Questions in an SEO-friendly way.", "wordpress-seo" ),
 		icon: "editor-ul",
 		category: "yoast-structured-data-blocks",
 		keywords: [

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -49,6 +49,7 @@ const attributes = {
 export default () => {
 	registerBlockType( "yoast/how-to-block", {
 		title: __( "How-to", "wordpress-seo" ),
+		description: __( "Create a How-to guide in an SEO-friendly way.", "wordpress-seo" ),
 		icon: "editor-ol",
 		category: "yoast-structured-data-blocks",
 		keywords: [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add descriptions to the How-to and FAQ blocks

## Test instructions

- build the JS
- add a How-to and a FAQ block to a post
- verify the blocks have a description in the Sidebar inspector

<img width="305" alt="screen shot 2018-08-24 at 15 15 29" src="https://user-images.githubusercontent.com/1682452/44586617-9d4dbb80-a7b0-11e8-91aa-3d491dea324f.png">

<img width="317" alt="screen shot 2018-08-24 at 15 15 38" src="https://user-images.githubusercontent.com/1682452/44586619-9d4dbb80-a7b0-11e8-824c-86ef02ccea6a.png">

Note:
running grunt eslint locally gives me one unrelated error in refreshAnalysis.js, will check where it comes from

Fixes #10765
