### PR TITLE
Check if Ryte has been enabled before doing the request

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -126,6 +126,7 @@ class Yoast_Dashboard_Widget {
 				__( 'Indexability check by %1$s', 'wordpress-seo' ),
 				'Ryte'
 			),
+			'ryteEnabled'      => ( WPSEO_Options::get( 'onpage_indexability' ) === true ),
 			'ryte_fetch'       => __( 'Fetch the current status', 'wordpress-seo' ),
 			'ryte_analyze'     => __( 'Analyze entire site', 'wordpress-seo' ),
 			'ryte_fetch_url'   => esc_attr( add_query_arg( 'wpseo-redo-onpage', '1' ) ) . '#wpseo-dashboard-overview',

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -71,7 +71,7 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 	 * @return bool True if this functionality can be used.
 	 */
 	public static function is_active() {
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX === true ) {
+		if ( wp_doing_ajax() ) {
 			return false;
 		}
 

--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -64,6 +64,10 @@ class DashboardWidget extends React.Component {
 	 * @returns {void}
 	 */
 	getRyte() {
+		if ( wpseoDashboardWidgetL10n.ryteEnabled !== "1" ) {
+			return;
+		}
+
 		wpseoApi.get( "ryte", ( response ) => {
 			if ( ! response.ryte ) {
 				return;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where we keep calling the Ryte endpoint even if the Ryte feature has been disabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout trunk
* Disable the Ryte feature under Yoast -> Features
* Go to the dashboard
* In the network tab of the debugging tools a request to yoast/v1/ryte has been done.
* Checkout this branch
* See the request not being done.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11750