### PR TITLE
CS: Move static arrays to a class property [5]

### DIFF
--- a/tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -17,6 +17,19 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	protected static $network_administrator;
 
 	/**
+	 * Methods to mock for a standard Mock WPSEO_Admin_Bar_menu object.
+	 *
+	 * @var array
+	 */
+	private $mock_wpseo_admin_bar_menu_methods = array(
+		'add_root_menu',
+		'add_keyword_research_submenu',
+		'add_analysis_submenu',
+		'add_settings_submenu',
+		'add_network_settings_submenu',
+	);
+
+	/**
 	 * Sets up user instances to use in tests.
 	 *
 	 * @param WP_UnitTest_Factory $factory Unit test factory instance.
@@ -55,13 +68,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 		$admin_bar_menu = $this
 			->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
 			->setConstructorArgs( array( $this->get_asset_manager() ) )
-			->setMethods( array(
-				'add_root_menu',
-				'add_keyword_research_submenu',
-				'add_analysis_submenu',
-				'add_settings_submenu',
-				'add_network_settings_submenu',
-			) )
+			->setMethods( $this->mock_wpseo_admin_bar_menu_methods )
 			->getMock();
 
 		$admin_bar_menu
@@ -100,13 +107,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 		$admin_bar_menu = $this
 			->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
 			->setConstructorArgs( array( $this->get_asset_manager() ) )
-			->setMethods( array(
-				'add_root_menu',
-				'add_keyword_research_submenu',
-				'add_analysis_submenu',
-				'add_settings_submenu',
-				'add_network_settings_submenu',
-			) )
+			->setMethods( $this->mock_wpseo_admin_bar_menu_methods )
 			->getMock();
 
 		$admin_bar_menu


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Remove some code duplication by setting a repeated array up as a class property instead.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.