### PR TITLE
Documentation: use (inline) @link tag where appropriate

### DIFF
--- a/admin/class-my-yoast-proxy.php
+++ b/admin/class-my-yoast-proxy.php
@@ -144,7 +144,7 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	/**
 	 * Tries to load the given url.
 	 *
-	 * @see https://php.net/manual/en/function.readfile.php
+	 * @link https://php.net/manual/en/function.readfile.php
 	 *
 	 * @codeCoverageIgnore
 	 *
@@ -185,7 +185,7 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @see https://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen
+	 * @link https://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen
 	 *
 	 * @return bool True when the PHP configuration allows for url loading via readfile.
 	 */

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -41,8 +41,8 @@ printf(
 	/* translators: %1$s expands to a link start tag to the Baidu Webmaster Tools site add page, %2$s is the link closing tag. */
 	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress-seo' ),
 	/**
-	 * Get the Baidu Webmaster Tools site add link from this 3rd party article
-	 * http://www.dragonmetrics.com/how-to-optimize-your-site-with-baidu-webmaster-tools/.
+	 * Get the Baidu Webmaster Tools site add link from this 3rd party article.
+	 * {@link http://www.dragonmetrics.com/how-to-optimize-your-site-with-baidu-webmaster-tools/}
 	 * We are unable to create a Baidu Webmaster Tools account due to the Chinese phone number verification.
 	 */
 	'<a target="_blank" href="' . esc_url( 'https://ziyuan.baidu.com/site/siteadd' ) . '" rel="noopener noreferrer">',

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -105,7 +105,7 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 	/**
 	 * Outputs code to allow recognition of page's position in the site hierarchy
 	 *
-	 * @Link https://developers.google.com/search/docs/data-types/breadcrumb
+	 * @link https://developers.google.com/search/docs/data-types/breadcrumb
 	 *
 	 * @return void
 	 */

--- a/frontend/class-opengraph-oembed.php
+++ b/frontend/class-opengraph-oembed.php
@@ -29,7 +29,7 @@ class WPSEO_OpenGraph_OEmbed implements WPSEO_WordPress_Integration {
 	 * @param array   $data The oEmbed data.
 	 * @param WP_Post $post The current Post object.
 	 *
-	 * @see https://developer.wordpress.org/reference/hooks/oembed_response_data/ for hook info
+	 * @link https://developer.wordpress.org/reference/hooks/oembed_response_data/ for hook info.
 	 *
 	 * @return array $filter_data - An array of oEmbed data with modified values where appropriate.
 	 */

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -297,7 +297,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * Last update/compare with FB list done on 2015-03-16 by Rarst
 	 *
-	 * @see  http://www.facebook.com/translations/FacebookLocales.xml for the list of supported locales
+	 * @link http://www.facebook.com/translations/FacebookLocales.xml for the list of supported locales.
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
 	 *

--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -20,7 +20,7 @@ class WPSEO_Custom_Fields {
 	/**
 	 * Retrieves the custom field names as an array.
 	 *
-	 * @see WordPress core: wp-admin/includes/template.php. Reused query from it.
+	 * @link WordPress core: wp-admin/includes/template.php. Reused query from it.
 	 *
 	 * @return array The custom fields.
 	 */

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1247,7 +1247,7 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieves the custom field names as an array.
 	 *
-	 * @see WordPress core: wp-admin/includes/template.php. Reused query from it.
+	 * @link WordPress core: wp-admin/includes/template.php. Reused query from it.
 	 *
 	 * @return array The custom fields.
 	 */

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -260,7 +260,7 @@ class WPSEO_Utils {
 	/**
 	 * Emulate the WP native sanitize_text_field function in a %%variable%% safe way.
 	 *
-	 * @see   https://core.trac.wordpress.org/browser/trunk/src/wp-includes/formatting.php for the original
+	 * @link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/formatting.php for the original.
 	 *
 	 * Sanitize a string from user input or from the db.
 	 *
@@ -514,8 +514,8 @@ class WPSEO_Utils {
 	/**
 	 * Do simple reliable math calculations without the risk of wrong results.
 	 *
-	 * @see   http://floating-point-gui.de/
-	 * @see   the big red warning on http://php.net/language.types.float.php
+	 * @link http://floating-point-gui.de/
+	 * @link http://php.net/language.types.float.php See the big red warning.
 	 *
 	 * In the rare case that the bcmath extension would not be loaded, it will return the normal calculation results.
 	 *

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -91,7 +91,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		$defaults = array(
 			// @todo Re-enable after plugin requirements raised to WP 4.6 with the fix.
-			// 'who'        => 'authors', Breaks meta keys, see https://core.trac.wordpress.org/ticket/36724#ticket R.
+			// 'who'        => 'authors', Breaks meta keys, {@link https://core.trac.wordpress.org/ticket/36724#ticket} R.
 			'meta_key'   => '_yoast_wpseo_profile_updated',
 			'orderby'    => 'meta_value_num',
 			'order'      => 'DESC',

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -627,7 +627,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		/*
 		 * Do not include external URLs.
 		 *
-		 * @see https://wordpress.org/plugins/page-links-to/ can rewrite permalinks to external URLs.
+		 * {@link https://wordpress.org/plugins/page-links-to/} can rewrite permalinks to external URLs.
 		 */
 		if ( $this->get_classifier()->classify( $url['loc'] ) === WPSEO_Link::TYPE_EXTERNAL ) {
 			return false;

--- a/inc/sitemaps/class-sitemap-timezone.php
+++ b/inc/sitemaps/class-sitemap-timezone.php
@@ -66,7 +66,7 @@ class WPSEO_Sitemap_Timezone {
 	/**
 	 * Returns the timezone string for a site, even if it's set to a UTC offset
 	 *
-	 * Adapted from http://www.php.net/manual/en/function.timezone-name-from-abbr.php#89155
+	 * Adapted from {@link http://www.php.net/manual/en/function.timezone-name-from-abbr.php#89155}.
 	 *
 	 * @return string valid PHP timezone string
 	 */

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -22,7 +22,7 @@ use YoastSEO_Vendor\ORM;
  * The methods documented below are magic methods that conform to PSR-1.
  * This documentation exposes these methods to doc generators and IDEs.
  *
- * @see http://www.php-fig.org/psr/psr-1/
+ * @link http://www.php-fig.org/psr/psr-1/
  *
  * @method void setOrm($orm)
  * @method $this setExpr($property, $value = null)

--- a/src/yoast-orm-wrapper.php
+++ b/src/yoast-orm-wrapper.php
@@ -21,7 +21,7 @@ use YoastSEO_Vendor\ORM;
  * The methods documented below are magic methods that conform to PSR-1.
  * This documentation exposes these methods to doc generators and IDEs.
  *
- * @see http://www.php-fig.org/psr/psr-1/
+ * @link http://www.php-fig.org/psr/psr-1/
  *
  * @method void setClassName($class_name)
  * @method static \ORMWrapper forTable($table_name, $connection_name = parent::DEFAULT_CONNECTION)

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -251,7 +251,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		 * The result of Upsert is the number of affected rows.
 		 * As it internally does an Insert and then an Update, it will count as 2 rows.
 		 *
-		 * @see https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+		 * {@link https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html}
 		 * "With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if the row is inserted as a new row and 2 if an existing row is updated."
 		 */
 		$this->assertSame( 2, $result );

--- a/tests/onpage/test-class-onpage.php
+++ b/tests/onpage/test-class-onpage.php
@@ -54,8 +54,8 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test if the weekly schedule is added to wp_get_schedules.
 	 *
-	 * @see https://github.com/Yoast/wordpress-seo/issues/9450
-	 * @see https://github.com/Yoast/wordpress-seo/issues/9475
+	 * @link https://github.com/Yoast/wordpress-seo/issues/9450
+	 * @link https://github.com/Yoast/wordpress-seo/issues/9475
 	 *
 	 * @covers WPSEO_OnPage::add_weekly_schedule
 	 */

--- a/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -262,7 +262,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests to make sure attachment is not added when parent is a protected post.
 	 *
-	 * Related: https://github.com/Yoast/wordpress-seo/issues/9194
+	 * @link https://github.com/Yoast/wordpress-seo/issues/9194
 	 */
 	public function test_password_protected_post_parent_attachment() {
 		// Enable attachments in the sitemap.

--- a/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
+++ b/tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
@@ -47,7 +47,7 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @covers WPSEO_Sitemap_Image_Parser::get_gallery_attachments
 	 *
-	 * Related: https://github.com/Yoast/wordpress-seo/issues/8634
+	 * @link https://github.com/Yoast/wordpress-seo/issues/8634
 	 */
 	public function test_parse_galleries() {
 		/** @var WPSEO_Sitemap_Image_Parser_Double $image_parser */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

`@see` is intended for structural elements, not for links. For links, the `@link` tag should be used.
Also, when links are used inline, the link tag should be surrounded by curly braces.

Ref: https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc-tags.md#56-link





## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
