### PR TITLE
Do not enqueue yoast-components.scss in the edit post and term pages

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -773,7 +773,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager->enqueue_style( 'metabox-css' );
 		$asset_manager->enqueue_style( 'scoring' );
 		$asset_manager->enqueue_style( 'select2' );
-		$asset_manager->enqueue_style( 'yoast-components' );
 
 		$asset_manager->enqueue_script( 'metabox' );
 		$asset_manager->enqueue_script( 'help-center' );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -103,7 +103,6 @@ class WPSEO_Taxonomy {
 			$asset_manager->enqueue_style( 'scoring' );
 			$asset_manager->enqueue_script( 'metabox' );
 			$asset_manager->enqueue_script( 'term-scraper' );
-			$asset_manager->enqueue_style( 'yoast-components' );
 
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper', 'wpseoTermScraperL10n', $this->localize_term_scraper_script() );
 			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();

--- a/css/src/_wp.scss
+++ b/css/src/_wp.scss
@@ -1,4 +1,4 @@
-/* WordPress-specific styling. */
+/* WordPress-specific styling to be used only for single-page apps like the Onboarding Wizard. */
 body {
 	background: #f1f1f1;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -4,6 +4,7 @@
 /*rtl:begin:ignore*/
 @import "../../node_modules/draft-js/dist/Draft";
 /*rtl:end:ignore*/
+@import "../../node_modules/yoast-components/css/loadingSpinner";
 
 @function svg-icon-list($color) {
 	@return inline-svg('<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path fill="#{$color}" d="M384 1408q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm0-512q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm1408 416v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5zm-1408-928q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm1408 416v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5zm0-512v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5z"/></svg>');

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -1,3 +1,4 @@
+/* This file is meant to be used exclusively for the Onboarding Wizard. */
 @import "../../node_modules/sassdash/scss/sassdash";
 @import "wp";
 @import "../../node_modules/yoast-components/css/all.scss";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix CSS conflicts by removing the enqueued `yoast-components` stylesheet from the edit post and edit term pages

## Relevant technical choices:

- `yoast-components.scss` is meant to be used in the Onboarding Wizard or other single-apps pages, it shouldn't be used in the WordPress pages as it uses some styles that conflict with the WordPress ones
- added a couple comments to clarify its usage
- removed the enqueued `yoast-components` added in #10628 and #10742
- added the styles for the loadingSpinner icon by directly importing the single `loadingSpinner.scss` from the yoast-component package, as we do for other similar cases
- this also avoids to import all the Onboarding Wizard styles in the edit post and term pages, where it's unused

## Test instructions

- create a new post in the Classic Editor and verify the placeholder for new post title ("Enter title here") doesn't look misplaced
- open an existing post and, while the analysis results are loading, verify the spinning icons appear correctly in the metabox, on the left of the "Readability" and "Focus Keyword" headings
- open an existing post in Gutenberg and verify the spinning icons appear correctly both in the metabox and in the plugin sidebar (you must be very fast to click to switch the sidebar to the plugin one)

Fixes #10774
Fixes https://github.com/Yoast/wordpress-seo/issues/10775