### PR TITLE
Ensure dependency management

### DIFF
--- a/src/config/dependency-management.php
+++ b/src/config/dependency-management.php
@@ -100,7 +100,7 @@ class Dependency_Management {
 	 * @return bool True if the class exists.
 	 */
 	protected function class_exists( $class ) {
-		return class_exists( $class );
+		return class_exists( $class ) || interface_exists( $class );
 	}
 
 	/**

--- a/src/loaders/oauth.php
+++ b/src/loaders/oauth.php
@@ -15,5 +15,8 @@ if ( file_exists( dirname( WPSEO_FILE ) . '/vendor_prefixed/guzzlehttp/guzzle/sr
 	require_once dirname( WPSEO_FILE ) . '/vendor_prefixed/guzzlehttp/guzzle/src/functions.php';
 }
 
+$yoast_seo_dependecy_management = new \Yoast\WP\Free\Config\Dependency_Management();
+$yoast_seo_dependecy_management->initialize();
+
 class_alias( \Yoast\WP\Free\Oauth\Client::class, 'WPSEO_MyYoast_Client' );
 class_alias( \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface::class, 'WPSEO_MyYoast_AccessToken_Interface' );


### PR DESCRIPTION
The dependency management class needs to be initialized to make sure class aliases are created for the non-namespaced dependencies when the plugin is installed via composer or with the `no-dev` flag.

## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Fixes the automated testing failures. This will make sure the class-aliases are loaded.

## Relevant technical choices:

* Makes sure the dependency manager is loaded
* This will be loaded twice in the current architecture, I'm working on a change in setup to better deal with this

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Remove *all the folders* inside the `vendor_prefixed` directory
* Remove the`vendor_prefixed/dependencies-prefixed.txt` file
* Run `composer install --no-dev`
* Have Query Monitor enabled 
* Visit any page where we are loaded
* See PHP warnings no longer being present

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #
