### PR TITLE
Extends the WPSEO_Meta class

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -8,7 +8,7 @@
 /**
  * This class generates the metabox on the edit post / page as well as contains all page analysis functionality.
  */
-class WPSEO_Metabox {
+class WPSEO_Metabox extends WPSEO_Meta {
 
 	/**
 	 * @var WPSEO_Social_Admin


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Bring back the extension of `WPSEO_Meta`

## Relevant technical choices:

* In #11978 we uncoupled the `WPSEO_Meta` entirely. This might break older versions of our extensions. We decided to bring back the extension of `WPSEO_Meta` to have backwards compatibility. In a future release we can remove the `extends` safely because the extensions will be more up-to-date for most sites.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the metabox doesn't break with old versions of extensions, for example Video SEO 9.4.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


