### PR TITLE
CS: Miscellanous other function call related fixes

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -205,13 +205,17 @@ class WPSEO_Help_Center {
 		$popup_content .= '<li>' . sprintf(
 			// We don't use strong text here, but we do use it in the "Add keyword" popup, this is just to have the same translatable strings.
 			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-				__( '%1$sNo more dead links%2$s: easy redirect manager', 'wordpress-seo' ), '', ''
+			__( '%1$sNo more dead links%2$s: easy redirect manager', 'wordpress-seo' ),
+			'',
+			''
 		) . '</li>';
 		$popup_content .= '<li>' . __( 'Superfast internal links suggestions', 'wordpress-seo' ) . '</li>';
 		$popup_content .= '<li>' . sprintf(
 			// We don't use strong text here, but we do use it in the "Add keyword" popup, this is just to have the same translatable strings.
 			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-				__( '%1$sSocial media preview%2$s: Facebook &amp; Twitter', 'wordpress-seo' ), '', ''
+			__( '%1$sSocial media preview%2$s: Facebook &amp; Twitter', 'wordpress-seo' ),
+			'',
+			''
 		) . '</li>';
 		$popup_content .= '<li>' . __( '24/7 support', 'wordpress-seo' ) . '</li>';
 		$popup_content .= '<li>' . __( 'No ads!', 'wordpress-seo' ) . '</li>';

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -411,9 +411,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'advanced',
 			$content,
 			__( 'Advanced', 'wordpress-seo' ),
-			array(
-				'single' => true,
-			)
+			array( 'single' => true )
 		);
 
 		return new WPSEO_Metabox_Tab_Section(

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -25,10 +25,10 @@ $yform->toggle_switch(
 		'noindex-archive-wpseo',
 		esc_html__( 'Help on the date archives search results setting', 'wordpress-seo' ),
 		sprintf(
-		/* translators: 1: expands to <code>noindex</code>; 2: link open tag; 3: link close tag. */
-		esc_html__( 'Not showing the date archives in the search results technically means those will have a %1$s robots meta. %2$sMore info on the search results settings%3$s.', 'wordpress-seo' ),
-		'<code>noindex</code>',
-		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/show-x' ) ) . '" target="_blank" rel="noopener noreferrer">',
+			/* translators: 1: expands to <code>noindex</code>; 2: link open tag; 3: link close tag. */
+			esc_html__( 'Not showing the date archives in the search results technically means those will have a %1$s robots meta. %2$sMore info on the search results settings%3$s.', 'wordpress-seo' ),
+			'<code>noindex</code>',
+			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/show-x' ) ) . '" target="_blank" rel="noopener noreferrer">',
 			'</a>'
 		)
 	);

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1096,10 +1096,8 @@ class WPSEO_Replace_Vars {
 	private static function register_help_text( $type, WPSEO_Replacement_Variable $replacement_variable ) {
 		$identifier = $replacement_variable->get_variable();
 
-		if ( ( is_string( $type ) && in_array( $type, array(
-					'basic',
-					'advanced',
-				), true ) ) && ( $identifier !== '' && ! isset( self::$help_texts[ $type ][ $identifier ] ) )
+		if ( ( is_string( $type ) && in_array( $type, array( 'basic', 'advanced' ), true ) )
+			&& ( $identifier !== '' && ! isset( self::$help_texts[ $type ][ $identifier ] ) )
 		) {
 			self::$help_texts[ $type ][ $identifier ] = $replacement_variable;
 		}

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -574,10 +574,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		static $original = null;
 
 		// Double-run this function to ensure renaming of the taxonomy options will work.
-		if ( ! isset( $original ) && has_action( 'wpseo_double_clean_titles', array(
-				$this,
-				'clean',
-			) ) === false
+		if ( ! isset( $original )
+			&& has_action( 'wpseo_double_clean_titles', array( $this, 'clean' ) ) === false
 		) {
 			add_action( 'wpseo_double_clean_titles', array( $this, 'clean' ) );
 			$original = $option_value;

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -102,12 +102,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	public function test_set_storage_on_field() {
 		$component = $this
 			->getMockBuilder( 'WPSEO_Config_Component' )
-			->setMethods( array(
-				'get_field',
-				'get_identifier',
-				'set_data',
-				'get_data',
-			) )
+			->setMethods( array( 'get_field', 'get_identifier', 'set_data', 'get_data' ) )
 			->getMock();
 
 		$field = $this

--- a/tests/src/unit-tests/config/database-migration-test.php
+++ b/tests/src/unit-tests/config/database-migration-test.php
@@ -21,10 +21,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	public function test_initialize_with_set_defines_failing() {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
-			->setConstructorArgs( array(
-				null,
-				new Dependency_Management(),
-			) )
+			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods( array( 'set_defines' ) )
 			->getMock();
 
@@ -43,9 +40,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
 			->disableOriginalConstructor()
-			->setMethods( array(
-				'get_migration_state',
-			) )
+			->setMethods( array( 'get_migration_state' ) )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -62,9 +57,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
 			->disableOriginalConstructor()
-			->setMethods( array(
-				'get_migration_state',
-			) )
+			->setMethods( array( 'get_migration_state' ) )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -80,14 +73,13 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	public function test_migration_success() {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
-			->setConstructorArgs( array(
-				null,
-				new Dependency_Management(),
-			) )
-			->setMethods( array(
-				'set_defines',
-				'get_framework_runner',
-			) )
+			->setConstructorArgs( array( null, new Dependency_Management() ) )
+			->setMethods(
+				array(
+					'set_defines',
+					'get_framework_runner',
+				)
+			)
 			->getMock();
 
 		$instance
@@ -111,10 +103,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	public function test_initialize_with_exception_thrown() {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
-			->setConstructorArgs( array(
-				null,
-				new Dependency_Management(),
-			) )
+			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods(
 				array(
 					'set_defines',
@@ -173,10 +162,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	public function test_set_define_success() {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
-			->setConstructorArgs( array(
-				null,
-				new Dependency_Management(),
-			) )
+			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods(
 				array( 'set_define', 'get_defines' )
 			)
@@ -202,10 +188,7 @@ class Database_Migration_Test extends \PHPUnit_Framework_TestCase {
 	public function test_set_define_failed() {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
-			->setConstructorArgs( array(
-				null,
-				new Dependency_Management(),
-			) )
+			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods(
 				array( 'set_define', 'get_defines' )
 			)

--- a/tests/src/unit-tests/config/plugin-test.php
+++ b/tests/src/unit-tests/config/plugin-test.php
@@ -258,9 +258,7 @@ class Plugin_Test extends \PHPUnit_Framework_TestCase {
 	public function test_add_frontend_integrations() {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Plugin' )
-			->setMethods( array(
-				'add_integration'
-			) )
+			->setMethods( array( 'add_integration' ) )
 			->getMock();
 
 		$instance
@@ -279,9 +277,7 @@ class Plugin_Test extends \PHPUnit_Framework_TestCase {
 	public function test_add_admin_integrations() {
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Plugin' )
-			->setMethods( array(
-				'add_integration'
-			) )
+			->setMethods( array( 'add_integration' ) )
 			->getMock();
 
 		$instance

--- a/tests/src/unit-tests/formatters/indexable-post-formatter-test.php
+++ b/tests/src/unit-tests/formatters/indexable-post-formatter-test.php
@@ -190,11 +190,7 @@ class Indexable_Post_Formatter_Test extends \PHPUnit_Framework_TestCase {
 		$formatter = $this
 			->getMockBuilder( '\Yoast\Tests\Doubles\Indexable_Post_Formatter_Double' )
 			->setConstructorArgs( array( 1 ) )
-			->setMethods(
-				array(
-					'get_seo_meta'
-				)
-			)
+			->setMethods( array( 'get_seo_meta' ) )
 			->getMock();
 
 		$seo_meta                      = new \stdClass();
@@ -222,11 +218,7 @@ class Indexable_Post_Formatter_Test extends \PHPUnit_Framework_TestCase {
 		$formatter = $this
 			->getMockBuilder( '\Yoast\Tests\Doubles\Indexable_Post_Formatter_Double' )
 			->setConstructorArgs( array( 1 ) )
-			->setMethods(
-				array(
-					'get_seo_meta'
-				)
-			)
+			->setMethods( array( 'get_seo_meta' ) )
 			->getMock();
 
 

--- a/tests/test-class-wpseo-statistics.php
+++ b/tests/test-class-wpseo-statistics.php
@@ -139,9 +139,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Statistics::get_post_count
 	 */
 	public function test_only_published_posts() {
-		$posts = $this->factory->post->create_many( 4, array(
-			'post_status' => 'draft',
-		) );
+		$posts = $this->factory->post->create_many( 4, array( 'post_status' => 'draft' ) );
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // No-focus.
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 1 ); // Bad.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

* When an array only contains one item, it doesn't _need_ to be multi-line and if the array is within a function call, having it as single line prevents having to create a separate variable for it.
* Similarly, when an array doesn't contain associative keys, it also doesn't _need_ to be multi-line. In the case of single-use arrays within a function call within a control structure condition, reformatting the conditions to span multiple lines, while having the non-associative array as single-line, can improve readability and again prevent having to create a separate variable for the array.
* Lastly, function call arguments should be indented one tab from the line containing the function call.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
