### PR TITLE
Fixed How To json/ld formatting and added unit-test

### DIFF
--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -90,7 +90,7 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns the JSON-LD for a step-section in a how-to block.
 	 *
-	 * @param array $step  The attributes of a step-section in the how-to block.
+	 * @param array $step The attributes of a step-section in the how-to block.
 	 *
 	 * @return array The JSON-LD representation of the step-section in a how-to block.
 	 */
@@ -117,13 +117,13 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns the JSON-LD for a step's description in a how-to block.
 	 *
-	 * @param array $step  The attributes of a step(-section) in the how-to block.
+	 * @param array $step The attributes of a step(-section) in the how-to block.
 	 *
 	 * @return array The JSON-LD representation of the step's description in a how-to block.
 	 */
 	protected function get_step_json_ld( array $step ) {
 		$step_json_ld = array(
-			'@type'    => 'HowToStep',
+			'@type' => 'HowToStep',
 		);
 
 		if ( ! empty( $step['jsonText'] ) ) {

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -79,8 +79,8 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 		if ( ! empty( $attributes['steps'] ) && is_array( $attributes['steps'] ) ) {
 			$json_ld['step'] = array();
 			$steps = array_filter( $attributes['steps'], 'is_array' );
-			foreach ( $steps as $index => $step ) {
-				$json_ld['step'][] = $this->get_section_json_ld( $step, $index );
+			foreach ( $steps as $step ) {
+				$json_ld['step'][] = $this->get_section_json_ld( $step );
 			}
 		}
 
@@ -88,38 +88,16 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Returns the JSON-LD for a step's description in a how-to block.
-	 *
-	 * @param array $step  The attributes of a step(-section) in the how-to block.
-	 * @param int   $index The index of the section in the how-to block.
-	 *
-	 * @return array The JSON-LD representation of the step's description in a how-to block.
-	 */
-	protected function get_step_json_ld( array $step, $index ) {
-		$step_json_ld = array(
-			'@type'    => 'HowToStep',
-			'position' => $index + 1,
-		);
-
-		if ( ! empty( $step['jsonText'] ) ) {
-			$step_json_ld['text'] = $step['jsonText'];
-		}
-
-		return $step_json_ld;
-	}
-
-	/**
 	 * Returns the JSON-LD for a step-section in a how-to block.
 	 *
 	 * @param array $step  The attributes of a step-section in the how-to block.
-	 * @param int   $index The index of the section in the how-to block.
 	 *
 	 * @return array The JSON-LD representation of the step-section in a how-to block.
 	 */
-	protected function get_section_json_ld( array $step, $index ) {
+	protected function get_section_json_ld( array $step ) {
 		$section_json_ld = array(
 			'@type'           => 'HowToSection',
-			'itemListElement' => $this->get_step_json_ld( $step, $index ),
+			'itemListElement' => $this->get_step_json_ld( $step ),
 		);
 
 		if ( ! empty( $step['jsonName'] ) ) {
@@ -127,12 +105,31 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 		}
 
 		if ( ! empty( $step['jsonImageSrc'] ) ) {
-			$section_json_ld['associatedMedia'] = array(
+			$section_json_ld['image'] = array(
 				'@type'      => 'ImageObject',
 				'contentUrl' => $step['jsonImageSrc'],
 			);
 		}
 
 		return $section_json_ld;
+	}
+
+	/**
+	 * Returns the JSON-LD for a step's description in a how-to block.
+	 *
+	 * @param array $step  The attributes of a step(-section) in the how-to block.
+	 *
+	 * @return array The JSON-LD representation of the step's description in a how-to block.
+	 */
+	protected function get_step_json_ld( array $step ) {
+		$step_json_ld = array(
+			'@type'    => 'HowToStep',
+		);
+
+		if ( ! empty( $step['jsonText'] ) ) {
+			$step_json_ld['text'] = $step['jsonText'];
+		}
+
+		return $step_json_ld;
 	}
 }

--- a/tests/doubles/class-how-to-block-double.php
+++ b/tests/doubles/class-how-to-block-double.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_How_To_Block_Double extends WPSEO_How_To_Block {
+	/**
+	 * @inheritdoc
+	 */
+	public function get_json_ld( array $attributes ) {
+		return parent::get_json_ld( $attributes );
+	}
+}

--- a/tests/inc/structured-data-blocks/test-class-how-to-block.php
+++ b/tests/inc/structured-data-blocks/test-class-how-to-block.php
@@ -8,6 +8,11 @@
  * Unit Test Class.
  */
 class WPSEO_How_To_Block_Test extends WPSEO_UnitTestCase {
+	/**
+	 * Tests the HowTo structured data object format that is output by get_json_ld.
+	 *
+	 * @covers WPSEO_How_To_Block::get_json_ld()
+	 */
 	public function test_get_json_ld() {
 		$instance = new WPSEO_How_To_Block_Double();
 

--- a/tests/inc/structured-data-blocks/test-class-how-to-block.php
+++ b/tests/inc/structured-data-blocks/test-class-how-to-block.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests
+ */
+/**
+ * Unit Test Class.
+ */
+class WPSEO_How_To_Block_Test extends WPSEO_UnitTestCase {
+	public function test_get_json_ld() {
+		$instance = new WPSEO_How_To_Block_Double();
+
+		$attributes = array(
+			'hasDuration'     => true,
+			'days'            => 1,
+			'hours'           => 12,
+			'minutes'         => 30,
+			'jsonDescription' => 'How to description!',
+			'steps'           => array(
+				array(
+					'jsonName'     => 'Step 1',
+					'jsonText'     => 'Step 1 text',
+					'jsonImageSrc' => 'https://www.image.com/image.jpg',
+				),
+				array(
+					'jsonName'     => 'Step 2',
+					'jsonText'     => 'Step 2 text',
+				),
+			),
+		);
+
+		$expected = array(
+			'@context'    => 'https://schema.org',
+			'@type'       => 'HowTo',
+			'totalTime'   => 'P1DT12H30M',
+			'description' => 'How to description!',
+			'step'        => array(
+				array(
+					'@type'           => 'HowToSection',
+					'itemListElement' => array(
+						'@type'    => 'HowToStep',
+						'text'     => 'Step 1 text',
+					),
+					'name' => 'Step 1',
+					'image' => array(
+						'@type'      => 'ImageObject',
+						'contentUrl' => 'https://www.image.com/image.jpg',
+					),
+				),
+				array(
+					'@type'           => 'HowToSection',
+					'itemListElement' => array(
+						'@type'    => 'HowToStep',
+						'text'     => 'Step 2 text',
+					),
+					'name' => 'Step 2',
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $instance->get_json_ld( $attributes ) );
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Rename `associatedMedia` property in the How To block's structured data output to `image`, to reflect a change in Google's guidelines.
* Remove superfluous `position` property from the How To block's structured data output.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* In Gutenberg, create a new post with a How To block.
* Add a how to step with a title and description.
* Add a how to step with a title, description and an image.
* Publish the post and inspect the `application/ld-json` script element.
* Optionally copy the content of the `script` element into https://jsonformatter.curiousconcept.com/ for better readability.
* Make sure all changes described in #11001 have been applied.
* Also copy the contents into https://search.google.com/structured-data/testing-tool/ and make sure the validation passes.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11001