### PR TITLE
Make og:url unpaginated by default

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -268,7 +268,7 @@ class WPSEO_OpenGraph {
 		 *
 		 * @api string $unsigned Canonical URL.
 		 */
-		$url = apply_filters( 'wpseo_opengraph_url', WPSEO_Frontend::get_instance()->canonical( false ) );
+		$url = apply_filters( 'wpseo_opengraph_url', WPSEO_Frontend::get_instance()->canonical( false, true ) );
 
 		if ( is_string( $url ) && $url !== '' ) {
 			$this->og_tag( 'og:url', esc_url( $url ) );


### PR DESCRIPTION
## Summary
Changes `og:url` to never have the paginated state of a page.

## Explanation
Google has a concept of `rel="next"` / `rel="prev"` in combination with `rel="canonical"` to deal with paginated states of archives. Facebook however has no such thing. Sharing page 2 of an archive therefore doesn't make all that much sense, especially as the content of that page is always going to be transient, because of the reverse chronological order of archives in WordPress.

This PR can be summarized in the following changelog entry:

* The `og:url` of archive URLs (category archives, author archives, blog archives) now always shows the non-paginated URL for that archive.

## Test instructions

This PR can be tested by following these steps:

* Go to page 2, 3, 4 of any archive, see the `og:url` is pointing to page 1.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
