### PR TITLE
Documentation: move an incorrectly placed function docblock

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -200,17 +200,11 @@ function wpseo_shortcode_yoast_breadcrumb() {
 
 add_shortcode( 'wpseo_breadcrumb', 'wpseo_shortcode_yoast_breadcrumb' );
 
-/**
- * Emulate PHP native ctype_digit() function for when the ctype extension would be disabled *sigh*.
- * Only emulates the behaviour for when the input is a string, does not handle integer input as ascii value.
- *
- * @param    string $string
- *
- * @return    bool
- */
 if ( ! extension_loaded( 'ctype' ) || ! function_exists( 'ctype_digit' ) ) {
-
 	/**
+	 * Emulate PHP native ctype_digit() function for when the ctype extension would be disabled *sigh*.
+	 * Only emulates the behaviour for when the input is a string, does not handle integer input as ascii value.
+	 *
 	 * @param string $string String input to validate.
 	 *
 	 * @return bool


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

The docblock should be above the function, not above the condition wrapping the function.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
