### PR TITLE
Hides the fields when author archives are disabled

### DIFF
--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -27,13 +27,13 @@ $wpseo_no_index_author_label = sprintf(
 	<textarea rows="5" cols="30" id="wpseo_author_metadesc"
 		class="yoast-settings__textarea yoast-settings__textarea--medium"
 		name="wpseo_author_metadesc"><?php echo esc_textarea( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea><br>
-	<?php endif; ?>
 
 	<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_noindex_author"
 		name="wpseo_noindex_author"
 		value="on" <?php echo ( get_the_author_meta( 'wpseo_noindex_author', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />
 	<label class="yoast-label-strong"
 		for="wpseo_noindex_author"><?php echo esc_html( $wpseo_no_index_author_label ); ?></label><br>
+	<?php endif; ?>
 
 	<?php if ( WPSEO_Options::get( 'keyword_analysis_active', false ) ) : ?>
 		<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_keyword_analysis_disable"

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -18,6 +18,7 @@ $wpseo_no_index_author_label = sprintf(
 
 	<h2 id="wordpress-seo"><?php echo esc_html( $wpseo_up_settings_header ); ?></h2>
 
+	<?php if ( ! WPSEO_Options::get( 'disable-author' ) ) : ?>
 	<label for="wpseo_author_title"><?php esc_html_e( 'Title to use for Author page', 'wordpress-seo' ); ?></label>
 	<input class="yoast-settings__text regular-text" type="text" id="wpseo_author_title" name="wpseo_author_title"
 		value="<?php echo esc_attr( get_the_author_meta( 'wpseo_title', $user->ID ) ); ?>"/><br>
@@ -26,6 +27,7 @@ $wpseo_no_index_author_label = sprintf(
 	<textarea rows="5" cols="30" id="wpseo_author_metadesc"
 		class="yoast-settings__textarea yoast-settings__textarea--medium"
 		name="wpseo_author_metadesc"><?php echo esc_textarea( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea><br>
+	<?php endif; ?>
 
 	<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_noindex_author"
 		name="wpseo_noindex_author"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Hides SEO title and metadescription fields on the author edit page when the author archives are disabled

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout trunk
* Disable the author archives 
* Edit an author and see that you can give a title and metadescription. You also can set the noindex value for the author.
* Checkout this branch
* See the three fields are hidden.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11497
