### PR TITLE
Remove lodash in favour of lodash-es

### DIFF
--- a/js/src/Pluggable.js
+++ b/js/src/Pluggable.js
@@ -1,11 +1,11 @@
-const forEach = require( "lodash/forEach" );
-const isArray = require( "lodash/isArray" );
-const isFunction = require( "lodash/isFunction" );
-const isNumber = require( "lodash/isNumber" );
-const isObject = require( "lodash/isObject" );
-const isString = require( "lodash/isString" );
-const isUndefined = require( "lodash/isUndefined" );
-const reduce = require( "lodash/reduce" );
+import { forEach } from "lodash-es";
+import { isArray } from "lodash-es";
+import { isFunction } from "lodash-es";
+import { isNumber } from "lodash-es";
+import { isObject } from "lodash-es";
+import { isString } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { reduce } from "lodash-es";
 
 /**
  * The plugins object takes care of plugin registrations, preloading and managing data modifications.

--- a/js/src/analysis/CustomAnalysisData.js
+++ b/js/src/analysis/CustomAnalysisData.js
@@ -1,5 +1,5 @@
-import isFunction from "lodash/isFunction";
-import merge from "lodash/merge";
+import { isFunction } from "lodash-es";
+import { merge } from "lodash-es";
 
 /**
  * Gets data from custom callback functions.

--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -1,7 +1,7 @@
 /* global jQuery, wpseoPostScraperL10n */
 
 /* External dependencies */
-import get from "lodash/get";
+import { get } from "lodash-es";
 import analysis from "yoastseo";
 const { removeMarks } = analysis.markers;
 

--- a/js/src/analysis/TermDataCollector.js
+++ b/js/src/analysis/TermDataCollector.js
@@ -1,7 +1,7 @@
 /* global jQuery, wpseoTermScraperL10n */
 
 /* External dependencies */
-import get from "lodash/get";
+import { get } from "lodash-es";
 
 /* Internal dependencies */
 import isKeywordAnalysisActive from "../analysis/isKeywordAnalysisActive";

--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -11,7 +11,7 @@ import {
 	mapCustomTaxonomies,
 } from "../helpers/replacementVariableHelpers";
 import tmceHelper, { tmceId } from "../wp-seo-tinymce";
-import debounce from "lodash/debounce";
+import { debounce } from "lodash-es";
 
 /**
  * Represents the classic editor data.

--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -1,5 +1,5 @@
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
+import { cloneDeep } from "lodash-es";
+import { merge } from "lodash-es";
 
 import measureTextWidth from "../helpers/measureTextWidth";
 import getContentLocale from "./getContentLocale";

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,4 +1,4 @@
-import debounce from "lodash/debounce";
+import { debounce } from "lodash-es";
 import {
 	updateReplacementVariable,
 	updateData,

--- a/js/src/analysis/getApplyMarks.js
+++ b/js/src/analysis/getApplyMarks.js
@@ -1,6 +1,6 @@
 /* global tinyMCE */
 
-import noop from "lodash/noop";
+import { noop } from "lodash-es";
 
 import tinyMCEHelper from "../wp-seo-tinymce";
 import { tinyMCEDecorator } from "../decorator/tinyMCE";

--- a/js/src/analysis/getContentLocale.js
+++ b/js/src/analysis/getContentLocale.js
@@ -1,5 +1,5 @@
 // External dependencies.
-import get from "lodash/get";
+import { get } from "lodash-es";
 
 // Internal dependencies.
 import getL10nObject from "./getL10nObject";

--- a/js/src/analysis/getDefaultQueryParams.js
+++ b/js/src/analysis/getDefaultQueryParams.js
@@ -1,5 +1,5 @@
 // External dependencies.
-import get from "lodash/get";
+import { get } from "lodash-es";
 
 /**
  * Retrieves the default query params.

--- a/js/src/analysis/getI18n.js
+++ b/js/src/analysis/getI18n.js
@@ -1,5 +1,5 @@
 var getTranslations = require( "./getTranslations" );
-var isEmpty = require( "lodash/isEmpty" );
+import { isEmpty } from "lodash-es";
 var Jed = require( "jed" );
 
 /**

--- a/js/src/analysis/getIndicatorForScore.js
+++ b/js/src/analysis/getIndicatorForScore.js
@@ -1,8 +1,8 @@
 /* global YoastSEO */
 
-import isUndefined  from "lodash/isUndefined";
+import { isUndefined } from "lodash-es";
 import { helpers } from "yoastseo";
-import isNil from "lodash/isNil";
+import { isNil } from "lodash-es";
 const { scoreToRating } = helpers;
 
 /**

--- a/js/src/analysis/getL10nObject.js
+++ b/js/src/analysis/getL10nObject.js
@@ -1,4 +1,4 @@
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 /**
  * Returns the l10n object for the current page, either term or post.

--- a/js/src/analysis/getTranslations.js
+++ b/js/src/analysis/getTranslations.js
@@ -1,6 +1,6 @@
 // External dependencies.
-import get from "lodash/get";
-import isUndefined from "lodash/isUndefined";
+import { get } from "lodash-es";
+import { isUndefined } from "lodash-es";
 
 // Internal dependencies.
 import getL10nObject from "./getL10nObject";

--- a/js/src/analysis/isContentAnalysisActive.js
+++ b/js/src/analysis/isContentAnalysisActive.js
@@ -1,6 +1,6 @@
 var getL10nObject = require( "./getL10nObject" );
 
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 /**
  * Returns whether or not the content analysis is active

--- a/js/src/analysis/isCornerstoneContentActive.js
+++ b/js/src/analysis/isCornerstoneContentActive.js
@@ -1,6 +1,6 @@
 var getL10nObject = require( "./getL10nObject" );
 
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 /**
  * Returns whether or not the cornerstone content is active

--- a/js/src/analysis/isKeywordAnalysisActive.js
+++ b/js/src/analysis/isKeywordAnalysisActive.js
@@ -1,6 +1,6 @@
 var getL10nObject = require( "./getL10nObject" );
 
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 /**
  * Returns whether or not the keyword analysis is active

--- a/js/src/analysis/isWordFormRecognitionActive.js
+++ b/js/src/analysis/isWordFormRecognitionActive.js
@@ -1,6 +1,6 @@
 var getL10nObject = require( "./getL10nObject" );
 
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 /**
  * Returns whether or not the word forms analysis is active.

--- a/js/src/analysis/snippetEditor.js
+++ b/js/src/analysis/snippetEditor.js
@@ -1,7 +1,7 @@
-import has from "lodash/has";
-import forEach from "lodash/forEach";
-import isEmpty from "lodash/isEmpty";
-import isUndefined from "lodash/isUndefined";
+import { has } from "lodash-es";
+import { forEach } from "lodash-es";
+import { isEmpty } from "lodash-es";
+import { isUndefined } from "lodash-es";
 
 /**
  * Gets the snippet editor data from a data collector.

--- a/js/src/analysis/usedKeywords.js
+++ b/js/src/analysis/usedKeywords.js
@@ -1,9 +1,9 @@
 /* global jQuery, ajaxurl */
 
-import has from "lodash/has";
-import debounce from "lodash/debounce";
-import isArray from "lodash/isArray";
-import isEqual from "lodash/isEqual";
+import { has } from "lodash-es";
+import { debounce } from "lodash-es";
+import { isArray } from "lodash-es";
+import { isEqual } from "lodash-es";
 
 var $ = jQuery;
 

--- a/js/src/analysis/worker.js
+++ b/js/src/analysis/worker.js
@@ -1,7 +1,7 @@
 // External dependencies.
-import get from "lodash/get";
-import isUndefined from "lodash/isUndefined";
-import merge from "lodash/merge";
+import { get } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { merge } from "lodash-es";
 import { AnalysisWorkerWrapper, createWorker } from "yoastseo";
 
 // Internal dependencies.

--- a/js/src/compatibility/compatibilityHelper.js
+++ b/js/src/compatibility/compatibilityHelper.js
@@ -1,6 +1,6 @@
 /* External dependencies */
-import defaults from "lodash/defaults";
-import noop from "lodash/noop";
+import { defaults } from "lodash-es";
+import { noop } from "lodash-es";
 
 /* Internal dependencies */
 import DiviHelper from "./diviHelper";

--- a/js/src/compatibility/diviHelper.js
+++ b/js/src/compatibility/diviHelper.js
@@ -1,4 +1,4 @@
-import forEach from "lodash/forEach";
+import { forEach } from "lodash-es";
 
 const DIVI_EDITOR_WRAPPER_ID = "et_pb_main_editor_wrap";
 const DIVI_CLASSIC_EDITOR_HIDDEN_CLASS = "et_pb_hidden";

--- a/js/src/components/PrimaryTaxonomyFilter.js
+++ b/js/src/components/PrimaryTaxonomyFilter.js
@@ -3,8 +3,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Fragment } from "@wordpress/element";
-import get from "lodash/get";
-import values from "lodash/values";
+import { get } from "lodash-es";
+import { values } from "lodash-es";
 import { __, sprintf } from "@wordpress/i18n";
 import { ClipboardButton } from "@wordpress/components";
 import styled from "styled-components";

--- a/js/src/components/PrimaryTaxonomyPicker.js
+++ b/js/src/components/PrimaryTaxonomyPicker.js
@@ -10,7 +10,7 @@ import { sprintf, __ } from "@wordpress/i18n";
 import apiFetch from "@wordpress/api-fetch";
 import { addQueryArgs } from "@wordpress/url";
 import styled from "styled-components";
-import diff from "lodash/difference";
+import { difference as diff } from "lodash-es";
 
 /* Internal dependencies */
 import TaxonomyPicker from "./TaxonomyPicker";

--- a/js/src/components/SettingsReplacementVariableEditors.js
+++ b/js/src/components/SettingsReplacementVariableEditors.js
@@ -4,8 +4,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
-import includes from "lodash/includes";
-import map from "lodash/map";
+import { includes } from "lodash-es";
+import { map } from "lodash-es";
 import { connect } from "react-redux";
 import { replacementVariablesShape } from "yoast-components";
 

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
-import isNil from "lodash/isNil";
+import { isNil } from "lodash-es";
 
 import Results from "./Results";
 import Collapsible from "../SidebarCollapsible";

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -14,7 +14,7 @@ import Suggestions from "./components/Suggestions";
 import FinalStep from "./components/FinalStep";
 
 import { setTranslations } from "yoast-components";
-import isUndefined from "lodash/isUndefined";
+import { isUndefined } from "lodash-es";
 
 import YoastIcon from "../../images/Yoast_SEO_Icon.svg";
 

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -3,8 +3,8 @@ import { connect } from "react-redux";
 import {
 	SnippetEditor,
 } from "yoast-components";
-import identity from "lodash/identity";
-import get from "lodash/get";
+import { identity } from "lodash-es";
+import { get } from "lodash-es";
 import { __ } from "@wordpress/i18n";
 import { dispatch as wpDataDispatch } from "@wordpress/data";
 import analysis from "yoastseo";

--- a/js/src/decorator/tinyMCE.js
+++ b/js/src/decorator/tinyMCE.js
@@ -1,7 +1,7 @@
 import analysis from "yoastseo";
 const { removeMarks } = analysis.markers;
 
-import _forEach from "lodash/forEach";
+import { forEach as _forEach } from "lodash-es";
 
 var MARK_TAG = "yoastmark";
 

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -5,9 +5,9 @@ import styled from "styled-components";
 import { Fragment } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import { combineReducers, registerStore } from "@wordpress/data";
-import get from "lodash/get";
-import pickBy from "lodash/pickBy";
-import noop from "lodash/noop";
+import { get } from "lodash-es";
+import { pickBy } from "lodash-es";
+import { noop } from "lodash-es";
 
 /* Internal dependencies */
 import Data from "./analysis/data.js";

--- a/js/src/helpers/i18n.js
+++ b/js/src/helpers/i18n.js
@@ -1,5 +1,5 @@
 import { setLocaleData } from "@wordpress/i18n";
-import get from "lodash/get";
+import { get } from "lodash-es";
 
 /**
  * Sets the l10n for the given textdomain in Jed.

--- a/js/src/helpers/isGutenbergAvailable.js
+++ b/js/src/helpers/isGutenbergAvailable.js
@@ -1,7 +1,7 @@
 /* global wp */
 
-import isUndefined from "lodash/isUndefined";
-import isFunction from "lodash/isFunction";
+import { isUndefined } from "lodash-es";
+import { isFunction } from "lodash-es";
 
 /**
  * Checks if the data API from Gutenberg is available.

--- a/js/src/helpers/isGutenbergDataAvailable.js
+++ b/js/src/helpers/isGutenbergDataAvailable.js
@@ -1,7 +1,7 @@
 /* global wp */
 
-import isUndefined from "lodash/isUndefined";
-import isFunction from "lodash/isFunction";
+import { isUndefined } from "lodash-es";
+import { isFunction } from "lodash-es";
 
 /**
  * Checks if the data API from Gutenberg is available.

--- a/js/src/helpers/replacementVariableHelpers.js
+++ b/js/src/helpers/replacementVariableHelpers.js
@@ -1,8 +1,8 @@
 /* global wp */
 
 /* External dependencies */
-import forEach from "lodash/forEach";
-import omit from "lodash/omit";
+import { forEach } from "lodash-es";
+import { omit } from "lodash-es";
 
 /* Internal dependencies */
 import { updateReplacementVariable } from "../redux/actions/snippetEditor";

--- a/js/src/helpers/sortComponentsByRenderPriority.js
+++ b/js/src/helpers/sortComponentsByRenderPriority.js
@@ -1,4 +1,4 @@
-import flatten from "lodash/flatten";
+import { flatten } from "lodash-es";
 
 /**
  * Sorts components by a prop `renderPriority`.

--- a/js/src/redux/reducers/preferences.js
+++ b/js/src/redux/reducers/preferences.js
@@ -1,4 +1,4 @@
-import isUndefined from "lodash/isUndefined";
+import { isUndefined } from "lodash-es";
 import isContentAnalysisActive from "../../analysis/isContentAnalysisActive";
 import isKeywordAnalysisActive from "../../analysis/isKeywordAnalysisActive";
 import isCornerstoneActive from "../../analysis/isCornerstoneContentActive";

--- a/js/src/redux/selectors/results.js
+++ b/js/src/redux/selectors/results.js
@@ -1,4 +1,4 @@
-import get from "lodash/get";
+import { get } from "lodash-es";
 
 /**
  * Gets the SEO results.

--- a/js/src/redux/utils/configureEnhancers.js
+++ b/js/src/redux/utils/configureEnhancers.js
@@ -2,7 +2,7 @@
 import { applyMiddleware } from "redux";
 import thunk from "redux-thunk";
 import logger from "redux-logger";
-import flowRight from "lodash/flowRight";
+import { flowRight } from "lodash-es";
 
 /**
  * Returns redux store enhancers.

--- a/js/src/search-appearance.js
+++ b/js/src/search-appearance.js
@@ -3,7 +3,7 @@
 /* External dependencies */
 import ReactDOM from "react-dom";
 import React from "react";
-import forEach from "lodash/forEach";
+import { forEach } from "lodash-es";
 import { Provider } from "react-redux";
 import { createStore, combineReducers } from "redux";
 

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -1,7 +1,7 @@
 /* External dependencies */
 import React from "react";
 import PropTypes from "prop-types";
-import isUndefined from "lodash/isUndefined";
+import { isUndefined } from "lodash-es";
 import { __ } from "@wordpress/i18n";
 
 /* Internal dependencies */

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -1,11 +1,11 @@
 /* External dependencies */
 import PropTypes from "prop-types";
 import HowToStep from "./HowToStep";
-import isUndefined from "lodash/isUndefined";
+import { isUndefined } from "lodash-es";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
-import toString from "lodash/toString";
-import get from "lodash/get";
+import { toString } from "lodash-es";
+import { get } from "lodash-es";
 
 /* Internal dependencies */
 import { stripHTML } from "../../../helpers/stringHelpers";

--- a/js/src/values/replaceVar.js
+++ b/js/src/values/replaceVar.js
@@ -1,7 +1,6 @@
-/* global require */
-var isEmpty = require( "lodash/isEmpty" );
-var indexOf = require( "lodash/indexOf" );
-var defaults = require( "lodash/defaults" );
+import { isEmpty } from "lodash-es";
+import { indexOf } from "lodash-es";
+import { defaults } from "lodash-es";
 
 ( function() {
 	var defaultOptions = { source: "wpseoReplaceVarsL10n", scope: [], aliases: [] };

--- a/js/src/wp-seo-help-center.js
+++ b/js/src/wp-seo-help-center.js
@@ -4,7 +4,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
-import get from "lodash/get";
+import { get } from "lodash-es";
 import { injectIntl, intlShape } from "react-intl";
 import IntlProvider from "./components/IntlProvider";
 import { setYoastComponentsL10n } from "./helpers/i18n";

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -2,8 +2,8 @@
 
 // External dependencies.
 import { App } from "yoastseo";
-import isUndefined from "lodash/isUndefined";
-import debounce from "lodash/debounce";
+import { isUndefined } from "lodash-es";
+import { debounce } from "lodash-es";
 import {
 	setReadabilityResults,
 	setSeoResultsForKeyword,

--- a/js/src/wp-seo-recalculate.js
+++ b/js/src/wp-seo-recalculate.js
@@ -10,7 +10,7 @@ import {
 	TaxonomyAssessor,
 } from "yoastseo";
 
-var isUndefined = require( "lodash/isUndefined" );
+import { isUndefined } from "lodash-es";
 
 ( function( $ ) {
 	var i18n = new Jed( {

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -1,8 +1,8 @@
 /* global wpseoReplaceVarsL10n, require, wp */
-import forEach from "lodash/forEach";
-import filter from "lodash/filter";
-import trim from "lodash/trim";
-import isUndefined from "lodash/isUndefined";
+import { forEach } from "lodash-es";
+import { filter } from "lodash-es";
+import { trim } from "lodash-es";
+import { isUndefined } from "lodash-es";
 import ReplaceVar from "./values/replaceVar";
 import {
 	removeReplacementVariable,

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -6,9 +6,9 @@ import {
 	setReadabilityResults,
 	setSeoResultsForKeyword,
 } from "yoast-components";
-import isUndefined from "lodash/isUndefined";
+import { isUndefined } from "lodash-es";
 import isShallowEqualObjects from "@wordpress/is-shallow-equal/objects";
-import debounce from "lodash/debounce";
+import { debounce } from "lodash-es";
 
 // Internal dependencies.
 import Edit from "./edit";

--- a/js/src/wp-seo-tinymce.js
+++ b/js/src/wp-seo-tinymce.js
@@ -2,8 +2,8 @@
 
 import CompatibilityHelper from "./compatibility/compatibilityHelper";
 
-var forEach = require( "lodash/forEach" );
-var isUndefined = require( "lodash/isUndefined" );
+import { forEach } from "lodash-es";
+import { isUndefined } from "lodash-es";
 var editorHasMarks = require( "./decorator/tinyMCE" ).editorHasMarks;
 var editorRemoveMarks = require( "./decorator/tinyMCE" ).editorRemoveMarks;
 import { setMarkerStatus } from "./redux/actions/markerButtons";

--- a/js/src/wp-seo-wp-globals-backport.js
+++ b/js/src/wp-seo-wp-globals-backport.js
@@ -5,7 +5,7 @@ import * as importedI18n from "@wordpress/i18n";
 import * as importedApiFetch from "@wordpress/api-fetch";
 import * as styledComponents from "styled-components";
 
-import get from "lodash/get";
+import { get } from "lodash-es";
 
 /*
  * If Gutenberg is present we can just use their wp.element and wp.data. Otherwise

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "grunt-wp-deploy": "^1.2.1",
     "interpolate-components": "^1.1.0",
     "jed": "^1.1.1",
-    "lodash": "^4.17.4",
+    "lodash-es": "^4.17.11",
     "marked": "^0.3.6",
     "material-ui": "^0.20.0",
     "moment": "2.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7316,7 +7316,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.10:
+lodash-es@^4.17.10, lodash-es@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaced lodash with lodash-es

## Relevant technical choices:

* Replace  all lodash imports with a named one like `import { isEqual } from "lodash-es"` for better [treeshaking support](https://github.com/Yoast/YoastSEO.js/issues/1736).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Clone this branch of the plugin by running:`git clone --single-branch -b mg/replace-lodash git@github.com:Yoast/wordpress-seo.git` in a bash terminal.
* Ensure that [yarn](https://yarnpkg.com/en/docs/install#mac-stable) and [composer](https://getcomposer.org/) are installed.
* Install the dependancies by running `yarn` in the folder where the plugin was cloned in.
* Build the plugin by running `grunt artifact`. This will generate a zip file in the root folder of the plugin to install on your wordpress site.
* [Install the generated zip file on your wordpress site](https://www.wpbeginner.com/beginners-guide/step-by-step-guide-to-install-a-wordpress-plugin-for-beginners/)
* Visit all pages containing javascript and test if there are any console errors that are related to wordpress seo.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


