### PR TITLE
CS: Move multi-line parameters out of function calls [1]

### DIFF
--- a/admin/class-admin-asset-analysis-worker-location.php
+++ b/admin/class-admin-asset-analysis-worker-location.php
@@ -33,10 +33,11 @@ final class WPSEO_Admin_Asset_Analysis_Worker_Location implements WPSEO_Admin_As
 		}
 
 		$this->asset_location = WPSEO_Admin_Asset_Manager::create_default_location();
-		$this->asset          = new WPSEO_Admin_Asset( array(
+		$asset_arguments      = array(
 			'name' => $name,
 			'src'  => 'wp-seo-' . $name . '-' . $flat_version,
-		) );
+		);
+		$this->asset          = new WPSEO_Admin_Asset( $asset_arguments );
 	}
 
 	/**

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -127,13 +127,12 @@ class WPSEO_Admin_Asset_Manager {
 	 */
 	public function special_styles() {
 		$flat_version = $this->flatten_version( WPSEO_VERSION );
-
-		return array(
-			'inside-editor' => new WPSEO_Admin_Asset( array(
-				'name' => 'inside-editor',
-				'src'  => 'inside-editor-' . $flat_version,
-			) ),
+		$asset_args   = array(
+			'name' => 'inside-editor',
+			'src'  => 'inside-editor-' . $flat_version,
 		);
+
+		return array( 'inside-editor' => new WPSEO_Admin_Asset( $asset_args ) );
 	}
 
 	/**

--- a/admin/class-admin-asset-yoast-components-l10n.php
+++ b/admin/class-admin-asset-yoast-components-l10n.php
@@ -16,10 +16,11 @@ final class WPSEO_Admin_Asset_Yoast_Components_L10n {
 	 * @return void
 	 */
 	public function localize_script( $script_handle ) {
-		wp_localize_script( $script_handle, 'wpseoYoastJSL10n', array(
+		$translations = array(
 			'yoast-components' => $this->get_translations( 'yoast-components' ),
 			'wordpress-seo'    => $this->get_translations( 'wordpress-seojs' ),
-		) );
+		);
+		wp_localize_script( $script_handle, 'wpseoYoastJSL10n', $translations );
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -109,10 +109,11 @@ class WPSEO_Admin_Init {
 
 		$current_url   = ( is_ssl() ? 'https://' : 'http://' );
 		$current_url  .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
-		$customize_url = add_query_arg( array(
+		$query_args    = array(
 			'autofocus[control]' => 'blogdescription',
 			'url'                => urlencode( $current_url ),
-		), wp_customize_url() );
+		);
+		$customize_url = add_query_arg( $query_args, wp_customize_url() );
 
 		$info_message = sprintf(
 			/* translators: 1: link open tag; 2: link close tag. */

--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -48,14 +48,14 @@ class WPSEO_Customizer {
 	 * Add the breadcrumbs section to the customizer
 	 */
 	private function breadcrumbs_section() {
-		$this->wp_customize->add_section(
-			'wpseo_breadcrumbs_customizer_section', array(
-				/* translators: %s is the name of the plugin */
-				'title'           => sprintf( __( '%s Breadcrumbs', 'wordpress-seo' ), 'Yoast SEO' ),
-				'priority'        => 999,
-				'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
-			)
+		$section_args = array(
+			/* translators: %s is the name of the plugin */
+			'title'           => sprintf( __( '%s Breadcrumbs', 'wordpress-seo' ), 'Yoast SEO' ),
+			'priority'        => 999,
+			'active_callback' => array( $this, 'breadcrumbs_active_callback' ),
 		);
+
+		$this->wp_customize->add_section( 'wpseo_breadcrumbs_customizer_section', $section_args );
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -207,12 +207,13 @@ class Yoast_Form {
 	 * @param array  $attr HTML attributes set.
 	 */
 	public function label( $text, $attr ) {
-		$attr = wp_parse_args( $attr, array(
-				'class' => 'checkbox',
-				'close' => true,
-				'for'   => '',
-			)
+		$defaults = array(
+			'class' => 'checkbox',
+			'close' => true,
+			'for'   => '',
 		);
+		$attr     = wp_parse_args( $attr, $defaults );
+
 		echo "<label class='" . esc_attr( $attr['class'] ) . "' for='" . esc_attr( $attr['for'] ) . "'>$text";
 		if ( $attr['close'] ) {
 			echo '</label>';
@@ -228,11 +229,11 @@ class Yoast_Form {
 	 * @param array  $attr HTML attributes set.
 	 */
 	public function legend( $text, $attr ) {
-		$attr = wp_parse_args( $attr, array(
-				'id'    => '',
-				'class' => '',
-			)
+		$defaults = array(
+			'id'    => '',
+			'class' => '',
 		);
+		$attr     = wp_parse_args( $attr, $defaults );
 
 		$id = ( '' === $attr['id'] ) ? '' : ' id="' . esc_attr( $attr['id'] ) . '"';
 		echo '<legend class="yoast-form-legend ' . esc_attr( $attr['class'] ) . '"' . $id . '>' . $text . '</legend>';
@@ -344,11 +345,13 @@ class Yoast_Form {
 				'class' => $attr,
 			);
 		}
-		$attr = wp_parse_args( $attr, array(
+
+		$defaults = array(
 			'placeholder' => '',
 			'class'       => '',
-		) );
-		$val  = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		);
+		$attr     = wp_parse_args( $attr, $defaults );
+		$val      = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
 
 		$this->label(
 			$label . ':',
@@ -375,12 +378,14 @@ class Yoast_Form {
 				'class' => $attr,
 			);
 		}
-		$attr = wp_parse_args( $attr, array(
+
+		$defaults = array(
 			'cols'  => '',
 			'rows'  => '',
 			'class' => '',
-		) );
-		$val  = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		);
+		$attr     = wp_parse_args( $attr, $defaults );
+		$val      = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
 
 		$this->label(
 			$label . ':',
@@ -534,10 +539,11 @@ class Yoast_Form {
 
 		if ( is_string( $legend ) && '' !== $legend ) {
 
-			$legend_attr = wp_parse_args( $legend_attr, array(
+			$defaults    = array(
 				'id'    => '',
 				'class' => 'radiogroup',
-			) );
+			);
+			$legend_attr = wp_parse_args( $legend_attr, $defaults );
 
 			$this->legend( $legend, $legend_attr );
 		}

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -181,14 +181,17 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'network-admin-script' );
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'network-admin-script', 'wpseoNetworkAdminGlobalL10n', array(
-
+		$translations = array(
 			/* translators: %s: success message */
 			'success_prefix' => __( 'Success: %s', 'wordpress-seo' ),
-
 			/* translators: %s: error message */
 			'error_prefix'   => __( 'Error: %s', 'wordpress-seo' ),
-		) );
+		);
+		wp_localize_script(
+			WPSEO_Admin_Asset_Manager::PREFIX . 'network-admin-script',
+			'wpseoNetworkAdminGlobalL10n',
+			$translations
+		);
 	}
 
 	/**

--- a/admin/class-yoast-network-settings-api.php
+++ b/admin/class-yoast-network-settings-api.php
@@ -41,10 +41,11 @@ class Yoast_Network_Settings_API {
 	 */
 	public function register_setting( $option_group, $option_name, $args = array() ) {
 
-		$args = wp_parse_args( $args, array(
+		$defaults = array(
 			'group'             => $option_group,
 			'sanitize_callback' => null,
-		) );
+		);
+		$args     = wp_parse_args( $args, $defaults );
 
 		if ( ! isset( $this->whitelist_options[ $option_group ] ) ) {
 			$this->whitelist_options[ $option_group ] = array();


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality, though careful review & spot testing is recommended.