### PR TITLE
Remove currentTranslations check because the used geti18n will be removed soon

### DIFF
--- a/js/src/helpers/i18n.js
+++ b/js/src/helpers/i18n.js
@@ -13,18 +13,13 @@ import get from "lodash/get";
  * @returns {void}
  */
 export function setTextdomainL10n( textdomain, l10nNamespace = "wpseoYoastJSL10n" ) {
-	const jed = getI18n();
-	const currentTranslations = get( jed, [ "options", "locale_data", textdomain ], false );
+	const translations = get( window, [ l10nNamespace, textdomain, "locale_data", textdomain ], false );
 
-	if ( currentTranslations === false ) {
-		const translations = get( window, [ l10nNamespace, textdomain, "locale_data", textdomain ], false );
-
-		if ( translations === false ) {
-			// Jed needs to have meta information in the object keyed by an empty string.
-			setLocaleData( { "": {} }, textdomain );
-		} else {
-			setLocaleData( translations, textdomain );
-		}
+	if ( translations === false ) {
+		// Jed needs to have meta information in the object keyed by an empty string.
+		setLocaleData( { "": {} }, textdomain );
+	} else {
+		setLocaleData( translations, textdomain );
 	}
 }
 

--- a/js/src/helpers/i18n.js
+++ b/js/src/helpers/i18n.js
@@ -1,4 +1,4 @@
-import { setLocaleData, getI18n } from "@wordpress/i18n";
+import { setLocaleData } from "@wordpress/i18n";
 import get from "lodash/get";
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Compatibility with Gutenberg 4.0.

## Relevant technical choices:

In Gutenberg 4.0 and the related release of `@WordPress/i18n`, the `getI18n` function will be removed from the API.

Like @atimmer wrote in #10945 :
>We are currently using getI18n() to retrieve the Jed instance from Gutenberg. (...) We don't strictly need it, but we were using it to detect if translations were already loaded, to prevent doing it a second time.

With this implementation we always (re)load the translations, even if they were already loaded. However, this load action is quite cheap, so this shouldn't cause any problems.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Gutenberg 3.9 
* (in Gutenberg, run composer install, npm install and npm run build)
* Checkout master/use 8.3.
* Set your site language to something that is not English. Please choose a language that has translations 😄. 
* Run `grunt build` (not only `grunt build:js`, `i18n` should be built as well)
* Open a post in Gutenberg. You should see translations.
* Checkout this branch
* Run `grunt build` (not only `grunt build:js`, `i18n` should be built as well)
* Open a post in Gutenberg. You should see the same translations.
* Merge this branch in premium, and check the translations.

### Gutenberg `master`/ Gutenberg 4.0 RC
* (in Gutenberg, run `composer install`, `npm install` and `npm run build`)
* Checkout master/use 8.3.
* Set your site language to something that is not English. Please choose a language that has translations 😄. 
* Run `grunt build` (not only `grunt build:js`, `i18n` should be built as well)
* Open a post in Gutenberg. The metabox will crashe, and there will be console errors.
* Checkout this branch
* Run `grunt build` (not only `grunt build:js`, `i18n` should be built as well)
* Open a post in Gutenberg. The metabox shouldn't crash and there should not be console errors. You should see the translations.
* Merge this branch in premium, and check the translations.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10945
