### PR TITLE
Auto-detect value for the WP_PLUGIN_DIR constant when loading the test suite

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,8 @@ echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 
 if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
+} else {
+	define( 'WP_PLUGIN_DIR', dirname( dirname( dirname( __FILE__ ) ) ) );
 }
 
 $GLOBALS['wp_tests_options'] = array(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where the test suite would not execute correctly without a `WP_PLUGIN_DIR` environment variable specified.

## Relevant technical choices:

* The correctly plugins directory will always be one level higher than the `wordpress-seo` plugin directory, so we can easily auto-detect it, independently of the `WP_PLUGIN_DIR` environment variable.
* This makes it easier to run test, as we no longer require to set up this environment variable on your setup (for example on VVV).

## Test instructions

This PR can be tested by following these steps:

* Use a setup like VVV.
* Run the plugin from a WordPress installation that is different from the one that hosts the WordPress core test suite you used (the core test suite's location used is typically set in either the `WP_TESTS_DIR` of `WP_DEVELOP_DIR` environment variable).
* Ensure that no `WP_PLUGIN_DIR` environment variable is set.
* Run the test suite and ensure you don't see any errors about undefined constants etc.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended (not applicable)

Fixes #10789 
