### PR TITLE
Composer: add "premium-fix-cs" script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,10 +68,10 @@
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs"
 		],
 		"premium-check-cs": [
-			"composer require yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
+			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
-			"composer require yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
+			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
 			"composer config-yoastcs"
 		],
 		"check-cs-errors": [
@@ -81,9 +81,9 @@
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcbf"
 		],
 		"premium-fix-cs": [
-			"composer require yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
+			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
-			"composer require yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
+			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
 			"composer config-yoastcs"
 		],
 		"prefix-dependencies": [

--- a/composer.json
+++ b/composer.json
@@ -68,12 +68,10 @@
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs"
 		],
 		"premium-check-cs": [
-			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
+			"@before-premium-cs",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
-			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
-			"git checkout composer.lock",
-			"composer config-yoastcs"
+			"@after-premium-cs"
 		],
 		"check-cs-errors": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --error-severity=1 --warning-severity=6"
@@ -82,8 +80,14 @@
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcbf"
 		],
 		"premium-fix-cs": [
-			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
+			"@before-premium-cs",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf || true",
+			"@after-premium-cs"
+		],
+		"before-premium-cs": [
+			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction"
+		],
+		"after-premium-cs": [
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
 			"git checkout composer.lock",
 			"composer config-yoastcs"

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
+			"git checkout composer.lock",
 			"composer config-yoastcs"
 		],
 		"check-cs-errors": [
@@ -84,6 +85,7 @@
 			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
+			"git checkout composer.lock",
 			"composer config-yoastcs"
 		],
 		"prefix-dependencies": [

--- a/composer.json
+++ b/composer.json
@@ -71,13 +71,20 @@
 			"composer require yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
-			"composer require yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction"
+			"composer require yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
+			"composer config-yoastcs"
 		],
 		"check-cs-errors": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --error-severity=1 --warning-severity=6"
 		],
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcbf"
+		],
+		"premium-fix-cs": [
+			"composer require yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+			"composer require yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
+			"composer config-yoastcs"
 		],
 		"prefix-dependencies": [
 			"composer prefix-ruckusing",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
 		],
 		"premium-fix-cs": [
 			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf || true",
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
 			"git checkout composer.lock",
 			"composer config-yoastcs"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

As discussed in https://github.com/Yoast/wordpress-seo/pull/11961#pullrequestreview-189052603.

This PR adds a `premium-fix-cs` script to the `composer.json` file.

This script does not need a separate run with a different `testVersion` setting for PHPCompatibility as that standard doesn't contain fixers, so one run over the code should work fine.


## Test instructions

This PR can be tested by following these steps:
Might be difficult depending on one's setup, but if both the Free as well as the Premium repos are setup as remotes for the same local repo, this is testable.
* Create a branch for the Premium plugin.
* Introduce some (fixable) errors in the Premium code, think: whitespace errors.
* Check that PHPCS picks up on the errors by running `composer premium-check-cs`.
* Cherrypick the commit from the PR to your branch.
* Run `composer premium-fix-cs` and verify that the scripts runs without problems and that the errors have been fixed by PHPCS.
* Throw away the temporary test branch.
