### PR TITLE
Uncouple wpseo meta and wpseo metabox

### DIFF
--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -55,16 +55,16 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 		foreach ( $social_networks as $network => $label ) {
 			if ( true === WPSEO_Options::get( $network, false ) ) {
 				/* translators: %s expands to the name of a social network. */
-				self::$meta_fields['social'][ $network . '-title' ]['title']       = sprintf( __( '%s Title', 'wordpress-seo' ), $label );
-				self::$meta_fields['social'][ $network . '-title' ]['description'] = sprintf( $title_text, $label );
+				WPSEO_Meta::$meta_fields['social'][ $network . '-title' ]['title']       = sprintf( __( '%s Title', 'wordpress-seo' ), $label );
+				WPSEO_Meta::$meta_fields['social'][ $network . '-title' ]['description'] = sprintf( $title_text, $label );
 
 				/* translators: %s expands to the name of a social network. */
-				self::$meta_fields['social'][ $network . '-description' ]['title']       = sprintf( __( '%s Description', 'wordpress-seo' ), $label );
-				self::$meta_fields['social'][ $network . '-description' ]['description'] = sprintf( $description_text, $label );
+				WPSEO_Meta::$meta_fields['social'][ $network . '-description' ]['title']       = sprintf( __( '%s Description', 'wordpress-seo' ), $label );
+				WPSEO_Meta::$meta_fields['social'][ $network . '-description' ]['description'] = sprintf( $description_text, $label );
 
 				/* translators: %s expands to the name of a social network. */
-				self::$meta_fields['social'][ $network . '-image' ]['title']       = sprintf( __( '%s Image', 'wordpress-seo' ), $label );
-				self::$meta_fields['social'][ $network . '-image' ]['description'] = sprintf( $image_text, $label ) . ' ' . sprintf( $image_size_text, $label, $recommended_image_sizes[ $network ] );
+				WPSEO_Meta::$meta_fields['social'][ $network . '-image' ]['title']       = sprintf( __( '%s Image', 'wordpress-seo' ), $label );
+				WPSEO_Meta::$meta_fields['social'][ $network . '-image' ]['description'] = sprintf( $image_text, $label ) . ' ' . sprintf( $image_size_text, $label, $recommended_image_sizes[ $network ] );
 			}
 		}
 	}
@@ -76,7 +76,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 */
 	public function get_meta_section() {
 		$tabs               = array();
-		$social_meta_fields = $this->get_meta_field_defs( 'social' );
+		$social_meta_fields = WPSEO_Meta::get_meta_field_defs( 'social' );
 		$single             = true;
 
 		$opengraph = WPSEO_Options::get( 'opengraph' );
@@ -201,7 +201,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 			return $field_defs;
 		}
 
-		return array_merge( $field_defs, self::get_meta_field_defs( 'social' ) );
+		return array_merge( $field_defs, WPSEO_Meta::get_meta_field_defs( 'social' ) );
 	}
 
 	/**
@@ -237,10 +237,10 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 		$reset_facebook_cache = false;
 
 		foreach ( $fields_to_compare as $field_to_compare ) {
-			$old_value = self::get_value( $field_to_compare, $post->ID );
+			$old_value = WPSEO_Meta::get_value( $field_to_compare, $post->ID );
 
 			$new_value = '';
-			$post_key  = self::$form_prefix . $field_to_compare;
+			$post_key  = WPSEO_Meta::$form_prefix . $field_to_compare;
 			if ( isset( $_POST[ $post_key ] ) ) {
 				$new_value = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
 			}
@@ -250,7 +250,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 				break;
 			}
 		}
-		unset( $field_to_compare, $old_value, $new_value );
+		unset( $old_value, $new_value );
 
 		if ( $reset_facebook_cache ) {
 			wp_remote_get(

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -41,8 +41,6 @@ class WPSEO_Metabox  {
 		add_action( 'wp_insert_post', array( $this, 'save_postdata' ) );
 		add_action( 'edit_attachment', array( $this, 'save_postdata' ) );
 		add_action( 'add_attachment', array( $this, 'save_postdata' ) );
-		add_action( 'post_submitbox_start', array( $this, 'publish_box' ) );
-		add_action( 'admin_init', array( $this, 'setup_page_analysis' ) );
 		add_action( 'admin_init', array( $this, 'translate_meta_boxes' ) );
 
 		// Check if one of the social settings is checked in the options, if so, initialize the social_admin object.
@@ -117,48 +115,6 @@ class WPSEO_Metabox  {
 	 */
 	public function display_metabox( $identifier = null, $type = 'post_type' ) {
 		return WPSEO_Utils::is_metabox_active( $identifier, $type );
-	}
-
-	/**
-	 * Sets up all the functionality related to the prominence of the page analysis functionality.
-	 */
-	public function setup_page_analysis() {
-		if ( apply_filters( 'wpseo_use_page_analysis', true ) === true ) {
-			add_action( 'post_submitbox_start', array( $this, 'publish_box' ) );
-		}
-	}
-
-	/**
-	 * Outputs the page analysis score in the Publish Box.
-	 */
-	public function publish_box() {
-		if ( $this->display_metabox() === false ) {
-			return;
-		}
-
-		$post = $this->get_metabox_post();
-
-		if ( self::get_value( 'meta-robots-noindex', $post->ID ) === '1' ) {
-			$score_label = 'noindex';
-			$title       = __( 'Post is set to noindex.', 'wordpress-seo' );
-			$score_title = $title;
-		}
-		else {
-			$score = self::get_value( 'linkdex', $post->ID );
-			if ( $score === '' ) {
-				$score_label = 'na';
-				$title       = __( 'No focus keyphrase set.', 'wordpress-seo' );
-			}
-			else {
-				$score_label = WPSEO_Utils::translate_score( $score );
-			}
-
-			$score_title = WPSEO_Utils::translate_score( $score, false );
-
-			if ( ! isset( $title ) ) {
-				$title = $score_title;
-			}
-		}
 	}
 
 	/**
@@ -1032,5 +988,31 @@ class WPSEO_Metabox  {
 	public static function is_post_edit( $page ) {
 		return 'post.php' === $page
 			|| 'post-new.php' === $page;
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Outputs the page analysis score in the Publish Box.
+	 *
+	 * @deprecated 9.6
+	 *
+	 * @return void
+	 */
+	public function publish_box() {
+		_deprecated_function( __METHOD__, 'WPSEO 9.6' );
+	}
+
+
+
+	/**
+	 * Sets up all the functionality related to the prominence of the page analysis functionality.
+	 *
+	 * @deprecated 9.6
+	 *
+	 * @return void
+	 */
+	public function setup_page_analysis() {
+		_deprecated_function( __METHOD__, 'WPSEO 9.6' );
 	}
 }

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -131,17 +131,13 @@ class WPSEO_Metabox  {
 			return;
 		}
 
-
 		$product_title = $this->get_product_title();
-
-		if ( get_current_screen() !== null ) {
-			$screen_id = get_current_screen()->id;
-			add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
-		}
 
 		$this->register_helpcenter_tab();
 
 		foreach ( $post_types as $post_type ) {
+			add_filter( "postbox_classes_{$post_type}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
+
 			add_meta_box(
 				'wpseo_meta',
 				$product_title,
@@ -1022,8 +1018,6 @@ class WPSEO_Metabox  {
 	public function publish_box() {
 		_deprecated_function( __METHOD__, 'WPSEO 9.6' );
 	}
-
-
 
 	/**
 	 * Sets up all the functionality related to the prominence of the page analysis functionality.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -132,14 +132,9 @@ class WPSEO_Metabox  {
 		}
 
 		$tab_registered = false;
+		$product_title = $this->get_product_title();
 
 		foreach ( $post_types as $post_type ) {
-			$product_title = 'Yoast SEO';
-
-			if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
-				$product_title .= ' Premium';
-			}
-
 			if ( get_current_screen() !== null ) {
 				$screen_id = get_current_screen()->id;
 				add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
@@ -985,6 +980,21 @@ class WPSEO_Metabox  {
 	public static function is_post_edit( $page ) {
 		return 'post.php' === $page
 			|| 'post-new.php' === $page;
+	}
+
+	/**
+	 * Retrieves the product title.
+	 *
+	 * @return string The product title.
+	 */
+	protected function get_product_title() {
+		$product_title = 'Yoast SEO';
+
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			$product_title .= ' Premium';
+		}
+
+		return $product_title;
 	}
 
 	/* ********************* DEPRECATED METHODS ********************* */

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -134,12 +134,12 @@ class WPSEO_Metabox  {
 		$tab_registered = false;
 		$product_title = $this->get_product_title();
 
-		foreach ( $post_types as $post_type ) {
-			if ( get_current_screen() !== null ) {
-				$screen_id = get_current_screen()->id;
-				add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
-			}
+		if ( get_current_screen() !== null ) {
+			$screen_id = get_current_screen()->id;
+			add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
+		}
 
+		foreach ( $post_types as $post_type ) {
 			if ( ! $tab_registered ) {
 				// Add template variables tab to the Help Center.
 				$tab = new WPSEO_Help_Center_Template_Variables_Tab();

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -131,7 +131,7 @@ class WPSEO_Metabox  {
 			return;
 		}
 
-		$tab_registered = false;
+
 		$product_title = $this->get_product_title();
 
 		if ( get_current_screen() !== null ) {
@@ -139,15 +139,9 @@ class WPSEO_Metabox  {
 			add_filter( "postbox_classes_{$screen_id}_wpseo_meta", array( $this, 'wpseo_metabox_class' ) );
 		}
 
+		$this->register_helpcenter_tab();
+
 		foreach ( $post_types as $post_type ) {
-			if ( ! $tab_registered ) {
-				// Add template variables tab to the Help Center.
-				$tab = new WPSEO_Help_Center_Template_Variables_Tab();
-				$tab->register_hooks();
-
-				$tab_registered = true;
-			}
-
 			add_meta_box(
 				'wpseo_meta',
 				$product_title,
@@ -995,6 +989,25 @@ class WPSEO_Metabox  {
 		}
 
 		return $product_title;
+	}
+
+	/**
+	 * Adds the template variables tab to the helpcenter.
+	 *
+	 * @return void
+	 */
+	protected function register_helpcenter_tab() {
+		static $tab_registered;
+
+		if ( $tab_registered ) {
+			return;
+		}
+
+		// Add template variables tab to the Help Center.
+		$tab = new WPSEO_Help_Center_Template_Variables_Tab();
+		$tab->register_hooks();
+
+		$tab_registered = true;
 	}
 
 	/* ********************* DEPRECATED METHODS ********************* */

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -125,6 +125,7 @@ class WPSEO_Metabox  {
 	 */
 	public function add_meta_box() {
 		$post_types = WPSEO_Post_Type::get_accessible_post_types();
+		$post_types = array_filter( $post_types, array( $this, 'display_metabox' ) );
 
 		if ( ! is_array( $post_types ) || $post_types === array() ) {
 			return;
@@ -133,10 +134,6 @@ class WPSEO_Metabox  {
 		$tab_registered = false;
 
 		foreach ( $post_types as $post_type ) {
-			if ( $this->display_metabox( $post_type ) === false ) {
-				continue;
-			}
-
 			$product_title = 'Yoast SEO';
 
 			if ( file_exists( WPSEO_PATH . 'premium/' ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -8,7 +8,7 @@
 /**
  * This class generates the metabox on the edit post / page as well as contains all page analysis functionality.
  */
-class WPSEO_Metabox extends WPSEO_Meta {
+class WPSEO_Metabox  {
 
 	/**
 	 * @var WPSEO_Social_Admin
@@ -24,6 +24,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @var WPSEO_Metabox_Analysis_Readability
 	 */
 	protected $analysis_readability;
+
+	/**
+	 * The metabox editor object.
+	 *
+	 * @var WPSEO_Metabox_Editor
+	 */
+	protected $editor;
 
 	/**
 	 * Class constructor.
@@ -57,43 +64,43 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * the main meta box definition array in the class WPSEO_Meta() as well!!!!
 	 */
 	public static function translate_meta_boxes() {
-		self::$meta_fields['general']['title']['title'] = __( 'SEO title', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['general']['title']['title'] = __( 'SEO title', 'wordpress-seo' );
 
-		self::$meta_fields['general']['metadesc']['title'] = __( 'Meta description', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['general']['metadesc']['title'] = __( 'Meta description', 'wordpress-seo' );
 
 		/* translators: %s expands to the post type name. */
-		self::$meta_fields['advanced']['meta-robots-noindex']['title'] = __( 'Allow search engines to show this %s in search results?', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-noindex']['title'] = __( 'Allow search engines to show this %s in search results?', 'wordpress-seo' );
 		if ( '0' === (string) get_option( 'blog_public' ) ) {
-			self::$meta_fields['advanced']['meta-robots-noindex']['description'] = '<p class="error-message">' . __( 'Warning: even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, so these settings won\'t have an effect.', 'wordpress-seo' ) . '</p>';
+			WPSEO_Meta::$meta_fields['advanced']['meta-robots-noindex']['description'] = '<p class="error-message">' . __( 'Warning: even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, so these settings won\'t have an effect.', 'wordpress-seo' ) . '</p>';
 		}
 		/* translators: %1$s expands to Yes or No,  %2$s expands to the post type name.*/
-		self::$meta_fields['advanced']['meta-robots-noindex']['options']['0'] = __( 'Default for %2$s, currently: %1$s', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-noindex']['options']['2'] = __( 'Yes', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-noindex']['options']['1'] = __( 'No', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-noindex']['options']['0'] = __( 'Default for %2$s, currently: %1$s', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-noindex']['options']['2'] = __( 'Yes', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-noindex']['options']['1'] = __( 'No', 'wordpress-seo' );
 
 		/* translators: %1$s expands to the post type name.*/
-		self::$meta_fields['advanced']['meta-robots-nofollow']['title']        = __( 'Should search engines follow links on this %1$s?', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-nofollow']['options']['0'] = __( 'Yes', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-nofollow']['options']['1'] = __( 'No', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-nofollow']['title']        = __( 'Should search engines follow links on this %1$s?', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-nofollow']['options']['0'] = __( 'Yes', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-nofollow']['options']['1'] = __( 'No', 'wordpress-seo' );
 
-		self::$meta_fields['advanced']['meta-robots-adv']['title']       = __( 'Meta robots advanced', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-adv']['description'] = __( 'Advanced <code>meta</code> robots settings for this page.', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-adv']['title']       = __( 'Meta robots advanced', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-adv']['description'] = __( 'Advanced <code>meta</code> robots settings for this page.', 'wordpress-seo' );
 		/* translators: %s expands to the advanced robots settings default as set in the site-wide settings.*/
-		self::$meta_fields['advanced']['meta-robots-adv']['options']['-']            = __( 'Site-wide default: %s', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-adv']['options']['none']         = __( 'None', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-adv']['options']['noimageindex'] = __( 'No Image Index', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-adv']['options']['noarchive']    = __( 'No Archive', 'wordpress-seo' );
-		self::$meta_fields['advanced']['meta-robots-adv']['options']['nosnippet']    = __( 'No Snippet', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-adv']['options']['-']            = __( 'Site-wide default: %s', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-adv']['options']['none']         = __( 'None', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-adv']['options']['noimageindex'] = __( 'No Image Index', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-adv']['options']['noarchive']    = __( 'No Archive', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['meta-robots-adv']['options']['nosnippet']    = __( 'No Snippet', 'wordpress-seo' );
 
-		self::$meta_fields['advanced']['bctitle']['title']       = __( 'Breadcrumbs Title', 'wordpress-seo' );
-		self::$meta_fields['advanced']['bctitle']['description'] = __( 'Title to use for this page in breadcrumb paths', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['bctitle']['title']       = __( 'Breadcrumbs Title', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['bctitle']['description'] = __( 'Title to use for this page in breadcrumb paths', 'wordpress-seo' );
 
-		self::$meta_fields['advanced']['canonical']['title'] = __( 'Canonical URL', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['canonical']['title'] = __( 'Canonical URL', 'wordpress-seo' );
 		/* translators: 1: link open tag; 2: link close tag. */
-		self::$meta_fields['advanced']['canonical']['description'] = sprintf( __( 'The canonical URL that this page should point to, leave empty to default to permalink. %1$sCross domain canonical%2$s supported too.', 'wordpress-seo' ), '<a target="_blank" href="http://googlewebmastercentral.blogspot.com/2009/12/handling-legitimate-cross-domain.html">', '</a>' );
+		WPSEO_Meta::$meta_fields['advanced']['canonical']['description'] = sprintf( __( 'The canonical URL that this page should point to, leave empty to default to permalink. %1$sCross domain canonical%2$s supported too.', 'wordpress-seo' ), '<a target="_blank" href="http://googlewebmastercentral.blogspot.com/2009/12/handling-legitimate-cross-domain.html">', '</a>' );
 
-		self::$meta_fields['advanced']['redirect']['title']       = __( '301 Redirect', 'wordpress-seo' );
-		self::$meta_fields['advanced']['redirect']['description'] = __( 'The URL that this page should redirect to.', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['redirect']['title']       = __( '301 Redirect', 'wordpress-seo' );
+		WPSEO_Meta::$meta_fields['advanced']['redirect']['description'] = __( 'The URL that this page should redirect to.', 'wordpress-seo' );
 
 		do_action( 'wpseo_tab_translate' );
 	}
@@ -463,7 +470,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	private function get_tab_content( $tab_name ) {
 		$content = '';
-		foreach ( $this->get_meta_field_defs( $tab_name ) as $key => $meta_field ) {
+		foreach ( WPSEO_Meta::get_meta_field_defs( $tab_name ) as $key => $meta_field ) {
 			$content .= $this->do_meta_box( $meta_field, $key );
 		}
 
@@ -482,8 +489,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	public function do_meta_box( $meta_field_def, $key = '' ) {
 		$content      = '';
-		$esc_form_key = esc_attr( self::$form_prefix . $key );
-		$meta_value   = self::get_value( $key, $this->get_metabox_post()->ID );
+		$esc_form_key = esc_attr( WPSEO_Meta::$form_prefix . $key );
+		$meta_value   = WPSEO_Meta::get_value( $key, $this->get_metabox_post()->ID );
 
 		$class = '';
 		if ( isset( $meta_field_def['class'] ) && $meta_field_def['class'] !== '' ) {
@@ -700,18 +707,18 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		do_action( 'wpseo_save_compare_data', $post );
 
 		$meta_boxes = apply_filters( 'wpseo_save_metaboxes', array() );
-		$meta_boxes = array_merge( $meta_boxes, $this->get_meta_field_defs( 'general', $post->post_type ), $this->get_meta_field_defs( 'advanced' ) );
+		$meta_boxes = array_merge( $meta_boxes, WPSEO_Meta::get_meta_field_defs( 'general', $post->post_type ), WPSEO_Meta::get_meta_field_defs( 'advanced' ) );
 
 		foreach ( $meta_boxes as $key => $meta_box ) {
 
 			// If analysis is disabled remove that analysis score value from the DB.
 			if ( $this->is_meta_value_disabled( $key ) ) {
-				self::delete( $key, $post_id );
+				WPSEO_Meta::delete( $key, $post_id );
 				continue;
 			}
 
 			$data       = null;
-			$field_name = self::$form_prefix . $key;
+			$field_name = WPSEO_Meta::$form_prefix . $key;
 
 			if ( 'checkbox' === $meta_box['type'] ) {
 				$data = isset( $_POST[ $field_name ] ) ? 'on' : 'off';
@@ -737,7 +744,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			}
 
 			if ( $data !== null ) {
-				self::set_value( $key, $data, $post_id );
+				WPSEO_Meta::set_value( $key, $data, $post_id );
 			}
 		}
 

--- a/tests/test-class-wpseo-metabox.php
+++ b/tests/test-class-wpseo-metabox.php
@@ -108,8 +108,8 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		$meta_fields = apply_filters( 'wpseo_save_metaboxes', array() );
 		$meta_fields = array_merge(
 			$meta_fields,
-			self::$class_instance->get_meta_field_defs( 'general', $post->post_type ),
-			self::$class_instance->get_meta_field_defs( 'advanced' )
+			WPSEO_Meta::get_meta_field_defs( 'general', $post->post_type ),
+			WPSEO_Meta::get_meta_field_defs( 'advanced' )
 		);
 
 		// Set $_POST data to be saved.
@@ -117,10 +117,10 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 
 			// Set text fields.
 			if ( $field['type'] === 'text' ) {
-				$_POST[ WPSEO_Metabox::$form_prefix . $key ] = 'text';
+				$_POST[ WPSEO_Meta::$form_prefix . $key ] = 'text';
 			}
 			elseif ( $field['type'] === 'checkbox' ) {
-				$_POST[ WPSEO_Metabox::$form_prefix . $key ] = 'on';
+				$_POST[ WPSEO_Meta::$form_prefix . $key ] = 'on';
 			}
 		}
 
@@ -131,11 +131,11 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		$custom = get_post_custom( $post->ID );
 		foreach ( $meta_fields as $key => $field ) {
 
-			if ( ! isset( $custom[ WPSEO_Metabox::$meta_prefix . $key ][0] ) ) {
+			if ( ! isset( $custom[ WPSEO_Meta::$meta_prefix . $key ][0] ) ) {
 				continue;
 			}
 
-			$value = $custom[ WPSEO_Metabox::$meta_prefix . $key ][0];
+			$value = $custom[ WPSEO_Meta::$meta_prefix . $key ][0];
 
 			// Set text fields.
 			if ( $field['type'] === 'text' ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Did some refactoring to uncouple the `WPSEO_Meta` as dependency for `WPSEO_Metabox` and `WPSEO_Social_Admin`

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* There is no visual change, make sure the values from the metabox are saved correctly and verify the metabox is loaded correctly.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
