### PR TITLE
CS: clean up after merges

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -718,8 +718,8 @@ class WPSEO_Admin_Init {
 			$warning = esc_html__( 'WARNING:', 'wordpress-seo' );
 			/* translators: %1$s and %2$s expand to <i> items to emphasize the word in the middle. */
 			$message = esc_html__( 'Changing your permalinks settings can seriously impact your search engine visibility. It should almost %1$s never %2$s be done on a live website.', 'wordpress-seo' );
-			$link = esc_html__( 'Learn about why permalinks are important for SEO.', 'wordpress-seo' );
-			$url = WPSEO_Shortlinker::get( 'https://yoa.st/why-permalinks/' );
+			$link    = esc_html__( 'Learn about why permalinks are important for SEO.', 'wordpress-seo' );
+			$url     = WPSEO_Shortlinker::get( 'https://yoa.st/why-permalinks/' );
 
 			echo '<div class="notice notice-warning"><p><strong>' . $warning . '</strong><br>' . sprintf( $message, '<i>', '</i>' ) . '<br><a href="' . $url . '" target="_blank">' . $link . '</a></p></div>';
 		}

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -60,7 +60,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$dismiss_msg = sprintf( __( 'Dismiss %s upgrade notice', 'wordpress-seo' ), 'Yoast SEO Premium' );
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$button_text = esc_html( sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ) );
+		$button_text  = esc_html( sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ) );
 		$button_text .= '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -73,8 +73,8 @@ class WPSEO_Metabox_Formatter {
 			 *
 			 * @param bool $showMarkers Should the markers being enabled. Default = true.
 			 */
-			'show_markers'          => apply_filters( 'wpseo_enable_assessment_markers', true ),
-			'publish_box'           => array(
+			'show_markers'              => apply_filters( 'wpseo_enable_assessment_markers', true ),
+			'publish_box'               => array(
 				'labels' => array(
 					'content' => array(
 						'na'   => sprintf(
@@ -130,8 +130,8 @@ class WPSEO_Metabox_Formatter {
 					),
 				),
 			),
-			'markdownEnabled'       => $this->is_markdown_enabled(),
-			'analysisHeadingTitle'  => __( 'Analysis', 'wordpress-seo' ),
+			'markdownEnabled'           => $this->is_markdown_enabled(),
+			'analysisHeadingTitle'      => __( 'Analysis', 'wordpress-seo' ),
 		);
 	}
 

--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -156,11 +156,11 @@ class WPSEO_GSC_Category_Filters {
 			)
 		);
 
-		$class = 'gsc_category';
+		$class        = 'gsc_category';
 		$aria_current = '';
 
 		if ( $this->category === $category ) {
-			$class .= ' current';
+			$class       .= ' current';
 			$aria_current = ' aria-current="page"';
 		}
 

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -254,7 +254,7 @@ class WPSEO_OpenGraph_Image {
 
 
 		$frontpage_image_url = WPSEO_Options::get( 'og_frontpage_image' );
-		$frontpage_image_id = WPSEO_Options::get( 'og_frontpage_image_id' );
+		$frontpage_image_id  = WPSEO_Options::get( 'og_frontpage_image_id' );
 
 		$this->add_image_by_id_or_url( $frontpage_image_id, $frontpage_image_url, array( $this, 'save_frontpage_image_id' ) );
 	}
@@ -370,7 +370,7 @@ class WPSEO_OpenGraph_Image {
 	 * @return void
 	 */
 	private function set_image_post_meta( $post_id = 0 ) {
-		$image_id = WPSEO_Meta::get_value( 'opengraph-image-id', $post_id );
+		$image_id  = WPSEO_Meta::get_value( 'opengraph-image-id', $post_id );
 		$image_url = WPSEO_Meta::get_value( 'opengraph-image', $post_id );
 
 		$this->add_image_by_id_or_url( $image_id, $image_url, array( $this, 'save_opengraph_image_id_meta' ) );

--- a/frontend/class-opengraph-oembed.php
+++ b/frontend/class-opengraph-oembed.php
@@ -9,6 +9,7 @@
  * Class WPSEO_OpenGraph_OEmbed
  */
 class WPSEO_OpenGraph_OEmbed implements WPSEO_WordPress_Integration {
+
 	/**
 	 * Registers the hooks.
 	 */

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -203,7 +203,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			$focus_keyword = $this->get_post_focus_keyword( $post );
 
 			if ( ! empty( $focus_keyword ) ) {
-				$trends_url  .= '#q=' . urlencode( $focus_keyword );
+				$trends_url .= '#q=' . urlencode( $focus_keyword );
 			}
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1119,7 +1119,7 @@ SVG;
 	 * @return string The log level to use.
 	 */
 	public static function get_analysis_worker_log_level() {
-		if ( defined( 'YOAST_SEO_DEBUG' ) && YOAST_SEO_DEBUG  ) {
+		if ( defined( 'YOAST_SEO_DEBUG' ) && YOAST_SEO_DEBUG ) {
 			return defined( 'YOAST_SEO_DEBUG_ANALYSIS_WORKER' ) ? YOAST_SEO_DEBUG_ANALYSIS_WORKER : 'INFO';
 		}
 

--- a/migrations/20171228151840_WpYoastIndexable.php
+++ b/migrations/20171228151840_WpYoastIndexable.php
@@ -12,6 +12,7 @@ use Yoast\YoastSEO\Yoast_Model;
  * Indexable migration.
  */
 class WpYoastIndexable extends Ruckusing_Migration_Base {
+
 	/**
 	 * Migration up.
 	 */

--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -222,7 +222,7 @@ class Database_Migration {
 	protected function get_defines( $table_name ) {
 		if ( $this->dependency_management->prefixed_available() ) {
 			return array(
-				YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_BASE'               => WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY . '/ruckusing',
+				YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_BASE' => WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY . '/ruckusing',
 				YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_TS_SCHEMA_TBL_NAME' => $table_name,
 			);
 		}

--- a/src/config/dependency-management.php
+++ b/src/config/dependency-management.php
@@ -14,6 +14,7 @@ use Composer\Installer\PackageEvent;
  * Sets up class aliases and defines required constants.
  */
 class Dependency_Management {
+
 	/**
 	 * Registers the autoloader to create class aliases when needed.
 	 *

--- a/src/exceptions/no-indexable-found.php
+++ b/src/exceptions/no-indexable-found.php
@@ -96,7 +96,7 @@ class No_Indexable_Found extends \OutOfRangeException {
 	 */
 	public static function from_meta_key( $meta_key, $indexable_id ) {
 		$message = \sprintf(
-		/* translators: 1: expands to the indexable id. 2: expand to the meta key */
+			/* translators: 1: expands to the indexable id. 2: expand to the meta key */
 			\__( 'There is no meta found for indexable id %1$s and meta key %2$s.', 'wordpress-seo' ),
 			$indexable_id,
 			$meta_key

--- a/src/formatters/indexable-author-formatter.php
+++ b/src/formatters/indexable-author-formatter.php
@@ -103,6 +103,7 @@ class Indexable_Author_Formatter {
 
 		return $value;
 	}
+
 	/**
 	 * Retrieves the permalink of a user.
 	 *

--- a/src/formatters/indexable-term-formatter.php
+++ b/src/formatters/indexable-term-formatter.php
@@ -6,6 +6,7 @@
  */
 
 namespace Yoast\YoastSEO\Formatters;
+
 use Yoast\YoastSEO\Models\Indexable;
 
 /**

--- a/src/loggers/migration-logger.php
+++ b/src/loggers/migration-logger.php
@@ -13,6 +13,7 @@ use YoastSEO_Vendor\Ruckusing_Util_Logger;
  * Logger to make sure the output is not written into a file.
  */
 class Migration_Logger extends Ruckusing_Util_Logger {
+
 	/**
 	 * Creates an instance of Ruckusing_Util_Logger
 	 *

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -204,7 +204,7 @@ class Indexable extends Yoast_Model {
 	 * @return void
 	 */
 	public function set_meta( $meta_key, $meta_value, $auto_create = true ) {
-		$meta = $this->get_meta( $meta_key, $auto_create );
+		$meta             = $this->get_meta( $meta_key, $auto_create );
 		$meta->meta_value = $meta_value;
 	}
 

--- a/src/models/primary-term.php
+++ b/src/models/primary-term.php
@@ -34,9 +34,9 @@ class Primary_Term extends Yoast_Model {
 	public static function find_by_postid_and_taxonomy( $post_id, $taxonomy, $auto_create = true ) {
 		/** @var \Yoast\YoastSEO\Models\Primary_Term $indexable */
 		$indexable = Yoast_Model::of_type( 'Primary_Term' )
-		                        ->where( 'post_id', $post_id )
-		                        ->where( 'taxonomy', $taxonomy )
-		                        ->find_one();
+			->where( 'post_id', $post_id )
+			->where( 'taxonomy', $taxonomy )
+			->find_one();
 
 		if ( $auto_create && ! $indexable ) {
 			$indexable = Yoast_Model::of_type( 'Primary_Term' )->create();
@@ -62,5 +62,4 @@ class Primary_Term extends Yoast_Model {
 
 		return parent::save();
 	}
-
 }

--- a/src/watchers/indexable-post-watcher.php
+++ b/src/watchers/indexable-post-watcher.php
@@ -16,6 +16,7 @@ use Yoast\YoastSEO\Models\Indexable;
  * Fills the Indexable according to Post data.
  */
 class Indexable_Post_Watcher implements Integration {
+
 	/**
 	 * Registers all hooks to WordPress.
 	 *

--- a/src/watchers/primary-term-watcher.php
+++ b/src/watchers/primary-term-watcher.php
@@ -249,5 +249,4 @@ class Primary_Term_Watcher implements Integration {
 	protected function is_referer_valid( $taxonomy ) {
 		return check_admin_referer( 'save-primary-term', \WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_nonce' );
 	}
-
 }

--- a/src/wordpress/integration.php
+++ b/src/wordpress/integration.php
@@ -11,6 +11,7 @@ namespace Yoast\YoastSEO\WordPress;
  * An interface for registering integrations with WordPress
  */
 interface Integration {
+
 	/**
 	 * Initializes the integration.
 	 *

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -31,7 +31,8 @@ use YoastSEO_Vendor\ORM;
  * @method Array asArray()
  */
 class Yoast_Model {
-	/*
+
+	/**
 	 * Default ID column for all models. Can be overridden by adding
 	 * a public static _id_column property to your model classes.
 	 */
@@ -441,9 +442,9 @@ class Yoast_Model {
 
 		/*
 			"   SELECT {$associated_table_name}.*
-				  FROM {$associated_table_name} JOIN {$join_table_name}
+				FROM {$associated_table_name} JOIN {$join_table_name}
 					ON {$associated_table_name}.{$associated_table_id_column} = {$join_table_name}.{$key_to_associated_table}
-				 WHERE {$join_table_name}.{$key_to_base_table} = {$this->$base_table_id_column} ;"
+				WHERE {$join_table_name}.{$key_to_base_table} = {$this->$base_table_id_column} ;"
 		*/
 		return static::factory( $associated_class_name, $connection_name )
 			->select( "{$associated_table_name}.*" )

--- a/tests/admin/test-class-admin-asset-analysis-worker-location.php
+++ b/tests/admin/test-class-admin-asset-analysis-worker-location.php
@@ -16,7 +16,7 @@ final class Test_WPSEO_Admin_Asset_Analysis_Worker_Location extends PHPUnit_Fram
 	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
 	 */
 	public function test_get_url() {
-		$suffix = YOAST_ENVIRONMENT === 'development' ? '' : '.min';
+		$suffix = ( YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
 
 		// Default name.
 		$expected_js = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/wp-seo-analysis-worker-test' . $suffix . '.js';
@@ -31,7 +31,7 @@ final class Test_WPSEO_Admin_Asset_Analysis_Worker_Location extends PHPUnit_Fram
 	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
 	 */
 	public function test_get_url_with_name() {
-		$suffix = YOAST_ENVIRONMENT === 'development' ? '' : '.min';
+		$suffix = ( YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
 
 		$expected_js = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/wp-seo-something-else-version' . $suffix . '.js';
 		$location    = new WPSEO_Admin_Asset_Analysis_Worker_Location( 'version', 'something-else' );

--- a/tests/admin/test-class-option-tabs.php
+++ b/tests/admin/test-class-option-tabs.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * WPSEO plugin test file.
  *

--- a/tests/config-ui/components/test-class-component-mailchimp-signup.php
+++ b/tests/config-ui/components/test-class-component-mailchimp-signup.php
@@ -10,7 +10,6 @@
  */
 class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 
-
 	/**
 	 * Tests the get_identifier
 	 *
@@ -21,7 +20,6 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( 'MailchimpSignup', $mailchimp_signup->get_identifier() );
 	}
-
 
 	/**
 	 * Tests the get_field
@@ -34,7 +32,6 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 		$this->assertInstanceOf( 'WPSEO_Config_Field', $mailchimp_signup->get_field() );
 	}
 
-
 	/**
 	 * Tests getting the data.
 	 *
@@ -45,7 +42,8 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals(
 			array( 'hasSignup' => false ),
-			$mailchimp_signup->get_data() );
+			$mailchimp_signup->get_data()
+		);
 	}
 
 	/**

--- a/tests/frontend/test-class-opengraph.php
+++ b/tests/frontend/test-class-opengraph.php
@@ -698,7 +698,7 @@ EXPECTED;
 	 */
 	public function test_taxonomy_description_with_replacevars() {
 		$expected_title = 'Test title';
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => $expected_title ) );
+		$term_id        = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => $expected_title ) );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-description', '%%term_title%%' );
 

--- a/tests/inc/indexables/test-class-object-type.php
+++ b/tests/inc/indexables/test-class-object-type.php
@@ -98,6 +98,6 @@ class WPSEO_Object_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Object_Type::is_subtype
 	 */
 	public function test_is_not_subtype() {
-		$this->assertFalse( $this->class_instance->is_subtype( 'term')  );
+		$this->assertFalse( $this->class_instance->is_subtype( 'term' ) );
 	}
 }

--- a/tests/src/doubles/indexable-author-formatter-double.php
+++ b/tests/src/doubles/indexable-author-formatter-double.php
@@ -5,6 +5,7 @@ namespace Yoast\Tests\Doubles;
 use Yoast\YoastSEO\Formatters\Indexable_Author_Formatter;
 
 class Indexable_Author_Formatter_Double extends Indexable_Author_Formatter {
+
 	/**
 	 * @inheritdoc
 	 */

--- a/tests/src/doubles/indexable-post-formatter-double.php
+++ b/tests/src/doubles/indexable-post-formatter-double.php
@@ -54,5 +54,4 @@ class Indexable_Post_Formatter_Double extends Indexable_Post_Formatter {
 	public function set_link_count( $indexable ) {
 		return parent::set_link_count( $indexable );
 	}
-
 }

--- a/tests/src/doubles/plugin.php
+++ b/tests/src/doubles/plugin.php
@@ -3,6 +3,7 @@
 namespace Yoast\Tests\Doubles;
 
 class Plugin extends \Yoast\YoastSEO\Config\Plugin {
+
 	/**
 	 * Sets the value for the initialize success property
 	 *

--- a/tests/src/integration-tests/config/database-migration-test.php
+++ b/tests/src/integration-tests/config/database-migration-test.php
@@ -12,6 +12,7 @@ use Yoast\YoastSEO\Config\Database_Migration;
  * @package Yoast\Tests
  */
 class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Tests if the migrations are usable.
 	 */
@@ -47,5 +48,4 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 		 */
 		$this->assertFalse( $instance->is_usable() );
 	}
-
 }

--- a/tests/src/integration-tests/config/upgrade-test.php
+++ b/tests/src/integration-tests/config/upgrade-test.php
@@ -11,9 +11,6 @@ use Yoast\YoastSEO\Config\Upgrade;
  */
 class Upgrade_Test extends \PHPUnit_Framework_TestCase {
 
-	/**
-	 *
-	 */
 	public function test_action_hooked() {
 		$migration = $this
 			->getMockBuilder( '\Yoast\YoastSEO\Config\Database_Migration' )

--- a/tests/src/unit-tests/config/admin-test.php
+++ b/tests/src/unit-tests/config/admin-test.php
@@ -10,6 +10,7 @@ use Yoast\YoastSEO\Config\Admin;
  * @package Yoast\Tests\Config
  */
 class Admin_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Tests if the class is based upon the Integration interface
 	 */

--- a/tests/src/unit-tests/config/database-migration-test.php
+++ b/tests/src/unit-tests/config/database-migration-test.php
@@ -14,6 +14,7 @@ use Yoast\YoastSEO\Config\Dependency_Management;
  * @package Yoast\Tests
  */
 class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Tests the initializing with the defining of constants fails.
 	 */
@@ -67,8 +68,8 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$instance->expects( $this->once() )
-				 ->method( 'get_migration_state' )
-				 ->will( $this->returnValue( Database_Migration::MIGRATION_STATE_ERROR ) );
+			->method( 'get_migration_state' )
+			->will( $this->returnValue( Database_Migration::MIGRATION_STATE_ERROR ) );
 
 		$this->assertFalse( $instance->is_usable() );
 	}
@@ -131,7 +132,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 		$instance
 			->expects( $this->once() )
 			->method( 'get_framework_runner' )
-			->will( $this->throwException( new \Exception ) );
+			->will( $this->throwException( new \Exception() ) );
 
 		$instance
 			->expects( $this->once() )
@@ -160,7 +161,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	 */
 	public function test_get_configuration() {
 		$instance = new Database_Migration_Double(
-			( object ) array( 'charset' => 'foo' ), new Dependency_Management()
+			(object) array( 'charset' => 'foo' ), new Dependency_Management()
 		);
 
 		$this->assertInternalType( 'array', $instance->get_configuration() );

--- a/tests/src/unit-tests/config/dependency-management-test.php
+++ b/tests/src/unit-tests/config/dependency-management-test.php
@@ -12,6 +12,7 @@ use Yoast\YoastSEO\Config\Dependency_Management;
  * @package Yoast\Tests
  */
 class Dependency_Management_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Tests if the alias is created with ideal conditions
 	 *

--- a/tests/src/unit-tests/config/frontend-test.php
+++ b/tests/src/unit-tests/config/frontend-test.php
@@ -10,6 +10,7 @@ use Yoast\YoastSEO\Config\Frontend;
  * @package Yoast\Tests\Config
  */
 class Frontend_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Tests if the class is based upon the Integration interface
 	 */

--- a/tests/src/unit-tests/config/plugin-test.php
+++ b/tests/src/unit-tests/config/plugin-test.php
@@ -15,6 +15,7 @@ use Yoast\YoastSEO\WordPress\Integration_Group;
  * @package Yoast\Tests\Config
  */
 class Plugin_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Tests if the class is based upon the Integration interface
 	 */
@@ -226,7 +227,7 @@ class Plugin_Test extends \PHPUnit_Framework_TestCase {
 
 		$instance->register_hooks();
 
-		$this->assertEquals( $action_count + 1, did_action( 'wpseo_load_integrations' ) );
+		$this->assertEquals( ( $action_count + 1 ), did_action( 'wpseo_load_integrations' ) );
 	}
 
 	/**

--- a/tests/src/unit-tests/config/upgrade-test.php
+++ b/tests/src/unit-tests/config/upgrade-test.php
@@ -9,9 +9,6 @@ namespace Yoast\Tests\UnitTests\Config;
  */
 class Upgrade_Test extends \PHPUnit_Framework_TestCase {
 
-	/**
-	 *
-	 */
 	public function test_do_upgrade() {
 		$migration = $this
 			->getMockBuilder( '\Yoast\YoastSEO\Config\Database_Migration' )
@@ -20,7 +17,7 @@ class Upgrade_Test extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$migration->expects( $this->once() )
-				  ->method( 'run_migrations' );
+			->method( 'run_migrations' );
 
 		$instance = $this
 			->getMockBuilder( '\Yoast\YoastSEO\Config\Upgrade' )

--- a/tests/src/unit-tests/exceptions/no-indexable-found-test.php
+++ b/tests/src/unit-tests/exceptions/no-indexable-found-test.php
@@ -47,7 +47,7 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 		try {
 			throw No_Indexable_Found::from_post_id( 1 );
 		}
-		catch( No_Indexable_Found $e ) {
+		catch ( No_Indexable_Found $e ) {
 			$this->assertEquals(
 				'There is no indexable found for post id 1.',
 				$e->getMessage()
@@ -65,7 +65,7 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 		try {
 			throw No_Indexable_Found::from_term_id( 1, 'category' );
 		}
-		catch( No_Indexable_Found $e ) {
+		catch ( No_Indexable_Found $e ) {
 			$this->assertEquals(
 				'There is no indexable found for term id 1 and taxonomy category.',
 				$e->getMessage()
@@ -83,7 +83,7 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 		try {
 			throw No_Indexable_Found::from_primary_term( 1, 'category' );
 		}
-		catch( No_Indexable_Found $e ) {
+		catch ( No_Indexable_Found $e ) {
 			$this->assertEquals(
 				'There is no primary term found for post id 1 and taxonomy category.',
 				$e->getMessage()
@@ -101,13 +101,14 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 		try {
 			throw No_Indexable_Found::from_author_id( 1 );
 		}
-		catch( No_Indexable_Found $e ) {
+		catch ( No_Indexable_Found $e ) {
 			$this->assertEquals(
 				'There is no indexable found for author id 1.',
 				$e->getMessage()
 			);
 		}
 	}
+
 	/**
 	 * Tests the exception for a non existing indexable meta.
 	 *
@@ -118,7 +119,7 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 		try {
 			throw No_Indexable_Found::from_meta_key( 'name', 1 );
 		}
-		catch( No_Indexable_Found $e ) {
+		catch ( No_Indexable_Found $e ) {
 			$this->assertEquals(
 				'There is no meta found for indexable id 1 and meta key name.',
 				$e->getMessage()

--- a/tests/src/unit-tests/formatters/indexable-author-formatter-test.php
+++ b/tests/src/unit-tests/formatters/indexable-author-formatter-test.php
@@ -36,8 +36,8 @@ class Indexable_Author_Formatter_Test extends \PHPUnit_Framework_TestCase {
 			->method( 'get_author_meta' )
 			->will(
 				$this->onConsecutiveCalls(
-					'title' ,
-				    'description' ,
+					'title',
+					'description',
 					'on'
 				)
 			);
@@ -62,5 +62,4 @@ class Indexable_Author_Formatter_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $instance->get_noindex_value( true ) );
 		$this->assertFalse( $instance->get_noindex_value( false ) );
 	}
-
 }

--- a/tests/src/unit-tests/formatters/indexable-post-formatter-test.php
+++ b/tests/src/unit-tests/formatters/indexable-post-formatter-test.php
@@ -96,7 +96,6 @@ class Indexable_Post_Formatter_Test extends \PHPUnit_Framework_TestCase {
 		$formatter->format( $indexable );
 	}
 
-
 	/**
 	 * Tests retreiving a meta value
 	 *
@@ -198,7 +197,7 @@ class Indexable_Post_Formatter_Test extends \PHPUnit_Framework_TestCase {
 			)
 			->getMock();
 
-		$seo_meta = new \stdClass();
+		$seo_meta                      = new \stdClass();
 		$seo_meta->internal_link_count = 404;
 		$seo_meta->incoming_link_count = 1337;
 
@@ -210,8 +209,8 @@ class Indexable_Post_Formatter_Test extends \PHPUnit_Framework_TestCase {
 		$indexable = new \stdClass();
 		$indexable = $formatter->set_link_count( $indexable );
 
-		$this->assertAttributeEquals( 404, 'link_count', $indexable  );
-		$this->assertAttributeEquals( 1337, 'incoming_link_count', $indexable  );
+		$this->assertAttributeEquals( 404, 'link_count', $indexable );
+		$this->assertAttributeEquals( 1337, 'incoming_link_count', $indexable );
 	}
 
 	/**

--- a/tests/src/unit-tests/formatters/indexable-term-formatter-test.php
+++ b/tests/src/unit-tests/formatters/indexable-term-formatter-test.php
@@ -25,7 +25,7 @@ class Indexable_Term_Formatter_Test extends \PHPUnit_Framework_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance =  new Indexable_Term_Formatter_Double( 1, 'category' );
+		$this->instance = new Indexable_Term_Formatter_Double( 1, 'category' );
 	}
 
 	/**
@@ -62,7 +62,7 @@ class Indexable_Term_Formatter_Test extends \PHPUnit_Framework_TestCase {
 						'wpseo_linkdex'         => 'linkdex',
 						'wpseo_noindex'         => 'noindex',
 						'wpseo_title'           => 'title',
-						'wpseo_opengraph-title' => 'opengraph title'
+						'wpseo_opengraph-title' => 'opengraph title',
 					)
 				)
 			);
@@ -153,5 +153,4 @@ class Indexable_Term_Formatter_Test extends \PHPUnit_Framework_TestCase {
 	public function test_get_indexable_meta_lookup() {
 		$this->assertInternalType( 'array', $this->instance->get_indexable_meta_lookup() );
 	}
-
 }

--- a/tests/src/unit-tests/watchers/indexable-author-watcher-test.php
+++ b/tests/src/unit-tests/watchers/indexable-author-watcher-test.php
@@ -106,7 +106,7 @@ class Indexable_Author_Watcher_Test extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$formatter_mock
-			->expects($this->once() )
+			->expects( $this->once() )
 			->method( 'format' )
 			->with( $indexable_mock )
 			->will( $this->returnValue( $indexable_mock ) );

--- a/tests/src/unit-tests/watchers/indexable-post-watcher-test.php
+++ b/tests/src/unit-tests/watchers/indexable-post-watcher-test.php
@@ -15,6 +15,7 @@ use Yoast\YoastSEO\Watchers\Indexable_Post_Watcher;
  * @package Yoast\Tests\Watchers
  */
 class Indexable_Post_Watcher_Test extends \PHPUnit_Framework_TestCase {
+
 	public function setUp() {
 		parent::setUp();
 
@@ -112,7 +113,7 @@ class Indexable_Post_Watcher_Test extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$formatter_mock
-			->expects($this->once() )
+			->expects( $this->once() )
 			->method( 'format' )
 			->with( $indexable_mock )
 			->will( $this->returnValue( $indexable_mock ) );
@@ -172,7 +173,6 @@ class Indexable_Post_Watcher_Test extends \PHPUnit_Framework_TestCase {
 
 		$instance->save_meta( 1 );
 	}
-
 
 	/**
 	 * Tests the save meta functionality

--- a/tests/src/unit-tests/watchers/indexable-term-watcher-test.php
+++ b/tests/src/unit-tests/watchers/indexable-term-watcher-test.php
@@ -14,6 +14,7 @@ use Yoast\YoastSEO\Watchers\Indexable_Term_Watcher;
  * @package Yoast\Tests\Watchers
  */
 class Indexable_Term_Watcher_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Tests if the expected hooks are registered
 	 *
@@ -104,7 +105,7 @@ class Indexable_Term_Watcher_Test extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$formatter_mock
-			->expects($this->once() )
+			->expects( $this->once() )
 			->method( 'format' )
 			->with( $indexable_mock )
 			->will( $this->returnValue( $indexable_mock ) );

--- a/tests/test-class-admin-asset-manager.php
+++ b/tests/test-class-admin-asset-manager.php
@@ -9,6 +9,7 @@
  * Unit Test Class.
  */
 class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
+
 	/**
 	 * @var WPSEO_Admin_Asset_Manager
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

Clean up violations against CS rules which were previously brought down to zero already.

Concerns:
* Use tabs for indentation, not spaces.
* No precision alignment.
* Spacing between functions (one line before/after, no line at end of class).
* One blank line after a namespace declaration.
* One space on the inside of parenthesis.
* No space within type casts, i.e. `(bool)`, not `( bool )`.
* One space between a control structure keyword and the open parenthesis.
* One space between an assignment operator and the value being assigned.
* No space before the comma separating function call arguments.
* The assignment operator for lines containing consecutive variable assignments should be aligned.
* The double arrow in multi-line arrays should be aligned, providing this doesn't extend the line overly much.
* Files should end on a new line.
* Always use parenthesis when instantiating a new object.
* Use parenthesis around arithmetic/comparison operations to prevent issues with operator precedence.
* Comma after last item in a multi-line array.

Includes removing two empty function docblocks. Yes, the function docblocks are needed, but just having an empty docblock is useless.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* _N/A_ (basically whitespace only changes, so no risk of anything breaking)
