### PR TITLE
Prepend home URL to @id of WebSite

### DIFF
--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -77,11 +77,14 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 		if ( ! is_front_page() ) {
 			return;
 		}
+
+		$home_url = $this->get_home_url();
+
 		$this->data = array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'WebSite',
-			'@id'      => '#website',
-			'url'      => $this->get_home_url(),
+			'@id'      => $home_url . '#website',
+			'url'      => $home_url,
 			'name'     => $this->get_website_name(),
 		);
 
@@ -153,11 +156,26 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 		$this->data = apply_filters( 'wpseo_json_ld_output', $this->data, $context );
 
 		if ( is_array( $this->data ) && ! empty( $this->data ) ) {
-			echo "<script type='application/ld+json'>", wp_json_encode( $this->data ), '</script>', "\n";
+			echo "<script type='application/ld+json'>", $this->format_data( $this->data ), '</script>', "\n";
 		}
 
 		// Empty the $data array so we don't output it twice.
 		$this->data = array();
+	}
+
+	/**
+	 * Prepares the data for outputting.
+	 *
+	 * @param array $data
+	 *
+	 * @return false|string The prepared string.
+	 */
+	public function format_data( $data ) {
+		if ( version_compare( PHP_VERSION, '5.4', '>=' ) ) {
+			return wp_json_encode( $data, JSON_UNESCAPED_SLASHES );
+		}
+
+		return wp_json_encode( $data );
 	}
 
 	/**

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -172,7 +172,8 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 */
 	public function format_data( $data ) {
 		if ( version_compare( PHP_VERSION, '5.4', '>=' ) ) {
-			return wp_json_encode( $data, JSON_UNESCAPED_SLASHES );
+			// @codingStandardsIgnoreLine
+			return wp_json_encode( $data, JSON_UNESCAPED_SLASHES ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.json_unescaped_slashesFound -- Version check present.
 		}
 
 		return wp_json_encode( $data );

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -166,7 +166,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	/**
 	 * Prepares the data for outputting.
 	 *
-	 * @param array $data
+	 * @param array $data The data to format.
 	 *
 	 * @return false|string The prepared string.
 	 */

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -40,10 +40,11 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 
 		$home_url   = WPSEO_Utils::home_url();
 		$search_url = $home_url . '?s={search_term_string}';
-		$json       = wp_json_encode( array(
+
+		$json       = self::$class_instance->format_data( array(
 			'@context'        => 'https://schema.org',
 			'@type'           => 'WebSite',
-			'@id'             => '#website',
+			'@id'             => $home_url . '#website',
 			'url'             => $home_url,
 			'name'            => get_bloginfo( 'name' ),
 			'potentialAction' => array(
@@ -52,7 +53,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 				'query-input' => 'required name=search_term_string',
 			),
 		) );
-		$expected   = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+
+		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+
 		$this->expectOutput( $expected, self::$class_instance->website() );
 	}
 
@@ -71,7 +74,8 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$this->go_to_home();
 
 		$home_url = WPSEO_Utils::home_url();
-		$json     = wp_json_encode( array(
+
+		$json = self::$class_instance->format_data( array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'Person',
 			'url'      => $home_url,
@@ -79,8 +83,10 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 			'@id'      => '#person',
 			'name'     => $name,
 		) );
+
 		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 		self::$class_instance->organization_or_person();
+
 		$this->expectOutput( $expected );
 	}
 
@@ -97,15 +103,18 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'person_name', $name );
 		WPSEO_Options::set( 'instagram_url', 'http://instagram.com:8080/{}yoast' );
 
-		$json     = wp_json_encode( array(
+		$json = self::$class_instance->format_data( array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'Person',
 			'url'      => $home_url,
-			'sameAs'   => array( 'http://instagram.com:8080/yoast' ), // The {} will be stripped out by saving the option.
+			'sameAs'   => array( 'http://instagram.com:8080/yoast' ),
+			// The {} will be stripped out by saving the option.
 			'@id'      => '#person',
 			'name'     => $name,
 		) );
+
 		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+
 		self::$class_instance->organization_or_person();
 		$this->expectOutput( $expected );
 	}
@@ -127,7 +136,8 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$this->go_to_home();
 
 		$home_url = WPSEO_Utils::home_url();
-		$json     = wp_json_encode( array(
+
+		$json = self::$class_instance->format_data( array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'Organization',
 			'url'      => $home_url,
@@ -136,7 +146,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 			'name'     => $name,
 			'logo'     => '',
 		) );
+
 		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+
 		$this->expectOutput( $expected, self::$class_instance->organization_or_person() );
 	}
 }


### PR DESCRIPTION
Also prevents escaping of the output when possible (PHP 5.4+).

## Summary

This PR can be summarized in the following changelog entry:

* Changes the output of schema preventing unnecessary escaping of forward slashes, only available on sites running PHP 5.4 or higher.
* Changes the website schema `@id` attribute to include the home URL to be a unique identifier.

## Relevant technical choices:

* See the descriptions in the relevant issues

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open the homepage and view the source, the structured data (ld+json)
`<script type='application/ld+json'>{"@context":"https://schema.org","@type":"WebSite","@id":"http://local.wordpress.test/#website","url":"http://local.wordpress.test/","name":"Default","potentialAction":{"@type":"SearchAction","target":"http://local.wordpress.test/?s={search_term_string}","query-input":"required name=search_term_string"}}</script>`
* Change from trunk is that the `@id` contains the `home_url`
* Change from trunk is that the forwards slashes are no longer escaped

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Replaces https://github.com/Yoast/wordpress-seo/pull/11146

Fixes #11305 
Fixes #10619
