### PR TITLE
Bump yoast components to 4.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.5",
+    "yoast-components": "^4.19.0",
     "yoastseo": "^1.46.0"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12611,9 +12611,10 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-"yoast-components@git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.5":
-  version "4.18.1"
-  resolved "git+https://github.com/Yoast/yoast-components.git#5813f5e644980aa1c6474cb1b86c44435d32170c"
+yoast-components@^4.19.0:
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.19.0.tgz#3f4e3761a90542f28b3d60d07b69cba20ce7adcc"
+  integrity sha512-fFAwSRVOCNyjtEvnaRcmNVVWOw5xNoXt1Vhakh/SbQDIzJuqtnimKSrytAx1Xvguxz+PPouHClph5uXsm9G2SQ==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -12635,7 +12636,7 @@ yauzl@^2.2.1:
     styled-components "^2.1.2"
     whatwg-fetch "^1.0.0"
     wicked-good-xpath "^1.3.0"
-    yoastseo "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.5"
+    yoastseo "^1.46.0"
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
@@ -12643,18 +12644,6 @@ yoastseo@^1.46.0:
   version "1.46.0"
   resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.46.0.tgz#59f23945dc79a0c18124a7be8965f7089b2a3639"
   integrity sha512-/hp/LQ/BPZtf8o/KFu9HxunnyIa/XpRoETdgCZCQ46mo1OKnGAOz+jiD8D3d+pn/7Wrxdfwz+egV5rhCcEvP3w==
-  dependencies:
-    "@wordpress/autop" "^2.0.2"
-    htmlparser2 "^3.9.2"
-    jed "^1.1.0"
-    lodash-es "^4.17.10"
-    loglevel "^1.6.1"
-    sassdash "0.9.0"
-    tokenizer2 "^2.0.1"
-
-"yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.5":
-  version "1.45.0"
-  resolved "git+https://github.com/Yoast/YoastSEO.js.git#767af2646d46cab03915cdd95893599f6eab6eb1"
   dependencies:
     "@wordpress/autop" "^2.0.2"
     htmlparser2 "^3.9.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Bump Yoast Components version to 4.19.0