### PR TITLE
Change keyword snippet variable label

### DIFF
--- a/js/src/values/defaultReplaceVariables.js
+++ b/js/src/values/defaultReplaceVariables.js
@@ -47,7 +47,7 @@ export default function getDefaultReplacementVariables() {
 		},
 		{
 			name: "focuskw",
-			label: __( "Focus keyword", "wordpress-seo" ),
+			label: __( "Focus keyphrase", "wordpress-seo" ),
 			value: "",
 		},
 		{


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch. 
* Open or create a post. Enter a focus keyword.
* Go to the snippet editor and type`%f`. You'll see 'focus keyphrase' in the dropdown.
* Select 'focus keyphrase'. The label of the snippet variable should read 'focus keyphrase' as well.
* **NB** The snippet variable value doesn't update when you change the focus keyword after you've put the snippet variable in the snippet editor. This is not related to this PR.
<img width="463" alt="schermafbeelding 2018-09-19 om 13 44 41" src="https://user-images.githubusercontent.com/17744553/45752442-c0d01e80-bc15-11e8-90b8-2b77e35a51c3.png">



## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11041
