### PR TITLE
Change yoast-components dependency to develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.6",
+    "yoast-components": "git+https://github.com/Yoast/yoast-components.git#develop",
     "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.6"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12625,9 +12625,9 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-"yoast-components@git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.6":
+"yoast-components@git+https://github.com/Yoast/yoast-components.git#develop":
   version "4.18.1"
-  resolved "git+https://github.com/Yoast/yoast-components.git#d0bf5f534c6fc3524350ccb272d6025c99d871d6"
+  resolved "git+https://github.com/Yoast/yoast-components.git#bbc74da25a81bde52c475a063c44eee2e7b0463e"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12627,7 +12627,7 @@ yauzl@^2.2.1:
 
 "yoast-components@git+https://github.com/Yoast/yoast-components.git#develop":
   version "4.18.1"
-  resolved "git+https://github.com/Yoast/yoast-components.git#bbc74da25a81bde52c475a063c44eee2e7b0463e"
+  resolved "git+https://github.com/Yoast/yoast-components.git#f7de512eb784fb21741a550fae761c8890cebc5b"
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Changes yoast-components dependency from release branch to `develop` to make sure we get no conflicts when merging changes introduced in both `wordpress-seo` and `yoast-components`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
