### PR TITLE
Show Youtube and Wikipedia input fields correctly in the configuration wizard

### DIFF
--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -44,7 +44,7 @@ class WPSEO_Configuration_Structure {
 			'profileUrlMySpace',
 			'profileUrlPinterest',
 			'profileUrlYouTube',
-			'profileUrlGooglePlus',
+			'profileUrlWikipedia',
 		),
 		'multipleAuthors'            => array( 'multipleAuthors' ),
 		'connectGoogleSearchConsole' => array(

--- a/admin/config-ui/fields/class-field-profile-url-wikipedia.php
+++ b/admin/config-ui/fields/class-field-profile-url-wikipedia.php
@@ -14,7 +14,7 @@ class WPSEO_Config_Field_Profile_URL_Wikipedia extends WPSEO_Config_Field {
 	 * WPSEO_Config_Field_Profile_URL_YouTube constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'profileUrlYouTube', 'Input' );
+		parent::__construct( 'profileUrlWikipedia', 'Input' );
 
 		$this->set_property( 'label', __( 'Wikipedia URL', 'wordpress-seo' ) );
 		$this->set_property( 'pattern', '^https:\/\/([a-z\-]+)\.wikipedia\.org\/([^/]+)$' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Fixes a bug where the Youtube input field would not show in the configuration wizard, and the Wikipedia input field would have an incorrect id.

## Relevant technical choices:

* Use the correct profileUrls field for Wikipedia

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the configuration wizard.
* Go to Step 4.
* See the Youtube and Wikipedia input field. 
* Check that their ids are the correct ones.
* Add a Youtube and Wikipedia URL.
* Go to the settings in Yoast SEO > Social. See that the Youtube and Wikipedia URL are filled.
* Change the Youtube and Wikipedia URL. 
* Go back to step 4 of the config wizard, and see the changed URLs.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12400