### PR TITLE
Only run a single js build on yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "webpack-analyze-bundle": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json js/dist",
     "i18n-yoast-components": "cross-env NODE_ENV=production babel node_modules/yoast-components --ignore node_modules/yoast-components/node_modules,tests/*Test.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",
-    "start": "grunt webpack:buildProd && grunt webpack:buildDev && webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
+    "start": "grunt build:css && grunt webpack:buildDev && webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
     "start-recalibration": "yarn start --env.recalibration=enabled"
   },
   "jest": {

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -34,8 +34,11 @@ const externals = {
 module.exports = function( env = { environment: "production", recalibration: "disabled" } ) {
 	const mode = env.environment || process.env.NODE_ENV || "production";
 	const isRecalibration = ( env.recalibration || process.env.YOAST_RECALIBRATION || "disabled" ) === "enabled";
-	const outputFilenamePostfix = mode === "development" ? ".js" : ".min.js";
-	const outputFilename = "[name]-" + pluginVersionSlug + outputFilenamePostfix;
+
+	const outputFilenameMinified = "[name]-" + pluginVersionSlug + ".min.js";
+	const outputFilenameUnminified = "[name]-" + pluginVersionSlug + ".js";
+
+	const outputFilename = mode === "development" ? outputFilenameUnminified : outputFilenameMinified;
 
 	const plugins = [
 		new webpack.DefinePlugin( {
@@ -186,7 +189,7 @@ module.exports = function( env = { environment: "production", recalibration: "di
 				},
 				output: {
 					path: paths.jsDist,
-					filename: "wp-" + outputFilename,
+					filename: "wp-" + outputFilenameMinified,
 					jsonpFunction: "yoastWebpackJsonp",
 					library: {
 						root: [ "wp", "[name]" ],
@@ -210,6 +213,11 @@ module.exports = function( env = { environment: "production", recalibration: "di
 			// Config for files that should not use any externals at all.
 			{
 				...base,
+				output: {
+					path: paths.jsDist,
+					filename: outputFilenameMinified,
+					jsonpFunction: "yoastWebpackJsonp",
+				},
 				entry: {
 					"wp-seo-analysis-worker": "./js/src/wp-seo-analysis-worker.js",
 					"babel-polyfill": "./js/src/babel-polyfill.js",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Output unminified files that should be minified (backports and "no externals") with a `.min.js` extension when running `grunt build:js` and `yarn start`, because the backend will always request these files as minified files. This way we don't have to do a `webpack:buildProd` when starting the dev server.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Do a `grunt clean` to remove all built assets.
* Run `grunt webpack:buildDev`. Notice that the backports, babel-polyfill and analysis worker files are output with a `.min.js` extension.
* Do a `grunt clean` again.
* Make sure you have the `YOAST_SEO_DEV_SERVER` flag enabled.
* Run `yarn start`.
* Notice it's faster to start up the dev server now.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Improves on #11695
