### PR TITLE
Move the x-redirect-header below the redirect method

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1332,8 +1332,8 @@ class WPSEO_Frontend {
 
 			$redir = $this->get_seo_meta_value( 'redirect', $post->ID );
 			if ( $redir !== '' ) {
-				header( 'X-Redirect-By: Yoast SEO' );
 				wp_redirect( $redir, 301 );
+				header( 'X-Redirect-By: Yoast SEO' );
 				exit;
 			}
 		}
@@ -1440,8 +1440,8 @@ class WPSEO_Frontend {
 	 * @return void
 	 */
 	public function do_attachment_redirect( $attachment_url ) {
-		header( 'X-Redirect-By: Yoast SEO' );
 		wp_redirect( $attachment_url, 301 );
+		header( 'X-Redirect-By: Yoast SEO' );
 		exit;
 	}
 
@@ -1647,8 +1647,8 @@ class WPSEO_Frontend {
 	 * @param int    $status   Status code to use.
 	 */
 	public function redirect( $location, $status = 302 ) {
-		header( 'X-Redirect-By: Yoast SEO' );
 		wp_safe_redirect( $location, $status );
+		header( 'X-Redirect-By: Yoast SEO' );
 		exit;
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1332,8 +1332,8 @@ class WPSEO_Frontend {
 
 			$redir = $this->get_seo_meta_value( 'redirect', $post->ID );
 			if ( $redir !== '' ) {
-				wp_redirect( $redir, 301 );
 				header( 'X-Redirect-By: Yoast SEO' );
+				wp_redirect( $redir, 301, 'Yoast SEO' );
 				exit;
 			}
 		}
@@ -1440,8 +1440,8 @@ class WPSEO_Frontend {
 	 * @return void
 	 */
 	public function do_attachment_redirect( $attachment_url ) {
-		wp_redirect( $attachment_url, 301 );
 		header( 'X-Redirect-By: Yoast SEO' );
+		wp_redirect( $attachment_url, 301, 'Yoast SEO' );
 		exit;
 	}
 
@@ -1647,8 +1647,8 @@ class WPSEO_Frontend {
 	 * @param int    $status   Status code to use.
 	 */
 	public function redirect( $location, $status = 302 ) {
-		wp_safe_redirect( $location, $status );
 		header( 'X-Redirect-By: Yoast SEO' );
+		wp_safe_redirect( $location, $status, 'Yoast SEO' );
 		exit;
 	}
 

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -103,8 +103,8 @@ class WPSEO_Rewrite {
 		if ( isset( $query_vars['wpseo_category_redirect'] ) ) {
 			$catlink = trailingslashit( get_option( 'home' ) ) . user_trailingslashit( $query_vars['wpseo_category_redirect'], 'category' );
 
-			wp_redirect( $catlink, 301 );
 			header( 'X-Redirect-By: Yoast SEO' );
+			wp_redirect( $catlink, 301, 'Yoast SEO' );
 			exit;
 		}
 

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -103,8 +103,8 @@ class WPSEO_Rewrite {
 		if ( isset( $query_vars['wpseo_category_redirect'] ) ) {
 			$catlink = trailingslashit( get_option( 'home' ) ) . user_trailingslashit( $query_vars['wpseo_category_redirect'], 'category' );
 
-			header( 'X-Redirect-By: Yoast SEO' );
 			wp_redirect( $catlink, 301 );
+			header( 'X-Redirect-By: Yoast SEO' );
 			exit;
 		}
 

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -60,8 +60,8 @@ class WPSEO_Sitemaps_Router {
 			return;
 		}
 
-		header( 'X-Redirect-By: Yoast SEO' );
 		wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
+		header( 'X-Redirect-By: Yoast SEO' );
 		exit;
 	}
 

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -60,8 +60,8 @@ class WPSEO_Sitemaps_Router {
 			return;
 		}
 
-		wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
 		header( 'X-Redirect-By: Yoast SEO' );
+		wp_redirect( home_url( '/sitemap_index.xml' ), 301, 'Yoast SEO' );
 		exit;
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Moves the `x-redirect-by` header below each `wp_redirect`/`wp_save_redirect` function call. This prevents the header from being overwritten by WordPress 5.1

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open Chrome in incognito mode (or a similar feature in your preferred browser).
* Open the Network tab in the devtools, and make sure `Preserve log` action is checked.
* In the browser navigate to `http://local.wordpress.test/sitemap.xml`.
* Make sure you are redirected to `http://local.wordpress.test/sitemap_index.xml`.
* In the devtools, look for the request with the name `sitemap.xml` and status `301`.
* Inspect the `Request Headers` of this request and make sure it has the `X-Redirect-By: Yoast SEO` header.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11385 
