### PR TITLE
Adds the myyoast connect endpoint

### DIFF
--- a/inc/endpoints/class-myyoast-connect.php
+++ b/inc/endpoints/class-myyoast-connect.php
@@ -20,6 +20,8 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 	/**
 	 * Registers the REST routes that are available on the endpoint.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @return void
 	 */
 	public function register() {
@@ -42,15 +44,13 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 	 * @return WP_REST_Response The response.
 	 */
 	public function handle_request( WP_REST_Request $request ) {
-		if ( $request->get_param( 'url' ) !== WPSEO_Utils::get_home_url() ) {
+		if ( $request->get_param( 'url' ) !== $this->get_home_url() ) {
 			return new WP_REST_Response(
 				'Bad request: URL mismatch.', 403
 			);
 		}
 
-		$client_id = $this->get_client_id();
-
-		if ( $request->get_param( 'clientId' ) !== $client_id ) {
+		if ( $request->get_param( 'clientId' ) !== $this->get_client_id() ) {
 			return new WP_REST_Response(
 				'Bad request: ClientID mismatch.', 403
 			);
@@ -80,6 +80,8 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 	/**
 	 * Saves the client secret.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @param string $clientSecret The secret to save.
 	 *
 	 * @return void
@@ -95,6 +97,8 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 	/**
 	 * Retrieves the current client id.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @return array The client id.
 	 */
 	protected function get_client_id() {
@@ -106,6 +110,8 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 	/**
 	 * Retrieves an instance of the client.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @return WPSEO_MyYoast_Client Instance of client.
 	 */
 	protected function get_client() {
@@ -116,5 +122,16 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 		}
 
 		return $client;
+	}
+
+	/**
+	 * Wraps the method for retrieving the home url.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return string Home url.
+	 */
+	protected function get_home_url() {
+		return WPSEO_Utils::get_home_url();
 	}
 }

--- a/inc/endpoints/class-myyoast-connect.php
+++ b/inc/endpoints/class-myyoast-connect.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Endpoint
+ */
+
+/**
+ * Represents an implementation of the WPSEO_Endpoint interface to register one or multiple endpoints.
+ */
+class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
+
+	/**
+	 * The namespace to use.
+	 *
+	 * @var string
+	 */
+	const REST_NAMESPACE = 'yoast/v1/myyoast';
+
+	/**
+	 * Registers the REST routes that are available on the endpoint.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'connect',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'handle_request' ),
+				'permission_callback' => array( $this, 'can_retrieve_data' ),
+			)
+		);
+	}
+
+	/**
+	 * Determines whether or not data can be retrieved for the registered endpoints.
+	 *
+	 * @param WP_REST_Request $request The current request.
+	 *
+	 * @return WP_REST_Response The response.
+	 */
+	public function handle_request( WP_REST_Request $request ) {
+		if ( $request->get_param( 'url' ) !== WPSEO_Utils::get_home_url() ) {
+			return new WP_REST_Response(
+				'Bad request: URL mismatch.', 403
+			);
+		}
+
+		$client_id = $this->get_client_id();
+
+		if ( $request->get_param( 'clientId' ) !== $client_id ) {
+			return new WP_REST_Response(
+				'Bad request: ClientID mismatch.', 403
+			);
+		}
+
+		$client_secret = $request->get_param('clientSecret');
+		if ( empty( $client_secret ) ) {
+			return new WP_REST_Response(
+				'Bad request: ClientSecret missing.', 403
+			);
+		}
+
+		$this->save_secret( $client_secret );
+
+		return new WP_REST_Response( 'Connection successful established.' );
+	}
+
+	/**
+	 * Determines whether or not data can be retrieved for the registered endpoints.
+	 *
+	 * @return bool Whether or not data can be retrieved.
+	 */
+	public function can_retrieve_data() {
+		return true;
+	}
+
+	/**
+	 * Saves the client secret.
+	 *
+	 * @param string $clientSecret The secret to save.
+	 *
+	 * @return void
+	 */
+	protected function save_secret( $clientSecret ) {
+		$this->get_client()->save_configuration(
+			array(
+				'secret' => $clientSecret,
+			)
+		);
+	}
+
+	/**
+	 * Retrieves the current client id.
+	 *
+	 * @return array The client id.
+	 */
+	protected function get_client_id() {
+		$config = $this->get_client()->get_configuration();
+
+		return $config['clientId'];
+	}
+
+	/**
+	 * Retrieves an instance of the client.
+	 *
+	 * @return WPSEO_MyYoast_Client Instance of client.
+	 */
+	protected function get_client() {
+		static $client;
+
+		if ( ! $client ) {
+			$client = new WPSEO_MyYoast_Client();
+		}
+
+		return $client;
+	}
+}

--- a/inc/endpoints/class-myyoast-connect.php
+++ b/inc/endpoints/class-myyoast-connect.php
@@ -56,7 +56,7 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 			);
 		}
 
-		$client_secret = $request->get_param('clientSecret');
+		$client_secret = $request->get_param( 'clientSecret' );
 		if ( empty( $client_secret ) ) {
 			return new WP_REST_Response(
 				'Bad request: ClientSecret missing.', 403
@@ -82,14 +82,14 @@ class WPSEO_Endpoint_MyYoast_Connect implements WPSEO_Endpoint {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param string $clientSecret The secret to save.
+	 * @param string $client_secret The secret to save.
 	 *
 	 * @return void
 	 */
-	protected function save_secret( $clientSecret ) {
+	protected function save_secret( $client_secret ) {
 		$this->get_client()->save_configuration(
 			array(
-				'secret' => $clientSecret,
+				'secret' => $client_secret,
 			)
 		);
 	}

--- a/tests/inc/endpoints/test-class-myyoast-connect.php
+++ b/tests/inc/endpoints/test-class-myyoast-connect.php
@@ -1,0 +1,199 @@
+<?php
+/**
+* WPSEO plugin test file.
+*
+* @package WPSEO\Tests
+*/
+
+/**
+* Unit Test Class.
+*
+* @group MyYoast
+*/
+class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Tests request handling with url mismatch.
+	 *
+	 * @covers WPSEO_Endpoint_MyYoast_Connect::handle_request
+	 */
+	public function test_get_handle_request_url_mismatch() {
+		$request = $this
+			->getMockBuilder( 'WP_REST_Request' )
+			->setMethods( array( 'get_param' ) )
+			->getMock();
+
+		$request
+			->expects( $this->once() )
+			->method( 'get_param' )
+			->will( $this->returnValue( 'http://example.org' ) );
+
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
+			->setMethods( array( 'get_home_url' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_home_url' )
+			->will( $this->returnValue( 'http://example2.org' ) );
+
+		$this->assertEquals(
+			new WP_REST_Response(
+				'Bad request: URL mismatch.', 403
+			),
+			$instance->handle_request( $request )
+		);
+	}
+
+	/**
+	 * Tests request handling with client id mismatch.
+	 *
+	 * @covers WPSEO_Endpoint_MyYoast_Connect::handle_request
+	 */
+	public function test_get_handle_request_client_id_mismatch() {
+		$request = $this
+			->getMockBuilder( 'WP_REST_Request' )
+			->setMethods( array( 'get_param' ) )
+			->getMock();
+
+		$request
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_param' )
+			->will(
+				$this->onConsecutiveCalls(
+					'http://example.org',
+					'123-456-7890'
+				)
+			);
+
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
+			->setMethods( array( 'get_home_url', 'get_client_id' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_home_url' )
+			->will( $this->returnValue( 'http://example.org' ) );
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_client_id' )
+			->will( $this->returnValue( '098-765-4321' ) );
+
+		$this->assertEquals(
+			new WP_REST_Response(
+				'Bad request: ClientID mismatch.', 403
+			),
+			$instance->handle_request( $request )
+		);
+	}
+
+	/**
+	 * Tests request handling with missing client secret.
+	 *
+	 * @covers WPSEO_Endpoint_MyYoast_Connect::handle_request
+	 */
+	public function test_get_handle_request_client_secret_missing() {
+		$request = $this
+			->getMockBuilder( 'WP_REST_Request' )
+			->setMethods( array( 'get_param' ) )
+			->getMock();
+
+		$request
+			->expects( $this->exactly( 3 ) )
+			->method( 'get_param' )
+			->will(
+				$this->onConsecutiveCalls(
+					'http://example.org',
+					'123-456-7890',
+					null
+				)
+			);
+
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
+			->setMethods( array( 'get_home_url', 'get_client_id' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_home_url' )
+			->will( $this->returnValue( 'http://example.org' ) );
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_client_id' )
+			->will( $this->returnValue( '123-456-7890' ) );
+
+		$this->assertEquals(
+			new WP_REST_Response(
+				'Bad request: ClientSecret missing.', 403
+			),
+			$instance->handle_request( $request )
+		);
+	}
+
+	/**
+	 * Tests request handling.
+	 *
+	 * @covers WPSEO_Endpoint_MyYoast_Connect::handle_request
+	 */
+	public function test_get_handle_request() {
+		$request = $this
+			->getMockBuilder( 'WP_REST_Request' )
+			->setMethods( array( 'get_param' ) )
+			->getMock();
+
+		$request
+			->expects( $this->exactly( 3 ) )
+			->method( 'get_param' )
+			->will(
+				$this->onConsecutiveCalls(
+					'http://example.org',
+					'123-456-7890',
+					'$3cr37'
+				)
+			);
+
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
+			->setMethods( array( 'get_home_url', 'get_client_id', 'save_secret' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_home_url' )
+			->will( $this->returnValue( 'http://example.org' ) );
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_client_id' )
+			->will( $this->returnValue( '123-456-7890' ) );
+
+		$instance
+			->expects( $this->once() )
+			->method( 'save_secret' )
+			->with( '$3cr37' );
+
+		$this->assertEquals(
+			new WP_REST_Response(
+				'Connection successful established.'
+			),
+			$instance->handle_request( $request )
+		);
+	}
+
+	/**
+	 * Tests result of can retrieve data.
+	 *
+	 * @covers WPSEO_Endpoint_MyYoast_Connect::can_retrieve_data
+	 */
+	public function test_can_retrieve_data() {
+		$instance = new WPSEO_Endpoint_MyYoast_Connect();
+
+		$this->assertTrue( $instance->can_retrieve_data() );
+	}
+
+}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -368,6 +368,7 @@ function wpseo_init_rest_api() {
 	$endpoints[] = new WPSEO_Endpoint_Indexable( new WPSEO_Indexable_Service() );
 	$endpoints[] = new WPSEO_Endpoint_File_Size( new WPSEO_File_Size_Service() );
 	$endpoints[] = new WPSEO_Endpoint_Statistics( $statistics_service );
+	$endpoints[] = new WPSEO_Endpoint_MyYoast_Connect();
 
 	/** @var WPSEO_Endpoint[] $endpoints */
 	foreach ( $endpoints as $endpoint ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Adds an endpoint for connecting with MyYoast

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* You can believe the unit tests, if these pass it is okay. But if you want to do a complicated test, please follow these steps:
  * Have #12131 merged in trunk and trunk in this branch.
  * Save a client id by adding the following code (somewhere in the WordPress runtime (wp-seo-main.php for example:
```php
add_action( 'init', function() { 
    $client = new WPSEO_MyYoast_Client();
    $client->save_configuration( array( 'clientId' => 'the-client-id' ) ); 
} );
```
  * Fire a `POST` request to {your-test-domain}/wp-json/yoast/v1/myyoast/connect with the following arguments in the body: url = {your-test-domain}, clientId = 'the-client-id' and clientSecret = 'knockknock'. You can do this in Postman:
![postman](https://user-images.githubusercontent.com/325040/53019930-2854f900-3456-11e9-9923-a5cf934ee830.png)
  * Verify if the secret has been set correctly:
```php

add_action( 'init', function() { 
    $client = new WPSEO_MyYoast_Client();
    print_r( $client->get_configuration() ); 
} );
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #12134
