### PR TITLE
Documentation: remove outdated comment

### DIFF
--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -49,8 +49,6 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		global $pagenow;
 		$pagenow = 'post-new.php';
 
-		// Prefix used in WPSEO-admin-asset-manager.
-
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->register_assets();
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

This comment is a left-over from before the `WPSEO_Admin_Asset_Manager::PREFIX` prefix was used and the prefix was set from within the test method. (checked via file history trace)


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.