### PR TITLE
Fix replacevar plugin error in trunk

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -206,7 +206,19 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'replace_vars'             => $this->get_replace_vars(),
 			'recommended_replace_vars' => $this->get_recommended_replace_vars(),
 			'scope'                    => $this->determine_scope(),
+			'has_taxonomies'           => $this->current_post_type_has_taxonomies(),
 		);
+	}
+
+	/**
+	 * Determines whether or not the current post type has registered taxonomies.
+	 *
+	 * @return bool Whether the current post type has taxonomies.
+	 */
+	private function current_post_type_has_taxonomies() {
+		$post_type = get_post_type();
+
+		return ! empty( get_object_taxonomies( $post_type ) );
 	}
 
 	/**

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -216,9 +216,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return bool Whether the current post type has taxonomies.
 	 */
 	private function current_post_type_has_taxonomies() {
-		$post_type = get_post_type();
+		$post_taxonomies = get_object_taxonomies( get_post_type() );
 
-		return ! empty( get_object_taxonomies( $post_type ) );
+		return ! empty( $post_taxonomies );
 	}
 
 	/**

--- a/js/src/helpers/taxonomy-replacevars.js
+++ b/js/src/helpers/taxonomy-replacevars.js
@@ -202,7 +202,7 @@ class TaxonomyReplacementVariables {
 	 */
 	listen() {
 		getPostType().then( postType => {
-			/* Pages don't support taxonomies */
+			// Pages don't have taxonomies.
 			if ( postType === "page" ) {
 				return null;
 			}

--- a/js/src/helpers/taxonomy-replacevars.js
+++ b/js/src/helpers/taxonomy-replacevars.js
@@ -214,7 +214,7 @@ class TaxonomyReplacementVariables {
 				const listener = new TaxonomyReplacementVariable( taxonomy );
 				listener.listen();
 			} );
-		} ).catch( () => {} );
+		} );
 	}
 }
 

--- a/js/src/helpers/taxonomy-replacevars.js
+++ b/js/src/helpers/taxonomy-replacevars.js
@@ -202,6 +202,11 @@ class TaxonomyReplacementVariables {
 	 */
 	listen() {
 		getPostType().then( postType => {
+			/* Pages don't support taxonomies */
+			if ( postType === "page" ) {
+				return null;
+			}
+
 			return getApplicableTaxonomies( postType );
 		} ).then( taxonomies => {
 			forEach( taxonomies, taxonomy => {

--- a/js/src/helpers/taxonomy-replacevars.js
+++ b/js/src/helpers/taxonomy-replacevars.js
@@ -1,3 +1,5 @@
+/* global wpseoReplaceVarsL10n */
+
 /* External dependencies */
 import {
 	subscribe,
@@ -202,8 +204,7 @@ class TaxonomyReplacementVariables {
 	 */
 	listen() {
 		getPostType().then( postType => {
-			// Pages don't have taxonomies.
-			if ( postType === "page" ) {
+			if ( wpseoReplaceVarsL10n.has_taxonomies === "" ) {
 				return null;
 			}
 
@@ -213,7 +214,7 @@ class TaxonomyReplacementVariables {
 				const listener = new TaxonomyReplacementVariable( taxonomy );
 				listener.listen();
 			} );
-		} );
+		} ).catch( () => {} );
 	}
 }
 

--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -159,7 +159,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
 		const wpData = window.wp.data;
 
-		wpData.subscribe( function() {
+		wpData.subscribe( () => {
 			const newParent = wpData.select( "core/editor" ).getEditedPostAttribute( "parent" );
 
 			if ( typeof newParent === "undefined" || currentParent === newParent ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Fixes error when editing page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new page or open an existing page.
* Make sure no console errors occur.
* Add a taxonomy to your page post type, you can install the following plugin for that.
[register-category-for-pages.php.zip](https://github.com/Yoast/wordpress-seo/files/2884056/register-category-for-pages.php.zip)
* Make sure no console errors occur.
* Also check if posts still work.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
