### PR TITLE
Uses get_queried_object_id instead get_queried_object in class-frontend

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -752,11 +752,11 @@ class WPSEO_Frontend {
 				if ( WPSEO_Options::get( 'noindex-author-wpseo', false ) ) {
 					$robots['index'] = 'noindex';
 				}
-				$curauth = $wp_query->get_queried_object();
-				if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', false ) && count_user_posts( $curauth->ID, 'any' ) === 0 ) {
+				$author_id = $wp_query->get_queried_object_id();
+				if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', false ) && $author_id && count_user_posts( $author_id, 'any' ) === 0 ) {
 					$robots['index'] = 'noindex';
 				}
-				if ( get_user_meta( $curauth->ID, 'wpseo_noindex_author', true ) === 'on' ) {
+				if ( $author_id && get_user_meta( $author_id, 'wpseo_noindex_author', true ) === 'on' ) {
 					$robots['index'] = 'noindex';
 				}
 			}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes trying to get property of non-object in class-frontend.php ( `function robots`).

## Relevant technical choices:

* Uses [`get_queried_object_id`](https://developer.wordpress.org/reference/classes/wp_query/get_queried_object_id/) instead of `get_queried_object`. There is needed only id which is easier to add into conditions.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Related PR #10461.
