### PR TITLE
Adds stale content notice

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -107,6 +107,7 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_Admin_Media_Purge_Notification();
 		$integrations[] = new WPSEO_Admin_Gutenberg_Compatibility_Notification();
 		$integrations[] = new WPSEO_Recalibration_Beta_Notification();
+		$integrations[] = new WPSEO_Stale_Content_Notification();
 		$integrations[] = new WPSEO_Expose_Shortlinks();
 		$integrations[] = new WPSEO_Recalibration_Beta();
 		$integrations   = array_merge( $integrations, $this->initialize_seo_links(), $this->initialize_cornerstone_content() );

--- a/admin/notifiers/class-stale-content.php
+++ b/admin/notifiers/class-stale-content.php
@@ -34,7 +34,7 @@ class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 	 * @return void.
 	 */
 	public function handle_notice() {
-		if ( $this->is_applicable( WPSEO_Recalibration_Beta::is_enabled(), WPSEO_Options::get( 'enable_cornerstone_content' ) ) ) {
+		if ( $this->show_notice( WPSEO_Recalibration_Beta::is_enabled(), WPSEO_Options::get( 'enable_cornerstone_content' ) ) ) {
 			$this->get_notification_center()->add_notification(
 				$this->get_notification()
 			);
@@ -121,7 +121,7 @@ class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 	 *
 	 * @return bool True whether a notice should be shown.
 	 */
-	protected function is_applicable( $is_beta_enabled, $is_cornerstone_content_enabled ) {
+	protected function show_notice( $is_beta_enabled, $is_cornerstone_content_enabled ) {
 		return $is_cornerstone_content_enabled && $is_beta_enabled;
 	}
 

--- a/admin/notifiers/class-stale-content.php
+++ b/admin/notifiers/class-stale-content.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Notifiers
+ */
+
+/**
+ * Represents the logic for showing recalibration beta notice.
+ */
+class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
+
+	/**
+	 * The name of the notifier.
+	 *
+	 * @var string
+	 */
+	protected $notification_identifier = 'stale-content-notification';
+
+	/**
+	 * Registers all hooks to WordPress
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'admin_init', array( $this, 'handle_notice' ), 15 );
+	}
+
+	/**
+	 * Shows the notification when applicable.
+	 *
+	 * @return void.
+	 */
+	public function handle_notice() {
+		if ( $this->is_applicable( WPSEO_Recalibration_Beta::is_enabled(), WPSEO_Options::get( 'enable_cornerstone_content' ) ) ) {
+			$this->get_notification_center()->add_notification(
+				$this->get_notification()
+			);
+
+			return;
+		}
+
+		$this->get_notification_center()->remove_notification_by_id( 'wpseo-' . $this->notification_identifier );
+	}
+
+	/**
+	 * Returns the notification.
+	 *
+	 * @return Yoast_Notification The notification for the notification center.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function get_notification() {
+		$message  = $this->get_notification_message( WPSEO_Post_Type::get_accessible_post_types() );
+		$message .= ' ';
+		$message .= sprintf(
+			esc_html__(
+				'Read more about %1$swhy you should always keep your cornerstone content up-to-date%2$s.',
+				'wordpress-seo'
+			),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/stale-content-filter' ) . '" target="_blank">',
+			'</a>'
+		);
+
+		$notification_options = array(
+			'type'         => Yoast_Notification::WARNING,
+			'id'           => 'wpseo-' . $this->notification_identifier,
+			'priority'     => 1.0,
+			'capabilities' => 'wpseo_manage_options',
+		);
+
+		return new Yoast_Notification( $message, $notification_options );
+	}
+
+	/**
+	 * Generates the notification message based on the available post type.
+	 *
+	 * @param array $post_types The accessible post types.
+	 *
+	 * @return string The notification message.
+	 */
+	protected function get_notification_message( array $post_types ) {
+		if ( array_key_exists( 'post', $post_types ) ) {
+			return sprintf(
+				esc_html__(
+					'In this beta, we introduce a stale cornerstone content filter. You can find it %1$son the post overview%2$s. This functionality is also available for other content types.',
+					'wordpress-seo'
+				),
+				'<a href="' . admin_url( 'edit.php' ) . '">',
+				'</a>'
+			);
+		}
+
+		if ( array_key_exists( 'page', $post_types ) ) {
+			return sprintf(
+				esc_html__(
+					'In this beta, we introduce a stale cornerstone content filter. You can find it %1$son the page overview%2$s. This functionality is also available for other content types.',
+					'wordpress-seo'
+				),
+				'<a href="' . admin_url( 'edit.php?post_type=page' ) . '">',
+				'</a>'
+			);
+		}
+
+		return esc_html__(
+			'In this beta, we introduce a stale cornerstone content filter. You can find it on content type overviews.',
+		'wordpress-seo'
+		);
+	}
+
+	/**
+	 * Checks if the beta is enabled.
+	 *
+	 * @param bool $is_beta_enabled             Checks if the beta has been enabled.
+	 * @param bool $cornerstone_content_enabled Is the cornerstone content enabled.
+	 *
+	 * @return bool Whether the beta is enabled or not.
+	 */
+	protected function is_applicable( $is_beta_enabled, $cornerstone_content_enabled ) {
+		return $cornerstone_content_enabled && $is_beta_enabled;
+	}
+
+	/**
+	 * Retrieves an instance of the notification center.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return Yoast_Notification_Center Instance of the notification center.
+	 */
+	protected function get_notification_center() {
+		return Yoast_Notification_Center::get();
+	}
+}

--- a/admin/notifiers/class-stale-content.php
+++ b/admin/notifiers/class-stale-content.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Represents the logic for showing recalibration beta notice.
+ * Represents the logic for showing the recalibration beta notice.
  */
 class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 

--- a/admin/notifiers/class-stale-content.php
+++ b/admin/notifiers/class-stale-content.php
@@ -57,6 +57,7 @@ class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 		$message .= ' ';
 		$message .= sprintf(
 			esc_html__(
+				/* translators: 1: Opening link tag to an article about stale content, 2: closing tag */
 				'Read more about %1$swhy you should always keep your cornerstone content up-to-date%2$s.',
 				'wordpress-seo'
 			),
@@ -85,6 +86,7 @@ class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 		if ( array_key_exists( 'post', $post_types ) ) {
 			return sprintf(
 				esc_html__(
+					/* translators: 1: Opening link tag to the post overview, 2: closing tag */
 					'In this beta, we introduce a stale cornerstone content filter. You can find it %1$son the post overview%2$s. This functionality is also available for other content types.',
 					'wordpress-seo'
 				),
@@ -96,6 +98,7 @@ class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 		if ( array_key_exists( 'page', $post_types ) ) {
 			return sprintf(
 				esc_html__(
+					/* translators: 1: Opening link tag to the page overview, 2: closing tag */
 					'In this beta, we introduce a stale cornerstone content filter. You can find it %1$son the page overview%2$s. This functionality is also available for other content types.',
 					'wordpress-seo'
 				),
@@ -111,15 +114,15 @@ class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Checks if the beta is enabled.
+	 * Determines if the notice should be shown.
 	 *
-	 * @param bool $is_beta_enabled             Checks if the beta has been enabled.
-	 * @param bool $cornerstone_content_enabled Is the cornerstone content enabled.
+	 * @param bool $is_beta_enabled                Checks if the beta has been enabled.
+	 * @param bool $is_cornerstone_content_enabled Is the cornerstone content enabled.
 	 *
-	 * @return bool Whether the beta is enabled or not.
+	 * @return bool True whether a notice should be shown.
 	 */
-	protected function is_applicable( $is_beta_enabled, $cornerstone_content_enabled ) {
-		return $cornerstone_content_enabled && $is_beta_enabled;
+	protected function is_applicable( $is_beta_enabled, $is_cornerstone_content_enabled ) {
+		return $is_cornerstone_content_enabled && $is_beta_enabled;
 	}
 
 	/**

--- a/admin/notifiers/class-stale-content.php
+++ b/admin/notifiers/class-stale-content.php
@@ -119,7 +119,7 @@ class WPSEO_Stale_Content_Notification implements WPSEO_WordPress_Integration {
 	 * @param bool $is_beta_enabled                Checks if the beta has been enabled.
 	 * @param bool $is_cornerstone_content_enabled Is the cornerstone content enabled.
 	 *
-	 * @return bool True whether a notice should be shown.
+	 * @return bool True when a notice should be shown.
 	 */
 	protected function show_notice( $is_beta_enabled, $is_cornerstone_content_enabled ) {
 		return $is_cornerstone_content_enabled && $is_beta_enabled;

--- a/tests/doubles/class-stale-content-notification.php
+++ b/tests/doubles/class-stale-content-notification.php
@@ -13,8 +13,8 @@ class WPSEO_Stale_Content_Notification_Double extends WPSEO_Stale_Content_Notifi
 	/**
 	 * @inheritdoc
 	 */
-	public function is_applicable( $is_beta_enabled, $is_cornerstone_content_enabled ) {
-		return parent::is_applicable( $is_beta_enabled, $is_cornerstone_content_enabled );
+	public function show_notice( $is_beta_enabled, $is_cornerstone_content_enabled ) {
+		return parent::show_notice( $is_beta_enabled, $is_cornerstone_content_enabled );
 	}
 
 	/**

--- a/tests/doubles/class-stale-content-notification.php
+++ b/tests/doubles/class-stale-content-notification.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Doubles
+ */
+
+/**
+ * Test Helper Class.
+ */
+class WPSEO_Stale_Content_Notification_Double extends WPSEO_Stale_Content_Notification {
+
+	/**
+	 * @inheritdoc
+	 */
+	public function is_applicable( $is_beta_enabled, $cornerstone_content_enabled ) {
+		return parent::is_applicable( $is_beta_enabled, $cornerstone_content_enabled );
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get_notification_message( array $post_types ) {
+		return parent::get_notification_message( $post_types );
+	}
+}
+

--- a/tests/doubles/class-stale-content-notification.php
+++ b/tests/doubles/class-stale-content-notification.php
@@ -13,8 +13,8 @@ class WPSEO_Stale_Content_Notification_Double extends WPSEO_Stale_Content_Notifi
 	/**
 	 * @inheritdoc
 	 */
-	public function is_applicable( $is_beta_enabled, $cornerstone_content_enabled ) {
-		return parent::is_applicable( $is_beta_enabled, $cornerstone_content_enabled );
+	public function is_applicable( $is_beta_enabled, $is_cornerstone_content_enabled ) {
+		return parent::is_applicable( $is_beta_enabled, $is_cornerstone_content_enabled );
 	}
 
 	/**

--- a/tests/notifiers/test-class-stale-content-notification.php
+++ b/tests/notifiers/test-class-stale-content-notification.php
@@ -33,12 +33,12 @@ class WPSEO_Stale_Content_Notification_Test extends WPSEO_UnitTestCase {
 
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Stale_Content_Notification' )
-			->setMethods( array( 'is_applicable', 'get_notification_center', 'get_notification' ) )
+			->setMethods( array( 'show_notice', 'get_notification_center', 'get_notification' ) )
 			->getMock();
 
 		$handler
 			->expects( $this->once() )
-			->method( 'is_applicable' )
+			->method( 'show_notice' )
 			->will( $this->returnValue( true ) );
 
 		$handler
@@ -72,12 +72,12 @@ class WPSEO_Stale_Content_Notification_Test extends WPSEO_UnitTestCase {
 
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Stale_Content_Notification' )
-			->setMethods( array( 'is_applicable', 'get_notification_center' ) )
+			->setMethods( array( 'show_notice', 'get_notification_center' ) )
 			->getMock();
 
 		$handler
 			->expects( $this->once() )
-			->method( 'is_applicable' )
+			->method( 'show_notice' )
 			->will( $this->returnValue( false ) );
 
 		$handler
@@ -89,17 +89,17 @@ class WPSEO_Stale_Content_Notification_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests is_applicable in some different situations
+	 * Tests show_notice in some different situations
 	 *
-	 * @covers WPSEO_Stale_Content_Notification::is_applicable()
+	 * @covers WPSEO_Stale_Content_Notification::show_notice()
 	 */
-	public function test_is_applicable() {
+	public function test_show_notice() {
 		$notifier = new WPSEO_Stale_Content_Notification_Double();
 
-		$this->assertTrue( $notifier->is_applicable( true, true ) );
-		$this->assertFalse( $notifier->is_applicable( true, false ) );
-		$this->assertFalse( $notifier->is_applicable( false, true ) );
-		$this->assertFalse( $notifier->is_applicable( false, false ) );
+		$this->assertTrue( $notifier->show_notice( true, true ) );
+		$this->assertFalse( $notifier->show_notice( true, false ) );
+		$this->assertFalse( $notifier->show_notice( false, true ) );
+		$this->assertFalse( $notifier->show_notice( false, false ) );
 	}
 
 	/**

--- a/tests/notifiers/test-class-stale-content-notification.php
+++ b/tests/notifiers/test-class-stale-content-notification.php
@@ -1,0 +1,146 @@
+<?php
+/**
+* WPSEO plugin test file.
+*
+* @package WPSEO\Tests\Notifiers
+*/
+
+/**
+* Unit Test Class.
+*
+* @group notifiers
+*/
+class WPSEO_Stale_Content_Notification_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Handles the notice when applicable.
+	 *
+	 * @covers WPSEO_Stale_Content_Notification::handle_notice()
+	 */
+	public function test_handle_notice_when_applicable() {
+		$notification = new Yoast_Notification( 'Notification' );
+
+		$notification_center = $this
+			->getMockBuilder( 'Yoast_Notification_Center' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
+
+		$notification_center
+			->expects( $this->once() )
+			->method( 'add_notification' )
+			->with( $notification );
+
+		$handler = $this
+			->getMockBuilder( 'WPSEO_Stale_Content_Notification' )
+			->setMethods( array( 'is_applicable', 'get_notification_center', 'get_notification' ) )
+			->getMock();
+
+		$handler
+			->expects( $this->once() )
+			->method( 'is_applicable' )
+			->will( $this->returnValue( true ) );
+
+		$handler
+			->expects( $this->once() )
+			->method( 'get_notification' )
+			->will( $this->returnValue( $notification ) );
+
+		$handler
+			->expects( $this->once() )
+			->method( 'get_notification_center' )
+			->will( $this->returnValue( $notification_center ) );
+
+		$handler->handle_notice();
+	}
+
+	/**
+	 * Handles the notice when not applicable.
+	 *
+	 * @covers WPSEO_Stale_Content_Notification::handle_notice()
+	 */
+	public function test_handle_notice_when_not_applicable() {
+		$notification_center = $this
+			->getMockBuilder( 'Yoast_Notification_Center' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'remove_notification_by_id' ) )
+			->getMock();
+
+		$notification_center
+			->expects( $this->once() )
+			->method( 'remove_notification_by_id' );
+
+		$handler = $this
+			->getMockBuilder( 'WPSEO_Stale_Content_Notification' )
+			->setMethods( array( 'is_applicable', 'get_notification_center' ) )
+			->getMock();
+
+		$handler
+			->expects( $this->once() )
+			->method( 'is_applicable' )
+			->will( $this->returnValue( false ) );
+
+		$handler
+			->expects( $this->once() )
+			->method( 'get_notification_center' )
+			->will( $this->returnValue( $notification_center ) );
+
+		$handler->handle_notice();
+	}
+
+	/**
+	 * Tests is_applicable in some different situations
+	 *
+	 * @covers WPSEO_Stale_Content_Notification::is_applicable()
+	 */
+	public function test_is_applicable() {
+		$notifier = new WPSEO_Stale_Content_Notification_Double();
+
+		$this->assertTrue( $notifier->is_applicable( true, true ) );
+		$this->assertFalse( $notifier->is_applicable( true, false ) );
+		$this->assertFalse( $notifier->is_applicable( false, true ) );
+		$this->assertFalse( $notifier->is_applicable( false, false ) );
+	}
+
+	/**
+	 * Tests the notification retrieval when post is enabled.
+	 *
+	 * @covers WPSEO_Stale_Content_Notification::get_notification_message()
+	 */
+	public function test_get_notification_message_with_post_enabled() {
+		$notifier = new WPSEO_Stale_Content_Notification_Double();
+
+		$this->assertEquals(
+			'In this beta, we introduce a stale cornerstone content filter. You can find it <a href="' . admin_url( 'edit.php' ) . '">on the post overview</a>. This functionality is also available for other content types.',
+			$notifier->get_notification_message( array( 'post' => 'post' ) )
+		);
+	}
+
+	/**
+	 * Tests the notification retrieval when post is disabled and page is enabled.
+	 *
+	 * @covers WPSEO_Stale_Content_Notification::get_notification_message()
+	 */
+	public function test_get_notification_message_with_post_disabled_and_page_enabled() {
+		$notifier = new WPSEO_Stale_Content_Notification_Double();
+
+		$this->assertEquals(
+			'In this beta, we introduce a stale cornerstone content filter. You can find it <a href="' . admin_url( 'edit.php?post_type=page' ) . '">on the page overview</a>. This functionality is also available for other content types.',
+			$notifier->get_notification_message( array( 'page' => 'page' ) )
+		);
+	}
+
+	/**
+	 * Tests the notification retrieval when both post and page are disabled.
+	 *
+	 * @covers WPSEO_Stale_Content_Notification::get_notification_message()
+	 */
+	public function test_get_notification_message_with_post_and_page_dishnabled() {
+		$notifier = new WPSEO_Stale_Content_Notification_Double();
+
+		$this->assertEquals(
+			'In this beta, we introduce a stale cornerstone content filter. You can find it on content type overviews.',
+			$notifier->get_notification_message( array() )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Shows a notice about stale content, when the recalibration beta is enabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Enable the recalibration beta under features
* See you have a notice on the dashboard that tells about the stale content and which refers to the post overview.
* Disable the post type `post` by adding the following filter somewhere in your code (wp-seo-main.php):
```
add_action( 'init', function() {
	global $wp_post_types;

	unset( $wp_post_types['post'] );
} );
```
* Now the notice refers to the page overview.
* Also disabled the post type `page` by adding:
```
add_action( 'init', function() {
	global $wp_post_types;

	unset( $wp_post_types['page'] );
} );
```
* Now the notice says something general.
* Disable the cornerstone content feature and see the notice is gone.
* Enable the cornerstone feature and see the notice is back.
* Disable the recalibration beta feature and see the notice is gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11604 
