### PR TITLE
Fix go premium link in plugins overview

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -221,13 +221,14 @@ class WPSEO_Admin {
 	}
 
 	/**
-	 * Show row meta on the plugin screen.
+	 * Manages the links on the meta data row on the plugin list.
 	 *
-	 * @param   mixed $links Plugin Row Meta.
-	 * @param   mixed $file  Plugin Base file.
-	 * @return  array
+	 * @param   array  $links Plugin row meta.
+	 * @param   string $file  Plugin base file.
+	 *
+	 * @return  array Modified list of links.
 	 */
-	public static function plugin_row_meta( $links, $file ) {
+	public function plugin_row_meta( $links, $file ) {
 		if ( WPSEO_BASENAME === $file ) {
 			$row_meta = array(
 				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yc' ) ) . '" target="_blank">' . __( 'FAQ', 'wordpress-seo' ) . '</a>',

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -217,7 +217,11 @@ class WPSEO_Admin {
 		}
 
 		// Add link to premium support landing page.
-		$premium_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yb' ) ) . '">' . __( 'Premium Support', 'wordpress-seo' ) . '</a>';
+		$support_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yb' ) ) . '">' . __( 'Get support', 'wordpress-seo' ) . '</a>';
+		array_unshift( $links, $support_link );
+
+		// Add link to premium landing page.
+		$premium_link = '<strong><a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/39q' ) ) . '">' . __( 'Go Premium', 'wordpress-seo' ) . '</a></strong>';
 		array_unshift( $links, $premium_link );
 
 		// Add link to docs.

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -217,7 +217,7 @@ class WPSEO_Admin {
 		}
 
 		// Add link to premium support landing page.
-		$support_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yb' ) ) . '">' . __( 'Get support', 'wordpress-seo' ) . '</a>';
+		$support_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/39r' ) ) . '">' . __( 'Get support', 'wordpress-seo' ) . '</a>';
 		array_unshift( $links, $support_link );
 
 		// Add link to premium landing page.

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -56,6 +56,7 @@ class WPSEO_Admin {
 		}
 
 		add_filter( 'plugin_action_links_' . WPSEO_BASENAME, array( $this, 'add_action_link' ), 10, 2 );
+		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'config_page_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_global_style' ) );
@@ -216,19 +217,28 @@ class WPSEO_Admin {
 			}
 		}
 
-		// Add link to premium support landing page.
-		$support_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/39r' ) ) . '">' . __( 'Get support', 'wordpress-seo' ) . '</a>';
-		array_unshift( $links, $support_link );
-
-		// Add link to premium landing page.
-		$premium_link = '<strong><a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/39q' ) ) . '">' . __( 'Go Premium', 'wordpress-seo' ) . '</a></strong>';
-		array_unshift( $links, $premium_link );
-
-		// Add link to docs.
-		$faq_link = '<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yc' ) ) . '">' . __( 'FAQ', 'wordpress-seo' ) . '</a>';
-		array_unshift( $links, $faq_link );
-
 		return $links;
+	}
+
+	/**
+	 * Show row meta on the plugin screen.
+	 *
+	 * @param   mixed $links Plugin Row Meta.
+	 * @param   mixed $file  Plugin Base file.
+	 * @return  array
+	 */
+	public static function plugin_row_meta( $links, $file ) {
+		if ( WPSEO_BASENAME === $file ) {
+			$row_meta = array(
+				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yc' ) ) . '" target="_blank">' . __( 'FAQ', 'wordpress-seo' ) . '</a>',
+				'<a style="font-weight: bold;" href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/39q' ) ) . '" target="_blank">' . __( 'Go Premium', 'wordpress-seo' ) . '</a>',
+				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/39r' ) ) . '" target="_blank">' . __( 'Get support', 'wordpress-seo' ) . '</a>',
+			);
+
+			return array_merge( $links, $row_meta );
+		}
+
+		return (array) $links;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

It now looks like this:

![go-premium](https://user-images.githubusercontent.com/487629/47521349-10e47580-d893-11e8-8b61-942a0cb43900.jpg)

This PR can be summarized in the following changelog entry:

* none needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to plugins page. See change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9014

