### PR TITLE
Documentation: improve method docblock @param tag formatting

### DIFF
--- a/admin/capabilities/class-abstract-capability-manager.php
+++ b/admin/capabilities/class-abstract-capability-manager.php
@@ -22,7 +22,7 @@ abstract class WPSEO_Abstract_Capability_Manager implements WPSEO_Capability_Man
 	 *
 	 * @param string $capability Capability to register.
 	 * @param array  $roles      Roles to add the capability to.
-	 * @param bool   $overwrite        Optional. Use add or overwrite as registration method.
+	 * @param bool   $overwrite  Optional. Use add or overwrite as registration method.
 	 */
 	public function register( $capability, array $roles, $overwrite = false ) {
 		if ( $overwrite || ! isset( $this->capabilities[ $capability ] ) ) {

--- a/admin/capabilities/class-capability-manager-integration.php
+++ b/admin/capabilities/class-capability-manager-integration.php
@@ -82,7 +82,7 @@ class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integratio
 	 *
 	 * @see    URE_Capabilities_Groups_Manager::get_groups_tree()
 	 *
-	 * @param  array $groups Current groups.
+	 * @param array $groups Current groups.
 	 *
 	 * @return array Filtered list of capabilty groups.
 	 */
@@ -103,8 +103,8 @@ class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integratio
 	 *
 	 * @see    URE_Capabilities_Groups_Manager::get_cap_groups()
 	 *
-	 * @param  array  $groups Current capability groups.
-	 * @param  string $cap_id Capability identifier.
+	 * @param array  $groups Current capability groups.
+	 * @param string $cap_id Capability identifier.
 	 *
 	 * @return array List of filtered groups.
 	 */

--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -28,9 +28,9 @@ class WPSEO_Admin_User_Profile {
 	 *
 	 * @since 3.1
 	 *
-	 * @param int    $meta_id The ID of the meta option changed.
+	 * @param int    $meta_id   The ID of the meta option changed.
 	 * @param int    $object_id The ID of the user.
-	 * @param string $meta_key The key of the meta field changed.
+	 * @param string $meta_key  The key of the meta field changed.
 	 */
 	public function clear_author_sitemap_cache( $meta_id, $object_id, $meta_key ) {
 		if ( '_yoast_wpseo_profile_updated' === $meta_key ) {

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -242,9 +242,9 @@ class WPSEO_Meta_Columns {
 	/**
 	 * Generates an <option> element.
 	 *
-	 * @param string $value       The option's value.
-	 * @param string $label       The option's label.
-	 * @param string $selected    HTML selected attribute for an option.
+	 * @param string $value    The option's value.
+	 * @param string $label    The option's label.
+	 * @param string $selected HTML selected attribute for an option.
 	 *
 	 * @return string The generated <option> element.
 	 */
@@ -439,7 +439,7 @@ class WPSEO_Meta_Columns {
 	/**
 	 * Uses the vars to create a complete filter query that can later be executed to filter out posts.
 	 *
-	 * @param array $vars Array containing the variables that will be used in the meta query.
+	 * @param array $vars    Array containing the variables that will be used in the meta query.
 	 * @param array $filters Array containing the filters that we need to apply in the meta query.
 	 *
 	 * @return array Array containing the complete filter query.
@@ -466,7 +466,7 @@ class WPSEO_Meta_Columns {
 	/**
 	 * Creates a Readability score filter.
 	 *
-	 * @param number $low The lower boundary of the score.
+	 * @param number $low  The lower boundary of the score.
 	 * @param number $high The higher boundary of the score.
 	 *
 	 * @return array The Readability Score filter.
@@ -485,7 +485,7 @@ class WPSEO_Meta_Columns {
 	/**
 	 * Creates an SEO score filter.
 	 *
-	 * @param number $low The lower boundary of the score.
+	 * @param number $low  The lower boundary of the score.
 	 * @param number $high The higher boundary of the score.
 	 *
 	 * @return array The SEO score filter.

--- a/admin/class-option-tabs.php
+++ b/admin/class-option-tabs.php
@@ -112,7 +112,7 @@ class WPSEO_Option_Tabs {
 	/**
 	 * Display the tabs
 	 *
-	 * @param Yoast_Form $yform   Yoast Form needed in the views.
+	 * @param Yoast_Form $yform Yoast Form needed in the views.
 	 */
 	public function display( Yoast_Form $yform ) {
 		$formatter = new WPSEO_Option_Tabs_Formatter();

--- a/admin/class-plugin-compatibility.php
+++ b/admin/class-plugin-compatibility.php
@@ -28,7 +28,7 @@ class WPSEO_Plugin_Compatibility {
 	/**
 	 * WPSEO_Plugin_Compatibility constructor.
 	 *
-	 * @param string     $version The version to check against.
+	 * @param string     $version              The version to check against.
 	 * @param null|class $availability_checker The checker to use.
 	 */
 	public function __construct( $version, $availability_checker = null ) {

--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -192,7 +192,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	/**
 	 * Filter over the meta boxes to save, this function adds the Social meta boxes.
 	 *
-	 * @param   array $field_defs Array of metaboxes to save.
+	 * @param array $field_defs Array of metaboxes to save.
 	 *
 	 * @return  array
 	 */

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -24,7 +24,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 * WPSEO_Suggested_Plugins constructor.
 	 *
 	 * @param WPSEO_Plugin_Availability $availability_checker The availability checker to use.
-	 * @param Yoast_Notification_Center $notification_center The notification center to add notifications to.
+	 * @param Yoast_Notification_Center $notification_center  The notification center to add notifications to.
 	 */
 	public function __construct( WPSEO_Plugin_Availability $availability_checker, Yoast_Notification_Center $notification_center ) {
 		$this->availability_checker = $availability_checker;
@@ -73,8 +73,8 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	/**
 	 * Build Yoast SEO suggested plugins notification.
 	 *
-	 * @param string $name   The plugin name to use for the unique ID.
-	 * @param array  $plugin The plugin to retrieve the data from.
+	 * @param string $name            The plugin name to use for the unique ID.
+	 * @param array  $plugin          The plugin to retrieve the data from.
 	 * @param string $dependency_name The name of the dependency.
 	 *
 	 * @return Yoast_Notification The notification containing the suggested plugin.
@@ -99,7 +99,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	/**
 	 * Creates a message to suggest the installation of a particular plugin.
 	 *
-	 * @param array $suggested_plugin The suggested plugin.
+	 * @param array $suggested_plugin   The suggested plugin.
 	 * @param array $third_party_plugin The third party plugin that we have a suggested plugin for.
 	 *
 	 * @return string The install suggested plugin message.
@@ -121,7 +121,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	/**
 	 * Creates a more information link that directs the user to WordPress.org Plugin repository.
 	 *
-	 * @param string $url The URL to the plugin's page.
+	 * @param string $url  The URL to the plugin's page.
 	 * @param string $name The name of the plugin.
 	 *
 	 * @return string The more information link.
@@ -139,7 +139,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	/**
 	 * Creates a message to suggest the activation of a particular plugin.
 	 *
-	 * @param array $suggested_plugin The suggested plugin.
+	 * @param array $suggested_plugin   The suggested plugin.
 	 * @param array $third_party_plugin The third party plugin that we have a suggested plugin for.
 	 *
 	 * @return string The activate suggested plugin message.

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -288,11 +288,11 @@ class Yoast_Form {
 	 *
 	 * @since 3.1
 	 *
-	 * @param string  $var        The variable within the option to create the checkbox for.
-	 * @param string  $label      The label element text for the checkbox.
-	 * @param array   $buttons    Array of two visual labels for the buttons (defaults Disabled/Enabled).
-	 * @param boolean $reverse    Reverse order of buttons (default true).
-	 * @param string  $help       Inline Help that will be printed out before the visible toggles text.
+	 * @param string $var     The variable within the option to create the checkbox for.
+	 * @param string $label   The label element text for the checkbox.
+	 * @param array  $buttons Array of two visual labels for the buttons (defaults Disabled/Enabled).
+	 * @param bool   $reverse Reverse order of buttons (default true).
+	 * @param string $help    Inline Help that will be printed out before the visible toggles text.
 	 */
 	public function light_switch( $var, $label, $buttons = array(), $reverse = true, $help = '' ) {
 
@@ -669,9 +669,9 @@ class Yoast_Form {
 	/**
 	 * Creates a toggle switch to define whether an indexable should be indexed or not.
 	 *
-	 * @param string $var    The variable within the option to create the radio buttons for.
-	 * @param string $label  The visual label for the radio buttons group, used as the fieldset legend.
-	 * @param string $help   Inline Help that will be printed out before the visible toggles text.
+	 * @param string $var   The variable within the option to create the radio buttons for.
+	 * @param string $label The visual label for the radio buttons group, used as the fieldset legend.
+	 * @param string $help  Inline Help that will be printed out before the visible toggles text.
 	 *
 	 * @return void
 	 */
@@ -696,10 +696,10 @@ class Yoast_Form {
 	/**
 	 * Creates a toggle switch to show hide certain options.
 	 *
-	 * @param string $var           The variable within the option to create the radio buttons for.
-	 * @param string $label         The visual label for the radio buttons group, used as the fieldset legend.
-	 * @param bool   $inverse_keys  Whether or not the option keys need to be inverted to support older functions.
-	 * @param string $help          Inline Help that will be printed out before the visible toggles text.
+	 * @param string $var          The variable within the option to create the radio buttons for.
+	 * @param string $label        The visual label for the radio buttons group, used as the fieldset legend.
+	 * @param bool   $inverse_keys Whether or not the option keys need to be inverted to support older functions.
+	 * @param string $help         Inline Help that will be printed out before the visible toggles text.
 	 *
 	 * @return void
 	 */

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -384,7 +384,7 @@ class Yoast_Notification_Center {
 	 * Remove notification after it has been displayed
 	 *
 	 * @param Yoast_Notification $notification Notification to remove.
-	 * @param bool               $resolve Resolve as fixed.
+	 * @param bool               $resolve      Resolve as fixed.
 	 */
 	public function remove_notification( Yoast_Notification $notification, $resolve = true ) {
 

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -45,7 +45,8 @@ class Yoast_Plugin_Conflict {
 	/**
 	 * For the use of singleton pattern. Create instance of itself and return his instance
 	 *
-	 * @param string $class_name Give the classname to initialize. If classname is false (empty) it will use it's own __CLASS__.
+	 * @param string $class_name Give the classname to initialize. If classname is
+	 *                           false (empty) it will use it's own __CLASS__.
 	 *
 	 * @return Yoast_Plugin_Conflict
 	 */

--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -48,7 +48,8 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $name         The name of the section, used as an identifier in the html. Can only contain URL safe characters.
+	 * @param string $name         The name of the section, used as an identifier in the html.
+	 *                             Can only contain URL safe characters.
 	 * @param string $link_content The text content of the section link.
 	 * @param string $content      Optional. Content to use above the React root element.
 	 * @param array  $options      Optional link attributes.

--- a/admin/metabox/class-metabox-tab-section.php
+++ b/admin/metabox/class-metabox-tab-section.php
@@ -43,7 +43,8 @@ class WPSEO_Metabox_Tab_Section implements WPSEO_Metabox_Section {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $name         The name of the section, used as an identifier in the html. Can only contain URL safe characters.
+	 * @param string $name         The name of the section, used as an identifier in the html.
+	 *                             Can only contain URL safe characters.
 	 * @param string $link_content The text content of the section link.
 	 * @param array  $tabs         The metabox tabs (`WPSEO_Metabox_Tabs[]`) to be included in the section.
 	 * @param array  $options      Optional link attributes.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -437,8 +437,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @todo [JRF] Check if $class is added appropriately everywhere.
 	 *
-	 * @param   array  $meta_field_def Contains the vars based on which output is generated.
-	 * @param   string $key            Internal key (without prefix).
+	 * @param array  $meta_field_def Contains the vars based on which output is generated.
+	 * @param string $key            Internal key (without prefix).
 	 *
 	 * @return  string
 	 */

--- a/admin/services/class-indexable-post-provider.php
+++ b/admin/services/class-indexable-post-provider.php
@@ -33,7 +33,8 @@ class WPSEO_Indexable_Service_Post_Provider extends WPSEO_Indexable_Provider {
 	 * Returns an array with data for the target object.
 	 *
 	 * @param integer $object_id The target object id.
-	 * @param bool    $as_object Optional. Whether or not to return the indexable as an object. Defaults to false.
+	 * @param bool    $as_object Optional. Whether or not to return the indexable
+	 *                           as an object. Defaults to false.
 	 *
 	 * @return array|WPSEO_Post_Indexable The retrieved data. Defaults to an array format.
 	 *

--- a/admin/services/class-indexable-term-provider.php
+++ b/admin/services/class-indexable-term-provider.php
@@ -32,7 +32,8 @@ class WPSEO_Indexable_Service_Term_Provider extends WPSEO_Indexable_Provider {
 	 * Returns an array with data for the target object.
 	 *
 	 * @param integer $object_id The target object id.
-	 * @param bool    $as_object Optional. Whether or not to return the indexable as an object. Defaults to false.
+	 * @param bool    $as_object Optional. Whether or not to return the indexable
+	 *                           as an object. Defaults to false.
 	 *
 	 * @return array|WPSEO_Term_Indexable The retrieved data. Defaults to an array format.
 	 */

--- a/admin/services/interface-indexable-provider.php
+++ b/admin/services/interface-indexable-provider.php
@@ -14,7 +14,8 @@ interface WPSEO_Indexable_Service_Provider {
 	 * Returns an array with data for the target object.
 	 *
 	 * @param integer $object_id The target object id.
-	 * @param bool    $as_object Optional. Whether or not to return the indexable as an object. Defaults to false.
+	 * @param bool    $as_object Optional. Whether or not to return the indexable
+	 *                           as an object. Defaults to false.
 	 *
 	 * @return array The retrieved data.
 	 */

--- a/admin/statistics/class-statistics-service.php
+++ b/admin/statistics/class-statistics-service.php
@@ -109,7 +109,7 @@ class WPSEO_Statistics_Service {
 	 * Set the statistics transient cache for a specific user
 	 *
 	 * @param array $transient The current stored transient with the cached data.
-	 * @param int   $user The user's ID to assign the retrieved values to.
+	 * @param int   $user      The user's ID to assign the retrieved values to.
 	 *
 	 * @return array The statistics transient for the user.
 	 */

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -157,7 +157,7 @@ class WPSEO_Taxonomy_Columns {
 	/**
 	 * Creates an icon by the given values.
 	 *
-	 * @param WPSEO_Rank $rank The ranking object.
+	 * @param WPSEO_Rank $rank  The ranking object.
 	 * @param string     $title Optional. The title to show. Defaults to the rank label.
 	 *
 	 * @return string The HTML for a score icon.

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -197,9 +197,9 @@ class WPSEO_Taxonomy_Fields_Presenter {
 	/**
 	 * Returns the HTML for the row which contains label, help and the field.
 	 *
-	 * @param string                 $label       The html for the label if there was a label set.
-	 * @param WPSEO_Admin_Help_Panel $help        The help panel to render in this row.
-	 * @param string                 $field       The html for the field.
+	 * @param string                 $label The html for the label if there was a label set.
+	 * @param WPSEO_Admin_Help_Panel $help  The help panel to render in this row.
+	 * @param string                 $field The html for the field.
 	 *
 	 * @return string
 	 */

--- a/admin/taxonomy/class-taxonomy-fields.php
+++ b/admin/taxonomy/class-taxonomy-fields.php
@@ -22,7 +22,7 @@ abstract class WPSEO_Taxonomy_Fields {
 	/**
 	 * Setting the class properties
 	 *
-	 * @param stdClass $term    The current term.
+	 * @param stdClass $term The current term.
 	 */
 	public function __construct( $term ) {
 		$this->term = $term;

--- a/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/admin/taxonomy/class-taxonomy-social-fields.php
@@ -20,7 +20,7 @@ class WPSEO_Taxonomy_Social_Fields extends WPSEO_Taxonomy_Fields {
 	/**
 	 * Setting the class properties
 	 *
-	 * @param stdClass|WP_Term $term    The current taxonomy.
+	 * @param stdClass|WP_Term $term The current taxonomy.
 	 */
 	public function __construct( $term ) {
 		parent::__construct( $term );

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -144,7 +144,8 @@ class Yoast_Feature_Toggles {
 		/**
 		 * Filter to add feature toggles from add-ons.
 		 *
-		 * @param array $feature_toggles Array with feature toggle objects where each object should have a `name`, `setting` and `label` property.
+		 * @param array $feature_toggles Array with feature toggle objects where each object
+		 *                               should have a `name`, `setting` and `label` property.
 		 */
 		$feature_toggles = apply_filters( 'wpseo_feature_toggles', $feature_toggles );
 

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -249,7 +249,7 @@ class WPSEO_Breadcrumbs {
 	/**
 	 * Get a term's parents.
 	 *
-	 * @param    object $term Term to get the parents for.
+	 * @param object $term Term to get the parents for.
 	 *
 	 * @return    array
 	 */

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -349,7 +349,7 @@ class WPSEO_Twitter {
 	 * Solves issues with filters returning urls and theme's/other plugins also adding a user meta
 	 * twitter field which expects url rather than an id (which is what we expect).
 	 *
-	 * @param  string $id Twitter ID or url.
+	 * @param string $id Twitter ID or url.
 	 *
 	 * @return string|bool Twitter ID or false if it failed to get a valid Twitter ID.
 	 */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

The contents of parameter tags should be aligned like so:
```php
 * @param[1 space]int [1 space after longest entry]$var     [1 space after longest entry]Description.
 * @param[1 space]bool[1 space after longest entry]$variable[1 space after longest entry]Description.
```


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.