### PR TITLE
Fix the analysis results headings hierarchy

### DIFF
--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -107,6 +107,7 @@ class Results extends React.Component {
 					onMarkButtonClick={ this.handleMarkButtonClick }
 					marksButtonClassName={ this.props.marksButtonClassName }
 					marksButtonStatus={ this.props.marksButtonStatus }
+					headingLevel={ 3 }
 				/>
 			</Fragment>
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix the headings hierarchy in the analysis results.


## Test instructions
In Chrome, you can check the heading hierarchy using this Chrome extension:

HeadingsMap
https://chrome.google.com/webstore/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi

- before switching to this branch, open a post that has analysis results
- expands the readability and focus keyphrase panels (in Gutenberg, also in the sidebar)
- use HeadingsMap and observe the headings hierarchy jumps from h2 to h4
- switch to this branch, build the assets
- repeat the steps above and verify the headings hierarchy is now correct

Fixes #11362
