### PR TITLE
Yoast CS: Fixes the input issues in ajax.php

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -258,13 +258,8 @@ function wpseo_save_all( $what ) {
 		wpseo_ajax_json_echo_die( $results );
 	}
 
-	// @todo the WPSEO Utils class can't filter arrays in POST yet.
-	$new_values      = wp_unslash( $_POST['items'] );
-	$original_values = wp_unslash( $_POST['existing_items'] );
-
-	if ( ! is_array( $new_values ) ) {
-		wpseo_ajax_json_echo_die( $results );
-	}
+	$new_values      = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), wp_unslash( (array) $_POST['items'] ) );
+	$original_values = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), wp_unslash( (array) $_POST['existing_items'] ) );
 
 	foreach ( $new_values as $post_id => $new_value ) {
 		$original_value = $original_values[ $post_id ];

--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -254,12 +254,12 @@ function wpseo_save_all( $what ) {
 	check_ajax_referer( 'wpseo-bulk-editor' );
 
 	$results = array();
-	if ( ! isset( $_POST['items'], $_POST['existing_items'] ) ) {
+	if ( ! isset( $_POST['items'], $_POST['existingItems'] ) ) {
 		wpseo_ajax_json_echo_die( $results );
 	}
 
 	$new_values      = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), wp_unslash( (array) $_POST['items'] ) );
-	$original_values = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), wp_unslash( (array) $_POST['existing_items'] ) );
+	$original_values = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), wp_unslash( (array) $_POST['existingItems'] ) );
 
 	foreach ( $new_values as $post_id => $new_value ) {
 		$original_value = $original_values[ $post_id ];

--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -253,18 +253,24 @@ add_action( 'wp_ajax_wpseo_save_all_descriptions', 'wpseo_save_all_descriptions'
 function wpseo_save_all( $what ) {
 	check_ajax_referer( 'wpseo-bulk-editor' );
 
-	// @todo the WPSEO Utils class can't filter arrays in POST yet.
-	$new_values      = $_POST['items'];
-	$original_values = $_POST['existing_items'];
-
 	$results = array();
-
-	if ( is_array( $new_values ) && $new_values !== array() ) {
-		foreach ( $new_values as $post_id => $new_value ) {
-			$original_value = $original_values[ $post_id ];
-			$results[]      = wpseo_upsert_new( $what, $post_id, $new_value, $original_value );
-		}
+	if ( ! isset( $_POST['items'], $_POST['existing_items'] ) ) {
+		wpseo_ajax_json_echo_die( $results );
 	}
+
+	// @todo the WPSEO Utils class can't filter arrays in POST yet.
+	$new_values      = wp_unslash( $_POST['items'] );
+	$original_values = wp_unslash( $_POST['existing_items'] );
+
+	if ( ! is_array( $new_values ) ) {
+		wpseo_ajax_json_echo_die( $results );
+	}
+
+	foreach ( $new_values as $post_id => $new_value ) {
+		$original_value = $original_values[ $post_id ];
+		$results[]      = wpseo_upsert_new( $what, $post_id, $new_value, $original_value );
+	}
+
 	wpseo_ajax_json_echo_die( $results );
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Fixes the input issues in ajax.php

## Relevant technical choices:

* Should fix these issues:
```
FILE: admin\ajax.php
--
------------------------------------------------------------------------
FOUND 6 ERRORS AFFECTING 2 LINES
------------------------------------------------------------------------
257 \| ERROR \| Detected usage of a non-validated input variable: $_POST
257 \| ERROR \| Missing wp_unslash() before sanitization.
257 \| ERROR \| Detected usage of a non-sanitized input variable: $_POST
258 \| ERROR \| Detected usage of a non-validated input variable: $_POST
258 \| ERROR \| Missing wp_unslash() before sanitization.
258 \| ERROR \| Detected usage of a non-sanitized input variable: $_POST
------------------------------------------------------------------------
```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the bulk editor (Yoast SEO > Tools > Bulk editor) still works when doing `save all`.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
