### PR TITLE
Don't run our JSON code on 404 pages

### DIFF
--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -38,7 +38,9 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	 * @since 1.8
 	 */
 	public function json_ld() {
-		do_action( 'wpseo_json_ld' );
+		if ( ! is_404() ) {
+			do_action( 'wpseo_json_ld' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes all JSON output from 404 pages.

## Test instructions
This PR can be tested by following these steps:

* Go look at a 404. See JSON is gone.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


