### PR TITLE
Refactor YoastShortcodePlugin to not use app directly

### DIFF
--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -478,7 +478,7 @@ setWordPressSeoL10n();
 		editStore.subscribe( handleStoreChange.bind( null, editStore, YoastSEO.app.refresh ) );
 
 		const replaceVarsPlugin = new YoastReplaceVarPlugin( app, editStore );
-		const shortcodePlugin = new YoastShortcodePlugin( app );
+		const shortcodePlugin = new YoastShortcodePlugin( YoastSEO.app.registerPlugin, YoastSEO.app.registerModification, YoastSEO.app.pluginReady, YoastSEO.app.pluginReloaded );
 
 		if ( wpseoPostScraperL10n.markdownEnabled ) {
 			const markdownPlugin = new YoastMarkdownPlugin( YoastSEO.app.registerPlugin, YoastSEO.app.registerModification );

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -478,12 +478,12 @@ setWordPressSeoL10n();
 		editStore.subscribe( handleStoreChange.bind( null, editStore, YoastSEO.app.refresh ) );
 
 		const replaceVarsPlugin = new YoastReplaceVarPlugin( app, editStore );
-		const shortcodePlugin = new YoastShortcodePlugin(
-			YoastSEO.app.registerPlugin,
-			YoastSEO.app.registerModification,
-			YoastSEO.app.pluginReady,
-			YoastSEO.app.pluginReloaded
-		);
+		const shortcodePlugin = new YoastShortcodePlugin( {
+			registerPlugin: YoastSEO.app.registerPlugin,
+			registerModification: YoastSEO.app.registerModification,
+			pluginReady: YoastSEO.app.pluginReady,
+			pluginReloaded: YoastSEO.app.pluginReloaded,
+		} );
 
 		if ( wpseoPostScraperL10n.markdownEnabled ) {
 			const markdownPlugin = new YoastMarkdownPlugin( YoastSEO.app.registerPlugin, YoastSEO.app.registerModification );

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -478,7 +478,12 @@ setWordPressSeoL10n();
 		editStore.subscribe( handleStoreChange.bind( null, editStore, YoastSEO.app.refresh ) );
 
 		const replaceVarsPlugin = new YoastReplaceVarPlugin( app, editStore );
-		const shortcodePlugin = new YoastShortcodePlugin( YoastSEO.app.registerPlugin, YoastSEO.app.registerModification, YoastSEO.app.pluginReady, YoastSEO.app.pluginReloaded );
+		const shortcodePlugin = new YoastShortcodePlugin(
+			YoastSEO.app.registerPlugin,
+			YoastSEO.app.registerModification,
+			YoastSEO.app.pluginReady,
+			YoastSEO.app.pluginReloaded
+		);
 
 		if ( wpseoPostScraperL10n.markdownEnabled ) {
 			const markdownPlugin = new YoastMarkdownPlugin( YoastSEO.app.registerPlugin, YoastSEO.app.registerModification );

--- a/js/src/wp-seo-shortcode-plugin.js
+++ b/js/src/wp-seo-shortcode-plugin.js
@@ -22,18 +22,19 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * @property {RegExp} nonCaptureRegex Used to match a given string for non capturing shortcodes.
 	 * @property {Array} parsedShortcodes Used to store parsed shortcodes.
 	 *
-	 * @param {function} registerPlugin       Register a plugin with Yoast SEO.
-	 * @param {function} registerModification Register a modification with Yoast SEO.
-	 * @param {function} pluginReady          Notify Yoast SEO that the plugin is ready.
-	 * @param {function} pluginReloaded       Notify Yoast SEO that the plugin has been reloaded.
+	 * @param {Object}   interface                      Object Formerly Known as App, but for backwards compatibility
+	 *                                                  still passed here as one argument.
+	 * @param {function} interface.registerPlugin       Register a plugin with Yoast SEO.
+	 * @param {function} interface.registerModification Register a modification with Yoast SEO.
+	 * @param {function} interface.pluginReady          Notify Yoast SEO that the plugin is ready.
+	 * @param {function} interface.pluginReloaded       Notify Yoast SEO that the plugin has been reloaded.
 	 */
-	var YoastShortcodePlugin = function( registerPlugin, registerModification, pluginReady, pluginReloaded ) {
-		this._registerPlugin = registerPlugin;
+	var YoastShortcodePlugin = function( { registerPlugin, registerModification, pluginReady, pluginReloaded } ) {
 		this._registerModification = registerModification;
 		this._pluginReady = pluginReady;
 		this._pluginReloaded = pluginReloaded;
 
-		this._registerPlugin( "YoastShortcodePlugin", { status: "loading" } );
+		registerPlugin( "YoastShortcodePlugin", { status: "loading" } );
 		this.bindElementEvents();
 
 		var keywordRegexString = "(" + wpseoShortcodePluginL10n.wpseo_shortcode_tags.join( "|" ) + ")";

--- a/js/src/wp-seo-shortcode-plugin.js
+++ b/js/src/wp-seo-shortcode-plugin.js
@@ -22,12 +22,18 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * @property {RegExp} nonCaptureRegex Used to match a given string for non capturing shortcodes.
 	 * @property {Array} parsedShortcodes Used to store parsed shortcodes.
 	 *
-	 * @param {app} app The app object.
+	 * @param {function} registerPlugin       Register a plugin with Yoast SEO.
+	 * @param {function} registerModification Register a modification with Yoast SEO.
+	 * @param {function} pluginReady          Notify Yoast SEO that the plugin is ready.
+	 * @param {function} pluginReloaded       Notify Yoast SEO that the plugin has been reloaded.
 	 */
-	var YoastShortcodePlugin = function( app ) {
-		this._app = app;
+	var YoastShortcodePlugin = function( registerPlugin, registerModification, pluginReady, pluginReloaded ) {
+		this._registerPlugin = registerPlugin;
+		this._registerModification = registerModification;
+		this._pluginReady = pluginReady;
+		this._pluginReloaded = pluginReloaded;
 
-		this._app.registerPlugin( "YoastShortcodePlugin", { status: "loading" } );
+		this._registerPlugin( "YoastShortcodePlugin", { status: "loading" } );
 		this.bindElementEvents();
 
 		var keywordRegexString = "(" + wpseoShortcodePluginL10n.wpseo_shortcode_tags.join( "|" ) + ")";
@@ -50,7 +56,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * @returns {void}
 	 */
 	YoastShortcodePlugin.prototype.declareReady = function() {
-		this._app.pluginReady( "YoastShortcodePlugin" );
+		this._pluginReady( "YoastShortcodePlugin" );
 		this.registerModifications();
 	};
 
@@ -60,7 +66,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * @returns {void}
 	 */
 	YoastShortcodePlugin.prototype.declareReloaded = function() {
-		this._app.pluginReloaded( "YoastShortcodePlugin" );
+		this._pluginReloaded( "YoastShortcodePlugin" );
 	};
 
 	/**
@@ -69,7 +75,7 @@ const shortcodeEndRegex = new RegExp( "\\[/" + shortcodeNameMatcher + "\\]", "g"
 	 * @returns {void}
 	 */
 	YoastShortcodePlugin.prototype.registerModifications = function() {
-		this._app.registerModification( "content", this.replaceShortcodes.bind( this ), "YoastShortcodePlugin" );
+		this._registerModification( "content", this.replaceShortcodes.bind( this ), "YoastShortcodePlugin" );
 	};
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Changes YoastShortcodePlugin to not use app directly.

## Relevant technical choices:

* Pass the functions used instead of the app.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Enable worker logs in `/VVV/www/wordpress-default/public_html/wp-config.php` enable the flags `define( 'YOAST_SEO_DEBUG', true );` and `define( 'YOAST_SEO_DEBUG_ANALYSIS_WORKER', 'TRACE' );`.
* Go to a post.
* Open the console and look at the currently supported shortcodes by running:  `wpseoShortcodePluginL10n.wpseo_shortcode_tags`.
* Test if a shortcode does not end up in the text that the analysis receives:
  * Add a shortcode that is not supported.
  * Ensure the paper text does not include the tags of those, but it does include the content in between the tags.
* Test if a shortcode's content ends up in the text that the analysis receives:
  * Add a shortcode that is supported.
  * Ensure the paper text includes the content that the shortcode would show in the frontend.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11760 