### PR TITLE
Moved primary term selector to separate script

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -514,6 +514,8 @@ class WPSEO_Admin_Asset_Manager {
 					'wp-i18n',
 					'wp-components',
 					'wp-data',
+					self::PREFIX . 'analysis',
+					self::PREFIX . 'components',
 					self::PREFIX . 'commons',
 				),
 			),

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -92,6 +92,15 @@ class WPSEO_Admin {
 			$integrations[] = new Yoast_Network_Admin();
 		}
 
+		$this->admin_features = array(
+			'google_search_console' => new WPSEO_GSC(),
+			'dashboard_widget'      => new Yoast_Dashboard_Widget(),
+		);
+
+		if ( WPSEO_Metabox::is_post_overview( $pagenow ) || WPSEO_Metabox::is_post_edit( $pagenow ) ) {
+			$this->admin_features['primary_category'] = new WPSEO_Primary_Term_Admin();
+		}
+
 		$integrations[] = new WPSEO_Yoast_Columns();
 		$integrations[] = new WPSEO_License_Page_Manager();
 		$integrations[] = new WPSEO_Statistic_Integration();
@@ -103,20 +112,12 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_MyYoast_Route();
 		$integrations[] = new WPSEO_Addon_Manager();
 
-		$this->admin_features = array();
-
-		if ( is_admin() ) {
-			$integrations[] = new WPSEO_GSC();
-			$this->admin_features['google_search_console'] = end( $integrations );
-
-			$integrations[] = new Yoast_Dashboard_Widget();
-			$this->admin_features['dashboard_widget'] = end( $integrations );
-
-			$integrations[] = new WPSEO_Primary_Term_Admin();
-			$this->admin_features['primary_category'] = end( $integrations );
-		}
-
-		$integrations   = array_merge( $integrations, $this->initialize_seo_links(), $this->initialize_cornerstone_content() );
+		$integrations = array_merge(
+			$integrations,
+			$this->get_admin_features(),
+			$this->initialize_seo_links(),
+			$this->initialize_cornerstone_content()
+		);
 
 		/** @var WPSEO_WordPress_Integration $integration */
 		foreach ( $integrations as $integration ) {

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -51,16 +51,6 @@ class WPSEO_Admin {
 			add_filter( 'wpseo_accessible_post_types', array( 'WPSEO_Post_Type', 'filter_attachment_post_type' ) );
 		}
 
-		$this->admin_features = array(
-			// Google Search Console.
-			'google_search_console' => new WPSEO_GSC(),
-			'dashboard_widget'      => new Yoast_Dashboard_Widget(),
-		);
-
-		if ( WPSEO_Metabox::is_post_overview( $pagenow ) || WPSEO_Metabox::is_post_edit( $pagenow ) ) {
-			$this->admin_features['primary_category'] = new WPSEO_Primary_Term_Admin();
-		}
-
 		if ( filter_input( INPUT_GET, 'page' ) === 'wpseo_tools' && filter_input( INPUT_GET, 'tool' ) === null ) {
 			new WPSEO_Recalculate_Scores();
 		}
@@ -112,7 +102,20 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_MyYoast_Proxy();
 		$integrations[] = new WPSEO_MyYoast_Route();
 		$integrations[] = new WPSEO_Addon_Manager();
-		$integrations[] = $this->admin_features['google_search_console'];
+
+		$this->admin_features = array();
+
+		if ( is_admin() ) {
+			$integrations[] = new WPSEO_GSC();
+			$this->admin_features['google_search_console'] = end( $integrations );
+
+			$integrations[] = new Yoast_Dashboard_Widget();
+			$this->admin_features['dashboard_widget'] = end( $integrations );
+
+			$integrations[] = new WPSEO_Primary_Term_Admin();
+			$this->admin_features['primary_category'] = end( $integrations );
+		}
+
 		$integrations   = array_merge( $integrations, $this->initialize_seo_links(), $this->initialize_cornerstone_content() );
 
 		/** @var WPSEO_WordPress_Integration $integration */

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -8,12 +8,22 @@
 /**
  * Adds the UI to change the primary term for a post.
  */
-class WPSEO_Primary_Term_Admin {
+class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 
 	/**
 	 * Constructor.
 	 */
-	public function __construct() {
+	public function register_hooks() {
+		global $pagenow;
+
+		if ( ! ( WPSEO_Metabox::is_post_overview( $pagenow ) || WPSEO_Metabox::is_post_edit( $pagenow ) ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_categories' ) ) {
+			return;
+		}
+
 		add_filter( 'wpseo_content_meta_section_content', array( $this, 'add_input_fields' ) );
 
 		add_action( 'admin_footer', array( $this, 'wp_footer' ), 10 );

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -14,12 +14,6 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 	 * Constructor.
 	 */
 	public function register_hooks() {
-		global $pagenow;
-
-		if ( ! ( WPSEO_Metabox::is_post_overview( $pagenow ) || WPSEO_Metabox::is_post_edit( $pagenow ) ) ) {
-			return;
-		}
-
 		add_filter( 'wpseo_content_meta_section_content', array( $this, 'add_input_fields' ) );
 
 		add_action( 'admin_footer', array( $this, 'wp_footer' ), 10 );

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -20,10 +20,6 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		if ( ! current_user_can( 'manage_categories' ) ) {
-			return;
-		}
-
 		add_filter( 'wpseo_content_meta_section_content', array( $this, 'add_input_fields' ) );
 
 		add_action( 'admin_footer', array( $this, 'wp_footer' ), 10 );

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -25,6 +25,11 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	 */
 	protected $statistics;
 
+	/**
+	 * Yoast_Dashboard_Widget constructor.
+	 *
+	 * @param WPSEO_Statistics|null $statistics WPSEO_Statistics instance.
+	 */
 	public function __construct( WPSEO_Statistics $statistics = null ) {
 		if ( $statistics === null ) {
 			$statistics = new WPSEO_Statistics();
@@ -35,7 +40,7 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * @param WPSEO_Statistics $statistics The statistics class to retrieve statistics from.
+	 * Register WordPress hooks.
 	 */
 	public function register_hooks() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_assets' ) );

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -8,7 +8,7 @@
 /**
  * Class to change or add WordPress dashboard widgets
  */
-class Yoast_Dashboard_Widget {
+class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 
 	/**
 	 * @var string
@@ -28,12 +28,8 @@ class Yoast_Dashboard_Widget {
 	/**
 	 * @param WPSEO_Statistics $statistics The statistics class to retrieve statistics from.
 	 */
-	public function __construct( WPSEO_Statistics $statistics = null ) {
-		if ( null === $statistics ) {
-			$statistics = new WPSEO_Statistics();
-		}
-
-		$this->statistics    = $statistics;
+	public function register_hooks() {
+		$this->statistics = new WPSEO_Statistics();
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_assets' ) );

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -25,13 +25,19 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	 */
 	protected $statistics;
 
+	public function __construct( WPSEO_Statistics $statistics = null ) {
+		if ( $statistics === null ) {
+			$statistics = new WPSEO_Statistics();
+		}
+
+		$this->statistics    = $statistics;
+		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
+	}
+
 	/**
 	 * @param WPSEO_Statistics $statistics The statistics class to retrieve statistics from.
 	 */
 	public function register_hooks() {
-		$this->statistics = new WPSEO_Statistics();
-		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
-
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_assets' ) );
 		add_action( 'admin_init', array( $this, 'queue_dashboard_widget' ) );
 	}

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -7,7 +7,6 @@ import { Slot } from "@wordpress/components";
 import { combineReducers, registerStore } from "@wordpress/data";
 import get from "lodash/get";
 import pickBy from "lodash/pickBy";
-import noop from "lodash/noop";
 
 /* Internal dependencies */
 import Data from "./analysis/data.js";
@@ -22,7 +21,6 @@ import * as selectors from "./redux/selectors";
 import * as actions from "./redux/actions";
 import { setSettings } from "./redux/actions/settings";
 import UsedKeywords from "./analysis/usedKeywords";
-import PrimaryTaxonomyFilter from "./components/PrimaryTaxonomyFilter";
 import { setMarkerStatus } from "./redux/actions";
 import { isAnnotationAvailable } from "./decorator/gutenberg";
 
@@ -66,8 +64,6 @@ class Edit {
 	_init() {
 		this._store = this._registerStoreInGutenberg();
 
-		this._registerCategorySelectorFilter();
-
 		this._registerPlugin();
 
 		this._data = this._initializeData();
@@ -92,31 +88,6 @@ class Edit {
 			selectors,
 			actions: pickBy( actions, x => typeof x === "function" ),
 		} );
-	}
-
-	_registerCategorySelectorFilter() {
-		if ( ! isGutenbergDataAvailable() ) {
-			return;
-		}
-
-		const addFilter = get( window, "wp.hooks.addFilter", noop );
-
-		addFilter(
-			"editor.PostTaxonomyType",
-			PLUGIN_NAMESPACE,
-			OriginalComponent => {
-				return class Filter extends React.Component {
-					render() {
-						return (
-							<PrimaryTaxonomyFilter
-								OriginalComponent={ OriginalComponent }
-								{ ...this.props }
-							/>
-						);
-					}
-				};
-			},
-		);
 	}
 
 	/**

--- a/js/src/wp-seo-metabox-category.js
+++ b/js/src/wp-seo-metabox-category.js
@@ -1,8 +1,15 @@
 /* global wp, _, wpseoPrimaryCategoryL10n */
 /* External dependencies */
 import { dispatch } from "@wordpress/data";
+import { Component } from "@wordpress/element";
+import get from "lodash/get";
+import noop from "lodash/noop";
 
 /* Internal dependencies */
+import PrimaryTaxonomyFilter from "./components/PrimaryTaxonomyFilter";
+import isGutenbergDataAvailable from "./helpers/isGutenbergDataAvailable";
+
+const PLUGIN_NAMESPACE = "yoast-seo";
 
 ( function( $ ) {
 	var primaryTermUITemplate, primaryTermScreenReaderTemplate;
@@ -230,6 +237,36 @@ import { dispatch } from "@wordpress/data";
 		};
 	}
 
+	/**
+	 * Add primary taxonomy picker in Gutenberg.
+	 *
+	 * @returns {void}
+	 */
+	function registerCategorySelectorFilter() {
+		if ( ! isGutenbergDataAvailable() ) {
+			return;
+		}
+
+		const addFilter = get( window, "wp.hooks.addFilter", noop );
+
+		addFilter(
+			"editor.PostTaxonomyType",
+			PLUGIN_NAMESPACE,
+			OriginalComponent => {
+				return class Filter extends Component {
+					render() {
+						return (
+							<PrimaryTaxonomyFilter
+								OriginalComponent={ OriginalComponent }
+								{ ...this.props }
+							/>
+						);
+					}
+				};
+			},
+		);
+	}
+
 	$.fn.initYstSEOPrimaryCategory = function() {
 		return this.each( function( i, taxonomy ) {
 			const metaboxTaxonomy = $( "#" + taxonomy.name + "div" );
@@ -251,5 +288,7 @@ import { dispatch } from "@wordpress/data";
 		primaryTermScreenReaderTemplate = wp.template( "primary-term-screen-reader" );
 
 		$( _.values( taxonomies ) ).initYstSEOPrimaryCategory();
+
+		registerCategorySelectorFilter();
 	} );
 }( jQuery ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Move the primary term picker to the JS file that actually manages the primary taxonomy.

## Relevant technical choices:

* Turned `WPSEO_Primary_Term_Admin` and `Yoast_Dashboard_Widget` into `WPSEO_Wordpress_Integration`s.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the primary taxonomy picker still works in Gutenberg and the classic editor.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
