### PR TITLE
Switch toggle clean-up and usability improvements

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -298,8 +298,8 @@ class Yoast_Form {
 			$this->options[ $var ] = 'on';
 		}
 
-		$class           = 'switch-light switch-candy switch-yoast-seo';
-		$aria_labelledby = esc_attr( $var ) . '-label';
+		$class = 'switch-light switch-candy switch-yoast-seo';
+		$id    = esc_attr( $var ) . '-label';
 
 		if ( $reverse ) {
 			$class .= ' switch-yoast-seo-reverse';
@@ -317,10 +317,9 @@ class Yoast_Form {
 		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
 
 		echo "<div class='switch-container$help_class'>",
-		"<span class='switch-light-visual-label'>{$label}</span>" . $help,
+		"<span class='switch-light-visual-label' id='{$id}'>{$label}</span>" . $help,
 		'<label class="', $class, '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>',
-		'<input type="checkbox" aria-labelledby="', $aria_labelledby, '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $this->options[ $var ], 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>',
-		"<b class='label-text screen-reader-text' id='{$aria_labelledby}'>{$label}</b>",
+		'<input type="checkbox" aria-labelledby="', $id, '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $this->options[ $var ], 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>',
 		'<span aria-hidden="true">
 			<span>', esc_html( $off_button ) ,'</span>
 			<span>', esc_html( $on_button ) ,'</span>

--- a/css/src/toggle-switch.scss
+++ b/css/src/toggle-switch.scss
@@ -127,13 +127,15 @@
 	}
 
 	.switch-toggle input + label {
-		position: relative;
-		z-index: 2;
-		display: block;
 		float: left;
 		padding: 0 0.5em;
 		margin: 0;
 		text-align: center;
+	}
+
+	.switch-toggle input:checked + label {
+		position: relative;
+		z-index: 2;
 	}
 
 	.switch-toggle a {
@@ -367,6 +369,24 @@
 		text-shadow: none;
 	}
 
+	// Makes the checkboxes switch toggle clickable by using a pseudo element
+	// for the checked checkbox label and by making it full width.
+	.switch-candy.switch-yoast-seo input + label::after {
+		content: "";
+		display: block;
+		width: 100%;
+		height: 100%;
+		position: absolute;
+		top: 0;
+		left: 0;
+		z-index: 3;
+	}
+
+	// Remove the pseudo element for the non-checked checkboxes.
+	.switch-candy.switch-yoast-seo input:checked + label::after {
+		content: none;
+	}
+
 	.switch-light.switch-yoast-seo-reverse input:checked ~ span a {
 		left: 0;
 	}
@@ -408,7 +428,6 @@
 		vertical-align: top;
 	}
 
-	.switch-container .label-text,
 	.switch-light-visual-label {
 		display: block;
 		margin: 8px 0;
@@ -426,6 +445,6 @@
 	}
 
 	.switch-container + p {
-		margin: -8px 0 16px 0;
+		margin: 0 0 16px 0;
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

This PR does two things and fixes the last pending item in #8924:
1
Removes a redundant visually hidden element used as target for `aria-labelledby` and targets the visible text instead (it already uses the same text value)

2
Solves a long standing _usability_ issues with the toggles: until now, there was a difference in the mouse interaction with the toggles. For example:

Author archives (based on radio buttons)
click worked only when clicking on one side of the toggle

Enable Breadcrumbs (based on a checkbox)
click worked when clicking anywhere within the toggle 

Now, it is possible to click anywhere within the two types of toggles to switch it. 🎉 This works with only CSS (as these toggles use only CSS): no JavaScript involved.

As per accessibility: the keyboard interaction stays unchanged:
- on the radio buttons toggles: arrow keys switch the toggle
- on the checkboxes toggles: spacebar switches the toggle

## Test instructions
- build the assets
- compare the two different kinds of toggles, for example
  - Author archives (based on radio buttons)
  - Enable Breadcrumbs (based on a checkbox)
- verify there are no visual regressions
- verify they work when clicking anywhere within them

I've tested on all browsers in macOS and Windows.

Fixes #8924 
