### PR TITLE
Add upsells to terms

### DIFF
--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -54,12 +54,46 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 	 * @return array The passed array with the additional shortlinks.
 	 */
 	public function expose_shortlinks( $input ) {
-		foreach ( $this->shortlinks as $key => $shortlink ) {
+		foreach ( $this->get_shortlinks() as $key => $shortlink ) {
 			$input[ $key ] = WPSEO_Shortlinker::get( $shortlink );
 		}
 
 		$input['default_query_params'] = WPSEO_Shortlinker::get_query_params();
 
 		return $input;
+	}
+
+	/**
+	 * Retrieves the shortlinks.
+	 *
+	 * @return array The shortlinks.
+	 */
+	private function get_shortlinks() {
+		if ( ! $this->is_term_edit() ) {
+			return $this->shortlinks;
+		}
+
+		$shortlinks = $this->shortlinks;
+
+		$shortlinks['shortlinks.upsell.metabox.focus_keyword_synonyms_link']     = 'https://yoa.st/textlink-synonyms-popup-metabox-term';
+		$shortlinks['shortlinks.upsell.metabox.focus_keyword_synonyms_button']   = 'https://yoa.st/keyword-synonyms-popup-term';
+		$shortlinks['shortlinks.upsell.metabox.focus_keyword_additional_link']   = 'https://yoa.st/textlink-keywords-popup-metabox-term';
+		$shortlinks['shortlinks.upsell.metabox.focus_keyword_additional_button'] = 'https://yoa.st/add-keywords-popup-term';
+		$shortlinks['shortlinks.upsell.metabox.additional_link']                 = 'https://yoa.st/textlink-keywords-metabox-term';
+		$shortlinks['shortlinks.upsell.metabox.additional_button']               = 'https://yoa.st/add-keywords-metabox-term';
+		$shortlinks['shortlinks.upsell.sidebar.morphology_upsell_metabox']       = 'https://yoa.st/morphology-upsell-metabox-term';
+
+		return $shortlinks;
+	}
+
+	/**
+	 * Checks if the current page is a term edit page.
+	 *
+	 * @return string True when page is term edit.
+	 */
+	private function is_term_edit() {
+		global $pagenow;
+
+		return WPSEO_Taxonomy::is_term_edit( $pagenow );
 	}
 }

--- a/admin/class-expose-shortlinks.php
+++ b/admin/class-expose-shortlinks.php
@@ -89,7 +89,7 @@ class WPSEO_Expose_Shortlinks implements WPSEO_WordPress_Integration {
 	/**
 	 * Checks if the current page is a term edit page.
 	 *
-	 * @return string True when page is term edit.
+	 * @return bool True when page is term edit.
 	 */
 	private function is_term_edit() {
 		global $pagenow;

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -429,10 +429,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	private function get_buy_premium_link() {
 		return sprintf(
-			'<div class="%1$s"><a target="_blank" rel="noopener noreferrer" href="%2$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%3$s</a></div>',
-			'wpseo-metabox-buy-premium',
+			'<div class="wpseo-metabox-buy-premium"><a target="_blank" href="%1$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%2$s%3$s</a></div>',
 			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3g6' ) ),
-			__( 'Go Premium', 'wordpress-seo' )
+			esc_html__( 'Go Premium', 'wordpress-seo' ),
+			WPSEO_Admin_Utils::get_new_tab_message()
 		);
 	}
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -235,8 +235,7 @@ class WPSEO_Taxonomy_Metabox {
 	 */
 	private function get_buy_premium_link() {
 		return sprintf(
-			'<div class="%1$s"><a target="_blank" rel="noopener noreferrer" href="%2$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%3$s</a></div>',
-			'wpseo-metabox-buy-premium',
+			'<div class="wpseo-metabox-buy-premium"><a target="_blank" rel="noopener noreferrer" href="%1$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%2$s</a></div>',
 			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3hh' ) ),
 			esc_html__( 'Go Premium', 'wordpress-seo' )
 		);

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -235,9 +235,10 @@ class WPSEO_Taxonomy_Metabox {
 	 */
 	private function get_buy_premium_link() {
 		return sprintf(
-			'<div class="wpseo-metabox-buy-premium"><a target="_blank" href="%1$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%2$s</a></div>',
+			'<div class="wpseo-metabox-buy-premium"><a target="_blank" href="%1$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%2$s%3$s</a></div>',
 			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3hh' ) ),
-			esc_html__( 'Go Premium', 'wordpress-seo' )
+			esc_html__( 'Go Premium', 'wordpress-seo' ),
+			WPSEO_Admin_Utils::get_new_tab_message()
 		);
 	}
 }

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -235,7 +235,7 @@ class WPSEO_Taxonomy_Metabox {
 	 */
 	private function get_buy_premium_link() {
 		return sprintf(
-			'<div class="wpseo-metabox-buy-premium"><a target="_blank" rel="noopener noreferrer" href="%1$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%2$s</a></div>',
+			'<div class="wpseo-metabox-buy-premium"><a target="_blank" href="%1$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%2$s</a></div>',
 			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3hh' ) ),
 			esc_html__( 'Go Premium', 'wordpress-seo' )
 		);

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -244,9 +244,9 @@ class WPSEO_Taxonomy_Metabox {
 	 */
 	private function get_buy_premium_link() {
 		return sprintf(
-			"<div class='%s'><a href='#wpseo-meta-section-premium' class='wpseo-meta-section-link'><span class='dashicons dashicons-star-filled wpseo-buy-premium'></span>%s</a></div>",
+			'<div class="%1$s"><a target="_blank" rel="noopener noreferrer" href="%2$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%3$s</a></div>',
 			'wpseo-metabox-buy-premium',
-			__( 'Go Premium', 'wordpress-seo' )
+			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3hh' ) ),
 		);
 	}
 
@@ -314,6 +314,7 @@ class WPSEO_Taxonomy_Metabox {
 				'link_aria_label' => 'Yoast SEO Premium',
 				'link_class'      => 'yoast-tooltip yoast-tooltip-e',
 			)
+			esc_html__( 'Go Premium', 'wordpress-seo' )
 		);
 	}
 }

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -86,10 +86,6 @@ class WPSEO_Taxonomy_Metabox {
 		echo '<div class="wpseo-metabox-sidebar"><ul>';
 
 		foreach ( $content_sections as $content_section ) {
-			if ( $content_section->name === 'premium' ) {
-				continue;
-			}
-
 			$content_section->display_link();
 		}
 
@@ -112,13 +108,8 @@ class WPSEO_Taxonomy_Metabox {
 		$content_sections = array();
 
 		$content_sections[] = $this->get_content_meta_section();
-
 		$content_sections[] = $this->get_social_meta_section();
 		$content_sections[] = $this->get_settings_meta_section();
-
-		if ( ! defined( 'WPSEO_PREMIUM_FILE' ) ) {
-			$content_sections[] = $this->get_buy_premium_section();
-		}
 
 		return $content_sections;
 	}
@@ -247,73 +238,6 @@ class WPSEO_Taxonomy_Metabox {
 			'<div class="%1$s"><a target="_blank" rel="noopener noreferrer" href="%2$s"><span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>%3$s</a></div>',
 			'wpseo-metabox-buy-premium',
 			esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3hh' ) ),
-		);
-	}
-
-	/**
-	 * Returns the metabox section for the Premium section..
-	 *
-	 * @return WPSEO_Metabox_Section
-	 */
-	private function get_buy_premium_section() {
-		$content = sprintf(
-			"<div class='wpseo-premium-description'>
-				%s
-				<ul class='wpseo-premium-advantages-list'>
-					<li>
-						<strong>%s</strong> - %s
-					</li>
-					<li>
-						<strong>%s</strong> - %s
-					</li>
-					<li>
-						<strong>%s</strong> - %s
-					</li>
-					<li>
-						<strong>%s</strong> - %s
-					</li>
-				</ul>
-	
-				<a target='_blank' id='wpseo-buy-premium-popup-button' class='button button-buy-premium wpseo-metabox-go-to' href='%s'>
-					%s
-				</a>
-	
-				<p><a target='_blank' class='wpseo-metabox-go-to' href='%s'>%s</a></p>
-			</div>",
-			/* translators: %1$s expands to Yoast SEO Premium. */
-			sprintf( __( 'You\'re not getting the benefits of %1$s yet. If you had %1$s, you could use its awesome features:', 'wordpress-seo' ), 'Yoast SEO Premium' ),
-			__( 'Redirect manager', 'wordpress-seo' ),
-			__( 'Create and manage redirects within your WordPress install.', 'wordpress-seo' ),
-			__( 'Synonyms & related keyphrases', 'wordpress-seo' ),
-			__( 'Optimize a single post for synonyms and related keyphrases.', 'wordpress-seo' ),
-			__( 'Social Previews', 'wordpress-seo' ),
-			__( 'Check what your Facebook or Twitter post will look like.', 'wordpress-seo' ),
-			__( 'Premium support', 'wordpress-seo' ),
-			__( 'Gain access to our 24/7 support team.', 'wordpress-seo' ),
-			WPSEO_Shortlinker::get( 'https://yoa.st/pe-buy-premium' ),
-			/* translators: %s expands to Yoast SEO Premium. */
-			sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ),
-			WPSEO_Shortlinker::get( 'https://yoa.st/3g5' ),
-			__( 'More info', 'wordpress-seo' )
-		);
-
-		$tab = new WPSEO_Metabox_Form_Tab(
-			'premium',
-			$content,
-			'Yoast SEO Premium',
-			array(
-				'single' => true,
-			)
-		);
-
-		return new WPSEO_Metabox_Tab_Section(
-			'premium',
-			'<span class="dashicons dashicons-star-filled wpseo-buy-premium"></span>',
-			array( $tab ),
-			array(
-				'link_aria_label' => 'Yoast SEO Premium',
-				'link_class'      => 'yoast-tooltip yoast-tooltip-e',
-			)
 			esc_html__( 'Go Premium', 'wordpress-seo' )
 		);
 	}

--- a/js/src/redux/reducers/preferences.js
+++ b/js/src/redux/reducers/preferences.js
@@ -15,7 +15,7 @@ function getDefaultState() {
 		isKeywordAnalysisActive: isKeywordAnalysisActive(),
 		isWordFormRecognitionActive: isUndefined( window.wpseoPremiumMetaboxData ) && isWordFormRecognitionActive(),
 		isCornerstoneActive: isCornerstoneActive() && isUndefined( window.wpseoTermScraperL10n ),
-		shouldUpsell: isUndefined( window.wpseoPremiumMetaboxData ) && isUndefined( window.wpseoTermScraperL10n ),
+		shouldUpsell: isUndefined( window.wpseoPremiumMetaboxData ),
 	};
 }
 

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -44,8 +44,7 @@
 			jQuery( "a.wpseo-meta-section-link" )
 				.on( "click", function( ev ) {
 					var targetTab = jQuery( this ).attr( "href" ),
-						targetTabElement = jQuery( targetTab ),
-						helpCenterToggleButton = jQuery( ".yoast-help-center__button" );
+						targetTabElement = jQuery( targetTab );
 
 					ev.preventDefault();
 
@@ -60,13 +59,6 @@
 					}
 
 					targetTabElement.addClass( "active" );
-
-					// Close the Help Center when clicking on the Go Premium link.
-					if ( targetTab === "#wpseo-meta-section-premium" ) {
-						if ( helpCenterToggleButton.attr( "aria-expanded" ) === "true" ) {
-							helpCenterToggleButton.click();
-						}
-					}
 
 					jQuery( this ).parent( "li" ).addClass( "active" );
 				} )


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Do the yarn and grunt magic
* Edit or add a term (e.g. a category)
* See there is an additional `add related keyphrase` item in the metabox. It should shown an upsell.
* Verify that other upsells are shown as well: morphology, add synonyms, add related keyphrase
* Make sure the links in the upsells have term in the url and are different compared to the ones for a post.
* Makes sure `Go Premium` at the top of the metabox refers to an external page.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11293
Fixes #11898
