### PR TITLE
Set minimum supported Gutenberg version to 3.9

### DIFF
--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -13,12 +13,12 @@ class WPSEO_Gutenberg_Compatibility {
 	/**
 	 * The currently released version of Gutenberg.
 	 */
-	const CURRENT_RELEASE = '3.5.0';
+	const CURRENT_RELEASE = '3.9.0';
 
 	/**
 	 * The minimally supported version of Gutenberg by the plugin.
 	 */
-	const MINIMUM_SUPPORTED = '3.5.0';
+	const MINIMUM_SUPPORTED = '3.9.0';
 
 	/**
 	 * @var string


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* We only support the latest version of Gutenberg. 3.9 is the latest version at this moment.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install and activate an old version of Gutenberg (< 3.9.0)
* Go to the Yoast Dashboard.
* See this notification:
<img width="1314" alt="schermafbeelding 2018-09-26 om 14 15 02" src="https://user-images.githubusercontent.com/17744553/46079184-b0c8b980-c196-11e8-8851-e14360f8d7c1.png">
* Install and activate Gutenberg 3.9.0.
* Go to the Yoast Dashboard.
* See no notification.

## Quality assurance

* [x] I have tested this code to the best of my abilities
