### PR TITLE
Enable babel-loader cache in development

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -68,6 +68,7 @@ module.exports = function( env = { environment: "production", recalibration: "di
 						{
 							loader: "babel-loader",
 							options: {
+								cacheDirectory: mode === "development",
 								env: {
 									development: {
 										plugins: [


### PR DESCRIPTION
This speeds up builds where the cache is loaded from around 2 minutes to 30s.

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* The default cache directory is fine for us:

> the loader will use the default cache directory in node_modules/.cache/babel-loader or fallback to the default OS temporary file directory if no node_modules folder could be found in any root directory.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build using `grunt webpack:buildDev`
* Build again using `grunt webpack:buildDev`. The build time should be MASSIVELY sped up.
* Change a JavaScript file to add a test `console.log`.
* Build again using `grunt webpack:buildDev`.
* The change should be present if you load your files in the browser. (Make sure the dev server is turned off, although it should also work with the dev server, but that's a different test.)

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended