### PR TITLE
Render error in separate if statement from primary taxonomy support

### DIFF
--- a/js/src/components/PrimaryTaxonomyFilter.js
+++ b/js/src/components/PrimaryTaxonomyFilter.js
@@ -31,7 +31,7 @@ class PrimaryTaxonomyFilter extends React.Component {
 		}
 
 		this.state = {
-			fallbackToOriginalComponent: false,
+			exceptionCaught: false,
 			error: null,
 		};
 	}
@@ -44,7 +44,7 @@ class PrimaryTaxonomyFilter extends React.Component {
 	 * @returns {void}
 	 */
 	componentDidCatch( error ) {
-		this.setState( { fallbackToOriginalComponent: true, error } );
+		this.setState( { exceptionCaught: true, error } );
 	}
 
 	/**
@@ -67,10 +67,8 @@ class PrimaryTaxonomyFilter extends React.Component {
 			OriginalComponent,
 		} = this.props;
 
-		if (
-			( ! this.taxonomyHasPrimaryTermSupport() ) ||
-			this.state.fallbackToOriginalComponent
-		) {
+		if ( this.state.exceptionCaught ) {
+			const stack = get( this.state, "error.stack" );
 			return (
 				<Fragment>
 					<OriginalComponent { ...this.props } />
@@ -81,10 +79,18 @@ class PrimaryTaxonomyFilter extends React.Component {
 							"Yoast SEO"
 						) }
 					</ErrorContainer>
-					<ClipboardButton isLarge text={ this.state.error.stack }>
-						{ __( "Copy error", "wordpress-seo" ) }
-					</ClipboardButton>
+					{
+						stack && <ClipboardButton isLarge text={ stack }>
+							{ __( "Copy error", "wordpress-seo" ) }
+						</ClipboardButton>
+					}
 				</Fragment>
+			);
+		}
+
+		if ( ! this.taxonomyHasPrimaryTermSupport() ) {
+			return (
+				<OriginalComponent { ...this.props } />
 			);
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:
* Install the classic editor plugin. Go to Settings > Writing. Set Classic editor settings to `Use the Gutenberg editor by default and include optional links back to the Classic editor.`
* Open a post and open the document sidebar (click the gear icon). You should see an error in the category picker. When you copy the error using the button, and paste it somewhere, you should see the error mentioned in https://github.com/Yoast/wordpress-seo/issues/10850. 
* Open the 'Tags' collapsible in the document sidebar. The editor should not crash and the tags panel should show. 
* Test the primary taxonomy picker in Gutenberg without the classic editor plugin active.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10931
