### PR TITLE
Bumped yoastseo and yoast-components for 9.6 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,8 +146,8 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.6",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.6"
+    "yoast-components": "^4.20.0",
+    "yoastseo": "^1.47.0"
   },
   "yoast": {
     "pluginVersion": "9.6-RC1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12618,9 +12618,10 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-"yoast-components@git+https://github.com/Yoast/yoast-components.git#release-yoast-seo/9.6":
-  version "4.19.0"
-  resolved "git+https://github.com/Yoast/yoast-components.git#8a06d42443db8f16daf9d7aa5206c41880f845f5"
+yoast-components@^4.20.0:
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.20.0.tgz#7577c2429502bf9ead806632beb16fb0f885998c"
+  integrity sha512-Gde+EqHn7BrqlaegctIWZf9U0XRNmLCzB3quvoUCDFLLP/pfr8aY0gvEig5N0KoXKn1P3ZztGjUZwQrAgFvEGw==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -12642,13 +12643,14 @@ yauzl@^2.2.1:
     styled-components "^2.1.2"
     whatwg-fetch "^1.0.0"
     wicked-good-xpath "^1.3.0"
-    yoastseo "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.6"
+    yoastseo "^1.47.0"
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-"yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.6":
-  version "1.45.0"
-  resolved "git+https://github.com/Yoast/YoastSEO.js.git#24cd0df77115fa43cd78c9d35e7e40e385915eb9"
+yoastseo@^1.47.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.47.0.tgz#3d9b80317f290187ea0bba7370c2625cf069ec99"
+  integrity sha512-SPDrQ/G6zNpjSz6a1o7qhEJN1eceJUFaSYM9xngDaLLs1YOXYu4tyXge9knlNPiC/dBpxJF5bEuigcuJ9llfyQ==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     htmlparser2 "^3.9.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Bumped `yoastseo` to 1.47
* Bumped `yoast-components` to 4.20

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
