### PR TITLE
Strip html tags og desc

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -630,6 +630,8 @@ class WPSEO_OpenGraph {
 		 */
 		$ogdesc = trim( apply_filters( 'wpseo_opengraph_desc', $ogdesc ) );
 
+		$ogdesc = wp_strip_all_tags( $ogdesc );
+
 		if ( is_string( $ogdesc ) && $ogdesc !== '' ) {
 			if ( $echo !== false ) {
 				$this->og_tag( 'og:description', $ogdesc );

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -630,11 +630,9 @@ class WPSEO_OpenGraph {
 		 */
 		$ogdesc = trim( apply_filters( 'wpseo_opengraph_desc', $ogdesc ) );
 
-		$ogdesc = wp_strip_all_tags( $ogdesc );
-
 		if ( is_string( $ogdesc ) && $ogdesc !== '' ) {
 			if ( $echo !== false ) {
-				$this->og_tag( 'og:description', $ogdesc );
+				$this->og_tag( 'og:description', wp_strip_all_tags( stripslashes( $ogdesc ) ) );
 			}
 		}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -632,7 +632,7 @@ class WPSEO_OpenGraph {
 
 		if ( is_string( $ogdesc ) && $ogdesc !== '' ) {
 			if ( $echo !== false ) {
-				$this->og_tag( 'og:description', wp_strip_all_tags( stripslashes( $ogdesc ) ) );
+				$this->og_tag( 'og:description', $ogdesc );
 			}
 		}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -334,8 +334,9 @@ class WPSEO_Replace_Vars {
 			}
 			elseif ( $this->args->post_content !== '' ) {
 				$content = strip_shortcodes( $this->args->post_content );
+				$content = wp_strip_all_tags( $content );
 
-				if ( strlen( utf8_decode( $content ) ) < 156 ) {
+				if ( strlen( utf8_decode( $content ) ) <= 156 ) {
 					return $content;
 				}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where escaped HTML is shown in the OpenGraph description.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* This should be tested on a Gutenberg post
* For the meta description use the `%excerpt%` replacement variable. Have no excerpt entered and enter some text as content. 
* Leave the OpenGraph description empty
* Save the post
* Go to the frontend and see a normal non escaped HTML string as meta description.
* But the `OG:description` will contain escaped HTML. For an example see the screenshot below:
![view-source_local_wordpress_test_uncategorized_this-is-the-excerpt-post_](https://user-images.githubusercontent.com/325040/48420371-8c329c00-e75a-11e8-8e48-a0ec19167d3e.png)
* Checkout this branch and see it is solved.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

