### PR TITLE
Fix the Courses page layout.

### DIFF
--- a/admin/pages/courses.php
+++ b/admin/pages/courses.php
@@ -12,7 +12,12 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-$yform = Yoast_Form::get_instance();
-$yform->admin_header( false );
+?>
+<div class="wrap yoast">
+<h1 id="wpseo-title"><?php echo esc_html( get_admin_page_title() ); ?></h1>
+<?php
 
 echo "<div id='yoast-courses-overview'></div>";
+
+?>
+</div>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the WordPress admin menu and footer in the Courses page

## Relevant technical choices:

Currently, the Courses page uses the `Yoast_Form` method `admin_header()` but omits to use `admin_footer()`. This breaks the admin layout and menu because of malformed HTML.

However, the Courses page is a special page that needs to display only the courses cards. Using `admin_footer()` would require to remove a few action hooks, including the one used to print out the "promo block" at the bottom of the page.
I'd propose to avoid this overhead altogether, as there's no need to use `Yoast_Form` in the first place:
- we don't need the form: there's nothing to submit
- we don't need the CSS table layout that is normally used in the admin pages (primarily meant for the banners sidebar)

## Test instructions
- before this PR
- go in the Courses page
- observe there's no visible WordPress footer
- scroll the page to the bottom, hover on a WP admin menu item and observe the "fly-out" menu with the sub items is misplaced
- switch to this branch
- verify the WP footer is visible and the admin menu works correctly

Fixes #11934 
