### PR TITLE
CS: Move multi-line parameters out of function calls [6]

### DIFF
--- a/admin/config-ui/components/class-component-configuration-choices.php
+++ b/admin/config-ui/components/class-component-configuration-choices.php
@@ -25,55 +25,69 @@ class WPSEO_Config_Component_Configuration_Choices implements WPSEO_Config_Compo
 	 * @return WPSEO_Config_Field
 	 */
 	public function get_field() {
-		$field = new WPSEO_Config_Field_Configuration_Choices();
+		/*
+		 * Set up the configuration choices.
+		 */
 
-		$field->set_property( 'label', sprintf(
-			/* translators: %s expands to 'Yoast SEO'. */
-			__( 'Please choose the %s configuration of your liking:', 'wordpress-seo' ), 'Yoast SEO' )
+		/* translators: %s expands to 'Yoast SEO'. */
+		$label = __( 'Please choose the %s configuration of your liking:', 'wordpress-seo' );
+		$label = sprintf( $label, 'Yoast SEO' );
+
+		$field = new WPSEO_Config_Field_Configuration_Choices();
+		$field->set_property( 'label', $label );
+
+		/* translators: %s expands to 'Yoast SEO'. */
+		$title = __( 'Configure %s in a few steps', 'wordpress-seo' );
+		$title = sprintf( $title, 'Yoast SEO' );
+
+		/*
+		 * Create first choice field.
+		 */
+
+		/* translators: %1$s expands to 'Yoast SEO'. */
+		$intro_text = __( 'Welcome to the %1$s configuration wizard. In a few simple steps we\'ll help you configure your SEO settings to match your website\'s needs! %1$s will take care of all the technical optimizations your site needs.', 'wordpress-seo' );
+		$intro_text = sprintf( $intro_text, 'Yoast SEO' );
+
+		/* translators: %s expands to 'Yoast SEO'. */
+		$button_text = sprintf( __( 'Configure %s', 'wordpress-seo' ), 'Yoast SEO' );
+		$button      = array(
+			'type'   => 'primary',
+			'label'  => $button_text,
+			'action' => 'nextStep',
 		);
 
 		$field->add_choice(
-			sprintf(
-				/* translators: %s expands to 'Yoast SEO'. */
-				__( 'Configure %s in a few steps', 'wordpress-seo' ),
-				'Yoast SEO'
-			),
-			sprintf(
-				/* translators: %1$s expands to 'Yoast SEO'. */
-				__( 'Welcome to the %1$s configuration wizard. In a few simple steps we\'ll help you configure your SEO settings to match your website\'s needs! %1$s will take care of all the technical optimizations your site needs.', 'wordpress-seo' ),
-				'Yoast SEO'
-			),
-			array(
-				'type'   => 'primary',
-				'label'  => sprintf(
-					/* translators: %s expands to 'Yoast SEO'. */
-					__( 'Configure %s', 'wordpress-seo' ), 'Yoast SEO'
-				),
-				'action' => 'nextStep',
-			),
+			$title,
+			$intro_text,
+			$button,
 			plugin_dir_url( WPSEO_FILE ) . '/images/Yoast_SEO_Icon.svg'
 		);
 
-		$plugin_training_text = sprintf(
-			/* translators: %1$s expands to 'Yoast SEO for WordPress', %2$s to Joost de Valk. */
-			__( 'If you want to take full advantage of the plugin, get our %1$s training. Get insights from renowned SEO expert %2$s and the team behind the plugin. Actionable tips that\'ll help you configure your site to perform even better in search and for your visitors. Hours of video, sliced into bite-sized clips for you to learn from!', 'wordpress-seo' ),
-			'Yoast SEO for WordPress',
-			'Joost de Valk'
+		/*
+		 * Create second choice field.
+		 */
+
+		/* translators: %s expands to 'Yoast SEO'. */
+		$title = __( 'Get the most out of the %s plugin', 'wordpress-seo' );
+		$title = sprintf( $title, 'Yoast SEO' );
+
+		/* translators: %1$s expands to 'Yoast SEO for WordPress', %2$s to Joost de Valk. */
+		$plugin_training_text = __( 'If you want to take full advantage of the plugin, get our %1$s training. Get insights from renowned SEO expert %2$s and the team behind the plugin. Actionable tips that\'ll help you configure your site to perform even better in search and for your visitors. Hours of video, sliced into bite-sized clips for you to learn from!', 'wordpress-seo' );
+		$plugin_training_text = sprintf( $plugin_training_text, 'Yoast SEO for WordPress', 'Joost de Valk' );
+
+		/* translators: %s expands to 'Yoast SEO'. */
+		$button_text = sprintf( __( 'Get the %s plugin training now', 'wordpress-seo' ), 'Yoast SEO' );
+		$button      = array(
+			'type'   => 'secondary',
+			'label'  => $button_text,
+			'action' => 'followURL',
+			'url'    => WPSEO_Shortlinker::get( 'https://yoa.st/2vg' ),
 		);
 
 		$field->add_choice(
-			sprintf(
-				/* translators: %s expands to 'Yoast SEO'. */
-				__( 'Get the most out of the %s plugin', 'wordpress-seo' ), 'Yoast SEO'
-			),
+			$title,
 			$plugin_training_text,
-			array(
-				'type'   => 'secondary',
-				/* translators: %s expands to 'Yoast SEO'. */
-				'label'  => sprintf( __( 'Get the %s plugin training now', 'wordpress-seo' ), 'Yoast SEO' ),
-				'action' => 'followURL',
-				'url'    => WPSEO_Shortlinker::get( 'https://yoa.st/2vg' ),
-			),
+			$button,
 			plugin_dir_url( WPSEO_FILE ) . 'images/yoast_seo_for_wp_2.svg'
 		);
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be  introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently  already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have  been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and  defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.