### PR TITLE
Updated styling of the premium upsell box in the settings. 

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -58,8 +58,16 @@ class WPSEO_Premium_Upsell_Admin_Block {
 
 		/* translators: %s expands to "Yoast SEO Premium". */
 		$dismiss_msg = sprintf( __( 'Dismiss %s upgrade motivation', 'wordpress-seo' ), 'Yoast SEO Premium' );
-		/* translators: %s expands to "Yoast SEO Premium". */
-		$upgrade_msg = sprintf( __( 'Find out why you should upgrade to %s &raquo;', 'wordpress-seo' ), 'Yoast SEO Premium' );
+
+		/* translators: %s expands to Yoast SEO Premium */
+		$button_text = sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+
+		$upgrade_button = sprintf(
+			'<a id="wpseo-%1$s-popup-button" class="yoast-button-upsell" href="%2$s" target="_blank" rel="noreferrer noopener">%3$s</a>',
+			$this->identifier,
+			$url,
+			$button_text
+		);
 
 		echo '<div class="' . esc_attr( $class ) . '">';
 		printf(
@@ -70,10 +78,10 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		);
 
 		echo '<div>';
-		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' . esc_html__( 'Go premium!', 'wordpress-seo' ) . '</h2>';
+		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' . esc_html__( 'Upgrade to Yoast SEO Premium', 'wordpress-seo' ) . '</h2>';
 		echo '<ul class="' . esc_attr( $class . '--motivation' ) . '">' . $arguments_html . '</ul>';
 
-		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $upgrade_msg ) . '</a><br />';
+		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . $upgrade_button . '</a><br />';
 		echo '</div>';
 
 		echo '</div>';

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -57,7 +57,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$class = $this->get_html_class();
 
 		/* translators: %s expands to "Yoast SEO Premium". */
-		$dismiss_msg = sprintf( __( 'Dismiss %s upgrade motivation', 'wordpress-seo' ), 'Yoast SEO Premium' );
+		$dismiss_msg = sprintf( __( 'Dismiss %s upgrade notice', 'wordpress-seo' ), 'Yoast SEO Premium' );
 
 		/* translators: %s expands to Yoast SEO Premium */
 		$button_text = sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
@@ -71,7 +71,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 
 		echo '<div class="' . esc_attr( $class ) . '">';
 		printf(
-			'<a href="%1$s" style="" class="alignright %2$s" aria-label="%3$s">X</a>',
+			'<a href="%1$s" style="" class="alignright button %2$s" aria-label="%3$s"><span class="dashicons dashicons-no-alt"></span></a>',
 			esc_url( add_query_arg( array( $this->get_query_variable_name() => 1 ) ) ),
 			esc_attr( $class . '--close' ),
 			esc_attr( $dismiss_msg )

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -66,7 +66,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 			'<a id="wpseo-%1$s-popup-button" class="yoast-button-upsell" href="%2$s" target="_blank" rel="noreferrer noopener">%3$s</a>',
 			$this->identifier,
 			$url,
-			$button_text
+			esc_html( $button_text )
 		);
 
 		echo '<div class="' . esc_attr( $class ) . '">';

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -78,7 +78,13 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		);
 
 		echo '<div>';
-		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' . esc_html__( 'Upgrade to Yoast SEO Premium', 'wordpress-seo' ) . '</h2>';
+		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' .
+			sprintf(
+				/* translators: %s expands to Yoast SEO Premium */
+				esc_html__( 'Upgrade to %s', 'wordpress-seo' ),
+				'Yoast SEO Premium'
+			) .
+		'</h2>';
 		echo '<ul class="' . esc_attr( $class . '--motivation' ) . '">' . $arguments_html . '</ul>';
 
 		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . $upgrade_button . '</a><br />';

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -567,13 +567,13 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	overflow: hidden;
 	margin-top: 2em;
 
-	&--close {
-		color: #333;
-		text-decoration: none;
-		font-weight: bold;
-		font-size: 16px;
-		border: 1px solid #ccc;
-		padding: 1px 4px;
+	.wp-core-ui &--close {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		padding: 0;
+		width: 24px;
+		height: 24px;
 	}
 
 	&--header {

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -577,6 +577,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	}
 
 	&--header {
+		color: $color-pink-dark;
 		margin-top: 0.3em;
 		font-size: 1.7em;
 		font-weight: bold;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A.

## Test instructions

This PR can be tested by following these steps:

* To reproduce: click "SEO" or "SEO->General" in the sidebar to the left in wp-admin. Scroll down and see the Premium upsell box with the "Go Premium!" title. 
* If the box is not there you may have dismissed it in the past. In that case you can get it back by going into the database. Go into the table `wp_usermeta`, look for the meta_key `wp_yoast_promo_hide_premium_upsell_admin_block` and change its meta_value into `0`.
* Checkout this branch and look at the box again, the styling should have been changed according to the instructions in the issue (#10982). Make sure to do a hard refresh if the styling does not change.
* Also make sure the button functions properly and goes to the right url. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10982 
