### PR TITLE
Reintroduce <br class="clear"/>' at the end of select boxes

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -468,6 +468,7 @@ class Yoast_Form {
 		echo $wrapper_start_tag;
 		$select->output_html();
 		echo $wrapper_end_tag;
+		echo '<br class="clear"/>';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Reintroduces `echo '<br class="clear"/>';` at the end of select boxes to avoid breaking the local SEO settings page.

## Relevant technical choices:

* Reintroduces `echo '<br class="clear"/>';` at the end of select boxes to avoid breaking the local SEO settings page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build this branch and test in combination with local SEO. See https://github.com/Yoast/wordpress-seo-local/issues/1437

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-local/issues/1437
