### PR TITLE
CS: various minor docs fixes

### DIFF
--- a/inc/exceptions/class-invalid-argument-exception.php
+++ b/inc/exceptions/class-invalid-argument-exception.php
@@ -11,7 +11,7 @@
 class WPSEO_Invalid_Argument_Exception extends InvalidArgumentException {
 
 	/**
-	 * Creates an invalid empty parameter exeception.
+	 * Creates an invalid empty parameter exception.
 	 *
 	 * @param string $name The name of the parameter.
 	 *

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -19,7 +19,6 @@ use YoastSEO_Vendor\ORM;
  * class Widget extends Model {
  * }
  *
- *
  * The methods documented below are magic methods that conform to PSR-1.
  * This documentation exposes these methods to doc generators and IDEs.
  *

--- a/tests/doubles/class-wpseo-gutenberg-compatibility-double.php
+++ b/tests/doubles/class-wpseo-gutenberg-compatibility-double.php
@@ -13,7 +13,7 @@ class WPSEO_Gutenberg_Compatibility_Double extends WPSEO_Gutenberg_Compatibility
 	/**
 	 * Sets the installed version for easier testing.
 	 *
-	 * @param $version The version to set.
+	 * @param string|null $version The version to set.
 	 *
 	 * @return void
 	 */

--- a/tests/doubles/wpseo-link-reindex-dashboard-double.php
+++ b/tests/doubles/wpseo-link-reindex-dashboard-double.php
@@ -13,7 +13,7 @@ class WPSEO_Link_Reindex_Dashboard_Double extends WPSEO_Link_Reindex_Dashboard {
 	/**
 	 * Sets the unprocessed count to test other methods.
 	 *
-	 * @param mixed $unprocessed
+	 * @param mixed $unprocessed Number of unprocessed items.
 	 *
 	 * @return void
 	 */

--- a/tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -91,6 +91,8 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 	 * Filters the home URL.
 	 *
 	 * @param string $home_url Original home URL.
+	 * @param string $path     Relative path.
+	 *
 	 * @return string Home URL to override, or value of $home_url.
 	 */
 	public function filter_home_url( $home_url, $path ) {

--- a/tests/src/integration-tests/config/upgrade-test.php
+++ b/tests/src/integration-tests/config/upgrade-test.php
@@ -5,7 +5,8 @@ namespace Yoast\Tests\IntegrationTests\Config;
 use Yoast\YoastSEO\Config\Upgrade;
 
 /**
- * Class Upgrade_Test
+ * Class Upgrade_Test.
+ *
  * @package Yoast\Tests\IntegrationTests\Config
  */
 class Upgrade_Test extends \PHPUnit_Framework_TestCase {

--- a/tests/src/unit-tests/config/upgrade-test.php
+++ b/tests/src/unit-tests/config/upgrade-test.php
@@ -3,7 +3,8 @@
 namespace Yoast\Tests\UnitTests\Config;
 
 /**
- * Class Upgrade_Test
+ * Class Upgrade_Test.
+ *
  * @package Yoast\Tests\UnitTests\Config
  */
 class Upgrade_Test extends \PHPUnit_Framework_TestCase {

--- a/tests/src/unit-tests/formatters/indexable-term-formatter-test.php
+++ b/tests/src/unit-tests/formatters/indexable-term-formatter-test.php
@@ -5,7 +5,7 @@ namespace Yoast\Tests\UnitTests\Formatters;
 use Yoast\Tests\Doubles\Indexable_Term_Formatter_Double;
 
 /**
- * Class Indexable_Term_Test
+ * Class Indexable_Term_Test.
  *
  * @group indexables
  * @group formatters
@@ -30,6 +30,7 @@ class Indexable_Term_Formatter_Test extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * Tests the formatting of the indexable data.
+	 *
 	 * @covers \Yoast\YoastSEO\Formatters\Indexable_Term_Formatter::format
 	 */
 	public function test_format() {

--- a/tests/src/unit-tests/wordpress/integration-group-test.php
+++ b/tests/src/unit-tests/wordpress/integration-group-test.php
@@ -37,7 +37,7 @@ class Integration_Group_Test extends \PHPUnit_Framework_TestCase {
 	 */
 	public function test_construct() {
 		$classname = '\Yoast\YoastSEO\WordPress\Integration_Group';
-		// make sure only integrations are loaded.
+		// Make sure only integrations are loaded.
 		$instance = $this
 			->getMockBuilder( $classname )
 			->setMethods( array( 'ensure_integration' ) )


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

Various minor documentation fixes:
* Spelling and punctuation.
* Blank line above the first `@tag`
* No two consecutive blank lines in a docblock.
* All function parameters should be documented.
* `@param` comments should specify parameter type + have a comment explaining what the parameter signifies.

## Test instructions
This PR can be tested by following these steps:

* _N/A_