### PR TITLE
Fix overlapping primary category label

### DIFF
--- a/js/src/components/PrimaryTaxonomyPicker.js
+++ b/js/src/components/PrimaryTaxonomyPicker.js
@@ -232,7 +232,7 @@ class PrimaryTaxonomyPicker extends React.Component {
 
 		return (
 			<PrimaryTaxonomyPickerField className="components-base-control__field">
-				<PrimaryTaxonomyPickerLabel
+				<label
 					htmlFor={ fieldId }
 					className="components-base-control__label"
 				>
@@ -243,7 +243,7 @@ class PrimaryTaxonomyPicker extends React.Component {
 							taxonomy.singularLabel.toLowerCase()
 						)
 					}
-				</PrimaryTaxonomyPickerLabel>
+				</label>
 				<TaxonomyPicker
 					value={ primaryTaxonomyId }
 					onChange={ this.onChange }

--- a/js/src/components/PrimaryTaxonomyPicker.js
+++ b/js/src/components/PrimaryTaxonomyPicker.js
@@ -15,7 +15,7 @@ import diff from "lodash/difference";
 /* Internal dependencies */
 import TaxonomyPicker from "./TaxonomyPicker";
 
-const PrimaryTaxonomyPickerLabel = styled.label`
+const PrimaryTaxonomyPickerField = styled.div`
 	padding-top: 16px;
 `;
 
@@ -231,7 +231,7 @@ class PrimaryTaxonomyPicker extends React.Component {
 		const fieldId = `yoast-primary-${ taxonomy.name }-picker`;
 
 		return (
-			<div className="components-base-control__field">
+			<PrimaryTaxonomyPickerField className="components-base-control__field">
 				<PrimaryTaxonomyPickerLabel
 					htmlFor={ fieldId }
 					className="components-base-control__label"
@@ -250,7 +250,7 @@ class PrimaryTaxonomyPicker extends React.Component {
 					id={ fieldId }
 					terms={ this.state.selectedTerms }
 				/>
-			</div>
+			</PrimaryTaxonomyPickerField>
 		);
 	}
 }

--- a/js/src/components/TaxonomyPicker.js
+++ b/js/src/components/TaxonomyPicker.js
@@ -1,6 +1,11 @@
 /* External dependencies */
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const SelectContainer = styled.div`
+	padding-top: 6px;
+`;
 
 /**
  * A select box for selecting a taxonomy.
@@ -20,27 +25,29 @@ const TaxonomyPicker = ( props ) => {
 	// Disable reason: UI needs to be re-designed.
 	/* eslint-disable jsx-a11y/no-onchange */
 	return (
-		<select
-			className="components-select-control__input"
-			id={ id }
-			value={ value }
-			onChange={ e => {
-				onChange( parseInt( e.target.value, 10 ) );
-			} }
-		>
-			{
-				terms.map( term => {
-					return (
-						<option
-							key={ term.id }
-							value={ term.id }
-						>
-							{ term.name }
-						</option>
-					);
-				} )
-			}
-		</select>
+		<SelectContainer>
+			<select
+				className="components-select-control__input"
+				id={ id }
+				value={ value }
+				onChange={ e => {
+					onChange( parseInt( e.target.value, 10 ) );
+				} }
+			>
+				{
+					terms.map( term => {
+						return (
+							<option
+								key={ term.id }
+								value={ term.id }
+							>
+								{ term.name }
+							</option>
+						);
+					} )
+				}
+			</select>
+		</SelectContainer>
 	);
 	/* eslint-enable jsx-a11y/no-onchange */
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the 'Select primary category' label in the primary taxonomy picker would overlap the 'Add new category' button.

## Relevant technical choices:

* I've added an extra `<div>` around the select (=dropdown) to add padding between the label and the dropdown, because:
     - adding padding/margin to the label above select didn't do anything
    -  styled-components can't add padding/margin to a `<select>`
* I've tested this with a screenreader, which seems to handle the added `<div>` well (i.e. not announcing it/not requiring extra tabs to reach the actual `<select>`)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

On trunk:
* Open the document panel in the Gutenberg sidebar. 
* Open the categories collapsible
* Select multiple categories, now the "Select the primary category" option appears. 
* Inspect the `select the primary category` label. Its padding overlaps the `Add new category` button, which makes it very hard to click the button (you have to click the top part).
<img width="245" alt="screen shot 2018-11-20 at 10 48 33" src="https://user-images.githubusercontent.com/17744553/48765581-b59b7c80-ecb2-11e8-8208-21f8af121f10.png">

* Click `Add new category` (Good luck 😉)
* Type in a category name and click the `Add new category` button
* Inspect the `select the primary category` label. It overlaps the `Add new category` button:
<img width="257" alt="screen shot 2018-11-19 at 11 42 35" src="https://user-images.githubusercontent.com/5389513/48702080-3f364600-ebf0-11e8-8dc0-b564381d842a.png">

On this branch:
* Repeat the above steps. Inspect the `select the primary category` label. It doesn't overlap the `Add new category` link or `Add new category` button anymore:
<img width="265" alt="schermafbeelding 2018-11-20 om 11 02 30" src="https://user-images.githubusercontent.com/17744553/48766075-e62fe600-ecb3-11e8-9a6a-40b3f4489709.png">
<img width="362" alt="schermafbeelding 2018-11-20 om 10 31 40" src="https://user-images.githubusercontent.com/17744553/48765023-9bad6a00-ecb1-11e8-891b-afa5988f0fb6.png">

* Also notice the pretty whitespace between the label and the dropdown.
* Use VoiceOver (in Safari!) to navigate to the `select the primary category` dropdown. Make sure it is announced correctly (and the `<div>` isn't announced).

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11632
