### PR TITLE
Deprecates language utils in WPSEO_Utils

### DIFF
--- a/admin/class-add-keyword-modal.php
+++ b/admin/class-add-keyword-modal.php
@@ -49,7 +49,7 @@ class WPSEO_Add_Keyword_Modal {
 	public function get_translations_for_js() {
 		$translations = $this->get_translations();
 		return array(
-			'locale' => WPSEO_Utils::get_user_locale(),
+			'locale' => WPSEO_Language_Utils::get_user_locale(),
 			'intl'   => $translations,
 		);
 	}

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -270,8 +270,8 @@ class WPSEO_Admin_Asset_Manager {
 	 */
 	protected function scripts_to_be_registered() {
 		$select2_language = 'en';
-		$user_locale      = WPSEO_Utils::get_user_locale();
-		$language         = WPSEO_Utils::get_language( $user_locale );
+		$user_locale      = WPSEO_Language_Utils::get_user_locale();
+		$language         = WPSEO_Language_Utils::get_language( $user_locale );
 
 		if ( file_exists( WPSEO_PATH . "js/dist/select2/i18n/{$user_locale}.js" ) ) {
 			$select2_language = $user_locale; // Chinese and some others use full locale.

--- a/admin/class-admin-asset-yoast-components-l10n.php
+++ b/admin/class-admin-asset-yoast-components-l10n.php
@@ -30,7 +30,7 @@ final class WPSEO_Admin_Asset_Yoast_Components_L10n {
 	 * @return object The translations in a Jed format for JS files.
 	 */
 	protected function get_translations( $component ) {
-		$locale = WPSEO_Utils::get_user_locale();
+		$locale = WPSEO_Language_Utils::get_user_locale();
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/' . $component . '-' . $locale . '.json';
 		if ( file_exists( $file ) ) {

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -86,7 +86,7 @@ class WPSEO_Admin_Pages {
 		wp_enqueue_script( 'dashboard' );
 		wp_enqueue_script( 'thickbox' );
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-script', 'wpseoSelect2Locale', WPSEO_Language_Utils::get_language( WPSEO_Language_Utils::get_user_locale() ) );
 
 		if ( in_array( $page, array( 'wpseo_social', WPSEO_Admin::PAGE_IDENTIFIER, 'wpseo_titles' ), true ) ) {
 			wp_enqueue_media();

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -238,7 +238,7 @@ class WPSEO_Help_Center {
 	public static function get_translated_texts() {
 		// Esc_html is not needed because React already handles HTML in the (translations of) these strings.
 		return array(
-			'locale'                             => WPSEO_Utils::get_user_locale(),
+			'locale'                             => WPSEO_Language_Utils::get_user_locale(),
 			'videoTutorial'                      => __( 'Video tutorial', 'wordpress-seo' ),
 			'knowledgeBase'                      => __( 'Knowledge base', 'wordpress-seo' ),
 			'getSupport'                         => __( 'Get support', 'wordpress-seo' ),

--- a/admin/class-keyword-synonyms-modal.php
+++ b/admin/class-keyword-synonyms-modal.php
@@ -50,7 +50,7 @@ class WPSEO_Keyword_Synonyms_Modal {
 		$translations = $this->get_translations();
 
 		return array(
-			'locale' => WPSEO_Utils::get_user_locale(),
+			'locale' => WPSEO_Language_Utils::get_user_locale(),
 			'intl'   => $translations,
 		);
 	}

--- a/admin/class-multiple-keywords-modal.php
+++ b/admin/class-multiple-keywords-modal.php
@@ -50,7 +50,7 @@ class WPSEO_Multiple_Keywords_Modal {
 		$translations = $this->get_translations();
 
 		return array(
-			'locale' => WPSEO_Utils::get_user_locale(),
+			'locale' => WPSEO_Language_Utils::get_user_locale(),
 			'intl'   => $translations,
 		);
 	}

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -265,7 +265,7 @@ class WPSEO_Configuration_Page {
 	public function get_translations() {
 		_deprecated_function( __METHOD__, 'WPSEO 4.9', 'WPSEO_' );
 
-		$translations = new WPSEO_Configuration_Translations( WPSEO_Utils::get_user_locale() );
+		$translations = new WPSEO_Configuration_Translations( WPSEO_Language_Utils::get_user_locale() );
 
 		return $translations->retrieve();
 	}

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -45,7 +45,7 @@ class WPSEO_Configuration_Service {
 		$this->set_components( new WPSEO_Configuration_Components() );
 		$this->set_endpoint( new WPSEO_Configuration_Endpoint() );
 		$this->set_structure( new WPSEO_Configuration_Structure() );
-		$this->set_translations( new WPSEO_Configuration_Translations( WPSEO_Utils::get_user_locale() ) );
+		$this->set_translations( new WPSEO_Configuration_Translations( WPSEO_Language_Utils::get_user_locale() ) );
 	}
 
 	/**

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -55,7 +55,7 @@ class WPSEO_Metabox_Formatter {
 			'keywordTab'                => __( 'Keyphrase:', 'wordpress-seo' ),
 			'removeKeyword'             => __( 'Remove keyphrase', 'wordpress-seo' ),
 			'contentLocale'             => get_locale(),
-			'userLocale'                => WPSEO_Utils::get_user_locale(),
+			'userLocale'                => WPSEO_Language_Utils::get_user_locale(),
 			'translations'              => $this->get_translations(),
 			'keyword_usage'             => array(),
 			'title_template'            => '',
@@ -66,7 +66,7 @@ class WPSEO_Metabox_Formatter {
 			'intl'                      => $this->get_content_analysis_component_translations(),
 			'isRtl'                     => is_rtl(),
 			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
-			'wordFormRecognitionActive' => ( WPSEO_Utils::get_language( get_locale() ) === 'en' ),
+			'wordFormRecognitionActive' => ( WPSEO_Language_Utils::get_language( get_locale() ) === 'en' ),
 			'recalibrationBetaActive'   => WPSEO_Recalibration_Beta::is_enabled(),
 
 			/**
@@ -158,7 +158,7 @@ class WPSEO_Metabox_Formatter {
 	private function get_content_analysis_component_translations() {
 		// Esc_html is not needed because React already handles HTML in the (translations of) these strings.
 		return array(
-			'locale'                                         => WPSEO_Utils::get_user_locale(),
+			'locale'                                         => WPSEO_Language_Utils::get_user_locale(),
 			'content-analysis.language-notice-link'          => __( 'Change language', 'wordpress-seo' ),
 			'content-analysis.errors'                        => __( 'Errors', 'wordpress-seo' ),
 			'content-analysis.problems'                      => __( 'Problems', 'wordpress-seo' ),
@@ -211,7 +211,7 @@ class WPSEO_Metabox_Formatter {
 	 * @return array
 	 */
 	private function get_translations() {
-		$locale = WPSEO_Utils::get_user_locale();
+		$locale = WPSEO_Language_Utils::get_user_locale();
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . $locale . '.json';
 		if ( file_exists( $file ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -835,7 +835,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'shortcode-plugin', 'wpseoShortcodePluginL10n', $this->localize_shortcode_plugin_script() );
 
 		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Language_Utils::get_language( WPSEO_Language_Utils::get_user_locale() ) );
 
 		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
 			$asset_manager->enqueue_style( 'featured-image' );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -123,7 +123,7 @@ class WPSEO_Taxonomy {
 			remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Utils::get_language( WPSEO_Utils::get_user_locale() ) );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Language_Utils::get_language( WPSEO_Language_Utils::get_user_locale() ) );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
 
 			$asset_manager->enqueue_script( 'admin-media' );

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1133,13 +1133,14 @@ SVG;
 	 *
 	 * @see        WPSEO_Language_Utils::get_language()
 	 *
-	 * @since      3.4
+	 * @since      9.4
 	 *
 	 * @param string $locale The locale to get the language of.
 	 *
 	 * @returns string The language part of the locale.
 	 */
 	public static function get_language( $locale ) {
+		_deprecated_function( __METHOD__, 'WPSEO 9.4', 'WPSEO_Language_Utils::get_language' );
 		return WPSEO_Language_Utils::get_language( $locale );
 	}
 
@@ -1154,11 +1155,13 @@ SVG;
 	 *
 	 * @see        WPSEO_Language_Utils::get_user_locale()
 	 *
-	 * @since      4.1
+	 * @since      9.4
 	 *
 	 * @returns string The locale.
 	 */
 	public static function get_user_locale() {
+		_deprecated_function( __METHOD__, 'WPSEO 9.4', 'WPSEO_Language_Utils::get_user_locale' );
+
 		return WPSEO_Language_Utils::get_user_locale();
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1133,7 +1133,7 @@ SVG;
 	 *
 	 * @see        WPSEO_Language_Utils::get_language()
 	 *
-	 * @since      9.4
+	 * @since      9.5
 	 *
 	 * @param string $locale The locale to get the language of.
 	 *
@@ -1155,7 +1155,7 @@ SVG;
 	 *
 	 * @see        WPSEO_Language_Utils::get_user_locale()
 	 *
-	 * @since      9.4
+	 * @since      9.5
 	 *
 	 * @returns string The locale.
 	 */

--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -44,7 +44,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Metabox_Formatter::get_translations
 	 */
 	public function test_with_fake_language_file() {
-		$file_name = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . WPSEO_Utils::get_user_locale() . '.json';
+		$file_name = plugin_dir_path( WPSEO_FILE ) . 'languages/wordpress-seo-' . WPSEO_Language_Utils::get_user_locale() . '.json';
 
 		// Make sure the folder exists.
 		wp_mkdir_p( plugin_dir_path( WPSEO_FILE ) . 'languages' );

--- a/tests/inc/test-language-utils.php
+++ b/tests/inc/test-language-utils.php
@@ -31,4 +31,17 @@ class WPSEO_Language_Utils_Test extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals( 'en', $language );
 	}
+
+	public function test_get_language() {
+		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( '' ) );
+		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( 'a' ) );
+		$this->assertEquals( 'nl', WPSEO_Language_Utils::get_language( 'nl_NL' ) );
+		$this->assertEquals( 'nl', WPSEO_Language_Utils::get_language( 'nl_XX' ) );
+		$this->assertEquals( 'nl', WPSEO_Language_Utils::get_language( 'nl' ) );
+		$this->assertEquals( 'haw', WPSEO_Language_Utils::get_language( 'haw_US' ) );
+		$this->assertEquals( 'rhg', WPSEO_Language_Utils::get_language( 'rhg' ) );
+		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( 'xxxx' ) );
+		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( 'xxxx_XX' ) );
+		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( '_XX' ) );
+	}
 }

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -168,19 +168,6 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( WPSEO_Utils::is_yoast_seo_free_page( $current_page ) );
 	}
 
-	public function test_get_language() {
-		$this->assertEquals( 'en', WPSEO_Utils::get_language( '' ) );
-		$this->assertEquals( 'en', WPSEO_Utils::get_language( 'a' ) );
-		$this->assertEquals( 'nl', WPSEO_Utils::get_language( 'nl_NL' ) );
-		$this->assertEquals( 'nl', WPSEO_Utils::get_language( 'nl_XX' ) );
-		$this->assertEquals( 'nl', WPSEO_Utils::get_language( 'nl' ) );
-		$this->assertEquals( 'haw', WPSEO_Utils::get_language( 'haw_US' ) );
-		$this->assertEquals( 'rhg', WPSEO_Utils::get_language( 'rhg' ) );
-		$this->assertEquals( 'en', WPSEO_Utils::get_language( 'xxxx' ) );
-		$this->assertEquals( 'en', WPSEO_Utils::get_language( 'xxxx_XX' ) );
-		$this->assertEquals( 'en', WPSEO_Utils::get_language( '_XX' ) );
-	}
-
 	/**
 	 * Tests whether the plugin is network-active or not.
 	 *


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Deprecates the methods `WPSEO_Utils::get_user_locale()` and `WPSEO_Utils:: get_language()`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* There is no visual change. Everything should still work without errors.

Please don't forget to check and merge these two pulls as well:
https://github.com/Yoast/wordpress-seo-premium/pull/2166
https://github.com/Yoast/wordpress-seo-local/pull/1312

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have ~added~ changed unittests to verify the code works as intended

Fixes #11058
