### PR TITLE
Always use an ID for the OpenGraph image

### DIFF
--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -33,7 +33,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 		$description_text = __( 'If you don\'t want to use the meta description for sharing the post on %s but want another description there, write it here.', 'wordpress-seo' );
 
 		/* translators: %s expands to the social network's name. */
-		$image_text = __( 'If you want to override the image used on %s for this post, upload / choose an image or add the URL here.', 'wordpress-seo' );
+		$image_text = __( 'If you want to override the image used on %s for this post, upload / choose an image here.', 'wordpress-seo' );
 
 		/* translators: %1$s expands to the social network, %2$s to the recommended image size. */
 		$image_size_text = __( 'The recommended image size for %1$s is %2$s pixels.', 'wordpress-seo' );
@@ -136,6 +136,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 			$medium . '-title',
 			$medium . '-description',
 			$medium . '-image',
+			$medium . '-image-id',
 		);
 
 		$tab_content = $this->get_premium_notice( $medium );

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -518,28 +518,36 @@ class Yoast_Form {
 
 		$id_field_id = 'wpseo_' . $var_esc . '_id';
 
-		echo '<input',
-			' class="textinput"',
-			' id="wpseo_', $var_esc, '"',
-			' type="text" size="36"',
-			' name="', esc_attr( $this->option_name ), '[', $var_esc, ']"',
-			' value="', esc_attr( $val ), '"',
-			' readonly="readonly"',
-			' />';
-		echo '<input',
-			' id="wpseo_', $var_esc, '_button"',
-			' class="wpseo_image_upload_button button"',
-			' type="button"',
-			' value="', esc_attr__( 'Upload Image', 'wordpress-seo' ), '"',
-			' data-target-id="', $id_field_id, '"',
-			disabled( $this->is_control_disabled( $var ), true, false ),
-			' />';
-		echo '<input',
-			' type="hidden"',
-			' id="', $id_field_id, '"',
-			' name="', esc_attr( $this->option_name ), '[', $var_esc, '_id]"',
-			' value="', $id_value, '"',
-			' />';
+		echo '<span>';
+			echo '<input',
+				' class="textinput"',
+				' id="wpseo_', $var_esc, '"',
+				' type="text" size="36"',
+				' name="', esc_attr( $this->option_name ), '[', $var_esc, ']"',
+				' value="', esc_attr( $val ), '"',
+				' readonly="readonly"',
+				' />';
+			echo '<input',
+				' id="wpseo_', $var_esc, '_button"',
+				' class="wpseo_image_upload_button button"',
+				' type="button"',
+				' value="', esc_attr__( 'Upload Image', 'wordpress-seo' ), '"',
+				' data-target-id="', esc_attr( $id_field_id ), '"',
+				disabled( $this->is_control_disabled( $var ), true, false ),
+				' />';
+			echo '<input',
+				' class="wpseo_image_remove_button button"',
+				' type="button"',
+				' value="', esc_attr__( 'Remove Image', 'wordpress-seo' ), '"',
+				disabled( $this->is_control_disabled( $var ), true, false ),
+				' />';
+			echo '<input',
+				' type="hidden"',
+				' id="', esc_attr( $id_field_id ), '"',
+				' name="', esc_attr( $this->option_name ), '[', $var_esc, '_id]"',
+				' value="', esc_attr( $id_value ), '"',
+				' />';
+		echo '</span>';
 		echo '<br class="clear"/>';
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -501,6 +501,11 @@ class Yoast_Form {
 			$val = $this->options[ $var ];
 		}
 
+		$id_value = '';
+		if ( isset( $this->options[ $var . '_id' ] ) ) {
+			$id_value = $this->options[ $var . '_id' ];
+		}
+
 		$var_esc = esc_attr( $var );
 
 		$this->label(
@@ -510,8 +515,31 @@ class Yoast_Form {
 				'class' => 'select',
 			)
 		);
-		echo '<input class="textinput" id="wpseo_', $var_esc, '" type="text" size="36" name="', esc_attr( $this->option_name ), '[', $var_esc, ']" value="', esc_attr( $val ), '" />';
-		echo '<input id="wpseo_', $var_esc, '_button" class="wpseo_image_upload_button button" type="button" value="', esc_attr__( 'Upload Image', 'wordpress-seo' ), '"', disabled( $this->is_control_disabled( $var ), true, false ), ' />';
+
+		$id_field_id = 'wpseo_' . $var_esc . '_id';
+
+		echo '<input',
+			' class="textinput"',
+			' id="wpseo_', $var_esc, '"',
+			' type="text" size="36"',
+			' name="', esc_attr( $this->option_name ), '[', $var_esc, ']"',
+			' value="', esc_attr( $val ), '"',
+			' readonly="readonly"',
+			' />';
+		echo '<input',
+			' id="wpseo_', $var_esc, '_button"',
+			' class="wpseo_image_upload_button button"',
+			' type="button"',
+			' value="', esc_attr__( 'Upload Image', 'wordpress-seo' ), '"',
+			' data-target-id="', $id_field_id, '"',
+			disabled( $this->is_control_disabled( $var ), true, false ),
+			' />';
+		echo '<input',
+			' type="hidden"',
+			' id="', $id_field_id, '"',
+			' name="', esc_attr( $this->option_name ), '[', $var_esc, '_id]"',
+			' value="', $id_value, '"',
+			' />';
 		echo '<br class="clear"/>';
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -526,7 +526,7 @@ class Yoast_Form {
 				' name="', esc_attr( $this->option_name ), '[', $var_esc, ']"',
 				' value="', esc_attr( $val ), '"',
 				' readonly="readonly"',
-				' />';
+				' /> ';
 			echo '<input',
 				' id="wpseo_', $var_esc, '_button"',
 				' class="wpseo_image_upload_button button"',
@@ -534,11 +534,11 @@ class Yoast_Form {
 				' value="', esc_attr__( 'Upload Image', 'wordpress-seo' ), '"',
 				' data-target-id="', esc_attr( $id_field_id ), '"',
 				disabled( $this->is_control_disabled( $var ), true, false ),
-				' />';
+				' /> ';
 			echo '<input',
 				' class="wpseo_image_remove_button button"',
 				' type="button"',
-				' value="', esc_attr__( 'Remove Image', 'wordpress-seo' ), '"',
+				' value="', esc_attr__( 'Clear Image', 'wordpress-seo' ), '"',
 				disabled( $this->is_control_disabled( $var ), true, false ),
 				' />';
 			echo '<input',

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -624,11 +624,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					' data-target-id="' . esc_attr( $esc_form_key ) . '-id"' .
 					' type="button"' .
 					' value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '"' .
-					' />';
+					' /> ';
 				$content .= '<input' .
 					' class="wpseo_image_remove_button button"' .
 					' type="button"' .
-					' value="' . esc_attr__( 'Remove Image', 'wordpress-seo' ) . '"' .
+					' value="' . esc_attr__( 'Clear Image', 'wordpress-seo' ) . '"' .
 					' />';
 				break;
 		}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -608,8 +608,23 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				break;
 
 			case 'upload':
-				$content .= '<input id="' . $esc_form_key . '" type="text" size="36" class="' . $class . '" name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '"' . $aria_describedby . ' />';
-				$content .= '<input id="' . $esc_form_key . '_button" class="wpseo_image_upload_button button" type="button" value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '" />';
+				$content .= '<input' .
+					' id="' . $esc_form_key . '"' .
+					' type="text"' .
+					' size="36"' .
+					' class="' . $class . '"' .
+					' name="' . $esc_form_key . '"' .
+					' value="' . esc_attr( $meta_value ) . '"' . $aria_describedby .
+					' readonly="readonly"' .
+					' />';
+				$content .= '<input' .
+					' id="' . $esc_form_key . '_button"' .
+					' class="wpseo_image_upload_button button"' .
+					' data-target="' . $esc_form_key . '"' .
+					' data-target-id="' . $esc_form_key . '-id"' .
+					' type="button"' .
+					' value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '"' .
+					' />';
 				break;
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -618,12 +618,17 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					' readonly="readonly"' .
 					' />';
 				$content .= '<input' .
-					' id="' . $esc_form_key . '_button"' .
+					' id="' . esc_attr( $esc_form_key ) . '_button"' .
 					' class="wpseo_image_upload_button button"' .
-					' data-target="' . $esc_form_key . '"' .
-					' data-target-id="' . $esc_form_key . '-id"' .
+					' data-target="' . esc_attr( $esc_form_key ) . '"' .
+					' data-target-id="' . esc_attr( $esc_form_key ) . '-id"' .
 					' type="button"' .
 					' value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '"' .
+					' />';
+				$content .= '<input' .
+					' class="wpseo_image_remove_button button"' .
+					' type="button"' .
+					' value="' . esc_attr__( 'Remove Image', 'wordpress-seo' ) . '"' .
 					' />';
 				break;
 		}

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -102,8 +102,22 @@ class WPSEO_Taxonomy_Fields_Presenter {
 				$field .= '<textarea class="large-text" rows="' . esc_attr( $rows ) . '" id="' . $field_name . '" name="' . $field_name . '"' . $aria_describedby . '>' . esc_textarea( $field_value ) . '</textarea>';
 				break;
 			case 'upload':
-				$field .= '<input id="' . $field_name . '" type="text" size="36" name="' . $field_name . '" value="' . esc_attr( $field_value ) . '"' . $aria_describedby . ' />';
-				$field .= '<input id="' . $field_name . '_button" class="wpseo_image_upload_button button" type="button" value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '" />';
+				$field .= '<input' .
+					' id="' . $field_name . '"' .
+					' type="text"' .
+					' size="36"' .
+					' name="' . $field_name . '"' .
+					' value="' . esc_attr( $field_value ) . '"' . $aria_describedby . '' .
+					' readonly="readonly"' .
+					' />';
+				$field .= '<input' .
+					' id="' . $field_name . '_button"' .
+					' class="wpseo_image_upload_button button"' .
+					' data-target="' . $field_name . '"' .
+					' data-target-id="hidden_' . $field_name . '-id"' .
+					' type="button"' .
+					' value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '"' .
+					' />';
 				break;
 			case 'select':
 				if ( is_array( $options ) && $options !== array() ) {

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -109,14 +109,20 @@ class WPSEO_Taxonomy_Fields_Presenter {
 					' name="' . $field_name . '"' .
 					' value="' . esc_attr( $field_value ) . '"' . $aria_describedby . '' .
 					' readonly="readonly"' .
-					' />';
+					' /> ';
 				$field .= '<input' .
-					' id="' . $field_name . '_button"' .
+					' id="' . esc_attr( $field_name ) . '_button"' .
 					' class="wpseo_image_upload_button button"' .
-					' data-target="' . $field_name . '"' .
-					' data-target-id="hidden_' . $field_name . '-id"' .
+					' data-target="' . esc_attr( $field_name ) . '"' .
+					' data-target-id="hidden_' . esc_attr( $field_name ) . '-id"' .
 					' type="button"' .
 					' value="' . esc_attr__( 'Upload Image', 'wordpress-seo' ) . '"' .
+					' /> ';
+				$field .= '<input' .
+					' id="' . esc_attr( $field_name ) . '_button"' .
+					' class="wpseo_image_remove_button button"' .
+					' type="button"' .
+					' value="' . esc_attr__( 'Clear Image', 'wordpress-seo' ) . '"' .
 					' />';
 				break;
 			case 'select':

--- a/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/admin/taxonomy/class-taxonomy-social-fields.php
@@ -67,6 +67,11 @@ class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
 				sprintf( __( 'The recommended image size for %1$s is %2$s pixels.', 'wordpress-seo' ), $settings['label'], $settings['size'] ),
 				'upload'
 			),
+			$settings['network'] . '-image-id' => $this->get_field_config(
+				'',
+				'',
+				'hidden'
+			),
 		);
 	}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -205,7 +205,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @return void
 	 */
-	private function add_image_by_id_or_url( $image_id, $image_url, callable $save_id ) {
+	private function add_image_by_id_or_url( $image_id, $image_url, $save_id ) {
 		switch ( $image_id ) {
 			case self::EXTERNAL_IMAGE_ID:
 				// Add image by URL, but skip attachment_to_id call. We already know this is an external image.

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -199,13 +199,13 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Adds an image by ID if possible and by URL if the ID isn't present.
 	 *
-	 * @param string   $image_id  The image ID as set in the database.
-	 * @param string   $image_url The saved URL for the image.
-	 * @param callable $save_id   Function to call to save the ID if it needs to be saved.
+	 * @param string   $image_id   The image ID as set in the database.
+	 * @param string   $image_url  The saved URL for the image.
+	 * @param callable $on_save_id Function to call to save the ID if it needs to be saved.
 	 *
 	 * @return void
 	 */
-	private function add_image_by_id_or_url( $image_id, $image_url, $save_id ) {
+	private function add_image_by_id_or_url( $image_id, $image_url, $on_save_id ) {
 		switch ( $image_id ) {
 			case self::EXTERNAL_IMAGE_ID:
 				// Add image by URL, but skip attachment_to_id call. We already know this is an external image.
@@ -217,7 +217,7 @@ class WPSEO_OpenGraph_Image {
 				$attachment_id = $this->add_image_by_url( $image_url );
 
 				if ( $attachment_id !== null ) {
-					call_user_func( $save_id, $attachment_id );
+					call_user_func( $on_save_id, $attachment_id );
 				}
 				break;
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -196,6 +196,15 @@ class WPSEO_OpenGraph_Image {
 		$this->images[ $image_url ] = $attachment;
 	}
 
+	/**
+	 * Adds an image by ID if possible and by URL if the ID isn't present.
+	 *
+	 * @param string   $image_id  The image ID as set in the database.
+	 * @param string   $image_url The saved URL for the image.
+	 * @param callable $save_id   Function to call to save the ID if it needs to be saved.
+	 *
+	 * @return void
+	 */
 	private function add_image_by_id_or_url( $image_id, $image_url, callable $save_id ) {
 		switch ( $image_id ) {
 			case self::EXTERNAL_IMAGE_ID:
@@ -219,6 +228,13 @@ class WPSEO_OpenGraph_Image {
 		}
 	}
 
+	/**
+	 * Saves the ID to the frontpage Open Graph image ID.
+	 *
+	 * @param string $attachment_id The ID to save.
+	 *
+	 * @return void
+	 */
 	private function save_frontpage_image_id( $attachment_id ) {
 		WPSEO_Options::set( 'og_frontpage_image_id', $attachment_id );
 	}
@@ -302,6 +318,13 @@ class WPSEO_OpenGraph_Image {
 		$this->set_featured_image( $post_id );
 	}
 
+	/**
+	 * Saves the default image ID for Open Graph images to the database.
+	 *
+	 * @param string $attachment_id The ID to save.
+	 *
+	 * @return void
+	 */
 	private function save_default_image_id( $attachment_id ) {
 		WPSEO_Options::set( 'og_default_image_id', $attachment_id );
 	}
@@ -325,6 +348,13 @@ class WPSEO_OpenGraph_Image {
 		$this->add_image_by_id_or_url( $default_image_id, $default_image_url, array( $this, 'save_default_image_id' ) );
 	}
 
+	/**
+	 * Saves the Open Graph image meta to the database for the current post.
+	 *
+	 * @param string $attachment_id The ID to save.
+	 *
+	 * @return
+	 */
 	private function save_opengraph_image_id_meta( $attachment_id ) {
 		$post_id = $this->get_queried_object_id();
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -353,7 +353,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @param string $attachment_id The ID to save.
 	 *
-	 * @return
+	 * @return void
 	 */
 	private function save_opengraph_image_id_meta( $attachment_id ) {
 		$post_id = $this->get_queried_object_id();

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -238,6 +238,7 @@ class WPSEO_Meta {
 		'title'       => 'text',
 		'description' => 'textarea',
 		'image'       => 'upload',
+		'image-id'    => 'hidden',
 	);
 
 	/**

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -21,25 +21,27 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 */
 	protected $defaults = array(
 		// Form fields.
-		'facebook_site'      => '', // Text field.
-		'instagram_url'      => '',
-		'linkedin_url'       => '',
-		'myspace_url'        => '',
-		'og_default_image'   => '', // Text field.
-		'og_frontpage_title' => '', // Text field.
-		'og_frontpage_desc'  => '', // Text field.
-		'og_frontpage_image' => '', // Text field.
-		'opengraph'          => true,
-		'pinterest_url'      => '',
-		'pinterestverify'    => '',
-		'plus-publisher'     => '', // Text field.
-		'twitter'            => true,
-		'twitter_site'       => '', // Text field.
-		'twitter_card_type'  => 'summary_large_image',
-		'youtube_url'        => '',
-		'google_plus_url'    => '',
+		'facebook_site'         => '', // Text field.
+		'instagram_url'         => '',
+		'linkedin_url'          => '',
+		'myspace_url'           => '',
+		'og_default_image'      => '', // Text field.
+		'og_default_image_id'   => '',
+		'og_frontpage_title'    => '', // Text field.
+		'og_frontpage_desc'     => '', // Text field.
+		'og_frontpage_image'    => '', // Text field.
+		'og_frontpage_image_id' => '',
+		'opengraph'             => true,
+		'pinterest_url'         => '',
+		'pinterestverify'       => '',
+		'plus-publisher'        => '', // Text field.
+		'twitter'               => true,
+		'twitter_site'          => '', // Text field.
+		'twitter_card_type'     => 'summary_large_image',
+		'youtube_url'           => '',
+		'google_plus_url'       => '',
 		// Form field, but not always available.
-		'fbadminapp'         => '', // Facebook app ID.
+		'fbadminapp'            => '', // Facebook app ID.
 	);
 
 	/**
@@ -111,6 +113,15 @@ class WPSEO_Option_Social extends WPSEO_Option {
 				case 'og_frontpage_title':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
+					}
+					break;
+
+				case 'og_default_image_id':
+				case 'og_frontpage_image_id':
+					$clean[ $key ] = intval( $dirty[ $key ] );
+
+					if ( $dirty[ $key ] === '' ) {
+						$clean[ $key ] = $dirty[ $key ];
 					}
 					break;
 

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -55,6 +55,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 		'wpseo_opengraph-title'       => '',
 		'wpseo_opengraph-description' => '',
 		'wpseo_opengraph-image'       => '',
+		'wpseo_opengraph-image-id'    => '',
 		'wpseo_twitter-title'         => '',
 		'wpseo_twitter-description'   => '',
 		'wpseo_twitter-image'         => '',

--- a/js/src/wp-seo-admin-media.js
+++ b/js/src/wp-seo-admin-media.js
@@ -68,9 +68,9 @@ jQuery( document ).ready(
 				wpseoCustomUploader.open();
 			} );
 
-			const deleteButton = $uploadImageButton
+			$uploadImageButton
 				.siblings( ".wpseo_image_remove_button" )
-				.on( 'click', ( e ) => {
+				.on( "click", ( e ) => {
 					e.preventDefault();
 
 					$urlInput.val( "" );

--- a/js/src/wp-seo-admin-media.js
+++ b/js/src/wp-seo-admin-media.js
@@ -1,8 +1,36 @@
 /* global wpseoMediaL10n */
 /* global wp */
-/* jshint -W097 */
-/* jshint -W003 */
-/* jshint unused:false */
+
+/**
+ * Returns the target HTML id for this button element.
+ *
+ * @param {Object} $button The image select button.
+ * @returns {string} The HTML id for the URL input field.
+ */
+function getTarget( $button ) {
+	$button = $( $button );
+
+	let target = $button.data( "target" );
+
+	// This is the implicit way to define which URL field to fill.
+	if ( ! target || target === "" ) {
+		target = $( $button ).attr( "id" ).replace( /_button$/, "" );
+	}
+
+	return target;
+}
+
+/**
+ * Returns the hidden ID input element for this button.
+ *
+ * @param {Object} $button The image select button.
+ * @returns {string} The HTML id for the ID input field.
+ */
+function getIdTarget( $button ) {
+	$button = $( $button );
+
+	return $button.data( "target-id" );
+}
 
 // Taken and adapted from http://www.webmaster-source.com/2013/02/06/using-the-wordpress-3-5-media-uploader-in-your-plugin-or-theme/
 jQuery( document ).ready(
@@ -12,7 +40,12 @@ jQuery( document ).ready(
 		}
 
 		$( ".wpseo_image_upload_button" ).each( function( index, element ) {
-			var wpseoTargetId = $( element ).attr( "id" ).replace( /_button$/, "" );
+			const urlInputHtmlId = getTarget( element );
+			const idInputHtmlId = getIdTarget( element );
+
+			const $urlInput = $( "#" + urlInputHtmlId );
+			const $idInput = $( "#" + idInputHtmlId );
+
 			// eslint-disable-next-line
 			var wpseoCustomUploader = wp.media.frames.file_frame = wp.media( {
 				title: wpseoMediaL10n.choose_image,
@@ -22,7 +55,9 @@ jQuery( document ).ready(
 
 			wpseoCustomUploader.on( "select", function() {
 				var attachment = wpseoCustomUploader.state().get( "selection" ).first().toJSON();
-				$( "#" + wpseoTargetId ).val( attachment.url );
+
+				$urlInput.val( attachment.url );
+				$idInput.val( attachment.id );
 			}
 			);
 

--- a/js/src/wp-seo-admin-media.js
+++ b/js/src/wp-seo-admin-media.js
@@ -61,10 +61,21 @@ jQuery( document ).ready(
 			}
 			);
 
-			$( element ).click( function( e ) {
+			const $uploadImageButton = $( element );
+
+			$uploadImageButton.click( function( e ) {
 				e.preventDefault();
 				wpseoCustomUploader.open();
 			} );
+
+			const deleteButton = $uploadImageButton
+				.siblings( ".wpseo_image_remove_button" )
+				.on( 'click', ( e ) => {
+					e.preventDefault();
+
+					$urlInput.val( "" );
+					$idInput.val( "" );
+				} );
 		} );
 	}
 );

--- a/tests/taxonomy/test-class-taxonomy-presenter.php
+++ b/tests/taxonomy/test-class-taxonomy-presenter.php
@@ -182,8 +182,11 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 			)
 		);
 
-		$this->assertContains( '<input id="wpseo_fieldname" type="text" size="36" name="wpseo_fieldname" value="" />', $output );
-		$this->assertContains( '<input id="wpseo_fieldname_button" class="wpseo_image_upload_button button" type="button" value="Upload Image" />', $output );
+		$this->assertContains( '<input id="wpseo_fieldname" type="text" size="36" name="wpseo_fieldname" value="" readonly="readonly" />', $output );
+		$this->assertContains(
+			'<input id="wpseo_fieldname_button" class="wpseo_image_upload_button button" data-target="wpseo_fieldname" data-target-id="hidden_wpseo_fieldname-id" type="button" value="Upload Image" />',
+			$output
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes OpenGraph image handling to always use an image from the media library. This makes the performance of the OpenGraph image handling much better.

## Relevant technical choices:

* I haven't changed anything to the Twitter image, because it doesn't have dimension information. I did add the ID field to the twitter image field, because that could prove useful in the future.
* The frontend will try to use the attachment ID, if there isn't an ID it will save the ID it finds from `attachment_url_to_postid`. This means that every page that doesn't have an ID saved yet, will get an ID after loading it once. This should massively reduce the amount of calls to `attachment_url_to_postid`.
* Because I changed the image URL field to be readonly, I've added a "Remove image" button so you can actually remove an image after it has been added.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Scenario 1:

* Have a post that only has a URL in the OpenGraph image pointing to an attachment image. (This can be achieved by using Yoast SEO before this branch, or using the branch an deleting the ID value from the database.)
* Open that post on the frontend.
* The ID value should now be set. (You can check this by checking the hidden input in the admin, or checking the database)
* `attachment_url_to_postid` should only be called on the initial load (the one that saves the ID).

Scenario 2:

* Have a post that only as a URL in the OpenGraph image pointing to an external URL.
* Open that post on the frontend.
* The ID value should now be set to `-1`
* `attachment_url_to_postid` should only be called on the initial load (the one that saves the ID).

Scenario 3:

* Go to SEO -> Social -> Facebook.
* Scroll down to Default Settings and select Upload Image to set an image. Please take note of the image's ID by hovering over / inspecting the `Edit Image` link and locate the number that follows after `post=` in the URL.
* In your Inspector, search for `wpseo_social[og_default_image_id]` and determine that the value is set to the correct ID that you determined in the previous step.
* As an extra check, you can take a look at the `wpseo_social` option in the database (in `wp_options`) and locate the `og_default_image_id` in the `option_value` field.
* Open a post on the frontpage that does not have a OpenGraph image set and determine that the default image is being used in the DOM.
* **Note: In case of a previously set, external image URL, ensure that the returned value is `-1` in the database. See scenario 2 for more info.**

Scenario 4:

* Go to SEO -> Social -> Facebook.
* Scroll down to Frontpage Settings and select Upload Image to set an image. Please take note of the image's ID by hovering over / inspecting the `Edit Image` link and locate the number that follows after `post=` in the URL.
* In your Inspector, search for `wpseo_social[og_frontpage_image_id]` and determine that the value is set to the correct ID that you determined in the previous step.
* As an extra check, you can take a look at the `wpseo_social` option in the database (in `wp_options`) and locate the `og_frontpage_image_id` in the `option_value` field.
* Open the frontpage and determine that the default frontpage image is being used in the DOM.
* **Note: In case of a previously set, external image URL, ensure that the returned value is `-1` in the database. See scenario 2 for more info.**

Extra:

* Go to SEO -> Search Appearance -> General.
* Scroll down to Knowledge Graph and change Company or Person to Company.
* See that the input field for the Company Logo is now read-only.
* Determine that both uploading and clearing an image properly works.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11264
Fixes #10195