### PR TITLE
Bump YoastSEO.js to 1.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.3",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.3"
+    "yoastseo": "^1.44.0"
   },
   "yoast": {
     "pluginVersion": "9.3-beta1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12251,6 +12251,19 @@ yauzl@^2.2.1:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
+yoastseo@^1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.44.0.tgz#4d1b66a96c4d3812b6a2ae403fed7e8cc31fc2ef"
+  integrity sha512-37woRKLULGW0LYtJvXounj1dNTUmURmWYZU2e5OhaQxzk9bZFPwSYwsLIdWm2dE0Svs/2ycTcqnq+jkKnmpKVw==
+  dependencies:
+    "@wordpress/autop" "^2.0.2"
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    lodash-es "^4.17.10"
+    loglevel "^1.6.1"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.1"
+
 "yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.3":
   version "1.43.0"
   resolved "git+https://github.com/Yoast/YoastSEO.js.git#04657b482fa45a19ea290baf224aeb809ae6a8a4"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Bumps the version of YoastSEO.js to 1.44.0.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
Check whether the following work:
* Fixes a bug where keyphrases weren't recognized in the URL when the words in the URL were separated by underscore characters instead of hyphens. https://github.com/Yoast/YoastSEO.js/pull/1979
* Fixes a bug that caused numbers to be stripped when marking a keyphrase containing a number, e.g. `Yoast SEO 9.3`. https://github.com/Yoast/YoastSEO.js/pull/2016
* Improves error handling in the analysis web worker by rejecting the last request instead of just throwing an error. https://github.com/Yoast/YoastSEO.js/pull/2035


## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended