### PR TITLE
Replace replacevars in Facebook description

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -603,6 +603,7 @@ class WPSEO_OpenGraph {
 			if ( $ogdesc === '' ) {
 				$ogdesc = WPSEO_Taxonomy_Meta::get_meta_without_term( 'desc' );
 			}
+			$ogdesc = wpseo_replace_vars( $ogdesc, get_queried_object() );
 		}
 
 		// Strip shortcodes if any.

--- a/tests/frontend/test-class-opengraph.php
+++ b/tests/frontend/test-class-opengraph.php
@@ -691,6 +691,32 @@ EXPECTED;
 	}
 
 	/**
+	 * Testing with an Open Graph meta description for the taxonomy.
+	 *
+	 * @covers WPSEO_OpenGraph::description
+	 */
+	public function test_taxonomy_description_with_replacevars() {
+		$expected_title = 'Test title';
+		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => $expected_title ) );
+
+		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-description', '%%term_title%%' );
+
+		$this->go_to( get_term_link( $term_id, 'category' ) );
+
+		$class_instance = new WPSEO_OpenGraph();
+
+		ob_start();
+
+		$class_instance->opengraph();
+
+		$output = ob_get_clean();
+
+		$expected_html  = '<meta property="og:description" content="' . $expected_title . '" />' . "\n";
+
+		$this->assertContains( $expected_html, $output );
+	}
+
+	/**
 	 * Testing with an Open Graph meta image for the taxonomy.
 	 *
 	 * @covers WPSEO_OpenGraph::image


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where snippet variables would not be replaced in the `og:description` of taxonomies when they were added in the Facebook Description input field.

## Relevant technical choices:

## Test instructions

This PR can be tested by following these steps:

* Create a category.
* Go to social settings  > Facebook in the metabox. 
* Use replacevars in the Facebook Description.
* Save and publish the post.
* Go to the frontend and inspect the page.
* The content of `<meta property=“og:description”` should show replaced replacevars.
* Repeat these steps for tags and custom taxonomies.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11002
