### PR TITLE
Implemented extra check to disable the markers if we're in the text view

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -9,6 +9,7 @@ import {
 	setSeoResultsForKeyword,
 } from "yoast-components";
 import isShallowEqualObjects from "@wordpress/is-shallow-equal/objects";
+import { select, subscribe } from "@wordpress/data";
 
 // Internal dependencies.
 import Edit from "./edit";
@@ -374,6 +375,33 @@ setWordPressSeoL10n();
 	}
 
 	/**
+	 * Toggles the markers status in the state, based on the editor mode.
+	 *
+	 * @param {string} editorMode The editor mode.
+	 * @param {Object} store      The store to update.
+	 *
+	 * @returns {void}
+	 */
+	function toggleMarkers( editorMode, store ) {
+		if ( editorMode === "text" ) {
+			store.dispatch( setMarkerStatus( "disabled" ) );
+
+			return;
+		}
+
+		store.dispatch( setMarkerStatus( "enabled" ) );
+	}
+
+	/**
+	 * Gets the current editor mode from the state.
+	 *
+	 * @returns {string} The current editor mode.
+	 */
+	function getEditorMode() {
+		return select( "core/edit-post" ).getEditorMode();
+	}
+
+	/**
 	 * Initializes analysis for the post edit screen.
 	 *
 	 * @returns {void}
@@ -549,6 +577,21 @@ setWordPressSeoL10n();
 			snippetEditorData.title = data.title;
 			snippetEditorData.slug = data.slug;
 			snippetEditorData.description = data.description;
+		} );
+
+		let editorMode = getEditorMode();
+
+		toggleMarkers( editorMode, editStore );
+
+		subscribe( () => {
+			const currentEditorMode = getEditorMode();
+
+			if ( currentEditorMode === editorMode ) {
+				return;
+			}
+
+			editorMode = currentEditorMode;
+			toggleMarkers( editorMode, editStore );
 		} );
 
 		if ( ! isGutenbergDataAvailable() ) {

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -383,13 +383,13 @@ setWordPressSeoL10n();
 	 * @returns {void}
 	 */
 	function toggleMarkers( editorMode, store ) {
-		if ( editorMode === "text" ) {
-			store.dispatch( setMarkerStatus( "disabled" ) );
+		if ( editorMode === "visual" ) {
+			store.dispatch( setMarkerStatus( "enabled" ) );
 
 			return;
 		}
 
-		store.dispatch( setMarkerStatus( "enabled" ) );
+		store.dispatch( setMarkerStatus( "disabled" ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the marker buttons would still be enabled in the text view, despite not being functional.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post in the Gutenberg editor and ensure that you see at least one eye marker button in the readability or SEO analysis.
* Ensure that the marker button properly works.
* Switch to the Code View by selecting the three dots in the upper-right corner.
* See that the eye marker button(s) is/are disabled.
* Save the post in the current view and refresh the page.
* Open up the readability analysis and see that the markers are still properly disabled on a page reload.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11593 
