### PR TITLE
Add wp-api dependency to post-scraper script

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -334,6 +334,7 @@ class WPSEO_Admin_Asset_Manager {
 					self::PREFIX . 'replacevar-plugin',
 					self::PREFIX . 'shortcode-plugin',
 					'wp-util',
+					'wp-api',
 					self::PREFIX . 'wp-globals-backport',
 					self::PREFIX . 'analysis',
 					self::PREFIX . 'react-dependencies',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes `TypeError: Cannot read property 'getCollectionByRoute' of undefined` error when editing a post in gutenberg.

## Relevant technical choices:

* Before Gutenberg 3.7, we were depending on Gutenberg loading Wordpress's `wp-api`. Since 3.7, Gutenberg is not loading `wp-api` anymore, which broke our implementation and resulted in the Gutenberg editor crashing. This PR adds `wp-api` to our asset manager as a dependency of post scraper.

## Test instructions

This PR can be tested by following these steps:

* Download Gutenberg 3.7 from the repo.
* Open `Settings` (GearWheel) > `Document` > `Categories`
* Open a post. See the editor crashing:
<img width="1077" alt="schermafbeelding 2018-08-31 om 16 33 48" src="https://user-images.githubusercontent.com/17744553/44919076-de0f7c80-ad3c-11e8-9325-c88cafc98437.png">
* Checkout this branch and build it. Open a post, and see the editor working.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10867 
