### PR TITLE
Documentation: use docblock format for constants

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -10,7 +10,13 @@
  */
 class WPSEO_Admin {
 
-	/** The page identifier used in WordPress to register the admin page !DO NOT CHANGE THIS! */
+	/**
+	 * The page identifier used in WordPress to register the admin page.
+	 *
+	 * !DO NOT CHANGE THIS!
+	 *
+	 * @var string
+	 */
 	const PAGE_IDENTIFIER = 'wpseo_dashboard';
 
 	/**

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -10,19 +10,52 @@
  */
 class WPSEO_Admin_Asset {
 
+	/**
+	 * @var string
+	 */
 	const TYPE_JS = 'js';
+
+	/**
+	 * @var string
+	 */
 	const TYPE_CSS = 'css';
 
+	/**
+	 * @var string
+	 */
 	const NAME = 'name';
+
+	/**
+	 * @var string
+	 */
 	const SRC = 'src';
+
+	/**
+	 * @var string
+	 */
 	const DEPS = 'deps';
+
+	/**
+	 * @var string
+	 */
 	const VERSION = 'version';
 
 	// Style specific.
+	/**
+	 * @var string
+	 */
 	const MEDIA = 'media';
+
+	/**
+	 * @var string
+	 */
 	const RTL = 'rtl';
 
 	// Script specific.
+
+	/**
+	 * @var string
+	 */
 	const IN_FOOTER = 'in_footer';
 
 	/**

--- a/admin/class-extension-manager.php
+++ b/admin/class-extension-manager.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Extension_Manager {
 
-	/** The transient key to save the cache in */
+	/**
+	 * The transient key to save the cache in.
+	 *
+	 * @var string
+	 */
 	const TRANSIENT_CACHE_KEY = 'wpseo_license_active_extensions';
 
 	/**

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -10,7 +10,11 @@
  */
 class Yoast_Notification_Center {
 
-	/** Option name to store notifications on */
+	/**
+	 * Option name to store notifications on.
+	 *
+	 * @var string
+	 */
 	const STORAGE_KEY = 'yoast_notifications';
 
 	/**

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -12,27 +12,37 @@
 class Yoast_Notification {
 
 	/**
-	 * @var string Type of capability check.
+	 * Type of capability check.
+	 *
+	 * @var string
 	 */
 	const MATCH_ALL = 'all';
 
 	/**
-	 * @var string Type of capability check.
+	 * Type of capability check.
+	 *
+	 * @var string
 	 */
 	const MATCH_ANY = 'any';
 
 	/**
-	 * @var string Notification type.
+	 * Notification type.
+	 *
+	 * @var string
 	 */
 	const ERROR = 'error';
 
 	/**
-	 * @var string Notification type.
+	 * Notification type.
+	 *
+	 * @var string
 	 */
 	const WARNING = 'warning';
 
 	/**
-	 * @var string Notification type.
+	 * Notification type.
+	 *
+	 * @var string
 	 */
 	const UPDATED = 'updated';
 

--- a/admin/config-ui/class-configuration-endpoint.php
+++ b/admin/config-ui/class-configuration-endpoint.php
@@ -10,11 +10,29 @@
  */
 class WPSEO_Configuration_Endpoint {
 
+	/**
+	 * @var string
+	 */
 	const REST_NAMESPACE = 'yoast/v1';
+
+	/**
+	 * @var string
+	 */
 	const ENDPOINT_RETRIEVE = 'configurator';
+
+	/**
+	 * @var string
+	 */
 	const ENDPOINT_STORE = 'configurator';
 
+	/**
+	 * @var string
+	 */
 	const CAPABILITY_RETRIEVE = 'wpseo_manage_options';
+
+	/**
+	 * @var string
+	 */
 	const CAPABILITY_STORE = 'wpseo_manage_options';
 
 	/**

--- a/admin/config-ui/class-configuration-options-adapter.php
+++ b/admin/config-ui/class-configuration-options-adapter.php
@@ -14,8 +14,19 @@
  */
 class WPSEO_Configuration_Options_Adapter {
 
+	/**
+	 * @var string
+	 */
 	const OPTION_TYPE_WORDPRESS = 'wordpress';
+
+	/**
+	 * @var string
+	 */
 	const OPTION_TYPE_YOAST = 'yoast';
+
+	/**
+	 * @var string
+	 */
 	const OPTION_TYPE_CUSTOM = 'custom';
 
 	/**

--- a/admin/config-ui/components/class-component-connect-google-search-console.php
+++ b/admin/config-ui/components/class-component-connect-google-search-console.php
@@ -10,7 +10,14 @@
  */
 class WPSEO_Config_Component_Connect_Google_Search_Console implements WPSEO_Config_Component {
 
+	/**
+	 * @var string
+	 */
 	const OPTION_ACCESS_TOKEN = 'wpseo-gsc-access_token';
+
+	/**
+	 * @var string
+	 */
 	const OPTION_REFRESH_TOKEN = 'wpseo-gsc-refresh_token';
 
 

--- a/admin/endpoints/class-endpoint-file-size.php
+++ b/admin/endpoints/class-endpoint-file-size.php
@@ -10,9 +10,19 @@
  */
 class WPSEO_Endpoint_File_Size implements WPSEO_Endpoint {
 
+	/**
+	 * @var string
+	 */
 	const REST_NAMESPACE = 'yoast/v1';
+
+	/**
+	 * @var string
+	 */
 	const ENDPOINT_SINGULAR = 'file_size';
 
+	/**
+	 * @var string
+	 */
 	const CAPABILITY_RETRIEVE = 'manage_options';
 
 	/**

--- a/admin/endpoints/class-endpoint-ryte.php
+++ b/admin/endpoints/class-endpoint-ryte.php
@@ -10,9 +10,19 @@
  */
 class WPSEO_Endpoint_Ryte implements WPSEO_Endpoint {
 
+	/**
+	 * @var string
+	 */
 	const REST_NAMESPACE = 'yoast/v1';
+
+	/**
+	 * @var string
+	 */
 	const ENDPOINT_RETRIEVE = 'ryte';
 
+	/**
+	 * @var string
+	 */
 	const CAPABILITY_RETRIEVE = 'manage_options';
 
 	/**

--- a/admin/endpoints/class-endpoint-statistics.php
+++ b/admin/endpoints/class-endpoint-statistics.php
@@ -10,9 +10,19 @@
  */
 class WPSEO_Endpoint_Statistics implements WPSEO_Endpoint {
 
+	/**
+	 * @var string
+	 */
 	const REST_NAMESPACE = 'yoast/v1';
+
+	/**
+	 * @var string
+	 */
 	const ENDPOINT_RETRIEVE = 'statistics';
 
+	/**
+	 * @var string
+	 */
 	const CAPABILITY_RETRIEVE = 'read';
 
 	/**

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -9,7 +9,13 @@
  * Registers the regular admin menu and network admin menu implementations.
  */
 class WPSEO_Menu implements WPSEO_WordPress_Integration {
-	/** The page identifier used in WordPress to register the admin page !DO NOT CHANGE THIS! */
+	/**
+	 * The page identifier used in WordPress to register the admin page.
+	 *
+	 * !DO NOT CHANGE THIS!
+	 *
+	 * @var string
+	 */
 	const PAGE_IDENTIFIER = 'wpseo_dashboard';
 
 	/**

--- a/admin/notifiers/class-configuration-notifier.php
+++ b/admin/notifiers/class-configuration-notifier.php
@@ -9,7 +9,15 @@
  * Represents the logic for showing the notification.
  */
 class WPSEO_Configuration_Notifier implements WPSEO_Listener {
+
+	/**
+	 * @var string
+	 */
 	const META_NAME = 'wpseo-dismiss-configuration-notice';
+
+	/**
+	 * @var string
+	 */
 	const META_VALUE = 'yes';
 
 	/**

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -10,19 +10,39 @@
  */
 class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 
-	/** The identifier used for the menu. */
+	/**
+	 * The identifier used for the menu.
+	 *
+	 * @var string
+	 */
 	const MENU_IDENTIFIER = 'wpseo-menu';
 
-	/** The identifier used for the Keyword Research submenu. */
+	/**
+	 * The identifier used for the Keyword Research submenu.
+	 *
+	 * @var string
+	 */
 	const KEYWORD_RESEARCH_SUBMENU_IDENTIFIER = 'wpseo-kwresearch';
 
-	/** The identifier used for the Analysis submenu. */
+	/**
+	 * The identifier used for the Analysis submenu.
+	 *
+	 * @var string
+	 */
 	const ANALYSIS_SUBMENU_IDENTIFIER = 'wpseo-analysis';
 
-	/** The identifier used for the Settings submenu. */
+	/**
+	 * The identifier used for the Settings submenu.
+	 *
+	 * @var string
+	 */
 	const SETTINGS_SUBMENU_IDENTIFIER = 'wpseo-settings';
 
-	/** The identifier used for the Network Settings submenu. */
+	/**
+	 * The identifier used for the Network Settings submenu.
+	 *
+	 * @var string
+	 */
 	const NETWORK_SETTINGS_SUBMENU_IDENTIFIER = 'wpseo-network-settings';
 
 	/**

--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -12,13 +12,25 @@
  */
 class WPSEO_Sitemaps_Cache_Validator {
 
-	/** @var string Prefix of the transient key for sitemap caches */
+	/**
+	 * Prefix of the transient key for sitemap caches.
+	 *
+	 * @var string
+	 */
 	const STORAGE_KEY_PREFIX = 'yst_sm_';
 
-	/** Name of the option that holds the global validation value */
+	/**
+	 * Name of the option that holds the global validation value.
+	 *
+	 * @var string
+	 */
 	const VALIDATION_GLOBAL_KEY = 'wpseo_sitemap_cache_validator_global';
 
-	/** The format which creates the key of the option that holds the type validation value */
+	/**
+	 * The format which creates the key of the option that holds the type validation value.
+	 *
+	 * @var string
+	 */
 	const VALIDATION_TYPE_KEY_FORMAT = 'wpseo_sitemap_%s_cache_validator';
 
 	/**

--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -16,9 +16,20 @@ use YoastSEO_Vendor\Ruckusing_FrameworkRunner;
  * Triggers database migrations and handles results.
  */
 class Database_Migration {
+
+	/**
+	 * @var int
+	 */
 	const MIGRATION_STATE_SUCCESS = 0;
+
+	/**
+	 * @var int
+	 */
 	const MIGRATION_STATE_ERROR = 1;
 
+	/**
+	 * @var string
+	 */
 	const MIGRATION_ERROR_TRANSIENT_KEY = 'yoast_migration_problem';
 
 	/**

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -35,10 +35,16 @@ class Yoast_Model {
 	/**
 	 * Default ID column for all models. Can be overridden by adding
 	 * a public static _id_column property to your model classes.
+	 *
+	 * @var string
 	 */
 	const DEFAULT_ID_COLUMN = 'id';
 
-	// Default foreign key suffix used by relationship methods.
+	/**
+	 * Default foreign key suffix used by relationship methods.
+	 *
+	 * @var string
+	 */
 	const DEFAULT_FOREIGN_KEY_SUFFIX = '_id';
 
 	/**


### PR DESCRIPTION


## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

Constants should be documented in the same way as properties, including the expected type for the value of the constant.

Documentation can still use more improvement, but this is a step in the right direction.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
