### PR TITLE
Fix taxonomy meta validation

### DIFF
--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -50,6 +50,8 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 		'wpseo_focuskw'               => '',
 		'wpseo_linkdex'               => '',
 		'wpseo_content_score'         => '',
+		'wpseo_focuskeywords'         => '[]',
+		'wpseo_keywordsynonyms'       => '[]',
 
 		// Social fields.
 		'wpseo_opengraph-title'       => '',
@@ -280,6 +282,21 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 						$clean[ $key ] = $old_meta[ $key ];
 					}
 					break;
+
+				case 'wpseo_focuskeywords':
+				case 'wpseo_keywordsynonyms':
+					if ( isset( $meta_data[ $key ] ) && is_string( $meta_data[ $key ] ) ) {
+						/*
+						 * Using `wp_slash` and `wp_unslash` here instead of `stripslashes`.
+						 * The data is stringified JSON. Therefore, `addslashes` has side effects.
+						 * Related issue: https://github.com/Yoast/YoastSEO.js/issues/2158
+						 */
+						$clean[ $key ] = wp_slash( $meta_data[ $key ] );
+						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $clean[ $key ] );
+						$clean[ $key ] = wp_unslash( $clean[ $key ] );
+					}
+					break;
+
 				case 'wpseo_focuskw':
 				case 'wpseo_title':
 				case 'wpseo_desc':

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -275,7 +275,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 
 				case 'wpseo_bctitle':
 					if ( isset( $meta_data[ $key ] ) ) {
-						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( stripslashes( $meta_data[ $key ] ) );
+						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $meta_data[ $key ] );
 					}
 					elseif ( isset( $old_meta[ $key ] ) ) {
 						// Retain old value if field currently not in use.
@@ -303,18 +303,16 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 				case 'wpseo_linkdex':
 				default:
 					if ( isset( $meta_data[ $key ] ) && is_string( $meta_data[ $key ] ) ) {
-						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( stripslashes( $meta_data[ $key ] ) );
+						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $meta_data[ $key ] );
 					}
 
 					if ( 'wpseo_focuskw' === $key ) {
 						$search = array(
 							'&lt;',
 							'&gt;',
-							'&quot',
 							'&#96',
 							'<',
 							'>',
-							'"',
 							'`',
 						);
 

--- a/tests/inc/options/test-class-wpseo-taxonomy-meta.php
+++ b/tests/inc/options/test-class-wpseo-taxonomy-meta.php
@@ -52,4 +52,29 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( '', WPSEO_Taxonomy_Meta::get_meta_without_term( 'meta_field' ) );
 	}
+
+	/**
+	 * Tests if data with slashes remains the same after validating.
+	 *
+	 * @dataProvider get_validated_term_meta_data_provider
+	 *
+	 * @param array  $expected The expected results - also used as input.
+	 *
+	 * @covers       WPSEO_Taxonomy_Meta::validate_term_meta_data()
+	 */
+	public function test_validate_term_meta_data( $expected ) {
+		$this->assertEquals( $expected, WPSEO_Taxonomy_Meta::validate_term_meta_data( $expected, WPSEO_Taxonomy_Meta::$defaults_per_term ) );
+	}
+
+	/**
+	 * DataProvider function for the test: test_validate_term_meta_data
+	 *
+	 * @return array With the $meta_key and $expected variables.
+	 */
+	public function get_validated_term_meta_data_provider() {
+		return array(
+			array( array( 'wpseo_focuskeywords' => '[{"keyword":"\\\"test\\\"","score":"good"},{"keyword":"\\\\","score":"bad"}]' ) ),
+			array( array( 'wpseo_keywordsynonyms' => '["","\\"\\"TESTING\\"\\"",""]' ) ),
+		);
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where related keyphrases and synonyms could be transformed after saving and reloading a taxonomy.
* Fixes a bug where a taxonomy's focus keyphrase could not include double quotes.

## Relevant technical choices:

* Added validation for the related keyphrases (`wpseo_focuskeywords`) and synonyms (`wpseo_keywordsynonyms`).
* Removed the use of `stripslashes` for the breadcrumb title, focus keyphrase title, description, score and default fields.
* Removed the sanitizing of `"` and `&quot` from the focus keyphrase.
* Added tests for `WPSEO_Taxonomy_Meta::validate_term_meta_data()`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Merge this PR in premium to test it.
* Go to a taxonomy page.

### Validation for related keyphrases and synonyms
* Enter a text with some escaped characters, like `\"test\"`.
* Update the taxonomy (which reloads the page).
* Ensure the values are still the same (unlike without this PR).

### Validation of the focus keyphrase
* Enter a text with double quotes and `&quot`, like `"test&quot`.
* Update the taxonomy (which reloads the page).
* Ensure the values are still the same (unlike without this PR).
* The following should get removed: `&lt;`, `&gt;`,`&#96`,`<`, `>` and ``` ` ``` (this was already the case)


### Validation for breadcrumb title, focus keyphrase title, description, keyphrase score and default fields
The default fields are fields that are not specified in this switch statement, but do have an entry in the defaults array. Which, at the moment of writing, can be any of these: content score, opengraph title, opengraph description, opengraph image, opengraph image id, twitter title, twitter description, twitter image or twitter image id
* Enter a text with some backslashes, like `\\test\\`.
* Update the taxonomy (which reloads the page).
* Ensure the values are still the same (unlike without this PR).

## UI changes
* [ ] ~~This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Related Yoast/YoastSEO.js#2158
See the PR for posts: Yoast/wordpress-seo#12306
