### PR TITLE
Add allowed hosts to the webpack dev server configuration

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -34,6 +34,7 @@ const externals = {
 module.exports = function( env = { environment: "production", recalibration: "disabled" } ) {
 	const mode = env.environment || process.env.NODE_ENV || "production";
 	const isRecalibration = ( env.recalibration || process.env.YOAST_RECALIBRATION || "disabled" ) === "enabled";
+	const allowedHosts = [ "local.wordpress.test" ].concat( ( process.env.ALLOWED_HOSTS || [] ).split( " " ) );
 
 	const outputFilenameMinified = "[name]-" + pluginVersionSlug + ".min.js";
 	const outputFilenameUnminified = "[name]-" + pluginVersionSlug + ".js";
@@ -263,6 +264,7 @@ module.exports = function( env = { environment: "production", recalibration: "di
 	if ( mode === "development" ) {
 		config[ 0 ].devServer = {
 			publicPath: "/",
+			allowedHosts,
 		};
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Fixes the cross-origin compatibility with `webpack-dev-server`'s security fix and our worker.

## Relevant technical choices:

* Added allowed hosts to the `webpack-dev-server`'s configuration, which always starts with `local.wordpress.test`. To add more hosts you can set `ALLOWED_HOSTS` as environment variable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Enable your dev server in WordPress: Go to your `/VVV/www/wordpress-default/public_html/wp-config.php` and check if his line is not commented
`define( 'YOAST_SEO_DEV_SERVER', true );` or add the line if it is not there at all.
* Install PHP packages: `composer install`
* Install JS packages: `yarn`
* Compile the code and run the dev server: `yarn start`
* Go to a post or taxonomy (a place with YoastSEO) in your WordPress install and open the console. Refresh the page if needed.
* Ensure there are no errors like below.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
The following error:
<img width="811" alt="invalid host" src="https://user-images.githubusercontent.com/35524806/51253524-d3c5e600-199e-11e9-946e-5f7abf7cfe16.png">
