### PR TITLE
Bump YoastSeo.js to 1.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "^4.12.0",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/8.3"
+    "yoastseo": "^1.40.0"
   },
   "yoast": {
     "pluginVersion": "8.3-RC2"

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ Bugfixes:
 * Fixes a bug where snippet variables would not be replaced in the `og:description` of taxonomies when they were added in the Facebook Description input field.
 * Fixes a bug where `babel-polyfill` would throw an error that there shouldn't be two instances of babel-polyfill.
 * Fixes a bug where the `bold` button was available in the How-to block's step title and the FAQ block's Question field while they were already bold by default.
+* Fixes a bug that caused keywords beginning with the Turkish characters `İ` / `i` and `I` / `ı` not to be recognized when changing that character from lowercase to uppercase and vice versa.
 
 Enhancements:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10521,6 +10521,16 @@ yoast-components@^4.12.0:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
+yoastseo@^1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.40.0.tgz#2be3b91422ddc614131ab4b6e5aab9e6c347170d"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    lodash-es "^4.17.10"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.1"
+
 "yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/8.3":
   version "1.39.2"
   resolved "git+https://github.com/Yoast/YoastSEO.js.git#0906e9a056640e2c6808fa3e12a9d15ac0196d99"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug that caused keywords beginning with the Turkish characters `İ` / `i` and `I` / `ı` not to be recognized when changing that character from lowercase to uppercase and vice versa.

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/YoastSEO.js/pull/1624
