### PR TITLE
Added specific annotation attributes for singleH1 assessment

### DIFF
--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -41,6 +41,16 @@ const ANNOTATION_ATTRIBUTES = {
 	],
 };
 
+const ASSESSMENT_SPECIFIC_ANNOTATION_ATTRIBUTES = {
+	singleH1: {
+		"core/heading": [
+			{
+				key: "content",
+			},
+		],
+	},
+};
+
 /**
  * Retrieves the next annotation from the annotation queue.
  *
@@ -255,11 +265,15 @@ export function calculateAnnotationsForTextFormat( text, mark ) {
  * @returns {string[]} The attributes that we can annotate.
  */
 function getAnnotatableAttributes( blockTypeName ) {
-	if ( ! ANNOTATION_ATTRIBUTES.hasOwnProperty( blockTypeName ) ) {
+	const activeMarker = select( "yoast-seo/editor" ).getActiveMarker();
+
+	const assessmentAttributes = ASSESSMENT_SPECIFIC_ANNOTATION_ATTRIBUTES[ activeMarker ] || ANNOTATION_ATTRIBUTES;
+
+	if ( ! assessmentAttributes.hasOwnProperty( blockTypeName ) ) {
 		return [];
 	}
 
-	return ANNOTATION_ATTRIBUTES[ blockTypeName ];
+	return assessmentAttributes[ blockTypeName ];
 }
 
 /**

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -46,6 +46,9 @@ const ASSESSMENT_SPECIFIC_ANNOTATION_ATTRIBUTES = {
 		"core/heading": [
 			{
 				key: "content",
+				filter: ( blockAttributes ) => {
+					return blockAttributes.level === 1;
+				},
 			},
 		],
 	},
@@ -288,8 +291,12 @@ function getAnnotatableAttributes( blockTypeName ) {
 function getAnnotationsForBlockAttribute( attribute, block, marks ) {
 	const attributeKey = attribute.key;
 
-	const { attributes } = block;
-	const attributeValue = attributes[ attributeKey ];
+	const { attributes: blockAttributes } = block;
+	const attributeValue = blockAttributes[ attributeKey ];
+
+	if ( attribute.filter && ! attribute.filter( blockAttributes ) ) {
+		return [];
+	}
 
 	// Create a rich text record, because those are easier to work with.
 	const record = create( {
@@ -350,6 +357,7 @@ export function applyAsAnnotations( paper, marks ) {
 
 	// For every block...
 	const annotations = flatMap( blocks, ( ( block ) => {
+
 		// We go through every annotatable attribute.
 		return flatMap(
 			getAnnotatableAttributes( block.name ),

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -357,7 +357,6 @@ export function applyAsAnnotations( paper, marks ) {
 
 	// For every block...
 	const annotations = flatMap( blocks, ( ( block ) => {
-
 		// We go through every annotatable attribute.
 		return flatMap(
 			getAnnotatableAttributes( block.name ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Fixes a bug where the h1 content would also be marked in the text in the single h1 header assessment.

## Relevant technical choices:

* Adds an additional `ASSESSMENT_SPECIFIC_ANNOTATION_ATTRIBUTES` object to the gutenberg decorator, to allow specific assessments to only be applied to certain blocks.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Activate the recalibration beta under `SEO` > `General` > `Features`.
* Create a new post in Gutenberg.
* Add some content. [Lorem ipsum](https://nl.lipsum.com/feed/html)
* Add a second H1 header. This can be accomplished by adding a Heading block and setting it to a `H1` in the block settings in the sidebar.
* Name the header `Test`.
* In the content also add the word `Test` a couple of times.
* In the SEO analysis activate the `Single title` assessment marker.
* Make sure the word `Test` is not annotated in the content, only in the heading.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11658 
