### PR TITLE
 Rename labelSiblingElement to helpLink

### DIFF
--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -272,7 +272,7 @@ class SeoAnalysis extends React.Component {
 						onChange={ this.props.onFocusKeywordChange }
 						keyword={ this.props.keyword }
 						label={ __( "Focus keyphrase", "wordpress-seo" ) }
-						labelSiblingElement={ this.renderHelpLink() }
+						helpLink={ this.renderHelpLink() }
 					/>
 					<Slot name="YoastSynonyms" />
 					{ this.props.shouldUpsell && <React.Fragment>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Rename labelSiblingElement to helpLink. See https://github.com/Yoast/wordpress-seo-premium/pull/2060#discussion_r225431144

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Link https://github.com/Yoast/yoast-components/pull/758
* Check if the question mark help link in the metabox and sidebar is still functioning and not throwing prop errors.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/wordpress-seo-premium/issues/2058
