### PR TITLE
Add question mark help link to readability analysis and change its color

### DIFF
--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -28,9 +28,7 @@ if ( window.wpseoPostScraperL10n ) {
 }
 
 const StyledHelpLink = styled( HelpLink )`
-	&::before {
-		padding: 0px 2px 2px 2px;
-	}
+	margin: -8px 0 -4px 4px;
 `;
 
 /**

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -5,13 +5,13 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
-import { utils } from "yoast-components";
 import isNil from "lodash/isNil";
 
 import Results from "./Results";
 import Collapsible from "../SidebarCollapsible";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
 import { getIconForScore } from "./mapResults";
+import { HelpLink } from "./SeoAnalysis";
 
 const AnalysisHeader = styled.span`
 	font-size: 1em;
@@ -27,8 +27,11 @@ if ( window.wpseoPostScraperL10n ) {
 	localizedData = wpseoTermScraperL10n;
 }
 
-const { makeOutboundLink } = utils;
-const LearnMoreLink = makeOutboundLink();
+const StyledHelpLink = styled( HelpLink )`
+	&::before {
+		padding: 0px 2px 2px 2px;
+	}
+`;
 
 /**
  * Redux container for the readability analysis.
@@ -50,14 +53,17 @@ class ReadabilityAnalysis extends React.Component {
 			>
 				<AnalysisHeader>
 					{ __( "Analysis results", "wordpress-seo" ) }
+					<StyledHelpLink
+						href={ wpseoAdminL10n[ "shortlinks.readability_analysis_info" ] }
+						rel={ null }
+						className="dashicons"
+					>
+						<span className="screen-reader-text">
+							{ __( "Learn more about the readability analysis", "wordpress-seo" ) }
+						</span>
+					</StyledHelpLink>
 				</AnalysisHeader>
-				<p>
-					{ __( "This analysis checks your writing for grammar and writing style so your content " +
-						"is as clear as it can be.", "wordpress-seo" ) + " " }
-					<LearnMoreLink href={ wpseoAdminL10n[ "shortlinks.readability_analysis_info" ] } rel={ null }>
-						{ __( "Learn more about the readability analysis.", "wordpress-seo" ) }
-					</LearnMoreLink>
-				</p>
+
 				<Results
 					canChangeLanguage={ ! ( localizedData.settings_link === "" ) }
 					showLanguageNotice={ true }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -36,6 +36,20 @@ export const HelpLink = utils.makeOutboundLink( styled.a`
 	margin: -4px 0;
 	vertical-align: middle;
 
+	color: ${ colors.$color_help_text };
+	
+	&:hover,
+	&:focus {
+		color: ${ colors.$color_snippet_focus };	
+	}
+	
+	// Overwrite the default blue active color for links.
+	&:active {
+		color: ${ colors.$color_help_text };	
+	}
+	
+	
+
 	&::before {
 		position: absolute;
 		top: 0;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Remove readability help text.
* Add question mark help link to readability analysis.
* Change the colors of the link. The colors should be similar to those of the question marks in the settings. This means: grey by default and when active, and blue when focus or hovered. I used colors from the colors.json, which means that the colors are slightly different from those in the SEO settings (where WP colors are used).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check that the readability help text is gone.
* Check that there is a question amrk help link after 'analysis results' in the readability analysis, and check if the styling is right.
* Check the colors of the link button in the keyword analysis sections. Don't forget to test the hover style etc. Also test them in the related keyword sections in premium.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11359
