### PR TITLE
Bump YoastSEO.js to 1.39.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "git+https://github.com/Yoast/yoast-components.git#develop",
-    "yoastseo": "^1.39.0"
+    "yoastseo": "^1.39.1"
   },
   "yoast": {
     "pluginVersion": "8.2-RC3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11131,6 +11131,18 @@ yoastseo@^1.39.0:
     sassdash "0.9.0"
     tokenizer2 "^2.0.0"
 
+yoastseo@^1.39.1:
+  version "1.39.1"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.1.tgz#cf8ba01fb2cbf90e94229a72b9d81169073641ec"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    jest "^23.0.0"
+    lodash "^4.14.1"
+    node-sass "^4.7.2"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.0"
+
 zip-stream@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-1.2.0.tgz#a8bc45f4c1b49699c6b90198baacaacdbcd4ba04"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where our JavaScript memory usage would increase indefinitely. This could result in a browser crash after a long enough period.

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/YoastSEO.js/pull/1782

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended