### PR TITLE
Add wp-polyfill as dependency to react to fix IE11 bug

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -182,7 +182,7 @@ class WPSEO_Admin_Asset_Manager {
 		$script = $wp_scripts->query( 'react' );
 
 		// IE11 needs wp-polyfill to be registered before react.
-		if( $script && ! in_array( 'wp-polyfill', $script->deps, true ) ) {
+		if ( $script && ! in_array( 'wp-polyfill', $script->deps, true ) ) {
 			$script->deps[] = 'wp-polyfill';
 		}
 

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -176,6 +176,16 @@ class WPSEO_Admin_Asset_Manager {
 	 * @return void
 	 */
 	public function register_wp_assets() {
+
+		global $wp_scripts;
+
+		$script = $wp_scripts->query( 'react' );
+
+		// IE11 needs wp-polyfill to be registered before react.
+		if( $script && ! in_array( 'wp-polyfill', $script->deps, true ) ) {
+			$script->deps[] = 'wp-polyfill';
+		}
+
 		$flat_version = $this->flatten_version( WPSEO_VERSION );
 
 		wp_register_script( 'lodash-base', plugins_url( 'js/vendor/lodash.min.js', WPSEO_FILE ), array(), false, true );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the configuration wizard would not load in Internet Explorer 11 when Gutenberg was active.

## Relevant technical choices:

* Because IE11 needs wp-polyfill to be registered before react, we add wp-polyfill as a dependency to react. If Gutenberg would do this, this fix can be reverted. I've created a PR on Gutenberg: https://github.com/WordPress/gutenberg/pull/11916.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Follow the steps from the issue.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11597
Fixes #11603
