### PR TITLE
Pass refreshAnalysis callback instead of app to bindElementEvents

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -501,7 +501,13 @@ setWordPressSeoL10n();
 		// Backwards compatibility.
 		YoastSEO.analyzerArgs = appArgs;
 
-		postDataCollector.bindElementEvents( app );
+		postDataCollector.bindElementEvents( debounce( () => refreshAnalysis(
+			YoastSEO.analysis.worker,
+			YoastSEO.analysis.collectData,
+			YoastSEO.analysis.applyMarks,
+			YoastSEO.store,
+			postDataCollector,
+		), refreshDelay ) );
 
 		// Hack needed to make sure Publish box and traffic light are still updated.
 		disableYoastSEORenderers( app );

--- a/js/src/wp-seo-term-scraper.js
+++ b/js/src/wp-seo-term-scraper.js
@@ -333,7 +333,13 @@ window.yoastHideMarkers = true;
 		YoastSEO._registerReactComponent = registerReactComponent;
 
 		initTermSlugWatcher();
-		termScraper.bindElementEvents( YoastSEO.app.refresh );
+		termScraper.bindElementEvents( debounce( () => refreshAnalysis(
+			YoastSEO.analysis.worker,
+			YoastSEO.analysis.collectData,
+			YoastSEO.analysis.applyMarks,
+			YoastSEO.store,
+			termScraper,
+		), refreshDelay )  );
 
 		if ( isKeywordAnalysisActive() ) {
 			initializeKeywordAnalysis( termScraper );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Fixes a bug where TinyMCE would throw console errors when typing or pasting in the classic editor visual mode.

## Relevant technical choices:

* We were passing the app (which is an object) to postDataCollector.bindElementEvents, which was expecting a callback. As a result, further down the road, TinyMCE received an object where it was expecting a function, which led to console errors and making it impossible to paste text. As a solution, we now pass the refreshAnalysis callback instead. 
* To termScraper.bindElementEvents we were still passing the old-skool YoastSEO.app.refresh. This is now replaced by the refreshAnalysis callback as well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use the classic editor in WP 4.9.8:
   * Create a post in the classic editor. Switch a couple of times between the visual mode and text mode. Don't see any console errors (see Yoast/wordpress-seo-premium/issues/2192 for the previous errors).
   * Type in the visual mode. Don't see any console errors.
   * Paste some text in the visual mode. See the text being pasted and don't see any console errors.
   * Write some words. Make sure that the SEO and readablity analysis results are updated (after a short debounce period) when the text has been changed.
   * Make sure the snippet preview still updates when changing the post title and slug.
   * Make sure a changed analysis is shown when toggling the cornerstone content toggle. For an easy check: look at the text length requirement in the SEO analysis (normal analysis: 300 words, cornerstone analysis: 900 words).
   * Repeat the above steps for terms.
* Test that the analysis still refreshes in Gutenberg and WP 5.0.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/wordpress-seo-premium/issues/2192
