### PR TITLE
CS: rename two local variables

### DIFF
--- a/tests/src/unit-tests/wordpress/integration-group-test.php
+++ b/tests/src/unit-tests/wordpress/integration-group-test.php
@@ -50,8 +50,8 @@ class Integration_Group_Test extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( array( 'a', 'b' ) ) );
 
 		// Trigger the constructor to test the implicit method call.
-		$reflectedClass = new \ReflectionClass( $classname );
-		$constructor    = $reflectedClass->getConstructor();
+		$reflected_class = new \ReflectionClass( $classname );
+		$constructor     = $reflected_class->getConstructor();
 		$constructor->invoke( $instance, array( 'a', 'b' ) );
 	}
 
@@ -75,8 +75,8 @@ class Integration_Group_Test extends \PHPUnit_Framework_TestCase {
 		$no_integration = new \stdClass();
 
 		// Trigger the constructor to test the implicit method call.
-		$reflectedClass = new \ReflectionClass( $classname );
-		$constructor    = $reflectedClass->getConstructor();
+		$reflected_class = new \ReflectionClass( $classname );
+		$constructor     = $reflected_class->getConstructor();
 		$constructor->invoke( $instance, array( $integration, $no_integration ) );
 
 		$this->assertAttributeEquals( array( $integration ), 'integrations', $instance );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

... to comply with the WP variable name naming convention, which is still `snake_case`.

## Test instructions
This PR can be tested by following these steps:

* As these are variables in a unit test file, all should be good if the unit tests pass.