### PR TITLE
Fix Go Premium button flexbox in IE11

### DIFF
--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -8,7 +8,6 @@ import { colors, SvgIcon, UpsellLinkButton, utils } from "yoast-components";
 
 const TextContainer = styled.p`
 	color: ${ colors.$color_upsell_text };
-	flex: 1;
 	margin: 0;
 	padding-right: 8px;
 `;
@@ -25,10 +24,6 @@ const Container = styled.div`
 	> ${ TextContainer } {
 		margin-bottom: ${ props => props.alignment === "vertical" && "16px" };
 	}
-`;
-
-const ButtonContainer = styled.div`
-	flex: 0;
 `;
 
 const Caret = styled( SvgIcon )`
@@ -60,7 +55,7 @@ const AnalysisUpsell = ( props ) => {
 					"Yoast SEO Premium"
 				) }
 			</TextContainer>
-			<ButtonContainer>
+			<div>
 				<OutboundLinkButton href={ url }>
 					{ sprintf(
 						/* translators: %s expands to Premium */
@@ -69,7 +64,7 @@ const AnalysisUpsell = ( props ) => {
 					) }
 					<Caret icon="arrow-right" size="8px" color={ colors.$color_black } />
 				</OutboundLinkButton>
-			</ButtonContainer>
+			</div>
 		</Container>
 	);
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- allows the flex items to be sized accordingly to their content:

## Test instructions
- test in IE11 the buttons in the metabox and sidebar look OK; previously, they looked this way:

![screenshot 106](https://user-images.githubusercontent.com/1682452/47164189-d198b080-d2f7-11e8-9ac6-bd1e115fbaee.png)

- check in modern browsers there are no visible changes (see screenshots below)

Chrome before:

<img width="1202" alt="screen shot 2018-10-18 at 16 32 49" src="https://user-images.githubusercontent.com/1682452/47163806-0e17dc80-d2f7-11e8-8544-63264e4598b2.png">

Chrome after:

<img width="1203" alt="screen shot 2018-10-18 at 16 47 49" src="https://user-images.githubusercontent.com/1682452/47163817-13752700-d2f7-11e8-8e6b-60e6c150b5ff.png">

Fixes #11331
