### PR TITLE
Build development workflow for plugin and monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ test.sh
 /js/vendor/*
 /css/dist/*
 !/css/dist/select2
+
+##############
+# JS Mono Repo
+##############
+/javascript/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "i18n-yoast-components": "cross-env NODE_ENV=production babel node_modules/yoast-components --ignore node_modules/yoast-components/node_modules,tests/*Test.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",
     "prestart": "grunt build:css && grunt webpack:buildDev",
-    "start": "webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development"
+    "start": "webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
+    "link-monorepo": "./scripts/link_monorepo_to_plugin.sh"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/js/tests/setupTests.js",

--- a/scripts/link_monorepo_to_plugin.sh
+++ b/scripts/link_monorepo_to_plugin.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-# Go to the root directory of the plugin
-# cd ..
-
 # Get the current branch of the plugin
 CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
 
 # Clone the monorepo to the javascript directory in the root directory of the plugin
-if [ -d javascript ]; then
+if [[ -d javascript ]]; then
   cd javascript
   git pull
 else
@@ -15,24 +12,34 @@ else
   cd javascript
 fi
 
-if [ "$CURRENT_BRANCH" = "trunk" ]; then
-	echo current branch is trunk
-else
-	echo current branch is bla
+JS_BRANCH=${CURRENT_BRANCH}
+
+if [[ "$CURRENT_BRANCH" = "trunk" ]]; then
+	JS_BRANCH="develop"
 fi
 
-exit 0
+git checkout ${JS_BRANCH}
+if [[ $? -ne 0 ]]; then
+	echo -e "${CURRENT_BRANCH} does not exist\nFallback to develop"
+	git checkout develop
+	git pull
+fi
 
-# Run yarn link-all inside the monorepo
+# Just to be sure.
+yarn install
+
+# Run yarn link-all inside the monorepo.
 yarn link-all
-
-# Get all the packages inside the yoastseo package.json that are scoped using @yoast
-packages=($(cat packages/yoastseo/package.json | tr '"' '\n' | grep @yoast))
 
 # Go back to the root directory of the plugin
 cd ..
 
+# Get all the packages inside the yoastseo package.json that are scoped using @yoast
+packages=($(cat package.json | tr '"' '\n' | grep -w @yoast))
+
 for package in ${packages[@]}
 do
-   yarn link $package
+   echo -e "Linking ${package}\n"
+   # We don't want to exit on errors since there are some packages that we simply can't link (yet).
+   yarn link ${package} || true
 done

--- a/scripts/link_monorepo_to_plugin.sh
+++ b/scripts/link_monorepo_to_plugin.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
-# Get the current branch of the plugin
-CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
+# Check to make sure that we get the correct branch if this is being run in TravisCI.
+if [[ ${CI} = "1" ]]; then
+    if [[ ${TRAVIS_PULL_REQUEST_BRANCH} = "" ]]; then
+        CURRENT_BRANCH=${TRAVIS_BRANCH}
+    else
+        CURRENT_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}
+    fi
+else
+    # Get the current branch of the plugin
+    CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
+fi
 
 # Clone the monorepo to the javascript directory in the root directory of the plugin
 if [[ -d javascript ]]; then
@@ -18,12 +27,14 @@ if [[ "$CURRENT_BRANCH" = "trunk" ]]; then
 	JS_BRANCH="develop"
 fi
 
+# Try to checkout the right branch with a fallback to develop.
 git checkout ${JS_BRANCH}
 if [[ $? -ne 0 ]]; then
 	echo -e "${CURRENT_BRANCH} does not exist\nFallback to develop"
 	git checkout develop
-	git pull
 fi
+
+git pull
 
 # Just to be sure.
 yarn install
@@ -43,3 +54,7 @@ do
    # We don't want to exit on errors since there are some packages that we simply can't link (yet).
    yarn link ${package} || true
 done
+
+# Manually link yoast-components and yoastseo because they don't adhere to the new naming conventions (yet).
+yarn link yoast-components
+yarn link yoastseo

--- a/scripts/link_monorepo_to_plugin.sh
+++ b/scripts/link_monorepo_to_plugin.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-cd ..
+# Go to the root directory of the plugin
+# cd ..
 
-# Clone the monorepo to the javascript directory in the parent folder
+# Get the current branch of the plugin
+CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
+
+# Clone the monorepo to the javascript directory in the root directory of the plugin
 if [ -d javascript ]; then
   cd javascript
   git pull
@@ -11,11 +15,24 @@ else
   cd javascript
 fi
 
-# Get the current branch name
-CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
-
 if [ "$CURRENT_BRANCH" = "trunk" ]; then
 	echo current branch is trunk
 else
 	echo current branch is bla
 fi
+
+exit 0
+
+# Run yarn link-all inside the monorepo
+yarn link-all
+
+# Get all the packages inside the yoastseo package.json that are scoped using @yoast
+packages=($(cat packages/yoastseo/package.json | tr '"' '\n' | grep @yoast))
+
+# Go back to the root directory of the plugin
+cd ..
+
+for package in ${packages[@]}
+do
+   yarn link $package
+done

--- a/scripts/link_monorepo_to_plugin.sh
+++ b/scripts/link_monorepo_to_plugin.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+cd ..
+
+# Clone the monorepo to the javascript directory in the parent folder
+if [ -d javascript ]; then
+  cd javascript
+  git pull
+else
+  git clone https://github.com/Yoast/javascript.git
+  cd javascript
+fi
+
+# Get the current branch name
+CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
+
+if [ "$CURRENT_BRANCH" = "trunk" ]; then
+	echo current branch is trunk
+else
+	echo current branch is bla
+fi


### PR DESCRIPTION
## Summary
We need a new script for linking the monorepo since we can no longer use the direct URLs of the repo's. This adds that.

This PR can be summarized in the following changelog entry:

* N/A - Not userfacing. Adds a script to link the monorepo to the plugin.

## Relevant technical choices:

* Script is written in Bash, GL HF.

## Test instructions
This PR can be tested by following these steps:

* Check that `yarn link-monorepo` works locally.
* Check the script also works on Travis.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/javascript#27
