### PR TITLE
Remove site separator when no site tagline is set.

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -780,8 +780,8 @@ class WPSEO_Utils {
 		
 		// Return out if no site tagline is set.
 		if( empty(get_bloginfo( 'description' ))) {
-            return;
-        }
+			return;
+		}
 		
 		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -777,6 +777,12 @@ class WPSEO_Utils {
 	 * @return string
 	 */
 	public static function get_title_separator() {
+		
+		// Return out if no site tagline is set.
+		if( empty(get_bloginfo( 'description' ))) {
+            return;
+        }
+		
 		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
 
 		// Get the titles option and the separator options.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixing issue when title/tagline separator shows even when no site tagline is set. As reported here: https://github.com/Yoast/wordpress-seo/issues/6450

## Relevant technical choices:

* n/a

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check title in tab with site name, no site tagline set before and after this patch.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
https://github.com/Yoast/wordpress-seo/issues/6450
