### PR TITLE
Replaced all references to Basic SEO training with Keyword research training

### DIFF
--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -51,11 +51,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 		}
 
 		$field->add_suggestion(
-			sprintf(
-				/* translators: %1$s resolves to Keyword research training */
-				__( 'Find out what words your audience uses to find you', 'wordpress-seo' ),
-				'Keyword research training'
-			),
+			__( 'Find out what words your audience uses to find you', 'wordpress-seo' ),
 			sprintf(
 				/* translators: %1$s resolves to Keyword research training */
 				__( 'Keyword research is essential in any SEO strategy. You decide the search terms you want to be found for, and figure out what words your audience uses to find you. Great keyword research tells you what content you need to start ranking for the terms you want to rank for. Make sure your efforts go into the keywords you actually have a chance at ranking for! The %1$s walks you through this process, step by step.', 'wordpress-seo' ),

--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -52,27 +52,26 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 
 		$field->add_suggestion(
 			sprintf(
-				/* translators: %1$s resolves to Basic SEO training */
-				__( 'Learn all about SEO with our %1$s', 'wordpress-seo' ),
-				'Basic SEO training'
+				/* translators: %1$s resolves to Keyword research training */
+				__( 'Find out what words your audience uses to find you', 'wordpress-seo' ),
+				'Keyword research training'
 			),
 			sprintf(
-				/* translators: %1$s resolves to Basic SEO training, 2: Yoast SEO */
-				__( 'Do you want to learn how you can improve your SEO yourself? In our %1$s you\'ll learn practical SEO skills from keyword research and copywriting to technical SEO and off-page SEO. Using the %2$s plugin is one thing. Doing good SEO day-to-day is another. You simply won\'t get the results you want without putting in work yourself. The %1$s teaches you how.', 'wordpress-seo' ),
-				'Basic SEO training',
-				'Yoast SEO'
+				/* translators: %1$s resolves to Keyword research training */
+				__( 'Keyword research is essential in any SEO strategy. You decide the search terms you want to be found for, and figure out what words your audience uses to find you. Great keyword research tells you what content you need to start ranking for the terms you want to rank for. Make sure your efforts go into the keywords you actually have a chance at ranking for! The %1$s walks you through this process, step by step.', 'wordpress-seo' ),
+				'Keyword research training'
 			),
 			array(
-				'label' => 'Basic SEO training',
+				'label' => 'Keyword research training',
 				'type'  => 'link',
-				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/2up' ),
+				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/3lg' ),
 			),
 			array(
-				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/2v0' ),
+				'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/3lf' ),
 				'title' => sprintf(
-					/* translators: %1$s expands to Basic SEO training. */
+					/* translators: %1$s expands to Keyword research training. */
 					__( '%1$s video', 'wordpress-seo' ),
-					'Basic SEO training'
+					'Keyword research training'
 				),
 			)
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaces all references to the Basic SEO training in the configuration wizard with references to the Keyword research training.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In the dashboard, go to the configuration wizard, step 11.
* You should see the following training suggestion:
<img width="1000" alt="53348940-52a62b00-391c-11e9-8bc7-c37677ba7526" src="https://user-images.githubusercontent.com/20280513/53400110-76fe1800-39ad-11e9-8057-5fbb497e264b.png">

* Check out this branch.
* The suggestion should now look as follows:
<img width="1000" alt="screen shot 2019-02-26 at 10 02 32" src="https://user-images.githubusercontent.com/20280513/53400225-b3ca0f00-39ad-11e9-853e-109b44d46f30.png">
* (At the moment, the Keyword research training button still results in a Page not found error, but this should change once 10.0 is released.)

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12314
