### PR TITLE
Change the type of the days, hours and minutes attributes from number to string

### DIFF
--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -12,13 +12,13 @@ const attributes = {
 		type: "boolean",
 	},
 	days: {
-		type: "number",
+		type: "string",
 	},
 	hours: {
-		type: "number",
+		type: "string",
 	},
 	minutes: {
-		type: "number",
+		type: "string",
 	},
 	description: {
 		type: "array",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Before, Gutenberg didn't check if the type of the attributes was the correct one. Days, hours and minutes were defined as type `number`, but were saved as `string`s  in the database. When you reopened the post, the mismatch causes the attributes to be stipped completely, which results in block validation errors. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install the Gutenberg 4.1 RC from https://make.wordpress.org/test/2018/10/19/call-for-testing-gutenberg-4-1-pre-release/
* See https://github.com/Yoast/wordpress-seo/issues/11364 for steps to reproduce. Make sure you set a duration in your how to block.
* Don't forget to test with Gutenberg 4.0 as well to make sure nothing breaks.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11364
