### PR TITLE
Fix the fake language file test

### DIFF
--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -44,7 +44,10 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Metabox_Formatter::get_translations
 	 */
 	public function test_with_fake_language_file() {
-		$file_name = plugin_dir_path( WPSEO_FILE ) . 'tests/assets/wordpress-seo-' . WPSEO_Utils::get_user_locale() . '.json';
+		$file_name = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . WPSEO_Utils::get_user_locale() . '.json';
+
+		// Make sure the folder exists.
+		wp_mkdir_p( plugin_dir_path( WPSEO_FILE ) . 'languages' );
 		file_put_contents(
 			$file_name,
 			json_encode( array( 'key' => 'value' ) )

--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -44,7 +44,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Metabox_Formatter::get_translations
 	 */
 	public function test_with_fake_language_file() {
-		$file_name = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . WPSEO_Utils::get_user_locale() . '.json';
+		$file_name = plugin_dir_path( WPSEO_FILE ) . 'tests/assets/wordpress-seo-' . WPSEO_Utils::get_user_locale() . '.json';
 		file_put_contents(
 			$file_name,
 			json_encode( array( 'key' => 'value' ) )


### PR DESCRIPTION
As the language folder has been removed from the repo, this no longer works in Travis.

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* ~Moved the location to store the file to the tests directory.~
* Creates the language folder if it does not exist yet

## Test instructions

This PR can be tested by following these steps:

* See the Travis builds pass again.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
