### PR TITLE
Introduce the remove-vendor-prefixed-folder grunt task.

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -101,6 +101,7 @@ check:
   - 'copy:composer-artifact'
   - 'clean:composer-files'
   - 'copy:composer-files'
+  - 'remove-vendor-prefixed-folder'
 
 # Get the project ready for release
 release:

--- a/grunt/config/remove-vendor-prefixed-folder.js
+++ b/grunt/config/remove-vendor-prefixed-folder.js
@@ -1,0 +1,37 @@
+/**
+ * A task which removes the vendor_prefixed folder mention from the composer.json in the artifact.
+ *
+ * @param {Object} grunt The grunt helper object.
+ * @returns {void}
+ */
+module.exports = function( grunt ) {
+	grunt.registerTask(
+		"remove-vendor-prefixed-folder",
+		"Removes the vendor_prefixed mention from the composer.json in the artifact",
+		function() {
+			const composerJsonPath = grunt.config.process( "<%= files.artifactComposer %>/composer.json" );
+			// Get the copied composer.json from the artifact-composer folder.
+			const currentComposerJson = grunt.file.read( composerJsonPath );
+
+			// Parse the json to make removal of the mention possible.
+			const parsedComposerJson = JSON.parse( currentComposerJson );
+
+			// Find the classmap in the composer.json.
+			const classmap = parsedComposerJson.autoload.classmap;
+
+			const vendorPrefixedIndex = classmap.indexOf( "vendor_prefixed/" );
+
+			// Make sure we don't get errors when there is no vendor_prefixed mention.
+			if ( vendorPrefixedIndex !== -1 ) {
+				// Remove the vendor_prefixed mention from the classmap.
+				classmap.splice( vendorPrefixedIndex, 1 );
+			}
+
+			// Stringify the json again to prepare it for being written to the composer.json file.
+			const newComposerJson = JSON.stringify( parsedComposerJson, null, "\t" );
+
+			// Write the changed json content to the composer.json file.
+			grunt.file.write( composerJsonPath, newComposerJson );
+		}
+	);
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Fixes a bug where the plugin could not be installed using composer.

## Relevant technical choices:

* This tasks removes the reference to the vendor_prefixed folder in the composer.json in the artifact-composer folder, because that folder doesn't contain a vendor_prefixed folder.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `grunt composer-artifact`.
* See that the autoload classmap array in the composer.json in the created composer-artifact folder does not contain `vendor_prefixed/` anymore.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12433
