### PR TITLE
CS: Move static arrays to a class property [2]

### DIFF
--- a/admin/config-ui/fields/class-field-upsell-configuration-service.php
+++ b/admin/config-ui/fields/class-field-upsell-configuration-service.php
@@ -11,6 +11,18 @@
 class WPSEO_Config_Field_Upsell_Configuration_Service extends WPSEO_Config_Field {
 
 	/**
+	 * HTML tags allowed in the upsell text.
+	 *
+	 * @var array
+	 */
+	private $allowed_html = array(
+		'a' => array(
+			'href'   => array(),
+			'target' => array( '_blank' ),
+		),
+	);
+
+	/**
 	 * WPSEO_Config_Field_Upsell_Configuration_Service constructor.
 	 */
 	public function __construct() {
@@ -32,13 +44,7 @@ class WPSEO_Config_Field_Upsell_Configuration_Service extends WPSEO_Config_Field
 		);
 
 		$html  = '<p>' . esc_html( $intro_text ) . '</p>';
-		$html .= '<p><em>' . wp_kses( $upsell_text, array(
-				'a' => array(
-					'target' => array( '_blank' ),
-					'href'   => array(),
-				),
-			) ) . '</em></p>';
-
+		$html .= '<p><em>' . wp_kses( $upsell_text, $this->allowed_html ) . '</em></p>';
 
 		$this->set_property( 'html', $html );
 	}

--- a/admin/config-ui/fields/class-field-upsell-site-review.php
+++ b/admin/config-ui/fields/class-field-upsell-site-review.php
@@ -11,6 +11,18 @@
 class WPSEO_Config_Field_Upsell_Site_Review extends WPSEO_Config_Field {
 
 	/**
+	 * HTML tags allowed in the upsell site review text.
+	 *
+	 * @var array
+	 */
+	private $allowed_html = array(
+		'a' => array(
+			'href'   => array(),
+			'target' => array( '_blank' ),
+		),
+	);
+
+	/**
 	 * WPSEO_Config_Field_Upsell_Site_Review constructor.
 	 */
 	public function __construct() {
@@ -24,14 +36,7 @@ class WPSEO_Config_Field_Upsell_Site_Review extends WPSEO_Config_Field {
 			'</a>'
 		);
 
-		$html = '<p>' .
-				wp_kses( $upsell_text, array(
-					'a' => array(
-						'href'   => array(),
-						'target' => array( '_blank' ),
-					),
-				) ) .
-				'</p>';
+		$html = '<p>' . wp_kses( $upsell_text, $this->allowed_html ) . '</p>';
 
 		$this->set_property( 'html', $html );
 	}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

As the "allowed_html" arrays don't change, there is no need to declare them in the function itself.
Declaring them in a class property improves the readability and maintainability of the code.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.