### PR TITLE
CS: Move multi-line parameters out of function calls [2]

### DIFF
--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -66,6 +66,20 @@ class WPSEO_Admin_Asset {
 	protected $suffix;
 
 	/**
+	 * Default asset arguments.
+	 *
+	 * @var array
+	 */
+	private $defaults = array(
+		'deps'      => array(),
+		'version'   => WPSEO_VERSION,
+		'in_footer' => true,
+		'rtl'       => true,
+		'media'     => 'all',
+		'suffix'    => WPSEO_CSSJS_SUFFIX,
+	);
+
+	/**
 	 * @param array $args The arguments for this asset.
 	 *
 	 * @throws InvalidArgumentException Throws when no name or src has been provided.
@@ -79,14 +93,7 @@ class WPSEO_Admin_Asset {
 			throw new InvalidArgumentException( 'src is a required argument' );
 		}
 
-		$args = array_merge( array(
-			'deps'      => array(),
-			'version'   => WPSEO_VERSION,
-			'in_footer' => true,
-			'rtl'       => true,
-			'media'     => 'all',
-			'suffix'    => WPSEO_CSSJS_SUFFIX,
-		), $args );
+		$args = array_merge( $this->defaults, $args );
 
 		$this->name      = $args['name'];
 		$this->src       = $args['src'];


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

In this particular case, the class constructor would merge passed arguments with a default array. This default array is static, i.e. it does not change based on arguments passed, so it can (should) be defined as a class property instead.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality, though testing that the assets still get added correctly is recommended.