### PR TITLE
Re-allow double quotes in the focus keyphrase field

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -492,19 +492,6 @@ class WPSEO_Meta {
 					$clean = WPSEO_Utils::sanitize_text_field( trim( $meta_value ) );
 				}
 
-				if ( $meta_key === self::$meta_prefix . 'focuskw' ) {
-					$clean = str_replace( array(
-						'&lt;',
-						'&gt;',
-						'&quot',
-						'&#96',
-						'<',
-						'>',
-						'"',
-						'`',
-					), '', $clean );
-				}
-
 				break;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Reverts the commit https://github.com/Yoast/wordpress-seo/commit/91aa78bce6a90f40237aa3e37c7eb4cb5e9a6cd3 to be able to save focus keyphrases enclosed in double quotes. This is needed to be able to make morphology-suppressing functionality functioning again.

## Relevant technical choices:

* The original modification that stripped double quotes from the focus keyphrase field was introduced as a security patch. This security issue is no more relevant after reactifying the focus keyphrase component. Thus, the stripping can be deprecated. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build the branch together with the release-yoast-seo/9.0 (e.g., using `yarn link`).
* Check if changing focus keyphrase field works as expected when creating, saving, changing the content of the field.
* Check if entering `<img src="z" onerror="prompt&#40document.cookie&#41"` as keyphrase does not produce any pop-up windows.
* Check if double quotes get saved correctly. I.e., if entered in the keyphrase field they get saved exactly the way they were entered.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11266 
