### PR TITLE
Changes alignment of labels in publish-box

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -561,7 +561,7 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 .yoast-seo-score .yoast-logo.svg {
 	float: left;
 	width: 18px;
-	margin-right: 5px;
+	margin-right: 7px;
 	height: 18px;
 	background: url(svg-icon-yoast(#999)) no-repeat;
 	background-size: 18px;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [visuals] Changes the alignment of Yoast labels in the publish-box to match the default WordPress content alignment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create or edit a page or post and check the alignment of all labels in the publish-box.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #4929 
