### PR TITLE
Adds page number to the visible breadcrumbs

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -615,8 +615,8 @@ class WPSEO_Breadcrumbs {
 
 		$this->crumbs[] = array(
 			'text'           => sprintf(
-				/* translators: %1$s expands to the current page */
-				__( 'Page %1$s', 'wordpress-seo' ),
+				/* translators: %s expands to the current page number */
+				__( 'Page %s', 'wordpress-seo' ),
 				$current_page
 			),
 			'url'            => '',

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -418,6 +418,8 @@ class WPSEO_Breadcrumbs {
 			);
 		}
 
+		$this->maybe_add_page_crumb();
+
 		/**
 		 * Filter: 'wpseo_breadcrumb_links' - Allow the developer to filter the Yoast SEO breadcrumb links, add to them, change order, etc.
 		 *
@@ -594,6 +596,32 @@ class WPSEO_Breadcrumbs {
 		$this->maybe_add_term_parent_crumbs( $term );
 
 		$this->add_term_crumb( $term );
+	}
+
+	/**
+	 * Adds a page crumb to the visible breadcrumbs.
+	 *
+	 * @return void
+	 */
+	private function maybe_add_page_crumb() {
+		if ( ! is_paged() ) {
+			return;
+		}
+
+		$current_page = get_query_var( 'paged', 1 );
+		if ( $current_page <= 1 ) {
+			return;
+		}
+
+		$this->crumbs[] = array(
+			'text'           => sprintf(
+				/* translators: %1$s expands to the current page */
+				__( 'Page %1$s', 'wordpress-seo' ),
+				$current_page
+			),
+			'url'            => '',
+			'hide_in_schema' => true,
+		);
 	}
 
 	/**

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -114,6 +114,10 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 		$broken               = false;
 
 		foreach ( $breadcrumbs as $index => $breadcrumb ) {
+			if ( ! empty( $breadcrumb['hide_in_schema'] ) ) {
+				continue;
+			}
+
 			if ( ! array_key_exists( 'url', $breadcrumb ) || ! array_key_exists( 'text', $breadcrumb ) ) {
 				$broken = true;
 				break;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the page number to the breadcrumbs when an archived page is entered.

## Relevant technical choices:

* Added `hide_in_schema ` to the breadcrumb to filter this out from the `schema.org` output. This can be change/undone when #9664 will be fixed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have a lot of posts, this results in pagination on the archives.
* Checkout this branch
* When navigation to the second page you will see 'Page 2' in the breadcrumbs.
* The Page 2 shouldn't be added to the JSON-LD Schema.org output
* Addition of the page number should only be applied for paginated pages like: the index and archives.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #1928 
