### PR TITLE
Use smart quotes

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -431,7 +431,7 @@ class WPSEO_Breadcrumbs {
 		}
 		elseif ( is_search() ) {
 			$this->add_predefined_crumb(
-				WPSEO_Options::get( 'breadcrumbs-searchprefix' ) . ' "' . esc_html( get_search_query() ) . '"',
+				WPSEO_Options::get( 'breadcrumbs-searchprefix' ) . ' “' . esc_html( get_search_query() ) . '”',
 				null,
 				true
 			);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaces the quotes in search breadcrumb for smart quotes.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have breadcrumbs in your theme (https://kb.yoast.com/kb/implement-wordpress-seo-breadcrumbs)
* To get the breadcrumbs in the search results, specifically put the code in `header.php` or `search.php`
* Search in your blog
* See the smart quotes around the search term in the breadcrumbs.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11754
