### PR TITLE
Yoast-CS: Added unslash and isset() check on superglobal. 

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -547,7 +547,8 @@ class Yoast_Notification_Center {
 	private static function get_user_input( $key ) {
 
 		$filter_input_type = INPUT_GET;
-		if ( 'POST' === strtoupper( $_SERVER['REQUEST_METHOD'] ) ) {
+
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === strtoupper( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) {
 			$filter_input_type = INPUT_POST;
 		}
 
@@ -555,9 +556,9 @@ class Yoast_Notification_Center {
 	}
 
 	/**
-	 * Retrieve the notifications from storage
+	 * Retrieve the notifications from storage.
 	 *
-	 * @return array Yoast_Notification[] Notifications
+	 * @return array|void Yoast_Notification[] Notifications.
 	 */
 	private function retrieve_notifications_from_storage() {
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Yoast-CS: Added unslash and isset() check on superglobal. 

## Relevant technical choices:

* Fixes the following errors:
```

FILE: admin\class-yoast-notification-center.php
--
----------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------
550 \| ERROR \| Detected usage of a non-validated input variable: $_SERVER
\|       \| (WordPress.Security.ValidatedSanitizedInput.InputNotValidated)
550 \| ERROR \| Missing wp_unslash() before sanitization.
\|       \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
550 \| ERROR \| Detected usage of a non-sanitized input variable: $_SERVER
\|       \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
----------------------------------------------------------------------------------------------------
```

This PR can be tested by following these steps:

* No functional changes.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
