### PR TITLE
Refactor the `WPSEO_Customizer` class

### DIFF
--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -16,6 +16,37 @@ class WPSEO_Customizer {
 	protected $wp_customize;
 
 	/**
+	 * Template for the setting IDs used for the customizer.
+	 *
+	 * @var string
+	 */
+	private $setting_template = 'wpseo_titles[%s]';
+
+	/**
+	 * Default arguments for the breadcrumbs customizer settings object.
+	 *
+	 * @var array
+	 */
+	private $default_setting_args = array(
+		'default'   => '',
+		'type'      => 'option',
+		'transport' => 'refresh',
+	);
+
+	/**
+	 * Default arguments for the breadcrumbs customizer control object.
+	 *
+	 * @var array
+	 */
+	private $default_control_args = array(
+		'label'    => '',
+		'type'     => 'text',
+		'section'  => 'wpseo_breadcrumbs_customizer_section',
+		'settings' => '',
+		'context'  => '',
+	);
+
+	/**
 	 * Construct Method.
 	 */
 	public function __construct() {
@@ -71,26 +102,14 @@ class WPSEO_Customizer {
 	 * Adds the breadcrumbs remove blog checkbox
 	 */
 	private function breadcrumbs_blog_remove_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-display-blog-page]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
+		$index        = 'breadcrumbs-display-blog-page';
+		$control_args = array(
+			'label'           => __( 'Remove blog page from breadcrumbs', 'wordpress-seo' ),
+			'type'            => 'checkbox',
+			'active_callback' => array( $this, 'breadcrumbs_blog_remove_active_cb' ),
 		);
 
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-display-blog-page', array(
-					'label'           => __( 'Remove blog page from breadcrumbs', 'wordpress-seo' ),
-					'type'            => 'checkbox',
-					'section'         => 'wpseo_breadcrumbs_customizer_section',
-					'settings'        => 'wpseo_titles[breadcrumbs-display-blog-page]',
-					'context'         => '',
-					'active_callback' => array( $this, 'breadcrumbs_blog_remove_active_cb' ),
-				)
-			)
-		);
+		$this->add_setting_and_control( $index, $control_args );
 	}
 
 	/**
@@ -106,149 +125,105 @@ class WPSEO_Customizer {
 	 * Adds the breadcrumbs separator text field
 	 */
 	private function breadcrumbs_separator_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-sep]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
+		$index        = 'breadcrumbs-sep';
+		$control_args = array(
+			'label' => __( 'Breadcrumbs separator:', 'wordpress-seo' ),
 		);
+		$id           = 'wpseo-breadcrumbs-separator';
 
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-separator', array(
-					'label'    => __( 'Breadcrumbs separator:', 'wordpress-seo' ),
-					'type'     => 'text',
-					'section'  => 'wpseo_breadcrumbs_customizer_section',
-					'settings' => 'wpseo_titles[breadcrumbs-sep]',
-					'context'  => '',
-				)
-			)
-		);
+		$this->add_setting_and_control( $index, $control_args, $id );
 	}
 
 	/**
 	 * Adds the breadcrumbs home anchor text field
 	 */
 	private function breadcrumbs_home_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-home]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
+		$index        = 'breadcrumbs-home';
+		$control_args = array(
+			'label' => __( 'Anchor text for the homepage:', 'wordpress-seo' ),
 		);
 
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-home', array(
-					'label'    => __( 'Anchor text for the homepage:', 'wordpress-seo' ),
-					'type'     => 'text',
-					'section'  => 'wpseo_breadcrumbs_customizer_section',
-					'settings' => 'wpseo_titles[breadcrumbs-home]',
-					'context'  => '',
-				)
-			)
-		);
+		$this->add_setting_and_control( $index, $control_args );
 	}
 
 	/**
 	 * Adds the breadcrumbs prefix text field
 	 */
 	private function breadcrumbs_prefix_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-prefix]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
+		$index        = 'breadcrumbs-prefix';
+		$control_args = array(
+			'label' => __( 'Prefix for breadcrumbs:', 'wordpress-seo' ),
 		);
 
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-prefix', array(
-					'label'    => __( 'Prefix for breadcrumbs:', 'wordpress-seo' ),
-					'type'     => 'text',
-					'section'  => 'wpseo_breadcrumbs_customizer_section',
-					'settings' => 'wpseo_titles[breadcrumbs-prefix]',
-					'context'  => '',
-				)
-			)
-		);
+		$this->add_setting_and_control( $index, $control_args );
 	}
 
 	/**
 	 * Adds the breadcrumbs archive prefix text field
 	 */
 	private function breadcrumbs_archiveprefix_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-archiveprefix]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
+		$index        = 'breadcrumbs-archiveprefix';
+		$control_args = array(
+			'label' => __( 'Prefix for archive pages:', 'wordpress-seo' ),
 		);
 
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-archiveprefix', array(
-					'label'    => __( 'Prefix for archive pages:', 'wordpress-seo' ),
-					'type'     => 'text',
-					'section'  => 'wpseo_breadcrumbs_customizer_section',
-					'settings' => 'wpseo_titles[breadcrumbs-archiveprefix]',
-					'context'  => '',
-				)
-			)
-		);
+		$this->add_setting_and_control( $index, $control_args );
 	}
 
 	/**
 	 * Adds the breadcrumbs search prefix text field
 	 */
 	private function breadcrumbs_searchprefix_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-searchprefix]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
+		$index        = 'breadcrumbs-searchprefix';
+		$control_args = array(
+			'label' => __( 'Prefix for search result pages:', 'wordpress-seo' ),
 		);
 
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-searchprefix', array(
-					'label'    => __( 'Prefix for search result pages:', 'wordpress-seo' ),
-					'type'     => 'text',
-					'section'  => 'wpseo_breadcrumbs_customizer_section',
-					'settings' => 'wpseo_titles[breadcrumbs-searchprefix]',
-					'context'  => '',
-				)
-			)
-		);
+		$this->add_setting_and_control( $index, $control_args );
 	}
 
 	/**
 	 * Adds the breadcrumb 404 prefix text field
 	 */
 	private function breadcrumbs_404_setting() {
-		$this->wp_customize->add_setting(
-			'wpseo_titles[breadcrumbs-404crumb]', array(
-				'default'   => '',
-				'type'      => 'option',
-				'transport' => 'refresh',
-			)
+		$index        = 'breadcrumbs-404crumb';
+		$control_args = array(
+			'label' => __( 'Breadcrumb for 404 pages:', 'wordpress-seo' ),
 		);
 
-		$this->wp_customize->add_control(
-			new WP_Customize_Control(
-				$this->wp_customize, 'wpseo-breadcrumbs-404crumb', array(
-					'label'    => __( 'Breadcrumb for 404 pages:', 'wordpress-seo' ),
-					'type'     => 'text',
-					'section'  => 'wpseo_breadcrumbs_customizer_section',
-					'settings' => 'wpseo_titles[breadcrumbs-404crumb]',
-					'context'  => '',
-				)
-			)
-		);
+		$this->add_setting_and_control( $index, $control_args );
+	}
+
+	/**
+	 * Adds the customizer setting and control.
+	 *
+	 * @param string $index         Array key index to use for the customizer setting.
+	 * @param array  $control_args  Customizer control object arguments.
+	 *                              Only those different from the default need to be passed.
+	 * @param string $id            Optional. Customizer control object ID.
+	 *                              Will default to 'wpseo-' . $index.
+	 * @param array  $settings_args Optional. Customizer setting arguments.
+	 *                              Only those different from the default need to be passed.
+	 */
+	private function add_setting_and_control( $index, $control_args, $id = null, $settings_args = array() ) {
+		$setting                  = sprintf( $this->setting_template, $index );
+		$control_args             = array_merge( $this->default_control_args, $control_args );
+		$control_args['settings'] = $setting;
+
+		if ( empty( $settings_args ) ) {
+			$settings_args = $this->default_setting_args;
+		}
+		else {
+			$settings_args = array_merge( $this->default_setting_args, $settings_args );
+		}
+
+		if ( ! isset( $id ) ) {
+			$id = 'wpseo-' . $index;
+		}
+
+		$this->wp_customize->add_setting( $setting, $settings_args );
+
+		$control_obj = new WP_Customize_Control( $this->wp_customize, $id, $control_args );
+		$this->wp_customize->add_control( $control_obj );
 	}
 }

--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -223,7 +223,7 @@ class WPSEO_Customizer {
 
 		$this->wp_customize->add_setting( $setting, $settings_args );
 
-		$control_obj = new WP_Customize_Control( $this->wp_customize, $id, $control_args );
-		$this->wp_customize->add_control( $control_obj );
+		$control = new WP_Customize_Control( $this->wp_customize, $id, $control_args );
+		$this->wp_customize->add_control( $control );
 	}
 }

--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -197,24 +197,22 @@ class WPSEO_Customizer {
 	/**
 	 * Adds the customizer setting and control.
 	 *
-	 * @param string $index         Array key index to use for the customizer setting.
-	 * @param array  $control_args  Customizer control object arguments.
-	 *                              Only those different from the default need to be passed.
-	 * @param string $id            Optional. Customizer control object ID.
-	 *                              Will default to 'wpseo-' . $index.
-	 * @param array  $settings_args Optional. Customizer setting arguments.
-	 *                              Only those different from the default need to be passed.
+	 * @param string $index           Array key index to use for the customizer setting.
+	 * @param array  $control_args    Customizer control object arguments.
+	 *                                Only those different from the default need to be passed.
+	 * @param string $id              Optional. Customizer control object ID.
+	 *                                Will default to 'wpseo-' . $index.
+	 * @param array  $custom_settings Optional. Customizer setting arguments.
+	 *                                Only those different from the default need to be passed.
 	 */
-	private function add_setting_and_control( $index, $control_args, $id = null, $settings_args = array() ) {
+	private function add_setting_and_control( $index, $control_args, $id = null, $custom_settings = array() ) {
 		$setting                  = sprintf( $this->setting_template, $index );
 		$control_args             = array_merge( $this->default_control_args, $control_args );
 		$control_args['settings'] = $setting;
 
-		if ( empty( $settings_args ) ) {
-			$settings_args = $this->default_setting_args;
-		}
-		else {
-			$settings_args = array_merge( $this->default_setting_args, $settings_args );
+		$settings_args = $this->default_setting_args;
+		if ( ! empty( $custom_settings ) ) {
+			$settings_args = array_merge( $settings_args, $custom_settings );
 		}
 
 		if ( ! isset( $id ) ) {


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.

While working on the multi-line function call changes, I noticed that the `WPSEO_Customizer` class contained a lot of duplicate code.

This PR:
* Abstracts the duplicate code to a private `add_setting_and_control()` utility/helper method.
* Moves the default settings used by nearly all of the methods to class properties.
* Adjusts the code in the methods to use the helper methods instead.

While working on this, I noticed one inconsistency: the breadcrumb separator setting has a different ID, `breadcrumbs-sep`, from the associated control `(wpseo-)breadcrumbs-separator`.
In all the other cases, these are in sync.

Please let me know if I should update this PR to let these IDs always be in sync.
In that case, the optional `$id` parameter of the new `add_setting_and_control()` method will be removed.

Also note that the new `add_setting_and_control()` method contains a `$settings_args` parameter which is currently not used as all settings use the default arguments. However, having the parameter there allows for the flexibility to pass different settings arguments if needs be.



## Test instructions

This PR can be tested by following these steps:
* Using the `trunk` branch, familiarize yourself with the breadcrumb settings in the Customizer.
    Take note of which settings are there and what they look like.
* Change over to this branch and verify that the breadcrumb settings in the Customizer:
    - Are the same as before.
    - Still work as expected.