### PR TITLE
10490 replace inlinks taget url gsc

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -273,9 +273,9 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		) );
 		$wp_admin_bar->add_menu( array(
 			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-inlinks-ose',
-			'title'  => __( 'Check Inlinks (OSE)', 'wordpress-seo' ),
-			'href'   => '//moz.com/researchtools/ose/links?site=' . urlencode( $url ),
+			'id'     => 'wpseo-inlinks',
+			'title'  => __( 'Check Inlinks', 'wordpress-seo' ),
+			'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . urlencode( $url ) . '&domain=',
 			'meta'   => array( 'target' => '_blank' ),
 		) );
 		$wp_admin_bar->add_menu( array(

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -274,7 +274,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$wp_admin_bar->add_menu( array(
 			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
 			'id'     => 'wpseo-inlinks',
-			'title'  => __( 'Check Inlinks', 'wordpress-seo' ),
+			'title'  => __( 'Check links to this URL', 'wordpress-seo' ),
 			'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . urlencode( $url ) . '&domain=',
 			'meta'   => array( 'target' => '_blank' ),
 		) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaces the "Check Inlinks (OSE)" menu item from the Yoast Admin bar dropdown "Analyze this page" from the Moz OpenSite Explorer (OSE) to Google Search Console as the former service is being disabled on August 30th 2018.

## Relevant technical choices:

* Change link to Google Search Console

## Test instructions

This PR can be tested by following these steps:

* Go to a page on the front-end of the site
* Use the "Y"-oast dropdown in the Admin Bar
  * Open "Analyze this page"
  * Use the "Check links to this URL"
  * See that it opens Google Search Console with the URL of the current page

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10490 
