### PR TITLE
Use the default author description for open graph

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -604,6 +604,10 @@ class WPSEO_OpenGraph {
 			}
 		}
 
+		if ( is_author() ) {
+			$ogdesc = $frontend->metadesc( false );
+		}
+
 		if ( is_category() || is_tag() || is_tax() ) {
 			$ogdesc = WPSEO_Taxonomy_Meta::get_meta_without_term( 'opengraph-description' );
 			if ( $ogdesc === '' ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `og:description` remain empty after setting the author description

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout trunk
* Edit an author page by setting the meta description.
* Save it and visit the author page. Make sure author archives are enabled 
* In the source no `og:description` is set.
* Checkout this branch
* It should be solved

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #7520
