### PR TITLE
Add $taxonomy to the arguments passed to the `wpseo_terms` filter.

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1424,8 +1424,9 @@ class WPSEO_Replace_Vars {
 		 * Allows filtering of the terms list used to replace %%category%%, %%tag%% and %%ct_<custom-tax-name>%% variables.
 		 *
 		 * @api    string    $output    Comma-delimited string containing the terms.
+		 * @api    string    $taxonomy  The taxonomy of the terms.
 		 */
-		return apply_filters( 'wpseo_terms', $output );
+		return apply_filters( 'wpseo_terms', $output, $taxonomy );
 	}
 } /* End of class WPSEO_Replace_Vars */
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds `$taxonomy` to the arguments passed to the `wpseo_terms` filter. Props to [polevaultweb](https://github.com/polevaultweb)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Adds a filter:
```
add_filter( 'wpseo_terms', function( $output , $taxonomy ) {
   var_dump( $taxonomy); 

    return $output;
}, 10, 2 );
```
* On `trunk` the second argument isn't passed, so it should give a php warning/error
* On this branch it will print the taxonomy value. 

Fixes #12118
