### PR TITLE
Accepts both / and \ in filepaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/js/tests/setupTests.js",
     "transformIgnorePatterns": [
-      "/node_modules/(?!yoast-components|yoastseo|lodash-es).+\\.js$"
+      "[/\\\\]node_modules[/\\\\](?!yoast-components|yoastseo|lodash-es).+\\.js$"
     ],
     "testPathIgnorePatterns": [
       "/js/tests/edit.test.js"

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = function( env = { environment: "production" } ) {
 			rules: [
 				{
 					test: /.jsx?$/,
-					exclude: /node_modules\/(?!(yoast-components|gutenberg|yoastseo|@wordpress)\/).*/,
+					exclude: /node_modules[/\\](?!(yoast-components|gutenberg|yoastseo|@wordpress)[/\\]).*/,
 					use: [
 						{
 							loader: "babel-loader",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* This should fix the webpack build on windows. It was erroring because it couldn't find `babel-preset-stage-0`, that is probably in a babel config of one of our dependencies. Fixing the exclude should properly exclude those packages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended