### PR TITLE
11802 convert faq block titles to headings

### DIFF
--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -29,6 +29,9 @@ export default () => {
 			additionalListCssClasses: {
 				type: "string",
 			},
+			header: {
+				type: "string",
+			},
 		},
 
 		/**

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -97,7 +97,6 @@ export default class FAQ extends Component {
 	 */
 	changeQuestion( newQuestion, newAnswer, previousQuestion, previousAnswer, index ) {
 		const questions = this.props.attributes.questions ? this.props.attributes.questions.slice() : [];
-
 		if ( index >= questions.length ) {
 			return;
 		}
@@ -128,7 +127,7 @@ export default class FAQ extends Component {
 	 * @param {number}       [index]      The index of the Question after which a new Question should be added.
 	 * @param {array|string} [question]   The question of the new Question.
 	 * @param {array|string} [answer]     The answer of the new Question.
-	 * @param {bool}         [focus=true] Whether or not to focus the new Question.
+	 * @param {boolean}      [focus=true] Whether or not to focus the new Question.
 	 *
 	 * @returns {void}
 	 */
@@ -142,7 +141,7 @@ export default class FAQ extends Component {
 		let lastIndex = questions.length - 1;
 		while ( lastIndex > index ) {
 			this.editorRefs[ `${ lastIndex + 1 }:question` ] = this.editorRefs[ `${ lastIndex }:question` ];
-			this.editorRefs[ `${ lastIndex + 1}:answer` ]    = this.editorRefs[ `${ lastIndex }:answer` ];
+			this.editorRefs[ `${ lastIndex + 1 }:answer` ]   = this.editorRefs[ `${ lastIndex }:answer` ];
 			lastIndex--;
 		}
 

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -1,3 +1,5 @@
+/* global wp */
+
 /* External dependencies */
 import React from "react";
 import PropTypes from "prop-types";
@@ -334,10 +336,10 @@ export default class FAQ extends Component {
 	 * @returns {Component} The component representing a FAQ block.
 	 */
 	static Content( attributes ) {
-		const { questions, className } = attributes;
+		const { questions, className, header } = attributes;
 
 		const questionList = questions ? questions.map( ( question, index ) =>
-			<QuestionContentWithAppendedSpace key={ index } { ...question } />
+			<QuestionContentWithAppendedSpace key={ index } header={ header } { ...question } />
 		) : null;
 
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );
@@ -350,11 +352,22 @@ export default class FAQ extends Component {
 	}
 
 	/**
+	 * Sets the header level for the questions in the FAQ block.
+	 *
+	 * @returns {void}
+	 */
+	setHeader(){
+		const blocks = wp.data.select( "core/editor" ).getBlocks();
+		this.props.setAttributes( { header: "h4" } );
+	}
+
+	/**
 	 * Renders this component.
 	 *
 	 * @returns {Component} The FAQ block editor.
 	 */
 	render() {
+		this.setHeader();
 		const { className } = this.props;
 
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -5,6 +5,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import isUndefined from "lodash/isUndefined";
 import { __ } from "@wordpress/i18n";
+import forEach from "lodash/forEach";
 
 /* Internal dependencies */
 import Question from "./Question";
@@ -352,13 +353,37 @@ export default class FAQ extends Component {
 	}
 
 	/**
+	 * Gets the correct header level for the questions in the FAQ block.
+	 *
+	 * @returns {string} The header tag.
+	 */
+	getHeader() {
+		const blocks = wp.data.select( "core/editor" ).getBlocks();
+		let header = "h2";
+
+		for ( let i = 0; i < blocks.length; i++ ) {
+			// Update header when preceding header is found.
+			if ( blocks[ i ].attributes.level ) {
+				header = "h" + ( blocks[ i ].attributes.level + 1 );
+			}
+			// Exit when faq-block is found.
+			if ( blocks[ i ].name === "yoast/faq-block" ) {
+				break;
+			}
+		}
+		return header;
+	}
+
+	/**
 	 * Sets the header level for the questions in the FAQ block.
 	 *
 	 * @returns {void}
 	 */
-	setHeader(){
-		const blocks = wp.data.select( "core/editor" ).getBlocks();
-		this.props.setAttributes( { header: "h4" } );
+	setHeader() {
+		const newHeader = this.getHeader();
+		if ( this.props.attributes.header !== newHeader ) {
+			this.props.setAttributes( { header: newHeader } );
+		}
 	}
 
 	/**
@@ -368,6 +393,7 @@ export default class FAQ extends Component {
 	 */
 	render() {
 		this.setHeader();
+
 		const { className } = this.props;
 
 		const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -361,7 +361,7 @@ export default class Question extends Component {
 			<div className="schema-faq-section" key={ id }>
 				<RichText
 					className="schema-faq-question"
-					tagName="p"
+					tagName={ this.props.questionHeader }
 					unstableOnSetup={ this.setQuestionRef }
 					key={ id + "-question" }
 					value={ question }
@@ -409,4 +409,9 @@ Question.propTypes = {
 	isSelected: PropTypes.bool.isRequired,
 	isFirst: PropTypes.bool.isRequired,
 	isLast: PropTypes.bool.isRequired,
+	questionHeader: PropTypes.string,
+};
+
+Question.defaultProps = {
+	questionHeader: "h2",
 };

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -310,7 +310,7 @@ export default class Question extends Component {
 		return (
 			<div className={ "schema-faq-section" } key={ question.id }>
 				<RichTextWithAppendedSpace
-					tagName="strong"
+					tagName={ question.header }
 					className="schema-faq-question"
 					key={ question.id + "-question" }
 					value={ question.question }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the rendering and results from our SEO analysis on pages which use an FAQ block by converting the question paragraphs into headings.

## Relevant technical choices:

* As headings levels need to match the correct hierarchy, each question now has a <H{x}> tag, where x is determined by the place of the FAQ block in the page structure. The last heading block before the FAQ block determines the heading level. Other factors, such as manually added headings by entering html blocks, are ignored. 
* The heading level for a question can never be lower than 2 or higher than 6. 

## Test instructions

This PR can be tested by following these steps:

* Build this branch. 
* Add a FAQ block, see that the questions are now headings instead of paragraphs with `<strong>` tags. If there is only a title in the post the heading tags of the questions should be h2. If there is a heading block before the FAQ block the h tags should be one level smaller than the heading block (so if the heading block is h4, the questions in the FAQ block should be h5).
* Any heading blocks after the FAQ block should be ignored.
* The headings in the FAQ block should update instantly when changed. 
* The headings should also be correct in the front end, but make sure the post is saved. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11802 
