### PR TITLE
Make sure we are in The Loop state

### DIFF
--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -115,9 +115,24 @@ class WPSEO_Link_Watcher {
 	 * @return void
 	 */
 	private function process( $post_id, $content ) {
+		global $post, $id, $authordata, $currentday, $currentmonth, $page, $pages, $multipage, $more, $numpages;
+
+		// Store the data of the global variables, so we can reset them calling the_content.
+		$stored = compact( 'post', 'id', 'authordata', 'currentday', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages' );
+
+		// Setup the post, to make sure filters can handle it as if we are in the loop.
+		$post = get_post( $post_id );
+		setup_postdata( $post_id );
+
 		// Apply the filters to have the same content as shown on the frontend.
 		$content = apply_filters( 'the_content', $content );
 		$content = str_replace( ']]>', ']]&gt;', $content );
+
+		/*
+		 * Not using `wp_reset_postdata` because we don't know if we are in The Loop because this can be called in the admin or during CLI.
+		 * Reset the global variables to what they were before setting up the postdata.
+		 */
+		extract( $stored, EXTR_OVERWRITE );
 
 		$this->content_processor->process( $post_id, $content );
 	}


### PR DESCRIPTION
🚧 In discussion, **DO NOT MERGE** 🚧 

As `the_content` filter should assume we are in the loop, and can call global functions, we need to prepare the environment to act that way.

Because WordPress backend does not use The Loop, we need to restore the set globals to their previous state, instead of doing a `wp_reset_postdata`.

## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Sets up the post data, to make sure filters can use the environment as if we are in the loop.

## Relevant technical choices:

* Store and restore global variables as `wp_reset_postdata` will leave the system in a different state than before. This _might_ cause unwanted side-effects.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] ~This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #11395 
