### PR TITLE
Improve link to googlewebmastercentral.

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -97,7 +97,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		WPSEO_Meta::$meta_fields['advanced']['canonical']['description'] = sprintf(
 			/* translators: 1: link open tag; 2: link close tag. */
-			__( 'The canonical URL that this page should point to, leave empty to default to permalink. %1$sCross domain canonical%2$s supported too.', 'wordpress-seo' ),
+			__( 'The canonical URL that this page should point to. Leave empty to default to permalink. %1$sCross domain canonical%2$s supported too.', 'wordpress-seo' ),
 			'<a href="https://googlewebmastercentral.blogspot.com/2009/12/handling-legitimate-cross-domain.html" target="_blank" rel="noopener">',
 			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
 		);

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -94,8 +94,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		WPSEO_Meta::$meta_fields['advanced']['bctitle']['description'] = __( 'Title to use for this page in breadcrumb paths', 'wordpress-seo' );
 
 		WPSEO_Meta::$meta_fields['advanced']['canonical']['title'] = __( 'Canonical URL', 'wordpress-seo' );
-		/* translators: 1: link open tag; 2: link close tag. */
-		WPSEO_Meta::$meta_fields['advanced']['canonical']['description'] = sprintf( __( 'The canonical URL that this page should point to, leave empty to default to permalink. %1$sCross domain canonical%2$s supported too.', 'wordpress-seo' ), '<a target="_blank" href="http://googlewebmastercentral.blogspot.com/2009/12/handling-legitimate-cross-domain.html">', '</a>' );
+
+		WPSEO_Meta::$meta_fields['advanced']['canonical']['description'] = sprintf(
+			/* translators: 1: link open tag; 2: link close tag. */
+			__( 'The canonical URL that this page should point to, leave empty to default to permalink. %1$sCross domain canonical%2$s supported too.', 'wordpress-seo' ),
+			'<a href="https://googlewebmastercentral.blogspot.com/2009/12/handling-legitimate-cross-domain.html" target="_blank" rel="noopener">',
+			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
+		);
 
 		WPSEO_Meta::$meta_fields['advanced']['redirect']['title']       = __( '301 Redirect', 'wordpress-seo' );
 		WPSEO_Meta::$meta_fields['advanced']['redirect']['description'] = __( 'The URL that this page should redirect to.', 'wordpress-seo' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not userfacing] Improve link to googlewebmastercentral in the meta box advanced tab

## Relevant technical choices:

- adds rel=noopener
- changes http to https
- adds visually hidden message "Opens in a new browser tab"

## Test instructions
- go in the meta box > Advanced tab
- check the link "Cross domain canonical" is now `https`
- as this link uses `target="_blank"` and doesn't point to yoast.com, it needs a `rel="noopener"` attribute and a visually hidden message "Opens in a new browser tab", check it has those

<img width="702" alt="screenshot 2019-01-21 at 15 14 57" src="https://user-images.githubusercontent.com/1682452/51479807-a8bd0700-1d8f-11e9-84e4-c3adc53fe237.png">

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.



Fixes #12018
