### PR TITLE
Little optimization for class WPSEO_WooCommerce_Shop_Page

### DIFF
--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -73,7 +73,8 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 			return false;
 		}
 
-		if ( $this->get_shop_page_id() > 0 ) {
+		self::$is_shop_page = false;
+		if ( $this->is_woo_activated() && $this->get_shop_page_id() > 0 ) {
 			self::$is_shop_page = is_shop() && ! is_search();
 		}
 

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -11,18 +11,14 @@
 class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 
 	/**
-	 * @var bool Holds the flag if shop page is set.
+	 * @var int Holds the shop page id.
 	 */
-	protected $shop_page_exists = false;
+	protected static $shop_page_id;
 
 	/**
-	 * Class constructor
+	 * @var bool Is current page the shop page?
 	 */
-	public function __construct() {
-		if ( $this->is_woo_activated() ) {
-			$this->shop_page_exists = $this->get_shop_page_id() > 0;
-		}
-	}
+	protected static $is_shop_page;
 
 	/**
 	 * Registers the hooks
@@ -30,7 +26,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		if ( ! $this->shop_page_exists ) {
+		if ( ! $this->is_woo_activated() ) {
 			return;
 		}
 
@@ -67,18 +63,21 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 * @return bool Whether the current page is the WooCommerce shop page.
 	 */
 	public function is_shop_page() {
-		static $is_shop_page;
+		global $wp_query;
 
-		if ( isset( $is_shop_page ) ) {
-			return $is_shop_page;
+		if ( isset( self::$is_shop_page ) ) {
+			return self::$is_shop_page;
 		}
 
-		$is_shop_page = false;
-		if ( $this->shop_page_exists ) {
-			$is_shop_page = is_shop() && ! is_search();
+		if ( ! isset( $wp_query ) ) {
+			return false;
 		}
 
-		return $is_shop_page;
+		if ( $this->get_shop_page_id() > 0 ) {
+			self::$is_shop_page = is_shop() && ! is_search();
+		}
+
+		return self::$is_shop_page;
 	}
 
 	/**
@@ -87,12 +86,10 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 * @return int The ID of the set page.
 	 */
 	public function get_shop_page_id() {
-		static $shop_page_id;
-
-		if ( ! $shop_page_id ) {
-			$shop_page_id = function_exists( 'wc_get_page_id' ) ? wc_get_page_id( 'shop' ) : ( -1 );
+		if ( ! isset( self::$shop_page_id ) ) {
+			self::$shop_page_id = function_exists( 'wc_get_page_id' ) ? wc_get_page_id( 'shop' ) : ( -1 );
 		}
 
-		return $shop_page_id;
+		return self::$shop_page_id;
 	}
 }

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -11,12 +11,39 @@
 class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 
 	/**
+	 * @var bool Holds the flag if shop page is set.
+	 */
+	protected $shop_page_exists = false;
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+		if ( $this->is_woo_activated() ) {
+			$this->shop_page_exists = $this->get_shop_page_id() > 0;
+		}
+	}
+
+	/**
 	 * Registers the hooks
 	 *
 	 * @return void
 	 */
 	public function register_hooks() {
+		if ( ! $this->shop_page_exists ) {
+			return;
+		}
+
 		add_filter( 'wpseo_frontend_page_type_simple_page_id', array( $this, 'get_page_id' ) );
+	}
+
+	/**
+	 * Check whether woocommerce plugin is active.
+	 *
+	 * @return bool
+	 */
+	private function is_woo_activated() {
+		return class_exists( 'WooCommerce', false );
 	}
 
 	/**
@@ -40,11 +67,18 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 * @return bool Whether the current page is the WooCommerce shop page.
 	 */
 	public function is_shop_page() {
-		if ( function_exists( 'is_shop' ) && function_exists( 'wc_get_page_id' ) ) {
-			return is_shop() && ! is_search();
+		static $is_shop_page;
+
+		if ( isset( $is_shop_page ) ) {
+			return $is_shop_page;
 		}
 
-		return false;
+		$is_shop_page = false;
+		if ( $this->shop_page_exists ) {
+			$is_shop_page = is_shop() && ! is_search();
+		}
+
+		return $is_shop_page;
 	}
 
 	/**

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -38,7 +38,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 *
 	 * @return bool True if woocommerce plugin is active.
 	 */
-	private static function is_woocommerce_active() {
+	private function is_woocommerce_active() {
 		return WPSEO_Utils::is_woocommerce_active();
 	}
 

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -26,7 +26,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		if ( ! $this->is_woo_activated() ) {
+		if ( ! $this->is_woocommerce_active() ) {
 			return;
 		}
 
@@ -34,12 +34,12 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Check whether woocommerce plugin is active.
+	 * Determines whether or not WooCommerce is active.
 	 *
-	 * @return bool True if woocommerce plugin is activated.
+	 * @return bool True if woocommerce plugin is active.
 	 */
-	private function is_woo_activated() {
-		return class_exists( 'WooCommerce', false );
+	private static function is_woocommerce_active() {
+		return WPSEO_Utils::is_woocommerce_active();
 	}
 
 	/**
@@ -71,7 +71,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 		}
 
 		if ( ! isset( self::$is_shop_page ) ) {
-			self::$is_shop_page = $this->is_woo_activated() && is_shop() && ! is_search();
+			self::$is_shop_page = $this->is_woocommerce_active() && is_shop() && ! is_search();
 		}
 
 		return self::$is_shop_page;

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -16,7 +16,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	protected static $shop_page_id;
 
 	/**
-	 * @var bool Is current page the shop page?
+	 * @var bool True when current page is the shop page.
 	 */
 	protected static $is_shop_page;
 
@@ -36,7 +36,7 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	/**
 	 * Check whether woocommerce plugin is active.
 	 *
-	 * @return bool
+	 * @return bool True if woocommerce plugin is activated.
 	 */
 	private function is_woo_activated() {
 		return class_exists( 'WooCommerce', false );
@@ -65,17 +65,13 @@ class WPSEO_WooCommerce_Shop_Page implements WPSEO_WordPress_Integration {
 	public function is_shop_page() {
 		global $wp_query;
 
-		if ( isset( self::$is_shop_page ) ) {
-			return self::$is_shop_page;
-		}
-
+		// Prevents too early "caching".
 		if ( ! isset( $wp_query ) ) {
 			return false;
 		}
 
-		self::$is_shop_page = false;
-		if ( $this->is_woo_activated() && $this->get_shop_page_id() > 0 ) {
-			self::$is_shop_page = is_shop() && ! is_search();
+		if ( ! isset( self::$is_shop_page ) ) {
+			self::$is_shop_page = $this->is_woo_activated() && is_shop() && ! is_search();
 		}
 
 		return self::$is_shop_page;

--- a/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
+++ b/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
@@ -8,14 +8,23 @@
 /**
  * Test Helper Class.
  */
-
 class WPSEO_WooCommerce_Shop_Page_Double extends WPSEO_WooCommerce_Shop_Page {
 
+	/**
+	 * Resets static variables.
+	 *
+	 * @return void
+	 */
 	public function reset() {
 		self::$shop_page_id = null;
 		self::$is_shop_page = null;
 	}
 
+	/**
+	 * "Simulate" that woocommerce is active.
+	 *
+	 * @return bool Always return true because it's "double" class.
+	 */
 	private function is_woo_activated() {
 		return true;
 	}

--- a/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
+++ b/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
@@ -11,6 +11,11 @@
 
 class WPSEO_WooCommerce_Shop_Page_Double extends WPSEO_WooCommerce_Shop_Page {
 
+	public function reset() {
+		self::$shop_page_id = null;
+		self::$is_shop_page = null;
+	}
+
 	private function is_woo_activated() {
 		return true;
 	}

--- a/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
+++ b/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
@@ -4,21 +4,11 @@
  *
  * @package WPSEO\Tests\Doubles
  */
-  
+
 /**
  * Test Helper Class.
  */
 class WPSEO_WooCommerce_Shop_Page_Double extends WPSEO_WooCommerce_Shop_Page {
-
-	/**
-	 * Resets static variables.
-	 *
-	 * @return void
-	 */
-	public function reset() {
-		self::$shop_page_id = null;
-		self::$is_shop_page = null;
-	}
 
 	/**
 	 * "Simulate" that woocommerce is active.

--- a/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
+++ b/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
@@ -25,7 +25,7 @@ class WPSEO_WooCommerce_Shop_Page_Double extends WPSEO_WooCommerce_Shop_Page {
 	 *
 	 * @return bool Always return true because it's "double" class.
 	 */
-	private function is_woo_activated() {
+	private function is_woocommerce_active() {
 		return true;
 	}
 }

--- a/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
+++ b/tests/doubles/class-wpseo-woocommerce-shop-page-double.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+  
+/**
+ * Test Helper Class.
+ */
+
+class WPSEO_WooCommerce_Shop_Page_Double extends WPSEO_WooCommerce_Shop_Page {
+
+	private function is_woo_activated() {
+		return true;
+	}
+}

--- a/tests/frontend/test-class-woocommerce-shop-page.php
+++ b/tests/frontend/test-class-woocommerce-shop-page.php
@@ -11,6 +11,28 @@
 class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 
 	/**
+	 * Tests the situation when woocommerce isn't activated.
+	 *
+	 * @covers WPSEO_WooCommerce_Shop_Page::get_shop_page_id()
+	 */
+	public function test_get_shop_page_id() {
+		$woocommerce_shop_page = new WPSEO_WooCommerce_Shop_Page();
+
+		$this->assertEquals( -1, $woocommerce_shop_page->get_shop_page_id() );
+	}
+
+	/**
+	 * Tests the situation when woocommerce isn't activated.
+	 *
+	 * @covers WPSEO_WooCommerce_Shop_Page::is_shop_page()
+	 */
+	public function test_is_shop_page() {
+		$woocommerce_shop_page = new WPSEO_WooCommerce_Shop_Page();
+
+		$this->assertEquals( false, $woocommerce_shop_page->is_shop_page() );
+	}
+
+	/**
 	 * Tests the situation where the currently opened page isn't a shop page.
 	 *
 	 * @covers WPSEO_WooCommerce_Shop_Page::get_page_id()

--- a/tests/frontend/test-class-woocommerce-shop-page.php
+++ b/tests/frontend/test-class-woocommerce-shop-page.php
@@ -18,7 +18,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	public function test_get_page_id_for_non_shop_page() {
 		/** @var $woocommerce_shop_page WPSEO_WooCommerce_Shop_Page */
 		$woocommerce_shop_page = $this
-			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page' )
+			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
 			->setMethods( array( 'is_shop_page', 'get_shop_page_id' ) )
 			->getMock();
 
@@ -42,7 +42,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	public function test_get_page_id_for_shop_page() {
 		/** @var $woocommerce_shop_page WPSEO_WooCommerce_Shop_Page */
 		$woocommerce_shop_page = $this
-			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page' )
+			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
 			->setMethods( array( 'is_shop_page', 'get_shop_page_id' ) )
 			->getMock();
 
@@ -68,7 +68,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	public function test_get_page_id_for_shop_page_with_missing_get_page_id_function() {
 		/** @var $woocommerce_shop_page WPSEO_WooCommerce_Shop_Page */
 		$woocommerce_shop_page = $this
-			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page' )
+			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
 			->setMethods( array( 'is_shop_page' ) )
 			->getMock();
 

--- a/tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
+++ b/tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
@@ -20,7 +20,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 	 * @return WPSEO_WooCommerce_Shop_page
 	 */
 	protected function get_woocommerce_shop_page_mock( $post ) {
-		$woocommerce_shop_page = $this->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page' )
+		$woocommerce_shop_page = $this->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
 			->setMethods( array( 'is_shop_page', 'get_shop_page_id' ) )
 			->getMock();
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds method `is_woocommerce_active` and check is woocommerce activate before registering hooks.
* Adds static variables to "cache" results of functions [`is_shop`](https://docs.woocommerce.com/wc-apidocs/function-is_shop.html) and [`wc_get_page_id`](https://docs.woocommerce.com/wc-apidocs/function-wc_get_page_id.html).

## Relevant technical choices:

* Adds method `is_woocommerce_active` which uses method `WPSEO_Utils::is_woocommerce_active` to check is woocommerce active. I've added new method because I want to overwrite it in "double" class to "simulate" that woocommerce is active.
* Addes "caching" for method is_shop_page to improve performance (prevents multiple calls of WC/WP API). Check if `$wp_query` exists to prevents too early "caching"  (and wrong detection).
* Addes "double" class for unit tests.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* We should repeat test from PR #8426:
  - Install [WooCommerce plugin](https://wordpress.org/plugins/woocommerce/) and create/set the shop page.
  - Edit the shop page's title and meta description.
  - View the shop page.
* Related to performance:
  - Deactivate WooCommerce plugin and set breakpoint to [this line](https://github.com/Yoast/wordpress-seo/blob/36534d27d12a6860b3f06a11bf4f9235b09ebbe2/frontend/class-woocommerce-shop-page.php#L33) ( `add_filter( 'wpseo_frontend_page_type_simple_page_id', ...` ). This line will not be executed.
  - Activate WooCommerce plugin and set breakpoint to these lines [class-woocommerce-shop-page.php#L74](https://github.com/Yoast/wordpress-seo/blob/36534d27d12a6860b3f06a11bf4f9235b09ebbe2/frontend/class-woocommerce-shop-page.php#L74) and [class-woocommerce-shop-page.php#L87](https://github.com/Yoast/wordpress-seo/blob/36534d27d12a6860b3f06a11bf4f9235b09ebbe2/frontend/class-woocommerce-shop-page.php#L87). These lines should be executed only once.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

