### PR TITLE
Added default duration text attribute to use as fallback

### DIFF
--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -39,6 +39,9 @@ const attributes = {
 	durationText: {
 		type: "string",
 	},
+	defaultDurationText: {
+		type: "string",
+	},
 };
 
 export default () => {

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -56,11 +56,8 @@ export default class HowTo extends Component {
 		this.toggleListType  = this.toggleListType.bind( this );
 		this.setDurationText = this.setDurationText.bind( this );
 
-		if ( ! this.props.attributes.durationText ) {
-			const defaultDurationText = this.getDefaultDurationText();
-
-			this.setDurationText( defaultDurationText );
-		}
+		const defaultDurationText = this.getDefaultDurationText();
+		this.setDefaultDurationText( defaultDurationText );
 
 		this.editorRefs = {};
 	}
@@ -89,12 +86,20 @@ export default class HowTo extends Component {
 	 * @returns {void}
 	 */
 	setDurationText( text ) {
-		if ( text === "" ) {
-			text = this.getDefaultDurationText();
-		}
 		this.props.setAttributes( { durationText: text } );
 	}
 
+	/**
+	 * Sets the default duration text to describe the time the guide in the how-to block takes, when no duration text
+	 * was provided.
+	 *
+	 * @param {string} text The text to describe the duration.
+	 *
+	 * @returns {void}
+	 */
+	setDefaultDurationText( text ) {
+		this.props.setAttributes( { defaultDurationText: text } );
+	}
 
 	/**
 	 * Generates a pseudo-unique id.
@@ -371,6 +376,7 @@ export default class HowTo extends Component {
 			additionalListCssClasses,
 			className,
 			durationText,
+			defaultDurationText,
 		} = props;
 
 		steps = steps
@@ -394,7 +400,7 @@ export default class HowTo extends Component {
 				{ ( hasDuration && typeof timeString === "string" && timeString.length > 0 ) &&
 					<p className="schema-how-to-total-time">
 						<span className="schema-how-to-duration-time-text">
-							{ durationText }
+							{ durationText || defaultDurationText }
 							&nbsp;
 						</span>
 						{ timeString + ". " }
@@ -491,7 +497,7 @@ export default class HowTo extends Component {
 				<legend
 					className="schema-how-to-duration-legend"
 				>
-					{ attributes.durationText }
+					{ attributes.durationText || this.getDefaultDurationText() }
 				</legend>
 				<span className="schema-how-to-duration-time-input">
 					<label

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -90,7 +90,7 @@ export default class HowTo extends Component {
 	}
 
 	/**
-	 * Sets the default duration text to describe the time the guide in the how-to block takes, when no duration text
+	 * Sets the default duration text to describe the time the instructions in the how-to block take, when no duration text
 	 * was provided.
 	 *
 	 * @param {string} text The text to describe the duration.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Adds `defaultDurationText` to fall back to when no `durationText` is specified. Because saving the default duration text (where the js filter is applied) as the `durationText` attribute makes it populate the field in the block settings when the editor is reloaded, and this is not what we want.

## Test instructions

This PR can be tested by following these steps:

* Follow the steps in #10983.
* Also test if overriding the duration text in the block settings still works, and try reverting to the default duration text again after that.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10983 
