### PR TITLE
Documentation: improve views var documentation

### DIFF
--- a/admin/views/form/fieldset.php
+++ b/admin/views/form/fieldset.php
@@ -3,6 +3,12 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin
+ *
+ * @uses string $id                ID attribute for the fieldset.
+ * @uses string $attributes        Additional attributes for the fieldset.
+ * @uses string $legend_attributes Additional attributes for the legend.
+ * @uses string $legend_content    The legend text.
+ * @uses string $content           The fieldset content, i.e. a set of logically grouped form controls.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {
@@ -11,13 +17,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-/**
- * @var string $id                ID attribute for the fieldset.
- * @var string $attributes        Additional attributes for the fieldset.
- * @var string $legend_attributes Additional attributes for the legend.
- * @var string $legend_content    The legend text.
- * @var string $content           The fieldset content, i.e. a set of logically grouped form controls.
- */
 ?>
 
 <fieldset id="<?php echo esc_attr( $id ); ?>"<?php echo $attributes; ?>>

--- a/admin/views/form/select.php
+++ b/admin/views/form/select.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin
  *
- * @uses string $attributes Additional attributes for the select
+ * @uses string $attributes Additional attributes for the select.
  * @uses string $name       Value for the select name attribute.
  * @uses string $id         ID attribute for the select.
  * @uses array  $options    Array with the options to show.

--- a/admin/views/form/select.php
+++ b/admin/views/form/select.php
@@ -3,6 +3,12 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin
+ *
+ * @uses string $attributes Additional attributes for the select
+ * @uses string $name       Value for the select name attribute.
+ * @uses string $id         ID attribute for the select.
+ * @uses array  $options    Array with the options to show.
+ * @uses string $selected   The current set options.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {
@@ -11,13 +17,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-/**
- * @var string $attributes Additional attributes for the select
- * @var string $name       Value for the select name attribute.
- * @var string $id         ID attribute for the select.
- * @var array  $options    Array with the options to show.
- * @var string $selected   The current set options.
- */
 ?>
 <select <?php echo $attributes; ?>name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $id ); ?>">
 	<?php foreach ( $options as $option_attribute_value => $option_html_value ) : ?>

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -4,13 +4,13 @@
  *
  * @package WPSEO\Admin\Views
  *
- * @var string $paper_id                  The id of the paper.
- * @var bool   $collapsible               Whether the collapsible should be rendered.
- * @var array  $collapsible_config        Configuration for the collapsible.
- * @var string $title                     The title
- * @var string $title_after               Additional content to render after the title.
- * @var string $view_file                 Path to the view file.
- * @var WPSEO_Admin_Help_Panel $help_text The help text.
+ * @uses string                 $paper_id           The id of the paper.
+ * @uses bool                   $collapsible        Whether the collapsible should be rendered.
+ * @uses array                  $collapsible_config Configuration for the collapsible.
+ * @uses string                 $title              The title
+ * @uses string                 $title_after        Additional content to render after the title.
+ * @uses string                 $view_file          Path to the view file.
+ * @uses WPSEO_Admin_Help_Panel $help_text          The help text.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -7,7 +7,7 @@
  * @uses string                 $paper_id           The id of the paper.
  * @uses bool                   $collapsible        Whether the collapsible should be rendered.
  * @uses array                  $collapsible_config Configuration for the collapsible.
- * @uses string                 $title              The title
+ * @uses string                 $title              The title.
  * @uses string                 $title_after        Additional content to render after the title.
  * @uses string                 $view_file          Path to the view file.
  * @uses WPSEO_Admin_Help_Panel $help_text          The help text.

--- a/admin/views/partial-alerts-errors.php
+++ b/admin/views/partial-alerts-errors.php
@@ -3,6 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin
+ *
+ * @uses array $alerts_data
  */
 
 $type     = 'alerts';

--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -3,6 +3,17 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin
+ *
+ * @uses string $type
+ * @uses string $dashicon
+ * @uses string $i18n_title
+ * @uses string $i18n_issues
+ * @uses string $i18n_no_issues
+ * @uses string $i18n_muted_issues_title
+ * @uses int    $active_total
+ * @uses        $total
+ * @uses array  $active
+ * @uses array  $dismissed
  */
 
 if ( ! function_exists( '_yoast_display_alerts' ) ) {

--- a/admin/views/partial-alerts-warnings.php
+++ b/admin/views/partial-alerts-warnings.php
@@ -3,6 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin
+ *
+ * @uses array $alerts_data
  */
 
 $type     = 'warnings';

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/dashboard/site-analysis.php
+++ b/admin/views/tabs/dashboard/site-analysis.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/metas/archives/help.php
+++ b/admin/views/tabs/metas/archives/help.php
@@ -3,8 +3,6 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views\Archive
- *
- * @uses Yoast_Form $yform Form object.
  */
 
 $archives_help_content = array(

--- a/admin/views/tabs/metas/archives/help.php
+++ b/admin/views/tabs/metas/archives/help.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Archive
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 $archives_help_content = array(

--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -4,9 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Archive
  *
- * @uses Yoast_Form                               $yform                        Form object.
- * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
- * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
+ * @uses Yoast_Form $yform Form object.
  */
 
 $yform->toggle_switch(

--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -4,9 +4,9 @@
  *
  * @package WPSEO\Admin\Views\Archive
  *
- * @var Yoast_Form                               $yform
- * @var WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
- * @var WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
+ * @uses Yoast_Form                               $yform                        Form object.
+ * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
+ * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */
 
 $yform->toggle_switch(

--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Breadcrumbs
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! current_theme_supports( 'yoast-seo-breadcrumbs' ) ) {

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -4,9 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Archive
  *
- * @uses Yoast_Form                               $yform                        Form object.
- * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
- * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
+ * @uses Yoast_Form $yform Form object.
  */
 
 $yform->toggle_switch(

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -4,9 +4,9 @@
  *
  * @package WPSEO\Admin\Views\Archive
  *
- * @var Yoast_Form                               $yform
- * @var WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
- * @var WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
+ * @uses Yoast_Form                               $yform                        Form object.
+ * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
+ * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */
 
 $yform->toggle_switch(

--- a/admin/views/tabs/metas/paper-content/general/force-rewrite-title.php
+++ b/admin/views/tabs/metas/paper-content/general/force-rewrite-title.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\General
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! current_theme_supports( 'title-tag' ) ) {

--- a/admin/views/tabs/metas/paper-content/general/homepage.php
+++ b/admin/views/tabs/metas/paper-content/general/homepage.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\General
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 ?>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\General
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 $knowledge_graph_help = new WPSEO_Admin_Help_Panel(

--- a/admin/views/tabs/metas/paper-content/general/title-separator.php
+++ b/admin/views/tabs/metas/paper-content/general/title-separator.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\General
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 $title_separator_help = new WPSEO_Admin_Help_Panel(

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Media
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 $wpseo_post_type              = get_post_type_object( 'attachment' );

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -4,11 +4,11 @@
  *
  * @package WPSEO\Admin\Views\Taxonomies
  *
- * @var Yoast_Form                               $yform
- * @var WP_Post_Type                             $wpseo_post_type
- * @var Yoast_View_Utils                         $view_utils
- * @var WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
- * @var WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
+ * @uses Yoast_Form                               $yform                        Form object.
+ * @uses WP_Post_Type                             $wpseo_post_type
+ * @uses Yoast_View_Utils                         $view_utils
+ * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
+ * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */
 
 $single_label = $wpseo_post_type->labels->singular_name;

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -4,11 +4,11 @@
  *
  * @package WPSEO\Admin\Views\PaperContent
  *
- * @var Yoast_Form                               $yform
- * @var WP_Taxonomy                              $wpseo_post_type
- * @var Yoast_View_Utils                         $view_utils
- * @var WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
- * @var WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
+ * @uses Yoast_Form                               $yform                        Form object.
+ * @uses WP_Taxonomy                              $wpseo_post_type
+ * @uses Yoast_View_Utils                         $view_utils
+ * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
+ * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */
 
 $show_post_type_help = $view_utils->search_results_setting_help( $wpseo_post_type );

--- a/admin/views/tabs/metas/paper-content/post_type/woocommerce-shop-page.php
+++ b/admin/views/tabs/metas/paper-content/post_type/woocommerce-shop-page.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\General
  *
- * @var WP_Post_Type $wpseo_post_type
+ * @uses WP_Post_Type $wpseo_post_type
  */
 
 $woocommerce_shop_page = new WPSEO_WooCommerce_Shop_Page();

--- a/admin/views/tabs/metas/paper-content/rss-content.php
+++ b/admin/views/tabs/metas/paper-content/rss-content.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Rss
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 $textarea_atts = array(

--- a/admin/views/tabs/metas/paper-content/special-pages.php
+++ b/admin/views/tabs/metas/paper-content/special-pages.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Archive
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 $special_pages_help = new WPSEO_Admin_Help_Panel(

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -4,11 +4,11 @@
  *
  * @package WPSEO\Admin\Views\Taxonomies
  *
- * @var Yoast_Form                               $yform
- * @var WP_Taxonomy                              $wpseo_taxonomy
- * @var Yoast_View_Utils                         $view_utils
- * @var WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
- * @var WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
+ * @uses Yoast_Form                               $yform                        Form object.
+ * @uses WP_Taxonomy                              $wpseo_taxonomy
+ * @uses Yoast_View_Utils                         $view_utils
+ * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
+ * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */
 
 if ( $wpseo_taxonomy->name === 'post_format' ) {

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -7,6 +7,7 @@
  * @uses Yoast_Form                               $yform                        Form object.
  * @uses WP_Taxonomy                              $wpseo_taxonomy
  * @uses Yoast_View_Utils                         $view_utils
+ * @uses string                                   $title
  * @uses WPSEO_Admin_Recommended_Replace_Vars     $recommended_replace_vars
  * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -3,12 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * Form object.
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -3,8 +3,6 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- *
- * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/metas/taxonomies/category-url.php
+++ b/admin/views/tabs/metas/taxonomies/category-url.php
@@ -4,7 +4,7 @@
  *
  * @package WPSEO\Admin\Views\Taxonomies
  *
- * @var Yoast_Form $yform
+ * @uses Yoast_Form $yform Form object.
  */
 
 $remove_buttons = array( __( 'Keep', 'wordpress-seo' ), __( 'Remove', 'wordpress-seo' ) );

--- a/admin/views/tabs/network/features.php
+++ b/admin/views/tabs/network/features.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/network/general.php
+++ b/admin/views/tabs/network/general.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/network/restore-site.php
+++ b/admin/views/tabs/network/restore-site.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/social/google.php
+++ b/admin/views/tabs/social/google.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/social/pinterest.php
+++ b/admin/views/tabs/social/pinterest.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -4,7 +4,8 @@
  *
  * @package WPSEO\Admin\Views
  *
- * @uses Yoast_Form $yform Form object.
+ * @uses Yoast_Form $yform                                   Form object.
+ * @uses array      WPSEO_Option_Social::$twitter_card_types
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -3,11 +3,9 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form                    $yform
- * @var WPSEO_Import_Plugins_Detector $import_check
+ *
+ * @uses Yoast_Form                    $yform        Form object.
+ * @uses WPSEO_Import_Plugins_Detector $import_check
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -3,9 +3,6 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- *
- * @uses Yoast_Form                    $yform        Form object.
- * @uses WPSEO_Import_Plugins_Detector $import_check
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/tool/wpseo-export.php
+++ b/admin/views/tabs/tool/wpseo-export.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/tool/wpseo-export.php
+++ b/admin/views/tabs/tool/wpseo-export.php
@@ -3,8 +3,6 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- *
- * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -3,10 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- */
-
-/**
- * @var Yoast_Form $yform
+ *
+ * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -3,8 +3,6 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin\Views
- *
- * @uses Yoast_Form $yform Form object.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -3,6 +3,8 @@
  * WPSEO plugin file.
  *
  * @package WPSEO\Admin
+ *
+ * @uses object $user
  */
 
 /* translators: %1$s expands to Yoast SEO */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

### Documentation/Views: improve @var information

* Have the tags in the file docblocks.
    The variables are, after all, used by the file.
* Improve alignment.
* Add (some) short descriptions.
* Use the more appropriate `@uses` tag instead of `@var`.
    `@var` is intended for property, constant and variable _declarations.
    As these aren't variable declarations, but variables which are made available from the function which includes the view, the `@uses` tag is more appropriate to use.
    Refs:
    * https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc-tags.md#521-uses
    * https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc-tags.md#522-var

### Documentation/Views: remove references to variables not actually being used in the view

### Documentation/Views: add missing references to external variables used in the view



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.

