### PR TITLE
Documentation: add missing @throws tags

### DIFF
--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -369,6 +369,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * Tests terminating an AJAX request.
 	 *
 	 * @covers Yoast_Network_Admin::terminate_request()
+	 *
+	 * @throws \WPDieException For test purposes.
 	 */
 	public function test_terminate_request_ajax() {
 		$admin = new Yoast_Network_Admin();

--- a/tests/src/unit-tests/exceptions/no-indexable-found-test.php
+++ b/tests/src/unit-tests/exceptions/no-indexable-found-test.php
@@ -42,6 +42,8 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::from_post_id()
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 *
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
 	public function test_from_post_id() {
 		try {
@@ -60,6 +62,8 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::from_term_id()
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 *
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
 	public function test_from_term_id() {
 		try {
@@ -78,6 +82,8 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::from_primary_term()
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 *
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
 	public function test_from_primary_term() {
 		try {
@@ -96,6 +102,8 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::from_author_id()
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 *
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
 	public function test_from_author_id() {
 		try {
@@ -114,6 +122,8 @@ class No_Indexable_Found_Test extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::from_meta_key()
 	 * @covers \Yoast\YoastSEO\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 *
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
 	public function test_from_meta_key() {
 		try {


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance. Adds missing `@throws` tags for functions which throw exceptions.

N.B.: The exception names used in the `@throws` tags for `tests/src/unit-tests/exceptions/no-indexable-found-test.php` presume that PR #11852 will be merged (soon).

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.