### PR TITLE
Fix upsell button line height

### DIFF
--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -470,7 +470,7 @@ td.column-wpseo-linked {
 	filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 	min-height: 48px;
 	text-transform: initial;
-	// Make space on the right for the caret background image. 9px at the top to vertically align with the caret.
+	// Make space on the right for the caret background image. 9px at the top to vertically align the text with the caret.
 	padding: 9px 1.5em 9px 1em;
 	box-sizing: border-box;
 	background: $color-button-upsell url(svg-icon-caret-right()) 97% 45% no-repeat;

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -470,13 +470,13 @@ td.column-wpseo-linked {
 	filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 	min-height: 48px;
 	text-transform: initial;
-	padding-left: 1em;
-	// Make space for the caret background image.
-	padding-right: 1.5em;
+	// Make space on the right for the caret background image. 9px at the top to vertically align with the caret.
+	padding: 9px 1.5em 9px 1em;
+	box-sizing: border-box;
 	background: $color-button-upsell url(svg-icon-caret-right()) 97% 45% no-repeat;
 	display: inline-block;
 	text-decoration: none;
-	line-height: 42px;
+	line-height: 24px;
 
 	&:hover,
 	&:focus,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Test for all buttons listed here https://github.com/Yoast/wordpress-seo/issues/10980#issue-359451824 that the line height is in proportion, when the text is spread over multiple lines (on small screens).
* Also check that those buttons still look nice on bigger screens.

Before:
<img width="301" alt="schermafbeelding 2018-10-05 om 11 52 09" src="https://user-images.githubusercontent.com/17744553/46528861-1f8fcc00-c895-11e8-87c0-e8206368658c.png">

After:
<img width="269" alt="schermafbeelding 2018-10-18 om 15 53 10" src="https://user-images.githubusercontent.com/17744553/47159350-f4be6280-d2ed-11e8-8499-18b92572d784.png">

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11189
