### PR TITLE
CS: Each parameter should start on a new line in multi-line function calls

### DIFF
--- a/admin/class-add-keyword-modal.php
+++ b/admin/class-add-keyword-modal.php
@@ -27,12 +27,14 @@ class WPSEO_Add_Keyword_Modal {
 			'link'                     => WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ),
 			'other'                    => sprintf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
-				__( 'Other benefits of %s for you:', 'wordpress-seo' ), 'Yoast SEO Premium'
+				__( 'Other benefits of %s for you:', 'wordpress-seo' ),
+				'Yoast SEO Premium'
 			),
 			'buylink'                  => WPSEO_Shortlinker::get( 'https://yoa.st/add-keywords-popup' ),
 			'buy'                      => sprintf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
-				__( 'Get %s now!', 'wordpress-seo' ), 'Yoast SEO Premium'
+				__( 'Get %s now!', 'wordpress-seo' ),
+				'Yoast SEO Premium'
 			),
 			'small'                    => __( '1 year free updates and upgrades included!', 'wordpress-seo' ),
 			'a11yNotice.opensInNewTab' => __( '(Opens in a new browser tab)', 'wordpress-seo' ),

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -567,7 +567,8 @@ class WPSEO_Admin_Init {
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',
 				'hook'        => 'wpseo_admin_promo_footer',
-			), false
+			),
+			false
 		);
 
 		$message = $i18n_module->get_promo_message();

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -483,7 +483,8 @@ class WPSEO_Admin {
 
 		$screen = get_current_screen();
 
-		$screen->set_help_sidebar( '
+		$screen->set_help_sidebar(
+			'
 			<p><strong>' . __( 'For more information:', 'wordpress-seo' ) . '</strong></p>
 			<p><a target="_blank" href="https://yoast.com/wordpress-seo/#titles">' . __( 'Title optimization', 'wordpress-seo' ) . '</a></p>
 			<p><a target="_blank" href="https://yoast.com/google-page-title/">' . __( 'Why Google won\'t display the right page title', 'wordpress-seo' ) . '</a></p>'

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -179,8 +179,8 @@ class WPSEO_Database_Proxy {
 	 * @return bool True when creation is successful.
 	 */
 	public function create_table( array $columns, array $indexes = array() ) {
-		$create_table = sprintf( '
-				CREATE TABLE IF NOT EXISTS %1$s ( %2$s ) %3$s',
+		$create_table = sprintf(
+			'CREATE TABLE IF NOT EXISTS %1$s ( %2$s ) %3$s',
 			$this->get_table_name(),
 			implode( ',', array_merge( $columns, $indexes ) ),
 			$this->database->get_charset_collate()

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -86,7 +86,8 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 	public function update_incoming_link_count( array $post_ids, WPSEO_Link_Storage $storage ) {
 		global $wpdb;
 
-		$query = $wpdb->prepare( '
+		$query = $wpdb->prepare(
+			'
 			SELECT COUNT( id ) AS incoming, target_post_id AS post_id
 			FROM ' . $storage->get_table_name() . '
 			WHERE target_post_id IN(' . implode( ',', array_fill( 0, count( $post_ids ), '%d' ) ) . ')

--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -115,7 +115,8 @@ class WPSEO_Plugin_Availability {
 				'title'         => 'Yoast SEO AMP Glue',
 				'description'   => sprintf(
 					/* translators: %1$s expands to Yoast SEO */
-					__( 'Seamlessly integrate %1$s into your AMP pages!', 'wordpress-seo' ), 'Yoast SEO'
+					__( 'Seamlessly integrate %1$s into your AMP pages!', 'wordpress-seo' ),
+					'Yoast SEO'
 				),
 				'installed'     => false,
 				'slug'          => 'glue-for-yoast-seo-amp/yoastseo-amp.php',


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

This commit addresses multi-line function calls where parameters did not each start on a new line.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.