### PR TITLE
[i18n] Remove new lines and tabs to improve i18n and l10n

### DIFF
--- a/admin/config-ui/fields/class-field-google-search-console-intro.php
+++ b/admin/config-ui/fields/class-field-google-search-console-intro.php
@@ -19,11 +19,10 @@ class WPSEO_Config_Field_Google_Search_Console_Intro extends WPSEO_Config_Field 
 		$html =
 			sprintf(
 				/* translators: %1$s is the plugin name. */
-				esc_html__( '%1$s integrates with Google Search Console, a must-have tool for site owners.', 'wordpress-seo' ),
+				__( '%1$s integrates with Google Search Console, a must-have tool for site owners.<br>It provides you with information about the health of your site.', 'wordpress-seo' ),
 				'Yoast SEO'
 			) . '<br>' .
-			__( 'It provides you with information about the health of your site.', 'wordpress-seo' ) . '<br>' .
-			__( 'Don\'t have a Google account or is your site not activated yet?', 'wordpress-seo' ) . '<br>' .
+			esc_html__( 'Don\'t have a Google account or is your site not activated yet?', 'wordpress-seo' ) . '<br>' .
 			sprintf(
 				/* translators: %1$s is a link start tag to a Yoast help page, %2$s is the link closing tag. */
 				esc_html__( 'Find out %1$show to connect Google Search Console to your site%2$s.', 'wordpress-seo' ),

--- a/admin/config-ui/fields/class-field-google-search-console-intro.php
+++ b/admin/config-ui/fields/class-field-google-search-console-intro.php
@@ -16,22 +16,24 @@ class WPSEO_Config_Field_Google_Search_Console_Intro extends WPSEO_Config_Field 
 	public function __construct() {
 		parent::__construct( 'googleSearchConsoleIntro', 'HTML' );
 
-		$html = sprintf(
-			/* translators: %1$s is the plugin name, %2$s is a link start tag to a Yoast help page, %3$s is the link closing tag. */
-			esc_html__(
-				'%1$s integrates with Google Search Console, a must-have tool for site owners.
- It provides you with information about the health of your site.
- Don\'t have a Google account or is your site not activated yet?
- Find out %2$show to connect Google Search Console to your site.%3$s',
-				'wordpress-seo'
-			),
-			'Yoast SEO',
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1ex' ) ) . '" target="_blank">',
-			'</a>'
-		);
+		$html =
+			sprintf(
+				/* translators: %1$s is the plugin name. */
+				esc_html__( '%1$s integrates with Google Search Console, a must-have tool for site owners.', 'wordpress-seo' ),
+				'Yoast SEO'
+			) . '<br>' .
+			__( 'It provides you with information about the health of your site.', 'wordpress-seo' ) . '<br>' .
+			__( 'Don\'t have a Google account or is your site not activated yet?', 'wordpress-seo' ) . '<br>' .
+			sprintf(
+				/* translators: %1$s is a link start tag to a Yoast help page, %2$s is the link closing tag. */
+				esc_html__( 'Find out %1$show to connect Google Search Console to your site%2$s.', 'wordpress-seo' ),
+				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1ex' ) ) . '" target="_blank">',
+				'</a>'
+			);
 
-		$disclaimer = __( 'Note: we don\'t store your data in any way and don\'t have full access to your account. 
-Your privacy is safe with us.', 'wordpress-seo' );
+		$disclaimer =
+			__( 'Note: we don\'t store your data in any way and don\'t have full access to your account.', 'wordpress-seo' ) . '<br>' .
+			__( 'Your privacy is safe with us.', 'wordpress-seo' );
 
 		$html = '<p>' . $html . '</p><small>' . esc_html( $disclaimer ) . '</small>';
 

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -61,7 +61,7 @@ switch ( $platform_tabs->current_tab() ) {
 			echo "</form>\n";
 		}
 		else {
-			$reset_button = '<a class="button" href="' . esc_url( add_query_arg( 'gsc_reset', 1 ) ) . '">' . esc_html__( 'Reauthenticate with Google ', 'wordpress-seo' ) . '</a>';
+			$reset_button = '<a class="button" href="' . esc_url( add_query_arg( 'gsc_reset', 1 ) ) . '">' . esc_html__( 'Reauthenticate with Google', 'wordpress-seo' ) . '</a>';
 			echo '<h3>', esc_html__( 'Current profile', 'wordpress-seo' ), '</h3>';
 			$profile = WPSEO_GSC_Settings::get_profile();
 			if ( $profile !== '' ) {

--- a/admin/links/class-link-compatibility-notifier.php
+++ b/admin/links/class-link-compatibility-notifier.php
@@ -34,16 +34,16 @@ class WPSEO_Link_Compatibility_Notifier {
 	protected function get_notification() {
 		return new Yoast_Notification(
 			sprintf(
-				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. %3$s: PHP version %4$s: The current PHP versione. %5$s link to knowledge base article about solving PHP issue. %6$s: is anchor closing. */
-				__(
-					'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s requires at least PHP version %3$s. We have detected PHP version %4$s on this website.
-					Please read the following %5$sknowledge base article%6$s to find out how to resolve this problem.',
-					'wordpress-seo'
-				),
+				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. %3$s: PHP version %4$s: The current PHP version. */
+				__( 'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s requires at least PHP version %3$s. We have detected PHP version %4$s on this website.', 'wordpress-seo' ),
 				'Yoast SEO',
 				'5.0',
 				'5.3',
-				phpversion(),
+				phpversion()
+			) . '<br>' .
+			sprintf(
+				/* translators: %1$s: link to knowledge base article about solving PHP issue. %2$s: is anchor closing. */
+				esc_html__( 'Please read the following %1$sknowledge base article%2$s to find out how to resolve this problem.', 'wordpress-seo' ),
 				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16f' ) . '" target="_blank">',
 				'</a>'
 			),

--- a/admin/links/class-link-compatibility-notifier.php
+++ b/admin/links/class-link-compatibility-notifier.php
@@ -34,10 +34,16 @@ class WPSEO_Link_Compatibility_Notifier {
 	protected function get_notification() {
 		return new Yoast_Notification(
 			sprintf(
-				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. %3$s: PHP version %4$s: The current PHP version. */
-				__( 'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s requires at least PHP version %3$s. We have detected PHP version %4$s on this website.', 'wordpress-seo' ),
+				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. */
+				__( 'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled.', 'wordpress-seo' ),
 				'Yoast SEO',
 				'5.0',
+				'5.3'
+			) . ' ' .
+			sprintf(
+				/* translators: %1$s: Yoast SEO. %2$s: PHP version %3$s: The current PHP version. */
+				__( 'For this feature to work %1$s requires at least PHP version %2$s. We have detected PHP version %3$s on this website.', 'wordpress-seo' ),
+				'Yoast SEO',
 				'5.3',
 				phpversion()
 			) . '<br>' .

--- a/admin/links/class-link-notifier.php
+++ b/admin/links/class-link-notifier.php
@@ -86,21 +86,14 @@ class WPSEO_Link_Notifier {
 	 */
 	protected function get_notification() {
 		return new Yoast_Notification(
+			__( 'To make sure all the links in your texts are counted, we need to analyze all your texts.', 'wordpress-seo' ) . '<br>' .
+			__( 'All you have to do is press the following button and we\'ll go through all your texts for you.', 'wordpress-seo' ) . '<br><br>' .
+			'<button type="button" id="noticeRunLinkIndex" class="button">' . __( 'Count links', 'wordpress-seo' ) . '</button><br><br>' .
 			sprintf(
-				/* translators: 1: link to yoast.com post about internal linking suggestion. 2: is anchor closing. 3: button to the recalculation option. 4: closing button */
-				__(
-					'To make sure all the links in your texts are counted, we need to analyze all your texts.
-					All you have to do is press the following button and we\'ll go through all your texts for you.
-
-					%3$sCount links%4$s
-
-					The Text link counter feature provides insights in how many links are found in your text and how many links are referring to your text. This is very helpful when you are improving your %1$sinternal linking%2$s.',
-					'wordpress-seo'
-				),
+				/* translators: 1: link to yoast.com post about internal linking suggestion. 2: is anchor closing. */
+				__( 'The Text link counter feature provides insights in how many links are found in your text and how many links are referring to your text. This is very helpful when you are improving your %1$sinternal linking%2$s.', 'wordpress-seo' ),
 				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15m' ) . '" target="_blank">',
-				'</a>',
-				'<button type="button" id="noticeRunLinkIndex" class="button">',
-				'</button>'
+				'</a>'
 			),
 			array(
 				'type'         => Yoast_Notification::WARNING,

--- a/admin/links/class-link-table-accessible-notifier.php
+++ b/admin/links/class-link-table-accessible-notifier.php
@@ -35,9 +35,14 @@ class WPSEO_Link_Table_Accessible_Notifier {
 		return new Yoast_Notification(
 			sprintf(
 				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. */
-				__( 'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.', 'wordpress-seo' ),
+				__( 'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled.', 'wordpress-seo' ),
 				'Yoast SEO',
 				'5.0'
+			) . ' ' .
+			sprintf(
+				/* translators: %1$s: Yoast SEO. */
+				__( 'For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.', 'wordpress-seo' ),
+				'Yoast SEO'
 			) . '<br>' .
 			sprintf(
 				/* translators: %1$s: link to knowledge base article about solving table issue. %2$s: is anchor closing. */

--- a/admin/links/class-link-table-accessible-notifier.php
+++ b/admin/links/class-link-table-accessible-notifier.php
@@ -34,14 +34,14 @@ class WPSEO_Link_Table_Accessible_Notifier {
 	protected function get_notification() {
 		return new Yoast_Notification(
 			sprintf(
-				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. %3$s: link to knowledge base article about solving table issue. %4$s: is anchor closing. */
-				__(
-					'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.
-					Please read the following %3$sknowledge base article%4$s to find out how to resolve this problem.',
-					'wordpress-seo'
-				),
+				/* translators: %1$s: Yoast SEO. %2$s: Version number of Yoast SEO. */
+				__( 'The <strong>Text link counter</strong> feature (introduced in %1$s %2$s) is currently disabled. For this feature to work %1$s needs to create a table in your database. We were unable to create this table automatically.', 'wordpress-seo' ),
 				'Yoast SEO',
-				'5.0',
+				'5.0'
+			) . '<br>' .
+			sprintf(
+				/* translators: %1$s: link to knowledge base article about solving table issue. %2$s: is anchor closing. */
+				esc_html__( 'Please read the following %1$sknowledge base article%2$s to find out how to resolve this problem.', 'wordpress-seo' ),
 				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15o' ) . '">',
 				'</a>'
 			),

--- a/admin/notifiers/class-post-type-archive-notification-handler.php
+++ b/admin/notifiers/class-post-type-archive-notification-handler.php
@@ -98,7 +98,7 @@ class WPSEO_Post_Type_Archive_Notification_Handler implements WPSEO_Listener, WP
 			/* translators: %1$s is the archive template link start tag, %2$s is the link closing tag, %3$s is a comma separated string with content types. */
 			_n(
 				'Please check the %1$sarchive template%2$s for the following content type: %3$s.',
-				' Please check the %1$sarchive templates%2$s for the following content types: %3$s.',
+				'Please check the %1$sarchive templates%2$s for the following content types: %3$s.',
 				count( $post_types ),
 				'wordpress-seo'
 			),

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -34,8 +34,7 @@ $yform->toggle_switch(
 
 	if ( WPSEO_Options::get( 'is-media-purge-relevant' ) && WPSEO_Options::get( $noindex_option_name ) === false ) {
 		$description =
-			__( 'By enabling this option, attachment URLs become visible to both your visitors and Google.', 'wordpress-seo' ) . '<br>' .
-			__( 'To add value to your website, they should contain useful information, or they might have a negative impact on your ranking.', 'wordpress-seo' ) . '<br>' .
+			__( 'By enabling this option, attachment URLs become visible to both your visitors and Google.<br>To add value to your website, they should contain useful information, or they might have a negative impact on your ranking.', 'wordpress-seo' ) . '<br>' .
 			sprintf(
 				/* translators: %1$s expands to the link to the article, %2$s closes the link to the article */
 				esc_html__( 'Please carefully consider this and %1$sread this post%2$s if you want more information about the impact of showing media in search results.', 'wordpress-seo' ),

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -33,16 +33,15 @@ $yform->toggle_switch(
 	$noindex_option_name = 'noindex-' . $wpseo_post_type->name;
 
 	if ( WPSEO_Options::get( 'is-media-purge-relevant' ) && WPSEO_Options::get( $noindex_option_name ) === false ) {
-		$description = sprintf(
-			/* translators: %1$s expands to the link to the article, %2$s closes the link to the article */
-			esc_html( __( 'By enabling this option, attachment URLs become visible to both your visitors and Google.
-				To add value to your website, they should contain useful information, or they might have a
-				negative impact on your ranking. Please carefully consider this and %1$sread this post%2$s if
-				you want more information about the impact of showing media in search results.', 'wordpress-seo'
-			) ),
-			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="noopener noreferrer" target="_blank">',
-			'</a>'
-		);
+		$description =
+			__( 'By enabling this option, attachment URLs become visible to both your visitors and Google.', 'wordpress-seo' ) . '<br>' .
+			__( 'To add value to your website, they should contain useful information, or they might have a negative impact on your ranking.', 'wordpress-seo' ) . '<br>' .
+			sprintf(
+				/* translators: %1$s expands to the link to the article, %2$s closes the link to the article */
+				esc_html__( 'Please carefully consider this and %1$sread this post%2$s if you want more information about the impact of showing media in search results.', 'wordpress-seo' ),
+				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="noopener noreferrer" target="_blank">',
+				'</a>'
+			);
 
 		echo '<div style="clear:both; background-color: #ffeb3b; color: #000000; padding: 16px; max-width: 450px; margin-bottom: 32px;">' . $description . '</div>';
 	}

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -34,10 +34,9 @@ $yform->toggle_switch(
 
 	if ( WPSEO_Options::get( 'is-media-purge-relevant' ) && WPSEO_Options::get( $noindex_option_name ) === false ) {
 		$description =
-			__( 'By enabling this option, attachment URLs become visible to both your visitors and Google.<br>To add value to your website, they should contain useful information, or they might have a negative impact on your ranking.', 'wordpress-seo' ) . '<br>' .
 			sprintf(
 				/* translators: %1$s expands to the link to the article, %2$s closes the link to the article */
-				esc_html__( 'Please carefully consider this and %1$sread this post%2$s if you want more information about the impact of showing media in search results.', 'wordpress-seo' ),
+				__( 'By enabling this option, attachment URLs become visible to both your visitors and Google.<br>To add value to your website, they should contain useful information, or they might have a negative impact on your ranking.<br>Please carefully consider this and %1$sread this post%2$s if you want more information about the impact of showing media in search results.', 'wordpress-seo' ),
 				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/2r8' ) ) . '" rel="noopener noreferrer" target="_blank">',
 				'</a>'
 			);

--- a/admin/views/tabs/metas/taxonomies.php
+++ b/admin/views/tabs/metas/taxonomies.php
@@ -45,5 +45,5 @@ if ( is_array( $wpseo_taxonomies ) && $wpseo_taxonomies !== array() ) {
 
 unset( $wpseo_taxonomies );
 
-printf( '<h2>%s</h2>', esc_html__( ' Category URLs', 'wordpress-seo' ) );
+printf( '<h2>%s</h2>', esc_html__( 'Category URLs', 'wordpress-seo' ) );
 require dirname( __FILE__ ) . '/taxonomies/category-url.php';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes new lines and tabs from translation strings
* Removes unnecessary spaces from strings beginning
* Removes unnecessary space from string ending
* Separate common sentences to reuses strings and avoid translation repeating

## Relevant technical choices:

* Used same code patterns used along the existent code
* Separated strings wherever exists a line break
* Kept sentences several strings in the same string if there weren't a line break

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #9353
