### PR TITLE
Replace function() by arrow function to make 'this' have the correct reference

### DIFF
--- a/js/src/wp-seo-replacevar-plugin.js
+++ b/js/src/wp-seo-replacevar-plugin.js
@@ -176,7 +176,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 				this.declareReloaded();
 				return;
 			}
-			wp.api.loadPromise.done( function() {
+			wp.api.loadPromise.done( () => {
 				const page = new wp.api.models.Page( { id: newParent } );
 				page.fetch().then(
 					response => {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where selecting a parent page for a page would lead to console errors and a not-working 'parent page' snippet variable.

## Relevant technical choices:

* Anonymous functions (`function()`) have an own context, while arrow functions refer to the context they are defined in (the 'parent' context).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See issue.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12267
