### PR TITLE
Change onBlur to unChange in the getProfileSelectBox to make the select input work again

### DIFF
--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -260,7 +260,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 
 		const profiles = this.state.profileList;
 		const profileKeys = Object.keys( profiles );
-
+		/* eslint-disable jsx-a11y/no-onchange */
 		return (
 			<div className="yoast-wizard-input">
 				<label
@@ -272,7 +272,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 				<select
 					className="yoast-wizard-input__select"
 					id="yoast-wizard-gsc-select-profile"
-					onBlur={ this.setProfile.bind( this ) }
+					onChange={ this.setProfile.bind( this ) }
 					name={ this.name } value={ this.state.profile }
 				>
 					<option value="">{ this.props.translate( "Choose a profile" ) }</option>
@@ -288,6 +288,7 @@ class ConnectGoogleSearchConsole extends React.Component {
 				</select>
 			</div>
 		);
+		/* eslint-enable jsx-a11y/no-onchange */
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Fixes a bug where it was impossible to select a site in the Search Console integration step in the configuration wizard.

## Relevant technical choices:

* While it might not be ideal a11y-wise (see https://github.com/Yoast/wordpress-seo/issues/11389#issuecomment-432589103), I've replaced `onBlur` by `onChange` again.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to step 8 op the configuration wizard. Connect to GSC and try to select a site.
   * on `master`: selecting a site is impossible
  * in this branch: selecting a site is possible. N.B. when you go to the next step and go back to step 8, you won't see the selected site (this is an unrelated issue). Go to the next step, refresh, and go back to step 8, instead. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11389
