### PR TITLE
Fix possible unminified build for the analysis worker

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -215,7 +215,7 @@ module.exports = function( env = { environment: "production", recalibration: "di
 				...base,
 				output: {
 					path: paths.jsDist,
-					filename: outputFilenameMinified,
+					filename: outputFilename,
 					jsonpFunction: "yoastWebpackJsonp",
 				},
 				entry: {

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -215,12 +215,27 @@ module.exports = function( env = { environment: "production", recalibration: "di
 				...base,
 				output: {
 					path: paths.jsDist,
+					filename: outputFilenameMinified,
+					jsonpFunction: "yoastWebpackJsonp",
+				},
+				entry: {
+					"babel-polyfill": "./js/src/babel-polyfill.js",
+				},
+				plugins,
+				optimization: {
+					runtimeChunk: false,
+				},
+			},
+			// Config for the analysis web worker.
+			{
+				...base,
+				output: {
+					path: paths.jsDist,
 					filename: outputFilename,
 					jsonpFunction: "yoastWebpackJsonp",
 				},
 				entry: {
 					"wp-seo-analysis-worker": "./js/src/wp-seo-analysis-worker.js",
-					"babel-polyfill": "./js/src/babel-polyfill.js",
 				},
 				plugins,
 				optimization: {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Fixes an issue where the development build did not work for `wp-seo-analysis-worker`.

## Relevant technical choices:

* Change the output filename of the analysis worker in webpack.
* Separate webpack configs for the no-externals and analysis worker. Due to babel polyfill always being required as minified (and that's correct).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Switch to this branch.
* Run `yarn install`
* Note: disable the dev server flag.

### Development
* Run `composer install`
* Run `grunt build`.
* Verify the file exists: `js/dist/wp-seo-analysis-worker-94-beta1.js`.
* Verify the metabox works as expected (no 404 errors).

### Release
* Run `composer install --no-dev`
* Run `grunt release`.
* Verify the file exists: `js/dist/wp-seo-analysis-worker-94-beta1.min.js`.
* Verify the metabox works as expected (no 404 errors).

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Related https://github.com/Yoast/wordpress-seo/pull/11738
