### PR TITLE
Hide the markers by default

### DIFF
--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -37,6 +37,7 @@ import { refreshDelay } from "./analysis/constants";
 import { refreshSnippetEditor, updateData } from "./redux/actions/snippetEditor";
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 import { setFocusKeyword } from "./redux/actions/focusKeyword";
+import { setMarkerStatus } from "./redux/actions/markerButtons";
 
 // Helper dependencies.
 import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
@@ -233,6 +234,8 @@ window.yoastHideMarkers = true;
 		insertTinyMCE();
 
 		termScraper = new TermDataCollector( { store } );
+
+		store.dispatch( setMarkerStatus( "hidden" ) );
 
 		args = {
 			// ID's of elements that need to trigger updating the analyzer.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where non-functional markers are shown for taxonomy pages .

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Checkout trunk 
1. Do the yarn and build magic
1. Edit an taxonomy by pasting text into its description
1. Go to the analysis and see some marker icons.
1. Press one the marker icons and see it is not working
1. Checkout this branch
1. Do the build magic (again)
1. Do step 3 again
1. Go to the analysis and verify the marker icons are gone. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10563
