### PR TITLE
Bump YoastSEO.js to v1.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
     "yoast-components": "git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.5",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.5"
+    "yoastseo": "^1.46.0"
   },
   "yoast": {
     "pluginVersion": "9.5-RC3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12639,6 +12639,19 @@ yauzl@^2.2.1:
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
+yoastseo@^1.46.0:
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.46.0.tgz#59f23945dc79a0c18124a7be8965f7089b2a3639"
+  integrity sha512-/hp/LQ/BPZtf8o/KFu9HxunnyIa/XpRoETdgCZCQ46mo1OKnGAOz+jiD8D3d+pn/7Wrxdfwz+egV5rhCcEvP3w==
+  dependencies:
+    "@wordpress/autop" "^2.0.2"
+    htmlparser2 "^3.9.2"
+    jed "^1.1.0"
+    lodash-es "^4.17.10"
+    loglevel "^1.6.1"
+    sassdash "0.9.0"
+    tokenizer2 "^2.0.1"
+
 "yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.5":
   version "1.45.0"
   resolved "git+https://github.com/Yoast/YoastSEO.js.git#767af2646d46cab03915cdd95893599f6eab6eb1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Bump YoastSEO.js to v1.46.0

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the functionality described in the [changelog](https://github.com/Yoast/YoastSEO.js/blob/develop/CHANGELOG.md) for 1.46 works as expected. See also the [individual PRs](https://github.com/Yoast/YoastSEO.js/milestone/85?closed=1).
