### PR TITLE
Add the SEO score text to the admin bar icon.

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -603,7 +603,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$score_class        = WPSEO_Utils::translate_score( $score );
 		$translated_score   = WPSEO_Utils::translate_score( $score, false );
 		/* translators: %s expands to the SEO score. */
-		$screen_reader_text = sprintf( __( 'SEO score: %s' ), $translated_score );
+		$screen_reader_text = sprintf( __( 'SEO score: %s', 'wordpress-seo' ), $translated_score );
 
 		$score_adminbar_element = '<div class="wpseo-score-icon adminbar-seo-score ' . $score_class . '"><span class="adminbar-seo-score-text screen-reader-text">' . $screen_reader_text . '</span></div>';
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -600,9 +600,12 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Score markup.
 	 */
 	protected function get_score( $score ) {
-		$score = WPSEO_Utils::translate_score( $score );
+		$score_class        = WPSEO_Utils::translate_score( $score );
+		$translated_score   = WPSEO_Utils::translate_score( $score, false );
+		/* translators: %s expands to the SEO score. */
+		$screen_reader_text = sprintf( __( 'SEO score: %s' ), $translated_score );
 
-		$score_adminbar_element = '<div class="wpseo-score-icon adminbar-seo-score ' . $score . '"><span class="adminbar-seo-score-text screen-reader-text"></span></div>';
+		$score_adminbar_element = '<div class="wpseo-score-icon adminbar-seo-score ' . $score_class . '"><span class="adminbar-seo-score-text screen-reader-text">' . $screen_reader_text . '</span></div>';
 
 		return $score_adminbar_element;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user facing] Add missing screen reader text to the SEO score icon in the front end

## Relevant technical choices:

This PR fixes the last part of #5145, the other parts have already been addressed with the refactoring of the admin bar menu in #9944.

- uses the translated score to build a string `SEO score: %s`
- in the front end, the score icon will use this string 
- in the admin this string will be used only initially on page load: when the analysis kicks in, it will replace the screen reader text on the fly

## Test instructions
- preview posts with different SEO scores
- verify the SEO score icon in the admin bar has a hidden screen reader text with the string `SEO score: %s` where `%s` is of course replaced with the actual score

Note: there's a bit of inconsistency across all the strings used for the scores. Some of them come from YoastSEO.js and still use "Bad" while we're now using "Needs improvements". Will create an issue.

Fixes #5145
