### PR TITLE
Test documentation: short description should be first

### DIFF
--- a/tests/test-class-wpseo-json-ld.php
+++ b/tests/test-class-wpseo-json-ld.php
@@ -60,9 +60,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_JSON_LD::organization_or_person
+	 * Test having person markup and one social profile.
 	 *
-	 * Test having person markup and one social profile
+	 * @covers WPSEO_JSON_LD::organization_or_person
 	 */
 	public function test_person() {
 		$name      = 'Joost de Valk';
@@ -120,9 +120,9 @@ class WPSEO_JSON_LD_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_JSON_LD::organization_or_person
+	 * Test having organization markup and two social profiles.
 	 *
-	 * Test having organization markup and two social profiles
+	 * @covers WPSEO_JSON_LD::organization_or_person
 	 */
 	public function test_organization() {
 		$name      = 'Yoast';


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

The short description should always be the first thing in a docblock, before any tags.

Includes minor punctuation fixes.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.