### PR TITLE
Remove deprecation warnings from `grunt build:css`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react": "^16.3.0",
     "react-dom": "16.3.0",
     "redux-logger": "^3.0.6",
-    "sassdash": "^0.8.1",
+    "sassdash": "^0.9.0",
     "svg-react-loader": "^0.4.5",
     "time-grunt": "^1.0.0",
     "unminified-webpack-plugin": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8710,13 +8710,9 @@ sass-graph@^2.1.1, sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
-sassdash@0.9.0:
+sassdash@0.9.0, sassdash@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/sassdash/-/sassdash-0.9.0.tgz#e2114e80af0c01639d1c6b88a3eb350740cb1169"
-
-sassdash@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/sassdash/-/sassdash-0.8.2.tgz#42d59b4932f13034695604bd8437e2b598afd368"
 
 sax@>=0.6.0, sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices

* Sassdash has fixed the deprecations, so we can just upgrade sassdash to get rid of the deprecations

## Test instructions

This PR can be tested by following these steps:

* Checkout `trunk`.
* Run `yarn`.
* Run `grunt build:css`.
* See a ton of `DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal in Sass 4.0. Use call(get-function("--join")) instead.`.
* Checkout this branch (`upgrade-sassdash`)
* Run `yarn`.
* Run `grunt build:css`.
* Don't see the deprecation warnings.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended