### PR TITLE
Add aria labels to the title separators UI in the Search Appearance

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -208,13 +208,16 @@ class Yoast_Form {
 	 */
 	public function label( $text, $attr ) {
 		$defaults = array(
-			'class' => 'checkbox',
-			'close' => true,
-			'for'   => '',
+			'class'      => 'checkbox',
+			'close'      => true,
+			'for'        => '',
+			'aria_label' => '',
 		);
-		$attr     = wp_parse_args( $attr, $defaults );
 
-		echo "<label class='" . esc_attr( $attr['class'] ) . "' for='" . esc_attr( $attr['for'] ) . "'>$text";
+		$attr       = wp_parse_args( $attr, $defaults );
+		$aria_label = ( $attr['aria_label'] !== '' ) ? ' aria-label="' . esc_attr( $attr['aria_label'] ) . '"' : '';
+
+		echo "<label class='" . esc_attr( $attr['class'] ) . "' for='" . esc_attr( $attr['for'] ) . "'$aria_label>$text";
 		if ( $attr['close'] ) {
 			echo '</label>';
 		}
@@ -575,23 +578,33 @@ class Yoast_Form {
 
 		if ( is_string( $legend ) && '' !== $legend ) {
 
-			$defaults    = array(
+			$defaults = array(
 				'id'    => '',
 				'class' => 'radiogroup',
 			);
+
 			$legend_attr = wp_parse_args( $legend_attr, $defaults );
 
 			$this->legend( $legend, $legend_attr );
 		}
 
 		foreach ( $values as $key => $value ) {
+			$label      = $value;
+			$aria_label = '';
+
+			if ( is_array( $value ) ) {
+				$label = isset( $value['label'] ) ? $value['label'] : '';
+				$aria_label = isset( $value['friendly_label'] ) ? $value['friendly_label'] : '';
+			}
+
 			$key_esc = esc_attr( $key );
 			echo '<input type="radio" class="radio" id="' . $var_esc . '-' . $key_esc . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $this->options[ $var ], $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />';
 			$this->label(
-				$value,
+				$label,
 				array(
-					'for'   => $var_esc . '-' . $key_esc,
-					'class' => 'radio',
+					'for'        => $var_esc . '-' . $key_esc,
+					'class'      => 'radio',
+					'aria_label' => $aria_label,
 				)
 			);
 		}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -215,7 +215,10 @@ class Yoast_Form {
 		);
 
 		$attr       = wp_parse_args( $attr, $defaults );
-		$aria_label = ( $attr['aria_label'] !== '' ) ? ' aria-label="' . esc_attr( $attr['aria_label'] ) . '"' : '';
+		$aria_label = '';
+		if ( $attr['aria_label'] !== '' ) {
+			$aria_label = ' aria-label="' . esc_attr( $attr['aria_label'] ) . '"';
+		}
 
 		echo "<label class='" . esc_attr( $attr['class'] ) . "' for='" . esc_attr( $attr['for'] ) . "'$aria_label>$text";
 		if ( $attr['close'] ) {
@@ -593,7 +596,7 @@ class Yoast_Form {
 			$aria_label = '';
 
 			if ( is_array( $value ) ) {
-				$label = isset( $value['label'] ) ? $value['label'] : '';
+				$label      = isset( $value['label'] ) ? $value['label'] : '';
 				$aria_label = isset( $value['friendly_label'] ) ? $value['friendly_label'] : '';
 			}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -597,7 +597,7 @@ class Yoast_Form {
 
 			if ( is_array( $value ) ) {
 				$label      = isset( $value['label'] ) ? $value['label'] : '';
-				$aria_label = isset( $value['friendly_label'] ) ? $value['friendly_label'] : '';
+				$aria_label = isset( $value['aria_label'] ) ? $value['aria_label'] : '';
 			}
 
 			$key_esc = esc_attr( $key );

--- a/admin/config-ui/fields/class-field-choice.php
+++ b/admin/config-ui/fields/class-field-choice.php
@@ -24,17 +24,17 @@ class WPSEO_Config_Field_Choice extends WPSEO_Config_Field {
 	/**
 	 * Add a choice to the properties
 	 *
-	 * @param string $value              Value op the option.
-	 * @param string $label              Label to display for the value.
-	 * @param string $screen_reader_text Optional. Screenreader text to use.
+	 * @param string $value          Value op the option.
+	 * @param string $label          Label to display for the value.
+	 * @param string $friendly_label Optional. Human friendly label text to use.
 	 */
-	public function add_choice( $value, $label, $screen_reader_text = '' ) {
+	public function add_choice( $value, $label, $friendly_label = '' ) {
 		$choice = array(
 			'label' => $label,
 		);
 
-		if ( $screen_reader_text ) {
-			$choice['screenReaderText'] = $screen_reader_text;
+		if ( $friendly_label ) {
+			$choice['screenReaderText'] = $friendly_label;
 		}
 
 		$this->properties['choices'][ $value ] = $choice;

--- a/admin/config-ui/fields/class-field-choice.php
+++ b/admin/config-ui/fields/class-field-choice.php
@@ -26,7 +26,7 @@ class WPSEO_Config_Field_Choice extends WPSEO_Config_Field {
 	 *
 	 * @param string $value          Value op the option.
 	 * @param string $label          Label to display for the value.
-	 * @param string $friendly_label Optional. Human friendly label text to use.
+	 * @param string $friendly_label Optional. Explanatory label text to use.
 	 */
 	public function add_choice( $value, $label, $friendly_label = '' ) {
 		$choice = array(

--- a/admin/config-ui/fields/class-field-choice.php
+++ b/admin/config-ui/fields/class-field-choice.php
@@ -24,17 +24,17 @@ class WPSEO_Config_Field_Choice extends WPSEO_Config_Field {
 	/**
 	 * Add a choice to the properties
 	 *
-	 * @param string $value          Value op the option.
-	 * @param string $label          Label to display for the value.
-	 * @param string $friendly_label Optional. Explanatory label text to use.
+	 * @param string $value      Value op the option.
+	 * @param string $label      Label to display for the value.
+	 * @param string $aria_label Optional. Aria label text to use.
 	 */
-	public function add_choice( $value, $label, $friendly_label = '' ) {
+	public function add_choice( $value, $label, $aria_label = '' ) {
 		$choice = array(
 			'label' => $label,
 		);
 
-		if ( $friendly_label ) {
-			$choice['screenReaderText'] = $friendly_label;
+		if ( $aria_label ) {
+			$choice['screenReaderText'] = $aria_label;
 		}
 
 		$this->properties['choices'][ $value ] = $choice;

--- a/admin/config-ui/fields/class-field-separator.php
+++ b/admin/config-ui/fields/class-field-separator.php
@@ -19,20 +19,17 @@ class WPSEO_Config_Field_Separator extends WPSEO_Config_Field_Choice {
 		$this->set_property( 'label', __( 'Title Separator', 'wordpress-seo' ) );
 		$this->set_property( 'explanation', __( 'Choose the symbol to use as your title separator. This will display, for instance, between your post title and site name. Symbols are shown in the size they\'ll appear in the search results.', 'wordpress-seo' ) );
 
-		$this->add_choice( 'sc-dash', '-', __( 'Dash', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-ndash', '&ndash;', __( 'En dash', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-mdash', '&mdash;', __( 'Em dash', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-colon', ':', __( 'Colon', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-middot', '&middot;', __( 'Middle dot', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-bull', '&bull;', __( 'Bullet', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-star', '*', __( 'Asterisk', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-smstar', '&#8902;', __( 'Low asterisk', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-pipe', '|', __( 'Vertical bar', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-tilde', '~', __( 'Small tilde', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-laquo', '&laquo;', __( 'Left angle quotation mark', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-raquo', '&raquo;', __( 'Right angle quotation mark', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-lt', '&lt;', __( 'Less than sign', 'wordpress-seo' ) );
-		$this->add_choice( 'sc-gt', '&gt;', __( 'Greater than sign', 'wordpress-seo' ) );
+		$this->add_choices();
+	}
+
+	/**
+	 * Adds the title separator choices.
+	 */
+	public function add_choices() {
+		$choices = WPSEO_Option_Titles::get_instance()->get_separator_options_for_display();
+		foreach ( $choices as $key => $value ) {
+			$this->add_choice( $key, $value['label'], $value['friendly_label'] );
+		}
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-separator.php
+++ b/admin/config-ui/fields/class-field-separator.php
@@ -25,7 +25,7 @@ class WPSEO_Config_Field_Separator extends WPSEO_Config_Field_Choice {
 	/**
 	 * Adds the title separator choices.
 	 */
-	public function add_choices() {
+	protected function add_choices() {
 		$choices = WPSEO_Option_Titles::get_instance()->get_separator_options_for_display();
 		foreach ( $choices as $key => $value ) {
 			$this->add_choice( $key, $value['label'], $value['friendly_label'] );

--- a/admin/config-ui/fields/class-field-separator.php
+++ b/admin/config-ui/fields/class-field-separator.php
@@ -28,7 +28,7 @@ class WPSEO_Config_Field_Separator extends WPSEO_Config_Field_Choice {
 	protected function add_choices() {
 		$choices = WPSEO_Option_Titles::get_instance()->get_separator_options_for_display();
 		foreach ( $choices as $key => $value ) {
-			$this->add_choice( $key, $value['label'], $value['friendly_label'] );
+			$this->add_choice( $key, $value['label'], $value['aria_label'] );
 		}
 	}
 

--- a/admin/views/tabs/metas/paper-content/general/title-separator.php
+++ b/admin/views/tabs/metas/paper-content/general/title-separator.php
@@ -20,6 +20,6 @@ $title_separator_help = new WPSEO_Admin_Help_Panel(
 	echo $title_separator_help->get_panel_html();
 	$legend      = __( 'Title separator symbol', 'wordpress-seo' );
 	$legend_attr = array( 'class' => 'radiogroup screen-reader-text' );
-	$yform->radio( 'separator', WPSEO_Option_Titles::get_instance()->get_separator_options(), $legend, $legend_attr );
+	$yform->radio( 'separator', WPSEO_Option_Titles::get_instance()->get_separator_options_for_display(), $legend, $legend_attr );
 	?>
 </div>

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -117,8 +117,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @todo [JRF => testers] Check if the extra actions below would run into problems if an option
 	 * is updated early on and if so, change the call to schedule these for a later action on add/update
 	 * instead of running them straight away.
-	 *
-	 * @return \WPSEO_Option_Titles
 	 */
 	protected function __construct() {
 		parent::__construct();
@@ -141,7 +139,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	/**
 	 * Get the singleton instance of this class.
 	 *
-	 * @return object
+	 * @return self
 	 */
 	public static function get_instance() {
 		if ( ! ( self::$instance instanceof self ) ) {
@@ -714,7 +712,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 			}
 			unset( $rename, $taxonomy_names, $post_type_names, $defaults, $tax, $old_prefix, $new_prefix );
 		}
-
 
 		/*
 		 * Make sure the values of the variable option key options are cleaned as they

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -806,59 +806,59 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		$separators = array(
 			'sc-dash'   => array(
 				'option' => '-',
-				'label'  => __( 'Dash', 'wordpress-seo' )
+				'label'  => __( 'Dash', 'wordpress-seo' ),
 			),
 			'sc-ndash'  => array(
 				'option' => '&ndash;',
-				'label'  => __( 'En dash', 'wordpress-seo' )
+				'label'  => __( 'En dash', 'wordpress-seo' ),
 			),
 			'sc-mdash'  => array(
 				'option' => '&mdash;',
-				'label'  => __( 'Em dash', 'wordpress-seo' )
+				'label'  => __( 'Em dash', 'wordpress-seo' ),
 			),
 			'sc-colon'  => array(
 				'option' => ':',
-				'label'  => __( 'Colon', 'wordpress-seo' )
+				'label'  => __( 'Colon', 'wordpress-seo' ),
 			),
 			'sc-middot' => array(
 				'option' => '&middot;',
-				'label'  => __( 'Middle dot', 'wordpress-seo' )
+				'label'  => __( 'Middle dot', 'wordpress-seo' ),
 			),
 			'sc-bull'   => array(
 				'option' => '&bull;',
-				'label'  => __( 'Bullet', 'wordpress-seo' )
+				'label'  => __( 'Bullet', 'wordpress-seo' ),
 			),
 			'sc-star'   => array(
 				'option' => '*',
-				'label'  => __( 'Asterisk', 'wordpress-seo' )
+				'label'  => __( 'Asterisk', 'wordpress-seo' ),
 			),
 			'sc-smstar' => array(
 				'option' => '&#8902;',
-				'label'  => __( 'Low asterisk', 'wordpress-seo' )
+				'label'  => __( 'Low asterisk', 'wordpress-seo' ),
 			),
 			'sc-pipe'   => array(
 				'option' => '|',
-				'label'  => __( 'Vertical bar', 'wordpress-seo' )
+				'label'  => __( 'Vertical bar', 'wordpress-seo' ),
 			),
 			'sc-tilde'  => array(
 				'option' => '~',
-				'label'  => __( 'Small tilde', 'wordpress-seo' )
+				'label'  => __( 'Small tilde', 'wordpress-seo' ),
 			),
 			'sc-laquo'  => array(
 				'option' => '&laquo;',
-				'label'  => __( 'Left angle quotation mark', 'wordpress-seo' )
+				'label'  => __( 'Left angle quotation mark', 'wordpress-seo' ),
 			),
 			'sc-raquo'  => array(
 				'option' => '&raquo;',
-				'label'  => __( 'Right angle quotation mark', 'wordpress-seo' )
+				'label'  => __( 'Right angle quotation mark', 'wordpress-seo' ),
 			),
 			'sc-lt'     => array(
 				'option' => '&lt;',
-				'label'  => __( 'Less than sign', 'wordpress-seo' )
+				'label'  => __( 'Less than sign', 'wordpress-seo' ),
 			),
 			'sc-gt'     => array(
 				'option' => '&gt;',
-				'label'  => __( 'Greater than sign', 'wordpress-seo' )
+				'label'  => __( 'Greater than sign', 'wordpress-seo' ),
 			),
 		);
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -112,26 +112,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	);
 
 	/**
-	 * @var array Array of the separator options. To get these options use WPSEO_Option_Titles::get_instance()->get_separator_options().
-	 */
-	private $separator_options = array(
-		'sc-dash'   => '-',
-		'sc-ndash'  => '&ndash;',
-		'sc-mdash'  => '&mdash;',
-		'sc-colon'  => ':',
-		'sc-middot' => '&middot;',
-		'sc-bull'   => '&bull;',
-		'sc-star'   => '*',
-		'sc-smstar' => '&#8902;',
-		'sc-pipe'   => '|',
-		'sc-tilde'  => '~',
-		'sc-laquo'  => '&laquo;',
-		'sc-raquo'  => '&raquo;',
-		'sc-lt'     => '&lt;',
-		'sc-gt'     => '&gt;',
-	);
-
-	/**
 	 * Add the actions and filters for the option.
 	 *
 	 * @todo [JRF => testers] Check if the extra actions below would run into problems if an option
@@ -177,7 +157,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @return array
 	 */
 	public function get_separator_options() {
-		$separators = $this->separator_options;
+		$separators = wp_list_pluck( $this->get_separator_option_list(), 'option' );
 
 		/**
 		 * Allow altering the array with separator options.
@@ -201,22 +181,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	public function get_separator_options_for_display() {
 		$separators = $this->get_separator_options();
 
-		$human_friendly_labels = array(
-			'sc-dash'   => __( 'Dash', 'wordpress-seo' ),
-			'sc-ndash'  => __( 'En dash', 'wordpress-seo' ),
-			'sc-mdash'  => __( 'Em dash', 'wordpress-seo' ),
-			'sc-colon'  => __( 'Colon', 'wordpress-seo' ),
-			'sc-middot' => __( 'Middle dot', 'wordpress-seo' ),
-			'sc-bull'   => __( 'Bullet', 'wordpress-seo' ),
-			'sc-star'   => __( 'Asterisk', 'wordpress-seo' ),
-			'sc-smstar' => __( 'Low asterisk', 'wordpress-seo' ),
-			'sc-pipe'   => __( 'Vertical bar', 'wordpress-seo' ),
-			'sc-tilde'  => __( 'Small tilde', 'wordpress-seo' ),
-			'sc-laquo'  => __( 'Left angle quotation mark', 'wordpress-seo' ),
-			'sc-raquo'  => __( 'Right angle quotation mark', 'wordpress-seo' ),
-			'sc-lt'     => __( 'Less than sign', 'wordpress-seo' ),
-			'sc-gt'     => __( 'Greater than sign', 'wordpress-seo' ),
-		);
+		$human_friendly_labels = wp_list_pluck( $this->get_separator_option_list(), 'label' );
 
 		/**
 		 * Allows altering the separator options friendly labels array.
@@ -841,5 +806,71 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		}
 
 		return $clean;
+	}
+
+	/**
+	 * Retrieves a list of separator options.
+	 *
+	 * @return array An array of the separator options.
+	 */
+	protected function get_separator_option_list() {
+		return array(
+			'sc-dash'   => array(
+				'option' => '-',
+				'label'  => __( 'Dash', 'wordpress-seo' )
+			),
+			'sc-ndash'  => array(
+				'option' => '&ndash;',
+				'label'  => __( 'En dash', 'wordpress-seo' )
+			),
+			'sc-mdash'  => array(
+				'option' => '&mdash;',
+				'label'  => __( 'Em dash', 'wordpress-seo' )
+			),
+			'sc-colon'  => array(
+				'option' => ':',
+				'label'  => __( 'Colon', 'wordpress-seo' )
+			),
+			'sc-middot' => array(
+				'option' => '&middot;',
+				'label'  => __( 'Middle dot', 'wordpress-seo' )
+			),
+			'sc-bull'   => array(
+				'option' => '&bull;',
+				'label'  => __( 'Bullet', 'wordpress-seo' )
+			),
+			'sc-star'   => array(
+				'option' => '*',
+				'label'  => __( 'Asterisk', 'wordpress-seo' )
+			),
+			'sc-smstar' => array(
+				'option' => '&#8902;',
+				'label'  => __( 'Low asterisk', 'wordpress-seo' )
+			),
+			'sc-pipe'   => array(
+				'option' => '|',
+				'label'  => __( 'Vertical bar', 'wordpress-seo' )
+			),
+			'sc-tilde'  => array(
+				'option' => '~',
+				'label'  => __( 'Small tilde', 'wordpress-seo' )
+			),
+			'sc-laquo'  => array(
+				'option' => '&laquo;',
+				'label'  => __( 'Left angle quotation mark', 'wordpress-seo' )
+			),
+			'sc-raquo'  => array(
+				'option' => '&raquo;',
+				'label'  => __( 'Right angle quotation mark', 'wordpress-seo' )
+			),
+			'sc-lt'     => array(
+				'option' => '&lt;',
+				'label'  => __( 'Less than sign', 'wordpress-seo' )
+			),
+			'sc-gt'     => array(
+				'option' => '&gt;',
+				'label'  => __( 'Greater than sign', 'wordpress-seo' )
+			),
+		);
 	}
 }

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -155,7 +155,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @return array
 	 */
 	public function get_separator_options() {
-		$separators = wp_list_pluck( $this->get_separator_option_list(), 'option' );
+		$separators = wp_list_pluck( self::get_separator_option_list(), 'option' );
 
 		/**
 		 * Allow altering the array with separator options.
@@ -178,7 +178,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 */
 	public function get_separator_options_for_display() {
 		$separators     = $this->get_separator_options();
-		$separator_list = $this->get_separator_option_list();
+		$separator_list = self::get_separator_option_list();
 
 		$separator_options = array();
 
@@ -802,7 +802,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 *
 	 * @return array An array of the separator options.
 	 */
-	protected function get_separator_option_list() {
+	protected static function get_separator_option_list() {
 		$separators = array(
 			'sc-dash'   => array(
 				'option' => '-',

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -194,9 +194,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	}
 
 	/**
-	 * Get the available separator options.
+	 * Get the available separator human friendly labels.
 	 *
-	 * @return array
+	 * @return array $friendly_separators Array with the separator human friendly labels.
 	 */
 	public function get_separator_options_for_display() {
 		$separators = $this->get_separator_options();
@@ -224,6 +224,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		 * @api array $human_friendly_labels Array with the separator options friendly labels.
 		 */
 		$filtered_human_friendly_labels = apply_filters( 'wpseo_separator_options_friendly_labels', $human_friendly_labels );
+
+		$friendly_separators = array();
 
 		foreach ( $separators as $key => $label ) {
 			$friendly_label = isset( $filtered_human_friendly_labels[ $key ] ) ? $filtered_human_friendly_labels[ $key ] : '';

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -194,6 +194,50 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	}
 
 	/**
+	 * Get the available separator options.
+	 *
+	 * @return array
+	 */
+	public function get_separator_options_for_display() {
+		$separators = $this->get_separator_options();
+
+		$human_friendly_labels = array(
+			'sc-dash'   => __( 'Dash', 'wordpress-seo' ),
+			'sc-ndash'  => __( 'En dash', 'wordpress-seo' ),
+			'sc-mdash'  => __( 'Em dash', 'wordpress-seo' ),
+			'sc-colon'  => __( 'Colon', 'wordpress-seo' ),
+			'sc-middot' => __( 'Middle dot', 'wordpress-seo' ),
+			'sc-bull'   => __( 'Bullet', 'wordpress-seo' ),
+			'sc-star'   => __( 'Asterisk', 'wordpress-seo' ),
+			'sc-smstar' => __( 'Low asterisk', 'wordpress-seo' ),
+			'sc-pipe'   => __( 'Vertical bar', 'wordpress-seo' ),
+			'sc-tilde'  => __( 'Small tilde', 'wordpress-seo' ),
+			'sc-laquo'  => __( 'Left angle quotation mark', 'wordpress-seo' ),
+			'sc-raquo'  => __( 'Right angle quotation mark', 'wordpress-seo' ),
+			'sc-lt'     => __( 'Less than sign', 'wordpress-seo' ),
+			'sc-gt'     => __( 'Greater than sign', 'wordpress-seo' ),
+		);
+
+		/**
+		 * Allows altering the separator options friendly labels array.
+		 *
+		 * @api array $human_friendly_labels Array with the separator options friendly labels.
+		 */
+		$filtered_human_friendly_labels = apply_filters( 'wpseo_separator_options_friendly_labels', $human_friendly_labels );
+
+		foreach ( $separators as $key => $label ) {
+			$friendly_label = isset( $filtered_human_friendly_labels[ $key ] ) ? $filtered_human_friendly_labels[ $key ] : '';
+
+			$friendly_separators[ $key ] = array(
+				'label'          => $label,
+				'friendly_label' => $friendly_label,
+			);
+		}
+
+		return $friendly_separators;
+	}
+
+	/**
 	 * Translate strings used in the option defaults.
 	 *
 	 * @return void

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -160,7 +160,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		/**
 		 * Allow altering the array with separator options.
 		 *
-		 * @api  array  $separator_options  Array with the separator options.
+		 * @api array $separator_options Array with the separator options.
 		 */
 		$filtered_separators = apply_filters( 'wpseo_separator_options', $separators );
 
@@ -172,26 +172,26 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	}
 
 	/**
-	 * Get the available separator human friendly labels.
+	 * Get the available separator options human friendly labels.
 	 *
-	 * @return array $friendly_separators Array with the separator human friendly labels.
+	 * @return array $separator_options Array with the separator options human friendly labels.
 	 */
 	public function get_separator_options_for_display() {
 		$separators     = $this->get_separator_options();
 		$separator_list = $this->get_separator_option_list();
 
-		$friendly_separators = array();
+		$separator_options = array();
 
 		foreach ( $separators as $key => $label ) {
 			$friendly_label = isset( $separator_list[ $key ]['label'] ) ? $separator_list[ $key ]['label'] : '';
 
-			$friendly_separators[ $key ] = array(
+			$separator_options[ $key ] = array(
 				'label'          => $label,
 				'friendly_label' => $friendly_label,
 			);
 		}
 
-		return $friendly_separators;
+		return $separator_options;
 	}
 
 	/**
@@ -865,7 +865,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		/**
 		 * Allows altering the separator options array.
 		 *
-		 * @api array $separators  Array with the separator options.
+		 * @api array $separators Array with the separator options.
 		 */
 		$separator_list = apply_filters( 'wpseo_separator_option_list', $separators );
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -177,21 +177,13 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @return array $friendly_separators Array with the separator human friendly labels.
 	 */
 	public function get_separator_options_for_display() {
-		$separators = $this->get_separator_options();
-
-		$human_friendly_labels = wp_list_pluck( $this->get_separator_option_list(), 'label' );
-
-		/**
-		 * Allows altering the separator options friendly labels array.
-		 *
-		 * @api array $human_friendly_labels Array with the separator options friendly labels.
-		 */
-		$filtered_human_friendly_labels = apply_filters( 'wpseo_separator_options_friendly_labels', $human_friendly_labels );
+		$separators     = $this->get_separator_options();
+		$separator_list = $this->get_separator_option_list();
 
 		$friendly_separators = array();
 
 		foreach ( $separators as $key => $label ) {
-			$friendly_label = isset( $filtered_human_friendly_labels[ $key ] ) ? $filtered_human_friendly_labels[ $key ] : '';
+			$friendly_label = isset( $separator_list[ $key ]['label'] ) ? $separator_list[ $key ]['label'] : '';
 
 			$friendly_separators[ $key ] = array(
 				'label'          => $label,
@@ -811,7 +803,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @return array An array of the separator options.
 	 */
 	protected function get_separator_option_list() {
-		return array(
+		$separators = array(
 			'sc-dash'   => array(
 				'option' => '-',
 				'label'  => __( 'Dash', 'wordpress-seo' )
@@ -869,5 +861,18 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				'label'  => __( 'Greater than sign', 'wordpress-seo' )
 			),
 		);
+
+		/**
+		 * Allows altering the separator options array.
+		 *
+		 * @api array $separators  Array with the separator options.
+		 */
+		$separator_list = apply_filters( 'wpseo_separator_option_list', $separators );
+
+		if ( ! is_array( $separator_list ) ) {
+			return $separators;
+		}
+
+		return $separator_list;
 	}
 }

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -172,9 +172,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	}
 
 	/**
-	 * Get the available separator options human friendly labels.
+	 * Get the available separator options aria-labels.
 	 *
-	 * @return array $separator_options Array with the separator options human friendly labels.
+	 * @return array $separator_options Array with the separator options aria-labels.
 	 */
 	public function get_separator_options_for_display() {
 		$separators     = $this->get_separator_options();
@@ -183,11 +183,11 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		$separator_options = array();
 
 		foreach ( $separators as $key => $label ) {
-			$friendly_label = isset( $separator_list[ $key ]['label'] ) ? $separator_list[ $key ]['label'] : '';
+			$aria_label = isset( $separator_list[ $key ]['label'] ) ? $separator_list[ $key ]['label'] : '';
 
 			$separator_options[ $key ] = array(
-				'label'          => $label,
-				'friendly_label' => $friendly_label,
+				'label'      => $label,
+				'aria_label' => $aria_label,
 			);
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve accessibility of the Title Separator setting.

## Relevant technical choices:

This is a first pass at adding aria labels to the title separators UI. Just a POC for now, code needs to be optimized and polished. I'd greatly appreciate some feedback.

In the configuration wizard, all the separator symbols already have aria-labels to expand the symbols name to a human friendly wording. Instead, in the Search Appearance there are no aria-labels so screen readers won't announce correctly some of the characters or may even also not announce them at all, depending also on the verbosity setting of the screen reader.

Also, the `wpseo_separator_options` filter never worked in the configuration wizard so adding a new separator will show up in the Search Appearance page but not in the wizard.

- makes the `wpseo_separator_options` work using the same method to build the separator choices in both places
- adds aria-labels
- avoids to modify the default array of separators `$separator_options` as I guess the filter should keep working there
- uses a new array with human friendly labels and adds a filter (this part is... meh... feedback needed)
- updates the yoast form `label()` method to render an optional aria-label

Having two arrays is less than ideal, feedback on how to manipulate those 2 arrays and still preserve the existing filter greatly appreciated.

Test instructions:
- go in Search Appearance > General and and verify the title separators have aria-labels 
- go in the Configuration Wizard > step 9 and verify the title separators have aria-labels
- use the old filter and new filter to add 2 new separators: put this in your theme's `functions.php`

```
add_filter( 'wpseo_separator_options', 'separator_options_old_filter' );
function separator_options_old_filter( $separators ) {
	$separators['sc-question-old'] = '?';

	return $separators;
}

add_filter( 'wpseo_separator_option_list', 'separator_options_new_filter' );
function separator_options_new_filter( $separators ) {
	$separators['sc-question-new'] = array( 'option' => '?', 'label' => 'exclamation mark' );

	return $separators;
}
```

- then if you're using VVV you may need to run `grunt build` in your WordPress `public_html` directory
- check again the Search Appearance > General and the Configuration Wizard
- the separator added with the old filter should have only the separator symbol and  no aria-label
- the separator added with the new filter should have both the symbol and the aria-label



Fixes #10930 
Fixes #9360 