### PR TITLE
Added days to how-to block's structured data

### DIFF
--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -57,16 +57,13 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 			'@type'    => 'HowTo',
 		);
 
-		if ( ! empty( $attributes['jsonTitle'] ) ) {
-			$json_ld['name'] = $attributes['jsonTitle'];
-		}
-
 		if ( ! empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] === true ) {
+			$days    = empty( $attributes['days'] ) ? 0 : $attributes['days'];
 			$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];
 			$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
 
-			if ( $hours !== 0 || $minutes !== 0 ) {
-				$json_ld['totalTime'] = 'PT' . $hours . 'H' . $minutes . 'M';
+			if ( ( $days + $hours + $minutes ) > 0 ) {
+				$json_ld['totalTime'] = 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M';
 			}
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Also removed `title`, which was removed from the How To block  in #10889

## Test instructions

This PR can be tested by following these steps:

* In gutenberg, create a how-to block with a duration, including at least 1 day.
* Press `preview`. Inspect the output of the How To block in the post.
* The output of the how to blick is prepended with a `div` with type `application/ld+json`.
* Copy the contents of this div into `https://search.google.com/structured-data/testing-tool/u/0/?hl=nl`
* Verify that the duration format in the structured data is correct, using https://en.wikipedia.org/wiki/ISO_8601#Durations.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10892 
