### PR TITLE
Implement fail-over for `allow_url_fopen` disabled servers

### DIFF
--- a/admin/class-admin-asset-analysis-worker-location.php
+++ b/admin/class-admin-asset-analysis-worker-location.php
@@ -34,7 +34,7 @@ final class WPSEO_Admin_Asset_Analysis_Worker_Location implements WPSEO_Admin_As
 
 		$analysis_worker = 'wp-seo-' . $name . '-' . $flat_version;
 		if ( $name === 'analysis-worker' && WPSEO_Recalibration_Beta::is_enabled() ) {
-			$analysis_worker = plugin_dir_url( WPSEO_FILE ) . 'admin/my-yoast-proxy.php?file=research-webworker';
+			$analysis_worker = plugin_dir_url( WPSEO_FILE ) . 'admin/my-yoast-proxy.php?file=research-webworker&plugin_version=' . $flat_version . '&suffix=' . WPSEO_CSSJS_SUFFIX;
 		}
 
 		$this->asset_location = WPSEO_Admin_Asset_Manager::create_default_location();

--- a/admin/class-admin-asset-analysis-worker-location.php
+++ b/admin/class-admin-asset-analysis-worker-location.php
@@ -34,7 +34,15 @@ final class WPSEO_Admin_Asset_Analysis_Worker_Location implements WPSEO_Admin_As
 
 		$analysis_worker = 'wp-seo-' . $name . '-' . $flat_version;
 		if ( $name === 'analysis-worker' && WPSEO_Recalibration_Beta::is_enabled() ) {
-			$analysis_worker = plugin_dir_url( WPSEO_FILE ) . 'admin/my-yoast-proxy.php?file=research-webworker&plugin_version=' . $flat_version . '&suffix=' . WPSEO_CSSJS_SUFFIX;
+			/*
+			 * Using a flag to determine whether the local file or the proxy is used.
+			 * This is for the recalibration development.
+			 */
+			if ( WPSEO_Recalibration_Beta::use_local_file() ) {
+				$analysis_worker = 'wp-seo-' . $name . '-recalibration-' . $flat_version;
+			} else {
+				$analysis_worker = plugin_dir_url( WPSEO_FILE ) . 'admin/my-yoast-proxy.php?file=research-webworker&plugin_version=' . $flat_version . '&suffix=' . WPSEO_CSSJS_SUFFIX;
+			}
 		}
 
 		$this->asset_location = WPSEO_Admin_Asset_Manager::create_default_location();

--- a/admin/class-recalibration-beta.php
+++ b/admin/class-recalibration-beta.php
@@ -135,7 +135,7 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	 * @return bool Whether the local file should be used.
 	 */
 	public static function use_local_file() {
-		return defined( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE' );
+		return defined( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE' ) && YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE;
 	}
 
 	/**

--- a/admin/class-recalibration-beta.php
+++ b/admin/class-recalibration-beta.php
@@ -128,6 +128,17 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	}
 
 	/**
+	 * Checks if the recalibration beta should use the local file.
+	 *
+	 * If false, the my-yoast-proxy should be used.
+	 *
+	 * @return bool Whether the local file should be used.
+	 */
+	public static function use_local_file() {
+		return defined( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE' );
+	}
+
+	/**
 	 * Checks if the user has a mailinglist subscription.
 	 *
 	 * @codeCoverageIgnore Reason: because it calls a WordPress function.

--- a/admin/my-yoast-proxy.php
+++ b/admin/my-yoast-proxy.php
@@ -15,12 +15,38 @@ switch ( filter_input( INPUT_GET, 'file', FILTER_SANITIZE_STRING ) ) {
 }
 
 if ( empty( $my_yoast_url ) ) {
+	header( 'HTTP/1.0 501 Requested file not implemented' );
 	exit;
 }
 
-header( 'Content-Type: ' . $my_yoast_url_content_type );
-header( 'Cache-Control: max-age=86400' );
+if ( ini_get('allow_url_fopen' ) ) {
+	header( 'Content-Type: ' . $my_yoast_url_content_type );
+	header( 'Cache-Control: max-age=86400' );
+	readfile( $my_yoast_url );
+	exit;
+}
 
-readfile( $my_yoast_url );
+// Try to load WordPress, to be able to use `wp_remote_get`.
+if ( ! is_file( $_SERVER['DOCUMENT_ROOT'] . '/wp-load.php' ) ) {
+	header( 'HTTP/1.0 500 Server configuration not compatible' );
+	exit;
+}
+
+require $_SERVER['DOCUMENT_ROOT'] . '/wp-load.php';
+
+$content = wp_remote_get( $my_yoast_url );
+if ( $content instanceof WP_Error ) {
+	header( 'HTTP/1.0 500 Unable to retrieve file from MyYoast' );
+	exit;
+}
+
+$status_code = $content['http_response']->get_status();
+if ( $status_code === 200 ) {
+	header( 'Content-Type: ' . $my_yoast_url_content_type );
+	header( 'Cache-Control: max-age=86400' );
+	echo $content['body'];
+}
+
+header( 'HTTP/1.0 500 Recieved unexpected response from MyYoast' );
 
 exit;

--- a/admin/my-yoast-proxy.php
+++ b/admin/my-yoast-proxy.php
@@ -33,6 +33,10 @@ $target = ini_get('allow_url_fopen' ) ? $my_yoast_url : $local_file;
 
 header( 'Content-Type: ' . $request_content_type );
 header( 'Cache-Control: max-age=86400' );
-readfile( $target );
+
+if ( readfile( $target ) === false ) {
+	header_remove();
+	header( 'HTTP/1.0 500 External server error' );
+};
 
 exit;

--- a/admin/my-yoast-proxy.php
+++ b/admin/my-yoast-proxy.php
@@ -7,7 +7,9 @@
  * @package WPSEO\Admin
  */
 
-$plugin_version = filter_input( INPUT_GET, 'plugin_version', FILTER_SANITIZE_NUMBER_INT );
+$plugin_version = filter_input( INPUT_GET, 'plugin_version', FILTER_SANITIZE_STRING );
+// Replace slashes to secure against requiring a file from another path.
+$plugin_version = str_replace( array( '/', '\\' ), '_', $plugin_version );
 
 $suffix = filter_input( INPUT_GET, 'suffix', FILTER_SANITIZE_STRING );
 if ( $suffix !== '.min' ) {

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -122,7 +122,8 @@ release:
 # Run the steps to deploy a new recalibration version.
 'deploy:recalibration':
   - 'update-recalibration'
-  - 'webpack:recalibration'
+  - 'clean:build-assets-js'
+  - 'release:js'
   - 'publish-recalibration'
 
 # Default task

--- a/grunt/config/webpack.js
+++ b/grunt/config/webpack.js
@@ -2,7 +2,6 @@
 const webpackConfig = require( "../../webpack/webpack.config" );
 
 module.exports = {
-	buildDev: webpackConfig( { environment: "development" } ),
-	buildProd: webpackConfig(),
-	recalibration: webpackConfig( { recalibration: "enabled" } ),
+	buildDev: () => webpackConfig( { environment: "development" } ),
+	buildProd: () => webpackConfig(),
 };

--- a/package.json
+++ b/package.json
@@ -18,12 +18,10 @@
   "scripts": {
     "test": "jest",
     "build": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --progress",
-    "build-recalibration": "yarn build --env.recalibration=enabled",
     "webpack-analyze-bundle": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json js/dist",
     "i18n-yoast-components": "cross-env NODE_ENV=production babel node_modules/yoast-components --ignore node_modules/yoast-components/node_modules,tests/*Test.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",
-    "start": "grunt build:css && grunt webpack:buildDev && webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
-    "start-recalibration": "yarn start --env.recalibration=enabled"
+    "start": "grunt build:css && grunt webpack:buildDev && webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/js/tests/setupTests.js",

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -31,9 +31,23 @@ const externals = {
 	lodash: "window.lodash",
 };
 
-module.exports = function( env = { environment: "production", recalibration: "disabled" } ) {
+/**
+ * Helper function to get the Webpack Define plugin with an optional recalibration flag.
+ *
+ * @param {boolean} isRecalibration Whether or not the recalibration is enabled.
+ *
+ * @returns {webpack.DefinePlugin|DefinePlugin} The define plugin.
+ */
+function getDefinePlugin( isRecalibration = false ) {
+	return new webpack.DefinePlugin( {
+		"process.env": {
+			YOAST_RECALIBRATION: JSON.stringify( isRecalibration ? "enabled" : "disabled" ),
+		},
+	} );
+}
+
+module.exports = function( env = { environment: "production" } ) {
 	const mode = env.environment || process.env.NODE_ENV || "production";
-	const isRecalibration = ( env.recalibration || process.env.YOAST_RECALIBRATION || "disabled" ) === "enabled";
 
 	const outputFilenameMinified = "[name]-" + pluginVersionSlug + ".min.js";
 	const outputFilenameUnminified = "[name]-" + pluginVersionSlug + ".js";
@@ -41,11 +55,6 @@ module.exports = function( env = { environment: "production", recalibration: "di
 	const outputFilename = mode === "development" ? outputFilenameUnminified : outputFilenameMinified;
 
 	const plugins = [
-		new webpack.DefinePlugin( {
-			"process.env": {
-				YOAST_RECALIBRATION: JSON.stringify( isRecalibration ? "enabled" : "disabled" ),
-			},
-		} ),
 		new CaseSensitivePathsPlugin(),
 	];
 
@@ -101,164 +110,154 @@ module.exports = function( env = { environment: "production", recalibration: "di
 		},
 	};
 
-	let config;
-
-	/*
-	 * When using recalibration in the production build:
-	 *
-	 * The only output should be files that use the analysis:
-	 * - Analysis Worker
-	 * - Analysis
-	 */
-	if ( isRecalibration && mode === "production" ) {
-		config = [
-			// Analysis web worker.
-			{
-				...base,
-				entry: {
-					"wp-seo-analysis-worker": "./js/src/wp-seo-analysis-worker.js",
-				},
-				optimization: {
-					runtimeChunk: false,
-				},
-				plugins,
+	const config = [
+		{
+			...base,
+			entry: {
+				...mainEntry,
+				"styled-components": "./js/src/styled-components.js",
+				analysis: "./js/src/analysis.js",
+				components: "./js/src/components.js",
 			},
-			// Analysis that is used as external (`window.yoastseo`).
-			{
-				...base,
-				entry: {
-					analysis: "./js/src/analysis.js",
-				},
-				plugins,
+			externals: {
+				...externals,
+
+				"@wordpress/element": "window.wp.element",
+				"@wordpress/data": "window.wp.data",
+				"@wordpress/components": "window.wp.components",
+				"@wordpress/i18n": "window.wp.i18n",
+				"@wordpress/api-fetch": "window.wp.apiFetch",
+				"@wordpress/rich-text": "window.wp.richText",
+				"@wordpress/compose": "window.wp.compose",
+
+				"styled-components": "window.yoast.styledComponents",
 			},
-		];
-	} else {
-		config = [
-			{
-				...base,
-				entry: {
-					...mainEntry,
-					"styled-components": "./js/src/styled-components.js",
-					analysis: "./js/src/analysis.js",
-					components: "./js/src/components.js",
-				},
-				externals: {
-					...externals,
-
-					"@wordpress/element": "window.wp.element",
-					"@wordpress/data": "window.wp.data",
-					"@wordpress/components": "window.wp.components",
-					"@wordpress/i18n": "window.wp.i18n",
-					"@wordpress/api-fetch": "window.wp.apiFetch",
-					"@wordpress/rich-text": "window.wp.richText",
-					"@wordpress/compose": "window.wp.compose",
-
-					"styled-components": "window.yoast.styledComponents",
-				},
-				plugins: [
-					...plugins,
-					new CopyWebpackPlugin( [
-						{
-							from: "node_modules/react/umd/react.production.min.js",
-							// Relative to js/dist.
-							to: "../vendor/react.min.js",
-						},
-						{
-							from: "node_modules/react-dom/umd/react-dom.production.min.js",
-							// Relative to js/dist.
-							to: "../vendor/react-dom.min.js",
-						},
-					] ),
-				],
-			},
-			// Config for wp packages files that are shipped for BC with WP 4.9.
-			{
-				...base,
-				externals: {
-					tinymce: "tinymce",
-
-					react: "React",
-					"react-dom": "ReactDOM",
-
-					lodash: "lodash",
-
-					"@wordpress/element": [ "wp", "element" ],
-					"@wordpress/data": [ "wp", "data" ],
-					"@wordpress/components": [ "wp",  "components" ],
-					"@wordpress/i18n": [ "wp", "i18n" ],
-					"@wordpress/api-fetch": [ "wp", "apiFetch" ],
-					"@wordpress/rich-text": [ "wp", "richText" ],
-					"@wordpress/compose": [ "wp", "compose" ],
-				},
-				output: {
-					path: paths.jsDist,
-					filename: "wp-" + outputFilenameMinified,
-					jsonpFunction: "yoastWebpackJsonp",
-					library: {
-						root: [ "wp", "[name]" ],
+			plugins: [
+				...plugins,
+				getDefinePlugin( false ),
+				new CopyWebpackPlugin( [
+					{
+						from: "node_modules/react/umd/react.production.min.js",
+						// Relative to js/dist.
+						to: "../vendor/react.min.js",
 					},
-					libraryTarget: "this",
-				},
-				entry: {
-					apiFetch: "./node_modules/@wordpress/api-fetch",
-					components: "./node_modules/@wordpress/components",
-					data: "./node_modules/@wordpress/data",
-					element: "./node_modules/@wordpress/element",
-					i18n: "./node_modules/@wordpress/i18n",
-					compose: "./node_modules/@wordpress/compose",
-					richText: "./node_modules/@wordpress/rich-text",
-				},
-				plugins,
-				optimization: {
-					runtimeChunk: false,
-				},
+					{
+						from: "node_modules/react-dom/umd/react-dom.production.min.js",
+						// Relative to js/dist.
+						to: "../vendor/react-dom.min.js",
+					},
+				] ),
+			],
+		},
+		// Config for wp packages files that are shipped for BC with WP 4.9.
+		{
+			...base,
+			externals: {
+				tinymce: "tinymce",
+
+				react: "React",
+				"react-dom": "ReactDOM",
+
+				lodash: "lodash",
+
+				"@wordpress/element": [ "wp", "element" ],
+				"@wordpress/data": [ "wp", "data" ],
+				"@wordpress/components": [ "wp",  "components" ],
+				"@wordpress/i18n": [ "wp", "i18n" ],
+				"@wordpress/api-fetch": [ "wp", "apiFetch" ],
+				"@wordpress/rich-text": [ "wp", "richText" ],
+				"@wordpress/compose": [ "wp", "compose" ],
 			},
-			// Config for files that should not use any externals at all.
-			{
-				...base,
-				output: {
-					path: paths.jsDist,
-					filename: outputFilenameMinified,
-					jsonpFunction: "yoastWebpackJsonp",
+			output: {
+				path: paths.jsDist,
+				filename: "wp-" + outputFilenameMinified,
+				jsonpFunction: "yoastWebpackJsonp",
+				library: {
+					root: [ "wp", "[name]" ],
 				},
-				entry: {
-					"babel-polyfill": "./js/src/babel-polyfill.js",
-				},
-				plugins,
-				optimization: {
-					runtimeChunk: false,
-				},
+				libraryTarget: "this",
 			},
-			// Config for the analysis web worker.
-			{
-				...base,
-				output: {
-					path: paths.jsDist,
-					filename: outputFilename,
-					jsonpFunction: "yoastWebpackJsonp",
-				},
-				entry: {
-					"wp-seo-analysis-worker": "./js/src/wp-seo-analysis-worker.js",
-				},
-				plugins,
-				optimization: {
-					runtimeChunk: false,
-				},
+			entry: {
+				apiFetch: "./node_modules/@wordpress/api-fetch",
+				components: "./node_modules/@wordpress/components",
+				data: "./node_modules/@wordpress/data",
+				element: "./node_modules/@wordpress/element",
+				i18n: "./node_modules/@wordpress/i18n",
+				compose: "./node_modules/@wordpress/compose",
+				richText: "./node_modules/@wordpress/rich-text",
 			},
-			// Config for files that should only use externals available in the web worker context.
-			{
-				...base,
-				externals: { yoastseo: "yoast.analysis" },
-				entry: {
-					"wp-seo-used-keywords-assessment": "./js/src/wp-seo-used-keywords-assessment.js",
-				},
-				plugins,
-				optimization: {
-					runtimeChunk: false,
-				},
+			plugins,
+			optimization: {
+				runtimeChunk: false,
 			},
-		];
-	}
+		},
+		// Config for files that should not use any externals at all.
+		{
+			...base,
+			output: {
+				path: paths.jsDist,
+				filename: outputFilenameMinified,
+				jsonpFunction: "yoastWebpackJsonp",
+			},
+			entry: {
+				"babel-polyfill": "./js/src/babel-polyfill.js",
+			},
+			plugins,
+			optimization: {
+				runtimeChunk: false,
+			},
+		},
+		// Config for the analysis web worker.
+		{
+			...base,
+			output: {
+				path: paths.jsDist,
+				filename: outputFilename,
+				jsonpFunction: "yoastWebpackJsonp",
+			},
+			entry: {
+				"wp-seo-analysis-worker": "./js/src/wp-seo-analysis-worker.js",
+			},
+			plugins: [
+				...plugins,
+				getDefinePlugin( false ),
+			],
+			optimization: {
+				runtimeChunk: false,
+			},
+		},
+		// Config for the analysis web worker with recalibration enabled.
+		{
+			...base,
+			output: {
+				path: paths.jsDist,
+				filename: outputFilename,
+				jsonpFunction: "yoastWebpackJsonp",
+			},
+			entry: {
+				"wp-seo-analysis-worker-recalibration": "./js/src/wp-seo-analysis-worker.js",
+			},
+			plugins: [
+				...plugins,
+				getDefinePlugin( true ),
+			],
+			optimization: {
+				runtimeChunk: false,
+			},
+		},
+		// Config for files that should only use externals available in the web worker context.
+		{
+			...base,
+			externals: { yoastseo: "yoast.analysis" },
+			entry: {
+				"wp-seo-used-keywords-assessment": "./js/src/wp-seo-used-keywords-assessment.js",
+			},
+			plugins,
+			optimization: {
+				runtimeChunk: false,
+			},
+		},
+	];
 
 	if ( mode === "development" ) {
 		config[ 0 ].devServer = {

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,6 +1,6 @@
 const webpack = require( "webpack" );
 const CaseSensitivePathsPlugin = require( "case-sensitive-paths-webpack-plugin" );
-const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
+const CopyWebpackPlugin = require( "copy-webpack-plugin" );
 const path = require( "path" );
 const mapValues = require( "lodash/mapValues" );
 const isString = require( "lodash/isString" );
@@ -32,17 +32,18 @@ const externals = {
 };
 
 /**
- * Helper function to get the Webpack Define plugin with an optional recalibration flag.
+ * Helper function for setting the user environment (in this Node process only) using a Webpack plugin.
  *
- * @param {boolean} isRecalibration Whether or not the recalibration is enabled.
+ * @see https://webpack.js.org/plugins/define-plugin/
+ * @see https://nodejs.org/api/all.html#process_process_env
+ *
+ * @param {Object} variableDefinitions The user environment variables to set and their values.
  *
  * @returns {webpack.DefinePlugin|DefinePlugin} The define plugin.
  */
-function getDefinePlugin( isRecalibration = false ) {
+function environmentVariablePlugin( variableDefinitions ) {
 	return new webpack.DefinePlugin( {
-		"process.env": {
-			YOAST_RECALIBRATION: JSON.stringify( isRecalibration ? "enabled" : "disabled" ),
-		},
+		"process.env": variableDefinitions,
 	} );
 }
 
@@ -134,7 +135,7 @@ module.exports = function( env = { environment: "production" } ) {
 			},
 			plugins: [
 				...plugins,
-				getDefinePlugin( false ),
+				environmentVariablePlugin( { YOAST_RECALIBRATION: '"disabled"' } ),
 				new CopyWebpackPlugin( [
 					{
 						from: "node_modules/react/umd/react.production.min.js",
@@ -220,7 +221,7 @@ module.exports = function( env = { environment: "production" } ) {
 			},
 			plugins: [
 				...plugins,
-				getDefinePlugin( false ),
+				environmentVariablePlugin( { YOAST_RECALIBRATION: '"disabled"' } ),
 			],
 			optimization: {
 				runtimeChunk: false,
@@ -239,7 +240,7 @@ module.exports = function( env = { environment: "production" } ) {
 			},
 			plugins: [
 				...plugins,
-				getDefinePlugin( true ),
+				environmentVariablePlugin( { YOAST_RECALIBRATION: '"enabled"' } ),
 			],
 			optimization: {
 				runtimeChunk: false,


### PR DESCRIPTION
# DO NOT MERGE
See https://github.com/Yoast/wordpress-seo/pull/12085#issuecomment-457097963

~Load WordPress to use `wp_remote_get` when the PHP `allow_url_fopen` configuration is set to `Off`.
This allows those servers to load the file from MyYoast.
For servers which don't have this configuration, it saves a lot of trees to directly load the URL from MyYoast skipping the load of entire WordPress.~
Load from the zipped recalibration file when the PHP `allow_url_fopen` configuration is set to `Off`.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes the Recalibration Beta to be loaded on specific server configurations.

## Technical decisions
* Added the `plugin_version` to the request, as we provide this to the script to be able to load the local file correctly, also adding this to the MyYoast request will allow us to have more control over the recalibration version we return for specific plugin versions.
* When the server does not support `allow_url_fopen` we cannot load the file from MyYoast, when this is the case we want to load the file from the plugin. This file will not be updated automatically, but the functionality will be available. For this to be implemented, we need to build the recalibration file and ship it in the zip.
* Build the recalibration beta JavaScript file in the `js/dist/` folder, so it can be used as fallback. The filename is `wp-seo-analysis-worker-recalibration-{version}{suffix}.js`. Where version is the Plugin version and suffix is `.min` or nothing.
* Add WordPress flag (`YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE`) to skip the recalibration beta proxy and use the local file instead. This is meant for local development.
* When using the webpack development server, in combination with a server that does not support `allow_url_fopen`, the proxy will fail. This is because the webpack development server does not write actual files, and the fallback is trying to serve an actual file. The developer should then use the `YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE` flag.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Configure `allow_url_fopen` to be set to `Off` in `/etc/php/7.2/fpm/php.ini` (on Vagrant)
* Use `sudo service php7.2-fpm restart` to restart PHP (and apply the configuration change)
* Load an edit page with the recalibration enabled
* See the spinners keeping spinning without this PR
* The readability and SEO analysis should work when using this PR

### Test the different build possibilities.
#### Production
* Build it:
```bash
composer install --no-dev
yarn
grunt release
```
* Remove the local file flag by removing `define( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE', true );` from `wp-config.php`. Or changing the `true` to `false`.
* Ensure the recalibration beta is enabled.
* Open the developer console on the network tab and filter for `worker`.
* *Ensure* the network request is via the proxy: `my-yoast-proxy.php?file=research-webworker&plugin_version=950&suffix=.min`.
* Add the local file flag by adding `define( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE', true );` to `wp-config.php`.
* Refresh the page.
* **Ensure** the network request is local: `wp-seo-analysis-worker-recalibration-950.min.js`. Specifically the `.min`, which indicates the production bit.

#### Development
* Build it:
```bash
composer install
yarn
grunt build
```
* Remove the local file flag by removing `define( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE', true );` from `wp-config.php`. Or changing the `true` to `false`.
* Ensure the recalibration beta is enabled.
* Open the developer console on the network tab and filter for `worker`.
* *Ensure* the network request is via the proxy: `my-yoast-proxy.php?file=research-webworker&plugin_version=950&suffix=`.
* Add the local file flag by adding `define( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE', true );` to `wp-config.php`.
* Refresh the page.
* **Ensure** the network request is local: `wp-seo-analysis-worker-recalibration-950.js`. Notice the lack of `.min`.

##### Webpack development server
* Build it:
```bash
composer install
yarn
yarn start
```
* Add the local file flag by adding `define( 'YOAST_SEO_RECALIBRATION_USE_LOCAL_FILE', true );` to `wp-config.php`.
* Add the development server flag by adding `define( 'YOAST_SEO_DEV_SERVER', true );` to `wp-config.php`.
* Ensure the recalibration beta is enabled.
* Open the developer console on the network tab and filter for `worker`.
* **Ensure** the network request is from the localhost: `http://localhost:8080/wp-seo-analysis-worker-recalibration-950.js`. Notice the lack of `.min`.

## UI changes
* [ ] ~This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #12032 
