### PR TITLE
Adjust the how-to time needed input fields styling.

### DIFF
--- a/css/src/structured-data-blocks.scss
+++ b/css/src/structured-data-blocks.scss
@@ -1,7 +1,8 @@
 .schema-how-to-duration .schema-how-to-duration-input[type="number"] {
 	width: 40px;
 	margin: 0 2px;
-	text-align: right;
+	padding: 6px 4px;
+	text-align: center;
 	-moz-appearance: textfield;
 
 	&::-webkit-outer-spin-button, &::-webkit-inner-spin-button {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

I've tried several things, seems Firefox Quantum reserves some space for the "spin buttons" in the number input fields  even if they're hidden. See codepen https://codepen.io/afercia/full/dqNVNr/ in Firefox and compare it to the rendering in Chrome.

The only thing I've found that worked in Firefox was `letter-spacing: -1px` but it didn't work in Edge. So the only solution I see is:
- reduce the left/right padding
- make the text in the input fields horizontally centered

## Test instructions

- build the CSS and JS
- add a How-to block, open the Time needed form
- check the placeholders, especially the `MM` one are fully visible in Firefox
- same in Edge

Screenshot:

<img width="410" alt="screen shot 2018-08-31 at 15 16 53" src="https://user-images.githubusercontent.com/1682452/44914556-ec579b80-ad30-11e8-8c75-f33ea3467eb7.png">

Fixes #10780
