### PR TITLE
Configuration wizard: manage focus when removing uploaded image.

### DIFF
--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -1,6 +1,5 @@
 /* global wp */
-
-import React from "react";
+import React, { createRef } from "react";
 import PropTypes from "prop-types";
 import RaisedButton from "material-ui/RaisedButton";
 import { localize } from "yoast-components";
@@ -22,6 +21,7 @@ class MediaUpload extends React.Component {
 		};
 
 		this.state.mediaUpload.on( "select", this.selectUpload.bind( this ) );
+		this.chooseButton = createRef();
 	}
 
 	/**
@@ -37,6 +37,11 @@ class MediaUpload extends React.Component {
 
 		if ( currentUploadChange ) {
 			this.sendChangeEvent();
+		}
+
+		// When the image gets removed, move focus back to the Choose Image button.
+		if ( currentUploadChange && this.state.currentUpload === "" ) {
+			this.chooseButton.current.refs.container.button.focus();
 		}
 	}
 
@@ -134,6 +139,7 @@ class MediaUpload extends React.Component {
 						onClick={ this.chooseUpload.bind( this ) }
 						type="button"
 						className="yoast-wizard-image-upload-container-buttons__choose"
+						ref={ this.chooseButton }
 					/>
 					{ this.renderRemoveButton() }
 				</div>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

When hiding or removing from the DOM an UI control that's currently focused, there's a focus loss. This should be avoided at all costs, as it's a terribly confusing experience for keyboard and assistive technology users. Either don't remove a focused element (preferable) or manage focus programmatically, moving it to the most logical place.
This PR avoifs a focus loss when removing an uploaded image in the configuration wizard.


## Test instructions
- go to the configuration wizard, step 4
- choose company
- choose an image
- now, using only the keyboard, remove the image:

<img width="610" alt="screen shot 2018-10-10 at 11 19 28" src="https://user-images.githubusercontent.com/1682452/46726653-15980f80-cc7f-11e8-8eb2-4e0f29241c6f.png">

- notice focus is lost (there's no focused element in the page); the focus loss is more evident in some browsers, for example IE11

Note: for testing purposes, I recommend to temporarily add this to the CSS in the browser's dev tools, as the material-ui buttons don't show the focus style when focused programmatically:
```
:focus {
	outline: 2px solid red !important;
}
```

- switch to this branch, build the JS
- hard-refresh the page, just in case
- repeat the steps above
- when removing the image, notice how focus gets moved back to the "Choose Image" button

Fixes #5701 
