### PR TITLE
Extract URL-encoded query arguments into its own function

### DIFF
--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -55,6 +55,8 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 			$input[ $key ] = WPSEO_Shortlinker::get( $shortlink );
 		}
 
+		$input['default_query_args'] = WPSEO_Shortlinker::get_encoded_query();
+
 		return $input;
 	}
 }

--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -11,6 +11,34 @@
 class WPSEO_Shortlinker {
 
 	/**
+	 * Gets the URL-encoded query string.
+	 *
+	 * @return string The URL-encoded query string.
+	 */
+	public static function get_encoded_query() {
+		$shortlinker = new WPSEO_Shortlinker();
+
+		return build_query( $shortlinker->collect_additional_shortlink_data() );
+	}
+
+	/**
+	 * Collects the additional data necessary for the shortlink.
+	 *
+	 * @return array The shortlink data.
+	 */
+	protected function collect_additional_shortlink_data() {
+		return array(
+			'php_version'      => $this->get_php_version(),
+			'platform'         => 'wordpress',
+			'platform_version' => $GLOBALS['wp_version'],
+			'software'         => $this->get_software(),
+			'software_version' => WPSEO_VERSION,
+			'role'             => $this->get_filtered_user_role(),
+			'days_active'      => $this->get_days_active(),
+		);
+	}
+
+	/**
 	 * Builds a URL to use in the plugin as shortlink.
 	 *
 	 * @param string $url The URL to build upon.
@@ -18,18 +46,7 @@ class WPSEO_Shortlinker {
 	 * @return string The final URL.
 	 */
 	public function build_shortlink( $url ) {
-		return add_query_arg(
-			array(
-				'php_version'      => $this->get_php_version(),
-				'platform'         => 'wordpress',
-				'platform_version' => $GLOBALS['wp_version'],
-				'software'         => $this->get_software(),
-				'software_version' => WPSEO_VERSION,
-				'role'             => $this->get_filtered_user_role(),
-				'days_active'      => $this->get_days_active(),
-			),
-			$url
-		);
+		return add_query_arg( $this->collect_additional_shortlink_data(), $url );
 	}
 
 	/**

--- a/tests/inc/test-class-wpseo-shortlinker.php
+++ b/tests/inc/test-class-wpseo-shortlinker.php
@@ -61,4 +61,18 @@ class WPSEO_Shortlinker_Test extends PHPUnit_Framework_TestCase {
 		$this->assertContains( 'platform_version', $shortlink );
 		$this->assertContains( 'software', $shortlink );
 	}
+
+	/**
+	 * Tests getting the encoded query data.
+	 *
+	 * @covers WPSEO_Shortlinker::get_encoded_query
+	 * @covers WPSEO_Shortlinker::collect_additional_shortlink_data
+	 */
+	public function test_get_encoded_query() {
+		$encoded_query = WPSEO_Shortlinker::get_encoded_query();
+
+		$this->assertContains( 'php_version', $encoded_query );
+		$this->assertContains( 'platform_version', $encoded_query );
+		$this->assertContains( 'software', $encoded_query );
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* This PR allows exposing of the query arguments that were previously only available in the Shortlinker so that they can be passed along to the webworker / YoastSEO.js via the `expose_shortlinks` function as a hard-coded property of `default_query_args`. See https://github.com/Yoast/wordpress-seo/issues/11254 as to why this is necessary.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* For RC testers: this is a non-userfacing change. The user-facing change will be made in https://github.com/Yoast/YoastSEO.js/issues/1876.
* Ensure that links that are currently being exposed via the `Expose_Shortlink` class still properly append the query arguments. Some links can be found in the Snippet Editor. 
* Ensure that the `default_query_args` key has been properly exposed and contains the correct system information. The easiest way to check this is by calling `wpseoAdminL10n` in your browser's console.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11284 
