### PR TITLE
Fills the extensions value in the redirect.

### DIFF
--- a/admin/class-my-yoast-route.php
+++ b/admin/class-my-yoast-route.php
@@ -110,10 +110,10 @@ class WPSEO_MyYoast_Route implements WPSEO_WordPress_Integration {
 		$this->redirect(
 			'https://my.yoast.com/connect',
 			array(
-				'url'          => WPSEO_Utils::get_home_url(),
-				'client_id'    => $client_id,
-				'extensions'   => $this->get_extensions(),
-				'redirect_url' => admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ),
+				'url'             => WPSEO_Utils::get_home_url(),
+				'client_id'       => $client_id,
+				'extensions'      => $this->get_extensions(),
+				'redirect_url'    => admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ),
 				'credentials_url' => rest_url( 'yoast/v1/myyoast/connect' ),
 			)
 		);
@@ -180,17 +180,16 @@ class WPSEO_MyYoast_Route implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Retrieves a list the activated extensions.
+	 * Retrieves a list of activated extensions slugs.
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return array The extensions.
+	 * @return array The extensions slugs.
 	 */
 	protected function get_extensions() {
 		$addon_manager = new WPSEO_Addon_Manager();
 
 		return array_keys( $addon_manager->get_subscriptions_for_active_addons() );
-
 	}
 
 	/**

--- a/admin/class-my-yoast-route.php
+++ b/admin/class-my-yoast-route.php
@@ -112,7 +112,7 @@ class WPSEO_MyYoast_Route implements WPSEO_WordPress_Integration {
 			array(
 				'url'          => WPSEO_Utils::get_home_url(),
 				'client_id'    => $client_id,
-				'extensions'   => array(),
+				'extensions'   => $this->get_extensions(),
 				'redirect_url' => admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ),
 				'credentials_url' => rest_url( 'yoast/v1/myyoast/connect' ),
 			)
@@ -177,6 +177,20 @@ class WPSEO_MyYoast_Route implements WPSEO_WordPress_Integration {
 	 */
 	protected function get_action() {
 		return filter_input( INPUT_GET, 'action' );
+	}
+
+	/**
+	 * Retrieves a list the activated extensions.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return array The extensions.
+	 */
+	protected function get_extensions() {
+		$addon_manager = new WPSEO_Addon_Manager();
+
+		return array_keys( $addon_manager->get_subscriptions_for_active_addons() );
+
 	}
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -314,7 +314,7 @@ class WPSEO_Addon_Manager {
 	 * @return array The filtered array,
 	 */
 	private function filter_by_key( $array_to_filter, $callback  ) {
-		$keys_to_filter  = array_filter( array_keys( $array_to_filter), $callback );
+		$keys_to_filter = array_filter( array_keys( $array_to_filter), $callback );
 		$filtered_array = array();
 		foreach ( $keys_to_filter as $filtered_key ) {
 			$filtered_array[ $filtered_key ] = $array_to_filter[ $filtered_key ];

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -314,7 +314,7 @@ class WPSEO_Addon_Manager {
 	 * @return array The filtered array,
 	 */
 	private function filter_by_key( $array_to_filter, $callback  ) {
-		$keys_to_filter = array_filter( array_keys( $array_to_filter), $callback );
+		$keys_to_filter = array_filter( array_keys( $array_to_filter ), $callback );
 		$filtered_array = array();
 		foreach ( $keys_to_filter as $filtered_key ) {
 			$filtered_array[ $filtered_key ] = $array_to_filter[ $filtered_key ];

--- a/tests/admin/test-class-my-yoast-route.php
+++ b/tests/admin/test-class-my-yoast-route.php
@@ -222,7 +222,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_connect() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route_Double' )
-			->setMethods( array( 'redirect', 'save_client_id', 'generate_uuid' ) )
+			->setMethods( array( 'redirect', 'save_client_id', 'generate_uuid', 'get_extensions' ) )
 			->getMock();
 
 		$instance
@@ -237,13 +237,18 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 
 		$instance
 			->expects( $this->once() )
+			->method( ( 'get_extensions' ) )
+			->will( $this->returnValue( array( 'yoast-seo-extension' ) ) );
+
+		$instance
+			->expects( $this->once() )
 			->method( 'redirect' )
 			->with(
 				'https://my.yoast.com/connect',
 				array(
 					'url'             => WPSEO_Utils::get_home_url(),
 					'client_id'       => '9740f9cf-608e-4327-8a16-24e3ff6a4c0d',
-					'extensions'      => array(),
+					'extensions'      => array( 'yoast-seo-extension' ),
 					'redirect_url'    => admin_url( 'admin.php?page=' . WPSEO_Admin::PAGE_IDENTIFIER ),
 					'credentials_url' => rest_url( 'yoast/v1/myyoast/connect' )
 				)

--- a/tests/doubles/class-admin-addon-manager-double.php
+++ b/tests/doubles/class-admin-addon-manager-double.php
@@ -51,4 +51,13 @@ class WPSEO_Addon_Manager_Double extends WPSEO_Addon_Manager {
 	public function get_installed_addons() {
 		return parent::get_installed_addons();
 	}
+
+	/**
+	 * Retrieves a list of active addons.
+	 *
+	 * @return array The active addons.
+	 */
+	public function get_active_addons() {
+		return parent::get_active_addons();
+	}
 }

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -191,7 +191,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests the retrieval subscriptions for the active addons.
+	 * Tests the retrieval of subscriptions for the active addons.
 	 *
 	 * @covers WPSEO_Addon_Manager::get_subscriptions_for_active_addons
 	 */

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -191,6 +191,57 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests the retrieval subscriptions for the active addons.
+	 *
+	 * @covers WPSEO_Addon_Manager::get_subscriptions_for_active_addons
+	 */
+	public function test_get_subscriptions_for_active_addons() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Addon_Manager' )
+			->setMethods( array( 'get_active_addons', 'get_subscriptions' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->any() )
+			->method( 'get_active_addons' )
+			->will(
+				$this->returnValue(
+					array(
+						'wp-seo-premium.php' => array(
+							'Version' => '10.0',
+						),
+					)
+				)
+			);
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_subscriptions' )
+			->will(
+				$this->returnValue( $this->get_subscriptions() )
+			);
+
+		$this->assertEquals(
+			array(
+				'yoast-seo-wordpress-premium' => (object) array(
+					'expires' => 'active',
+					'product' => ( object ) array(
+						'version'     => '10.0',
+						'name'        => 'Extension',
+						'slug'        => 'yoast-seo-wordpress-premium',
+						'url'         => 'https://example.org/extension',
+						'lastUpdated' => 'yesterday',
+						'storeUrl'    => 'https://example.org/store',
+						'download'    => 'https://example.org/extension.zip',
+						'changelog'   => 'changelog',
+					),
+				)
+			),
+			$instance->get_subscriptions_for_active_addons()
+		);
+	}
+
+	/**
 	 * Tests retrieval of the plugin information.
 	 *
 	 * @dataProvider get_plugin_information_provider
@@ -377,6 +428,58 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			$instance->get_installed_addons()
 		);
 	}
+
+
+	/**
+	 * Tests get_installed_plugins with no yoast addons installed.
+	 *
+	 * @covers WPSEO_Addon_Manager::get_active_addons
+	 */
+	public function test_get_active_addons() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Addon_Manager_Double' )
+			->setMethods( array( 'get_plugins', 'is_plugin_active' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'get_plugins' )
+			->will(
+				$this->returnValue(
+					array(
+						'wp-seo-premium.php' => array(
+							'Version' => '10.0',
+						),
+						'no-yoast-seo-extension-php' => array(
+							'Version' => '10.0',
+						),
+						'wpseo-news.php' => array(
+							'Version' => '9.5'
+						),
+					)
+				)
+			);
+
+		$instance
+			->expects( $this->exactly( 2 ) )
+			->method( 'is_plugin_active' )
+			->will(
+				$this->onConsecutiveCalls(
+					true,
+					false
+				)
+			);
+
+		$this->assertEquals(
+			array(
+				'wp-seo-premium.php' => array(
+					'Version' => '10.0',
+				),
+			),
+			$instance->get_active_addons()
+		);
+	}
+
 
 	/**
 	 * Provides data to the check_for_updates test.


### PR DESCRIPTION
Also added unittests.

## Summary

This PR can be summarized in the following changelog entry:

* N/A - Filled the extensions value, because we have the WPSEO_Addon manager now

## Relevant technical choices:

* I was using `array_filter` in combination with the `ARRAY_FILTER_USE_KEY` constant. Unfortunately this constant is **too modern** for  WordPress. This is because it has been introduced in PHP 5.5. 
  * Decided to make a private method with a similar routine. 
  * Added  a `@coveCoverageIgnore` 
  * This method can be replaced with a array_filter + constant implementation when WordPress has minimal 5.6 support.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* N/A Functionality is covered in unit tests and we will connect everything together later on.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #12250
