### PR TITLE
Documentation: fix incorrect info in method @param tags

### DIFF
--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -152,7 +152,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Checks whether or not a plugin is known within the Yoast SEO collection.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param string $plugin The plugin to search for.
 	 *
 	 * @return bool Whether or not the plugin is exists.
 	 */
@@ -172,7 +172,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Gets a specific plugin. Returns an empty array if it cannot be found.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param string $plugin The plugin to search for.
 	 *
 	 * @return array The plugin properties.
 	 */
@@ -187,7 +187,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Gets the version of the plugin.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param array $plugin The information available about the plugin.
 	 *
 	 * @return string The version associated with the plugin.
 	 */
@@ -202,7 +202,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Checks if there are dependencies available for the plugin.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param array $plugin The information available about the plugin.
 	 *
 	 * @return bool Whether or not there is a dependency present.
 	 */
@@ -213,7 +213,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Gets the dependencies for the plugin.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param array $plugin The information available about the plugin.
 	 *
 	 * @return array Array containing all the dependencies associated with the plugin.
 	 */
@@ -228,7 +228,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Checks if all dependencies are satisfied.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param array $plugin The information available about the plugin.
 	 *
 	 * @return bool Whether or not the dependencies are satisfied.
 	 */
@@ -246,7 +246,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Checks whether or not one of the plugins is properly installed and usable.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param array $plugin The information available about the plugin.
 	 *
 	 * @return bool Whether or not the plugin is properly installed.
 	 */
@@ -278,7 +278,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Checks for the availability of the plugin.
 	 *
-	 * @param {string} $plugin The plugin to search for.
+	 * @param array $plugin The information available about the plugin.
 	 *
 	 * @return bool Whether or not the plugin is available.
 	 */
@@ -289,7 +289,7 @@ class WPSEO_Plugin_Availability {
 	/**
 	 * Checks whether a dependency is available.
 	 *
-	 * @param {string} $dependency The dependency to look for.
+	 * @param array $dependency The information about the dependency to look for.
 	 *
 	 * @return bool Whether or not the dependency is available.
 	 */

--- a/admin/config-ui/fields/class-field-multiple-authors.php
+++ b/admin/config-ui/fields/class-field-multiple-authors.php
@@ -65,7 +65,7 @@ class WPSEO_Config_Field_Multiple_Authors extends WPSEO_Config_Field_Choice {
 	/**
 	 * Set the data in the options.
 	 *
-	 * @param {string} $data The data to set for the field.
+	 * @param string $data The data to set for the field.
 	 *
 	 * @return bool Returns true or false for successful storing the data.
 	 */

--- a/admin/config-ui/fields/class-field-site-name.php
+++ b/admin/config-ui/fields/class-field-site-name.php
@@ -50,7 +50,7 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	/**
 	 * Set the data in the options.
 	 *
-	 * @param {string} $data The data to set for the field.
+	 * @param string $data The data to set for the field.
 	 *
 	 * @return bool Returns true or false for successful storing the data.
 	 */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

`{string}` is not a recognized, nor an accepted parameter type annotation in PHP.

The corrected information is based on the code found within the affected functions.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.

