### PR TITLE
Make Go Premium links more unique

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -435,7 +435,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	private function get_buy_premium_link() {
 		return sprintf( '<div class="%1$s"><a target="_blank" rel="noopener noreferrer" href="%2$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%3$s</a></div>',
 			'wpseo-metabox-buy-premium',
-			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ) ),
+			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3g6' ) ),
 			__( 'Go Premium', 'wordpress-seo' )
 		);
 	}

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -288,7 +288,7 @@ class WPSEO_Taxonomy_Metabox {
 			WPSEO_Shortlinker::get( 'https://yoa.st/pe-buy-premium' ),
 			/* translators: %s expands to Yoast SEO Premium. */
 			sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ),
-			WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ),
+			WPSEO_Shortlinker::get( 'https://yoa.st/3g5' ),
 			__( 'More info', 'wordpress-seo' )
 		);
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -24,12 +24,13 @@ $extensions->add(
 	'wordpress-seo-premium',
 	new WPSEO_Extension(
 		array(
-			'url'       => WPSEO_Shortlinker::get( 'https://yoa.st/pe-premium-page' ),
-			'title'     => 'Yoast SEO Premium',
+			'buyUrl'   => WPSEO_Shortlinker::get( 'https://yoa.st/zz' ),
+			'infoUrl'  => WPSEO_Shortlinker::get( 'https://yoa.st/zy' ),
+			'title'    => 'Yoast SEO Premium',
 			/* translators: %1$s expands to Yoast SEO */
-			'desc'      => sprintf( __( 'The premium version of %1$s with more features & support.', 'wordpress-seo' ), 'Yoast SEO' ),
-			'image'     => plugins_url( 'images/extensions-premium-ribbon.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-			'benefits'  => array(),
+			'desc'     => sprintf( __( 'The premium version of %1$s with more features & support.', 'wordpress-seo' ), 'Yoast SEO' ),
+			'image'    => plugins_url( 'images/extensions-premium-ribbon.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+			'benefits' => array(),
 		)
 	)
 );
@@ -188,14 +189,14 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 
 			<?php else : ?>
 
-				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zz' ); ?>" class="yoast-button-upsell"><?php
+				<a target="_blank" href="<?php echo esc_url( $extension->get_buy_url() ); ?>" class="yoast-button-upsell"><?php
 					/* translators: $1$s expands to Yoast SEO Premium */
 					printf( __( 'Buy %1$s', 'wordpress-seo' ), $extension->get_title() );
 					echo $new_tab_message;
 					echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 				?></a>
 
-				<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/zy' ); ?>" class="yoast-link--more-info">
+				<a target="_blank" href="<?php echo esc_url( $extension->get_info_url() ); ?>" class="yoast-link--more-info">
 					<?php
 					printf(
 						/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user facing] Replaces duplicate usage of `pe-premium-page` shortlink with unique ones that better describe the context they are used in.

## Relevant technical choices:

* Converted the Premium extension configuration to use the `buyUrl` and `infoUrl` formats introduced recently.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Taxonomy
* Go to the Taxonomy metabox
* Use the `Go premium` link on the top-right
* Hover the `More info` link
* Make sure the shortlink does not use `pe-premium-page`

Content type
* Go to the Post metabox
* Hover or Click the `Go premium` link on the top-right
* Make sure the shortlink does not use `pe-premium-page`

Licenses/Premium
* Go to the "Premium" menu item under "SEO"
* Hover or Click on the Premium "buy" or "info" links and see they are `zz` and `zy` respectively

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #
