### PR TITLE
CS: Move multi-line parameters out of function calls [3]

### DIFF
--- a/admin/capabilities/class-capability-manager-integration.php
+++ b/admin/capabilities/class-capability-manager-integration.php
@@ -62,15 +62,15 @@ class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integratio
 		if ( ! function_exists( 'members_register_cap_group' ) ) {
 			return;
 		}
+
 		// Register the yoast group.
-		members_register_cap_group( 'wordpress-seo',
-			array(
-				'label'      => esc_html__( 'Yoast SEO', 'wordpress-seo' ),
-				'caps'       => $this->get_capabilities(),
-				'icon'       => 'dashicons-admin-plugins',
-				'diff_added' => true,
-			)
+		$args = array(
+			'label'      => esc_html__( 'Yoast SEO', 'wordpress-seo' ),
+			'caps'       => $this->get_capabilities(),
+			'icon'       => 'dashicons-admin-plugins',
+			'diff_added' => true,
 		);
+		members_register_cap_group( 'wordpress-seo', $args );
 	}
 
 	/**

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -39,10 +39,12 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 			$choices['-'] = __( 'None', 'wordpress-seo' );
 		}
 
-		$sites = get_sites( array(
+		$criteria = array(
 			'deleted'    => 0,
 			'network_id' => get_current_network_id(),
-		) );
+		);
+		$sites    = get_sites( $criteria );
+
 		foreach ( $sites as $site ) {
 			$site_name = $site->domain . $site->path;
 			if ( $show_title ) {

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -76,10 +76,11 @@ class Yoast_Notification_Center {
 		if ( false === ( $notification instanceof Yoast_Notification ) ) {
 
 			// Permit legacy.
-			$notification = new Yoast_Notification( '', array(
+			$options      = array(
 				'id'            => $notification_id,
 				'dismissal_key' => $notification_id,
-			) );
+			);
+			$notification = new Yoast_Notification( '', $options );
 		}
 
 		if ( self::maybe_dismiss_notification( $notification ) ) {

--- a/admin/config-ui/fields/class-field-multiple-authors.php
+++ b/admin/config-ui/fields/class-field-multiple-authors.php
@@ -51,10 +51,11 @@ class WPSEO_Config_Field_Multiple_Authors extends WPSEO_Config_Field_Choice {
 
 		if ( ! isset( $value ) || is_null( $value ) ) {
 			// If there are more than one users with level > 1 default to multiple authors.
-			$users = get_users( array(
+			$user_criteria = array(
 				'fields' => 'IDs',
 				'who'    => 'authors',
-			) );
+			);
+			$users         = get_users( $user_criteria );
 
 			$value = count( $users ) > 1;
 		}

--- a/admin/config-ui/fields/class-field-success-message.php
+++ b/admin/config-ui/fields/class-field-success-message.php
@@ -24,14 +24,13 @@ class WPSEO_Config_Field_Success_Message extends WPSEO_Config_Field {
 
 		$this->set_property( 'title', __( 'You\'ve done it!', 'wordpress-seo' ) );
 		$this->set_property( 'message', $success_message );
-		$this->set_property( 'video', array(
-				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ),
-				'title' => sprintf(
-					/* translators: %1$s expands to Yoast SEO. */
-					__( '%1$s video tutorial', 'wordpress-seo' ),
-					'Yoast SEO'
-				),
-			)
+
+		/* translators: %1$s expands to Yoast SEO. */
+		$video_title = __( '%1$s video tutorial', 'wordpress-seo' );
+		$video_args  = array(
+			'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ),
+			'title' => sprintf( $video_title, 'Yoast SEO' ),
 		);
+		$this->set_property( 'video', $video_args );
 	}
 }

--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -129,10 +129,12 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	 * @return string The url to activate this filter.
 	 */
 	protected function get_filter_url() {
-		return add_query_arg( array(
+		$query_args = array(
 			self::FILTER_QUERY_ARG => $this->get_query_val(),
 			'post_type'            => $this->get_current_post_type(),
-		), 'edit.php' );
+		);
+
+		return add_query_arg( $query_args, 'edit.php' );
 	}
 
 	/**
@@ -151,11 +153,11 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	 * @return string The current post type.
 	 */
 	protected function get_current_post_type() {
-		return filter_input(
-			INPUT_GET, 'post_type', FILTER_DEFAULT, array(
-				'options' => array( 'default' => 'post' ),
-			)
+		$filter_options = array(
+			'options' => array( 'default' => 'post' ),
 		);
+
+		return filter_input( INPUT_GET, 'post_type', FILTER_DEFAULT, $filter_options );
 	}
 
 	/**

--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -239,11 +239,13 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	 * @param int $posts_per_page Number of items per page.
 	 */
 	private function set_pagination( $total_items, $posts_per_page ) {
-		$this->set_pagination_args( array(
+		$pagination_args = array(
 			'total_items' => $total_items,
 			'total_pages' => ceil( ( $total_items / $posts_per_page ) ),
 			'per_page'    => $posts_per_page,
-		) );
+		);
+
+		$this->set_pagination_args( $pagination_args );
 	}
 
 	/**

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -144,11 +144,13 @@ class WPSEO_GSC {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'admin-gsc' );
 		$asset_manager->enqueue_style( 'metabox-css' );
-		add_screen_option( 'per_page', array(
+
+		$screen_options = array(
 			'label'   => __( 'Crawl errors per page', 'wordpress-seo' ),
 			'default' => 50,
 			'option'  => 'errors_per_page',
-		) );
+		);
+		add_screen_option( 'per_page', $screen_options );
 	}
 
 	/**

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -107,12 +107,13 @@ switch ( $platform_tabs->current_tab() ) {
 	default:
 		$form_action_url = add_query_arg( 'page', esc_attr( filter_input( INPUT_GET, 'page' ) ) );
 
-		get_current_screen()->set_screen_reader_content( array(
+		$screen_reader_content = array(
 			// There are no views links in this screen, so no need for the views heading.
 			'heading_views'      => null,
 			'heading_pagination' => __( 'Crawl issues list navigation', 'wordpress-seo' ),
 			'heading_list'       => __( 'Crawl issues list', 'wordpress-seo' ),
-		) );
+		);
+		get_current_screen()->set_screen_reader_content( $screen_reader_content );
 
 		// Open <form>.
 		echo "<form id='wpseo-crawl-issues-table-form' action='" . esc_url( $form_action_url ) . "' method='post'>\n";

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -819,11 +819,17 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$analysis_worker_location          = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ) );
 		$used_keywords_assessment_location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ), 'used-keywords-assessment' );
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'wpseoAnalysisWorkerL10n', array(
+
+		$localization_data = array(
 			'url'                     => $analysis_worker_location->get_url( $analysis_worker_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
 			'keywords_assessment_url' => $used_keywords_assessment_location->get_url( $used_keywords_assessment_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
 			'log_level'               => WPSEO_Utils::get_analysis_worker_log_level(),
-		) );
+		);
+		wp_localize_script(
+			WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper',
+			'wpseoAnalysisWorkerL10n',
+			$localization_data
+		);
 
 		/**
 		 * Remove the emoji script as it is incompatible with both React and any

--- a/admin/onpage/class-onpage-request.php
+++ b/admin/onpage/class-onpage-request.php
@@ -27,11 +27,12 @@ class WPSEO_OnPage_Request {
 	 * @throws Exception The error message that can be used to show to the user.
 	 */
 	protected function get_remote( $target_url, $parameters = array() ) {
-		$parameters = array_merge( array(
+		$defaults   = array(
 			'url'          => $target_url,
 			'wp_version'   => $GLOBALS['wp_version'],
 			'yseo_version' => WPSEO_VERSION,
-		), $parameters );
+		);
+		$parameters = array_merge( $defaults, $parameters );
 
 		$url = add_query_arg( $parameters, $this->onpage_endpoint );
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -110,11 +110,23 @@ class WPSEO_Taxonomy {
 
 			$analysis_worker_location          = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ) );
 			$used_keywords_assessment_location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ), 'used-keywords-assessment' );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper', 'wpseoAnalysisWorkerL10n', array(
-				'url'                     => $analysis_worker_location->get_url( $analysis_worker_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
-				'keywords_assessment_url' => $used_keywords_assessment_location->get_url( $used_keywords_assessment_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
+
+			$localization_data = array(
+				'url'                     => $analysis_worker_location->get_url(
+					$analysis_worker_location->get_asset(),
+					WPSEO_Admin_Asset::TYPE_JS
+				),
+				'keywords_assessment_url' => $used_keywords_assessment_location->get_url(
+					$used_keywords_assessment_location->get_asset(),
+					WPSEO_Admin_Asset::TYPE_JS
+				),
 				'log_level'               => WPSEO_Utils::get_analysis_worker_log_level(),
-			) );
+			);
+			wp_localize_script(
+				WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper',
+				'wpseoAnalysisWorkerL10n',
+				$localization_data
+			);
 
 			/**
 			 * Remove the emoji script as it is incompatible with both React and any

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -14,14 +14,17 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 <script type="text/html" id="tmpl-primary-term-ui">
 	<?php
+	/* translators: accessibility text. %1$s expands to the term title, %2$s to the taxonomy title. */
+	$yoast_free_js_button_label = __( 'Make %1$s primary %2$s', 'wordpress-seo' );
+	$yoast_free_js_button_label = sprintf(
+		$yoast_free_js_button_label,
+		'{{data.term}}',
+		'{{data.taxonomy.title}}'
+	);
+
 	printf(
 		'<button type="button" class="wpseo-make-primary-term" aria-label="%1$s">%2$s</button>',
-		esc_attr( sprintf(
-			/* translators: accessibility text. %1$s expands to the term title, %2$s to the taxonomy title. */
-			__( 'Make %1$s primary %2$s', 'wordpress-seo' ),
-			'{{data.term}}',
-			'{{data.taxonomy.title}}'
-		) ),
+		esc_attr( $yoast_free_js_button_label ),
 		esc_html__( 'Make primary', 'wordpress-seo' )
 	);
 	?>

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -15,16 +15,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 <script type="text/html" id="tmpl-primary-term-ui">
 	<?php
 	/* translators: accessibility text. %1$s expands to the term title, %2$s to the taxonomy title. */
-	$yoast_free_js_button_label = __( 'Make %1$s primary %2$s', 'wordpress-seo' );
-	$yoast_free_js_button_label = sprintf(
-		$yoast_free_js_button_label,
+	$yoast_seo_js_button_label = __( 'Make %1$s primary %2$s', 'wordpress-seo' );
+	$yoast_seo_js_button_label = sprintf(
+		$yoast_seo_js_button_label,
 		'{{data.term}}',
 		'{{data.taxonomy.title}}'
 	);
 
 	printf(
 		'<button type="button" class="wpseo-make-primary-term" aria-label="%1$s">%2$s</button>',
-		esc_attr( $yoast_free_js_button_label ),
+		esc_attr( $yoast_seo_js_button_label ),
 		esc_html__( 'Make primary', 'wordpress-seo' )
 	);
 	?>

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -15,16 +15,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 <script type="text/html" id="tmpl-primary-term-ui">
 	<?php
 	/* translators: accessibility text. %1$s expands to the term title, %2$s to the taxonomy title. */
-	$yoast_seo_js_button_label = __( 'Make %1$s primary %2$s', 'wordpress-seo' );
-	$yoast_seo_js_button_label = sprintf(
-		$yoast_seo_js_button_label,
+	$yoast_free_js_button_label = __( 'Make %1$s primary %2$s', 'wordpress-seo' );
+	$yoast_free_js_button_label = sprintf(
+		$yoast_free_js_button_label,
 		'{{data.term}}',
 		'{{data.taxonomy.title}}'
 	);
 
 	printf(
 		'<button type="button" class="wpseo-make-primary-term" aria-label="%1$s">%2$s</button>',
-		esc_attr( $yoast_seo_js_button_label ),
+		esc_attr( $yoast_free_js_button_label ),
 		esc_html__( 'Make primary', 'wordpress-seo' )
 	);
 	?>

--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -26,10 +26,15 @@ if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) 
 	$yform->show_hide_switch( 'breadcrumbs-display-blog-page', __( 'Show Blog page', 'wordpress-seo' ) );
 }
 
-$yform->toggle_switch( 'breadcrumbs-boldlast', array(
+$yoast_free_breadcrumb_bold_texts = array(
 	'on'  => __( 'Bold', 'wordpress-seo' ),
 	'off' => __( 'Regular', 'wordpress-seo' ),
-), __( 'Bold the last page', 'wordpress-seo' ) );
+);
+$yform->toggle_switch(
+	'breadcrumbs-boldlast',
+	$yoast_free_breadcrumb_bold_texts,
+	__( 'Bold the last page', 'wordpress-seo' )
+);
 
 echo '<br/><br/>';
 

--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -26,13 +26,13 @@ if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) 
 	$yform->show_hide_switch( 'breadcrumbs-display-blog-page', __( 'Show Blog page', 'wordpress-seo' ) );
 }
 
-$yoast_free_breadcrumb_bold_texts = array(
+$yoast_seo_breadcrumb_bold_texts = array(
 	'on'  => __( 'Bold', 'wordpress-seo' ),
 	'off' => __( 'Regular', 'wordpress-seo' ),
 );
 $yform->toggle_switch(
 	'breadcrumbs-boldlast',
-	$yoast_free_breadcrumb_bold_texts,
+	$yoast_seo_breadcrumb_bold_texts,
 	__( 'Bold the last page', 'wordpress-seo' )
 );
 

--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -26,13 +26,13 @@ if ( get_option( 'show_on_front' ) === 'page' && get_option( 'page_for_posts' ) 
 	$yform->show_hide_switch( 'breadcrumbs-display-blog-page', __( 'Show Blog page', 'wordpress-seo' ) );
 }
 
-$yoast_seo_breadcrumb_bold_texts = array(
+$yoast_free_breadcrumb_bold_texts = array(
 	'on'  => __( 'Bold', 'wordpress-seo' ),
 	'off' => __( 'Regular', 'wordpress-seo' ),
 );
 $yform->toggle_switch(
 	'breadcrumbs-boldlast',
-	$yoast_seo_breadcrumb_bold_texts,
+	$yoast_free_breadcrumb_bold_texts,
 	__( 'Bold the last page', 'wordpress-seo' )
 );
 

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -23,11 +23,12 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	<h2 class="help-button-inline"><?php echo esc_html__( 'Knowledge Graph', 'wordpress-seo' ) . $knowledge_graph_help->get_button_html(); ?></h2>
 	<?php
 	echo $knowledge_graph_help->get_panel_html();
-	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), array(
+	$yoast_free_kg_select_options = array(
 		''        => __( 'Choose whether you\'re a company or person', 'wordpress-seo' ),
 		'company' => __( 'Company', 'wordpress-seo' ),
 		'person'  => __( 'Person', 'wordpress-seo' ),
-	) );
+	);
+	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), $yoast_free_kg_select_options );
 	?>
 	<div id="knowledge-graph-company">
 		<h3><?php esc_html_e( 'Company', 'wordpress-seo' ); ?></h3>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -23,12 +23,12 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	<h2 class="help-button-inline"><?php echo esc_html__( 'Knowledge Graph', 'wordpress-seo' ) . $knowledge_graph_help->get_button_html(); ?></h2>
 	<?php
 	echo $knowledge_graph_help->get_panel_html();
-	$yoast_free_kg_select_options = array(
+	$yoast_seo_kg_select_options = array(
 		''        => __( 'Choose whether you\'re a company or person', 'wordpress-seo' ),
 		'company' => __( 'Company', 'wordpress-seo' ),
 		'person'  => __( 'Person', 'wordpress-seo' ),
 	);
-	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), $yoast_free_kg_select_options );
+	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), $yoast_seo_kg_select_options );
 	?>
 	<div id="knowledge-graph-company">
 		<h3><?php esc_html_e( 'Company', 'wordpress-seo' ); ?></h3>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -23,12 +23,12 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	<h2 class="help-button-inline"><?php echo esc_html__( 'Knowledge Graph', 'wordpress-seo' ) . $knowledge_graph_help->get_button_html(); ?></h2>
 	<?php
 	echo $knowledge_graph_help->get_panel_html();
-	$yoast_seo_kg_select_options = array(
+	$yoast_free_kg_select_options = array(
 		''        => __( 'Choose whether you\'re a company or person', 'wordpress-seo' ),
 		'company' => __( 'Company', 'wordpress-seo' ),
 		'person'  => __( 'Person', 'wordpress-seo' ),
 	);
-	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), $yoast_seo_kg_select_options );
+	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), $yoast_free_kg_select_options );
 	?>
 	<div id="knowledge-graph-company">
 		<h3><?php esc_html_e( 'Company', 'wordpress-seo' ); ?></h3>

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -15,12 +15,13 @@ $view_utils                   = new Yoast_View_Utils();
 <p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
 <?php
 
+$yoast_free_disable_attachments_texts = array(
+	'on'  => __( 'Yes', 'wordpress-seo' ),
+	'off' => __( 'No', 'wordpress-seo' ),
+);
 $yform->toggle_switch(
 	'disable-attachment',
-	array(
-		'on'  => __( 'Yes', 'wordpress-seo' ),
-		'off' => __( 'No', 'wordpress-seo' ),
-	),
+	$yoast_free_disable_attachments_texts,
 	__( 'Redirect attachment URLs to the attachment itself?', 'wordpress-seo' )
 );
 

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -15,13 +15,13 @@ $view_utils                   = new Yoast_View_Utils();
 <p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
 <?php
 
-$yoast_seo_disable_attachments_texts = array(
+$yoast_free_disable_attachments_texts = array(
 	'on'  => __( 'Yes', 'wordpress-seo' ),
 	'off' => __( 'No', 'wordpress-seo' ),
 );
 $yform->toggle_switch(
 	'disable-attachment',
-	$yoast_seo_disable_attachments_texts,
+	$yoast_free_disable_attachments_texts,
 	__( 'Redirect attachment URLs to the attachment itself?', 'wordpress-seo' )
 );
 

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -15,13 +15,13 @@ $view_utils                   = new Yoast_View_Utils();
 <p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
 <?php
 
-$yoast_free_disable_attachments_texts = array(
+$yoast_seo_disable_attachments_texts = array(
 	'on'  => __( 'Yes', 'wordpress-seo' ),
 	'off' => __( 'No', 'wordpress-seo' ),
 );
 $yform->toggle_switch(
 	'disable-attachment',
-	$yoast_free_disable_attachments_texts,
+	$yoast_seo_disable_attachments_texts,
 	__( 'Redirect attachment URLs to the attachment itself?', 'wordpress-seo' )
 );
 

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -15,11 +15,12 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $wpseo_bulk_titles_table      = new WPSEO_Bulk_Title_Editor_List_Table();
 $wpseo_bulk_description_table = new WPSEO_Bulk_Description_List_Table();
 
-get_current_screen()->set_screen_reader_content( array(
+$yoast_free_screen_reader_content = array(
 	'heading_views'      => __( 'Filter posts list', 'wordpress-seo' ),
 	'heading_pagination' => __( 'Posts list navigation', 'wordpress-seo' ),
 	'heading_list'       => __( 'Posts list', 'wordpress-seo' ),
-) );
+);
+get_current_screen()->set_screen_reader_content( $yoast_free_screen_reader_content );
 
 // If type is empty, fill it with value of first tab (title).
 $_GET['type'] = ( ! empty( $_GET['type'] ) ) ? $_GET['type'] : 'title';
@@ -34,11 +35,20 @@ if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
  */
 function wpseo_render_help_center() {
 	$tabs = new WPSEO_Option_Tabs( '', '' );
-	$tabs->add_tab( new WPSEO_Option_Tab( 'title', __( 'Bulk editor', 'wordpress-seo' ),
-		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
 
-	$tabs->add_tab( new WPSEO_Option_Tab( 'description', __( 'Bulk editor', 'wordpress-seo' ),
-		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) ) ) );
+	$bulk_editor_tab_title = new WPSEO_Option_Tab(
+		'title',
+		__( 'Bulk editor', 'wordpress-seo' ),
+		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) )
+	);
+	$tabs->add_tab( $bulk_editor_tab_title );
+
+	$bulk_editor_tab_description = new WPSEO_Option_Tab(
+		'description',
+		__( 'Bulk editor', 'wordpress-seo' ),
+		array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-bulk-editor' ) )
+	);
+	$tabs->add_tab( $bulk_editor_tab_description );
 
 	$helpcenter = new WPSEO_Help_Center( '', $tabs, WPSEO_Utils::is_yoast_seo_premium() );
 	$helpcenter->localize_data();

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -15,12 +15,12 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $wpseo_bulk_titles_table      = new WPSEO_Bulk_Title_Editor_List_Table();
 $wpseo_bulk_description_table = new WPSEO_Bulk_Description_List_Table();
 
-$yoast_free_screen_reader_content = array(
+$yoast_seo_screen_reader_content = array(
 	'heading_views'      => __( 'Filter posts list', 'wordpress-seo' ),
 	'heading_pagination' => __( 'Posts list navigation', 'wordpress-seo' ),
 	'heading_list'       => __( 'Posts list', 'wordpress-seo' ),
 );
-get_current_screen()->set_screen_reader_content( $yoast_free_screen_reader_content );
+get_current_screen()->set_screen_reader_content( $yoast_seo_screen_reader_content );
 
 // If type is empty, fill it with value of first tab (title).
 $_GET['type'] = ( ! empty( $_GET['type'] ) ) ? $_GET['type'] : 'title';

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -15,12 +15,12 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $wpseo_bulk_titles_table      = new WPSEO_Bulk_Title_Editor_List_Table();
 $wpseo_bulk_description_table = new WPSEO_Bulk_Description_List_Table();
 
-$yoast_seo_screen_reader_content = array(
+$yoast_free_screen_reader_content = array(
 	'heading_views'      => __( 'Filter posts list', 'wordpress-seo' ),
 	'heading_pagination' => __( 'Posts list navigation', 'wordpress-seo' ),
 	'heading_list'       => __( 'Posts list', 'wordpress-seo' ),
 );
-get_current_screen()->set_screen_reader_content( $yoast_seo_screen_reader_content );
+get_current_screen()->set_screen_reader_content( $yoast_free_screen_reader_content );
 
 // If type is empty, fill it with value of first tab (title).
 $_GET['type'] = ( ! empty( $_GET['type'] ) ) ? $_GET['type'] : 'title';

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -160,30 +160,33 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			$alert_popup = $this->get_notification_alert_popup();
 		}
 
-		$wp_admin_bar->add_menu( array(
+		$admin_bar_menu_args = array(
 			'id'    => self::MENU_IDENTIFIER,
 			'title' => $title . $score . $counter . $alert_popup,
 			'href'  => $settings_url,
 			'meta'  => array( 'tabindex' => ! empty( $settings_url ) ? false : '0' ),
-		) );
+		);
+		$wp_admin_bar->add_menu( $admin_bar_menu_args );
 
 		if ( ! empty( $counter ) ) {
-			$wp_admin_bar->add_menu( array(
+			$admin_bar_menu_args = array(
 				'parent' => self::MENU_IDENTIFIER,
 				'id'     => 'wpseo-notifications',
 				'title'  => __( 'Notifications', 'wordpress-seo' ) . $counter,
 				'href'   => $settings_url,
 				'meta'   => array( 'tabindex' => ! empty( $settings_url ) ? false : '0' ),
-			) );
+			);
+			$wp_admin_bar->add_menu( $admin_bar_menu_args );
 		}
 
 		if ( ! is_network_admin() && $can_manage_options ) {
-			$wp_admin_bar->add_menu( array(
+			$admin_bar_menu_args = array(
 				'parent' => self::MENU_IDENTIFIER,
 				'id'     => 'wpseo-configuration-wizard',
 				'title'  => __( 'Configuration Wizard', 'wordpress-seo' ),
 				'href'   => admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ),
-			) );
+			);
+			$wp_admin_bar->add_menu( $admin_bar_menu_args );
 		}
 	}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1302,6 +1302,14 @@ class WPSEO_Replace_Vars {
 	 * Set/translate the help texts for the WPSEO standard basic variables.
 	 */
 	private static function set_basic_help_texts() {
+		/* translators: %s: wp_title() function. */
+		$separator_description = __( 'The separator defined in your theme\'s %s tag.', 'wordpress-seo' );
+		$separator_description = sprintf(
+			$separator_description,
+			// '<code>wp_title()</code>'
+			'wp_title()'
+		);
+
 		$replacement_variables = array(
 			new WPSEO_Replacement_Variable( 'date', __( 'Date', 'wordpress-seo' ), __( 'Replaced with the date of the post/page', 'wordpress-seo' ) ),
 			new WPSEO_Replacement_Variable( 'title', __( 'Title', 'wordpress-seo' ), __( 'Replaced with the title of the post/page', 'wordpress-seo' ) ),
@@ -1319,12 +1327,7 @@ class WPSEO_Replace_Vars {
 			new WPSEO_Replacement_Variable( 'term_description', __( 'Term description', 'wordpress-seo' ), __( 'Replaced with the term description', 'wordpress-seo' ) ),
 			new WPSEO_Replacement_Variable( 'term_title', __( 'Term title', 'wordpress-seo' ), __( 'Replaced with the term name', 'wordpress-seo' ) ),
 			new WPSEO_Replacement_Variable( 'searchphrase', __( 'Search phrase', 'wordpress-seo' ), __( 'Replaced with the current search phrase', 'wordpress-seo' ) ),
-			new WPSEO_Replacement_Variable( 'sep', __( 'Separator', 'wordpress-seo' ), sprintf(
-				/* translators: %s: wp_title() function. */
-				__( 'The separator defined in your theme\'s %s tag.', 'wordpress-seo' ),
-				// '<code>wp_title()</code>'
-				'wp_title()'
-			) ),
+			new WPSEO_Replacement_Variable( 'sep', __( 'Separator', 'wordpress-seo' ), $separator_description ),
 		);
 
 		foreach ( $replacement_variables as $replacement_variable ) {

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -290,7 +290,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 					}
 
 					if ( 'wpseo_focuskw' === $key ) {
-						$clean[ $key ] = str_replace( array(
+						$search = array(
 							'&lt;',
 							'&gt;',
 							'&quot',
@@ -299,7 +299,9 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 							'>',
 							'"',
 							'`',
-						), '', $clean[ $key ] );
+						);
+
+						$clean[ $key ] = str_replace( $search, '', $clean[ $key ] );
 					}
 					break;
 			}

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -142,12 +142,12 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return $links;
 		}
 
-		$users = $this->get_users( array(
+		$user_criteria = array(
 			'offset' => ( $current_page - 1 ) * $max_entries,
 			'number' => $max_entries,
-		) );
-
-		$users = $this->exclude_users( $users );
+		);
+		$users         = $this->get_users( $user_criteria );
+		$users         = $this->exclude_users( $users );
 
 		if ( empty( $users ) ) {
 			$users = array();
@@ -196,7 +196,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	protected function update_user_meta() {
 
-		$users = get_users( array(
+		$user_criteria = array(
 			'who'        => 'authors',
 			'meta_query' => array(
 				array(
@@ -204,7 +204,8 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 					'compare' => 'NOT EXISTS',
 				),
 			),
-		) );
+		);
+		$users         = get_users( $user_criteria );
 
 		$time = time();
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be  introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently  already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have  been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and  defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.