### PR TITLE
Improve logic for page_on_front and page_for_posts in sitemaps

### DIFF
--- a/tests/doubles/class-wpseo-post-type-sitemap-provider-double.php
+++ b/tests/doubles/class-wpseo-post-type-sitemap-provider-double.php
@@ -36,7 +36,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Double extends WPSEO_Post_Type_Sitemap_Pr
 	/**
 	 * @inheritdoc
 	 */
-	public function get_excluded_posts() {
-		return parent::get_excluded_posts();
+	public function get_excluded_posts( $post_type ) {
+		return parent::get_excluded_posts( $post_type );
 	}
 }

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -111,7 +111,15 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_output' ) );
 
-		$this->assertEquals( array( 5, 600, 23, 0, 0, 3 ), $sitemap_provider->get_excluded_posts() );
+		$expected = array(
+			0 => 5,
+			1 => 600,
+			2 => 23,
+			3 => 0,
+			5 => 3,
+		);
+
+		$this->assertEquals( $expected, $sitemap_provider->get_excluded_posts( 'post' ) );
 
 		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_output' ) );
 	}
@@ -126,7 +134,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_invalid_output' ) );
 
-		$this->assertEquals( array(), $sitemap_provider->get_excluded_posts( '1,2,3,4' ) );
+		$this->assertEquals( array(), $sitemap_provider->get_excluded_posts( 'post' ) );
 
 		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_invalid_output' ) );
 	}
@@ -157,7 +165,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return string An invalid value.
 	 */
 	public function filter_with_invalid_output( $excluded_post_ids ) {
-		return '';
+		return '1,2,3,4';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Moves logic for page_on_front and page_for_posts outside "loop" in `class-post-type-sitemap-provider.php`.

## Relevant technical choices:

* Improves method `get_first_links` for pages. If front page is set as static, then retrieves post for _page_on_front_ and put it on the begin of page sitemap. I've left same logic as before (home_url is added if _page_on_front_ isn't set).
* If _page_on_front_ is set then addes it in array `$posts_to_exclude` to avoid processing of front page in "loop". It's done after filter `wpseo_exclude_from_sitemap_by_post_ids` to prevent removing front page from page sitemap.
* If _page_for_posts_ is set then addes it in filter `wpseo_exclude_from_sitemap_by_post_ids` to remove it from page sitemap.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create blog page and set it as _page_for_posts_.
* Check page sitemap. This page shouldn't shown in  page sitemap
* Check post sitemap. This page should be on the begin of post sitemap.
* Unset _page_for_posts_. Blog page should be only in page sitemap.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Partially fixes #10994.
