### PR TITLE
Fix recalibration version being set as plugin version

### DIFF
--- a/grunt/config/set-version.js
+++ b/grunt/config/set-version.js
@@ -7,11 +7,4 @@ module.exports = {
 		},
 		src: "package.json",
 	},
-	recalibration: {
-		options: {
-			base: "yoast",
-			target: "recalibrationVersion",
-		},
-		src: "package.json",
-	},
 };

--- a/grunt/custom/update-recalibration.js
+++ b/grunt/custom/update-recalibration.js
@@ -10,11 +10,19 @@ module.exports = function( grunt ) {
 		"update-recalibration",
 		"Bumps the recalibration version.",
 		function() {
-			const packageJson = require( "../../package.json" );
+			const file = "package.json";
+			const packageJson = require( "../../" + file );
 			const version = parseInt( packageJson.yoast.recalibrationVersion, 10 ) + 1;
 
-			grunt.option( "new-version", JSON.stringify( version ) );
-			grunt.task.run( "set-version:recalibration" );
+			/*
+			 * The set-version command is used in our process without any specification. E.g. grunt set-version --new-version=X.X
+			 * This is a temporary script. Therefore, removing the recalibration from set-version to not have to adapt our process.
+			 *
+			 * The following is copied from: https://github.com/Yoast/plugin-grunt-tasks/blob/master/tasks/set-version.js
+			 */
+
+			packageJson.yoast.recalibrationVersion = version.toString();
+			grunt.file.write( file, JSON.stringify( packageJson, null, "  " ) + "\n" );
 		}
 	);
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

### What happened
Due to the grunt task of the `set-version` not being called with a task specification, the current process also runs the recalibration set-version task with the version of the plugin.

### Why this solution
The recalibration task is temporary. Therefore, it seems better to adjust that task than to adjust the process.

### Solution

* Move recalibration from set-version into update-recalibration.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Seeing the issue at work
* Checkout the release branch: `git checkout release/9.3`.
* Run the set version command as used in the process: `grunt set-version --new-version=9.3-test`.
* Check `package.json` to see what changed: `git diff package.json`.
* Verify that both the pluginVersion and the recalibrationVersion are now on `9.3-test`. This is what should be fixed by this PR.
* Throw away the changes: `git checkout package.json`.

### Testing this PR
* Checkout this branch: `git checkout 11650-fix-plugin-version-overwriting-recalibration-version`.
* Run the set version command as used in the process: `grunt set-version --new-version=9.3-test`.
* Check `package.json` to see what changed: `git diff package.json`.
* Verify that only the pluginVersion is changed to `9.3-test`.
* Throw away the changes: `git checkout package.json`.
* Run the update recalibration task `grunt update-recalibration`.
* Check `package.json` to see what changed: `git diff package.json`.
* Verify that only the recalibrationVersion is changed to the old one + 1, so `11` if it was `10` before.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11650 
