### PR TITLE
Yoast CS: Add sanitization for inc\sitemaps\class-sitemaps-router.php

### DIFF
--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -80,13 +80,20 @@ class WPSEO_Sitemaps_Router {
 			$protocol = 'https://';
 		}
 
-		$domain = sanitize_text_field( $_SERVER['SERVER_NAME'] );
-		$path   = sanitize_text_field( $_SERVER['REQUEST_URI'] );
+		$domain = '';
+		if ( isset( $_SERVER['SERVER_NAME'] ) ) {
+			$domain = sanitize_text_field( wp_unslash( $_SERVER['SERVER_NAME'] ) );
+		}
+
+		$path = '';
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$path = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		}
 
 		// Due to different environment configurations, we need to check both SERVER_NAME and HTTP_HOST.
 		$check_urls = array( $protocol . $domain . $path );
 		if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
-			$check_urls[] = $protocol . sanitize_text_field( $_SERVER['HTTP_HOST'] ) . $path;
+			$check_urls[] = $protocol . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) . $path;
 		}
 
 		return $wp_query->is_404 && in_array( home_url( '/sitemap.xml' ), $check_urls, true );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Fixes the input issues in inc/sitemaps/class-sitemaps-router.php

## Relevant technical choices:

* Fixes the following issues:
```
FILE: inc\sitemaps\class-sitemaps-router.php
--
-------------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 3 LINES
-------------------------------------------------------------------------
83 \| ERROR \| Detected usage of a non-validated input variable: $_SERVER
83 \| ERROR \| Missing wp_unslash() before sanitization.
84 \| ERROR \| Detected usage of a non-validated input variable: $_SERVER
84 \| ERROR \| Missing wp_unslash() before sanitization.
89 \| ERROR \| Missing wp_unslash() before sanitization.
-------------------------------------------------------------------------
```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
