### PR TITLE
Check if properties exists instead of forcing a specific object

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -467,7 +467,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
     /**
      * Gets the focus keyword for a given post.
      *
-     * @param $post Post object to get its focus keyword.
+     * @param WP_POST $post Post object to get its focus keyword.
      *
      * @return string Focus keyword, or empty string if none available.
      */
@@ -476,6 +476,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
             return '';
         }
 
+        /**
+         * Filter: 'wpseo_use_page_analysis' - Determines if the analysis should be enabled.
+         *
+         * @api        bool - Determines if the analysis should be enabled.
+         */
         if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
             return '';
         }

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -464,17 +464,21 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		return $post;
 	}
 
-	/**
-	 * Gets the focus keyword for a given post.
-	 *
-	 * @param WP_Post $post Post object to get its focus keyword.
-	 *
-	 * @return string Focus keyword, or empty string if none available.
-	 */
-	protected function get_post_focus_keyword( WP_Post $post ) {
-		if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
-			return '';
-		}
+    /**
+     * Gets the focus keyword for a given post.
+     *
+     * @param $post Post object to get its focus keyword.
+     *
+     * @return string Focus keyword, or empty string if none available.
+     */
+    protected function get_post_focus_keyword( $post ) {
+        if ( ! is_object( $post ) || ! property_exists( $post, 'ID' ) ) {
+            return '';
+        }
+
+        if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
+            return '';
+        }
 
 		return WPSEO_Meta::get_value( 'focuskw', $post->ID );
 	}

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -464,26 +464,26 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		return $post;
 	}
 
-    /**
-     * Gets the focus keyword for a given post.
-     *
-     * @param WP_POST $post Post object to get its focus keyword.
-     *
-     * @return string Focus keyword, or empty string if none available.
-     */
-    protected function get_post_focus_keyword( $post ) {
-        if ( ! is_object( $post ) || ! property_exists( $post, 'ID' ) ) {
-            return '';
-        }
+	/**
+	 * Gets the focus keyword for a given post.
+	 *
+	 * @param WP_POST $post Post object to get its focus keyword.
+	 *
+	 * @return string Focus keyword, or empty string if none available.
+	 */
+	protected function get_post_focus_keyword( $post ) {
+		if ( ! is_object( $post ) || ! property_exists( $post, 'ID' ) ) {
+			return '';
+		}
 
-        /**
-         * Filter: 'wpseo_use_page_analysis' - Determines if the analysis should be enabled.
-         *
-         * @api        bool - Determines if the analysis should be enabled.
-         */
-        if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
-            return '';
-        }
+		/**
+		 * Filter: 'wpseo_use_page_analysis' Determines if the analysis should be enabled.
+		 *
+		 * @api bool Determines if the analysis should be enabled.
+		 */
+		if ( apply_filters( 'wpseo_use_page_analysis', true ) !== true ) {
+			return '';
+		}
 
 		return WPSEO_Meta::get_value( 'focuskw', $post->ID );
 	}

--- a/tests/doubles/class-admin-bar-menu-double.php
+++ b/tests/doubles/class-admin-bar-menu-double.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Admin_Bar_Menu_Double extends WPSEO_Admin_Bar_Menu {
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get_post_focus_keyword( $post ) {
+		return parent::get_post_focus_keyword( $post );
+	}
+}

--- a/tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -227,6 +227,59 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the situation where everything is going well.
+	 *
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 */
+	public function test_get_post_focus_keyword() {
+		$post = self::factory()->post->create_and_get();
+
+		WPSEO_Meta::set_value( 'focuskw', 'focus keyword', $post->ID );
+
+		$instance = new WPSEO_Admin_Bar_Menu_Double();
+
+		$this->assertEquals( 'focus keyword', $instance->get_post_focus_keyword( $post ) );
+	}
+
+	/**
+	 * Tests the situation with a non object given as argument.
+	 *
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 */
+	public function test_get_post_focus_keyword_with_invalid_object() {
+		$instance = new WPSEO_Admin_Bar_Menu_Double();
+
+		$this->assertEquals( '', $instance->get_post_focus_keyword( null ) );
+	}
+
+
+	/**
+	 * Tests the situation where the given object doesn't have an id.
+	 *
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 */
+	public function test_get_post_focus_keyword_with_valid_object_but_no_id_property() {
+		$post     = new stdClass();
+		$instance = new WPSEO_Admin_Bar_Menu_Double();
+
+		$this->assertEquals( '', $instance->get_post_focus_keyword( $post ) );
+	}
+
+	/**
+	 * Tests the situation where the page analysis is disabled by filter.
+	 *
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 */
+	public function test_get_post_focus_keyword_with_page_analysis_filter_disabled() {
+		add_filter( 'wpseo_use_page_analysis', '__return_false' );
+
+		$post     = self::factory()->post->create_and_get();
+		$instance = new WPSEO_Admin_Bar_Menu_Double();
+
+		$this->assertEquals( '', $instance->get_post_focus_keyword( $post ) );
+	}
+
+	/**
 	 * Filters an option so that the sub option 'enable_admin_bar_menu' is true.
 	 *
 	 * @param array $result Option result.

--- a/tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -252,7 +252,6 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( '', $instance->get_post_focus_keyword( null ) );
 	}
 
-
 	/**
 	 * Tests the situation where the given object doesn't have an id.
 	 *


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a type error is thrown when the posts or terms focus keyword isn't of the type WP_Post as this can collide with third-party plugins.

## Relevant technical choices:

* Instead of forcing the object type I just check if the argument is an object and if it contains the needed properties.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the bullet still works on the adminbar in the frontend when viewing a post and term page.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10825
