### PR TITLE
Fix featured image API call

### DIFF
--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -116,17 +116,6 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		}
 	}
 
-	/**
-	 * Checks whether the featuredImageId is invalid.
-	 *
-	 * @param {any} featuredImageId The possibly invalid featuredImage Id.
-	 *
-	 * @returns {boolean} True if the featured image id is valid.
-	 */
-	function isFeaturedImageIdInvalid( featuredImageId ) {
-		return typeof featuredImageId === "undefined" || featuredImageId === null || featuredImageId === 0;
-	}
-
 	$( document ).ready( function() {
 		var featuredImage = wp.media.featuredImage.frame();
 
@@ -183,7 +172,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		wp.data.subscribe( () => {
 			const featuredImageId = wp.data.select( "core/editor" ).getEditedPostAttribute( "featured_media" );
 
-			if ( isFeaturedImageIdInvalid( featuredImageId ) ) {
+			if ( typeof featuredImageId === "number" && featuredImageId > 0 ) {
 				return;
 			}
 

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -116,6 +116,17 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		}
 	}
 
+	/**
+	 * Checks whether the featuredImageId is invalid.
+	 *
+	 * @param {any} featuredImageId The possible invalid featuredImage Id.
+	 *
+	 * @returns {boolean} True if the featured image id is valid.
+	 */
+	function isFeaturedImageIdInvalid( featuredImageId ) {
+		return typeof featuredImageId === "undefined" || featuredImageId === null || featuredImageId === 0;
+	}
+
 	$( document ).ready( function() {
 		var featuredImage = wp.media.featuredImage.frame();
 
@@ -171,6 +182,10 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		let previousImageData;
 		wp.data.subscribe( () => {
 			const featuredImageId = wp.data.select( "core/editor" ).getEditedPostAttribute( "featured_media" );
+
+			if ( isFeaturedImageIdInvalid( featuredImageId ) ) {
+				return;
+			}
 
 			if ( typeof featuredImageId === "undefined" || featuredImageId === null ) {
 				return;

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -119,7 +119,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 	/**
 	 * Checks whether the featuredImageId is invalid.
 	 *
-	 * @param {any} featuredImageId The possible invalid featuredImage Id.
+	 * @param {any} featuredImageId The possibly invalid featuredImage Id.
 	 *
 	 * @returns {boolean} True if the featured image id is valid.
 	 */

--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -187,10 +187,6 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 				return;
 			}
 
-			if ( typeof featuredImageId === "undefined" || featuredImageId === null ) {
-				return;
-			}
-
 			imageData = wp.data.select( "core" ).getMedia( featuredImageId );
 
 			if ( typeof imageData === "undefined" ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* In https://github.com/Yoast/wordpress-seo/pull/11377 functionality to include Gutenberg featured images in the analysis. However, when no featured image was set, an API call with id `0` was done, resulting in a 404. This PR returns if the assumed featureImageId is 0, meaning no API will be done.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Check out and build release/9.1.
* Open a new Gutenberg post. Open the document sidebar (where you can set a featured image, but don't do that ;) ). See the following console errors:
<img width="587" alt="schermafbeelding 2018-10-29 om 08 35 15" src="https://user-images.githubusercontent.com/17744553/47635707-47054c00-db56-11e8-8672-fbfdb283b0fd.png">

* Open an existing Gutenberg post without a featured image. Open the document sidebar and see the same console errors.
* Check out this branch. Repeat the first two steps, and see no API call returning a 404.
* Also test *with* featured images, as described in https://github.com/Yoast/wordpress-seo/pull/11377.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11430 
