### PR TITLE
Move the help out of the new "feature toggles" legend

### DIFF
--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -19,7 +19,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 
 ?>
 <h2><?php esc_html_e( 'Features', 'wordpress-seo' ); ?></h2>
-<div style="max-width:600px">
+<div class="yoast-measure">
 	<?php
 	echo sprintf(
 		/* translators: %1$s expands to Yoast SEO */
@@ -54,7 +54,8 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 				'on'  => __( 'On', 'wordpress-seo' ),
 				'off' => __( 'Off', 'wordpress-seo' ),
 			),
-			'<strong>' . $feature->name . $feature_help->get_button_html() . '</strong>' . $feature_help->get_panel_html()
+			'<strong>' . $feature->name . '</strong>',
+			$feature_help->get_button_html() . $feature_help->get_panel_html()
 		);
 	}
 	?>

--- a/admin/views/tabs/network/features.php
+++ b/admin/views/tabs/network/features.php
@@ -19,7 +19,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 
 ?>
 <h2><?php esc_html_e( 'Features', 'wordpress-seo' ); ?></h2>
-<div style="max-width:600px">
+<div class="yoast-measure">
 	<?php
 	echo sprintf(
 		/* translators: %s expands to Yoast SEO */
@@ -54,7 +54,8 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 				'on'  => __( 'Allow Control', 'wordpress-seo' ),
 				'off' => __( 'Disable', 'wordpress-seo' ),
 			),
-			'<strong>' . $feature->name . $feature_help->get_button_html() . '</strong>' . $feature_help->get_panel_html()
+			'<strong>' . $feature->name . '</strong>',
+			$feature_help->get_button_html() . $feature_help->get_panel_html()
 		);
 	}
 	?>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- fieldset legends should only contain the name of the fieldset, to give a name to the controls they group
- in #10844 the Help button and text was passed as part of the `toggle_switch()` 3rd parameter, which ended up within the fieldset legend
- this PR passes the Help as 4th parameter, which is the one to be used for the Help
- also removes an inline style: we already have the `.yoast-measure` CSS class to apply a `max-width: 600px`

## Test instructions
- go to SEO > General > Features  `wp-admin/admin.php?page=wpseo_dashboard#top#features`
- verify there are no visual or functional changes to the toggles and their Help
- on a multisite installation, go to Network > SEO > General > Features `wp-admin/network/admin.php?page=wpseo_dashboard#top#features`
- verify there are no visual or functional changes to the toggles and their Help
- on both pages, verify the fieldset legends contain just the fieldset name, e.g.: `<legend><strong>SEO analysis</strong></legend>`

Note: there's just one small difference of 10 pixels in the width of the Help, which is now (correctly) 600 pixels 

Fixes #11122 
