### PR TITLE
Cs escape translated output

### DIFF
--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -48,7 +48,16 @@ class WPSEO_Export {
 
 		echo '<p>';
 		/* translators: %1$s expands to Import settings */
-		printf( esc_html__( 'Copy all these settings to another site\'s %1$s tab and click "%1$s" there.', 'wordpress-seo' ), __( 'Import settings', 'wordpress-seo' ) );
+		printf(
+			esc_html__(
+				'Copy all these settings to another site\'s %1$s tab and click "%1$s" there.',
+				'wordpress-seo'
+			),
+			esc_html__(
+				'Import settings',
+				'wordpress-seo'
+			)
+		);
 		echo '</p>';
 		echo '<textarea id="wpseo-export" rows="20" cols="100">' . $this->export . '</textarea>';
 	}

--- a/admin/class-recalibration-beta.php
+++ b/admin/class-recalibration-beta.php
@@ -36,7 +36,7 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 
 		echo '<div class="switch-container">';
 		echo '<fieldset id="', esc_attr( $this->option_name ), '" class="fieldset-switch-toggle">';
-		echo '<legend><strong>', __( 'Get an even better analysis', 'wordpress-seo' ), '</strong></legend>';
+		echo '<legend><strong>', esc_html__( 'Get an even better analysis', 'wordpress-seo' ), '</strong></legend>';
 		echo '<p class="clear">';
 		printf(
 			/* translators: 1: link opening tag, 2: link closing tag, 3: strong opening tag, 4: strong closing tag */

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -255,7 +255,7 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 		check_admin_referer( $action, $query_arg );
 
 		if ( ! $has_access ) {
-			wp_die( __( 'You are not allowed to perform this action.', 'wordpress-seo' ) );
+			wp_die( esc_html__( 'You are not allowed to perform this action.', 'wordpress-seo' ) );
 		}
 	}
 

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -84,7 +84,7 @@ switch ( $platform_tabs->current_tab() ) {
 				$profiles = $this->service->get_sites();
 				if ( ! empty( $profiles ) ) {
 					$show_save = true;
-					echo Yoast_Form::get_instance()->select( 'profile', __( 'Profile', 'wordpress-seo' ), $profiles );
+					Yoast_Form::get_instance()->select( 'profile', esc_html__( 'Profile', 'wordpress-seo' ), $profiles );
 				}
 				else {
 					$show_save = false;

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -95,7 +95,7 @@ switch ( $platform_tabs->current_tab() ) {
 				echo '<p>';
 
 				if ( $show_save ) {
-					echo '<input type="submit" name="submit" id="submit" class="button button-primary wpseo-gsc-save-profile" value="' . esc_attr__( 'Save Profile', 'wordpress-seo' ) . '" /> ' . __( 'or', 'wordpress-seo' ) , ' ';
+					echo '<input type="submit" name="submit" id="submit" class="button button-primary wpseo-gsc-save-profile" value="' . esc_attr__( 'Save Profile', 'wordpress-seo' ) . '" /> ' .esc_html__( 'or', 'wordpress-seo' ) , ' ';
 				}
 				echo $reset_button;
 				echo '</p>';

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -222,7 +222,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				$yoast_seo_extensions = '<span class="yoast-heading-highlight">' . $yoast_seo_extensions . '</span>';
 
 				/* translators: %1$s expands to Yoast SEO extensions */
-				printf( __( '%1$s to optimize your site even further', 'wordpress-seo' ), $yoast_seo_extensions );
+				printf( esc_html__( '%1$s to optimize your site even further', 'wordpress-seo' ), $yoast_seo_extensions );
 				?></h2>
 
 			<?php foreach ( $extensions->get_all() as $id => $extension ) : ?>

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -25,7 +25,7 @@ if ( ! defined( 'WPSEO_NAMESPACES' ) || ! WPSEO_NAMESPACES ) {
 	printf(
 		/* translators: 1: Import settings button string from below. */
 		esc_html__( 'Import settings by pasting the settings you copied from another site here and clicking "%s".', 'wordpress-seo' ),
-		__( 'Import settings', 'wordpress-seo' )
+		esc_html__( 'Import settings', 'wordpress-seo' )
 	);
 	?>
 </p>

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1187,8 +1187,8 @@ class WPSEO_Frontend {
 			printf(
 				/* Translators: %1$s resolves to the SEO menu item, %2$s resolves to the Search Appearance submenu item. */
 				esc_html__( 'Admin only notice: this page does not show a meta description because it does not have one, either write it for this page specifically or go into the [%1$s - %2$s] menu and set up a template.', 'wordpress-seo' ),
-				__( 'SEO', 'wordpress-seo' ),
-				__( 'Search Appearance', 'wordpress-seo' )
+				esc_html__( 'SEO', 'wordpress-seo' ),
+				esc_html__( 'Search Appearance', 'wordpress-seo' )
 			);
 			echo ' -->' . "\n";
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* I've escaped some translated strings. This should still work, there was no functional change. The only page I don't know where to find is `admin/class-yoast-network-admin.php`. The rest of the fixes can be verified by looking at:
- Yoast SEO > Tools > Import & Export > Export settings
- Yoast SEO > Tools > Import & Export > Import settings
- Yoast SEO > Premium  
- Yoast SEO > General > Features > Recalibration beta
- Yoast SEO > Search Console > Settings - The Google Search console profile selector
- Frontend: Open a page with no set metadescription and view the source, there is a html comment.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
