### PR TITLE
Prefix the collapsible paper block id

### DIFF
--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 ?>
-<div class="paper tab-block" id="wpseo-<?php echo esc_attr( $paper_id ); ?>">
+<div class="paper tab-block" id="<?php if ( $paper_id ) { echo esc_attr( 'wpseo-' . $paper_id ); } ?>">
 
 	<?php
 	if ( ! empty( $title ) ) {

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 ?>
-<div class="paper tab-block" id="<?php if ( $paper_id ) { echo esc_attr( 'wpseo-' . $paper_id ); } ?>">
+<div class="paper tab-block" <?php if ( $paper_id ) { echo 'id="' . esc_attr( 'wpseo-' . $paper_id ) . '""'; } ?>>
 
 	<?php
 	if ( ! empty( $title ) ) {

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 ?>
-<div class="paper tab-block" id="<?php echo esc_attr( $paper_id ); ?>">
+<div class="paper tab-block" id="wpseo-<?php echo esc_attr( $paper_id ); ?>">
 
 	<?php
 	if ( ! empty( $title ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the search appearance setting for a custom posttype named `profile` will have the wrong styling.

## Relevant technical choices:

* I've chosen to prefix the id of the paper collapsible block

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the code from issue #11618 to have a custom post type named profile
* Go search appearance and open tab post types.
* See the styling of the profile will be wrong
* Checkout this branch and see it is solved.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11618 
