### PR TITLE
Do not copy the vendor_prefixed folder when running composer-artifact

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -109,6 +109,7 @@ module.exports = {
 			cwd: "<%= files.artifact %>",
 			src: [
 				"**/*",
+				"!vendor_prefixed/**",
 			],
 			dest: "<%= files.artifactComposer %>",
 		} ],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Removes the `vendor_prefixed` folder from `Yoast-dist`

## Relevant technical choices:

* In the `composer-artifact` command, the `vendor_prefixed` folder is no longer copied

## Test instructions

This PR can be tested by following these steps:

* Run `grunt artifact` and then `grunt composer-artifact` on `trunk`. You should see the `vendor_prefixed` folder in the `artifact_composer` folder.
* Check out this branch, and run `grunt artifact` and then `grunt composer-artifact`. You should NOT see the `vendor_prefixed` folder in the `artifact_composer` folder.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12371
