### PR TITLE
Replaced Urls with shortlinks in admin bar "Keyword Research" menu

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -195,9 +195,9 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	protected function add_keyword_research_submenu( WP_Admin_Bar $wp_admin_bar ) {
-		$adwords_url = 'https://ads.google.com/home/tools/keyword-planner/';
-		$trends_url  = 'https://www.google.com/trends/explore';
-		$seobook_url = 'http://tools.seobook.com/keyword-tools/seobook/';
+		$adwords_url = 'https://yoa.st/keywordplanner';
+		$trends_url  = 'https://yoa.st/google-trends';
+		$seobook_url = 'https://yoa.st/seo-book';
 
 		$post = $this->get_singular_post();
 		if ( $post ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Make sure Yoast SEO is active in the admin bar. This is default but can be deactivated: https://kb.yoast.com/kb/remove-yoast-seo-admin-bar/
* Hover over the yoast icon, go to the "Keyword Research" menu and see that its subitems "Google Ads", "Google Trents" and "SEO book" are now linking to a shortlink.
* Make sure the links go to their original destination. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Related #11471 
