### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ jobs:
         - grunt composer-artifact
       if: tag IS present
       before_install:
-        - nvm install node
+        - nvm install lts/*
         - curl -o- -L https://yarnpkg.com/install.sh | bash
         - export PATH=$HOME/.yarn/bin:$PATH
         - openssl aes-256-cbc -K $encrypted_06a9c1b95cfa_key -iv $encrypted_06a9c1b95cfa_iv -in ./deploy_keys/travis_dist_id_rsa.enc -out ./deploy_keys/travis_dist_id_rsa -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=latest PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=node
+      env: WP_VERSION=latest PHPLINT=1 PHPCS=1 CHECKJS=1 TRAVIS_NODE_VERSION=lts/*
     - php: 7.3
       env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
     - php: 5.6

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -59,6 +59,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 	?>
 </div>
 <?php
+
 /*
  * Required to prevent our settings framework from saving the default because the field isn't
  * explicitly set when saving the Dashboard page.

--- a/admin/views/tabs/network/features.php
+++ b/admin/views/tabs/network/features.php
@@ -59,6 +59,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 	?>
 </div>
 <?php
+
 /*
  * Required to prevent our settings framework from saving the default because the field
  * isn't explicitly set when saving the Dashboard page.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* It was failing because of a bug in Node 11. I think for wordpress-seo
in general it is better to run lts/*. We check our code with the
latest node in the Yoast/javascript repository.

Check https://stackoverflow.com/questions/55059748/travis-jest-typeerror-cannot-assign-to-read-only-property-symbolsymbol-tostr.

## Test instructions

This PR can be tested by following these steps:

* Travis is greeeeeeeen.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/yoast-components/issues/844.