### PR TITLE
Always slash data for post meta values

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -655,7 +655,8 @@ class WPSEO_Meta {
 			if ( $custom[ self::$meta_prefix . $key ][0] === $unserialized ) {
 				return $custom[ self::$meta_prefix . $key ][0];
 			}
-			else {
+
+			if ( isset( self::$fields_index[ self::$meta_prefix . $key ] ) ) {
 				$field_def = self::$meta_fields[ self::$fields_index[ self::$meta_prefix . $key ]['subset'] ][ self::$fields_index[ self::$meta_prefix . $key ]['key'] ];
 				if ( isset( $field_def['serialized'] ) && $field_def['serialized'] === true ) {
 					// Ok, serialize value expected/allowed.
@@ -668,13 +669,12 @@ class WPSEO_Meta {
 		if ( isset( self::$defaults[ self::$meta_prefix . $key ] ) ) {
 			return self::$defaults[ self::$meta_prefix . $key ];
 		}
-		else {
-			/*
-			 * Shouldn't ever happen, means not one of our keys as there will always be a default available
-			 * for all our keys.
-			 */
-			return '';
-		}
+
+		/*
+		 * Shouldn't ever happen, means not one of our keys as there will always be a default available
+		 * for all our keys.
+		 */
+		return '';
 	}
 
 	/**
@@ -689,6 +689,12 @@ class WPSEO_Meta {
 	 * @return bool   whether the value was changed
 	 */
 	public static function set_value( $key, $meta_value, $post_id ) {
+		/*
+		 * Slash the data, because `update_metadata` will unslash it and we have already unslashed it.
+		 * Related issue: https://github.com/Yoast/YoastSEO.js/issues/2158
+		 */
+		$meta_value = wp_slash( $meta_value );
+
 		return update_post_meta( $post_id, self::$meta_prefix . $key, $meta_value );
 	}
 

--- a/tests/test-class-wpseo-meta.php
+++ b/tests/test-class-wpseo-meta.php
@@ -7,10 +7,14 @@
 
 /**
  * Unit Test Class.
+ *
+ * @todo Test for defaults.
  */
 class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 
 	/**
+	 * Tests if data can be stored.
+	 *
 	 * @covers WPSEO_Meta::set_value()
 	 */
 	public function test_set_value() {
@@ -23,6 +27,8 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests if data can be retrieved.
+	 *
 	 * @covers WPSEO_Meta::get_value()
 	 */
 	public function test_get_value() {
@@ -31,16 +37,143 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
 
-		update_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'test_get_value_key', 'test_get_value_value' );
+		$key = 'test_get_value_key';
+		$this->register_meta_key( $key );
 
-		$this->assertEquals( 'test_get_value_value', WPSEO_Meta::get_value( 'test_get_value_key' ) );
+		update_post_meta( $post_id, WPSEO_Meta::$meta_prefix . $key, 'test_get_value_value' );
 
-		// @todo Test for defaults.
-		// @todo Test if non-existing keys return an empty string.
+		$this->assertEquals( 'test_get_value_value', WPSEO_Meta::get_value( $key ) );
 	}
 
 	/**
-	 * Test if default meta values are removed when updating post_meta.
+	 * Tests if an unregistered field with flat data will return what is stored.
+	 *
+	 * This is debatable functionality.
+	 *
+	 * When unserialized data is stored it will not be returned because the
+	 * field definition is missing which declares if the data is serialized.
+	 *
+	 * See self::test_get_value_unregistered_field_serialized()
+	 *
+	 * @covers WPSEO_Meta::set_value()
+	 * @covers WPSEO_Meta::get_value()
+	 */
+	public function test_get_value_non_registered_field() {
+
+		// Create and go to post.
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$key = 'non_registered_key';
+
+		// The field exists on the post - because it will be saved.
+		update_post_meta( $post_id, WPSEO_Meta::$meta_prefix . $key, 'some_value' );
+
+		// As the field is not registered, we should ignore the value in the database.
+		$this->assertEquals( 'some_value', WPSEO_Meta::get_value( $key ) );
+	}
+
+	/**
+	 * Tests if an unregistered field with serialized data will return nothing.
+	 *
+	 * Because the field definition does not exist in WPSEO_Meta the serialized
+	 * data cannot be confirmed to be expected and thus an empty string will
+	 * be returned.
+	 *
+	 * @covers WPSEO_Meta::get_value()
+	 */
+	public function test_get_value_unregistered_field_serialized() {
+
+		// Create and go to post.
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$key = 'non_registered_key_array';
+
+		// The field exists on the post - because it will be saved.
+		update_post_meta( $post_id, WPSEO_Meta::$meta_prefix . $key, array( 'some_value' ) );
+
+		// As the field is not registered, we should ignore the value in the database.
+		$this->assertEquals( '', WPSEO_Meta::get_value( $key ) );
+	}
+
+	/**
+	 * Tests if a non existing key returns an empty string.
+	 *
+	 * @covers WPSEO_Meta::get_value()
+	 */
+	public function test_get_value_non_existing_key() {
+
+		// Create and go to post.
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		// The post meta is never saved, so it is totally unknown.
+		$key = 'non_existing_key_2';
+		$this->assertEquals( '', WPSEO_Meta::get_value( $key ) );
+	}
+
+	/**
+	 * Tests if data with slashes remains the same after storing.
+	 *
+	 * @covers WPSEO_Meta::get_value()
+	 */
+	public function test_set_value_slashed() {
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$key = 'test_set_value_key_slashed';
+		$this->register_meta_key( $key );
+
+		$value = '\\"data\\"';
+
+		WPSEO_Meta::set_value( $key, $value, $post_id );
+		$this->assertEquals( $value, WPSEO_Meta::get_value( $key, $post_id ) );
+	}
+
+	/**
+	 * Tests if data, registered as serialized, with slashes remains the same
+	 * after storing.
+	 *
+	 * @covers WPSEO_Meta::set_value()
+	 * @covers WPSEO_Meta::get_value()
+	 */
+	public function test_get_and_set_value_slashed_array() {
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$key = 'test_set_value_key_slashed_array';
+		$this->register_meta_key( $key, true );
+
+		$value = array( 'k\"ey' => '""slashed data" \\"' );
+
+		WPSEO_Meta::set_value( $key, $value, $post_id );
+		$this->assertEquals( $value, WPSEO_Meta::get_value( $key, $post_id ) );
+	}
+
+	/**
+	 * Tests if serialized data, registered as serialized, with slashes remains
+	 * the same after storing.
+	 *
+	 * @covers WPSEO_Meta::set_value()
+	 * @covers WPSEO_Meta::get_value()
+	 */
+	public function test_get_and_set_value_serialized_and_slashed_array() {
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$key = 'test_set_value_key_slashed_array';
+		$this->register_meta_key( $key, true );
+
+		$array = array( 'ke\\y' => '""slashed data" \\"' );
+		$value = serialize( $array );
+
+		WPSEO_Meta::set_value( $key, $value, $post_id );
+		$this->assertEquals( $value, WPSEO_Meta::get_value( $key, $post_id ) );
+	}
+
+	/**
+	 * Tests if default meta values are removed when updating post_meta.
 	 *
 	 * @covers WPSEO_Meta::remove_meta_if_default
 	 */
@@ -50,6 +183,8 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 
 		// Generate key.
 		$key = WPSEO_Meta::$meta_prefix . 'meta-robots-noindex';
+
+		$this->register_meta_key( $key );
 
 		// Set post meta to default value.
 		$default_value = WPSEO_Meta::$defaults[ $key ];
@@ -61,7 +196,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test if default meta values aren't saved when updating post_meta.
+	 * Tests if default meta values aren't saved when updating post_meta.
 	 *
 	 * @covers WPSEO_Meta::dont_save_meta_if_default
 	 */
@@ -83,6 +218,8 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests if default meta values are detected as default meta values.
+	 *
 	 * @covers WPSEO_Meta::meta_value_is_default
 	 */
 	public function test_meta_value_is_default() {
@@ -93,7 +230,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test if two arrays are recursively merged, the latter overwriting the first.
+	 * Tests if two arrays are recursively merged, the latter overwriting the first.
 	 *
 	 * @covers WPSEO_Meta::array_merge_recursive_distinct
 	 */
@@ -116,20 +253,52 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests if meta robots validation prioritizes and cleans the output.
+	 *
 	 * @covers WPSEO_Meta::validate_meta_robots_adv
 	 */
 	public function test_validate_meta_robots_adv() {
 
 		// None should take precedence.
 		$this->assertEquals( 'none', WPSEO_Meta::validate_meta_robots_adv( 'none, something-invalid, noarchive' ) );
-		$this->assertEquals( 'none', WPSEO_Meta::validate_meta_robots_adv( array( 'none', 'something-invalid', 'noarchive' ) ) );
+		$this->assertEquals( 'none', WPSEO_Meta::validate_meta_robots_adv( array(
+			'none',
+			'something-invalid',
+			'noarchive',
+		) ) );
 
 		// - should take precedence.
 		$this->assertEquals( '-', WPSEO_Meta::validate_meta_robots_adv( '-, something-invalid, noarchive' ) );
-		$this->assertEquals( '-', WPSEO_Meta::validate_meta_robots_adv( array( '-', 'something-invalid', 'noarchive' ) ) );
+		$this->assertEquals( '-', WPSEO_Meta::validate_meta_robots_adv( array(
+			'-',
+			'something-invalid',
+			'noarchive',
+		) ) );
 
 		// String should be cleaned.
 		$this->assertEquals( 'noarchive,nosnippet', WPSEO_Meta::validate_meta_robots_adv( 'noarchive, nosnippet' ) );
-		$this->assertEquals( 'noarchive,nosnippet', WPSEO_Meta::validate_meta_robots_adv( array( 'noarchive', 'nosnippet' ) ) );
+		$this->assertEquals( 'noarchive,nosnippet', WPSEO_Meta::validate_meta_robots_adv( array(
+			'noarchive',
+			'nosnippet',
+		) ) );
+	}
+
+	/**
+	 * Registers a field on the WPSEO_Meta class.
+	 *
+	 * @param string $key The key to register.
+	 * @param bool   $serialized If the key is stored as serialized data.
+	 *
+	 * @returns {void}
+	 */
+	protected function register_meta_key( $key, $serialized = false ) {
+		WPSEO_Meta::$fields_index[ WPSEO_Meta::$meta_prefix . $key ] = array(
+			'subset' => 'test',
+			'key'    => $key,
+		);
+
+		WPSEO_Meta::$meta_fields['test'] = array(
+			$key => array( 'type' => 'hidden', 'serialized' => $serialized ),
+		);
 	}
 }


### PR DESCRIPTION
Reverts Yoast/wordpress-seo#12301
Original PR Yoast/wordpress-seo#12282 - now on `release/10.0` instead of `release/9.7`

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where slashed data would be transformed to unslashed data after saving and reloading a post.

## Relevant technical choices:

* Slash the data, because `update_metadata` will unslash it and we have already unslashed it.
* Added tests for slashed values.
* Added tests for serialized values, where serialized and unregistered could result in an error before.
* Testing registered and unregistered fields, where the `get_value` function now gets used; also introducing a helper function for registration.
* Documentation improvements.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to a post and add escaped data like `\"test\"` into a metabox input, for example, focus keyphrase.
* Save the post and refresh the page.
* Ensure the input field has the same value as before. Where previously the escaping would be removed, e.g. `\"test\"` would have become `"test"`.
* Try the same with double quotes like `""test""`.

## UI changes
* [ ] ~~This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Related https://github.com/Yoast/YoastSEO.js/issues/2158
