### PR TITLE
CS: Each parameter should start on a new line in multi-line function calls [2]

### DIFF
--- a/admin/config-ui/class-configuration-options-adapter.php
+++ b/admin/config-ui/class-configuration-options-adapter.php
@@ -72,10 +72,11 @@ class WPSEO_Configuration_Options_Adapter {
 			throw new InvalidArgumentException( 'Custom option must be callable.' );
 		}
 
-		$this->add_lookup( $class_name, self::OPTION_TYPE_CUSTOM, array(
-			$callback_get,
-			$callback_set,
-		) );
+		$this->add_lookup(
+			$class_name,
+			self::OPTION_TYPE_CUSTOM,
+			array( $callback_get, $callback_set )
+		);
 	}
 
 	/**

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -115,7 +115,8 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 		global $wpdb;
 
 		return (int) $wpdb->get_var(
-			$wpdb->prepare( '
+			$wpdb->prepare(
+				'
 				SELECT COUNT( 1 )
 				FROM ' . $wpdb->postmeta . '
 				WHERE post_id IN( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = %s ) &&

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -193,12 +193,14 @@ class WPSEO_Metabox_Formatter {
 			'link'                     => WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ),
 			'other'                    => sprintf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
-				__( 'Other benefits of %s for you:', 'wordpress-seo' ), 'Yoast SEO Premium'
+				__( 'Other benefits of %s for you:', 'wordpress-seo' ),
+				'Yoast SEO Premium'
 			),
 			'buylink'                  => WPSEO_Shortlinker::get( 'https://yoa.st/add-keywords-popup' ),
 			'buy'                      => sprintf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
-				__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium'
+				__( 'Get %s', 'wordpress-seo' ),
+				'Yoast SEO Premium'
 			),
 			'small'                    => __( '1 year free updates and upgrades included!', 'wordpress-seo' ),
 			'a11yNotice.opensInNewTab' => __( '(Opens in a new browser tab)', 'wordpress-seo' ),

--- a/admin/links/class-link-column-count.php
+++ b/admin/links/class-link-column-count.php
@@ -56,7 +56,8 @@ class WPSEO_Link_Column_Count {
 		$storage = new WPSEO_Meta_Storage();
 
 		$results = $wpdb->get_results(
-			$wpdb->prepare( '
+			$wpdb->prepare(
+				'
 				SELECT internal_link_count, incoming_link_count, object_id
 				FROM ' . $storage->get_table_name() . '
 				WHERE object_id IN (' . implode( ',', array_fill( 0, count( $post_ids ), '%d' ) ) . ')',

--- a/admin/links/class-link-factory.php
+++ b/admin/links/class-link-factory.php
@@ -42,10 +42,10 @@ class WPSEO_Link_Factory {
 	 */
 	public function build( array $extracted_links ) {
 		$extracted_links = array_map( array( $this, 'build_link' ), $extracted_links );
-		$filtered_links  = array_filter( $extracted_links, array(
-			$this->filter,
-			'internal_link_with_fragment_filter',
-		) );
+		$filtered_links  = array_filter(
+			$extracted_links,
+			array( $this->filter, 'internal_link_with_fragment_filter' )
+		);
 
 		return $filtered_links;
 	}

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -82,7 +82,8 @@ class WPSEO_Link_Reindex_Dashboard {
 		$blocks = array();
 
 		if ( ! $this->has_unprocessed() ) {
-			$inner_text = sprintf( '<p>%s</p>',
+			$inner_text = sprintf(
+				'<p>%s</p>',
 				esc_html__( 'All your texts are already counted, there is no need to count them again.', 'wordpress-seo' )
 			);
 		}
@@ -99,7 +100,8 @@ class WPSEO_Link_Reindex_Dashboard {
 			$inner_text .= sprintf( '<p>%s</p>', $progress );
 		}
 
-		$blocks[] = sprintf( '<div><p>%s</p>%s</div>',
+		$blocks[] = sprintf(
+			'<div><p>%s</p>%s</div>',
 			esc_html__( 'Counting links in your texts', 'wordpress-seo' ),
 			$inner_text
 		);

--- a/admin/links/class-link-storage.php
+++ b/admin/links/class-link-storage.php
@@ -72,7 +72,8 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 		global $wpdb;
 
 		$results = $this->database_proxy->get_results(
-			$wpdb->prepare( '
+			$wpdb->prepare(
+				'
 				SELECT url, post_id, target_post_id, type
 				FROM ' . $this->get_table_name() . '
 				WHERE post_id = %d',

--- a/admin/menu/class-replacevar-editor.php
+++ b/admin/menu/class-replacevar-editor.php
@@ -72,7 +72,8 @@ class WPSEO_Replacevar_Editor {
 		$this->yform->hidden( $this->arguments['title'], $this->arguments['title'] );
 		$this->yform->hidden( $this->arguments['description'], $this->arguments['description'] );
 
-		printf( '<div
+		printf(
+			'<div
 				data-react-replacevar-editor
 				data-react-replacevar-title-field-id="%1$s"
 				data-react-replacevar-metadesc-field-id="%2$s"

--- a/admin/menu/class-replacevar-field.php
+++ b/admin/menu/class-replacevar-field.php
@@ -61,12 +61,13 @@ class WPSEO_Replacevar_Field {
 	public function render() {
 		$this->yform->hidden( $this->field_id, $this->field_id );
 
-		printf( '<div
-			data-react-replacevar-field
-			data-react-replacevar-field-id="%1$s"
-			data-react-replacevar-field-label="%2$s"
-			data-react-replacevar-page-type-recommended="%3$s"
-			data-react-replacevar-page-type-specific="%4$s"></div>',
+		printf(
+			'<div
+				data-react-replacevar-field
+				data-react-replacevar-field-id="%1$s"
+				data-react-replacevar-field-label="%2$s"
+				data-react-replacevar-page-type-recommended="%3$s"
+				data-react-replacevar-page-type-specific="%4$s"></div>',
 			esc_attr( $this->field_id ),
 			esc_attr( $this->label ),
 			esc_attr( $this->page_type_recommended ),

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -193,12 +193,15 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				$tab_registered = true;
 			}
 
-			add_meta_box( 'wpseo_meta', $product_title, array(
-				$this,
-				'meta_box',
-			), $post_type, 'normal', apply_filters( 'wpseo_metabox_prio', 'high' ), array(
-				'__block_editor_compatible_meta_box' => true,
-			) );
+			add_meta_box(
+				'wpseo_meta',
+				$product_title,
+				array( $this, 'meta_box' ),
+				$post_type,
+				'normal',
+				apply_filters( 'wpseo_metabox_prio', 'high' ),
+				array( '__block_editor_compatible_meta_box' => true )
+			);
 		}
 	}
 
@@ -305,8 +308,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	public function meta_box() {
 		$content_sections = $this->get_content_sections();
 
-		$helpcenter_tab = new WPSEO_Option_Tab( 'metabox', __( 'Meta box', 'wordpress-seo' ),
-			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ) ) );
+		$helpcenter_tab = new WPSEO_Option_Tab(
+			'metabox',
+			__( 'Meta box', 'wordpress-seo' ),
+			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-screencast' ) )
+		);
 
 		$help_center = new WPSEO_Help_Center( '', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );
 		$help_center->localize_data();
@@ -433,7 +439,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return string
 	 */
 	private function get_buy_premium_link() {
-		return sprintf( '<div class="%1$s"><a target="_blank" rel="noopener noreferrer" href="%2$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%3$s</a></div>',
+		return sprintf(
+			'<div class="%1$s"><a target="_blank" rel="noopener noreferrer" href="%2$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%3$s</a></div>',
 			'wpseo-metabox-buy-premium',
 			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ) ),
 			__( 'Go Premium', 'wordpress-seo' )

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -66,8 +66,11 @@ class WPSEO_Taxonomy_Metabox {
 
 		echo '<div class="inside">';
 
-		$helpcenter_tab = new WPSEO_Option_Tab( 'tax-metabox', __( 'Meta box', 'wordpress-seo' ),
-			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-taxonomy-screencast' ) ) );
+		$helpcenter_tab = new WPSEO_Option_Tab(
+			'tax-metabox',
+			__( 'Meta box', 'wordpress-seo' ),
+			array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/metabox-taxonomy-screencast' ) )
+		);
 
 		$helpcenter = new WPSEO_Help_Center( 'tax-metabox', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );
 		$helpcenter->localize_data();
@@ -240,7 +243,8 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return string
 	 */
 	private function get_buy_premium_link() {
-		return sprintf( "<div class='%s'><a href='#wpseo-meta-section-premium' class='wpseo-meta-section-link'><span class='dashicons dashicons-star-filled wpseo-buy-premium'></span>%s</a></div>",
+		return sprintf(
+			"<div class='%s'><a href='#wpseo-meta-section-premium' class='wpseo-meta-section-link'><span class='dashicons dashicons-star-filled wpseo-buy-premium'></span>%s</a></div>",
 			'wpseo-metabox-buy-premium',
 			__( 'Go Premium', 'wordpress-seo' )
 		);
@@ -252,29 +256,30 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return WPSEO_Metabox_Section
 	 */
 	private function get_buy_premium_section() {
-		$content = sprintf( "<div class='wpseo-premium-description'>
-			%s
-			<ul class='wpseo-premium-advantages-list'>
-				<li>
-					<strong>%s</strong> - %s
-				</li>
-				<li>
-					<strong>%s</strong> - %s
-				</li>
-				<li>
-					<strong>%s</strong> - %s
-				</li>
-				<li>
-					<strong>%s</strong> - %s
-				</li>
-			</ul>
-
-			<a target='_blank' id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
+		$content = sprintf(
+			"<div class='wpseo-premium-description'>
 				%s
-			</a>
-
-			<p><a target='_blank' class='wpseo-metabox-go-to' href='%s'>%s</a></p>
-		</div>",
+				<ul class='wpseo-premium-advantages-list'>
+					<li>
+						<strong>%s</strong> - %s
+					</li>
+					<li>
+						<strong>%s</strong> - %s
+					</li>
+					<li>
+						<strong>%s</strong> - %s
+					</li>
+					<li>
+						<strong>%s</strong> - %s
+					</li>
+				</ul>
+	
+				<a target='_blank' id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
+					%s
+				</a>
+	
+				<p><a target='_blank' class='wpseo-metabox-go-to' href='%s'>%s</a></p>
+			</div>",
 			/* translators: %1$s expands to Yoast SEO Premium. */
 			sprintf( __( 'You\'re not getting the benefits of %1$s yet. If you had %1$s, you could use its awesome features:', 'wordpress-seo' ), 'Yoast SEO Premium' ),
 			__( 'Redirect manager', 'wordpress-seo' ),

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -140,9 +140,11 @@ class WPSEO_Taxonomy {
 
 			$asset_manager->enqueue_script( 'admin-media' );
 
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-media', 'wpseoMediaL10n', array(
-				'choose_image' => __( 'Use Image', 'wordpress-seo' ),
-			) );
+			wp_localize_script(
+				WPSEO_Admin_Asset_Manager::PREFIX . 'admin-media',
+				'wpseoMediaL10n',
+				array( 'choose_image' => __( 'Use Image', 'wordpress-seo' ) )
+			);
 		}
 
 		if ( self::is_term_overview( $pagenow ) ) {

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -97,8 +97,11 @@ if ( isset( $msg ) && ! empty( $msg ) ) {
 	echo '<div id="message" class="notice notice-success"><p>', esc_html( $msg ), '</p></div>';
 }
 
-$helpcenter_tab = new WPSEO_Option_Tab( 'bulk-editor', __( 'Bulk editor', 'wordpress-seo' ),
-	array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-file-editor' ) ) );
+$helpcenter_tab = new WPSEO_Option_Tab(
+	'bulk-editor',
+	__( 'Bulk editor', 'wordpress-seo' ),
+	array( 'video_url' => WPSEO_Shortlinker::get( 'https://yoa.st/screencast-tools-file-editor' ) )
+);
 
 $helpcenter = new WPSEO_Help_Center( 'bulk-editor', $helpcenter_tab, WPSEO_Utils::is_yoast_seo_premium() );
 $helpcenter->localize_data();

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -117,8 +117,11 @@ foreach ( $tabs as $identifier => $tab ) {
 	if ( ! empty( $tab['screencast_video_url'] ) ) {
 		$tab_video_url = $tab['screencast_video_url'];
 
-		$helpcenter_tab = new WPSEO_Option_Tab( $identifier, $tab['label'],
-			array( 'video_url' => $tab['screencast_video_url'] ) );
+		$helpcenter_tab = new WPSEO_Option_Tab(
+			$identifier,
+			$tab['label'],
+			array( 'video_url' => $tab['screencast_video_url'] )
+		);
 	}
 
 	$helpcenter_tabs->add_tab( $helpcenter_tab );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -329,7 +329,8 @@ class WPSEO_Upgrade {
 		$meta_key = $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY;
 
 		$usermetas = $wpdb->get_results(
-			$wpdb->prepare( '
+			$wpdb->prepare(
+				'
 				SELECT user_id, meta_value
 				FROM ' . $wpdb->usermeta . '
 				WHERE meta_key = %s AND meta_value LIKE %s

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -276,9 +276,11 @@ class WPSEO_Meta {
 		foreach ( self::$meta_fields as $subset => $field_group ) {
 			foreach ( $field_group as $key => $field_def ) {
 
-				register_meta( 'post', self::$meta_prefix . $key, array(
-					'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ),
-				) );
+				register_meta(
+					'post',
+					self::$meta_prefix . $key,
+					array( 'sanitize_callback' => array( __CLASS__, 'sanitize_post_meta' ) )
+				);
 
 				// Set the $fields_index property for efficiency.
 				self::$fields_index[ self::$meta_prefix . $key ] = array(

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -20,9 +20,10 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		register_block_type( 'yoast/faq-block', array(
-			'render_callback' => array( $this, 'render' ),
-		) );
+		register_block_type(
+			'yoast/faq-block',
+			array( 'render_callback' => array( $this, 'render' ) )
+		);
 	}
 
 	/**

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -20,9 +20,10 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		register_block_type( 'yoast/how-to-block', array(
-			'render_callback' => array( $this, 'render' ),
-		) );
+		register_block_type(
+			'yoast/how-to-block',
+			array( 'render_callback' => array( $this, 'render' ) )
+		);
 	}
 
 	/**

--- a/migrations/20171228151840_WpYoastIndexable.php
+++ b/migrations/20171228151840_WpYoastIndexable.php
@@ -63,7 +63,8 @@ class WpYoastIndexable extends Ruckusing_Migration_Base {
 		// Exexcute the SQL to create the table.
 		$indexable_table->finish();
 
-		$this->add_index( $table_name,
+		$this->add_index(
+			$table_name,
 			array(
 				'permalink',
 			),

--- a/tests/admin/import/test-class-import-premium-seo-pack.php
+++ b/tests/admin/import/test-class-import-premium-seo-pack.php
@@ -354,18 +354,20 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 		remove_all_filters( 'query' );
 
 		global $wpdb;
-		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$wpdb->prefix}psp (
-			`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-			`blog_id` int(10) NOT NULL,
-			`post_id` bigint(20) NOT NULL DEFAULT '0',
-			`URL` varchar(255) NOT NULL,
-			`url_hash` varchar(32) NOT NULL,
-			`seo` text NOT NULL,
-			`date_time` datetime NOT NULL,
-			PRIMARY KEY (`id`),
-			UNIQUE KEY `url_hash` (`url_hash`) USING BTREE,
-			KEY `post_id` (`post_id`) USING BTREE,
-			KEY `blog_id_url_hash` (`blog_id`,`url_hash`) USING BTREE
-		) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8" );
+		$wpdb->query(
+			"CREATE TABLE IF NOT EXISTS {$wpdb->prefix}psp (
+				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				`blog_id` int(10) NOT NULL,
+				`post_id` bigint(20) NOT NULL DEFAULT '0',
+				`URL` varchar(255) NOT NULL,
+				`url_hash` varchar(32) NOT NULL,
+				`seo` text NOT NULL,
+				`date_time` datetime NOT NULL,
+				PRIMARY KEY (`id`),
+				UNIQUE KEY `url_hash` (`url_hash`) USING BTREE,
+				KEY `post_id` (`post_id`) USING BTREE,
+				KEY `blog_id_url_hash` (`blog_id`,`url_hash`) USING BTREE
+			) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8"
+		);
 	}
 }

--- a/tests/admin/import/test-class-import-squirrly.php
+++ b/tests/admin/import/test-class-import-squirrly.php
@@ -389,18 +389,20 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 		remove_all_filters( 'query' );
 
 		global $wpdb;
-		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$wpdb->prefix}qss (
-			`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-			`blog_id` int(10) NOT NULL,
-			`post_id` bigint(20) NOT NULL DEFAULT '0',
-			`URL` varchar(255) NOT NULL,
-			`url_hash` varchar(32) NOT NULL,
-			`seo` text NOT NULL,
-			`date_time` datetime NOT NULL,
-			PRIMARY KEY (`id`),
-			UNIQUE KEY `url_hash` (`url_hash`) USING BTREE,
-			KEY `post_id` (`post_id`) USING BTREE,
-			KEY `blog_id_url_hash` (`blog_id`,`url_hash`) USING BTREE
-		) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8" );
+		$wpdb->query(
+			"CREATE TABLE IF NOT EXISTS {$wpdb->prefix}qss (
+				`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				`blog_id` int(10) NOT NULL,
+				`post_id` bigint(20) NOT NULL DEFAULT '0',
+				`URL` varchar(255) NOT NULL,
+				`url_hash` varchar(32) NOT NULL,
+				`seo` text NOT NULL,
+				`date_time` datetime NOT NULL,
+				PRIMARY KEY (`id`),
+				UNIQUE KEY `url_hash` (`url_hash`) USING BTREE,
+				KEY `post_id` (`post_id`) USING BTREE,
+				KEY `blog_id_url_hash` (`blog_id`,`url_hash`) USING BTREE
+			) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8"
+		);
 	}
 }

--- a/tests/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/config-ui/test-class-configuration-options-adapter.php
@@ -302,10 +302,11 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 
 		$field = new WPSEO_Config_Field( 'field', 'component' );
 
-		$this->adapter->add_custom_lookup( $field->get_identifier(), '__return_true', array(
-			$catcher,
-			'set',
-		) );
+		$this->adapter->add_custom_lookup(
+			$field->get_identifier(),
+			'__return_true',
+			array( $catcher, 'set' )
+		);
 
 		$this->assertTrue( $this->adapter->set( $field, 'value' ) );
 	}

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -28,10 +28,10 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		remove_action( 'rest_api_init', array(
-			$this->configuration_service,
-			'initialize',
-		) );
+		remove_action(
+			'rest_api_init',
+			array( $this->configuration_service, 'initialize' )
+		);
 	}
 
 	/**

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -386,9 +386,8 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-image', '/test.png' );
 
 		$url = add_query_arg(
-			array(
-				'cat' => $term_id,
-			), '/'
+			array( 'cat' => $term_id ),
+			'/'
 		);
 		$this->go_to( $url );
 

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -701,12 +701,14 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function get_sample_notifications() {
 		return array(
-			new Yoast_Notification( 'notification', array(
-				'id' => 'some_id',
-			) ),
-			new Yoast_Notification( 'notification', array(
-				'id' => 'another_id',
-			) ),
+			new Yoast_Notification(
+				'notification',
+				array( 'id' => 'some_id' )
+			),
+			new Yoast_Notification(
+				'notification',
+				array( 'id' => 'another_id' )
+			),
 		);
 	}
 

--- a/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
+++ b/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
@@ -32,9 +32,9 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 		$content_src   = 'http://example.org/content-image.jpg';
 		$content_title = 'Content image title.';
 		$content_alt   = 'Content image alt.';
-		$post_id       = $this->factory->post->create( array(
-			'post_content' => "<img src='{$content_src}' title='{$content_title}' alt='{$content_alt}' />",
-		) );
+		$post_id       = $this->factory->post->create(
+			array( 'post_content' => "<img src='{$content_src}' title='{$content_title}' alt='{$content_alt}' />" )
+		);
 
 		$images = self::$class_instance->get_images( get_post( $post_id ) );
 		$this->assertNotEmpty( $images[0] );

--- a/tests/src/unit-tests/config/database-migration-test.php
+++ b/tests/src/unit-tests/config/database-migration-test.php
@@ -148,7 +148,8 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	 */
 	public function test_get_charset() {
 		$instance = new Database_Migration_Double(
-			(object) array( 'charset' => 'foo' ), new Dependency_Management()
+			(object) array( 'charset' => 'foo' ),
+			new Dependency_Management()
 		);
 
 		$this->assertEquals( 'foo', $instance->get_charset() );
@@ -161,7 +162,8 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	 */
 	public function test_get_configuration() {
 		$instance = new Database_Migration_Double(
-			(object) array( 'charset' => 'foo' ), new Dependency_Management()
+			(object) array( 'charset' => 'foo' ),
+			new Dependency_Management()
 		);
 
 		$this->assertInternalType( 'array', $instance->get_configuration() );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -425,29 +425,41 @@ function wpseo_admin_init() {
  */
 function wpseo_cli_init() {
 	if ( WPSEO_Utils::is_yoast_seo_premium() ) {
-		WP_CLI::add_command( 'yoast redirect list', 'WPSEO_CLI_Redirect_List_Command', array(
-			'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
-		) );
+		WP_CLI::add_command(
+			'yoast redirect list',
+			'WPSEO_CLI_Redirect_List_Command',
+			array( 'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce' )
+		);
 
-		WP_CLI::add_command( 'yoast redirect create', 'WPSEO_CLI_Redirect_Create_Command', array(
-			'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
-		) );
+		WP_CLI::add_command(
+			'yoast redirect create',
+			'WPSEO_CLI_Redirect_Create_Command',
+			array( 'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce' )
+		);
 
-		WP_CLI::add_command( 'yoast redirect update', 'WPSEO_CLI_Redirect_Update_Command', array(
-			'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
-		) );
+		WP_CLI::add_command(
+			'yoast redirect update',
+			'WPSEO_CLI_Redirect_Update_Command',
+			array( 'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce' )
+		);
 
-		WP_CLI::add_command( 'yoast redirect delete', 'WPSEO_CLI_Redirect_Delete_Command', array(
-			'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
-		) );
+		WP_CLI::add_command(
+			'yoast redirect delete',
+			'WPSEO_CLI_Redirect_Delete_Command',
+			array( 'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce' )
+		);
 
-		WP_CLI::add_command( 'yoast redirect has', 'WPSEO_CLI_Redirect_Has_Command', array(
-			'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
-		) );
+		WP_CLI::add_command(
+			'yoast redirect has',
+			'WPSEO_CLI_Redirect_Has_Command',
+			array( 'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce' )
+		);
 
-		WP_CLI::add_command( 'yoast redirect follow', 'WPSEO_CLI_Redirect_Follow_Command', array(
-			'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce',
-		) );
+		WP_CLI::add_command(
+			'yoast redirect follow',
+			'WPSEO_CLI_Redirect_Follow_Command',
+			array( 'before_invoke' => 'WPSEO_CLI_Premium_Requirement::enforce' )
+		);
 	}
 
 	// Only add the namespace if the required base class exists (WP-CLI 1.5.0+).


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding- Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding- Standards/issues/1330

This commit addresses multi-line function calls where parameters did not each start  on a new line.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.