### PR TITLE
Prevents redirect for old post feeds

### DIFF
--- a/frontend/class-handle-404.php
+++ b/frontend/class-handle-404.php
@@ -64,6 +64,8 @@ class WPSEO_Handle_404 implements WPSEO_WordPress_Integration {
 		$wp_query->is_feed = false;
 		$this->set_404();
 
+		add_filter( 'old_slug_redirect_url', '__return_false' );
+
 		return true;
 	}
 

--- a/frontend/class-handle-404.php
+++ b/frontend/class-handle-404.php
@@ -65,6 +65,7 @@ class WPSEO_Handle_404 implements WPSEO_WordPress_Integration {
 		$this->set_404();
 
 		add_filter( 'old_slug_redirect_url', '__return_false' );
+		add_filter( 'redirect_canonical', '__return_false' );
 
 		return true;
 	}


### PR DESCRIPTION
Co-authored-by: stodorovic

## Summary

This PR can be summarized in the following changelog entry:

* Uses filter [old_slug_redirect_url](https://developer.wordpress.org/reference/hooks/old_slug_redirect_url/) to prevent redirects for feeds if post slug is changed. Props to [stodorovic](https://github.com/stodorovic).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create post with slug "test_post".
* Check feed /test_post/feed/ - it shows correct feed.
* Go to change post slug to "test_post1".
* Browse to old feed /test_post/feed/ - it should show 404 error.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12041 