### PR TITLE
Don't sanitize text field for array

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -720,7 +720,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				if ( isset( $_POST[ $field_name ] ) ) {
 					$data = wp_unslash( $_POST[ $field_name ] );
 
-					// For multi-select
+					// For multi-select.
 					if ( is_array( $data ) ) {
 						$data = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), $data );
 					}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -718,10 +718,25 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			}
 			else {
 				if ( isset( $_POST[ $field_name ] ) ) {
-					$data = WPSEO_Utils::sanitize_text_field( wp_unslash( $_POST[ $field_name ] ) );
+					$data = wp_unslash( $_POST[ $field_name ] );
+
+					// For multi-select
+					if ( is_array( $data ) ) {
+						$data = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), $data );
+					}
+
+					if ( is_string( $data ) ) {
+						$data = WPSEO_Utils::sanitize_text_field( $data );
+					}
+				}
+
+				// Reset options when no entry is present with multiselect - only applies to `meta-robots-adv` currently.
+				if ( ! isset( $_POST[ $field_name ] ) && ( $meta_box['type'] === 'multiselect' ) ) {
+					$data = array();
 				}
 			}
-			if ( isset( $data ) ) {
+
+			if ( $data !== null ) {
 				self::set_value( $key, $data, $post_id );
 			}
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user facing] Fixes a problem introduced in trunk where the input was sanitized too aggressively on multi-select input (advanced robots settings)

## Relevant technical choices:

* Convert no input for multiselect to empty array
* Added array map for input data instead of plain `sanitize_text_field` which will convert any array to an empty string.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open a post/page and set advanced robots to a certain value
* Save the settings
* (Reload the page when using Gutenberg)
* See the settings being saved

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes https://github.com/Yoast/wordpress-seo/issues/11917
