### PR TITLE
Add target="_blank" to open new tab when click

### DIFF
--- a/admin/config-ui/fields/class-field-google-search-console-intro.php
+++ b/admin/config-ui/fields/class-field-google-search-console-intro.php
@@ -26,7 +26,7 @@ class WPSEO_Config_Field_Google_Search_Console_Intro extends WPSEO_Config_Field 
 				'wordpress-seo'
 			),
 			'Yoast SEO',
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1ex' ) ) . '">',
+			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1ex' ) ) . '" target="_blank">',
 			'</a>'
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add `target="_blank"` to the "How to connect to GSC" link to open a new tab when click.

## Relevant technical choices:

* None

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the Configuration Wizard.
* Go to step 8 "Google Search Console".
* Click the link "how to connect Google Search Console to your site."

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11028
