### PR TITLE
CS: Move multi-line parameters out of function calls [10]

### DIFF
--- a/tests/test-class-admin-asset-manager.php
+++ b/tests/test-class-admin-asset-manager.php
@@ -212,6 +212,20 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_scripts() {
 
+		$asset_args = array(
+			0 => array(
+				'name' => 'testfile',
+				'src'  => 'testfile',
+			),
+			1 => array(
+				'name'      => 'testfile2',
+				'src'       => 'testfile2',
+				'deps'      => array( 'dep1' ),
+				'version'   => 'version1',
+				'in_footer' => false,
+			),
+		);
+
 		$class_instance =
 			$this
 				->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
@@ -222,38 +236,17 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 			->expects( $this->at( 0 ) )
 			->method( 'register_script' )
 			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( array(
-					'name' => 'testfile',
-					'src'  => 'testfile',
-				)))
+				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[0] ) )
 			);
 
 		$class_instance
 			->expects( $this->at( 1 ) )
 			->method( 'register_script' )
 			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( array(
-					'name'      => 'testfile2',
-					'src'       => 'testfile2',
-					'deps'      => array( 'dep1' ),
-					'version'   => 'version1',
-					'in_footer' => false,
-				)))
+				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[1] ) )
 			);
 
-		$class_instance->register_scripts( array(
-			array(
-				'name' => 'testfile',
-				'src'  => 'testfile',
-			),
-			array(
-				'name'      => 'testfile2',
-				'src'       => 'testfile2',
-				'deps'      => array( 'dep1' ),
-				'version'   => 'version1',
-				'in_footer' => false,
-			),
-		) );
+		$class_instance->register_scripts( $asset_args );
 	}
 
 	/**
@@ -262,6 +255,20 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_styles
 	 */
 	public function test_register_styles() {
+
+		$asset_args = array(
+			0 => array(
+				'name' => 'testfile',
+				'src'  => 'testfile',
+			),
+			1 => array(
+				'name'    => 'testfile2',
+				'src'     => 'testfile2',
+				'deps'    => array( 'dep1' ),
+				'version' => 'version1',
+				'media'   => 'screen',
+			),
+		);
 
 		$class_instance =
 			$this
@@ -273,38 +280,17 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 			->expects( $this->at( 0 ) )
 			->method( 'register_style' )
 			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( array(
-					'name'      => 'testfile',
-					'src'       => 'testfile',
-				)))
+				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[0] ) )
 			);
 
 		$class_instance
 			->expects( $this->at( 1 ) )
 			->method( 'register_style' )
 			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( array(
-					'name'      => 'testfile2',
-					'src'       => 'testfile2',
-					'deps'      => array( 'dep1' ),
-					'version'   => 'version1',
-					'media'     => 'screen',
-				)))
+				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[1] ) )
 			);
 
-		$class_instance->register_styles( array(
-			array(
-				'name' => 'testfile',
-				'src'  => 'testfile',
-			),
-			array(
-				'name'    => 'testfile2',
-				'src'     => 'testfile2',
-				'deps'    => array( 'dep1' ),
-				'version' => 'version1',
-				'media'   => 'screen',
-			),
-		) );
+		$class_instance->register_styles( $asset_args );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

As the `input` for the functions being tested, as well as the `expected output` is the same, these two test methods also contained duplicate information, making the code more difficult to maintain.

This code duplication has also been removed.

Note: a further abstraction of the test data to a class property could be considered, however as the data for the two functions involved is not 100% the same and the test class contains quite some test methods which don't use the same data, I felt that it would be more obvious what the tests were doing to keep the data as a class variable.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
