### PR TITLE
Fixed FAQ json/ld formatting and added unit-test

### DIFF
--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -62,7 +62,7 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			$json_ld['name'] = $post_title;
 		}
 
-		if ( ! is_array( $attributes['questions'] ) ) {
+		if ( ! array_key_exists( 'questions', $attributes ) || ! is_array( $attributes['questions'] ) ) {
 			return $json_ld;
 		}
 

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -66,14 +66,14 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			return $json_ld;
 		}
 
-		$mainEntity = array();
+		$main_entity = array();
 
 		$questions = array_filter( $attributes['questions'], 'is_array' );
 		foreach ( $questions as $question ) {
-			$mainEntity[] = $this->get_question_json_ld( $question );
+			$main_entity[] = $this->get_question_json_ld( $question );
 		}
 
-		$json_ld[ 'mainEntity' ] = $mainEntity;
+		$json_ld['mainEntity'] = $main_entity;
 
 		return $json_ld;
 	}

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -27,12 +27,12 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	/**
 	 * Renders the block.
 	 *
-	 * Because we can't save script tags in Gutenberg without sufficient user permissions we render these server-side.
+	 * Because we can't save script tags in Gutenberg without sufficient user permissions, we render these server-side.
 	 *
 	 * @param array  $attributes The attributes of the block.
 	 * @param string $content    The HTML content of the block.
 	 *
-	 * @return string The block preceded by it's JSON LD script.
+	 * @return string The block preceded by its JSON-LD script.
 	 */
 	public function render( $attributes, $content ) {
 		if ( ! is_array( $attributes ) || ! is_singular() ) {
@@ -45,11 +45,11 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Returns the JSON LD for a FAQ block in array form.
+	 * Returns the JSON-LD for a FAQ block in array form.
 	 *
 	 * @param array $attributes The attributes of the FAQ block.
 	 *
-	 * @return array The JSON LD representation of the FAQ block in array form.
+	 * @return array The JSON-LD representation of the FAQ block in array form.
 	 */
 	protected function get_json_ld( array $attributes ) {
 		$json_ld = array(
@@ -79,11 +79,11 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Returns the JSON LD for a question in a faq block in array form.
+	 * Returns the JSON-LD for a question in a FAQ block in array form.
 	 *
-	 * @param array $question The attributes of a question in the faq block.
+	 * @param array $question The attributes of a question in the FAQ block.
 	 *
-	 * @return array The JSON LD representation of the question in a faq block in array form.
+	 * @return array The JSON-LD representation of the question in a FAQ block in array form.
 	 */
 	protected function get_question_json_ld( array $question ) {
 		$json_ld = array(

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -54,35 +54,26 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	protected function get_json_ld( array $attributes ) {
 		$json_ld = array(
 			'@context' => 'https://schema.org',
-			'@graph'   => array( $this->get_faq_json_ld() ),
-		);
-
-		if ( ! is_array( $attributes['questions'] ) ) {
-			return $json_ld;
-		}
-
-		$questions = array_filter( $attributes['questions'], 'is_array' );
-		foreach ( $questions as $question ) {
-			$json_ld['@graph'][] = $this->get_question_json_ld( $question );
-		}
-
-		return $json_ld;
-	}
-
-	/**
-	 * Returns the JSON LD for a FAQPage in a faq block in array form.
-	 *
-	 * @return array The JSON LD representation of the FAQPage in a faq block in array form.
-	 */
-	protected function get_faq_json_ld() {
-		$json_ld = array(
-			'@type' => 'FAQPage',
+			'@type'    => 'FAQPage',
 		);
 
 		$post_title = get_the_title();
 		if ( ! empty( $post_title ) ) {
 			$json_ld['name'] = $post_title;
 		}
+
+		if ( ! is_array( $attributes['questions'] ) ) {
+			return $json_ld;
+		}
+
+		$mainEntity = array();
+
+		$questions = array_filter( $attributes['questions'], 'is_array' );
+		foreach ( $questions as $question ) {
+			$mainEntity[] = $this->get_question_json_ld( $question );
+		}
+
+		$json_ld[ 'mainEntity' ] = $mainEntity;
 
 		return $json_ld;
 	}
@@ -111,7 +102,7 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			);
 
 			if ( ! empty( $question['jsonImageSrc'] ) ) {
-				$json_ld['acceptedAnswer']['associatedMedia'] = array(
+				$json_ld['acceptedAnswer']['image'] = array(
 					'@type'      => 'ImageObject',
 					'contentUrl' => $question['jsonImageSrc'],
 				);

--- a/tests/doubles/class-faq-block-double.php
+++ b/tests/doubles/class-faq-block-double.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_FAQ_Block_Double extends WPSEO_FAQ_Block {
+	/**
+	 * @inheritdoc
+	 */
+	public function get_json_ld( array $attributes ) {
+		return parent::get_json_ld( $attributes );
+	}
+}

--- a/tests/inc/structured-data-blocks/test-class-faq-block.php
+++ b/tests/inc/structured-data-blocks/test-class-faq-block.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests
+ */
+
+/**
+ * Unit Test Class.
+ */
+class WPSEO_FAQ_Block_Test extends WPSEO_UnitTestCase {
+	public function test_get_json_ld() {
+		$instance = new WPSEO_FAQ_Block_Double();
+
+		$attributes = array(
+			'questions' => array(
+				array(
+					'jsonQuestion' => 'What to do?',
+					'jsonAnswer'   => 'All the things!',
+					'jsonImageSrc' => 'https://www.images.com/image.jpg',
+				),
+				array(
+					'jsonQuestion' => 'What to do again?',
+					'jsonAnswer'   => 'All the things! (Again)',
+				),
+			),
+		);
+
+		$expected = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
+			'mainEntity' => array(
+				array(
+					'@type'          => 'Question',
+					'name'           => 'What to do?',
+					'answerCount'    => 1,
+					'acceptedAnswer' => array(
+						'@type' => 'Answer',
+						'text'  => 'All the things!',
+						'image' => array(
+							'@type'      => 'ImageObject',
+							'contentUrl' => 'https://www.images.com/image.jpg'
+						)
+					),
+				),
+				array(
+					'@type'          => 'Question',
+					'name'           => 'What to do again?',
+					'answerCount'    => 1,
+					'acceptedAnswer' => array(
+						'@type' => 'Answer',
+						'text'  => 'All the things! (Again)',
+					),
+				)
+			),
+		);
+
+		$this->assertEquals( $expected, $instance->get_json_ld( $attributes ) );
+	}
+}

--- a/tests/inc/structured-data-blocks/test-class-faq-block.php
+++ b/tests/inc/structured-data-blocks/test-class-faq-block.php
@@ -9,6 +9,11 @@
  * Unit Test Class.
  */
 class WPSEO_FAQ_Block_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Tests the FAQ structured data object format that is output by get_json_ld.
+	 *
+	 * @covers WPSEO_FAQ_Block::get_json_ld()
+	 */
 	public function test_get_json_ld() {
 		$instance = new WPSEO_FAQ_Block_Double();
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Rename `associatedMedia` property in the FAQ block's structured data output to `image`, to reflect a change in Google's guidelines.
* Moved the `@type` and `name` properties to the root of the FAQ block's structured data output.
* Nested `Question` objects in the newly introduced `mainEntity` propery in the FAQ block's structured data output.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* In Gutenberg, create a new post with a FAQ block.
* Add a question with a question, answer and image.
* Add a question with a question and an answer.
* Publish the post and inspect the `application/ld-json` script element.
* Optionally copy the content of the `script` element into https://jsonformatter.curiousconcept.com/ for better readability.
* Make sure all changes described in #11004 have been applied.
* Also copy the contents into https://search.google.com/structured-data/testing-tool/ and make sure the validation passes.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11004 
