### PR TITLE
Fix bug where local time instead of UTC time is used for publication_time in metadata. 

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -725,7 +725,7 @@ class WPSEO_OpenGraph {
 
 		$post = get_post();
 
-		$pub = mysql2date( DATE_W3C, $post->post_date, false );
+		$pub = mysql2date( DATE_W3C, $post->post_date_gmt, false );
 		$this->og_tag( 'article:published_time', $pub );
 
 		$mod = mysql2date( DATE_W3C, $post->post_modified, false );

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -728,7 +728,7 @@ class WPSEO_OpenGraph {
 		$pub = mysql2date( DATE_W3C, $post->post_date_gmt, false );
 		$this->og_tag( 'article:published_time', $pub );
 
-		$mod = mysql2date( DATE_W3C, $post->post_modified, false );
+		$mod = mysql2date( DATE_W3C, $post->post_modified_gmt, false );
 		if ( $mod !== $pub ) {
 			$this->og_tag( 'article:modified_time', $mod );
 			$this->og_tag( 'og:updated_time', $mod );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes incorrect time in OG metadata for published_time.

## Relevant technical choices:

* published_time used post_date instead of post_date_gmt, leading to a local time without a timezone modifier in the metadata. 

## Test instructions

This PR can be tested by following these steps:

**How to reproduce:** 
* Go to `Settings->General`, set timezone to **"UTC+2"**.
* Create a new post, put the local UTC time in the title (just to make it easier to read). In this example let's say it's '14:19'. If you want to double check the current utc time,  type "current utc time" in google, to make sure you are comparing the news sitemap time with the correct time. 
* Now open the post and view its source. Look for the `meta property="article:published_time"`, it should be "16:19:05+00:00", which is incorrect. This is the local time without the timezone modifier applied. 
* Now go to `Settings->General`, set timezone to **"Amsterdam"**.
* The metadata should read:   "16:19:05+00:00", Which is correct. 

**How to test:** 
* Now checkout this branch and repeat the steps. 
* The time should now just be the UTC time without a modifier. For example. If the timezone setting for your website is on Amsterdam and your post is published at 11:00, the time in the sitemap should be 9:00. 

* timezone **"Amsterdam"**:
The metadata should read:   "14:19:05+00:00", Which is correct. 

* Timezone **"UTC+2"**.
The metadata should read:   "14:19:05+00:00", Which is correct.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10971
