### PR TITLE
Improve how-to and faq movers tab order and place them to the bottom

### DIFF
--- a/css/src/structured-data-blocks.scss
+++ b/css/src/structured-data-blocks.scss
@@ -58,9 +58,7 @@ legend.schema-how-to-duration-legend {
 }
 
 .schema-how-to-step-mover {
-	position: absolute;
-	top: 0;
-	left: -29px;
+	display: inline-block;
 }
 
 .schema-how-to-step-button {
@@ -89,6 +87,7 @@ legend.schema-how-to-duration-legend {
 }
 
 .schema-how-to-step-button-container {
+	display: inline-block;
 	text-align: right;
 
 	.schema-how-to-step-add-media {
@@ -115,12 +114,11 @@ legend.schema-how-to-duration-legend {
 }
 
 .schema-faq-section-mover {
-	position: absolute;
-	top: 0;
-	left: -29px;
+	display: inline-block;
 }
 
 .schema-faq-section-button-container {
+	display: inline-block;
 	text-align: right;
 
 	.schema-faq-section-add-media {
@@ -139,5 +137,25 @@ legend.schema-how-to-duration-legend {
 	button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
 		box-shadow: none;
 		color: #007cba;
+	}
+}
+
+.schema-how-to-step-mover,
+.schema-faq-section-mover {
+	.editor-block-mover__control {
+		display: inline-flex;
+		width: 36px;
+		height: 36px;
+	}
+}
+
+.schema-how-to-step-controls-container,
+.schema-faq-section-controls-container {
+	text-align: right;
+	margin-left: -28px; // compensate the 32px wrapper padding and keep a 4px space
+
+	.dashicons-arrow-up-alt2 {
+		position: relative;
+		top: -1px; // fix dashicon shape vertical centering
 	}
 }

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -201,8 +201,8 @@ export default class Question extends Component {
 					placeholder={ __( "Enter the answer to the question", "wordpress-seo" ) }
 					keepPlaceholderOnFocus={ true }
 				/>
-				{ isSelected && this.getButtons() }
 				{ isSelected && this.getMover() }
+				{ isSelected && this.getButtons() }
 			</div>
 		);
 	}

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -68,22 +68,20 @@ export default class Question extends Component {
 	 */
 	getMover() {
 		return <div className="schema-faq-section-mover">
-			{ ! this.props.isFirst &&
 			<IconButton
 				className="editor-block-mover__control"
-				onClick={ this.props.onMoveUp }
+				onClick={ this.props.isFirst ? null : this.props.onMoveUp }
 				icon="arrow-up-alt2"
 				label={ __( "Move question up", "wordpress-seo" ) }
+				aria-disabled={ this.props.isFirst }
 			/>
-			}
-			{ ! this.props.isLast &&
 			<IconButton
 				className="editor-block-mover__control"
-				onClick={ this.props.onMoveDown }
+				onClick={ this.props.isLast ? null : this.props.onMoveDown }
 				icon="arrow-down-alt2"
 				label={ __( "Move question down", "wordpress-seo" ) }
+				aria-disabled={ this.props.isLast }
 			/>
-			}
 		</div>;
 	}
 
@@ -201,8 +199,12 @@ export default class Question extends Component {
 					placeholder={ __( "Enter the answer to the question", "wordpress-seo" ) }
 					keepPlaceholderOnFocus={ true }
 				/>
-				{ isSelected && this.getMover() }
-				{ isSelected && this.getButtons() }
+				{ isSelected &&
+					<div className="schema-faq-section-controls-container">
+						{ this.getMover() }
+						{ this.getButtons() }
+					</div>
+				}
 			</div>
 		);
 	}

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -81,22 +81,20 @@ export default class HowToStep extends Component {
 	 */
 	getMover() {
 		return <div className="schema-how-to-step-mover">
-			{ ! this.props.isFirst &&
 			<IconButton
 				className="editor-block-mover__control"
-				onClick={ this.props.onMoveUp }
+				onClick={ this.props.isFirst ? null : this.props.onMoveUp }
 				icon="arrow-up-alt2"
 				label={ __( "Move step up", "wordpress-seo" ) }
+				aria-disabled={ this.props.isFirst }
 			/>
-			}
-			{ ! this.props.isLast &&
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ this.props.isLast ? null : this.props.onMoveDown }
 				icon="arrow-down-alt2"
 				label={ __( "Move step down", "wordpress-seo" ) }
+				aria-disabled={ this.props.isLast }
 			/>
-			}
 		</div>;
 	}
 
@@ -222,8 +220,12 @@ export default class HowToStep extends Component {
 					setFocusedElement={ () => onFocus( "text" ) }
 					keepPlaceholderOnFocus={ true }
 				/>
-				{ isSelected && this.getMover() }
-				{ isSelected && this.getButtons() }
+				{ isSelected &&
+					<div className="schema-how-to-step-controls-container">
+						{ this.getMover() }
+						{ this.getButtons() }
+					</div>
+				}
 			</li>
 		);
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- place the mover buttons in same tab order in the How-to and FAQ blocks
- also as discussed with @hedgefield moves the buttons to the bottom bar together with the other buttons
- makes the inactive button always rendered, as Gutenberg does, and just noop-it and makes it look disabled (uses an aria-disabled attribute)

This implementation is better than the Gutenberg one (which places the buttons at the bottom only in the mobile view) for a couple reasons:
- the tab order is more logical: first the content, then the UI controls
- it makes visual order match DOM order (which is a WCAG requirement)

Also improves the layout in the mobile view, as the mover buttons were partially out of the viewport, see below:

<img width="358" alt="screen shot 2018-09-24 at 14 56 12" src="https://user-images.githubusercontent.com/1682452/45964643-a8ea0780-c026-11e8-852a-fea5a61442e5.png">

Example of the new placement:

<img width="642" alt="screen shot 2018-09-24 at 18 25 17" src="https://user-images.githubusercontent.com/1682452/45964986-860c2300-c027-11e8-9d1e-8acb5ce1720d.png">

Responsive view (minimum supported 320px):

<img width="378" alt="screen shot 2018-09-24 at 18 25 38" src="https://user-images.githubusercontent.com/1682452/45964997-8f958b00-c027-11e8-8b18-01cd31a58edd.png">

With longer translations the arrows stay in their own line and the other buttons go in a new line which, at least, is a bit better then before (please also consider this is the minimum viewport width we support: 320px, which is rare in modern smartphones):

<img width="342" alt="screen shot 2018-09-24 at 18 26 07" src="https://user-images.githubusercontent.com/1682452/45965106-ddaa8e80-c027-11e8-8346-53ddc5d0322b.png">

Note:
pre-existing issue: some of these buttons styling is inherited from Gutenberg. Ideally, this should be avoided. Out of the scope of this PR though.

## Test instructions
- build JS and CSS
- create a new post and add a How-to and a FAQ block with more than 2 steps / Q&A
- test the mover buttons with both mouse and keyboard
- test also in the mobile view

Fixes #10757 
