### PR TITLE
Documentation: use correct tag for deprecated methods

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1190,9 +1190,7 @@ SVG;
 	 *
 	 * @see        WPSEO_Language_Utils::get_language()
 	 *
-	 * @deprecated  9.5
-	 * @since       9.5
-	 *
+	 * @deprecated 9.5
 	 * @codeCoverageIgnore
 	 *
 	 * @param string $locale The locale to get the language of.
@@ -1215,9 +1213,7 @@ SVG;
 	 *
 	 * @see        WPSEO_Language_Utils::get_user_locale()
 	 *
-	 * @deprecated  9.5
-	 * @since       9.5
-	 *
+	 * @deprecated 9.5
 	 * @codeCoverageIgnore
 	 *
 	 * @return string The locale.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

These methods were not _added_ in `9.5`, but _deprecated_ in `9.5`. Fixed the tag annotating this.

Also added the `@codeCoverageIgnore` tag which is required for all deprecated methods.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
