### PR TITLE
Build/Travis: test builds against PHP 7.3 / WP 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ branches:
 jobs:
   fast_finish: true
   include:
-    - php: 7.2
-      env: WP_VERSION=latest WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
-    - php: 7.2
-      env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
+    - php: 7.3
+      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
+    - php: 7.3
+      env: WP_VERSION=5.0 WP_MULTISITE=1 COVERAGE=1
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
@@ -26,11 +26,11 @@ jobs:
     - php: 5.3
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.0
     - php: 5.6
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.0
     - php: 7.0
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.0
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
@@ -234,7 +234,7 @@ script:
   fi
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 
 after_script:
 - if [[ "$COVERAGE" == "1" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Tested against PHP 7.3 and the upcoming WP 5.0 release.

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

Travis has (finally) made a PHP 7.3 alias available, so I've updated the "highest" build to test against PHP 7.3 so there won't be any unwelcome surprises when PHP 7.3 comes out.

As WP 5.0 is being developed against a dedicated branch and `latest` is WP 5.1 (to be), WPSEO wasn't being tested against WP 5.0, so - until WP development moves back to `trunk` -, the `WP_VERSION` for bleeding edge should be `5.0`, not `latest`.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    Once the current, existing, build failure is fixed, restart the build for this PR and check that it passes.