### PR TITLE
Rename Focus KW to Keyphrase in Screen Options

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -75,7 +75,7 @@ class WPSEO_Meta_Columns {
 		$added_columns['wpseo-metadesc'] = __( 'Meta Desc.', 'wordpress-seo' );
 
 		if ( $this->analysis_seo->is_enabled() ) {
-			$added_columns['wpseo-focuskw'] = __( 'Focus KW', 'wordpress-seo' );
+			$added_columns['wpseo-focuskw'] = __( 'Keyphrase', 'wordpress-seo' );
 		}
 
 		return array_merge( $columns, $added_columns );

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -44,7 +44,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	public function get_values() {
 		$values = array();
 
-		// Todo: a column needs to be added on the termpages to add a filter for the keyword, so this can be used in the focus kw doubles.
+		// Todo: a column needs to be added on the termpages to add a filter for the keyword, so this can be used in the focus keyphrase doubles.
 		if ( is_object( $this->term ) && property_exists( $this->term, 'taxonomy' ) ) {
 			$values = array(
 				'search_url'        => $this->search_url(),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Renames the "Focus KW" column to "Keyphrase" on the content-type overview pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #11794 
