### PR TITLE
Improve the upsell button caret icon position in RTL languages

### DIFF
--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -77,8 +77,10 @@ class WPSEO_Premium_Popup {
 		$assets_uri = trailingslashit( plugin_dir_url( WPSEO_FILE ) );
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$cta_text = sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
-		$classes  = '';
+		$cta_text        = sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+		$new_tab_message = '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>';
+		$caret_icon      = '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+		$classes         = '';
 		if ( $popup ) {
 			$classes = ' hidden';
 		}
@@ -89,7 +91,9 @@ class WPSEO_Premium_Popup {
 	<img class="alignright wpseo-premium-popup-icon" src="{$assets_uri}images/Yoast_SEO_Icon.svg" width="150" height="150" alt="Yoast SEO"/>
 	<{$this->heading_level} id="wpseo-contact-support-popup-title" class="wpseo-premium-popup-title">{$this->title}</{$this->heading_level}>
 	{$this->content}
-	<a id="wpseo-{$this->identifier}-popup-button" class="yoast-button-upsell" href="{$this->url}" target="_blank" rel="noreferrer noopener">{$cta_text}</a><br/>
+	<a id="wpseo-{$this->identifier}-popup-button" class="yoast-button-upsell" href="{$this->url}" target="_blank">
+		{$cta_text} {$new_tab_message} {$caret_icon}
+	</a><br/>
 	<small>{$micro_copy}</small>
 </div>
 EO_POPUP;

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -211,7 +211,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 					echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 				?></a>
 
-				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zy' ); ?>" class="yoast-link--more-info"><?php
+				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zy' ); ?>" class="yoast-link--more-info">
+					<?php
 					printf(
 						/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 						__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
@@ -220,7 +221,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 						$extension->get_title()
 					);
 					echo $new_tab_message;
-				?></a>
+					?>
+				 </a>
 			<?php endif; ?>
 			<?php if ( ! $extensions->is_activated( 'wordpress-seo-premium' ) ) { ?>
 				<p><small class="yoast-money-back-guarantee"><?php esc_html_e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small></p>
@@ -275,7 +277,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 							?></a>
 
-							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension->get_info_url() ); ?>"><?php
+							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension->get_info_url() ); ?>">
+								<?php
 								printf(
 									/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 									__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
@@ -284,7 +287,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 									$extension->get_title()
 								);
 								echo $new_tab_message;
-							?></a>
+								?>
+							</a>
 						<?php endif; ?>
 					</div>
 				</section>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -197,11 +197,14 @@ $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Y
 
 			<?php else : ?>
 
-				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zz' ); ?>" class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-buy">
+				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zz' ); ?>" class="yoast-button-upsell">
 					<?php
-					/* translators: $1$s expands to Yoast SEO Premium */
-					printf( __( 'Buy %1$s', 'wordpress-seo' ), $extension->get_title() );
-					?></a>
+						/* translators: $1$s expands to Yoast SEO Premium */
+						printf( __( 'Buy %1$s', 'wordpress-seo' ), $extension->get_title() );
+						echo '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>';
+						echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+					?>
+				</a>
 
 				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zy' ); ?>" class="yoast-link--more-info"><?php
 					printf(
@@ -252,9 +255,13 @@ $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Y
 								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
 							<?php endif; ?>
 						<?php else : ?>
-							<a target="_blank" class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-buy" href="<?php echo esc_url( $extension->get_buy_url() ); ?>">
-								<?php /* translators: %s expands to the product name */ ?>
-								<?php printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() ); ?>
+							<a target="_blank" class="yoast-button-upsell" href="<?php echo esc_url( $extension->get_buy_url() ); ?>">
+								<?php
+									/* translators: %s expands to the product name */
+									printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
+									echo '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>';
+									echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+								?>
 							</a>
 
 							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension->get_info_url() ); ?>"><?php

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -138,6 +138,7 @@ if ( WPSEO_Utils::is_woocommerce_active() ) {
 
 /* translators: %1$s expands to Yoast SEO. */
 $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );
+$new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>'
 
 ?>
 
@@ -188,23 +189,27 @@ $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Y
 
 				<?php if ( $extensions->is_activated( 'wordpress-seo-premium' ) ) : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php
+						esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' );
+						echo $new_tab_message;
+					?></a>
 				<?php else : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
+						esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' );
+						echo $new_tab_message;
+					?></a>
 				<?php endif; ?>
 				</a>
 
 			<?php else : ?>
 
-				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zz' ); ?>" class="yoast-button-upsell">
-					<?php
-						/* translators: $1$s expands to Yoast SEO Premium */
-						printf( __( 'Buy %1$s', 'wordpress-seo' ), $extension->get_title() );
-						echo '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>';
-						echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
-					?>
-				</a>
+				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zz' ); ?>" class="yoast-button-upsell"><?php
+					/* translators: $1$s expands to Yoast SEO Premium */
+					printf( __( 'Buy %1$s', 'wordpress-seo' ), $extension->get_title() );
+					echo $new_tab_message;
+					echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+				?></a>
 
 				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zy' ); ?>" class="yoast-link--more-info"><?php
 					printf(
@@ -212,8 +217,10 @@ $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Y
 						__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 						'<span class="screen-reader-text">',
 						'</span>',
-						$extension->get_title() );
-					?></a>
+						$extension->get_title()
+					);
+					echo $new_tab_message;
+				?></a>
 			<?php endif; ?>
 			<?php if ( ! $extensions->is_activated( 'wordpress-seo-premium' ) ) { ?>
 				<p><small class="yoast-money-back-guarantee"><?php esc_html_e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small></p>
@@ -249,20 +256,24 @@ $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Y
 
 							<?php if ( $extensions->is_activated( $id ) ) : ?>
 								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' ); ?></a>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php
+									esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' );
+									echo $new_tab_message;
+								?></a>
 							<?php else : ?>
 								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' ); ?></a>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
+									esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' );
+									echo $new_tab_message;
+								?></a>
 							<?php endif; ?>
 						<?php else : ?>
-							<a target="_blank" class="yoast-button-upsell" href="<?php echo esc_url( $extension->get_buy_url() ); ?>">
-								<?php
-									/* translators: %s expands to the product name */
-									printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
-									echo '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>';
-									echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
-								?>
-							</a>
+							<a target="_blank" class="yoast-button-upsell" href="<?php echo esc_url( $extension->get_buy_url() ); ?>"><?php
+								/* translators: %s expands to the product name */
+								printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
+								echo $new_tab_message;
+								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+							?></a>
 
 							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension->get_info_url() ); ?>"><?php
 								printf(
@@ -270,9 +281,10 @@ $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Y
 									__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 									'<span class="screen-reader-text">',
 									'</span>',
-									$extension->get_title() );
-								?>
-							</a>
+									$extension->get_title()
+								);
+								echo $new_tab_message;
+							?></a>
 						<?php endif; ?>
 					</div>
 				</section>

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -36,6 +36,8 @@ $wpseo_plugin_dir_url = plugin_dir_url( WPSEO_FILE );
 				<?php
 				/* translators: %s is replaced by the plugin name */
 				printf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+				echo '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>';
+				echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 				?>
 			</a><br>
 		</div>

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -215,9 +215,15 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 			. $first_sentence
 			. ' ' . __( 'Search engines and other websites can still send traffic to your deleted post.', 'wordpress-seo' )
 			. ' ' . __( 'You should create a redirect to ensure your visitors do not get a 404 error when they click on the no longer working URL.', 'wordpress-seo' )
-			. ' ' . __( 'With Yoast SEO Premium, you can easily create such redirects.', 'wordpress-seo' )
+			/* translators: %s expands to Yoast SEO Premium */
+			. ' ' . sprintf( __( 'With %s, you can easily create such redirects.', 'wordpress-seo' ), 'Yoast SEO Premium' )
 			. '</p>'
-			. '<p><a class="yoast-button-upsell" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">' . __( 'Get Yoast SEO Premium', 'wordpress-seo' ) . '</a></p>';
+			. '<p><a class="yoast-button-upsell" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1d0' ) . '" target="_blank">'
+			/* translators: %s expands to Yoast SEO Premium */
+			. sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' )
+			. '<span class="screen-reader-text">' . __( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>'
+			. '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>'
+			. '</a></p>';
 	}
 
 	/**

--- a/css/src/_icons.scss
+++ b/css/src/_icons.scss
@@ -21,3 +21,7 @@
 @function svg-icon-caret-right() {
 	@return inline-svg('<svg width="16" height="16" viewBox="0 0 192 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path fill="#{$color-black}" d="M 0 384.662 V 127.338 c 0 -17.818 21.543 -26.741 34.142 -14.142 l 128.662 128.662 c 7.81 7.81 7.81 20.474 0 28.284 L 34.142 398.804 C 21.543 411.404 0 402.48 0 384.662 Z"/></svg>');
 }
+
+@function svg-icon-caret-left() {
+	@return inline-svg('<svg width="16" height="16" viewBox="0 0 192 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path fill="#{$color-black}" d="M192 127.338v257.324c0 17.818-21.543 26.741-34.142 14.142L29.196 270.142c-7.81-7.81-7.81-20.474 0-28.284l128.662-128.662c12.599-12.6 34.142-3.676 34.142 14.142z"/></svg>');
+}

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -464,6 +464,7 @@ td.column-wpseo-linked {
 .yoast-button-upsell {
 	display: inline-flex;
 	align-items: center;
+	justify-content: center;
 	font-size: 16px;
 	font-family: $font-stack-default;
 	color: $color-black;

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -462,6 +462,8 @@ td.column-wpseo-linked {
 }
 
 .yoast-button-upsell {
+	display: inline-flex;
+	align-items: center;
 	font-size: 16px;
 	font-family: $font-stack-default;
 	color: $color-black;
@@ -469,14 +471,10 @@ td.column-wpseo-linked {
 	box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2);
 	filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 	min-height: 48px;
-	text-transform: initial;
-	padding-left: 1em;
-	// Make space for the caret background image.
-	padding-right: 1.5em;
-	background: $color-button-upsell url(svg-icon-caret-right()) 97% 45% no-repeat;
-	display: inline-block;
+	padding: 0 1em;
 	text-decoration: none;
 	line-height: 42px;
+	background-color: $color-button-upsell;
 
 	&:hover,
 	&:focus,
@@ -507,5 +505,17 @@ td.column-wpseo-linked {
 
 	&#wpseo-premium-button {
 		color: $color-black;
+	}
+
+	&__caret {
+		width: 8px;
+		height: 16px;
+		// Negative margin to compensate the icon white space within its viewbox.
+		margin: 0 -2px 0 6px;
+		background: transparent url(svg-icon-caret-right()) center no-repeat;
+
+		.rtl & {
+			background-image: url(svg-icon-caret-left());
+		}
 	}
 }

--- a/css/src/extensions.scss
+++ b/css/src/extensions.scss
@@ -67,48 +67,6 @@
 				margin-left: 0;
 			}
 
-			&-buy {
-				font-size: 16px;
-				color: $color-black;
-				border-radius: 4px;
-				box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2);
-				filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
-				min-height: 48px;
-				text-transform: initial;
-				padding-left: 1em;
-				// Make space for the caret background image.
-				padding-right: 1.5em;
-				background: $color-button-upsell url(svg-icon-caret-right()) 97% 45% no-repeat;
-
-				&:hover,
-				&:focus,
-				&:active {
-					color: $color-black;
-					background-color: $color-button-upsell-hover;
-					text-decoration: none;
-				}
-
-				// Keep grey inset and add blue focus style.
-				&:focus {
-					box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2), 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, .8);
-				}
-
-				&:active {
-					transform: translateY( 1px );
-					box-shadow: none;
-					filter: none;
-				}
-
-				// Only needed for IE 10+. Don't add spaces within brackets for this to work.
-				@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-					::after {
-						display: inline-block;
-						content: "";
-						min-height: 32px;
-					}
-				}
-			}
-
 			&-installed, &-activated, &-not-activated {
 				&:hover {
 					text-decoration: none;
@@ -134,7 +92,17 @@
 					background-color: $color_green_medium;
 				}
 			}
+		}
 
+		&-upsell {
+			width: 100%;
+			margin-bottom: 1em;
+
+			@media only screen and (min-width: $page-width-small) {
+				width: auto;
+				margin-right: 1.36rem;
+				margin-bottom: 0;
+			}
 		}
 	}
 
@@ -147,9 +115,6 @@
 			width: 100%;
 			margin-left: $gutter;
 			margin-bottom: $gutter;
-		}
-		.yoast-button.yoast-button--extension-buy {
-			font-size: 16px;
 		}
 	}
 
@@ -213,7 +178,10 @@
 					width: 48%;
 				}
 			}
+		}
 
+		.yoast-button-upsell {
+			width: 100%;
 		}
 
 		h3 {
@@ -270,7 +238,7 @@
 		padding-left: calc( 1em + 5px );
 		background-size: 1em;
 		background-repeat: no-repeat;
-		background-position: left 0.2em;
+		background-position: left center;
 
 		&:after {
 			content: " \00BB";
@@ -279,7 +247,7 @@
 		.yoast-promo-extension & {
 			display: block;
 			margin: 1em 0 0 0;
-			background-position: left 0.4em;
+			background-position: left center;
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- introduces a new (left) caret icon 
- instead of using background images directly on the button, use the image as background of an inline `<span>` element so it behaves like inline content
- refactors the CSS to use `inline-flex` so the text and the icon are better aligned vertically
- the upsell button can now be used also without an icon (if necessary) so it's better reusable
- reuses the `yoast-button-upsell` also in the Extensions page
- adds the "new tab message" to all links that open in a new tab in the extensions page.

## Test instructions
The upsell button needs to be checked everywhere it appears, and also in the responsive view. As far as I know, it is used:
- in the notice when trashing a published post
- in the Help Center > Get support
- in the sidebar in the admin pages
- in the extensions page (SEO > Premium) also known as "licenses" page `wp-admin/admin.php?page=wpseo_licenses`

All these places need to be tested in LTR and RTL.

Example screenshot:

<img width="508" alt="screen shot 2018-10-18 at 15 51 44" src="https://user-images.githubusercontent.com/1682452/47159298-d5273a00-d2ed-11e8-912a-2849cc6b004f.png">


Fixes #11174
