### PR TITLE
Documentation: don't use the @static tag

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -34,7 +34,6 @@ class WPSEO_Meta {
 	 * Prefix for all WPSEO meta values in the database.
 	 *
 	 * @var string
-	 * @static
 	 *
 	 * {@internal If at any point this would change, quite apart from an upgrade routine,
 	 *            this also will need to be changed in the wpml-config.xml file.}}
@@ -46,7 +45,6 @@ class WPSEO_Meta {
 	 * Prefix for all WPSEO meta value form field names and ids.
 	 *
 	 * @var string
-	 * @static
 	 */
 	public static $form_prefix = 'yoast_wpseo_';
 
@@ -55,7 +53,6 @@ class WPSEO_Meta {
 	 * Allowed length of the meta description.
 	 *
 	 * @var int
-	 * @static
 	 */
 	public static $meta_length = 156;
 
@@ -64,7 +61,6 @@ class WPSEO_Meta {
 	 * Reason the meta description is not the default length.
 	 *
 	 * @var string
-	 * @static
 	 */
 	public static $meta_length_reason = '';
 
@@ -102,8 +98,6 @@ class WPSEO_Meta {
 	 *                (optional)        'serialized'   => (bool) whether the value is expected to be serialized,
 	 *                                                     i.e. an array or object, defaults to false
 	 *                                                     Currently only used by add-on plugins.
-	 *
-	 * @static
 	 *
 	 * {@internal
 	 * - Titles, help texts, description text and option labels are added via a translate_meta_boxes() method
@@ -222,7 +216,6 @@ class WPSEO_Meta {
 	 *         ['key']       => (string) internal key
 	 *
 	 * @var array
-	 * @static
 	 */
 	public static $fields_index = array();
 
@@ -232,7 +225,6 @@ class WPSEO_Meta {
 	 * [full meta key including prefix]    => (string) default value
 	 *
 	 * @var array
-	 * @static
 	 */
 	public static $defaults = array();
 
@@ -240,7 +232,6 @@ class WPSEO_Meta {
 	 * Helper property to define the social network meta field definitions - networks.
 	 *
 	 * @var array
-	 * @static
 	 */
 	private static $social_networks = array(
 		'opengraph'  => 'opengraph',
@@ -251,7 +242,6 @@ class WPSEO_Meta {
 	 * Helper property to define the social network meta field definitions - fields and their type.
 	 *
 	 * @var array
-	 * @static
 	 */
 	private static $social_fields = array(
 		'title'       => 'text',
@@ -263,7 +253,6 @@ class WPSEO_Meta {
 	/**
 	 * Register our actions and filters
 	 *
-	 * @static
 	 * @return void
 	 */
 	public static function init() {
@@ -325,8 +314,6 @@ class WPSEO_Meta {
 
 	/**
 	 * Retrieve the meta box form field definitions for the given tab and post type.
-	 *
-	 * @static
 	 *
 	 * @param  string $tab       Tab for which to retrieve the field definitions.
 	 * @param  string $post_type Post type of the current post.
@@ -407,8 +394,6 @@ class WPSEO_Meta {
 
 	/**
 	 * Validate the post meta values
-	 *
-	 * @static
 	 *
 	 * @param  mixed  $meta_value The new value.
 	 * @param  string $meta_key   The full meta key (including prefix).
@@ -508,8 +493,6 @@ class WPSEO_Meta {
 	 *
 	 * @todo [JRF => Yoast] Verify that this logic for the prioritisation is correct
 	 *
-	 * @static
-	 *
 	 * @param  array|string $meta_value The value to validate.
 	 *
 	 * @return string       Clean value
@@ -555,8 +538,6 @@ class WPSEO_Meta {
 	/**
 	 * Prevent saving of default values and remove potential old value from the database if replaced by a default
 	 *
-	 * @static
-	 *
 	 * @param  bool   $check      The current status to allow updating metadata for the given type.
 	 * @param  int    $object_id  ID of the current object for which the meta is being updated.
 	 * @param  string $meta_key   The full meta key (including prefix).
@@ -584,8 +565,6 @@ class WPSEO_Meta {
 	/**
 	 * Prevent adding of default values to the database
 	 *
-	 * @static
-	 *
 	 * @param  bool   $check      The current status to allow adding metadata for the given type.
 	 * @param  int    $object_id  ID of the current object for which the meta is being added.
 	 * @param  string $meta_key   The full meta key (including prefix).
@@ -605,8 +584,6 @@ class WPSEO_Meta {
 	/**
 	 * Is the given meta value the same as the default value ?
 	 *
-	 * @static
-	 *
 	 * @param  string $meta_key   The full meta key (including prefix).
 	 * @param  mixed  $meta_value The value to check.
 	 *
@@ -623,8 +600,6 @@ class WPSEO_Meta {
 	 * {@internal Unfortunately there isn't a filter available to hook into before returning
 	 *            the results for get_post_meta(), get_post_custom() and the likes. That
 	 *            would have been the preferred solution.}}
-	 *
-	 * @static
 	 *
 	 * @param  string $key    Internal key of the value to get (without prefix).
 	 * @param  int    $postid Post ID of the post to get the value for.
@@ -682,8 +657,6 @@ class WPSEO_Meta {
 	/**
 	 * Update a meta value for a post
 	 *
-	 * @static
-	 *
 	 * @param  string $key        The internal key of the meta value to change (without prefix).
 	 * @param  mixed  $meta_value The value to set the meta to.
 	 * @param  int    $post_id    The ID of the post to change the meta for.
@@ -703,8 +676,6 @@ class WPSEO_Meta {
 	/**
 	 * Deletes a meta value for a post
 	 *
-	 * @static
-	 *
 	 * @param string $key The internal key of the meta value to change (without prefix).
 	 * @param int    $post_id The ID of the post to change the meta for.
 	 *
@@ -718,8 +689,6 @@ class WPSEO_Meta {
 	 * Used for imports, this functions imports the value of $old_metakey into $new_metakey for those post
 	 * where no WPSEO meta data has been set.
 	 * Optionally deletes the $old_metakey values.
-	 *
-	 * @static
 	 *
 	 * @param  string $old_metakey The old key of the meta value.
 	 * @param  string $new_metakey The new key, usually the WPSEO meta key (including prefix).
@@ -773,7 +742,6 @@ class WPSEO_Meta {
 	 * - Remove potentially lingering old meta keys
 	 * - Remove all default and invalid values
 	 *
-	 * @static
 	 * @return void
 	 */
 	public static function clean_up() {
@@ -1041,8 +1009,6 @@ class WPSEO_Meta {
 	/**
 	 * Get a value from $_POST for a given key
 	 * Returns the $_POST value if exists, returns an empty string if key does not exist
-	 *
-	 * @static
 	 *
 	 * @deprecated 9.6
 	 * @codeCoverageIgnore

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -14,22 +14,18 @@ class WPSEO_Utils {
 
 	/**
 	 * @var bool $has_filters Whether the PHP filter extension is enabled.
-	 * @static
 	 * @since 1.8.0
 	 */
 	public static $has_filters;
 
 	/**
 	 * @var array Notifications to be shown in the JavaScript console.
-	 * @static
 	 * @since 3.3.2
 	 */
 	protected static $console_notifications = array();
 
 	/**
 	 * Check whether the current user is allowed to access the configuration.
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 *
@@ -55,8 +51,6 @@ class WPSEO_Utils {
 	 *
 	 * {@internal current_user_can() checks internally whether a user is on wp-ms and adjusts accordingly.}}
 	 *
-	 * @static
-	 *
 	 * @since    1.8.0
 	 *
 	 * @return bool
@@ -81,8 +75,6 @@ class WPSEO_Utils {
 	/**
 	 * Check if the web server is running on Apache.
 	 *
-	 * @static
-	 *
 	 * @since 1.8.0
 	 *
 	 * @return bool
@@ -99,8 +91,6 @@ class WPSEO_Utils {
 
 	/**
 	 * Check if the web server is running on Nginx.
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 *
@@ -177,8 +167,6 @@ class WPSEO_Utils {
 	 *
 	 * @since 1.8.0
 	 *
-	 * @static
-	 *
 	 * @return array $roles
 	 */
 	public static function get_roles() {
@@ -212,8 +200,6 @@ class WPSEO_Utils {
 	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
 	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
 	 *
-	 * @static
-	 *
 	 * @since 1.8.0
 	 *
 	 * @param string $text Input string that might contain shortcodes.
@@ -227,8 +213,6 @@ class WPSEO_Utils {
 	/**
 	 * Recursively trim whitespace round a string value or of string values within an array.
 	 * Only trims strings to avoid typecasting a variable (to string).
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 *
@@ -249,8 +233,6 @@ class WPSEO_Utils {
 
 	/**
 	 * Translates a decimal analysis score into a textual one.
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 *
@@ -281,8 +263,6 @@ class WPSEO_Utils {
 	 * - Strip all tags,
 	 * - Remove line breaks, tabs and extra white space,
 	 * - Strip octets - BUT DO NOT REMOVE (part of) VARIABLES WHICH WILL BE REPLACED.
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 *
@@ -346,8 +326,6 @@ class WPSEO_Utils {
 	/**
 	 * Validate a value as boolean.
 	 *
-	 * @static
-	 *
 	 * @since 1.8.0
 	 *
 	 * @param mixed $value Value to validate.
@@ -369,8 +347,6 @@ class WPSEO_Utils {
 
 	/**
 	 * Cast a value to bool.
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 *
@@ -436,8 +412,6 @@ class WPSEO_Utils {
 	/**
 	 * Validate a value as integer.
 	 *
-	 * @static
-	 *
 	 * @since 1.8.0
 	 *
 	 * @param mixed $value Value to validate.
@@ -459,8 +433,6 @@ class WPSEO_Utils {
 
 	/**
 	 * Cast a value to integer.
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 *
@@ -502,8 +474,6 @@ class WPSEO_Utils {
 	/**
 	 * Clears the WP or W3TC cache depending on which is used.
 	 *
-	 * @static
-	 *
 	 * @since 1.8.0
 	 */
 	public static function clear_cache() {
@@ -518,8 +488,6 @@ class WPSEO_Utils {
 	/**
 	 * Flush W3TC cache after succesfull update/add of taxonomy meta option.
 	 *
-	 * @static
-	 *
 	 * @since 1.8.0
 	 */
 	public static function flush_w3tc_cache() {
@@ -530,8 +498,6 @@ class WPSEO_Utils {
 
 	/**
 	 * Clear rewrite rules.
-	 *
-	 * @static
 	 *
 	 * @since 1.8.0
 	 */
@@ -546,8 +512,6 @@ class WPSEO_Utils {
 	 * @see   the big red warning on http://php.net/language.types.float.php
 	 *
 	 * In the rare case that the bcmath extension would not be loaded, it will return the normal calculation results.
-	 *
-	 * @static
 	 *
 	 * @since 1.5.0
 	 * @since 1.8.0 Moved from stand-alone function to this class.

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -43,8 +43,6 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	 * @var  array $allowed_access_options Available options for the 'access' setting
 	 *                    Used for input validation
 	 *
-	 * @static
-	 *
 	 * {@internal Important: Make sure the options added to the array here are in line
 	 *            with the keys for the options set for the select box in the
 	 *            admin/pages/network.php file.}}

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -16,7 +16,6 @@ class WPSEO_Options {
 	 * Options this class uses.
 	 *
 	 * @var array Array format: (string) option_name  => (string) name of concrete class for the option.
-	 * @static
 	 */
 	public static $options = array(
 		'wpseo'               => 'WPSEO_Option_Wpseo',
@@ -150,7 +149,6 @@ class WPSEO_Options {
 	/**
 	 * Retrieve an array of the options which should be included in get_all() and reset().
 	 *
-	 * @static
 	 * @return  array  Array of option names
 	 */
 	public static function get_option_names() {
@@ -174,7 +172,6 @@ class WPSEO_Options {
 	 * @todo [JRF] see if we can get some extra efficiency for this one, though probably not as options may
 	 * well change between calls (enriched defaults and such)
 	 *
-	 * @static
 	 * @return  array  Array combining the values of all the options
 	 */
 	public static function get_all() {
@@ -183,8 +180,6 @@ class WPSEO_Options {
 
 	/**
 	 * Retrieve one or more options for the SEO plugin.
-	 *
-	 * @static
 	 *
 	 * @param array $option_names An array of option names of the options you want to get.
 	 *
@@ -205,8 +200,6 @@ class WPSEO_Options {
 
 	/**
 	 * Retrieve a single option for the SEO plugin.
-	 *
-	 * @static
 	 *
 	 * @param string $option_name The name of the option you want to get.
 	 *
@@ -277,8 +270,6 @@ class WPSEO_Options {
 	/**
 	 * Get an option only if it's been auto-loaded.
 	 *
-	 * @static
-	 *
 	 * @param string     $option  The option to retrieve.
 	 * @param bool|mixed $default A default value to return.
 	 *
@@ -345,7 +336,6 @@ class WPSEO_Options {
 	/**
 	 * Initialize some options on first install/activate/reset.
 	 *
-	 * @static
 	 * @return void
 	 */
 	public static function initialize() {
@@ -358,7 +348,6 @@ class WPSEO_Options {
 	/**
 	 * Reset all options to their default values and rerun some tests.
 	 *
-	 * @static
 	 * @return void
 	 */
 	public static function reset() {
@@ -383,8 +372,6 @@ class WPSEO_Options {
 	/**
 	 * Initialize default values for a new multisite blog.
 	 *
-	 * @static
-	 *
 	 * @param  bool $force_init Whether to always do the initialization routine (title/desc test).
 	 *
 	 * @return void
@@ -406,8 +393,6 @@ class WPSEO_Options {
 	/**
 	 * Reset all options for a specific multisite blog to their default values based upon a
 	 * specified default blog if one was chosen on the network page or the plugin defaults if it was not.
-	 *
-	 * @static
 	 *
 	 * @param  int|string $blog_id Blog id of the blog for which to reset the options.
 	 *

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -33,13 +33,11 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 
 	/**
 	 * @var  string  Option name - same as $option_name property, but now also available to static methods.
-	 * @static
 	 */
 	public static $name;
 
 	/**
 	 * @var  array  Array of defaults for individual taxonomy meta entries.
-	 * @static
 	 */
 	public static $defaults_per_term = array(
 		'wpseo_title'                 => '',
@@ -67,8 +65,6 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * @var  array  Available index options.
 	 *        Used for form generation and input validation.
-	 *
-	 * @static
 	 *
 	 * {@internal Labels (translation) added on admin_init via WPSEO_Taxonomy::translate_meta_options().}}
 	 */
@@ -124,8 +120,6 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * Helper method - Combines a fixed array of default values with an options array
 	 * while filtering out any keys which are not in the defaults array.
-	 *
-	 * @static
 	 *
 	 * @param  string $option_key Option name of the option we're doing the merge for.
 	 * @param  array  $options    Optional. Current options. If not set, the option defaults for the $option_key will be returned.
@@ -231,8 +225,6 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 
 	/**
 	 * Validate the meta data for one individual term and removes default values (no need to save those).
-	 *
-	 * @static
 	 *
 	 * @param  array $meta_data New values.
 	 * @param  array $old_meta  The original values.
@@ -424,8 +416,6 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 
 	/**
 	 * Retrieve a taxonomy term's meta value(s).
-	 *
-	 * @static
 	 *
 	 * @param  mixed  $term     Term to get the meta value for
 	 *                          either (string) term name, (int) term id or (object) term.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

> Note: This tag has been used in the past, but should no longer be used.
Just using the static keyword in your code is enough for PhpDocumentor on PHP5 to recognize static variables and methods, and PhpDocumentor will mark them as static.

Ref: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#phpdoc-tags




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
