### PR TITLE
[WIP] Allow webpack entries to be filtered

### DIFF
--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -1,12 +1,13 @@
 /* global require, module */
 const path = require( "path" );
+const pick = require( "lodash/pick" );
 
 const jsDistPath = path.resolve( "js", "dist" );
 const jsSrcPath = path.resolve( "js", "src" );
 const cssDistPath = path.resolve( "css", "dist" );
 
 // Output filename: Entry file (relative to jsSrcPath)
-const entry = {
+let entry = {
 	vendor: [
 		"react",
 		"react-dom",
@@ -40,6 +41,26 @@ const entry = {
 	"wp-seo-quick-edit-handler": "./wp-seo-quick-edit-handler.js",
 	"wp-seo-network-admin": "./wp-seo-network-admin.js",
 };
+
+
+// A tool for development to build only defined bundles from the entries list.
+if ( process.env.ENTRY_FILTER ) {
+	const filterTerms = process.env.ENTRY_FILTER.split( "," );
+	const filterEntryNames = ( entryName ) => {
+		return filterTerms.some( ( filterTerm ) => {
+			return entryName.includes( filterTerm );
+		} );
+	};
+
+	const filteredEntryKeys = Object.keys( entry ).filter( filterEntryNames );
+
+	console.log( filteredEntryKeys );
+
+	entry = pick(
+		entry,
+		filteredEntryKeys
+	);
+}
 
 /**
  * Flattens a version for usage in a filename.

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = function( env = { environment: "production" } ) {
 		externals,
 	};
 
-	const config = [
+	let config = [
 		{
 			...base,
 			externals: {
@@ -144,6 +144,12 @@ module.exports = function( env = { environment: "production" } ) {
 		config[ 0 ].devServer = {
 			publicPath: "/",
 		};
+	}
+
+	// Remove unnecessary configuration
+	if ( process.env.ENTRY_FILTER ) {
+		config = config[ 0 ];
+		config.plugins = plugins;
 	}
 
 	return config;


### PR DESCRIPTION
## Summary

Sometimes you are specifically working on one bundle.

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* On Mac/Linux run `ENTRY_FILTER="post-scraper,search-appearance" grunt webpack:buildDev` to only build `wp-seo-post-scraper` and `search-appearance` bundles.
* On windows, you can install `cross-env` globally (`npm i -g cross-env`) and run `cross-env ENTRY_FILTER="post-scraper,search-appearance" grunt webpack:buildDev`.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #
