### PR TITLE
Prepare for PHP 5.2-5.5 drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
+      env: WP_VERSION=latest PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
     - php: 7.3
-      env: WP_VERSION=5.0 WP_MULTISITE=1 COVERAGE=1
+      env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=5.0 PHPUNIT=1
+      env: WP_VERSION=latest PHPUNIT=1
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ jobs:
       dist: precise
       env: WP_VERSION=4.9 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
     - php: 7.3
-      env: WP_VERSION=master
+      env: WP_VERSION=master PHPUNIT=1
     - php: nightly
-      env: WP_VERSION=master
+      env: WP_VERSION=latest PHPUNIT=1
     - stage: 🚀 deployment
       name: "Deploy to S3"
       if: branch = deploy # Only build when on the `deploy` branch, this functionality is not used yet and is taking a long time to complete.

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ before_script:
   fi
 - PLUGIN_SLUG=$(basename $(pwd))
 - export WP_DEVELOP_DIR=/tmp/wordpress/
-- git clone --depth=50 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
+- git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
 - cd ..
 - cp -r "$PLUGIN_SLUG" "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
 - cd /tmp/wordpress/

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,22 +25,13 @@ jobs:
       env: WP_VERSION=5.0 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
     - php: 7.3
       env: WP_VERSION=5.0 WP_MULTISITE=1 COVERAGE=1
-    - php: 5.2
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1
-    - php: 5.3
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-      env: WP_VERSION=5.0
     - php: 5.6
-      env: WP_VERSION=5.0
-    - php: 7.0
-      env: WP_VERSION=5.0
       env: WP_VERSION=5.0 PHPUNIT=1
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
+      env: WP_VERSION=4.9 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
+    - php: 7.3
       env: WP_VERSION=master
     - php: nightly
       env: WP_VERSION=master
@@ -122,7 +113,7 @@ before_install:
   fi
 
 install:
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.6.13; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
 - |
   if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     composer remove humbug/php-scoper --dev --ignore-platform-reqs
@@ -136,7 +127,7 @@ install:
     composer install --no-dev --no-interaction --ignore-platform-reqs
   fi
 - composer dump-autoload
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local --unset; fi
 - |
   if [[ "$CHECKJS" == "1" ]]; then
     yarn global add grunt-cli
@@ -246,7 +237,7 @@ script:
   fi
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 
 after_script:
 - if [[ "$COVERAGE" == "1" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: xenial
+dist: trusty
 sudo: false
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: xenial
 sudo: false
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,8 +92,9 @@ jobs:
   allow_failures:
     # Allow failures for unstable builds.
     - php: nightly
-    - env: WP_VERSION=master
-
+      env: WP_VERSION=latest PHPUNIT=1
+    - php: 7.3
+      env: WP_VERSION=master PHPUNIT=1
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
-dist: trusty
+dist: xenial
 sudo: false
+
+services:
+  - mysql
 
 branches:
   only:
@@ -27,6 +30,8 @@ jobs:
       env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
     - php: 5.6
       env: WP_VERSION=latest PHPUNIT=1
+      # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
+      dist: trusty
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
       env: WP_VERSION=5.0
     - php: 7.0
       env: WP_VERSION=5.0
+      env: WP_VERSION=5.0 PHPUNIT=1
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
@@ -230,7 +231,7 @@ script:
   fi
 # PHP Unit
 - |
-  if [[ "$COVERAGE" != "1" ]]; then
+  if [[ "$PHPUNIT" == "1" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
     $PHPUNIT_BIN -c phpunit.xml
     travis_time_finish && travis_fold end "PHP.tests"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
 
 	<!-- Test namespaced classes only for PHP 5.3.0 and above -->
 	<testsuites>
-		<testsuite name="php53+">
-			<directory suffix="-test.php" phpVersion="5.3.0" phpVersionOperator=">=">./tests/src/</directory>
+		<testsuite name="php56+">
+			<directory suffix="-test.php" phpVersion="5.6.0" phpVersionOperator=">=">./tests/src/</directory>
 		</testsuite>
 	</testsuites>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,7 +20,7 @@
 		</testsuite>
 	</testsuites>
 
-	<!-- Test namespaced classes only for PHP 5.3.0 and above -->
+	<!-- Test namespaced classes only for PHP 5.6.0 and above -->
 	<testsuites>
 		<testsuite name="php56+">
 			<directory suffix="-test.php" phpVersion="5.6.0" phpVersionOperator=">=">./tests/src/</directory>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Optimizing the Travis builds to reduce the work that needs to be done before the checks pass

## Relevant technical choices:

**PHPUnit `/src/tests` PHP version requirements**
Instead of requiring PHP 5.3 we up the minimum required version for the tests to 5.6
This allows us to have one modern test suite next to the legacy test suite. Instead of having one for 5.2, 5.3 and 5.6+
This is also needed for preparation of the WordPress test mocking framework.

**Explicitly set PHPUNIT execution**
Instead of assuming that PHPUnit must be run when Coverage is not being run.
This will speed up the build because the 7.3 linting/phpcs build doesn't also have to run all the tests.

**Remove unwanted builds**
* Removing PHP 5.3 build
* Removing PHP 7.0 build
* Bumping the WordPress version to 4.9

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See the builds pass in Travis

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] ~I have tested this code to the best of my abilities~
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #12128 
