### PR TITLE
Excludes vendor directories from php-compatibility-checker

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -507,6 +507,8 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		add_action( 'plugins_loaded', 'wpseo_cli_init', 20 );
 	}
+
+	add_filter( 'phpcompat_whitelist', 'yoast_wpseo_phpcompat_whitelist' );
 }
 
 // Activation and deactivation hook.
@@ -623,4 +625,19 @@ function yoast_wpseo_self_deactivate() {
 			unset( $_GET['activate'] );
 		}
 	}
+}
+
+/**
+ * Excludes vendor directories from php-compatibility-checker.
+ *
+ * @since 9.4
+ *
+ * @param array $ignored Array of ignored directories/files.
+ *
+ * @return array Array of ignored directories/files.
+ */
+function yoast_wpseo_phpcompat_whitelist( $ignored ) {
+	$ignored[] = '*/wordpress-seo/vendor*';
+
+	return $ignored;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses filter `phpcompat_whitelist` to excludes vendor directories from [php-compatibility-checker](https://github.com/wpengine/phpcompat).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install plugin [PHP Compatibility Checker](https://wordpress.org/plugins/php-compatibility-checker/)
* Scan site (Tools/PHP Compatibility)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11798
