### PR TITLE
Bump YoastSEO.js to 1.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.1",
-    "yoastseo": "https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.1"
+    "yoastseo": "^1.42.0"
   },
   "yoast": {
     "pluginVersion": "9.1-RC4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12130,6 +12130,17 @@ yauzl@^2.2.1:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
+yoastseo@^1.42.0:
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.42.0.tgz#ca8f83778a184553d92e3a7bda5c671af257695a"
+  integrity sha512-ikZZ6zP3LrbXpKo6nEJcEc3zoc/YBO+IBWIpIHaBIj05uRGeyiT8+obNxnDY1p7httgHLYZur78B4b2kM53Xaw==
+  dependencies:
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    lodash-es "^4.17.10"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.1"
+
 "yoastseo@https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.1":
   version "1.41.1"
   resolved "https://github.com/Yoast/YoastSEO.js.git#7773587cb3ac1474f995a8fa3232f70f8807654b"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Bumps YoastSEO.js to v. 1.42.0.

## Test instructions

This PR can be tested by following these steps:

* Check whether the following works: 
  * https://github.com/Yoast/YoastSEO.js/pull/1823
  * https://github.com/Yoast/YoastSEO.js/pull/1912

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
