### PR TITLE
Uses class WPSEO_WooCommerce_Shop_Page in Class WPSEO_Breadcrumbs

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -367,9 +367,7 @@ class WPSEO_Breadcrumbs {
 			}
 		}
 		elseif ( is_post_type_archive() ) {
-			$shop_id = $this->woocommerce_shop_page->is_shop_page()
-				? $this->woocommerce_shop_page->get_shop_page_id()
-				: ( -1 );
+			$shop_id = $this->woocommerce_shop_page->is_shop_page() ? $this->woocommerce_shop_page->get_shop_page_id() : ( -1 );
 
 			if ( $shop_id !== -1 ) {
 				$this->add_single_post_crumb( $shop_id );

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -367,13 +367,16 @@ class WPSEO_Breadcrumbs {
 			}
 		}
 		elseif ( is_post_type_archive() ) {
-			$post_type = $wp_query->get( 'post_type' );
+			$shop_id = $this->woocommerce_shop_page->is_shop_page()
+				? $this->woocommerce_shop_page->get_shop_page_id()
+				: ( -1 );
 
-			if ( WPSEO_Utils::is_woocommerce_active() && is_shop() ) {
-				$id = wc_get_page_id( 'shop' );
-				$this->add_single_post_crumb( $id );
+			if ( $shop_id !== -1 ) {
+				$this->add_single_post_crumb( $shop_id );
 			}
 			else {
+				$post_type = $wp_query->get( 'post_type' );
+
 				if ( $post_type && is_string( $post_type ) ) {
 					$this->add_ptarchive_crumb( $post_type );
 				}

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -367,10 +367,10 @@ class WPSEO_Breadcrumbs {
 			}
 		}
 		elseif ( is_post_type_archive() ) {
-			$shop_id = $this->woocommerce_shop_page->is_shop_page() ? $this->woocommerce_shop_page->get_shop_page_id() : ( -1 );
-
-			if ( $shop_id !== -1 ) {
-				$this->add_single_post_crumb( $shop_id );
+			if ( $this->woocommerce_shop_page->is_shop_page() &&
+				$this->woocommerce_shop_page->get_shop_page_id() !== -1
+			) {
+				$this->add_single_post_crumb( $this->woocommerce_shop_page->get_shop_page_id() );
 			}
 			else {
 				$post_type = $wp_query->get( 'post_type' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses class _WPSEO_WooCommerce_Shop_Page_ instead of function [_wc_get_page_id_](https://docs.woocommerce.com/wc-apidocs/function-wc_get_page_id.html).

## Relevant technical choices:

* Class _WPSEO_Breadcrumbs_ already uses class _WPSEO_WooCommerce_Shop_Page_, but there is old code which uses WC api. This PR makes consistency in usage of class _WPSEO_WooCommerce_Shop_Page_.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Testing isn't needed because this PR uses already tested methods from class _WPSEO_WooCommerce_Shop_Page_. Also, it's possible to repeat test from PR #10229.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes inconsistency in class _WPSEO_Breadcrumbs_.
