### PR TITLE
Use AND instead of OR

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -225,7 +225,7 @@ class WPSEO_Twitter {
 			$meta_desc = $this->fallback_description();
 		}
 
-		if ( is_string( $meta_desc ) || $meta_desc !== '' ) {
+		if ( is_string( $meta_desc ) && $meta_desc !== '' ) {
 			return $meta_desc;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the empty twitter description is shown instead of the term description itself.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* To reproduce follow the steps in #11701 
* This pull should fix that

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11701 
