### PR TITLE
Checks if attachments are disabled for Yoast SEO

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1014,6 +1014,10 @@ SVG;
 			return false;
 		}
 
+		if ( $post_type === 'attachment' && WPSEO_Options::get( 'disable-attachment' ) ) {
+			return false;
+		}
+
 		return WPSEO_Options::get( 'display-metabox-pt-' . $post_type );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast metabox is visible even when the attachment urls are redirected to the attachment file itself.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Disable the media feature under search appearance - media
* Edit a media item and see the yoast metabox being visible
* Checkout this branch
* The metabox should be gone. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
