### PR TITLE
GSC table: Avoid to print out the same button twice

### DIFF
--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -217,6 +217,20 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Generates and display row actions links for the list table.
+	 *
+	 * We override the parent class method to avoid doubled buttons to be printed out.
+	 *
+	 * @param object $item        The item being acted upon.
+	 * @param string $column_name Current column name.
+	 * @param string $primary     Primary column name.
+	 * @return string Empty string.
+	 */
+	protected function handle_row_actions( $item, $column_name, $primary ) {
+		return '';
+	}
+
+	/**
 	 * Running the setup of the columns
 	 */
 	private function setup_columns() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the Google Search Console table accessibility by removing a doubled button.

## Relevant technical choices:

- In WP 4.3 some changes were introduced to make the tables responsive, introducing new methods in the table Class
- this PR just overrides one of the methods introduced in WP 4.3 which, in combination with our custom implementation, printed out a double button to expand a table row

## Test instructions

- go in the GSC table page, authenticate to see the table filled with rows
- on trunk:
- in the responsive view, check there are actually 2 buttons to expand a row: they're perfectly overlapped so check the markup

<img width="580" alt="screenshot 2018-12-13 at 11 40 19" src="https://user-images.githubusercontent.com/1682452/49933481-07a77a80-fecc-11e8-8338-2c45e42661e5.png">

- switch to this branch
- check there's now just one button


Fixes #5958
