### PR TITLE
Yoast CS: Adds sanitization in file class-remove-reply-to-com.php

### DIFF
--- a/frontend/class-remove-reply-to-com.php
+++ b/frontend/class-remove-reply-to-com.php
@@ -49,7 +49,10 @@ class WPSEO_Remove_Reply_To_Com implements WPSEO_WordPress_Integration {
 		if ( isset( $_GET['replytocom'] ) && is_singular() ) {
 			$url          = get_permalink( $GLOBALS['post']->ID );
 			$hash         = sanitize_text_field( wp_unslash( $_GET['replytocom'] ) );
-			$query_string = remove_query_arg( 'replytocom', sanitize_text_field( wp_unslash( $_SERVER['QUERY_STRING'] ) ) );
+			$query_string = '';
+			if ( isset( $_SERVER['QUERY_STRING'] ) ) {
+				$query_string = remove_query_arg( 'replytocom', sanitize_text_field( wp_unslash( $_SERVER['QUERY_STRING'] ) ) );
+			}
 			if ( ! empty( $query_string ) ) {
 				$url .= '?' . $query_string;
 			}

--- a/frontend/class-remove-reply-to-com.php
+++ b/frontend/class-remove-reply-to-com.php
@@ -48,8 +48,8 @@ class WPSEO_Remove_Reply_To_Com implements WPSEO_WordPress_Integration {
 	public function replytocom_redirect() {
 		if ( isset( $_GET['replytocom'] ) && is_singular() ) {
 			$url          = get_permalink( $GLOBALS['post']->ID );
-			$hash         = sanitize_text_field( $_GET['replytocom'] );
-			$query_string = remove_query_arg( 'replytocom', sanitize_text_field( $_SERVER['QUERY_STRING'] ) );
+			$hash         = sanitize_text_field( wp_unslash( $_GET['replytocom'] ) );
+			$query_string = remove_query_arg( 'replytocom', sanitize_text_field( wp_unslash( $_SERVER['QUERY_STRING'] ) ) );
 			if ( ! empty( $query_string ) ) {
 				$url .= '?' . $query_string;
 			}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Fixes the following issues:
```
FILE: frontend\class-remove-reply-to-com.php
--
----------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AND 1 WARNING AFFECTING 3 LINES
----------------------------------------------------------------------------------------------------
51 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
52 \| ERROR   \| Detected usage of a non-validated input variable: $_SERVER
\|         \| (WordPress.Security.ValidatedSanitizedInput.InputNotValidated)
52 \| ERROR   \| Missing wp_unslash() before sanitization.
\|         \| (WordPress.Security.ValidatedSanitizedInput.MissingUnslash)
----------------------------------------------------------------------------------------------------
```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have a reply on a post.
* Press on the reply button for the reply. 
* There is no visible change thus this should still work.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
