### PR TITLE
Fix an incompatibility between WP 5.0 and Yoast SEO resulting in console errors. 

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -114,9 +114,9 @@ class WPSEO_Admin_Asset_Manager {
 	}
 
 	/**
-	 * Registers all the styles it recieves.
+	 * Registers all the styles it receives.
 	 *
-	 * @param array $styles Styles that need to be registerd.
+	 * @param array $styles Styles that need to be registered.
 	 */
 	public function register_styles( $styles ) {
 		foreach ( $styles as $style ) {

--- a/admin/class-yoast-modal.php
+++ b/admin/class-yoast-modal.php
@@ -15,18 +15,9 @@ class Yoast_Modal {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'admin_footer', array( $this, 'print_localized_config' ) );
 	}
-
-	/**
-	 * Enqueues the assets needed for the modal.
-	 */
-	public function enqueue_assets() {
-		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		$asset_manager->enqueue_script( 'yoast-modal' );
-	}
-
+	
 	/**
 	 * Prints the modals configuration.
 	 */

--- a/admin/class-yoast-modal.php
+++ b/admin/class-yoast-modal.php
@@ -17,7 +17,7 @@ class Yoast_Modal {
 	public function __construct() {
 		add_action( 'admin_footer', array( $this, 'print_localized_config' ) );
 	}
-	
+
 	/**
 	 * Prints the modals configuration.
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Removes an enqueue assets from Yoast Modal that was incompatible with WP 5.0 and resulted in console errors. Also, it seemed an unnecessary enqueue. 

## Test instructions

This PR can be tested by following these steps:

To reproduce:
* Install and activate WordPress Beta Tester.
* Go to Tools -> Beta Testing.
* Choose Bleeding edge nightlies and Save changes.
* Go to Dashboard -> Updates.
* Click "Update now" for "An updated version of WordPress is available.".
* Check that you're now running 5.0 beta (at the bottom of the page you can see it).
* Go to plugins and activate Yoast SEO
* Check console and see a list of errors. See original issue for screenshot. 

Checkout this branch.
* Check console again, errors should be gone. 
* Install/Activate the query monitor plugin and make sure it gives no errors or warnings.
* Create a new post and open one of the Yoast Modals (for example under "Focus Keyphrase" --> "Add synonyms" or "Add related keyphrase". And make sure that gives no errors. 
* Also test with classic editor plugin, and test latest WP stable release. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11418 
