### PR TITLE
Fix bug where nl_NL would not contain all translations

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -43,6 +43,11 @@ build:
 # Download and build the latest translations
 'build:i18n:translations':
   - 'glotpress_download'
+
+  # Custom tasks required because of WordPress.org
+  - 'copy:de_CH-informal'
+  - 'clean:after-po-download'
+
   - 'copy:json-translations'
   - 'po2json'
   - 'i18n-clean-json'

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -4,6 +4,9 @@ module.exports = {
 		"<%= paths.languages %>*",
 		"!<%= paths.languages %>index.php",
 	],
+	"after-po-download": [
+		"<%= paths.languages %><%= pkg.plugin.textdomain %>-*-{formal,informal,ao90}.{po,json}",
+	],
 	"po-files": [
 		"<%= paths.languages %>*.po",
 		"<%= paths.languages %><%= pkg.plugin.textdomain %>-temp.pot",

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -42,6 +42,20 @@ module.exports = {
 		src: "gettext.pot",
 		dest: "<%= files.pot.wordpressSeoJs %>",
 	},
+	// The default de_CH is formal on WordPress.org, but that one is not translated enough for wordpress-seo.
+	// So we need to copy the `-informal` so we have a good translation.
+	"de_CH-informal": {
+		files: [
+			{
+				src: "<%= paths.languages %>/<%= pkg.plugin.textdomain %>-de_CH-informal.po",
+				dest: "<%= paths.languages %>/<%= pkg.plugin.textdomain %>-de_CH.po",
+			},
+			{
+				src: "<%= paths.languages %>/<%= pkg.plugin.textdomain %>-de_CH-informal.json",
+				dest: "<%= paths.languages %>/<%= pkg.plugin.textdomain %>-de_CH.json",
+			},
+		],
+	},
 	artifact: {
 		files: [
 			{

--- a/grunt/config/glotpress_download.js
+++ b/grunt/config/glotpress_download.js
@@ -4,7 +4,7 @@ module.exports = {
 		options: {
 			url: "<%= pkg.plugin.glotpress %>",
 			domainPath: "<%= paths.languages %>",
-			file_format: "%domainPath%/%textdomain%-%wp_locale%.%format%",
+			file_format: "%domainPath%/%textdomain%-%wp_locale%%slugSuffix%.%format%",
 			slug: "wp-plugins/<%= pkg.plugin.textdomain %>/dev/",
 			textdomain: "<%= pkg.plugin.textdomain %>",
 			formats: [ "po" ],
@@ -19,7 +19,7 @@ module.exports = {
 		options: {
 			url: "<%= pkg.plugin.glotpress %>",
 			domainPath: "<%= paths.languages %>",
-			file_format: "%domainPath%/%textdomain%-%wp_locale%.json",
+			file_format: "%domainPath%/%textdomain%-%wp_locale%%slugSuffix%.json",
 			slug: "wp-plugins/<%= pkg.plugin.textdomain %>/dev/",
 			textdomain: "<%= pkg.plugin.textdomain %>",
 			formats: [ "jed1x" ],

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "grunt-contrib-cssmin": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-eslint": "^19.0.0",
-    "grunt-glotpress": "^0.2.2",
+    "grunt-glotpress": "https://github.com/Yoast/grunt-glotpress.git#master",
     "grunt-phpcs": "^0.4.0",
     "grunt-phplint": "^0.1.0",
     "grunt-po2json": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4578,9 +4578,9 @@ grunt-eslint@^19.0.0:
     chalk "^1.0.0"
     eslint "^3.0.0"
 
-grunt-glotpress@^0.2.2:
+"grunt-glotpress@https://github.com/Yoast/grunt-glotpress.git#master":
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/grunt-glotpress/-/grunt-glotpress-0.2.2.tgz#1bdb00c80157f42740163fb3772a091f16f35d97"
+  resolved "https://github.com/Yoast/grunt-glotpress.git#6c0b12698cdc3e6e1b686bd74286c5595615e5b2"
   dependencies:
     request "^2.79.0"
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

But only sometimes. This was because it would be overwritten by its formal counterpart. It seemed random because the last one to download would be the file on disk.

This required a change in grunt-glotpress, because it didn't expose the slug before. The slug has the formal/informal information. With this change we can change the fileFormat. That makes sure that the files are not overwritten.

Some additional changes are necessary to cleanup the languages folder. All files with suffixes are removed. This is because we currently don't support any formal languages. We can fix this later.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn`
* Run `grunt build:i18n` and see that all languages are correctly downloaded.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended