### PR TITLE
Update store if primary taxonomy term has changed in classic editor

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -389,6 +389,7 @@ class WPSEO_Admin_Asset_Manager {
 					'jquery',
 					'wp-util',
 					self::PREFIX . 'react-dependencies',
+					self::PREFIX . 'wp-globals-backport',
 				),
 			),
 			array(

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -1,5 +1,8 @@
 /* global wp, _, wpseoPrimaryCategoryL10n */
+/* External dependencies */
+import { dispatch } from "@wordpress/data";
 
+/* Internal dependencies */
 import "./helpers/babel-polyfill";
 
 ( function( $ ) {
@@ -34,6 +37,24 @@ import "./helpers/babel-polyfill";
 	}
 
 	/**
+	 * Gets the name of a term for the category taxonomy.
+	 *
+	 * @param {number} categoryTermId The terms's id.
+	 *
+	 * @returns {string} The term's name.
+	 */
+	function getCategoryTermName( categoryTermId ) {
+		const categoryListItem = $( "#category-all" )
+			.find( `#category-${ categoryTermId } > label` );
+		if( categoryListItem.length === 0 ) {
+			return "";
+		}
+		const clone = categoryListItem.clone();
+		clone.children().remove();
+		return $.trim( clone.text() );
+	}
+
+	/**
 	 * Sets the primary term for a taxonomy.
 	 *
 	 * @param {string} taxonomyName The taxonomy name.
@@ -42,10 +63,21 @@ import "./helpers/babel-polyfill";
 	 * @returns {void}
 	 */
 	function setPrimaryTerm( taxonomyName, termId ) {
-		var primaryTermInput;
-
-		primaryTermInput = $( "#yoast-wpseo-primary-" + taxonomyName );
+		const primaryTermInput = $( "#yoast-wpseo-primary-" + taxonomyName );
 		primaryTermInput.val( termId ).trigger( "change" );
+
+		const yoastEditor = dispatch( "yoast-seo/editor" );
+		if( yoastEditor ) {
+			const termIdInt = parseInt( termId, 10 );
+			yoastEditor.setPrimaryTaxonomyId( taxonomyName, termIdInt );
+			// If the taxonomy is category update the replacement variable.
+			if ( taxonomyName === "category" ) {
+				yoastEditor.updateReplacementVariable(
+					"primary_category",
+					getCategoryTermName( termIdInt )
+				);
+			}
+		}
 	}
 
 	/**

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -46,11 +46,12 @@ import "./helpers/babel-polyfill";
 	function getCategoryTermName( categoryTermId ) {
 		const categoryListItem = $( "#category-all" )
 			.find( `#category-${ categoryTermId } > label` );
-		if( categoryListItem.length === 0 ) {
+		if ( categoryListItem.length === 0 ) {
 			return "";
 		}
 		const clone = categoryListItem.clone();
 		clone.children().remove();
+		console.log( $.trim( categoryListItem.text() ), $.trim( clone.text() ) );
 		return $.trim( clone.text() );
 	}
 
@@ -67,7 +68,7 @@ import "./helpers/babel-polyfill";
 		primaryTermInput.val( termId ).trigger( "change" );
 
 		const yoastEditor = dispatch( "yoast-seo/editor" );
-		if( yoastEditor ) {
+		if ( yoastEditor ) {
 			const termIdInt = parseInt( termId, 10 );
 			yoastEditor.setPrimaryTaxonomyId( taxonomyName, termIdInt );
 			// If the taxonomy is category update the replacement variable.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix primary taxonomy replacement variable in the classic editor.

## Test instructions

This PR can be tested by following these steps:

* Create a post, add a title and save it.
* Add the `Primary category` replacement variable.
* Select a different primary category, make sure it updates.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10902
