### PR TITLE
#7461 Removed the local Tooltips fix for Edge support.

### DIFF
--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -218,14 +218,10 @@ th.column-wpseo-score-readability .yoast-tooltip {
 }
 
 .column-wpseo-links .yoast-tooltip-multiline::after {
-	/* Edge doesn't support width: max-content; */
-	width: 999px;
 	max-width: 160px;
 }
 
 .column-wpseo-linked .yoast-tooltip-multiline::after {
-	/* Edge doesn't support width: max-content; */
-	width: 999px;
 	max-width: 170px;
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Tooltips: remove local fix for Edge support

## Relevant technical choices:

* Removed a deprecated browser fix.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open your WP Admin Area in the Microsoft Edge browser on a desktop device.
* Go to the Admin Post List (/wp-admin/edit.php).
* Hover the Internal Links counter.
* Everything should look as usual.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #7461
