### PR TITLE
CS: Fix newly detected issues

### DIFF
--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -139,7 +139,7 @@ class WPSEO_Export {
 		foreach ( $options as $key => $elem ) {
 			if ( is_array( $elem ) ) {
 				$count = count( $elem );
-				for ( $i = 0; $i < $count; $i ++ ) {
+				for ( $i = 0; $i < $count; $i++ ) {
 					$this->write_setting( $key . '[]', $elem[ $i ] );
 				}
 			}

--- a/admin/class-extension-manager.php
+++ b/admin/class-extension-manager.php
@@ -27,7 +27,7 @@ class WPSEO_Extension_Manager {
 	 *
 	 * @var array
 	 */
-	static protected $active_extensions;
+	protected static $active_extensions;
 
 	/**
 	 * Adds an extension to the manager.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

* The next version of YoastCS will detect and start complaining about whitespace between incrementor/decrementor operators and the variable they apply to.
* The next version of WPCS (2.0.0) will start complaining about the order in which scope keywords for properties are set. The expected order is `visibility [static] $property`.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.