### PR TITLE
Only show default opengraph image when content doesn't contain images.

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -523,7 +523,7 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @return void
 	 */
-	private function set_images() {
+	protected function set_images() {
 		/**
 		 * Filter: wpseo_add_opengraph_images - Allow developers to add images to the OpenGraph tags.
 		 *
@@ -649,11 +649,10 @@ class WPSEO_OpenGraph_Image {
 		return get_queried_object_id();
 	}
 
-
 	/**
 	 * Adds the first usable attachment image from the post content.
 	 *
-	 * @param object $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return void
 	 */

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -329,15 +329,20 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	private function maybe_set_default_image() {
-		if (
-			$this->has_images() ||
-			WPSEO_Options::get( 'og_default_image', '' ) === ''
-		) {
+		if ( $this->has_images() ) {
 			return;
 		}
 
-		$default_image_url = WPSEO_Options::get( 'og_default_image' );
-		$default_image_id = WPSEO_Options::get( 'og_default_image_id' );
+		if ( $this->content_contain_images() ) {
+			return;
+		}
+
+		$default_image_url = WPSEO_Options::get( 'og_default_image', '' );
+		$default_image_id  = WPSEO_Options::get( 'og_default_image_id', '' );
+
+		if ( $default_image_url === '' && $default_image_id === '' ) {
+			return;
+		}
 
 		$this->add_image_by_id_or_url( $default_image_id, $default_image_url, array( $this, 'save_default_image_id' ) );
 	}

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -641,4 +641,36 @@ class WPSEO_OpenGraph_Image {
 	protected function get_queried_object_id() {
 		return get_queried_object_id();
 	}
+
+	/**
+	 * Checks if the post content contains any images.
+	 *
+	 * @return bool Whether there is an image in then or not.
+	 */
+	private function content_contain_images() {
+		$post = get_post();
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		/**
+		 * Filter: 'wpseo_pre_analysis_post_content' - Allow filtering the content before analysis.
+		 *
+		 * @api string $post_content The Post content string
+		 *
+		 * @param object $post - The post object.
+		 */
+		$content = apply_filters( 'wpseo_pre_analysis_post_content', $post->post_content, $post );
+
+		if ( preg_match_all( '`<img [^>]+>`', $content, $matches ) ) {
+			foreach ( $matches[0] as $img ) {
+				if ( preg_match( '`src=(["\'])(.*?)\1`', $img, $match ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 }

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -435,6 +435,10 @@ class WPSEO_Twitter {
 				$this->gallery_images_output();
 				return;
 			}
+
+			if ( $this->image_from_content_output( $post_id ) ) {
+				return;
+			}
 		}
 	}
 
@@ -592,6 +596,31 @@ class WPSEO_Twitter {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Retrieve the image from the content.
+	 *
+	 * @param int $post_id The post id to extract the images from.
+	 *
+	 * @return bool True when images output succeeded.
+	 */
+	private function image_from_content_output( $post_id ) {
+		$image_finder = new WPSEO_Content_Images();
+		$images       = $image_finder->get_images( $post_id );
+
+		if ( ! is_array( $images ) || $images === array() ) {
+			return false;
+		}
+
+		$image_url = reset( $images );
+		if ( ! $image_url ) {
+			return false;
+		}
+
+		$this->image_output( $image_url );
+
+		return true;
 	}
 
 	/**

--- a/tests/doubles/class-opengraph-image-double.php
+++ b/tests/doubles/class-opengraph-image-double.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Opengraph_Image_Double extends WPSEO_OpenGraph_Image {
+
+	/**
+	 * @inheritdoc
+	 */
+	public function set_images() {
+		parent::set_images();
+	}
+}

--- a/tests/frontend/test-class-twitter.php
+++ b/tests/frontend/test-class-twitter.php
@@ -370,7 +370,19 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		self::$class_instance->image();
 		$this->expectOutput( $expected );
 	}
-	
+
+	/**
+	 * @covers WPSEO_Twitter::image()
+	 */
+	public function test_post_content_image() {
+		$url     = 'http://example.com/example.jpg';
+		$post_id = $this->factory->post->create( array( 'post_content' => "Bla <img src='$url'/> bla" ) );
+		$this->go_to( get_permalink( $post_id ) );
+		$expected = $this->metatag( 'image', $url );
+		self::$class_instance->image();
+		$this->expectOutput( $expected );
+	}
+
 	/**
 	 * Testing with a twitter title set for the taxonomy.
 	 *

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -411,6 +411,45 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Test getting the image from post content.
+	 *
+	 * @covers WPSEO_OpenGraph_Image::set_images()
+	 * @covers WPSEO_OpenGraph_Image::add_first_usable_content_image()
+	 */
+	public function test_get_images_from_content() {
+		$image_url    = 'https://cdn.yoast.com/app/uploads/2018/03/Caroline_Blog_SEO_FI-600x314.jpg';
+		$post_content = '<p>This is a post. It has an image hosted on a cdn:</p>	
+		<img src="' . $image_url . '"/>	
+		<p>End of post</p>';
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => $post_content,
+			)
+		);
+
+		$opengraph_image = $this
+			->getMockBuilder( 'WPSEO_Opengraph_Image_Double' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'add_image' ) )
+			->getMock();
+
+		$opengraph_image
+			->expects( $this->once() )
+			->method( 'add_image' )
+			->with(
+				array(
+					'url' => $image_url,
+				)
+			);
+
+		// Run our test.
+		$this->go_to( get_permalink( $post_id ) );
+
+		$opengraph_image->set_images();
+	}
+
+	/**
 	 * Test using an image that's already uploaded to another post as OG setting.
 	 */
 	public function test_uploaded_image_added_by_id() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Checkout `release/9.0`
1. Set a default opengraph image under Yoast - Social - Facebook
 Create a post (without any images being set in there)
1. Open the post and view its source. Verify that the default og image has been set as `og:image` metatag.
1. Edit the post by adding some images to its content.
1. View the source again and see the metatag is still there.
1. Checkout this branch
1. Refresh the page and see the first content image is set in the metatag

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have (re)added unittests to verify the code works as intended

Fixes #11345 
