### PR TITLE
Yoast CS: Do sanitization and nonce verification in class-bulk-editor-list-table.php

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -133,25 +133,14 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 		$this->populate_editable_post_types();
 	}
-
+	
 	/**
 	 * Verifies nonce if additional parameters have been sent.
 	 *
 	 * Shows an error notification if the nonce check fails.
 	 */
 	private function verify_nonce() {
-		if ( wp_verify_nonce( filter_input( INPUT_GET, 'nonce' ), 'bulk-editor-table' ) ) {
-			return;
-		}
-
-		Yoast_Notification_Center::get()->add_notification(
-			new Yoast_Notification(
-				__( 'You are not allowed to access this page.', 'wordpress-seo' ),
-				array( 'type' => Yoast_Notification::ERROR )
-			)
-		);
-		Yoast_Notification_Center::get()->display_notifications();
-		die;
+		check_admin_referer( 'bulk-editor-table', filter_input( INPUT_GET, 'nonce' ) );
 	}
 
 	/**

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -102,11 +102,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	protected $pagination = array();
 
 	/**
-	 * The fields from the input get.
+	 * Holds the sanitized data from the user input.
 	 *
 	 * @var array
 	 */
-	protected $input_get = array();
+	protected $input_fields = array();
 
 	/**
 	 * Class constructor
@@ -114,18 +114,18 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	public function __construct() {
 		parent::__construct( $this->settings );
 
-		$this->input_get = $this->sanitize_input_fields();
-		if ( ! empty( $this->input_get ) ) {
+		$this->input_fields = $this->sanitize_input_fields();
+		if ( ! empty( $this->input_fields ) ) {
 			$this->verify_nonce();
 		}
 
 		$this->request_url    = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-		$this->current_page   = ( ! empty( $this->input_get['paged'] ) ) ? $this->input_get['paged'] : 1;
-		$this->current_filter = ( ! empty( $this->input_get['post_type_filter'] ) ) ? $this->input_get['post_type_filter'] : 1;
-		$this->current_status = ( ! empty( $this->input_get['post_status'] ) ) ? $this->input_get['post_status'] : 1;
+		$this->current_page   = ( ! empty( $this->input_fields['paged'] ) ) ? $this->input_fields['paged'] : 1;
+		$this->current_filter = ( ! empty( $this->input_fields['post_type_filter'] ) ) ? $this->input_fields['post_type_filter'] : 1;
+		$this->current_status = ( ! empty( $this->input_fields['post_status'] ) ) ? $this->input_fields['post_status'] : 1;
 		$this->current_order  = array(
-			'order'   => ( ! empty( $this->input_get['order'] ) ) ? $this->input_get['order'] : 'asc',
-			'orderby' => ( ! empty( $this->input_get['orderby'] ) ) ? $this->input_get['orderby'] : 'post_title',
+			'order'   => ( ! empty( $this->input_fields['order'] ) ) ? $this->input_fields['order'] : 'asc',
+			'orderby' => ( ! empty( $this->input_fields['orderby'] ) ) ? $this->input_fields['orderby'] : 'post_title',
 		);
 
 		$this->nonce    = wp_create_nonce( 'bulk-editor-table' );
@@ -133,7 +133,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 		$this->populate_editable_post_types();
 	}
-	
+
 	/**
 	 * Verifies nonce if additional parameters have been sent.
 	 *
@@ -144,7 +144,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Checks if additional parameters have been sent to determine if nonce should be checked or not.
+	 * Sanitizes the parameters that have been sent.
 	 *
 	 * @return array The sanitized fields.
 	 */
@@ -462,7 +462,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$current_order  = $this->current_order;
 
 		// If current type doesn't compare with objects page_type, than we have to unset some vars in the requested url (which will be use for internal table urls).
-		if ( isset( $this->input_get['type'] ) && $this->input_get['type'] !== $this->page_type ) {
+		if ( isset( $this->input_fields['type'] ) && $this->input_fields['type'] !== $this->page_type ) {
 			$request_url = remove_query_arg( 'paged', $request_url ); // Page will be set with value 1 below.
 			$request_url = remove_query_arg( 'post_type_filter', $request_url );
 			$request_url = remove_query_arg( 'post_status', $request_url );
@@ -703,8 +703,8 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$states          = get_post_stati( array( 'show_in_admin_all_list' => true ) );
 		$states['trash'] = 'trash';
 
-		if ( ! empty( $this->input_get['post_status'] ) ) {
-			$requested_state = $this->input_get['post_status'];
+		if ( ! empty( $this->input_fields['post_status'] ) ) {
+			$requested_state = $this->input_fields['post_status'];
 			if ( in_array( $requested_state, $states, true ) ) {
 				$states = array( $requested_state );
 			}

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -140,7 +140,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 * Shows an error notification if the nonce check fails.
 	 */
 	private function verify_nonce() {
-		check_admin_referer( 'bulk-editor-table', filter_input( INPUT_GET, 'nonce' ) );
+		check_admin_referer( 'bulk-editor-table', 'nonce' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Fixes the input issues in file class-bulk-editor-list-table.php

## Relevant technical choices:

* Should fixes a lot of the following issues:
```
FILE: admin\class-bulk-editor-list-table.php
--
----------------------------------------------------------------------------------------------------
FOUND 15 ERRORS AND 12 WARNINGS AFFECTING 9 LINES
----------------------------------------------------------------------------------------------------
110 \| ERROR   \| Detected usage of a non-validated input variable: $_SERVER
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotValidated)
110 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
110 \| ERROR   \| Detected usage of a non-sanitized input variable: $_SERVER
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
111 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
111 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
111 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
111 \| ERROR   \| Detected usage of a non-sanitized input variable: $_GET
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
112 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
112 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
112 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
112 \| ERROR   \| Detected usage of a non-sanitized input variable: $_GET
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
113 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
113 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
113 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
113 \| ERROR   \| Detected usage of a non-sanitized input variable: $_GET
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
115 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
115 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
115 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
115 \| ERROR   \| Detected usage of a non-sanitized input variable: $_GET
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
116 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
116 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
550 \| ERROR \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
116 \| ERROR   \| Detected usage of a non-sanitized input variable: $_GET
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
461 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
461 \| ERROR   \| Detected usage of a non-validated input variable: $_GET
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotValidated)
702 \| WARNING \| Processing form data without nonce verification.
\|         \| (WordPress.Security.NonceVerification.NoNonceVerification)
703 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
----------------------------------------------------------------------------------------------------
```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Verify the bulk editor is still working.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
