### PR TITLE
Add autocomplete support to fields collecting user information

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -431,7 +431,7 @@ class Yoast_Form {
 	 * @param string $var            The variable within the option to create the select for.
 	 * @param string $label          The label to show for the variable.
 	 * @param array  $select_options The select options to choose from.
-	 * @param string $styled         Whether the select is styled. Default is unstyled.
+	 * @param string $styled         The select style. Use 'styled' to get a styled select. Default 'unstyled'.
 	 */
 	public function select( $var, $label, array $select_options, $styled = 'unstyled' ) {
 
@@ -450,7 +450,7 @@ class Yoast_Form {
 		$select_name       = esc_attr( $this->option_name ) . '[' . esc_attr( $var ) . ']';
 		$active_option     = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
 		$wrapper_start_tag = '';
-		$wrapper_start_end = '';
+		$wrapper_end_tag   = '';
 
 		$select = new Yoast_Input_Select( $var, $select_name, $select_options, $active_option );
 		$select->add_attribute( 'class', 'select' );
@@ -460,12 +460,12 @@ class Yoast_Form {
 
 		if ( $styled === 'styled' ) {
 			$wrapper_start_tag = '<span class="yoast-styled-select">';
-			$wrapper_start_end = '</span>';
+			$wrapper_end_tag   = '</span>';
 		}
 
 		echo $wrapper_start_tag;
 		$select->output_html();
-		echo $wrapper_start_end;
+		echo $wrapper_end_tag;
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -431,8 +431,9 @@ class Yoast_Form {
 	 * @param string $var            The variable within the option to create the select for.
 	 * @param string $label          The label to show for the variable.
 	 * @param array  $select_options The select options to choose from.
+	 * @param string $styled         Whether the select is styled. Default is unstyled.
 	 */
-	public function select( $var, $label, array $select_options ) {
+	public function select( $var, $label, array $select_options, $styled = 'unstyled' ) {
 
 		if ( empty( $select_options ) ) {
 			return;
@@ -446,17 +447,25 @@ class Yoast_Form {
 			)
 		);
 
-		$select_name   = esc_attr( $this->option_name ) . '[' . esc_attr( $var ) . ']';
-		$active_option = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		$select_name       = esc_attr( $this->option_name ) . '[' . esc_attr( $var ) . ']';
+		$active_option     = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		$wrapper_start_tag = '';
+		$wrapper_start_end = '';
 
 		$select = new Yoast_Input_Select( $var, $select_name, $select_options, $active_option );
 		$select->add_attribute( 'class', 'select' );
 		if ( $this->is_control_disabled( $var ) ) {
 			$select->add_attribute( 'disabled', 'disabled' );
 		}
-		$select->output_html();
 
-		echo '<br class="clear"/>';
+		if ( $styled === 'styled' ) {
+			$wrapper_start_tag = '<span class="yoast-styled-select">';
+			$wrapper_start_end = '</span>';
+		}
+
+		echo $wrapper_start_tag;
+		$select->output_html();
+		echo $wrapper_start_end;
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -350,12 +350,13 @@ class Yoast_Form {
 			);
 		}
 
-		$defaults = array(
+		$defaults     = array(
 			'placeholder' => '',
 			'class'       => '',
 		);
-		$attr     = wp_parse_args( $attr, $defaults );
-		$val      = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		$attr         = wp_parse_args( $attr, $defaults );
+		$val          = isset( $this->options[ $var ] ) ? $this->options[ $var ] : '';
+		$autocomplete = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';
 
 		$this->label(
 			$label . ':',
@@ -364,7 +365,7 @@ class Yoast_Form {
 				'class' => 'textinput',
 			)
 		);
-		echo '<input class="textinput ' . esc_attr( $attr['class'] ) . ' " placeholder="' . esc_attr( $attr['placeholder'] ) . '" type="text" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '<br class="clear" />';
+		echo '<input' . $autocomplete . ' class="textinput ' . esc_attr( $attr['class'] ) . ' " placeholder="' . esc_attr( $attr['placeholder'] ) . '" type="text" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '<br class="clear" />';
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-company-name.php
+++ b/admin/config-ui/fields/class-field-company-name.php
@@ -17,6 +17,7 @@ class WPSEO_Config_Field_Company_Name extends WPSEO_Config_Field {
 		parent::__construct( 'publishingEntityCompanyName', 'Input' );
 
 		$this->set_property( 'label', __( 'The name of the company', 'wordpress-seo' ) );
+		$this->set_property( 'autoComplete', 'organization' );
 
 		$this->set_requires( 'publishingEntityType', 'company' );
 	}

--- a/admin/config-ui/fields/class-field-person-name.php
+++ b/admin/config-ui/fields/class-field-person-name.php
@@ -17,6 +17,7 @@ class WPSEO_Config_Field_Person_Name extends WPSEO_Config_Field {
 		parent::__construct( 'publishingEntityPersonName', 'Input' );
 
 		$this->set_property( 'label', __( 'The name of the person', 'wordpress-seo' ) );
+		$this->set_property( 'autoComplete', 'name' );
 
 		$this->set_requires( 'publishingEntityType', 'person' );
 	}

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -28,7 +28,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		'company' => __( 'Company', 'wordpress-seo' ),
 		'person'  => __( 'Person', 'wordpress-seo' ),
 	);
-	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), $yoast_free_kg_select_options );
+	$yform->select( 'company_or_person', __( 'Company or person', 'wordpress-seo' ), $yoast_free_kg_select_options, 'styled' );
 	?>
 	<div id="knowledge-graph-company">
 		<h3><?php esc_html_e( 'Company', 'wordpress-seo' ); ?></h3>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -33,12 +33,12 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	<div id="knowledge-graph-company">
 		<h3><?php esc_html_e( 'Company', 'wordpress-seo' ); ?></h3>
 		<?php
-		$yform->textinput( 'company_name', __( 'Company name', 'wordpress-seo' ) );
+		$yform->textinput( 'company_name', __( 'Company name', 'wordpress-seo' ), array( 'autocomplete' => 'organization' ) );
 		$yform->media_input( 'company_logo', __( 'Company logo', 'wordpress-seo' ) );
 		?>
 	</div>
 	<div id="knowledge-graph-person">
 		<h3><?php esc_html_e( 'Person', 'wordpress-seo' ); ?></h3>
-		<?php $yform->textinput( 'person_name', __( 'Your name', 'wordpress-seo' ) ); ?>
+		<?php $yform->textinput( 'person_name', __( 'Your name', 'wordpress-seo' ), array( 'autocomplete' => 'name' ) ); ?>
 	</div>
 </div>

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -11,7 +11,8 @@
 
 	padding-top: 2em;
 
-	input[type="text"] {
+	input[type="text"],
+	input[type="email"] {
 		min-width: 250px;
 
 		& + div {

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -695,6 +695,79 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	}
 }
 
+/* Styled select. */
+.yoast-styled-select {
+	display: inline-flex;
+	align-items: center;
+	position: relative;
+	margin-bottom: 1em;
+
+	&::after,
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		pointer-events: none;
+	}
+	&::before {
+		width: 28px;
+		right: 0;
+	}
+	&::after {
+		width: 0;
+		height: 0;
+		border: 4px solid transparent;
+		border-top: 5px solid #555;
+		border-bottom-width: 0;
+		margin: auto;
+		right: 6px;
+		z-index: 1;
+	}
+
+	select {
+		height: 28px;
+		box-sizing: border-box;
+		margin: 0;
+		padding: 4px 32px 4px 8px;
+		max-width: 100%;
+		appearance: none;
+		background: transparent;
+		border: 1px solid #aaa;
+		border-radius: 4px;
+		line-height: 1;
+		color: #32373c;
+
+		.wpseo_content_wrapper &.select {
+			margin: 0;
+		}
+
+		/* Inherits other focus styles from WordPress */
+		&:focus {
+			border-color: #5b9dd9;
+		}
+
+		/* Reset Firefox selected option inner outline */
+		&:-moz-focusring {
+			color: transparent;
+			text-shadow: 0 0 0 #32373c;
+		}
+
+		&[disabled] {
+			opacity: .75;
+		}
+
+		/* Remove background focus style from IE11 while keeping focus style available on option elements. */
+		&::-ms-value {
+			background: transparent;
+		}
+		/* Remove the default down arrow in IE/Edge. */
+		&::-ms-expand {
+			display: none;
+		}
+	}
+}
+
 /* Responsive layout. */
 @media screen and ( max-width: 1024px ) {
 	.wpseo_content_wrapper,

--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -194,9 +194,10 @@ class MailchimpSignup extends React.Component {
 			id="mailchimpEmail"
 			className="yoast-wizard-text-input-field"
 			ref={ this.setEmailInputRef }
-			type="text"
+			type="email"
 			name={ this.props.name }
 			defaultValue={ this.props.properties.currentUserEmail }
+			autoComplete="email"
 		/>;
 		const button = <RaisedButton
 			primary={ true }

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -130,12 +130,6 @@ import a11ySpeak from "a11y-speak";
 	function initSelect2() {
 		var select2Width = "400px";
 
-		// Select2 for General settings: your info: company or person. Width is the same as the width for the other fields on this page.
-		jQuery( "#company_or_person" ).select2( {
-			width: select2Width,
-			language: wpseoSelect2Locale,
-		} );
-
 		// Select2 for Twitter card meta data in Settings
 		jQuery( "#twitter_card_type" ).select2( {
 			width: select2Width,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add support for browsers auto-fill in the form fields that collect user information

## Relevant technical choices:
- use the proper field type `email` on the Configuration wizard newsletter subscription field, this allows assistive technologies to properly identify the field type
- adds `autocomplete` attributes to the Person/Company and newsletter fields: this enables the browsers auto-fill to work

Both points are required by the WCAG 1.3.5 Identify Input Purpose
https://www.w3.org/TR/WCAG21/#identify-input-purpose

And allow us to declare support for this item in the Voluntary Product Accessibility Template (VPAT) we're preparing for Yoast SEO.

Additionally, removes the Select2 used for Company/Person and uses a styled select element.

## Test instructions
- yarn link the yoast-components branch `12171-autocomplete-user-fields`
- run `yarn && grunt build:css && grunt build:js && grunt webpack:buildProd`
- test with Chrome: you need to have actual data already saved in the browser > Auto-fill, if you don't yet you can add them in the Chrome settings > Auto-fill > Addresses and more
- test the Company/Person fields **in both the settings page and in the Configuration wizard**
- test the newsletter email field in the Configuration wizard
- when you click on the fields, Chrome suggests an Auto-fill entry, see screenshot below:

<img width="669" alt="screenshot 2019-02-06 at 15 59 35" src="https://user-images.githubusercontent.com/1682452/52350167-3d7a6280-2a28-11e9-9eb0-c011393535ec.png">

Note: as mentioned in the issue, I've removed Select2, as it's not accessible and its filtering functionality doesn't make much sense when there are only 2 options. Replaces with a native, styled, select as done in MyYoast https://github.com/Yoast/my-yoast/pull/2213
It is possible to style only the select "box", not the option within the select. The styling tries to reproduce the Select2 styling:

The get the styled select, just pass a `styled` parameter to `Yoast_Form->select()`.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #12171 