### PR TITLE
Fix replacevars in Snippet Editor for taxonomies.

### DIFF
--- a/js/src/helpers/taxonomy-replacevars.js
+++ b/js/src/helpers/taxonomy-replacevars.js
@@ -1,0 +1,133 @@
+import {
+	subscribe,
+	select,
+	dispatch,
+} from "@wordpress/data";
+import forEach from "lodash/forEach";
+
+function getPostType() {
+	return new Promise( resolve => {
+		let postType = select( "core/editor" ).getEditedPostAttribute( "type" );
+
+		if ( postType ) {
+			return resolve( postType );
+		}
+
+		const unsubscribe = subscribe( () => {
+			postType = select( "core/editor" ).getEditedPostAttribute( "type" );
+
+			if ( postType ) {
+				unsubscribe();
+
+				return resolve( postType );
+			}
+		} );
+	} );
+}
+
+function resolveGetEntityRecords( args ) {
+	return new Promise( resolve => {
+		const getEntityRecords = select( "core" ).getEntityRecords.bind( null, ...args );
+		const hasFinishedResolution = select( "core/data" ).hasFinishedResolution.bind( null, "core", "getEntityRecords", args );
+
+		const records = getEntityRecords();
+
+		if ( hasFinishedResolution() ) {
+			return resolve( records );
+		}
+
+		const unsubscribe = subscribe( () => {
+			if ( hasFinishedResolution() ) {
+				unsubscribe();
+
+				resolve( getEntityRecords() );
+			}
+		} );
+	} );
+}
+
+function getApplicableTaxonomies( postType ) {
+	const args = [ "root", "taxonomy", { type: postType } ];
+
+	return resolveGetEntityRecords( args );
+}
+
+function getTerms( taxonomy ) {
+	const args = [ "taxonomy", taxonomy.slug ];
+
+	return resolveGetEntityRecords( args );
+}
+
+class TaxonomyReplacementVariable {
+	constructor( taxonomy ) {
+		this.taxonomy  = taxonomy;
+		this.terms     = [];
+		this.isBuiltIn = [ "category", "tag" ].includes( taxonomy.slug );
+	}
+
+	updateReplacementVariable() {
+		const termIds = select( "core/editor" ).getEditedPostAttribute( this.taxonomy.rest_base );
+
+		const termNames = [];
+
+		forEach( termIds, termId => {
+			const term = this.terms.find( term => term.id === termId );
+
+			if ( ! term ) {
+				return;
+			}
+
+			termNames.push( term.name );
+		} );
+
+		const replacementVariableValue = termNames.join( ", " );
+		const replacementVariableName = this.isBuiltIn ? this.taxonomy.slug : `ct_${ this.taxonomy.slug }`;
+
+		dispatch( "yoast-seo/editor" ).updateReplacementVariable( replacementVariableName, replacementVariableValue );
+	}
+
+	listenForTermChanges() {
+		subscribe( () => {
+			const nextTermIds = select( "core/editor" ).getEditedPostAttribute( this.taxonomy.rest_base );
+			if ( this.termIds !== nextTermIds ) {
+				this.termIds = nextTermIds;
+
+				this.updateReplacementVariable();
+			}
+		} );
+	}
+
+	listen() {
+		getTerms( this.taxonomy ).then( terms => {
+			this.terms = terms;
+			this.updateReplacementVariable();
+			this.listenForTermChanges();
+		} );
+	}
+}
+
+/**
+ * Handles all taxonomy replacement variables.
+ */
+class TaxonomyReplacementVariables {
+	constructor() {
+		this.taxonomies = [];
+		this.terms = {};
+	}
+
+	listen() {
+		// Make sure taxonomy resolution has started.
+		getPostType().then( postType => {
+			return getApplicableTaxonomies( postType );
+		} ).then( taxonomies => {
+			this.taxonomies = taxonomies;
+
+			forEach( taxonomies, taxonomy => {
+				const listener = new TaxonomyReplacementVariable( taxonomy );
+				listener.listen();
+			} );
+		} );
+	}
+}
+
+export default TaxonomyReplacementVariables;

--- a/js/src/helpers/taxonomy-replacevars.js
+++ b/js/src/helpers/taxonomy-replacevars.js
@@ -115,6 +115,11 @@ class TaxonomyReplacementVariable {
 		forEach( termIds, termId => {
 			const term = this.terms.find( currentTerm => currentTerm.id === termId );
 
+			/**
+			 * If a term cannot be found it is most likely because a new term has been added through the gutenberg interface.
+			 * In order to get a new list of terms we should invalidate the resolution of terms. In this.haveTermsChanged
+			 * we check for a new list of terms being retrieved, and if so we call this.updateReplacementVariable again.
+			 */
 			if ( ! term ) {
 				/* eslint-disable-next-line camelcase */
 				dispatch( "core/data" ).invalidateResolution( "core", "getEntityRecords", [ "taxonomy", this.taxonomy.slug, { per_page: -1 } ] );

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -216,7 +216,8 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		handleCategories();
 
 		const fetchedParents = { 0: "" };
-		let currentParent  = null;
+		let currentParent    = null;
+
 		const wpData = window.wp.data;
 
 		wpData.subscribe( function() {

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -145,7 +145,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		const taxonomyIds = {};
 		let applicableTaxonomies = null;
 
-		wpData.subscribe( async function() {
+		wpData.subscribe( function() {
 			if ( ! wp.data.select( "core/data" ).hasFinishedResolution( "core", "getTaxonomies" ) ) {
 				return;
 			}
@@ -219,7 +219,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		let currentParent  = null;
 		const wpData = window.wp.data;
 
-		wpData.subscribe( async function() {
+		wpData.subscribe( function() {
 			const newParent = wpData.select( "core/editor" ).getEditedPostAttribute( "parent" );
 
 			if ( typeof newParent === "undefined" || currentParent === newParent ) {

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -9,7 +9,7 @@ import {
 	updateReplacementVariable,
 	refreshSnippetEditor,
 } from "./redux/actions/snippetEditor";
-import TaxonomyReplacmentVariables from "./helpers/taxonomy-replacevars";
+import TaxonomyReplacementVariables from "./helpers/taxonomy-replacevars";
 
 import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
@@ -138,7 +138,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 	 * @returns {void}
 	 */
 	const handleCategories = function() {
-		const taxonomyReplacementVariables = new TaxonomyReplacmentVariables();
+		const taxonomyReplacementVariables = new TaxonomyReplacementVariables();
 		taxonomyReplacementVariables.listen();
 	};
 

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -171,7 +171,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
 				const termIds = wpData.select( "core/editor" ).getEditedPostAttribute( taxonomy.rest_base );
 
-				if ( typeof taxonomyIds[ taxonomy.rest_base ] === "undefined" || taxonomyIds[ taxonomy.rest_base ] !== termIds ) {
+				if ( taxonomyIds[ taxonomy.rest_base ] !== termIds ) {
 					taxonomyIds[ taxonomy.rest_base ] = termIds;
 
 					const termNames = [];
@@ -185,7 +185,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 						if ( term ) {
 							termNames.push( term.name );
 						} else {
-							wpData.dispatch( "core/data" ).invalidateResolution( "core", "getEntityRecords", [ "taxonomy", "category" ] );
+							wpData.dispatch( "core/data" ).invalidateResolution( "core", "getEntityRecords", [ "taxonomy", taxonomy.slug ] );
 						}
 					} );
 

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -130,6 +130,12 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 		}
 	};
 
+	/**
+	 * Handle replace vars for taxonomies. Makes sure the taxonomy replacement variables are updated
+	 * when the selected terms for a post change.
+	 *
+	 * @returns {void}
+	 */
 	const handleCategories = function() {
 		const wpData = window.wp.data;
 
@@ -209,11 +215,11 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
 		handleCategories();
 
+		const fetchedParents = { 0: "" };
+		let currentParent  = null;
 		const wpData = window.wp.data;
 
 		wpData.subscribe( async function() {
-			const fetchedParents = { 0: "" };
-			let currentParent  = null;
 			const newParent = wpData.select( "core/editor" ).getEditedPostAttribute( "parent" );
 
 			if ( typeof newParent === "undefined" || currentParent === newParent ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where taxonomy terms weren't shown correctly in the Snippet Preview, for example when using the `Categories`, `Tags` or any custom taxonomy replacement variable.

## Relevant technical choices:

* This implementation fixes the `Category`, `Tag` and all custom taxonomy replacement variables.
* I have not written unit tests since the code relies heavily on wordpress' data api.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new post.
* Give it a title and save it.
* Add the `Category` replacement variable in the snippet editor.
* Add one or more categories and make sure the title is properly updated.
* Do the same thing for tags and one or more custom taxonomies.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #8555 
