### PR TITLE
Undo special recalibration version for the non-worker analysis file

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -280,11 +280,6 @@ class WPSEO_Admin_Asset_Manager {
 
 		$flat_version = $this->flatten_version( WPSEO_VERSION );
 
-		$analysis = 'analysis-' . $flat_version;
-		if ( WPSEO_Recalibration_Beta::is_enabled() ) {
-			$analysis = 'https://my.yoast.com/api/downloads/file/analysis';
-		}
-
 		return array(
 			array(
 				'name' => 'commons',
@@ -565,7 +560,7 @@ class WPSEO_Admin_Asset_Manager {
 			),
 			array(
 				'name' => 'analysis',
-				'src'  => $analysis,
+				'src'  => 'analysis' . $flat_version,
 				'deps' => array(
 					'lodash',
 					self::PREFIX . 'commons',

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -560,7 +560,7 @@ class WPSEO_Admin_Asset_Manager {
 			),
 			array(
 				'name' => 'analysis',
-				'src'  => 'analysis' . $flat_version,
+				'src'  => 'analysis-' . $flat_version,
 				'deps' => array(
 					'lodash',
 					self::PREFIX . 'commons',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Undo recalibration file for non-worker. See original implementation PR: https://github.com/Yoast/wordpress-seo/pull/11575/files#diff-9b8b9d5ca686b29d63b5d9a9b95db6a6
This is because there are no recalibration things used from this version. All of those exist in the web worker space.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build the plugin from this branch: `composer install && yarn && grunt build:css && grunt build:js`.
* If you are using the webpack development server you should then run `yarn start`, if not ignore this. But please ensure your `wp-config.php` setting for this matches.
* Verify that the analysis file is not downloaded from MyYoast anymore:
  - Disable the recalibration beta: `SEO -> General -> Features -> Get an even better analysis: Off`.
  - Check the browser console network, filter on `analysis`.
  - Verify the found network request is from your `localhost`, not `myyoast`.
* Verify that the recalibration beta analysis functions just like before:
  - Enable the recalibration beta: `SEO -> General -> Features -> Get an even better analysis: On`.
  - Create or go to a post, switch to the text editor and include two `h1` headers in your content: `<h1>header</h1><h1>header</h1>`.
  - Verify that the Focus Keyphrase analysis results includes a bad result: `Single title: H1s should only be used as your main title. Find all H1s in your text that aren't your main title and change them to a lower heading level!`.
  - Switch the recalibration beta to `Off`.
  - Verify the above Single title assessment is no longer there.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

