### PR TITLE
Remove Local for Woo from the extensions page

### DIFF
--- a/admin/class-extension.php
+++ b/admin/class-extension.php
@@ -32,6 +32,15 @@ class WPSEO_Extension {
 	}
 
 	/**
+	 * Returns the product title to display.
+	 *
+	 * @return string The title to display on the license page.
+	 */
+	public function get_display_title() {
+		return empty( $this->config['display_title'] ) ? $this->get_title() : $this->config['display_title'];
+	}
+
+	/**
 	 * Returns URL to the page where the product can be bought.
 	 *
 	 * @return string The buy url.

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -37,11 +37,6 @@ class WPSEO_Extensions {
 			'identifier' => 'wpseo-local',
 			'classname'  => 'WPSEO_Local_Core',
 		),
-		'Local SEO for WooCommerce' => array(
-			'slug'       => 'local-seo-for-woocommerce',
-			'identifier' => 'wpseo-local-woocommerce',
-			'classname'  => 'WPSEO_Local_WooCommerce',
-		),
 	);
 
 	/**

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -36,22 +36,22 @@ $extensions->add(
 
 $extensions->add(
     'wpseo-local',
-    new WPSEO_Extension(
-        array(
-            'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
-            'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
-            'title'         => 'Local SEO',
-            'display_title' => 'Stop losing customers to other local businesses',
-            'desc'          => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
-            'image'         => plugins_url( 'images/extensions-local.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-            'benefits'      => array(
-                __( 'Get better search results in local search', 'wordpress-seo' ),
-                __( 'Easily insert Google Maps, a store locator, opening hours and more', 'wordpress-seo' ),
-                /* translators: %1$s expands to WooCommerce  */
-                sprintf( __( 'Allow customers to pick up their %s order locally', 'wordpress-seo' ), 'WooCommerce' ),
-            ),
-        )
-    )
+	new WPSEO_Extension(
+		array(
+			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
+			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
+			'title'         => 'Local SEO',
+			'display_title' => 'Stop losing customers to other local businesses',
+			'desc'          => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
+			'image'         => plugins_url( 'images/extensions-local.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+			'benefits'      => array(
+				__( 'Get better search results in local search', 'wordpress-seo' ),
+				__( 'Easily insert Google Maps, a store locator, opening hours and more', 'wordpress-seo' ),
+				/* translators: %1$s expands to WooCommerce  */
+				sprintf( __( 'Allow customers to pick up their %s order locally', 'wordpress-seo' ), 'WooCommerce' ),
+			),
+		)
+	)
 );
 
 $extensions->add(

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -34,27 +34,25 @@ $extensions->add(
 	)
 );
 
-if ( ! defined( 'WPSEO_LOCAL_WOOCOMMERCE_VERSION' ) ) {
-	$extensions->add(
-		'wpseo-local',
-		new WPSEO_Extension(
-			array(
-				'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
-				'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
-				'title'         => 'Local SEO',
-				'display_title' => 'Stop losing customers to other local businesses',
-				'desc'          => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
-				'image'         => plugins_url( 'images/extensions-local.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-				'benefits'      => array(
-					__( 'Get better search results in local search', 'wordpress-seo' ),
-					__( 'Easily insert Google Maps, a store locator, opening hours and more', 'wordpress-seo' ),
-					/* translators: %1$s expands to WooCommerce  */
-					sprintf( __( 'Allow customers to pick up their %s order locally', 'wordpress-seo' ), 'WooCommerce' ),
-				),
-			)
-		)
-	);
-}
+$extensions->add(
+    'wpseo-local',
+    new WPSEO_Extension(
+        array(
+            'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
+            'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
+            'title'         => 'Local SEO',
+            'display_title' => 'Stop losing customers to other local businesses',
+            'desc'          => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
+            'image'         => plugins_url( 'images/extensions-local.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+            'benefits'      => array(
+                __( 'Get better search results in local search', 'wordpress-seo' ),
+                __( 'Easily insert Google Maps, a store locator, opening hours and more', 'wordpress-seo' ),
+                /* translators: %1$s expands to WooCommerce  */
+                sprintf( __( 'Allow customers to pick up their %s order locally', 'wordpress-seo' ), 'WooCommerce' ),
+            ),
+        )
+    )
+);
 
 $extensions->add(
 	'wpseo-video',
@@ -181,7 +179,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				<?php else : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
 					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
-						esc_html_e( 'Activate your site on MyYoast', 'wordpress-seo' );
+						/* translators: %s expands to the extension title */
+						printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 						echo $new_tab_message;
 					?></a>
 				<?php endif; ?>
@@ -251,7 +250,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 							<?php else : ?>
 								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
 								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
-									esc_html_e( 'Activate your site on MyYoast', 'wordpress-seo' );
+									/* translators: %s expands to the extension title */
+									printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
 								?></a>
 							<?php endif; ?>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -81,33 +81,15 @@ if ( ! defined( 'WPSEO_LOCAL_WOOCOMMERCE_VERSION' ) ) {
 				'desc'      => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
 				'image'     => plugins_url( 'images/extensions-local.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
 				'benefits'  => array(
-					__( 'Get found by potential clients', 'wordpress-seo' ),
+					__( 'Get better search results in local search', 'wordpress-seo' ),
 					__( 'Easily insert Google Maps, a store locator, opening hours and more', 'wordpress-seo' ),
-					__( 'Improve the usability of your contact page', 'wordpress-seo' ),
+					/* translators: %1$s expands to WooCommerce  */
+					sprintf( __( 'Allow customers to pick up their %s order locally', 'wordpress-seo' ), 'WooCommerce' ),
 				),
 			)
 		)
 	);
 }
-
-$extensions->add(
-	'wpseo-local-woocommerce',
-	new WPSEO_Extension(
-		array(
-			'buyUrl'    => WPSEO_Shortlinker::get( 'https://yoa.st/272' ),
-			'infoUrl'   => WPSEO_Shortlinker::get( 'https://yoa.st/273' ),
-			'title'     => 'Local SEO for WooCommerce',
-			'desc'      => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
-			'image'     => plugins_url( 'images/extensions-local-for-woocommerce.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-			'benefits'  => array(
-				esc_html__( 'Get better search results in local search', 'wordpress-seo' ),
-				esc_html__( 'Enhance your contact pages with Google Maps, opening hours and a store locator', 'wordpress-seo' ),
-				/* translators: %1$s expands to WooCommerce  */
-				sprintf( esc_html__( 'Allow customers to pick up their %s order locally', 'wordpress-seo' ), 'WooCommerce' ),
-			),
-		)
-	)
-);
 
 // Add Yoast WooCommerce SEO when WooCommerce is active.
 if ( WPSEO_Utils::is_woocommerce_active() ) {

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -35,7 +35,7 @@ $extensions->add(
 );
 
 $extensions->add(
-    'wpseo-local',
+	'wpseo-local',
 	new WPSEO_Extension(
 		array(
 			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -34,53 +34,18 @@ $extensions->add(
 	)
 );
 
-$extensions->add(
-	'wpseo-video',
-	new WPSEO_Extension(
-		array(
-			'buyUrl'    => WPSEO_Shortlinker::get( 'https://yoa.st/zx/' ),
-			'infoUrl'   => WPSEO_Shortlinker::get( 'https://yoa.st/zw/' ),
-			'title'     => 'Video SEO',
-			'desc'      => __( 'Optimize your videos to show them off in search results and get more clicks!', 'wordpress-seo' ),
-			'image'     => plugins_url( 'images/extensions-video.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-			'benefits'  => array(
-				__( 'Show your videos in Google Videos', 'wordpress-seo' ),
-				__( 'Enhance the experience of sharing posts with videos', 'wordpress-seo' ),
-				__( 'Make videos responsive through enabling fitvids.js', 'wordpress-seo' ),
-			),
-		)
-	)
-);
-
-$extensions->add(
-	'wpseo-news',
-	new WPSEO_Extension(
-		array(
-			'buyUrl'    => WPSEO_Shortlinker::get( 'https://yoa.st/zv/' ),
-			'infoUrl'   => WPSEO_Shortlinker::get( 'https://yoa.st/zu/' ),
-			'title'     => 'News SEO',
-			'desc'      => __( 'Are you in Google News? Increase your traffic from Google News by optimizing for it!', 'wordpress-seo' ),
-			'image'     => plugins_url( 'images/extensions-news.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-			'benefits'  => array(
-				__( 'Optimize your site for Google News', 'wordpress-seo' ),
-				__( 'Immediately pings Google on the publication of a new post', 'wordpress-seo' ),
-				__( 'Creates XML News Sitemaps', 'wordpress-seo' ),
-			),
-		)
-	)
-);
-
 if ( ! defined( 'WPSEO_LOCAL_WOOCOMMERCE_VERSION' ) ) {
 	$extensions->add(
 		'wpseo-local',
 		new WPSEO_Extension(
 			array(
-				'buyUrl'    => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
-				'infoUrl'   => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
-				'title'     => 'Local SEO',
-				'desc'      => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
-				'image'     => plugins_url( 'images/extensions-local.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-				'benefits'  => array(
+				'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
+				'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
+				'title'         => 'Local SEO',
+				'display_title' => 'Stop losing customers to other local businesses',
+				'desc'          => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
+				'image'         => plugins_url( 'images/extensions-local.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+				'benefits'      => array(
 					__( 'Get better search results in local search', 'wordpress-seo' ),
 					__( 'Easily insert Google Maps, a store locator, opening hours and more', 'wordpress-seo' ),
 					/* translators: %1$s expands to WooCommerce  */
@@ -91,32 +56,69 @@ if ( ! defined( 'WPSEO_LOCAL_WOOCOMMERCE_VERSION' ) ) {
 	);
 }
 
+$extensions->add(
+	'wpseo-video',
+	new WPSEO_Extension(
+		array(
+			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zx/' ),
+			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zw/' ),
+			'title'         => 'Video SEO',
+			'display_title' => 'Start ranking better for your videos',
+			'desc'          => __( 'Optimize your videos to show them off in search results and get more clicks!', 'wordpress-seo' ),
+			'image'         => plugins_url( 'images/extensions-video.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+			'benefits'      => array(
+				__( 'Show your videos in Google Videos', 'wordpress-seo' ),
+				__( 'Enhance the experience of sharing posts with videos', 'wordpress-seo' ),
+				__( 'Make videos responsive through enabling fitvids.js', 'wordpress-seo' ),
+			),
+		)
+	)
+);
+
 // Add Yoast WooCommerce SEO when WooCommerce is active.
 if ( WPSEO_Utils::is_woocommerce_active() ) {
 	$extensions->add(
 		'wpseo-woocommerce',
 		new WPSEO_Extension(
 			array(
-				'buyUrl'     => WPSEO_Shortlinker::get( 'https://yoa.st/zr' ),
-				'infoUrl'    => WPSEO_Shortlinker::get( 'https://yoa.st/zq' ),
-				'title'      => 'Yoast WooCommerce SEO',
+				'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zr' ),
+				'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zq' ),
+				'title'         => 'Yoast WooCommerce SEO',
+				'display_title' => 'Make your products stand out in Google',
 				/* translators: %1$s expands to Yoast SEO */
-				'desc'       => sprintf( __( 'Seamlessly integrate WooCommerce with %1$s and get extra features!', 'wordpress-seo' ), 'Yoast SEO' ),
-				'image'      => plugins_url( 'images/extensions-woo.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-				'benefits'   => array(
-					sprintf( __( 'Improve sharing on Pinterest', 'wordpress-seo' ) ),
-
+				'desc'          => sprintf( __( 'Seamlessly integrate WooCommerce with %1$s and get extra features!', 'wordpress-seo' ), 'Yoast SEO' ),
+				'image'         => plugins_url( 'images/extensions-woo.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+				'benefits'      => array(
+					sprintf( __( 'Improve sharing on Facebook and Pinterest', 'wordpress-seo' ) ),
 					/* translators: %1$s expands to Yoast, %2$s expands to WooCommerce */
 					sprintf( __( 'Use %1$s breadcrumbs instead of %2$s ones', 'wordpress-seo' ), 'Yoast', 'WooCommerce' ),
-
 					/* translators: %1$s expands to Yoast SEO, %2$s expands to WooCommerce */
 					sprintf( __( 'A seamless integration between %1$s and %2$s', 'wordpress-seo' ), 'Yoast SEO', 'WooCommerce' ),
 				),
-				'buy_button' => 'WooCommerce SEO',
+				'buy_button'    => 'WooCommerce SEO',
 			)
 		)
 	);
 }
+
+$extensions->add(
+	'wpseo-news',
+	new WPSEO_Extension(
+		array(
+			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zv/' ),
+			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zu/' ),
+			'title'         => 'News SEO',
+			'display_title' => 'Everything you need for Google News',
+			'desc'          => __( 'Are you in Google News? Increase your traffic from Google News by optimizing for it!', 'wordpress-seo' ),
+			'image'         => plugins_url( 'images/extensions-news.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+			'benefits'      => array(
+				__( 'Optimize your site for Google News', 'wordpress-seo' ),
+				__( 'Immediately pings Google on the publication of a new post', 'wordpress-seo' ),
+				__( 'Creates XML News Sitemaps', 'wordpress-seo' ),
+			),
+		)
+	)
+);
 
 /* translators: %1$s expands to Yoast SEO. */
 $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );
@@ -172,13 +174,14 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				<?php if ( $extensions->is_activated( 'wordpress-seo-premium' ) ) : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
 					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php
-						esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' );
+						/* translators: %s expands to the extension title */
+						printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 						echo $new_tab_message;
 					?></a>
 				<?php else : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
 					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
-						esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' );
+						esc_html_e( 'Activate your site on MyYoast', 'wordpress-seo' );
 						echo $new_tab_message;
 					?></a>
 				<?php endif; ?>
@@ -226,7 +229,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 			<?php foreach ( $extensions->get_all() as $id => $extension ) : ?>
 				<section class="yoast-promoblock secondary yoast-promo-extension">
 					<img alt="" width="280" height="147" src="<?php echo esc_attr( $extension->get_image() ); ?>" />
-					<h3><?php echo esc_html( $extension->get_title() ); ?></h3>
+					<h3><?php echo esc_html( $extension->get_display_title() ); ?></h3>
 
 					<ul class="yoast-list--usp">
 						<?php foreach ( $extension->get_benefits() as $benefit ) : ?>
@@ -241,13 +244,14 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 							<?php if ( $extensions->is_activated( $id ) ) : ?>
 								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
 								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php
-									esc_html_e( 'Manage your subscription on My Yoast', 'wordpress-seo' );
+									/* translators: %s expands to the extension title */
+									printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
 								?></a>
 							<?php else : ?>
 								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
 								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
-									esc_html_e( 'Activate your site on My Yoast', 'wordpress-seo' );
+									esc_html_e( 'Activate your site on MyYoast', 'wordpress-seo' );
 									echo $new_tab_message;
 								?></a>
 							<?php endif; ?>


### PR DESCRIPTION
Adjust the copy of the Local SEO upsells to include the important Local SEO for Woo entry.

## Summary

This PR can be summarized in the following changelog entry:

* Removes Local SEO for WooCommerce from the Premium page as this plugin is merged into Local SEO since 9.2.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the Premium page under SEO
* See Local SEO for WooCommerce is no longer there
* See the Local SEO upsells being updated
* See the order of extensions being changed

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #11561
