### PR TITLE
Add missing label element in the Configuration Wizard

### DIFF
--- a/js/src/components/ConnectGoogleSearchConsole.js
+++ b/js/src/components/ConnectGoogleSearchConsole.js
@@ -306,14 +306,17 @@ class ConnectGoogleSearchConsole extends React.Component {
 						"and press the Authenticate button."
 					) }
 				</p>
-
+				<label
+					className="yoast-wizard-text-input-label"
+					htmlFor="gsc_authorization_code"
+				>
+					{ this.props.translate( "Authorization code" ) }
+				</label>
 				<input
 					type="text"
 					id="gsc_authorization_code"
 					name="gsc_authorization_code"
 					defaultValue=""
-					placeholder={ this.props.translate( "Enter authorization code here..." ) }
-					aria-labelledby="gsc-enter-code-label"
 				/>
 				<RaisedButton
 					label={ this.props.translate( "Authenticate" ) }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a missing label element for a field input in the Configuration Wizard

## Relevant technical choices:

Very small patch to:
- remove the placeholder text
- remove an `aria-labelledby` attribute that points to nothing
- add a visible `<label>` element

Before:

<img width="604" alt="before" src="https://user-images.githubusercontent.com/1682452/49236063-a4ade200-f3fb-11e8-9298-345f414c65d1.png">

After:

<img width="602" alt="after" src="https://user-images.githubusercontent.com/1682452/49236072-a8d9ff80-f3fb-11e8-8524-0c3deca5e695.png">

Note: the visible label is standard for all the input fields in the Wizard, for example:

<img width="337" alt="screenshot 2018-11-29 at 17 17 31" src="https://user-images.githubusercontent.com/1682452/49236080-ad061d00-f3fb-11e8-93df-f9f678517d5b.png">

## Test instructions
- build the assets
- go in the WIzard > step 8
- if already authenticated, click "Reauthenticate with Google:
- the auth code input field appears
- verify the new label is properly associated (click on it)

Fixes #11045 
