### PR TITLE
Add fallback to replace everything from the store

### DIFF
--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -220,8 +220,29 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 			// This order currently needs to be maintained until we can figure out a nicer way to replace this.
 			data = this.parentReplace( data );
 			data = this.replaceCustomTaxonomy( data );
+			data = this.replaceByStore( data );
 			data = this.replacePlaceholders( data );
 		}
+
+		return data;
+	};
+
+	/**
+	 * Runs the different replacements on the data-string.
+	 *
+	 * @param {string} data The data that needs its placeholders replaced.
+	 * @returns {string} The data with all its placeholders replaced by actual values.
+	 */
+	YoastReplaceVarPlugin.prototype.replaceByStore = function( data ) {
+		const replacementVariables = this._store.getState().snippetEditor.replacementVariables;
+
+		forEach( replacementVariables, ( replacementVariable ) => {
+			if ( replacementVariable.value === "" ) {
+				return;
+			}
+
+			data = data.replace( "%%"  + replacementVariable.name + "%%", replacementVariable.value );
+		} );
 
 		return data;
 	};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* This pull introduces a fallback where the replacementVariables from the store are used to replace missed replacement variables.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test this together with https://github.com/Yoast/wordpress-seo-premium/pull/2112

