### PR TITLE
Uses method is_simple_page instead of is_singular in method robots

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -679,7 +679,7 @@ class WPSEO_Frontend {
 		$robots['follow'] = 'follow';
 		$robots['other']  = array();
 
-		if ( ( is_object( $post ) && is_singular() ) || $this->woocommerce_shop_page->is_shop_page() ) {
+		if ( is_object( $post ) && $this->frontend_page_type->is_simple_page() ) {
 			$private = 'private' === $post->post_status;
 			$noindex = ! WPSEO_Post_Type::is_post_type_indexable( $post->post_type );
 
@@ -687,7 +687,7 @@ class WPSEO_Frontend {
 				$robots['index'] = 'noindex';
 			}
 
-			$robots = $this->robots_for_single_post( $robots );
+			$robots = $this->robots_for_single_post( $robots, $this->frontend_page_type->get_simple_page_id() );
 		}
 		else {
 			if ( is_search() || is_404() ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses method `is_simple_page` instead of `is_singular` in method robots. It's a little optimization and it covers all "simple" pages (not only shop page as now). Props to: [stodorovic](https://github.com/stodorovic)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* N/A This is a code-only change and should have no effect on the functionality.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Partially fixes: #9402.
