### PR TITLE
Add spaces to structured data output

### DIFF
--- a/js/src/components/higherorder/appendSpace.js
+++ b/js/src/components/higherorder/appendSpace.js
@@ -1,0 +1,22 @@
+import React, { Fragment } from "react";
+
+/**
+ * Appends a space to the passed component.
+ *
+ * @param {ReactElement} WrappedComponent The component to append a space to.
+ * @returns {ReactElement} The component with an appended space.
+ */
+const appendSpace = function( WrappedComponent ) {
+	return class ComponentWithAppendedSpace extends React.Component {
+		render() {
+			return(
+				<Fragment>
+					<WrappedComponent { ...this.props }/>
+					{ " " }
+				</Fragment>
+			);
+		}
+	};
+};
+
+export default appendSpace;

--- a/js/src/components/higherorder/appendSpace.js
+++ b/js/src/components/higherorder/appendSpace.js
@@ -1,10 +1,10 @@
 import React, { Fragment } from "react";
 
 /**
- * Appends a space to the passed component.
+ * A higher order component that appends a space to the given component.
  *
- * @param {ReactElement} WrappedComponent The component to append a space to.
- * @returns {ReactElement} The component with an appended space.
+ * @param {ReactComponent} WrappedComponent The component to append a space to.
+ * @returns {ReactComponent} The component with an appended space.
  */
 const appendSpace = function( WrappedComponent ) {
 	return class ComponentWithAppendedSpace extends React.Component {

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, {Fragment} from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import isUndefined from "lodash/isUndefined";
 import { __ } from "@wordpress/i18n";

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { Fragment } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import isUndefined from "lodash/isUndefined";
 import { __ } from "@wordpress/i18n";
@@ -7,10 +7,14 @@ import { __ } from "@wordpress/i18n";
 /* Internal dependencies */
 import Question from "./Question";
 import { stripHTML } from "../../../helpers/stringHelpers";
+import appendSpace from "../../../components/higherorder/appendSpace";
 
 const { RichText } = window.wp.editor;
 const { IconButton } = window.wp.components;
 const { Component, renderToString } = window.wp.element;
+
+const QuestionContentWithAppendedSpace = appendSpace( Question.Content );
+const RichTextContentWithAppendedSpace = appendSpace( RichText.Content );
 
 /**
  * A FAQ block component.
@@ -267,7 +271,7 @@ export default class FAQ extends Component {
 							onMoveUp={ () => this.swapQuestions( index, index - 1 ) }
 							onMoveDown={ () => this.swapQuestions( index, index + 1 ) }
 							isFirst={ index === 0 }
-							isLast={ index === attributes.questions.length-1 }
+							isLast={ index === attributes.questions.length - 1 }
 						/>
 					);
 				}
@@ -284,20 +288,17 @@ export default class FAQ extends Component {
 	 * @returns {Component} The component representing a FAQ block.
 	 */
 	static Content( attributes ) {
-		let { title, questions, className } = attributes;
+		const { title, questions, className } = attributes;
 
 		let questionList = questions ? questions.map( ( question ) =>
-			<Fragment>
-				<Question.Content { ...question } />
-				{ " " }
-			</Fragment>
+			<QuestionContentWithAppendedSpace { ...question } />
 		) : null;
 
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );
 
 		return (
 			<div className={ classNames }>
-				<RichText.Content
+				<RichTextContentWithAppendedSpace
 					tagName="strong"
 					className="schema-faq-title"
 					value={ title }
@@ -314,8 +315,7 @@ export default class FAQ extends Component {
 	 * @returns {Component} The FAQ block editor.
 	 */
 	render() {
-		let { attributes, setAttributes, className } = this.props;
-
+		const { attributes, setAttributes, className } = this.props;
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );
 
 		return (

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import React, {Fragment} from "react";
 import PropTypes from "prop-types";
 import isUndefined from "lodash/isUndefined";
 import { __ } from "@wordpress/i18n";
@@ -287,7 +287,10 @@ export default class FAQ extends Component {
 		let { title, questions, className } = attributes;
 
 		let questionList = questions ? questions.map( ( question ) =>
-			<Question.Content { ...question } />
+			<Fragment>
+				<Question.Content { ...question } />
+				{ " " }
+			</Fragment>
 		) : null;
 
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -316,6 +316,7 @@ export default class FAQ extends Component {
 	 */
 	render() {
 		const { attributes, setAttributes, className } = this.props;
+
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );
 
 		return (

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -6,6 +6,12 @@ const { Component } = window.wp.element;
 const { IconButton } = window.wp.components;
 const { RichText, MediaUpload } = window.wp.editor;
 
+/* Internal dependencies */
+import appendSpace from "../../../components/higherorder/appendSpace";
+import React from "react";
+
+const RichTextWithAppendedSpace = appendSpace( RichText.Content );
+
 /**
  * A Question and answer pair within a FAQ block.
  */
@@ -135,14 +141,13 @@ export default class Question extends Component {
 	static Content( question ) {
 		return(
 			<div className={ "schema-faq-question" } key={ question.id }>
-				<RichText.Content
+				<RichTextWithAppendedSpace
 					tagName="strong"
 					className="schema-faq-question-question"
 					key={ question.id + "-question" }
 					value={ question.question }
 				/>
-				{ " " }
-				<RichText.Content
+				<RichTextWithAppendedSpace
 					tagName="p"
 					className="schema-faq-question-answer"
 					key={ question.id + "-answer" }

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -141,6 +141,7 @@ export default class Question extends Component {
 					key={ question.id + "-question" }
 					value={ question.question }
 				/>
+				{ " " }
 				<RichText.Content
 					tagName="p"
 					className="schema-faq-question-answer"

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -1,4 +1,5 @@
 /* External dependencies */
+import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 
@@ -8,7 +9,6 @@ const { RichText, MediaUpload } = window.wp.editor;
 
 /* Internal dependencies */
 import appendSpace from "../../../components/higherorder/appendSpace";
-import React from "react";
 
 const RichTextWithAppendedSpace = appendSpace( RichText.Content );
 

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -9,10 +9,13 @@ import toString from "lodash/toString";
 /* Internal dependencies */
 import { stripHTML } from "../../../helpers/stringHelpers";
 import buildDurationString from "../utils/buildDurationString";
+import appendSpace from "../../../components/higherorder/appendSpace";
 
 const { RichText, InspectorControls } = window.wp.editor;
 const { IconButton, PanelBody, TextControl, ToggleControl } = window.wp.components;
 const { Component, renderToString } = window.wp.element;
+
+const RichTextWithAppendedSpace = appendSpace( RichText.Content );
 
 /**
  * Modified Text Control to provide a better layout experience.
@@ -445,16 +448,14 @@ export default class HowTo extends Component {
 					<p className="schema-how-to-total-time">
 						{ __( "Time needed:", "wordpress-seo" ) }
 						&nbsp;
-						{ timeString }.
+						{ timeString + ". " }
 					</p>
 				}
-				{ " " }
-				<RichText.Content
+				<RichTextWithAppendedSpace
 					tagName="p"
 					className="schema-how-to-description"
 					value={ description }
 				/>
-				{ " " }
 				{ unorderedList
 					? <ul className={ listClassNames }>{ steps }</ul>
 					: <ol className={ listClassNames }>{ steps }</ol>

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -448,11 +448,13 @@ export default class HowTo extends Component {
 						{ timeString }.
 					</p>
 				}
+				{ " " }
 				<RichText.Content
 					tagName="p"
 					className="schema-how-to-description"
 					value={ description }
 				/>
+				{ " " }
 				{ unorderedList
 					? <ul className={ listClassNames }>{ steps }</ul>
 					: <ol className={ listClassNames }>{ steps }</ol>

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -154,22 +154,20 @@ export default class HowToStep extends Component {
 	 */
 	static Content( step ) {
 		return(
-			<Fragment>
-				<li className={ "schema-how-to-step" } key={ step.id } >
-					<RichTextContentWithAppendedSpace
-						tagName="strong"
-						className="schema-how-to-step-name"
-						key={ step.id + "-name" }
-						value={ step.name }
-					/>
-					<RichTextContentWithAppendedSpace
-						tagName="p"
-						className="schema-how-to-step-text"
-						key={ step.id + "-text" }
-						value={ step.text }
-					/>
-				</li>
-			</Fragment>
+			<li className={ "schema-how-to-step" } key={ step.id } >
+				<RichTextContentWithAppendedSpace
+					tagName="strong"
+					className="schema-how-to-step-name"
+					key={ step.id + "-name" }
+					value={ step.name }
+				/>
+				<RichTextContentWithAppendedSpace
+					tagName="p"
+					className="schema-how-to-step-text"
+					key={ step.id + "-text" }
+					value={ step.text }
+				/>
+			</li>
 		);
 	}
 

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -1,6 +1,7 @@
 /* External dependencies */
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
+import {Fragment} from "react";
 
 const { Component } = window.wp.element;
 const { IconButton } = window.wp.components;
@@ -149,20 +150,24 @@ export default class HowToStep extends Component {
 	 */
 	static Content( step ) {
 		return(
-			<li className={ "schema-how-to-step" } key={ step.id } >
-				<RichText.Content
-					tagName="strong"
-					className="schema-how-to-step-name"
-					key={ step.id + "-name" }
-					value={ step.name }
-				/>
-				<RichText.Content
-					tagName="p"
-					className="schema-how-to-step-text"
-					key={ step.id + "-text" }
-					value={ step.text }
-				/>
-			</li>
+			<Fragment>
+				<li className={ "schema-how-to-step" } key={ step.id } >
+					<RichText.Content
+						tagName="strong"
+						className="schema-how-to-step-name"
+						key={ step.id + "-name" }
+						value={ step.name }
+					/>
+					{ " " }
+					<RichText.Content
+						tagName="p"
+						className="schema-how-to-step-text"
+						key={ step.id + "-text" }
+						value={ step.text }
+					/>
+				</li>
+				{ " " }
+			</Fragment>
 		);
 	}
 

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -2,10 +2,14 @@
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { Fragment } from "react";
+import appendSpace from "../../../components/higherorder/appendSpace";
 
 const { Component } = window.wp.element;
 const { IconButton } = window.wp.components;
 const { RichText, MediaUpload } = window.wp.editor;
+
+const RichTextWithAppendedSpace = appendSpace( RichText );
+const RichTextContentWithAppendedSpace = appendSpace( RichText.Content );
 
 /**
  * A How-to step within a How-to block.
@@ -152,21 +156,19 @@ export default class HowToStep extends Component {
 		return(
 			<Fragment>
 				<li className={ "schema-how-to-step" } key={ step.id } >
-					<RichText.Content
+					<RichTextContentWithAppendedSpace
 						tagName="strong"
 						className="schema-how-to-step-name"
 						key={ step.id + "-name" }
 						value={ step.name }
 					/>
-					{ " " }
-					<RichText.Content
+					<RichTextContentWithAppendedSpace
 						tagName="p"
 						className="schema-how-to-step-text"
 						key={ step.id + "-text" }
 						value={ step.text }
 					/>
 				</li>
-				{ " " }
 			</Fragment>
 		);
 	}
@@ -198,7 +200,7 @@ export default class HowToStep extends Component {
 						: ( index + 1 ) + "."
 					}
 				</span>
-				<RichText
+				<RichTextWithAppendedSpace
 					className="schema-how-to-step-name"
 					tagName="p"
 					onSetup={ ( ref ) => editorRef( "name", ref ) }
@@ -210,7 +212,7 @@ export default class HowToStep extends Component {
 					setFocusedElement={ () => onFocus( "name" ) }
 					keepPlaceholderOnFocus={ true }
 				/>
-				<RichText
+				<RichTextWithAppendedSpace
 					className="schema-how-to-step-text"
 					tagName="p"
 					onSetup={ ( ref ) => editorRef( "text", ref ) }

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -1,7 +1,7 @@
 /* External dependencies */
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import {Fragment} from "react";
+import { Fragment } from "react";
 
 const { Component } = window.wp.element;
 const { IconButton } = window.wp.components;

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -1,7 +1,6 @@
 /* External dependencies */
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import { Fragment } from "react";
 import appendSpace from "../../../components/higherorder/appendSpace";
 
 const { Component } = window.wp.element;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* I've used a HOC to append a space to components. This HOC cannot be used for the duration string in the HowTo block (because that's not a component), which is why I added a space manually there.

## Test instructions

This PR can be tested by following these steps:

* Go to our settings > Search Appearance > Content Types > Posts. Set the metadescription field to `%excerpt%` 
* Create a HowTo block. Fill in all fields. Don't forget the time needed input.
* Create an FAQ block. Fill in all fields.
* Publish/Save the post and view the post/preview.
* Look at `<meta name="description"`  in the page source (right click --> view page source).
* It should be a generated metadescription. This PR makes sure that there are spaces added between all Gutenblock HTML fields that are rendered on the front end, which means that there are also spaces between the strings within the generated meta description. Old situation: `Question1Answer 1`. New situation: `Question 1 Answer 1` etc.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended

Fixes #10939 
