### PR TITLE
Change description below upsell button

### DIFF
--- a/admin/class-add-keyword-modal.php
+++ b/admin/class-add-keyword-modal.php
@@ -36,7 +36,7 @@ class WPSEO_Add_Keyword_Modal {
 				__( 'Get %s', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			),
-			'small'                    => __( '1 year free updates and upgrades included!', 'wordpress-seo' ),
+			'small'                    => __( '1 year free support and updates included!', 'wordpress-seo' ),
 			'a11yNotice.opensInNewTab' => __( '(Opens in a new browser tab)', 'wordpress-seo' ),
 		);
 	}

--- a/admin/class-keyword-synonyms-modal.php
+++ b/admin/class-keyword-synonyms-modal.php
@@ -36,7 +36,7 @@ class WPSEO_Keyword_Synonyms_Modal {
 				__( 'Get %s', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			),
-			'small'                    => __( '1 year free updates and upgrades included!', 'wordpress-seo' ),
+			'small'                    => __( '1 year free support and updates included!', 'wordpress-seo' ),
 			'a11yNotice.opensInNewTab' => __( '(Opens in a new browser tab)', 'wordpress-seo' ),
 		);
 	}

--- a/admin/class-multiple-keywords-modal.php
+++ b/admin/class-multiple-keywords-modal.php
@@ -36,7 +36,7 @@ class WPSEO_Multiple_Keywords_Modal {
 				__( 'Get %s', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			),
-			'small'                    => __( '1 year free updates and upgrades included!', 'wordpress-seo' ),
+			'small'                    => __( '1 year free support and updates included!', 'wordpress-seo' ),
 			'a11yNotice.opensInNewTab' => __( '(Opens in a new browser tab)', 'wordpress-seo' ),
 		);
 	}

--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -85,7 +85,7 @@ class WPSEO_Premium_Popup {
 		if ( $popup ) {
 			$classes = ' hidden';
 		}
-		$micro_copy = __( '1 year free updates and upgrades included!', 'wordpress-seo' );
+		$micro_copy = __( '1 year free support and updates included!', 'wordpress-seo' );
 
 		$popup = <<<EO_POPUP
 <div id="wpseo-{$this->identifier}-popup" class="wpseo-premium-popup wp-clearfix$classes">

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -203,7 +203,7 @@ class WPSEO_Metabox_Formatter {
 				__( 'Get %s', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			),
-			'small'                    => __( '1 year free updates and upgrades included!', 'wordpress-seo' ),
+			'small'                    => __( '1 year free support and updates included!', 'wordpress-seo' ),
 			'a11yNotice.opensInNewTab' => __( '(Opens in a new browser tab)', 'wordpress-seo' ),
 		);
 	}

--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -69,7 +69,7 @@ const KeywordSynonyms = ( props ) => {
 				className: "yoast-button-upsell",
 				rel: null,
 			} }
-			upsellButtonLabel={ __( "1 year free updates and upgrades included!", "wordpress-seo" ) }
+			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
 		/>
 	);
 };

--- a/js/src/components/modals/MultipleKeywords.js
+++ b/js/src/components/modals/MultipleKeywords.js
@@ -69,7 +69,7 @@ const MultipleKeywords = ( props ) => {
 				className: "yoast-button-upsell",
 				rel: null,
 			} }
-			upsellButtonLabel={ __( "1 year free updates and upgrades included!", "wordpress-seo" ) }
+			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
 		/>
 	);
 };

--- a/js/src/components/modals/RedirectUpsell.js
+++ b/js/src/components/modals/RedirectUpsell.js
@@ -129,7 +129,7 @@ class RedirectUpsell extends React.Component {
 							className: "yoast-button-upsell",
 							rel: null,
 						} }
-						upsellButtonLabel={ __( "1 year free updates and upgrades included!", "wordpress-seo" ) }
+						upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }
 					/>
 				</ModalContainer>
 			</YoastModal>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [Not for changelog] Changes the text below the upsell buttons.

## Relevant technical choices:

* Changes all occurrences of `1 year free updates and upgrades included!` to `1 year free support and updates included!`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Find all the upsells and verify that the text has changed.
* Or: find one modal and one other occurrence, and believe in the power of PHP 😄 

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12448
