### PR TITLE
Removed the alt image tag for Open Graph.

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -44,7 +44,6 @@ class WPSEO_OpenGraph_Image {
 	private $image_tags = array(
 		'width'     => 'width',
 		'height'    => 'height',
-		'alt'       => 'alt',
 		'mime-type' => 'type',
 	);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Removes the `og:image:alt` tag from Yoast SEO.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In your WordPress environment, go to `Posts`, choose a post to edit, and go to the social media tab.
* Upload a Facebook image to the post, and make sure you fill out the `Alt Text` field under `ATTACHMENT DETAILS`.
* Update, view post and inspect.
* In `Elements`, under `head`, you should see the `og:image:alt` tag with as its content the text you just entered.
* Check out this branch.
* Refresh your post and inspect again. The `og:image:alt` tag should be gone.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12210
