### PR TITLE
Remove Gutenblocks featureflag

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -307,9 +307,7 @@ function wpseo_init() {
 	$integrations   = array();
 	$integrations[] = new WPSEO_Slug_Change_Watcher();
 
-	if ( defined( 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' ) ) {
 		$integrations[] = new WPSEO_Structured_Data_Blocks();
-	}
 
 	foreach ( $integrations as $integration ) {
 		$integration->register_hooks();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* On trunk, make sure the How To and FAQ gutenblocks are only visible when you have the 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' feature flag in your wp-config.php, and not when you don't.
* Check out this branch. Remove 'YOAST_FEATURE_GUTENBERG_STRUCTURED_DATA_BLOCKS' from your wp-config.php. Make sure the How To and FAQ Gutenblock are still available.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


Fixes #10778 
