### PR TITLE
Allow repeated sentences and multiple parts within a sentence to be annotated.

### DIFF
--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -10,6 +10,9 @@ const { stripHTMLTags } = string;
 
 const ANNOTATION_SOURCE = "yoast";
 
+export const START_MARK = "<yoastmark class='yoast-text-mark'>";
+export const END_MARK =   "</yoastmark>";
+
 let annotationQueue = [];
 
 const ANNOTATION_ATTRIBUTES = {
@@ -100,32 +103,29 @@ export function isAnnotationAvailable() {
  *
  * @returns {Array<{startOffset: number, endOffset: number}>} The start and end indices for this mark.
  */
-function getOffsets( mark ) {
+export function getOffsets( mark ) {
 	let marked = mark.getMarked();
 
-	const startMark = "<yoastmark class='yoast-text-mark'>";
-	const endMark = "</yoastmark>";
-
-	let startMarkIndex = marked.indexOf( startMark );
+	let startMarkIndex = marked.indexOf( START_MARK );
 	let endMarkIndex = null;
 
 	const offsets = [];
 
 	while ( startMarkIndex >= 0 ) {
-		marked = marked.replace( startMark, "" );
-		endMarkIndex = marked.indexOf( endMark );
+		marked = marked.replace( START_MARK, "" );
+		endMarkIndex = marked.indexOf( END_MARK );
 
-		if ( endMarkIndex < 0 ) {
-			return null;
+		if ( endMarkIndex < startMarkIndex ) {
+			return [];
 		}
-		marked = marked.replace( endMark, "" );
+		marked = marked.replace( END_MARK, "" );
 
 		offsets.push( {
 			startOffset: startMarkIndex,
 			endOffset: endMarkIndex,
 		} );
 
-		startMarkIndex = marked.indexOf( startMark );
+		startMarkIndex = marked.indexOf( START_MARK );
 		endMarkIndex = null;
 	}
 
@@ -141,7 +141,7 @@ function getOffsets( mark ) {
  *
  * @returns {Array} All indices of the found occurrences.
  */
-function getIndicesOf( text, value, caseSensitive = true ) {
+export function getIndicesOf( text, value, caseSensitive = true ) {
 	const indices = [];
 
 	if ( text.length  === 0 ) {

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -107,7 +107,7 @@ export function getYoastmarkOffsets( marked ) {
 	const offsets = [];
 
 	/**
-	 * Step by step search for a yoastmark-tag and it's corresponding en tag. Each time a tag is found
+	 * Step by step search for a yoastmark-tag and its corresponding en tag. Each time a tag is found
 	 * it is removed from the string because the function should return the indexes based on the string
 	 * without the tags.
 	 */
@@ -148,7 +148,7 @@ export function getIndicesOf( text, stringToFind, caseSensitive = true ) {
 		return indices;
 	}
 
-	let textIndex = 0;
+	let searchStartIndex = 0;
 	let index;
 
 	if ( ! caseSensitive ) {
@@ -156,9 +156,9 @@ export function getIndicesOf( text, stringToFind, caseSensitive = true ) {
 		text = text.toLowerCase();
 	}
 
-	while ( ( index = text.indexOf( stringToFind, textIndex ) ) > -1 ) {
+	while ( ( index = text.indexOf( stringToFind, searchStartIndex ) ) > -1 ) {
 		indices.push( index );
-		textIndex = index + stringToFind.length;
+		searchStartIndex = index + stringToFind.length;
 	}
 
 	return indices;

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -232,7 +232,7 @@ function calculateAnnotationsForTextFormat( content, mark, block, multilineTag =
 			 * endOffset =   ( sentenceIndex ) 13 + ( yoastmarkOffset.endOffset ) 14  = 27
 			 *
 			 * "A cool text. A cool keyword."
-			 *                      ^20   ^27
+			 *      ( startOffset ) ^20   ^27 ( endOffset )
 			 */
 			const startOffset = sentenceIndex + yoastmarkOffset.startOffset;
 			let endOffset = sentenceIndex + yoastmarkOffset.endOffset;

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -167,19 +167,12 @@ export function getIndicesOf( text, stringToFind, caseSensitive = true ) {
 /**
  * Calculates an annotation if the given mark is applicable to the content of a block.
  *
- * @param {string} content             The content of the block.
- * @param {Mark}   mark                The mark to apply to the content.
- * @param {string} block               The block ID to apply the mark to.
- * @param {string} multilineTag        The tag the block uses to signify multiple parts.
- * @param {string} multilineWrapperTag The tag the block uses as a container.
+ * @param {string} text The content of the block.
+ * @param {Mark}   mark The mark to apply to the content.
  *
  * @returns {Array} The annotations to apply.
  */
-function calculateAnnotationsForTextFormat( content, mark, block, multilineTag = false, multilineWrapperTag = false ) {
-	// Create a rich text record, because those are easier to work with.
-	const record = create( { html: content, multilineTag, multilineWrapperTag } );
-	const { text } = record;
-
+export function calculateAnnotationsForTextFormat( text, mark ) {
 	/*
 	 * Remove all tags from the original sentence.
 	 *
@@ -246,7 +239,6 @@ function calculateAnnotationsForTextFormat( content, mark, block, multilineTag =
 			}
 
 			blockOffsets.push( {
-				block: block.clientId,
 				startOffset,
 				endOffset,
 			} );
@@ -285,14 +277,19 @@ function getAnnotationsForBlockAttribute( attribute, block, marks ) {
 	const { attributes } = block;
 	const attributeValue = attributes[ attributeKey ];
 
+	// Create a rich text record, because those are easier to work with.
+	const record = create( {
+		html: attributeValue,
+		multilineTag: attribute.multilineTag,
+		multilineWrapperTag: attribute.multilineWrapperTag,
+	} );
+	const text = record.text;
+
 	// For each mark see if it applies to this block.
 	return flatMap( marks, ( ( mark ) => {
 		const annotations = calculateAnnotationsForTextFormat(
-			attributeValue,
+			text,
 			mark,
-			block,
-			attribute.multilineTag,
-			attribute.multilineWrapperTag,
 		);
 
 		if ( ! annotations ) {
@@ -302,6 +299,7 @@ function getAnnotationsForBlockAttribute( attribute, block, marks ) {
 		return annotations.map( annotation => {
 			return {
 				...annotation,
+				block: block.clientId,
 				richTextIdentifier: attributeKey,
 			};
 		} );

--- a/js/tests/decorator/__mocks__/@wordpress/rich-text/index.js
+++ b/js/tests/decorator/__mocks__/@wordpress/rich-text/index.js
@@ -1,0 +1,1 @@
+export default null;

--- a/js/tests/decorator/gutenberg.test.js
+++ b/js/tests/decorator/gutenberg.test.js
@@ -24,10 +24,7 @@ function mockMark( original, marked ) {
 
 describe( "getOffsets", () => {
 	it( "successfully finds offsets for a single mark at the start of the text", () => {
-		const mark = mockMark(
-			"A marked text.",
-			`${ START_MARK }A marked${ END_MARK } text.`
-		);
+		const markedText = `${ START_MARK }A marked${ END_MARK } text.`;
 
 		const expected = [
 			{
@@ -36,14 +33,11 @@ describe( "getOffsets", () => {
 			},
 		];
 
-		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( markedText ) ).toEqual( expected );
 	} );
 
 	it( "successfully finds offsets for a single mark at the end of the text", () => {
-		const mark = mockMark(
-			"A marked text.",
-			`A ${ START_MARK }marked text.${ END_MARK }`
-		);
+		const markedText = `A ${ START_MARK }marked text.${ END_MARK }`;
 
 		const expected = [
 			{
@@ -52,14 +46,11 @@ describe( "getOffsets", () => {
 			},
 		];
 
-		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( markedText ) ).toEqual( expected );
 	} );
 
 	it( "successfully finds multiple offsets for multiple marks", () => {
-		const mark = mockMark(
-			"A marked text.",
-			`${ START_MARK }A${ END_MARK } marked ${ START_MARK }text.${ END_MARK }`
-		);
+		const markedText = `${ START_MARK }A${ END_MARK } marked ${ START_MARK }text.${ END_MARK }`;
 
 		const expected = [
 			{
@@ -72,18 +63,15 @@ describe( "getOffsets", () => {
 			},
 		];
 
-		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( markedText ) ).toEqual( expected );
 	} );
 
 	it( "returns an empty array if the start and end tags are in a incorrect order", () => {
-		const mark = mockMark(
-			"A marked text.",
-			`${ START_MARK }A${ END_MARK } marked ${ END_MARK }text.${ START_MARK }`
-		);
+		const markedText = `${ START_MARK }A${ END_MARK } marked ${ END_MARK }text.${ START_MARK }`;
 
 		const expected = [];
 
-		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( markedText ) ).toEqual( expected );
 	} );
 } );
 

--- a/js/tests/decorator/gutenberg.test.js
+++ b/js/tests/decorator/gutenberg.test.js
@@ -67,6 +67,10 @@ describe( "getOffsets", () => {
 		expect( getYoastmarkOffsets( markedText ) ).toEqual( expected );
 	} );
 
+	/**
+	 * If we receive an unexpected string we don't do anything to avoid code complexity. We
+	 * expect YoastSEO.js to provide us with proper marked sentences after all.
+	 */
 	it( "returns an empty array if the start and end tags are in a incorrect order", () => {
 		const markedText = `${ START_MARK }A${ END_MARK } marked ${ END_MARK }text.${ START_MARK }`;
 
@@ -101,7 +105,7 @@ describe( "calculateAnnotationsForTextFormat", () => {
 
 		/*
 		 * "A long text. A marked text."
-		 *                 ^ 15       ^ 26
+		 *                     22 ^   ^ 26
 		 */
 		const expected = [
 			{
@@ -133,6 +137,31 @@ describe( "calculateAnnotationsForTextFormat", () => {
 		const expected = [ {
 			startOffset: 15,
 			endOffset: 26,
+		} ];
+
+		const actual = calculateAnnotationsForTextFormat(
+			text,
+			mark
+		);
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "correctly calculates offsets in a text with invalid HTML markup", () => {
+		const text = "A long text. A marked text.";
+
+		const mark = mockMark(
+			"A marked text.",
+			`A ${ START_MARK }<b>marked${ END_MARK } text</b>.`,
+		);
+
+		/*
+		 * "A long text. A marked text."
+		 *                 ^ 15  ^ 21
+		 */
+		const expected = [ {
+			startOffset: 15,
+			endOffset: 21,
 		} ];
 
 		const actual = calculateAnnotationsForTextFormat(

--- a/js/tests/decorator/gutenberg.test.js
+++ b/js/tests/decorator/gutenberg.test.js
@@ -1,7 +1,7 @@
 import {
 	START_MARK,
 	END_MARK,
-	getOffsets,
+	getYoastmarkOffsets,
 	getIndicesOf,
 } from "../../src/decorator/gutenberg";
 
@@ -36,7 +36,7 @@ describe( "getOffsets", () => {
 			},
 		];
 
-		expect( getOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
 	} );
 
 	it( "successfully finds offsets for a single mark at the end of the text", () => {
@@ -52,7 +52,7 @@ describe( "getOffsets", () => {
 			},
 		];
 
-		expect( getOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
 	} );
 
 	it( "successfully finds multiple offsets for multiple marks", () => {
@@ -72,7 +72,7 @@ describe( "getOffsets", () => {
 			},
 		];
 
-		expect( getOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
 	} );
 
 	it( "returns an empty array if the start and end tags are in a incorrect order", () => {
@@ -83,7 +83,7 @@ describe( "getOffsets", () => {
 
 		const expected = [];
 
-		expect( getOffsets( mark ) ).toEqual( expected );
+		expect( getYoastmarkOffsets( mark ) ).toEqual( expected );
 	} );
 } );
 

--- a/js/tests/decorator/gutenberg.test.js
+++ b/js/tests/decorator/gutenberg.test.js
@@ -3,6 +3,7 @@ import {
 	END_MARK,
 	getYoastmarkOffsets,
 	getIndicesOf,
+	calculateAnnotationsForTextFormat,
 } from "../../src/decorator/gutenberg";
 
 jest.setMock( "@wordpress/rich-text", null );
@@ -86,5 +87,26 @@ describe( "getIndicesOf", () => {
 		const expected = [ 0, 3 ];
 
 		expect( getIndicesOf( "la LA", "LA", false ) ).toEqual( expected );
+	} );
+} );
+
+describe( "calculateAnnotationsForTextFormat", () => {
+	it( "correctly calculates offsets in a text with HTML tags", () => {
+		const mark = mockMark(
+			"A marked text.",
+			`A ${ START_MARK }<b>marked text</b>${ END_MARK }.`,
+		);
+
+		const expected = [ {
+			startOffset: 15,
+			endOffset: 26,
+		} ];
+
+		const actual = calculateAnnotationsForTextFormat(
+			"A long text. A marked text.",
+			mark
+		);
+
+		expect( actual ).toEqual( expected );
 	} );
 } );

--- a/js/tests/decorator/gutenberg.test.js
+++ b/js/tests/decorator/gutenberg.test.js
@@ -91,19 +91,52 @@ describe( "getIndicesOf", () => {
 } );
 
 describe( "calculateAnnotationsForTextFormat", () => {
+	it( "correctly calculates multiple offsets for a single sentence in a text", () => {
+		const text = "A long text. A marked text.";
+
+		const mark = mockMark(
+			"A marked text.",
+			`A marked ${ START_MARK }text${ END_MARK }.`,
+		);
+
+		/*
+		 * "A long text. A marked text."
+		 *                 ^ 15       ^ 26
+		 */
+		const expected = [
+			{
+				startOffset: 22,
+				endOffset: 26,
+			},
+		];
+
+		const actual = calculateAnnotationsForTextFormat(
+			text,
+			mark
+		);
+
+		expect( actual ).toEqual( expected );
+	} );
+
 	it( "correctly calculates offsets in a text with HTML tags", () => {
+		const text = "A long text. A marked text.";
+
 		const mark = mockMark(
 			"A marked text.",
 			`A ${ START_MARK }<b>marked text</b>${ END_MARK }.`,
 		);
 
+		/*
+		 * "A long text. A marked text."
+		 *                 ^ 15       ^ 26
+		 */
 		const expected = [ {
 			startOffset: 15,
 			endOffset: 26,
 		} ];
 
 		const actual = calculateAnnotationsForTextFormat(
-			"A long text. A marked text.",
+			text,
 			mark
 		);
 

--- a/js/tests/decorator/gutenberg.test.js
+++ b/js/tests/decorator/gutenberg.test.js
@@ -1,0 +1,102 @@
+import {
+	START_MARK,
+	END_MARK,
+	getOffsets,
+	getIndicesOf,
+} from "../../src/decorator/gutenberg";
+
+jest.setMock( "@wordpress/rich-text", null );
+
+/**
+ * Mocks a YoastSEO.js Mark object.
+ *
+ * @param {string} original The sentence without yoastmark tags.
+ * @param {string} marked   The sentence with yoastmark tags.
+ *
+ * @returns {Object} Mark mock.
+ */
+function mockMark( original, marked ) {
+	return {
+		getOriginal: () => original,
+		getMarked: () => marked,
+	};
+}
+
+describe( "getOffsets", () => {
+	it( "successfully finds offsets for a single mark at the start of the text", () => {
+		const mark = mockMark(
+			"A marked text.",
+			`${ START_MARK }A marked${ END_MARK } text.`
+		);
+
+		const expected = [
+			{
+				startOffset: 0,
+				endOffset: 8,
+			},
+		];
+
+		expect( getOffsets( mark ) ).toEqual( expected );
+	} );
+
+	it( "successfully finds offsets for a single mark at the end of the text", () => {
+		const mark = mockMark(
+			"A marked text.",
+			`A ${ START_MARK }marked text.${ END_MARK }`
+		);
+
+		const expected = [
+			{
+				startOffset: 2,
+				endOffset: 14,
+			},
+		];
+
+		expect( getOffsets( mark ) ).toEqual( expected );
+	} );
+
+	it( "successfully finds multiple offsets for multiple marks", () => {
+		const mark = mockMark(
+			"A marked text.",
+			`${ START_MARK }A${ END_MARK } marked ${ START_MARK }text.${ END_MARK }`
+		);
+
+		const expected = [
+			{
+				startOffset: 0,
+				endOffset: 1,
+			},
+			{
+				startOffset: 9,
+				endOffset: 14,
+			},
+		];
+
+		expect( getOffsets( mark ) ).toEqual( expected );
+	} );
+
+	it( "returns an empty array if the start and end tags are in a incorrect order", () => {
+		const mark = mockMark(
+			"A marked text.",
+			`${ START_MARK }A${ END_MARK } marked ${ END_MARK }text.${ START_MARK }`
+		);
+
+		const expected = [];
+
+		expect( getOffsets( mark ) ).toEqual( expected );
+	} );
+} );
+
+describe( "getIndicesOf", () => {
+	it( "finds a single case sensitive occurence", () => {
+		const expected = [ 3 ];
+
+		expect( getIndicesOf( "la LA", "LA" ) ).toEqual( expected );
+	} );
+
+	it( "finds multiple case insensitive occurences", () => {
+		const expected = [ 0, 3 ];
+
+		expect( getIndicesOf( "la LA", "LA", false ) ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* in Gutenberg, create an article with the following paragraph:
`
Parked men were sitting in a parked car, parked, waiting to pick someone up. Parked men were Sitting in a parked car, parked, waiting to pick someone up d. Parked men were Sitting in a parked car, parked, waiting to pick someone up. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In ipsum mi, malesuada convallis purus ut, feugiat tempus arcu. Integer id blandit mauris. Nullam quis mauris rutrum, imperdiet sapien ut, porta est. Quisque commodo odio at dolor tempor pulvinar. Fusce lorem tellus, faucibus et auctor at, porttitor non purus. Duis bibendum quam non tortor blandit, nec varius felis tincidunt. Curabitur vehicula imperdiet elit, efficitur tempus turpis ornare id. Nunc vulputate dictum enim, vitae convallis lorem parked cursus ac. Vestibulum vel consectetur metus. Nullam blandit et lorem sit amet mollis. Donec a enim ultrices, consectetur felis id, vestibulum sapien. Sed non tortor eget sem fermentum aliquam. Etiam at maximus tellus. Donec a enim ultrices, consectetur felis id, vestibulum sapien. Sed non tortor eget sem fermentum aliquam. Etiam at maximus tellus.
`
* In the readability analysis activate the marker for the `Consecutive sentences` assessment. Make sure the first three sentences are marked.
* In the readability analysis activate the marker for the `Paragraph length` assessment. Make sure the entire paragraph is marked.
* Add `parked` as a focus keyword.
* In the keyphrase analysis select the `Keyphrase density` assessment. Make sure all occurences of the keyphrase are marked.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11576 
Fixes #11554
