### PR TITLE
Update the upgrade routine to correctly clear the beta notification

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -650,12 +650,9 @@ class WPSEO_Upgrade {
 	 */
 	private function clean_all_notifications() {
 		global $wpdb;
-		$query = $wpdb->prepare(
-			'DELETE FROM ' . $wpdb->usermeta . ' WHERE meta_key=%s', $wpdb->prefix . Yoast_Notification_Center::STORAGE_KEY
-			);
-		$wpdb->query( $query );
+		delete_metadata( 'user', 0, $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY, '', true );
 	}
-
+	
 	/**
 	 * Removes the post meta fields for a given meta key.
 	 *

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -652,7 +652,7 @@ class WPSEO_Upgrade {
 		global $wpdb;
 		delete_metadata( 'user', 0, $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY, '', true );
 	}
-	
+
 	/**
 	 * Removes the post meta fields for a given meta key.
 	 *
@@ -662,7 +662,6 @@ class WPSEO_Upgrade {
 	 */
 	private function delete_post_meta( $meta_key ) {
 		global $wpdb;
-
 		$deleted = $wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $meta_key ), array( '%s' ) );
 
 		if ( $deleted ) {

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -124,8 +124,8 @@ class WPSEO_Upgrade {
 			$this->upgrade90();
 		}
 
-		if ( version_compare( $version, '9.6-RC0', '<' ) ) {
-			$this->upgrade96();
+		if ( version_compare( $version, '10.0-RC0', '<' ) ) {
+			$this->upgrade100();
 		}
 
 		// Since 3.7.
@@ -635,12 +635,25 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 9.6 upgrade.
+	 * Performs the 10.0 upgrade.
 	 *
 	 * @return void
 	 */
-	private function upgrade96() {
-		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-recalibration-meta-notification' );
+	private function upgrade100() {
+		$this->clean_all_notifications();
+	}
+
+	/**
+	 * Removes all notifications saved in the database under 'wp_yoast_notifications'.
+	 *
+	 * @return void
+	 */
+	private function clean_all_notifications() {
+		global $wpdb;
+		$query = $wpdb->prepare(
+			'DELETE FROM ' . $wpdb->usermeta . ' WHERE meta_key=%s', $wpdb->prefix . Yoast_Notification_Center::STORAGE_KEY
+			);
+		$wpdb->query( $query );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the recalibration beta notification would still show after the beta ended. 

## Relevant technical choices:

* The upgrade routine did not correctly remove the notification from the database. This PR introduces a new function `clean_all_notifications` which clears all notification from the database field 'wp_yoast_notifications' in the table 'wp_usermeta'. 

## Test instructions

This PR can be tested by following these steps:

* Reproduce the issue as described in #12281. 
* Checkout this branch / install the build zip. The notification should be gone. 

* If this is difficult to test or you don't have an installation where the notification still shows you can bring it back to test it. Add the following function to `class-upgrade.php`
```
	/**
	 * Returns the notification.
	 *
	 * @return Yoast_Notification The notification for the notification center.
	 *
	 * @codeCoverageIgnore
	 */
	protected function get_notification() {
		$message = sprintf(
			/* translators: 1: link opening tag to the features page, 2: link closing tag, 3: Link to KB article, 4: expands to Yoast SEO */
			esc_html__(
				'We\'d love for you to try our new and improved %4$s analysis! Use the toggle on the %1$sFeatures tab%2$s in your %4$s settings. %3$sRead more about the new analysis%2$s.',
				'wordpress-seo'
			),
			'<a href="#top#features" onclick="jQuery(\'#features-tab\').click()">',
			'</a>',
			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/recalibration-beta-notice' ) . '" target="_blank">',
			'Yoast SEO'
		);

		$notification_options = array(
			'type'         => Yoast_Notification::WARNING,
			'id'           => 'wpseo-' . $this->notification_identifier,
			'priority'     => 1.0,
			'capabilities' => 'wpseo_manage_options',
		);

		return new Yoast_Notification( $message, $notification_options );
	}
```
* Add the following line to the `upgrade100()` method. 
```
Yoast_Notification_Center::get()->add_notification( $this->get_notification() );
```
* Use the Yoast test helper to switch versions and trigger the upgrade routine. 
* The notification should also be removed as expected on a multisite. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12281
