### PR TITLE
Add WPSEO_VERSION as version to WordPress_register_script

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -192,14 +192,15 @@ class WPSEO_Admin_Asset_Manager {
 			'react',
 			plugins_url( 'js/vendor/react.min.js', WPSEO_FILE ),
 			array(),
-			WPSEO_VERSION,
+			'v16.6.1',
 			true
 		);
 
-		wp_register_script( 'react-dom',
+		wp_register_script(
+			'react-dom',
 			plugins_url( 'js/vendor/react-dom.min.js', WPSEO_FILE ),
 			array( 'react' ),
-			WPSEO_VERSION,
+			'v16.6.1',
 			true
 		);
 
@@ -207,7 +208,7 @@ class WPSEO_Admin_Asset_Manager {
 			'lodash-base',
 			plugins_url( 'js/vendor/lodash.min.js', WPSEO_FILE ),
 			array(),
-			WPSEO_VERSION,
+			'4.17.5',
 			true
 		);
 

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -294,7 +294,7 @@ class WPSEO_Admin_Asset_Manager {
 			'wp-annotations',
 			null
 		);
-		// phpcs:enable
+		// phpcs:enable -- End of disable.
 	}
 
 	/**

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -188,17 +188,50 @@ class WPSEO_Admin_Asset_Manager {
 
 		$flat_version = $this->flatten_version( WPSEO_VERSION );
 
-		wp_register_script( 'react', plugins_url( 'js/vendor/react.min.js', WPSEO_FILE ), array(), false, true );
-		wp_register_script( 'react-dom', plugins_url( 'js/vendor/react-dom.min.js', WPSEO_FILE ), array( 'react' ), false, true );
-		wp_register_script( 'lodash-base', plugins_url( 'js/vendor/lodash.min.js', WPSEO_FILE ), array(), false, true );
-		wp_register_script( 'lodash', plugins_url( 'js/vendor/lodash-noconflict.js', WPSEO_FILE ), array( 'lodash-base' ), false, true );
-		wp_register_script( 'wp-polyfill', plugins_url( 'js/dist/babel-polyfill-' . $flat_version . '.min.js', WPSEO_FILE ), array(), false, true );
+		wp_register_script(
+			'react',
+			plugins_url( 'js/vendor/react.min.js', WPSEO_FILE ),
+			array(),
+			WPSEO_VERSION,
+			true
+		);
+
+		wp_register_script( 'react-dom',
+			plugins_url( 'js/vendor/react-dom.min.js', WPSEO_FILE ),
+			array( 'react' ),
+			WPSEO_VERSION,
+			true
+		);
+
+		wp_register_script(
+			'lodash-base',
+			plugins_url( 'js/vendor/lodash.min.js', WPSEO_FILE ),
+			array(),
+			WPSEO_VERSION,
+			true
+		);
+
+		wp_register_script(
+			'lodash',
+			plugins_url( 'js/vendor/lodash-noconflict.js', WPSEO_FILE ),
+			array( 'lodash-base' ),
+			WPSEO_VERSION,
+			true
+		);
+
+		wp_register_script(
+			'wp-polyfill',
+			plugins_url( 'js/dist/babel-polyfill-' . $flat_version . '.min.js', WPSEO_FILE ),
+			array(),
+			WPSEO_VERSION,
+			true
+		);
 
 		wp_register_script(
 			'wp-element',
 			plugins_url( 'js/dist/wp-element-' . $flat_version . '.min.js', WPSEO_FILE ),
 			array( 'lodash', 'wp-polyfill', 'react', 'react-dom' ),
-			false,
+			WPSEO_VERSION,
 			true
 		);
 
@@ -206,7 +239,7 @@ class WPSEO_Admin_Asset_Manager {
 			'wp-api-fetch',
 			plugins_url( 'js/dist/wp-apiFetch-' . $flat_version . '.min.js', WPSEO_FILE ),
 			array( 'wp-i18n', 'wp-polyfill' ),
-			false,
+			WPSEO_VERSION,
 			true
 		);
 
@@ -214,7 +247,7 @@ class WPSEO_Admin_Asset_Manager {
 			'wp-components',
 			plugins_url( 'js/dist/wp-components-' . $flat_version . '.min.js', WPSEO_FILE ),
 			array( 'lodash', 'wp-api-fetch', 'wp-i18n', 'wp-polyfill', 'wp-compose' ),
-			false,
+			WPSEO_VERSION,
 			true
 		);
 
@@ -222,7 +255,7 @@ class WPSEO_Admin_Asset_Manager {
 			'wp-data',
 			plugins_url( 'js/dist/wp-data-' . $flat_version . '.min.js', WPSEO_FILE ),
 			array( 'lodash', 'wp-element', 'wp-polyfill', 'wp-compose' ),
-			false,
+			WPSEO_VERSION,
 			true
 		);
 
@@ -230,7 +263,7 @@ class WPSEO_Admin_Asset_Manager {
 			'wp-i18n',
 			plugins_url( 'js/dist/wp-i18n-' . $flat_version . '.min.js', WPSEO_FILE ),
 			array( 'wp-polyfill' ),
-			false,
+			WPSEO_VERSION,
 			true
 		);
 
@@ -238,7 +271,7 @@ class WPSEO_Admin_Asset_Manager {
 			'wp-rich-text',
 			plugins_url( 'js/dist/wp-rich-text-' . $flat_version . '.min.js', WPSEO_FILE ),
 			array( 'lodash', 'wp-polyfill', 'wp-data' ),
-			false,
+			WPSEO_VERSION,
 			true
 		);
 
@@ -246,7 +279,7 @@ class WPSEO_Admin_Asset_Manager {
 			'wp-compose',
 			plugins_url( 'js/dist/wp-compose-' . $flat_version . '.min.js', WPSEO_FILE ),
 			array( 'lodash', 'wp-polyfill' ),
-			false,
+			WPSEO_VERSION,
 			true
 		);
 

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -288,6 +288,7 @@ class WPSEO_Admin_Asset_Manager {
 		 * The no-op achieves that our scripts that depend on this are actually loaded. Because WordPress doesn't
 		 * load a script if any of the dependencies are missing.
 		 */
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters -- The no-op does not require these settings.
 		wp_register_script(
 			'wp-annotations',
 			null

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -287,12 +287,14 @@ class WPSEO_Admin_Asset_Manager {
 		 * wp-annotations only exists from Gutenberg 4.3 and onwards, so we register a no-op in earlier versions.
 		 * The no-op achieves that our scripts that depend on this are actually loaded. Because WordPress doesn't
 		 * load a script if any of the dependencies are missing.
+		 *
+		 * @phpcs:disable WordPress.WP.EnqueuedResourceParameters -- The no-op does not require these settings.
 		 */
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters -- The no-op does not require these settings.
 		wp_register_script(
 			'wp-annotations',
 			null
 		);
+		// phpcs:enable
 	}
 
 	/**


### PR DESCRIPTION
As these files are shipped with the plugin, we need to cache-bust them with the version of the plugin. False will use the current WordPress version, which refrains us from keeping them up to date.

Fixes the following CS errors:

```
FILE: admin\class-admin-asset-manager.php
----------------------------------------------------------------------------------------------------
FOUND 13 ERRORS AND 1 WARNING AFFECTING 13 LINES
----------------------------------------------------------------------------------------------------
191 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
192 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
193 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
194 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
195 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
197 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
205 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
213 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
221 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
229 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
237 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
245 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of
    |         | "false" for wp_register_script; This means that the WordPress core version will be
    |         | used which is not recommended for plugin or theme development.
    |         | (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
258 | WARNING | In footer ($in_footer) is not set explicitly wp_register_script; It is recommended
    |         | to load scripts in the footer. Please set this value to `true` to load it in the
    |         | footer, or explicitly `false` if it should be loaded in the header.
    |         | (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
258 | ERROR   | Resource version not set in call to wp_register_script(). This means new versions
    |         | of the script will not always be loaded due to browser caching.
    |         | (WordPress.WP.EnqueuedResourceParameters.MissingVersion)
----------------------------------------------------------------------------------------------------
```

The last warning and error are resolved by adding an ignore for the sniff:
```
258 | WARNING | In footer ($in_footer) is not set explicitly wp_register_script; It is recommended
    |         | to load scripts in the footer. Please set this value to `true` to load it in the
    |         | footer, or explicitly `false` if it should be loaded in the header.
    |         | (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
258 | ERROR   | Resource version not set in call to wp_register_script(). This means new versions
    |         | of the script will not always be loaded due to browser caching.
    |         | (WordPress.WP.EnqueuedResourceParameters.MissingVersion)
```


## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Added `WPSEO_VERSION` for all requests except the no-op register for the annotations API.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use WordPress 4.9.8 or lower and make sure the `?ver=` argument reflects the plugin version, instead of the WordPress version for the enqueues that reside in our plugin path `wordpress-seo/js/dist/*`

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
