### PR TITLE
Cache WPSEO_Option_Titles::enrich_defaults()

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -279,12 +279,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'metadesc-tax-' . $tax->name ]        = ''; // Text area.
 				$enriched_defaults[ 'display-metabox-tax-' . $tax->name ] = true;
 
-				if ( $tax->name !== 'post_format' ) {
-					$enriched_defaults[ 'noindex-tax-' . $tax->name ] = false;
-				}
-				else {
-					$enriched_defaults[ 'noindex-tax-' . $tax->name ] = true;
-				}
+				$enriched_defaults[ 'noindex-tax-' . $tax->name ] = ( $tax->name !== 'post_format' );
 
 				if ( ! $tax->_builtin ) {
 					$enriched_defaults[ 'taxonomy-' . $tax->name . '-ptparent' ] = 0; // Select box;.

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -148,8 +148,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		add_action( 'unregistered_post_type',                array( $this, 'invalidate_enrich_defaults_cache' ) );
 		add_action( 'registered_taxonomy',                   array( $this, 'invalidate_enrich_defaults_cache' ) );
 		add_action( 'unregistered_taxonomy',                 array( $this, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'registered_taxonomy_for_object_type',   array( $this, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'unregistered_taxonomy_for_object_type', array( $this, 'invalidate_enrich_defaults_cache' ) );
 	}
 
 
@@ -245,15 +243,12 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 			$archive = sprintf( __( '%s Archive', 'wordpress-seo' ), '%%pt_plural%%' );
 
 			foreach ( $post_type_objects as $pt ) {
-				$enriched_defaults[ 'title-' . $pt->name ]              = '%%title%% %%page%% %%sep%% %%sitename%%'; // Text field.
-				$enriched_defaults[ 'metadesc-' . $pt->name ]           = ''; // Text area.
-				$enriched_defaults[ 'noindex-' . $pt->name ]            = false;
-				$enriched_defaults[ 'showdate-' . $pt->name ]           = false;
-				$enriched_defaults[ 'display-metabox-pt-' . $pt->name ] = true;
-
-				if ( get_object_taxonomies( $pt->name, 'names' ) ) {
-					$enriched_defaults[ 'post_types-' . $pt->name . '-maintax' ] = 0; // Select box.
-				}
+				$enriched_defaults[ 'title-' . $pt->name ]                   = '%%title%% %%page%% %%sep%% %%sitename%%'; // Text field.
+				$enriched_defaults[ 'metadesc-' . $pt->name ]                = ''; // Text area.
+				$enriched_defaults[ 'noindex-' . $pt->name ]                 = false;
+				$enriched_defaults[ 'showdate-' . $pt->name ]                = false;
+				$enriched_defaults[ 'display-metabox-pt-' . $pt->name ]      = true;
+				$enriched_defaults[ 'post_types-' . $pt->name . '-maintax' ] = 0; // Select box.
 
 				if ( ! $pt->_builtin ) {
 					if ( ! WPSEO_Post_Type::has_archive( $pt ) ) {
@@ -297,7 +292,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * Called from actions:
 	 *     (un)registered_post_type
 	 *     (un)registered_taxonomy
-	 *     (un)registered_taxonomy_for_object_type
 	 *
 	 * @return void
 	 */

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -274,7 +274,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'metadesc-tax-' . $tax->name ]        = ''; // Text area.
 				$enriched_defaults[ 'display-metabox-tax-' . $tax->name ] = true;
 
-				$enriched_defaults[ 'noindex-tax-' . $tax->name ] = ( $tax->name !== 'post_format' );
+				$enriched_defaults[ 'noindex-tax-' . $tax->name ] = ( $tax->name === 'post_format' );
 
 				if ( ! $tax->_builtin ) {
 					$enriched_defaults[ 'taxonomy-' . $tax->name . '-ptparent' ] = 0; // Select box;.

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -250,11 +250,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'display-metabox-pt-' . $pt->name ]      = true;
 				$enriched_defaults[ 'post_types-' . $pt->name . '-maintax' ] = 0; // Select box.
 
-				if ( ! $pt->_builtin ) {
-					if ( ! WPSEO_Post_Type::has_archive( $pt ) ) {
-						continue;
-					}
-
+				if ( ! $pt->_builtin && WPSEO_Post_Type::has_archive( $pt ) ) {
 					$enriched_defaults[ 'title-ptarchive-' . $pt->name ]    = $archive . ' %%page%% %%sep%% %%sitename%%'; // Text field.
 					$enriched_defaults[ 'metadesc-ptarchive-' . $pt->name ] = ''; // Text area.
 					$enriched_defaults[ 'bctitle-ptarchive-' . $pt->name ]  = ''; // Text field.

--- a/tests/inc/options/test-class-wpseo-option-titles.php
+++ b/tests/inc/options/test-class-wpseo-option-titles.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Inc\Options
+ */
+
+/**
+ * Unit Test Class.
+ */
+class WPSEO_Option_Titles_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Tests if the enrich_defaults() cache is properly invalidated
+     * when a new post type or taxonomy is registered.
+	 *
+	 * @covers WPSEO_Option_Titles::enrich_defaults()
+	 */
+	public function test_enrich_defaults_cache_invalidation() {
+		$wpseo_option_titles = WPSEO_Option_Titles::get_instance();
+
+		register_post_type( 'custom-post-type', array( 'public' => true ) );
+		$this->assertArrayHasKey( 'title-custom-post-type', $wpseo_option_titles->get_defaults() );
+
+		register_taxonomy( 'custom-taxonomy', 'post' );
+		$this->assertArrayHasKey( 'title-tax-custom-taxonomy', $wpseo_option_titles->get_defaults() );
+
+		register_taxonomy_for_object_type( 'custom-taxonomy', 'custom-post-type' );
+		$this->assertArrayHasKey( 'post_types-custom-post-type-maintax', $wpseo_option_titles->get_defaults() );
+
+		unregister_taxonomy_for_object_type( 'custom-taxonomy', 'custom-post-type' );
+		unregister_taxonomy( 'custom-taxonomy' );
+		unregister_post_type( 'custom-post-type' );
+	}
+
+}

--- a/tests/inc/options/test-class-wpseo-option-titles.php
+++ b/tests/inc/options/test-class-wpseo-option-titles.php
@@ -25,10 +25,6 @@ class WPSEO_Option_Titles_Test extends WPSEO_UnitTestCase {
 		register_taxonomy( 'custom-taxonomy', 'post' );
 		$this->assertArrayHasKey( 'title-tax-custom-taxonomy', $wpseo_option_titles->get_defaults() );
 
-		register_taxonomy_for_object_type( 'custom-taxonomy', 'custom-post-type' );
-		$this->assertArrayHasKey( 'post_types-custom-post-type-maintax', $wpseo_option_titles->get_defaults() );
-
-		unregister_taxonomy_for_object_type( 'custom-taxonomy', 'custom-post-type' );
 		unregister_taxonomy( 'custom-taxonomy' );
 		unregister_post_type( 'custom-post-type' );
 	}


### PR DESCRIPTION
## Summary

Called every time `get_option( 'wpseo_titles' )` or `WPSEO_Options::get_all()` is called, `WPSEO_Option_Titles::enrich_defaults()` does a lot of processing (`get_post_types()`, `get_taxonomies()`, etc.)

Microoptimized and cached (with smart invalidation) now.

This PR can be summarized in the following changelog entry:

* Optimize and cache `WPSEO_Option_Titles::enrich_defaults()`

## Relevant technical choices:

* Uses the WordPress Cache API
* Developed and discussed (in Russian) here https://youtu.be/9ieVrctyMls

## Test instructions

This PR can be tested by following these steps:

* Profile the difference to feel it. Here's a snippet I used (10 CPTs, 10 taxonomies, 10000 iterations):
```
for ( $i = 0; $i < 10; $i++ ) {
	register_post_type( "custom-post-type-$i", array( 'public' => true ) );
	register_taxonomy( "custom-taxonomy-$i", "custom-post-type-$i" );
}

$start = microtime( true );

for ( $i = 0; $i < 10000; $i++ ) {
	get_option( 'wpseo_titles' );
	WPSEO_Options::get_instance()::get_all();
}

$end = microtime( true );

printf( 'The code took %.3f seconds to complete.', $end - $start );
```
Yoast SEO 8.1.1: `The code took 17.351 seconds to complete.`
With this PR: `The code took 2.534 seconds to complete.`

Not quite the same results as @soulseekah got in #10529 (100ms vs 3ms; ~30 times performance increase), probably due to a clean environment with no other plugins or a different profiling method, but a ~7 times performance increase still seems good.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10529