### PR TITLE
Bump YoastSEO.js to 1.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.2",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.2"
+    "yoastseo": "^1.43.0"
   },
   "yoast": {
     "pluginVersion": "9.2-RC3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12256,6 +12256,19 @@ yauzl@^2.2.1:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
+yoastseo@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.43.0.tgz#c57ac5e8524fe410ce5100cf704fe736ba577ecc"
+  integrity sha512-wSoSsN0T/Im1l+f8nvKFM8ZiRu+1Ns0N0KR61Zb9f8Lt3P4w6nSmWNqF5r4ZGJZGVjVnGkja/fFmKoHh4UJZ4w==
+  dependencies:
+    "@wordpress/autop" "^2.0.2"
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    lodash-es "^4.17.10"
+    loglevel "^1.6.1"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.1"
+
 "yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.2":
   version "1.42.0"
   resolved "git+https://github.com/Yoast/YoastSEO.js.git#3044845f305456076e402bb00a7043e3173a29a9"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Bumps the version of YoastSEO.js to 1.43.0.

## Test instructions
This PR can be tested by following these steps:
Check whether the following work:
* Fixes assessments failing when using a `<` sign in the content. https://github.com/Yoast/YoastSEO.js/pull/1898
* Fixes a bug where paragraphs were sometimes not correctly detected because paragraph tags were not automatically added in WordPress-like fashion. https://github.com/Yoast/YoastSEO.js/pull/1911
* Disables the non-functioning markers for the subheading distribution assessment. https://github.com/Yoast/YoastSEO.js/pull/1958

## Quality assurance
* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

