### PR TITLE
Change http://schema.org url to https in json/ld

### DIFF
--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -53,7 +53,7 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	 */
 	protected function get_json_ld( array $attributes ) {
 		$json_ld = array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@graph'   => array( $this->get_faq_json_ld() ),
 		);
 

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -53,7 +53,7 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	 */
 	protected function get_json_ld( array $attributes ) {
 		$json_ld = array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@type'    => 'HowTo',
 		);
 


### PR DESCRIPTION
## Summary

Changes `@context` param from `http://schema.org` to `https://schema.org` in structured data blocks output.

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Create a post in Gutenberg, add a FAQ and How to structured data block, with some data.
* Preview the post and inspect the html, and search for the `application/ld+json` script tags output by the FAQ and How To blocks.
* Make sure that the `@context` parameter has the value `https:\/\/schema.org` and **not** `http:\/\/schema.org`.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #
