### PR TITLE
Fix fatal error on Yoast settings pages that do not have a dedicated option class

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -28,15 +28,15 @@ class Yoast_Form {
 	 * @var array
 	 * @since 2.0
 	 */
-	public $options;
+	public $options = array();
 
 	/**
 	 * Option instance.
 	 *
 	 * @since 8.4
-	 * @var WPSEO_Option
+	 * @var WPSEO_Option|null
 	 */
-	protected $option_instance;
+	protected $option_instance = null;
 
 	/**
 	 * Get the singleton instance of this class
@@ -109,9 +109,17 @@ class Yoast_Form {
 	 * @param string $option_name Option key.
 	 */
 	public function set_option( $option_name ) {
+		$this->option_name = $option_name;
+
+		$this->options = WPSEO_Options::get_option( $option_name );
+		if ( ! $this->options ) {
+			$this->options = array();
+		}
+
 		$this->option_instance = WPSEO_Options::get_option_instance( $option_name );
-		$this->option_name     = $option_name;
-		$this->options         = WPSEO_Options::get_option( $option_name );
+		if ( ! $this->option_instance ) {
+			$this->option_instance = null;
+		}
 	}
 
 	/**
@@ -659,6 +667,10 @@ class Yoast_Form {
 	 * @return bool True if control should be disabled, false otherwise.
 	 */
 	protected function is_control_disabled( $var ) {
+		if ( $this->option_instance === null ) {
+			return false;
+		}
+
 		return $this->option_instance->is_disabled( $var );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix fatal error on Yoast settings pages that do not have a dedicated option class.

## Relevant technical choices:

* This PR ensures that `Yoast_Form::$option_instance` is either the option instance or null, and that no methods on it if it is null.
* In addition, this PR ensures `Yoast_Form::$options` is always an array and also works for options that are not "whitelisted" through having a `WPSEO_Option` class.
* See #11132 for related bug that should be fixed in the future.

## Test instructions

This PR can be tested by following these steps:

* Go to the Yoast SEO > Search Console page.
* Connect your site with Google Search Console.
* Verify no fatal error occurs on the page once the connection is set.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11126 
