### PR TITLE
QA: use `wp_rand()` instead of `mt_rand()` [2]

### DIFF
--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -239,7 +239,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	public function test_set_attachment_page_image() {
 		$post_id         = $this->create_post();
 		$image           = '/assets/yoast.png';
-		$rand            = rand( 1000, 9999 );
+		$rand            = wp_rand( 1000, 9999 );
 		$basename        = str_replace( '.png', '-attachment-test-' . $rand . '.png', basename( $image ) );
 		$upload_dir      = wp_upload_dir();
 		$source_image    = dirname( __FILE__ ) . '/..' . $image;


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.

The `wp_rand()` function is less predictable than the `mt_rand()` function and therefore the better function to use.

Refs:
* https://developer.wordpress.org/reference/functions/wp_rand/
* http://php.net/manual/en/function.mt-rand.php

This is a change to the random number generation used in a unit test and should have no noticeable effects. All should be good if the unit test still passes.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.