### PR TITLE
Test documentation: use correct @expectedException annotations

### DIFF
--- a/tests/admin/test-class-my-yoast-proxy.php
+++ b/tests/admin/test-class-my-yoast-proxy.php
@@ -112,7 +112,8 @@ class WPSEO_MyYoast_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
 	 *
-	 * @expectedException Exception Received unexpected response from MyYoast
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage Received unexpected response from MyYoast
 	 */
 	public function test_render_proxy_page_for_the_research_webworker_file_errored_and_wordpress_not_found() {
 		/** @var WPSEO_MyYoast_Proxy $instance */
@@ -208,7 +209,8 @@ class WPSEO_MyYoast_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
 	 *
-	 * @expectedException Exception Unable to retrieve file from MyYoast
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage Unable to retrieve file from MyYoast
 	 */
 	public function test_render_proxy_page_via_wordpress_errored() {
 		/** @var WPSEO_MyYoast_Proxy $instance */

--- a/tests/admin/test-class-my-yoast-proxy.php
+++ b/tests/admin/test-class-my-yoast-proxy.php
@@ -111,9 +111,6 @@ class WPSEO_MyYoast_Proxy_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
-	 *
-	 * @expectedException        Exception
-	 * @expectedExceptionMessage Received unexpected response from MyYoast
 	 */
 	public function test_render_proxy_page_for_the_research_webworker_file_errored_and_wordpress_not_found() {
 		/** @var WPSEO_MyYoast_Proxy $instance */
@@ -208,9 +205,6 @@ class WPSEO_MyYoast_Proxy_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
-	 *
-	 * @expectedException        Exception
-	 * @expectedExceptionMessage Unable to retrieve file from MyYoast
 	 */
 	public function test_render_proxy_page_via_wordpress_errored() {
 		/** @var WPSEO_MyYoast_Proxy $instance */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

PHPUnit offers the following annotations for testing `Exception`s:
* `@expectedException` to indicate an exception is expected and the type of the exception.
* `@expectedExceptionCode` to narrow this down to a specific error code if set/available.
* `@expectedExceptionMessage` to test whether the received message from the Exception is as expected.
* `@expectExceptionMessageRegExp` to test whether the received message from the Exception follows an expected pattern.

Adding the `message` as part of the `@expectedException` annotation does _not_ actually test the message and prevent the "expected Exception" from being tested.

Refs:
* https://phpunit.de/manual/6.5/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.exceptions
* https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.expectedException
* https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.expectedExceptionCode
* https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.expectedExceptionMessage


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
    This change does have effect on the unit tests as, as of now, both the Exception `type` as well as the actual message will be tested.
    So, if the unit tests for this PR would not pass, that is an indication of an underlying issue with the exception being thrown.