### PR TITLE
Fixes a bug where the featured image was not recognised in our SEO analysis is in Gutenberg. 

### DIFF
--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -172,13 +172,13 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		wp.data.subscribe( () => {
 			const featuredImageId = wp.data.select( "core/editor" ).getEditedPostAttribute( "featured_media" );
 
-			if ( featuredImageId === undefined || featuredImageId === null ) {
+			if ( typeof featuredImageId === "undefined" || featuredImageId === null ) {
 				return;
 			}
 
 			imageData = wp.data.select( "core" ).getMedia( featuredImageId );
 
-			if ( imageData === undefined ) {
+			if ( typeof imageData === "undefined" ) {
 				return;
 			}
 

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -163,28 +163,31 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		}
 
 		// Fallback for Gutenberg, as the featured image id does not exist there.
-		let imageData;
-		if ( isGutenbergDataAvailable() ) {
-			wp.data.subscribe( () => {
-				const featuredImageId = wp.data.select( "core/editor" ).getEditedPostAttribute( "featured_media" );
-
-				if ( featuredImageId === undefined ) {
-					return;
-				}
-
-				// Only continue if image data has changed.
-				if ( imageData !== wp.data.select( "core" ).getMedia( featuredImageId ) ) {
-
-					imageData = wp.data.select( "core" ).getMedia( featuredImageId );
-					if ( imageData === undefined ) {
-						return;
-					}
-
-					const featuredImageHTML = `<img src="` + imageData.source_url + `" alt="` + imageData.alt_text + `" >`;
-					featuredImagePlugin.setFeaturedImage( featuredImageHTML );
-				}
-			} );
+		if ( ! isGutenbergDataAvailable() ) {
+			return;
 		}
+
+		let imageData;
+		let previousImageData;
+		wp.data.subscribe( () => {
+			const featuredImageId = wp.data.select( "core/editor" ).getEditedPostAttribute( "featured_media" );
+
+			if ( featuredImageId === undefined || featuredImageId === null ) {
+				return;
+			}
+
+			imageData = wp.data.select( "core" ).getMedia( featuredImageId );
+
+			if ( imageData === undefined ) {
+				return;
+			}
+
+			if ( imageData !== previousImageData ) {
+				previousImageData = imageData;
+				const featuredImageHTML = `<img src="${imageData.source_url}" alt="${imageData.alt_text}" >`;
+				featuredImagePlugin.setFeaturedImage( featuredImageHTML );
+			}
+		} );
 	} );
 }( jQuery ) );
 

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -4,6 +4,7 @@
 /* jshint -W097 */
 /* jshint -W003 */
 import a11ySpeak from "a11y-speak";
+import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
 ( function( $ ) {
 	var featuredImagePlugin;
@@ -159,6 +160,22 @@ import a11ySpeak from "a11y-speak";
 		$featuredImageElement = $( "#set-post-thumbnail > img" );
 		if ( "undefined" !== typeof $featuredImageElement.prop( "src" ) ) {
 			featuredImagePlugin.setFeaturedImage( $( "#set-post-thumbnail " ).html() );
+		}
+
+		let imageData;
+		if ( isGutenbergDataAvailable() ) {
+			wp.data.subscribe( () => {
+				const featuredImageId = wp.data.select( "core/editor" ).getEditedPostAttribute( "featured_media" );
+
+				// Only continue if data has changed.
+				if ( imageData !== wp.data.select( "core" ).getMedia( featuredImageId ) ) {
+					imageData = wp.data.select( "core" ).getMedia( featuredImageId );
+					if ( imageData !== undefined ) {
+						const featuredImageHTML = `<img src=` + imageData.source_url + ` alt=` + imageData.alt_text + ` >`;
+						featuredImagePlugin.setFeaturedImage( featuredImageHTML );
+					}
+				}
+			} );
 		}
 	} );
 }( jQuery ) );

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -162,18 +162,26 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 			featuredImagePlugin.setFeaturedImage( $( "#set-post-thumbnail " ).html() );
 		}
 
+		// Fallback for Gutenberg, as the featured image id does not exist there.
 		let imageData;
 		if ( isGutenbergDataAvailable() ) {
 			wp.data.subscribe( () => {
 				const featuredImageId = wp.data.select( "core/editor" ).getEditedPostAttribute( "featured_media" );
 
-				// Only continue if data has changed.
+				if ( featuredImageId === undefined ) {
+					return;
+				}
+
+				// Only continue if image data has changed.
 				if ( imageData !== wp.data.select( "core" ).getMedia( featuredImageId ) ) {
+
 					imageData = wp.data.select( "core" ).getMedia( featuredImageId );
-					if ( imageData !== undefined ) {
-						const featuredImageHTML = `<img src=` + imageData.source_url + ` alt=` + imageData.alt_text + ` >`;
-						featuredImagePlugin.setFeaturedImage( featuredImageHTML );
+					if ( imageData === undefined ) {
+						return;
 					}
+
+					const featuredImageHTML = `<img src="` + imageData.source_url + `" alt="` + imageData.alt_text + `" >`;
+					featuredImagePlugin.setFeaturedImage( featuredImageHTML );
 				}
 			} );
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the featured image was not recognized in the SEO analysis when using Gutenberg. 

## Relevant technical choices:

* The featured image has no id anymore in Gutenberg, used the store instead to get the data for the analysis. 

## Test instructions
This PR can be tested by following these steps:

* Reproduce by creating a new post, with Gutenberg activated, and adding a new featured image. The SEO analysis should still give the red dot: 'Image alt attributes: No images appear on this page. Add some!'. 
* Open the same post in the classic editor and see the image is recognised correctly there.
* Checkout this branch and go back to the post in the Gutenberg editor: The image should now be recognised (orange dot). If you change the image's alt text so it includes your keyphrase you should get the green dot in the analysis.
* Replace the featured image and make sure it still works. 
 
## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11240 
