### PR TITLE
Documentation: use full docblocks for properties

### DIFF
--- a/admin/endpoints/class-endpoint-file-size.php
+++ b/admin/endpoints/class-endpoint-file-size.php
@@ -16,7 +16,9 @@ class WPSEO_Endpoint_File_Size implements WPSEO_Endpoint {
 	const CAPABILITY_RETRIEVE = 'manage_options';
 
 	/**
-	 * @var WPSEO_File_Size_Service The service provider.
+	 * The service provider.
+	 *
+	 * @var WPSEO_File_Size_Service
 	 */
 	private $service;
 

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -63,54 +63,76 @@ abstract class WPSEO_Option {
 	const ALLOW_KEY_PREFIX = 'allow_';
 
 	/**
-	 * @var  string  Option name - MUST be set in concrete class and set to public.
+	 * Option name - MUST be set in concrete class and set to public.
+	 *
+	 * @var string
 	 */
 	protected $option_name;
 
 	/**
-	 * @var  string  Option group name for use in settings forms
-	 *               - will be set automagically if not set in concrete class
-	 *               (i.e. if it confirm to the normal pattern 'yoast' . $option_name . 'options',
-	 *               only set in conrete class if it doesn't)
+	 * Option group name for use in settings forms.
+	 *
+	 * Will be set automagically if not set in concrete class (i.e.
+	 * if it confirm to the normal pattern 'yoast' . $option_name . 'options',
+	 * only set in conrete class if it doesn't).
+	 *
+	 * @var string
 	 */
 	public $group_name;
 
 	/**
-	 * @var  bool  Whether to include the option in the return for WPSEO_Options::get_all().
-	 *             Also determines which options are copied over for ms_(re)set_blog().
+	 * Whether to include the option in the return for WPSEO_Options::get_all().
+	 *
+	 * Also determines which options are copied over for ms_(re)set_blog().
+	 *
+	 * @var bool
 	 */
 	public $include_in_all = true;
 
 	/**
-	 * @var  bool  Whether this option is only for when the install is multisite.
+	 * Whether this option is only for when the install is multisite.
+	 *
+	 * @var bool
 	 */
 	public $multisite_only = false;
 
 	/**
-	 * @var  array  Array of defaults for the option - MUST be set in concrete class.
-	 *              Shouldn't be requested directly, use $this->get_defaults();
+	 * Array of defaults for the option - MUST be set in concrete class.
+	 *
+	 * Shouldn't be requested directly, use $this->get_defaults();
+	 *
+	 * @var array
 	 */
 	protected $defaults;
 
 	/**
-	 * @var  array  Array of variable option name patterns for the option - if any -
-	 *              Set this when the option contains array keys which vary based on post_type
-	 *              or taxonomy.
+	 * Array of variable option name patterns for the option - if any -.
+	 *
+	 * Set this when the option contains array keys which vary based on post_type
+	 * or taxonomy.
+	 *
+	 * @var array
 	 */
 	protected $variable_array_key_patterns;
 
 	/**
-	 * @var array  Array of sub-options which should not be overloaded with multi-site defaults.
+	 * Array of sub-options which should not be overloaded with multi-site defaults.
+	 *
+	 * @var array
 	 */
 	public $ms_exclude = array();
 
 	/**
-	 * @var string Name for an option higher in the hierarchy to override setting access.
+	 * Name for an option higher in the hierarchy to override setting access.
+	 *
+	 * @var string
 	 */
 	protected $override_option_name;
 
 	/**
-	 * @var  object  Instance of this class.
+	 * Instance of this class.
+	 *
+	 * @var object
 	 */
 	protected static $instance;
 

--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -22,12 +22,14 @@ class Database_Migration {
 	const MIGRATION_ERROR_TRANSIENT_KEY = 'yoast_migration_problem';
 
 	/**
-	 * @var \wpdb WPDB instance
+	 * WPDB instance.
+	 *
+	 * @var \wpdb
 	 */
 	protected $wpdb;
 
 	/**
-	 * @var Dependency_Management
+	 * @var \Dependency_Management
 	 */
 	protected $dependency_management;
 

--- a/tests/admin/links/test-class-link-type-classifier.php
+++ b/tests/admin/links/test-class-link-type-classifier.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 
-	/** @var WPSEO_Link_Type_Classifier */
+	/**
+	 * @var WPSEO_Link_Type_Classifier
+	 */
 	protected $classifier;
 
 	/**

--- a/tests/admin/services/test-class-indexable-post-provider.php
+++ b/tests/admin/services/test-class-indexable-post-provider.php
@@ -12,7 +12,9 @@
  */
 class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 
-	/** @var WPSEO_Indexable_Service_Post_Provider_Double */
+	/**
+	 * @var WPSEO_Indexable_Service_Post_Provider_Double
+	 */
 	protected $provider;
 
 	/**

--- a/tests/admin/test-class-admin-recommended-replace-vars.php
+++ b/tests/admin/test-class-admin-recommended-replace-vars.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 
-	/** @var WPSEO_Admin_Recommended_Replace_Vars */
+	/**
+	 * @var WPSEO_Admin_Recommended_Replace_Vars
+	 */
 	protected $class_instance;
 
 	/**

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -10,10 +10,14 @@
  */
 class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	private static $proxy_table_name;
 
-	/** @var WPSEO_Database_Proxy */
+	/**
+	 * @var WPSEO_Database_Proxy
+	 */
 	private static $proxy;
 
 	/**

--- a/tests/admin/watchers/test-class-slug-change-watcher.php
+++ b/tests/admin/watchers/test-class-slug-change-watcher.php
@@ -10,16 +10,32 @@
  */
 class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 
-	/** @var int Post ID. */
+	/**
+	 * Post ID.
+	 *
+	 * @var int
+	 */
 	private static $post_id;
 
-	/** @var int Nav menu item ID. */
+	/**
+	 * Nav menu item ID.
+	 *
+	 * @var int
+	 */
 	private static $nav_menu_item_id;
 
-	/** @var int Category ID (public taxonomy). */
+	/**
+	 * Category ID (public taxonomy).
+	 *
+	 * @var int
+	 */
 	private static $category_id;
 
-	/** @var int Nav menu ID (non-public taxonomy). */
+	/**
+	 * Nav menu ID (non-public taxonomy).
+	 *
+	 * @var int
+	 */
 	private static $nav_menu_id;
 
 	/**

--- a/tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/tests/config-ui/components/test-class-component-connect-gsc.php
@@ -10,10 +10,16 @@
  */
 class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_Framework_TestCase {
 
-	/** @var WPSEO_Config_Component_Connect_Google_Search_Console_Mock */
+	/**
+	 * @var WPSEO_Config_Component_Connect_Google_Search_Console_Mock
+	 */
 	protected $component;
 
-	/** @var array List of stub calls */
+	/**
+	 * List of stub calls.
+	 *
+	 * @var array
+	 */
 	protected $stub_calls = array();
 
 	/**

--- a/tests/doubles/wpseo-config-component-connect-google-search-console-mock.php
+++ b/tests/doubles/wpseo-config-component-connect-google-search-console-mock.php
@@ -9,10 +9,14 @@
  * Class WPSEO_Config_Component_Connect_Google_Search_Console_Mock
  */
 class WPSEO_Config_Component_Connect_Google_Search_Console_Mock extends WPSEO_Config_Component_Connect_Google_Search_Console {
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $profile;
 
-	/** @var WPSEO_UnitTestCase */
+	/**
+	 * @var WPSEO_UnitTestCase
+	 */
 	protected $test;
 
 	/**

--- a/tests/doubles/wpseo-role-manager-mock.php
+++ b/tests/doubles/wpseo-role-manager-mock.php
@@ -10,10 +10,18 @@
  */
 class WPSEO_Role_Manager_Mock extends WPSEO_Abstract_Role_Manager {
 
-	/** @var array Added roles. */
+	/**
+	 * Added roles.
+	 *
+	 * @var array
+	 */
 	public $added_roles = array();
 
-	/** @var array Removed roles. */
+	/**
+	 * Removed roles.
+	 *
+	 * @var array
+	 */
 	public $removed_roles = array();
 
 	/**

--- a/tests/framework/class-wpseo-unit-test-case-frontend.php
+++ b/tests/framework/class-wpseo-unit-test-case-frontend.php
@@ -9,7 +9,9 @@
  * Helper class to provide needed shared code to implementations.
  */
 abstract class WPSEO_UnitTestCase_Frontend extends WPSEO_UnitTestCase {
-	/** @var WPSEO_Frontend_Double */
+	/**
+	 * @var WPSEO_Frontend_Double
+	 */
 	protected static $class_instance;
 
 	/**

--- a/tests/frontend/test-class-front-end-page-type.php
+++ b/tests/frontend/test-class-front-end-page-type.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 
-	/** @var WPSEO_Frontend_Page_Type */
+	/**
+	 * @var WPSEO_Frontend_Page_Type
+	 */
 	protected $frontend_page_type;
 
 	/**

--- a/tests/frontend/test-class-opengraph.php
+++ b/tests/frontend/test-class-opengraph.php
@@ -12,7 +12,9 @@
  */
 class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 
-	/** @var WPSEO_OpenGraph */
+	/**
+	 * @var WPSEO_OpenGraph
+	 */
 	private static $class_instance;
 
 	/**

--- a/tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -10,10 +10,18 @@
  */
 class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 
-	/** @var int WP SEO manager user ID. */
+	/**
+	 * WP SEO manager user ID.
+	 *
+	 * @var int
+	 */
 	protected static $wpseo_manager;
 
-	/** @var int Network administrator user ID. */
+	/**
+	 * Network administrator user ID.
+	 *
+	 * @var int
+	 */
 	protected static $network_administrator;
 
 	/**

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -10,7 +10,11 @@
  */
 class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
-	/** @var int User ID */
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
 	private $user_id;
 
 	/**

--- a/tests/notifications/test-class-yoast-notification.php
+++ b/tests/notifications/test-class-yoast-notification.php
@@ -10,10 +10,18 @@
  */
 class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 
-	/** @var array Test capability filters get set */
+	/**
+	 * Test capability filters get set.
+	 *
+	 * @var array
+	 */
 	private $verify_capability_filter_args = array();
 
-	/** @var array Test filter capability match */
+	/**
+	 * Test filter capability match.
+	 *
+	 * @var array
+	 */
 	private $verify_capability_match_filter_args = array();
 
 	/**

--- a/tests/recalculate/test-class-recalculate-scores-ajax.php
+++ b/tests/recalculate/test-class-recalculate-scores-ajax.php
@@ -10,10 +10,18 @@
  */
 class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 
-	/** @var \WPSEO_Recalculate_Scores_Ajax Class instance. */
+	/**
+	 * Class instance.
+	 *
+	 * @var \WPSEO_Recalculate_Scores_Ajax
+	 */
 	private $instance;
 
-	/** @var array test posts. */
+	/**
+	 * Test posts.
+	 *
+	 * @var array
+	 */
 	private $posts = array();
 
 	/**

--- a/tests/test-class-primary-term-admin.php
+++ b/tests/test-class-primary-term-admin.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 
-	/** @var WPSEO_Primary_Term_Admin */
+	/**
+	 * @var WPSEO_Primary_Term_Admin
+	 */
 	protected $class_instance;
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

More of the same as #11876, but now mostly for the `tests` directory.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.