### PR TITLE
CS: Move multi-line parameters out of function calls [9]

### DIFF
--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -227,11 +227,20 @@ class Yoast_Model {
 	 * @return string The table name.
 	 */
 	protected static function _class_name_to_table_name( $class_name ) {
-		return \strtolower( \preg_replace( array( '/\\\\/', '/(?<=[a-z])([A-Z])/', '/__/' ), array(
+		$find         = array(
+			'/\\\\/',
+			'/(?<=[a-z])([A-Z])/',
+			'/__/',
+		);
+		$replacements = array(
 			'_',
 			'_$1',
 			'_',
-		), \ltrim( $class_name, '\\' ) ) );
+		);
+
+		$class_name = \ltrim( $class_name, '\\' );
+		$class_name = \preg_replace( $find, $replacements, $class_name );
+		return \strtolower( $class_name );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

This commit effectively changes the code in this function from a complicated nested multi-function call one-liner to a more readable format.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
