### PR TITLE
CS: Move multi-line parameters out of function calls [4]

### DIFF
--- a/admin/config-ui/class-configuration-endpoint.php
+++ b/admin/config-ui/class-configuration-endpoint.php
@@ -34,30 +34,20 @@ class WPSEO_Configuration_Endpoint {
 	 */
 	public function register() {
 		// Register fetch config.
-		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_RETRIEVE, array(
+		$route_args = array(
 			'methods'             => 'GET',
-			'callback'            => array(
-				$this->service,
-				'get_configuration',
-			),
-			'permission_callback' => array(
-				$this,
-				'can_retrieve_data',
-			),
-		) );
+			'callback'            => array( $this->service, 'get_configuration' ),
+			'permission_callback' => array( $this, 'can_retrieve_data' ),
+		);
+		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_RETRIEVE, $route_args );
 
 		// Register save changes.
-		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_STORE, array(
+		$route_args = array(
 			'methods'             => 'POST',
-			'callback'            => array(
-				$this->service,
-				'set_configuration',
-			),
-			'permission_callback' => array(
-				$this,
-				'can_save_data',
-			),
-		) );
+			'callback'            => array( $this->service, 'set_configuration' ),
+			'permission_callback' => array( $this, 'can_save_data' ),
+		);
+		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_STORE, $route_args );
 	}
 
 	/**

--- a/admin/endpoints/class-endpoint-ryte.php
+++ b/admin/endpoints/class-endpoint-ryte.php
@@ -32,17 +32,12 @@ class WPSEO_Endpoint_Ryte implements WPSEO_Endpoint {
 	 */
 	public function register() {
 		// Register fetch config.
-		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_RETRIEVE, array(
+		$route_args = array(
 			'methods'             => 'GET',
-			'callback'            => array(
-				$this->service,
-				'get_statistics',
-			),
-			'permission_callback' => array(
-				$this,
-				'can_retrieve_data',
-			),
-		) );
+			'callback'            => array( $this->service, 'get_statistics' ),
+			'permission_callback' => array( $this, 'can_retrieve_data' ),
+		);
+		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_RETRIEVE, $route_args );
 	}
 
 	/**

--- a/admin/endpoints/class-endpoint-statistics.php
+++ b/admin/endpoints/class-endpoint-statistics.php
@@ -32,17 +32,12 @@ class WPSEO_Endpoint_Statistics implements WPSEO_Endpoint {
 	 */
 	public function register() {
 		// Register fetch config.
-		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_RETRIEVE, array(
+		$route_args = array(
 			'methods'             => 'GET',
-			'callback'            => array(
-				$this->service,
-				'get_statistics',
-			),
-			'permission_callback' => array(
-				$this,
-				'can_retrieve_data',
-			),
-		) );
+			'callback'            => array( $this->service, 'get_statistics' ),
+			'permission_callback' => array( $this, 'can_retrieve_data' ),
+		);
+		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_RETRIEVE, $route_args );
 	}
 
 	/**

--- a/admin/links/class-link-reindex-post-endpoint.php
+++ b/admin/links/class-link-reindex-post-endpoint.php
@@ -31,17 +31,12 @@ class WPSEO_Link_Reindex_Post_Endpoint {
 	 * Register the REST endpoint to WordPress.
 	 */
 	public function register() {
-		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_QUERY, array(
+		$route_args = array(
 			'methods'             => 'GET',
-			'callback'            => array(
-				$this->service,
-				'reindex',
-			),
-			'permission_callback' => array(
-				$this,
-				'can_retrieve_data',
-			),
-		) );
+			'callback'            => array( $this->service, 'reindex' ),
+			'permission_callback' => array( $this, 'can_retrieve_data' ),
+		);
+		register_rest_route( self::REST_NAMESPACE, self::ENDPOINT_QUERY, $route_args );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be  introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently  already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have  been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and  defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.