### PR TITLE
Remove sanitize_text_field that breaks the saving of settings

### DIFF
--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -116,7 +116,8 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 		foreach ( $whitelist_options as $option_name ) {
 			$value = null;
 			if ( isset( $_POST[ $option_name ] ) ) { // WPCS: CSRF ok.
-				$value = sanitize_text_field( wp_unslash( $_POST[ $option_name ] ) ); // WPCS: CSRF ok.
+			    // Adding sanitize_text_field around this will break the saving of settings because it expects a string: https://github.com/Yoast/wordpress-seo/issues/12440.
+				$value = wp_unslash( $_POST[ $option_name ] ); // WPCS: CSRF ok.
 			}
 
 			WPSEO_Options::update_site_option( $option_name, $value );

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,13 @@ You'll find answers to many of your questions on [kb.yoast.com](https://yoa.st/1
 
 == Changelog ==
 
+= 10.0.1 =
+Release Date: March 18th, 2019
+
+Bugfixes:
+
+* Fixes a bug where side-wide settings were not saved on multisite environments.
+
 = 10.0.0 =
 Release Date: March 12th, 2019
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where side-wide settings were not saved on multisite environments.

## Relevant technical choices:

* I removed the `sanitize_text_field ` that was added in the CS week in https://github.com/Yoast/wordpress-seo/pull/11896/files. This function expects a string, but receives an array. As a result, it returns an empty string, which means all settings are gone. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See #12440 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12440 
