### PR TITLE
Yoast CS: Adds isset() check on superglobal. 

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -96,20 +96,8 @@ class WPSEO_Admin_Init {
 	 * Notify about the default tagline if the user hasn't changed it
 	 */
 	public function tagline_notice() {
-
-		$current_url = ( is_ssl() ? 'https://' : 'http://' );
-
-		if ( isset( $_SERVER['SERVER_NAME'] ) ) {
-			$current_url .= sanitize_text_field( wp_unslash( $_SERVER['SERVER_NAME'] ) );
-		}
-
-		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			$current_url .= sanitize_file_name( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-		}
-
 		$query_args    = array(
 			'autofocus[control]' => 'blogdescription',
-			'url'                => rawurlencode( $current_url ),
 		);
 		$customize_url = add_query_arg( $query_args, wp_customize_url() );
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -97,11 +97,19 @@ class WPSEO_Admin_Init {
 	 */
 	public function tagline_notice() {
 
-		$current_url   = ( is_ssl() ? 'https://' : 'http://' );
-		$current_url  .= sanitize_text_field( $_SERVER['SERVER_NAME'] ) . sanitize_text_field( $_SERVER['REQUEST_URI'] );
+		$current_url = ( is_ssl() ? 'https://' : 'http://' );
+
+		if ( isset( $_SERVER['SERVER_NAME'] ) ) {
+			$current_url .= sanitize_text_field( wp_unslash( $_SERVER['SERVER_NAME'] ) );
+		}
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$current_url .= sanitize_file_name( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		}
+
 		$query_args    = array(
 			'autofocus[control]' => 'blogdescription',
-			'url'                => urlencode( $current_url ),
+			'url'                => rawurlencode( $current_url ),
 		);
 		$customize_url = add_query_arg( $query_args, wp_customize_url() );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Yoast CS: Adds isset() check on superglobal. 

## Relevant technical choices:

* Fixes the following errors: 
```

FILE: admin\class-admin-init.php
--
--------------------------------------------------------------------------
FOUND 4 ERRORS AFFECTING 1 LINE
--------------------------------------------------------------------------
101 \| ERROR \| Detected usage of a non-validated input variable: $_SERVER
101 \| ERROR \| Missing wp_unslash() before sanitization.
101 \| ERROR \| Detected usage of a non-validated input variable: $_SERVER
101 \| ERROR \| Missing wp_unslash() before sanitization.
--------------------------------------------------------------------------
```

This PR can be tested by following these steps:

* This PR should not change anything nor break anything :)

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
