### PR TITLE
Applies a filter to add some fields to the metabox

### DIFF
--- a/admin/taxonomy/class-taxonomy-content-fields.php
+++ b/admin/taxonomy/class-taxonomy-content-fields.php
@@ -48,7 +48,13 @@ class WPSEO_Taxonomy_Content_Fields extends WPSEO_Taxonomy_Fields {
 				''
 			),
 		);
+		/**
+		 * Filter: 'wpseo_taxonomy_content_fields' - Adds the possibility to register additional content fields.
+		 *
+		 * @api array - The additional fields.
+		 */
+		$additional_fields = apply_filters( 'wpseo_taxonomy_content_fields', array() );
 
-		return $this->filter_hidden_fields( $fields );
+		return $this->filter_hidden_fields( array_merge( $fields, $additional_fields ) );
 	}
 }

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -303,6 +303,10 @@ window.yoastHideMarkers = true;
 					YoastSEO.app.pluggable._registerAssessment( YoastSEO.app.cornerStoneSeoAssessor, name, assessment, pluginName );
 			}
 		};
+		YoastSEO.app.changeAssessorOptions = function( assessorOptions ) {
+			YoastSEO.analysis.worker.initialize( assessorOptions );
+			YoastSEO.app.refresh();
+		};
 
 		edit.initializeUsedKeywords( app, "get_term_keyword_usage" );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Introduces the `wpseo_taxonomy_content_fields` filter to add additional fields to the taxonomy metabox.



## Test instructions

This PR can be tested by following these steps:

* This should be tested in combination with https://github.com/Yoast/wordpress-seo-premium/pull/1998

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #[397](https://github.com/Yoast/wordpress-seo-premium/issues/397)