### PR TITLE
Fix test to take into account the WordPress 5.1 Rest API notice

### DIFF
--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -89,6 +89,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new WPSEO_WP_REST_Server_Mock();
+		do_action( 'rest_api_init', $wp_rest_server );
 
 		$this->endpoint->register();
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user facing] fix test

This PR illustrates a way to fix the `WPSEO_Configuration_Endpoint_Test` test to take into account the change introduced in WordPress 5.1 for the Rest API notice. See details on the issue #12062 

There are probably better ways to fix it, the aim of this PR is to illustrate the issue.

## Test instructions
- on wordpress-seo trunk and WordPress trunk (5.1)
- run `phpunit`
- see the test failure described in #12062 
- switch to this branch
- see no failure

Fixes #12062 
