### PR TITLE
Use the same callback function for the hook

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -249,30 +249,21 @@ function _wpseo_deactivate() {
  * {@internal Unfortunately will fail if the plugin is in the must-use directory.
  *            {@link https://core.trac.wordpress.org/ticket/24205} }}
  *
- * @param int $blog_id Blog ID.
+ * @param int|WP_Site $blog_id Blog ID.
  */
 function wpseo_on_activate_blog( $blog_id ) {
 	if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
 
+	if ( $blog_id instanceof WP_Site ) {
+		$blog_id = (int) $blog_id->blog_id;
+	}
+
 	if ( is_plugin_active_for_network( plugin_basename( WPSEO_FILE ) ) ) {
 		switch_to_blog( $blog_id );
 		wpseo_activate( false );
 		restore_current_blog();
-	}
-}
-
-/**
- * Alternative method for calling wpseo_on_activate_blog, for when supplied with a WP_site object instead of an ID.
- *
- * @param object $blog The WP_Site object received from wp_insert_site.
- *
- * @return void
- */
-function wpseo_on_activate_blog_from_wp_site( $blog ) {
-	if ( is_object( $blog ) && isset( $blog->blog_id ) ) {
-		wpseo_on_activate_blog( (int) $blog->blog_id );
 	}
 }
 
@@ -545,7 +536,7 @@ if ( version_compare( $wp_version,'5.1', '<' ) ) {
 	add_action( 'wpmu_new_blog', 'wpseo_on_activate_blog' );
 }
 else {
-	add_action( 'wp_initialize_site', 'wpseo_on_activate_blog_from_wp_site', 99 );
+	add_action( 'wp_initialize_site', 'wpseo_on_activate_blog', 99 );
 }
 
 add_action( 'activate_blog', 'wpseo_on_activate_blog' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A - Additional improvement for #12320

## Relevant technical choices:

* Removed the workaround for the failing tests introduced earlier in #12291, to test if the tests pass now. 

## Test instructions
This PR can be tested by following these steps:

The issue is hard to test as the deprecation warning is not shown, probably because the page redirects.I would expect a deprecation warning when adding a new site under WP 5.1 on a multisite but no deprecation warning is thrown. The solution is to use WP_DEBUG_LOG.

To reproduce the issue: 
* Open a multisite, make sure the installed WordPress version is 5.1 or higher. 
* In your `wp-config.php` file add the line `define( 'WP_DEBUG_LOG', true );`
* Go to 'My sites' -> 'Network Admin' -> 'Sites'
* Click 'Add New' and add a new site. 
* (This is the moment the hook is triggered). 
* Everything should function correctly. 
* A log file is created: `debug.log` inside the /wp-content/ directory. In this file you should see: 
`PHP Notice:  wpmu_new_blog is <strong>deprecated</strong> since version 5.1.0! Use wp_insert_site instead.`

To test the fix: 
* Checkout this branch.
* Create a new site. There should be no deprecated notice in the log. 
* Everything should still work as expected. 
* Don't forget to remove the WP_DEBUG_LOG from your config when finished. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
