### PR TITLE
Only attempt to remove notifications storage if it was previously set

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -58,6 +58,13 @@ class Yoast_Notification_Center {
 	private $notifications_retrieved = false;
 
 	/**
+	 * Internal flag for whether the persistent store of this user's notifications
+	 * was empty when we loaded from it.
+	 * @var bool
+	 */
+	private $notifications_storage_empty = false;
+
+	/**
 	 * Construct
 	 */
 	private function __construct() {
@@ -530,9 +537,11 @@ class Yoast_Notification_Center {
 		 */
 		$notifications = apply_filters( 'yoast_notifications_before_storage', $notifications );
 
-		// No notifications to store, clear storage.
+		// No notifications to store, clear storage if it was previously present.
 		if ( empty( $notifications ) ) {
-			$this->remove_storage();
+			if ( ! $notifications_storage_empty ) {
+				$this->remove_storage();
+			}
 
 			return;
 		}
@@ -598,6 +607,7 @@ class Yoast_Notification_Center {
 
 		// Check if notifications are stored.
 		if ( empty( $stored_notifications ) ) {
+			$notifications_storage_empty = true;
 			return;
 		}
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -60,6 +60,7 @@ class Yoast_Notification_Center {
 	/**
 	 * Internal flag for whether the persistent store of this user's notifications
 	 * was empty when we loaded from it.
+	 *
 	 * @var bool
 	 */
 	private $notifications_storage_empty = false;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes #12049: avoid unnecessary DB query to remove notifications storage when already empty

## Relevant technical choices:

* This takes the approach of avoiding the DB query by only calling `remove_storage` when appropriate. An alternative approach might be to avoid hooking the shutdown action when we're being called in a context when Yoast notifications are never going to be seen anyway (e.g. `admin-ajax.php`).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Enable logging of database queries using your preferred mechanism
* While logged in, perform a call to some AJAX method using admin-ajax.php
* Note that there's a query to SELECT umeta_id FROM wp_usermeta WHERE meta_key = 'wp_yoast_notifications' AND user_id = <current user ID> resulting from the shutdown action hook.
* After applying this PR, the DB query is absent, but notifications are still persisted.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12049
