### PR TITLE
Update YoastSEO.js to 1.39.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "git+https://github.com/Yoast/yoast-components.git#develop",
-    "yoastseo": "^1.39.1"
+    "yoastseo": "^1.39.2"
   },
   "yoast": {
     "pluginVersion": "8.2-RC4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11118,9 +11118,21 @@ yauzl@^2.2.1:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.39.0, yoastseo@^1.39.1:
+yoastseo@^1.39.0:
   version "1.39.1"
   resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.1.tgz#cf8ba01fb2cbf90e94229a72b9d81169073641ec"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    jest "^23.0.0"
+    lodash "^4.14.1"
+    node-sass "^4.7.2"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.0"
+
+yoastseo@^1.39.2:
+  version "1.39.2"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.2.tgz#c8cbf62d744f735a197da0a21d38a4d850dc8be2"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Bumps YoastSEO.js to v. 1.39.2

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/YoastSEO.js/pull/1787