### PR TITLE
Fix OpenGraph output for overridden canonicals

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -268,7 +268,14 @@ class WPSEO_OpenGraph {
 		 *
 		 * @api string $unsigned Canonical URL.
 		 */
-		$url = apply_filters( 'wpseo_opengraph_url', WPSEO_Frontend::get_instance()->canonical( false, true ) );
+		$url = apply_filters( 'wpseo_opengraph_url', WPSEO_Frontend::get_instance()->canonical( false ) );
+
+		$unpaged_url = WPSEO_Frontend::get_instance()->canonical( false, true );
+		// If the unpaged URL is the same as the normal URL but just with pagination added, use that.
+		// This makes sure we always use the unpaged URL when we can, but doesn't break for overridden canonicals.
+		if ( is_string( $unpaged_url ) && strpos( $url, $unpaged_url ) === 0 ) {
+			$url = $unpaged_url;
+		}
 
 		if ( is_string( $url ) && $url !== '' ) {
 			$this->og_tag( 'og:url', esc_url( $url ) );

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -263,10 +263,13 @@ class WPSEO_OpenGraph {
 	 * @return boolean
 	 */
 	public function url() {
-		$url         = WPSEO_Frontend::get_instance()->canonical( false );
+		$url         = WPSEO_Frontend::get_instance()->canonical( false, false );
 		$unpaged_url = WPSEO_Frontend::get_instance()->canonical( false, true );
-		// If the unpaged URL is the same as the normal URL but just with pagination added, use that.
-		// This makes sure we always use the unpaged URL when we can, but doesn't break for overridden canonicals.
+
+		/*
+		 * If the unpaged URL is the same as the normal URL but just with pagination added, use that.
+		 * This makes sure we always use the unpaged URL when we can, but doesn't break for overridden canonicals.
+		 */
 		if ( is_string( $unpaged_url ) && strpos( $url, $unpaged_url ) === 0 ) {
 			$url = $unpaged_url;
 		}

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -263,19 +263,20 @@ class WPSEO_OpenGraph {
 	 * @return boolean
 	 */
 	public function url() {
-		/**
-		 * Filter: 'wpseo_opengraph_url' - Allow changing the OpenGraph URL.
-		 *
-		 * @api string $unsigned Canonical URL.
-		 */
-		$url = apply_filters( 'wpseo_opengraph_url', WPSEO_Frontend::get_instance()->canonical( false ) );
-
+		$url         = WPSEO_Frontend::get_instance()->canonical( false );
 		$unpaged_url = WPSEO_Frontend::get_instance()->canonical( false, true );
 		// If the unpaged URL is the same as the normal URL but just with pagination added, use that.
 		// This makes sure we always use the unpaged URL when we can, but doesn't break for overridden canonicals.
 		if ( is_string( $unpaged_url ) && strpos( $url, $unpaged_url ) === 0 ) {
 			$url = $unpaged_url;
 		}
+
+		/**
+		 * Filter: 'wpseo_opengraph_url' - Allow changing the OpenGraph URL.
+		 *
+		 * @api string $unsigned Canonical URL.
+		 */
+		$url = apply_filters( 'wpseo_opengraph_url', $url );
 
 		if ( is_string( $url ) && $url !== '' ) {
 			$this->og_tag( 'og:url', esc_url( $url ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Properly output the manually set canonical as the `og:url` on pages where it is set manually.

## Test instructions

This PR can be tested by following these steps:

* Set a manual canonical on a category and see if the `og:url` reflects that canonical.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10837
