### PR TITLE
Use a paragraph for the How-to and FAQ fields edit mode

### DIFF
--- a/css/src/structured-data-blocks.scss
+++ b/css/src/structured-data-blocks.scss
@@ -69,6 +69,12 @@ legend.schema-how-to-duration-legend {
 	text-align: right;
 }
 
+.schema-how-to-step-name,
+.schema-faq-title,
+.schema-faq-question-question {
+	font-weight: 600;
+}
+
 .schema-how-to-step-button-container {
 	text-align: right;
 

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -318,7 +318,7 @@ export default class FAQ extends Component {
 		return (
 			<div className={ classNames }>
 				<RichText
-					tagName="strong"
+					tagName="p"
 					className="schema-faq-title"
 					value={ attributes.title }
 					isSelected={ this.state.focus === "title" }

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -172,7 +172,7 @@ export default class Question extends Component {
 			<div className="schema-faq-question" key={ id } >
 				<RichText
 					className="schema-faq-question-question"
-					tagName="strong"
+					tagName="p"
 					onSetup={ ( ref ) => editorRef( "question", ref ) }
 					key={ id + "-question" }
 					value={ question }
@@ -216,4 +216,3 @@ Question.propTypes = {
 	isFirst: PropTypes.bool,
 	isLast: PropTypes.bool,
 };
-

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -581,7 +581,7 @@ export default class HowTo extends Component {
 		return (
 			<div className={ classNames }>
 				<RichText
-					tagName="strong"
+					tagName="p"
 					id={ attributes.headingID }
 					className="schema-how-to-title"
 					value={ attributes.title }

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -195,7 +195,7 @@ export default class HowToStep extends Component {
 				</span>
 				<RichText
 					className="schema-how-to-step-name"
-					tagName="strong"
+					tagName="p"
 					onSetup={ ( ref ) => editorRef( "name", ref ) }
 					key={ `${ id }-name` }
 					value={ name }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- Uses a `<p>` element instead of a `<strong>` element for the How-to and FAQ fields in the block "edit mode"
- Keeps using a `<strong>` in save mode (in the front-end)

Reasona:
- in IE11, `pointer-events: none` on the placeholder doesn't work for inline elements (the strong) thus it's hard to click on the field when the placeholder is displayed
- since the `<strong>` element is an inline element, when it's emptied it has a width of `0` making very hard to click inside the field

## Test instructions

I'd suggest to test in IE 11 and also in other browsers:

- build the JS and CSS

IE11:
- follow the steps on #10851 and see if clicking the placeholder actually puts the caret in the field
- check also the FAQ block

All browsers:
- create a How-to block and a FAQ block
- fill in the fields
- check that clicking in the title (main title and step / question titles) on any point along the width of the field works
- remove the titles, check again clicking in any point in the fields works
- enter again titles, check again
- copy / paste titles, try to break it and verify clicking still works
- verify the tilte fields in the editor are rendered as `<p>` elements
- verify the title fields in the front-end are rendered as `<strong>` elements

Fixes #10851 
