### PR TITLE
Use $ jQuery shortcut only within jQuery wrapper

### DIFF
--- a/js/src/wp-seo-admin-media.js
+++ b/js/src/wp-seo-admin-media.js
@@ -1,42 +1,42 @@
 /* global wpseoMediaL10n */
 /* global wp */
 
-/**
- * Returns the target HTML id for this button element.
- *
- * @param {Object} $button The image select button.
- * @returns {string} The HTML id for the URL input field.
- */
-function getTarget( $button ) {
-	$button = $( $button );
-
-	let target = $button.data( "target" );
-
-	// This is the implicit way to define which URL field to fill.
-	if ( ! target || target === "" ) {
-		target = $( $button ).attr( "id" ).replace( /_button$/, "" );
-	}
-
-	return target;
-}
-
-/**
- * Returns the hidden ID input element for this button.
- *
- * @param {Object} $button The image select button.
- * @returns {string} The HTML id for the ID input field.
- */
-function getIdTarget( $button ) {
-	$button = $( $button );
-
-	return $button.data( "target-id" );
-}
-
 // Taken and adapted from http://www.webmaster-source.com/2013/02/06/using-the-wordpress-3-5-media-uploader-in-your-plugin-or-theme/
 jQuery( document ).ready(
 	function( $ ) {
 		if ( typeof wp.media === "undefined" ) {
 			return;
+		}
+
+		/**
+		 * Returns the target HTML id for this button element.
+		 *
+		 * @param {Object} $button The image select button.
+		 * @returns {string} The HTML id for the URL input field.
+		 */
+		function getTarget( $button ) {
+			$button = $( $button );
+
+			let target = $button.data( "target" );
+
+			// This is the implicit way to define which URL field to fill.
+			if ( ! target || target === "" ) {
+				target = $( $button ).attr( "id" ).replace( /_button$/, "" );
+			}
+
+			return target;
+		}
+
+		/**
+		 * Returns the hidden ID input element for this button.
+		 *
+		 * @param {Object} $button The image select button.
+		 * @returns {string} The HTML id for the ID input field.
+		 */
+		function getIdTarget( $button ) {
+			$button = $( $button );
+
+			return $button.data( "target-id" );
 		}
 
 		$( ".wpseo_image_upload_button" ).each( function( index, element ) {

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,13 @@ You'll find answers to many of your questions on [kb.yoast.com](https://yoa.st/1
 
 == Changelog ==
 
+= 9.0.1 =
+Release Date: October 23rd, 2018
+
+Bugfixes:
+
+* Fixes error with using `$` in wp-seo-admin-media.js. Now we use `jQuery` instead.
+
 = 9.0.0 =
 Release Date: October 23rd, 2018
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes error with using `$` in wp-seo-admin-media.js. Now we use `jQuery` instead.

Fixes #11378