### PR TITLE
register_meta is here to stay

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -274,12 +274,10 @@ class WPSEO_Meta {
 
 		foreach ( self::$meta_fields as $subset => $field_group ) {
 			foreach ( $field_group as $key => $field_def ) {
+				
 				register_meta( 'post', self::$meta_prefix . $key, array(
 					'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
 				) );
-				else {
-					add_filter( 'sanitize_post_meta_' . self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ), 10, 2 );
-				}
 
 				// Set the $fields_index property for efficiency.
 				self::$fields_index[ self::$meta_prefix . $key ] = array(

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -272,15 +272,11 @@ class WPSEO_Meta {
 		}
 		unset( $extra_fields );
 
-		$register = function_exists( 'register_meta' );
-
 		foreach ( self::$meta_fields as $subset => $field_group ) {
 			foreach ( $field_group as $key => $field_def ) {
-				if ( $register === true ) {
-					register_meta( 'post', self::$meta_prefix . $key, array(
-						'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
-					) );
-				}
+				register_meta( 'post', self::$meta_prefix . $key, array(
+					'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
+				) );
 				else {
 					add_filter( 'sanitize_post_meta_' . self::$meta_prefix . $key, array( __CLASS__, 'sanitize_post_meta' ), 10, 2 );
 				}

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -297,7 +297,7 @@ class WPSEO_Meta {
 				}
 			}
 		}
-		unset( $subset, $field_group, $key, $field_def, $register );
+		unset( $subset, $field_group, $key, $field_def );
 
 		add_filter( 'update_post_metadata', array( __CLASS__, 'remove_meta_if_default' ), 10, 5 );
 		add_filter( 'add_post_metadata', array( __CLASS__, 'dont_save_meta_if_default' ), 10, 4 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removing check for register_meta as it will be sticking around. Discussed in this issue: https://github.com/Yoast/wordpress-seo/issues/6688

## Relevant technical choices:

* Less code, less bloat!

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* N/A

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
