### PR TITLE
Fix admin asset location interface implementation

### DIFF
--- a/admin/class-admin-asset-analysis-worker-location.php
+++ b/admin/class-admin-asset-analysis-worker-location.php
@@ -40,6 +40,15 @@ final class WPSEO_Admin_Asset_Analysis_Worker_Location implements WPSEO_Admin_As
 	}
 
 	/**
+	 * Retrieves the analysis worker asset.
+	 *
+	 * @return WPSEO_Admin_Asset The analysis worker asset.
+	 */
+	public function get_asset() {
+		return $this->asset;
+	}
+
+	/**
 	 * Determines the URL of the asset on the dev server.
 	 *
 	 * @param WPSEO_Admin_Asset $asset The asset to determine the URL for.
@@ -47,10 +56,7 @@ final class WPSEO_Admin_Asset_Analysis_Worker_Location implements WPSEO_Admin_As
 	 *
 	 * @return string The URL of the asset.
 	 */
-	public function get_url( WPSEO_Admin_Asset $asset = null, $type = WPSEO_Admin_Asset::TYPE_JS ) {
-		if ( $asset === null ) {
-			$asset = $this->asset;
-		}
+	public function get_url( WPSEO_Admin_Asset $asset, $type ) {
 		return $this->asset_location->get_url( $asset, $type );
 	}
 }

--- a/admin/class-admin-asset-analysis-worker-location.php
+++ b/admin/class-admin-asset-analysis-worker-location.php
@@ -13,12 +13,12 @@ final class WPSEO_Admin_Asset_Analysis_Worker_Location implements WPSEO_Admin_As
 	/**
 	 * @var WPSEO_Admin_Asset_Location $asset_location.
 	 */
-	protected $asset_location;
+	private $asset_location;
 
 	/**
 	 * @var WPSEO_Admin_Asset $asset.
 	 */
-	protected $asset;
+	private $asset;
 
 	/**
 	 * Constructs the location of the analysis worker asset.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -790,8 +790,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$analysis_worker_location          = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ) );
 		$used_keywords_assessment_location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ), 'used-keywords-assessment' );
 		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'wpseoAnalysisWorkerL10n', array(
-			'url'                     => $analysis_worker_location->get_url(),
-			'keywords_assessment_url' => $used_keywords_assessment_location->get_url(),
+			'url'                     => $analysis_worker_location->get_url( $analysis_worker_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
+			'keywords_assessment_url' => $used_keywords_assessment_location->get_url( $used_keywords_assessment_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
 		) );
 
 		/**

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -111,8 +111,8 @@ class WPSEO_Taxonomy {
 			$analysis_worker_location          = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ) );
 			$used_keywords_assessment_location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ), 'used-keywords-assessment' );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper', 'wpseoAnalysisWorkerL10n', array(
-				'url'                     => $analysis_worker_location->get_url(),
-				'keywords_assessment_url' => $used_keywords_assessment_location->get_url(),
+				'url'                     => $analysis_worker_location->get_url( $analysis_worker_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
+				'keywords_assessment_url' => $used_keywords_assessment_location->get_url( $used_keywords_assessment_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
 			) );
 
 			/**

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ Bugfixes:
 * Fixes a bug where the Gutenberg editor in the Classic Editor plugin would crash when the primary category picker was loaded. If something goes wrong in the primary category picker, it now shows a notification, instead of making the entire editor crash.
 * Fixes a bug where the readability analysis would not show the correct scores for cornerstone content.
 * Fixes a bug where switching off the SEO analysis would stop the readability analysis from loading.
+* Fixes a fatal error on the Term and Post-edit pages when the server is running on PHP 5.2.
 
 = 8.1.2 =
 Release Date: September 5th, 2018

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,7 @@ Bugfixes:
 * Fixes a bug where the Gutenberg editor in the Classic Editor plugin would crash when the primary category picker was loaded. If something goes wrong in the primary category picker, it now shows a notification, instead of making the entire editor crash.
 * Fixes a bug where the readability analysis would not show the correct scores for cornerstone content.
 * Fixes a bug where switching off the SEO analysis would stop the readability analysis from loading.
-* Fixes a fatal error on the Term and Post-edit pages when the server is running on PHP 5.2.
+* Fixes a fatal error on the Term and Post edit pages when the server is running on PHP 5.2.
 
 = 8.1.2 =
 Release Date: September 5th, 2018

--- a/tests/admin/test-class-admin-asset-analysis-worker-location.php
+++ b/tests/admin/test-class-admin-asset-analysis-worker-location.php
@@ -21,8 +21,14 @@ final class Test_WPSEO_Admin_Asset_Analysis_Worker_Location extends PHPUnit_Fram
 		$location    = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'test' );
 		$actual_js   = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
 		$this->assertEquals( $expected_js, $actual_js );
+	}
 
-		// Specified name.
+	/**
+	 * Tests the get_url function when we pass a name.
+	 *
+	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
+	 */
+	public function test_get_url_with_name() {
 		$expected_js = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/wp-seo-something-else-version.js';
 		$location    = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'version', 'something-else' );
 		$actual_js   = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );

--- a/tests/admin/test-class-admin-asset-analysis-worker-location.php
+++ b/tests/admin/test-class-admin-asset-analysis-worker-location.php
@@ -21,9 +21,7 @@ final class Test_WPSEO_Admin_Asset_Analysis_Worker_Location extends PHPUnit_Fram
 		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'test' );
 
 		$actual_js = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
-		$actual_null = $location->get_url( $location->get_asset(), null );
 
 		$this->assertEquals( $expected_js, $actual_js );
-		$this->assertEquals( $expected_js, $actual_null );
 	}
 }

--- a/tests/admin/test-class-admin-asset-analysis-worker-location.php
+++ b/tests/admin/test-class-admin-asset-analysis-worker-location.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin
+ */
+
+/**
+ * Tests WPSEO_Admin_Asset
+ */
+final class Test_WPSEO_Admin_Asset_Analysis_Worker_Location extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Tests the get_url function.
+	 *
+	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
+	 */
+	public function test_get_url() {
+		$expected_js = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/wp-seo-analysis-worker-test.js';
+
+		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'test' );
+
+		$actual_js = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
+		$actual_null = $location->get_url( $location->get_asset(), null );
+
+		$this->assertEquals( $expected_js, $actual_js );
+		$this->assertEquals( $expected_js, $actual_null );
+	}
+}

--- a/tests/admin/test-class-admin-asset-analysis-worker-location.php
+++ b/tests/admin/test-class-admin-asset-analysis-worker-location.php
@@ -16,12 +16,16 @@ final class Test_WPSEO_Admin_Asset_Analysis_Worker_Location extends PHPUnit_Fram
 	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
 	 */
 	public function test_get_url() {
+		// Default name.
 		$expected_js = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/wp-seo-analysis-worker-test.js';
+		$location    = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'test' );
+		$actual_js   = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
+		$this->assertEquals( $expected_js, $actual_js );
 
-		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'test' );
-
-		$actual_js = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
-
+		// Specified name.
+		$expected_js = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/wp-seo-something-else-version.js';
+		$location    = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'version', 'something-else' );
+		$actual_js   = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
 		$this->assertEquals( $expected_js, $actual_js );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a fatal error on the Term and Post-edit pages when the server is running on PHP 5.2.

## Relevant technical choices:

* Do not change parameters of interface functions.

## Test instructions

This PR can be tested by following these steps:

* Check the tests in version 7.2

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10925 
