### PR TITLE
Add filter for filtering the opengraph images

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -141,7 +141,17 @@ class WPSEO_OpenGraph_Image {
 	 * @return array The images.
 	 */
 	public function get_images() {
-		return $this->images;
+		/**
+		 * Filter: 'wpseo_opengraph_images' - Allow changing the images for OpenGraph.
+		 *
+		 * @api array $images The images for OpenGraph.
+		 */
+		$images = apply_filters( 'wpseo_opengraph_images', $this->images );
+		if ( ! is_array( $images ) ) {
+			return $this->images;
+		}
+
+		return $images;
 	}
 
 	/**
@@ -150,7 +160,9 @@ class WPSEO_OpenGraph_Image {
 	 * @return bool True if we have images, false if we don't.
 	 */
 	public function has_images() {
-		return ! empty( $this->images );
+		$images = $this->get_images();
+
+		return ! empty( $images );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a filter `wpseo_opengraph_images` for altering the list of images to use for OpenGraph.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set some images for OpenGraph
* Add the filter by doing:
```php
add_filter( 'wpseo_opengraph_images', function( $images ) { 
   return array();
}  );
```
* You should now have no OG image output.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #3638 
