### PR TITLE
Disable sitemap cache by default

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -120,6 +120,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_772();
 		}
 
+		if ( version_compare( $version, '9.0-RC0', '<' ) ) {
+			$this->upgrade90();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -606,6 +610,15 @@ class WPSEO_Upgrade {
 		if ( WPSEO_Utils::is_woocommerce_active() ) {
 			$this->migrate_woocommerce_archive_setting_to_shop_page();
 		}
+	}
+
+	/**
+	 * Performs the 9.0 upgrade.
+	 *
+	 * @return void
+	 */
+	private function upgrade90() {
+		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -618,11 +618,15 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade90() {
+		global $wpdb;
+
 		// Invalidate all sitemap cache transients.
 		WPSEO_Sitemaps_Cache_Validator::invalidate_storage();
 
 		// Removes all scheduled tasks for hitting the sitemap index.
 		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );
+
+		$wpdb->query( 'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE "wpseo_sitemap_%"' );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -618,8 +618,10 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade90() {
+		// Invalidate all sitemap cache transients.
 		WPSEO_Sitemaps_Cache_Validator::invalidate_storage();
 
+		// Removes all schedules tasks for hitting the sitemap index.
 		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -621,7 +621,7 @@ class WPSEO_Upgrade {
 		global $wpdb;
 
 		// Invalidate all sitemap cache transients.
-		WPSEO_Sitemaps_Cache_Validator::invalidate_storage();
+		WPSEO_Sitemaps_Cache_Validator::cleanup_database();
 
 		// Removes all scheduled tasks for hitting the sitemap index.
 		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -618,6 +618,8 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade90() {
+		WPSEO_Sitemaps_Cache_Validator::invalidate_storage();
+
 		wp_clear_scheduled_hook( 'wpseo_hit_sitemap_index' );
 	}
 

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -59,6 +59,14 @@ class WPSEO_Sitemaps_Admin {
 			return;
 		}
 
+		if ( WP_CACHE && ! wp_next_scheduled( 'wpseo_hit_sitemap_index' ) ) {
+			$sitemap_cache = new WPSEO_Sitemaps_Cache();
+
+			if (  $sitemap_cache->is_enabled() ) {
+				wp_schedule_single_event( ( time() + 300 ), 'wpseo_hit_sitemap_index' );
+			}
+		}
+
 		/**
 		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default)
 		 *

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -59,10 +59,6 @@ class WPSEO_Sitemaps_Admin {
 			return;
 		}
 
-		if ( WP_CACHE ) {
-			wp_schedule_single_event( ( time() + 300 ), 'wpseo_hit_sitemap_index' );
-		}
-
 		/**
 		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default)
 		 *

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -59,14 +59,6 @@ class WPSEO_Sitemaps_Admin {
 			return;
 		}
 
-		if ( WP_CACHE && ! wp_next_scheduled( 'wpseo_hit_sitemap_index' ) ) {
-			$sitemap_cache = new WPSEO_Sitemaps_Cache();
-
-			if (  $sitemap_cache->is_enabled() ) {
-				wp_schedule_single_event( ( time() + 300 ), 'wpseo_hit_sitemap_index' );
-			}
-		}
-
 		/**
 		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default)
 		 *

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -16,7 +16,7 @@ class WPSEO_Sitemaps_Cache {
 	protected static $cache_clear = array();
 
 	/** @var bool $is_enabled Mirror of enabled status for static calls. */
-	protected static $is_enabled = true;
+	protected static $is_enabled = false;
 
 	/** @var bool $clear_all Holds the flag to clear all cache. */
 	protected static $clear_all = false;

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -67,7 +67,7 @@ class WPSEO_Sitemaps_Cache {
 		 *
 		 * @param bool $unsigned Enable cache or not, defaults to true
 		 */
-		return apply_filters( 'wpseo_enable_xml_sitemap_transient_caching', true );
+		return apply_filters( 'wpseo_enable_xml_sitemap_transient_caching', false );
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -427,7 +427,7 @@ class WPSEO_Sitemaps {
 		if ( ! $this->cache->is_enabled() ) {
 			return;
 		}
-		
+
 		wp_remote_get( WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ) );
 	}
 

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -419,9 +419,15 @@ class WPSEO_Sitemaps {
 	}
 
 	/**
-	 * Make a request for the sitemap index so as to cache it before the arrival of the search engines.
+	 * Makes a request for the sitemap index so as to cache it before the arrival of the search engines.
+	 *
+	 * @return void
 	 */
 	public function hit_sitemap_index() {
+		if ( ! $this->cache->is_enabled() ) {
+			return;
+		}
+		
 		wp_remote_get( WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ) );
 	}
 

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -419,7 +419,7 @@ class WPSEO_Sitemaps {
 	}
 
 	/**
-	 * Makes a request for the sitemap index so as to cache it before the arrival of the search engines.
+	 * Makes a request to the sitemap index so as to cache it before the arrival of the search engines.
 	 *
 	 * @return void
 	 */

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -419,7 +419,7 @@ class WPSEO_Sitemaps {
 	}
 
 	/**
-	 * Makes a request to the sitemap index so as to cache it before the arrival of the search engines.
+	 * Makes a request to the sitemap index to cache it before the arrival of the search engines.
 	 *
 	 * @return void
 	 */

--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -102,7 +102,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$content   = get_transient( $cache_key );
 
 		// Assert.
-		$this->assertEmpty( $content );
+		$this->assertEquals( $test_content, $content );
 	}
 
 	/**
@@ -126,7 +126,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$result    = get_transient( $cache_key );
 
 		// Assert.
-		$this->assertEmpty( $result );
+		$this->assertEquals( $test_content, $result );
 	}
 
 	/**
@@ -151,7 +151,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$result          = get_transient( $index_cache_key );
 
 		// Assert.
-		$this->assertEmpty( $result );
+		$this->assertEquals( $test_index_content, $result );
 	}
 
 	/**
@@ -223,6 +223,6 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$result    = get_transient( $cache_key );
 
 		// Assert.
-		$this->assertEmpty( $result );
+		$this->assertEquals( $test_content, $result );
 	}
 }

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -48,6 +48,9 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Sitemaps::redirect
 	 */
 	public function test_main_sitemap() {
+
+		add_filter( 'wpseo_enable_xml_sitemap_transient_caching', '__return_true' );
+
 		self::$class_instance->reset();
 
 		set_query_var( 'sitemap', '1' );
@@ -72,6 +75,8 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 			'</sitemapindex>',
 			'Served from transient cache',
 		) );
+
+		remove_filter( 'wpseo_enable_xml_sitemap_transient_caching', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the performance of the sitemap by disabling cache for it by default.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout trunk and make sure caching is enabled.
* Open the database (phpmyadmin) and navigate to the `wp_options` table. Use the search and for the field `option_name` you enter `%transient%` as searchphrase. 
* You should have a couple of transiens with `yst` in it.
* Checkout this branch. 
* In the Yoast Test helper plugin set the version to 8.4
* Go to the database and see the transients are gone
* Refresh the sitemap_index.xml and verify no transients are being saved.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have updated unittests to verify the code works as intended

Fixes #11258 
