### PR TITLE
Fix SeoAnalysis proptype errors

### DIFF
--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -299,7 +299,6 @@ class SeoAnalysis extends React.Component {
 SeoAnalysis.propTypes = {
 	results: PropTypes.array,
 	marksButtonStatus: PropTypes.string.isRequired,
-	hideMarksButtons: PropTypes.bool.isRequired,
 	keyword: PropTypes.string,
 	onFocusKeywordChange: PropTypes.func.isRequired,
 	shouldUpsell: PropTypes.bool,
@@ -328,11 +327,11 @@ function mapStateToProps( state, ownProps ) {
 
 	const keyword = state.focusKeyword;
 
-	let results = null;
-	let overallScore = null;
+	let results = [];
+	let overallScore = 0;
 	if ( state.analysis.seo[ keyword ] ) {
 		results = state.analysis.seo[ keyword ].results;
-		overallScore = state.analysis.seo[ keyword ].overallScore;
+		overallScore = state.analysis.seo[ keyword ].overallScore || 0;
 	}
 	return {
 		results,

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -303,7 +303,7 @@ SeoAnalysis.propTypes = {
 	onFocusKeywordChange: PropTypes.func.isRequired,
 	shouldUpsell: PropTypes.bool,
 	shouldUpsellWordFormRecognition: PropTypes.bool,
-	overallScore: PropTypes.number.isRequired,
+	overallScore: PropTypes.number,
 	location: PropTypes.string.isRequired,
 };
 
@@ -312,6 +312,7 @@ SeoAnalysis.defaultProps = {
 	keyword: "",
 	shouldUpsell: false,
 	shouldUpsellWordFormRecognition: false,
+	overallScore: null,
 };
 
 /**
@@ -328,10 +329,10 @@ function mapStateToProps( state, ownProps ) {
 	const keyword = state.focusKeyword;
 
 	let results = [];
-	let overallScore = 0;
+	let overallScore = null;
 	if ( state.analysis.seo[ keyword ] ) {
 		results = state.analysis.seo[ keyword ].results;
-		overallScore = state.analysis.seo[ keyword ].overallScore || 0;
+		overallScore = state.analysis.seo[ keyword ].overallScore;
 	}
 	return {
 		results,

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -298,7 +298,7 @@ class SeoAnalysis extends React.Component {
 
 SeoAnalysis.propTypes = {
 	results: PropTypes.array,
-	marksButtonStatus: PropTypes.string.isRequired,
+	marksButtonStatus: PropTypes.string,
 	keyword: PropTypes.string,
 	onFocusKeywordChange: PropTypes.func.isRequired,
 	shouldUpsell: PropTypes.bool,
@@ -309,6 +309,7 @@ SeoAnalysis.propTypes = {
 
 SeoAnalysis.defaultProps = {
 	results: [],
+	marksButtonStatus: null,
 	keyword: "",
 	shouldUpsell: false,
 	shouldUpsellWordFormRecognition: false,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* I've changed the default of `results` in mapStateToProps to make it more sensible.
* The overallScore prop is no longer required. The default value is `null`, to make sure the loading spinner is shown as long as there is no overallScore set. 
* The marksButtonStatus prop is no longer required. The default value is `null`, to make sure there are no prop type warnings on the first pass of mapStateToProps, before the marksButtonStatus is set.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout release/9.0. Open the analysis at a post. Check that the console errors from the issue are there.
* Checkout this branch. Open the analysis at a post. Check that the console errors from the issue are gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11323
