### PR TITLE
Add missing tracking data to shortlink

### DIFF
--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -33,6 +33,8 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 		'shortlinks.readability_analysis_info'                      => 'https://yoa.st/readability-analysis',
 		'shortlinks.activate_premium_info'                          => 'https://yoa.st/activate-subscription',
 		'shortlinks.recalibration_beta_metabox'                     => 'https://yoa.st/recalibration-beta-metabox',
+		'shortlinks.upsell.sidebar.morphology_upsell_metabox'       => 'https://yoa.st/morphology-upsell-metabox',
+		'shortlinks.upsell.sidebar.morphology_upsell_sidebar'       => 'https://yoa.st/morphology-upsell-sidebar',
 	);
 
 	/**

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -235,8 +235,8 @@ class SeoAnalysis extends React.Component {
 	renderWordFormsUpsell( location ) {
 		return <AnalysisUpsell
 			url={ location === "sidebar"
-				? "https://yoa.st/morphology-upsell-sidebar"
-				: "https://yoa.st/morphology-upsell-metabox" }
+				? wpseoAdminL10n[ "shortlinks.upsell.sidebar.morphology_upsell_sidebar" ]
+				: wpseoAdminL10n[ "shortlinks.upsell.sidebar.morphology_upsell_metabox" ] }
 			alignment={ location === "sidebar" ? "vertical" : "horizontal" }
 		/>;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user facing] Adds Shortlinker data to the upsell buttons in the metabox and sidebar under the "Focus keyphrase"

## Relevant technical choices:

* Used the Shortlink Exposer

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11887 
