### PR TITLE
Remove recalibration functionality

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -104,7 +104,6 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_Capability_Manager_Integration( WPSEO_Capability_Manager_Factory::get() );
 		$integrations[] = new WPSEO_Admin_Media_Purge_Notification();
 		$integrations[] = new WPSEO_Admin_Gutenberg_Compatibility_Notification();
-		$integrations[] = new WPSEO_Recalibration_Beta_Notification();
 		$integrations[] = new WPSEO_Stale_Content_Notification();
 		$integrations[] = new WPSEO_Expose_Shortlinks();
 		$integrations[] = new WPSEO_Recalibration_Beta();

--- a/admin/class-recalibration-beta.php
+++ b/admin/class-recalibration-beta.php
@@ -29,6 +29,9 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function show_feature_toggle() {
+		// Temporary disable the toggle.
+		return;
+
 		$values = array(
 			'on'  => __( 'On', 'wordpress-seo' ),
 			'off' => __( 'Off', 'wordpress-seo' ),
@@ -82,7 +85,13 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
+		// Temporary disable the toggle.
+		return;
+
 		add_action( 'update_option_wpseo', array( $this, 'update_option' ), 10, 2 );
+
+		$notification = new WPSEO_Recalibration_Beta_Notification();
+		$notification->register_hooks();
 	}
 
 	/**
@@ -160,6 +169,9 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	protected function subscribe_newsletter() {
+		// Temporary disable the toggle.
+		return;
+
 		if ( $this->has_mailinglist_subscription() ) {
 			return;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Chosen to disable the feature by early return. We can revert these easily. I also moved the instantiation of the recalibration notice to the `WPSEO_Recalibration_Beta` class, because it is functionality that belong together.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if you get no recalibration related features: toggle, notification and stale content filter.
* Make sure the value for `recalibration_beta` is set to `false` in the option `wpseo`

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11744
