### PR TITLE
Add permalink warning on settings page

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -48,6 +48,7 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_init', array( $this, 'show_hook_deprecation_warnings' ) );
 		add_action( 'admin_init', array( 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ) );
 		add_action( 'admin_init', array( $this, 'handle_notifications' ), 15 );
+		add_action( 'admin_notices', array( $this, 'permalink_settings_notice' ) );
 
 		$listeners   = array();
 		$listeners[] = new WPSEO_Post_Type_Archive_Notification_Handler();
@@ -704,5 +705,22 @@ class WPSEO_Admin_Init {
 	 */
 	private function has_postname_in_permalink() {
 		return ( false !== strpos( get_option( 'permalink_structure' ), '%postname%' ) );
+	}
+
+	/**
+	 * Shows a notice on the permalink settings page.
+	 */
+	public function permalink_settings_notice() {
+		global $pagenow;
+
+		if ( $pagenow === 'options-permalink.php' ) {
+			$warning = esc_html__( 'WARNING:', 'wordpress-seo' );
+			/* translators: %1$s and %2$s expand to <i> items to emphasize the word in the middle. */
+			$message = esc_html__( 'Changing your permalinks settings can seriously impact your search engine visibility. It should almost %1$s never %2$s be done on a live website.', 'wordpress-seo' );
+			$link = esc_html__( 'Learn about why permalinks are important for SEO.', 'wordpress-seo' );
+			$url = WPSEO_Shortlinker::get( 'https://yoa.st/why-permalinks/' );
+
+			echo '<div class="notice notice-warning"><p><strong>' . $warning . '</strong><br>' . sprintf( $message, '<i>', '</i>' ) . '<br><a href="' . $url . '" target="_blank">' . $link . '</a></p></div>';
+		}
 	}
 }


### PR DESCRIPTION
I preferred to maintain the Wordpress look and feel for the warning box. But I may change it according to the issue if necessary.
![image](https://user-images.githubusercontent.com/3065339/47151696-d71ed800-d2b0-11e8-95f1-ebaf738cb09a.png)


## Summary

This PR can be summarized in the following changelog entry:

* Adds a warning notification to the permalink settings page, linking to a KN article. Props to @valtlfelipe 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Going to Permalink settings page

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9616
