### PR TITLE
Fix wp dependency backporting in classic editor

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -48,6 +48,7 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_init', array( $this, 'show_hook_deprecation_warnings' ) );
 		add_action( 'admin_init', array( 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ) );
 		add_action( 'admin_init', array( $this, 'handle_notifications' ), 15 );
+		add_action( 'admin_enqueue_scripts', array( $this->asset_manager, 'register_wp_assets' ) );
 
 		$listeners   = array();
 		$listeners[] = new WPSEO_Post_Type_Archive_Notification_Handler();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open/create a post in the following scenarios, and make sure there are no console errors and the metabox is not empty:
    -  Classic editor without Gutenberg.
    -  Gutenberg without classic editor plugin.
    -  Classic editor in classic editor plugin with Gutenberg.
    -  Gutenberg in classic editor plugin with Gutenberg.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11449
