### PR TITLE
Documentation: fix inline docs in a specific function

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -148,10 +148,14 @@ class WPSEO_Upgrade {
 	protected function finish_up() {
 		WPSEO_Options::set( 'version', WPSEO_VERSION );
 
-		add_action( 'shutdown', 'flush_rewrite_rules' );                     // Just flush rewrites, always, to at least make them work after an upgrade.
-		WPSEO_Sitemaps_Cache::clear();                                       // Flush the sitemap cache.
+		// Just flush rewrites, always, to at least make them work after an upgrade.
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 
-		WPSEO_Options::ensure_options_exist();                               // Make sure all our options always exist - issue #1245.
+		// Flush the sitemap cache.
+		WPSEO_Sitemaps_Cache::clear();
+
+		// Make sure all our options always exist - issue #1245.
+		WPSEO_Options::ensure_options_exist();
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

These docs were set up with a weird alignment way past the end of the code.
The inline docs have now been placed above each line they apply to.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
