### PR TITLE
Updated styling of button to match design

### DIFF
--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -17,8 +17,7 @@ const Container = styled.div`
 	font-size: 1em;
 	display: flex;
 	flex-direction: ${ props => props.alignment === "horizontal" ? "row" : "column" };
-	border-left: ${ getRtlStyle( "4px solid #a4286a", "none" ) };
-	border-right: ${ getRtlStyle( "none", "4px solid #a4286a" ) };
+	${ getRtlStyle( "border-left", "border-right" ) }: 4px solid ${ colors.$color_pink_dark };
 	margin: 16px 0;
 	padding: 0 0 0 8px;
 	max-width: 600px;

--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -9,6 +9,7 @@ const TextContainer = styled.p`
 	color: ${ colors.$color_upsell_text };
 	flex: 1;
 	margin: 0;
+	padding-right: 8px;
 `;
 
 const Container = styled.div`
@@ -29,8 +30,8 @@ const ButtonContainer = styled.div`
 	flex: 0;
 `;
 
-const Caret = styled.div`
-	padding-left: 3px;
+const Caret = styled( SvgIcon )`
+	margin: 0 0 0 4px;
 `;
 
 const OutboundLinkButton = utils.makeOutboundLink( UpsellLinkButton );
@@ -66,9 +67,7 @@ const AnalysisUpsell = ( props ) => {
 						__( "Go %s!", "wordpress-seo" ),
 						"Premium"
 					) }
-					<Caret>
-						<SvgIcon icon="arrow-right" size="8px" color={ colors.$color_black } />
-					</Caret>
+					<Caret icon="arrow-right" size="8px" color={ colors.$color_black } />
 				</OutboundLinkButton>
 			</ButtonContainer>
 		</Container>

--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
+import { getRtlStyle } from "yoast-components";
 
 import { colors, SvgIcon, UpsellLinkButton, utils } from "yoast-components";
 
@@ -16,7 +17,8 @@ const Container = styled.div`
 	font-size: 1em;
 	display: flex;
 	flex-direction: ${ props => props.alignment === "horizontal" ? "row" : "column" };
-	border-left: 4px solid ${ colors.$color_pink_dark };
+	border-left: ${ getRtlStyle( "4px solid #a4286a", "none" ) };
+	border-right: ${ getRtlStyle( "none", "4px solid #a4286a" ) };
 	margin: 16px 0;
 	padding: 0 0 0 8px;
 	max-width: 600px;
@@ -31,7 +33,8 @@ const ButtonContainer = styled.div`
 `;
 
 const Caret = styled( SvgIcon )`
-	margin: 0 0 0 4px;
+	margin: ${ getRtlStyle( "0 0 0 4px", "0 4px 0 0" ) };
+	transform: ${ getRtlStyle( "rotate(0deg)", "rotate(180deg)" ) };
 `;
 
 const OutboundLinkButton = utils.makeOutboundLink( UpsellLinkButton );

--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -17,7 +17,8 @@ const Container = styled.div`
 	flex-direction: ${ props => props.alignment === "horizontal" ? "row" : "column" };
 	border-left: 4px solid ${ colors.$color_pink_dark };
 	margin: 16px 0;
-	padding: 0 8px;
+	padding: 0 0 0 8px;
+	max-width: 600px;
 
 	> ${ TextContainer } {
 		margin-bottom: ${ props => props.alignment === "vertical" && "16px" };
@@ -26,6 +27,10 @@ const Container = styled.div`
 
 const ButtonContainer = styled.div`
 	flex: 0;
+`;
+
+const Caret = styled.div`
+	padding-left: 3px;
 `;
 
 const OutboundLinkButton = utils.makeOutboundLink( UpsellLinkButton );
@@ -61,7 +66,9 @@ const AnalysisUpsell = ( props ) => {
 						__( "Go %s!", "wordpress-seo" ),
 						"Premium"
 					) }
-					<SvgIcon icon="arrow-right" size="8px" color={ colors.$color_black } />
+					<Caret>
+						<SvgIcon icon="arrow-right" size="8px" color={ colors.$color_black } />
+					</Caret>
 				</OutboundLinkButton>
 			</ButtonContainer>
 		</Container>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A.

## Relevant technical choices:

* Added a new styled.div to give the caret in the button padding. Another solution would be to give the styled.svg component in yoast-components an additional prop for receiving padding. 

## Test instructions
This PR can be tested by following these steps:

* Before checking out this branch, check the current situation. You should see that in the metabox, in the "Focus keyphrase" section the "Go Premium!" button is to the far right. Also, the caret in the button is right behind the text, without any space between. 
* Checkout this branch, build and look at the style again: The button should be outlined with the snippet preview. The upsell box (text and button) should have the same with as the snippet preview. Also, space should be added between the "Go Premium!" text on the button and the caret, 4px to be exact.  
* Switch to an Rtl language by going to `Settings` -> `Site Language`. Some examples of Rtl languages are Arabic, Farsi, Azeri, Hebrew and Urdu. Make sure the layout is correctly flipped: The caret should point the other direction and the purple line in front of the text should be on the other side.   

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11280 
