### PR TITLE
Added new filter wpseo_sitemap_post_type_archive_links

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -430,7 +430,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		/**
 		 * Filter the URL Yoast SEO uses in the XML sitemap for this post type archive.
 		 *
-		 * @param string $archive_url The URL of this archive
+		 * @param string $archive_url The URL of this archive.
 		 * @param string $post_type   The post type this archive is for.
 		 */
 		$archive_url = apply_filters( 'wpseo_sitemap_post_type_archive_link', $archive_url, $post_type );
@@ -440,8 +440,8 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			/**
 			 * Filter post type archive URL as an array, allowing it to work with many links.
 			 *
-			 * @param array $archive_url A list of archive URLs.
-			 * @param string $post_type  The post type this archive is for.
+			 * @param array  $archive_url A list of archive URLs.
+			 * @param string $post_type   The post type this archive is for.
 			 */
 			$archive_urls = apply_filters( 'wpseo_sitemap_post_type_archive_links', array( $archive_url ), $post_type );
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -438,11 +438,10 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		if ( $archive_url ) {
 
 			/**
-			 * Filter post type archive URL as an array,
-			 * allowing it to work with many links
+			 * Filter post type archive URL as an array, allowing it to work with many links.
 			 *
-			 * @param array $archive_url A list of archive URLs
-			 * @param string $post_type  The post type this archive is for
+			 * @param array $archive_url A list of archive URLs.
+			 * @param string $post_type  The post type this archive is for.
 			 */
 			$archive_urls = apply_filters( 'wpseo_sitemap_post_type_archive_links', array( $archive_url ), $post_type );
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -436,20 +436,32 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$archive_url = apply_filters( 'wpseo_sitemap_post_type_archive_link', $archive_url, $post_type );
 
 		if ( $archive_url ) {
-			/**
-			 * Filter the priority of the URL Yoast SEO uses in the XML sitemap.
-			 *
-			 * @param float  $priority  The priority for this URL, ranging from 0 to 1
-			 * @param string $post_type The post type this archive is for.
-			 */
-			$links[] = array(
-				'loc' => $archive_url,
-				'mod' => WPSEO_Sitemaps::get_last_modified_gmt( $post_type ),
 
-				// Deprecated, kept for backwards data compat. R.
-				'chf' => 'daily',
-				'pri' => 1,
-			);
+			/**
+			 * Filter post type archive URL as an array,
+			 * allowing it to work with many links
+			 *
+			 * @param array $archive_url A list of archive URLs
+			 * @param string $post_type  The post type this archive is for
+			 */
+			$archive_urls = apply_filters( 'wpseo_sitemap_post_type_archive_links', array( $archive_url ), $post_type );
+
+			foreach ( $archive_urls as $url ) {
+				/**
+				 * Filter the priority of the URL Yoast SEO uses in the XML sitemap.
+				 *
+				 * @param float  $priority  The priority for this URL, ranging from 0 to 1
+				 * @param string $post_type The post type this archive is for.
+				 */
+				$links[] = array(
+					'loc' => $url,
+					'mod' => WPSEO_Sitemaps::get_last_modified_gmt( $post_type ),
+
+					// Deprecated, kept for backwards data compat. R.
+					'chf' => 'daily',
+					'pri' => 1,
+				);
+			}
 		}
 
 		return $links;


### PR DESCRIPTION
## Summary

The aim of this filter is to let third parties add many links to post type archive sitemap. Very useful for multilingual plugins.

Fixes #11024


This PR can be summarized in the following changelog entry:

Add new filter wpseo_sitemap_post_type_archive_links

## Relevant technical choices:

There is a filter `wpseo_sitemap_post_type_archive_link`, however, I didn't want to break backward compatibility, so I chose a new one, just plural form of the same.

## Test instructions

This PR can be tested by following these steps:

* Paste the code below in the `functions.php` file of the current active theme:

```php
add_filter( 'wpseo_sitemap_post_type_archive_links', function( $links, $post_type ) {
	$links[] = 'http://dev.otgs/pt-br/blog/school';
	return $links;
}, 10, 2 );
```

* Now open the sitemap.xml of this particular post type URL, in this case Schools (e.g.: http://dev.otgs/school-sitemap.xml)
* Assert that you can see your new URL in the list of links, `http://dev.otgs/pt-br/blog/school`

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
