### PR TITLE
Reduce zip size with compression level

### DIFF
--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -9,14 +9,13 @@ module.exports = {
 	],
 	"po-files": [
 		"<%= paths.languages %>*.po",
-		"<%= paths.languages %><%= pkg.plugin.textdomain %>-temp.pot",
+		"<%= paths.languages %>*.pot",
 		"<%= paths.languages %>yoast-seo.json",
 
 		"<%= files.pot.yoastComponents %>",
 		"<%= files.pot.yoastComponentsConfigurationWizard %>",
 		"<%= files.pot.yoastComponentsRemaining %>",
 		"<%= files.pot.wordpressSeoJs %>",
-		"<%= paths.languages %>yoast-components.pot",
 		"<%= paths.languages %>yoast-components.json",
 
 		"<%= files.pot.yoastseojs %>",

--- a/grunt/config/compress.js
+++ b/grunt/config/compress.js
@@ -2,6 +2,7 @@ module.exports = {
 	artifact: {
 		options: {
 			archive: "artifact.zip",
+			level: 9,
 		},
 		files: [
 			{


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Increases the zip compression level in the grunt configuration, this results in a highly reduced artifact filesize.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn`
* Run `grunt artifact`
* See the `artifact.zip` filesize being smaller than without this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #
