### PR TITLE
Update Yoast Components to v.4.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components.git#develop",
+    "yoast-components": "^4.11.0",
     "yoastseo": "^1.39.2"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11089,9 +11089,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-"yoast-components@git+https://github.com/Yoast/yoast-components.git#develop":
-  version "4.10.1"
-  resolved "git+https://github.com/Yoast/yoast-components.git#b71c7a91fa1d7dbd2b47d349da6a829b8180eb1c"
+yoast-components@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.11.0.tgz#339251b9a85693b4345feb5aea9b8281dd086053"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Bumps the version of Yoast Components to 4.11.0.

## Test instructions

This PR can be tested by following these steps:

* Test changelog items of Yoast Components 4.11.