### PR TITLE
Documentation: improve method docblock @return tag formatting

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -232,7 +232,8 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 * This function takes into account the post types in which the current user can
 	 * edit all posts, and the ones the current user can only edit his/her own.
 	 *
-	 * @return string $subquery The subquery, which should always be used in $wpdb->prepare(), passing the current user_id in as the first parameter.
+	 * @return string The subquery, which should always be used in $wpdb->prepare(),
+	 *                passing the current user_id in as the first parameter.
 	 */
 	public function get_base_subquery() {
 		global $wpdb;

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -238,7 +238,7 @@ class WPSEO_Help_Center {
 	 *
 	 * %s is replaced with <code>%s</code> and replaced again in the javascript with the actual variable.
 	 *
-	 * @return  array Translated text strings for the help center.
+	 * @return array Translated text strings for the help center.
 	 */
 	public static function get_translated_texts() {
 		// Esc_html is not needed because React already handles HTML in the (translations of) these strings.

--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -194,7 +194,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 *
 	 * @param array $field_defs Array of metaboxes to save.
 	 *
-	 * @return  array
+	 * @return array
 	 */
 	public function save_meta_boxes( $field_defs ) {
 		if ( ! isset( $_POST['yoast_free_metabox_social_nonce'] ) || ! wp_verify_nonce( $_POST['yoast_free_metabox_social_nonce'], 'yoast_free_metabox_social' ) ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -240,7 +240,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	/**
 	 * Pass some variables to js for the edit / post page overview, etc.
 	 *
-	 * @return  array
+	 * @return array
 	 */
 	public function localize_shortcode_plugin_script() {
 		return array(
@@ -440,7 +440,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @param array  $meta_field_def Contains the vars based on which output is generated.
 	 * @param string $key            Internal key (without prefix).
 	 *
-	 * @return  string
+	 * @return string
 	 */
 	public function do_meta_box( $meta_field_def, $key = '' ) {
 		$content      = '';
@@ -623,7 +623,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @param int $post_id Post ID.
 	 *
-	 * @return  bool|void   Boolean false if invalid save post request.
+	 * @return bool|void Boolean false if invalid save post request.
 	 */
 	public function save_postdata( $post_id ) {
 		// Bail if this is a multisite installation and the site has been switched.
@@ -810,7 +810,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	/**
 	 * Pass some variables to js for upload module.
 	 *
-	 * @return  array
+	 * @return array
 	 */
 	public function localize_media_script() {
 		return array(

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -251,7 +251,7 @@ class WPSEO_Breadcrumbs {
 	 *
 	 * @param object $term Term to get the parents for.
 	 *
-	 * @return    array
+	 * @return array
 	 */
 	private function get_term_parents( $term ) {
 		$tax     = $term->taxonomy;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -792,7 +792,7 @@ class WPSEO_Frontend {
 	 * @param array $robots  Robots data array.
 	 * @param int   $post_id The post ID for which to determine the $robots values, defaults to current post.
 	 *
-	 * @return    array
+	 * @return array
 	 */
 	public function robots_for_single_post( $robots, $post_id = 0 ) {
 		$noindex = $this->get_seo_meta_value( 'meta-robots-noindex', $post_id );

--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -440,7 +440,8 @@ class WPSEO_OpenGraph_Image {
 	 *
 	 * @param string $url The given URL.
 	 *
-	 * @return null|number Returns the found attachment ID if it exists. Otherwise -1. If the URL is empty we return null.
+	 * @return null|number Returns the found attachment ID if it exists. Otherwise -1.
+	 *                     If the URL is empty we return null.
 	 */
 	public function add_image_by_url( $url ) {
 		if ( empty( $url ) ) {

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -39,6 +39,7 @@ class WPSEO_Rewrite {
 	 * If the flush option is set, flush the rewrite rules.
 	 *
 	 * @since 1.2.8
+	 *
 	 * @return bool
 	 */
 	public function flush() {

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -318,7 +318,7 @@ class WPSEO_Meta {
 	 * @param  string $tab       Tab for which to retrieve the field definitions.
 	 * @param  string $post_type Post type of the current post.
 	 *
-	 * @return array             Array containing the meta box field definitions
+	 * @return array Array containing the meta box field definitions.
 	 */
 	public static function get_meta_field_defs( $tab, $post_type = 'post' ) {
 		if ( ! isset( self::$meta_fields[ $tab ] ) ) {
@@ -397,7 +397,7 @@ class WPSEO_Meta {
 	 * @param  mixed  $meta_value The new value.
 	 * @param  string $meta_key   The full meta key (including prefix).
 	 *
-	 * @return string             Validated meta value
+	 * @return string Validated meta value.
 	 */
 	public static function sanitize_post_meta( $meta_value, $meta_key ) {
 		$field_def = self::$meta_fields[ self::$fields_index[ $meta_key ]['subset'] ][ self::$fields_index[ $meta_key ]['key'] ];
@@ -497,7 +497,7 @@ class WPSEO_Meta {
 	 *
 	 * @param  array|string $meta_value The value to validate.
 	 *
-	 * @return string       Clean value
+	 * @return string Clean value.
 	 */
 	public static function validate_meta_robots_adv( $meta_value ) {
 		$clean   = self::$meta_fields['advanced']['meta-robots-adv']['default_value'];
@@ -546,7 +546,7 @@ class WPSEO_Meta {
 	 * @param  string $meta_value New meta value.
 	 * @param  string $prev_value The old meta value.
 	 *
-	 * @return null|bool          true = stop saving, null = continue saving
+	 * @return null|bool True = stop saving, null = continue saving.
 	 */
 	public static function remove_meta_if_default( $check, $object_id, $meta_key, $meta_value, $prev_value = '' ) {
 		/* If it's one of our meta fields, check against default */
@@ -572,7 +572,7 @@ class WPSEO_Meta {
 	 * @param  string $meta_key   The full meta key (including prefix).
 	 * @param  string $meta_value New meta value.
 	 *
-	 * @return null|bool          true = stop saving, null = continue saving
+	 * @return null|bool True = stop saving, null = continue saving.
 	 */
 	public static function dont_save_meta_if_default( $check, $object_id, $meta_key, $meta_value ) {
 		/* If it's one of our meta fields, check against default */
@@ -606,13 +606,13 @@ class WPSEO_Meta {
 	 * @param  string $key    Internal key of the value to get (without prefix).
 	 * @param  int    $postid Post ID of the post to get the value for.
 	 *
-	 * @return string         All 'normal' values returned from get_post_meta() are strings.
-	 *                        Objects and arrays are possible, but not used by this plugin
-	 *                        and therefore discarted (except when the special 'serialized' field def
-	 *                        value is set to true - only used by add-on plugins for now).
-	 *                        Will return the default value if no value was found..
-	 *                        Will return empty string if no default was found (not one of our keys) or
-	 *                        if the post does not exist.
+	 * @return string All 'normal' values returned from get_post_meta() are strings.
+	 *                Objects and arrays are possible, but not used by this plugin
+	 *                and therefore discarted (except when the special 'serialized' field def
+	 *                value is set to true - only used by add-on plugins for now).
+	 *                Will return the default value if no value was found.
+	 *                Will return empty string if no default was found (not one of our keys) or
+	 *                if the post does not exist.
 	 */
 	public static function get_value( $key, $postid = 0 ) {
 		global $post;
@@ -663,7 +663,7 @@ class WPSEO_Meta {
 	 * @param  mixed  $meta_value The value to set the meta to.
 	 * @param  int    $post_id    The ID of the post to change the meta for.
 	 *
-	 * @return bool   whether the value was changed
+	 * @return bool Whether the value was changed.
 	 */
 	public static function set_value( $key, $meta_value, $post_id ) {
 		/*
@@ -1017,8 +1017,8 @@ class WPSEO_Meta {
 	 *
 	 * @param  string $key Key of the value to get from $_POST.
 	 *
-	 * @return string      Returns $_POST value, which will be a string the majority of the time
-	 *                     Will return empty string if key does not exists in $_POST
+	 * @return string Returns $_POST value, which will be a string the majority of the time.
+	 *                Will return empty string if key does not exists in $_POST.
 	 */
 	public static function get_post_value( $key ) {
 		_deprecated_function( __METHOD__, 'WPSEO 9.6' );

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -93,7 +93,7 @@ class WPSEO_Replace_Vars {
 	 * @param  string $type             Type of variable: 'basic' or 'advanced', defaults to 'advanced'.
 	 * @param  string $help_text        Help text to be added to the help tab for this variable.
 	 *
-	 * @return bool     Whether the replacement function was succesfully registered.
+	 * @return bool Whether the replacement function was succesfully registered.
 	 */
 	public static function register_replacement( $var, $replace_function, $type = 'advanced', $help_text = '' ) {
 		$success = false;
@@ -1044,7 +1044,7 @@ class WPSEO_Replace_Vars {
 	 *
 	 * @param    string $type Either 'basic' or 'advanced'.
 	 *
-	 * @return   string Help text table.
+	 * @return string Help text table.
 	 */
 	private static function create_variable_help_table( $type ) {
 		if ( ! in_array( $type, array( 'basic', 'advanced' ), true ) ) {

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -530,11 +530,11 @@ class WPSEO_Utils {
 	 * @param int    $decimals    Decimals for rounding operation. Defaults to 0.
 	 * @param int    $precision   Calculation precision. Defaults to 10.
 	 *
-	 * @return mixed            Calculation Result or false if either or the numbers isn't scalar or
-	 *                          an invalid operation was passed.
-	 *                          - for compare the result will always be an integer.
-	 *                          - for all other operations, the result will either be an integer (preferred)
-	 *                            or a float.
+	 * @return mixed Calculation Result or false if either or the numbers isn't scalar or
+	 *               an invalid operation was passed.
+	 *               - For compare the result will always be an integer.
+	 *               - For all other operations, the result will either be an integer (preferred)
+	 *                 or a float.
 	 */
 	public static function calc( $number1, $action, $number2, $round = false, $decimals = 0, $precision = 10 ) {
 		static $bc;

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -91,7 +91,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	/**
 	 * Add filters to make sure that the option default is returned if the option is not set
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function add_default_filters() {
 		// Don't change, needs to check for false as could return prio 0 which would evaluate to false.
@@ -104,7 +104,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	 * Remove the default filters.
 	 * Called from the validate() method to prevent failure to add new options
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function remove_default_filters() {
 		remove_filter( 'default_site_option_' . $this->option_name, array( $this, 'get_defaults' ) );
@@ -113,7 +113,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	/**
 	 * Add filters to make sure that the option is merged with its defaults before being returned
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function add_option_filters() {
 		// Don't change, needs to check for false as could return prio 0 which would evaluate to false.
@@ -126,7 +126,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	 * Remove the option filters.
 	 * Called from the clean_up methods to make sure we retrieve the original old option
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function remove_option_filters() {
 		remove_filter( 'site_option_' . $this->option_name, array( $this, 'get_option' ) );
@@ -141,7 +141,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	 * @param  array $clean Clean value for the option, normally the defaults.
 	 * @param  array $old   Old value of the option.
 	 *
-	 * @return  array      Validated clean value for the option to be saved to the database
+	 * @return array Validated clean value for the option to be saved to the database.
 	 */
 	protected function validate_option( $dirty, $clean, $old ) {
 
@@ -219,7 +219,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 	 * @param  array  $all_old_option_values (optional) Only used when importing old options to have
 	 *                                       access to the real old values, in contrast to the saved ones.
 	 *
-	 * @return  array            Cleaned option
+	 * @return array Cleaned option.
 	 */
 
 	/*

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -101,7 +101,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 * @param  array $clean Clean value for the option, normally the defaults.
 	 * @param  array $old   Old value of the option.
 	 *
-	 * @return  array      Validated clean value for the option to be saved to the database.
+	 * @return array Validated clean value for the option to be saved to the database.
 	 */
 	protected function validate_option( $dirty, $clean, $old ) {
 
@@ -221,7 +221,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
 	 *                                       access to the real old values, in contrast to the saved ones.
 	 *
-	 * @return  array Cleaned option.
+	 * @return array Cleaned option.
 	 */
 	protected function clean_option( $option_value, $current_version = null, $all_old_option_values = null ) {
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -174,7 +174,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	/**
 	 * Get the available separator options aria-labels.
 	 *
-	 * @return array $separator_options Array with the separator options aria-labels.
+	 * @return array Array with the separator options aria-labels.
 	 */
 	public function get_separator_options_for_display() {
 		$separators     = $this->get_separator_options();
@@ -302,7 +302,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @param  array $clean Clean value for the option, normally the defaults.
 	 * @param  array $old   Old value of the option.
 	 *
-	 * @return  array      Validated clean value for the option to be saved to the database.
+	 * @return array Validated clean value for the option to be saved to the database.
 	 */
 	protected function validate_option( $dirty, $clean, $old ) {
 		$allowed_post_types = $this->get_allowed_post_types();
@@ -568,7 +568,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
 	 *                                       access to the real old values, in contrast to the saved ones.
 	 *
-	 * @return  array            Cleaned option.
+	 * @return array Cleaned option.
 	 */
 	protected function clean_option( $option_value, $current_version = null, $all_old_option_values = null ) {
 		static $original = null;
@@ -760,7 +760,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 *                      have already been removed and any options which weren't set
 	 *                      have been set to their defaults.
 	 *
-	 * @return  array
+	 * @return array
 	 */
 	protected function retain_variable_keys( $dirty, $clean ) {
 		if ( ( is_array( $this->variable_array_key_patterns ) && $this->variable_array_key_patterns !== array() ) && ( is_array( $dirty ) && $dirty !== array() ) ) {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -217,7 +217,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	 * @param  array $clean Clean value for the option, normally the defaults.
 	 * @param  array $old   Old value of the option.
 	 *
-	 * @return  array      Validated clean value for the option to be saved to the database.
+	 * @return array Validated clean value for the option to be saved to the database.
 	 */
 	protected function validate_option( $dirty, $clean, $old ) {
 
@@ -381,7 +381,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
 	 *                                       access to the real old values, in contrast to the saved ones.
 	 *
-	 * @return  array            Cleaned option.
+	 * @return array Cleaned option.
 	 */
 	protected function clean_option( $option_value, $current_version = null, $all_old_option_values = null ) {
 		return $option_value;

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -238,7 +238,7 @@ abstract class WPSEO_Option {
 	/**
 	 * Add filters to make sure that the option default is returned if the option is not set.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function add_default_filters() {
 		// Don't change, needs to check for false as could return prio 0 which would evaluate to false.
@@ -358,7 +358,7 @@ abstract class WPSEO_Option {
 	 * Remove the default filters.
 	 * Called from the validate() method to prevent failure to add new options.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function remove_default_filters() {
 		remove_filter( 'default_option_' . $this->option_name, array( $this, 'get_defaults' ) );
@@ -372,7 +372,7 @@ abstract class WPSEO_Option {
 	 * {@internal The enrich_defaults method is used to set defaults for variable array keys
 	 *            in an option, such as array keys depending on post_types and/or taxonomies.}}
 	 *
-	 * @return  array
+	 * @return array
 	 */
 	public function get_defaults() {
 		if ( method_exists( $this, 'translate_defaults' ) ) {
@@ -389,7 +389,7 @@ abstract class WPSEO_Option {
 	/**
 	 * Add filters to make sure that the option is merged with its defaults before being returned.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function add_option_filters() {
 		// Don't change, needs to check for false as could return prio 0 which would evaluate to false.
@@ -402,7 +402,7 @@ abstract class WPSEO_Option {
 	 * Remove the option filters.
 	 * Called from the clean_up methods to make sure we retrieve the original old option.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function remove_option_filters() {
 		remove_filter( 'option_' . $this->option_name, array( $this, 'get_option' ) );
@@ -415,7 +415,7 @@ abstract class WPSEO_Option {
 	 *
 	 * @param   mixed $options Option value.
 	 *
-	 * @return  mixed        Option merged with the defaults for that option.
+	 * @return mixed Option merged with the defaults for that option.
 	 */
 	public function get_option( $options = null ) {
 		$filtered = $this->array_filter_merge( $options );
@@ -463,7 +463,7 @@ abstract class WPSEO_Option {
 	 *
 	 * @param  mixed $option_value The unvalidated new value for the option.
 	 *
-	 * @return  array          Validated new value for the option.
+	 * @return array Validated new value for the option.
 	 */
 	public function validate( $option_value ) {
 		$clean = $this->get_defaults();
@@ -503,6 +503,7 @@ abstract class WPSEO_Option {
 	 * with 'allow_'.
 	 *
 	 * @param string $key Option key.
+	 *
 	 * @return bool True if option key is disabled, false otherwise.
 	 */
 	public function is_disabled( $key ) {
@@ -675,7 +676,7 @@ abstract class WPSEO_Option {
 	 *
 	 * @param  array $options Optional. Current options. If not set, the option defaults for the $option_key will be returned.
 	 *
-	 * @return  array  Combined and filtered options array.
+	 * @return array Combined and filtered options array.
 	 */
 	protected function array_filter_merge( $options = null ) {
 
@@ -760,7 +761,7 @@ abstract class WPSEO_Option {
 	 *                      have already been removed and any options which weren't set
 	 *                      have been set to their defaults.
 	 *
-	 * @return  array
+	 * @return array
 	 */
 	protected function retain_variable_keys( $dirty, $clean ) {
 		if ( ( is_array( $this->variable_array_key_patterns ) && $this->variable_array_key_patterns !== array() ) && ( is_array( $dirty ) && $dirty !== array() ) ) {
@@ -791,8 +792,8 @@ abstract class WPSEO_Option {
 	 *
 	 * @param  string $key Array key to check.
 	 *
-	 * @return string      Pattern if it conforms, original array key if it doesn't or if the option
-	 *              does not have variable array keys.
+	 * @return string Pattern if it conforms, original array key if it doesn't or if the option
+	 *                does not have variable array keys.
 	 */
 	protected function get_switch_key( $key ) {
 		if ( ! isset( $this->variable_array_key_patterns ) || ( ! is_array( $this->variable_array_key_patterns ) || $this->variable_array_key_patterns === array() ) ) {

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -86,7 +86,7 @@ class WPSEO_Options {
 	 *
 	 * @param  string $option_name The option for which you want to retrieve the option group name.
 	 *
-	 * @return  string|bool
+	 * @return string|bool
 	 */
 	public static function get_group_name( $option_name ) {
 		if ( isset( self::$option_instances[ $option_name ] ) ) {
@@ -102,7 +102,7 @@ class WPSEO_Options {
 	 * @param  string $option_name The option for which you want to retrieve a default.
 	 * @param  string $key         The key within the option who's default you want.
 	 *
-	 * @return  mixed
+	 * @return mixed
 	 */
 	public static function get_default( $option_name, $key ) {
 		if ( isset( self::$option_instances[ $option_name ] ) ) {
@@ -136,7 +136,7 @@ class WPSEO_Options {
 	 *
 	 * @param  string $option_name The option for which you want to retrieve the instance.
 	 *
-	 * @return  object|bool
+	 * @return object|bool
 	 */
 	public static function get_option_instance( $option_name ) {
 		if ( isset( self::$option_instances[ $option_name ] ) ) {
@@ -149,7 +149,7 @@ class WPSEO_Options {
 	/**
 	 * Retrieve an array of the options which should be included in get_all() and reset().
 	 *
-	 * @return  array  Array of option names
+	 * @return array Array of option names.
 	 */
 	public static function get_option_names() {
 		static $option_names = array();
@@ -172,7 +172,7 @@ class WPSEO_Options {
 	 * @todo [JRF] see if we can get some extra efficiency for this one, though probably not as options may
 	 * well change between calls (enriched defaults and such)
 	 *
-	 * @return  array  Array combining the values of all the options
+	 * @return array Array combining the values of all the options.
 	 */
 	public static function get_all() {
 		return self::get_options( self::get_option_names() );
@@ -183,7 +183,7 @@ class WPSEO_Options {
 	 *
 	 * @param array $option_names An array of option names of the options you want to get.
 	 *
-	 * @return  array  Array combining the values of the requested options
+	 * @return array Array combining the values of the requested options.
 	 */
 	public static function get_options( array $option_names ) {
 		$options      = array();
@@ -295,7 +295,7 @@ class WPSEO_Options {
 	 * @param  string       $current_version Optional. Version from which to upgrade, if not set,
 	 *                                       version specific upgrades will be disregarded.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public static function clean_up( $option_name = null, $current_version = null ) {
 		if ( isset( $option_name ) && is_string( $option_name ) && $option_name !== '' ) {
@@ -325,7 +325,7 @@ class WPSEO_Options {
 	/**
 	 * Check that all options exist in the database and add any which don't.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public static function ensure_options_exist() {
 		foreach ( self::$option_instances as $instance ) {
@@ -396,7 +396,7 @@ class WPSEO_Options {
 	 *
 	 * @param  int|string $blog_id Blog id of the blog for which to reset the options.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public static function reset_ms_blog( $blog_id ) {
 		if ( is_multisite() ) {

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -124,7 +124,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * @param  string $option_key Option name of the option we're doing the merge for.
 	 * @param  array  $options    Optional. Current options. If not set, the option defaults for the $option_key will be returned.
 	 *
-	 * @return  array  Combined and filtered options array.
+	 * @return array Combined and filtered options array.
 	 */
 
 	/*
@@ -177,7 +177,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * @param  array $clean Clean value for the option, normally the defaults.
 	 * @param  array $old   Old value of the option.
 	 *
-	 * @return  array      Validated clean value for the option to be saved to the database.
+	 * @return array Validated clean value for the option to be saved to the database.
 	 */
 	protected function validate_option( $dirty, $clean, $old ) {
 		/*
@@ -229,7 +229,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * @param  array $meta_data New values.
 	 * @param  array $old_meta  The original values.
 	 *
-	 * @return  array        Validated and filtered value.
+	 * @return array Validated and filtered value.
 	 */
 	public static function validate_term_meta_data( $meta_data, $old_meta ) {
 
@@ -353,7 +353,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * @param  array  $all_old_option_values Optional. Only used when importing old options to have
 	 *                                       access to the real old values, in contrast to the saved ones.
 	 *
-	 * @return  array            Cleaned option.
+	 * @return array Cleaned option.
 	 */
 	protected function clean_option( $option_value, $current_version = null, $all_old_option_values = null ) {
 
@@ -422,9 +422,9 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * @param  string $taxonomy Name of the taxonomy to which the term is attached.
 	 * @param  string $meta     Optional. Meta value to get (without prefix).
 	 *
-	 * @return  mixed|bool    Value for the $meta if one is given, might be the default.
-	 *              If no meta is given, an array of all the meta data for the term.
-	 *              False if the term does not exist or the $meta provided is invalid.
+	 * @return mixed|bool Value for the $meta if one is given, might be the default.
+	 *                    If no meta is given, an array of all the meta data for the term.
+	 *                    False if the term does not exist or the $meta provided is invalid.
 	 */
 	public static function get_term_meta( $term, $taxonomy, $meta = null ) {
 		/* Figure out the term id. */

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -136,7 +136,7 @@ function wpseo_replace_vars( $string, $args, $omit = array() ) {
  * @param  string $type             Type of variable: 'basic' or 'advanced', defaults to 'advanced'.
  * @param  string $help_text        Help text to be added to the help tab for this variable.
  *
- * @return bool  Whether the replacement function was succesfully registered.
+ * @return bool Whether the replacement function was succesfully registered.
  */
 function wpseo_register_var_replacement( $var, $replace_function, $type = 'advanced', $help_text = '' ) {
 	return WPSEO_Replace_Vars::register_replacement( $var, $replace_function, $type, $help_text );

--- a/tests/doubles/class-wpseo-option-social-double.php
+++ b/tests/doubles/class-wpseo-option-social-double.php
@@ -24,7 +24,7 @@ class WPSEO_Option_Social_Double extends WPSEO_Option_Social {
 	 * @param  array $clean Clean value for the option, normally the defaults.
 	 * @param  array $old   Old value of the option.
 	 *
-	 * @return  array      Validated clean value for the option to be saved to the database.
+	 * @return array Validated clean value for the option to be saved to the database.
 	 */
 	public function validate_option( $dirty, $clean, $old ) {
 		return parent::validate_option( $dirty, $clean, $old );

--- a/tests/frontend/test-class-wpseo-handle-404.php
+++ b/tests/frontend/test-class-wpseo-handle-404.php
@@ -13,7 +13,7 @@ class WPSEO_Handle_404_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets the handle 404 object.
 	 *
-	 * @return void;
+	 * @return void
 	 */
 	public function setUp() {
 		parent::setUp();

--- a/tests/test-class-wpseo-meta.php
+++ b/tests/test-class-wpseo-meta.php
@@ -296,7 +296,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 * @param string $key The key to register.
 	 * @param bool   $serialized If the key is stored as serialized data.
 	 *
-	 * @returns {void}
+	 * @return void
 	 */
 	protected function register_meta_key( $key, $serialized = false ) {
 		WPSEO_Meta::$fields_index[ WPSEO_Meta::$meta_prefix . $key ] = array(


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

Improve method docblock `@return` tag formatting

Includes minor punctuation fixes.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.