### PR TITLE
Add aria-current to the breadcrumbs active item.

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -629,7 +629,7 @@ class WPSEO_Breadcrumbs {
 	private function add_crumbs_for_taxonomy() {
 		$term = $GLOBALS['wp_query']->get_queried_object();
 
-		// @todo adjust function name!!
+		// @todo adjust function name.
 		$this->maybe_add_preferred_term_parent_crumb( $term );
 
 		$this->maybe_add_term_parent_crumbs( $term );
@@ -958,7 +958,7 @@ class WPSEO_Breadcrumbs {
 					$inner_elm = 'strong';
 				}
 
-				$link_output .= '<' . $inner_elm . ' class="breadcrumb_last">' . $link['text'] . '</' . $inner_elm . '>';
+				$link_output .= '<' . $inner_elm . ' class="breadcrumb_last" aria-current="page">' . $link['text'] . '</' . $inner_elm . '>';
 				// This is the last element, now close all previous elements.
 				while ( $i > 0 ) {
 					$link_output .= '</' . $this->element . '>';
@@ -998,7 +998,7 @@ class WPSEO_Breadcrumbs {
 	}
 
 	/**
-	 * Wrap a complete breadcrumb string in a Breadcrumb RDFA wrapper.
+	 * Wrap a complete breadcrumb string in a wrapper.
 	 */
 	private function wrap_breadcrumb() {
 		if ( is_string( $this->output ) && $this->output !== '' ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve the breadcrumbs accessibility by adding `aria-current` to the active item

## Relevant technical choices:
- adds `aria-current` to the active item
- gets rid of a phpcs warning
- removes reference to RDFA from an old docblock 

## Test instructions
Add the breadcrumbs in the `single` template of your theme, following the example on https://kb.yoast.com/kb/implement-wordpress-seo-breadcrumbs/
```
if ( function_exists( 'yoast_breadcrumb' ) ) {
	yoast_breadcrumb( '<p id="breadcrumbs">', '</p>' );
}
```

Visit a single post page and verify the breadcrumbs active item as an `aria-current="page"` attribute

Fixes #12109 
