### PR TITLE
Add grunt webpack:buildProd && grunt webpack:buildDev to yarn start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "webpack-analyze-bundle": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json js/dist",
     "i18n-yoast-components": "cross-env NODE_ENV=production babel node_modules/yoast-components --ignore node_modules/yoast-components/node_modules,tests/*Test.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",
-    "start": "grunt build:js && webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
+    "start": "grunt webpack:buildProd && grunt webpack:buildDev && webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
     "start-recalibration": "yarn start --env.recalibration=enabled"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "webpack-analyze-bundle": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json js/dist",
     "i18n-yoast-components": "cross-env NODE_ENV=production babel node_modules/yoast-components --ignore node_modules/yoast-components/node_modules,tests/*Test.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",
-    "start": "webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
+    "start": "grunt build:js && webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
     "start-recalibration": "yarn start --env.recalibration=enabled"
   },
   "jest": {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* `&&` doesn't work on Windows. However, no one from the team uses the dev server on Windows. 
* I added both webpack:buildProd as well as webpack:buildDev: minified because that is where the 404 were coming from, and unminified for easy debugging.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add `define( 'YOAST_SEO_DEV_SERVER', true );` to your wp-config.php.
* Install Gutenberg + the classic editor plugin.
* Make sure there are no built js files in js/dist
* On trunk: 
    - `composer install && yarn install && grunt build:css && yarn start`
    - Navigate to a post edit screen in either the classic editor plugin or the default classic editor, and see the following errors: 
<img width="796" alt="schermafbeelding 2018-11-19 om 12 58 30" src="https://user-images.githubusercontent.com/17744553/48705925-e6b87600-ebfa-11e8-8173-73e0865ead76.png">

* On this branch:
     - `composer install && yarn install && grunt build:css && yarn start`
     - Navigate to a post edit screen in either the classic editor plugin or the default classic editor, and see all 404 errors are gone (and you have both minified and unminified js files in `js/dist`).
     - The bottom 2 errors from the screenshot will be fixed in #11699

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11635 