### PR TITLE
6343 only handle own sitemap

### DIFF
--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -26,7 +26,13 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	public function handles_type( $type ) {
 
-		return taxonomy_exists( $type );
+		$taxonomy = get_taxonomy( $type );
+
+		if ( $taxonomy === false || ! $this->is_valid_taxonomy( $taxonomy->name ) || ! $taxonomy->public ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -141,15 +147,14 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 * @return array
 	 */
 	public function get_sitemap_links( $type, $max_entries, $current_page ) {
-
 		global $wpdb;
 
-		$links    = array();
-		$taxonomy = get_taxonomy( $type );
-
-		if ( $taxonomy === false || ! $this->is_valid_taxonomy( $taxonomy->name ) || ! $taxonomy->public ) {
+		$links = array();
+		if ( ! $this->handles_type( $type ) ) {
 			return $links;
 		}
+
+		$taxonomy = get_taxonomy( $type );
 
 		$steps  = $max_entries;
 		$offset = ( $current_page > 1 ) ? ( ( $current_page - 1 ) * $max_entries ) : 0;

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -286,15 +286,4 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		// Expect the attachment not to be added to the list.
 		$this->assertCount( 0, self::$class_instance->get_sitemap_links( 'attachment', 100, 0 ) );
 	}
-
-	/**
-	 * Filter to exclude desired posts from the sitemap.
-	 *
-	 * @param array $post_ids List of post ids.
-	 *
-	 * @return array
-	 */
-	public function exclude_post( $post_ids ) {
-		return $this->excluded_posts;
-	}
 }

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -286,4 +286,15 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		// Expect the attachment not to be added to the list.
 		$this->assertCount( 0, self::$class_instance->get_sitemap_links( 'attachment', 100, 0 ) );
 	}
+
+	/**
+	 * Filter to exclude desired posts from the sitemap.
+	 *
+	 * @param array $post_ids List of post ids.
+	 *
+	 * @return array
+	 */
+	public function exclude_post( $post_ids ) {
+		return $this->excluded_posts;
+	}
 }

--- a/tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -59,5 +59,32 @@ class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
 		$this->expectOutputContains(
 			'<loc>http://example.org/author-sitemap.xml</loc>'
 		);
+
+		unregister_taxonomy( 'author' );
+	}
+
+	/**
+	 * Makes sure the private taxonomy "author" does not override the "Author" sitemap.
+	 */
+	public function test_private_taxonomy_author_overlap_author_in_sitemap() {
+		// Create private taxonomy "author", overlapping the "author" sitemap.
+		register_taxonomy( 'author', array( 'post' ), array( 'public' => false ) );
+
+		// Create a user with a post.
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+
+		// Fetch the global sitemap.
+		set_query_var( 'sitemap', 'author' );
+
+		// Load the sitemap.
+		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
+
+		// Expect the author-sitemap to be present in the index.
+		$this->expectOutputContains(
+			'<loc>' . get_author_posts_url( $user_id ) . '</loc>'
+		);
+
+		unregister_taxonomy( 'author' );
 	}
 }

--- a/tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Sitemaps
+ */
+
+/**
+ * Class Test_WPSEO_Sitemap_Provider_Overlap
+ *
+ * @group sitemaps
+ */
+class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
+	/**
+	 * @var WPSEO_Sitemaps_Double
+	 */
+	private static $class_instance;
+
+	/**
+	 * Set up our double class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		self::$class_instance = new WPSEO_Sitemaps_Double();
+
+		// Reset the instance
+		self::$class_instance->reset();
+	}
+
+	/**
+	 * Set up our double class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Make sure the author archives are enabled.
+		WPSEO_Options::set( 'disable-author', false );
+	}
+
+	/**
+	 * Makes sure the private taxonomy "author" does not override the "Author" sitemap.
+	 */
+	public function test_private_taxonomy_author_overlap() {
+		// Create private taxonomy "author", overlapping the "author" sitemap.
+		register_taxonomy( 'author', array( 'post' ), array( 'public' => false ) );
+
+		// Create a user with a post.
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+
+		// Fetch the global sitemap.
+		set_query_var( 'sitemap', '1' );
+
+		// Load the sitemap.
+		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
+
+		// Expect the author-sitemap to be present in the index.
+		$this->expectOutputContains(
+			'<loc>http://example.org/author-sitemap.xml</loc>'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a problem where taxonomy sitemap provider would not handle private taxonomies as expected, resulting in sitemaps not being accessible in specific situations.

## Relevant technical choices:

* Because the taxonomy provider would not check if a taxonomy is valid and public in the `handles_type` it would declare ownership over such taxonomy resulting in a 404 sitemap because there would be no entries.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Before checking out this branch:

* Go to SEO > Search Appearance > Archives - and enables Author archives
* Visit the `author-sitemap.xml` and see that it returns a sitemap
* Install the `Co-Authors` plugin - which will create a private taxonomy "authors"
* Visit the `author-sitemap.xml` and see that it returns a 404

After checking out this branch:

* Go to SEO > Search Appearance > Archives - and enables Author archives
* Visit the `author-sitemap.xml` and see that it returns a sitemap
* Install the `Co-Authors` plugin - which will create a private taxonomy "authors"
* Visit the `author-sitemap.xml` and see that it returns a sitemap

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #6343
