### PR TITLE
CS/QA: make a variable check more specific

### DIFF
--- a/src/config/plugin.php
+++ b/src/config/plugin.php
@@ -53,8 +53,8 @@ class Plugin implements Integration {
 	 */
 	public function __construct( Dependency_Management $dependency_management = null, Database_Migration $database_migration = null ) {
 		// @codingStandardsIgnoreStart
-		$this->dependency_management = $dependency_management ?: new Dependency_Management();
-		$this->database_migration    = $database_migration ?: new Database_Migration( $GLOBALS['wpdb'], $this->dependency_management );
+		$this->dependency_management = isset( $dependency_management ) ?: new Dependency_Management();
+		$this->database_migration    = isset( $database_migration ) ?: new Database_Migration( $GLOBALS['wpdb'], $this->dependency_management );
 		// @codingStandardsIgnoreEnd
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

A `if ( $dependency )` check is a loose comparison against `false`.

As the method contains type declarations, we know that the parameters will be either `null` or an instance of the class annotated in the type declaration, so check against `null` using `isset()` instead.

## Test instructions

This PR can be tested by following these steps:

* _N/A_
