### PR TITLE
Add debounce to refresh

### DIFF
--- a/js/src/analysis/constants.js
+++ b/js/src/analysis/constants.js
@@ -1,0 +1,1 @@
+export const refreshDelay = 1000;

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -34,6 +34,7 @@ import isContentAnalysisActive from "./analysis/isContentAnalysisActive";
 import snippetEditorHelpers from "./analysis/snippetEditor";
 import CustomAnalysisData from "./analysis/CustomAnalysisData";
 import getApplyMarks from "./analysis/getApplyMarks";
+import { refreshDelay } from "./analysis/constants";
 
 // Redux dependencies.
 import { setFocusKeyword } from "./redux/actions/focusKeyword";
@@ -417,13 +418,13 @@ setWordPressSeoL10n();
 		window.YoastSEO.analysis.applyMarks = ( paper, marks ) => getApplyMarks( YoastSEO.store )( paper, marks );
 
 		// YoastSEO.app overwrites.
-		YoastSEO.app.refresh = () => refreshAnalysis(
+		YoastSEO.app.refresh = debounce( () => refreshAnalysis(
 			YoastSEO.analysis.worker,
 			YoastSEO.analysis.collectData,
 			YoastSEO.analysis.applyMarks,
 			YoastSEO.store,
 			postDataCollector,
-		);
+		), refreshDelay );
 		YoastSEO.app.registerCustomDataCallback = customAnalysisData.register;
 		YoastSEO.app.pluggable = new Pluggable( YoastSEO.app.refresh );
 		YoastSEO.app.registerPlugin = YoastSEO.app.pluggable._registerPlugin;

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -12,7 +12,7 @@ import debounce from "lodash/debounce";
 
 // Internal dependencies.
 import Edit from "./edit";
-import { termsTmceId as tmceId } from "./wp-seo-tinymce";
+import { termsTmceId } from "./wp-seo-tinymce";
 import Pluggable from "./Pluggable";
 
 // UI dependencies.
@@ -31,7 +31,6 @@ import snippetEditorHelpers from "./analysis/snippetEditor";
 import TermDataCollector from "./analysis/TermDataCollector";
 import CustomAnalysisData from "./analysis/CustomAnalysisData";
 import getApplyMarks from "./analysis/getApplyMarks";
-import { termsTmceId } from "./wp-seo-tinymce";
 
 // Redux dependencies.
 import { refreshSnippetEditor, updateData } from "./redux/actions/snippetEditor";
@@ -238,7 +237,7 @@ window.yoastHideMarkers = true;
 
 		args = {
 			// ID's of elements that need to trigger updating the analyzer.
-			elementTarget: [ tmceId, "yoast_wpseo_focuskw", "yoast_wpseo_metadesc", "excerpt", "editable-post-name", "editable-post-name-full" ],
+			elementTarget: [ termsTmceId, "yoast_wpseo_focuskw", "yoast_wpseo_metadesc", "excerpt", "editable-post-name", "editable-post-name-full" ],
 			targets: retrieveTargets(),
 			callbacks: {
 				getData: termScraper.getData.bind( termScraper ),

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -31,6 +31,7 @@ import snippetEditorHelpers from "./analysis/snippetEditor";
 import TermDataCollector from "./analysis/TermDataCollector";
 import CustomAnalysisData from "./analysis/CustomAnalysisData";
 import getApplyMarks from "./analysis/getApplyMarks";
+import { refreshDelay } from "./analysis/constants";
 
 // Redux dependencies.
 import { refreshSnippetEditor, updateData } from "./redux/actions/snippetEditor";
@@ -285,13 +286,13 @@ window.yoastHideMarkers = true;
 		window.YoastSEO.analysis.applyMarks = ( paper, result ) => getApplyMarks( YoastSEO.store )( paper, result );
 
 		// YoastSEO.app overwrites.
-		YoastSEO.app.refresh = () => refreshAnalysis(
+		YoastSEO.app.refresh = debounce( () => refreshAnalysis(
 			YoastSEO.analysis.worker,
 			YoastSEO.analysis.collectData,
 			YoastSEO.analysis.applyMarks,
 			YoastSEO.store,
 			termScraper
-		);
+		), refreshDelay );
 		YoastSEO.app.registerCustomDataCallback = customAnalysisData.register;
 		YoastSEO.app.pluggable = new Pluggable( YoastSEO.app.refresh );
 		YoastSEO.app.registerPlugin = YoastSEO.app.pluggable._registerPlugin;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where the user input would trigger an analysis every time.

## Relevant technical choices:

* Added a debounce of 1 sec to the refresh.

## Test instructions

This PR can be tested by following these steps:

* Check how often the refresh is getting called when you spam.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/YoastSEO.js/issues/1742
