### PR TITLE
Check if value exists in dirty

### DIFF
--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -118,13 +118,14 @@ class WPSEO_Option_Social extends WPSEO_Option {
 
 				case 'og_default_image_id':
 				case 'og_frontpage_image_id':
-					$clean[ $key ] = intval( $dirty[ $key ] );
+					if ( isset( $dirty[ $key ] ) ) {
+						$clean[ $key ] = (int) $dirty[ $key ];
 
-					if ( $dirty[ $key ] === '' ) {
-						$clean[ $key ] = $dirty[ $key ];
+						if ( $dirty[ $key ] === '' ) {
+							$clean[ $key ] = $dirty[ $key ];
+						}
 					}
 					break;
-
 
 				/* URL text fields - no ftp allowed. */
 				case 'facebook_site':

--- a/tests/doubles/class-wpseo-option-social-double.php
+++ b/tests/doubles/class-wpseo-option-social-double.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin
+ */
+
+/**
+ * Class WPSEO_Option_Social_Double
+ */
+class WPSEO_Option_Social_Double extends WPSEO_Option_Social {
+
+	/**
+	 * Exposes the constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+	}
+
+	/**
+	 * Validate the option.
+	 *
+	 * @param  array $dirty New value for the option.
+	 * @param  array $clean Clean value for the option, normally the defaults.
+	 * @param  array $old   Old value of the option.
+	 *
+	 * @return  array      Validated clean value for the option to be saved to the database.
+	 */
+	public function validate_option( $dirty, $clean, $old ) {
+		return parent::validate_option( $dirty, $clean, $old );
+	}
+}

--- a/tests/inc/options/test-class-wpseo-option-social.php
+++ b/tests/inc/options/test-class-wpseo-option-social.php
@@ -40,7 +40,7 @@ class WPSEO_Option_Social_Test extends WPSEO_UnitTestCase {
 		return array(
 			array(
 				'expected' => array( 'og_default_image_id' => 'value' ),
-				'dirty'    => array(  ),
+				'dirty'    => array(),
 				'clean'    => array( 'og_default_image_id' => 'value' ),
 				'old'      => array(),
 			),

--- a/tests/inc/options/test-class-wpseo-option-social.php
+++ b/tests/inc/options/test-class-wpseo-option-social.php
@@ -19,7 +19,7 @@ class WPSEO_Option_Social_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider validate_option_provider
 	 *
-	 * @group test
+	 * @covers WPSEO_Option_Social::validate_option()
 	 */
 	public function test_validate_option( $expected, $dirty, $clean, $old ) {
 		$instance = new WPSEO_Option_Social_Double();

--- a/tests/inc/options/test-class-wpseo-option-social.php
+++ b/tests/inc/options/test-class-wpseo-option-social.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Inc\Options
+ */
+
+/**
+ * Unit Test Class.
+ */
+class WPSEO_Option_Social_Test extends WPSEO_UnitTestCase {
+
+
+	/**
+	 * @param string $expected The expected value.
+	 * @param array  $dirty    New value for the option.
+	 * @param array  $clean    Clean value for the option, normally the defaults.
+	 * @param array  $old      Old value of the option.
+	 *
+	 * @dataProvider validate_option_provider
+	 *
+	 * @group test
+	 */
+	public function test_validate_option( $expected, $dirty, $clean, $old ) {
+		$instance = new WPSEO_Option_Social_Double();
+
+		$this->assertEquals(
+			$expected,
+			$instance->validate_option( $dirty, $clean, $old )
+		);
+
+	}
+
+	/**
+	 * Data for the test_validate_option test.
+	 *
+	 * @return array The test data.
+	 */
+	public function validate_option_provider() {
+		return array(
+			array(
+				'expected' => array( 'og_default_image_id' => 'value' ),
+				'dirty'    => array(  ),
+				'clean'    => array( 'og_default_image_id' => 'value' ),
+				'old'      => array(),
+			),
+			array(
+				'expected' => array( 'og_frontpage_image_id' => 'value' ),
+				'dirty'    => array(),
+				'clean'    => array( 'og_frontpage_image_id' => 'value' ),
+				'old'      => array(),
+			),
+			array(
+				'expected' => array( 'og_default_image_id' => '' ),
+				'dirty'    => array( 'og_default_image_id' => '' ),
+				'clean'    => array( 'og_default_image_id' => '' ),
+				'old'      => array(),
+			),
+			array(
+				'expected' => array( 'og_frontpage_image_id' => '' ),
+				'dirty'    => array( 'og_frontpage_image_id' => '' ),
+				'clean'    => array( 'og_frontpage_image_id' => '' ),
+				'old'      => array(),
+			),
+			array(
+				'expected' => array( 'og_default_image_id' => 123 ),
+				'dirty'    => array( 'og_default_image_id' => '123' ),
+				'clean'    => array( 'og_default_image_id' => '' ),
+				'old'      => array(),
+			),
+			array(
+				'expected' => array( 'og_frontpage_image_id' => 0 ),
+				'dirty'    => array( 'og_frontpage_image_id' => 'testen' ),
+				'clean'    => array( 'og_frontpage_image_id' => '' ),
+				'old'      => array(),
+			),
+		);
+	}
+}


### PR DESCRIPTION
Also added some unit tests

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where undefined warnings are given for two recently added social options.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* _This issue might be hard to test, because of error reporting. Therefore I've also added unit tests._
* Have error reporting enabled
* Remove the `wpseo_option` option (`wp_options`) from the database. Or set its value to: 
```
a:20:{s:13:"facebook_site";s:12:"http://sdddd";s:13:"instagram_url";s:0:"";s:12:"linkedin_url";s:0:"";s:11:"myspace_url";s:0:"";s:16:"og_default_image";s:0:"";s:18:"og_frontpage_title";s:0:"";s:17:"og_frontpage_desc";s:0:"";s:18:"og_frontpage_image";s:0:"";s:0:"";s:9:"opengraph";b:1;s:13:"pinterest_url";s:0:"";s:15:"pinterestverify";s:0:"";s:14:"plus-publisher";s:0:"";s:7:"twitter";b:1;s:12:"twitter_site";s:0:"";s:17:"twitter_card_type";s:19:"summary_large_image";s:11:"youtube_url";s:0:"";s:15:"google_plus_url";s:0:"";s:10:"fbadminapp";s:0:"";}
```
* Go to social and save set an image for Facebook (frontpage and the default)
* You should get an error. If not, please verify if the values are saved correctly

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11741
