### PR TITLE
checking if post object is_a WP_Post in get_singular_post function

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -457,7 +457,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			return null;
 		}
 
-		if ( ! isset( $post ) || ! is_object( $post ) ) {
+		if ( ! isset( $post ) || ! is_object( $post ) || ! is_a( $post, 'WP_Post' )  ) {
 			return null;
 		}
 


### PR DESCRIPTION
## Summary

This is a partial fix for a similar issue to #10836 when using the WP Property plugin. The plugin creates the `$post` object as an instance of `stdClass` rather than `WP_Post`. Which is likely in itself a bad coding practice from the WP Property plugin. I wanted to share the code that got it working for me as a potential fix to the Timber issues as well.

* Verifies that variable `post` is an instance of `WP_Post` in `WPSEO_Admin_Bar_Menu ::get_singular_post()`. Props to [@yingles](https://github.com/yingles).

## Relevant technical choices:

* `is_a` function http://php.net/manual/en/function.is-a.php

## Test instructions

This PR can be tested by following these steps:

* Using the WP Property plugin navigate to the Property custom post type and see if the Admin Bar loads or gets a PHP Fatal Error

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes potentially #10836
