### PR TITLE
Uses the function instead of the global

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -178,7 +178,7 @@ class WPSEO_Twitter {
 			$meta_desc = $this->fallback_description();
 		}
 
-		$meta_desc = wpseo_replace_vars( $meta_desc, $GLOBALS['wp_query']->get_queried_object() );
+		$meta_desc = wpseo_replace_vars( $meta_desc, get_queried_object() );
 
 		/**
 		 * Filter: 'wpseo_twitter_description' - Allow changing the Twitter description as output in the Twitter card by Yoast SEO
@@ -257,7 +257,7 @@ class WPSEO_Twitter {
 			$title = $this->fallback_title();
 		}
 
-		$title = wpseo_replace_vars( $title, $GLOBALS['wp_query']->get_queried_object() );
+		$title = wpseo_replace_vars( $title, get_queried_object() );
 
 		/**
 		 * Filter: 'wpseo_twitter_title' - Allow changing the Twitter title as output in the Twitter card by Yoast SEO

--- a/tests/frontend/test-class-twitter.php
+++ b/tests/frontend/test-class-twitter.php
@@ -462,16 +462,16 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_OpenGraph::opengraph
+	 * @covers WPSEO_Twitter::twitter
 	 */
-	public function test_opengraph() {
+	public function test_twitter_action_execution() {
 		self::$class_instance->twitter();
 		$this->assertEquals( 1, did_action( 'wpseo_twitter' ) );
 		ob_clean();
 	}
 
 	/**
-	 * @covers WPSEO_OpenGraph::og_title
+	 * @covers WPSEO_Twitter::title
 	 */
 	public function test_twitter_title_with_variables() {
 		$expected_title = 'Test title';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Use the WordPress function that is doing the same, this prevents us to rely on a `global`. 

## Test instructions

This PR can be tested by following these steps:

* Copied from #10827 
* Create a post that uses snippet variables in its twitter card title and description, see them work.
* Create a category / tag that uses snippet variables in its twitter card title and description, see them work.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [] I have added unittests to verify the code works as intended

