### PR TITLE
CS: Move multi-line parameters out of function calls [8]

### DIFF
--- a/tests/admin/help_center/test-class-help-center-template-variables-tab.php
+++ b/tests/admin/help_center/test-class-help-center-template-variables-tab.php
@@ -21,10 +21,11 @@ class WPSEO_Help_Center_Template_Variables_Tab_Test extends WPSEO_UnitTestCase {
 		$instance = new WPSEO_Help_Center_Template_Variables_Tab();
 		$instance->register_hooks();
 
-		$this->assertEquals( 10, has_filter( 'wpseo_help_center_items', array(
-			$instance,
-			'add_meta_options_help_center_tabs',
-		) ) );
+		$has_filter = has_filter(
+			'wpseo_help_center_items',
+			array( $instance, 'add_meta_options_help_center_tabs' )
+		);
+		$this->assertEquals( 10, $has_filter );
 		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_assets' ) ) );
 	}
 
@@ -38,10 +39,11 @@ class WPSEO_Help_Center_Template_Variables_Tab_Test extends WPSEO_UnitTestCase {
 		$instance = new WPSEO_Help_Center_Template_Variables_Tab( 20 );
 		$instance->register_hooks();
 
-		$this->assertEquals( 20, has_filter( 'wpseo_help_center_items', array(
-			$instance,
-			'add_meta_options_help_center_tabs',
-		) ) );
+		$has_filter = has_filter(
+			'wpseo_help_center_items',
+			array( $instance, 'add_meta_options_help_center_tabs' )
+		);
+		$this->assertEquals( 20, $has_filter );
 	}
 
 	/**

--- a/tests/admin/test-class-admin-asset-seo-location.php
+++ b/tests/admin/test-class-admin-asset-seo-location.php
@@ -16,7 +16,7 @@ final class Test_WPSEO_Admin_Asset_SEO_Location extends PHPUnit_Framework_TestCa
 	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url()
 	 */
 	public function test_get_url() {
-		$asset = new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name'      => 'name',
 			'src'       => 'src',
 			'deps'      => array( 'deps' ),
@@ -25,7 +25,8 @@ final class Test_WPSEO_Admin_Asset_SEO_Location extends PHPUnit_Framework_TestCa
 			'in_footer' => false,
 			'suffix'    => '.suffix',
 			'rtl'       => false,
-		) );
+		);
+		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
 		$expected_js    = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/src.suffix.js';
 		$expected_css   = home_url() . '/wp-content/plugins/wordpress-seo/css/dist/src.suffix.css';

--- a/tests/admin/test-class-yoast-network-settings-api.php
+++ b/tests/admin/test-class-yoast-network-settings-api.php
@@ -18,10 +18,11 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	public function test_register_setting() {
 		$api = new Yoast_Network_Settings_API();
 
-		$api->register_setting( 'yst_ms_group', 'yst_ms_option', array(
+		$setting_args = array(
 			'sanitize_callback' => 'absint',
 			'default'           => 1,
-		) );
+		);
+		$api->register_setting( 'yst_ms_group', 'yst_ms_option', $setting_args );
 
 		$this->assertInternalType( 'int', has_filter( 'sanitize_option_yst_ms_option', array( $api, 'filter_sanitize_option' ) ) );
 		$this->assertInternalType( 'int', has_filter( 'default_site_option_yst_ms_option', array( $api, 'filter_default_option' ) ) );

--- a/tests/admin/watchers/test-class-slug-change-watcher.php
+++ b/tests/admin/watchers/test-class-slug-change-watcher.php
@@ -76,10 +76,11 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_post_trash_no_visible_post_status() {
 
 		// Make sure we're working with a draft.
-		wp_update_post( array(
+		$post_args = array(
 			'ID'          => self::$post_id,
 			'post_status' => 'draft',
-		) );
+		);
+		wp_update_post( $post_args );
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
@@ -142,10 +143,11 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_detect_post_delete_trashed_post() {
 		// Make sure we're working with a trashed post.
-		wp_update_post( array(
+		$post_args = array(
 			'ID'          => self::$post_id,
 			'post_status' => 'trash',
-		) );
+		);
+		wp_update_post( $post_args );
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
@@ -191,10 +193,11 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_post_delete_when_not_visible() {
 
 		// Make sure we're working with a pending post.
-		wp_update_post( array(
+		$post_args = array(
 			'ID'          => self::$post_id,
 			'post_status' => 'pending',
-		) );
+		);
+		wp_update_post( $post_args );
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )

--- a/tests/frontend/test-class-opengraph.php
+++ b/tests/frontend/test-class-opengraph.php
@@ -176,11 +176,12 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	public function test_og_title_with_variables() {
 		$expected_title = 'Test title';
 		// Create and go to post.
-		$post_id = $this->factory->post->create();
-		wp_update_post( array(
+		$post_id   = $this->factory->post->create();
+		$post_args = array(
 			'ID'         => $post_id,
 			'post_title' => $expected_title,
-		) );
+		);
+		wp_update_post( $post_args );
 		WPSEO_Meta::set_value( 'opengraph-title', '%%title%%', $post_id );
 
 		$this->go_to( get_permalink( $post_id ) );
@@ -698,7 +699,11 @@ EXPECTED;
 	 */
 	public function test_taxonomy_description_with_replacevars() {
 		$expected_title = 'Test title';
-		$term_id        = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => $expected_title ) );
+		$term_args      = array(
+			'taxonomy' => 'category',
+			'name'     => $expected_title,
+		);
+		$term_id        = $this->factory->term->create( $term_args );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-description', '%%term_title%%' );
 

--- a/tests/frontend/test-class-twitter.php
+++ b/tests/frontend/test-class-twitter.php
@@ -356,12 +356,13 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Twitter::image()
 	 */
 	public function test_post_thumbnail_image() {
-		$post_id       = $this->factory->post->create();
-		$filename      = 'post-thumbnail.jpg';
-		$attachment_id = $this->factory->attachment->create_object( $filename, 0, array(
+		$post_id         = $this->factory->post->create();
+		$filename        = 'post-thumbnail.jpg';
+		$attachment_args = array(
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
-		) );
+		);
+		$attachment_id   = $this->factory->attachment->create_object( $filename, 0, $attachment_args );
 		update_post_meta( $post_id, '_thumbnail_id', $attachment_id );
 		$this->go_to( get_permalink( $post_id ) );
 
@@ -442,12 +443,13 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		$expected = $this->metatag( 'card', 'summary_large_image' );
 
 		// Insert image into DB so we have something to test against.
-		$filename  = 'image.jpg';
-		$id        = $this->factory->attachment->create_object( $filename, 0, array(
+		$filename        = 'image.jpg';
+		$attachment_args = array(
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
-		) );
-		$expected .= $this->metatag( 'image', 'http://' . WP_TESTS_DOMAIN . "/wp-content/uploads/$filename" );
+		);
+		$id              = $this->factory->attachment->create_object( $filename, 0, $attachment_args );
+		$expected       .= $this->metatag( 'image', 'http://' . WP_TESTS_DOMAIN . "/wp-content/uploads/$filename" );
 
 		// Create and go to post.
 		$content = '[gallery ids="' . $id . '"]';
@@ -474,11 +476,12 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	public function test_twitter_title_with_variables() {
 		$expected_title = 'Test title';
 		// Create and go to post.
-		$post_id = $this->factory->post->create();
-		wp_update_post( array(
+		$post_id   = $this->factory->post->create();
+		$post_args = array(
 			'ID'         => $post_id,
 			'post_title' => $expected_title,
-		) );
+		);
+		wp_update_post( $post_args );
 		WPSEO_Meta::set_value( 'twitter-title', '%%title%%', $post_id );
 
 		$this->go_to( get_permalink( $post_id ) );
@@ -496,12 +499,12 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		$expected_title = 'Post title';
 
 		// Create and go to post.
-		$post_id = $this->factory->post->create();
-		wp_update_post( array(
-				'ID'         => $post_id,
-				'post_title' => $expected_title,
-			)
+		$post_id   = $this->factory->post->create();
+		$post_args = array(
+			'ID'         => $post_id,
+			'post_title' => $expected_title,
 		);
+		wp_update_post( $post_args );
 
 		// Test wpseo meta.
 		WPSEO_Meta::set_value( 'twitter-description', '%%title%%', $post_id );

--- a/tests/inc/options/test-class-wpseo-options-backfill.php
+++ b/tests/inc/options/test-class-wpseo-options-backfill.php
@@ -38,13 +38,14 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 			'excluded-posts'         => array(),
 		);
 
-		$this->set_options( array(
-			'enable_xml_sitemap'     => true,
+		$option_input = array(
+			'enable_xml_sitemap'     => true, // Note: this is a different key than in $expected!
 			'disable_author_sitemap' => false,
 			'disable_author_noposts' => true,
 			'entries-per-page'       => 1000,
 			'excluded-posts'         => array(),
-		) );
+		);
+		$this->set_options( $option_input );
 
 		$this->assertEquals( $expected, get_option( 'wpseo_xml' ) );
 	}
@@ -67,10 +68,11 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 			'trailingslash'                   => false,
 		);
 
-		$this->set_options( array(
+		$unexpected = array(
 			'disable-attachment' => true,
 			'stripcategorybase'  => false,
-		) );
+		);
+		$this->set_options( $unexpected );
 
 		$this->assertEquals( $expected, get_option( 'wpseo_permalinks' ) );
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -190,10 +190,11 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 		new WPSEO_Sitemaps_Cache();
 		// Hook will be added on default priority.
-		$this->assertEquals( 10, has_action( 'update_option', array(
-			'WPSEO_Sitemaps_Cache',
-			'clear_on_option_update',
-		) ) );
+		$has_action = has_action(
+			'update_option',
+			array( 'WPSEO_Sitemaps_Cache', 'clear_on_option_update' )
+		);
+		$this->assertEquals( 10, $has_action );
 	}
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -36,10 +36,11 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
 
-		$this->expectOutputContains( array(
+		$expected_contains = array(
 			'<?xml',
 			'<urlset ',
-		) );
+		);
+		$this->expectOutputContains( $expected_contains );
 	}
 
 	/**
@@ -59,22 +60,24 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 		// Go to the XML sitemap twice, see if transient cache is set.
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
-		$this->expectOutputContains( array(
+		$expected_contains = array(
 			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
 			'<sitemap>',
 			'<lastmod>',
 			'</sitemapindex>',
-		) );
+		);
+		$this->expectOutputContains( $expected_contains );
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
 
-		$this->expectOutputContains( array(
+		$expected_contains = array(
 			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
 			'<sitemap>',
 			'<lastmod>',
 			'</sitemapindex>',
 			'Served from transient cache',
-		) );
+		);
+		$this->expectOutputContains( $expected_contains );
 
 		remove_filter( 'wpseo_enable_xml_sitemap_transient_caching', '__return_true' );
 	}
@@ -89,28 +92,21 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 		$older_date  = '2015-01-01 12:00:00';
 		$newest_date = '2016-01-01 12:00:00';
 
-		register_post_type(
-			'yoast',
-			array(
-				'public'      => true,
-				'has_archive' => true,
-			)
+		$post_type_args = array(
+			'public'      => true,
+			'has_archive' => true,
 		);
+		register_post_type( 'yoast', $post_type_args );
 
-		$this->factory->post->create(
-			array(
-				'post_status' => 'publish',
-				'post_type'   => 'yoast',
-				'post_date'   => $newest_date,
-			)
+		$post_args = array(
+			'post_status' => 'publish',
+			'post_type'   => 'yoast',
+			'post_date'   => $newest_date,
 		);
-		$this->factory->post->create(
-			array(
-				'post_status' => 'publish',
-				'post_type'   => 'yoast',
-				'post_date'   => $older_date,
-			)
-		);
+		$this->factory->post->create( $post_args );
+
+		$post_args['post_date'] = $older_date;
+		$this->factory->post->create( $post_args );
 
 		$this->assertEquals( $newest_date, WPSEO_Sitemaps::get_last_modified_gmt( array( 'yoast' ) ) );
 	}

--- a/tests/src/unit-tests/config/plugin-test.php
+++ b/tests/src/unit-tests/config/plugin-test.php
@@ -169,15 +169,16 @@ class Plugin_Test extends \PHPUnit_Framework_TestCase {
 	 * @covers \Yoast\YoastSEO\Config\Plugin::trigger_integration_hook()
 	 */
 	public function test_register_hooks() {
+		$methods = array(
+			'is_admin',
+			'is_frontend',
+			'add_admin_integrations',
+			'add_frontend_integrations',
+			'get_integration_group',
+		);
 		$instance = $this
 			->getMockBuilder( 'Yoast\Tests\Doubles\Plugin' )
-			->setMethods( array(
-				'is_admin',
-				'is_frontend',
-				'add_admin_integrations',
-				'add_frontend_integrations',
-				'get_integration_group'
-			) )
+			->setMethods( $methods )
 			->getMock();
 
 		$instance

--- a/tests/test-class-admin-asset-manager.php
+++ b/tests/test-class-admin-asset-manager.php
@@ -77,13 +77,14 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_script
 	 */
 	public function test_register_script() {
-		$this->asset_manager->register_script( new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name'      => 'handle',
 			'src'       => 'src',
 			'deps'      => array( 'deps' ),
 			'version'   => 'version',
 			'in_footer' => 'in_footer',
-		) ) );
+		);
+		$this->asset_manager->register_script( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2
 		// Use the WordPress internals to assert instead.
@@ -106,13 +107,14 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_script
 	 */
 	public function test_register_script_with_prefix() {
-		$prefix = 'yoast-custom-prefix';
-
+		$prefix        = 'yoast-custom-prefix';
 		$asset_manager = new WPSEO_Admin_Asset_Manager( null, $prefix );
-		$asset_manager->register_script( new WPSEO_Admin_Asset( array(
+
+		$asset_args = array(
 			'name'      => 'handle',
 			'src'       => 'src',
-		) ) );
+		);
+		$asset_manager->register_script( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2
 		// Use the WordPress internals to assert instead.
@@ -125,11 +127,12 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_script
 	 */
 	public function test_register_script_suffix() {
-		$this->asset_manager->register_script( new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name'   => 'handle2', // Handles have to be unique, isolation YaY ¯\_(ツ)_/¯.
 			'src'    => 'src',
 			'suffix' => '.suffix',
-		) ) );
+		);
+		$this->asset_manager->register_script( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2
 		// Use the WordPress internals to assert instead.
@@ -144,13 +147,14 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_style
 	 */
 	public function test_register_style() {
-		$this->asset_manager->register_style( new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name'    => 'handle',
 			'src'     => 'src',
 			'deps'    => array( 'deps' ),
 			'version' => 'version',
 			'media'   => 'print',
-		) ) );
+		);
+		$this->asset_manager->register_style( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_style here but we can't because of PHP 5.2
 		// Use the WordPress internals to assert instead.
@@ -173,13 +177,14 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_style
 	 */
 	public function test_register_style_with_prefix() {
-		$prefix = 'yoast-custom-prefix';
-
+		$prefix        = 'yoast-custom-prefix';
 		$asset_manager = new WPSEO_Admin_Asset_Manager( null, $prefix );
-		$asset_manager->register_style( new WPSEO_Admin_Asset( array(
+
+		$asset_args = array(
 			'name'      => 'handle',
 			'src'       => 'src',
-		) ) );
+		);
+		$asset_manager->register_style( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2
 		// Use the WordPress internals to assert instead.
@@ -192,11 +197,12 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_script
 	 */
 	public function test_register_style_suffix() {
-		$this->asset_manager->register_style( new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name'   => 'handle2', // Handles have to be unique, isolation YaY ¯\_(ツ)_/¯.
 			'src'    => 'src',
 			'suffix' => '.suffix',
-		) ) );
+		);
+		$this->asset_manager->register_style( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2
 		// Use the WordPress internals to assert instead.

--- a/tests/test-class-admin-asset.php
+++ b/tests/test-class-admin-asset.php
@@ -21,19 +21,21 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @expectedException InvalidArgumentException
 	 */
 	public function test_constructor_missing_src() {
-		new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name' => 'name',
-		) );
+		);
+		new WPSEO_Admin_Asset( $asset_args );
 	}
 
 	/**
 	 * Test default values.
 	 */
 	public function test_constructor_default_values() {
-		$asset = new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name' => 'name',
 			'src'  => 'src',
-		) );
+		);
+		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
 		$this->assertEquals( 'name', $asset->get_name() );
 		$this->assertEquals( 'src', $asset->get_src() );
@@ -49,7 +51,7 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * Test getters.
 	 */
 	public function test_getters() {
-		$asset = new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name'      => 'name',
 			'src'       => 'src',
 			'deps'      => array( 'deps' ),
@@ -58,7 +60,8 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 			'in_footer' => false,
 			'suffix'    => '.suffix',
 			'rtl'       => false,
-		) );
+		);
+		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
 		$this->assertEquals( array( 'deps' ), $asset->get_deps() );
 		$this->assertEquals( 'version', $asset->get_version() );
@@ -74,10 +77,11 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @expectedDeprecated WPSEO_Admin_Asset::get_url
 	 */
 	public function test_deprecated_get_url() {
-		$asset = new WPSEO_Admin_Asset( array(
+		$asset_args = array(
 			'name' => 'name',
 			'src'  => 'src',
-		) );
+		);
+		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
 		$default_location = new WPSEO_Admin_Asset_SEO_Location( WPSEO_FILE );
 

--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -41,7 +41,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		$home_url   = WPSEO_Utils::home_url();
 		$search_url = $home_url . '?s={search_term_string}';
 
-		$json = self::$class_instance->format_data( array(
+		$data_array = array(
 			'@context'        => 'https://schema.org',
 			'@type'           => 'WebSite',
 			'@id'             => $home_url . '#website',
@@ -52,9 +52,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 				'target'      => $search_url,
 				'query-input' => 'required name=search_term_string',
 			),
-		) );
-
-		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+		);
+		$json       = self::$class_instance->format_data( $data_array );
+		$expected   = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 
 		$this->expectOutput( $expected, self::$class_instance->website() );
 	}
@@ -73,18 +73,17 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 
 		$this->go_to_home();
 
-		$home_url = WPSEO_Utils::home_url();
-
-		$json = self::$class_instance->format_data( array(
+		$home_url   = WPSEO_Utils::home_url();
+		$data_array = array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'Person',
 			'url'      => $home_url,
 			'sameAs'   => array( $instagram ),
 			'@id'      => '#person',
 			'name'     => $name,
-		) );
-
-		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+		);
+		$json       = self::$class_instance->format_data( $data_array );
+		$expected   = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 		self::$class_instance->organization_or_person();
 
 		$this->expectOutput( $expected );
@@ -103,7 +102,7 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'person_name', $name );
 		WPSEO_Options::set( 'instagram_url', 'http://instagram.com:8080/{}yoast' );
 
-		$json = self::$class_instance->format_data( array(
+		$data_array = array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'Person',
 			'url'      => $home_url,
@@ -111,9 +110,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 			// The {} will be stripped out by saving the option.
 			'@id'      => '#person',
 			'name'     => $name,
-		) );
-
-		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+		);
+		$json       = self::$class_instance->format_data( $data_array );
+		$expected   = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 
 		self::$class_instance->organization_or_person();
 		$this->expectOutput( $expected );
@@ -135,9 +134,8 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 
 		$this->go_to_home();
 
-		$home_url = WPSEO_Utils::home_url();
-
-		$json = self::$class_instance->format_data( array(
+		$home_url   = WPSEO_Utils::home_url();
+		$data_array = array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'Organization',
 			'url'      => $home_url,
@@ -145,9 +143,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 			'@id'      => $home_url . '#organization',
 			'name'     => $name,
 			'logo'     => '',
-		) );
-
-		$expected = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
+		);
+		$json       = self::$class_instance->format_data( $data_array );
+		$expected   = '<script type=\'application/ld+json\'>' . $json . '</script>' . "\n";
 
 		$this->expectOutput( $expected, self::$class_instance->organization_or_person() );
 	}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduces a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be  introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/ 1330

With this mind, function calls with multi-line parameters which are currently  already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have  been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and  defining it as a variable before passing it to the function call.

This commit contains changes for the second variant for test files.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
