### PR TITLE
Add filesize to the whitelist of parameters allowed on $image. 

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -101,7 +101,7 @@ class WPSEO_Image_Utils {
 		}
 
 		// Keep only the keys we need, and nothing else.
-		return array_intersect_key( $image, array_flip( array( 'id', 'alt', 'path', 'width', 'height', 'pixels', 'type', 'size', 'url' ) ) );
+		return array_intersect_key( $image, array_flip( array( 'id', 'alt', 'path', 'width', 'height', 'pixels', 'type', 'size', 'url', 'filesize' ) ) );
 	}
 
 	/**

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -74,12 +74,13 @@ class WPSEO_Image_Utils {
 	 * @return false|array $image {
 	 *     Array of image data
 	 *
-	 *     @type string $alt    Image's alt text.
-	 *     @type string $alt    Image's alt text.
-	 *     @type int    $width  Width of image.
-	 *     @type int    $height Height of image.
-	 *     @type string $type   Image's MIME type.
-	 *     @type string $url    Image's URL.
+	 *     @type string $alt      Image's alt text.
+	 *     @type string $alt      Image's alt text.
+	 *     @type int    $width    Width of image.
+	 *     @type int    $height   Height of image.
+	 *     @type string $type     Image's MIME type.
+	 *     @type string $url      Image's URL.
+	 *     @type int    $filesize The file size in bytes, if already set.
 	 * }
 	 */
 	public static function get_data( $image, $attachment_id ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds `filesize` to whitelisted properties on `$image`. Props to [cmmarslender](https://github.com/cmmarslender)

## Relevant technical choices:

* Needs to be whitelisted in order for the check in `WPSEO_Image_Utils::get_file_size()` to work properly.
## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12367 
