### PR TITLE
Fix indexable endpoint singular route.

### DIFF
--- a/admin/endpoints/class-endpoint-indexable.php
+++ b/admin/endpoints/class-endpoint-indexable.php
@@ -11,7 +11,7 @@
 class WPSEO_Endpoint_Indexable implements WPSEO_Endpoint, WPSEO_Endpoint_Storable {
 
 	const REST_NAMESPACE 	= 'yoast/v1';
-	const ENDPOINT_SINGULAR = 'indexables/(?P<object_id>\d+)';
+	const ENDPOINT_SINGULAR = 'indexables/(?P<object_type>\w+)/(?P<object_id>\d+)';
 
 	const CAPABILITY_RETRIEVE = 'manage_options';
 	const CAPABILITY_STORE 	  = 'manage_options';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Should be no changelog as the indexable rest endpoint hasn't been released yet.

## Relevant technical choices:

* Makes the indexable endpoint unique and future proof on the basis of URL alone.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* A post's indexable should be accessible with `/wp-json/yoast/v1/indexables/post/<POST_ID>`.
* A term's indexable should be accessible with `/wp-json/yoast/v1/indexables/term/<TERM_ID>`.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11138.
