### PR TITLE
Fix store in term scraper

### DIFF
--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -56,7 +56,6 @@ window.yoastHideMarkers = true;
 
 	var termSlugInput;
 
-	let store;
 	let edit;
 	const customAnalysisData = new CustomAnalysisData();
 
@@ -110,7 +109,7 @@ window.yoastHideMarkers = true;
 			slug: termSlugInput.val(),
 		};
 
-		store.dispatch( updateData( snippetEditorData ) );
+		YoastSEO.store.dispatch( updateData( snippetEditorData ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where changing the WordPress slug would not correctly update the snippet editor.

## Relevant technical choices:

* Remove the store from the jQuery scope and use the window scope instead.

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10820 
