### PR TITLE
CS: Move multi-line parameters out of function calls [11]

### DIFF
--- a/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/admin/taxonomy/class-taxonomy-social-fields.php
@@ -97,16 +97,24 @@ class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
 	 * @return array
 	 */
 	private function get_social_networks() {
+		// Source: https://developers.facebook.com/docs/sharing/best-practices#images.
+		$fb_image_size = sprintf(
+			/* translators: %1$s expands to the image recommended width, %2$s to its height. */
+			__( '%1$s by %2$s', 'wordpress-seo' ),
+			'1200',
+			'630'
+		);
+
+		$twitter_image_size = sprintf(
+			/* translators: %1$s expands to the image recommended width, %2$s to its height. */
+			__( '%1$s by %2$s', 'wordpress-seo' ),
+			'1024',
+			'512'
+		);
+
 		$social_networks = array(
-			// Source: https://developers.facebook.com/docs/sharing/best-practices#images.
-			'opengraph' => $this->social_network( 'opengraph', __( 'Facebook', 'wordpress-seo' ), sprintf(
-				/* translators: %1$s expands to the image recommended width, %2$s to its height. */
-				__( '%1$s by %2$s', 'wordpress-seo' ), '1200', '630'
-			) ),
-			'twitter'   => $this->social_network( 'twitter', __( 'Twitter', 'wordpress-seo' ), sprintf(
-				/* translators: %1$s expands to the image recommended width, %2$s to its height. */
-				__( '%1$s by %2$s', 'wordpress-seo' ), '1024', '512'
-			) ),
+			'opengraph' => $this->social_network( 'opengraph', __( 'Facebook', 'wordpress-seo' ), $fb_image_size ),
+			'twitter'   => $this->social_network( 'twitter', __( 'Twitter', 'wordpress-seo' ), $twitter_image_size ),
 		);
 
 		return $this->filter_social_networks( $social_networks );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
