### PR TITLE
CS: Move multi-line parameters out of function calls [13]

### DIFF
--- a/src/wordpress/integration-group.php
+++ b/src/wordpress/integration-group.php
@@ -42,12 +42,11 @@ class Integration_Group implements Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		array_map(
-			function( Integration $integration ) {
-				$integration->register_hooks();
-			},
-			$this->integrations
-		);
+		$register_hooks = function( Integration $integration ) {
+			$integration->register_hooks();
+		};
+
+		array_map( $register_hooks, $this->integrations );
 	}
 
 	/**
@@ -58,8 +57,10 @@ class Integration_Group implements Integration {
 	 * @return array List of Integrations.
 	 */
 	protected function ensure_integration( array $integrations ) {
-		return array_filter( $integrations, function( $integration ) {
+		$is_integration = function( $integration ) {
 			return $integration instanceof Integration;
-		} );
+		};
+
+		return array_filter( $integrations, $is_integration );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
