### PR TITLE
Add filters to handle custom post statuses when generating sitemap

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -584,7 +584,14 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		global $wpdb;
 
 		$join   = '';
-		$status = "{$wpdb->posts}.post_status = 'publish'";
+		/**
+		 * Filter post status list for sitemap query for the post type.
+		 *
+		 * @param Array $post_status_names      Post status list, defaults to array( 'publish' ).
+		 * @param string $post_type Post type name.
+		 */
+		$post_status_names = apply_filters( 'wpseo_sitemap_poststatus' , array( 'publish' ), $post_type );
+		$status = "{$wpdb->posts}.post_status IN ('" . implode( "','", $post_status_names ) . "')";
 
 		// Based on WP_Query->get_posts(). R.
 		if ( 'attachment' === $post_type ) {

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -591,7 +591,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 * @param string $post_type Post type name.
 		 */
 		$post_status_names = apply_filters( 'wpseo_sitemap_poststatus' , array( 'publish' ), $post_type );
-		$status = "{$wpdb->posts}.post_status IN ('" . implode( "','", $post_status_names ) . "')";
+		$status = "{$wpdb->posts}.post_status IN ('" . implode( "','", array_map( 'esc_sql', $post_status_names ) ) . "')";
 
 		// Based on WP_Query->get_posts(). R.
 		if ( 'attachment' === $post_type ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -504,7 +504,7 @@ class WPSEO_Sitemaps {
 				$sql = "
 				SELECT post_type, MAX(post_modified_gmt) AS date
 				FROM $wpdb->posts
-				WHERE post_status IN ('" . implode( "','", $post_status_names ) . "')
+				WHERE post_status IN ('" . implode( "','", array_map( 'esc_sql', $post_status_names ) ) . "')
 					AND post_type IN ('" . implode( "','", $post_type_names ) . "')
 				GROUP BY post_type
 				ORDER BY post_modified_gmt DESC

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -495,10 +495,16 @@ class WPSEO_Sitemaps {
 			$post_type_names = get_post_types( array( 'public' => true ) );
 
 			if ( ! empty( $post_type_names ) ) {
+				/**
+				 * Filter post status list for sitemap query for the post type.
+				 *
+				 * @param Array $post_status_names      Post status list, defaults to array( 'publish', 'inherit' ).
+				 */
+				$post_status_names = apply_filters( 'wpseo_sitemap_poststatus_lastmodified' , array( 'publish', 'inherit' ) );
 				$sql = "
 				SELECT post_type, MAX(post_modified_gmt) AS date
 				FROM $wpdb->posts
-				WHERE post_status IN ('publish','inherit')
+				WHERE post_status IN ('" . implode( "','", $post_status_names ) . "')
 					AND post_type IN ('" . implode( "','", $post_type_names ) . "')
 				GROUP BY post_type
 				ORDER BY post_modified_gmt DESC


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add filters to handle custom post statuses when generating sitemap


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Create a custom post type
2. Enable Edit Flow plugin or otherwise create custom post status for the custom post type
3. Create one or more posts with the custom post status - see that they do not appear in the sitemap.xml created by Yoast SEO
4. Add a filter for 'wpseo_sitemap_poststatus' and 'wpseo_sitemap_poststatus_lastmodified' to add the custom post status to the array of post status names.
5. See that the posts are now included in the sitemap.xml

## UI changes
* This PR does not change the UI in the plugin.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #12074
