### PR TITLE
Add check to make sure edit-post is loaded

### DIFF
--- a/js/src/helpers/isGutenbergDataAvailable.js
+++ b/js/src/helpers/isGutenbergDataAvailable.js
@@ -12,6 +12,7 @@ const isGutenbergDataAvailable = () => {
 	return (
 		! isUndefined( window.wp ) &&
 		! isUndefined( wp.data ) &&
+		! isUndefined( wp.data.select( "core/edit-post" ) ) &&
 		! isUndefined( wp.data.select( "core/editor" ) ) &&
 		isFunction( wp.data.select( "core/editor" ).getEditedPostAttribute )
 	);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where errors are given on classic editor when Gutenberg assets are enqueued.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install the `Classic editor` and the `Advanced Rich Text Tools for Gutenberg`
* Add or Edit a post in Classic Editor mode
* Check if there are any console errors
* Checkout this branch
* Follow the steps before and verify the errors are gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11919
