### PR TITLE
QA/XSS: always escape output - 35

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -181,7 +181,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				   class="yoast-button-upsell">
 					<?php
 						/* translators: $1$s expands to Yoast SEO Premium */
-						printf( __( 'Buy %1$s', 'wordpress-seo' ), $premium_extension->get_title() );
+						printf( esc_html__( 'Buy %1$s', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
 						echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 					?>
@@ -192,7 +192,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 					<?php
 					printf(
 						/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
-						__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
+						esc_html__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 						'<span class="screen-reader-text">',
 						'</span>',
 						$premium_extension->get_title()
@@ -261,7 +261,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 							   href="<?php echo esc_url( $extension->get_buy_url() ); ?>">
 								<?php
 									/* translators: %s expands to the product name */
-									printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
+									printf( esc_html__( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
 									echo $new_tab_message;
 									echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 								?>
@@ -272,7 +272,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								<?php
 								printf(
 								/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
-									__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
+									esc_html__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 									'<span class="screen-reader-text">',
 									'</span>',
 									$extension->get_title()


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _security hardening_

## Relevant technical choices:

Translated text should also be escaped.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality (except when a translation would add (malicious) HTML).