### PR TITLE
CS: Consistency, newly deprecated method

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -689,12 +689,15 @@ class Yoast_Form {
 		return '<p class="disabled-note">' . esc_html__( 'This feature has been disabled by the network admin.', 'wordpress-seo' ) . '</p>';
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Retrieve options based on whether we're on multisite or not.
 	 *
 	 * @since 1.2.4
 	 * @since 2.0   Moved to this class.
 	 * @deprecated 8.4
+	 * @codeCoverageIgnore
 	 *
 	 * @return array The option's value.
 	 */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.

See #11067. This PR basically applies the same for a newly deprecated method.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.