### PR TITLE
Add isBundle prop to courses overview

### DIFF
--- a/js/src/courses-overview.js
+++ b/js/src/courses-overview.js
@@ -116,6 +116,7 @@ class CoursesOverview extends React.Component {
 							<CardDetails
 								description={ course.content }
 								courseUrl={ course.link }
+								isBundle={ course.isBundle }
 								readMoreLinkText={ course.readMoreLinkText }
 								ctaButtonData={ this.getButtonData( course ) }
 							/>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Fixes a bug where course bundles on the course page would have a button with an empty href.

## Relevant technical choices:

* @diedexx added an isBundle boolean to the feed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Link yoast-components `dont-show-empty-read-more-button` branch to this branch.
* Go to the courses page.
* Check *all* buttons and links.

  - For bundles: 

<img width="587" alt="schermafbeelding_2019-01-15_om_08_44_07" src="https://user-images.githubusercontent.com/17744553/51165944-2372b780-18a2-11e9-9c60-0d829a5c23ea.png">

   - For single courses:
<img width="594" alt="schermafbeelding_2019-01-15_om_08_44_01" src="https://user-images.githubusercontent.com/17744553/51165885-ec9ca180-18a1-11e9-9f95-d6497a6f3d42.png">

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended

Fixes #12030
