### PR TITLE
Add an OpenGraph image cache

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -71,6 +71,8 @@ class WPSEO_Admin {
 
 		add_action( 'admin_init', array( $this, 'map_manage_options_cap' ) );
 
+		add_action( 'save_post', array( $this, 'clear_opengraph_image_cache' ), 10, 1 );
+
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'wpseo' );
 		WPSEO_Sitemaps_Cache::register_clear_on_option_update( 'home' );
 
@@ -327,6 +329,17 @@ class WPSEO_Admin {
 	 */
 	public function check_php_version() {
 		// Intentionally left empty.
+	}
+
+	/**
+	 * Removes the opengraph image cache for a post.
+	 *
+	 * @param int $post_id Post to remove the cache for.
+	 *
+	 * @return void
+	 */
+	public function clear_opengraph_image_cache( $post_id ) {
+		delete_post_meta( $post_id, 'wpseo_opengraph_image_cache' );
 	}
 
 	/**

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -217,14 +217,17 @@ class WPSEO_OpenGraph_Image {
 	 */
 	private function set_posts_page_image() {
 		$post_id = get_option( 'page_for_posts' );
-
-		$this->set_image_post_meta( $post_id );
-
-		if ( $this->has_images() ) {
+		if ( $this->get_image_cache( $post_id ) ) {
 			return;
 		}
 
-		$this->set_featured_image( $post_id );
+		$this->set_image_post_meta( $post_id );
+
+		if ( ! $this->has_images() ) {
+			$this->set_featured_image( $post_id );
+		}
+
+		$this->store_image_cache( $post_id );
 	}
 
 	/**
@@ -238,14 +241,17 @@ class WPSEO_OpenGraph_Image {
 		if ( $post_id === null ) {
 			$post_id = $this->get_queried_object_id();
 		}
-
-		$this->set_user_defined_image( $post_id );
-
-		if ( $this->has_images() ) {
+		if ( $this->get_image_cache( $post_id ) ) {
 			return;
 		}
 
-		$this->add_first_usable_content_image( get_post( $post_id ) );
+		$this->set_user_defined_image( $post_id );
+
+		if ( ! $this->has_images() ) {
+			$this->add_first_usable_content_image( get_post( $post_id ) );
+		}
+
+		$this->store_image_cache( $post_id );
 	}
 
 	/**
@@ -600,5 +606,30 @@ class WPSEO_OpenGraph_Image {
 	 */
 	protected function get_queried_object_id() {
 		return get_queried_object_id();
+	}
+
+	/**
+	 * Retrieves cached image array from postmeta, if it exists.
+	 *
+	 * @param int $post_id The post we're grabbing the cache for.
+	 *
+	 * @return bool Whether we could get a cache or not.
+	 */
+	private function get_image_cache( $post_id ) {
+		$cache = get_post_meta( $post_id, 'wpseo_opengraph_image_cache', true );
+		if ( is_array( $cache ) ) {
+			$this->images = $cache;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Stores the value of the current images array to postmeta for caching.
+	 *
+	 * @param int $post_id The post to save the cache for.
+	 */
+	private function store_image_cache( $post_id ) {
+		update_post_meta( $post_id, 'wpseo_opengraph_image_cache', $this->images );
 	}
 }

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -217,7 +217,7 @@ class WPSEO_OpenGraph_Image {
 	 */
 	private function set_posts_page_image() {
 		$post_id = get_option( 'page_for_posts' );
-		if ( $this->get_image_cache( $post_id ) ) {
+		if ( $this->has_image_cache( $post_id ) ) {
 			return;
 		}
 
@@ -241,7 +241,7 @@ class WPSEO_OpenGraph_Image {
 		if ( $post_id === null ) {
 			$post_id = $this->get_queried_object_id();
 		}
-		if ( $this->get_image_cache( $post_id ) ) {
+		if ( $this->has_image_cache( $post_id ) ) {
 			return;
 		}
 
@@ -615,7 +615,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @return bool Whether we could get a cache or not.
 	 */
-	private function get_image_cache( $post_id ) {
+	private function has_image_cache( $post_id ) {
 		$cache = get_post_meta( $post_id, 'wpseo_opengraph_image_cache', true );
 		if ( is_array( $cache ) ) {
 			$this->images = $cache;


### PR DESCRIPTION
## Summary

Our OG image generation process is far too slow to be run on every pageview. Hence: caching.

This PR can be summarized in the following changelog entry:

* Cache the image URL, width and height for images that are used for OpenGraph images in postmeta. 

## Test instructions

This PR can be tested by following these steps:

* See `wpseo_opengraph_image_cache` postmeta fields being created and when you step through the code, see that the cache is used.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10195 
