### PR TITLE
Remove console.log leftover

### DIFF
--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -51,7 +51,6 @@ import "./helpers/babel-polyfill";
 		}
 		const clone = categoryListItem.clone();
 		clone.children().remove();
-		console.log( $.trim( categoryListItem.text() ), $.trim( clone.text() ) );
 		return $.trim( clone.text() );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- removes a `console.log` leftover from trunk after #10911 see also #10919

