### PR TITLE
Fix nested links

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -65,9 +65,9 @@ class WPSEO_Premium_Upsell_Admin_Block {
 			'<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 
 		$upgrade_button = sprintf(
-			'<a id="wpseo-%1$s-popup-button" class="yoast-button-upsell" href="%2$s" target="_blank" rel="noreferrer noopener">%3$s</a>',
+			'<a id="wpseo-%1$s-popup-button" class="yoast-button-upsell" href="%2$s" target="_blank">%3$s</a>',
 			$this->identifier,
-			$url,
+			esc_url( $url ),
 			$button_text
 		);
 
@@ -89,7 +89,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		'</h2>';
 		echo '<ul class="' . esc_attr( $class . '--motivation' ) . '">' . $arguments_html . '</ul>';
 
-		echo '<p><a href="' . esc_url( $url ) . '" target="_blank">' . $upgrade_button . '</a><br />';
+		echo '<p>' . $upgrade_button . '</p>';
 		echo '</div>';
 
 		echo '</div>';

--- a/js/src/components/contentAnalysis/RecalibrationBetaNotification.js
+++ b/js/src/components/contentAnalysis/RecalibrationBetaNotification.js
@@ -3,22 +3,26 @@
 import React from "react";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
-import { colors } from "yoast-components";
-import HelpLink from "./HelpLink";
+import { colors, utils } from "yoast-components";
 
-const RecalibrationBetaNotificationLink = styled.a`
+const RecalibrationBetaNotificationLink = utils.makeOutboundLink( styled.a`
+	display: inline-block;
+	position: relative;
+	margin: 6px 0 12px -2px;
 	font-size: 1em;
-	font-weight: normal;
-	text-decoration: underline;
-	margin: 6px 0px 12px -10px;
-	display: block;
 	color: ${ colors.$palette_blue_medium };
-`;
+` );
 
-const RecalibrationBetaNotificationIcon = styled( HelpLink )`
-	margin: -8px 4px -4px 4px;
-	color: ${ colors.$palette_blue_medium };
-	&:hover { color: #00a0d2 };
+const RecalibrationBetaNotificationIcon = styled.span`
+	display: inline-block;
+	margin-right: 6px;
+
+	&::before {
+		position: absolute;
+		top: 0;
+		left: 0;
+		content: "\f223";
+	}
 `;
 
 /**
@@ -30,17 +34,9 @@ const RecalibrationBetaNotification = () => {
 	return (
 		<RecalibrationBetaNotificationLink
 			href={ wpseoAdminL10n[ "shortlinks.recalibration_beta_metabox" ] }
-			target={ "_blank" }
-			rel={ "noopener noreferrer" }
+			rel={ null }
 		>
-			<RecalibrationBetaNotificationIcon
-				href={ wpseoAdminL10n[ "shortlinks.recalibration_beta_metabox" ] }
-				className="dashicons"
-			>
-				<span className="screen-reader-text">
-					{ __( "Learn more about the Recalibration beta", "wordpress-seo" ) }
-				</span>
-			</RecalibrationBetaNotificationIcon>
+			<RecalibrationBetaNotificationIcon className="dashicons" />
 			{ __( "Recalibration beta is active", "wordpress-seo" ) }
 		</RecalibrationBetaNotificationLink>
 	);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Fixes nested links.

## Relevant technical choices:

- nested links not only are invalid HTML... they do affect keyboard accessibility and the way links are reported by assistive technologies
- this PR fixes the "Recalibration beta" link and the upsell link in the block at the bottom of the settings pages

## Test instructions
- activate the Recalibration beta feature
- build the assets
- check the Recalibration beta link in the metabox and in the Gutenberg sidebar
- verify there's just one link, no nested links
- verify there are no visual regressions

before:

<img width="498" alt="before" src="https://user-images.githubusercontent.com/1682452/49232919-2c442280-f3f5-11e8-8cc0-1ab30ce0a121.png">

after (slightly better aligned):

<img width="501" alt="after" src="https://user-images.githubusercontent.com/1682452/49232930-3108d680-f3f5-11e8-9bbd-dace067bc107.png">

- go to any settings page
- at the bottom of the page, in the upsell block, check the upsell link "Get Yoast SEO Premium" 

<img width="722" alt="screenshot 2018-11-29 at 16 29 41" src="https://user-images.githubusercontent.com/1682452/49233059-70cfbe00-f3f5-11e8-8870-91a8b1b41fbe.png">

- verify there's just one link, no nested links
- verify there are no visual regressions

I've also removed `rel="noopener noreferrer"` as these links point to yoast.com and we must not use the rel attribute for yoast.com

Fixes #11610
Fixes #11704 
