### PR TITLE
Add wp compose dependency to wp data

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -209,7 +209,7 @@ class WPSEO_Admin_Asset_Manager {
 		wp_register_script(
 			'wp-data',
 			plugins_url( 'js/dist/wp-data-' . $flat_version . '.min.js', WPSEO_FILE ),
-			array( 'lodash', 'wp-element', 'wp-polyfill' ),
+			array( 'lodash', 'wp-element', 'wp-polyfill', 'wp-compose' ),
 			false,
 			true
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* This was already fixed by [this commit](https://github.com/Yoast/wordpress-seo/pull/11579/commits/f0519594feb06cc03869e9ec6d7731976dea8778#diff-9b8b9d5ca686b29d63b5d9a9b95db6a6R204).  But to be sure we don't get the same error as in Yoast/wordpress-seo-premium#2126 if we only enqueue `wp-data`, without `wp-components`, I created this PR.
The reason we do this is because `wp-data` also depends on `wp-compose` in Gutenberg.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if all dependencies are loaded properly in the scenario explained in Fixes Yoast/wordpress-seo-premium#2126.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes Yoast/wordpress-seo-premium#2126
