### PR TITLE
Make the snippet preview modal content always scrollable

### DIFF
--- a/js/src/components/SnippetPreviewModal.js
+++ b/js/src/components/SnippetPreviewModal.js
@@ -36,7 +36,6 @@ class SnippetPreviewModal extends React.Component {
 				/>
 				{ this.state.isOpen && <Modal
 					title={ __( "Snippet preview", "wordpress-seo" ) }
-					style={ { height: "initial", minHeight: "50px" } }
 					onRequestClose={ this.closeModal }>
 					<SnippetEditorWrapper showCloseButton={ false } hasPaperStyle={ false } />
 					<Button isDefault onClick={ this.closeModal }>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

This PR restores the plugin modal scrolling when the viewport height is smaller than the modal height.
Previously, the modal used an inline style set via the component `style` prop:

`style={ { height: "initial", minHeight: "50px" } }`

The modal content uses `overflow: auto` to make its content scrollable but the scrolling mechanism needs a computed height to work. It doesn't work with `height: initial` or `height: auto` so this inline style is not a viable option. The PR removes this inline style. Now the modal content is scrollable again. The downside is that on big screens the modal height won't be based on its content height any longer and it will be the default height of the Gutenberg component (70%). This should be improved upstream and there's already an issue for that. I've also explored a possible solution, will push a PR soon.

## Test instructions

This PR can be tested by following these steps:

- first, reproduce the bug on master:
- use the Chrome device emulator and set it to `iPhone 6/7/8` or `iPhone 6/7/8 Plus` in landscape orientation
- edit a post and open the snippet preview modal from the plugin sidebar
- verify the modal content is not scrollable
- switch to this branch and build the JS
- test again and verify the modal content is now scrollable

As said, on big screens the modal won't extend his height to the content height and will be limited to 70%, see in the screenshot below:

![screen shot 2018-08-29 at 08 53 56](https://user-images.githubusercontent.com/1682452/44771208-a81a9e80-ab6a-11e8-9e38-6464b0a317a9.png)

Fixes #10811 
Fixes #10703 
