### PR TITLE
Documentation: use full property docblocks

### DIFF
--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -11,7 +11,9 @@
 class WPSEO_Custom_Fields {
 
 	/**
-	 * @var array Cache the custom fields.
+	 * Custom fields cache.
+	 *
+	 * @var array
 	 */
 	protected static $custom_fields = null;
 

--- a/inc/class-wpseo-custom-taxonomies.php
+++ b/inc/class-wpseo-custom-taxonomies.php
@@ -11,7 +11,9 @@
 class WPSEO_Custom_Taxonomies {
 
 	/**
-	 * @var array Cache the custom taxonomies.
+	 * Custom taxonomies cache.
+	 *
+	 * @var array
 	 */
 	protected static $custom_taxonomies = null;
 

--- a/inc/class-wpseo-endpoint-factory.php
+++ b/inc/class-wpseo-endpoint-factory.php
@@ -11,7 +11,9 @@
 class WPSEO_Endpoint_Factory {
 
 	/**
-	 * @var array The valid HTTP methods.
+	 * The valid HTTP methods.
+	 *
+	 * @var array
 	 */
 	private $valid_http_methods = array(
 		'GET',
@@ -22,32 +24,44 @@ class WPSEO_Endpoint_Factory {
 	);
 
 	/**
-	 * @var array The arguments.
+	 * The arguments.
+	 *
+	 * @var array
 	 */
 	protected $args = array();
 
 	/**
-	 * @var string The namespace.
+	 * The namespace.
+	 *
+	 * @var string
 	 */
 	private $namespace;
 
 	/**
-	 * @var string The endpoint URL.
+	 * The endpoint URL.
+	 *
+	 * @var string
 	 */
 	private $endpoint;
 
 	/**
-	 * @var callable The callback to execute if the endpoint is called.
+	 * The callback to execute if the endpoint is called.
+	 *
+	 * @var callable
 	 */
 	private $callback;
 
 	/**
-	 * @var callable The permission callback to execute to determine permissions.
+	 * The permission callback to execute to determine permissions.
+	 *
+	 * @var callable
 	 */
 	private $permission_callback;
 
 	/**
-	 * @var string The HTTP method to use.
+	 * The HTTP method to use.
+	 *
+	 * @var string
 	 */
 	private $method;
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -22,7 +22,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 class WPSEO_Replace_Vars {
 
 	/**
-	 * @var    array    Default post/page/cpt information.
+	 * Default post/page/cpt information.
+	 *
+	 * @var array
 	 */
 	protected $defaults = array(
 		'ID'            => '',
@@ -39,17 +41,23 @@ class WPSEO_Replace_Vars {
 	);
 
 	/**
-	 * @var object    Current post/page/cpt information.
+	 * Current post/page/cpt information.
+	 *
+	 * @var object
 	 */
 	protected $args;
 
 	/**
-	 * @var    array    Help texts for use in WPSEO -> Search appearance tabs.
+	 * Help texts for use in WPSEO -> Search appearance tabs.
+	 *
+	 * @var array
 	 */
 	protected static $help_texts = array();
 
 	/**
-	 * @var array    Register of additional variable replacements registered by other plugins/themes.
+	 * Register of additional variable replacements registered by other plugins/themes.
+	 *
+	 * @var array
 	 */
 	protected static $external_replacements = array();
 

--- a/inc/class-wpseo-replacement-variable.php
+++ b/inc/class-wpseo-replacement-variable.php
@@ -14,17 +14,23 @@
 class WPSEO_Replacement_Variable {
 
 	/**
-	 * @var string The variable to use.
+	 * The variable to use.
+	 *
+	 * @var string
 	 */
 	protected $variable;
 
 	/**
-	 * @var string The label of the replacement variable.
+	 * The label of the replacement variable.
+	 *
+	 * @var string
 	 */
 	protected $label;
 
 	/**
-	 * @var string The description of the replacement variable.
+	 * The description of the replacement variable.
+	 *
+	 * @var string
 	 */
 	protected $description;
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -13,14 +13,20 @@
 class WPSEO_Utils {
 
 	/**
-	 * @var bool $has_filters Whether the PHP filter extension is enabled.
+	 * Whether the PHP filter extension is enabled.
+	 *
 	 * @since 1.8.0
+	 *
+	 * @var bool $has_filters
 	 */
 	public static $has_filters;
 
 	/**
-	 * @var array Notifications to be shown in the JavaScript console.
+	 * Notifications to be shown in the JavaScript console.
+	 *
 	 * @since 3.3.2
+	 *
+	 * @var array
 	 */
 	protected static $console_notifications = array();
 

--- a/inc/indexables/class-indexable.php
+++ b/inc/indexables/class-indexable.php
@@ -11,17 +11,23 @@
 abstract class WPSEO_Indexable {
 
 	/**
-	 * @var array The updateable fields.
+	 * The updateable fields.
+	 *
+	 * @var array
 	 */
 	protected $updateable_fields = array();
 
 	/**
-	 * @var array The indexable's data.
+	 * The indexable's data.
+	 *
+	 * @var array
 	 */
 	protected $data;
 
 	/**
-	 * @var array The available validators to run.
+	 * The available validators to run.
+	 *
+	 * @var array
 	 */
 	protected $validators = array(
 		'WPSEO_Object_Type_Validator',

--- a/inc/indexables/class-object-type.php
+++ b/inc/indexables/class-object-type.php
@@ -11,22 +11,30 @@
 abstract class WPSEO_Object_Type {
 
 	/**
-	 * @var int The ID of the object.
+	 * The ID of the object.
+	 *
+	 * @var int
 	 */
 	protected $id;
 
 	/**
-	 * @var string The type of the object.
+	 * The type of the object.
+	 *
+	 * @var string
 	 */
 	protected $type;
 
 	/**
-	 * @var string The subtype of the object.
+	 * The subtype of the object.
+	 *
+	 * @var string
 	 */
 	protected $sub_type;
 
 	/**
-	 * @var string The permalink of the object.
+	 * The permalink of the object.
+	 *
+	 * @var string
 	 */
 	protected $permalink;
 

--- a/inc/indexables/class-post-indexable.php
+++ b/inc/indexables/class-post-indexable.php
@@ -11,7 +11,9 @@
 class WPSEO_Post_Indexable extends WPSEO_Indexable {
 
 	/**
-	 * @var array The updateable fields.
+	 * The updateable fields.
+	 *
+	 * @var array
 	 */
 	protected $updateable_fields = array(
 		'canonical',

--- a/inc/indexables/class-term-indexable.php
+++ b/inc/indexables/class-term-indexable.php
@@ -11,7 +11,9 @@
 class WPSEO_Term_Indexable extends WPSEO_Indexable {
 
 	/**
-	 * @var array The updateable fields.
+	 * The updateable fields.
+	 *
+	 * @var array
 	 */
 	protected $updateable_fields = array(
 		'canonical',

--- a/inc/indexables/validators/class-robots-validator.php
+++ b/inc/indexables/validators/class-robots-validator.php
@@ -11,7 +11,9 @@
 class WPSEO_Robots_Validator implements WPSEO_Endpoint_Validator {
 
 	/**
-	 * @var array The robots keys to validate.
+	 * The robots keys to validate.
+	 *
+	 * @var array
 	 */
 	private $robots_to_validate = array(
 		'is_robots_nofollow',

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -14,38 +14,50 @@
 class WPSEO_Option_MS extends WPSEO_Option {
 
 	/**
-	 * @var  string  option name
+	 * Option name.
+	 *
+	 * @var string
 	 */
 	public $option_name = 'wpseo_ms';
 
 	/**
-	 * @var  string  option group name for use in settings forms
+	 * Option group name for use in settings forms.
+	 *
+	 * @var string
 	 */
 	public $group_name = 'yoast_wpseo_multisite_options';
 
 	/**
-	 * @var  bool  whether to include the option in the return for WPSEO_Options::get_all()
+	 * Whether to include the option in the return for WPSEO_Options::get_all().
+	 *
+	 * @var bool
 	 */
 	public $include_in_all = false;
 
 	/**
-	 * @var  bool  whether this option is only for when the install is multisite
+	 * Whether this option is only for when the install is multisite.
+	 *
+	 * @var bool
 	 */
 	public $multisite_only = true;
 
 	/**
-	 * @var  array  Array of defaults for the option
-	 *        Shouldn't be requested directly, use $this->get_defaults();
+	 * Array of defaults for the option.
+	 *
+	 * Shouldn't be requested directly, use $this->get_defaults();
+	 *
+	 * @var array
 	 */
 	protected $defaults = array();
 
 	/**
-	 * @var  array $allowed_access_options Available options for the 'access' setting
-	 *                    Used for input validation
+	 * Available options for the 'access' setting. Used for input validation.
 	 *
 	 * {@internal Important: Make sure the options added to the array here are in line
 	 *            with the keys for the options set for the select box in the
 	 *            admin/pages/network.php file.}}
+	 *
+	 * @var array
 	 */
 	public static $allowed_access_options = array(
 		'admin',

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -11,13 +11,18 @@
 class WPSEO_Option_Social extends WPSEO_Option {
 
 	/**
-	 * @var  string  Option name.
+	 * Option name.
+	 *
+	 * @var string
 	 */
 	public $option_name = 'wpseo_social';
 
 	/**
-	 * @var  array  Array of defaults for the option.
-	 *        Shouldn't be requested directly, use $this->get_defaults();
+	 * Array of defaults for the option.
+	 *
+	 * Shouldn't be requested directly, use $this->get_defaults();
+	 *
+	 * @var array
 	 */
 	protected $defaults = array(
 		// Form fields.
@@ -45,7 +50,9 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	);
 
 	/**
-	 * @var array  Array of sub-options which should not be overloaded with multi-site defaults.
+	 * Array of sub-options which should not be overloaded with multi-site defaults.
+	 *
+	 * @var array
 	 */
 	public $ms_exclude = array(
 		/* Privacy. */
@@ -54,12 +61,15 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	);
 
 	/**
-	 * @var  array  Array of allowed twitter card types.
-	 *              While we only have the options summary and summary_large_image in the
-	 *              interface now, we might change that at some point.
+	 * Array of allowed twitter card types.
+	 *
+	 * While we only have the options summary and summary_large_image in the
+	 * interface now, we might change that at some point.
 	 *
 	 * {@internal Uncomment any of these to allow them in validation *and* automatically
 	 *            add them as a choice in the options page.}}
+	 *
+	 * @var array
 	 */
 	public static $twitter_card_types = array(
 		'summary'             => '',

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -11,15 +11,20 @@
 class WPSEO_Option_Titles extends WPSEO_Option {
 
 	/**
-	 * @var  string  Option name.
+	 * Option name.
+	 *
+	 * @var string
 	 */
 	public $option_name = 'wpseo_titles';
 
 	/**
-	 * @var  array  Array of defaults for the option.
-	 *        Shouldn't be requested directly, use $this->get_defaults();
+	 * Array of defaults for the option.
+	 *
+	 * Shouldn't be requested directly, use $this->get_defaults();
 	 *
 	 * {@internal Note: Some of the default values are added via the translate_defaults() method.}}
+	 *
+	 * @var array
 	 */
 	protected $defaults = array(
 		// Non-form fields, set via (ajax) function.
@@ -89,7 +94,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	);
 
 	/**
-	 * @var  array  Array of variable option name patterns for the option.
+	 * Array of variable option name patterns for the option.
+	 *
+	 * @var array
 	 */
 	protected $variable_array_key_patterns = array(
 		'title-',
@@ -103,7 +110,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	);
 
 	/**
-	 * @var array  Array of sub-options which should not be overloaded with multi-site defaults.
+	 * Array of sub-options which should not be overloaded with multi-site defaults.
+	 *
+	 * @var array
 	 */
 	public $ms_exclude = array(
 		/* theme dependent */

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -11,33 +11,44 @@
 class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 
 	/**
-	 * @var  string  Option name.
+	 * Option name.
+	 *
+	 * @var string
 	 */
 	public $option_name = 'wpseo_taxonomy_meta';
 
 	/**
-	 * @var  bool  Whether to include the option in the return for WPSEO_Options::get_all().
+	 * Whether to include the option in the return for WPSEO_Options::get_all().
+	 *
+	 * @var bool
 	 */
 	public $include_in_all = false;
 
 	/**
-	 * @var  array  Array of defaults for the option.
-	 *        Shouldn't be requested directly, use $this->get_defaults();
+	 * Array of defaults for the option.
+	 *
+	 * Shouldn't be requested directly, use $this->get_defaults();
 	 *
 	 * {@internal Important: in contrast to most defaults, the below array format is
 	 *            very bare. The real option is in the format [taxonomy_name][term_id][...]
 	 *            where [...] is any of the $defaults_per_term options shown below.
 	 *            This is of course taken into account in the below methods.}}
+	 *
+	 * @var array
 	 */
 	protected $defaults = array();
 
 	/**
-	 * @var  string  Option name - same as $option_name property, but now also available to static methods.
+	 * Option name - same as $option_name property, but now also available to static methods.
+	 *
+	 * @var string
 	 */
 	public static $name;
 
 	/**
-	 * @var  array  Array of defaults for individual taxonomy meta entries.
+	 * Array of defaults for individual taxonomy meta entries.
+	 *
+	 * @var array
 	 */
 	public static $defaults_per_term = array(
 		'wpseo_title'                 => '',
@@ -63,10 +74,13 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	);
 
 	/**
-	 * @var  array  Available index options.
-	 *        Used for form generation and input validation.
+	 * Available index options.
+	 *
+	 * Used for form generation and input validation.
 	 *
 	 * {@internal Labels (translation) added on admin_init via WPSEO_Taxonomy::translate_meta_options().}}
+	 *
+	 * @var array
 	 */
 	public static $no_index_options = array(
 		'default' => '',

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -11,7 +11,9 @@
 class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var int Network administrator user ID.
+	 * Network administrator user ID.
+	 *
+	 * @var int
 	 */
 	protected static $network_administrator;
 

--- a/tests/config-ui/test-class-configuration-components.php
+++ b/tests/config-ui/test-class-configuration-components.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 
-	/** @var WPSEO_Configuration_Components_Mock */
+	/**
+	 * @var WPSEO_Configuration_Components_Mock
+	 */
 	protected $components;
 
 	/**

--- a/tests/config-ui/test-class-configuration-endpoint.php
+++ b/tests/config-ui/test-class-configuration-endpoint.php
@@ -9,7 +9,9 @@
  * Class WPSEO_Configuration_Endpoint_Test
  */
 class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
-	/** @var WPSEO_Configuration_Endpoint_Mock */
+	/**
+	 * @var WPSEO_Configuration_Endpoint_Mock
+	 */
 	protected $endpoint;
 
 	/**

--- a/tests/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/config-ui/test-class-configuration-options-adapter.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCase {
 
-	/** @var WPSEO_Configuration_Options_Adapter_Mock */
+	/**
+	 * @var WPSEO_Configuration_Options_Adapter_Mock
+	 */
 	protected $adapter;
 
 	/**

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 
-	/** @var WPSEO_Configuration_Service instance */
+	/**
+	 * Instance.
+	 *
+	 * @var WPSEO_Configuration_Service
+	 */
 	protected $configuration_service;
 
 	/**

--- a/tests/config-ui/test-class-configuration-storage.php
+++ b/tests/config-ui/test-class-configuration-storage.php
@@ -9,7 +9,9 @@
  * Class WPSEO_Configuration_Storage_Test
  */
 class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
-	/** @var WPSEO_Configuration_Storage_Mock */
+	/**
+	 * @var WPSEO_Configuration_Storage_Mock
+	 */
 	protected $storage;
 
 	/**

--- a/tests/config-ui/test-class-configuration-structure.php
+++ b/tests/config-ui/test-class-configuration-structure.php
@@ -10,7 +10,11 @@
  */
 class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 
-	/** @var WPSEO_Configuration_Service_Mock Mock holder */
+	/**
+	 * Mock holder.
+	 *
+	 * @var WPSEO_Configuration_Service_Mock
+	 */
 	protected $structure;
 
 	/**

--- a/tests/doubles/class-indexable-double.php
+++ b/tests/doubles/class-indexable-double.php
@@ -10,7 +10,9 @@
  */
 class WPSEO_Indexable_Double extends WPSEO_Indexable {
 	/**
-	 * @var array The updateable fields.
+	 * The updateable fields.
+	 *
+	 * @var array
 	 */
 	protected $updateable_fields = array(
 		'title',

--- a/tests/doubles/class-wpseo-plugin-availability-double.php
+++ b/tests/doubles/class-wpseo-plugin-availability-double.php
@@ -11,7 +11,9 @@
 class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 
 	/**
-	 * @var array Array containing fake dependency slugs.
+	 * Array containing fake dependency slugs.
+	 *
+	 * @var array
 	 */
 	private $available_dependencies = array( 'test-plugin/test-plugin.php' );
 

--- a/tests/inc/test-class-wpseo-primary-term.php
+++ b/tests/inc/test-class-wpseo-primary-term.php
@@ -11,17 +11,23 @@
 class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var string name of the taxonomy
+	 * Name of the taxonomy.
+	 *
+	 * @var string
 	 */
 	private $taxonomy_name = 'category';
 
 	/**
-	 * @var int post id
+	 * Post ID.
+	 *
+	 * @var int
 	 */
 	private $post_id = 1;
 
 	/**
-	 * @var int id of the primary term
+	 * ID of the primary term.
+	 *
+	 * @var int
 	 */
 	private $primary_term_id = 54;
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache-data.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache-data.php
@@ -11,7 +11,9 @@
 class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var WPSEO_Sitemap_Cache_Data subject to test against.
+	 * Subject to test against.
+	 *
+	 * @var WPSEO_Sitemap_Cache_Data
 	 */
 	private $subject;
 

--- a/tests/taxonomy/test-class-taxonomy-content-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-content-fields.php
@@ -16,7 +16,9 @@ class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 	private $class_instance;
 
 	/**
-	 * @var stdClass The created term.
+	 * The created term.
+	 *
+	 * @var stdClass
 	 */
 	private $term;
 

--- a/tests/taxonomy/test-class-taxonomy-presenter.php
+++ b/tests/taxonomy/test-class-taxonomy-presenter.php
@@ -17,7 +17,9 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	private $class_instance;
 
 	/**
-	 * @var stdClass The created term.
+	 * The created term.
+	 *
+	 * @var stdClass
 	 */
 	private $term;
 

--- a/tests/taxonomy/test-class-taxonomy-settings-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-settings-fields.php
@@ -16,7 +16,9 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	private $class_instance;
 
 	/**
-	 * @var stdClass The created term.
+	 * The created term.
+	 *
+	 * @var stdClass
 	 */
 	private $term;
 

--- a/tests/taxonomy/test-class-taxonomy-social-fields.php
+++ b/tests/taxonomy/test-class-taxonomy-social-fields.php
@@ -11,7 +11,9 @@
 class WPSEO_Taxonomy_Social_Fields_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @var stdClass The created term.
+	 * The created term.
+	 *
+	 * @var stdClass
 	 */
 	private $term;
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

More of the same as #11876, #11895 and #12270.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.