### PR TITLE
CS/I18n: Remove line breaks from translatable strings

### DIFF
--- a/admin/config-ui/fields/class-field-company-or-person.php
+++ b/admin/config-ui/fields/class-field-company-or-person.php
@@ -18,8 +18,7 @@ class WPSEO_Config_Field_Company_Or_Person extends WPSEO_Config_Field_Choice {
 
 		$this->set_property( 'label', __( 'Does your site represent a person or company?', 'wordpress-seo' ) );
 
-		$this->set_property( 'description', __( 'This information will be used in Google\'s Knowledge Graph Card, the big
- block of information you see on the right side of the search results.', 'wordpress-seo' ) );
+		$this->set_property( 'description', __( 'This information will be used in Google\'s Knowledge Graph Card, the big block of information you see on the right side of the search results.', 'wordpress-seo' ) );
 
 		$this->add_choice( 'company', __( 'Company', 'wordpress-seo' ) );
 		$this->add_choice( 'person', __( 'Person', 'wordpress-seo' ) );

--- a/admin/config-ui/fields/class-field-environment.php
+++ b/admin/config-ui/fields/class-field-environment.php
@@ -18,9 +18,7 @@ class WPSEO_Config_Field_Environment extends WPSEO_Config_Field_Choice {
 
 		$this->set_property( 'label', __( 'Please specify if your site is under construction or already active.', 'wordpress-seo' ) );
 
-		$this->set_property( 'description', __( 'Choose under construction if you want to keep the site out of the index
- of search engines. Don\'t forget to activate it once you\'re ready to
- publish your site.', 'wordpress-seo' ) );
+		$this->set_property( 'description', __( 'Choose under construction if you want to keep the site out of the index of search engines. Don\'t forget to activate it once you\'re ready to publish your site.', 'wordpress-seo' ) );
 
 		$this->add_choice( 'production', __( 'Option A: My site is live and ready to be indexed', 'wordpress-seo' ) );
 		$this->add_choice( 'staging', __( 'Option B: My site is under construction and should not be indexed', 'wordpress-seo' ) );

--- a/admin/config-ui/fields/class-field-google-search-console-intro.php
+++ b/admin/config-ui/fields/class-field-google-search-console-intro.php
@@ -25,8 +25,7 @@ class WPSEO_Config_Field_Google_Search_Console_Intro extends WPSEO_Config_Field 
 				'</a>'
 			);
 
-		$disclaimer =
-			__( 'Note: we don\'t store your data in any way and don\'t have full access to your account. Your privacy is safe with us.', 'wordpress-seo' );
+		$disclaimer = __( 'Note: we don\'t store your data in any way and don\'t have full access to your account. Your privacy is safe with us.', 'wordpress-seo' );
 
 		$html = '<p>' . $html . '</p><small>' . esc_html( $disclaimer ) . '</small>';
 

--- a/admin/config-ui/fields/class-field-multiple-authors.php
+++ b/admin/config-ui/fields/class-field-multiple-authors.php
@@ -18,8 +18,7 @@ class WPSEO_Config_Field_Multiple_Authors extends WPSEO_Config_Field_Choice {
 
 		$this->set_property( 'label', __( 'Does, or will, your site have multiple authors?', 'wordpress-seo' ) );
 
-		$this->set_property( 'description', __( 'If you choose no, your author archives will be deactivated to prevent
- duplicate content issues.', 'wordpress-seo' ) );
+		$this->set_property( 'description', __( 'If you choose no, your author archives will be deactivated to prevent  duplicate content issues.', 'wordpress-seo' ) );
 
 		$this->add_choice( 'yes', __( 'Yes', 'wordpress-seo' ) );
 		$this->add_choice( 'no', __( 'No', 'wordpress-seo' ) );

--- a/admin/config-ui/fields/class-field-post-type-visibility.php
+++ b/admin/config-ui/fields/class-field-post-type-visibility.php
@@ -16,9 +16,7 @@ class WPSEO_Config_Field_Post_Type_Visibility extends WPSEO_Config_Field {
 	public function __construct() {
 		parent::__construct( 'postTypeVisibility', 'HTML' );
 
-		$copy = __( 'Please specify what content types you would like to appear in search engines.
- If you do not know the differences between these, it\'s best to choose the
- default settings.', 'wordpress-seo' );
+		$copy = __( 'Please specify what content types you would like to appear in search engines. If you do not know the differences between these, it\'s best to choose the default settings.', 'wordpress-seo' );
 
 		$html = '<p>' . esc_html( $copy ) . '</p><br/>';
 

--- a/admin/config-ui/fields/class-field-social-profiles-intro.php
+++ b/admin/config-ui/fields/class-field-social-profiles-intro.php
@@ -18,9 +18,7 @@ class WPSEO_Config_Field_Social_Profiles_Intro extends WPSEO_Config_Field {
 
 		$intro_text = sprintf(
 			/* translators: %1$s is the plugin name, %2$s is a link opening tag, %3$s is a link closing tag. */
-			__( '%1$s can tell search engines about your social media profiles.
- These will be used in Google\'s Knowledge Graph. There are additional
- sharing options in the %1$s Social settings. %2$sRead more%3$s about these options.', 'wordpress-seo' ),
+			__( '%1$s can tell search engines about your social media profiles. These will be used in Google\'s Knowledge Graph. There are additional sharing options in the %1$s Social settings. %2$sRead more%3$s about these options.', 'wordpress-seo' ),
 			'Yoast SEO',
 			'<a target="_blank" rel="noopener noreferrer" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/1ey' ) . '">',
 			'</a>'

--- a/admin/config-ui/fields/class-field-title-intro.php
+++ b/admin/config-ui/fields/class-field-title-intro.php
@@ -16,11 +16,7 @@ class WPSEO_Config_Field_Title_Intro extends WPSEO_Config_Field {
 	public function __construct() {
 		parent::__construct( 'titleIntro', 'HTML' );
 
-		$html = __( 'On this page, you can change the name of your site and choose which
- separator to use. The separator will display, for instance, between your
- post title and site name. Symbols are shown in the size they\'ll appear in
- the search results. Choose the one that fits your brand best or takes up
- the least space in the snippets.', 'wordpress-seo' );
+		$html = __( 'On this page, you can change the name of your site and choose which separator to use. The separator will display, for instance, between your post title and site name. Symbols are shown in the size they\'ll appear in the search results. Choose the one that fits your brand best or takes up the least space in the snippets.', 'wordpress-seo' );
 
 		$html = '<p>' . esc_html( $html ) . '</p>';
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

This is a bit of an awkward one as it is unclear to me whether these phrases had line-breaks in them on purpose or accidentally.

If on purpose: the phrases were now often broken up mid-way in a sentence.
For translators, line-breaks in translatable strings -especially when at semi-random places - are difficult to work with as words have different lengths in different languages, let alone in different writing systems.

If there was a purpose to the line-breaks, it would be great to know the reason and we can figure what would be a better solution (if any).

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
