### PR TITLE
Adds a fallback for showing the right template

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -429,8 +429,7 @@ class WPSEO_Frontend {
 			$title = $this->get_title_from_options( 'title-home-wpseo' );
 		}
 		elseif ( $this->woocommerce_shop_page->is_shop_page() ) {
-			$post  = get_post( $this->woocommerce_shop_page->get_shop_page_id() );
-			$title = $this->get_seo_title( $post );
+			$title = $this->get_woocommerce_title();
 
 			if ( ! is_string( $title ) || $title === '' ) {
 				$title = $this->get_post_type_archive_title( $separator, $separator_location );
@@ -1725,6 +1724,42 @@ class WPSEO_Frontend {
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Retrieves the WooCommerce title.
+	 *
+	 * @return string The WooCommerce title.
+	 */
+	protected function get_woocommerce_title() {
+		$post  = get_post( $this->woocommerce_shop_page->get_shop_page_id() );
+		$title = $this->get_seo_title( $post );
+
+		if ( is_string( $title ) && $title !== '' ) {
+			return $title;
+		}
+
+		if ( $this->woocommerce_shop_page->get_shop_page_id() !== -1 && is_archive() ) {
+			$title = $this->get_template( 'title-' . $post->post_type );
+			$title = $this->replace_vars( $title, $post );
+
+			if ( is_string( $title ) && $title !== '' ) {
+				return $title;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Retrieves an template from the options.
+	 *
+	 * @param string $template The template to retrieve.
+	 *
+	 * @return string The set template.
+	 */
+	protected function get_template( $template ) {
+		return WPSEO_Options::get( $template );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the wrong title is rendered for the WooCommerce product archive

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout trunk
* Under search appearance - content types sets the title template for a product.
* Sets a page as the WooCommerce archive page.
* Set the title in the snippet editor: `%%title%% %%page%% %%sep%% %%sitename%%`.
* Save the page and see view it.
* The product title template will be used..
* Checkout this branch and verify it is solved.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11123
