### PR TITLE
Introduces a wrapper method for easily disabling the oAuth way.

### DIFF
--- a/inc/class-my-yoast-api-request.php
+++ b/inc/class-my-yoast-api-request.php
@@ -351,7 +351,7 @@ class WPSEO_MyYoast_Api_Request {
 	/**
 	 * Wraps the has_access_token support method.
 	 *
-	 * @codeCoverageIgnore 
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool False to disable the support.
 	 */
@@ -359,6 +359,6 @@ class WPSEO_MyYoast_Api_Request {
 		return false;
 
 		// @todo: Uncomment the following statement when we are implementing the oAuth flow.
-		return WPSEO_Utils::has_access_token_support();
+		// return WPSEO_Utils::has_access_token_support();
 	}
 }

--- a/inc/class-my-yoast-api-request.php
+++ b/inc/class-my-yoast-api-request.php
@@ -164,7 +164,7 @@ class WPSEO_MyYoast_Api_Request {
 		}
 
 		// Authentication failed, throw an exception.
-		if ( strpos( $response_code, '401' ) && WPSEO_Utils::has_access_token_support() ) {
+		if ( strpos( $response_code, '401' ) && $this->has_oauth_support() ) {
 			throw new WPSEO_MyYoast_Authentication_Exception( esc_html( $response_message ), 401 );
 		}
 
@@ -224,7 +224,7 @@ class WPSEO_MyYoast_Api_Request {
 	 * @return array The request body.
 	 */
 	public function get_request_body() {
-		if ( ! WPSEO_Utils::has_access_token_support() ) {
+		if ( ! $this->has_oauth_support() ) {
 			return array( 'url' => WPSEO_Utils::get_home_url() );
 		}
 
@@ -327,7 +327,7 @@ class WPSEO_MyYoast_Api_Request {
 	 * @return void
 	 */
 	protected function remove_access_token( $user_id ) {
-		if ( ! WPSEO_Utils::has_access_token_support() ) {
+		if ( ! $this->has_oauth_support() ) {
 			return;
 		}
 
@@ -346,5 +346,19 @@ class WPSEO_MyYoast_Api_Request {
 		$addon_manager = new WPSEO_Addon_Manager();
 
 		return $addon_manager->get_installed_addons_versions();
+	}
+
+	/**
+	 * Wraps the has_access_token support method.
+	 *
+	 * @codeCoverageIgnore 
+	 *
+	 * @return bool False to disable the support.
+	 */
+	protected function has_oauth_support() {
+		return false;
+
+		// @todo: Uncomment the following statement when we are implementing the oAuth flow.
+		return WPSEO_Utils::has_access_token_support();
 	}
 }

--- a/tests/src/unit-tests/oauth/client-test.php
+++ b/tests/src/unit-tests/oauth/client-test.php
@@ -259,6 +259,9 @@ class Oauth_Client_Test extends \PHPUnit_Framework_TestCase {
 	 * @covers \Yoast\WP\Free\Oauth\Client::get_provider
 	 */
 	public function test_get_provider() {
+
+		$this->markTestSkipped( 'Temporarily skipped, see: https://github.com/Yoast/wordpress-seo/pull/12399' );
+
 		$this->class_instance->save_configuration(
 			[
 				'clientId' => 123456789,

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -345,7 +345,7 @@ function wpseo_init() {
 	// When namespaces are not available, stop further execution.
 	if ( version_compare( PHP_VERSION, '5.6.0', '>=' ) ) {
 		require_once WPSEO_PATH . 'src/loaders/indexable.php';
-		require_once WPSEO_PATH . 'src/loaders/oauth.php';
+		// require_once WPSEO_PATH . 'src/loaders/oauth.php'; Temporary disabled.
 	}
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -345,7 +345,7 @@ function wpseo_init() {
 	// When namespaces are not available, stop further execution.
 	if ( version_compare( PHP_VERSION, '5.6.0', '>=' ) ) {
 		require_once WPSEO_PATH . 'src/loaders/indexable.php';
-		// require_once WPSEO_PATH . 'src/loaders/oauth.php'; Temporary disabled.
+		// require_once WPSEO_PATH . 'src/loaders/oauth.php'; Temporarily disabled.
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A -

## Relevant technical choices:

* Made a wrapper for easily disabling the oauth feature. This returns false at the moment. Should be returning the commented value when oAuth is implemented.
* Also commented out the oAuth loader, to make sure the oAuth feature isn't loaded.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Previously the add-ons update process would go through the license manager. This got rewritten with the MyYoast connection flow. Unfortunately, this is more complicated and should get reverted a bit for now.

Therefore, we should test if the detecting and actual updating of the add-ons functions as before.
* Install an older version of an add-on (see releases tab on GitHub).
* Ensure that it still detects that there is a newer version available (it should see this on the plugins page, but there is also a `Check Again` button in the `Dashboard - Updates` page).
* Ensure that updating the add-on works.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
