### PR TITLE
Prevent an error in Gutenberg when Readability marker is active

### DIFF
--- a/js/src/redux/selectors/results.js
+++ b/js/src/redux/selectors/results.js
@@ -56,9 +56,19 @@ export function getResultsForFocusKeyword( state ) {
  * @returns {Object|null} The assessment result.
  */
 export function getResultById( state, id ) {
+	let resultsForFocusKeyphrase = getResultsForFocusKeyword( state ).results;
+	if ( typeof resultsForFocusKeyphrase === "undefined" ) {
+		resultsForFocusKeyphrase = {};
+	}
+
+	let resultsForReadability = getReadabilityResults( state ).results;
+	if ( typeof resultsForReadability === "undefined" ) {
+		resultsForReadability = {};
+	}
+
 	const allResults = [
-		...getResultsForFocusKeyword( state ).results,
-		...getReadabilityResults( state ).results,
+		...resultsForFocusKeyphrase,
+		...resultsForReadability,
 	];
 
 	return allResults.find( result => result._identifier === id );

--- a/js/src/redux/selectors/results.js
+++ b/js/src/redux/selectors/results.js
@@ -17,12 +17,12 @@ export function getSeoResults( state ) {
  * @param {Object} state The state.
  * @param {string} keyword The keyword to get the results for.
  *
- * @returns {Array} The SEO results for the keyword.
+ * @returns {object} The results and overall score for the SEO analysis.
  */
 export function getResultsForKeyword( state, keyword ) {
 	const seoResults = getSeoResults( state );
 
-	return get( seoResults, keyword, [] );
+	return get( seoResults, keyword, {} );
 }
 
 /**
@@ -33,7 +33,7 @@ export function getResultsForKeyword( state, keyword ) {
  * @returns {object} The results and overall score for the readability analysis.
  */
 export function getReadabilityResults( state ) {
-	return get( state, [ "analysis", "readability" ] );
+	return get( state, [ "analysis", "readability" ], {} );
 }
 
 /**
@@ -56,19 +56,12 @@ export function getResultsForFocusKeyword( state ) {
  * @returns {Object|null} The assessment result.
  */
 export function getResultById( state, id ) {
-	let resultsForFocusKeyphrase = getResultsForFocusKeyword( state ).results;
-	if ( typeof resultsForFocusKeyphrase === "undefined" ) {
-		resultsForFocusKeyphrase = {};
-	}
-
-	let resultsForReadability = getReadabilityResults( state ).results;
-	if ( typeof resultsForReadability === "undefined" ) {
-		resultsForReadability = {};
-	}
+	const focusKeywordResults = getResultsForFocusKeyword( state ).results || [];
+	const readabilityResults = getReadabilityResults( state ).results || [];
 
 	const allResults = [
-		...resultsForFocusKeyphrase,
-		...resultsForReadability,
+		...focusKeywordResults,
+		...readabilityResults,
 	];
 
 	return allResults.find( result => result._identifier === id );
@@ -84,4 +77,3 @@ export function getResultById( state, id ) {
 export function getMarkButtonStatus( state ) {
 	return state.marksButtonStatus;
 }
-


### PR DESCRIPTION
This branch is a rebase of PR#[11709](https://github.com/Yoast/wordpress-seo/pull/11709), which was based on trunk. 

## Summary

This PR can be summarized in the following changelog entry:

* N/a

## Test instructions
This PR can be tested by following these steps:

* Follow the steps in #11703 to reproduce the issue.
* Checkout this branch
* Is should be solved.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11703 
