### PR TITLE
Yoast CS: Adds input sanitization

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -77,7 +77,7 @@ class WPSEO_Sitemaps {
 		$this->cache    = new WPSEO_Sitemaps_Cache();
 
 		if ( ! empty( $_SERVER['SERVER_PROTOCOL'] ) ) {
-			$this->http_protocol = sanitize_text_field( $_SERVER['SERVER_PROTOCOL'] );
+			$this->http_protocol = sanitize_text_field( wp_unslash( $_SERVER['SERVER_PROTOCOL'] ) );
 		}
 	}
 
@@ -112,7 +112,7 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
-		$request_uri = $_SERVER['REQUEST_URI'];
+		$request_uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 		$extension   = substr( $request_uri, -4 );
 
 		if ( false !== stripos( $request_uri, 'sitemap' ) && in_array( $extension, array( '.xml', '.xsl' ), true ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Fixes the input issues in inc\sitemaps\class-sitemaps.php

## Relevant technical choices:

* Fixes the following CS issues:
```
FILE: inc\sitemaps\class-sitemaps.php
--
--------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------
80 \| ERROR \| Missing wp_unslash() before sanitization.
115 \| ERROR \| Missing wp_unslash() before sanitization.
115 \| ERROR \| Detected usage of a non-sanitized input variable: $_SERVER
--------------------------------------------------------------------------
```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
