### PR TITLE
Settings: add input validation to social accounts 

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -341,7 +341,7 @@ class Yoast_Form {
 	 *
 	 * @param string       $var   The variable within the option to create the text input field for.
 	 * @param string       $label The label to show for the variable.
-	 * @param array|string $attr  Extra class to add to the input field.
+	 * @param array|string $attr  Extra CSS class or an array of attributes to assign to the input field.
 	 */
 	public function textinput( $var, $label, $attr = array() ) {
 		if ( ! is_array( $attr ) ) {
@@ -351,11 +351,17 @@ class Yoast_Form {
 		}
 
 		$defaults = array(
-			'placeholder' => '',
 			'class'       => '',
+			'pattern'     => '',
+			'placeholder' => '',
+			'type'        => 'text',
 		);
-		$attr     = wp_parse_args( $attr, $defaults );
-		$val      = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+
+		$attr        = wp_parse_args( $attr, $defaults );
+		$class       = ( $attr['class'] === '' ) ? '' : ' ' . $attr['class'];
+		$pattern     = ( $attr['pattern'] === '' ) ? '' : ' pattern="' . esc_attr( $attr['pattern'] ) . '"';
+		$placeholder = ( $attr['placeholder'] === '' ) ? '' : ' placeholder="' . esc_attr( $attr['placeholder'] ) . '"';
+		$val         = isset( $this->options[ $var ] ) ? $this->options[ $var ] : '';
 
 		$this->label(
 			$label . ':',
@@ -364,7 +370,7 @@ class Yoast_Form {
 				'class' => 'textinput',
 			)
 		);
-		echo '<input class="textinput ' . esc_attr( $attr['class'] ) . ' " placeholder="' . esc_attr( $attr['placeholder'] ) . '" type="text" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '<br class="clear" />';
+		echo '<input class="textinput', esc_attr( $class ), '"', $placeholder, $pattern, ' type="', esc_attr( $attr['type'] ), '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '<br class="clear" />';
 	}
 
 	/**

--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -75,7 +75,14 @@ class WPSEO_Configuration_Structure {
 			__( 'Company or person', 'wordpress-seo' ),
 			$this->fields['publishingEntity']
 		);
-		$this->add_step( 'profile-urls', __( 'Social profiles', 'wordpress-seo' ), $this->fields['profileUrls'] );
+		$this->add_step(
+			'profile-urls',
+			__( 'Social profiles', 'wordpress-seo' ),
+			$this->fields['profileUrls'],
+			true,
+			false,
+			true
+		);
 
 		$fields = array( 'postTypeVisibility' );
 
@@ -105,18 +112,20 @@ class WPSEO_Configuration_Structure {
 	/**
 	 * Add a step to the structure
 	 *
-	 * @param string $identifier Identifier for this step.
-	 * @param string $title      Title to display for this step.
-	 * @param array  $fields     Fields to use on the step.
-	 * @param bool   $navigation Show navigation buttons.
-	 * @param bool   $full_width Wheter the step content is full width or not.
+	 * @param string $identifier     Identifier for this step.
+	 * @param string $title          Title to display for this step.
+	 * @param array  $fields         Fields to use on the step.
+	 * @param bool   $navigation     Show navigation buttons.
+	 * @param bool   $full_width     Wheter the step content is full width or not.
+	 * @param bool   $has_validation Wheter the step content has a form with validation.
 	 */
-	protected function add_step( $identifier, $title, $fields, $navigation = true, $full_width = false ) {
+	protected function add_step( $identifier, $title, $fields, $navigation = true, $full_width = false, $has_validation = false ) {
 		$this->steps[ $identifier ] = array(
 			'title'          => $title,
 			'fields'         => $fields,
 			'hideNavigation' => ! (bool) $navigation,
 			'fullWidth'      => $full_width,
+			'hasValidation'  => $has_validation,
 		);
 	}
 

--- a/admin/config-ui/fields/class-field-profile-url-facebook.php
+++ b/admin/config-ui/fields/class-field-profile-url-facebook.php
@@ -17,7 +17,8 @@ class WPSEO_Config_Field_Profile_URL_Facebook extends WPSEO_Config_Field {
 		parent::__construct( 'profileUrlFacebook', 'Input' );
 
 		$this->set_property( 'label', __( 'Facebook Page URL', 'wordpress-seo' ) );
-		$this->set_property( 'pattern', '^https:\/\/www\.facebook\.com\/([^/]+)\/$' );
+		$this->set_property( 'type', 'url' );
+		$this->set_property( 'pattern', '^https:\/\/www\.facebook\.com\/[^\s\/]+' );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-facebook.php
+++ b/admin/config-ui/fields/class-field-profile-url-facebook.php
@@ -18,7 +18,7 @@ class WPSEO_Config_Field_Profile_URL_Facebook extends WPSEO_Config_Field {
 
 		$this->set_property( 'label', __( 'Facebook Page URL', 'wordpress-seo' ) );
 		$this->set_property( 'type', 'url' );
-		$this->set_property( 'pattern', '^https:\/\/www\.facebook\.com\/[^\s\/]+' );
+		$this->set_property( 'pattern', WPSEO_Validation::get_pattern( 'facebook_site' ) );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-googleplus.php
+++ b/admin/config-ui/fields/class-field-profile-url-googleplus.php
@@ -17,7 +17,8 @@ class WPSEO_Config_Field_Profile_URL_GooglePlus extends WPSEO_Config_Field {
 		parent::__construct( 'profileUrlGooglePlus', 'Input' );
 
 		$this->set_property( 'label', __( 'Google+ URL', 'wordpress-seo' ) );
-		$this->set_property( 'pattern', '^https:\/\/plus\.google\.com\/([^/]+)$' );
+		$this->set_property( 'type', 'url' );
+		$this->set_property( 'pattern', '^https:\/\/plus\.google\.com\/[^\s\/]+' );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-googleplus.php
+++ b/admin/config-ui/fields/class-field-profile-url-googleplus.php
@@ -18,7 +18,7 @@ class WPSEO_Config_Field_Profile_URL_GooglePlus extends WPSEO_Config_Field {
 
 		$this->set_property( 'label', __( 'Google+ URL', 'wordpress-seo' ) );
 		$this->set_property( 'type', 'url' );
-		$this->set_property( 'pattern', '^https:\/\/plus\.google\.com\/[^\s\/]+' );
+		$this->set_property( 'pattern', WPSEO_Validation::get_pattern( 'google_plus_url' ) );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-instagram.php
+++ b/admin/config-ui/fields/class-field-profile-url-instagram.php
@@ -18,7 +18,7 @@ class WPSEO_Config_Field_Profile_URL_Instagram extends WPSEO_Config_Field {
 
 		$this->set_property( 'label', __( 'Instagram URL', 'wordpress-seo' ) );
 		$this->set_property( 'type', 'url' );
-		$this->set_property( 'pattern', '^https:\/\/www\.instagram\.com\/[^\s\/]+' );
+		$this->set_property( 'pattern', WPSEO_Validation::get_pattern( 'instagram_url' ) );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-instagram.php
+++ b/admin/config-ui/fields/class-field-profile-url-instagram.php
@@ -17,7 +17,8 @@ class WPSEO_Config_Field_Profile_URL_Instagram extends WPSEO_Config_Field {
 		parent::__construct( 'profileUrlInstagram', 'Input' );
 
 		$this->set_property( 'label', __( 'Instagram URL', 'wordpress-seo' ) );
-		$this->set_property( 'pattern', '^https:\/\/www\.instagram\.com\/([^/]+)\/$' );
+		$this->set_property( 'type', 'url' );
+		$this->set_property( 'pattern', '^https:\/\/www\.instagram\.com\/[^\s\/]+' );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-linkedin.php
+++ b/admin/config-ui/fields/class-field-profile-url-linkedin.php
@@ -17,7 +17,8 @@ class WPSEO_Config_Field_Profile_URL_LinkedIn extends WPSEO_Config_Field {
 		parent::__construct( 'profileUrlLinkedIn', 'Input' );
 
 		$this->set_property( 'label', __( 'LinkedIn URL', 'wordpress-seo' ) );
-		$this->set_property( 'pattern', '^https:\/\/www\.linkedin\.com\/in\/([^/]+)$' );
+		$this->set_property( 'type', 'url' );
+		$this->set_property( 'pattern', '^https:\/\/www\.linkedin\.com\/in\/[^\s\/]+' );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-linkedin.php
+++ b/admin/config-ui/fields/class-field-profile-url-linkedin.php
@@ -18,7 +18,7 @@ class WPSEO_Config_Field_Profile_URL_LinkedIn extends WPSEO_Config_Field {
 
 		$this->set_property( 'label', __( 'LinkedIn URL', 'wordpress-seo' ) );
 		$this->set_property( 'type', 'url' );
-		$this->set_property( 'pattern', '^https:\/\/www\.linkedin\.com\/in\/[^\s\/]+' );
+		$this->set_property( 'pattern', WPSEO_Validation::get_pattern( 'linkedin_url' ) );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-myspace.php
+++ b/admin/config-ui/fields/class-field-profile-url-myspace.php
@@ -18,7 +18,7 @@ class WPSEO_Config_Field_Profile_URL_MySpace extends WPSEO_Config_Field {
 
 		$this->set_property( 'label', __( 'MySpace URL', 'wordpress-seo' ) );
 		$this->set_property( 'type', 'url' );
-		$this->set_property( 'pattern', '^https:\/\/myspace\.com\/[^\s\/]+' );
+		$this->set_property( 'pattern', WPSEO_Validation::get_pattern( 'myspace_url' ) );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-myspace.php
+++ b/admin/config-ui/fields/class-field-profile-url-myspace.php
@@ -17,7 +17,8 @@ class WPSEO_Config_Field_Profile_URL_MySpace extends WPSEO_Config_Field {
 		parent::__construct( 'profileUrlMySpace', 'Input' );
 
 		$this->set_property( 'label', __( 'MySpace URL', 'wordpress-seo' ) );
-		$this->set_property( 'pattern', '^https:\/\/myspace\.com\/([^/]+)\/$' );
+		$this->set_property( 'type', 'url' );
+		$this->set_property( 'pattern', '^https:\/\/myspace\.com\/[^\s\/]+' );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-pinterest.php
+++ b/admin/config-ui/fields/class-field-profile-url-pinterest.php
@@ -18,7 +18,7 @@ class WPSEO_Config_Field_Profile_URL_Pinterest extends WPSEO_Config_Field {
 
 		$this->set_property( 'label', __( 'Pinterest URL', 'wordpress-seo' ) );
 		$this->set_property( 'type', 'url' );
-		$this->set_property( 'pattern', '^https:\/\/www\.pinterest\.com\/[^\s\/]+' );
+		$this->set_property( 'pattern', WPSEO_Validation::get_pattern( 'pinterest_url' ) );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-pinterest.php
+++ b/admin/config-ui/fields/class-field-profile-url-pinterest.php
@@ -17,7 +17,8 @@ class WPSEO_Config_Field_Profile_URL_Pinterest extends WPSEO_Config_Field {
 		parent::__construct( 'profileUrlPinterest', 'Input' );
 
 		$this->set_property( 'label', __( 'Pinterest URL', 'wordpress-seo' ) );
-		$this->set_property( 'pattern', '^https:\/\/www\.pinterest\.com\/([^/]+)\/$' );
+		$this->set_property( 'type', 'url' );
+		$this->set_property( 'pattern', '^https:\/\/www\.pinterest\.com\/[^\s\/]+' );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-youtube.php
+++ b/admin/config-ui/fields/class-field-profile-url-youtube.php
@@ -18,7 +18,7 @@ class WPSEO_Config_Field_Profile_URL_YouTube extends WPSEO_Config_Field {
 
 		$this->set_property( 'label', __( 'YouTube URL', 'wordpress-seo' ) );
 		$this->set_property( 'type', 'url' );
-		$this->set_property( 'pattern', '^https:\/\/www\.youtube\.com\/[^\s\/]+' );
+		$this->set_property( 'pattern', WPSEO_Validation::get_pattern( 'youtube_url' ) );
 	}
 
 	/**

--- a/admin/config-ui/fields/class-field-profile-url-youtube.php
+++ b/admin/config-ui/fields/class-field-profile-url-youtube.php
@@ -17,7 +17,8 @@ class WPSEO_Config_Field_Profile_URL_YouTube extends WPSEO_Config_Field {
 		parent::__construct( 'profileUrlYouTube', 'Input' );
 
 		$this->set_property( 'label', __( 'YouTube URL', 'wordpress-seo' ) );
-		$this->set_property( 'pattern', '^https:\/\/www\.youtube\.com\/([^/]+)$' );
+		$this->set_property( 'type', 'url' );
+		$this->set_property( 'pattern', '^https:\/\/www\.youtube\.com\/[^\s\/]+' );
 	}
 
 	/**

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -24,13 +24,13 @@ echo '<h2 class="help-button-inline">' . esc_html__( 'Your social profiles', 'wo
 echo $social_profiles_help->get_panel_html();
 
 $yform = Yoast_Form::get_instance();
-$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ) );
+$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.facebook\.com\/[^\s\/]+' ) );
 $yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ) );
-$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ) );
-$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ) );
-$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ) );
-$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ) );
-$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ) );
-$yform->textinput( 'google_plus_url', __( 'Google+ URL', 'wordpress-seo' ) );
+$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.instagram\.com\/[^\s\/]+' ) );
+$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.linkedin\.com\/in\/[^\s\/]+' ) );
+$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/myspace\.com\/[^\s\/]+' ) );
+$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.pinterest\.com\/[^\s\/]+' ) );
+$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.youtube\.com\/[^\s\/]+' ) );
+$yform->textinput( 'google_plus_url', __( 'Google+ URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/plus\.google\.com\/[^\s\/]+' ) );
 
 do_action( 'wpseo_admin_other_section' );

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -24,13 +24,13 @@ echo '<h2 class="help-button-inline">' . esc_html__( 'Your social profiles', 'wo
 echo $social_profiles_help->get_panel_html();
 
 $yform = Yoast_Form::get_instance();
-$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.facebook\.com\/[^\s\/]+' ) );
+$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => WPSEO_Validation::get_pattern( 'facebook_site' ) ) );
 $yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ) );
-$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.instagram\.com\/[^\s\/]+' ) );
-$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.linkedin\.com\/in\/[^\s\/]+' ) );
-$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/myspace\.com\/[^\s\/]+' ) );
-$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.pinterest\.com\/[^\s\/]+' ) );
-$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/www\.youtube\.com\/[^\s\/]+' ) );
-$yform->textinput( 'google_plus_url', __( 'Google+ URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => '^https:\/\/plus\.google\.com\/[^\s\/]+' ) );
+$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => WPSEO_Validation::get_pattern( 'instagram_url' ) ) );
+$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => WPSEO_Validation::get_pattern( 'linkedin_url' ) ) );
+$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => WPSEO_Validation::get_pattern( 'myspace_url' ) ) );
+$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => WPSEO_Validation::get_pattern( 'pinterest_url' ) ) );
+$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => WPSEO_Validation::get_pattern( 'youtube_url' ) ) );
+$yform->textinput( 'google_plus_url', __( 'Google+ URL', 'wordpress-seo' ), array( 'type' => 'url', 'pattern' => WPSEO_Validation::get_pattern( 'google_plus_url' ) ) );
 
 do_action( 'wpseo_admin_other_section' );

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -11,8 +11,14 @@
 
 	padding-top: 2em;
 
-	input[type="text"] {
+	input[type="text"],
+	input[type="url"] {
 		min-width: 250px;
+
+		&:not(:focus):invalid {
+			outline: 3px dashed $color-error;
+			outline-offset: -1px;
+		}
 
 		& + div {
 			margin-right: 1em;

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -56,6 +56,11 @@ tr.yst_row.even {
 	textarea,
 	select {
 		width: 400px;
+
+		&:not(:focus):invalid {
+			outline: 3px dashed $color-error;
+			outline-offset: -1px;
+		}
 	}
 
 	input.large-text,

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -178,7 +178,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 									'_' . $key, // Suffix-id for the error message box.
 									sprintf(
 										/* translators: %s expands to a twitter user name. */
-										__( '%s does not seem to be a valid Twitter user-id. Please correct.', 'wordpress-seo' ),
+										__( '%s does not seem to be a valid Twitter Username. Please correct.', 'wordpress-seo' ),
 										'<strong>' . esc_html( sanitize_text_field( $dirty[ $key ] ) ) . '</strong>'
 									), // The error message.
 									'error' // Error type, either 'error' or 'updated'.

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -326,8 +326,20 @@ abstract class WPSEO_Option {
 	 */
 	public function validate_url( $key, $dirty, $old, &$clean ) {
 		if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
+			/*
+			 * Note: `WPSEO_Utils::sanitize_url()` uses WordPress `esc_url_raw()`
+			 * which uses `esc_url()` which prepends `http://` if the URL doesn't
+			 * appear to contain a scheme, unless it's a relative URL starting
+			 * with /, # or ? or a php file.
+			 */
 			$url = WPSEO_Utils::sanitize_url( $dirty[ $key ] );
-			if ( $url !== '' ) {
+
+			// In old Yoast SEO versions, users could enter OpenGraph images with root-relative paths.
+			if ( WPSEO_Utils::is_url_relative( $url ) === true && $url !== '' ) {
+				$clean[ $key ] = $url;
+			}
+			// Validate absolute URLs. `FILTER_VALIDATE_URL` already checks for empty.
+			elseif ( filter_var( $url, FILTER_VALIDATE_URL ) ) {
 				$clean[ $key ] = $url;
 			}
 			else {

--- a/inc/validation/class-wpseo-validation.php
+++ b/inc/validation/class-wpseo-validation.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Validation
+ */
+
+/**
+ * Handles form inputs validation.
+ */
+class WPSEO_Validation {
+
+	/**
+	 * Validation patterns for input constraint validation API.
+	 *
+	 * @var array
+	 */
+	public static $patterns = array(
+		'facebook_site'   => '^https:\/\/www\.facebook\.com\/[^\s\/]+',
+		'instagram_url'   => '^https:\/\/www\.instagram\.com\/[^\s\/]+',
+		'linkedin_url'    => '^https:\/\/www\.linkedin\.com\/in\/[^\s\/]+',
+		'myspace_url'     => '^https:\/\/myspace\.com\/[^\s\/]+',
+		'pinterest_url'   => '^https:\/\/www\.pinterest\.com\/[^\s\/]+',
+		'youtube_url'     => '^https:\/\/www\.youtube\.com\/[^\s\/]+',
+		'google_plus_url' => '^https:\/\/plus\.google\.com\/[^\s\/]+',
+	);
+
+	/**
+	 * Retrieves a validation pattern.
+	 *
+	 * @param string $key The key of the validation pattern to retrieve.
+	 *
+	 * @return string The validation pattern to use or empty string if not found.
+	 */
+	public static function get_pattern( $key ) {
+		if ( isset( self::$patterns[ $key ] ) ) {
+			return self::$patterns[ $key ];
+		}
+
+		return '';
+	}
+}

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -79,6 +79,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 				'fields'         => $fields,
 				'hideNavigation' => false,
 				'fullWidth'      => false,
+				'hasValidation'  => false,
 			),
 			$steps[ $identifier ]
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add input validation to the social accounts in the settings and configuration wizard

**Please note this PR can be refined but I'm at a point where I think it needs an initial review and feedback. See notes and todo below.** It's a first step to address #12173 

## Relevant technical choices:
- leverages browsers constraint validation API
- introduces `WPSEO_Validation`: for now, this class is only used to get validation patterns from a centralized location
- adds type and pattern to Yoast_Form text input
- improves a bit `textinput()` output
- adds type and pattern to the fields in the configuration wizard (note: the patterns already existed, I guess at some point there was a previous attempt to use them)
- changes the fields type to `url`
- adds a red dashed outline to the invalid fields
- makes `WPSEO_Option->validate_url()` work properly

Notes:

Previously, `WPSEO_Option->validate_url()` didn't validate anything actually, as its entire `else` part didn't ever run. There was no notice displaying the error. The culprit is `sanitize_url()` uses WordPress `esc_url_raw()` which in turn uses `esc_url()` which prepends `http://` if the URL doesn't appear to contain a scheme...

Basically, it always prepended `http://` so the submitted url was never empty (and the `else` part didn't run).

This PR changes how `validate_url()` works in this way:
- if the submitted url is detected as relative e.g. `/frontpage.png` it keeps the previous behavior and doesn't validate the URL
- if the submitted url is detected as absolute, then it uses `FILTER_VALIDATE_URL` which renders an error is the url is invalid

To test this specific point:
- go to Social > Google+ tab 
- enter `aaa bbb` in the "Google Publisher Page" field
- on trunk: validation doesn't work
- on this branch: works 

In the Accounts tab and in the Configuration wizard, it uses the browsers validation constraint API. Screenshots:

value without a scheme:

![screenshot 2019-02-18 at 14 35 07](https://user-images.githubusercontent.com/1682452/52959489-9afe9f80-3396-11e9-8b2d-f2e2737ccd68.png)

value with a scheme but doesn't match the required pattern: notice that browsers only say to match the format so there's the need to inform users about the required format (see todo)
 
![screenshot 2019-02-18 at 14 34 55](https://user-images.githubusercontent.com/1682452/52959498-9fc35380-3396-11e9-90f3-d8b69856336e.png)

Each browser uses a different "bubble", here's Firefox:

![screenshot 2019-02-18 at 14 34 42](https://user-images.githubusercontent.com/1682452/52959557-bec1e580-3396-11e9-8aa2-5bab330563b0.png)

IE 11 doesn't support the `reportValidity()` method, see https://caniuse.com/#search=reportvalidity so we shouldn't rely on this new features for important data.

Todo:

1
each field should also describe the expected format; best accessible option for all users would be adding a visible description below each field (referenced by `aria-describedby`). For example:

<img width="678" alt="screenshot 2019-02-18 at 15 01 36" src="https://user-images.githubusercontent.com/1682452/52959715-36901000-3397-11e9-8ce3-341523aa6505.png">

I'd recommend it but I realize it needs design feedback and discussion. The clear advantage is that users are informed even before filling in the fields.

Another option would be using `setCustomValidity()` from the API to set a custom message, but that needs DOM methods to get each field so I wouldn't recommend it.

2
do we want to force users to enter `https`? Worth noting the `s` can be made optional in the validation pattern. Two considerations:
- the behavior of `esc_url()` which prepends `http://` is highly confusing for users: we may want to consider alternate methods
- forcing `https` would make a visible description of the format even more necessary

3
styling of the invalid fields is very basic for now, can be improved if desired


## Test instructions
- yarn link the yoast-components `12173-input-validation-social-accounts` branch
- `yarn && grunt build:css && grunt build:js && grunt webpack:buildProd`
- `composer du`
- go to Social > Accounts
- enter random strings, invalid URLs, and URLs that don't match the expected format
- submit
- check browser validation works and submission is prevented
- ener valid URLs
- submit, check data are saved correctly

In the configuration wizard:
- go to step 5
- enter random strings, invalid URLs, and URLs that don't match the expected format
- click on Next, **or any other step number at the top**
- check validation works
- check no data get posted
- enter valid URLs e.g. `https://www.facebook.com/yoast` for FB
- click on Next, or any other step number at the top
- go back to step 5 verify data were saved correctly

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

See #12173 
Fixes #12373