### PR TITLE
Issue Fix: 11332 - Conf wizard welcome page in IE11

### DIFF
--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -51,8 +51,8 @@
 		text-align: center;
 		text-transform: uppercase;
 		box-shadow:
-			rgba( $color_black, 0.12 ) 0px 1px 6px,
-			rgba( $color_black, 0.12 ) 0px 1px 4px;
+						rgba( $color_black, 0.12 ) 0px 1px 6px,
+						rgba( $color_black, 0.12 ) 0px 1px 4px;
 		transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 
 		&:hover {
@@ -63,15 +63,15 @@
 		&:focus {
 			outline: none;
 			box-shadow:
-				0 0 0 1px #5b9dd9,
-				0 0 2px 1px rgba(30, 140, 190, .8);
+							0 0 0 1px #5b9dd9,
+							0 0 2px 1px rgba(30, 140, 190, .8);
 		}
 
 		&:active {
 			background: rgb( 235, 235, 235 );
 			box-shadow:
-				rgba( $color_black, 0.16 ) 0px 3px 10px,
-				rgba( $color_black, 0.23 ) 0px 3px 10px;
+							rgba( $color_black, 0.16 ) 0px 3px 10px,
+							rgba( $color_black, 0.23 ) 0px 3px 10px;
 			transform: none;
 		}
 
@@ -179,6 +179,10 @@
 	&--choice {
 		& > .yoast-wizard--rows {
 			height: 100%;
+			/* Target IE10+ */
+			@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+				width:100%;
+			}
 		}
 
 		& div {
@@ -234,6 +238,10 @@
 
 			& > div {
 				margin-left: 0;
+				/* Target IE10+ */
+				@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+					width:95.5%;
+				}
 			}
 
 			& > .yoast-wizard--column__push_ {

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -51,8 +51,8 @@
 		text-align: center;
 		text-transform: uppercase;
 		box-shadow:
-						rgba( $color_black, 0.12 ) 0px 1px 6px,
-						rgba( $color_black, 0.12 ) 0px 1px 4px;
+			rgba( $color_black, 0.12 ) 0px 1px 6px,
+			rgba( $color_black, 0.12 ) 0px 1px 4px;
 		transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 
 		&:hover {
@@ -63,15 +63,15 @@
 		&:focus {
 			outline: none;
 			box-shadow:
-							0 0 0 1px #5b9dd9,
-							0 0 2px 1px rgba(30, 140, 190, .8);
+				0 0 0 1px #5b9dd9,
+				0 0 2px 1px rgba(30, 140, 190, .8);
 		}
 
 		&:active {
 			background: rgb( 235, 235, 235 );
 			box-shadow:
-							rgba( $color_black, 0.16 ) 0px 3px 10px,
-							rgba( $color_black, 0.23 ) 0px 3px 10px;
+				rgba( $color_black, 0.16 ) 0px 3px 10px,
+				rgba( $color_black, 0.23 ) 0px 3px 10px;
 			transform: none;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where texts in the configuration wizard would overlap each other and break out of the columns in Internet Explorer 11. Props [DrGrimshaw](https://github.com/DrGrimshaw)

## Relevant technical choices:

* Use of IE specific media queries so as to not affect other browsers

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use IE11 to view the welcome page of the configuration wizard

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11332
