### PR TITLE
Improve internal links table headers strings and accessibility.

### DIFF
--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -174,8 +174,8 @@ class WPSEO_Link_Columns {
 
 		$columns[ 'wpseo-' . self::COLUMN_LINKS ] = sprintf(
 			'<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="%1$s"><span class="screen-reader-text">%2$s</span></span>',
-			esc_attr__( 'Number of internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ),
-			esc_html__( 'Internal links', 'wordpress-seo' )
+			esc_attr__( 'Number of outgoing internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ),
+			esc_html__( 'Outgoing internal links', 'wordpress-seo' )
 		);
 
 		if ( ! WPSEO_Link_Query::has_unprocessed_posts( $this->public_post_types ) ) {

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -171,10 +171,10 @@ class WPSEO_Link_Columns {
 		if ( ! is_array( $columns ) ) {
 			return $columns;
 		}
-		$columns[ 'wpseo-' . self::COLUMN_LINKS ] = '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-label="' . esc_attr__( 'Number of internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( '# links in post', 'wordpress-seo' ) . '</span></span>';
+		$columns[ 'wpseo-' . self::COLUMN_LINKS ] = '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'Number of internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'Internal links', 'wordpress-seo' ) . '</span></span>';
 
 		if ( ! WPSEO_Link_Query::has_unprocessed_posts( $this->public_post_types ) ) {
-			$columns[ 'wpseo-' . self::COLUMN_LINKED ] = '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-label="' . esc_attr__( 'Number of internal links linking to this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( '# internal links to', 'wordpress-seo' ) . '</span></span>';
+			$columns[ 'wpseo-' . self::COLUMN_LINKED ] = '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'Number of internal links linking to this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'Received internal links', 'wordpress-seo' ) . '</span></span>';
 		}
 
 		return $columns;

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -171,10 +171,19 @@ class WPSEO_Link_Columns {
 		if ( ! is_array( $columns ) ) {
 			return $columns;
 		}
-		$columns[ 'wpseo-' . self::COLUMN_LINKS ] = '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'Number of internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'Internal links', 'wordpress-seo' ) . '</span></span>';
+
+		$columns[ 'wpseo-' . self::COLUMN_LINKS ] = sprintf(
+			'<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="%1$s"><span class="screen-reader-text">%2$s</span></span>',
+			esc_attr__( 'Number of internal links in this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ),
+			esc_html__( 'Internal links', 'wordpress-seo' )
+		);
 
 		if ( ! WPSEO_Link_Query::has_unprocessed_posts( $this->public_post_types ) ) {
-			$columns[ 'wpseo-' . self::COLUMN_LINKED ] = '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-tooltip-text="' . esc_attr__( 'Number of internal links linking to this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ) . '"><span class="screen-reader-text">' . __( 'Received internal links', 'wordpress-seo' ) . '</span></span>';
+			$columns[ 'wpseo-' . self::COLUMN_LINKED ] = sprintf(
+				'<span class="yoast-linked-from yoast-column-header-has-tooltip" data-tooltip-text="%1$s"><span class="screen-reader-text">%2$s</span></span>',
+				esc_attr__( 'Number of internal links linking to this post. See "Yoast Columns" text in the help tab for more info.', 'wordpress-seo' ),
+				esc_html__( 'Received internal links', 'wordpress-seo' )
+			);
 		}
 
 		return $columns;

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -783,15 +783,15 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$is_editor = self::is_post_overview( $pagenow ) || self::is_post_edit( $pagenow );
 
-		/* Filter 'wpseo_always_register_metaboxes_on_admin' documented in wpseo-main.php */
-		if ( ( $is_editor === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->display_metabox() === false ) {
-			return;
-		}
-
 		if ( self::is_post_overview( $pagenow ) ) {
 			$asset_manager->enqueue_style( 'edit-page' );
 			$asset_manager->enqueue_script( 'edit-page-script' );
 
+			return;
+		}
+
+		/* Filter 'wpseo_always_register_metaboxes_on_admin' documented in wpseo-main.php */
+		if ( ( $is_editor === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->display_metabox() === false ) {
 			return;
 		}
 

--- a/js/src/wp-seo-edit-page.js
+++ b/js/src/wp-seo-edit-page.js
@@ -4,13 +4,7 @@
 		var parentLink = $( this ).closest( "th" ).find( "a" );
 
 		parentLink
-			.addClass( "yoast-tooltip yoast-tooltip-n yoast-tooltip-multiline" )
-			.attr( "aria-label", $( this ).data( "label" ) );
-	} );
-
-	// Clean up the columns titles HTML for the Screen Options checkboxes labels.
-	$( ".yoast-column-header-has-tooltip, .yoast-tooltip", "#screen-meta" ).each( function() {
-		var text = $( this ).text();
-		$( this ).replaceWith( text );
+			.addClass( "yoast-tooltip yoast-tooltip-alt yoast-tooltip-n yoast-tooltip-multiline" )
+			.attr( "data-label", $( this ).data( "tooltip-text" ) );
 	} );
 }( jQuery ) );

--- a/js/src/wp-seo-edit-page.js
+++ b/js/src/wp-seo-edit-page.js
@@ -5,6 +5,7 @@
 
 		parentLink
 			.addClass( "yoast-tooltip yoast-tooltip-alt yoast-tooltip-n yoast-tooltip-multiline" )
-			.attr( "data-label", $( this ).data( "tooltip-text" ) );
+			.attr( "data-label", $( this ).data( "tooltip-text" ) )
+			.attr( "aria-label", $( this ).text() );
 	} );
 }( jQuery ) );

--- a/tests/admin/links/test-class-link-columns.php
+++ b/tests/admin/links/test-class-link-columns.php
@@ -85,8 +85,8 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 	public function test_add_post_columns() {
 		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
 		$expected     = array(
-			'wpseo-links'  => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-label="Number of internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># links in post</span></span>',
-			'wpseo-linked' => '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-label="Number of internal links linking to this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text"># internal links to</span></span>',
+			'wpseo-links'  => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="Number of internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text">Internal links</span></span>',
+			'wpseo-linked' => '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-tooltip-text="Number of internal links linking to this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text">Received internal links</span></span>',
 		);
 
 		$this->assertEquals(

--- a/tests/admin/links/test-class-link-columns.php
+++ b/tests/admin/links/test-class-link-columns.php
@@ -85,7 +85,7 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 	public function test_add_post_columns() {
 		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
 		$expected     = array(
-			'wpseo-links'  => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="Number of internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text">Internal links</span></span>',
+			'wpseo-links'  => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="Number of outgoing internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text">Outgoing internal links</span></span>',
 			'wpseo-linked' => '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-tooltip-text="Number of internal links linking to this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text">Received internal links</span></span>',
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the Internal links table headers text for better translations and accessibility.

## Relevant technical choices:

- changes the table headers text from `# links to this post` / `# internal links to` to batter translatable `Internal links` and `Received internal links` as asked in #7655
- makes the tooltips only a visual aid: screen reader users will perceive the visually hidden text, which is simpler and shorter, instead of the whole tooltip text. this addresses #7385 
- removes some no longer used JS
- moves the enqueueing of the related CSS and JS above a conditional check that was preventing the tooltip to work correctly in the Pages screen. See #11829

## Test instructions
- in the Posts and Pages screens, check:
- the tooltips on the internal links icons still work correctly
- in the Screen Options, the table columns have the new names:
<img width="802" alt="screenshot 2018-12-14 at 15 14 19" src="https://user-images.githubusercontent.com/1682452/50007997-10bf4700-ffb3-11e8-8144-827616c07820.png">

- in the mobile view, expand a post row and verify the new strings are used: 
<img width="520" alt="screenshot 2018-12-14 at 15 02 07" src="https://user-images.githubusercontent.com/1682452/50008013-1d439f80-ffb3-11e8-89c6-a78aaa0c88ad.png">




Fixes #7655
Fixes #7385
