### PR TITLE
Merged upgrade routines

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -125,11 +125,7 @@ class WPSEO_Upgrade {
 		}
 
 		if ( version_compare( $version, '10.0-RC0', '<' ) ) {
-			$this->upgrade100();
-		}
-
-		if ( version_compare( $version, '10.0-RC0', '<' ) ) {
-			$this->upgrade_10_0();
+			$this->upgrade_100();
 		}
 
 		// Since 3.7.
@@ -643,8 +639,13 @@ class WPSEO_Upgrade {
 	 *
 	 * @return void
 	 */
-	private function upgrade100() {
+	private function upgrade_100() {
+		// Removes recalibration notifications.
 		$this->clean_all_notifications();
+
+		// Removes recalibration options.
+		WPSEO_Options::clean_up( 'wpseo' );
+		delete_option( 'wpseo_recalibration_beta_mailinglist_subscription' );
 	}
 
 	/**
@@ -655,15 +656,6 @@ class WPSEO_Upgrade {
 	private function clean_all_notifications() {
 		global $wpdb;
 		delete_metadata( 'user', 0, $wpdb->get_blog_prefix() . Yoast_Notification_Center::STORAGE_KEY, '', true );
-	}
-
-	/**
-	 * Performs the 10.0 upgrade.
-	 *
-	 * @return void
-	 */
-	private function upgrade_10_0() {
-		WPSEO_Options::clean_up( 'wpseo' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Combines two separate upgrade routines for 10.0.
* [not-userfacing] Checks if 

## Relevant technical choices:

* Also makes sure `wpseo_recalibration_beta_mailing_subscription` option is removed upon upgrading to 10.0.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the `Yoast Test Helper` is installed.
* Make sure you still have the `wpseo_recalibration_beta_mailing_subscription` option is present. If not check out 9.5 to reactivate it.
* Make sure the `recalibration_beta` value is present in the `wpseo` option in the `wp_options` table.
* In the Yoast Test helper set the version to 9.6 and save. This triggers the 10.0 upgrade routine.
* Check if the `wpseo_recalibration_beta_mailing_subscription` option has been removed from the `wp_options` table.
* Check if the `recalibration_beta` value has been removed from the `wpseo` option in the `wp_options` table.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
