### PR TITLE
CS: don't use underscore prefixed property names [1]

### DIFF
--- a/src/models/seo-meta.php
+++ b/src/models/seo-meta.php
@@ -20,9 +20,9 @@ class SEO_Meta extends Yoast_Model {
 	/**
 	 * Overwrites the default ID column name.
 	 *
-	 * @var string $_id_column
+	 * @var string
 	 */
-	public static $_id_column = 'object_id';
+	public static $id_column = 'object_id';
 
 	/**
 	 * Finds the SEO meta for given post.

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -34,7 +34,7 @@ class Yoast_Model {
 
 	/**
 	 * Default ID column for all models. Can be overridden by adding
-	 * a public static _id_column property to your model classes.
+	 * a public static $id_column property to your model classes.
 	 *
 	 * @var string
 	 */
@@ -258,7 +258,7 @@ class Yoast_Model {
 	 * @return string|null The ID column name.
 	 */
 	protected static function get_id_column_name( $class_name ) {
-		return static::get_static_property( $class_name, '_id_column', static::DEFAULT_ID_COLUMN );
+		return static::get_static_property( $class_name, 'id_column', static::DEFAULT_ID_COLUMN );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Properties should not be prefixed with an `_` (to indicate visibility or for whatever other reason). This is an outdated PHP4-style habit.

Renaming the property and instances of it in child classes fixes this.

As the `Yoast_Model` class is set up as a parent class, this should be considered a BC-break.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.