### PR TITLE
Add clean tasks to build:js and build:css

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -10,10 +10,10 @@ build:
 'build:sass':
   - 'sass:build'
 'build:css':
+  - 'clean:build-assets-css'
   - 'build:sass'
   - 'postcss:build'
   - 'wpcss'
-  - 'clean:before-rtlcss'
   - 'rtlcss'
   - 'cssmin'
 # Optimise images from source to production
@@ -21,6 +21,7 @@ build:
   - 'imagemin'
 # Build JavaScript from assets to production
 'build:js':
+  - 'clean:build-assets-js'
   - 'copy:dependencies'
   - 'webpack:buildDev'
 
@@ -52,6 +53,10 @@ build:
   - 'po2json'
   - 'i18n-clean-json'
   - 'clean:po-files'
+
+clean:build-assets:
+  - 'clean:build-assets-js'
+  - 'clean:build-assets-css'
 
 # Check health of the project
 check:

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -20,15 +20,12 @@ module.exports = {
 
 		"<%= files.pot.yoastseojs %>",
 	],
-	"build-assets": [
-		"<%= paths.css %>/*.css",
+	"build-assets-js": [
 		"js/dist/*.js",
 		"!js/dist/jquery.tablesorter.min.js",
 	],
-	"before-rtlcss": [
-		"css/dist/*-rtl*",
-		"css/dist/toggle-switch/*.css",
-		"!css/dist/select2/*.min.css",
+	"build-assets-css": [
+		"<%= paths.css %>/*.css",
 	],
 	artifact: [
 		"<%= files.artifact %>",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:
* Split `grunt clean:build-assets` into `grunt clean:build-assets-js` and `grunt clean:build-assets-css`, which are added to `grunt build:js` and `grunt build:css` respectively. This makes sure that old built CSS and JS files are always removed on every build. This change was induced by returning css build errors, as reported in https://github.com/Yoast/wordpress-seo/issues/11412 and https://github.com/Yoast/wordpress-seo/pull/11117.

* Removes `before-rtlcss`, because` 'clean:build-assets-css'` now does the same (and `"css/dist/toggle-switch/*.css"` no longer exists).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Run `grunt clean:build-assets` and see that  `grunt clean:build-assets-js` and `grunt clean:build-assets-css` are run.
* Run `grunt build:js` and `grunt build:css` and check if `grunt clean:build-assets-js` and `grunt clean:build-assets-css` are run respectively.

* For RC testers: this is no user-facing change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
