### PR TITLE
Added the AnalysisUpsell component for the word forms upsell

### DIFF
--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -18,7 +18,7 @@ const Container = styled.div`
 	border-left: 4px solid ${ colors.$color_pink_dark };
 	margin: 16px 0;
 	padding: 0 8px;
-	
+
 	> ${ TextContainer } {
 		margin-bottom: ${ props => props.alignment === "vertical" && "16px" };
 	}
@@ -49,7 +49,7 @@ const AnalysisUpsell = ( props ) => {
 				{ sprintf(
 					/* eslint-disable max-len */
 					/* translators: %s expands to Yoast SEO Premium */
-					__( "Did you know %s also analyses the different word forms of your keyphrase, like plurals, different word orders and past tenses?", "wordpress-seo" ),
+					__( "Did you know %s also analyzes the different word forms of your keyphrase, like plurals, different word orders and past tenses?", "wordpress-seo" ),
 					/* eslint-enable */
 					"Yoast SEO Premium"
 				) }

--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -47,8 +47,10 @@ const AnalysisUpsell = ( props ) => {
 		<Container alignment={ alignment }>
 			<TextContainer>
 				{ sprintf(
+					/* eslint-disable max-len */
 					/* translators: %s expands to Yoast SEO Premium */
 					__( "Did you know %s also analyses the different word forms of your keyphrase, like plurals, different word orders and past tenses?", "wordpress-seo" ),
+					/* eslint-enable */
 					"Yoast SEO Premium"
 				) }
 			</TextContainer>

--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -1,0 +1,78 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { __, sprintf } from "@wordpress/i18n";
+
+import { colors, SvgIcon, UpsellLinkButton, utils } from "yoast-components";
+
+const TextContainer = styled.p`
+	color: ${ colors.$color_upsell_text };
+	flex: 1;
+	margin: 0;
+`;
+
+const Container = styled.div`
+	font-size: 1em;
+	display: flex;
+	flex-direction: ${ props => props.alignment === "horizontal" ? "row" : "column" };
+	border-left: 4px solid ${ colors.$color_pink_dark };
+	margin: 16px 0;
+	padding: 0 8px;
+	
+	> ${ TextContainer } {
+		margin-bottom: ${ props => props.alignment === "vertical" && "16px" };
+	}
+`;
+
+const ButtonContainer = styled.div`
+	flex: 0;
+`;
+
+const OutboundLinkButton = utils.makeOutboundLink( UpsellLinkButton );
+
+/**
+ * Renders the AnalysisUpsell component.
+ *
+ * @param {Object} props The component's props.
+ *
+ * @returns {ReactElement} The rendered AnalysisUpsell component.
+ */
+const AnalysisUpsell = ( props ) => {
+	const {
+		alignment,
+		url,
+	} = props;
+
+	return (
+		<Container alignment={ alignment }>
+			<TextContainer>
+				{ sprintf(
+					/* translators: %s expands to Yoast SEO Premium */
+					__( "Did you know %s also analyses the different word forms of your keyphrase, like plurals, different word orders and past tenses?", "wordpress-seo" ),
+					"Yoast SEO Premium"
+				) }
+			</TextContainer>
+			<ButtonContainer>
+				<OutboundLinkButton href={ url }>
+					{ sprintf(
+						/* translators: %s expands to Premium */
+						__( "Go %s!", "wordpress-seo" ),
+						"Premium"
+					) }
+					<SvgIcon icon="arrow-right" size="8px" color={ colors.$color_black } />
+				</OutboundLinkButton>
+			</ButtonContainer>
+		</Container>
+	);
+};
+
+AnalysisUpsell.propTypes = {
+	alignment: PropTypes.oneOf( [ "horizontal", "vertical" ] ),
+	url: PropTypes.string.isRequired,
+};
+
+AnalysisUpsell.defaultProps = {
+	alignment: "vertical",
+};
+
+export default AnalysisUpsell;

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -196,6 +196,11 @@ class SeoAnalysis extends React.Component {
 		);
 	}
 
+	/**
+	 * Renders the AnalysisUpsell component.
+	 *
+	 * @returns {ReactElement} The AnalysisUpsell component.
+	 */
 	renderWordFormsUpsell() {
 		return <AnalysisUpsell
 			url={ this.props.location === "sidebar"
@@ -240,9 +245,11 @@ class SeoAnalysis extends React.Component {
 						keyword={ this.props.keyword }
 					/>
 					<Slot name="YoastSynonyms" />
-					{ this.props.shouldUpsell && this.renderSynonymsUpsell(	this.props.location	) }
-					{ this.props.shouldUpsell && this.renderMultipleKeywordsUpsell( this.props.location ) }
-					{ this.props.shouldUpsell && this.renderWordFormsUpsell() }
+					{ this.props.shouldUpsell && <React.Fragment>
+						{ this.renderSynonymsUpsell( this.props.location ) }
+						{ this.renderMultipleKeywordsUpsell( this.props.location ) }
+						{ this.renderWordFormsUpsell() }
+					</React.Fragment> }
 					<AnalysisHeader>
 						{ __( "Analysis results", "wordpress-seo" ) }
 					</AnalysisHeader>
@@ -265,7 +272,7 @@ SeoAnalysis.propTypes = {
 	hideMarksButtons: PropTypes.bool,
 	keyword: PropTypes.string,
 	onFocusKeywordChange: PropTypes.func,
-	shouldUpsell:	PropTypes.bool,
+	shouldUpsell: PropTypes.bool,
 	overallScore: PropTypes.number,
 	location: PropTypes.string,
 };

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -18,6 +18,7 @@ import Modal from "../modals/Modal";
 import MultipleKeywords from "../modals/MultipleKeywords";
 import YoastSeoIcon from "yoast-components/composites/basic/YoastSeoIcon";
 import Icon from "yoast-components/composites/Plugin/Shared/components/Icon";
+import AnalysisUpsell from "../AnalysisUpsell";
 
 const AnalysisHeader = styled.span`
 	font-size: 1em;
@@ -195,6 +196,15 @@ class SeoAnalysis extends React.Component {
 		);
 	}
 
+	renderWordFormsUpsell() {
+		return <AnalysisUpsell
+			url={ this.props.location === "sidebar"
+				? "https://yoa.st/morphology-upsell-sidebar"
+				: "https://yoa.st/morphology-upsell-metabox" }
+			alignment={ this.props.location === "sidebar" ? "vertical" : "horizontal" }
+		/>;
+	}
+
 	/**
 	 * Renders the SEO Analysis component.
 	 *
@@ -232,6 +242,7 @@ class SeoAnalysis extends React.Component {
 					<Slot name="YoastSynonyms" />
 					{ this.props.shouldUpsell && this.renderSynonymsUpsell(	this.props.location	) }
 					{ this.props.shouldUpsell && this.renderMultipleKeywordsUpsell( this.props.location ) }
+					{ this.props.shouldUpsell && this.renderWordFormsUpsell() }
 					<AnalysisHeader>
 						{ __( "Analysis results", "wordpress-seo" ) }
 					</AnalysisHeader>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Free
* Link `yoast-components` branch `11199-add-upsell-link-button-component` and build the project.
* In Gutenberg, make sure the upsell like shown in #11199, is visible in both the sidebar (Where the button should be under the text) and in the metabox (Where the button should be right of the text).
* In the classic editor, make sure the upsell is visible in the metabox.

### Premium
* Merge this branch into `wordpress-seo-premium`.
* Make sure upsell is not shown in both Gutenberg and the classic efitor.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #11199
