### PR TITLE
Fix replacement variable editor cursor jumping on content change

### DIFF
--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -221,7 +221,7 @@ class ClassicEditorData {
 	 */
 	handleEditorChange( newData ) {
 		// Handle excerpt change
-		if ( this._data.excerpt !== newData.excerpt ) {
+		if ( this._previousData.excerpt !== newData.excerpt ) {
 			this._store.dispatch( updateReplacementVariable( "excerpt", newData.excerpt ) );
 			this._store.dispatch( updateReplacementVariable( "excerpt_only", newData.excerpt_only ) );
 		}

--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -31,7 +31,7 @@ class ClassicEditorData {
 	constructor( refresh, store, settings = { tinyMceId: "" } ) {
 		this._refresh = refresh;
 		this._store = store;
-		this._data = {};
+		this._initialData = {};
 		// This will be used for the comparison whether the title, description and slug are dirty.
 		this._previousData = {};
 		this._settings = settings;
@@ -40,15 +40,15 @@ class ClassicEditorData {
 	}
 
 	/**
-	 * Initializes the class by filling this._data and subscribing to relevant elements.
+	 * Initializes the class by filling this._initialData and subscribing to relevant elements.
 	 *
 	 * @param {Object} replaceVars The replacement variables passed in the wp-seo-post-scraper args.
 	 *
 	 * @returns {void}
 	 */
 	initialize( replaceVars ) {
-		this._data = this.getInitialData( replaceVars );
-		fillReplacementVariables( this._data, this._store );
+		this._initialData = this.getInitialData( replaceVars );
+		fillReplacementVariables( this._initialData, this._store );
 		this.subscribeToElements();
 		this.subscribeToStore();
 	}
@@ -165,7 +165,7 @@ class ClassicEditorData {
 			replaceValue = this.getExcerpt();
 		}
 
-		this._data[ targetReplaceVar ] = replaceValue;
+		this._initialData[ targetReplaceVar ] = replaceValue;
 
 		this._store.dispatch( updateReplacementVariable( targetReplaceVar, replaceValue ) );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the title and meta description field's cursor would jump to the start when typing.

## Relevant technical choices:

* In `classicEditorData.js`I changed the `_data` variable's name to `_initialData` to avoid similar mistakes in the future.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post in the classic editor.
* Add content that's less than 156 characters.
* Type in both the title and meta description field in the snippet editor.
* Make sure the cursor retains its position after 600 ms.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11644 
