### PR TITLE
CS/I18n: fix missing text domain in gettext call

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -212,7 +212,7 @@ class WPSEO_Admin_Init {
 
 		// We are checking against the WordPress internal translation.
 		// @codingStandardsIgnoreLine
-		$translated_blog_description = __( 'Just another WordPress site' );
+		$translated_blog_description = __( 'Just another WordPress site', 'default' );
 
 		return $translated_blog_description === $blog_description || $default_blog_description === $blog_description;
 	}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Plugins/themes should use their own text domain. however, in some cases, using the WP Core translation for a string is warranted, like in this case.

The WP Core text-domain is `default` and while all gettext function call have a [default value of `default` for the `$domain` parameter](https://developer.wordpress.org/reference/functions/__/), explicitly setting the `$domain` in a gettext function call to `default` documents that the intention for this function call was to use the WP Core translation.

For CS purposes, the line still has to be ignored (for now) as it doesn't use the WPSEO text domain.
Once WPSEO upgrades to a more recent version of WordPressCS, the ignore comment can be removed as since WPCS 0.11.0, a plugin can indicate that it uses more than one text-domain.


## Test instructions

This PR can be tested by following these steps:
* On `trunk`:
    * In a virgin WP install, go to the Yoast notification center and see the notification about the tagline still being the default WordPress tagline.
    * Now, change the language of the install to something else and verify that the notification is still there, i.e. WPSEO recognizes the translated WP Core tagline as the default tagline.
    * Change the tagline to something else and verify that the notification is no longer displayed with either English or another language as the site language.
* Now, on a new virgin WP install, change to this PR branch and repeat the above steps. All is good if you get the same results.