### PR TITLE
CS: Move static arrays to a class property [4]

### DIFF
--- a/tests/admin/test-class-admin-asset-dev-server-location.php
+++ b/tests/admin/test-class-admin-asset-dev-server-location.php
@@ -11,15 +11,22 @@
 final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestCase {
 
 	/**
+	 * Default arguments to use for creating a new Admin_Asset.
+	 *
+	 * @var array
+	 */
+	private $asset_defaults = array(
+		'name' => 'commons',
+		'src'  => 'commons',
+	);
+
+	/**
 	 * Basic get_url test.
 	 *
 	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url()
 	 */
 	public function test_get_url() {
-		$asset = new WPSEO_Admin_Asset( array(
-			'name' => 'commons',
-			'src'  => 'commons',
-		) );
+		$asset = new WPSEO_Admin_Asset( $this->asset_defaults );
 
 		$dev_server_location = new WPSEO_Admin_Asset_Dev_Server_Location();
 
@@ -34,10 +41,7 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url()
 	 */
 	public function test_get_url_different_url() {
-		$asset = new WPSEO_Admin_Asset( array(
-			'name' => 'commons',
-			'src'  => 'commons',
-		) );
+		$asset = new WPSEO_Admin_Asset( $this->asset_defaults );
 
 		$dev_server_location = new WPSEO_Admin_Asset_Dev_Server_Location( 'https://localhost:8081' );
 
@@ -55,10 +59,9 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url()
 	 */
 	public function test_get_url_default() {
-		$asset = new WPSEO_Admin_Asset( array(
-			'name' => 'commons',
-			'src'  => 'select2',
-		) );
+		$asset_args        = $this->asset_defaults;
+		$asset_args['src'] = 'select2';
+		$asset             = new WPSEO_Admin_Asset( $asset_args );
 
 		$dev_server_location = new WPSEO_Admin_Asset_Dev_Server_Location();
 		$default_location    = new WPSEO_Admin_Asset_SEO_Location( WPSEO_FILE );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Remove some code duplication by setting a repeated array up as a class property instead.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
