### PR TITLE
Fix building of wp-* scripts

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -245,7 +245,7 @@ class WPSEO_Admin_Asset_Manager {
 		wp_register_script(
 			'wp-compose',
 			plugins_url( 'js/dist/wp-compose-' . $flat_version . '.min.js', WPSEO_FILE ),
-			array( 'wp-polyfill' ),
+			array( 'lodash', 'wp-polyfill' ),
 			false,
 			true
 		);

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -183,7 +183,10 @@ module.exports = function( env = { environment: "production", recalibration: "di
 					path: paths.jsDist,
 					filename: "wp-" + outputFilename,
 					jsonpFunction: "yoastWebpackJsonp",
-					library: [ "wp", "[name]" ],
+					library: {
+						root: [ "wp", "[name]" ],
+					},
+					libraryTarget: "this",
 				},
 				entry: {
 					apiFetch: "./node_modules/@wordpress/api-fetch",

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -169,15 +169,20 @@ module.exports = function( env = { environment: "production", recalibration: "di
 			{
 				...base,
 				externals: {
-					...externals,
+					tinymce: "tinymce",
 
-					"@wordpress/element": "window.wp.element",
-					"@wordpress/data": "window.wp.data",
-					"@wordpress/components": "window.wp.components",
-					"@wordpress/i18n": "window.wp.i18n",
-					"@wordpress/api-fetch": "window.wp.apiFetch",
-					"@wordpress/rich-text": "window.wp.richText",
-					"@wordpress/compose": "window.wp.compose",
+					react: "React",
+					"react-dom": "ReactDOM",
+
+					lodash: "lodash",
+
+					"@wordpress/element": [ "wp", "element" ],
+					"@wordpress/data": [ "wp", "data" ],
+					"@wordpress/components": [ "wp",  "components" ],
+					"@wordpress/i18n": [ "wp", "i18n" ],
+					"@wordpress/api-fetch": [ "wp", "apiFetch" ],
+					"@wordpress/rich-text": [ "wp", "richText" ],
+					"@wordpress/compose": [ "wp", "compose" ],
 				},
 				output: {
 					path: paths.jsDist,
@@ -198,6 +203,9 @@ module.exports = function( env = { environment: "production", recalibration: "di
 					richText: "./node_modules/@wordpress/rich-text",
 				},
 				plugins,
+				optimization: {
+					runtimeChunk: false,
+				},
 			},
 			// Config for files that should not use any externals at all.
 			{


### PR DESCRIPTION
After the upgrade to webpack 4 the assignment to the window was broken.

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Test instructions
- Don't have Gutenberg active.
- Click around in the plugin: dashboard, metabox, configuration wizard etc. 
- Don't see the following errors anywhere:
<img width="1068" alt="screenshot 2018-11-28 at 09 43 42" src="https://user-images.githubusercontent.com/17744553/49145065-384db880-f2ff-11e8-817b-4686466489a6.png">
<img width="1041" alt="screenshot 2018-11-28 at 09 43 48" src="https://user-images.githubusercontent.com/17744553/49145066-384db880-f2ff-11e8-9d00-8c5d97f77e02.png">
