### PR TITLE
Add Colon as a title separator

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -118,6 +118,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'sc-dash'   => '-',
 		'sc-ndash'  => '&ndash;',
 		'sc-mdash'  => '&mdash;',
+		'sc-colon'  => ':',
 		'sc-middot' => '&middot;',
 		'sc-bull'   => '&bull;',
 		'sc-star'   => '*',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

We all know that Google sometimes modifies the SEO title in the search results and when it does, it mostly used the colon `:` to separate the site title and tagline. Not only that, the colon `:` takes much shorter space than others and it also looks good in search results.

## Test instructions

This PR can be tested by following these steps:

* Go to Yoast SEO -> Search Appearance -> Title Separator.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10099 
