### PR TITLE
QA: use `wp_rand()` instead of `mt_rand()` [1]

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -56,12 +56,12 @@ class WPSEO_Image_Utils {
 		$id = attachment_url_to_postid( $url );
 
 		if ( empty( $id ) ) {
-			wp_cache_set( $cache_key, 'not_found', '', ( 12 * HOUR_IN_SECONDS + mt_rand( 0, ( 4 * HOUR_IN_SECONDS ) ) ) );
+			wp_cache_set( $cache_key, 'not_found', '', ( 12 * HOUR_IN_SECONDS + wp_rand( 0, ( 4 * HOUR_IN_SECONDS ) ) ) );
 			return 0;
 		}
 
 		// We have the Post ID, but it's not in the cache yet. We do that here and return.
-		wp_cache_set( $cache_key, $id, '', ( 24 * HOUR_IN_SECONDS + mt_rand( 0, ( 12 * HOUR_IN_SECONDS ) ) ) );
+		wp_cache_set( $cache_key, $id, '', ( 24 * HOUR_IN_SECONDS + wp_rand( 0, ( 12 * HOUR_IN_SECONDS ) ) ) );
 		return $id;
 	}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.

The `wp_rand()` function is less predictable than the `mt_rand()` function and therefore the better function to use.

Refs:
* https://developer.wordpress.org/reference/functions/wp_rand/
* http://php.net/manual/en/function.mt-rand.php


## Test instructions

This PR can be tested by following these steps:
* Good question, but testing this would be a good idea.
    Basically, the caching of the post ID retrieval based on an attachment URl, including using the cache when available and setting it when not, should be unaffected.