### PR TITLE
QA: replace json_encode() calls with wp_json_encode()

### DIFF
--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -280,7 +280,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 						// The data is stringified JSON. Use `json_decode` and `json_encode` around the sanitation.
 						$input         = json_decode( $meta_data[ $key ], true );
 						$sanitized     = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), $input );
-						$clean[ $key ] = json_encode( $sanitized );
+						$clean[ $key ] = wp_json_encode( $sanitized );
 					}
 					elseif ( isset( $old_meta[ $key ] ) ) {
 						// Retain old value if field currently not in use.
@@ -302,7 +302,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 							);
 						}
 
-						$clean[ $key ] = json_encode( $sanitized );
+						$clean[ $key ] = wp_json_encode( $sanitized );
 					}
 					elseif ( isset( $old_meta[ $key ] ) ) {
 						// Retain old value if field currently not in use.

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -167,7 +167,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 		$data = new WP_REST_Request();
 		$data->set_header( 'content-type', 'application/json' );
 
-		$data->set_body( json_encode( $expected ) );
+		$data->set_body( wp_json_encode( $expected ) );
 
 		$storage
 			->expects( $this->once() )

--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -50,7 +50,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		wp_mkdir_p( plugin_dir_path( WPSEO_FILE ) . 'languages' );
 		file_put_contents(
 			$file_name,
-			json_encode( array( 'key' => 'value' ) )
+			wp_json_encode( array( 'key' => 'value' ) )
 		);
 
 		$class_instance = new WPSEO_Metabox_Formatter(

--- a/tests/inc/options/test-class-wpseo-taxonomy-meta.php
+++ b/tests/inc/options/test-class-wpseo-taxonomy-meta.php
@@ -68,7 +68,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 			'wpseo_noindex'         => 'index',
 			'wpseo_canonical'       => 'https://yoast.com/',
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
-			'wpseo_focuskeywords'   => json_encode(
+			'wpseo_focuskeywords'   => wp_json_encode(
 				array(
 					array(
 						'keyword' => '\"test\"',
@@ -80,7 +80,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 					),
 				)
 			),
-			'wpseo_keywordsynonyms' => json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => wp_json_encode( array( '""TESTING""', '""""' ) ),
 			'wpseo_focuskw'         => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_title'           => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" and \backslashes\.',
@@ -103,7 +103,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 		$expected = array(
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
 			'wpseo_canonical'       => 'https://yoast.com/test%20space',
-			'wpseo_focuskeywords'   => json_encode(
+			'wpseo_focuskeywords'   => wp_json_encode(
 				array(
 					array(
 						'keyword' => '\"test\"',
@@ -115,7 +115,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 					),
 				)
 			),
-			'wpseo_keywordsynonyms' => json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => wp_json_encode( array( '""TESTING""', '""""' ) ),
 			'wpseo_focuskw'         => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_title'           => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" and \backslashes\.',
@@ -126,7 +126,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 			'wpseo_noindex'         => 'extra something',
 			'wpseo_canonical'       => 'https://yoast.com/test space',
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
-			'wpseo_focuskeywords'   => json_encode(
+			'wpseo_focuskeywords'   => wp_json_encode(
 				array(
 					array(
 						'keyword' => '\"test\"',
@@ -139,7 +139,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 					),
 				)
 			),
-			'wpseo_keywordsynonyms' => json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => wp_json_encode( array( '""TESTING""', '""""' ) ),
 			'wpseo_focuskw'         => '  &quotdouble quotes" `>&lt;&gt;&#96<`and \backslashes\.  ',
 			'wpseo_title'           => '&quotdouble quotes"			and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" <>and<> \backslashes\.',

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -658,7 +658,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	protected function get_subscriptions() {
 		return json_decode(
-			json_encode(
+			wp_json_encode(
 				array(
 					'wp-seo-premium.php' => array(
 						'expires' => 'active',


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

`wp_json_encode()` is basically `json_encode()` with PHP cross-version compatibility handling, which is why it should be used instead.

Refs:
* http://php.net/manual/en/function.json-encode.php
* https://developer.wordpress.org/reference/functions/wp_json_encode/


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality (other than for low PHP versions).
