### PR TITLE
Add colon as a title separator choice in the onboarding wizard

### DIFF
--- a/admin/config-ui/fields/class-field-separator.php
+++ b/admin/config-ui/fields/class-field-separator.php
@@ -21,8 +21,8 @@ class WPSEO_Config_Field_Separator extends WPSEO_Config_Field_Choice {
 
 		$this->add_choice( 'sc-dash', '-', __( 'Dash', 'wordpress-seo' ) );
 		$this->add_choice( 'sc-ndash', '&ndash;', __( 'En dash', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-colon', ':', __( 'Colon', 'wordpress-seo' ) );
 		$this->add_choice( 'sc-mdash', '&mdash;', __( 'Em dash', 'wordpress-seo' ) );
+		$this->add_choice( 'sc-colon', ':', __( 'Colon', 'wordpress-seo' ) );
 		$this->add_choice( 'sc-middot', '&middot;', __( 'Middle dot', 'wordpress-seo' ) );
 		$this->add_choice( 'sc-bull', '&bull;', __( 'Bullet', 'wordpress-seo' ) );
 		$this->add_choice( 'sc-star', '*', __( 'Asterisk', 'wordpress-seo' ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds colon as a title separator choice in the onboarding wizard.

## Test instructions

This PR can be tested by following these steps:

* Open te onboarding wizard (`SEO` > `General` > `Open the configuration wizard again`).
* Go to step 9 `Title Settings`.
* Check that the 4th option is "colon"/`:`.
* Select this option, click next, close the onboarding wizard.
* Go to `SEO` > `Search Appearance` > `General`.
* Check if the selected title separator is updated to "colon"/`:`.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #10989
