### PR TITLE
CS: clean up after merges

### DIFF
--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -40,7 +40,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 					'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-premium' ),
 				),
 				array(
-					'url' => WPSEO_Shortlinker::get( 'https://yoa.st/video-yoast-seo-premium' ),
+					'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/video-yoast-seo-premium' ),
 					'title' => sprintf(
 						/* translators: %1$s expands to Yoast SEO Premium. */
 						__( '%1$s video', 'wordpress-seo' ),
@@ -68,7 +68,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/2up' ),
 			),
 			array(
-				'url' => WPSEO_Shortlinker::get( 'https://yoa.st/2v0' ),
+				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/2v0' ),
 				'title' => sprintf(
 					/* translators: %1$s expands to Basic SEO training. */
 					__( '%1$s video', 'wordpress-seo' ),
@@ -88,7 +88,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-plugin-course' ),
 			),
 			array(
-				'url' => WPSEO_Shortlinker::get( 'https://yoa.st/video-plugin-course' ),
+				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/video-plugin-course' ),
 				'title' => sprintf(
 					/* translators: %1$s expands to Yoast SEO plugin training. */
 					__( '%1$s video', 'wordpress-seo' ),
@@ -109,7 +109,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 					'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-localseo' ),
 				),
 				array(
-					'url' => WPSEO_Shortlinker::get( 'https://yoa.st/video-localseo' ),
+					'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/video-localseo' ),
 					'title' => sprintf(
 						/* translators: %1$s expands to Local SEO. */
 						__( '%1$s video', 'wordpress-seo' ),

--- a/admin/endpoints/class-endpoint-indexable.php
+++ b/admin/endpoints/class-endpoint-indexable.php
@@ -10,11 +10,11 @@
  */
 class WPSEO_Endpoint_Indexable implements WPSEO_Endpoint, WPSEO_Endpoint_Storable {
 
-	const REST_NAMESPACE 	= 'yoast/v1';
+	const REST_NAMESPACE    = 'yoast/v1';
 	const ENDPOINT_SINGULAR = 'indexables/(?P<object_type>\w+)/(?P<object_id>\d+)';
 
 	const CAPABILITY_RETRIEVE = 'manage_options';
-	const CAPABILITY_STORE 	  = 'manage_options';
+	const CAPABILITY_STORE    = 'manage_options';
 
 	/**
 	 * @var WPSEO_Indexable_Service The indexable service.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -231,7 +231,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			new WPSEO_Post_Metabox_Formatter( $post, array(), $permalink )
 		);
 
-		$values     = $post_formatter->get_values();
+		$values = $post_formatter->get_values();
 
 		/** This filter is documented in admin/filters/class-cornerstone-filter.php */
 		$post_types = apply_filters( 'wpseo_cornerstone_post_types', WPSEO_Post_Type::get_accessible_post_types() );

--- a/admin/services/class-indexable-post-provider.php
+++ b/admin/services/class-indexable-post-provider.php
@@ -14,19 +14,19 @@ class WPSEO_Indexable_Service_Post_Provider extends WPSEO_Indexable_Provider {
 	 * @var array List of fields that need to be renamed.
 	 */
 	protected $renameable_fields = array(
-		'description'				  => 'metadesc',
-		'breadcrumb_title'			  => 'bctitle',
-		'og_title'					  => 'opengraph-title',
-		'og_description'			  => 'opengraph-description',
-		'og_image'					  => 'opengraph-image',
-		'twitter_title'				  => 'twitter-title',
-		'twitter_description'		  => 'twitter-description',
-		'twitter_image'				  => 'twitter-image',
-		'is_robots_noindex'			  => 'meta-robots-noindex',
-		'is_robots_nofollow'		  => 'meta-robots-nofollow',
-		'primary_focus_keyword'		  => 'focuskw',
+		'description'                 => 'metadesc',
+		'breadcrumb_title'            => 'bctitle',
+		'og_title'                    => 'opengraph-title',
+		'og_description'              => 'opengraph-description',
+		'og_image'                    => 'opengraph-image',
+		'twitter_title'               => 'twitter-title',
+		'twitter_description'         => 'twitter-description',
+		'twitter_image'               => 'twitter-image',
+		'is_robots_noindex'           => 'meta-robots-noindex',
+		'is_robots_nofollow'          => 'meta-robots-nofollow',
+		'primary_focus_keyword'       => 'focuskw',
 		'primary_focus_keyword_score' => 'linkdex',
-		'readability_score'			  => 'content_score',
+		'readability_score'           => 'content_score',
 	);
 
 	/**
@@ -56,13 +56,13 @@ class WPSEO_Indexable_Service_Post_Provider extends WPSEO_Indexable_Provider {
 	/**
 	 * Handles the patching of values for an existing indexable.
 	 *
-	 * @param int 	$object_id 		The ID of the object.
-	 * @param array $requestdata 	The request data to store.
+	 * @param int   $object_id   The ID of the object.
+	 * @param array $requestdata The request data to store.
 	 *
 	 * @return array The patched indexable.
 	 *
 	 * @throws WPSEO_Invalid_Indexable_Exception The invalid argument exception.
-	 * @throws WPSEO_REST_Request_Exception		 Exception that is thrown if patching the object has failed.
+	 * @throws WPSEO_REST_Request_Exception      Exception that is thrown if patching the object has failed.
 	 */
 	public function patch( $object_id, $requestdata ) {
 		$indexable = $this->get( $object_id, true );
@@ -89,7 +89,7 @@ class WPSEO_Indexable_Service_Post_Provider extends WPSEO_Indexable_Provider {
 	 * @return bool True if saving was successful.
 	 */
 	protected function store_indexable( WPSEO_Indexable $indexable ) {
-		$values = $this->convert_indexable_data( $indexable->to_array() );
+		$values         = $this->convert_indexable_data( $indexable->to_array() );
 		$renamed_values = $this->rename_indexable_data( $values );
 
 		foreach ( $renamed_values as $key => $item ) {

--- a/admin/services/class-indexable-term-provider.php
+++ b/admin/services/class-indexable-term-provider.php
@@ -14,18 +14,18 @@ class WPSEO_Indexable_Service_Term_Provider extends WPSEO_Indexable_Provider {
 	 * @var array List of fields that need to be renamed.
 	 */
 	protected $renameable_fields = array(
-		'description'				  => 'desc',
-		'breadcrumb_title'			  => 'bctitle',
-		'og_title'					  => 'opengraph-title',
-		'og_description'			  => 'opengraph-description',
-		'og_image'					  => 'opengraph-image',
-		'twitter_title'				  => 'twitter-title',
-		'twitter_description'		  => 'twitter-description',
-		'twitter_image'				  => 'twitter-image',
-		'is_robots_noindex'			  => 'noindex',
-		'primary_focus_keyword'		  => 'focuskw',
+		'description'                 => 'desc',
+		'breadcrumb_title'            => 'bctitle',
+		'og_title'                    => 'opengraph-title',
+		'og_description'              => 'opengraph-description',
+		'og_image'                    => 'opengraph-image',
+		'twitter_title'               => 'twitter-title',
+		'twitter_description'         => 'twitter-description',
+		'twitter_image'               => 'twitter-image',
+		'is_robots_noindex'           => 'noindex',
+		'primary_focus_keyword'       => 'focuskw',
 		'primary_focus_keyword_score' => 'linkdex',
-		'readability_score'			  => 'content_score',
+		'readability_score'           => 'content_score',
 	);
 
 	/**
@@ -59,7 +59,7 @@ class WPSEO_Indexable_Service_Term_Provider extends WPSEO_Indexable_Provider {
 	 * @return array The patched indexable.
 	 *
 	 * @throws WPSEO_Invalid_Indexable_Exception The indexable exception.
-	 * @throws WPSEO_REST_Request_Exception		 Exception that is thrown if patching the object has failed.
+	 * @throws WPSEO_REST_Request_Exception      Exception that is thrown if patching the object has failed.
 	 */
 	public function patch( $object_id, $requestdata ) {
 		$indexable = $this->get( $object_id, true );
@@ -86,7 +86,7 @@ class WPSEO_Indexable_Service_Term_Provider extends WPSEO_Indexable_Provider {
 	 * @return bool True if the indexable object was successfully stored.
 	 */
 	protected function store_indexable( WPSEO_Indexable $indexable ) {
-		$values 		 = $this->convert_indexable_data( $indexable->to_array() );
+		$values          = $this->convert_indexable_data( $indexable->to_array() );
 		$renamed_values  = $this->rename_indexable_data( $values );
 		$prefixed_values = $this->prefix_indexable_data( $renamed_values );
 
@@ -162,5 +162,4 @@ class WPSEO_Indexable_Service_Term_Provider extends WPSEO_Indexable_Provider {
 
 		return 'default';
 	}
-
 }

--- a/admin/services/class-indexable.php
+++ b/admin/services/class-indexable.php
@@ -19,7 +19,7 @@ class WPSEO_Indexable_Service {
 	 */
 	public function get_indexable( WP_REST_Request $request ) {
 		$object_type = $request->get_param( 'object_type' );
-		$object_id 	 = $request->get_param( 'object_id' );
+		$object_id   = $request->get_param( 'object_id' );
 
 		try {
 			$provider  = $this->get_provider( $object_type );
@@ -41,10 +41,10 @@ class WPSEO_Indexable_Service {
 	 */
 	public function patch_indexable( WP_REST_Request $request ) {
 		$object_type = $request->get_param( 'object_type' );
-		$object_id 	 = $request->get_param( 'object_id' );
+		$object_id   = $request->get_param( 'object_id' );
 
 		try {
-			$provider = $this->get_provider( $object_type );
+			$provider       = $this->get_provider( $object_type );
 			$patched_result = $provider->patch( $object_id, $request->get_params() );
 
 			return new WP_REST_Response( $patched_result );

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -21,37 +21,37 @@ $yform->toggle_switch(
 ?>
 <div id='date-archives-titles-metas-content' class='archives-titles-metas-content'>
 	<?php
-		$date_archives_help = new WPSEO_Admin_Help_Panel(
-			'noindex-archive-wpseo',
-			esc_html__( 'Help on the date archives search results setting', 'wordpress-seo' ),
-			sprintf(
-			/* translators: 1: expands to <code>noindex</code>; 2: link open tag; 3: link close tag. */
-			esc_html__( 'Not showing the date archives in the search results technically means those will have a %1$s robots meta and will be excluded from XML sitemaps. %2$sMore info on the search results settings%3$s.', 'wordpress-seo' ),
-			'<code>noindex</code>',
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/show-x' ) ) . '" target="_blank" rel="noopener noreferrer">',
-				'</a>'
-			)
-		);
+	$date_archives_help = new WPSEO_Admin_Help_Panel(
+		'noindex-archive-wpseo',
+		esc_html__( 'Help on the date archives search results setting', 'wordpress-seo' ),
+		sprintf(
+		/* translators: 1: expands to <code>noindex</code>; 2: link open tag; 3: link close tag. */
+		esc_html__( 'Not showing the date archives in the search results technically means those will have a %1$s robots meta and will be excluded from XML sitemaps. %2$sMore info on the search results settings%3$s.', 'wordpress-seo' ),
+		'<code>noindex</code>',
+		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/show-x' ) ) . '" target="_blank" rel="noopener noreferrer">',
+			'</a>'
+		)
+	);
 
-		$yform->index_switch(
-			'noindex-archive-wpseo',
-			__( 'date archives', 'wordpress-seo' ),
-			$date_archives_help->get_button_html() . $date_archives_help->get_panel_html()
-		);
+	$yform->index_switch(
+		'noindex-archive-wpseo',
+		__( 'date archives', 'wordpress-seo' ),
+		$date_archives_help->get_button_html() . $date_archives_help->get_panel_html()
+	);
 
-		$recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
-		$editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
+	$recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
+	$editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
 
-		$editor = new WPSEO_Replacevar_Editor(
-			$yform,
-			array(
-				'title'                 => 'title-archive-wpseo',
-				'description'           => 'metadesc-archive-wpseo',
-				'page_type_recommended' => $recommended_replace_vars->determine_for_archive( 'date' ),
-				'page_type_specific'    => $editor_specific_replace_vars->determine_for_archive( 'date' ),
-				'paper_style'           => false,
-			)
-		);
-		$editor->render();
+	$editor = new WPSEO_Replacevar_Editor(
+		$yform,
+		array(
+			'title'                 => 'title-archive-wpseo',
+			'description'           => 'metadesc-archive-wpseo',
+			'page_type_recommended' => $recommended_replace_vars->determine_for_archive( 'date' ),
+			'page_type_specific'    => $editor_specific_replace_vars->determine_for_archive( 'date' ),
+			'paper_style'           => false,
+		)
+	);
+	$editor->render();
 	?>
 </div>

--- a/inc/class-wpseo-endpoint-factory.php
+++ b/inc/class-wpseo-endpoint-factory.php
@@ -115,9 +115,9 @@ class WPSEO_Endpoint_Factory {
 	 */
 	public function register() {
 		$config = array(
-			'methods'				=> $this->method,
-			'callback'				=> $this->callback,
-			'permission_callback'	=> $this->permission_callback,
+			'methods'             => $this->method,
+			'callback'            => $this->callback,
+			'permission_callback' => $this->permission_callback,
 		);
 
 		if ( $this->has_arguments() ) {
@@ -135,7 +135,7 @@ class WPSEO_Endpoint_Factory {
 	 * @return string The validated method.
 	 *
 	 * @throws WPSEO_Invalid_Argument_Exception The invalid argument exception.
-	 * @throws InvalidArgumentException The invalid argument exception.
+	 * @throws InvalidArgumentException         The invalid argument exception.
 	 */
 	protected function validate_method( $method ) {
 		if ( ! WPSEO_Validator::is_string( $method ) ) {
@@ -152,10 +152,10 @@ class WPSEO_Endpoint_Factory {
 	/**
 	 * Adds an argument to the endpoint.
 	 *
-	 * @param string $name		  The name of the argument.
+	 * @param string $name        The name of the argument.
 	 * @param string $description The description associated with the argument.
-	 * @param string $type		  The type of value that can be assigned to the argument.
-	 * @param bool 	 $required	  Whether or not it's a required argument. Defaults to true.
+	 * @param string $type        The type of value that can be assigned to the argument.
+	 * @param bool   $required    Whether or not it's a required argument. Defaults to true.
 	 *
 	 * @return void
 	 */
@@ -165,9 +165,9 @@ class WPSEO_Endpoint_Factory {
 		}
 
 		$this->args[ $name ] = array(
-			'description'	=> $description,
-			'type'			=> $type,
-			'required'		=> $required,
+			'description' => $description,
+			'type'        => $type,
+			'required'    => $required,
 		);
 	}
 }

--- a/inc/exceptions/class-invalid-argument-exception.php
+++ b/inc/exceptions/class-invalid-argument-exception.php
@@ -31,7 +31,7 @@ class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 	 * Creates an invalid parameter exception.
 	 *
 	 * @param mixed  $parameter The parameter value of the field.
-	 * @param string $name	    The name of the field.
+	 * @param string $name      The name of the field.
 	 * @param string $expected  The expected type.
 	 *
 	 * @return WPSEO_Invalid_Argument_Exception The exception.
@@ -52,7 +52,7 @@ class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 	 * Creates an invalid integer parameter exception.
 	 *
 	 * @param mixed  $parameter The parameter value of the field.
-	 * @param string $name	    The name of the field.
+	 * @param string $name      The name of the field.
 	 *
 	 * @return WPSEO_Invalid_Argument_Exception The exception.
 	 */
@@ -64,7 +64,7 @@ class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 	 * Creates an invalid string parameter exception.
 	 *
 	 * @param mixed  $parameter The parameter value of the field.
-	 * @param string $name	    The name of the field.
+	 * @param string $name      The name of the field.
 	 *
 	 * @return WPSEO_Invalid_Argument_Exception The exception.
 	 */
@@ -76,7 +76,7 @@ class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 	 * Creates an invalid boolean parameter exception.
 	 *
 	 * @param mixed  $parameter The parameter value of the field.
-	 * @param string $name	    The name of the field.
+	 * @param string $name      The name of the field.
 	 *
 	 * @return WPSEO_Invalid_Argument_Exception The exception.
 	 */
@@ -88,7 +88,7 @@ class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 	 * Creates an invalid callable parameter exception.
 	 *
 	 * @param mixed  $parameter The parameter value of the field.
-	 * @param string $name	    The name of the field.
+	 * @param string $name      The name of the field.
 	 *
 	 * @return WPSEO_Invalid_Argument_Exception The exception.
 	 */
@@ -117,7 +117,7 @@ class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 	 * Creates an invalid object subtype exception.
 	 *
 	 * @param string $subtype The invalid subtype.
-	 * @param string $type 	  The parent type of the subtype.
+	 * @param string $type    The parent type of the subtype.
 	 *
 	 * @return WPSEO_Invalid_Argument_Exception The exception.
 	 */
@@ -135,8 +135,8 @@ class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 	/**
 	 * Creates an unknown object exception.
 	 *
-	 * @param int 	 $id 	The ID that was searched for.
-	 * @param string $type 	The type of object that was being searched for.
+	 * @param int    $id   The ID that was searched for.
+	 * @param string $type The type of object that was being searched for.
 	 *
 	 * @return WPSEO_Invalid_Argument_Exception The exception.
 	 */

--- a/inc/exceptions/class-rest-request-exception.php
+++ b/inc/exceptions/class-rest-request-exception.php
@@ -13,8 +13,8 @@ class WPSEO_REST_Request_Exception extends Exception {
 	/**
 	 * Creates a patch failure exception.
 	 *
-	 * @param string $object_type 	The name of the parameter.
-	 * @param string $object_id 	The ID of the parameter.
+	 * @param string $object_type The name of the parameter.
+	 * @param string $object_id   The ID of the parameter.
 	 *
 	 * @return WPSEO_REST_Request_Exception The exception.
 	 */

--- a/inc/indexables/class-indexable.php
+++ b/inc/indexables/class-indexable.php
@@ -66,8 +66,8 @@ abstract class WPSEO_Indexable {
 	/**
 	 * Determines whether the advanced robot metas value contains the passed value.
 	 *
-	 * @param int 	 $object_id	The ID of the object to check.
-	 * @param string $value 	The name of the advanced robots meta value to look for.
+	 * @param int    $object_id The ID of the object to check.
+	 * @param string $value     The name of the advanced robots meta value to look for.
 	 *
 	 * @return bool Whether or not the advanced robots meta values contains the passed string.
 	 */

--- a/inc/indexables/class-object-type.php
+++ b/inc/indexables/class-object-type.php
@@ -32,14 +32,14 @@ abstract class WPSEO_Object_Type {
 	/**
 	 * WPSEO_Object_Type constructor.
 	 *
-	 * @param int 	 $id 		The ID of the object.
-	 * @param string $type		The type of object.
-	 * @param string $subtype	The subtype of the object.
-	 * @param string $permalink	The permalink of the object.
+	 * @param int    $id        The ID of the object.
+	 * @param string $type      The type of object.
+	 * @param string $subtype   The subtype of the object.
+	 * @param string $permalink The permalink of the object.
 	 */
 	public function __construct( $id, $type, $subtype, $permalink ) {
-		$this->id 	 	 = (int) $id;
-		$this->type 	 = $type;
+		$this->id        = (int) $id;
+		$this->type      = $type;
 		$this->sub_type  = $subtype;
 		$this->permalink = $permalink;
 	}

--- a/inc/indexables/class-term-indexable.php
+++ b/inc/indexables/class-term-indexable.php
@@ -94,7 +94,7 @@ class WPSEO_Term_Indexable extends WPSEO_Indexable {
 	/**
 	 * Returns the needed term meta field.
 	 *
-	 * @param string 				 $field The requested field.
+	 * @param string                 $field The requested field.
 	 * @param WPSEO_Term_Object_Type $term  The term object.
 	 *
 	 * @return bool|mixed The value of the requested field.

--- a/inc/indexables/validators/class-object-type-validator.php
+++ b/inc/indexables/validators/class-object-type-validator.php
@@ -28,7 +28,7 @@ class WPSEO_Object_Type_Validator implements WPSEO_Endpoint_Validator {
 	/**
 	 * Validates whether the passed subtype is valid or not.
 	 *
-	 * @param string $type	  The type to validate.
+	 * @param string $type    The type to validate.
 	 * @param string $subtype The subtype to validate.
 	 *
 	 * @return void

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -145,10 +145,10 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		add_action( 'update_option_' . $this->option_name, array( 'WPSEO_Utils', 'clear_cache' ) );
 		add_action( 'init', array( $this, 'end_of_init' ), 999 );
 
-		add_action( 'registered_post_type',                  array( $this, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'unregistered_post_type',                array( $this, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'registered_taxonomy',                   array( $this, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'unregistered_taxonomy',                 array( $this, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'registered_post_type', array( $this, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'unregistered_post_type', array( $this, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'registered_taxonomy', array( $this, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'unregistered_taxonomy', array( $this, 'invalidate_enrich_defaults_cache' ) );
 	}
 
 	/**

--- a/tests/admin/services/test-class-endpoint-indexable.php
+++ b/tests/admin/services/test-class-endpoint-indexable.php
@@ -103,7 +103,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	public function test_get_indexable_for_valid_post_type_with_an_indexable_object() {
 		$provider = $this
 			->getMockBuilder( 'WPSEO_Indexable_Foo_Provider' )
-			->setMethods( array('get' ) )
+			->setMethods( array( 'get' ) )
 			->getMock();
 
 		$provider

--- a/tests/admin/services/test-class-indexable-post-provider.php
+++ b/tests/admin/services/test-class-indexable-post-provider.php
@@ -177,10 +177,10 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the conversion of the robots values.
 	 *
-	 * @param string    $robot_value 	The key to test with.
+	 * @param string    $robot_value    The key to test with.
 	 * @param string    $supplied_value The value to test with.
-	 * @param bool|null $expected		The expected conversion.
-	 * @param string    $description	Description of the test.
+	 * @param bool|null $expected       The expected conversion.
+	 * @param string    $description    Description of the test.
 	 *
 	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_indexable_data()
 	 *
@@ -195,18 +195,18 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the conversion of the advanced robots values.
 	 *
-	 * @param string    $robot_value 	The key to test with.
+	 * @param string    $robot_value    The key to test with.
 	 * @param string    $supplied_value The value to test with.
-	 * @param bool|null $expected		The expected conversion.
-	 * @param string    $description	Description of the test.
+	 * @param bool|null $expected       The expected conversion.
+	 * @param string    $description    Description of the test.
 	 *
 	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_advanced()
 	 *
 	 * @dataProvider advanced_indexable_data_conversion_provider
 	 */
 	public function test_convert_advanced( $robot_value, $supplied_value, $expected, $description ) {
-		$indexable 	= array( $robot_value => $supplied_value );
-		$data 		= $this->provider->convert_advanced( $indexable );
+		$indexable = array( $robot_value => $supplied_value );
+		$data      = $this->provider->convert_advanced( $indexable );
 
 		$this->assertEquals( $expected, $data, $description );
 	}
@@ -270,7 +270,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	public function indexable_data_conversion_provider() {
 		return array(
 			array( 'is_robots_nofollow', 'true', '1', 'With is_robots_nofollow value set to nofollow' ),
-			array( 'is_robots_nofollow', false,  '0', 'With is_robots_nofollow value set to follow' ),
+			array( 'is_robots_nofollow', false, '0', 'With is_robots_nofollow value set to follow' ),
 			array( 'is_robots_noindex', 'false', '2', 'With is_robots_noindex value set to index' ),
 			array( 'is_robots_noindex', 'true', '1', 'With is_robots_noindex value set to noindex' ),
 			array( 'is_robots_noindex', null, null, 'With is_robots_noindex value set to default' ),

--- a/tests/admin/services/test-class-indexable-term-provider.php
+++ b/tests/admin/services/test-class-indexable-term-provider.php
@@ -159,33 +159,33 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_rename_indexable_data() {
 		$supplied_values = array(
-			'description'				  => '',
-			'breadcrumb_title'			  => '',
-			'og_title'					  => '',
-			'og_description'			  => '',
-			'og_image'					  => '',
-			'twitter_title'				  => '',
-			'twitter_description'		  => '',
-			'twitter_image'				  => '',
-			'is_robots_noindex'			  => '',
-			'primary_focus_keyword'		  => '',
+			'description'                 => '',
+			'breadcrumb_title'            => '',
+			'og_title'                    => '',
+			'og_description'              => '',
+			'og_image'                    => '',
+			'twitter_title'               => '',
+			'twitter_description'         => '',
+			'twitter_image'               => '',
+			'is_robots_noindex'           => '',
+			'primary_focus_keyword'       => '',
 			'primary_focus_keyword_score' => '',
-			'readability_score'			  => '',
+			'readability_score'           => '',
 		);
 
 		$expected = array(
-			'desc'					=> '',
-			'bctitle'				=> '',
-			'opengraph-title'		=> '',
+			'desc'                  => '',
+			'bctitle'               => '',
+			'opengraph-title'       => '',
 			'opengraph-description' => '',
-			'opengraph-image'		=> '',
-			'twitter-title'			=> '',
-			'twitter-description'	=> '',
-			'twitter-image'			=> '',
-			'noindex'				=> '',
-			'focuskw'				=> '',
-			'linkdex'				=> '',
-			'content_score'			=> '',
+			'opengraph-image'       => '',
+			'twitter-title'         => '',
+			'twitter-description'   => '',
+			'twitter-image'         => '',
+			'noindex'               => '',
+			'focuskw'               => '',
+			'linkdex'               => '',
+			'content_score'         => '',
 		);
 
 		$data = $this->provider->rename_indexable_data( $supplied_values );
@@ -207,21 +207,21 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 				->getMock();
 
 		$instance->expects( $this->once() )
-				 ->method( 'convert_noindex' )
-				 ->will( $this->returnArgument( 0 ) );
+				->method( 'convert_noindex' )
+				->will( $this->returnArgument( 0 ) );
 
 		$supplied_values = array(
-			'desc'				=> 'I am the test description',
-			'bctitle'			=> 'Some breadcrumb title',
-			'opengraph-title'	=> 'The OpenGraph title',
-			'is_robots_noindex'	=> 'index',
+			'desc'              => 'I am the test description',
+			'bctitle'           => 'Some breadcrumb title',
+			'opengraph-title'   => 'The OpenGraph title',
+			'is_robots_noindex' => 'index',
 		);
 
 		$expected = array(
-			'desc'				=> 'I am the test description',
-			'bctitle'			=> 'Some breadcrumb title',
-			'opengraph-title'	=> 'The OpenGraph title',
-			'is_robots_noindex'	=> 'index',
+			'desc'              => 'I am the test description',
+			'bctitle'           => 'Some breadcrumb title',
+			'opengraph-title'   => 'The OpenGraph title',
+			'is_robots_noindex' => 'index',
 		);
 
 		$data = $instance->convert_indexable_data( $supplied_values );
@@ -245,5 +245,4 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 			array( '0', 'default', 'With noindex set to string value of 0' ),
 		);
 	}
-
 }

--- a/tests/inc/indexables/test-class-indexable.php
+++ b/tests/inc/indexables/test-class-indexable.php
@@ -15,9 +15,9 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the conversion of the noindex value.
 	 *
-	 * @param string	$value		 The value to test with.
-	 * @param bool|null $expected	 The expected conversion.
-	 * @param string	$description Description of the test.
+	 * @param string    $value       The value to test with.
+	 * @param bool|null $expected    The expected conversion.
+	 * @param string    $description Description of the test.
 	 *
 	 * @dataProvider noindex_conversion_provider
 	 * @covers WPSEO_Indexable::get_robots_noindex_value()
@@ -38,7 +38,7 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 			->getMockBuilder( 'WPSEO_Indexable_Double' )
 			->setConstructorArgs(
 				array(
-					array( 'field' => 'value' )
+					array( 'field' => 'value' ),
 				)
 			)
 			->setMethods( array( 'validate_data' ) )
@@ -60,24 +60,24 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 			->setConstructorArgs(
 				array(
 					array(
-						'object_id' => '1',
+						'object_id'   => '1',
 						'description' => '',
-						'title' => '',
-					)
+						'title'       => '',
+					),
 				)
 			)
 			->setMethods( array( 'validate_data' ) )
 			->getMock();
 
 		$supplied_values = array(
-			'object_id'		=> '1',
-			'description'	=> '',
-			'title'			=> '',
+			'object_id'   => '1',
+			'description' => '',
+			'title'       => '',
 		);
 
 		$expected = array(
-			'description'	=> '',
-			'title'			=> '',
+			'description' => '',
+			'title'       => '',
 		);
 
 		$data = $instance->filter_updateable_data( $supplied_values );

--- a/tests/inc/indexables/test-class-post-indexable.php
+++ b/tests/inc/indexables/test-class-post-indexable.php
@@ -58,7 +58,7 @@ class WPSEO_Post_Indexable_Test extends WPSEO_UnitTestCase {
 				)
 			);
 
-		$instance = WPSEO_Post_Indexable::from_object( $post->ID );
+		$instance     = WPSEO_Post_Indexable::from_object( $post->ID );
 		$new_instance = $instance->update(
 			array( 'is_robots_noindex' => true )
 		);

--- a/tests/inc/indexables/test-class-term-indexable.php
+++ b/tests/inc/indexables/test-class-term-indexable.php
@@ -15,9 +15,9 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the conversion of the robots noindex value.
 	 *
-	 * @param string    $noindex_value	The value to test with.
-	 * @param bool|null $expected		The expected converted value.
-	 * @param string    $description	Description of the test.
+	 * @param string    $noindex_value The value to test with.
+	 * @param bool|null $expected      The expected converted value.
+	 * @param string    $description   Description of the test.
 	 *
 	 * @covers WPSEO_Term_Indexable::get_robots_noindex_value()
 	 *
@@ -75,7 +75,7 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 				)
 			);
 
-		$instance = WPSEO_Term_Indexable_Double::from_object( $term->term_id );
+		$instance     = WPSEO_Term_Indexable_Double::from_object( $term->term_id );
 		$new_instance = $instance->update(
 			array( 'is_robots_noindex' => true )
 		);

--- a/tests/inc/options/test-class-wpseo-option-titles.php
+++ b/tests/inc/options/test-class-wpseo-option-titles.php
@@ -12,7 +12,7 @@ class WPSEO_Option_Titles_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if the enrich_defaults() cache is properly invalidated
-     * when a new post type or taxonomy is registered.
+	 * when a new post type or taxonomy is registered.
 	 *
 	 * @covers WPSEO_Option_Titles::enrich_defaults()
 	 */
@@ -28,5 +28,4 @@ class WPSEO_Option_Titles_Test extends WPSEO_UnitTestCase {
 		unregister_taxonomy( 'custom-taxonomy' );
 		unregister_post_type( 'custom-post-type' );
 	}
-
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Mostly whitespace fixes, a few missing comma's after last array item.

Someone clearly got the wrong idea about tabs vs spaces as I saw a lot of newly introduced issues with inline tabs.
Just to be clear, to comply with WPCS, *tabs* should be used to _indent_ code. Spaces should be used for mid-line alignment.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.