### PR TITLE
Add time needed setting with filter

### DIFF
--- a/css/src/structured-data-blocks.scss
+++ b/css/src/structured-data-blocks.scss
@@ -11,6 +11,10 @@
 	}
 }
 
+.schema-how-to-duration-time-input {
+	white-space: nowrap;
+}
+
 .schema-how-to-buttons {
 	text-align: center;
 

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -39,6 +39,9 @@ const attributes = {
 	unorderedList: {
 		type: "boolean",
 	},
+	durationText: {
+		type: "string",
+	},
 	headingID: {
 		type: "string",
 	},

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -42,6 +42,8 @@ export default class HowTo extends Component {
 	constructor( props ) {
 		super( props );
 
+		const applyFilters = get( window, "wp.hooks.applyFilters", noop );
+		const defaultDurationText = applyFilters( "wpseo_duration_text", __( "Time needed:" ) );
 		this.state = { focus: "" };
 
 		this.changeStep      = this.changeStep.bind( this );
@@ -54,17 +56,9 @@ export default class HowTo extends Component {
 		this.toggleListType  = this.toggleListType.bind( this );
 		this.setDurationText = this.setDurationText.bind( this );
 
-		const applyFilters = get( window, "wp.hooks.applyFilters", noop );
-
 		if( ! this.props.attributes.durationText ) {
-			this.props.attributes.durationText = applyFilters( "wpseo_duration_text", __( "Time needed:" ) );
+			this.setDurationText( defaultDurationText );
 		}
-
-		const addFilter = get( window, "wp.hooks.addFilter", noop );
-
-		addFilter( "wpseo_duration_text", "", () => {
-			return "newDing";
-		}  );
 
 		this.editorRefs = {};
 	}

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -5,6 +5,8 @@ import isUndefined from "lodash/isUndefined";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
 import toString from "lodash/toString";
+import noop from "lodash/noop";
+import get from "lodash/get";
 
 /* Internal dependencies */
 import { stripHTML } from "../../../helpers/stringHelpers";
@@ -51,6 +53,18 @@ export default class HowTo extends Component {
 		this.getListTypeHelp = this.getListTypeHelp.bind( this );
 		this.toggleListType  = this.toggleListType.bind( this );
 		this.setDurationText = this.setDurationText.bind( this );
+
+		const applyFilters = get( window, "wp.hooks.applyFilters", noop );
+
+		if( ! this.props.attributes.durationText ) {
+			this.props.attributes.durationText = applyFilters( "wpseo_duration_text", __( "Time needed:" ) );
+		}
+
+		const addFilter = get( window, "wp.hooks.addFilter", noop );
+
+		addFilter( "wpseo_duration_text", "", () => {
+			return "newDing";
+		}  );
 
 		this.editorRefs = {};
 	}
@@ -336,7 +350,7 @@ export default class HowTo extends Component {
 				<legend
 					className="schema-how-to-duration-legend"
 				>
-					{ attributes.durationText || __( "Time needed:", "wordpress-seo" ) }
+					{ attributes.durationText }
 				</legend>
 				<span className="schema-how-to-duration-time-input">
 					<label
@@ -447,7 +461,7 @@ export default class HowTo extends Component {
 			<div className={ classNames }>
 				{ ( hasDuration && typeof timeString === "string" && timeString.length > 0 ) &&
 					<p className="schema-how-to-total-time">
-						{ durationText || __( "Time needed:", "wordpress-seo" ) }
+						{ durationText }
 						&nbsp;
 						{ timeString }.
 					</p>

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -50,6 +50,7 @@ export default class HowTo extends Component {
 		this.addCSSClasses   = this.addCSSClasses.bind( this );
 		this.getListTypeHelp = this.getListTypeHelp.bind( this );
 		this.toggleListType  = this.toggleListType.bind( this );
+		this.setDurationText = this.setDurationText.bind( this );
 
 		this.editorRefs = {};
 	}
@@ -335,69 +336,71 @@ export default class HowTo extends Component {
 				<legend
 					className="schema-how-to-duration-legend"
 				>
-					{ __( "Time needed:", "wordpress-seo" ) }
+					{ attributes.durationText || __( "Time needed:", "wordpress-seo" ) }
 				</legend>
-				<label
-					htmlFor="schema-how-to-duration-days"
-					className="screen-reader-text"
-				>
-					{ __( "days", "wordpress-seo" ) }
-				</label>
-				<input
-					id="schema-how-to-duration-days"
-					className="schema-how-to-duration-input"
-					type="number"
-					value={ attributes.days }
-					onFocus={ () => this.setFocus( "days" ) }
-					onChange={ ( event ) => {
-						const newValue = this.formatDuration( event.target.value );
-						setAttributes( { days: toString( newValue ) } );
-					} }
-					placeholder="DD"
-				/>
-				<label
-					htmlFor="schema-how-to-duration-hours"
-					className="screen-reader-text"
-				>
-					{ __( "hours", "wordpress-seo" ) }
-				</label>
-				<input
-					id="schema-how-to-duration-hours"
-					className="schema-how-to-duration-input"
-					type="number"
-					value={ attributes.hours }
-					onFocus={ () => this.setFocus( "hours" ) }
-					placeholder="HH"
-					onChange={ ( event ) => {
-						const newValue = this.formatDuration( event.target.value, 23 );
-						setAttributes( { hours: toString( newValue ) } );
-					} }
-				/>
-				<span aria-hidden="true">:</span>
-				<label
-					htmlFor="schema-how-to-duration-minutes"
-					className="screen-reader-text"
-				>
-					{ __( "minutes", "wordpress-seo" ) }
-				</label>
-				<input
-					id="schema-how-to-duration-minutes"
-					className="schema-how-to-duration-input"
-					type="number"
-					value={ attributes.minutes }
-					onFocus={ () => this.setFocus( "minutes" ) }
-					onChange={ ( event ) => {
-						const newValue = this.formatDuration( event.target.value, 59 );
-						setAttributes( { minutes: toString( newValue ) } );
-					} }
-					placeholder="MM"
-				/>
-				<IconButton
-					className="schema-how-to-duration-button editor-inserter__toggle"
-					icon="trash"
-					label={ __( "Delete total time", "wordpress-seo" ) }
-					onClick={ () => setAttributes( { hasDuration: false } ) }
-				/>
+				<span className="schema-how-to-duration-time-input">
+					<label
+						htmlFor="schema-how-to-duration-days"
+						className="screen-reader-text"
+					>
+						{ __( "days", "wordpress-seo" ) }
+					</label>
+					<input
+						id="schema-how-to-duration-days"
+						className="schema-how-to-duration-input"
+						type="number"
+						value={ attributes.days }
+						onFocus={ () => this.setFocus( "days" ) }
+						onChange={ ( event ) => {
+							const newValue = this.formatDuration( event.target.value );
+							setAttributes( { days: toString( newValue ) } );
+						} }
+						placeholder="DD"
+					/>
+					<label
+						htmlFor="schema-how-to-duration-hours"
+						className="screen-reader-text"
+					>
+						{ __( "hours", "wordpress-seo" ) }
+					</label>
+					<input
+						id="schema-how-to-duration-hours"
+						className="schema-how-to-duration-input"
+						type="number"
+						value={ attributes.hours }
+						onFocus={ () => this.setFocus( "hours" ) }
+						placeholder="HH"
+						onChange={ ( event ) => {
+							const newValue = this.formatDuration( event.target.value, 23 );
+							setAttributes( { hours: toString( newValue ) } );
+						} }
+					/>
+					<span aria-hidden="true">:</span>
+					<label
+						htmlFor="schema-how-to-duration-minutes"
+						className="screen-reader-text"
+					>
+						{ __( "minutes", "wordpress-seo" ) }
+					</label>
+					<input
+						id="schema-how-to-duration-minutes"
+						className="schema-how-to-duration-input"
+						type="number"
+						value={ attributes.minutes }
+						onFocus={ () => this.setFocus( "minutes" ) }
+						onChange={ ( event ) => {
+							const newValue = this.formatDuration( event.target.value, 59 );
+							setAttributes( { minutes: toString( newValue ) } );
+						} }
+						placeholder="MM"
+					/>
+					<IconButton
+						className="schema-how-to-duration-button editor-inserter__toggle"
+						icon="trash"
+						label={ __( "Delete total time", "wordpress-seo" ) }
+						onClick={ () => setAttributes( { hasDuration: false } ) }
+					/>
+				</span>
 			</fieldset>
 		);
 	}
@@ -421,6 +424,7 @@ export default class HowTo extends Component {
 			unorderedList,
 			additionalListCssClasses,
 			className,
+			durationText,
 		} = props;
 
 		steps = steps
@@ -443,7 +447,7 @@ export default class HowTo extends Component {
 			<div className={ classNames }>
 				{ ( hasDuration && typeof timeString === "string" && timeString.length > 0 ) &&
 					<p className="schema-how-to-total-time">
-						{ __( "Time needed:", "wordpress-seo" ) }
+						{ durationText || __( "Time needed:", "wordpress-seo" ) }
 						&nbsp;
 						{ timeString }.
 					</p>
@@ -501,6 +505,17 @@ export default class HowTo extends Component {
 	}
 
 	/**
+	 * Sets the duration text to describe the time to intruction takes.
+	 *
+	 * @param {string} text The text to describe the duration.
+	 *
+	 * @returns {void}
+	 */
+	setDurationText( text ) {
+		this.props.setAttributes( { durationText: text } );
+	}
+
+	/**
 	 * Returns the help text for this how-to block"s list type.
 	 *
 	 * @param {boolean} checked Whether or not the list is unordered.
@@ -518,10 +533,11 @@ export default class HowTo extends Component {
 	 *
 	 * @param {boolean} unorderedList     Whether to show the list as an unordered list.
 	 * @param {string}  additionalClasses The additional CSS classes to add to the list.
+	 * @param {string}  durationText      The text to describe the duration.
 	 *
 	 * @returns {Component} The controls to add to the sidebar.
 	 */
-	getSidebar( unorderedList, additionalClasses ) {
+	getSidebar( unorderedList, additionalClasses, durationText ) {
 		return <InspectorControls>
 			<PanelBody title={ __( "Settings", "wordpress-seo" ) } className="blocks-font-size">
 				<SpacedTextControl
@@ -529,6 +545,12 @@ export default class HowTo extends Component {
 					value={ additionalClasses }
 					onChange={ this.addCSSClasses }
 					help={ __( "Optional. This can give you better control over the styling of the steps.", "wordpress-seo" ) }
+				/>
+				<SpacedTextControl
+					label={ __( "Describe the duration of the guide:", "wordpress-seo" ) }
+					value={ durationText }
+					onChange={ this.setDurationText }
+					help={ __( "Optional. Customize how you want to describe the duration of the guide.", "wordpress-seo" ) }
 				/>
 				<ToggleControl
 					label={ __( "Unordered list", "wordpress-seo" ) }
@@ -571,7 +593,7 @@ export default class HowTo extends Component {
 					{ this.getSteps() }
 				</ul>
 				<div className="schema-how-to-buttons">{ this.getAddStepButton() }</div>
-				{ this.getSidebar( attributes.unorderedList, attributes.additionalListCssClasses ) }
+				{ this.getSidebar( attributes.unorderedList, attributes.additionalListCssClasses, attributes.durationText ) }
 			</div>
 		);
 	}

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -537,7 +537,7 @@ export default class HowTo extends Component {
 	 * @returns {void}
 	 */
 	setDurationText( text ) {
-		if( text === "" ) {
+		if ( text === "" ) {
 			text = this.getDefaultDurationText();
 		}
 		this.props.setAttributes( { durationText: text } );
@@ -566,7 +566,7 @@ export default class HowTo extends Component {
 	 * @returns {Component} The controls to add to the sidebar.
 	 */
 	getSidebar( unorderedList, additionalClasses, durationText ) {
-		if( durationText === this.getDefaultDurationText() ) {
+		if ( durationText === this.getDefaultDurationText() ) {
 			durationText = "";
 		}
 

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -513,7 +513,7 @@ export default class HowTo extends Component {
 	}
 
 	/**
-	 * Sets the duration text to describe the time to intruction takes.
+	 * Sets the duration text to describe the time the guide in the how-to block takes.
 	 *
 	 * @param {string} text The text to describe the duration.
 	 *

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -5,7 +5,6 @@ import isUndefined from "lodash/isUndefined";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
 import toString from "lodash/toString";
-import noop from "lodash/noop";
 import get from "lodash/get";
 
 /* Internal dependencies */
@@ -42,8 +41,6 @@ export default class HowTo extends Component {
 	constructor( props ) {
 		super( props );
 
-		const applyFilters = get( window, "wp.hooks.applyFilters", noop );
-		const defaultDurationText = applyFilters( "wpseo_duration_text", __( "Time needed:" ) );
 		this.state = { focus: "" };
 
 		this.changeStep      = this.changeStep.bind( this );
@@ -56,11 +53,29 @@ export default class HowTo extends Component {
 		this.toggleListType  = this.toggleListType.bind( this );
 		this.setDurationText = this.setDurationText.bind( this );
 
-		if( ! this.props.attributes.durationText ) {
+		if ( ! this.props.attributes.durationText ) {
+			const defaultDurationText = this.getDefaultDurationText();
+
 			this.setDurationText( defaultDurationText );
 		}
 
 		this.editorRefs = {};
+	}
+
+	/**
+	 * Returns the default duration text.
+	 *
+	 * @returns {string} The default duration text.
+	 */
+	getDefaultDurationText() {
+		const applyFilters = get( window, "wp.hooks.applyFilters" );
+		let defaultDurationText = __( "Time needed:", "wordpress-seo" );
+
+		if ( applyFilters ) {
+			defaultDurationText = applyFilters( "wpseo_duration_text", defaultDurationText );
+		}
+
+		return defaultDurationText;
 	}
 
 	/**
@@ -455,8 +470,10 @@ export default class HowTo extends Component {
 			<div className={ classNames }>
 				{ ( hasDuration && typeof timeString === "string" && timeString.length > 0 ) &&
 					<p className="schema-how-to-total-time">
-						{ durationText }
-						&nbsp;
+						<span className="schema-how-to-duration-time-text">
+							{ durationText }
+							&nbsp;
+						</span>
 						{ timeString }.
 					</p>
 				}
@@ -520,6 +537,9 @@ export default class HowTo extends Component {
 	 * @returns {void}
 	 */
 	setDurationText( text ) {
+		if( text === "" ) {
+			text = this.getDefaultDurationText();
+		}
 		this.props.setAttributes( { durationText: text } );
 	}
 
@@ -546,6 +566,10 @@ export default class HowTo extends Component {
 	 * @returns {Component} The controls to add to the sidebar.
 	 */
 	getSidebar( unorderedList, additionalClasses, durationText ) {
+		if( durationText === this.getDefaultDurationText() ) {
+			durationText = "";
+		}
+
 		return <InspectorControls>
 			<PanelBody title={ __( "Settings", "wordpress-seo" ) } className="blocks-font-size">
 				<SpacedTextControl
@@ -555,10 +579,11 @@ export default class HowTo extends Component {
 					help={ __( "Optional. This can give you better control over the styling of the steps.", "wordpress-seo" ) }
 				/>
 				<SpacedTextControl
-					label={ __( "Describe the duration of the guide:", "wordpress-seo" ) }
+					label={ __( "Describe the duration of the instruction:", "wordpress-seo" ) }
 					value={ durationText }
 					onChange={ this.setDurationText }
-					help={ __( "Optional. Customize how you want to describe the duration of the guide.", "wordpress-seo" ) }
+					help={ __( "Optional. Customize how you want to describe the duration of the instruction", "wordpress-seo" ) }
+					placeholder={ this.getDefaultDurationText() }
 				/>
 				<ToggleControl
 					label={ __( "Unordered list", "wordpress-seo" ) }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a setting and filter allowing users to edit the text describing the needed time for a how-to guide.

## Relevant technical choices:

* Added a filter to allow to change the text via filter.
* Used the same structure as existing settings for the how-to block.
* Prioritised the user-input in the settings over the filter.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch.
* build this branch `yarn, grunt build:js && grunt build:css && yarn start`
* Create a new post. add a how-to block to the new post. 
* Check that the text before the needed time reads `time needed:`.
* go to the settings of the how-to block.
* Check that the default text of `time needed:` is in the input field as a placeholder.
* Change the placeholder text in the settings.
* Check that the text is changed to the user input in the how-to block.
* Save draft, Check that the text is changed to the user input on the post preview.

To Test the filter:
* Go to `js/src/structured-data-blocks/how-to/block.js` and add the following:
```
import get from "lodash/get";
```
and inside the `edit` function before tue return of `<howTo`:
```
const addFilter = get( window, "wp.hooks.addFilter" );
addFilter( "wpseo_duration_text", "random", ( defaultValue ) => {
	return "ReplacedViaFilter";
} );
```
* Go to a (new) post-edit page.
* Add a how-to block ( delete the one if it already exists in the post), one with the default value is needed.
* Add a duration to the how-to.
* Check that the text for the duration time is `ReplacedViaFilter` (changed by the filter).
* Change the text in the settings of the how-to page.
* Check that the text for the duration time is changed in the block.
* Save draft, check that the text for the duration time is changed in the preview of the post.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10665 
