### PR TITLE
Add option to make breadcrumbs a nav element.

### DIFF
--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -36,6 +36,24 @@ $yform->toggle_switch(
 	__( 'Bold the last page', 'wordpress-seo' )
 );
 
+$breadcrumbsnav_help = new WPSEO_Admin_Help_Panel(
+	'breadcrumbs-nav-wrapper',
+	esc_html__( 'Help on the breadcrumbs as navigation setting', 'wordpress-seo' ),
+	sprintf(
+		/* translators: %s expands to <code><nav></code> */
+		esc_html__( 'Wrap the breadcrumbs in a %s element for better semantics and accessibility.', 'wordpress-seo' ),
+		'<code>&lt;nav&gt;</code>'
+	)
+);
+
+$yform->light_switch(
+	'breadcrumbs-nav-wrapper',
+	__( 'Use breadcrumbs as navigation', 'wordpress-seo' ),
+	array(),
+	true,
+	$breadcrumbsnav_help->get_button_html() . $breadcrumbsnav_help->get_panel_html()
+);
+
 echo '<br/><br/>';
 
 /*

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -149,7 +149,7 @@ class WPSEO_Breadcrumbs {
 
 		// Override the before and after strings when breadcrumbs are set to be within a `<nav>` element.
 		if ( WPSEO_Options::get( 'breadcrumbs-nav-wrapper' ) === true ) {
-			$before = '<nav aria-label="' . __( 'Breadcrumbs', 'wordpress-seo' ) . '"' . self::get_output_id() . self::get_output_class() . '>';
+			$before = '<nav aria-label="' . __( 'Breadcrumbs', 'wordpress-seo' ) . '"' . $instance->get_output_id() . $instance->get_output_class() . '>';
 			$after  = '</nav>';
 		}
 
@@ -1009,7 +1009,7 @@ class WPSEO_Breadcrumbs {
 	 */
 	private function wrap_breadcrumb() {
 		if ( is_string( $this->output ) && $this->output !== '' ) {
-			$output = '<' . $this->wrapper . self::get_output_id() . self::get_output_class() . '>' . $this->output . '</' . $this->wrapper . '>';
+			$output = '<' . $this->wrapper . $this->get_output_id() . $this->get_output_class() . '>' . $this->output . '</' . $this->wrapper . '>';
 
 			// Don't print out the wrapper when breadcrumbs are within a `<nav>` element.
 			if ( WPSEO_Options::get( 'breadcrumbs-nav-wrapper' ) === true ) {
@@ -1036,7 +1036,7 @@ class WPSEO_Breadcrumbs {
 	 *
 	 * @return string
 	 */
-	private static function get_output_id() {
+	private function get_output_id() {
 		/**
 		 * Filter: 'wpseo_breadcrumb_output_id' - Allow changing the HTML ID on the Yoast SEO breadcrumbs wrapper element.
 		 *
@@ -1055,7 +1055,7 @@ class WPSEO_Breadcrumbs {
 	 *
 	 * @return string
 	 */
-	private static function get_output_class() {
+	private function get_output_class() {
 		/**
 		 * Filter: 'wpseo_breadcrumb_output_class' - Allow changing the HTML class on the Yoast SEO breadcrumbs wrapper element.
 		 *

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -146,7 +146,14 @@ class WPSEO_Breadcrumbs {
 		self::$after  = $after;
 
 		$instance = self::get_instance();
-		$output   = $before . $instance->output . $after;
+
+		// Override the before and after strings when breadcrumbs are set to be within a `<nav>` element.
+		if ( WPSEO_Options::get( 'breadcrumbs-nav-wrapper' ) === true ) {
+			$before = '<nav aria-label="' . __( 'Breadcrumbs', 'wordpress-seo' ) . '"' . self::get_output_id() . self::get_output_class() . '>';
+			$after  = '</nav>';
+		}
+
+		$output = $before . $instance->output . $after;
 
 		if ( $display === true ) {
 			echo $output;
@@ -629,7 +636,7 @@ class WPSEO_Breadcrumbs {
 	private function add_crumbs_for_taxonomy() {
 		$term = $GLOBALS['wp_query']->get_queried_object();
 
-		// @todo adjust function name!!
+		// @todo adjust function name.
 		$this->maybe_add_preferred_term_parent_crumb( $term );
 
 		$this->maybe_add_term_parent_crumbs( $term );
@@ -958,7 +965,7 @@ class WPSEO_Breadcrumbs {
 					$inner_elm = 'strong';
 				}
 
-				$link_output .= '<' . $inner_elm . ' class="breadcrumb_last">' . $link['text'] . '</' . $inner_elm . '>';
+				$link_output .= '<' . $inner_elm . ' class="breadcrumb_last" aria-current="page">' . $link['text'] . '</' . $inner_elm . '>';
 				// This is the last element, now close all previous elements.
 				while ( $i > 0 ) {
 					$link_output .= '</' . $this->element . '>';
@@ -998,11 +1005,16 @@ class WPSEO_Breadcrumbs {
 	}
 
 	/**
-	 * Wrap a complete breadcrumb string in a Breadcrumb RDFA wrapper.
+	 * Wrap a complete breadcrumb string in a wrapper.
 	 */
 	private function wrap_breadcrumb() {
 		if ( is_string( $this->output ) && $this->output !== '' ) {
-			$output = '<' . $this->wrapper . $this->get_output_id() . $this->get_output_class() . '>' . $this->output . '</' . $this->wrapper . '>';
+			$output = '<' . $this->wrapper . self::get_output_id() . self::get_output_class() . '>' . $this->output . '</' . $this->wrapper . '>';
+
+			// Don't print out the wrapper when breadcrumbs are within a `<nav>` element.
+			if ( WPSEO_Options::get( 'breadcrumbs-nav-wrapper' ) === true ) {
+				$output = $this->output;
+			}
 
 			/**
 			 * Filter: 'wpseo_breadcrumb_output' - Allow changing the HTML output of the Yoast SEO breadcrumbs class.
@@ -1012,7 +1024,7 @@ class WPSEO_Breadcrumbs {
 			$output = apply_filters( 'wpseo_breadcrumb_output', $output );
 
 			if ( WPSEO_Options::get( 'breadcrumbs-prefix' ) !== '' ) {
-				$output = "\t" . WPSEO_Options::get( 'breadcrumbs-prefix' ) . "\n" . $output;
+				$output = "\t" . '<span class="breadcrumbs-prefix">' . WPSEO_Options::get( 'breadcrumbs-prefix' ) . "</span>\n" . $output;
 			}
 
 			$this->output = $output;
@@ -1024,7 +1036,7 @@ class WPSEO_Breadcrumbs {
 	 *
 	 * @return string
 	 */
-	private function get_output_id() {
+	private static function get_output_id() {
 		/**
 		 * Filter: 'wpseo_breadcrumb_output_id' - Allow changing the HTML ID on the Yoast SEO breadcrumbs wrapper element.
 		 *
@@ -1043,7 +1055,7 @@ class WPSEO_Breadcrumbs {
 	 *
 	 * @return string
 	 */
-	private function get_output_class() {
+	private static function get_output_class() {
 		/**
 		 * Filter: 'wpseo_breadcrumb_output_class' - Allow changing the HTML class on the Yoast SEO breadcrumbs wrapper element.
 		 *

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -58,6 +58,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'breadcrumbs-prefix'            => '', // Text field.
 		'breadcrumbs-searchprefix'      => '', // Text field.
 		'breadcrumbs-sep'               => '&raquo;', // Text field.
+		'breadcrumbs-nav-wrapper'       => false,
 
 		'website_name'                  => '',
 		'person_name'                   => '',
@@ -515,6 +516,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				 *  'breadcrumbs-display-blog-page'
 				 *  'breadcrumbs-boldlast'
 				 *  'breadcrumbs-enable'
+				 *  'breadcrumbs-nav-wrapper'
 				 *  'stripcategorybase'
 				 *  'is-media-purge-relevant'
 				 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add an option to make the Breadcrumbs contained in a `<nav>` element for better SEO, semantics, and accessibility.

## Relevant technical choices:
Things are a bit complicated in terms of backwards compatibility because the rendered markup depends on parameters e.g. the before / after and the filters. Also, there's the related shortcode to take into consideration.

To keep things simple, I've opted for adding an user option and _override the rendered markup_. I guess this would need to be discussed, any feedback welcome. I couldn't think of an alternate, reasonable, way to do it.

- adds an option to wrap the breadcrumbs in a `<nav>` element with an `aria-label` attribute
- adds `aria-current` to the active item
- adds a wrapper `<span>` to the prefix, as this text was rendered without an easy way to target it with CSS


## Test instructions

Add the breadcrumbs in the `single` template of your theme, following the example on https://kb.yoast.com/kb/implement-wordpress-seo-breadcrumbs/
```
if ( function_exists( 'yoast_breadcrumb' ) ) {
	yoast_breadcrumb( '<p id="breadcrumbs">', '</p>' );
}
```

Add the following quick'n dirty core in your theme's `functions.php` to test the filters for the ID and CSS class:
```
add_filter( 'wpseo_breadcrumb_output_class', 'myclass' );
add_filter( 'wpseo_breadcrumb_output_id', 'myid' );
function myclass() {
	return 'classfromtheme';
}
function myid() {
	return 'idfromtheme';
}
```

Add the shortcode in one of your posts:
`[wpseo_breadcrumb]`

- view the post
- before activating the option:
- check the breadcrumbs are wrapped in the `<p>` passed as parameter
- check the inner `<span>` wrapper has the ID and class added via filters
- check the last item has the `aria-current` attribute
- check also the breadcrumbs in the post content added via the shortcode

Then, go in Search Appearance > Breadcrumbs and enable the "Use breadcrumbs as navigation" option
- refresh the post
- check the breadcrumbs are now within a `<nav>` element
- the `<nav>` element has the ID and class added via filters
- it also has `aria-label="Breadcrumbs"`
- the inner `<span>` wrapper is removed
- check the last item has the `aria-current` attribute

Note: also the breadcrumbs in the content added via the shortcode are now within a `<nav>` element. One one hand, users set an option so this would be expected. On the other hand, we can't predict where the shortcode will be placed into the content so there might be edge cases where layout is affected. Any suggestions welcome.

As said, with the option enabled the `$before`, $after, and the `wpseo_breadcrumb_output_wrapper` filter won't have any effect. I guess this should be documented somewhere.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #6728 
