### PR TITLE
Register hooks isn't doing anything, remove it

### DIFF
--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -8,15 +8,7 @@
 /**
  * WPSEO_Content_Images
  */
-class WPSEO_Content_Images implements WPSEO_WordPress_Integration {
-
-	/**
-	 * Registers the hooks.
-	 *
-	 * @return void
-	 */
-	public function register_hooks() {
-	}
+class WPSEO_Content_Images {
 
 	/**
 	 * Retrieves images from the post content.
@@ -126,5 +118,16 @@ class WPSEO_Content_Images implements WPSEO_WordPress_Integration {
 	 */
 	public function clear_cached_images( $post_id ) {
 		_deprecated_function( __METHOD__, '7.7.0' );
+	}
+
+	/**
+	 * Registers the hooks.
+	 *
+	 * @deprecated 9.5
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		_deprecated_function( __METHOD__, 'WPSEO 9.5' );
 	}
 }

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -123,11 +123,12 @@ class WPSEO_Content_Images {
 	/**
 	 * Registers the hooks.
 	 *
-	 * @deprecated 9.5
+	 * @deprecated 9.6
+	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */
 	public function register_hooks() {
-		_deprecated_function( __METHOD__, 'WPSEO 9.5' );
+		_deprecated_function( __METHOD__, 'WPSEO 9.6' );
 	}
 }

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -338,9 +338,6 @@ function wpseo_init() {
 	$wpseo_onpage = new WPSEO_OnPage();
 	$wpseo_onpage->register_hooks();
 
-	$wpseo_content_images = new WPSEO_Content_Images();
-	$wpseo_content_images->register_hooks();
-
 	// When namespaces are not available, stop further execution.
 	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
 		require_once WPSEO_PATH . 'src/loaders/indexable.php';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes an unnecessary instantiation of `WPSEO_Content_Images`

## Relevant technical choices:

* This class has an empty `register_hooks` method. This method contained logic to remove cache, but that has been removed in 7.7. Decided to deprecate the method and remove that instantiation of the class.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure everything still works. There is no visible change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11319
