### PR TITLE
Use expiryDate instead of expires in addon manager

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -188,7 +188,7 @@ class WPSEO_Addon_Manager {
 	 * @return bool Has the plugin expired.
 	 */
 	private function has_subscription_expired( $subscription ) {
-		return time() - strtotime( $subscription->expiryDate ) < 0;
+		return ( strtotime( $subscription->expiryDate ) - time() ) < 0;
 	}
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -145,7 +145,7 @@ class WPSEO_Addon_Manager {
 		}
 
 		$subscription = $this->get_subscription( $args->slug );
-		if ( ! $subscription || $subscription->expires === 'expired' ) {
+		if ( ! $subscription || $this->has_subscription_expired( $subscription ) ) {
 			return $data;
 		}
 
@@ -168,7 +168,7 @@ class WPSEO_Addon_Manager {
 			$subscription_slug = $this->get_slug_by_plugin_file( $plugin_file );
 			$subscription      = $this->get_subscription( $subscription_slug );
 
-			if ( ! $subscription || $subscription->expires === 'expired' ) {
+			if ( ! $subscription || $this->has_subscription_expired( $subscription ) ) {
 				continue;
 			}
 
@@ -178,6 +178,17 @@ class WPSEO_Addon_Manager {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Checks whether a plugin expiry date has been passed.
+	 *
+	 * @param stdClass $subscription Plugin subscription.
+	 *
+	 * @return bool Has the plugin expired.
+	 */
+	private function has_subscription_expired( $subscription ) {
+		return time() - strtotime( $subscription->expiryDate ) < 0;
 	}
 
 	/**

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -233,7 +233,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals(
 			array(
 				'yoast-seo-wordpress-premium' => (object) array(
-					'expiryDate' => '2000-01-01T00:00:00.000Z',
+					'expiryDate' => '3000-01-01T00:00:00.000Z',
 					'product' => (object) array(
 						'version'     => '10.0',
 						'name'        => 'Extension',
@@ -661,7 +661,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			json_encode(
 				array(
 					'wp-seo-premium.php' => array(
-						'expiryDate' => '2000-01-01T00:00:00.000Z',
+						'expiryDate' => '3000-01-01T00:00:00.000Z',
 						'product' => array(
 							'version'     => '10.0',
 							'name'        => 'Extension',

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -13,6 +13,11 @@
 class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 
 	/**
+	 * @var string|null Date in the future.
+	 */
+	private $future_date = null;
+
+	/**
 	 * Tests retrieval of site information that will return the defaults.
 	 *
 	 * @covers WPSEO_Addon_Manager::get_site_information
@@ -51,7 +56,21 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 		$expected_return = $this->returnValue(
 			(object) array(
 				'url'           => 'https://example.org',
-				'subscriptions' => array( 'subscription' ),
+				'subscriptions' => array(
+					(object) array(
+						'expiryDate' => 'date',
+						'renewalUrl' => 'url',
+						'product'     => (object) array(
+							'version'     => '1.0',
+							'name'        => 'product',
+							'slug'        => 'product-slug',
+							'lastUpdated' => 'date',
+							'storeUrl'    => 'store-url',
+							'download'    => 'download-url',
+							'changelog'   => 'changelog',
+						),
+					)
+				),
 			)
 		);
 
@@ -67,7 +86,21 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals(
 			(object) array(
 				'url'           => 'https://example.org',
-				'subscriptions' => array( 'subscription' ),
+				'subscriptions' => array(
+					(object) array(
+						'expiry_date' => 'date',
+						'renewal_url' => 'url',
+						'product'     => (object) array(
+							'version'      => '1.0',
+							'name'         => 'product',
+							'slug'         => 'product-slug',
+							'last_updated' => 'date',
+							'store_url'    => 'store-url',
+							'download'     => 'download-url',
+							'changelog'    => 'changelog',
+						),
+					)
+				),
 			),
 			$instance->get_site_information()
 		);
@@ -233,7 +266,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals(
 			array(
 				'yoast-seo-wordpress-premium' => (object) array(
-					'expiryDate' => '3000-01-01T00:00:00.000Z',
+					'expiry_date' => $this->get_future_date(),
 					'product' => (object) array(
 						'version'     => '10.0',
 						'name'        => 'Extension',
@@ -661,7 +694,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			json_encode(
 				array(
 					'wp-seo-premium.php' => array(
-						'expiryDate' => '3000-01-01T00:00:00.000Z',
+						'expiry_date' => $this->get_future_date(),
 						'product' => array(
 							'version'     => '10.0',
 							'name'        => 'Extension',
@@ -675,5 +708,18 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Gets a date string that lies in the future.
+	 *
+	 * @return string Future date.
+	 */
+	protected function get_future_date() {
+		if ( $this->future_date === null ) {
+			$this->future_date = gmdate( 'Y-m-d\TH:i:s\Z', time() + DAY_IN_SECONDS );
+		}
+
+		return $this->future_date;
 	}
 }

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -233,7 +233,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals(
 			array(
 				'yoast-seo-wordpress-premium' => (object) array(
-					'expires' => 'active',
+					'expiryDate' => '2000-01-01T00:00:00.000Z',
 					'product' => (object) array(
 						'version'     => '10.0',
 						'name'        => 'Extension',
@@ -661,7 +661,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			json_encode(
 				array(
 					'wp-seo-premium.php' => array(
-						'expires' => 'active',
+						'expiryDate' => '2000-01-01T00:00:00.000Z',
 						'product' => array(
 							'version'     => '10.0',
 							'name'        => 'Extension',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Fix bug where the addon manager would throw an error due to a non-existing value.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In `WPSEO_Addon_Manager` in the `get_site_information_transient` comment out the first 5 lines to avoid the transient from being used:
```
		$site_information = $this->get_site_information_transient();

		if ( $site_information ) {
			return $site_information;
		}
```
* In `WPSEO_Addon_Manager` in the `get_site_information` you can now check the new results from `get_site_information_transient` by doing a `$this->get_site_information(); die;`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
