### PR TITLE
Composer: improve compatibility with Windows OS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,17 +61,17 @@
 	},
 	"scripts": {
 		"config-yoastcs": [
-			"\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp",
-			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
+			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp",
+			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set default_standard Yoast"
 		],
 		"check-cs": [
-			"\"vendor/bin/phpcs\""
+			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs"
 		],
 		"check-cs-errors": [
-			"\"vendor/bin/phpcs\" --error-severity=1 --warning-severity=6"
+			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --error-severity=1 --warning-severity=6"
 		],
 		"fix-cs": [
-			"\"vendor/bin/phpcbf\""
+			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcbf"
 		],
 		"prefix-dependencies": [
 			"composer prefix-ruckusing",
@@ -80,10 +80,10 @@
 			"composer du"
 		],
 		"prefix-ruckusing": [
-			"./vendor/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/ruckusing --config=config/php-scoper/ruckusing.inc.php --force --quiet"
+			"@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/ruckusing --config=config/php-scoper/ruckusing.inc.php --force --quiet"
 		],
 		"prefix-idiorm": [
-			"./vendor/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/j4mie/idiorm --config=config/php-scoper/idiorm.inc.php --force --quiet"
+			"@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/j4mie/idiorm --config=config/php-scoper/idiorm.inc.php --force --quiet"
 		],
 		"post-install-cmd": [
 			"xrstf\\Composer52\\Generator::onPostInstallCmd",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _Improved compatibility with Windows for developers_ (if this should be mentioned at all)

## Relevant technical choices:

1. While the PHPCS related scripts already worked on Windows, the "prefix" related scripts did not.
     For a call to those to work on Windows, a path to a `bin` script like `./vendor/bin/php-scoper` should be changed to `\"vendor/bin/php-scoper\"`.
2. Next, we run into another problem, which is that the system default PHP version will be used instead of the PHP version which is set for Composer.
     Note: As far as I know, this issue is platform independent.
     To explain: A dev may have several PHP versions installed on their system and can point Composer to use a certain version. If so, when running `composer install` et al, that PHP version will be used to run Composer and to negotiate the platform requirements for the dependencies.
     However, when running a _script_ via Composer, like `composer prefix-ruckusing`, the system default PHP version will be used again...
     So, say you have Composer set to run on PHP 7.2, but the system default is PHP 5.6, the install will work fine and install all dependencies compatible with PHP 7.2, but then scripts will break on parse errors as PHP 5.6 will be used to run them.
     To fix this issue, you need to prefix the script with `@php` and then the PHP version used for Composer will be used.
      Ref: https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts
3. All good so far, however, now on Windows, instead of **_running_** the `*.bat` files in the `vendor/bin` directory, the non-suffixed version of the file (i.e. the CL PHP file), will be _printed to the screen_ instead...
     *sigh* Ok, so to fix that as well, you need to point to the _actual_ script which is being called from the file in `vendor/bin` instead of to the file in `vendor/bin` and only then, the script will actually run.
     Also see: https://github.com/composer/composer/issues/7645

Ok, so while all this will get us very far in getting things to run on Windows properly as well and this change is a very big improvement, the `prefix-*` scripts still run into problems on Windows with the filesystem and calls to `mk_dir()` failing, but that's a bug in a dependency (which should be fixed, but that's another issue).


## Test instructions
This PR **should** be tested by following these steps:

* Run `composer install`
* Run each and every script via `composer script-name` and make sure the script runs as expected.

**IMPORTANT**: these tests should preferably be run on Linux, Mac OS **_and_** Windows.

## Quality assurance

* [x] I have tested this code to the best of my abilities (on Windows 7)
