### PR TITLE
Add grunt webpack:recalibrationDev task

### DIFF
--- a/grunt/config/webpack.js
+++ b/grunt/config/webpack.js
@@ -2,7 +2,8 @@
 const webpackConfig = require( "../../webpack/webpack.config" );
 
 module.exports = {
-	buildDev: webpackConfig( { environment: "development" } ),
-	buildProd: webpackConfig(),
-	recalibration: webpackConfig( { recalibration: "enabled" } ),
+	buildDev: () => webpackConfig( { environment: "development" } ),
+	buildProd: () => webpackConfig(),
+	recalibrationDev: () => webpackConfig( { environment: "development", recalibration: "enabled" } ),
+	recalibration: () => webpackConfig( { recalibration: "enabled" } ),
 };


### PR DESCRIPTION
To make it possible to also have a dev build without the webpack dev server.
This is needed since a change in the way the analysis worker minified or not.
See: https://github.com/Yoast/wordpress-seo/pull/11872 and
https://github.com/Yoast/wordpress-seo/pull/11738

## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Fix an issue where it was no longer possible to build a recalibration version without the Webpack Development Server.

## Relevant technical choices:

* The adding of the anonymous functions seems necessary for the grunt plugin to not always run all the tasks.
* The `recalibrationDev` is the added task, that changes the environment to `development`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Follow the without development server step (**you can skip the linking and start from step 6**): https://github.com/Yoast/YoastSEO.js/wiki/How-to-test-Recalibration-locally%3F#without-development-server
* Test if you have the actual recalibration build:
  * Add 2 H1s in the content of a post. There should be a a problem in your SEO analysis result: `Single title: H1s should only be used as your main title. Find all H1s in your text that aren't your main title and change them to a lower heading level!`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/YoastSEO.js/issues/2100
