### PR TITLE
Retrieves noindex from page_id instead of post_type archive into sitemaps

### DIFF
--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -17,6 +17,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 */
 	public function register_hooks() {
 		add_filter( 'wpseo_frontend_page_type_simple_page_id', array( $this, 'get_page_id' ) );
+		add_filter( 'wpseo_sitemap_page_for_post_type_archive', array( $this, 'get_page_id_for_sitemap' ), 10, 2 );
 	}
 
 	/**
@@ -28,6 +29,22 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 */
 	public function get_page_id( $page_id ) {
 		if ( ! $this->is_shop_page() ) {
+			return $page_id;
+		}
+
+		return $this->get_shop_page_id();
+	}
+
+	/**
+	 * Returns the ID of the WooCommerce shop page when product's archive is requested.
+	 *
+	 * @param int    $page_id   The page id.
+	 * @param string $post_type The post type of the archive.
+	 *
+	 * @return int The Page ID of the shop.
+	 */
+	public function get_page_id_for_sitemap( $page_id, $post_type ) {
+		if ( 'product' !== $post_type ) {
 			return $page_id;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Retrieves "index status" from dedicated pages instead of post_type archives in case when URL for both page is same (as _posts page_, _shop page_ ).
* Retrieves archive URL for posts via method _get_post_type_archive_link_.

## Relevant technical choices:

* Since WordPress 4.5, function [`get_post_type_archive_link`](https://developer.wordpress.org/reference/functions/get_post_type_archive_link/) returns posts_page URL (or home_url) as archive page for posts. So, it's safe to we use method `get_post_type_archive_link` for posts and remove related logic in method `get_first_links` (which is needed before WordPress 4.5).
* From other side, we should add logic in method `get_post_type_archive_link` which handles two cases when page URL is same as post type archive URL (posts page and shop page). This PR is introducing the filter `wpseo_sitemap_page_for_post_type_archive` for this purpose. On this way, we could use this filter in class `WPSEO_WooCommerce_Shop_Page` to remove archive page from product sitemap when this page isn't "index-able". Also, it could be used  for other similar cases.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create "blog" page and set it as "Posts page" (_Settings_/_Reading_).
* Check both sitemaps (page and post). This page should be listed in both sitemaps.
* Set _noindex_ for "blog" page.
* Check both sitemaps (page and post). This page should be removed in both sitemaps.
* Install [WooCommerce](https://wordpress.org/plugins/woocommerce/), create and set "shop" page and repeat same as for "blog" page.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11350, #7002.