### PR TITLE
call wp.api.models.Page when ready

### DIFF
--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -158,19 +158,21 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 				this.declareReloaded();
 				return;
 			}
-			const page = new wp.api.models.Page( { id: newParent } );
-			page.fetch().then(
-				response => {
-					this._currentParentPageTitle = response.title.rendered;
-					fetchedParents[ newParent ]  = this._currentParentPageTitle;
-					this.declareReloaded();
-				}
-			).fail(
-				() => {
-					this._currentParentPageTitle = "";
-					this.declareReloaded();
-				}
-			);
+			wp.api.loadPromise.done( function() {
+				const page = new wp.api.models.Page( { id: newParent } );
+				page.fetch().then(
+					response => {
+						this._currentParentPageTitle = response.title.rendered;
+						fetchedParents[ newParent ]  = this._currentParentPageTitle;
+						this.declareReloaded();
+					}
+				).fail(
+					() => {
+						this._currentParentPageTitle = "";
+						this.declareReloaded();
+					}
+				);
+			} );
 		} );
 	};
 


### PR DESCRIPTION
Fixes error when wp.api.models.Page is called to get Parent page.
Issue reported on https://github.com/Yoast/wordpress-seo/issues/11767

## Summary

This PR can be summarized in the following changelog entry:

* Fixes error when wp.api.models.Page is called before the function was ready.
* Likely occurs in particular connection speeds.
* When it occurs can be produced consistently on all browsers when editing Child page to a New tab
* Error is not present on refresh.

## Relevant technical choices:

* Using wp.api.loadPromise.done to ensure the wp.api.models.Page is only called when it is ready.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new page enter a title and publish ( Page A )
* Create another page ( Page B ) and choose Page A as a parent page from page attributes. Publish the page.
* Goto page-list screen in wp-admin. Click the edit link under Page B and open it as a new tab which displays a blank page.
* Refresh again and there is no error. Edit page displays correctly.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11931
Fixes #11767
