### PR TITLE
Documentation: use docblock format for constants [2]

### DIFF
--- a/admin/ajax/class-yoast-dismissable-notice.php
+++ b/admin/ajax/class-yoast-dismissable-notice.php
@@ -12,17 +12,23 @@
 class Yoast_Dismissable_Notice_Ajax {
 
 	/**
-	 * @var string Notice type toggle value for user notices.
+	 * Notice type toggle value for user notices.
+	 *
+	 * @var string
 	 */
 	const FOR_USER = 'user_meta';
 
 	/**
-	 * @var string Notice type toggle value for network notices.
+	 * Notice type toggle value for network notices.
+	 *
+	 * @var string
 	 */
 	const FOR_NETWORK = 'site_option';
 
 	/**
-	 * @var string Notice type toggle value for site notices.
+	 * Notice type toggle value for site notices.
+	 *
+	 * @var string
 	 */
 	const FOR_SITE = 'option';
 

--- a/admin/class-admin-asset-dev-server-location.php
+++ b/admin/class-admin-asset-dev-server-location.php
@@ -9,6 +9,10 @@
  * Changes the asset paths to dev server paths.
  */
 final class WPSEO_Admin_Asset_Dev_Server_Location implements WPSEO_Admin_Asset_Location {
+
+	/**
+	 * @var string
+	 */
 	const DEFAULT_URL = 'http://localhost:8080';
 
 	/**

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -16,7 +16,9 @@ class WPSEO_Admin_Asset_Manager {
 	protected $asset_location;
 
 	/**
-	 *  Prefix for naming the assets.
+	 * Prefix for naming the assets.
+	 *
+	 * @var string
 	 */
 	const PREFIX = 'yoast-seo-';
 

--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -11,6 +11,10 @@
  * Class with functionality to export the WP SEO settings
  */
 class WPSEO_Export {
+
+	/**
+	 * @var string
+	 */
 	const NONCE_ACTION = 'wpseo_export';
 
 	/**

--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -12,11 +12,15 @@ class WPSEO_Gutenberg_Compatibility {
 
 	/**
 	 * The currently released version of Gutenberg.
+	 *
+	 * @var string
 	 */
 	const CURRENT_RELEASE = '4.8.0';
 
 	/**
 	 * The minimally supported version of Gutenberg by the plugin.
+	 *
+	 * @var string
 	 */
 	const MINIMUM_SUPPORTED = '4.8.0';
 

--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -11,12 +11,16 @@
 class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 
 	/**
-	 * @var string Version number for License Page Manager.
+	 * Version number for License Page Manager.
+	 *
+	 * @var string
 	 */
 	const VERSION_LEGACY = '1';
 
 	/**
-	 * @var string Version number for License Page Manager.
+	 * Version number for License Page Manager.
+	 *
+	 * @var string
 	 */
 	const VERSION_BACKWARDS_COMPATIBILITY = '2';
 

--- a/admin/class-meta-storage.php
+++ b/admin/class-meta-storage.php
@@ -10,6 +10,11 @@
  */
 class WPSEO_Meta_Storage implements WPSEO_Installable {
 
+	/**
+	 * Table name for the meta storage.
+	 *
+	 * @var string
+	 */
 	const TABLE_NAME = 'yoast_seo_meta';
 
 	/**

--- a/admin/class-meta-table-accessible.php
+++ b/admin/class-meta-table-accessible.php
@@ -10,7 +10,14 @@
  */
 class WPSEO_Meta_Table_Accessible {
 
-	const ACCESSIBLE   = '0';
+	/**
+	 * @var string
+	 */
+	const ACCESSIBLE = '0';
+
+	/**
+	 * @var string
+	 */
 	const INACCESSBILE = '1';
 
 	/**

--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -10,8 +10,14 @@
  */
 class WPSEO_Product_Upsell_Notice {
 
+	/**
+	 * @var string
+	 */
 	const USER_META_DISMISSED = 'wpseo-remove-upsell-notice';
 
+	/**
+	 * @var string
+	 */
 	const OPTION_NAME = 'wpseo';
 
 	/**

--- a/admin/class-remote-request.php
+++ b/admin/class-remote-request.php
@@ -10,8 +10,15 @@
  */
 class WPSEO_Remote_Request {
 
+	/**
+	 * @var string
+	 */
 	const METHOD_POST = 'post';
-	const METHOD_GET  = 'get';
+
+	/**
+	 * @var string
+	 */
+	const METHOD_GET = 'get';
 
 	/**
 	 * @var string

--- a/admin/class-yoast-alerts.php
+++ b/admin/class-yoast-alerts.php
@@ -10,6 +10,9 @@
  */
 class Yoast_Alerts {
 
+	/**
+	 * @var string
+	 */
 	const ADMIN_PAGE = 'wpseo_dashboard';
 
 	/**

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -10,6 +10,9 @@
  */
 class Yoast_Dashboard_Widget {
 
+	/**
+	 * @var string
+	 */
 	const CACHE_TRANSIENT_KEY = 'wpseo-dashboard-totals';
 
 	/**

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -12,11 +12,15 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 
 	/**
 	 * Action identifier for updating plugin network options.
+	 *
+	 * @var string
 	 */
 	const UPDATE_OPTIONS_ACTION = 'yoast_handle_network_options';
 
 	/**
 	 * Action identifier for restoring a site.
+	 *
+	 * @var string
 	 */
 	const RESTORE_SITE_ACTION = 'yoast_restore_site';
 

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -10,6 +10,9 @@
  */
 class WPSEO_Configuration_Page {
 
+	/**
+	 * @var string
+	 */
 	const PAGE_IDENTIFIER = 'wpseo_configurator';
 
 	/**

--- a/admin/config-ui/components/class-component-mailchimp-signup.php
+++ b/admin/config-ui/components/class-component-mailchimp-signup.php
@@ -10,6 +10,9 @@
  */
 class WPSEO_Config_Component_Mailchimp_Signup implements WPSEO_Config_Component {
 
+	/**
+	 * @var string
+	 */
 	const META_NAME = 'wpseo-has-mailchimp-signup';
 
 	/**

--- a/admin/endpoints/class-endpoint-indexable.php
+++ b/admin/endpoints/class-endpoint-indexable.php
@@ -10,11 +10,25 @@
  */
 class WPSEO_Endpoint_Indexable implements WPSEO_Endpoint, WPSEO_Endpoint_Storable {
 
-	const REST_NAMESPACE    = 'yoast/v1';
+	/**
+	 * @var string
+	 */
+	const REST_NAMESPACE = 'yoast/v1';
+
+	/**
+	 * @var string
+	 */
 	const ENDPOINT_SINGULAR = 'indexables/(?P<object_type>\w+)/(?P<object_id>\d+)';
 
+	/**
+	 * @var string
+	 */
 	const CAPABILITY_RETRIEVE = 'manage_options';
-	const CAPABILITY_STORE    = 'manage_options';
+
+	/**
+	 * @var string
+	 */
+	const CAPABILITY_STORE = 'manage_options';
 
 	/**
 	 * @var WPSEO_Indexable_Service The indexable service.

--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -10,6 +10,9 @@
  */
 abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration {
 
+	/**
+	 * @var string
+	 */
 	const FILTER_QUERY_ARG = 'yoast_filter';
 
 	/**

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -12,6 +12,8 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 
 	/**
 	 * Name of the meta value.
+	 *
+	 * @var string
 	 */
 	const META_NAME = 'is_cornerstone';
 

--- a/admin/google_search_console/class-gsc-count.php
+++ b/admin/google_search_console/class-gsc-count.php
@@ -11,12 +11,16 @@
 class WPSEO_GSC_Count {
 
 	/**
-	 * @var string The name of the option containing the last checked timestamp.
+	 * The name of the option containing the last checked timestamp.
+	 *
+	 * @var string
 	 */
 	const OPTION_CI_LAST_FETCH = 'wpseo_gsc_last_fetch';
 
 	/**
-	 * @var string The option name where the issues counts are saved.
+	 * The option name where the issues counts are saved.
+	 *
+	 * @var string
 	 */
 	const OPTION_CI_COUNTS = 'wpseo_gsc_issues_counts';
 

--- a/admin/google_search_console/class-gsc-table.php
+++ b/admin/google_search_console/class-gsc-table.php
@@ -14,6 +14,9 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
  */
 class WPSEO_GSC_Table extends WP_List_Table {
 
+	/**
+	 * @var int
+	 */
 	const FREE_MODAL_HEIGHT = 140;
 
 	/**

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -12,6 +12,8 @@ class WPSEO_GSC implements WPSEO_WordPress_Integration {
 
 	/**
 	 * The option where data will be stored.
+	 *
+	 * @var string
 	 */
 	const OPTION_WPSEO_GSC = 'wpseo-gsc';
 

--- a/admin/import/class-import-settings.php
+++ b/admin/import/class-import-settings.php
@@ -11,6 +11,12 @@
  * Class with functionality to import the Yoast SEO settings.
  */
 class WPSEO_Import_Settings {
+
+	/**
+	 * Nonce action key.
+	 *
+	 * @var string
+	 */
 	const NONCE_ACTION = 'wpseo-import-settings';
 
 	/**

--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -11,12 +11,16 @@
 class WPSEO_Link_Columns {
 
 	/**
-	 * @var string Partial column name.
+	 * Partial column name.
+	 *
+	 * @var string
 	 */
 	const COLUMN_LINKED = 'linked';
 
 	/**
-	 * @var string Partial column name.
+	 * Partial column name.
+	 *
+	 * @var string
 	 */
 	const COLUMN_LINKS = 'links';
 

--- a/admin/links/class-link-compatibility-notifier.php
+++ b/admin/links/class-link-compatibility-notifier.php
@@ -10,6 +10,9 @@
  */
 class WPSEO_Link_Compatibility_Notifier {
 
+	/**
+	 * @var string
+	 */
 	const NOTIFICATION_ID = 'wpseo-links-compatibility';
 
 	/**

--- a/admin/links/class-link-notifier.php
+++ b/admin/links/class-link-notifier.php
@@ -10,6 +10,9 @@
  */
 class WPSEO_Link_Notifier {
 
+	/**
+	 * @var string
+	 */
 	const NOTIFICATION_ID = 'wpseo-reindex-links';
 
 	/**

--- a/admin/links/class-link-reindex-post-endpoint.php
+++ b/admin/links/class-link-reindex-post-endpoint.php
@@ -10,9 +10,19 @@
  */
 class WPSEO_Link_Reindex_Post_Endpoint {
 
+	/**
+	 * @var string
+	 */
 	const REST_NAMESPACE = 'yoast/v1';
+
+	/**
+	 * @var string
+	 */
 	const ENDPOINT_QUERY = 'reindex_posts';
 
+	/**
+	 * @var string
+	 */
 	const CAPABILITY_RETRIEVE = 'edit_posts';
 
 	/**

--- a/admin/links/class-link-storage.php
+++ b/admin/links/class-link-storage.php
@@ -10,6 +10,11 @@
  */
 class WPSEO_Link_Storage implements WPSEO_Installable {
 
+	/**
+	 * Table name for the link storage.
+	 *
+	 * @var string
+	 */
 	const TABLE_NAME = 'yoast_seo_links';
 
 	/**

--- a/admin/links/class-link-table-accessible-notifier.php
+++ b/admin/links/class-link-table-accessible-notifier.php
@@ -10,6 +10,9 @@
  */
 class WPSEO_Link_Table_Accessible_Notifier {
 
+	/**
+	 * @var string
+	 */
 	const NOTIFICATION_ID = 'wpseo-links-table-not-accessible';
 
 	/**

--- a/admin/links/class-link-table-accessible.php
+++ b/admin/links/class-link-table-accessible.php
@@ -10,7 +10,14 @@
  */
 class WPSEO_Link_Table_Accessible {
 
-	const ACCESSIBLE   = '0';
+	/**
+	 * @var string
+	 */
+	const ACCESSIBLE = '0';
+
+	/**
+	 * @var string
+	 */
 	const INACCESSBILE = '1';
 
 	/**

--- a/admin/links/class-link.php
+++ b/admin/links/class-link.php
@@ -10,7 +10,14 @@
  */
 class WPSEO_Link {
 
+	/**
+	 * @var string
+	 */
 	const TYPE_EXTERNAL = 'external';
+
+	/**
+	 * @var string
+	 */
 	const TYPE_INTERNAL = 'internal';
 
 	/**

--- a/admin/onpage/class-onpage-option.php
+++ b/admin/onpage/class-onpage-option.php
@@ -10,28 +10,51 @@
  */
 class WPSEO_OnPage_Option {
 
-	const NOT_FETCHED      = 99;
-	const IS_INDEXABLE     = 1;
-	const IS_NOT_INDEXABLE = 0;
-	const CANNOT_FETCH     = -1;
+	/**
+	 * @var int
+	 */
+	const NOT_FETCHED = 99;
 
 	/**
-	 *  The name of the option where data will be stored
+	 * @var int
+	 */
+	const IS_INDEXABLE = 1;
+
+	/**
+	 * @var int
+	 */
+	const IS_NOT_INDEXABLE = 0;
+
+	/**
+	 * @var int
+	 */
+	const CANNOT_FETCH = -1;
+
+	/**
+	 *  The name of the option where data will be stored.
+	 *
+	 * @var string
 	 */
 	const OPTION_NAME = 'wpseo_onpage';
 
 	/**
-	 * The key of the status in the option
+	 * The key of the status in the option.
+	 *
+	 * @var string
 	 */
 	const STATUS = 'status';
 
 	/**
 	 * The key of the last fetch date in the option.
+	 *
+	 * @var string
 	 */
 	const LAST_FETCH = 'last_fetch';
 
 	/**
 	 * The limit for fetching the status manually.
+	 *
+	 * @var int
 	 */
 	const FETCH_LIMIT = 15;
 

--- a/admin/onpage/class-onpage.php
+++ b/admin/onpage/class-onpage.php
@@ -12,6 +12,8 @@ class WPSEO_OnPage implements WPSEO_WordPress_Integration {
 
 	/**
 	 * The name of the user meta key for storing the dismissed status.
+	 *
+	 * @var string
 	 */
 	const USER_META_KEY = 'wpseo_dismiss_onpage';
 

--- a/admin/statistics/class-statistics-service.php
+++ b/admin/statistics/class-statistics-service.php
@@ -10,6 +10,9 @@
  */
 class WPSEO_Statistics_Service {
 
+	/**
+	 * @var string
+	 */
 	const CACHE_TRANSIENT_KEY = 'wpseo-statistics-totals';
 
 	/**

--- a/deprecated/class-cornerstone.php
+++ b/deprecated/class-cornerstone.php
@@ -12,8 +12,14 @@
  */
 class WPSEO_Cornerstone {
 
+	/**
+	 * @var string
+	 */
 	const META_NAME = 'is_cornerstone';
 
+	/**
+	 * @var string
+	 */
 	const FIELD_NAME = 'yoast_wpseo_is_cornerstone';
 
 	/**

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -9,6 +9,10 @@
  * Class WPSEO_OpenGraph_Image
  */
 class WPSEO_OpenGraph_Image {
+
+	/**
+	 * @var string
+	 */
 	const EXTERNAL_IMAGE_ID = '-1';
 
 	/**

--- a/inc/class-wpseo-rank.php
+++ b/inc/class-wpseo-rank.php
@@ -10,10 +10,29 @@
  */
 class WPSEO_Rank {
 
-	const BAD      = 'bad';
-	const OK       = 'ok';
-	const GOOD     = 'good';
+	/**
+	 * @var string
+	 */
+	const BAD = 'bad';
+
+	/**
+	 * @var string
+	 */
+	const OK = 'ok';
+
+	/**
+	 * @var string
+	 */
+	const GOOD = 'good';
+
+	/**
+	 * @var string
+	 */
 	const NO_FOCUS = 'na';
+
+	/**
+	 * @var string
+	 */
 	const NO_INDEX = 'noindex';
 
 	/**

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -59,6 +59,8 @@ abstract class WPSEO_Option {
 
 	/**
 	 * Prefix for override option keys that allow or disallow the option key of the same name.
+	 *
+	 * @var string
 	 */
 	const ALLOW_KEY_PREFIX = 'allow_';
 

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -12,7 +12,11 @@
  */
 class WPSEO_Sitemaps {
 
-	/** Sitemap index identifier. */
+	/**
+	 * Sitemap index identifier.
+	 *
+	 * @var string
+	 */
 	const SITEMAP_INDEX_TYPE = '1';
 
 	/**

--- a/inc/sitemaps/interface-sitemap-cache-data.php
+++ b/inc/sitemaps/interface-sitemap-cache-data.php
@@ -10,13 +10,25 @@
  */
 interface WPSEO_Sitemap_Cache_Data_Interface {
 
-	/** Status for normal, usable sitemap. */
+	/**
+	 * Status for normal, usable sitemap.
+	 *
+	 * @var string
+	 */
 	const OK = 'ok';
 
-	/** Status for unusable sitemap. */
+	/**
+	 * Status for unusable sitemap.
+	 *
+	 * @var string
+	 */
 	const ERROR = 'error';
 
-	/** Status for unusable sitemap because it cannot be identified. */
+	/**
+	 * Status for unusable sitemap because it cannot be identified.
+	 *
+	 * @var string
+	 */
 	const UNKNOWN = 'unknown';
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* No functional changes.

Constants should be documented in the same way as properties, including the expected type for the value of the constant.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.

