### PR TITLE
Remove negative tabindex from the button to start the configuration wizard

### DIFF
--- a/js/src/components/RaisedDefaultButton.js
+++ b/js/src/components/RaisedDefaultButton.js
@@ -25,14 +25,12 @@ RaisedDefaultButton.propTypes = {
 	type: PropTypes.string,
 	disableFocusRipple: PropTypes.bool,
 	disableTouchRipple: PropTypes.bool,
-	disableKeyboardFocus: PropTypes.bool,
 };
 
 RaisedDefaultButton.defaultProps = {
 	type: "",
 	disableFocusRipple: true,
 	disableTouchRipple: true,
-	disableKeyboardFocus: true,
 };
 
 export default RaisedDefaultButton;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

- Fixes a bug where the button to start the configuration wizard was not focusable with the keyboard

## Relevant technical choices:
- removes the `disableKeyboardFocus` prop  to remove a `tabindex="-1"` set on the button

## Test instructions
- build assets
- before: the button is not focusable with the keyboard
- after: the button is focusable

As far as I see, there are no relevant visual changes.

Fixes #12332
