### PR TITLE
Bump Yoast Components to 4.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "^4.12.0",
+    "yoast-components": "^4.12.1",
     "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/8.3"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10492,9 +10492,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yoast-components@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.12.0.tgz#3b336a7681890d051c1632425f17177670511f52"
+yoast-components@^4.12.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.12.1.tgz#21ea158280fdc9d117f8513552648e09b0c51653"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -10517,9 +10517,19 @@ yoast-components@^4.12.0:
     striptags "^3.1.0"
     styled-components "^2.1.2"
     whatwg-fetch "^1.0.0"
-    yoastseo "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/8.3"
+    yoastseo "^1.40"
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
+
+yoastseo@^1.40:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.40.0.tgz#2be3b91422ddc614131ab4b6e5aab9e6c347170d"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    lodash-es "^4.17.10"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.1"
 
 "yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/8.3":
   version "1.39.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Bumps Yoast Components to v. 4.12.1
