### PR TITLE
Publish and modify date time should not be localized

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -712,10 +712,12 @@ class WPSEO_OpenGraph {
 			}
 		}
 
-		$pub = get_the_date( DATE_W3C );
+		$post = get_post();
+
+		$pub = mysql2date( DATE_W3C, $post->post_date, false );
 		$this->og_tag( 'article:published_time', $pub );
 
-		$mod = get_the_modified_date( DATE_W3C );
+		$mod = mysql2date( DATE_W3C, $post->post_modified, false );
 		if ( $mod !== $pub ) {
 			$this->og_tag( 'article:modified_time', $mod );
 			$this->og_tag( 'og:updated_time', $mod );


### PR DESCRIPTION
I'm changing the date time string to Bangla character which is Unicode. You can see the code [here](https://gist.github.com/AminulBD/7ae9ac9f5043db986433f28ba69f6cea) This function makes the date time string to Unicode characters which are invalid for facebook. That's why the date time should not be localized or translated by any other method.

Problem screenshot:
![fix](https://user-images.githubusercontent.com/5006546/44874184-276bb780-acbc-11e8-99c3-f1b001aff87f.png)



## Summary

This PR can be summarized in the following changelog entry:

* Prevent localize the Open Graph publish and modify DateTime string.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Install and activate the plugin from the gist linked above.
* Make sure the OpenGraph meta tags for dates do not show localized numbers.

## Quality assurance

- [x] Mercury I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
