### PR TITLE
Adds yoast branding to structured data blocks group

### DIFF
--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -56,7 +56,11 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 	public function add_block_category( $categories ) {
 		$categories[] = array(
 			'slug'  => 'yoast-structured-data-blocks',
-			'title' => __( 'Structured Data Blocks', 'wordpress-seo' ),
+			'title' => sprintf(
+				/* translators: %1$s expands to Yoast SEO. */
+				__( '%1$s Structured Data Blocks', 'wordpress-seo' ),
+				'Yoast SEO'
+			),
 		);
 
 		return $categories;

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -57,9 +57,9 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 		$categories[] = array(
 			'slug'  => 'yoast-structured-data-blocks',
 			'title' => sprintf(
-				/* translators: %1$s expands to Yoast SEO. */
+				/* translators: %1$s expands to Yoast. */
 				__( '%1$s Structured Data Blocks', 'wordpress-seo' ),
-				'Yoast SEO'
+				'Yoast'
 			),
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds Yoast branding to structured data blocks group

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Check if the structured data blocks group in Gutenberg is prepended with "Yoast SEO"

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10915 
