### PR TITLE
Fix Courses Overview layout in IE11 and add RTL support

### DIFF
--- a/admin/courses-overview.php
+++ b/admin/courses-overview.php
@@ -27,13 +27,14 @@ class WPSEO_Courses_Overview implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns the Yoast SEO version the user currently is using.
 	 *
-	 * @return array An array the version: Free or Premium.
+	 * @return string The version: Free or Premium.
 	 */
 	private function get_version() {
 		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
-			return array( 'version' => 'premium' );
+			return 'premium';
 		}
-		return array( 'version' => 'free' );
+
+		return 'free';
 	}
 
 	/**
@@ -43,6 +44,6 @@ class WPSEO_Courses_Overview implements WPSEO_WordPress_Integration {
 	 */
 	public function enqueue_scripts() {
 		wp_enqueue_script( WPSEO_Admin_Asset_Manager::PREFIX . 'courses-overview' );
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'courses-overview', 'wpseoCoursesOverviewL10n', $this->get_version() );
+		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'courses-overview', 'wpseoCoursesOverviewL10n', array( 'version' => $this->get_version(), 'isRtl' => is_rtl() ) );
 	}
 }

--- a/js/src/courses-overview.js
+++ b/js/src/courses-overview.js
@@ -1,25 +1,27 @@
 /* global wpseoCoursesOverviewL10n */
 
-import styled from "styled-components";
-import { CardDetails, FullHeightCard, utils } from "yoast-components";
+import styled, { ThemeProvider } from "styled-components";
+import { CardDetails, FullHeightCard, utils, getRtlStyle } from "yoast-components";
 import React from "react";
 import ReactDOM from "react-dom";
 import { __ } from "@wordpress/i18n";
 const { getCourseFeed } = utils;
 
-const OuterContainer = styled.ul`
-	display: grid;
-	grid-template-columns: repeat(auto-fill, 288px);
-	grid-column-gap: 16px;
-	grid-row-gap: 16px;
-	align-items: flex-start;
+const CoursesList = styled.ul`
+	display: flex;
+	flex-wrap: wrap;
+	list-style-type: none;
 	padding: 0;
+	/* Max 5 cards per row. */
+	max-width: 1520px;
 `;
 
 const CourseListItem = styled.li`
-	list-style-type: none;
-	height: 100%;
-	width: 100%;
+	/* Higher specificity to override WordPress margins. */
+	&& {
+		flex: 0 0 288px;
+		margin: ${ getRtlStyle( "0 16px 16px 0", "0 0 16px 16px" ) };
+	}
 `;
 
 /**
@@ -42,7 +44,7 @@ class CoursesOverview extends React.Component {
 	/**
 	 * Fetches data from the yoast.com feed, parses it and sets it to the state.
 	 *
-	 * @param {String} version Active Yoast SEO version.
+	 * @param {String} version The active Yoast SEO version.
 	 *
 	 * @returns {void}
 	 */
@@ -92,7 +94,7 @@ class CoursesOverview extends React.Component {
 	/**
 	 * Render the component.
 	 *
-	 * @returns {ReactElement} The OuterContainer component which contains all the courses cards.
+	 * @returns {ReactElement} The CoursesList component which contains all the courses cards.
 	 */
 	render() {
 		const courses = this.state.courses;
@@ -102,7 +104,7 @@ class CoursesOverview extends React.Component {
 		}
 
 		return (
-			<OuterContainer>
+			<CoursesList>
 				{ courses.map( course =>
 					<CourseListItem key={ course.id }>
 						<FullHeightCard
@@ -120,7 +122,7 @@ class CoursesOverview extends React.Component {
 						</FullHeightCard>
 					</CourseListItem>
 				) }
-			</OuterContainer>
+			</CoursesList>
 		);
 	}
 }
@@ -128,5 +130,14 @@ class CoursesOverview extends React.Component {
 const element = document.getElementById( "yoast-courses-overview" );
 
 if ( element ) {
-	ReactDOM.render( <CoursesOverview />, element );
+	const theme = {
+		isRtl: wpseoCoursesOverviewL10n.isRtl,
+	};
+
+	ReactDOM.render(
+		<ThemeProvider theme={ theme }>
+			<CoursesOverview />
+		</ThemeProvider>,
+		element
+	);
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the Courses Overview layout in Internet Explorer 11

## Relevant technical choices:

- switches the layout from CSS grids to flexbox
- adds missing support for RTL

## Test instructions
- to test the yoast-components standalone app, see instructions on https://github.com/Yoast/yoast-components/pull/805

Test in the plugin:
- yarn link to the yoast-components branch `11953-courses-overview-layout-ie11`
- do the yarn and grunt magic
- use IE11
- go to SEO > Courses
- check the Cards layout is rendered correctly
- the Cards in a row must have the same height
- each row must have max 5 Cards (if testing on a small screen, zoom out and verify there are max 5 Cards in a row)
- activate the RTL tester plugin
- click the RTL tester link to change language direction
  - verify the Cards margins are OK
  - verify the green checkmarks are on the right
- check there are no visual regressions in other browsers

Fixes #11953 
