### PR TITLE
Change the exposed shortlinks default_query_args to be an array instead of a string

### DIFF
--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -55,7 +55,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 			$input[ $key ] = WPSEO_Shortlinker::get( $shortlink );
 		}
 
-		$input['default_query_args'] = WPSEO_Shortlinker::get_encoded_query();
+		$input['default_query_params'] = WPSEO_Shortlinker::get_query_params();
 
 		return $input;
 	}

--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -11,28 +11,6 @@
 class WPSEO_Shortlinker {
 
 	/**
-	 * Gets the URL-encoded query string.
-	 *
-	 * @return string The URL-encoded query string.
-	 */
-	public static function get_encoded_query() {
-		$shortlinker = new WPSEO_Shortlinker();
-
-		return build_query( $shortlinker->collect_additional_shortlink_data() );
-	}
-
-	/**
-	 * Gets the shortlink's query params.
-	 *
-	 * @return array The shortlink's query params.
-	 */
-	public static function get_query_params() {
-		$shortlinker = new WPSEO_Shortlinker();
-
-		return $shortlinker->collect_additional_shortlink_data();
-	}
-
-	/**
 	 * Collects the additional data necessary for the shortlink.
 	 *
 	 * @return array The shortlink data.
@@ -68,7 +46,7 @@ class WPSEO_Shortlinker {
 	 * @return string The final URL.
 	 */
 	public static function get( $url ) {
-		$shortlinker = new WPSEO_Shortlinker();
+		$shortlinker = new self();
 
 		return $shortlinker->build_shortlink( $url );
 	}
@@ -80,6 +58,17 @@ class WPSEO_Shortlinker {
 	 */
 	public static function show( $url ) {
 		echo esc_url( self::get( $url ) );
+	}
+
+	/**
+	 * Gets the shortlink's query params.
+	 *
+	 * @return array The shortlink's query params.
+	 */
+	public static function get_query_params() {
+		$shortlinker = new self();
+
+		return $shortlinker->collect_additional_shortlink_data();
 	}
 
 	/**

--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -22,6 +22,17 @@ class WPSEO_Shortlinker {
 	}
 
 	/**
+	 * Gets the shortlink's query params.
+	 *
+	 * @return array The shortlink's query params.
+	 */
+	public static function get_query_params() {
+		$shortlinker = new WPSEO_Shortlinker();
+
+		return $shortlinker->collect_additional_shortlink_data();
+	}
+
+	/**
 	 * Collects the additional data necessary for the shortlink.
 	 *
 	 * @return array The shortlink data.

--- a/js/src/analysis/getDefaultQueryParams.js
+++ b/js/src/analysis/getDefaultQueryParams.js
@@ -2,9 +2,9 @@
 import get from "lodash/get";
 
 /**
- * Retrieves the content locale for the current page.
+ * Retrieves the default query params.
  *
- * @returns {string} The content locale. Defaults to en_US.
+ * @returns {Object} The default query params.
  */
 export default function getDefaultQueryParams() {
 	return get( window, [ "wpseoAdminL10n", "default_query_params" ], {} );

--- a/js/src/analysis/getDefaultQueryParams.js
+++ b/js/src/analysis/getDefaultQueryParams.js
@@ -1,0 +1,11 @@
+// External dependencies.
+import get from "lodash/get";
+
+/**
+ * Retrieves the content locale for the current page.
+ *
+ * @returns {string} The content locale. Defaults to en_US.
+ */
+export default function getDefaultQueryParams() {
+	return get( window, [ "wpseoAdminL10n", "default_query_params" ], {} );
+}

--- a/js/src/analysis/worker.js
+++ b/js/src/analysis/worker.js
@@ -1,14 +1,15 @@
 // External dependencies.
-import { AnalysisWorkerWrapper, createWorker } from "yoastseo";
 import get from "lodash/get";
 import isUndefined from "lodash/isUndefined";
 import merge from "lodash/merge";
+import { AnalysisWorkerWrapper, createWorker } from "yoastseo";
 
 // Internal dependencies.
 import getContentLocale from "./getContentLocale";
 import getTranslations from "./getTranslations";
 import isContentAnalysisActive from "./isContentAnalysisActive";
 import isKeywordAnalysisActive from "./isKeywordAnalysisActive";
+import getDefaultQueryParams from "./getDefaultQueryParams";
 
 /**
  * Instantiates an analysis worker (wrapper).
@@ -32,6 +33,7 @@ export function getAnalysisConfiguration( customConfiguration = {} ) {
 		locale: getContentLocale(),
 		contentAnalysisActive: isContentAnalysisActive(),
 		keywordAnalysisActive: isKeywordAnalysisActive(),
+		queryStringAppender: { params: getDefaultQueryParams() },
 	};
 
 	configuration = merge( configuration, customConfiguration );

--- a/tests/inc/test-class-wpseo-shortlinker.php
+++ b/tests/inc/test-class-wpseo-shortlinker.php
@@ -75,4 +75,18 @@ class WPSEO_Shortlinker_Test extends PHPUnit_Framework_TestCase {
 		$this->assertContains( 'platform_version', $encoded_query );
 		$this->assertContains( 'software', $encoded_query );
 	}
+
+	/**
+	 * Tests getting the query params.
+	 *
+	 * @covers WPSEO_Shortlinker::get_query_params
+	 * @covers WPSEO_Shortlinker::collect_additional_shortlink_data
+	 */
+	public function test_get_query_params() {
+		$query_param_keys = array_keys( WPSEO_Shortlinker::get_query_params() );
+
+		$this->assertContains( 'php_version', $query_param_keys );
+		$this->assertContains( 'platform_version', $query_param_keys );
+		$this->assertContains( 'software', $query_param_keys );
+	}
 }

--- a/tests/inc/test-class-wpseo-shortlinker.php
+++ b/tests/inc/test-class-wpseo-shortlinker.php
@@ -63,20 +63,6 @@ class WPSEO_Shortlinker_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Tests getting the encoded query data.
-	 *
-	 * @covers WPSEO_Shortlinker::get_encoded_query
-	 * @covers WPSEO_Shortlinker::collect_additional_shortlink_data
-	 */
-	public function test_get_encoded_query() {
-		$encoded_query = WPSEO_Shortlinker::get_encoded_query();
-
-		$this->assertContains( 'php_version', $encoded_query );
-		$this->assertContains( 'platform_version', $encoded_query );
-		$this->assertContains( 'software', $encoded_query );
-	}
-
-	/**
 	 * Tests getting the query params.
 	 *
 	 * @covers WPSEO_Shortlinker::get_query_params


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Change the exposed shortlinks `default_query_params` to be an array instead of a string [introduced in PR](https://github.com/Yoast/wordpress-seo/pull/11285). Because this is how it is handled on the JS side.
* Includes the `default_query_params` in the analysis worker initialize call.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Ensure that the `default_query_params` key has been properly exposed and contains the correct system information. The easiest way to check this is by calling `wpseoAdminL10n.default_query_params` in your browser's console.
* _Can only be done in development_ See the console for the first `wrapper -> worker initialize` message. Ensure `queryStringAppender` is included in the configuration object and contains the same object as above.
* Goto https://github.com/Yoast/YoastSEO.js/pull/1877 for the other test steps.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/YoastSEO.js/issues/1876
