### PR TITLE
Use esc_attr for the value

### DIFF
--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -61,7 +61,7 @@ if ( 'posts' === get_option( 'show_on_front' ) ) {
 			)
 		);
 
-		echo '<input type="hidden" id="meta_description" value="', $homepage_meta_description, '" />';
+		echo '<input type="hidden" id="meta_description" value="', esc_attr( $homepage_meta_description ), '" />';
 		echo '<div class="label desc copy-home-meta-description">' .
 				'<button type="button" id="copy-home-meta-description" class="button">', $copy_home_description_button_label, '</button>' .
 				$copy_home_meta_desc_help->get_button_html() .


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the home description can contain HTML resulting in unexpected characters on the Facebook social settings

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set the description for the home page ( search appearance ) to something like: `Description "/>`
* Open the facebook settings ( social ) and see some weird output `"/>`, that doesn't belong there.
* Checkout this branch
* See it is gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11230
