### PR TITLE
Sitemap empty entries and overlapping taxonomy/author fix

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -130,10 +130,6 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			$total_count = $this->get_post_type_count( $post_type );
 
-			if ( $total_count === 0 ) {
-				continue;
-			}
-
 			$max_pages = 1;
 
 			if ( $total_count > $max_entries ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -324,16 +324,10 @@ class WPSEO_Sitemaps {
 			}
 
 			$links = $provider->get_sitemap_links( $type, $entries_per_page, $this->current_page );
-
-			if ( empty( $links ) ) {
-				$this->bad_sitemap = true;
-
+			if ( ! empty( $links ) ) {
+				$this->sitemap = $this->renderer->get_sitemap( $links, $type, $this->current_page );
 				return;
 			}
-
-			$this->sitemap = $this->renderer->get_sitemap( $links, $type, $this->current_page );
-
-			return;
 		}
 
 		if ( has_action( 'wpseo_do_sitemap_' . $type ) ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -324,10 +324,8 @@ class WPSEO_Sitemaps {
 			}
 
 			$links = $provider->get_sitemap_links( $type, $entries_per_page, $this->current_page );
-			if ( ! empty( $links ) ) {
-				$this->sitemap = $this->renderer->get_sitemap( $links, $type, $this->current_page );
-				return;
-			}
+			$this->sitemap = $this->renderer->get_sitemap( $links, $type, $this->current_page );
+			return;
 		}
 
 		if ( has_action( 'wpseo_do_sitemap_' . $type ) ) {

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -22,7 +22,13 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	public function handles_type( $type ) {
 
-		return taxonomy_exists( $type );
+		$taxonomy = get_taxonomy( $type );
+
+		if ( $taxonomy === false || ! $this->is_valid_taxonomy( $taxonomy->name ) || ! $taxonomy->public ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -137,15 +143,14 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 * @return array
 	 */
 	public function get_sitemap_links( $type, $max_entries, $current_page ) {
-
 		global $wpdb;
 
-		$links    = array();
-		$taxonomy = get_taxonomy( $type );
-
-		if ( $taxonomy === false || ! $this->is_valid_taxonomy( $taxonomy->name ) || ! $taxonomy->public ) {
+		$links = array();
+		if ( ! $this->handles_type( $type ) ) {
 			return $links;
 		}
+
+		$taxonomy = get_taxonomy( $type );
 
 		$steps  = $max_entries;
 		$offset = ( $current_page > 1 ) ? ( ( $current_page - 1 ) * $max_entries ) : 0;

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -32,7 +32,9 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	public function test_get_index_links() {
 
 		$index_links = self::$class_instance->get_index_links( 1 );
-		$this->assertEmpty( $index_links );
+		$this->assertNotEmpty( $index_links );
+		$this->assertContains( 'http://example.org/post-sitemap.xml', $index_links[0] );
+		$this->assertContains( 'http://example.org/page-sitemap.xml', $index_links[1] );
 
 		$this->factory->post->create();
 		$index_links = self::$class_instance->get_index_links( 1 );

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -40,11 +40,45 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$index_links = self::$class_instance->get_index_links( 1 );
 		$this->assertNotEmpty( $index_links );
 		$this->assertContains( 'http://example.org/post-sitemap.xml', $index_links[0] );
+		$this->assertContains( 'http://example.org/page-sitemap.xml', $index_links[1] );
 
 		$this->factory->post->create();
 		$index_links = self::$class_instance->get_index_links( 1 );
 		$this->assertContains( 'http://example.org/post-sitemap1.xml', $index_links[0] );
 		$this->assertContains( 'http://example.org/post-sitemap2.xml', $index_links[1] );
+	}
+
+	/**
+	 * Makes sure the filtered out entries do not cause a sitemap index link to return a 404.
+	 *
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
+	 */
+	public function test_get_index_links_empty_bucket() {
+
+		$this->factory->post->create();
+		$this->excluded_posts = array( $this->factory->post->create() ); // remove this post.
+		$this->factory->post->create();
+
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_post' ) );
+		add_filter( 'wpseo_sitemap_entries_per_page', function() {
+			return 1;
+		} );
+
+		// Fetch the global sitemap.
+		set_query_var( 'sitemap', 'post' );
+		set_query_var( 'sitemap_n', '2' );
+
+		// Load the sitemap.
+		$sitemaps = new WPSEO_Sitemaps_Double();
+		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
+
+		// Expect an empty list to be output.
+		$this->expectOutputContains(
+			'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\r\n" . '</urlset>'
+		);
+
+		// Remove the filter.
+		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_post' ) );
 	}
 
 	/**
@@ -287,5 +321,9 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 		// Expect the attachment not to be added to the list.
 		$this->assertCount( 0, self::$class_instance->get_sitemap_links( 'attachment', 100, 0 ) );
+	}
+
+	public function exclude_post( $post_ids ) {
+		return $this->excluded_posts;
 	}
 }

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -60,9 +60,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->factory->post->create();
 
 		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_post' ) );
-		add_filter( 'wpseo_sitemap_entries_per_page', function() {
-			return 1;
-		} );
+		add_filter( 'wpseo_sitemap_entries_per_page', array( $this, 'return_one' ) );
 
 		// Fetch the global sitemap.
 		set_query_var( 'sitemap', 'post' );
@@ -323,7 +321,23 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->assertCount( 0, self::$class_instance->get_sitemap_links( 'attachment', 100, 0 ) );
 	}
 
+	/**
+	 * Filter to exclude desired posts from the sitemap.
+	 *
+	 * @param array $post_ids List of post ids.
+	 *
+	 * @return array
+	 */
 	public function exclude_post( $post_ids ) {
 		return $this->excluded_posts;
+	}
+
+	/**
+	 * Sets the number of entries in the sitemap to one.
+	 *
+	 * @return int
+	 */
+	public function return_one() {
+		return 1;
 	}
 }

--- a/tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Sitemaps
+ */
+
+/**
+ * Class Test_WPSEO_Sitemap_Provider_Overlap
+ *
+ * @group sitemaps
+ */
+class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
+	/**
+	 * @var WPSEO_Sitemaps_Double
+	 */
+	private static $class_instance;
+
+	/**
+	 * Set up our double class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		self::$class_instance = new WPSEO_Sitemaps_Double();
+
+		// Reset the instance
+		self::$class_instance->reset();
+	}
+
+	/**
+	 * Set up our double class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Make sure the author archives are enabled.
+		WPSEO_Options::set( 'disable-author', false );
+	}
+
+	/**
+	 * Makes sure the private taxonomy "author" does not override the "Author" sitemap.
+	 */
+	public function test_private_taxonomy_author_overlap() {
+		// Create private taxonomy "author", overlapping the "author" sitemap.
+		register_taxonomy( 'author', array( 'post' ), array( 'public' => false ) );
+
+		// Create a user with a post.
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+
+		// Fetch the global sitemap.
+		set_query_var( 'sitemap', '1' );
+
+		// Load the sitemap.
+		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
+
+		// Expect the author-sitemap to be present in the index.
+		$this->expectOutputContains(
+			'<loc>http://example.org/author-sitemap.xml</loc>'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a problem where the sitemap would return a 404 status-code when no entries are present.
* Fixes a problem where a private taxonomy with the same name as the author sitemap would not be accessible anymore.

## Relevant technical choices:

* As the overlapping of the private taxonomy / author code is caused by the "empty" check it did make sense to fix both problems in the same PR

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Empty sitemap listing being 404:
* Remove all posts or pages from your install (or filter them out)
* See the sitemap-index still contains the Post or Page sitemap
* Open the sitemap and see only the homepage referenced

Private taxonomy overlap:
* Install the Co-Author plugin
* See the author sitemap still working

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have *updated* unittests to verify the code works as intended
* [x] I have added unittests to verify the code works as intended

Todo:
- [x] This needs another unit-test with a private taxonomy called "author" in combination with an author sitemap, to verify the author sitemap is rendered as expected.
- [x] This needs another unit-test with paginated sitemaps where sub-pages have no entries.

Fixes #6343 
Fixes #11428 
