### PR TITLE
11289 implement keyphrase notice

### DIFF
--- a/js/src/analysis/refreshAnalysis.js
+++ b/js/src/analysis/refreshAnalysis.js
@@ -3,6 +3,7 @@ import {
 	setOverallSeoScore,
 	setReadabilityResults,
 	setSeoResultsForKeyword,
+	setKeyphraseNotice,
 } from "yoast-components/composites/Plugin/ContentAnalysis/actions/contentAnalysis";
 import { refreshSnippetEditor } from "../redux/actions/snippetEditor";
 
@@ -52,6 +53,7 @@ export default function refreshAnalysis( worker, collectData, applyMarks, store,
 
 				store.dispatch( setSeoResultsForKeyword( paper.getKeyword(), seoResults.results ) );
 				store.dispatch( setOverallSeoScore( seoResults.score, paper.getKeyword() ) );
+				store.dispatch( setKeyphraseNotice( paper.getKeyword(), seoResults.keyphraseNotice ) );
 				store.dispatch( refreshSnippetEditor() );
 
 				dataCollector.saveScores( seoResults.score, paper.getKeyword() );

--- a/js/src/components/KeyphraseNotice.js
+++ b/js/src/components/KeyphraseNotice.js
@@ -3,9 +3,8 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { colors } from "yoast-components";
 
-// TODO: Add background color to style guide?
 const Notice = styled.p`
-	background: #FFEEA3;
+	background: ${ colors.$color_notice_yellow };
 	color: ${ colors.$color_grey_dark };
 	padding: 4px 8px;
 `;
@@ -19,18 +18,19 @@ class KeyphraseNotice extends React.Component {
 	 * @returns {React.Component} the keyphrase notice component.
 	 */
 	render() {
-		return ( <Notice>
-			{ this.props.text }
-		</Notice> );
+		if ( this.props.innerHtml && this.props.innerHtml.length > 0 ) {
+			return <Notice dangerouslySetInnerHTML={ { __html: this.props.innerHtml } } />;
+		}
+		return null;
 	}
 }
 
 export default KeyphraseNotice;
 
 KeyphraseNotice.propTypes = {
-	text: PropTypes.string,
+	innerHtml: PropTypes.string,
 };
 
 KeyphraseNotice.defaultProps = {
-	text: "",
+	innerHtml: "",
 };

--- a/js/src/components/KeyphraseNotice.js
+++ b/js/src/components/KeyphraseNotice.js
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { colors } from "yoast-components";
+
+// TODO: Add background color to style guide?
+const Notice = styled.p`
+	background: #FFEEA3;
+	color: ${ colors.$color_grey_dark };
+	padding: 4px 8px;
+`;
+
+/**
+ * A notice to be shown inside the metabox.
+ */
+class KeyphraseNotice extends React.Component {
+	/**
+	 * Renders the keyphrase notice.
+	 * @returns {React.Component} the keyphrase notice component.
+	 */
+	render() {
+		return ( <Notice>
+			{ this.props.text }
+		</Notice> );
+	}
+}
+
+export default KeyphraseNotice;
+
+KeyphraseNotice.propTypes = {
+	text: PropTypes.string,
+};
+
+KeyphraseNotice.defaultProps = {
+	text: "",
+};

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -275,7 +275,7 @@ class SeoAnalysis extends React.Component {
 						label={ __( "Focus keyphrase", "wordpress-seo" ) }
 						labelSiblingElement={ this.renderHelpLink() }
 					/>
-					<KeyphraseNotice text={ "Hey, this is a notice about your keyphrase!" } />
+					<KeyphraseNotice innerHtml={ this.props.keyphraseNotice } />
 					<Slot name="YoastSynonyms" />
 					{ this.props.shouldUpsell && <React.Fragment>
 						{ this.renderSynonymsUpsell( this.props.location ) }
@@ -324,15 +324,18 @@ function mapStateToProps( state, ownProps ) {
 
 	let results = null;
 	let overallScore = null;
+	let keyphraseNotice = null;
 	if ( state.analysis.seo[ keyword ] ) {
 		results = state.analysis.seo[ keyword ].results;
 		overallScore = state.analysis.seo[ keyword ].overallScore;
+		keyphraseNotice = state.analysis.seo[ keyword ].notice;
 	}
 	return {
 		results,
 		marksButtonStatus,
 		keyword,
 		overallScore,
+		keyphraseNotice,
 	};
 }
 

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -17,6 +17,7 @@ import MultipleKeywords from "../modals/MultipleKeywords";
 import YoastSeoIcon from "yoast-components/composites/basic/YoastSeoIcon";
 import Icon from "yoast-components/composites/Plugin/Shared/components/Icon";
 import AnalysisUpsell from "../AnalysisUpsell";
+import KeyphraseNotice from "../KeyphraseNotice";
 
 const AnalysisHeader = styled.span`
 	font-size: 1em;
@@ -274,6 +275,7 @@ class SeoAnalysis extends React.Component {
 						label={ __( "Focus keyphrase", "wordpress-seo" ) }
 						labelSiblingElement={ this.renderHelpLink() }
 					/>
+					<KeyphraseNotice text={ "Hey, this is a notice about your keyphrase!" } />
 					<Slot name="YoastSynonyms" />
 					{ this.props.shouldUpsell && <React.Fragment>
 						{ this.renderSynonymsUpsell( this.props.location ) }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a notification to the metabox, shown under the focus keyphrase input element. This notification will be used to tell the user when the entered keyphrase may not work as expected (see #11260 and #11261).

## Relevant technical choices:

* The Redux action and adaptions to the SEO analysis results reducer are located in `yoast-components` (see https://github.com/Yoast/yoast-components/pull/761). The changes in that PR should be tested at the same time as this one.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure that a local `yoast-components` repository is `yarn link`ed to your `wordpress-seo` repository.
  * Make sure that a local `YoastSEO.js` is also linked.
* Checkout the `add-keyphrase-notice-action-and-reducer` branch in your local `yoast-components` repo. (This is to make sure that the necessary action and reducer changes are available).
* Start up WordPress and go to a post.
    * The area below the focus keyphrase input box should be empty as normal:
<img width="442" alt="screen shot 2018-10-16 at 15 37 07" src="https://user-images.githubusercontent.com/10195175/47020410-98c2d500-d159-11e8-9af9-eda94416f449.png">

* In your local `YoastSEO.js` repo, add this line to the `analyze` method in `src/worker/AnalysisWebWorker.js` (or something similar, include a link and/or bold text):
```js
this._results.seo[""].keyphraseNotice = "There is something wrong with your <a href='https://www.google.com'>keyphrase</a>.";
```
* Go to a post in WordPress.
   * The area below the focus keyphrase input box should show the message you entered above, including links and html markup:
<img width="440" alt="screen shot 2018-10-16 at 15 37 59" src="https://user-images.githubusercontent.com/10195175/47021010-d411d380-d15a-11e8-81a9-88d379ec66f1.png">
 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11289 
