### PR TITLE
CS/QA: deprecated functions consistency

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -362,8 +362,7 @@ new WPSEO_Taxonomy_Columns();
 // Setting the notice for the recalculate the posts.
 new Yoast_Dismissable_Notice_Ajax( 'recalculate', Yoast_Dismissable_Notice_Ajax::FOR_SITE );
 
-/********************** DEPRECATED METHODS **********************/
-
+/* ********************* DEPRECATED FUNCTIONS ********************* */
 
 /**
  * Removes stopword from the sample permalink that is generated in an AJAX request

--- a/admin/class-admin-utils.php
+++ b/admin/class-admin-utils.php
@@ -67,10 +67,13 @@ class WPSEO_Admin_Utils {
 		);
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Determines whether or not the user has an invalid version of PHP installed.
 	 *
 	 * @deprecated 8.1
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool Whether or not PHP 5.2 or lower is installed.
 	 */

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -319,17 +319,6 @@ class WPSEO_Admin {
 	}
 
 	/**
-	 * Initializes Whip to show a notice for outdated PHP versions.
-	 *
-	 * @deprecated 8.1
-	 *
-	 * @return void
-	 */
-	public function check_php_version() {
-		// Intentionally left empty.
-	}
-
-	/**
 	 * Whether we are on the admin dashboard page.
 	 *
 	 * @returns bool
@@ -408,13 +397,13 @@ class WPSEO_Admin {
 		return $integrations;
 	}
 
-	/********************** DEPRECATED METHODS **********************/
+	/* ********************* DEPRECATED METHODS ********************* */
 
-	// @codeCoverageIgnoreStart
 	/**
 	 * Register the menu item and its sub menu's.
 	 *
 	 * @deprecated 5.5
+	 * @codeCoverageIgnore
 	 */
 	public function register_settings_page() {
 		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
@@ -424,6 +413,7 @@ class WPSEO_Admin {
 	 * Register the settings page for the Network settings.
 	 *
 	 * @deprecated 5.5
+	 * @codeCoverageIgnore
 	 */
 	public function register_network_settings_page() {
 		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
@@ -433,6 +423,7 @@ class WPSEO_Admin {
 	 * Load the form for a WPSEO admin page.
 	 *
 	 * @deprecated 5.5
+	 * @codeCoverageIgnore
 	 */
 	public function load_page() {
 		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
@@ -442,6 +433,7 @@ class WPSEO_Admin {
 	 * Loads the form for the network configuration page.
 	 *
 	 * @deprecated 5.5
+	 * @codeCoverageIgnore
 	 */
 	public function network_config_page() {
 		_deprecated_function( __METHOD__, 'WPSEO 5.5.0' );
@@ -451,6 +443,8 @@ class WPSEO_Admin {
 	 * Filters all advanced settings pages from the given pages.
 	 *
 	 * @deprecated 5.5
+	 * @codeCoverageIgnore
+	 *
 	 * @param array $pages The pages to filter.
 	 */
 	public function filter_settings_pages( array $pages ) {
@@ -461,6 +455,7 @@ class WPSEO_Admin {
 	 * Cleans stopwords out of the slug, if the slug hasn't been set yet.
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */
@@ -472,6 +467,7 @@ class WPSEO_Admin {
 	 * Filter the stopwords from the slug.
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */
@@ -483,6 +479,7 @@ class WPSEO_Admin {
 	 * Adds contextual help to the titles & metas page.
 	 *
 	 * @deprecated 5.6.0
+	 * @codeCoverageIgnore
 	 */
 	public function title_metas_help_tab() {
 		_deprecated_function( __METHOD__, '5.6.0' );
@@ -526,5 +523,15 @@ class WPSEO_Admin {
 		);
 	}
 
-	// @codeCoverageIgnoreEnd
+	/**
+	 * Initializes Whip to show a notice for outdated PHP versions.
+	 *
+	 * @deprecated 8.1
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	public function check_php_version() {
+		// Intentionally left empty.
+	}
 }

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -266,10 +266,13 @@ class WPSEO_Help_Center {
 		);
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Outputs the help center.
 	 *
 	 * @deprecated 5.6
+	 * @codeCoverageIgnore
 	 */
 	public function output_help_center() {
 		_deprecated_function( 'WPSEO_Help_Center::output_help_center', 'WPSEO 5.6.0', 'WPSEO_Help_Center::mount()' );

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -90,10 +90,13 @@ class WPSEO_Meta_Table_Accessible {
 		return 'wpseo_meta_table_inaccessible';
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
 	 *
 	 * @deprecated 6.0
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool True if table is accessible.
 	 */

--- a/admin/config-ui/class-configuration-options-adapter.php
+++ b/admin/config-ui/class-configuration-options-adapter.php
@@ -58,22 +58,6 @@ class WPSEO_Configuration_Options_Adapter {
 	}
 
 	/**
-	 * Add a lookup for a Yoast option
-	 *
-	 * @param string $class_name Class to bind to the lookup.
-	 * @param string $option     Option group to use.
-	 * @param string $key        Key in the option group to bind to.
-	 *
-	 * @deprecated 7.0
-	 *
-	 * @throws InvalidArgumentException Thrown when invalid input is provided.
-	 */
-	public function add_yoast_lookup( $class_name, $option, $key ) {
-		_deprecated_function( __METHOD__, 'WPSEO 7.0', 'WPSEO_Configuration_Options_Adapter::add_option_lookup' );
-		$this->add_option_lookup( $class_name, $key );
-	}
-
-	/**
 	 * Add a lookup for a custom implementation
 	 *
 	 * @param string   $class_name   Class to bind to the lookup.
@@ -195,5 +179,24 @@ class WPSEO_Configuration_Options_Adapter {
 		}
 
 		return $this->lookup[ $class_name ]['option'];
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Add a lookup for a Yoast option
+	 *
+	 * @deprecated 7.0
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $class_name Class to bind to the lookup.
+	 * @param string $option     Option group to use.
+	 * @param string $key        Key in the option group to bind to.
+	 *
+	 * @throws InvalidArgumentException Thrown when invalid input is provided.
+	 */
+	public function add_yoast_lookup( $class_name, $option, $key ) {
+		_deprecated_function( __METHOD__, 'WPSEO 7.0', 'WPSEO_Configuration_Options_Adapter::add_option_lookup' );
+		$this->add_option_lookup( $class_name, $key );
 	}
 }

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -191,21 +191,6 @@ class WPSEO_Configuration_Page {
 	}
 
 	/**
-	 * Returns the translations necessary for the configuration wizard.
-	 *
-	 * @deprecated 4.9
-	 *
-	 * @returns array The translations for the configuration wizard.
-	 */
-	public function get_translations() {
-		_deprecated_function( __METHOD__, 'WPSEO 4.9', 'WPSEO_' );
-
-		$translations = new WPSEO_Configuration_Translations( WPSEO_Utils::get_user_locale() );
-
-		return $translations->retrieve();
-	}
-
-	/**
 	 * Adds a notification to the notification center.
 	 */
 	private function add_notification() {
@@ -264,5 +249,23 @@ class WPSEO_Configuration_Page {
 	 */
 	private function remove_notification_option() {
 		WPSEO_Options::set( 'show_onboarding_notice', false );
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Returns the translations necessary for the configuration wizard.
+	 *
+	 * @deprecated 4.9
+	 * @codeCoverageIgnore
+	 *
+	 * @returns array The translations for the configuration wizard.
+	 */
+	public function get_translations() {
+		_deprecated_function( __METHOD__, 'WPSEO 4.9', 'WPSEO_' );
+
+		$translations = new WPSEO_Configuration_Translations( WPSEO_Utils::get_user_locale() );
+
+		return $translations->retrieve();
 	}
 }

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -67,39 +67,6 @@ class WPSEO_Link_Reindex_Dashboard {
 	}
 
 	/**
-	 * Add the indexing interface for links to the dashboard.
-	 *
-	 * @deprecated 7.0
-	 *
-	 * @return void
-	 */
-	public function add_link_index_interface() {
-		_deprecated_function( __METHOD__, 'WPSEO 7.0' );
-
-		$html  = '';
-		$html .= '<h2>' . esc_html__( 'Text link counter', 'wordpress-seo' ) . '</h2>';
-		$html .= '<p>' . sprintf(
-			/* translators: 1: link to yoast.com post about internal linking suggestion. 4: is Yoast.com 3: is anchor closing. */
-			__( 'The links in all your public texts need to be counted. This will provide insights of which texts need more links to them. If you want to know more about the why and how of internal linking, check out %1$sthe article about internal linking on %2$s%3$s.', 'wordpress-seo' ),
-				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15n' ) . '" target="_blank">',
-				'Yoast.com',
-				'</a>'
-		) . '</p>';
-
-		if ( ! $this->has_unprocessed() ) {
-			$html .= '<p>' . $this->message_already_indexed() . '</p>';
-		}
-
-		if ( $this->has_unprocessed() ) {
-			$html .= '<p id="reindexLinks">' . $this->message_start_indexing() . '</p>';
-		}
-
-		$html .= '<br />';
-
-		echo $html;
-	}
-
-	/**
 	 * Generates the model box.
 	 *
 	 * @return void
@@ -220,5 +187,41 @@ class WPSEO_Link_Reindex_Dashboard {
 			175,
 			esc_attr__( 'Count links in your texts', 'wordpress-seo' )
 		);
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Add the indexing interface for links to the dashboard.
+	 *
+	 * @deprecated 7.0
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	public function add_link_index_interface() {
+		_deprecated_function( __METHOD__, 'WPSEO 7.0' );
+
+		$html  = '';
+		$html .= '<h2>' . esc_html__( 'Text link counter', 'wordpress-seo' ) . '</h2>';
+		$html .= '<p>' . sprintf(
+			/* translators: 1: link to yoast.com post about internal linking suggestion. 4: is Yoast.com 3: is anchor closing. */
+			__( 'The links in all your public texts need to be counted. This will provide insights of which texts need more links to them. If you want to know more about the why and how of internal linking, check out %1$sthe article about internal linking on %2$s%3$s.', 'wordpress-seo' ),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15n' ) . '" target="_blank">',
+			'Yoast.com',
+			'</a>'
+		) . '</p>';
+
+		if ( ! $this->has_unprocessed() ) {
+			$html .= '<p>' . $this->message_already_indexed() . '</p>';
+		}
+
+		if ( $this->has_unprocessed() ) {
+			$html .= '<p id="reindexLinks">' . $this->message_start_indexing() . '</p>';
+		}
+
+		$html .= '<br />';
+
+		echo $html;
 	}
 }

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -90,10 +90,13 @@ class WPSEO_Link_Table_Accessible {
 		return 'wpseo_link_table_inaccessible';
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Checks if the table exists if not, set the transient to indicate the inaccessible table.
 	 *
 	 * @deprecated 6.0
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool True if table is accessible.
 	 */

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -358,10 +358,13 @@ class WPSEO_Taxonomy {
 		add_action( "{$this->taxonomy}_term_edit_form_top", array( $this, 'custom_category_description_editor' ) );
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Adds shortcode support to category descriptions.
 	 *
 	 * @deprecated 7.9.0
+	 * @codeCoverageIgnore
 	 *
 	 * @param string $desc String to add shortcodes in.
 	 *

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -195,45 +195,6 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * Determine whether this is the homepage and shows posts.
-	 *
-	 * @deprecated 7.7
-	 *
-	 * @return bool Whether or not the current page is the homepage that displays posts.
-	 */
-	public function is_home_posts_page() {
-		_deprecated_function( __FUNCTION__, '7.7', 'WPSEO_Frontend_Page_Type::is_home_posts_page' );
-
-		return $this->frontend_page_type->is_home_posts_page();
-	}
-
-	/**
-	 * Determine whether the this is the static frontpage.
-	 *
-	 * @deprecated 7.7
-	 *
-	 * @return bool Whether or not the current page is a static frontpage.
-	 */
-	public function is_home_static_page() {
-		_deprecated_function( __FUNCTION__, '7.7', 'WPSEO_Frontend_Page_Type::is_home_static_page' );
-
-		return $this->frontend_page_type->is_home_static_page();
-	}
-
-	/**
-	 * Determine whether this is the posts page, when it's not the frontpage.
-	 *
-	 * @deprecated 7.7
-	 *
-	 * @return bool Whether or not it's a non-frontpage, posts page.
-	 */
-	public function is_posts_page() {
-		_deprecated_function( __FUNCTION__, '7.7', 'WPSEO_Frontend_Page_Type::is_posts_page' );
-
-		return $this->frontend_page_type->is_posts_page();
-	}
-
-	/**
 	 * Used for static home and posts pages as well as singular titles.
 	 *
 	 * @param object|null $object If filled, object to get the title for.
@@ -1823,12 +1784,13 @@ class WPSEO_Frontend {
 		return $desc;
 	}
 
-	/** Deprecated functions */
-	// @codeCoverageIgnoreStart
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Outputs or returns the debug marker, which is also used for title replacement when force rewrite is active.
 	 *
 	 * @deprecated 4.4
+	 * @codeCoverageIgnore
 	 *
 	 * @param bool $echo Whether or not to echo the debug marker.
 	 *
@@ -1846,6 +1808,7 @@ class WPSEO_Frontend {
 	 * Outputs the meta keywords element.
 	 *
 	 * @deprecated 6.3
+	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */
@@ -1859,6 +1822,7 @@ class WPSEO_Frontend {
 	 * Removes unneeded query variables from the URL.
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */
@@ -1873,6 +1837,7 @@ class WPSEO_Frontend {
 	 * Trailing slashes for everything except is_single().
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 */
 	public function add_trailingslash() {
 		// As this is a frontend method, we want to make sure it is not displayed for non-logged in users.
@@ -1885,6 +1850,7 @@ class WPSEO_Frontend {
 	 * Removes the ?replytocom variable from the link, replacing it with a #comment-<number> anchor.
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 *
 	 * @param string $link The comment link as a string.
 	 *
@@ -1901,6 +1867,7 @@ class WPSEO_Frontend {
 	 * Redirects out the ?replytocom variables.
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 *
 	 * @return boolean True when redirect has been done.
 	 */
@@ -1910,5 +1877,46 @@ class WPSEO_Frontend {
 		$remove_replytocom = new WPSEO_Remove_Reply_To_Com();
 		return $remove_replytocom->replytocom_redirect();
 	}
-	// @codeCoverageIgnoreEnd
+
+	/**
+	 * Determine whether this is the homepage and shows posts.
+	 *
+	 * @deprecated 7.7
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool Whether or not the current page is the homepage that displays posts.
+	 */
+	public function is_home_posts_page() {
+		_deprecated_function( __FUNCTION__, '7.7', 'WPSEO_Frontend_Page_Type::is_home_posts_page' );
+
+		return $this->frontend_page_type->is_home_posts_page();
+	}
+
+	/**
+	 * Determine whether the this is the static frontpage.
+	 *
+	 * @deprecated 7.7
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool Whether or not the current page is a static frontpage.
+	 */
+	public function is_home_static_page() {
+		_deprecated_function( __FUNCTION__, '7.7', 'WPSEO_Frontend_Page_Type::is_home_static_page' );
+
+		return $this->frontend_page_type->is_home_static_page();
+	}
+
+	/**
+	 * Determine whether this is the posts page, when it's not the frontpage.
+	 *
+	 * @deprecated 7.7
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool Whether or not it's a non-frontpage, posts page.
+	 */
+	public function is_posts_page() {
+		_deprecated_function( __FUNCTION__, '7.7', 'WPSEO_Frontend_Page_Type::is_posts_page' );
+
+		return $this->frontend_page_type->is_posts_page();
+	}
 }

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -752,6 +752,8 @@ class WPSEO_OpenGraph {
 		}
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Outputs the site owner.
 	 *

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -19,19 +19,6 @@ class WPSEO_Content_Images implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Removes the cached images on post save.
-	 *
-	 * @deprecated 7.7
-	 *
-	 * @param int $post_id The post id to remove the images from.
-	 *
-	 * @return void
-	 */
-	public function clear_cached_images( $post_id ) {
-		_deprecated_function( __METHOD__, '7.7.0' );
-	}
-
-	/**
 	 * Retrieves images from the post content.
 	 *
 	 * @param int      $post_id The post ID.
@@ -123,5 +110,21 @@ class WPSEO_Content_Images implements WPSEO_WordPress_Integration {
 		}
 
 		return $content;
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Removes the cached images on post save.
+	 *
+	 * @deprecated 7.7
+	 * @codeCoverageIgnore
+	 *
+	 * @param int $post_id The post id to remove the images from.
+	 *
+	 * @return void
+	 */
+	public function clear_cached_images( $post_id ) {
+		_deprecated_function( __METHOD__, '7.7.0' );
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -998,42 +998,6 @@ SVG;
 			&& version_compare( REST_API_VERSION, $minimum_version, '>=' ) );
 	}
 
-	/********************** DEPRECATED METHODS **********************/
-
-	/**
-	 * Returns the language part of a given locale, defaults to english when the $locale is empty.
-	 *
-	 * @see        WPSEO_Language_Utils::get_language()
-	 *
-	 * @since      3.4
-	 *
-	 * @param string $locale The locale to get the language of.
-	 *
-	 * @returns string The language part of the locale.
-	 */
-	public static function get_language( $locale ) {
-		return WPSEO_Language_Utils::get_language( $locale );
-	}
-
-	/**
-	 * Returns the user locale for the language to be used in the admin.
-	 *
-	 * WordPress 4.7 introduced the ability for users to specify an Admin language
-	 * different from the language used on the front end. This checks if the feature
-	 * is available and returns the user's language, with a fallback to the site's language.
-	 * Can be removed when support for WordPress 4.6 will be dropped, in favor
-	 * of WordPress get_user_locale() that already fallbacks to the site's locale.
-	 *
-	 * @see        WPSEO_Language_Utils::get_user_locale()
-	 *
-	 * @since      4.1
-	 *
-	 * @returns string The locale.
-	 */
-	public static function get_user_locale() {
-		return WPSEO_Language_Utils::get_user_locale();
-	}
-
 	/**
 	 * Determine whether or not the metabox should be displayed for a post type.
 	 *
@@ -1138,5 +1102,41 @@ SVG;
 		}
 
 		return $wpseo_admin_l10n;
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Returns the language part of a given locale, defaults to english when the $locale is empty.
+	 *
+	 * @see        WPSEO_Language_Utils::get_language()
+	 *
+	 * @since      3.4
+	 *
+	 * @param string $locale The locale to get the language of.
+	 *
+	 * @returns string The language part of the locale.
+	 */
+	public static function get_language( $locale ) {
+		return WPSEO_Language_Utils::get_language( $locale );
+	}
+
+	/**
+	 * Returns the user locale for the language to be used in the admin.
+	 *
+	 * WordPress 4.7 introduced the ability for users to specify an Admin language
+	 * different from the language used on the front end. This checks if the feature
+	 * is available and returns the user's language, with a fallback to the site's language.
+	 * Can be removed when support for WordPress 4.6 will be dropped, in favor
+	 * of WordPress get_user_locale() that already fallbacks to the site's locale.
+	 *
+	 * @see        WPSEO_Language_Utils::get_user_locale()
+	 *
+	 * @since      4.1
+	 *
+	 * @returns string The locale.
+	 */
+	public static function get_user_locale() {
+		return WPSEO_Language_Utils::get_user_locale();
 	}
 }

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -511,12 +511,15 @@ class WPSEO_Options {
 		return $pattern_table;
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Correct the inadvertent removal of the fallback to default values from the breadcrumbs.
 	 *
 	 * @since 1.5.2.3
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 */
 	public static function bring_back_breadcrumb_defaults() {
 		_deprecated_function( __METHOD__, 'WPSEO 7.0' );

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -33,15 +33,6 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	}
 
 	/**
-	 * Get all the options
-	 *
-	 * @deprecated 7.0
-	 */
-	protected function get_options() {
-		_deprecated_function( __METHOD__, 'WPSEO 7.0', 'WPSEO_Options::get' );
-	}
-
-	/**
 	 * Get front page ID
 	 *
 	 * @return int
@@ -637,5 +628,17 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$url['images'] = $this->get_image_parser()->get_images( $post );
 
 		return $url;
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Get all the options
+	 *
+	 * @deprecated 7.0
+	 * @codeCoverageIgnore
+	 */
+	protected function get_options() {
+		_deprecated_function( __METHOD__, 'WPSEO 7.0', 'WPSEO_Options::get' );
 	}
 }

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -134,11 +134,13 @@ class WPSEO_Sitemaps_Admin {
 		WPSEO_Sitemaps::ping_search_engines();
 	}
 
-	// @codeCoverageIgnoreStart
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Find sitemaps residing on disk as they will block our rewrite.
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 */
 	public function delete_sitemaps() {
 		_deprecated_function( 'WPSEO_Sitemaps_Admin::delete_sitemaps', '7.0' );
@@ -148,9 +150,9 @@ class WPSEO_Sitemaps_Admin {
 	 * Find sitemaps residing on disk as they will block our rewrite.
 	 *
 	 * @deprecated 7.0
+	 * @codeCoverageIgnore
 	 */
 	public function detect_blocking_filesystem_sitemaps() {
 		_deprecated_function( 'WPSEO_Sitemaps_Admin::delete_sitemaps', '7.0' );
 	}
-	// @codeCoverageIgnoreEnd
 } /* End of class */

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -26,15 +26,6 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	}
 
 	/**
-	 * Get all the options
-	 *
-	 * @deprecated 7.0
-	 */
-	protected function get_options() {
-		_deprecated_function( __METHOD__, 'WPSEO 7.0', 'WPSEO_Options::get' );
-	}
-
-	/**
 	 * @param int $max_entries Entries per sitemap.
 	 *
 	 * @return array
@@ -260,5 +251,17 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		}
 
 		return self::$image_parser;
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Get all the options
+	 *
+	 * @deprecated 7.0
+	 * @codeCoverageIgnore
+	 */
+	protected function get_options() {
+		_deprecated_function( __METHOD__, 'WPSEO 7.0', 'WPSEO_Options::get' );
 	}
 }

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -56,7 +56,7 @@ function allow_custom_field_edits( $required_capabilities, $capabilities, $args 
 
 add_filter( 'user_has_cap', 'allow_custom_field_edits', 0, 3 );
 
-/********************** DEPRECATED FUNCTIONS **********************/
+/* ********************* DEPRECATED FUNCTIONS ********************* */
 
 /**
  * Adds an SEO admin bar menu to the site admin, with several options.
@@ -64,6 +64,7 @@ add_filter( 'user_has_cap', 'allow_custom_field_edits', 0, 3 );
  * If the current user is an admin he can also go straight to several settings menu's from here.
  *
  * @deprecated 7.9 Use WPSEO_Admin_Bar_Menu::add_menu() instead
+ * @codeCoverageIgnore
  *
  * @return void
  */
@@ -92,6 +93,7 @@ function wpseo_admin_bar_menu() {
  * Returns the SEO score element for the admin bar.
  *
  * @deprecated 7.9
+ * @codeCoverageIgnore
  *
  * @return string
  */
@@ -107,6 +109,7 @@ function wpseo_adminbar_seo_score() {
  * Returns the content score element for the adminbar.
  *
  * @deprecated 7.9
+ * @codeCoverageIgnore
  *
  * @return string
  */
@@ -122,6 +125,7 @@ function wpseo_adminbar_content_score() {
  * Returns the SEO score element for the adminbar.
  *
  * @deprecated 7.9
+ * @codeCoverageIgnore
  *
  * @return string
  */
@@ -141,6 +145,7 @@ function wpseo_tax_adminbar_seo_score() {
  * Returns the Content score element for the adminbar.
  *
  * @deprecated 7.9
+ * @codeCoverageIgnore
  *
  * @return string
  */
@@ -160,6 +165,7 @@ function wpseo_tax_adminbar_content_score() {
  * Takes The SEO score and makes the score icon for the adminbar with it.
  *
  * @deprecated 7.9
+ * @codeCoverageIgnore
  *
  * @param int $score The 0-100 rating of the score. Can be either SEO score or content score.
  *
@@ -179,6 +185,7 @@ function wpseo_adminbar_score( $score ) {
  * Enqueue CSS to format the Yoast SEO adminbar item.
  *
  * @deprecated 7.9 Use WPSEO_Admin_Bar_Menu::enqueue_assets() instead
+ * @codeCoverageIgnore
  */
 function wpseo_admin_bar_style() {
 	_deprecated_function( __FUNCTION__, 'WPSEO 7.9', 'WPSEO_Admin_Bar_Menu::enqueue_assets()' );
@@ -199,6 +206,7 @@ function wpseo_admin_bar_style() {
  * Detects if the advanced settings are enabled.
  *
  * @deprecated 7.0
+ * @codeCoverageIgnore
  */
 function wpseo_advanced_settings_enabled() {
 	_deprecated_function( __FUNCTION__, 'WPSEO 7.0', null );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.

This PR addresses some inconsistencies related to deprecated functions. It basically applies the following rules:
* Deprecated functions/methods should be at the end of the file/class.
* They should be preceded by a `/* *** DEPRECATED METHODS *** */` delimiter to clearly indicate the start of the deprecated functions.
* Deprecated functions should be ignored for the purposes of calculating code coverage via PHPUnit and therefore should each have a `@codeCoverageIgnore` tag in their docblock.

Loosely related to #11058 in that it already moves the two methods that ticket targets down. The functional deprecation of those methods is _not_ addressed in this PR.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.