### PR TITLE
Fix capital in Go Premium upsell admin block

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -70,7 +70,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		);
 
 		echo '<div>';
-		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' . esc_html__( 'Go premium!', 'wordpress-seo' ) . '</h2>';
+		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' . esc_html__( 'Go Premium!', 'wordpress-seo' ) . '</h2>';
 		echo '<ul class="' . esc_attr( $class . '--motivation' ) . '">' . $arguments_html . '</ul>';
 
 		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $upgrade_msg ) . '</a><br />';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a small typo.

## Relevant technical choices:

* Not relevant

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check the upsell notice in your dashboard at the bottom of the page, it should show "Go Premium" instead of "Go premium". 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9302