### PR TITLE
Replace h3 with strong

### DIFF
--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -136,7 +136,7 @@ export default class Question extends Component {
 		return(
 			<div className={ "schema-faq-question" } key={ question.id }>
 				<RichText.Content
-					tagName="h3"
+					tagName="strong"
 					className="schema-faq-question-question"
 					key={ question.id + "-question" }
 					value={ question.question }
@@ -172,7 +172,7 @@ export default class Question extends Component {
 			<div className="schema-faq-question" key={ id } >
 				<RichText
 					className="schema-faq-question-question"
-					tagName="h3"
+					tagName="strong"
 					onSetup={ ( ref ) => editorRef( "question", ref ) }
 					key={ id + "-question" }
 					value={ question }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Howto block now has strongs, so made the FAQ block look more alike.

## Test instructions

This PR can be tested by following these steps:

* Verify that both in the editor and in published posts the FAQ block has no headers, but strongs.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


