### PR TITLE
Fix json ld title how to block

### DIFF
--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -59,7 +59,7 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 
 		$post = get_post();
 		if ( $post->post_title ) {
-			$json_ld['name'] = get_post()->post_title;
+			$json_ld['name'] = $post->post_title;
 		}
 
 		if ( ! is_array( $attributes['questions'] ) ) {

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -57,7 +57,8 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			'@graph'   => array( $this->get_faq_json_ld() ),
 		);
 
-		if ( get_post()->post_title ) {
+		$post = get_post();
+		if ( $post->post_title ) {
 			$json_ld['name'] = get_post()->post_title;
 		}
 

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -57,11 +57,6 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			'@graph'   => array( $this->get_faq_json_ld() ),
 		);
 
-		$post = get_post();
-		if ( $post->post_title ) {
-			$json_ld['name'] = $post->post_title;
-		}
-
 		if ( ! is_array( $attributes['questions'] ) ) {
 			return $json_ld;
 		}
@@ -83,6 +78,11 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 		$json_ld = array(
 			'@type' => 'FAQPage',
 		);
+
+		$post = get_post();
+		if ( $post->post_title ) {
+			$json_ld['name'] = $post->post_title;
+		}
 
 		return $json_ld;
 	}

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -54,7 +54,7 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	protected function get_json_ld( array $attributes ) {
 		$json_ld = array(
 			'@context' => 'http://schema.org',
-			'@graph'   => array( $this->get_faq_json_ld( $attributes ) ),
+			'@graph'   => array( $this->get_faq_json_ld() ),
 		);
 
 		if ( ! is_array( $attributes['questions'] ) ) {
@@ -72,17 +72,15 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns the JSON LD for a FAQPage in a faq block in array form.
 	 *
-	 * @param array $attributes The attributes of the faq block.
-	 *
 	 * @return array The JSON LD representation of the FAQPage in a faq block in array form.
 	 */
-	protected function get_faq_json_ld( array $attributes ) {
+	protected function get_faq_json_ld() {
 		$json_ld = array(
 			'@type' => 'FAQPage',
 		);
 
-		if ( ! empty( $attributes['jsonTitle'] ) ) {
-			$json_ld['name'] = $attributes['jsonTitle'];
+		if ( ! get_post()->post_title ) {
+			$json_ld['name'] = get_post()->post_title;
 		}
 
 		return $json_ld;

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -57,6 +57,10 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			'@graph'   => array( $this->get_faq_json_ld() ),
 		);
 
+		if ( get_post()->post_title ) {
+			$json_ld['name'] = get_post()->post_title;
+		}
+
 		if ( ! is_array( $attributes['questions'] ) ) {
 			return $json_ld;
 		}

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -45,11 +45,11 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Returns the JSON LD for a how-to block in array form.
+	 * Returns the JSON LD for a FAQ block in array form.
 	 *
-	 * @param array $attributes The attributes of the how-to block.
+	 * @param array $attributes The attributes of the FAQ block.
 	 *
-	 * @return array The JSON LD representation of the how-to block in array form.
+	 * @return array The JSON LD representation of the FAQ block in array form.
 	 */
 	protected function get_json_ld( array $attributes ) {
 		$json_ld = array(
@@ -83,10 +83,6 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 		$json_ld = array(
 			'@type' => 'FAQPage',
 		);
-
-		if ( ! get_post()->post_title ) {
-			$json_ld['name'] = get_post()->post_title;
-		}
 
 		return $json_ld;
 	}

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -79,9 +79,9 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			'@type' => 'FAQPage',
 		);
 
-		$post = get_post();
-		if ( $post->post_title ) {
-			$json_ld['name'] = $post->post_title;
+		$post_title = get_the_title();
+		if ( ! empty( $post_title ) ) {
+			$json_ld['name'] = $post_title;
 		}
 
 		return $json_ld;

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -57,7 +57,8 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 			'@type'    => 'HowTo',
 		);
 
-		if ( get_post()->post_title ) {
+		$post = get_post();
+		if ( $post->post_title ) {
 			$json_ld['name'] = get_post()->post_title;
 		}
 

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -59,7 +59,7 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 
 		$post = get_post();
 		if ( $post->post_title ) {
-			$json_ld['name'] = get_post()->post_title;
+			$json_ld['name'] = $post->post_title;
 		}
 
 		if ( ! empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] === true ) {

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -57,9 +57,9 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 			'@type'    => 'HowTo',
 		);
 
-		$post = get_post();
-		if ( $post->post_title ) {
-			$json_ld['name'] = $post->post_title;
+		$post_title = get_the_title();
+		if ( ! empty( $post_title ) ) {
+			$json_ld['name'] = $post_title;
 		}
 
 		if ( ! empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] === true ) {

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -57,6 +57,10 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 			'@type'    => 'HowTo',
 		);
 
+		if ( get_post()->post_title ) {
+			$json_ld['name'] = get_post()->post_title;
+		}
+
 		if ( ! empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] === true ) {
 			$days    = empty( $attributes['days'] ) ? 0 : $attributes['days'];
 			$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];

--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -23,14 +23,6 @@ export default () => {
 		},
 		// Block attributes - decides what to save and how to parse it from and to HTML.
 		attributes: {
-			title: {
-				type: "array",
-				source: "children",
-				selector: ".schema-faq-title",
-			},
-			jsonTitle: {
-				type: "string",
-			},
 			questions: {
 				type: "array",
 			},

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -9,7 +9,6 @@ import Question from "./Question";
 import { stripHTML } from "../../../helpers/stringHelpers";
 import appendSpace from "../../../components/higherorder/appendSpace";
 
-const { RichText } = window.wp.editor;
 const { IconButton } = window.wp.components;
 const { Component, renderToString } = window.wp.element;
 

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -186,7 +186,7 @@ export default class FAQ extends Component {
 		delete this.editorRefs[ `${ deletedIndex }:question` ];
 		delete this.editorRefs[ `${ deletedIndex }:answer` ];
 
-		let fieldToFocus = "title";
+		let fieldToFocus = "0:question";
 		if ( this.editorRefs[ `${ index }:question` ] ) {
 			fieldToFocus = `${ index }:question`;
 		} else if ( this.editorRefs[ `${ index - 1 }:answer` ] ) {
@@ -284,7 +284,7 @@ export default class FAQ extends Component {
 	 * @returns {Component} The component representing a FAQ block.
 	 */
 	static Content( attributes ) {
-		let { title, questions, className } = attributes;
+		let { questions, className } = attributes;
 
 		let questionList = questions ? questions.map( ( question ) =>
 			<Question.Content { ...question } />
@@ -294,12 +294,6 @@ export default class FAQ extends Component {
 
 		return (
 			<div className={ classNames }>
-				<RichText.Content
-					tagName="h2"
-					className="schema-faq-title"
-					value={ title }
-					id={ stripHTML( renderToString( title ) ).toLowerCase().replace( /\s+/g, "-" ) }
-				/>
 				{ questionList }
 			</div>
 		);
@@ -311,25 +305,12 @@ export default class FAQ extends Component {
 	 * @returns {Component} The FAQ block editor.
 	 */
 	render() {
-		let { attributes, setAttributes, className } = this.props;
+		let { className } = this.props;
 
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );
 
 		return (
 			<div className={ classNames }>
-				<RichText
-					tagName="h2"
-					className="schema-faq-title"
-					value={ attributes.title }
-					isSelected={ this.state.focus === "title" }
-					setFocusedElement={ () => this.setFocus( "title" ) }
-					onChange={ ( title ) => setAttributes( { title, jsonTitle: stripHTML( renderToString( title ) ) } ) }
-					onSetup={ ( ref ) => {
-						this.editorRefs.title = ref;
-					} }
-					placeholder={ __( "Enter a title for your FAQ section", "wordpress-seo" ) }
-					keepPlaceholderOnFocus={ true }
-				/>
 				<div>
 					{ this.getQuestions() }
 				</div>

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -7,9 +7,6 @@ import HowTo from "./components/HowTo";
 const { registerBlockType } = window.wp.blocks;
 
 const attributes = {
-	jsonTitle: {
-		type: "string",
-	},
 	hasDuration: {
 		type: "boolean",
 	},


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix json ld title for how to and FAQ block

## Relevant technical choices:

* Used `get_post` to retrieve title for post.

## Test instructions

This PR can be tested by following these steps:

* Create a post with a title.
* Publish and view the post, inspect the page and look for the generated `json/ld` on the page.

## Quality assurance

* [x] I have tested this code to the best of my abilities
