### PR TITLE
CS: Move multi-line parameters out of function calls [5]

### DIFF
--- a/admin/onpage/class-ryte-service.php
+++ b/admin/onpage/class-ryte-service.php
@@ -60,42 +60,47 @@ class WPSEO_Ryte_Service {
 		}
 
 		if ( $status === WPSEO_OnPage_Option::IS_NOT_INDEXABLE ) {
+			/* translators: %1$s: opens a link to a related knowledge base article. %2$s: closes the link. */
+			$label = __( '%1$sYour homepage cannot be indexed by search engines%2$s. This is very bad for SEO and should be fixed.', 'wordpress-seo' );
+			$label = sprintf(
+				$label,
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpageindexerror' ) . '" target="_blank">',
+				'</a>'
+			);
+
 			return array(
 				'score'     => 'bad',
-				'label'     => sprintf(
-					/* translators: %1$s: opens a link to a related knowledge base article. %2$s: closes the link. */
-					__( '%1$sYour homepage cannot be indexed by search engines%2$s. This is very bad for SEO and should be fixed.', 'wordpress-seo' ),
-					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpageindexerror' ) . '" target="_blank">',
-					'</a>'
-				),
+				'label'     => $label,
 				'can_fetch' => $fetch,
 			);
 		}
 
 		if ( $status === WPSEO_OnPage_Option::CANNOT_FETCH ) {
+			/* translators: %1$s: opens a link to a related knowledge base article, %2$s: expands to Yoast SEO, %3$s: closes the link, %4$s: expands to Ryte. */
+			$label = __( '%1$s%2$s has not been able to fetch your site\'s indexability status%3$s from %4$s', 'wordpress-seo' );
+			$label = sprintf(
+				$label,
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpagerequestfailed' ) . '" target="_blank">',
+				'Yoast SEO',
+				'</a>',
+				'Ryte'
+			);
+
 			return array(
 				'score'     => 'na',
-				'label'     => sprintf(
-					/* translators: %1$s: opens a link to a related knowledge base article, %2$s: expands to Yoast SEO, %3$s: closes the link, %4$s: expands to Ryte. */
-					__( '%1$s%2$s has not been able to fetch your site\'s indexability status%3$s from %4$s', 'wordpress-seo' ),
-					'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/onpagerequestfailed' ) . '" target="_blank">',
-					'Yoast SEO',
-					'</a>',
-					'Ryte'
-				),
+				'label'     => $label,
 				'can_fetch' => $fetch,
 			);
 		}
 
 		if ( $status === WPSEO_OnPage_Option::NOT_FETCHED ) {
+			/* translators: %1$s: expands to Yoast SEO, %2$s: expands to Ryte. */
+			$label = __( '%1$s has not fetched your site\'s indexability status yet from %2$s', 'wordpress-seo' );
+			$label = sprintf( $label, 'Yoast SEO', 'Ryte' );
+
 			return array(
 				'score'     => 'na',
-				'label'     => esc_html( sprintf(
-					/* translators: %1$s: expands to Yoast SEO, %2$s: expands to Ryte. */
-					__( '%1$s has not fetched your site\'s indexability status yet from %2$s', 'wordpress-seo' ),
-					'Yoast SEO',
-					'Ryte'
-				) ),
+				'label'     => esc_html( $label ),
 				'can_fetch' => $fetch,
 			);
 		}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be  introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding- Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding- Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently  already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have  been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and  defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

Note: only one of these is strictly _needed_ (the last one, where a `sprintf()` was nested in an `esc_html()`), but for the code readability and consistency, I've applied the same code pattern to the other arrays as well.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
