### PR TITLE
Documentation: don't use docblocks for inline comments

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -779,7 +779,7 @@ class WPSEO_Meta {
 	public static function clean_up() {
 		global $wpdb;
 
-		/**
+		/*
 		 * Clean up '_yoast_wpseo_meta-robots'
 		 *
 		 * Retrieve all '_yoast_wpseo_meta-robots' meta values and convert if no new values found
@@ -828,7 +828,7 @@ class WPSEO_Meta {
 		delete_post_meta_by_key( self::$meta_prefix . 'meta-robots' );
 
 
-		/**
+		/*
 		 * Remove all default values and (most) invalid option values
 		 * Invalid option values for the multiselect (meta-robots-adv) field will be dealt with seperately
 		 *
@@ -907,7 +907,7 @@ class WPSEO_Meta {
 		unset( $query, $meta_ids, $count, $object_id );
 
 
-		/**
+		/*
 		 * Deal with the multiselect (meta-robots-adv) field
 		 *
 		 * Removes invalid option combinations, such as 'none,noarchive'

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -653,7 +653,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		unset( $rename, $old, $new );
 
 
-		/**
+		/*
 		 * {@internal This clean-up action can only be done effectively once the taxonomies
 		 *            and post_types have been registered, i.e. at the end of the init action.}}
 		 */

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -621,7 +621,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 */
 		$url['loc'] = apply_filters( 'wpseo_xml_sitemap_post_url', get_permalink( $post ), $post );
 
-		/**
+		/*
 		 * Do not include external URLs.
 		 *
 		 * @see https://wordpress.org/plugins/page-links-to/ can rewrite permalinks to external URLs.

--- a/inc/sitemaps/class-sitemap-cache-data.php
+++ b/inc/sitemaps/class-sitemap-cache-data.php
@@ -37,7 +37,7 @@ class WPSEO_Sitemap_Cache_Data implements WPSEO_Sitemap_Cache_Data_Interface, Se
 
 		$this->sitemap = $sitemap;
 
-		/**
+		/*
 		 * Empty sitemap is not usable.
 		 */
 		if ( ! empty( $sitemap ) ) {

--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -88,7 +88,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 	 * @throws OutOfRangeException When there is less than 15 characters of space for a key that is originally longer.
 	 */
 	public static function truncate_type( $type, $prefix = '', $postfix = '' ) {
-		/**
+		/*
 		 * This length has been restricted by the database column length of 64 in the past.
 		 * The prefix added by WordPress is '_transient_' because we are saving to a transient.
 		 * We need to use a timeout on the transient, otherwise the values get autoloaded, this adds
@@ -101,7 +101,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 		if ( strlen( $type ) > $max_length ) {
 
 			if ( $max_length < 15 ) {
-				/**
+				/*
 				 * If this happens the most likely cause is a page number that is too high.
 				 *
 				 * So this would not happen unintentionally..
@@ -179,7 +179,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 			$like = sprintf( '%1$s%2$s_%%', self::STORAGE_KEY_PREFIX, $type );
 		}
 
-		/**
+		/*
 		 * Add slashes to the LIKE "_" single character wildcard.
 		 *
 		 * We can't use `esc_like` here because we need the % in the query.

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -86,7 +86,7 @@ class Indexable extends Yoast_Model {
 	 * @return bool|Indexable Instance of indexable.
 	 */
 	public static function create_for_id_and_type( $object_id, $object_type ) {
-		/**
+		/*
 		 * Indexable instance.
 		 *
 		 * @var Indexable $indexable


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

Docblocks `/** .... */` are intended for use with structural elements, like functions, classes, hooks etc.

For "ordinary" multi-line inline comments, block comment style `/* ... */` should be used.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
