### PR TITLE
Show 404s for feeds that don't exist

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -125,6 +125,7 @@ class WPSEO_Frontend {
 		$integrations = array(
 			new WPSEO_Frontend_Primary_Category(),
 			new WPSEO_JSON_LD(),
+			new WPSEO_Handle_404(),
 			new WPSEO_Remove_Reply_To_Com(),
 			new WPSEO_OpenGraph_OEmbed(),
 			$this->woocommerce_shop_page,

--- a/frontend/class-handle-404.php
+++ b/frontend/class-handle-404.php
@@ -6,9 +6,9 @@
  */
 
 /**
- * Class WPSEO_JSON_LD
+ * Class WPSEO_Handle_404
  *
- * Outputs schema code specific for Google's JSON LD stuff.
+ * Handles intercepting requests.
  *
  * @since 1.8
  */

--- a/frontend/class-handle-404.php
+++ b/frontend/class-handle-404.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Frontend
+ */
+
+/**
+ * Class WPSEO_JSON_LD
+ *
+ * Outputs schema code specific for Google's JSON LD stuff.
+ *
+ * @since 1.8
+ */
+class WPSEO_Handle_404 implements WPSEO_WordPress_Integration {
+	/**
+	 * Registers all hooks to WordPress
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_filter( 'pre_handle_404', array( $this, 'filter_feed_404s' ), 10, 2 );
+	}
+
+	/**
+	 * If there are no posts in a feed, make it 404 instead of sending an empty RSS feed.
+	 *
+	 * @param boolean  $handled  Whether we've handled the request.
+	 * @param WP_Query $wp_query The Query object.
+	 *
+	 * @return bool
+	 */
+	public function filter_feed_404s( $handled, $wp_query ) {
+		global $wp_query;
+		if ( is_feed() ) {
+			if ( $wp_query->found_posts === 0 ) {
+				// Guess it's time to 404, we need to overwrite the already sent XML header.
+				header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_bloginfo( 'charset' ), true );
+				$wp_query->set_404();
+				$wp_query->is_feed = false;
+				status_header( 404 );
+				nocache_headers();
+
+				return true;
+			}
+		}
+
+		return $handled;
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* For non-existing pages, WordPress still shows feeds, with 200 status codes. This makes it not do that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to `<random-post>/feed/`, see a 200.
* Apply patch.
* Go to `<random-post>/feed/`, see that it returns a 404 instead of a 200.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/yoast.com/issues/3884
