### PR TITLE
Documentation: use full docblocks for properties

### DIFF
--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -9,7 +9,11 @@
  * Abstract Capability Manager shared code.
  */
 abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Manager {
-	/** @var array Registered capabilities */
+	/**
+	 * Registered capabilities.
+	 *
+	 * @var array
+	 */
 	protected $capabilities = array();
 
 	/**

--- a/admin/capabilities/class-capability-manager-integration.php
+++ b/admin/capabilities/class-capability-manager-integration.php
@@ -13,7 +13,11 @@
  */
 class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integration {
 
-	/** @var WPSEO_Capability_Manager Capability manager to use. */
+	/**
+	 * Capability manager to use.
+	 *
+	 * @var WPSEO_Capability_Manager
+	 */
 	public $manager;
 
 	/**

--- a/admin/class-collector.php
+++ b/admin/class-collector.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Collector {
 
-	/** @var WPSEO_Collection[] */
+	/**
+	 * @var WPSEO_Collection[]
+	 */
 	protected $collections = array();
 
 	/**

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -10,19 +10,29 @@
  */
 class WPSEO_Database_Proxy {
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $table_name;
 
-	/** @var bool */
+	/**
+	 * @var bool
+	 */
 	protected $suppress_errors = true;
 
-	/** @var bool */
+	/**
+	 * @var bool
+	 */
 	protected $is_multisite_table = false;
 
-	/** @var bool */
+	/**
+	 * @var bool
+	 */
 	protected $last_suppressed_state;
 
-	/** @var wpdb */
+	/**
+	 * @var wpdb
+	 */
 	protected $database;
 
 	/**

--- a/admin/class-extension-manager.php
+++ b/admin/class-extension-manager.php
@@ -13,10 +13,16 @@ class WPSEO_Extension_Manager {
 	/** The transient key to save the cache in */
 	const TRANSIENT_CACHE_KEY = 'wpseo_license_active_extensions';
 
-	/** @var WPSEO_Extension[] */
+	/**
+	 * @var WPSEO_Extension[]
+	 */
 	protected $extensions = array();
 
-	/** @var array List of active plugins */
+	/**
+	 * List of active plugins.
+	 *
+	 * @var array
+	 */
 	static protected $active_extensions;
 
 	/**

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Extensions {
 
-	/** @var array Array with the Yoast extensions */
+	/**
+	 * Array with the Yoast extensions.
+	 *
+	 * @var array
+	 */
 	protected $extensions = array(
 		'Yoast SEO Premium' => array(
 			'slug'       => 'yoast-seo-premium',

--- a/admin/class-help-center-item.php
+++ b/admin/class-help-center-item.php
@@ -10,16 +10,32 @@
  */
 class WPSEO_Help_Center_Item {
 
-	/** @var string Identifier for this tab. */
+	/**
+	 * Identifier for this tab.
+	 *
+	 * @var string
+	 */
 	private $identifier;
 
-	/** @var string Label to display. */
+	/**
+	 * Label to display.
+	 *
+	 * @var string
+	 */
 	private $label;
 
-	/** @var string The dashicon classname to display in front of the label. */
+	/**
+	 * The dashicon classname to display in front of the label.
+	 *
+	 * @var string
+	 */
 	private $dashicon;
 
-	/** @var array Optional arguments. */
+	/**
+	 * Optional arguments.
+	 *
+	 * @var array
+	 */
 	private $args = array();
 
 	/**

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -12,10 +12,16 @@ class WPSEO_Meta_Storage implements WPSEO_Installable {
 
 	const TABLE_NAME = 'yoast_seo_meta';
 
-	/** @var WPSEO_Database_Proxy */
+	/**
+	 * @var WPSEO_Database_Proxy
+	 */
 	protected $database_proxy;
 
-	/** @var null|string Deprecated. */
+	/**
+	 * @deprecated
+	 *
+	 * @var null|string
+	 */
 	protected $table_prefix;
 
 	/**

--- a/admin/class-option-tab.php
+++ b/admin/class-option-tab.php
@@ -10,13 +10,25 @@
  */
 class WPSEO_Option_Tab {
 
-	/** @var string Name of the tab */
+	/**
+	 * Name of the tab.
+	 *
+	 * @var string
+	 */
 	private $name;
 
-	/** @var string Label of the tab */
+	/**
+	 * Label of the tab.
+	 *
+	 * @var string
+	 */
 	private $label;
 
-	/** @var array Optional arguments */
+	/**
+	 * Optional arguments.
+	 *
+	 * @var array
+	 */
 	private $arguments;
 
 	/**

--- a/admin/class-option-tabs.php
+++ b/admin/class-option-tabs.php
@@ -10,13 +10,25 @@
  */
 class WPSEO_Option_Tabs {
 
-	/** @var string Tabs base */
+	/**
+	 * Tabs base.
+	 *
+	 * @var string
+	 */
 	private $base;
 
-	/** @var array The tabs in this group */
+	/**
+	 * The tabs in this group.
+	 *
+	 * @var array
+	 */
 	private $tabs = array();
 
-	/** @var string Name of the active tab */
+	/**
+	 * Name of the active tab.
+	 *
+	 * @var string
+	 */
 	private $active_tab = '';
 
 	/**

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -9,10 +9,18 @@
  * Class WPSEO_Premium_Upsell_Admin_Block
  */
 class WPSEO_Premium_Upsell_Admin_Block {
-	/** @var string Hook to display the block on. */
+	/**
+	 * Hook to display the block on.
+	 *
+	 * @var string
+	 */
 	protected $hook;
 
-	/** @var string Identifier to use in the dismissal functionality. */
+	/**
+	 * Identifier to use in the dismissal functionality.
+	 *
+	 * @var string
+	 */
 	protected $identifier = 'premium_upsell_admin_block';
 
 	/**

--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -14,7 +14,9 @@ class WPSEO_Product_Upsell_Notice {
 
 	const OPTION_NAME = 'wpseo';
 
-	/** @var array */
+	/**
+	 * @var array
+	 */
 	protected $options;
 
 	/**

--- a/admin/class-remote-request.php
+++ b/admin/class-remote-request.php
@@ -13,20 +13,28 @@ class WPSEO_Remote_Request {
 	const METHOD_POST = 'post';
 	const METHOD_GET  = 'get';
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $endpoint = '';
 
-	/** @var array */
+	/**
+	 * @var array
+	 */
 	protected $args = array(
 		'blocking'  => false,
 		'sslverify' => false,
 		'timeout'   => 2,
 	);
 
-	/** @var WP_Error|null */
+	/**
+	 * @var WP_Error|null
+	 */
 	protected $response_error;
 
-	/** @var mixed */
+	/**
+	 * @var mixed
+	 */
 	protected $response_body;
 
 	/**

--- a/admin/class-yoast-alerts.php
+++ b/admin/class-yoast-alerts.php
@@ -12,21 +12,49 @@ class Yoast_Alerts {
 
 	const ADMIN_PAGE = 'wpseo_dashboard';
 
-	/** @var int Total notifications count */
+	/**
+	 * Total notifications count.
+	 *
+	 * @var int
+	 */
 	private static $notification_count = 0;
 
-	/** @var array All error notifications */
+	/**
+	 * All error notifications.
+	 *
+	 * @var array
+	 */
 	private static $errors = array();
-	/** @var array Active errors */
+	/**
+	 * Active errors.
+	 *
+	 * @var array
+	 */
 	private static $active_errors = array();
-	/** @var array Dismissed errors */
+	/**
+	 * Dismissed errors.
+	 *
+	 * @var array
+	 */
 	private static $dismissed_errors = array();
 
-	/** @var array All warning notifications */
+	/**
+	 * All warning notifications.
+	 *
+	 * @var array
+	 */
 	private static $warnings = array();
-	/** @var array Active warnings */
+	/**
+	 * Active warnings.
+	 *
+	 * @var array
+	 */
 	private static $active_warnings = array();
-	/** @var array Dismissed warnings */
+	/**
+	 * Dismissed warnings.
+	 *
+	 * @var array
+	 */
 	private static $dismissed_warnings = array();
 
 	/**

--- a/admin/class-yoast-network-settings-api.php
+++ b/admin/class-yoast-network-settings-api.php
@@ -11,17 +11,23 @@
 class Yoast_Network_Settings_API {
 
 	/**
-	 * @var array Registered network settings.
+	 * Registered network settings.
+	 *
+	 * @var array
 	 */
 	private $registered_settings = array();
 
 	/**
-	 * @var array Options whitelist, keyed by option group.
+	 * Options whitelist, keyed by option group.
+	 *
+	 * @var array
 	 */
 	private $whitelist_options = array();
 
 	/**
-	 * @var Yoast_Network_Settings_API The singleton instance of this class.
+	 * The singleton instance of this class.
+	 *
+	 * @var Yoast_Network_Settings_API
 	 */
 	private static $instance = null;
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -13,22 +13,44 @@ class Yoast_Notification_Center {
 	/** Option name to store notifications on */
 	const STORAGE_KEY = 'yoast_notifications';
 
-	/** @var \Yoast_Notification_Center The singleton instance of this object */
+	/**
+	 * The singleton instance of this object.
+	 *
+	 * @var \Yoast_Notification_Center
+	 */
 	private static $instance = null;
 
-	/** @var $notifications Yoast_Notification[] */
+	/**
+	 * @var \Yoast_Notification[]
+	 */
 	private $notifications = array();
 
-	/** @var array Notifications there are newly added */
+	/**
+	 * Notifications there are newly added.
+	 *
+	 * @var array
+	 */
 	private $new = array();
 
-	/** @var array Notifications that were resolved this execution */
+	/**
+	 * Notifications that were resolved this execution.
+	 *
+	 * @var array
+	 */
 	private $resolved = 0;
 
-	/** @var array Internal storage for transaction before notifications have been retrieved from storage. */
+	/**
+	 * Internal storage for transaction before notifications have been retrieved from storage.
+	 *
+	 * @var array
+	 */
 	private $queued_transactions = array();
 
-	/** @var bool Internal flag for whether notifications have been retrieved from storage. */
+	/**
+	 * Internal flag for whether notifications have been retrieved from storage.
+	 *
+	 * @var bool
+	 */
 	private $notifications_retrieved = false;
 
 	/**

--- a/admin/config-ui/class-configuration-components.php
+++ b/admin/config-ui/class-configuration-components.php
@@ -10,10 +10,18 @@
  */
 class WPSEO_Configuration_Components {
 
-	/** @var WPSEO_Config_Component[] List of registered components */
+	/**
+	 * List of registered components.
+	 *
+	 * @var WPSEO_Config_Component[]
+	 */
 	protected $components = array();
 
-	/** @var WPSEO_Configuration_Options_Adapter Adapter */
+	/**
+	 * Adapter.
+	 *
+	 * @var WPSEO_Configuration_Options_Adapter
+	 */
 	protected $adapter;
 
 	/**

--- a/admin/config-ui/class-configuration-endpoint.php
+++ b/admin/config-ui/class-configuration-endpoint.php
@@ -17,7 +17,11 @@ class WPSEO_Configuration_Endpoint {
 	const CAPABILITY_RETRIEVE = 'wpseo_manage_options';
 	const CAPABILITY_STORE = 'wpseo_manage_options';
 
-	/** @var WPSEO_Configuration_Service Service to use */
+	/**
+	 * Service to use.
+	 *
+	 * @var WPSEO_Configuration_Service
+	 */
 	protected $service;
 
 	/**

--- a/admin/config-ui/class-configuration-options-adapter.php
+++ b/admin/config-ui/class-configuration-options-adapter.php
@@ -18,7 +18,11 @@ class WPSEO_Configuration_Options_Adapter {
 	const OPTION_TYPE_YOAST = 'yoast';
 	const OPTION_TYPE_CUSTOM = 'custom';
 
-	/** @var array List of registered lookups */
+	/**
+	 * List of registered lookups.
+	 *
+	 * @var array
+	 */
 	protected $lookup = array();
 
 	/**

--- a/admin/config-ui/class-configuration-service.php
+++ b/admin/config-ui/class-configuration-service.php
@@ -10,22 +10,34 @@
  */
 class WPSEO_Configuration_Service {
 
-	/** @var WPSEO_Configuration_Structure */
+	/**
+	 * @var WPSEO_Configuration_Structure
+	 */
 	protected $structure;
 
-	/** @var WPSEO_Configuration_Components */
+	/**
+	 * @var WPSEO_Configuration_Components
+	 */
 	protected $components;
 
-	/** @var WPSEO_Configuration_Storage */
+	/**
+	 * @var WPSEO_Configuration_Storage
+	 */
 	protected $storage;
 
-	/** @var WPSEO_Configuration_Endpoint */
+	/**
+	 * @var WPSEO_Configuration_Endpoint
+	 */
 	protected $endpoint;
 
-	/** @var WPSEO_Configuration_Options_Adapter */
+	/**
+	 * @var WPSEO_Configuration_Options_Adapter
+	 */
 	protected $adapter;
 
-	/** @var WPSEO_Configuration_Translations */
+	/**
+	 * @var WPSEO_Configuration_Translations
+	 */
 	protected $translations;
 
 	/**

--- a/admin/config-ui/class-configuration-storage.php
+++ b/admin/config-ui/class-configuration-storage.php
@@ -10,10 +10,14 @@
  */
 class WPSEO_Configuration_Storage {
 
-	/** @var WPSEO_Configuration_Options_Adapter */
+	/**
+	 * @var \WPSEO_Configuration_Options_Adapter
+	 */
 	protected $adapter;
 
-	/** @var array WPSEO_Config_Field */
+	/**
+	 * @var \WPSEO_Config_Field[]
+	 */
 	protected $fields = array();
 
 	/**

--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Configuration_Structure {
 
-	/** @var array Registered steps */
+	/**
+	 * Registered steps.
+	 *
+	 * @var array
+	 */
 	protected $steps = array();
 
 	/**

--- a/admin/config-ui/class-configuration-translations.php
+++ b/admin/config-ui/class-configuration-translations.php
@@ -10,10 +10,18 @@
  */
 class WPSEO_Configuration_Translations {
 
-	/** @var array Registered steps */
+	/**
+	 * Registered steps.
+	 *
+	 * @var array
+	 */
 	protected $translations = array();
 
-	/** @var string The locale */
+	/**
+	 * The locale.
+	 *
+	 * @var string
+	 */
 	protected $locale;
 
 	/**

--- a/admin/config-ui/components/class-component-connect-google-search-console.php
+++ b/admin/config-ui/components/class-component-connect-google-search-console.php
@@ -14,7 +14,11 @@ class WPSEO_Config_Component_Connect_Google_Search_Console implements WPSEO_Conf
 	const OPTION_REFRESH_TOKEN = 'wpseo-gsc-refresh_token';
 
 
-	/** @var WPSEO_GSC_Service Service to use */
+	/**
+	 * Service to use.
+	 *
+	 * @var WPSEO_GSC_Service
+	 */
 	protected $gsc_service;
 
 	/**

--- a/admin/config-ui/factories/class-factory-post-type.php
+++ b/admin/config-ui/factories/class-factory-post-type.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Config_Factory_Post_Type {
 
-	/** @var WPSEO_Config_Field_Choice_Post_Type[] List of fields */
+	/**
+	 * List of fields.
+	 *
+	 * @var WPSEO_Config_Field_Choice_Post_Type[]
+	 */
 	protected static $fields = array();
 
 	/**

--- a/admin/config-ui/fields/class-field-choice-post-type.php
+++ b/admin/config-ui/fields/class-field-choice-post-type.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Config_Field_Choice_Post_Type extends WPSEO_Config_Field_Choice {
 
-	/** @var string Post type */
+	/**
+	 * Post type.
+	 *
+	 * @var string
+	 */
 	protected $post_type;
 
 	/**

--- a/admin/config-ui/fields/class-field.php
+++ b/admin/config-ui/fields/class-field.php
@@ -9,19 +9,39 @@
  * Class WPSEO_Config_Field
  */
 class WPSEO_Config_Field {
-	/** @var string Field name */
+	/**
+	 * Field name.
+	 *
+	 * @var string
+	 */
 	protected $field;
 
-	/** @var string Component to use */
+	/**
+	 * Component to use.
+	 *
+	 * @var string
+	 */
 	protected $component;
 
-	/** @var array Properties of this field */
+	/**
+	 * Properties of this field.
+	 *
+	 * @var array
+	 */
 	protected $properties = array();
 
-	/** @var array Field requirements */
+	/**
+	 * Field requirements.
+	 *
+	 * @var array
+	 */
 	protected $requires = array();
 
-	/** @var array|mixed Value of this field */
+	/**
+	 * Value of this field.
+	 *
+	 * @var array|mixed
+	 */
 	protected $data = array();
 
 	/**

--- a/admin/endpoints/class-endpoint-ryte.php
+++ b/admin/endpoints/class-endpoint-ryte.php
@@ -15,7 +15,11 @@ class WPSEO_Endpoint_Ryte implements WPSEO_Endpoint {
 
 	const CAPABILITY_RETRIEVE = 'manage_options';
 
-	/** @var WPSEO_Ryte_Service Service to use */
+	/**
+	 * Service to use.
+	 *
+	 * @var WPSEO_Ryte_Service
+	 */
 	protected $service;
 
 	/**

--- a/admin/endpoints/class-endpoint-statistics.php
+++ b/admin/endpoints/class-endpoint-statistics.php
@@ -15,7 +15,11 @@ class WPSEO_Endpoint_Statistics implements WPSEO_Endpoint {
 
 	const CAPABILITY_RETRIEVE = 'read';
 
-	/** @var WPSEO_Statistics_Service Service to use */
+	/**
+	 * Service to use.
+	 *
+	 * @var WPSEO_Statistics_Service
+	 */
 	protected $service;
 
 	/**

--- a/admin/google_search_console/class-gsc-modal.php
+++ b/admin/google_search_console/class-gsc-modal.php
@@ -10,13 +10,19 @@
  */
 class WPSEO_GSC_Modal {
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $view;
 
-	/** @var int */
+	/**
+	 * @var int
+	 */
 	protected $height;
 
-	/** @var array */
+	/**
+	 * @var array
+	 */
 	protected $view_vars;
 
 	/**

--- a/admin/links/class-link-column-count.php
+++ b/admin/links/class-link-column-count.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Link_Column_Count {
 
-	/** @var array */
+	/**
+	 * @var array
+	 */
 	protected $count = array();
 
 	/**

--- a/admin/links/class-link-content-processor.php
+++ b/admin/links/class-link-content-processor.php
@@ -11,10 +11,14 @@
  */
 class WPSEO_Link_Content_Processor {
 
-	/** @var WPSEO_Link_Storage */
+	/**
+	 * @var WPSEO_Link_Storage
+	 */
 	protected $storage;
 
-	/** @var WPSEO_Meta_Storage */
+	/**
+	 * @var WPSEO_Meta_Storage
+	 */
 	private $count_storage;
 
 	/**

--- a/admin/links/class-link-extractor.php
+++ b/admin/links/class-link-extractor.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Link_Extractor {
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $content;
 
 	/**

--- a/admin/links/class-link-factory.php
+++ b/admin/links/class-link-factory.php
@@ -10,14 +10,19 @@
  */
 class WPSEO_Link_Factory {
 
-	/** @var WPSEO_Link_Type_Classifier */
+	/**
+	 * @var WPSEO_Link_Type_Classifier
+	 */
 	protected $classifier;
 
-	/** @var WPSEO_Link_Internal_Lookup */
-
+	/**
+	 * @var WPSEO_Link_Internal_Lookup
+	 */
 	protected $internal_lookup;
 
-	/** @var WPSEO_Link_Filter */
+	/**
+	 * @var WPSEO_Link_Filter
+	 */
 	protected $filter;
 
 	/**

--- a/admin/links/class-link-filter.php
+++ b/admin/links/class-link-filter.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Link_Filter {
 
-	/** @var string|null */
+	/**
+	 * @var string|null
+	 */
 	protected $current_page_path;
 
 	/**

--- a/admin/links/class-link-installer.php
+++ b/admin/links/class-link-installer.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Link_Installer {
 
-	/** @var WPSEO_Installable[] */
+	/**
+	 * @var WPSEO_Installable[]
+	 */
 	protected $installables = array();
 
 	/**

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -9,10 +9,18 @@
  * Handles the reindexing of links interface in the Dashboard.
  */
 class WPSEO_Link_Reindex_Dashboard {
-	/** @var array Public post types to scan for unprocessed items */
+	/**
+	 * Public post types to scan for unprocessed items.
+	 *
+	 * @var array
+	 */
 	protected $public_post_types = array();
 
-	/** @var int Number of unprocessed items */
+	/**
+	 * Number of unprocessed items.
+	 *
+	 * @var int
+	 */
 	protected $unprocessed = 0;
 
 	/**

--- a/admin/links/class-link-reindex-post-endpoint.php
+++ b/admin/links/class-link-reindex-post-endpoint.php
@@ -15,7 +15,9 @@ class WPSEO_Link_Reindex_Post_Endpoint {
 
 	const CAPABILITY_RETRIEVE = 'edit_posts';
 
-	/** @var WPSEO_Link_Reindex_Post_Service */
+	/**
+	 * @var WPSEO_Link_Reindex_Post_Service
+	 */
 	protected $service;
 
 	/**

--- a/admin/links/class-link-storage.php
+++ b/admin/links/class-link-storage.php
@@ -12,10 +12,16 @@ class WPSEO_Link_Storage implements WPSEO_Installable {
 
 	const TABLE_NAME = 'yoast_seo_links';
 
-	/** @var WPSEO_Database_Proxy */
+	/**
+	 * @var WPSEO_Database_Proxy
+	 */
 	protected $database_proxy;
 
-	/** @var null|string Deprecated. */
+	/**
+	 * @deprecated
+	 *
+	 * @var null|string
+	 */
 	protected $table_prefix;
 
 	/**

--- a/admin/links/class-link-type-classifier.php
+++ b/admin/links/class-link-type-classifier.php
@@ -10,10 +10,14 @@
  */
 class WPSEO_Link_Type_Classifier {
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $base_host = '';
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $base_path = '';
 
 	/**

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Link_Watcher {
 
-	/** @var WPSEO_Link_Content_Processor */
+	/**
+	 * @var WPSEO_Link_Content_Processor
+	 */
 	protected $content_processor;
 
 	/**

--- a/admin/links/class-link.php
+++ b/admin/links/class-link.php
@@ -13,13 +13,19 @@ class WPSEO_Link {
 	const TYPE_EXTERNAL = 'external';
 	const TYPE_INTERNAL = 'internal';
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $url;
 
-	/** @var int */
+	/**
+	 * @var int
+	 */
 	protected $target_post_id;
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $type;
 
 	/**

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -10,7 +10,11 @@
  */
 abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 
-	/** @var WPSEO_Menu Menu */
+	/**
+	 * A menu.
+	 *
+	 * @var WPSEO_Menu
+	 */
 	protected $menu;
 
 	/**

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -12,7 +12,11 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 	/** The page identifier used in WordPress to register the admin page !DO NOT CHANGE THIS! */
 	const PAGE_IDENTIFIER = 'wpseo_dashboard';
 
-	/** @var array List of classes that add admin functionality. */
+	/**
+	 * List of classes that add admin functionality.
+	 *
+	 * @var array
+	 */
 	protected $admin_features;
 
 	/**

--- a/admin/menu/class-replacevar-editor.php
+++ b/admin/menu/class-replacevar-editor.php
@@ -10,14 +10,16 @@
  */
 class WPSEO_Replacevar_Editor {
 	/**
-	 * @var Yoast_Form Yoast Forms instance.
+	 * Yoast Forms instance.
+	 *
+	 * @var Yoast_Form
 	 */
 	private $yform;
 
 	/**
-	 * @var array {
-	 *      The arguments required for the div to render.
+	 * The arguments required for the div to render.
 	 *
+	 * @var array {
 	 *      @type string $title                 The title field id.
 	 *      @type string $description           The description field id.
 	 *      @type string $page_type_recommended The page type for the context of the recommended replace vars.

--- a/admin/notifiers/class-configuration-notifier.php
+++ b/admin/notifiers/class-configuration-notifier.php
@@ -12,7 +12,9 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 	const META_NAME = 'wpseo-dismiss-configuration-notice';
 	const META_VALUE = 'yes';
 
-	/** @var bool */
+	/**
+	 * @var bool
+	 */
 	protected $show_notification;
 
 	/**

--- a/admin/roles/class-abstract-role-manager.php
+++ b/admin/roles/class-abstract-role-manager.php
@@ -9,7 +9,11 @@
  * Abstract Role Manager template.
  */
 abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
-	/** @var array Registered roles. */
+	/**
+	 * Registered roles.
+	 *
+	 * @var array
+	 */
 	protected $roles = array();
 
 	/**

--- a/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/admin/taxonomy/class-taxonomy-social-fields.php
@@ -9,7 +9,11 @@
  * This class parses all the values for the social tab in the Yoast SEO settings metabox
  */
 class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
-	/** @var array List of social networks */
+	/**
+	 * List of social networks.
+	 *
+	 * @var array
+	 */
 	protected $networks;
 
 	/**

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -10,13 +10,19 @@
  */
 class WPSEO_Tracking {
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $option_name = 'wpseo_tracking_last_request';
 
-	/** @var int */
+	/**
+	 * @var int
+	 */
 	protected $threshold = 0;
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $endpoint = '';
 
 	/**

--- a/admin/views/class-view-utils.php
+++ b/admin/views/class-view-utils.php
@@ -9,7 +9,11 @@
  * Class Yoast_View_Utils
  */
 class Yoast_View_Utils {
-	/** @var Yoast_Form Form to use. */
+	/**
+	 * Form to use.
+	 *
+	 * @var Yoast_Form
+	 */
 	protected $form;
 
 	/**

--- a/admin/views/class-yoast-feature-toggle.php
+++ b/admin/views/class-yoast-feature-toggle.php
@@ -10,25 +10,53 @@
  */
 class Yoast_Feature_Toggle {
 
-	/** @var string Feature toggle identifier. */
+	/**
+	 * Feature toggle identifier.
+	 *
+	 * @var string
+	 */
 	protected $name = '';
 
-	/** @var string Name of the setting the feature toggle is associated with. */
+	/**
+	 * Name of the setting the feature toggle is associated with.
+	 *
+	 * @var string
+	 */
 	protected $setting = '';
 
-	/** @var string Feature toggle label. */
+	/**
+	 * Feature toggle label.
+	 *
+	 * @var string
+	 */
 	protected $label = '';
 
-	/** @var string URL to learn more about the feature. */
+	/**
+	 * URL to learn more about the feature.
+	 *
+	 * @var string
+	 */
 	protected $read_more_url = '';
 
-	/** @var string Label for the learn more link. */
+	/**
+	 * Label for the learn more link.
+	 *
+	 * @var string
+	 */
 	protected $read_more_label = '';
 
-	/** @var string Additional help content for the feature. */
+	/**
+	 * Additional help content for the feature.
+	 *
+	 * @var string
+	 */
 	protected $extra = '';
 
-	/** @var string Value to specify the feature toggle order. */
+	/**
+	 * Value to specify the feature toggle order.
+	 *
+	 * @var string
+	 */
 	protected $order = 100;
 
 	/**

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -10,10 +10,18 @@
  */
 class Yoast_Feature_Toggles {
 
-	/** @var array Available feature toggles. */
+	/**
+	 * Available feature toggles.
+	 *
+	 * @var array
+	 */
 	protected $toggles;
 
-	/** @var self|null Instance holder. */
+	/**
+	 * Instance holder.
+	 *
+	 * @var self|null
+	 */
 	protected static $instance = null;
 
 	/**

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -11,74 +11,100 @@
 class WPSEO_Breadcrumbs {
 
 	/**
-	 * @var object    Instance of this class
+	 * Instance of this class.
+	 *
+	 * @var object
 	 */
 	public static $instance;
 
 	/**
-	 * @var string    Last used 'before' string
+	 * Last used 'before' string.
+	 *
+	 * @var string
 	 */
 	public static $before = '';
 
 	/**
-	 * @var string    Last used 'after' string
+	 * Last used 'after' string.
+	 *
+	 * @var string
 	 */
 	public static $after = '';
 
 
 	/**
-	 * @var string    Blog's show on front setting, 'page' or 'posts'
+	 * Blog's show on front setting, 'page' or 'posts'.
+	 *
+	 * @var string
 	 */
 	private $show_on_front;
 
 	/**
-	 * @var mixed    Blog's page for posts setting, page id or false
+	 * Blog's page for posts setting, page id or false.
+	 *
+	 * @var mixed
 	 */
 	private $page_for_posts;
 
 	/**
-	 * @var mixed    Current post object
+	 * Current post object.
+	 *
+	 * @var mixed
 	 */
 	private $post;
 
 	/**
-	 * @var string    HTML wrapper element for a single breadcrumb element
+	 * HTML wrapper element for a single breadcrumb element.
+	 *
+	 * @var string
 	 */
 	private $element = 'span';
 
 	/**
-	 * @var string    Yoast SEO breadcrumb separator
+	 * Yoast SEO breadcrumb separator.
+	 *
+	 * @var string
 	 */
 	private $separator = '';
 
 	/**
-	 * @var string    HTML wrapper element for the Yoast SEO breadcrumbs output
+	 * HTML wrapper element for the Yoast SEO breadcrumbs output.
+	 *
+	 * @var string
 	 */
 	private $wrapper = 'span';
 
 	/**
-	 * @var array    Array of crumbs
+	 * Array of crumbs.
 	 *
 	 * Each element of the crumbs array can either have one of these keys:
 	 *    "id"         for post types;
 	 *    "ptarchive"  for a post type archive;
 	 *    "term"       for a taxonomy term.
 	 * OR it consists of a predefined set of 'text', 'url' and 'allow_html'.
+	 *
+	 * @var array
 	 */
 	private $crumbs = array();
 
 	/**
-	 * @var array    Count of the elements in the $crumbs property
+	 * Count of the elements in the $crumbs property.
+	 *
+	 * @var array
 	 */
 	private $crumb_count = 0;
 
 	/**
-	 * @var array    Array of individual (linked) html strings created from crumbs
+	 * Array of individual (linked) html strings created from crumbs.
+	 *
+	 * @var array
 	 */
 	private $links = array();
 
 	/**
-	 * @var string    Breadcrumb html string
+	 * Breadcrumb html string.
+	 *
+	 * @var string
 	 */
 	private $output;
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -11,11 +11,15 @@
  */
 class WPSEO_Frontend {
 	/**
-	 * @var    object    Instance of this class.
+	 * Instance of this class.
+	 *
+	 * @var object
 	 */
 	public static $instance;
 	/**
-	 * @var boolean Boolean indicating whether output buffering has been started.
+	 * Toggle indicating whether output buffering has been started.
+	 *
+	 * @var boolean
 	 */
 	private $ob_started = false;
 	/**
@@ -48,10 +52,14 @@ class WPSEO_Frontend {
 	 * @var string
 	 */
 	private $title = null;
-	/** @var WPSEO_Frontend_Page_Type */
+	/**
+	 * @var WPSEO_Frontend_Page_Type
+	 */
 	protected $frontend_page_type;
 
-	/** @var WPSEO_WooCommerce_Shop_Page */
+	/**
+	 * @var WPSEO_WooCommerce_Shop_Page
+	 */
 	protected $woocommerce_shop_page;
 
 	/**

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -14,11 +14,15 @@
  */
 class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	/**
-	 * @var array Holds the social profiles for the entity
+	 * Holds the social profiles for the entity.
+	 *
+	 * @var array
 	 */
 	private $profiles = array();
 	/**
-	 * @var array Holds the data to put out
+	 * Holds the data to put out.
+	 *
+	 * @var array
 	 */
 	private $data = array();
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_OpenGraph {
 
-	/** @var WPSEO_Frontend_Page_Type */
+	/**
+	 * @var WPSEO_Frontend_Page_Type
+	 */
 	protected $frontend_page_type;
 
 	/**

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -13,21 +13,29 @@
 class WPSEO_Twitter {
 
 	/**
-	 * @var    object    Instance of this class
+	 * Instance of this class.
+	 *
+	 * @var object
 	 */
 	public static $instance;
 
 	/**
-	 * @var array Images
+	 * Images.
+	 *
+	 * @var array
 	 */
 	private $images = array();
 
 	/**
-	 * @var array Images
+	 * Images.
+	 *
+	 * @var array
 	 */
 	public $shown_images = array();
 
-	/** @var WPSEO_Frontend_Page_Type */
+	/**
+	 * @var WPSEO_Frontend_Page_Type
+	 */
 	protected $frontend_page_type;
 
 	/**

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -25,7 +25,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	/** The identifier used for the Network Settings submenu. */
 	const NETWORK_SETTINGS_SUBMENU_IDENTIFIER = 'wpseo-network-settings';
 
-	/** @var WPSEO_Admin_Asset_Manager Asset manager instance. */
+	/**
+	 * Asset manager instance.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
 	protected $asset_manager;
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -11,13 +11,18 @@
 class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 	/**
-	 * @var  string  Option name.
+	 * Option name.
+	 *
+	 * @var string
 	 */
 	public $option_name = 'wpseo';
 
 	/**
-	 * @var  array  Array of defaults for the option.
-	 *        Shouldn't be requested directly, use $this->get_defaults();
+	 * Array of defaults for the option.
+	 *
+	 * {@internal Shouldn't be requested directly, use $this->get_defaults();}}
+	 *
+	 * @var  array
 	 */
 	protected $defaults = array(
 		// Non-form fields, set via (ajax) function.
@@ -47,7 +52,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	);
 
 	/**
-	 * @var array Sub-options which should not be overloaded with multi-site defaults.
+	 * Sub-options which should not be overloaded with multi-site defaults.
+	 *
+	 * @var array
 	 */
 	public $ms_exclude = array(
 		/* Privacy. */
@@ -57,7 +64,11 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'yandexverify',
 	);
 
-	/** @var array Possible values for the site_type option. */
+	/**
+	 * Possible values for the site_type option.
+	 *
+	 * @var array
+	 */
 	protected $site_types = array(
 		'',
 		'blog',
@@ -68,7 +79,11 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'personalOther',
 	);
 
-	/** @var array Possible environment types. */
+	/**
+	 * Possible environment types.
+	 *
+	 * @var array
+	 */
 	protected $environment_types = array(
 		'',
 		'production',
@@ -76,7 +91,11 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'development',
 	);
 
-	/** @var array Possible has_multiple_authors options. */
+	/**
+	 * Possible has_multiple_authors options.
+	 *
+	 * @var array
+	 */
 	protected $has_multiple_authors_options = array(
 		'',
 		true,
@@ -84,7 +103,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	);
 
 	/**
-	 * @var string Name for an option higher in the hierarchy to override setting access.
+	 * Name for an option higher in the hierarchy to override setting access.
+	 *
+	 * @var string
 	 */
 	protected $override_option_name = 'wpseo_ms';
 

--- a/inc/options/class-wpseo-options-backfill.php
+++ b/inc/options/class-wpseo-options-backfill.php
@@ -11,7 +11,11 @@
  * @since 7.0.2
  */
 class WPSEO_Options_Backfill implements WPSEO_WordPress_Integration {
-	/** @var bool Are the filters hooked or not. */
+	/**
+	 * Are the filters hooked or not.
+	 *
+	 * @var bool
+	 */
 	protected $hooked = false;
 
 	/**

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -12,8 +12,9 @@
  */
 class WPSEO_Options {
 	/**
-	 * @var  array  Options this class uses.
-	 *              Array format:  (string) option_name  => (string) name of concrete class for the option
+	 * Options this class uses.
+	 *
+	 * @var array Array format: (string) option_name  => (string) name of concrete class for the option.
 	 * @static
 	 */
 	public static $options = array(
@@ -24,15 +25,23 @@ class WPSEO_Options {
 		'wpseo_taxonomy_meta' => 'WPSEO_Taxonomy_Meta',
 	);
 	/**
-	 * @var  array   Array of instantiated option objects.
+	 * Array of instantiated option objects.
+	 *
+	 * @var array
 	 */
 	protected static $option_instances = array();
 	/**
-	 * @var  object  Instance of this class.
+	 * Instance of this class.
+	 *
+	 * @var object
 	 */
 	protected static $instance;
 
-	/** @var WPSEO_Options_Backfill Backfill instance. */
+	/**
+	 * Backfill instance.
+	 *
+	 * @var WPSEO_Options_Backfill
+	 */
 	protected static $backfill;
 
 	/**

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -10,19 +10,39 @@
  */
 class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
-	/** @var string $home_url Holds the home_url() value. */
+	/**
+	 * Holds the home_url() value.
+	 *
+	 * @var string
+	 */
 	protected static $home_url;
 
-	/** @var WPSEO_Sitemap_Image_Parser $image_parser Holds image parser instance. */
+	/**
+	 * Holds image parser instance.
+	 *
+	 * @var WPSEO_Sitemap_Image_Parser
+	 */
 	protected static $image_parser;
 
-	/** @var object $classifier Holds instance of classifier for a link. */
+	/**
+	 * Holds instance of classifier for a link.
+	 *
+	 * @var object
+	 */
 	protected static $classifier;
 
-	/** @var int $page_on_front_id Static front page ID. */
+	/**
+	 * Static front page ID.
+	 *
+	 * @var int
+	 */
 	protected static $page_on_front_id;
 
-	/** @var int $page_for_posts_id Posts page ID. */
+	/**
+	 * Posts page ID.
+	 *
+	 * @var int
+	 */
 	protected static $page_for_posts_id;
 
 	/**

--- a/inc/sitemaps/class-sitemap-cache-data.php
+++ b/inc/sitemaps/class-sitemap-cache-data.php
@@ -10,10 +10,18 @@
  */
 class WPSEO_Sitemap_Cache_Data implements WPSEO_Sitemap_Cache_Data_Interface, Serializable {
 
-	/** @var string Sitemap XML data. */
+	/**
+	 * Sitemap XML data.
+	 *
+	 * @var string
+	 */
 	private $sitemap = '';
 
-	/** @var string Status of the sitemap, usable or not. */
+	/**
+	 * Status of the sitemap, usable or not.
+	 *
+	 * @var string
+	 */
 	private $status = self::UNKNOWN;
 
 	/**

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -10,19 +10,39 @@
  */
 class WPSEO_Sitemap_Image_Parser {
 
-	/** @var string $home_url Holds the home_url() value to speed up loops. */
+	/**
+	 * Holds the home_url() value to speed up loops.
+	 *
+	 * @var string
+	 */
 	protected $home_url = '';
 
-	/** @var string $host Holds site URL hostname. */
+	/**
+	 * Holds site URL hostname.
+	 *
+	 * @var string
+	 */
 	protected $host = '';
 
-	/** @var string $scheme Holds site URL protocol. */
+	/**
+	 * Holds site URL protocol.
+	 *
+	 * @var string
+	 */
 	protected $scheme = 'http';
 
-	/** @var array $attachments Cached set of attachments for multiple posts. */
+	/**
+	 * Cached set of attachments for multiple posts.
+	 *
+	 * @var array
+	 */
 	protected $attachments = array();
 
-	/** @var string $charset Holds blog charset value for use in DOM parsing. */
+	/**
+	 * Holds blog charset value for use in DOM parsing.
+	 *
+	 * @var string
+	 */
 	protected $charset = 'UTF-8';
 
 	/**

--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Sitemaps_Admin {
 	/**
-	 * @var array Post_types that are being imported.
+	 * Post_types that are being imported.
+	 *
+	 * @var array
 	 */
 	private $importing_post_types = array();
 

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -12,16 +12,32 @@
  */
 class WPSEO_Sitemaps_Cache {
 
-	/** @var array $cache_clear Holds the options that, when updated, should cause the cache to clear. */
+	/**
+	 * Holds the options that, when updated, should cause the cache to clear.
+	 *
+	 * @var array
+	 */
 	protected static $cache_clear = array();
 
-	/** @var bool $is_enabled Mirror of enabled status for static calls. */
+	/**
+	 * Mirror of enabled status for static calls.
+	 *
+	 * @var bool
+	 */
 	protected static $is_enabled = false;
 
-	/** @var bool $clear_all Holds the flag to clear all cache. */
+	/**
+	 * Holds the flag to clear all cache.
+	 *
+	 * @var bool
+	 */
 	protected static $clear_all = false;
 
-	/** @var array $clear_types Holds the array of types to clear. */
+	/**
+	 * Holds the array of types to clear.
+	 *
+	 * @var array
+	 */
 	protected static $clear_types = array();
 
 	/**

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -10,19 +10,39 @@
  */
 class WPSEO_Sitemaps_Renderer {
 
-	/** @var string $stylesheet XSL stylesheet for styling a sitemap for web browsers. */
+	/**
+	 * XSL stylesheet for styling a sitemap for web browsers.
+	 *
+	 * @var string
+	 */
 	protected $stylesheet = '';
 
-	/** @var string $charset Holds the get_bloginfo( 'charset' ) value to reuse for performance. */
+	/**
+	 * Holds the get_bloginfo( 'charset' ) value to reuse for performance.
+	 *
+	 * @var string
+	 */
 	protected $charset = 'UTF-8';
 
-	/** @var string $output_charset Holds charset of output, might be converted. */
+	/**
+	 * Holds charset of output, might be converted.
+	 *
+	 * @var string
+	 */
 	protected $output_charset = 'UTF-8';
 
-	/** @var bool $needs_conversion If data encoding needs to be converted for output. */
+	/**
+	 * If data encoding needs to be converted for output.
+	 *
+	 * @var bool
+	 */
 	protected $needs_conversion = false;
 
-	/** @var WPSEO_Sitemap_Timezone $timezone */
+	/**
+	 * Timezone.
+	 *
+	 * @var WPSEO_Sitemap_Timezone
+	 */
 	protected $timezone;
 
 	/**

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -15,48 +15,73 @@ class WPSEO_Sitemaps {
 	/** Sitemap index identifier. */
 	const SITEMAP_INDEX_TYPE = '1';
 
-	/** @var string $sitemap Content of the sitemap to output. */
+	/**
+	 * Content of the sitemap to output.
+	 *
+	 * @var string
+	 */
 	protected $sitemap = '';
 
-	/** @var bool $bad_sitemap Flag to indicate if this is an invalid or empty sitemap. */
+	/**
+	 * Flag to indicate if this is an invalid or empty sitemap.
+	 *
+	 * @var bool
+	 */
 	public $bad_sitemap = false;
 
-	/** @var bool $transient Whether or not the XML sitemap was served from a transient or not. */
+	/**
+	 * Whether or not the XML sitemap was served from a transient or not.
+	 *
+	 * @var bool
+	 */
 	private $transient = false;
 
 	/**
-	 * @var string $http_protocol HTTP protocol to use in headers.
+	 * HTTP protocol to use in headers.
+	 *
 	 * @since 3.2
+	 *
+	 * @var string
 	 */
 	protected $http_protocol = 'HTTP/1.1';
 
-	/** @var int $current_page Holds the n variable. */
+	/**
+	 * Holds the n variable.
+	 *
+	 * @var int
+	 */
 	private $current_page = 1;
 
-	/** @var WPSEO_Sitemap_Timezone $timezone */
+	/**
+	 * @var WPSEO_Sitemap_Timezone
+	 */
 	private $timezone;
 
 	/**
-	 * @var WPSEO_Sitemaps_Router $router
 	 * @since 3.2
+	 *
+	 * @var WPSEO_Sitemaps_Router
 	 */
 	public $router;
 
 	/**
-	 * @var WPSEO_Sitemaps_Renderer $renderer
 	 * @since 3.2
+	 *
+	 * @var WPSEO_Sitemaps_Renderer
 	 */
 	public $renderer;
 
 	/**
-	 * @var WPSEO_Sitemaps_Cache $cache
 	 * @since 3.2
+	 *
+	 * @var WPSEO_Sitemaps_Cache
 	 */
 	public $cache;
 
 	/**
-	 * @var WPSEO_Sitemap_Provider[] $providers
 	 * @since 3.2
+	 *
+	 * @var WPSEO_Sitemap_Provider[]
 	 */
 	public $providers;
 

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
-	/** @var WPSEO_Sitemap_Image_Parser $image_parser Holds image parser instance. */
+	/**
+	 * Holds image parser instance.
+	 *
+	 * @var WPSEO_Sitemap_Image_Parser
+	 */
 	protected static $image_parser;
 
 	/**

--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -21,10 +21,14 @@ class Database_Migration {
 
 	const MIGRATION_ERROR_TRANSIENT_KEY = 'yoast_migration_problem';
 
-	/** @var \wpdb WPDB instance */
+	/**
+	 * @var \wpdb WPDB instance
+	 */
 	protected $wpdb;
 
-	/** @var Dependency_Management */
+	/**
+	 * @var Dependency_Management
+	 */
 	protected $dependency_management;
 
 	/**

--- a/src/wordpress/integration-group.php
+++ b/src/wordpress/integration-group.php
@@ -11,7 +11,11 @@ namespace Yoast\YoastSEO\WordPress;
  * Manage integrations and registers hooks at the required moment.
  */
 class Integration_Group implements Integration {
-	/** @var Integration[] List of integrations. */
+	/**
+	 * List of integrations.
+	 *
+	 * @var Integration[]
+	 */
 	protected $integrations = array();
 
 	/**

--- a/tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -10,10 +10,16 @@
  */
 class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 
-	/** @var string Temporary home URL storage. */
+	/**
+	 * Temporary home URL storage.
+	 *
+	 * @var string
+	 */
 	private $home_url = '';
 
-	/** @var WPSEO_Sitemaps_Router */
+	/**
+	 * @var WPSEO_Sitemaps_Router
+	 */
 	private static $class_instance;
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance. Goes a long way to fix "Docblock should start with a short description" issues.
* Includes some punctuation and spelling fixes.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.