### PR TITLE
Add sitemap posts filter

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -232,6 +232,13 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				continue;
 			}
 
+			/**
+			 * Filter: 'wpseo_sitemap_entries' - Allow modifying the posts to include.
+			 *
+			 * @param array $posts Array of posts.
+			 */
+			$posts = apply_filters( 'wpseo_sitemap_entries', $posts );
+
 			foreach ( $posts as $post ) {
 
 				if ( in_array( $post->ID, $posts_to_exclude, true ) ) {

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -102,6 +102,24 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the included posts with the usage of the filter.
+	 *
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links()
+	 */
+	public function test_get_sitemap_links_with_set_filter() {
+		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
+
+		add_filter( 'wpseo_sitemap_entries', array( $this, 'filter_posts_with_output' ) );
+
+		$this->factory->post->create();
+
+		// Expect the created post to be duplicated in the sitemap list.
+		$this->assertCount( 2, self::$class_instance->get_sitemap_links( 'post', 100, 0 ) );
+
+		remove_filter( 'wpseo_sitemap_entries', array( $this, 'filter_posts_with_output' ) );
+	}
+
+	/**
 	 * Tests the excluded posts with the usage of the filter.
 	 *
 	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_excluded_posts()
@@ -137,6 +155,17 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( array(), $sitemap_provider->get_excluded_posts( 'post' ) );
 
 		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_invalid_output' ) );
+	}
+
+	/**
+	 * Filter method for test.
+	 *
+	 * @param array $posts The included post objects.
+	 *
+	 * @return array Duplicated array of posts.
+	 */
+	public function filter_posts_with_output( $posts ) {
+		return array_merge($posts, $posts);
 	}
 
 	/**


### PR DESCRIPTION
I have some specific needs which lead me to the need of editing the full `$posts` array for every generated sitemap. I took a look at `class-post-type-sitemap-provider.php` file, specifically at `get_sitemap_links` method, so I noticed no filter was already provided for this.

## Summary

This PR can be summarized in the following changelog entry:

* Add a new filter for sitemap posts array: `wpseo_sitemap_entries`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add an `add_filter` that hooks to the new `wpseo_sitemap_entries` filter from your theme or plugin.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
