### PR TITLE
Replace deprecated hook `wpmu_new_blog` by `wp_insert_site`

### DIFF
--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -68,28 +68,6 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
 	}
 
-
-	/**
-	 * Tests getting site choices.
-	 *
-	 * @group ms-required
-	 *
-	 * @covers Yoast_Network_Admin::get_site_choices()
-	 */
-	public function test_get_site_choices_with_deprecated_exception() {
-		$admin = new Yoast_Network_Admin();
-
-		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );
-
-		$choices = $admin->get_site_choices();
-		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
-
-		array_unshift( $site_ids, '-' );
-
-		$choices = $admin->get_site_choices( true );
-		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
-	}
-
 	/**
 	 * Tests getting site choices output.
 	 *
@@ -124,35 +102,6 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	public function test_get_site_states() {
 		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
 			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
-
-			return;
-		}
-
-		$admin = new Yoast_Network_Admin();
-
-		$active_states = array(
-			'public' => '1',
-			'mature' => '1',
-			'spam'   => '1',
-		);
-
-		$site_id = self::factory()->blog->create();
-		update_blog_details( $site_id, $active_states );
-
-		$site_states = $admin->get_site_states( get_site( $site_id ) );
-		$this->assertSame( array_keys( $active_states ), array_keys( $site_states ) );
-	}
-
-	/**
-	 * Tests getting a site's states.
-	 *
-	 * @group ms-required
-	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
-	 * @covers Yoast_Network_Admin::get_site_states()
-	 */
-	public function test_get_site_states_with_deprecated_exception() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
 
 			return;
 		}

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -55,12 +55,6 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Admin::get_site_choices()
 	 */
 	public function test_get_site_choices() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
-
-			return;
-		}
-
 		$admin = new Yoast_Network_Admin();
 
 		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );
@@ -80,17 +74,9 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
-	 *
 	 * @covers Yoast_Network_Admin::get_site_choices()
 	 */
 	public function test_get_site_choices_with_deprecated_exception() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
-
-			return;
-		}
-
 		$admin = new Yoast_Network_Admin();
 
 		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -471,12 +471,6 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::dismiss_notification()
 	 */
 	public function test_dismiss_notification_is_per_site() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
-
-			return;
-		}
-
 		$site2 = self::factory()->blog->create();
 
 		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
@@ -500,17 +494,9 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
-	 *
 	 * @covers Yoast_Notification_Center::dismiss_notification()
 	 */
 	public function test_dismiss_notification_is_per_site_with_deprecation_exception() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
-
-			return;
-		}
-
 		$site2 = self::factory()->blog->create();
 
 		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
@@ -537,12 +523,6 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::restore_notification()
 	 */
 	public function test_restore_notification_is_per_site() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
-
-			return;
-		}
-
 		$site2 = self::factory()->blog->create();
 
 		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
@@ -572,17 +552,9 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
-	 *
 	 * @covers Yoast_Notification_Center::restore_notification()
 	 */
 	public function test_restore_notification_is_per_site_with_deprecation_notice() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
-
-			return;
-		}
-
 		$site2 = self::factory()->blog->create();
 
 		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
@@ -643,18 +615,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * Tests that checking for dismissed notifications applies only to the current site in multisite.
 	 *
 	 * @group ms-required
-	 *        
-	 * @expectedExceptionMessage Unexpected deprecated notice for wpmu_new_blog
 	 *
 	 * @covers Yoast_Notification_Center::is_notification_dismissed()
 	 */
 	public function test_is_notification_dismissed_is_per_site_with_deprecation_notice() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
-			$this->markTestSkipped( 'Skipped we expected a deprecation notice for the hook wpmu_new_blog (WordPress 5.1)' );
-
-			return;
-		}
-
 		$site2 = self::factory()->blog->create();
 
 		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -554,32 +554,6 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that checking for dismissed notifications applies only to the current site in multisite.
-	 *
-	 * @group ms-required
-	 *
-	 * @covers Yoast_Notification_Center::is_notification_dismissed()
-	 */
-	public function test_is_notification_dismissed_is_per_site_with_deprecation_notice() {
-		$site2 = self::factory()->blog->create();
-
-		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
-		$dismissal_key = $notification->get_dismissal_key();
-
-		// Dismiss notification for the current site.
-		update_user_option( $this->user_id, $dismissal_key, 'seen' );
-
-		$site1_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
-
-		switch_to_blog( $site2 );
-		$site2_dismissed = Yoast_Notification_Center::is_notification_dismissed( $notification );
-		restore_current_blog();
-
-		$this->assertTrue( $site1_dismissed );
-		$this->assertFalse( $site2_dismissed );
-	}
-
-	/**
 	 * Tests that checking for dismissed notifications falls back to user meta if no user options.
 	 *
 	 * @covers Yoast_Notification_Center::is_notification_dismissed()

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -522,38 +522,6 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that restoring a notification only affects the current site in multisite.
-	 *
-	 * @group ms-required
-	 *
-	 * @covers Yoast_Notification_Center::restore_notification()
-	 */
-	public function test_restore_notification_is_per_site_with_deprecation_notice() {
-		$site2 = self::factory()->blog->create();
-
-		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
-		$dismissal_key = $notification->get_dismissal_key();
-
-		// Dismiss notification for both sites.
-		update_user_option( $this->user_id, $dismissal_key, 'seen' );
-		switch_to_blog( $site2 );
-		update_user_option( $this->user_id, $dismissal_key, 'seen' );
-		restore_current_blog();
-
-		// Restore notification for the current site.
-		Yoast_Notification_Center::restore_notification( $notification );
-
-		$site1_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
-
-		switch_to_blog( $site2 );
-		$site2_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
-		restore_current_blog();
-
-		$this->assertFalse( $site1_dismissed );
-		$this->assertTrue( $site2_dismissed );
-	}
-
-	/**
 	 * Tests that checking for dismissed notifications applies only to the current site in multisite.
 	 *
 	 * @group ms-required

--- a/tests/notifications/test-class-yoast-notification-center.php
+++ b/tests/notifications/test-class-yoast-notification-center.php
@@ -490,32 +490,6 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests that dismissing a notification only affects the current site in multisite.
-	 *
-	 * @group ms-required
-	 *
-	 * @covers Yoast_Notification_Center::dismiss_notification()
-	 */
-	public function test_dismiss_notification_is_per_site_with_deprecation_exception() {
-		$site2 = self::factory()->blog->create();
-
-		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
-		$dismissal_key = $notification->get_dismissal_key();
-
-		// Dismiss notification for the current site.
-		Yoast_Notification_Center::dismiss_notification( $notification );
-
-		$site1_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
-
-		switch_to_blog( $site2 );
-		$site2_dismissed = (bool) get_user_option( $dismissal_key, $this->user_id );
-		restore_current_blog();
-
-		$this->assertTrue( $site1_dismissed );
-		$this->assertFalse( $site2_dismissed );
-	}
-
-	/**
 	 * Tests that restoring a notification only affects the current site in multisite.
 	 *
 	 * @group ms-required

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -270,7 +270,7 @@ function wpseo_on_activate_blog( $blog_id ) {
  *
  * @return void
  */
-function wpseo_on_activate_blog_from_WP_Site( $blog ) {
+function wpseo_on_activate_blog_from_wp_site( $blog ) {
 	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
 		wpseo_on_activate_blog( $blog->blog_id );
 	}
@@ -545,7 +545,7 @@ if ( version_compare( $wp_version,'5.1', '<' ) ) {
 	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 }
 else {
-	add_action( 'wp_insert_site', 'wpseo_on_activate_blog_from_WP_Site' );
+	add_action( 'wp_insert_site', 'wpseo_on_activate_blog_from_wp_site' );
 }
 
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -526,7 +526,15 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 // Activation and deactivation hook.
 register_activation_hook( WPSEO_FILE, 'wpseo_activate' );
 register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
-add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
+
+// Wpmu_new_blog has been deprecated in 5.1 and replaced by wp_insert_site.
+global $wp_version;
+if(version_compare($wp_version,'5.1', '<') ) {
+	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
+} else {
+	add_action( 'wp_insert_site', 'wpseo_on_activate_blog' );
+}
+
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );
 
 // Registers SEO capabilities.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -272,7 +272,7 @@ function wpseo_on_activate_blog( $blog_id ) {
  */
 function wpseo_on_activate_blog_from_wp_site( $blog ) {
 	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
-		wpseo_on_activate_blog( intval( $blog->blog_id ) );
+		wpseo_on_activate_blog( (int) $blog->blog_id );
 	}
 }
 
@@ -545,7 +545,7 @@ if ( version_compare( $wp_version,'5.1', '<' ) ) {
 	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 }
 else {
-	add_action( 'wp_insert_site', 'wpseo_on_activate_blog_from_wp_site' );
+	add_action( 'wp_initialize_site', 'wpseo_on_activate_blog_from_wp_site', 99 );
 }
 
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -267,12 +267,13 @@ function wpseo_on_activate_blog( $blog_id ) {
  * Alternative method for calling wpseo_on_activate_blog, for when supplied with a WP_site object instead of an ID.
  *
  * @param object $blog The WP_Site object received from wp_insert_site.
+ *
+ * @return void
  */
 function wpseo_on_activate_blog_from_WP_Site( $blog ) {
 	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
-		$blog = $blog->blog_id;
+		wpseo_on_activate_blog( $blog->blog_id );
 	}
-	wpseo_on_activate_blog( $blog );
 }
 
 /* ***************************** PLUGIN LOADING *************************** */

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -535,9 +535,10 @@ register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
 
 // Wpmu_new_blog has been deprecated in 5.1 and replaced by wp_insert_site.
 global $wp_version;
-if( version_compare($wp_version,'5.1', '<') ) {
+if ( version_compare( $wp_version,'5.1', '<' ) ) {
 	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
-} else {
+}
+else {
 	add_action( 'wp_insert_site', 'wpseo_on_activate_blog' );
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -249,15 +249,21 @@ function _wpseo_deactivate() {
  * {@internal Unfortunately will fail if the plugin is in the must-use directory.
  *            {@link https://core.trac.wordpress.org/ticket/24205} }}
  *
- * @param int $blog_id Blog ID.
+ * @param int || object $blog The blog id or blog object, depending on the hook used to call this method.
  */
-function wpseo_on_activate_blog( $blog_id ) {
+function wpseo_on_activate_blog( $blog ) {
+
+	// In WP >= 5.1, wp_insert_site replaced wpmu_new_blog, which returns an object instead of an ID.
+	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
+		$blog = $blog->blog_id;
+	}
+
 	if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
 
 	if ( is_plugin_active_for_network( plugin_basename( WPSEO_FILE ) ) ) {
-		switch_to_blog( $blog_id );
+		switch_to_blog( $blog );
 		wpseo_activate( false );
 		restore_current_blog();
 	}
@@ -529,7 +535,7 @@ register_deactivation_hook( WPSEO_FILE, 'wpseo_deactivate' );
 
 // Wpmu_new_blog has been deprecated in 5.1 and replaced by wp_insert_site.
 global $wp_version;
-if(version_compare($wp_version,'5.1', '<') ) {
+if( version_compare($wp_version,'5.1', '<') ) {
 	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 } else {
 	add_action( 'wp_insert_site', 'wpseo_on_activate_blog' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -272,7 +272,7 @@ function wpseo_on_activate_blog( $blog_id ) {
  */
 function wpseo_on_activate_blog_from_wp_site( $blog ) {
 	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
-		wpseo_on_activate_blog( $blog->blog_id );
+		wpseo_on_activate_blog( intval( $blog->blog_id ) );
 	}
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -249,26 +249,31 @@ function _wpseo_deactivate() {
  * {@internal Unfortunately will fail if the plugin is in the must-use directory.
  *            {@link https://core.trac.wordpress.org/ticket/24205} }}
  *
- * @param int || object $blog The blog id or blog object, depending on the hook used to call this method.
+ * @param int $blog_id Blog ID.
  */
-function wpseo_on_activate_blog( $blog ) {
-
-	// In WP >= 5.1, wp_insert_site replaced wpmu_new_blog, which returns an object instead of an ID.
-	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
-		$blog = $blog->blog_id;
-	}
-
+function wpseo_on_activate_blog( $blog_id ) {
 	if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
 
 	if ( is_plugin_active_for_network( plugin_basename( WPSEO_FILE ) ) ) {
-		switch_to_blog( $blog );
+		switch_to_blog( $blog_id );
 		wpseo_activate( false );
 		restore_current_blog();
 	}
 }
 
+/**
+ * Alternative method for calling wpseo_on_activate_blog, for when supplied with a WP_site object instead of an ID.
+ *
+ * @param object $blog The WP_Site object received from wp_insert_site.
+ */
+function wpseo_on_activate_blog_from_WP_Site( $blog ) {
+	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
+		$blog = $blog->blog_id;
+	}
+	wpseo_on_activate_blog( $blog );
+}
 
 /* ***************************** PLUGIN LOADING *************************** */
 
@@ -539,7 +544,7 @@ if ( version_compare( $wp_version,'5.1', '<' ) ) {
 	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 }
 else {
-	add_action( 'wp_insert_site', 'wpseo_on_activate_blog' );
+	add_action( 'wp_insert_site', 'wpseo_on_activate_blog_from_WP_Site' );
 }
 
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replaces the`wpmu_new_blog` by the `wp_insert_site` hook in websites running WP5.1 or higher. 

## Relevant technical choices:

* Removed the workaround for the failing tests introduced earlier in #12291, to test if the tests pass now. 
* `Use another hook (`wp_initialize_site `), because in that hook the tables will be created`

## Test instructions
This PR can be tested by following these steps:

The issue is hard to test as the deprecation warning is not shown, problably because the page redirects.I would expect a deprecation warning when adding a new site under WP 5.1 on a multisite but no deprecation warning is thrown. The solution is to use WP_DEBUG_LOG.

To reproduce the issue: 
* Open a multisite, make sure the installed WordPress version is 5.1 or higher. 
* In your `wp-config.php` file add the line `define( 'WP_DEBUG_LOG', true );`
* Go to 'My sites' -> 'Network Admin' -> 'Sites'
* Click 'Add New' and add a new site. 
* (This is the moment the hook is triggered). 
* Everything should function correctly. 
* A log file is created: `debug.log` inside the /wp-content/ directory. In this file you should see: 
`PHP Notice:  wpmu_new_blog is <strong>deprecated</strong> since version 5.1.0! Use wp_insert_site instead.`

To test the fix: 
* Checkout this branch.
* Create a new site. There should be no deprecated notice in the log. 
* Everything should still work as expected. 
* Don't forget to remove the WP_DEBUG_LOG from your config when finished. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12292 
