### PR TITLE
Add `aria-current` to the list tables current view link

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -298,15 +298,15 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		);
 
 
-		$post_status    = filter_input( INPUT_GET, 'post_status' );
-		$class          = empty( $post_status ) ? ' class="current"' : '';
-		$localized_text = sprintf(
+		$post_status             = filter_input( INPUT_GET, 'post_status' );
+		$current_link_attributes = empty( $post_status ) ? ' class="current" aria-current="page"' : '';
+		$localized_text          = sprintf(
 			/* translators: %s expands to the number of posts in localized format. */
 			_nx( 'All <span class="count">(%s)</span>', 'All <span class="count">(%s)</span>', $total_posts, 'posts', 'wordpress-seo' ),
 			number_format_i18n( $total_posts )
 		);
 
-		$status_links['all'] = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=bulk-editor' . $this->page_url ) ) . '"' . $class . '>' . $localized_text . '</a>';
+		$status_links['all'] = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=bulk-editor' . $this->page_url ) ) . '"' . $current_link_attributes . '>' . $localized_text . '</a>';
 
 		$post_stati = get_post_stati( array( 'show_in_admin_all_list' => true ), 'objects' );
 		if ( is_array( $post_stati ) && $post_stati !== array() ) {
@@ -328,15 +328,15 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 					continue;
 				}
 
-				$class = '';
+				$current_link_attributes = '';
 				if ( $status_name === $post_status ) {
-					$class = ' class="current"';
+					$current_link_attributes = ' class="current" aria-current="page"';
 				}
 
-				$status_links[ $status_name ] = '<a href="' . esc_url( add_query_arg( array( 'post_status' => $status_name ), admin_url( 'admin.php?page=wpseo_tools&tool=bulk-editor' . $this->page_url ) ) ) . '"' . $class . '>' . sprintf( translate_nooped_plural( $status->label_count, $total ), number_format_i18n( $total ) ) . '</a>';
+				$status_links[ $status_name ] = '<a href="' . esc_url( add_query_arg( array( 'post_status' => $status_name ), admin_url( 'admin.php?page=wpseo_tools&tool=bulk-editor' . $this->page_url ) ) ) . '"' . $current_link_attributes . '>' . sprintf( translate_nooped_plural( $status->label_count, $total ), number_format_i18n( $total ) ) . '</a>';
 			}
 		}
-		unset( $post_stati, $status, $status_name, $total, $class );
+		unset( $post_stati, $status, $status_name, $total, $current_link_attributes );
 
 		$trashed_posts = $wpdb->get_var(
 			"
@@ -345,9 +345,9 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				"
 		);
 
-		$class = '';
+		$current_link_attributes = '';
 		if ( 'trash' === $post_status ) {
-			$class = 'class="current"';
+			$current_link_attributes = 'class="current" aria-current="page"';
 		}
 
 		$localized_text = sprintf(
@@ -356,7 +356,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			number_format_i18n( $trashed_posts )
 		);
 
-		$status_links['trash'] = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=bulk-editor&post_status=trash' . $this->page_url ) ) . '"' . $class . '>' . $localized_text . '</a>';
+		$status_links['trash'] = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=bulk-editor&post_status=trash' . $this->page_url ) ) . '"' . $current_link_attributes . '>' . $localized_text . '</a>';
 
 		return $status_links;
 	}

--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -157,9 +157,11 @@ class WPSEO_GSC_Category_Filters {
 		);
 
 		$class = 'gsc_category';
+		$aria_current = '';
 
 		if ( $this->category === $category ) {
 			$class .= ' current';
+			$aria_current = ' aria-current="page"';
 		}
 
 		$help_button = '';
@@ -171,14 +173,15 @@ class WPSEO_GSC_Category_Filters {
 		}
 
 		return sprintf(
-			'<a href="%1$s" class="%2$s">%3$s</a> (<span id="gsc_count_%4$s">%5$s</span>) %6$s %7$s',
+			'<a href="%1$s" class="%2$s"%8$s>%3$s</a> (<span id="gsc_count_%4$s">%5$s</span>) %6$s %7$s',
 			esc_attr( $href ),
 			$class,
 			$this->filter_values[ $category ]['value'],
 			$category,
 			$count,
 			$help_button,
-			$help_panel
+			$help_panel,
+			$aria_current
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve the accessibility of the "Bulk editor" and "Search console" tables.

## Relevant technical choices:

* adds an `aria-current="page"` to the list table current view link, also for consistency with what WordPress does

## Test instructions
- navigate through the "Bulk editor" and "Search console" tables "views" (e.g. All, Published, Scheduled... Not found...)
- verify the current link (the bolded one with a `current` CSS class) has an `aria-current="page"` attribute

Fixes #7933 
