### PR TITLE
Build/PHPCS: add PHP cross-version compatibility checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
 	"require-dev": {
 		"yoast/php-development-environment": "^1.0",
 		"yoast/yoastcs": "~0.4.3",
-		"roave/security-advisories": "dev-master"
+		"roave/security-advisories": "dev-master",
+		"phpcompatibility/phpcompatibility-wp": "1.0.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -51,7 +52,7 @@
 	},
 	"scripts": {
 		"config-yoastcs": [
-			"\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",
+			"\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-wp",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
 		],
 		"check-cs": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23b85a5ee3913a0c5b36f8dec7cf9caf",
+    "content-hash": "181195277c30284182f74ba2b89cd4b6",
     "packages": [
         {
             "name": "composer/installers",
@@ -316,6 +316,105 @@
             ],
             "description": "Official version of pdepend to be handled with Composer",
             "time": "2017-01-19T14:23:36+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "8.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PHPCompatibility\\": "PHPCompatibility/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-07-17T13:42:26+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^8.1"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2018-07-16T22:10:02+00:00"
         },
         {
             "name": "phpmd/phpmd",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -41,4 +41,40 @@
     <rule ref="WordPress.VIP.RestrictedFunctions">
         <exclude-pattern>inc/class-wpseo-image-utils.php</exclude-pattern>
     </rule>
+
+	<!--
+	#############################################################################
+	SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
+	#############################################################################
+	-->
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibilityWP"/>
+
+	<!-- WP-CLI has a minimum PHP requirement of PHP 5.3. -->
+	<rule ref="PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound">
+		<exclude-pattern>*/cli/class-cli-*\.php$</exclude-pattern>
+		<exclude-pattern>*/premium/cli/cli-*\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewKeywords.t_useFound">
+		<exclude-pattern>*/cli/class-cli-*\.php$</exclude-pattern>
+		<exclude-pattern>*/premium/cli/cli-*\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewMagicMethods.__invokeFound">
+		<exclude-pattern>*/premium/cli/cli-*\.php$</exclude-pattern>
+	</rule>
+
+	<!-- These usages of PHP > 5.2 code are surrounded by the correct safeguards. -->
+	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.parse_ini_file_scanner_modeFound">
+		<exclude-pattern>*/admin/import/class-import-settings\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewConstants.ini_scanner_rawFound">
+		<exclude-pattern>*/admin/import/class-import-settings\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.http_build_query_enc_typeFound">
+		<exclude-pattern>*/inc/sitemaps/class-sitemaps-renderer\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.array_unique_sort_flagsFound">
+		<exclude-pattern>*/inc/sitemaps/class-sitemap-image-parser\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

The PHPCompatibility ruleset is part of YoastCS 1.0+. However, as the WPSEO plugin does not yet comply with the WordPressCS rules from the more recent WPCS/YoastCS versions, WPSEO cannot yet update to YoastCS 1.0+ and still uses YoastCS 0.4.3 which contains WPCS 0.10.0 in combination with PHP_CodeSniffer 2.8.1.

The `PHPCompatibility(WP)` project, fortunately, is still compatible with older PHP_CodeSniffer versions, so while we're working through the WPCS issues, we _can_ already activate the PHPCompatibility checks for WPSEO Free, and by extension, Premium.

To do so:
* The `PHPCompatibilityWP` dev dependency has been added to the `composer.json` file.
* The `config-yoastcs` script in the `composer.json` file has been adjusted to include adding the new rulesets.
* The `PHPCompatibilityWP` standard + configuration setting has been added to the `phpcs.xml` ruleset.
* Furthermore, the WP-CLI related files are excluded from some PHP 5.2 specific checks as WP-CLI has a minimum PHP requirement of PHP 5.3.
* Two other files have also been excluded for select, very specific error codes as the code has the necessary safeguards around it (`defined()`/`function_exists()` check respectively) .

Note: once the CS project is finished and WPSEO can update to YoastCS 1.0+, this PR should - in part - be reverted before (or as part of) that PR.

## Test instructions
This PR can be tested by following these steps:

* Primarily, check that the Travis build passes as if it does, all is ok.
* To test this manually, run the following commands from the command line while in the root directory of the WPSEO project:
    - Run `composer install`
    - Run `composer config-yoastcs`
    - Next, run `vendor/bin/phpcs -i`
       The output of this command should be:
        ```
        The installed coding standards are MySource, PEAR, PHPCS, PSR1, PSR2, Squiz, Zend, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra, WordPress-VIP, Yoast, PHPCompatibility and PHPCompatibilityWP
        ```
    - To test the codebase just and only for PHP cross version compatibility, run the following command:
        ```bash
        vendor/bin/phpcs -p . --standard=PHPCompatibilityWP --extensions=php --ignore=*/vendor/* --runtime-set testVersion 5.2-
        ```
        As output you should now see something like this as the result:
        ```
        FILE: path/to/wordpress-seo/admin/import/class-import-settings.php
        ------------------------------------------------------------------------------------------
        FOUND 2 ERRORS AFFECTING 1 LINE
        ------------------------------------------------------------------------------------------
         153 | ERROR | The function parse_ini_file() does not have a parameter "scanner_mode" in
             |       | PHP version 5.2 or earlier
         153 | ERROR | The constant "INI_SCANNER_RAW" is not present in PHP version 5.2 or
             |       | earlier
        ------------------------------------------------------------------------------------------

        FILE: path/to/wordpress-seo/cli/class-cli-redirect-upsell-command-namespace.php
        ------------------------------------------------------------------------------------------
        FOUND 3 ERRORS AFFECTING 1 LINE
        ------------------------------------------------------------------------------------------
         8 | ERROR | "use" keyword (for traits/namespaces/anonymous functions) is not present in
           |       | PHP version 5.2 or earlier
         8 | ERROR | the \ operator (for namespaces) is not present in PHP version 5.2 or earlier
         8 | ERROR | the \ operator (for namespaces) is not present in PHP version 5.2 or earlier
        ------------------------------------------------------------------------------------------

        FILE: path/to/wordpress-seo/cli/class-cli-yoast-command-namespace.php
        ------------------------------------------------------------------------------------------
        FOUND 3 ERRORS AFFECTING 1 LINE
        ------------------------------------------------------------------------------------------
         8 | ERROR | "use" keyword (for traits/namespaces/anonymous functions) is not present in
           |       | PHP version 5.2 or earlier
         8 | ERROR | the \ operator (for namespaces) is not present in PHP version 5.2 or earlier
         8 | ERROR | the \ operator (for namespaces) is not present in PHP version 5.2 or earlier
        ------------------------------------------------------------------------------------------

        FILE: path/to/wordpress-seo/inc/sitemaps/class-sitemaps-renderer.php
        ------------------------------------------------------------------------------------------
        FOUND 1 ERROR AFFECTING 1 LINE
        ------------------------------------------------------------------------------------------
         314 | ERROR | The function http_build_query() does not have a parameter "enc_type" in
             |       | PHP version 5.3 or earlier
        ------------------------------------------------------------------------------------------
        ```
    - If, just for fun, you want to see that it actually works with a wider range of PHP versions and errors :smiling_imp: :
        - Open the `wp-seo.php file`.
        - Add the following code snippet to the bottom of the file:
           ```php
            function ( string $a ) : int {
            	global $HTTP_POST_VARS;
            	static $b = $a * 10;
            	return __NAMESPACE__;
            }
            ```
        - Now run the following command:
            ```bash
            vendor/bin/phpcs -p ./wp-seo.php --standard=PHPCompatibilityWP --runtime-set testVersion 5.2-
            ```
        - As output you should now see something like this as the result:
            ```
            FILE: path/to/wordpress-seo/wp-seo.php
            ------------------------------------------------------------------------------------------
            FOUND 6 ERRORS AFFECTING 4 LINES
            ------------------------------------------------------------------------------------------
             50 | ERROR | Closures / anonymous functions are not available in PHP 5.2 or earlier
             50 | ERROR | 'string' type declaration is not present in PHP version 5.6 or earlier
             50 | ERROR | int return type is not present in PHP version 5.6 or earlier
             51 | ERROR | Global variable '$HTTP_POST_VARS' is deprecated since PHP 5.3 and removed
                |       | since PHP 5.4; Use $_POST instead
             52 | ERROR | Constant scalar expressions are not allowed in static variable declarations
                |       | in PHP 5.5 or earlier. Found: $b = $a * 10;
             53 | ERROR | __NAMESPACE__ magic constant is not present in PHP version 5.2 or earlier
            ------------------------------------------------------------------------------------------
            ```
    - To test the codebase with the WPSEO custom ruleset, which now includes the PHPCompatibilityWP ruleset and excludes the errors you saw above (except for the ones introduced in the `wp-seo.php` of course), run the following command:
        ```bash
        vendor/bin/phpcs
        ```