### PR TITLE
Fixes the unit tests to work with WordPress 5.1

### DIFF
--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -51,9 +51,46 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * Tests getting site choices.
 	 *
 	 * @group ms-required
+	 *
 	 * @covers Yoast_Network_Admin::get_site_choices()
 	 */
 	public function test_get_site_choices() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
+
+			return;
+		}
+
+		$admin = new Yoast_Network_Admin();
+
+		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );
+
+		$choices = $admin->get_site_choices();
+		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
+
+		array_unshift( $site_ids, '-' );
+
+		$choices = $admin->get_site_choices( true );
+		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
+	}
+
+
+	/**
+	 * Tests getting site choices.
+	 *
+	 * @group ms-required
+	 *
+	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
+	 *
+	 * @covers Yoast_Network_Admin::get_site_choices()
+	 */
+	public function test_get_site_choices_with_deprecated_exception() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
+
+			return;
+		}
+
 		$admin = new Yoast_Network_Admin();
 
 		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );
@@ -99,6 +136,41 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Admin::get_site_states()
 	 */
 	public function test_get_site_states() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
+
+			return;
+		}
+
+		$admin = new Yoast_Network_Admin();
+
+		$active_states = array(
+			'public' => '1',
+			'mature' => '1',
+			'spam'   => '1',
+		);
+
+		$site_id = self::factory()->blog->create();
+		update_blog_details( $site_id, $active_states );
+
+		$site_states = $admin->get_site_states( get_site( $site_id ) );
+		$this->assertSame( array_keys( $active_states ), array_keys( $site_states ) );
+	}
+
+	/**
+	 * Tests getting a site's states.
+	 *
+	 * @group ms-required
+	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
+	 * @covers Yoast_Network_Admin::get_site_states()
+	 */
+	public function test_get_site_states_with_deprecated_exception() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
+
+			return;
+		}
+
 		$admin = new Yoast_Network_Admin();
 
 		$active_states = array(

--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -18,6 +18,8 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		do_action( 'rest_api_init' );
+
 		$this->endpoint = new WPSEO_Configuration_Endpoint_Mock();
 	}
 

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -471,6 +471,45 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::dismiss_notification()
 	 */
 	public function test_dismiss_notification_is_per_site() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
+
+			return;
+		}
+
+		$site2 = self::factory()->blog->create();
+
+		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
+		$dismissal_key = $notification->get_dismissal_key();
+
+		// Dismiss notification for the current site.
+		Yoast_Notification_Center::dismiss_notification( $notification );
+
+		$site1_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
+
+		switch_to_blog( $site2 );
+		$site2_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
+		restore_current_blog();
+
+		$this->assertTrue( $site1_dismissed );
+		$this->assertFalse( $site2_dismissed );
+	}
+
+	/**
+	 * Tests that dismissing a notification only affects the current site in multisite.
+	 *
+	 * @group ms-required
+	 *
+	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
+	 *
+	 * @covers Yoast_Notification_Center::dismiss_notification()
+	 */
+	public function test_dismiss_notification_is_per_site_with_deprecation_exception() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
+
+			return;
+		}
 
 		$site2 = self::factory()->blog->create();
 
@@ -498,6 +537,51 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::restore_notification()
 	 */
 	public function test_restore_notification_is_per_site() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
+
+			return;
+		}
+
+		$site2 = self::factory()->blog->create();
+
+		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
+		$dismissal_key = $notification->get_dismissal_key();
+
+		// Dismiss notification for both sites.
+		update_user_option( $this->user_id, $dismissal_key, 'seen' );
+		switch_to_blog( $site2 );
+		update_user_option( $this->user_id, $dismissal_key, 'seen' );
+		restore_current_blog();
+
+		// Restore notification for the current site.
+		Yoast_Notification_Center::restore_notification( $notification );
+
+		$site1_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
+
+		switch_to_blog( $site2 );
+		$site2_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
+		restore_current_blog();
+
+		$this->assertFalse( $site1_dismissed );
+		$this->assertTrue( $site2_dismissed );
+	}
+
+	/**
+	 * Tests that restoring a notification only affects the current site in multisite.
+	 *
+	 * @group ms-required
+	 *
+	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
+	 *
+	 * @covers Yoast_Notification_Center::restore_notification()
+	 */
+	public function test_restore_notification_is_per_site_with_deprecation_notice() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
+
+			return;
+		}
 
 		$site2 = self::factory()->blog->create();
 
@@ -531,6 +615,45 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::is_notification_dismissed()
 	 */
 	public function test_is_notification_dismissed_is_per_site() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
+
+			return;
+		}
+
+		$site2 = self::factory()->blog->create();
+
+		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
+		$dismissal_key = $notification->get_dismissal_key();
+
+		// Dismiss notification for the current site.
+		update_user_option( $this->user_id, $dismissal_key, 'seen' );
+
+		$site1_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
+
+		switch_to_blog( $site2 );
+		$site2_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
+		restore_current_blog();
+
+		$this->assertTrue( $site1_dismissed );
+		$this->assertFalse( $site2_dismissed );
+	}
+
+	/**
+	 * Tests that checking for dismissed notifications applies only to the current site in multisite.
+	 *
+	 * @group ms-required
+	 *        
+	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
+	 *
+	 * @covers Yoast_Notification_Center::is_notification_dismissed()
+	 */
+	public function test_is_notification_dismissed_is_per_site_with_deprecation_notice() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
+			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
+
+			return;
+		}
 
 		$site2 = self::factory()->blog->create();
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -526,7 +526,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 // Activation and deactivation hook.
 register_activation_hook( WPSEO_FILE, 'wpseo_activate' );
 register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
-add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
+add_action( 'wp_insert_site', 'wpseo_on_activate_blog' );
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );
 
 // Registers SEO capabilities.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -526,7 +526,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 // Activation and deactivation hook.
 register_activation_hook( WPSEO_FILE, 'wpseo_activate' );
 register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
-add_action( 'wp_insert_site', 'wpseo_on_activate_blog' );
+add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );
 
 // Registers SEO capabilities.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* ~Fixes a bug where the `wpmu_new_blog` hook has been called. This hook is deprecated in WordPress 5.1 and replaced by `wp_insert_site`~

## Relevant technical choices:

* ~See: https://developer.wordpress.org/reference/hooks/wpmu_new_blog/~
* See: https://make.wordpress.org/core/2019/01/11/new-rest-api-notice-in-5-1/ - See the part about unit tests to have context.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* The unit test should pass. 


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
