### PR TITLE
CS: remove an unnecessary property declaration

### DIFF
--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -22,11 +22,6 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	private $search_string;
 
 	/**
-	 * @var array
-	 */
-	protected $_column_headers;
-
-	/**
 	 * The category that is displayed
 	 *
 	 * @var mixed|string


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Properties should not be prefixed with an `_` to indicate visibility. This is an outdated PHP4-style habit.

In this case, the property name can not be changed as the property comes from the WP native `WP_List_Table` class which this class extends, but as the property is declared in the parent class and the property declaration in this child class does not overwrite a default value or change the visibility of the property, there is no need to declare it in the child class in the first place, so we may as well remove it.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.