### PR TITLE
Remove unused method

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -647,19 +647,4 @@ class WPSEO_Admin_Asset_Manager {
 			),
 		);
 	}
-
-	/**
-	 * Checks if the Gutenberg assets must be loaded.
-	 *
-	 * @return bool True when the Gutenberg assets must be loaded.
-	 */
-	protected function should_load_gutenberg_assets() {
-
-		// When working in the classic editor shipped with Gutenberg, the assets shouldn't be loaded. Fixes IE11 bug.
-		if ( isset( $_GET['classic-editor'] ) ) {
-			return false;
-		}
-
-		return wp_script_is( 'wp-element', 'registered' );
-	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* After Herre's PR refactoring the wp assets, this method is no longer in use.