### PR TITLE
Add whitelists for specific vendor files

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -507,6 +507,8 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		add_action( 'plugins_loaded', 'wpseo_cli_init', 20 );
 	}
+
+	add_filter( 'phpcompat_whitelist', 'yoast_free_phpcompat_whitelist' );
 }
 
 // Activation and deactivation hook.
@@ -623,4 +625,27 @@ function yoast_wpseo_self_deactivate() {
 			unset( $_GET['activate'] );
 		}
 	}
+}
+
+/**
+ * Excludes specific files from php-compatibility-checker.
+ *
+ * @since 9.4
+ *
+ * @param array $ignored Array of ignored directories/files.
+ *
+ * @return array Array of ignored directories/files.
+ */
+function yoast_free_phpcompat_whitelist( $ignored ) {
+	$path = '*/' . basename( WPSEO_PATH ) . '/';
+
+	// To prevent: (warning) File has mixed line endings; this may cause incorrect results
+	$ignored[] = $path . 'vendor/ruckusing/lib/Ruckusing/FrameworkRunner.php';
+	$ignored[] = $path . 'vendor_prefixed/ruckusing/lib/Ruckusing/FrameworkRunner.php';
+
+	// To prevent: (error) Extension 'sqlite' is removed since PHP 5.4
+	$ignored[] = $path . 'vendor/ruckusing/lib/Ruckusing/Adapter/Sqlite3/Base.php';
+	$ignored[] = $path . 'vendor_prefixed/ruckusing/lib/Ruckusing/Adapter/Sqlite3/Base.php';
+
+	return $ignored;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Avoids irrelevant warning and error in the WPEngine PHP Compatibility plugin.

## Relevant technical choices:

* Only whitelist the specific files in which problems are found

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install plugin [PHP Compatibility Checker](https://wordpress.org/plugins/php-compatibility-checker/)
* Scan site (Tools/PHP Compatibility)

I had problems testing this on Vagrant, so I used Local by Flywheel.

This is the zip created from the branch:
[wordpress-seo-9.4-phpcompat-whitelist.zip](https://github.com/Yoast/wordpress-seo/files/2702028/wordpress-seo-9.4-phpcompat-whitelist.zip)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes https://github.com/Yoast/wordpress-seo/issues/11798
Replaces https://github.com/Yoast/wordpress-seo/pull/11836