### PR TITLE
Use the has_metabox_enabled filter

### DIFF
--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -24,6 +24,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 		parent::register_hooks();
 
 		add_filter( 'wpseo_cornerstone_post_types', array( 'WPSEO_Post_Type', 'filter_attachment_post_type' ) );
+		add_filter( 'wpseo_cornerstone_post_types', array( 'WPSEO_Post_Type', 'has_metabox_enabled' ) );
 	}
 
 	/**

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -24,7 +24,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 		parent::register_hooks();
 
 		add_filter( 'wpseo_cornerstone_post_types', array( 'WPSEO_Post_Type', 'filter_attachment_post_type' ) );
-		add_filter( 'wpseo_cornerstone_post_types', array( 'WPSEO_Post_Type', 'has_metabox_enabled' ) );
+		add_filter( 'wpseo_cornerstone_post_types', array( $this, 'filter_metabox_disabled' ) );
 	}
 
 	/**
@@ -54,6 +54,26 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 		}
 
 		return $where;
+	}
+
+	/**
+	 * Filters the post types that have the metabox disabled.
+	 *
+	 * @param array $post_types The post types to filter.
+	 *
+	 * @return array The filtered post types.
+	 */
+	public function filter_metabox_disabled( $post_types ) {
+		$filtered_post_types = array();
+		foreach ( $post_types as $post_type_key => $post_type ) {
+			if ( ! WPSEO_Post_Type::has_metabox_enabled( $post_type_key ) ) {
+				continue;
+			}
+
+			$filtered_post_types[ $post_type_key ] = $post_type;
+		}
+
+		return $filtered_post_types;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the cornerstone filter is still visible when the metabox is disabled.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Disable the Yoast metabox for the posttype: post
* Go the the post overview and see the cornerstone filter still being visible.
* Checkout this branch
* Refresh the post overview page and verify that the cornerstone filter is gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9294
