### PR TITLE
Update DashboardWidget

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 215,
+			maxWarnings: 191,
 		},
 	},
 	tests: {

--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -97,7 +97,6 @@ class DashboardWidget extends React.Component {
 				feed.items = feed.items.map( ( item ) => {
 					item.description = jQuery( `<div>${ item.description }</div>` ).text();
 					item.description = item.description.replace( `The post ${ item.title } appeared first on Yoast.`, "" ).trim();
-					item.content = jQuery( `<div>${ item.content }</div>` ).text();
 
 					return item;
 				} );
@@ -167,7 +166,7 @@ class DashboardWidget extends React.Component {
 			key="yoast-seo-blog-feed"
 			title={ wpseoDashboardWidgetL10n.feed_header }
 			feed={ this.state.feed }
-			footerHtml={ wpseoDashboardWidgetL10n.feed_footer }
+			footerLinkText={ wpseoDashboardWidgetL10n.feed_footer }
 		/>;
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user facing] Updates prop name and removes unused content passed to the Dashboard Widget

## Relevant technical choices:

- required for https://github.com/Yoast/yoast-components/pull/800 please see test instructions there
- changes prop name `footerHTML` to `footerLinkText`, as it's a text string
- removes `item.content` which is not used

Fixes https://github.com/Yoast/wordpress-seo/issues/11073
Fixes https://github.com/Yoast/wordpress-seo/issues/11935
