### PR TITLE
Fixes import of scoreToRating.

### DIFF
--- a/js/src/analysis/getIndicatorForScore.js
+++ b/js/src/analysis/getIndicatorForScore.js
@@ -1,9 +1,9 @@
 /* global YoastSEO */
 
 import isUndefined  from "lodash/isUndefined";
-import { helpers } from "yoastseo";
+import analysis from "yoastseo";
 import isNil from "lodash/isNil";
-const { scoreToRating } = helpers;
+const { scoreToRating } = analysis.helpers;
 
 /**
  * Returns whether or not the current page has presenters.

--- a/js/src/analysis/getIndicatorForScore.js
+++ b/js/src/analysis/getIndicatorForScore.js
@@ -1,9 +1,9 @@
 /* global YoastSEO */
 
 import isUndefined  from "lodash/isUndefined";
-import analysis from "yoastseo";
+import { helpers } from "yoastseo";
 import isNil from "lodash/isNil";
-const { scoreToRating } = analysis.helpers;
+const { scoreToRating } = helpers;
 
 /**
  * Returns whether or not the current page has presenters.

--- a/js/src/components/contentAnalysis/mapResults.js
+++ b/js/src/components/contentAnalysis/mapResults.js
@@ -1,7 +1,7 @@
-import analysis from "yoastseo";
+import { helpers } from "yoastseo";
 import { colors } from "yoast-components";
 
-const { scoreToRating } = analysis.helpers;
+const { scoreToRating } = helpers;
 
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the import of `scoreToRating` in `mapResults.js` to be consistent with the import of the same function in `getIndicatorForScore.js`.

## Relevant technical choices:

* This is needed for `YoastSEO.js` to be correctly integrated after its migration from `require`s to ES6 modules.

## Test instructions

This PR can be tested by following these steps:

**Note**: To be able to test this PR you will need the changes in [this PR](https://github.com/Yoast/YoastSEO.js/pull/1795) in `YoastSEO.js`. It makes sure that the code in `YoastSEO.js` is correctly exported as ES6 modules.
So either make sure that a local `YoastSEO.js` repo is linked to your local `wordpress-seo` repo and checkout the appropriate branch (`1794-Convert-requires-to-es-modules-index-js`), or wait until the PR in `YoastSEO.js` has been merged.

* Checkout this branch.
* Open an existing post or make a new one.
* Check if the content analysis tab of the plugin loads and works as expected.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
