### PR TITLE
CS: Move multi-line parameters out of function calls [12]

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -210,33 +210,42 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			}
 		}
 
-		$wp_admin_bar->add_menu( array(
+		$menu_args = array(
 			'parent' => self::MENU_IDENTIFIER,
 			'id'     => self::KEYWORD_RESEARCH_SUBMENU_IDENTIFIER,
 			'title'  => __( 'Keyword Research', 'wordpress-seo' ),
 			'meta'   => array( 'tabindex' => '0' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::KEYWORD_RESEARCH_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-kwresearchtraining',
-			'title'  => __( 'Keyword research training', 'wordpress-seo' ),
-			'href'   => WPSEO_Shortlinker::get( 'https://yoa.st/wp-admin-bar' ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::KEYWORD_RESEARCH_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-adwordsexternal',
-			'title'  => __( 'Google Ads', 'wordpress-seo' ),
-			'href'   => $adwords_url,
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::KEYWORD_RESEARCH_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-googleinsights',
-			'title'  => __( 'Google Trends', 'wordpress-seo' ),
-			'href'   => $trends_url,
-			'meta'   => array( 'target' => '_blank' ),
-		) );
+		);
+		$wp_admin_bar->add_menu( $menu_args );
+
+		$submenu_items = array(
+			array(
+				'id'     => 'wpseo-kwresearchtraining',
+				'title'  => __( 'Keyword research training', 'wordpress-seo' ),
+				'href'   => WPSEO_Shortlinker::get( 'https://yoa.st/wp-admin-bar' ),
+			),
+			array(
+				'id'     => 'wpseo-adwordsexternal',
+				'title'  => __( 'Google Ads', 'wordpress-seo' ),
+				'href'   => $adwords_url,
+			),
+			array(
+				'id'     => 'wpseo-googleinsights',
+				'title'  => __( 'Google Trends', 'wordpress-seo' ),
+				'href'   => $trends_url,
+			),
+		);
+
+		foreach ( $submenu_items as $menu_item ) {
+			$menu_args = array(
+				'parent' => self::KEYWORD_RESEARCH_SUBMENU_IDENTIFIER,
+				'id'     => $menu_item['id'],
+				'title'  => $menu_item['title'],
+				'href'   => $menu_item['href'],
+				'meta'   => array( 'target' => '_blank' ),
+			);
+			$wp_admin_bar->add_menu( $menu_args );
+		}
 	}
 
 	/**
@@ -259,90 +268,84 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			$focus_keyword = $this->get_post_focus_keyword( $post );
 		}
 
-		$wp_admin_bar->add_menu( array(
+		$menu_args = array(
 			'parent' => self::MENU_IDENTIFIER,
 			'id'     => self::ANALYSIS_SUBMENU_IDENTIFIER,
 			'title'  => __( 'Analyze this page', 'wordpress-seo' ),
 			'meta'   => array( 'tabindex' => '0' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-inlinks',
-			'title'  => __( 'Check links to this URL', 'wordpress-seo' ),
-			'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . urlencode( $url ) . '&domain=',
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-kwdensity',
-			'title'  => __( 'Check Keyphrase Density', 'wordpress-seo' ),
-			// HTTPS not available.
-			'href'   => 'http://www.zippy.co.uk/keyworddensity/index.php?url=' . urlencode( $url ) . '&keyword=' . urlencode( $focus_keyword ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-cache',
-			'title'  => __( 'Check Google Cache', 'wordpress-seo' ),
-			'href'   => '//webcache.googleusercontent.com/search?strip=1&q=cache:' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-header',
-			'title'  => __( 'Check Headers', 'wordpress-seo' ),
-			'href'   => '//quixapp.com/headers/?r=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-structureddata',
-			'title'  => __( 'Google Structured Data Test', 'wordpress-seo' ),
-			'href'   => 'https://search.google.com/structured-data/testing-tool#url=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-facebookdebug',
-			'title'  => __( 'Facebook Debugger', 'wordpress-seo' ),
-			'href'   => '//developers.facebook.com/tools/debug/og/object?q=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-pinterestvalidator',
-			'title'  => __( 'Pinterest Rich Pins Validator', 'wordpress-seo' ),
-			'href'   => 'https://developers.pinterest.com/tools/url-debugger/?link=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-htmlvalidation',
-			'title'  => __( 'HTML Validator', 'wordpress-seo' ),
-			'href'   => '//validator.w3.org/check?uri=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-cssvalidation',
-			'title'  => __( 'CSS Validator', 'wordpress-seo' ),
-			'href'   => '//jigsaw.w3.org/css-validator/validator?uri=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-pagespeed',
-			'title'  => __( 'Google Page Speed Test', 'wordpress-seo' ),
-			'href'   => '//developers.google.com/speed/pagespeed/insights/?url=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
-		$wp_admin_bar->add_menu( array(
-			'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
-			'id'     => 'wpseo-google-mobile-friendly',
-			'title'  => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
-			'href'   => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . urlencode( $url ),
-			'meta'   => array( 'target' => '_blank' ),
-		) );
+		);
+		$wp_admin_bar->add_menu( $menu_args );
+
+		$encoded_url   = urlencode( $url );
+		$submenu_items = array(
+			array(
+				'id'     => 'wpseo-inlinks',
+				'title'  => __( 'Check links to this URL', 'wordpress-seo' ),
+				'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . $encoded_url . '&domain=',
+			),
+			array(
+				'id'     => 'wpseo-kwdensity',
+				'title'  => __( 'Check Keyphrase Density', 'wordpress-seo' ),
+				// HTTPS not available.
+				'href'   => 'http://www.zippy.co.uk/keyworddensity/index.php?url=' . $encoded_url . '&keyword=' . urlencode( $focus_keyword ),
+			),
+			array(
+				'id'     => 'wpseo-cache',
+				'title'  => __( 'Check Google Cache', 'wordpress-seo' ),
+				'href'   => '//webcache.googleusercontent.com/search?strip=1&q=cache:' . $encoded_url,
+			),
+			array(
+				'id'     => 'wpseo-header',
+				'title'  => __( 'Check Headers', 'wordpress-seo' ),
+				'href'   => '//quixapp.com/headers/?r=' . urlencode( $url ),
+			),
+			array(
+				'id'     => 'wpseo-structureddata',
+				'title'  => __( 'Google Structured Data Test', 'wordpress-seo' ),
+				'href'   => 'https://search.google.com/structured-data/testing-tool#url=' . $encoded_url,
+			),
+			array(
+				'id'     => 'wpseo-facebookdebug',
+				'title'  => __( 'Facebook Debugger', 'wordpress-seo' ),
+				'href'   => '//developers.facebook.com/tools/debug/og/object?q=' . $encoded_url,
+			),
+			array(
+				'id'     => 'wpseo-pinterestvalidator',
+				'title'  => __( 'Pinterest Rich Pins Validator', 'wordpress-seo' ),
+				'href'   => 'https://developers.pinterest.com/tools/url-debugger/?link=' . $encoded_url,
+			),
+			array(
+				'id'     => 'wpseo-htmlvalidation',
+				'title'  => __( 'HTML Validator', 'wordpress-seo' ),
+				'href'   => '//validator.w3.org/check?uri=' . $encoded_url,
+			),
+			array(
+				'id'     => 'wpseo-cssvalidation',
+				'title'  => __( 'CSS Validator', 'wordpress-seo' ),
+				'href'   => '//jigsaw.w3.org/css-validator/validator?uri=' . $encoded_url,
+			),
+			array(
+				'id'     => 'wpseo-pagespeed',
+				'title'  => __( 'Google Page Speed Test', 'wordpress-seo' ),
+				'href'   => '//developers.google.com/speed/pagespeed/insights/?url=' . $encoded_url,
+			),
+			array(
+				'id'     => 'wpseo-google-mobile-friendly',
+				'title'  => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
+				'href'   => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . $encoded_url,
+			),
+		);
+
+		foreach ( $submenu_items as $menu_item ) {
+			$menu_args = array(
+				'parent' => self::ANALYSIS_SUBMENU_IDENTIFIER,
+				'id'     => $menu_item['id'],
+				'title'  => $menu_item['title'],
+				'href'   => $menu_item['href'],
+				'meta'   => array( 'target' => '_blank' ),
+			);
+			$wp_admin_bar->add_menu( $menu_args );
+		}
 	}
 
 	/**
@@ -360,12 +363,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$admin_menu    = new WPSEO_Admin_Menu( new WPSEO_Menu() );
 		$submenu_pages = $admin_menu->get_submenu_pages();
 
-		$wp_admin_bar->add_menu( array(
+		$menu_args = array(
 			'parent' => self::MENU_IDENTIFIER,
 			'id'     => self::SETTINGS_SUBMENU_IDENTIFIER,
 			'title'  => __( 'SEO Settings', 'wordpress-seo' ),
 			'meta'   => array( 'tabindex' => '0' ),
-		) );
+		);
+		$wp_admin_bar->add_menu( $menu_args );
 
 		foreach ( $submenu_pages as $submenu_page ) {
 			if ( ! current_user_can( $submenu_page[3] ) ) {
@@ -377,12 +381,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				$id = 'wpseo-general';
 			}
 
-			$wp_admin_bar->add_menu( array(
+			$menu_args = array(
 				'parent' => self::SETTINGS_SUBMENU_IDENTIFIER,
 				'id'     => $id,
 				'title'  => $submenu_page[2],
 				'href'   => admin_url( 'admin.php?page=' . urlencode( $submenu_page[4] ) ),
-			) );
+			);
+			$wp_admin_bar->add_menu( $menu_args );
 		}
 	}
 
@@ -401,12 +406,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$network_admin_menu = new WPSEO_Network_Admin_Menu( new WPSEO_Menu() );
 		$submenu_pages      = $network_admin_menu->get_submenu_pages();
 
-		$wp_admin_bar->add_menu( array(
+		$menu_args = array(
 			'parent' => self::MENU_IDENTIFIER,
 			'id'     => self::NETWORK_SETTINGS_SUBMENU_IDENTIFIER,
 			'title'  => __( 'SEO Settings', 'wordpress-seo' ),
 			'meta'   => array( 'tabindex' => '0' ),
-		) );
+		);
+		$wp_admin_bar->add_menu( $menu_args );
 
 		foreach ( $submenu_pages as $submenu_page ) {
 			if ( ! current_user_can( $submenu_page[3] ) ) {
@@ -418,12 +424,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				$id = 'wpseo-general';
 			}
 
-			$wp_admin_bar->add_menu( array(
+			$menu_args = array(
 				'parent' => self::NETWORK_SETTINGS_SUBMENU_IDENTIFIER,
 				'id'     => $id,
 				'title'  => $submenu_page[2],
 				'href'   => network_admin_url( 'admin.php?page=' . urlencode( $submenu_page[4] ) ),
-			) );
+			);
+			$wp_admin_bar->add_menu( $menu_args );
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

This commit effectively refactors the code in these functions and removes duplicate code.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
