### PR TITLE
Remove Genesis checks in adjacent_rel_links()

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1000,16 +1000,6 @@ class WPSEO_Frontend {
 	 * @since 1.0.3
 	 */
 	public function adjacent_rel_links() {
-		// Don't do this for Genesis, as the way Genesis handles homepage functionality is different and causes issues sometimes.
-		/**
-		 * Filter 'wpseo_genesis_force_adjacent_rel_home' - Allows devs to allow echoing rel="next" / rel="prev" by Yoast SEO on Genesis installs.
-		 *
-		 * @api bool $unsigned Whether or not to rel=next / rel=prev .
-		 */
-		if ( is_home() && function_exists( 'genesis' ) && apply_filters( 'wpseo_genesis_force_adjacent_rel_home', false ) === false ) {
-			return;
-		}
-
 		/**
 		 * Filter: 'wpseo_disable_adjacent_rel_links' - Allows disabling of Yoast adjacent links if this is being handled by other code.
 		 *


### PR DESCRIPTION
Genesis disables it’s internal SEO features if Yoast is active so there is no risk of duplicate rel links.

Fixes https://github.com/Yoast/wordpress-seo/issues/9331

## Summary

This PR can be summarized in the following changelog entry:

* Remove Genesis checks in adjacent_rel_links() method.

## Relevant technical choices:

* Genesis disables its SEO functionality when Yoast is active so there is no risk of duplicate links. Right now we have no links in Genesis because of this check.

## Test instructions

Genesis by itself shows rel prev/next links.
Genesis with Yoast does not show rel prev/next links.
Genesis with Yoast and the following filter does show rel prev/next links:
`add_filter( 'wpseo_genesis_force_adjacent_rel_home', '__return_true' );`

This PR can be tested by following these steps:

* Genesis with Yoast and no additional code will now show rel prev/next links

## Quality assurance

* [X ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9331 
