### PR TITLE
Additional default allowed hosts in webpack.config.js

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -33,6 +33,8 @@ const externals = {
 
 const defaultAllowedHosts = [
 	"local.wordpress.test",
+	"one.wordpress.test",
+	"two.wordpress.test",
 	"build.wordpress-develop.test",
 	"src.wordpress-develop.test",
 ];


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Since the VVV default configuration has been updated (see [here](https://github.com/Varying-Vagrant-Vagrants/VVV/pull/1650)), the local WordPress installations have been renamed `wordpress-one` and `wordpress-two` rather than `wordpress-local`.
* This PR adds these two installs to the default allowed hosts in the webpack config.

## Test instructions

This PR can be tested by following these steps:

* Start `one.wordpress.test` in your browser (you have to have the local VVV installation called `wordpress-one`).
* In the browser console, find the error message `ERR_CONNECTION_REFUSED`.
* Check out this branch.
* After building and running `yarn start`, the error message should have disappeared.
* The same steps apply to `two.wordpress.test`.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended