### PR TITLE
Call marker function again when content changed in Gutenberg

### DIFF
--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,7 +1,5 @@
 import debounce from "lodash/debounce";
-import {
-	select
-} from "@wordpress/data";
+import { select } from "@wordpress/data";
 import {
 	updateReplacementVariable,
 	updateData,
@@ -12,7 +10,6 @@ import {
 	mapCustomFields,
 	mapCustomTaxonomies,
 } from "../helpers/replacementVariableHelpers";
-
 
 /**
  * Represents the data.

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -199,25 +199,6 @@ class Data {
 	}
 
 	/**
-	 * Refreshes YoastSEO's app when the Gutenberg data is dirty.
-	 *
-	 * @returns {void}
-	 */
-	refreshYoastSEO() {
-		const gutenbergData = this.collectGutenbergData();
-
-		// Set isDirty to true if the current data and Gutenberg data are unequal.
-		const isDirty = ! this.isShallowEqual( this._data, gutenbergData );
-
-		if ( isDirty ) {
-			this.handleEditorChange( gutenbergData );
-			this.reapplyMarkers();
-			this._data = gutenbergData;
-			this._refresh();
-		}
-	}
-
-	/**
 	 * If a marker is active, find the associated assessment result and applies the marker on that result.
 	 *
 	 * @returns {void}
@@ -244,6 +225,25 @@ class Data {
 
 		if ( marker ) {
 			marker();
+		}
+	}
+
+	/**
+	 * Refreshes YoastSEO's app when the Gutenberg data is dirty.
+	 *
+	 * @returns {void}
+	 */
+	refreshYoastSEO() {
+		const gutenbergData = this.collectGutenbergData();
+
+		// Set isDirty to true if the current data and Gutenberg data are unequal.
+		const isDirty = ! this.isShallowEqual( this._data, gutenbergData );
+
+		if ( isDirty ) {
+			this.handleEditorChange( gutenbergData );
+			this.reapplyMarkers();
+			this._data = gutenbergData;
+			this._refresh();
 		}
 	}
 

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -242,9 +242,9 @@ class Data {
 	}
 
 	/**
-	 * Checks whether new analysis results are available in the store..
+	 * Checks whether new analysis results are available in the store.
 	 *
-	 * @returns {bool} Whether new analysis results are available.
+	 * @returns {boolean} Whether new analysis results are available.
 	 */
 	areNewAnalysisResultsAvailable() {
 		const yoastSeoEditorSelectors = this._wpData.select( "yoast-seo/editor" );
@@ -264,7 +264,7 @@ class Data {
 	}
 
 	/**
-	 * Function that is called when new analysis results are available.
+	 * Reapplies the markers when new analysis results are available.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,5 +1,4 @@
 import debounce from "lodash/debounce";
-import { select } from "@wordpress/data";
 import {
 	updateReplacementVariable,
 	updateData,
@@ -227,7 +226,7 @@ class Data {
 		const {
 			getActiveMarker,
 			getResultById,
-		} = select( "yoast-seo/editor" );
+		} = this._wpData.select( "yoast-seo/editor" );
 
 		const activeMarker = getActiveMarker();
 

--- a/js/src/analysis/data.js
+++ b/js/src/analysis/data.js
@@ -1,5 +1,8 @@
 import debounce from "lodash/debounce";
 import {
+	select
+} from "@wordpress/data";
+import {
 	updateReplacementVariable,
 	updateData,
 } from "../redux/actions/snippetEditor";
@@ -212,8 +215,39 @@ class Data {
 
 		if ( isDirty ) {
 			this.handleEditorChange( gutenbergData );
+			this.reapplyMarkers();
 			this._data = gutenbergData;
 			this._refresh();
+		}
+	}
+
+	/**
+	 * If a marker is active, find the associated assessment result and applies the marker on that result.
+	 *
+	 * @returns {void}
+	 */
+	reapplyMarkers() {
+		const {
+			getActiveMarker,
+			getResultById,
+		} = select( "yoast-seo/editor" );
+
+		const activeMarker = getActiveMarker();
+
+		if ( ! activeMarker ) {
+			return;
+		}
+
+		const markedResult = getResultById( activeMarker );
+
+		if ( ! markedResult ) {
+			return;
+		}
+
+		const marker = markedResult.getMarker();
+
+		if ( marker ) {
+			marker();
 		}
 	}
 

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -3,7 +3,7 @@ import isFunction from "lodash/isFunction";
 import isUndefined from "lodash/isUndefined";
 import flatMap from "lodash/flatMap";
 import { create } from "@wordpress/rich-text";
-import { select, dispatch, subscribe } from "@wordpress/data";
+import { select, dispatch } from "@wordpress/data";
 
 const ANNOTATION_SOURCE = "yoast";
 

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -356,7 +356,6 @@ export function applyAsAnnotations( paper, marks ) {
 
 	// For every block...
 	const annotations = flatMap( blocks, ( ( block ) => {
-
 		// We go through every annotatable attribute.
 		return flatMap(
 			getAnnotatableAttributes( block.name ),
@@ -393,7 +392,7 @@ function removeAllAnnotationsFromBlock( blockClientId ) {
  */
 export function reapplyAnnotationsForSelectedBlock() {
 	const block = select( "core/editor" ).getSelectedBlock();
-	const activeMarker  = select( "yoast-seo/editor" ).getActiveMarker()
+	const activeMarker  = select( "yoast-seo/editor" ).getActiveMarker();
 
 	if ( ! block || ! activeMarker ) {
 		return;

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -3,7 +3,7 @@ import isFunction from "lodash/isFunction";
 import isUndefined from "lodash/isUndefined";
 import flatMap from "lodash/flatMap";
 import { create } from "@wordpress/rich-text";
-import { select, dispatch } from "@wordpress/data";
+import { select, dispatch, subscribe } from "@wordpress/data";
 
 const ANNOTATION_SOURCE = "yoast";
 
@@ -316,6 +316,14 @@ function removeAllAnnotations() {
 	dispatch( "core/annotations" ).__experimentalRemoveAnnotationsBySource( ANNOTATION_SOURCE );
 }
 
+/**
+ * Formats annotations to objects the Gutenberg annotations API works with, and adds
+ * them to the queue to be scheduled for adding them to the editor.
+ *
+ * @param {array} annotations Annotations to be mapped to the queue.
+ *
+ * @returns {void}
+ */
 function fillAnnotationQueue( annotations ) {
 	annotationQueue = annotations.map( ( annotation ) => ( {
 		blockClientId: annotation.block,
@@ -379,7 +387,7 @@ function removeAllAnnotationsOnBlock( blockClientId ) {
 }
 
 /**
- * Apply.
+ * Reapply annotations in the currently selected block.
  *
  * @returns {void}
  */

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -356,8 +356,8 @@ export function applyAsAnnotations( paper, marks ) {
 
 	// For every block...
 	const annotations = flatMap( blocks, ( ( block ) => {
-		// We go through every annotatable attribute.
 
+		// We go through every annotatable attribute.
 		return flatMap(
 			getAnnotatableAttributes( block.name ),
 			( ( attribute ) => getAnnotationsForBlockAttribute( attribute, block, marks ) )
@@ -376,7 +376,7 @@ export function applyAsAnnotations( paper, marks ) {
  *
  * @returns {void}
  */
-function removeAllAnnotationsOnBlock( blockClientId ) {
+function removeAllAnnotationsFromBlock( blockClientId ) {
 	const annotationsInBlock = select( "core/annotations" )
 		.__experimentalGetAnnotations()
 		.filter( annotation => annotation.blockClientId === blockClientId && annotation.source === ANNOTATION_SOURCE );
@@ -399,7 +399,7 @@ export function reapplyAnnotationsForSelectedBlock() {
 		return;
 	}
 
-	removeAllAnnotationsOnBlock( block.clientId );
+	removeAllAnnotationsFromBlock( block.clientId );
 
 	const marksForActiveMarker = select( "yoast-seo/editor" ).getResultById( activeMarker ).marks;
 

--- a/js/src/redux/selectors/results.js
+++ b/js/src/redux/selectors/results.js
@@ -30,7 +30,7 @@ export function getResultsForKeyword( state, keyword ) {
  *
  * @param {object} state The state.
  *
- * @returns {object} The readability results and score for the focus keyword.
+ * @returns {object} The results and score for the readability analysis.
  */
 export function getReadabilityResults( state ) {
 	return get( state, [ "analysis", "readability" ] );
@@ -41,7 +41,7 @@ export function getReadabilityResults( state ) {
  *
  * @param {object} state The state.
  *
- * @returns {object} The SEO results and score for the focus keyword.
+ * @returns {object} The SEO results and overall score for the focus keyword.
  */
 export function getResultsForFocusKeyword( state ) {
 	return getResultsForKeyword( state, state.focusKeyword );

--- a/js/src/redux/selectors/results.js
+++ b/js/src/redux/selectors/results.js
@@ -30,7 +30,7 @@ export function getResultsForKeyword( state, keyword ) {
  *
  * @param {object} state The state.
  *
- * @returns {object} The results and score for the readability analysis.
+ * @returns {object} The results and overall score for the readability analysis.
  */
 export function getReadabilityResults( state ) {
 	return get( state, [ "analysis", "readability" ] );

--- a/js/src/redux/selectors/results.js
+++ b/js/src/redux/selectors/results.js
@@ -4,7 +4,8 @@ import get from "lodash/get";
  * Gets the SEO results.
  *
  * @param {Object} state The state.
- * @returns {Object} The SEO results.
+ *
+ * @returns {Object} The SEO results for all keywords.
  */
 export function getSeoResults( state ) {
 	return get( state, [ "analysis", "seo" ], {} );
@@ -15,12 +16,52 @@ export function getSeoResults( state ) {
  *
  * @param {Object} state The state.
  * @param {string} keyword The keyword to get the results for.
+ *
  * @returns {Array} The SEO results for the keyword.
  */
 export function getResultsForKeyword( state, keyword ) {
 	const seoResults = getSeoResults( state );
 
 	return get( seoResults, keyword, [] );
+}
+
+/**
+ * Gets the readability results for the focus keyword.
+ *
+ * @param {object} state The state.
+ *
+ * @returns {object} The readability results and score for the focus keyword.
+ */
+export function getReadabilityResults( state ) {
+	return get( state, [ "analysis", "readability" ] );
+}
+
+/**
+ * Gets the SEO results for the focus keyword.
+ *
+ * @param {object} state The state.
+ *
+ * @returns {object} The SEO results and score for the focus keyword.
+ */
+export function getResultsForFocusKeyword( state ) {
+	return getResultsForKeyword( state, state.focusKeyword );
+}
+
+/**
+ * Get a result by id from both the focus keyword and readability analysis.
+ *
+ * @param {object} state The state.
+ * @param {string} id    The assessment's identifier.
+ *
+ * @returns {Object|null} The assessment result.
+ */
+export function getResultById( state, id ) {
+	const allResults = [
+		...getResultsForFocusKeyword( state ).results,
+		...getReadabilityResults( state ).results,
+	];
+
+	return allResults.find( result => result._identifier === id );
 }
 
 /**

--- a/js/tests/data.test.js
+++ b/js/tests/data.test.js
@@ -16,7 +16,10 @@ const mockSelect = jest.fn();
 const mockGetEditedPostAttribute = jest.fn().mockImplementation( value => value );
 
 // Ensures mockSelect.getEditedPostAttribute is a function.
-mockSelect.mockReturnValue( { getEditedPostAttribute: mockGetEditedPostAttribute } );
+mockSelect.mockReturnValue( {
+	getEditedPostAttribute: mockGetEditedPostAttribute,
+	getActiveMarker: () => null,
+} );
 
 data._wpData.select = mockSelect;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In Gutenberg, create a new post and write some content that will trigger readability assessments with markers. For instance paragraph length.
* Enter a keyphrase that is found within your content.
* Now activate a marker.
* Edit the content of your post and notice that the markers are updated after a short while.

Also:
- Test functionality in Classic editor markings
- Test functionality in Classic Editor plugin

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #11571 
