### PR TITLE
Yoast CS: Resolve unslash and sanitization issues

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -88,11 +88,13 @@ class WPSEO_Utils {
 	 * @return bool
 	 */
 	public static function is_apache() {
-		if ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWARE'], 'apache' ) !== false ) {
-			return true;
+		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) ) {
+			return '';
 		}
 
-		return false;
+		$software = sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) );
+
+		return stripos( $software, 'apache' ) !== false;
 	}
 
 	/**
@@ -105,11 +107,13 @@ class WPSEO_Utils {
 	 * @return bool
 	 */
 	public static function is_nginx() {
-		if ( isset( $_SERVER['SERVER_SOFTWARE'] ) && stristr( $_SERVER['SERVER_SOFTWARE'], 'nginx' ) !== false ) {
-			return true;
+		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) ) {
+			return '';
 		}
 
-		return false;
+		$software = sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) );
+
+		return stripos( $software, 'nginx' ) !== false;
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -89,7 +89,7 @@ class WPSEO_Utils {
 	 */
 	public static function is_apache() {
 		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) ) {
-			return '';
+			return false;
 		}
 
 		$software = sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) );
@@ -108,7 +108,7 @@ class WPSEO_Utils {
 	 */
 	public static function is_nginx() {
 		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) ) {
-			return '';
+			return false;
 		}
 
 		$software = sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Adds sanitization and use unslash for `inc\class-wpseo-utils.php`

## Relevant technical choices:

* Fixes the following issues:
```
FILE: inc\class-wpseo-utils.php
--
----------------------------------------------------------------------------------------------------
FOUND 4 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------------
91 \| ERROR \| Missing wp_unslash() before sanitization.
\|       \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
91 \| ERROR \| Detected usage of a non-sanitized input variable: $_SERVER
\|       \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
108 \| ERROR \| Missing wp_unslash() before sanitization.
\|       \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
108 \| ERROR \| Detected usage of a non-sanitized input variable: $_SERVER
\|       \| (WordPress.Security.ValidatedSanitizedInput.InputNotSanitized)
----------------------------------------------------------------------------------------------------
```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the unit tests will still pass.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
