### PR TITLE
Disable archives for authors without posts toggle when author archives are disabled

### DIFF
--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -21,6 +21,7 @@ $yform->toggle_switch(
 ?>
 
 <div id='author-archives-titles-metas-content' class='archives-titles-metas-content'>
+
 <?php
 $author_archives_help = new WPSEO_Admin_Help_Panel(
 	'noindex-author-wpseo',
@@ -43,7 +44,6 @@ $yform->index_switch(
 ?>
 
 <div id='noindex-author-noposts-wpseo-container'>
-
 <?php
 
 $author_archives_no_posts_help = new WPSEO_Admin_Help_Panel(

--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -41,6 +41,12 @@ $yform->index_switch(
 	$author_archives_help->get_button_html() . $author_archives_help->get_panel_html()
 );
 
+?>
+
+<div id='noindex-author-noposts-wpseo-container'>
+
+<?php
+
 $author_archives_no_posts_help = new WPSEO_Admin_Help_Panel(
 	'noindex-author-noposts-wpseo',
 	esc_html__( 'Help on the authors without posts archive search results setting', 'wordpress-seo' ),
@@ -58,6 +64,12 @@ $yform->index_switch(
 	__( 'archives for authors without posts', 'wordpress-seo' ),
 	$author_archives_no_posts_help->get_button_html() . $author_archives_no_posts_help->get_panel_html()
 );
+
+?>
+
+</div>
+
+<?php
 
 $recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
 $editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();

--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -21,7 +21,6 @@ $yform->toggle_switch(
 ?>
 
 <div id='author-archives-titles-metas-content' class='archives-titles-metas-content'>
-
 <?php
 $author_archives_help = new WPSEO_Admin_Help_Panel(
 	'noindex-author-wpseo',
@@ -66,7 +65,6 @@ $yform->index_switch(
 );
 
 ?>
-
 </div>
 
 <?php

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -186,32 +186,23 @@ import a11ySpeak from "a11y-speak";
 	}
 
 	/**
-	 * Toggles the "Show archives for authors without posts" toggle to false
-	 * and disables the toggle.
+	 * Hides or shows the Author without posts toggle.
+	 *
+	 * @param {bool} visible Whether or not the authors without posts toggle should be visible.
 	 *
 	 * @returns {void}
 	 */
-	function disableAuthorsWithoutPostsToggle() {
-		const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
-		const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
+	function setAuthorsWithoutPostsToggleVisibilty( visible ) {
+		/**
+		 * Get the container surrounding the toggle.
+		 */
+		const toggleContainer = jQuery( "#noindex-author-noposts-wpseo-container" );
 
-		noPostsOn.prop( "checked", true );
-
-		noPostsOff.prop( "disabled", true );
-		noPostsOn.prop( "disabled", true );
-	}
-
-	/**
-	 * Enables the "Show archives for authors without posts" toggle.
-	 *
-	 * @returns {void}
-	 */
-	function enableAuthorsWithoutPostsToggle() {
-		const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
-		const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
-
-		noPostsOff.prop( "disabled", false );
-		noPostsOn.prop( "disabled", false );
+		if ( visible ) {
+			toggleContainer.show();
+		} else {
+			toggleContainer.hide();
+		}
 	}
 
 	window.wpseoDetectWrongVariables = wpseoDetectWrongVariables;
@@ -238,20 +229,20 @@ import a11ySpeak from "a11y-speak";
 		const authorArchivesEnabled  = jQuery( "#noindex-author-wpseo-on" );
 
 		if ( ! authorArchivesDisabled.is( ":checked" ) ) {
-			disableAuthorsWithoutPostsToggle();
+			setAuthorsWithoutPostsToggleVisibilty( false );
 		}
 
 		// Disable Author archives without posts when Show author archives is toggled off.
 		authorArchivesEnabled.change( () => {
 			if ( ! jQuery( this ).is( ":checked" ) ) {
-				disableAuthorsWithoutPostsToggle();
+				setAuthorsWithoutPostsToggleVisibilty( false );
 			}
 		} );
 
 		// Enable Author archives without posts when Show author archives is toggled on.
 		authorArchivesDisabled.change( () => {
 			if ( ! jQuery( this ).is( ":checked" ) ) {
-				enableAuthorsWithoutPostsToggle();
+				setAuthorsWithoutPostsToggleVisibilty( true );
 			}
 		} );
 

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -185,18 +185,40 @@ import a11ySpeak from "a11y-speak";
 		jQuery( "#" + activeTabId + "-tab" ).addClass( "nav-tab-active" ).click();
 	}
 
+	/**
+	 * Toggles the "Show archives for authors without posts" toggle to false
+	 * and disables the toggle.
+	 *
+	 * @returns {void}
+	 */
+	function disableAuthorsWithoutPostsToggle() {
+		const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
+		const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
+
+		noPostsOn.prop( "checked", true );
+
+		noPostsOff.prop( "disabled", true );
+		noPostsOn.prop( "disabled", true );
+	}
+
+	/**
+	 * Enables the "Show archives for authors without posts" toggle.
+	 *
+	 * @returns {void}
+	 */
+	function enableAuthorsWithoutPostsToggle() {
+		const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
+		const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
+
+		noPostsOff.prop( "disabled", false );
+		noPostsOn.prop( "disabled", false );
+	}
+
 	window.wpseoDetectWrongVariables = wpseoDetectWrongVariables;
 	window.setWPOption = setWPOption;
 	window.wpseoCopyHomeMeta = wpseoCopyHomeMeta;
 	// eslint-disable-next-line
 	window.wpseoSetTabHash = wpseoSetTabHash;
-
-	function setArchivesForAuthorsWithoutPostsToggleDisabledAttribute() {
-		const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
-		const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
-		noPostsOff.prop( "disabled", false );
-		noPostsOn.prop( "disabled", false );
-	}
 
 	jQuery( document ).ready( function() {
 		/**
@@ -212,27 +234,24 @@ import a11ySpeak from "a11y-speak";
 			}
 		} ).change();
 
+		const authorArchivesDisabled = jQuery( "#noindex-author-wpseo-off" );
+		const authorArchivesEnabled  = jQuery( "#noindex-author-wpseo-on" );
+
+		if ( ! authorArchivesDisabled.is( ":checked" ) ) {
+			disableAuthorsWithoutPostsToggle();
+		}
+
 		// Disable Author archives without posts when Show author archives is toggled off.
-		jQuery( "#noindex-author-wpseo-on" ).change( () => {
+		authorArchivesEnabled.change( () => {
 			if ( ! jQuery( this ).is( ":checked" ) ) {
-				const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
-				const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
-
-				noPostsOn.prop( "checked", true );
-
-				noPostsOff.prop( "disabled", true );
-				noPostsOn.prop( "disabled", true );
+				disableAuthorsWithoutPostsToggle();
 			}
 		} );
 
 		// Enable Author archives without posts when Show author archives is toggled on.
-		jQuery( "#noindex-author-wpseo-off" ).change( () => {
+		authorArchivesDisabled.change( () => {
 			if ( ! jQuery( this ).is( ":checked" ) ) {
-				const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
-				const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
-
-				noPostsOff.prop( "disabled", false );
-				noPostsOn.prop( "disabled", false );
+				enableAuthorsWithoutPostsToggle();
 			}
 		} );
 

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -191,6 +191,13 @@ import a11ySpeak from "a11y-speak";
 	// eslint-disable-next-line
 	window.wpseoSetTabHash = wpseoSetTabHash;
 
+	function setArchivesForAuthorsWithoutPostsToggleDisabledAttribute() {
+		const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
+		const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
+		noPostsOff.prop( "disabled", false );
+		noPostsOn.prop( "disabled", false );
+	}
+
 	jQuery( document ).ready( function() {
 		/**
 		 * When the hash changes, get the base url from the action and then add the current hash.
@@ -204,6 +211,30 @@ import a11ySpeak from "a11y-speak";
 				jQuery( "#author-archives-titles-metas-content" ).toggle( jQuery( this ).val() === "off" );
 			}
 		} ).change();
+
+		// Disable Author archives without posts when Show author archives is toggled off.
+		jQuery( "#noindex-author-wpseo-on" ).change( () => {
+			if ( ! jQuery( this ).is( ":checked" ) ) {
+				const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
+				const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
+
+				noPostsOn.prop( "checked", true );
+
+				noPostsOff.prop( "disabled", true );
+				noPostsOn.prop( "disabled", true );
+			}
+		} );
+
+		// Enable Author archives without posts when Show author archives is toggled on.
+		jQuery( "#noindex-author-wpseo-off" ).change( () => {
+			if ( ! jQuery( this ).is( ":checked" ) ) {
+				const noPostsOn  = jQuery( "#noindex-author-noposts-wpseo-on" );
+				const noPostsOff = jQuery( "#noindex-author-noposts-wpseo-off" );
+
+				noPostsOff.prop( "disabled", false );
+				noPostsOn.prop( "disabled", false );
+			}
+		} );
 
 		// Toggle the Date archives section.
 		jQuery( "#disable-date input[type='radio']" ).change( function() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Disables the `Show archives for authors without posts in search results?` toggle when the `Show author archives in search results?` toggle is disabled on the `Search Appearance` > `Archives` Page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this PR and build the project.
* Go to `SEO` > `Seach Appearance` > `Archives` > `Author archive settings`.
* Enable `Show author archives in search results?` and `Show archives for authors without posts in search results?`.
* Now disable `Show author archives in search results?`, and notice that the `Show archives for authors without posts in search results?` toggle is switched to `Off` and disabled.
* Save the options and notice teh changes are saved.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9098 
