### PR TITLE
[i18n] Add missing gettext function

### DIFF
--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -111,7 +111,7 @@ $wpseo_plugin_dir_url = plugin_dir_url( WPSEO_FILE );
 			</div>
 		</div>
 		<div class="yoast-sidebar_section">
-			<strong>Remove these ads?</strong>
+			<strong><?php esc_html_e( 'Remove these ads?', 'wordpress-seo' ); ?></strong>
 			<p>
 				<a target="_blank" rel="noopener noreferrer" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jy' ); ?>">
 					<?php


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Wrap string "Remove these ads?" in `esc_html_e()` function to allow translation

## Relevant technical choices:

* Use the exact same gettext functions for similar strings in the same sidebar

## Test instructions

This PR can be tested by following these steps:

* Sweep the code again with Poedit
* Translate new string
* Visit Yoast SEO dashboard to check if the string is translated

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #11195
