### PR TITLE
11536 configuration wizard registered scripts

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -79,6 +79,7 @@ class WPSEO_Configuration_Page {
 		 */
 		wp_enqueue_style( 'forms' );
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		// $asset_manager->register_wp_assets();
 		$asset_manager->register_assets();
 		$asset_manager->enqueue_script( 'configuration-wizard' );
 		$asset_manager->enqueue_style( 'yoast-components' );

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -79,7 +79,7 @@ class WPSEO_Configuration_Page {
 		 */
 		wp_enqueue_style( 'forms' );
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		// $asset_manager->register_wp_assets();
+		$asset_manager->register_wp_assets();
 		$asset_manager->register_assets();
 		$asset_manager->enqueue_script( 'configuration-wizard' );
 		$asset_manager->enqueue_style( 'yoast-components' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- to my understanding, in the configuration wizard page the `configuration-wizard` dependencies are not registered so `configuration-wizard` is not enqueued
- added `$asset_manager->register_wp_assets();` to register the necessary WP scripts

## Test instructions
With the recent changes to the WP dependencies and scripts registrations in #11504 this should be carefully tested in a variety of conditions:
- in WP 4.9.8 with either Gutenberg / Classic editor activated or deactivated
- in WP 5.0 with either Gutenberg / Classic editor activated or deactivated

Note: at some point, after I set `define( 'SCRIPT_DEBUG', false );` in WordPress I was getting a few 404 errors, for example:
`wp-includes/js/dist/element.js?ver=5.0-beta3-20181109.111012 net::ERR_ABORTED 404 (Not Found)`

After building WordPress I couldn't reproduce the issue. I'd recommend to double check WP 5.0 will always have both the non-minified and the minified files in the `wp-includes/js/dist/` directory. 

Fixes #11536 
