### PR TITLE
Travis/Composer: update YoastCS to 1.2.1 for the Premium plugin only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,7 +221,11 @@ script:
 - |
   if [[ "$PHPCS" == "1" ]]; then
     travis_fold start "PHP.code-style" && travis_time_start
-    vendor/bin/phpcs -q --runtime-set ignore_warnings_on_exit 1
+    if [[ -d "premium" ]]; then
+      composer premium-check-cs
+    else
+      vendor/bin/phpcs -q --runtime-set ignore_warnings_on_exit 1
+    fi
     travis_time_finish && travis_fold end "PHP.code-style"
   fi
 # PHP Unit

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,12 @@
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs"
 		],
+		"premium-check-cs": [
+			"composer require yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/ --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
+			"composer require yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction"
+		],
 		"check-cs-errors": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --error-severity=1 --warning-severity=6"
 		],

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -66,18 +66,15 @@
 	<!-- WP-CLI and src (indexables) have a minimum PHP requirement of PHP 5.3. -->
 	<rule ref="PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound">
 		<exclude-pattern>*/cli/class-cli-*\.php$</exclude-pattern>
-		<exclude-pattern>*/premium/cli/cli-*\.php$</exclude-pattern>
 		<exclude-pattern>*/src/*.php$</exclude-pattern>
 		<exclude-pattern>*/migrations/*.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.Keywords.NewKeywords.t_useFound">
 		<exclude-pattern>*/cli/class-cli-*\.php$</exclude-pattern>
-		<exclude-pattern>*/premium/cli/cli-*\.php$</exclude-pattern>
 		<exclude-pattern>*/src/*.php$</exclude-pattern>
 		<exclude-pattern>*/migrations/*.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__invokeFound">
-		<exclude-pattern>*/premium/cli/cli-*\.php$</exclude-pattern>
 		<exclude-pattern>*/src/*.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.Classes.NewLateStaticBinding.Found">


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

A bit hacki-di-hacky, but it works.

This adds a separate Composer script to allow both devs, as well as Travis, to test code in the Premium repo against YoastCS 1.2.1, even though the Free plugin is not ready to upgrade yet.

To still allows devs to easily switch between testing the Free repo against the old requirements and the Premium repo against the new ones, the update to YoastCS 1.2.1 for the Premium CS check is reverted after the CS checks have run.

Also takes note of the fact that `premium-check-cs` script contains **2** PHPCS runs.

The PHPCompatibility `testVersion` can not be set per directory (inherent to how config settings work in PHPCS), however the `testVersion` as set in a ruleset, can - since PHPCS 3.3.0 - be overruled from the command-line.
This allows us to test the PHP 5.2 compatible code with a `testVersion` of `5.2-`, which is the default in YoastCS, while we test the PHP 5.3+ compatible code (in the `cli` directory) with a `testVersion` of `5.3-`.

The same will be applied to the `check-cs` script once the Free plugin upgrades to the current version of YoastCS.
This also means that we won't need a slew of ruleset exclusions for directories with different PHP requirements.

The `fix-cs` script has not been adjusted as the `PHPCompatibility` standard does not contain fixers, so there won't be an issue there.

Lastly, as the Premium repo will have its own PHPCS ruleset, we can now remove Premium specific exclusions from the PHPCS ruleset used by the Free plugin.

Once this PR has been merged and Free merged back into Premium, you should be able to see the results of this change in the Travis PHP 7.3 build in Premium.

The proof of concept for this change has been tested extensively. Results for a (successful) test run on Travis using the same code as included in this PR, are available here: https://travis-ci.com/Yoast/wordpress-seo-premium/builds/95946057#L2403


## Test instructions
This PR can be tested by following these steps:

* This PR has been tested via test builds in the Premium repo (see above).
* For devs, it would be good to test the composer script added by this PR on a local machine.


