### PR TITLE
Fix false positive external links in sitemaps

### DIFF
--- a/admin/links/class-link-type-classifier.php
+++ b/admin/links/class-link-type-classifier.php
@@ -91,7 +91,7 @@ class WPSEO_Link_Type_Classifier {
 
 		// When there is a path.
 		if ( isset( $url_parts['path'] ) ) {
-            return false;
+			return ( strpos( $url_parts['path'], $this->base_path ) === false );
 		}
 
 		return true;

--- a/admin/links/class-link-type-classifier.php
+++ b/admin/links/class-link-type-classifier.php
@@ -91,7 +91,7 @@ class WPSEO_Link_Type_Classifier {
 
 		// When there is a path.
 		if ( isset( $url_parts['path'] ) ) {
-			return ( strpos( $url_parts['path'], $this->base_path ) === false );
+            return false;
 		}
 
 		return true;

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -46,10 +46,38 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	protected static $page_for_posts_id;
 
 	/**
+	 * The with_front rewrite setting.
+	 *
+	 * @var boolean
+	 */
+	private $post_type_has_front = true;
+
+	/**
 	 * Set up object properties for data reuse.
 	 */
 	public function __construct() {
 		add_filter( 'save_post', array( $this, 'save_post' ) );
+	}
+
+	/**
+	 * Sets the post type has front boolean.
+	 *
+	 * @param string $post_type_has_front the post type.
+	 *
+	 * @return void
+	 */
+	protected function set_post_type_has_front($post_type) {
+		$post_type_has_front = get_post_type_object($post_type)->rewrite["with_front"];
+		$this->post_type_has_front = $post_type_has_front === false ? false : true;
+	}
+
+	/**
+	 * Get if the post type has with_front rewrite setting set to true.
+	 *
+	 * @return boolean with_front rewrite setting.
+	 */
+	protected function get_post_type_has_front() {
+		return $this->post_type_has_front;
 	}
 
 	/**
@@ -244,6 +272,8 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		while ( $total > $offset ) {
 
 			$posts = $this->get_posts( $post_type, $steps, $offset );
+
+			$this->set_post_type_has_front($post_type);
 
 			$offset += $steps;
 
@@ -626,7 +656,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 *
 		 * @see https://wordpress.org/plugins/page-links-to/ can rewrite permalinks to external URLs.
 		 */
-		if ( $this->get_classifier()->classify( $url['loc'] ) === WPSEO_Link::TYPE_EXTERNAL ) {
+		$post_type_has_front = $this->get_post_type_has_front();
+
+		if ( $this->get_classifier()->classify( $url['loc'] ) === WPSEO_Link::TYPE_EXTERNAL && $post_type_has_front ) {
 			return false;
 		}
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -129,8 +129,8 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$home_url = $this->get_home_url();
 			$post_type_has_front = $this->get_post_type_has_front();
 
-			// remove path from home_url if post type with_front rewrite option is set to false
-			if (!$post_type_has_front) {
+			// Remove path from home_url if post type with_front rewrite option is set to false.
+			if ( ! $post_type_has_front ) {
 				$url_path = wp_parse_url( $home_url, PHP_URL_PATH );
 				$home_url = str_replace( $url_path, '/', $home_url );
 			}

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -62,13 +62,13 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	/**
 	 * Sets the post type has front boolean.
 	 *
-	 * @param string $post_type_has_front the post type.
+	 * @param string $post_type the post type.
 	 *
 	 * @return void
 	 */
 	protected function set_post_type_has_front($post_type) {
 		$post_type_has_front = get_post_type_object($post_type)->rewrite["with_front"];
-		$this->post_type_has_front = $post_type_has_front === false ? false : true;
+		$this->post_type_has_front = ( $post_type_has_front === false ? false : true );
 	}
 
 	/**

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -66,9 +66,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 *
 	 * @return void
 	 */
-	protected function set_post_type_has_front($post_type) {
-		$post_type_has_front = get_post_type_object($post_type)->rewrite["with_front"];
-		$this->post_type_has_front = ( $post_type_has_front === false ? false : true );
+	protected function set_post_type_has_front( $post_type ) {
+		$post_type_has_front = get_post_type_object( $post_type )->rewrite['with_front'];
+		$this->post_type_has_front = ( $post_type_has_front === false ) ? false : true;
 	}
 
 	/**
@@ -273,7 +273,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			$posts = $this->get_posts( $post_type, $steps, $offset );
 
-			$this->set_post_type_has_front($post_type);
+			$this->set_post_type_has_front( $post_type );
 
 			$offset += $steps;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix false positive external links in sitemaps. Links to custom post types with `with_front` set to `false` were marked as external.

## Test instructions

This PR can be tested by following these steps:

* To reproduce follow the steps in #9634
* This pull should fix that

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9634
