### PR TITLE
Documentation: improve method docblock @param tag formatting

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -492,7 +492,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Gets the focus keyword for a given post.
 	 *
-	 * @param WP_POST $post Post object to get its focus keyword.
+	 * @param WP_Post $post Post object to get its focus keyword.
 	 *
 	 * @return string Focus keyword, or empty string if none available.
 	 */

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -315,8 +315,8 @@ class WPSEO_Meta {
 	/**
 	 * Retrieve the meta box form field definitions for the given tab and post type.
 	 *
-	 * @param  string $tab       Tab for which to retrieve the field definitions.
-	 * @param  string $post_type Post type of the current post.
+	 * @param string $tab       Tab for which to retrieve the field definitions.
+	 * @param string $post_type Post type of the current post.
 	 *
 	 * @return array             Array containing the meta box field definitions
 	 */
@@ -383,8 +383,8 @@ class WPSEO_Meta {
 		 * Filter the WPSEO metabox form field definitions for a tab
 		 * {tab} can be 'general', 'advanced' or 'social'
 		 *
-		 * @param  array  $field_defs Metabox form field definitions.
-		 * @param  string $post_type  Post type of the post the metabox is for, defaults to 'post'.
+		 * @param array  $field_defs Metabox form field definitions.
+		 * @param string $post_type  Post type of the post the metabox is for, defaults to 'post'.
 		 *
 		 * @return array
 		 */
@@ -394,8 +394,8 @@ class WPSEO_Meta {
 	/**
 	 * Validate the post meta values
 	 *
-	 * @param  mixed  $meta_value The new value.
-	 * @param  string $meta_key   The full meta key (including prefix).
+	 * @param mixed  $meta_value The new value.
+	 * @param string $meta_key   The full meta key (including prefix).
 	 *
 	 * @return string             Validated meta value
 	 */
@@ -495,7 +495,7 @@ class WPSEO_Meta {
 	 *
 	 * @todo [JRF => Yoast] Verify that this logic for the prioritisation is correct
 	 *
-	 * @param  array|string $meta_value The value to validate.
+	 * @param array|string $meta_value The value to validate.
 	 *
 	 * @return string       Clean value
 	 */
@@ -540,11 +540,11 @@ class WPSEO_Meta {
 	/**
 	 * Prevent saving of default values and remove potential old value from the database if replaced by a default
 	 *
-	 * @param  bool   $check      The current status to allow updating metadata for the given type.
-	 * @param  int    $object_id  ID of the current object for which the meta is being updated.
-	 * @param  string $meta_key   The full meta key (including prefix).
-	 * @param  string $meta_value New meta value.
-	 * @param  string $prev_value The old meta value.
+	 * @param bool   $check      The current status to allow updating metadata for the given type.
+	 * @param int    $object_id  ID of the current object for which the meta is being updated.
+	 * @param string $meta_key   The full meta key (including prefix).
+	 * @param string $meta_value New meta value.
+	 * @param string $prev_value The old meta value.
 	 *
 	 * @return null|bool          true = stop saving, null = continue saving
 	 */
@@ -567,10 +567,10 @@ class WPSEO_Meta {
 	/**
 	 * Prevent adding of default values to the database
 	 *
-	 * @param  bool   $check      The current status to allow adding metadata for the given type.
-	 * @param  int    $object_id  ID of the current object for which the meta is being added.
-	 * @param  string $meta_key   The full meta key (including prefix).
-	 * @param  string $meta_value New meta value.
+	 * @param bool   $check      The current status to allow adding metadata for the given type.
+	 * @param int    $object_id  ID of the current object for which the meta is being added.
+	 * @param string $meta_key   The full meta key (including prefix).
+	 * @param string $meta_value New meta value.
 	 *
 	 * @return null|bool          true = stop saving, null = continue saving
 	 */
@@ -586,8 +586,8 @@ class WPSEO_Meta {
 	/**
 	 * Is the given meta value the same as the default value ?
 	 *
-	 * @param  string $meta_key   The full meta key (including prefix).
-	 * @param  mixed  $meta_value The value to check.
+	 * @param string $meta_key   The full meta key (including prefix).
+	 * @param mixed  $meta_value The value to check.
 	 *
 	 * @return bool
 	 */
@@ -603,8 +603,8 @@ class WPSEO_Meta {
 	 *            the results for get_post_meta(), get_post_custom() and the likes. That
 	 *            would have been the preferred solution.}}
 	 *
-	 * @param  string $key    Internal key of the value to get (without prefix).
-	 * @param  int    $postid Post ID of the post to get the value for.
+	 * @param string $key    Internal key of the value to get (without prefix).
+	 * @param int    $postid Post ID of the post to get the value for.
 	 *
 	 * @return string         All 'normal' values returned from get_post_meta() are strings.
 	 *                        Objects and arrays are possible, but not used by this plugin
@@ -659,9 +659,9 @@ class WPSEO_Meta {
 	/**
 	 * Update a meta value for a post
 	 *
-	 * @param  string $key        The internal key of the meta value to change (without prefix).
-	 * @param  mixed  $meta_value The value to set the meta to.
-	 * @param  int    $post_id    The ID of the post to change the meta for.
+	 * @param string $key        The internal key of the meta value to change (without prefix).
+	 * @param mixed  $meta_value The value to set the meta to.
+	 * @param int    $post_id    The ID of the post to change the meta for.
 	 *
 	 * @return bool   whether the value was changed
 	 */
@@ -692,9 +692,9 @@ class WPSEO_Meta {
 	 * where no WPSEO meta data has been set.
 	 * Optionally deletes the $old_metakey values.
 	 *
-	 * @param  string $old_metakey The old key of the meta value.
-	 * @param  string $new_metakey The new key, usually the WPSEO meta key (including prefix).
-	 * @param  bool   $delete_old  Whether to delete the old meta key/value-sets.
+	 * @param string $old_metakey The old key of the meta value.
+	 * @param string $new_metakey The new key, usually the WPSEO meta key (including prefix).
+	 * @param bool   $delete_old  Whether to delete the old meta key/value-sets.
 	 *
 	 * @return void
 	 */
@@ -1015,7 +1015,7 @@ class WPSEO_Meta {
 	 * @deprecated 9.6
 	 * @codeCoverageIgnore
 	 *
-	 * @param  string $key Key of the value to get from $_POST.
+	 * @param string $key Key of the value to get from $_POST.
 	 *
 	 * @return string      Returns $_POST value, which will be a string the majority of the time
 	 *                     Will return empty string if key does not exists in $_POST

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -85,13 +85,13 @@ class WPSEO_Replace_Vars {
 	 *
 	 * @see wpseo_register_var_replacement() for a usage example.
 	 *
-	 * @param  string $var              The name of the variable to replace, i.e. '%%var%%'
-	 *                                  - the surrounding %% are optional.
-	 * @param  mixed  $replace_function Function or method to call to retrieve the replacement value for the variable
-	 *                                  Uses the same format as add_filter/add_action function parameter and
-	 *                                  should *return* the replacement value. DON'T echo it.
-	 * @param  string $type             Type of variable: 'basic' or 'advanced', defaults to 'advanced'.
-	 * @param  string $help_text        Help text to be added to the help tab for this variable.
+	 * @param string $var              The name of the variable to replace, i.e. '%%var%%'.
+	 *                                 Note: the surrounding %% are optional.
+	 * @param mixed  $replace_function Function or method to call to retrieve the replacement value for the variable.
+	 *                                 Uses the same format as add_filter/add_action function parameter and
+	 *                                 should *return* the replacement value. DON'T echo it.
+	 * @param string $type             Type of variable: 'basic' or 'advanced', defaults to 'advanced'.
+	 * @param string $help_text        Help text to be added to the help tab for this variable.
 	 *
 	 * @return bool     Whether the replacement function was succesfully registered.
 	 */
@@ -169,8 +169,8 @@ class WPSEO_Replace_Vars {
 		 *
 		 * @api     array   $replacements The replacements.
 		 *
-		 * @param   array   $args The object some of the replacement values might come from,
-		 *                       could be a post, taxonomy or term.
+		 * @param array $args The object some of the replacement values might come from,
+		 *                    could be a post, taxonomy or term.
 		 */
 		$replacements = apply_filters( 'wpseo_replacements', $replacements, $this->args );
 
@@ -1042,7 +1042,7 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Create a variable help text table.
 	 *
-	 * @param    string $type Either 'basic' or 'advanced'.
+	 * @param string $type Either 'basic' or 'advanced'.
 	 *
 	 * @return   string Help text table.
 	 */
@@ -1099,8 +1099,8 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Set the help text for a user/plugin/theme defined extra variable.
 	 *
-	 * @param  string                     $type                 Type of variable: 'basic' or 'advanced'.
-	 * @param  WPSEO_Replacement_Variable $replacement_variable The replacement variable to register.
+	 * @param string                     $type                 Type of variable: 'basic' or 'advanced'.
+	 * @param WPSEO_Replacement_Variable $replacement_variable The replacement variable to register.
 	 */
 	private static function register_help_text( $type, WPSEO_Replacement_Variable $replacement_variable ) {
 		$identifier = $replacement_variable->get_variable();
@@ -1375,7 +1375,7 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Remove the '%%' delimiters from a variable string.
 	 *
-	 * @param  string $string Variable string to be cleaned.
+	 * @param string $string Variable string to be cleaned.
 	 *
 	 * @return string
 	 */
@@ -1386,7 +1386,7 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Add the '%%' delimiters to a variable string.
 	 *
-	 * @param  string $string Variable string to be delimited.
+	 * @param string $string Variable string to be delimited.
 	 *
 	 * @return string
 	 */

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -516,19 +516,19 @@ class WPSEO_Utils {
 	 * @since 1.5.0
 	 * @since 1.8.0 Moved from stand-alone function to this class.
 	 *
-	 * @param mixed  $number1     Scalar (string/int/float/bool).
-	 * @param string $action      Calculation action to execute. Valid input:
-	 *                            '+' or 'add' or 'addition',
-	 *                            '-' or 'sub' or 'subtract',
-	 *                            '*' or 'mul' or 'multiply',
-	 *                            '/' or 'div' or 'divide',
-	 *                            '%' or 'mod' or 'modulus'
-	 *                            '=' or 'comp' or 'compare'.
-	 * @param mixed  $number2     Scalar (string/int/float/bool).
-	 * @param bool   $round       Whether or not to round the result. Defaults to false.
-	 *                            Will be disregarded for a compare operation.
-	 * @param int    $decimals    Decimals for rounding operation. Defaults to 0.
-	 * @param int    $precision   Calculation precision. Defaults to 10.
+	 * @param mixed  $number1   Scalar (string/int/float/bool).
+	 * @param string $action    Calculation action to execute. Valid input:
+	 *                          '+' or 'add' or 'addition',
+	 *                          '-' or 'sub' or 'subtract',
+	 *                          '*' or 'mul' or 'multiply',
+	 *                          '/' or 'div' or 'divide',
+	 *                          '%' or 'mod' or 'modulus'
+	 *                          '=' or 'comp' or 'compare'.
+	 * @param mixed  $number2   Scalar (string/int/float/bool).
+	 * @param bool   $round     Whether or not to round the result. Defaults to false.
+	 *                          Will be disregarded for a compare operation.
+	 * @param int    $decimals  Decimals for rounding operation. Defaults to 0.
+	 * @param int    $precision Calculation precision. Defaults to 10.
 	 *
 	 * @return mixed            Calculation Result or false if either or the numbers isn't scalar or
 	 *                          an invalid operation was passed.

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -137,9 +137,9 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	/**
 	 * Validate the option
 	 *
-	 * @param  array $dirty New value for the option.
-	 * @param  array $clean Clean value for the option, normally the defaults.
-	 * @param  array $old   Old value of the option.
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
 	 *
 	 * @return  array      Validated clean value for the option to be saved to the database
 	 */
@@ -212,12 +212,12 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	/**
 	 * Clean a given option value
 	 *
-	 * @param  array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                       clean according to the rules for this option.
-	 * @param  string $current_version       (optional) Version from which to upgrade, if not set,
-	 *                                       version specific upgrades will be disregarded.
-	 * @param  array  $all_old_option_values (optional) Only used when importing old options to have
-	 *                                       access to the real old values, in contrast to the saved ones.
+	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                      clean according to the rules for this option.
+	 * @param string $current_version       (optional) Version from which to upgrade, if not set,
+	 *                                      version specific upgrades will be disregarded.
+	 * @param array  $all_old_option_values (optional) Only used when importing old options to have
+	 *                                      access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return  array            Cleaned option
 	 */

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -97,9 +97,9 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	/**
 	 * Validate the option.
 	 *
-	 * @param  array $dirty New value for the option.
-	 * @param  array $clean Clean value for the option, normally the defaults.
-	 * @param  array $old   Old value of the option.
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
 	 *
 	 * @return  array      Validated clean value for the option to be saved to the database.
 	 */
@@ -214,12 +214,12 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	/**
 	 * Clean a given option value.
 	 *
-	 * @param  array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                       clean according to the rules for this option.
-	 * @param  string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                       version specific upgrades will be disregarded.
-	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                       access to the real old values, in contrast to the saved ones.
+	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                      clean according to the rules for this option.
+	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                      version specific upgrades will be disregarded.
+	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                      access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return  array Cleaned option.
 	 */

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -298,9 +298,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	/**
 	 * Validate the option.
 	 *
-	 * @param  array $dirty New value for the option.
-	 * @param  array $clean Clean value for the option, normally the defaults.
-	 * @param  array $old   Old value of the option.
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
 	 *
 	 * @return  array      Validated clean value for the option to be saved to the database.
 	 */
@@ -561,12 +561,12 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	/**
 	 * Clean a given option value.
 	 *
-	 * @param  array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                       clean according to the rules for this option.
-	 * @param  string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                       version specific upgrades will be disregarded.
-	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                       access to the real old values, in contrast to the saved ones.
+	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                      clean according to the rules for this option.
+	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                      version specific upgrades will be disregarded.
+	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                      access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return  array            Cleaned option.
 	 */
@@ -755,10 +755,10 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 *            variable key does not get removed. IMPORTANT: keep this method in line with
 	 *            the parent on which it is based!}}
 	 *
-	 * @param  array $dirty Original option as retrieved from the database.
-	 * @param  array $clean Filtered option where any options which shouldn't be in our option
-	 *                      have already been removed and any options which weren't set
-	 *                      have been set to their defaults.
+	 * @param array $dirty Original option as retrieved from the database.
+	 * @param array $clean Filtered option where any options which shouldn't be in our option
+	 *                     have already been removed and any options which weren't set
+	 *                     have been set to their defaults.
 	 *
 	 * @return  array
 	 */

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -213,9 +213,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	/**
 	 * Validate the option.
 	 *
-	 * @param  array $dirty New value for the option.
-	 * @param  array $clean Clean value for the option, normally the defaults.
-	 * @param  array $old   Old value of the option.
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
 	 *
 	 * @return  array      Validated clean value for the option to be saved to the database.
 	 */
@@ -374,12 +374,12 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	/**
 	 * Clean a given option value.
 	 *
-	 * @param  array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                       clean according to the rules for this option.
-	 * @param  string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                       version specific upgrades will be disregarded.
-	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                       access to the real old values, in contrast to the saved ones.
+	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                      clean according to the rules for this option.
+	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                      version specific upgrades will be disregarded.
+	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                      access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return  array            Cleaned option.
 	 */

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -413,7 +413,7 @@ abstract class WPSEO_Option {
 	 *
 	 * This method should *not* be called directly!!! It is only meant to filter the get_option() results.
 	 *
-	 * @param   mixed $options Option value.
+	 * @param mixed $options Option value.
 	 *
 	 * @return  mixed        Option merged with the defaults for that option.
 	 */
@@ -461,7 +461,7 @@ abstract class WPSEO_Option {
 	/**
 	 * Validate the option
 	 *
-	 * @param  mixed $option_value The unvalidated new value for the option.
+	 * @param mixed $option_value The unvalidated new value for the option.
 	 *
 	 * @return  array          Validated new value for the option.
 	 */
@@ -518,9 +518,9 @@ abstract class WPSEO_Option {
 	 * All concrete classes must contain a validate_option() method which validates all
 	 * values within the option.
 	 *
-	 * @param  array $dirty New value for the option.
-	 * @param  array $clean Clean value for the option, normally the defaults.
-	 * @param  array $old   Old value of the option.
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
 	 */
 	abstract protected function validate_option( $dirty, $clean, $old );
 
@@ -601,7 +601,8 @@ abstract class WPSEO_Option {
 	 * @uses WPSEO_Option::get_original_option()
 	 * @uses WPSEO_Option::import()
 	 *
-	 * @param  string $current_version Optional. Version from which to upgrade, if not set, version specific upgrades will be disregarded.
+	 * @param string $current_version Optional. Version from which to upgrade, if not set,
+	 *                                version specific upgrades will be disregarded.
 	 *
 	 * @return void
 	 */
@@ -624,9 +625,12 @@ abstract class WPSEO_Option {
 	 *    once the admin has dismissed the message (add ajax function)
 	 * Important: all validation routines which add_settings_errors would need to be changed for this to work
 	 *
-	 * @param  array  $option_value          Option value to be imported.
-	 * @param  string $current_version       Optional. Version from which to upgrade, if not set, version specific upgrades will be disregarded.
-	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have access to the real old values, in contrast to the saved ones.
+	 * @param array  $option_value          Option value to be imported.
+	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                      version specific upgrades will be disregarded.
+	 * @param array  $all_old_option_values Optional. Only used when importing old options to
+	 *                                      have access to the real old values, in contrast to
+	 *                                      the saved ones.
 	 *
 	 * @return void
 	 */
@@ -673,7 +677,8 @@ abstract class WPSEO_Option {
 	 * @todo [JRF] - shouldn't this be a straight array merge ? at the end of the day, the validation
 	 * removes any invalid keys on save.
 	 *
-	 * @param  array $options Optional. Current options. If not set, the option defaults for the $option_key will be returned.
+	 * @param array $options Optional. Current options. If not set, the option defaults
+	 *                       for the $option_key will be returned.
 	 *
 	 * @return  array  Combined and filtered options array.
 	 */
@@ -755,10 +760,10 @@ abstract class WPSEO_Option {
 	 * {@internal The wpseo_titles concrete class overrules this method. Make sure that any
 	 *            changes applied here, also get ported to that version.}}
 	 *
-	 * @param  array $dirty Original option as retrieved from the database.
-	 * @param  array $clean Filtered option where any options which shouldn't be in our option
-	 *                      have already been removed and any options which weren't set
-	 *                      have been set to their defaults.
+	 * @param array $dirty Original option as retrieved from the database.
+	 * @param array $clean Filtered option where any options which shouldn't be in our option
+	 *                     have already been removed and any options which weren't set
+	 *                     have been set to their defaults.
 	 *
 	 * @return  array
 	 */
@@ -789,7 +794,7 @@ abstract class WPSEO_Option {
 	 *
 	 * @usedby validate_option() methods for options with variable array keys.
 	 *
-	 * @param  string $key Array key to check.
+	 * @param string $key Array key to check.
 	 *
 	 * @return string      Pattern if it conforms, original array key if it doesn't or if the option
 	 *              does not have variable array keys.

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -84,7 +84,7 @@ class WPSEO_Options {
 	/**
 	 * Get the group name of an option for use in the settings form.
 	 *
-	 * @param  string $option_name The option for which you want to retrieve the option group name.
+	 * @param string $option_name The option for which you want to retrieve the option group name.
 	 *
 	 * @return  string|bool
 	 */
@@ -99,8 +99,8 @@ class WPSEO_Options {
 	/**
 	 * Get a specific default value for an option.
 	 *
-	 * @param  string $option_name The option for which you want to retrieve a default.
-	 * @param  string $key         The key within the option who's default you want.
+	 * @param string $option_name The option for which you want to retrieve a default.
+	 * @param string $key         The key within the option who's default you want.
 	 *
 	 * @return  mixed
 	 */
@@ -118,8 +118,8 @@ class WPSEO_Options {
 	/**
 	 * Update a site_option.
 	 *
-	 * @param  string $option_name The option name of the option to save.
-	 * @param  mixed  $value       The new value for the option.
+	 * @param string $option_name The option name of the option to save.
+	 * @param mixed  $value       The new value for the option.
 	 *
 	 * @return bool
 	 */
@@ -134,7 +134,7 @@ class WPSEO_Options {
 	/**
 	 * Get the instantiated option instance.
 	 *
-	 * @param  string $option_name The option for which you want to retrieve the instance.
+	 * @param string $option_name The option for which you want to retrieve the instance.
 	 *
 	 * @return  object|bool
 	 */
@@ -289,11 +289,11 @@ class WPSEO_Options {
 	/**
 	 * Run the clean up routine for one or all options.
 	 *
-	 * @param  array|string $option_name     Optional. the option you want to clean or an array of
-	 *                                       option names for the options you want to clean.
-	 *                                       If not set, all options will be cleaned.
-	 * @param  string       $current_version Optional. Version from which to upgrade, if not set,
-	 *                                       version specific upgrades will be disregarded.
+	 * @param array|string $option_name     Optional. the option you want to clean or an array of
+	 *                                      option names for the options you want to clean.
+	 *                                      If not set, all options will be cleaned.
+	 * @param string       $current_version Optional. Version from which to upgrade, if not set,
+	 *                                      version specific upgrades will be disregarded.
 	 *
 	 * @return  void
 	 */
@@ -372,7 +372,7 @@ class WPSEO_Options {
 	/**
 	 * Initialize default values for a new multisite blog.
 	 *
-	 * @param  bool $force_init Whether to always do the initialization routine (title/desc test).
+	 * @param bool $force_init Whether to always do the initialization routine (title/desc test).
 	 *
 	 * @return void
 	 */
@@ -394,7 +394,7 @@ class WPSEO_Options {
 	 * Reset all options for a specific multisite blog to their default values based upon a
 	 * specified default blog if one was chosen on the network page or the plugin defaults if it was not.
 	 *
-	 * @param  int|string $blog_id Blog id of the blog for which to reset the options.
+	 * @param int|string $blog_id Blog id of the blog for which to reset the options.
 	 *
 	 * @return  void
 	 */
@@ -436,7 +436,7 @@ class WPSEO_Options {
 	 *
 	 * @param string $wpseo_options_group_name The name for the wpseo option group in the database.
 	 * @param string $option_name              The name for the option to set.
-	 * @param *      $option_value             The value for the option.
+	 * @param mixed  $option_value             The value for the option.
 	 *
 	 * @return boolean Returns true if the option is successfully saved in the database.
 	 */

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -121,8 +121,9 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * Helper method - Combines a fixed array of default values with an options array
 	 * while filtering out any keys which are not in the defaults array.
 	 *
-	 * @param  string $option_key Option name of the option we're doing the merge for.
-	 * @param  array  $options    Optional. Current options. If not set, the option defaults for the $option_key will be returned.
+	 * @param string $option_key Option name of the option we're doing the merge for.
+	 * @param array  $options    Optional. Current options. If not set, the option defaults
+	 *                           for the $option_key will be returned.
 	 *
 	 * @return  array  Combined and filtered options array.
 	 */
@@ -173,9 +174,9 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * Validate the option.
 	 *
-	 * @param  array $dirty New value for the option.
-	 * @param  array $clean Clean value for the option, normally the defaults.
-	 * @param  array $old   Old value of the option.
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
 	 *
 	 * @return  array      Validated clean value for the option to be saved to the database.
 	 */
@@ -226,8 +227,8 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * Validate the meta data for one individual term and removes default values (no need to save those).
 	 *
-	 * @param  array $meta_data New values.
-	 * @param  array $old_meta  The original values.
+	 * @param array $meta_data New values.
+	 * @param array $old_meta  The original values.
 	 *
 	 * @return  array        Validated and filtered value.
 	 */
@@ -346,12 +347,12 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * - Convert old option values to new
 	 * - Fixes strings which were escaped (should have been sanitized - escaping is for output)
 	 *
-	 * @param  array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                       clean according to the rules for this option.
-	 * @param  string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                       version specific upgrades will be disregarded.
-	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                       access to the real old values, in contrast to the saved ones.
+	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                      clean according to the rules for this option.
+	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                      version specific upgrades will be disregarded.
+	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                      access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return  array            Cleaned option.
 	 */
@@ -417,10 +418,10 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * Retrieve a taxonomy term's meta value(s).
 	 *
-	 * @param  mixed  $term     Term to get the meta value for
-	 *                          either (string) term name, (int) term id or (object) term.
-	 * @param  string $taxonomy Name of the taxonomy to which the term is attached.
-	 * @param  string $meta     Optional. Meta value to get (without prefix).
+	 * @param mixed  $term     Term to get the meta value for
+	 *                         either (string) term name, (int) term id or (object) term.
+	 * @param string $taxonomy Name of the taxonomy to which the term is attached.
+	 * @param string $meta     Optional. Meta value to get (without prefix).
 	 *
 	 * @return  mixed|bool    Value for the $meta if one is given, might be the default.
 	 *              If no meta is given, an array of all the meta data for the term.

--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -39,7 +39,8 @@ class WPSEO_Sitemap_Timezone {
 	/**
 	 * Get the datetime object, in site's time zone, if the datetime string was valid
 	 *
-	 * @param string $datetime_string The datetime string in UTC time zone, that needs to be converted to a DateTime object.
+	 * @param string $datetime_string The datetime string in UTC time zone, that needs
+	 *                                to be converted to a DateTime object.
 	 *
 	 * @return DateTime|null in site's time zone
 	 */

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -134,8 +134,8 @@ class WPSEO_Sitemaps_Renderer {
 	/**
 	 * Produce final XML output with debug information.
 	 *
-	 * @param string  $sitemap    Sitemap XML.
-	 * @param boolean $transient  Transient cache flag.
+	 * @param string  $sitemap   Sitemap XML.
+	 * @param boolean $transient Transient cache flag.
 	 *
 	 * @return string
 	 */
@@ -291,7 +291,7 @@ class WPSEO_Sitemaps_Renderer {
 		 *
 		 * @api   string $output The output for the sitemap url tag.
 		 *
-		 * @param array  $url The sitemap url array on which the output is based.
+		 * @param array $url The sitemap url array on which the output is based.
 		 */
 		return apply_filters( 'wpseo_sitemap_url', $output, $url );
 	}

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -240,8 +240,8 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		/**
 		 * Filter to exclude the taxonomy from the XML sitemap.
 		 *
-		 * @param boolean $exclude        Defaults to false.
-		 * @param string  $taxonomy_name  Name of the taxonomy to exclude..
+		 * @param boolean $exclude       Defaults to false.
+		 * @param string  $taxonomy_name Name of the taxonomy to exclude..
 		 */
 		if ( apply_filters( 'wpseo_sitemap_exclude_taxonomy', false, $taxonomy_name ) ) {
 			return false;

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -129,15 +129,15 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
  *
  * @since 1.5.4
  *
- * @param string $var              The name of the variable to replace, i.e. '%%var%%'
- *                                 - the surrounding %% are optional, name can only contain [A-Za-z0-9_-].
+ * @param string $var              The name of the variable to replace, i.e. '%%var%%'.
+ *                                 Note: the surrounding %% are optional, name can only contain [A-Za-z0-9_-].
  * @param mixed  $replace_function Function or method to call to retrieve the replacement value for the variable.
  *                                 Uses the same format as add_filter/add_action function parameter and
  *                                 should *return* the replacement value. DON'T echo it.
  * @param string $type             Type of variable: 'basic' or 'advanced', defaults to 'advanced'.
  * @param string $help_text        Help text to be added to the help tab for this variable.
  *
- * @return bool  Whether the replacement function was succesfully registered.
+ * @return bool  Whether the replacement function was successfully registered.
  */
 function wpseo_register_var_replacement( $var, $replace_function, $type = 'advanced', $help_text = '' ) {
 	return WPSEO_Replace_Vars::register_replacement( $var, $replace_function, $type, $help_text );

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -84,7 +84,8 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
  * Replace `%%variable_placeholders%%` with their real value based on the current requested page/post/cpt.
  *
  * @param string $string The string to replace the variables in.
- * @param object $args   The object some of the replacement values might come from, could be a post, taxonomy or term.
+ * @param object $args   The object some of the replacement values might come from,
+ *                       could be a post, taxonomy or term.
  * @param array  $omit   Variables that should not be replaced by this function.
  *
  * @return string
@@ -128,13 +129,13 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
  *
  * @since 1.5.4
  *
- * @param  string $var              The name of the variable to replace, i.e. '%%var%%'
- *                                  - the surrounding %% are optional, name can only contain [A-Za-z0-9_-].
- * @param  mixed  $replace_function Function or method to call to retrieve the replacement value for the variable
- *                                  Uses the same format as add_filter/add_action function parameter and
- *                                  should *return* the replacement value. DON'T echo it.
- * @param  string $type             Type of variable: 'basic' or 'advanced', defaults to 'advanced'.
- * @param  string $help_text        Help text to be added to the help tab for this variable.
+ * @param string $var              The name of the variable to replace, i.e. '%%var%%'
+ *                                 - the surrounding %% are optional, name can only contain [A-Za-z0-9_-].
+ * @param mixed  $replace_function Function or method to call to retrieve the replacement value for the variable.
+ *                                 Uses the same format as add_filter/add_action function parameter and
+ *                                 should *return* the replacement value. DON'T echo it.
+ * @param string $type             Type of variable: 'basic' or 'advanced', defaults to 'advanced'.
+ * @param string $help_text        Help text to be added to the help tab for this variable.
  *
  * @return bool  Whether the replacement function was succesfully registered.
  */

--- a/src/exceptions/no-indexable-found.php
+++ b/src/exceptions/no-indexable-found.php
@@ -34,8 +34,8 @@ class No_Indexable_Found extends \OutOfRangeException {
 	/**
 	 * Returns an exception when an indexable for a taxonomy is not found.
 	 *
-	 * @param int    $term_id     The term the indexable is based upon.
-	 * @param string $taxonomy    The taxonomy the indexable belongs to.
+	 * @param int    $term_id  The term the indexable is based upon.
+	 * @param string $taxonomy The taxonomy the indexable belongs to.
 	 *
 	 * @return No_Indexable_Found The exception.
 	 */

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -150,9 +150,9 @@ class Yoast_Model {
 	 * class or the property does not exist, returns the default
 	 * value supplied as the third argument (which defaults to null).
 	 *
-	 * @param  string      $class_name The target class name.
-	 * @param  string      $property   The property to get the value for.
-	 * @param  null|string $default    Default value when property does not exist.
+	 * @param string      $class_name The target class name.
+	 * @param string      $property   The property to get the value for.
+	 * @param null|string $default    Default value when property does not exist.
 	 *
 	 * @return string The value of the property.
 	 */
@@ -179,7 +179,7 @@ class Yoast_Model {
 	 * property $table_use_short_name == true then $class_name passed
 	 * to class_name_to_table_name() is stripped of namespace information.
 	 *
-	 * @param  string $class_name The class name to get the table name for.
+	 * @param string $class_name The class name to get the table name for.
 	 *
 	 * @return string The table name.
 	 */
@@ -228,7 +228,7 @@ class Yoast_Model {
 	 * For example, CarTyre would be converted to car_tyre. And
 	 * Project\Models\CarTyre would be project_models_car_tyre.
 	 *
-	 * @param  string $class_name The class name to get the table name for.
+	 * @param string $class_name The class name to get the table name for.
 	 *
 	 * @return string The table name.
 	 */
@@ -253,7 +253,7 @@ class Yoast_Model {
 	 * Return the ID column name to use for this class. If it is
 	 * not set on the class, returns null.
 	 *
-	 * @param  string $class_name The class name to get the ID column for.
+	 * @param string $class_name The class name to get the ID column for.
 	 *
 	 * @return string|null The ID column name.
 	 */
@@ -267,8 +267,8 @@ class Yoast_Model {
 	 * argument (the name of the table) with the default foreign key column
 	 * suffix appended.
 	 *
-	 * @param  string $specified_foreign_key_name The keyname to build.
-	 * @param  string $table_name                 The table name to build the key name for.
+	 * @param string $specified_foreign_key_name The keyname to build.
+	 * @param string $table_name                 The table name to build the key name for.
 	 *
 	 * @return string The built foreign key name.
 	 */
@@ -289,8 +289,8 @@ class Yoast_Model {
 	 * responsible for returning instances of the correct class when
 	 * its find_one or find_many methods are called.
 	 *
-	 * @param  string      $class_name      The target class name.
-	 * @param  null|string $connection_name The name of the connection.
+	 * @param string      $class_name      The target class name.
+	 * @param null|string $connection_name The name of the connection.
 	 *
 	 * @return ORMWrapper Instance of the ORM wrapper.
 	 */
@@ -313,10 +313,10 @@ class Yoast_Model {
 	 * only difference is whether find_one or find_many is used to complete
 	 * the method chain.
 	 *
-	 * @param  string      $associated_class_name                    The associated class name.
-	 * @param  null|string $foreign_key_name                         The foreign key name in the associated table.
-	 * @param  null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
-	 * @param  null|string $connection_name                          The name of the connection.
+	 * @param string      $associated_class_name                    The associated class name.
+	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
+	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
+	 * @param null|string $connection_name                          The name of the connection.
 	 *
 	 * @return ORMWrapper
 	 * @throws \Exception When ID of urrent model has a null value.
@@ -345,10 +345,10 @@ class Yoast_Model {
 	 * Helper method to manage one-to-one relations where the foreign
 	 * key is on the associated table.
 	 *
-	 * @param  string      $associated_class_name                    The associated class name.
-	 * @param  null|string $foreign_key_name                         The foreign key name in the associated table.
-	 * @param  null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
-	 * @param  null|string $connection_name                          The name of the connection.
+	 * @param string      $associated_class_name                    The associated class name.
+	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
+	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
+	 * @param null|string $connection_name                          The name of the connection.
 	 *
 	 * @return ORMWrapper Instance of the ORM.
 	 * @throws \Exception  When ID of urrent model has a null value.
@@ -361,10 +361,10 @@ class Yoast_Model {
 	 * Helper method to manage one-to-many relations where the foreign
 	 * key is on the associated table.
 	 *
-	 * @param  string      $associated_class_name                    The associated class name.
-	 * @param  null|string $foreign_key_name                         The foreign key name in the associated table.
-	 * @param  null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
-	 * @param  null|string $connection_name                          The name of the connection.
+	 * @param string      $associated_class_name                    The associated class name.
+	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
+	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
+	 * @param null|string $connection_name                          The name of the connection.
 	 *
 	 * @return ORMWrapper Instance of the ORM.
 	 * @throws \Exception When ID has a null value.
@@ -379,10 +379,10 @@ class Yoast_Model {
 	 * Helper method to manage one-to-one and one-to-many relations where
 	 * the foreign key is on the base table.
 	 *
-	 * @param  string      $associated_class_name                       The associated class name.
-	 * @param  null|string $foreign_key_name                            The foreign key in the current models table.
-	 * @param  null|string $foreign_key_name_in_associated_models_table The foreign key in the associated table.
-	 * @param  null|string $connection_name                             The name of the connection.
+	 * @param string      $associated_class_name                       The associated class name.
+	 * @param null|string $foreign_key_name                            The foreign key in the current models table.
+	 * @param null|string $foreign_key_name_in_associated_models_table The foreign key in the associated table.
+	 * @param null|string $connection_name                             The name of the connection.
 	 *
 	 * @return $this|null Instance of the foreign model.
 	 */
@@ -410,13 +410,13 @@ class Yoast_Model {
 	 * Helper method to manage many-to-many relationships via an intermediate model. See
 	 * README for a full explanation of the parameters.
 	 *
-	 * @param  string      $associated_class_name   The associated class name.
-	 * @param  null|string $join_class_name         The class name to join.
-	 * @param  null|string $key_to_base_table       The key to the the current models table.
-	 * @param  null|string $key_to_associated_table The key to the associated table.
-	 * @param  null|string $key_in_base_table       The key in the current models table.
-	 * @param  null|string $key_in_associated_table The key in the associated table.
-	 * @param  null|string $connection_name         The name of the connection.
+	 * @param string      $associated_class_name   The associated class name.
+	 * @param null|string $join_class_name         The class name to join.
+	 * @param null|string $key_to_base_table       The key to the the current models table.
+	 * @param null|string $key_to_associated_table The key to the associated table.
+	 * @param null|string $key_in_base_table       The key in the current models table.
+	 * @param null|string $key_in_associated_table The key in the associated table.
+	 * @param null|string $connection_name         The name of the connection.
 	 *
 	 * @return ORMWrapper Instance of the ORM.
 	 */
@@ -480,7 +480,7 @@ class Yoast_Model {
 	/**
 	 * Set the wrapped ORM instance associated with this Model instance.
 	 *
-	 * @param  ORM $orm The ORM instance to set.
+	 * @param ORM $orm The ORM instance to set.
 	 *
 	 * @return void
 	 */
@@ -491,7 +491,7 @@ class Yoast_Model {
 	/**
 	 * Magic getter method, allows $model->property access to data.
 	 *
-	 * @param  string $property The property to get.
+	 * @param string $property The property to get.
 	 *
 	 * @return null|string The value of the property
 	 */
@@ -502,8 +502,8 @@ class Yoast_Model {
 	/**
 	 * Magic setter method, allows $model->property = 'value' access to data.
 	 *
-	 * @param  string $property The property to set.
-	 * @param  string $value    The value to set.
+	 * @param string $property The property to set.
+	 * @param string $value    The value to set.
 	 *
 	 * @return void
 	 */
@@ -514,7 +514,7 @@ class Yoast_Model {
 	/**
 	 * Magic unset method, allows unset($model->property)
 	 *
-	 * @param  string $property The property to unset.
+	 * @param string $property The property to unset.
 	 *
 	 * @return void
 	 */
@@ -525,7 +525,7 @@ class Yoast_Model {
 	/**
 	 * Magic isset method, allows isset($model->property) to work correctly.
 	 *
-	 * @param  string $property The property to check.
+	 * @param string $property The property to check.
 	 *
 	 * @return bool True when value is set.
 	 */
@@ -536,7 +536,7 @@ class Yoast_Model {
 	/**
 	 * Getter method, allows $model->get('property') access to data
 	 *
-	 * @param  string $property The property to get.
+	 * @param string $property The property to get.
 	 *
 	 * @return string The value of a property.
 	 */
@@ -547,8 +547,8 @@ class Yoast_Model {
 	/**
 	 * Setter method, allows $model->set('property', 'value') access to data.
 	 *
-	 * @param  string|array $property The property to set.
-	 * @param  string|null  $value    The value to give.
+	 * @param string|array $property The property to set.
+	 * @param string|null  $value    The value to give.
 	 *
 	 * @return static Current object.
 	 */
@@ -561,8 +561,8 @@ class Yoast_Model {
 	/**
 	 * Setter method, allows $model->set_expr('property', 'value') access to data.
 	 *
-	 * @param  string|array $property The property to set.
-	 * @param  string|null  $value    The value to give.
+	 * @param string|array $property The property to set.
+	 * @param string|null  $value    The value to give.
 	 *
 	 * @return static Current object.
 	 */
@@ -648,8 +648,8 @@ class Yoast_Model {
 	/**
 	 * Calls static methods directly on the ORMWrapper
 	 *
-	 * @param  string $method    The method to call.
-	 * @param  array  $arguments The arguments to use.
+	 * @param string $method    The method to call.
+	 * @param array  $arguments The arguments to use.
 	 *
 	 * @return array Result of the static call.
 	 */
@@ -671,8 +671,8 @@ class Yoast_Model {
 	 * This allows us to call methods using camel case and remain
 	 * backwards compatible.
 	 *
-	 * @param  string $name      The method to call.
-	 * @param  array  $arguments The arguments to use.
+	 * @param string $name      The method to call.
+	 * @param array  $arguments The arguments to use.
 	 *
 	 * @throws Missing_Method When the method does not exist.
 	 *

--- a/src/yoast-orm-wrapper.php
+++ b/src/yoast-orm-wrapper.php
@@ -78,8 +78,8 @@ class ORMWrapper extends ORM {
 	 * A repeat of content in parent::for_table, so that created class is
 	 * ORMWrapper, not ORM
 	 *
-	 * @param  string $table_name      The table to create instance for.
-	 * @param  string $connection_name The connection name.
+	 * @param string $table_name      The table to create instance for.
+	 * @param string $connection_name The connection name.
 	 *
 	 * @return ORMWrapper Instance of the ORM wrapper.
 	 */

--- a/tests/doubles/class-wpseo-option-social-double.php
+++ b/tests/doubles/class-wpseo-option-social-double.php
@@ -20,9 +20,9 @@ class WPSEO_Option_Social_Double extends WPSEO_Option_Social {
 	/**
 	 * Validate the option.
 	 *
-	 * @param  array $dirty New value for the option.
-	 * @param  array $clean Clean value for the option, normally the defaults.
-	 * @param  array $old   Old value of the option.
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
 	 *
 	 * @return  array      Validated clean value for the option to be saved to the database.
 	 */

--- a/tests/doubles/class-wpseo-plugin-availability-double.php
+++ b/tests/doubles/class-wpseo-plugin-availability-double.php
@@ -131,7 +131,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 	/**
 	 * Checks whether a dependency is available.
 	 *
-	 * @param {string} $dependency The dependency to look for.
+	 * @param string $dependency The dependency to look for.
 	 *
 	 * @return bool Whether or not the dependency is available.
 	 */

--- a/tests/doubles/class-wpseo-suggested-plugins-double.php
+++ b/tests/doubles/class-wpseo-suggested-plugins-double.php
@@ -14,7 +14,7 @@ class WPSEO_Suggested_Plugins_Double extends WPSEO_Suggested_Plugins {
 	 * WPSEO_Suggested_Plugins_Double constructor.
 	 *
 	 * @param WPSEO_Plugin_Availability $availability_checker The availability checker to use.
-	 * @param Yoast_Notification_Center $notification_center The notification center to add notifications to.
+	 * @param Yoast_Notification_Center $notification_center  The notification center to add notifications to.
 	 */
 	public function __construct( WPSEO_Plugin_Availability $availability_checker, Yoast_Notification_Center $notification_center ) {
 		$this->availability_checker = $availability_checker;

--- a/tests/test-class-wpseo-meta.php
+++ b/tests/test-class-wpseo-meta.php
@@ -293,7 +293,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Registers a field on the WPSEO_Meta class.
 	 *
-	 * @param string $key The key to register.
+	 * @param string $key        The key to register.
 	 * @param bool   $serialized If the key is stored as serialized data.
 	 *
 	 * @returns {void}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

More of the same as #12272.

The contents of parameter tags should be aligned like so:
```php
 * @param[1 space]int [1 space after longest entry]$var     [1 space after longest entry]Description.
 * @param[1 space]bool[1 space after longest entry]$variable[1 space after longest entry]Description.
```

Includes some minor punctuation fixes.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.