### PR TITLE
Feature/valid image url filter

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -549,7 +549,9 @@ class WPSEO_OpenGraph_Image {
 
 		$image_extension = $this->get_extension_from_url( $url );
 
-		return in_array( $image_extension, $this->valid_image_extensions, true );
+		$is_valid = in_array( $image_extension, $this->valid_image_extensions, true );
+
+		return apply_filters( 'wpseo_opengraph_is_valid_image_url', $is_valid, $url );
 	}
 
 	/**

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -551,6 +551,13 @@ class WPSEO_OpenGraph_Image {
 
 		$is_valid = in_array( $image_extension, $this->valid_image_extensions, true );
 
+		/**
+		 * Filter: 'wpseo_opengraph_is_valid_image_url' - Allows extra validation for an image url.
+		 *
+		 * @api bool - Current validation result.
+		 *
+		 * @param string $url The image url to validate
+		 */
 		return apply_filters( 'wpseo_opengraph_is_valid_image_url', $is_valid, $url );
 	}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -556,7 +556,7 @@ class WPSEO_OpenGraph_Image {
 		 *
 		 * @api bool - Current validation result.
 		 *
-		 * @param string $url The image url to validate
+		 * @param string $url The image url to validate.
 		 */
 		return apply_filters( 'wpseo_opengraph_is_valid_image_url', $is_valid, $url );
 	}

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -119,6 +119,8 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests the wpseo_opengraph_is_valid_image_url filter.
+	 *
+	 * @covers WPSEO_OpenGraph_Image:: is_valid_image_url
 	 */
 	public function test_is_valid_image_url_filter() {
 
@@ -128,19 +130,19 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		// Without the filter, this isn't considered a valid image URL.
 		$this->assertEmpty( $class_instance->get_images() );
 
+		$callback = function( $is_valid, $url ) {
+			return 'https://via.placeholder.com/350x150' === $url;
+		};
+
 		// Enable the filter
-		add_filter( 'wpseo_opengraph_is_valid_image_url', array( $this, 'is_valid_image_url_filter' ), 10, 2 );
+		add_filter( 'wpseo_opengraph_is_valid_image_url', $callback, 10, 2 );
 
 		$class_instance->add_image( 'https://via.placeholder.com/350x150' );
 
 		// Verify the image was added.
 		$this->assertArrayHasKey( 'https://via.placeholder.com/350x150', $class_instance->get_images() );
 
-		remove_filter( 'wpseo_opengraph_is_valid_image_url', array( $this, 'is_valid_image_url_filter' ) );
-	}
-
-	public function is_valid_image_url_filter( $is_valid, $url ) {
-		return 'https://via.placeholder.com/350x150' === $url;
+		remove_filter( 'wpseo_opengraph_is_valid_image_url', $callback );
 	}
 
 	/**

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -130,7 +130,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		// Without the filter, this isn't considered a valid image URL.
 		$this->assertEmpty( $class_instance->get_images() );
 
-		// Enable the filter
+		// Enable the filter.
 		add_filter( 'wpseo_opengraph_is_valid_image_url', '__return_true', 10, 2 );
 
 		$class_instance->add_image( 'https://via.placeholder.com/350x150' );

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -118,6 +118,32 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the wpseo_opengraph_is_valid_image_url filter.
+	 */
+	public function test_is_valid_image_url_filter() {
+
+		$class_instance = $this->setup_class();
+		$class_instance->add_image( 'https://via.placeholder.com/350x150' );
+
+		// Without the filter, this isn't considered a valid image URL.
+		$this->assertEmpty( $class_instance->get_images() );
+
+		// Enable the filter
+		add_filter( 'wpseo_opengraph_is_valid_image_url', array( $this, 'is_valid_image_url_filter' ), 10, 2 );
+
+		$class_instance->add_image( 'https://via.placeholder.com/350x150' );
+
+		// Verify the image was added.
+		$this->assertArrayHasKey( 'https://via.placeholder.com/350x150', $class_instance->get_images() );
+
+		remove_filter( 'wpseo_opengraph_is_valid_image_url', array( $this, 'is_valid_image_url_filter' ) );
+	}
+
+	public function is_valid_image_url_filter( $is_valid, $url ) {
+		return 'https://via.placeholder.com/350x150' === $url;
+	}
+
+	/**
 	 * Tests the situations where an image won't added.
 	 *
 	 * @dataProvider invalid_image_provider

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -120,7 +120,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the wpseo_opengraph_is_valid_image_url filter.
 	 *
-	 * @covers WPSEO_OpenGraph_Image:: is_valid_image_url
+	 * @covers WPSEO_OpenGraph_Image::is_valid_image_url
 	 */
 	public function test_is_valid_image_url_filter() {
 

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -130,19 +130,15 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		// Without the filter, this isn't considered a valid image URL.
 		$this->assertEmpty( $class_instance->get_images() );
 
-		$callback = function( $is_valid, $url ) {
-			return 'https://via.placeholder.com/350x150' === $url;
-		};
-
 		// Enable the filter
-		add_filter( 'wpseo_opengraph_is_valid_image_url', $callback, 10, 2 );
+		add_filter( 'wpseo_opengraph_is_valid_image_url', '__return_true', 10, 2 );
 
 		$class_instance->add_image( 'https://via.placeholder.com/350x150' );
 
 		// Verify the image was added.
 		$this->assertArrayHasKey( 'https://via.placeholder.com/350x150', $class_instance->get_images() );
 
-		remove_filter( 'wpseo_opengraph_is_valid_image_url', $callback );
+		remove_filter( 'wpseo_opengraph_is_valid_image_url', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The `WPSEO_OpenGraph_Image` class, `is_valid_image_url()` function does not allow image URLs that do not have an extension. A client recently needed to use images for opengraph tags from a CDN that did not have extensions on the images (example [https://via.placeholder.com/350x150](https://via.placeholder.com/350x150)). This PR adds a filter to allow overriding the validity of an image URL.

The workaround we currently have in place is to add "/fake-seo-image.gif" to the URL, add it using the `add_image()` method, then removing the fake file name before the meta tag is output.

* Added `wpseo_opengraph_is_valid_image_url` filter to the `is_valid_image_url()` function

## Test instructions

This PR can be tested by following these steps:

* Running PHPUnit with the `--filter=test_is_valid_image_url_filter` option.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended


