### PR TITLE
Replace keyword help text by a question mark link

### DIFF
--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -197,16 +197,13 @@ class SeoAnalysis extends React.Component {
 	}
 
 	/**
-	 * Renders a label with a label text and a help link.
-	 *
-	 * @param {string} labelText The label text.
+	 * Renders a help link.
 	 *
 	 * @returns {ReactElement} The Label component.
 	 */
-	renderLabel( labelText ) {
+	renderHelpLink() {
 		return (
 			<Fragment>
-				{ labelText + " " }
 				[<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
 					{ "?" }
 				</FocusKeywordLink>]
@@ -227,8 +224,6 @@ class SeoAnalysis extends React.Component {
 			score.screenReaderReadabilityText = __( "Enter a focus keyphrase to calculate the SEO score", "wordpress-seo" );
 		}
 
-		const label = __( "Focus keyphrase", "wordpress-seo" );
-
 		return (
 			<React.Fragment>
 				<Collapsible
@@ -242,8 +237,8 @@ class SeoAnalysis extends React.Component {
 						id="focus-keyword-input"
 						onChange={ this.props.onFocusKeywordChange }
 						keyword={ this.props.keyword }
-						label={ this.renderLabel( label ) }
-						ariaLabel={ label }
+						label={ __( "Focus keyphrase", "wordpress-seo" ) }
+						postLabelElement={ this.renderHelpLink() }
 					/>
 					<Slot name="YoastSynonyms" />
 					{ this.props.shouldUpsell && this.renderSynonymsUpsell(	this.props.location	) }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -26,14 +26,21 @@ const AnalysisHeader = styled.span`
 
 const FocusKeywordLink = utils.makeOutboundLink( styled.a`
 	display: inline-block;
-	vertical-align: middle;
+	position: relative;
+	outline: none;
 	text-decoration: none;
-	padding: 2px;
-	margin: -2px 0;
+	border-radius: 100%;
+	width: 24px;
+	height: 24px;
+	margin: -4px 0;
+	vertical-align: middle;
 
-	&:hover,
-	&:focus {
-		text-decoration: underline;
+	&::before {
+		position: absolute;
+		top: 0;
+		left: 0;
+		padding: 2px;
+		content: "\f223";
 	}
 ` );
 
@@ -211,11 +218,14 @@ class SeoAnalysis extends React.Component {
 	 */
 	renderHelpLink() {
 		return (
-			<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
+			<FocusKeywordLink
+				href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] }
+				rel={ null }
+				className="dashicons"
+			>
 				<span className="screen-reader-text">
 					{ __( "Help on choosing the perfect focus keyphrase", "wordpress-seo" ) }
 				</span>
-				<span aria-hidden="true">{ "[?]" }</span>
 			</FocusKeywordLink>
 		);
 	}

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -1,5 +1,5 @@
 /* globals wpseoAdminL10n */
-import React from "react";
+import React, {Fragment} from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components";
@@ -26,7 +26,8 @@ const AnalysisHeader = styled.span`
 	display: block;
 `;
 
-const FocusKeywordLink = utils.makeOutboundLink();
+const FocusKeywordLink = utils.makeOutboundLink( styled.a`
+` );
 
 const StyledContainer = styled.div`
 	min-width: 600px;
@@ -195,6 +196,17 @@ class SeoAnalysis extends React.Component {
 		);
 	}
 
+	renderLabel( label ) {
+		return (
+			<Fragment>
+				{ label + " " }
+				[<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
+					{ "?" }
+				</FocusKeywordLink>]
+			</Fragment>
+		);
+	}
+
 	/**
 	 * Renders the SEO Analysis component.
 	 *
@@ -208,6 +220,8 @@ class SeoAnalysis extends React.Component {
 			score.screenReaderReadabilityText = __( "Enter a focus keyphrase to calculate the SEO score", "wordpress-seo" );
 		}
 
+		const label = __( "Focus keyphrase", "wordpress-seo" )
+
 		return (
 			<React.Fragment>
 				<Collapsible
@@ -217,17 +231,12 @@ class SeoAnalysis extends React.Component {
 					prefixIconCollapsed={ getIconForScore( score.className ) }
 					subTitle={ this.props.keyword }
 				>
-					<HelpText>
-						{ __( "A focus keyphrase is the phrase you'd like to be found for in search engines. " +
-							"Enter it below to see how you can improve your text for this term.", "wordpress-seo" ) + " " }
-						<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
-							{ __( "Learn more about the keyphrase analysis.", "wordpress-seo" ) }
-						</FocusKeywordLink>
-					</HelpText>
 					<KeywordInput
 						id="focus-keyword-input"
 						onChange={ this.props.onFocusKeywordChange }
 						keyword={ this.props.keyword }
+						label={ this.renderLabel( label ) }
+						ariaLabel={ label }
 					/>
 					<Slot name="YoastSynonyms" />
 					{ this.props.shouldUpsell && this.renderSynonymsUpsell(	this.props.location	) }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -5,14 +5,12 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { Slot } from "@wordpress/components";
 import { __, sprintf } from "@wordpress/i18n";
-import { getRtlStyle } from "yoast-components";
+import { getRtlStyle, KeywordInput, colors, utils } from "yoast-components";
 import Collapsible from "../SidebarCollapsible";
-import { KeywordInput, colors } from "yoast-components";
 import Results from "./Results";
 import { setFocusKeyword } from "../../redux/actions/focusKeyword";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
 import { getIconForScore } from "./mapResults";
-import { utils } from "yoast-components";
 import KeywordSynonyms from "../modals/KeywordSynonyms";
 import Modal from "../modals/Modal";
 import MultipleKeywords from "../modals/MultipleKeywords";
@@ -27,6 +25,16 @@ const AnalysisHeader = styled.span`
 `;
 
 const FocusKeywordLink = utils.makeOutboundLink( styled.a`
+	display: inline-block;
+	vertical-align: middle;
+	text-decoration: none;
+	padding: 2px;
+	margin: -2px 0;
+
+	&:hover,
+	&:focus {
+		text-decoration: underline;
+	}
 ` );
 
 const StyledContainer = styled.div`
@@ -203,11 +211,12 @@ class SeoAnalysis extends React.Component {
 	 */
 	renderHelpLink() {
 		return (
-			<Fragment>
-				[<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
-					{ "?" }
-				</FocusKeywordLink>]
-			</Fragment>
+			<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
+				<span className="screen-reader-text">
+					{ __( "Help on choosing the perfect focus keyphrase", "wordpress-seo" ) }
+				</span>
+				<span aria-hidden="true">{ "[?]" }</span>
+			</FocusKeywordLink>
 		);
 	}
 
@@ -225,7 +234,7 @@ class SeoAnalysis extends React.Component {
 		}
 
 		return (
-			<React.Fragment>
+			<Fragment>
 				<Collapsible
 					title={ __( "Focus keyphrase", "wordpress-seo" ) }
 					titleScreenReaderText={ score.screenReaderReadabilityText }
@@ -238,7 +247,7 @@ class SeoAnalysis extends React.Component {
 						onChange={ this.props.onFocusKeywordChange }
 						keyword={ this.props.keyword }
 						label={ __( "Focus keyphrase", "wordpress-seo" ) }
-						postLabelElement={ this.renderHelpLink() }
+						labelSiblingElement={ this.renderHelpLink() }
 					/>
 					<Slot name="YoastSynonyms" />
 					{ this.props.shouldUpsell && this.renderSynonymsUpsell(	this.props.location	) }
@@ -254,7 +263,7 @@ class SeoAnalysis extends React.Component {
 					/>
 				</Collapsible>
 				{ this.props.shouldUpsell && this.renderKeywordUpsell( this.props.location ) }
-			</React.Fragment>
+			</Fragment>
 		);
 	}
 }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -200,6 +200,7 @@ class SeoAnalysis extends React.Component {
 	 * Renders a label with a label text and a help link.
 	 *
 	 * @param {string} labelText The label text.
+	 *
 	 * @returns {ReactElement} The Label component.
 	 */
 	renderLabel( labelText ) {

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -1,11 +1,11 @@
 /* globals wpseoAdminL10n */
-import React, {Fragment} from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { Slot } from "@wordpress/components";
 import { __, sprintf } from "@wordpress/i18n";
-import { getRtlStyle, HelpText } from "yoast-components";
+import { getRtlStyle } from "yoast-components";
 import Collapsible from "../SidebarCollapsible";
 import { KeywordInput, colors } from "yoast-components";
 import Results from "./Results";
@@ -196,10 +196,16 @@ class SeoAnalysis extends React.Component {
 		);
 	}
 
-	renderLabel( label ) {
+	/**
+	 * Renders a label with a label text and a help link.
+	 *
+	 * @param {string} labelText The label text.
+	 * @returns {ReactElement} The Label component.
+	 */
+	renderLabel( labelText ) {
 		return (
 			<Fragment>
-				{ label + " " }
+				{ labelText + " " }
 				[<FocusKeywordLink href={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } rel={ null }>
 					{ "?" }
 				</FocusKeywordLink>]
@@ -220,7 +226,7 @@ class SeoAnalysis extends React.Component {
 			score.screenReaderReadabilityText = __( "Enter a focus keyphrase to calculate the SEO score", "wordpress-seo" );
 		}
 
-		const label = __( "Focus keyphrase", "wordpress-seo" )
+		const label = __( "Focus keyphrase", "wordpress-seo" );
 
 		return (
 			<React.Fragment>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* In order to position the question mark link,
* It would make it a lot more complex to make the question mark and brackets unbolded. That's why I decided to keep it bold. @hedgefield does agree.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Link https://github.com/Yoast/yoast-components/pull/757
* Look at the metabox and sidebar and see if they match the screenshots from the issue.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/wordpress-seo#11235

Requires Yoast/yoast-components#757
