### PR TITLE
Add check to verify if current page is a singular post

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -532,8 +532,8 @@ class WPSEO_Breadcrumbs {
 			return;
 		}
 
-		// When the current page isn't a singular post.
-		if ( is_home() || is_search() || ( ! is_singular( 'post' ) ) ) {
+		// When the current page is the home page, searchpage or isn't a singular post.
+		if ( is_home() || is_search() || ! is_singular( 'post' ) ) {
 			return;
 		}
 

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -533,7 +533,7 @@ class WPSEO_Breadcrumbs {
 		}
 
 		// When the current page isn't a singular post.
-		if ( is_home() || is_search() || ! is_singular( 'post' )  ) {
+		if ( is_home() || is_search() || ( ! is_singular( 'post' ) ) ) {
 			return;
 		}
 

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -518,13 +518,26 @@ class WPSEO_Breadcrumbs {
 
 	/**
 	 * Add Blog crumb to the crumbs property for single posts where Home != blogpage.
+	 *
+	 * @return void
 	 */
 	private function maybe_add_blog_crumb() {
-		if ( ( 'page' === $this->show_on_front && 'post' === get_post_type() ) && ( ! is_home() && ! is_search() ) ) {
-			if ( $this->page_for_posts && WPSEO_Options::get( 'breadcrumbs-display-blog-page' ) === true ) {
-				$this->add_blog_crumb();
-			}
+		// When the show blog page is not enabled.
+		if ( WPSEO_Options::get( 'breadcrumbs-display-blog-page' ) !== true ) {
+			return;
 		}
+
+		// When there is no page configured as blog page.
+		if ( 'page' !== $this->show_on_front || ! $this->page_for_posts ) {
+			return;
+		}
+
+		// When the current page isn't a singular post.
+		if ( is_home() || is_search() || ! is_singular( 'post' )  ) {
+			return;
+		}
+
+		$this->add_blog_crumb();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the blog page will be shown on non singular posts.

## Relevant technical choices:

* Did some refactoring to make the method more readable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Sets a page as the post page ( this will be the 'blog page' )
* Go to the Yoast SEO - Search Appearance -> Breadcumbs and enable the 'show blog page' toggle
* Go to a post and see the blog page as a breadcrumbs
* Go to the category and see the blog page still being visible as breadcrumb
* Go to a empty category and the blog page will be hidden
* Checkout this branch and see the previous the previous 2 being solved.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10949