### PR TITLE
CS/best practices: use incrementor/decrementor were appropriate

### DIFF
--- a/admin/google_search_console/class-gsc-marker.php
+++ b/admin/google_search_console/class-gsc-marker.php
@@ -137,7 +137,7 @@ class WPSEO_GSC_Marker {
 		$total_issues = $counts->get_issue_count( $this->platform, $this->category );
 
 		// Lower the current count with 1.
-		$total_issues = ( $total_issues - 1 );
+		--$total_issues;
 
 		// And update the count.
 		$counts->update_issue_count( $this->platform, $this->category, $total_issues );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Decrementors exist for a reason :wink: 

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.