### PR TITLE
Set Gutenberg compatibility flag to true for meta boxes

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -197,7 +197,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				$this,
 				'meta_box',
 			), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ), array(
-				'__block_editor_compatible_meta_box' => false,
+				'__block_editor_compatible_meta_box' => true,
 			) );
 		}
 	}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -196,7 +196,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			add_meta_box( 'wpseo_meta', $product_title, array(
 				$this,
 				'meta_box',
-			), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ) );
+			), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ), array(
+				'__block_editor_compatible_meta_box' => false,
+			) );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Sets the `__block_editor_compatible_meta_box` flag to true in our metaboxes. Right now this does not do anything, but it may prevent incompatibility warning messages in the future. 
* Though the flag is specifically for metaboxes, there have also been reports that the warning message is also shown in dashboard widgets. This seems to have been unintended (as wp internally uses `add_meta_box` in it’s `wp_add_dashboard_widget` function). As far as I know this has been fixed: I have not been able to reproduce the message in the widget. 

## Test instructions

This PR can be tested by following these steps:

* As this is a fix to prevent something from changing, there is no change to test. Nothing should break though.
* If you really, really want to test this issue you could change the `__block_editor_compatible_meta_box` flag from 'true' to 'false' in `admin/metabox/class-metabox.php`, to see the message appear in the metabox. It appears both in WP5.0 as well as 4.9.8 with Gutenberg enabled. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11396
