### PR TITLE
Ensure invalidation of author caches happen when all conditions are met

### DIFF
--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -191,23 +191,27 @@ class WPSEO_Sitemaps_Cache {
 	 *
 	 * @param int $user_id User ID.
 	 *
-	 * @return void
+	 * @return bool True if the sitemap was properly invalidated. False otherwise.
 	 */
 	public static function invalidate_author( $user_id ) {
 
 		$user = get_user_by( 'id', $user_id );
 
 		if ( $user === false ) {
-			return;
+			return false;
 		}
 
 		if ( 'user_register' === current_action() ) {
 			update_user_meta( $user_id, '_yoast_wpseo_profile_updated', time() );
 		}
 
-		if ( ! empty( $user->roles ) && ! in_array( 'subscriber', $user->roles, true ) ) {
-			self::invalidate( 'author' );
+		if ( empty( $user->roles ) || in_array( 'subscriber', $user->roles, true ) ) {
+			return false;
 		}
+
+		self::invalidate( 'author' );
+
+		return true;
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -190,16 +190,22 @@ class WPSEO_Sitemaps_Cache {
 	 * Invalidate sitemap cache for authors.
 	 *
 	 * @param int $user_id User ID.
+	 *
+	 * @return void
 	 */
 	public static function invalidate_author( $user_id ) {
 
 		$user = get_user_by( 'id', $user_id );
 
+		if ( $user === false ) {
+			return;
+		}
+
 		if ( 'user_register' === current_action() ) {
 			update_user_meta( $user_id, '_yoast_wpseo_profile_updated', time() );
 		}
 
-		if ( ! in_array( 'subscriber', $user->roles, true ) ) {
+		if ( ! empty( $user->roles ) && ! in_array( 'subscriber', $user->roles, true ) ) {
 			self::invalidate( 'author' );
 		}
 	}

--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -225,4 +225,39 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		// Assert.
 		$this->assertEmpty( $result );
 	}
+
+	/**
+	 * Tests the attempt to clear the author sitemap for an unknown user, which should return false.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::invalidate_author
+	 */
+	public function test_clearing_author_sitemap_by_unknown_userid() {
+		$this->assertFalse( WPSEO_Sitemaps_Cache::invalidate_author( -1 ) );
+	}
+
+	/**
+	 * Tests the attempt to clear the author sitemap for a user with the proper roles, which should return true.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::invalidate_author
+	 */
+	public function test_clearing_author_sitemap_by_userid() {
+		$user_id = $this->factory->user->create(
+			array( 'role' => 'administrator' )
+		);
+
+		$this->assertTrue( WPSEO_Sitemaps_Cache::invalidate_author( $user_id ) );
+	}
+
+	/**
+	 * Tests the attempt to clear the author sitemap for a user with the subscriber role, which should return false.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::invalidate_author
+	 */
+	public function test_clearing_author_sitemap_by_userid_with_subscriber_role() {
+		$user_id = $this->factory->user->create(
+			array( 'role' => 'subscriber' )
+		);
+
+		$this->assertFalse( WPSEO_Sitemaps_Cache::invalidate_author( $user_id ) );
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where author caches would be attempted to be invalidated despite not all conditions being met.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* There is no real way to test this from a user's perspective, as it's not user-facing. The only way to validate that this is working correctly, is to see that the tests pass.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11255 
