### PR TITLE
Replace usage of WPSEO_Extension_Manager in favor of WPSEO_Addon_Manager

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -219,13 +219,9 @@ class WPSEO_Admin {
 			array_unshift( $links, $settings_link );
 		}
 
-		if ( class_exists( 'WPSEO_Product_Premium' ) ) {
-			$product_premium   = new WPSEO_Product_Premium();
-			$extension_manager = new WPSEO_Extension_Manager();
-
-			if ( $extension_manager->is_activated( $product_premium->get_slug() ) ) {
-				return $links;
-			}
+		$addon_manager = new WPSEO_Addon_Manager();
+		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+			return $links;
 		}
 
 		// Add link to premium support landing page.

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -20,31 +20,31 @@ class WPSEO_Extensions {
 			'slug'       => 'yoast-seo-premium',
 			'identifier' => 'wordpress-seo-premium',
 			'classname'  => 'WPSEO_Premium',
-			'my-yoast'   => WPSEO_Addon_Manager::PREMIUM_SLUG,
+			'my-yoast-slug'   => WPSEO_Addon_Manager::PREMIUM_SLUG,
 		),
 		'News SEO' => array(
 			'slug'       => 'news-seo',
 			'identifier' => 'wpseo-news',
 			'classname'  => 'WPSEO_News',
-			'my-yoast'   => WPSEO_Addon_Manager::NEWS_SLUG,
+			'my-yoast-slug'   => WPSEO_Addon_Manager::NEWS_SLUG,
 		),
 		'Yoast WooCommerce SEO' => array(
 			'slug'       => 'woocommerce-yoast-seo',
 			'identifier' => 'wpseo-woocommerce',
 			'classname'  => 'Yoast_WooCommerce_SEO',
-			'my-yoast'   => WPSEO_Addon_Manager::WOOCOMMERCE_SLUG,
+			'my-yoast-slug'   => WPSEO_Addon_Manager::WOOCOMMERCE_SLUG,
 		),
 		'Video SEO' => array(
 			'slug'       => 'video-seo-for-wordpress',
 			'identifier' => 'wpseo-video',
 			'classname'  => 'WPSEO_Video_Sitemap',
-			'my-yoast'   => WPSEO_Addon_Manager::VIDEO_SLUG,
+			'my-yoast-slug'   => WPSEO_Addon_Manager::VIDEO_SLUG,
 		),
 		'Local SEO' => array(
 			'slug'       => 'local-seo-for-wordpress',
 			'identifier' => 'wpseo-local',
 			'classname'  => 'WPSEO_Local_Core',
-			'my-yoast'   => WPSEO_Addon_Manager::LOCAL_SLUG,
+			'my-yoast-slug'   => WPSEO_Addon_Manager::LOCAL_SLUG,
 		),
 	);
 
@@ -66,7 +66,7 @@ class WPSEO_Extensions {
 	 */
 	public function is_valid( $extension ) {
 		$addon_manager = new WPSEO_Addon_Manager();
-		return $addon_manager->has_valid_subscription( $this->extensions[ $extension ]['my-yoast'] );
+		return $addon_manager->has_valid_subscription( $this->extensions[ $extension ]['my-yoast-slug'] );
 	}
 
 	/**

--- a/admin/class-extensions.php
+++ b/admin/class-extensions.php
@@ -20,26 +20,31 @@ class WPSEO_Extensions {
 			'slug'       => 'yoast-seo-premium',
 			'identifier' => 'wordpress-seo-premium',
 			'classname'  => 'WPSEO_Premium',
+			'my-yoast'   => WPSEO_Addon_Manager::PREMIUM_SLUG,
 		),
 		'News SEO' => array(
 			'slug'       => 'news-seo',
 			'identifier' => 'wpseo-news',
 			'classname'  => 'WPSEO_News',
+			'my-yoast'   => WPSEO_Addon_Manager::NEWS_SLUG,
 		),
 		'Yoast WooCommerce SEO' => array(
 			'slug'       => 'woocommerce-yoast-seo',
 			'identifier' => 'wpseo-woocommerce',
 			'classname'  => 'Yoast_WooCommerce_SEO',
+			'my-yoast'   => WPSEO_Addon_Manager::WOOCOMMERCE_SLUG,
 		),
 		'Video SEO' => array(
 			'slug'       => 'video-seo-for-wordpress',
 			'identifier' => 'wpseo-video',
 			'classname'  => 'WPSEO_Video_Sitemap',
+			'my-yoast'   => WPSEO_Addon_Manager::VIDEO_SLUG,
 		),
 		'Local SEO' => array(
 			'slug'       => 'local-seo-for-wordpress',
 			'identifier' => 'wpseo-local',
 			'classname'  => 'WPSEO_Local_Core',
+			'my-yoast'   => WPSEO_Addon_Manager::LOCAL_SLUG,
 		),
 	);
 
@@ -60,8 +65,8 @@ class WPSEO_Extensions {
 	 * @return bool Returns true when valid.
 	 */
 	public function is_valid( $extension ) {
-		$extensions = new WPSEO_Extension_Manager();
-		return $extensions->is_activated( $this->extensions[ $extension ]['identifier'] );
+		$addon_manager = new WPSEO_Addon_Manager();
+		return $addon_manager->has_valid_subscription( $this->extensions[ $extension ]['my-yoast'] );
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -186,15 +186,10 @@ class Yoast_Form {
 	 * @since 2.0
 	 */
 	public function admin_sidebar() {
-
 		// No banners in Premium.
-		if ( class_exists( 'WPSEO_Product_Premium' ) ) {
-			$product_premium   = new WPSEO_Product_Premium();
-			$extension_manager = new WPSEO_Extension_Manager();
-
-			if ( $extension_manager->is_activated( $product_premium->get_slug() ) ) {
-				return;
-			}
+		$addon_manager = new WPSEO_Addon_Manager();
+		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+			return;
 		}
 
 		require_once 'views/sidebar.php';

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -161,33 +161,37 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 						/* translators: %s expands to the extension title */
 						printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
-						?></a>
+						?>
+					</a>
 				<?php else : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
 					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
-					   class="yoast-link--license"><?php
-						/* translators: %s expands to the extension title */
-						printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
-						echo $new_tab_message;
-						?></a>
+					   class="yoast-link--license">
+						<?php
+							/* translators: %s expands to the extension title */
+							printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
+							echo $new_tab_message;
+						?>
+					</a>
 				<?php endif; ?>
-				</a>
 
 			<?php else : ?>
 
 				<a target="_blank" href="<?php echo esc_url( $premium_extension->get_buy_url() ); ?>"
-				   class="yoast-button-upsell"><?php
-					/* translators: $1$s expands to Yoast SEO Premium */
-					printf( __( 'Buy %1$s', 'wordpress-seo' ), $premium_extension->get_title() );
-					echo $new_tab_message;
-					echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
-					?></a>
+				   class="yoast-button-upsell">
+					<?php
+						/* translators: $1$s expands to Yoast SEO Premium */
+						printf( __( 'Buy %1$s', 'wordpress-seo' ), $premium_extension->get_title() );
+						echo $new_tab_message;
+						echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+					?>
+				</a>
 
 				<a target="_blank" href="<?php echo esc_url( $premium_extension->get_info_url() ); ?>"
 				   class="yoast-link--more-info">
 					<?php
 					printf(
-					/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
+						/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 						__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 						'<span class="screen-reader-text">',
 						'</span>',
@@ -234,28 +238,34 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 							<?php if ( $addon_manager->has_valid_subscription( $slug ) ) : ?>
 								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
 								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
-								   class="yoast-link--license"><?php
-									/* translators: %s expands to the extension title */
-									printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
-									echo $new_tab_message;
-									?></a>
+								   class="yoast-link--license">
+									<?php
+										/* translators: %s expands to the extension title */
+										printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
+										echo $new_tab_message;
+									?>
+								</a>
 							<?php else : ?>
 								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
 								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
-								   class="yoast-link--license"><?php
-									/* translators: %s expands to the extension title */
-									printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
-									echo $new_tab_message;
-									?></a>
+								   class="yoast-link--license">
+									<?php
+										/* translators: %s expands to the extension title */
+										printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
+										echo $new_tab_message;
+									?>
+								</a>
 							<?php endif; ?>
 						<?php else : ?>
 							<a target="_blank" class="yoast-button-upsell"
-							   href="<?php echo esc_url( $extension->get_buy_url() ); ?>"><?php
-								/* translators: %s expands to the product name */
-								printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
-								echo $new_tab_message;
-								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
-								?></a>
+							   href="<?php echo esc_url( $extension->get_buy_url() ); ?>">
+								<?php
+									/* translators: %s expands to the product name */
+									printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
+									echo $new_tab_message;
+									echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+								?>
+							</a>
 
 							<a target="_blank" class="yoast-link--more-info"
 							   href="<?php echo esc_url( $extension->get_info_url() ); ?>">

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -18,26 +18,20 @@ $extensions     = $extension_list->get();
 // First invalidate all licenses.
 array_map( array( $extension_list, 'invalidate' ), $extensions );
 
-$extensions = new WPSEO_Extension_Manager();
-
-$extensions->add(
-	'wordpress-seo-premium',
-	new WPSEO_Extension(
-		array(
-			'buyUrl'   => WPSEO_Shortlinker::get( 'https://yoa.st/zz' ),
-			'infoUrl'  => WPSEO_Shortlinker::get( 'https://yoa.st/zy' ),
-			'title'    => 'Yoast SEO Premium',
-			/* translators: %1$s expands to Yoast SEO */
-			'desc'     => sprintf( __( 'The premium version of %1$s with more features & support.', 'wordpress-seo' ), 'Yoast SEO' ),
-			'image'    => plugins_url( 'images/extensions-premium-ribbon.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-			'benefits' => array(),
-		)
+$premium_extension = new WPSEO_Extension(
+	array(
+		'buyUrl'   => WPSEO_Shortlinker::get( 'https://yoa.st/zz' ),
+		'infoUrl'  => WPSEO_Shortlinker::get( 'https://yoa.st/zy' ),
+		'title'    => 'Yoast SEO Premium',
+		/* translators: %1$s expands to Yoast SEO */
+		'desc'     => sprintf( __( 'The premium version of %1$s with more features & support.', 'wordpress-seo' ), 'Yoast SEO' ),
+		'image'    => plugins_url( 'images/extensions-premium-ribbon.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+		'benefits' => array(),
 	)
 );
 
-$extensions->add(
-	'wpseo-local',
-	new WPSEO_Extension(
+$extensions = array(
+	WPSEO_Addon_Manager::LOCAL_SLUG => new WPSEO_Extension(
 		array(
 			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
 			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
@@ -52,12 +46,8 @@ $extensions->add(
 				sprintf( __( 'Allow customers to pick up their %s order locally', 'wordpress-seo' ), 'WooCommerce' ),
 			),
 		)
-	)
-);
-
-$extensions->add(
-	'wpseo-video',
-	new WPSEO_Extension(
+	),
+	WPSEO_Addon_Manager::VIDEO_SLUG => new WPSEO_Extension(
 		array(
 			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zx/' ),
 			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zw/' ),
@@ -71,14 +61,28 @@ $extensions->add(
 				__( 'Make videos responsive through enabling fitvids.js', 'wordpress-seo' ),
 			),
 		)
-	)
+	),
+	WPSEO_Addon_Manager::NEWS_SLUG  => new WPSEO_Extension(
+		array(
+			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zv/' ),
+			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zu/' ),
+			'title'         => 'News SEO',
+			'display_title' => 'Everything you need for Google News',
+			'desc'          => __( 'Are you in Google News? Increase your traffic from Google News by optimizing for it!', 'wordpress-seo' ),
+			'image'         => plugins_url( 'images/extensions-news.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
+			'benefits'      => array(
+				__( 'Optimize your site for Google News', 'wordpress-seo' ),
+				__( 'Immediately pings Google on the publication of a new post', 'wordpress-seo' ),
+				__( 'Creates XML News Sitemaps', 'wordpress-seo' ),
+			),
+		)
+	),
 );
 
 // Add Yoast WooCommerce SEO when WooCommerce is active.
 if ( WPSEO_Utils::is_woocommerce_active() ) {
-	$extensions->add(
-		'wpseo-woocommerce',
-		new WPSEO_Extension(
+	$extensions = array_merge( $extensions, array(
+		WPSEO_Addon_Manager::WOOCOMMERCE_SLUG => new WPSEO_Extension(
 			array(
 				'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zr' ),
 				'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zq' ),
@@ -96,28 +100,12 @@ if ( WPSEO_Utils::is_woocommerce_active() ) {
 				),
 				'buy_button'    => 'WooCommerce SEO',
 			)
-		)
-	);
+		),
+	) );
 }
 
-$extensions->add(
-	'wpseo-news',
-	new WPSEO_Extension(
-		array(
-			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zv/' ),
-			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zu/' ),
-			'title'         => 'News SEO',
-			'display_title' => 'Everything you need for Google News',
-			'desc'          => __( 'Are you in Google News? Increase your traffic from Google News by optimizing for it!', 'wordpress-seo' ),
-			'image'         => plugins_url( 'images/extensions-news.png?v=' . WPSEO_VERSION, WPSEO_FILE ),
-			'benefits'      => array(
-				__( 'Optimize your site for Google News', 'wordpress-seo' ),
-				__( 'Immediately pings Google on the publication of a new post', 'wordpress-seo' ),
-				__( 'Creates XML News Sitemaps', 'wordpress-seo' ),
-			),
-		)
-	)
-);
+$addon_manager                  = new WPSEO_Addon_Manager();
+$has_valid_premium_subscription = $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG );
 
 /* translators: %1$s expands to Yoast SEO. */
 $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );
@@ -127,97 +115,99 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 
 <div class="wrap yoast wpseo_table_page">
 
-	<h1 id="wpseo-title" class="yoast-h1"><?php echo esc_html( $wpseo_extensions_header ); ?></h1>
+    <h1 id="wpseo-title" class="yoast-h1"><?php echo esc_html( $wpseo_extensions_header ); ?></h1>
 
-	<div id="extensions">
-		<section class="yoast-seo-premium-extension">
-			<?php
-			$extension = $extensions->get( 'wordpress-seo-premium' );
-			$extensions->remove( 'wordpress-seo-premium' );
-			?>
-				<h2>
-					<?php
-					printf(
-						/* translators: %1$s expands to Yoast SEO Premium */
-						esc_html__( '%1$s, take your optimization to the next level!', 'wordpress-seo' ),
-						'<span class="yoast-heading-highlight">' . $extension->get_title() . '</span>'
-					);
-					?>
-				</h2>
-
-			<?php
-			if ( ! $extensions->is_activated( 'wordpress-seo-premium' ) ) :
+    <div id="extensions">
+        <section class="yoast-seo-premium-extension">
+            <h2>
+				<?php
+				printf(
+				/* translators: %1$s expands to Yoast SEO Premium */
+					esc_html__( '%1$s, take your optimization to the next level!', 'wordpress-seo' ),
+					'<span class="yoast-heading-highlight">' . $premium_extension->get_title() . '</span>'
+				);
 				?>
-				<ul class="yoast-seo-premium-benefits yoast-list--usp">
-					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Redirect manager', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'create and manage redirects from within your WordPress install.', 'wordpress-seo' ); ?></span>
-					</li>
-					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Synonyms & related keyphrases', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'optimize a single post for synonyms and related keyphrases.', 'wordpress-seo' ); ?></span>
-					</li>
-					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Social previews', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'check what your Facebook or Twitter post will look like.', 'wordpress-seo' ); ?></span>
-					</li>
-					<li class="yoast-seo-premium-benefits__item">
-						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Premium support', 'wordpress-seo' ); ?></span>
-						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'gain access to our 24/7 support team.', 'wordpress-seo' ); ?></span>
-					</li>
-				</ul>
-			<?php endif; ?>
-			<?php if ( $extension_list->is_installed( $extension->get_title() ) ) : ?>
-				<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
+            </h2>
 
-				<?php if ( $extensions->is_activated( 'wordpress-seo-premium' ) ) : ?>
-					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php
+			<?php
+			if ( ! $has_valid_premium_subscription ) :
+				?>
+                <ul class="yoast-seo-premium-benefits yoast-list--usp">
+                    <li class="yoast-seo-premium-benefits__item">
+                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Redirect manager', 'wordpress-seo' ); ?></span>
+                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'create and manage redirects from within your WordPress install.', 'wordpress-seo' ); ?></span>
+                    </li>
+                    <li class="yoast-seo-premium-benefits__item">
+                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Synonyms & related keyphrases', 'wordpress-seo' ); ?></span>
+                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'optimize a single post for synonyms and related keyphrases.', 'wordpress-seo' ); ?></span>
+                    </li>
+                    <li class="yoast-seo-premium-benefits__item">
+                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Social previews', 'wordpress-seo' ); ?></span>
+                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'check what your Facebook or Twitter post will look like.', 'wordpress-seo' ); ?></span>
+                    </li>
+                    <li class="yoast-seo-premium-benefits__item">
+                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Premium support', 'wordpress-seo' ); ?></span>
+                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'gain access to our 24/7 support team.', 'wordpress-seo' ); ?></span>
+                    </li>
+                </ul>
+			<?php endif; ?>
+			<?php if ( $extension_list->is_installed( $premium_extension->get_title() ) ) : ?>
+                <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
+
+				<?php if ( $has_valid_premium_subscription ) : ?>
+                    <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
+                    <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
+                       class="yoast-link--license"><?php
 						/* translators: %s expands to the extension title */
-						printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
+						printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
-					?></a>
+						?></a>
 				<?php else : ?>
-					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
-					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
+                    <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
+                    <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
+                       class="yoast-link--license"><?php
 						/* translators: %s expands to the extension title */
-						printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
+						printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
-					?></a>
+						?></a>
 				<?php endif; ?>
-				</a>
+                </a>
 
 			<?php else : ?>
 
-				<a target="_blank" href="<?php echo esc_url( $extension->get_buy_url() ); ?>" class="yoast-button-upsell"><?php
+                <a target="_blank" href="<?php echo esc_url( $premium_extension->get_buy_url() ); ?>"
+                   class="yoast-button-upsell"><?php
 					/* translators: $1$s expands to Yoast SEO Premium */
-					printf( __( 'Buy %1$s', 'wordpress-seo' ), $extension->get_title() );
+					printf( __( 'Buy %1$s', 'wordpress-seo' ), $premium_extension->get_title() );
 					echo $new_tab_message;
 					echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
-				?></a>
+					?></a>
 
-				<a target="_blank" href="<?php echo esc_url( $extension->get_info_url() ); ?>" class="yoast-link--more-info">
+                <a target="_blank" href="<?php echo esc_url( $premium_extension->get_info_url() ); ?>"
+                   class="yoast-link--more-info">
 					<?php
 					printf(
-						/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
+					/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 						__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 						'<span class="screen-reader-text">',
 						'</span>',
-						$extension->get_title()
+						$premium_extension->get_title()
 					);
 					echo $new_tab_message;
 					?>
-				</a>
+                </a>
 			<?php endif; ?>
-			<?php if ( ! $extensions->is_activated( 'wordpress-seo-premium' ) ) { ?>
-				<p><small class="yoast-money-back-guarantee"><?php esc_html_e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small></p>
+			<?php if ( ! $has_valid_premium_subscription ) { ?>
+                <p>
+                    <small class="yoast-money-back-guarantee"><?php esc_html_e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small>
+                </p>
 			<?php } ?>
-		</section>
+        </section>
 
-		<hr class="yoast-hr" aria-hidden="true" />
+        <hr class="yoast-hr" aria-hidden="true"/>
 
-		<section class="yoast-promo-extensions">
-			<h2><?php
+        <section class="yoast-promo-extensions">
+            <h2><?php
 				/* translators: %1$s expands to Yoast SEO */
 				$yoast_seo_extensions = sprintf( __( '%1$s extensions', 'wordpress-seo' ), 'Yoast SEO' );
 				$yoast_seo_extensions = '<span class="yoast-heading-highlight">' . $yoast_seo_extensions . '</span>';
@@ -226,48 +216,52 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				printf( esc_html__( '%1$s to optimize your site even further', 'wordpress-seo' ), $yoast_seo_extensions );
 				?></h2>
 
-			<?php foreach ( $extensions->get_all() as $id => $extension ) : ?>
-				<section class="yoast-promoblock secondary yoast-promo-extension">
-					<img alt="" width="280" height="147" src="<?php echo esc_attr( $extension->get_image() ); ?>" />
-					<h3><?php echo esc_html( $extension->get_display_title() ); ?></h3>
+			<?php foreach ( $extensions as $slug => $extension ) : ?>
+                <section class="yoast-promoblock secondary yoast-promo-extension">
+                    <img alt="" width="280" height="147" src="<?php echo esc_attr( $extension->get_image() ); ?>"/>
+                    <h3><?php echo esc_html( $extension->get_display_title() ); ?></h3>
 
-					<ul class="yoast-list--usp">
+                    <ul class="yoast-list--usp">
 						<?php foreach ( $extension->get_benefits() as $benefit ) : ?>
-							<li><?php echo esc_html( $benefit ); ?></li>
+                            <li><?php echo esc_html( $benefit ); ?></li>
 						<?php endforeach; ?>
-					</ul>
+                    </ul>
 
-					<div class="yoast-button-container">
+                    <div class="yoast-button-container">
 						<?php if ( $extension_list->is_installed( $extension->get_title() ) ) : ?>
-							<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
+                            <div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
 
-							<?php if ( $extensions->is_activated( $id ) ) : ?>
-								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>" class="yoast-link--license"><?php
+							<?php if ( $addon_manager->has_valid_subscription( $slug ) ) : ?>
+                                <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
+                                <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
+                                   class="yoast-link--license"><?php
 									/* translators: %s expands to the extension title */
 									printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
-								?></a>
+									?></a>
 							<?php else : ?>
-								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
-								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>" class="yoast-link--license"><?php
+                                <div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
+                                <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
+                                   class="yoast-link--license"><?php
 									/* translators: %s expands to the extension title */
 									printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
-								?></a>
+									?></a>
 							<?php endif; ?>
 						<?php else : ?>
-							<a target="_blank" class="yoast-button-upsell" href="<?php echo esc_url( $extension->get_buy_url() ); ?>"><?php
+                            <a target="_blank" class="yoast-button-upsell"
+                               href="<?php echo esc_url( $extension->get_buy_url() ); ?>"><?php
 								/* translators: %s expands to the product name */
 								printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
 								echo $new_tab_message;
 								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
-							?></a>
+								?></a>
 
-							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension->get_info_url() ); ?>">
+                            <a target="_blank" class="yoast-link--more-info"
+                               href="<?php echo esc_url( $extension->get_info_url() ); ?>">
 								<?php
 								printf(
-									/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
+								/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
 									__( 'More information %1$sabout %3$s%2$s', 'wordpress-seo' ),
 									'<span class="screen-reader-text">',
 									'</span>',
@@ -275,12 +269,12 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								);
 								echo $new_tab_message;
 								?>
-							</a>
+                            </a>
 						<?php endif; ?>
-					</div>
-				</section>
+                    </div>
+                </section>
 			<?php endforeach; ?>
-		</section>
-	</div>
+        </section>
+    </div>
 
 </div>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -115,11 +115,11 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 
 <div class="wrap yoast wpseo_table_page">
 
-    <h1 id="wpseo-title" class="yoast-h1"><?php echo esc_html( $wpseo_extensions_header ); ?></h1>
+	<h1 id="wpseo-title" class="yoast-h1"><?php echo esc_html( $wpseo_extensions_header ); ?></h1>
 
-    <div id="extensions">
-        <section class="yoast-seo-premium-extension">
-            <h2>
+	<div id="extensions">
+		<section class="yoast-seo-premium-extension">
+			<h2>
 				<?php
 				printf(
 				/* translators: %1$s expands to Yoast SEO Premium */
@@ -127,64 +127,64 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 					'<span class="yoast-heading-highlight">' . $premium_extension->get_title() . '</span>'
 				);
 				?>
-            </h2>
+			</h2>
 
 			<?php
 			if ( ! $has_valid_premium_subscription ) :
 				?>
-                <ul class="yoast-seo-premium-benefits yoast-list--usp">
-                    <li class="yoast-seo-premium-benefits__item">
-                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Redirect manager', 'wordpress-seo' ); ?></span>
-                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'create and manage redirects from within your WordPress install.', 'wordpress-seo' ); ?></span>
-                    </li>
-                    <li class="yoast-seo-premium-benefits__item">
-                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Synonyms & related keyphrases', 'wordpress-seo' ); ?></span>
-                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'optimize a single post for synonyms and related keyphrases.', 'wordpress-seo' ); ?></span>
-                    </li>
-                    <li class="yoast-seo-premium-benefits__item">
-                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Social previews', 'wordpress-seo' ); ?></span>
-                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'check what your Facebook or Twitter post will look like.', 'wordpress-seo' ); ?></span>
-                    </li>
-                    <li class="yoast-seo-premium-benefits__item">
-                        <span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Premium support', 'wordpress-seo' ); ?></span>
-                        <span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'gain access to our 24/7 support team.', 'wordpress-seo' ); ?></span>
-                    </li>
-                </ul>
+				<ul class="yoast-seo-premium-benefits yoast-list--usp">
+					<li class="yoast-seo-premium-benefits__item">
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Redirect manager', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'create and manage redirects from within your WordPress install.', 'wordpress-seo' ); ?></span>
+					</li>
+					<li class="yoast-seo-premium-benefits__item">
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Synonyms & related keyphrases', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'optimize a single post for synonyms and related keyphrases.', 'wordpress-seo' ); ?></span>
+					</li>
+					<li class="yoast-seo-premium-benefits__item">
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Social previews', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'check what your Facebook or Twitter post will look like.', 'wordpress-seo' ); ?></span>
+					</li>
+					<li class="yoast-seo-premium-benefits__item">
+						<span class="yoast-seo-premium-benefits__title"><?php esc_html_e( 'Premium support', 'wordpress-seo' ); ?></span>
+						<span class="yoast-seo-premium-benefits__description"><?php esc_html_e( 'gain access to our 24/7 support team.', 'wordpress-seo' ); ?></span>
+					</li>
+				</ul>
 			<?php endif; ?>
 			<?php if ( $extension_list->is_installed( $premium_extension->get_title() ) ) : ?>
-                <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
+				<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
 
 				<?php if ( $has_valid_premium_subscription ) : ?>
-                    <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
-                    <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
-                       class="yoast-link--license"><?php
+					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
+					   class="yoast-link--license"><?php
 						/* translators: %s expands to the extension title */
 						printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
 						?></a>
 				<?php else : ?>
-                    <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
-                    <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
-                       class="yoast-link--license"><?php
+					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
+					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
+					   class="yoast-link--license"><?php
 						/* translators: %s expands to the extension title */
 						printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
 						?></a>
 				<?php endif; ?>
-                </a>
+				</a>
 
 			<?php else : ?>
 
-                <a target="_blank" href="<?php echo esc_url( $premium_extension->get_buy_url() ); ?>"
-                   class="yoast-button-upsell"><?php
+				<a target="_blank" href="<?php echo esc_url( $premium_extension->get_buy_url() ); ?>"
+				   class="yoast-button-upsell"><?php
 					/* translators: $1$s expands to Yoast SEO Premium */
 					printf( __( 'Buy %1$s', 'wordpress-seo' ), $premium_extension->get_title() );
 					echo $new_tab_message;
 					echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 					?></a>
 
-                <a target="_blank" href="<?php echo esc_url( $premium_extension->get_info_url() ); ?>"
-                   class="yoast-link--more-info">
+				<a target="_blank" href="<?php echo esc_url( $premium_extension->get_info_url() ); ?>"
+				   class="yoast-link--more-info">
 					<?php
 					printf(
 					/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
@@ -195,19 +195,19 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 					);
 					echo $new_tab_message;
 					?>
-                </a>
+				</a>
 			<?php endif; ?>
 			<?php if ( ! $has_valid_premium_subscription ) { ?>
-                <p>
-                    <small class="yoast-money-back-guarantee"><?php esc_html_e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small>
-                </p>
+				<p>
+					<small class="yoast-money-back-guarantee"><?php esc_html_e( 'Comes with our 30-day no questions asked money back guarantee', 'wordpress-seo' ); ?></small>
+				</p>
 			<?php } ?>
-        </section>
+		</section>
 
-        <hr class="yoast-hr" aria-hidden="true"/>
+		<hr class="yoast-hr" aria-hidden="true"/>
 
-        <section class="yoast-promo-extensions">
-            <h2><?php
+		<section class="yoast-promo-extensions">
+			<h2><?php
 				/* translators: %1$s expands to Yoast SEO */
 				$yoast_seo_extensions = sprintf( __( '%1$s extensions', 'wordpress-seo' ), 'Yoast SEO' );
 				$yoast_seo_extensions = '<span class="yoast-heading-highlight">' . $yoast_seo_extensions . '</span>';
@@ -217,48 +217,48 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				?></h2>
 
 			<?php foreach ( $extensions as $slug => $extension ) : ?>
-                <section class="yoast-promoblock secondary yoast-promo-extension">
-                    <img alt="" width="280" height="147" src="<?php echo esc_attr( $extension->get_image() ); ?>"/>
-                    <h3><?php echo esc_html( $extension->get_display_title() ); ?></h3>
+				<section class="yoast-promoblock secondary yoast-promo-extension">
+					<img alt="" width="280" height="147" src="<?php echo esc_attr( $extension->get_image() ); ?>"/>
+					<h3><?php echo esc_html( $extension->get_display_title() ); ?></h3>
 
-                    <ul class="yoast-list--usp">
+					<ul class="yoast-list--usp">
 						<?php foreach ( $extension->get_benefits() as $benefit ) : ?>
-                            <li><?php echo esc_html( $benefit ); ?></li>
+							<li><?php echo esc_html( $benefit ); ?></li>
 						<?php endforeach; ?>
-                    </ul>
+					</ul>
 
-                    <div class="yoast-button-container">
+					<div class="yoast-button-container">
 						<?php if ( $extension_list->is_installed( $extension->get_title() ) ) : ?>
-                            <div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
+							<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-installed"><?php esc_html_e( 'Installed', 'wordpress-seo' ); ?></div>
 
 							<?php if ( $addon_manager->has_valid_subscription( $slug ) ) : ?>
-                                <div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
-                                <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
-                                   class="yoast-link--license"><?php
+								<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
+								   class="yoast-link--license"><?php
 									/* translators: %s expands to the extension title */
 									printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
 									?></a>
 							<?php else : ?>
-                                <div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
-                                <a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
-                                   class="yoast-link--license"><?php
+								<div class="yoast-button yoast-button--noarrow  yoast-button--extension yoast-button--extension-not-activated"><?php esc_html_e( 'Not activated', 'wordpress-seo' ); ?></div>
+								<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13i' ); ?>"
+								   class="yoast-link--license"><?php
 									/* translators: %s expands to the extension title */
 									printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
 									?></a>
 							<?php endif; ?>
 						<?php else : ?>
-                            <a target="_blank" class="yoast-button-upsell"
-                               href="<?php echo esc_url( $extension->get_buy_url() ); ?>"><?php
+							<a target="_blank" class="yoast-button-upsell"
+							   href="<?php echo esc_url( $extension->get_buy_url() ); ?>"><?php
 								/* translators: %s expands to the product name */
 								printf( __( 'Buy %s', 'wordpress-seo' ), $extension->get_buy_button() );
 								echo $new_tab_message;
 								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 								?></a>
 
-                            <a target="_blank" class="yoast-link--more-info"
-                               href="<?php echo esc_url( $extension->get_info_url() ); ?>">
+							<a target="_blank" class="yoast-link--more-info"
+							   href="<?php echo esc_url( $extension->get_info_url() ); ?>">
 								<?php
 								printf(
 								/* translators: Text between %1$s and %2$s will only be shown to screen readers. %3$s expands to the product name. */
@@ -269,12 +269,12 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								);
 								echo $new_tab_message;
 								?>
-                            </a>
+							</a>
 						<?php endif; ?>
-                    </div>
-                </section>
+					</div>
+				</section>
 			<?php endforeach; ?>
-        </section>
-    </div>
+		</section>
+	</div>
 
 </div>

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -251,7 +251,7 @@ class WPSEO_Addon_Manager {
 			return false;
 		}
 
-		return $subscription->expires !== 'expired';
+		return ! $this->has_subscription_expired( $subscription );
 	}
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -153,6 +153,24 @@ class WPSEO_Addon_Manager {
 	}
 
 	/**
+	 * Checks if the subscription for the given slug is valid.
+	 *
+	 * @param string $slug The plugin slug to retrieve.
+	 *
+	 * @return bool True when the subscription is valid.
+	 */
+	public function has_valid_subscription( $slug ) {
+		$subscription = $this->get_subscription( $slug );
+
+		// An non-existing subscription is never valid.
+		if ( $subscription === false ) {
+			return false;
+		}
+
+		return $subscription->expires !== 'expired';
+	}
+
+	/**
 	 * Checks if there are addon updates.
 	 *
 	 * @param stdClass|mixed $data The current data for update_plugins.

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -18,18 +18,60 @@ class WPSEO_Addon_Manager {
 	const SITE_INFORMATION_TRANSIENT = 'wpseo_site_information';
 
 	/**
+	 * Holds the slug for YoastSEO free.
+	 *
+	 * @var string
+	 */
+	const FREE_SLUG = 'yoast-seo-wordpress';
+
+	/**
+	 * Holds the slug for YoastSEO Premium.
+	 *
+	 * @var string
+	 */
+	const PREMIUM_SLUG = 'yoast-seo-wordpress-premium';
+
+	/**
+	 * Holds the slug for Yoast News.
+	 *
+	 * @var string
+	 */
+	const NEWS_SLUG = 'yoast-seo-news';
+
+	/**
+	 * Holds the slug for Video.
+	 *
+	 * @var string
+	 */
+	const VIDEO_SLUG = 'yoast-seo-video';
+
+	/**
+	 * Holds the slug for WooCommerce.
+	 *
+	 * @var string
+	 */
+	const WOOCOMMERCE_SLUG = 'yoast-seo-woocommerce';
+
+	/**
+	 * Holds the slug for Local.
+	 *
+	 * @var string
+	 */
+	const LOCAL_SLUG = 'yoast-seo-local';
+
+	/**
 	 * The expected addon data.
 	 *
 	 * @var array
 	 */
 	protected static $addons = array(
 		// Yoast SEO Free isn't an addon actually, but we needed it in some cases.
-		'wp-seo.php'            => 'yoast-seo-wordpress',
-		'wp-seo-premium.php'    => 'yoast-seo-wordpress-premium',
-		'wpseo-news.php'        => 'yoast-seo-news',
-		'video-seo.php'         => 'yoast-seo-video',
-		'wpseo-woocommerce.php' => 'yoast-seo-woocommerce',
-		'local-seo.php'         => 'yoast-seo-local',
+		'wp-seo.php'            => self::FREE_SLUG,
+		'wp-seo-premium.php'    => self::PREMIUM_SLUG,
+		'wpseo-news.php'        => self::NEWS_SLUG,
+		'video-seo.php'         => self::VIDEO_SLUG,
+		'wpseo-woocommerce.php' => self::WOOCOMMERCE_SLUG,
+		'local-seo.php'         => self::LOCAL_SLUG,
 	);
 
 	/**

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -361,7 +361,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			->getMock();
 
 		$instance
-			->expects( $this->any() )
+			->expects( $this->once() )
 			->method( 'get_subscriptions' )
 			->will( $this->returnValue( $this->get_subscriptions() ) );
 
@@ -383,7 +383,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			->getMock();
 
 		$instance
-			->expects( $this->any() )
+			->expects( $this->once() )
 			->method( 'get_subscriptions' )
 			->will( $this->returnValue( $this->get_subscriptions() ) );
 
@@ -405,7 +405,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			->getMock();
 
 		$instance
-			->expects( $this->any() )
+			->expects( $this->once() )
 			->method( 'get_subscriptions' )
 			->will( $this->returnValue( $this->get_subscriptions() ) );
 

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -286,7 +286,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider get_plugin_information_provider
 	 *
-	 * @covers WPSEO_Addon_Manager::get_plugin_information
+	 * @covers       WPSEO_Addon_Manager::get_plugin_information
 	 *
 	 * @param string $action   The action to use.
 	 * @param array  $args     The arguments to pass to the method.
@@ -308,6 +308,72 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			$expected,
 			$instance->get_plugin_information( false, $action, (object) $args ),
 			$message
+		);
+	}
+
+	/**
+	 * Tests the validation of a valid subscription.
+	 *
+	 * @covers WPSEO_Addon_Manager::has_valid_subscription
+	 */
+	public function test_has_valid_subscription() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Addon_Manager' )
+			->setMethods( array( 'get_subscriptions' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->any() )
+			->method( 'get_subscriptions' )
+			->will( $this->returnValue( $this->get_subscriptions() ) );
+
+		$this->assertEquals(
+			true,
+			$instance->has_valid_subscription( 'yoast-seo-wordpress-premium' )
+		);
+	}
+
+	/**
+	 * Tests the validation of an invalid subscription.
+	 *
+	 * @covers WPSEO_Addon_Manager::has_valid_subscription
+	 */
+	public function test_has_valid_subscription_with_an_expired_subscription() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Addon_Manager' )
+			->setMethods( array( 'get_subscriptions' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->any() )
+			->method( 'get_subscriptions' )
+			->will( $this->returnValue( $this->get_subscriptions() ) );
+
+		$this->assertEquals(
+			false,
+			$instance->has_valid_subscription( 'yoast-seo-news' )
+		);
+	}
+
+	/**
+	 * Tests the validation of an unknown subscription.
+	 *
+	 * @covers WPSEO_Addon_Manager::has_valid_subscription
+	 */
+	public function test_has_valid_subscription_with_an_unknown_subscription() {
+		$instance = $this
+			->getMockBuilder( 'WPSEO_Addon_Manager' )
+			->setMethods( array( 'get_subscriptions' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->any() )
+			->method( 'get_subscriptions' )
+			->will( $this->returnValue( $this->get_subscriptions() ) );
+
+		$this->assertEquals(
+			false,
+			$instance->has_valid_subscription( 'unknown-slug' )
 		);
 	}
 
@@ -485,13 +551,13 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 			->will(
 				$this->returnValue(
 					array(
-						'wp-seo-premium.php' => array(
+						'wp-seo-premium.php'         => array(
 							'Version' => '10.0',
 						),
 						'no-yoast-seo-extension-php' => array(
 							'Version' => '10.0',
 						),
-						'wpseo-news.php' => array(
+						'wpseo-news.php'             => array(
 							'Version' => '9.5',
 						),
 					)
@@ -666,6 +732,18 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 							'version'     => '10.0',
 							'name'        => 'Extension',
 							'slug'        => 'yoast-seo-wordpress-premium',
+							'lastUpdated' => 'yesterday',
+							'storeUrl'    => 'https://example.org/store',
+							'download'    => 'https://example.org/extension.zip',
+							'changelog'   => 'changelog',
+						),
+					),
+					'wpseo-news.php' => array(
+						'expires' => 'expired',
+						'product' => array(
+							'version'     => '10.0',
+							'name'        => 'Extension',
+							'slug'        => 'yoast-seo-news',
 							'lastUpdated' => 'yesterday',
 							'storeUrl'    => 'https://example.org/store',
 							'download'    => 'https://example.org/extension.zip',

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -18,6 +18,11 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 	private $future_date = null;
 
 	/**
+	 * @var string|null Date in the past.
+	 */
+	private $past_date = null;
+
+	/**
 	 * Tests retrieval of site information that will return the defaults.
 	 *
 	 * @covers WPSEO_Addon_Manager::get_site_information
@@ -772,7 +777,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 						),
 					),
 					'wpseo-news.php' => array(
-						'expires' => 'expired',
+						'expiry_date' => $this->get_past_date(),
 						'product' => array(
 							'version'     => '10.0',
 							'name'        => 'Extension',
@@ -799,5 +804,17 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 		}
 
 		return $this->future_date;
+	}
+
+	/**
+	 * Gets a date string that lies in the past.
+	 *
+	 * @return string Past date.
+	 */
+	protected function get_past_date() {
+		if ( $this->past_date === null ) {
+			$this->past_date = gmdate( 'Y-m-d\TH:i:s\Z', time() - DAY_IN_SECONDS );
+		}
+		return $this->past_date;
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Replaces usage of WPSEO_Extension_Manager in favor of WPSEO_Addon_Manager.

## Relevant technical choices:

* Added a helper function called `has_valid_subscription` to the `WPSEO_Addon_Manager` that gets the subscription via a slug and checks if the subscription is expired.
* Create contants for the addon slugs in `WPSEO_Addon_Manager`. This is so we can access them seperately from the protected $addons array, not having to know the key.
* `WPSEO_Extension_Manager` was used in the following locations:
	* `admin/class-admin.php` (`WPSEO_Admin`) -> `add_action_link`: the premium activated check.
	* `admin/class-extensions.php` (`WPSEO_Extensions`) -> `is_valid`: extensions activated check.
	* `admin/class-yoast-form.php` (`Yoast_Form`) -> `admin_sidebar`: the premium activated check.
	* `admin/views/licenses.php` -> Now uses an array with the slug constants as key.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

These changes can only really be checked in premium. But the code lives in free.
* Create a test branch and merge this branch in there before you test (see https://github.com/Yoast/Wiki/wiki/Merging-Free-into-Premium for some more info on how).
* Be sure to install the add-ons!
* Also, after checking the things below, for some it would be nice to check if it detects the difference if a license is not active anymore. Please ask Herre, he can change this for `local.wordpress.test`.

The following places where affected:

### WPSEO_Admin
* Go to the WordPress plugins page.
* It should not have the `FAQ` and `Premium Support` links when you have an activated Premium.
<img width="583" alt="class_admin change" src="https://user-images.githubusercontent.com/35524806/54687709-812eb480-4b1c-11e9-871b-b1604df866c6.png">


### WPSEO_Extensions
* Go to the Yoast SEO Dashboard.
* It should not show the problem notices `You are not receiving updates or support!`.
<details><summary>Notices screenshot</summary>
<img width="903" alt="Screenshot 2019-03-18 at 12 17 28" src="https://user-images.githubusercontent.com/19681708/54526699-d382a080-4977-11e9-81c3-4c29efcd77e2.png">
</details>

### Yoast_Form
* Go to the Yoast SEO Dashboard.
* It should not have a sidebar.
<details><summary>Sidebar screenshot</summary>
<img width="370" alt="Screenshot 2019-03-18 at 12 20 55" src="https://user-images.githubusercontent.com/19681708/54526833-4c81f800-4978-11e9-81fe-c7584a8d931a.png">
</details>

### Yoast SEO Dashboard -> Premium page
* Go to the Yoast SEO Dashboard -> Premium page.
* It should indicate `ACTIVATED` instead of `NOT ACTIVATED` for Premium and the addons.
<details><summary>Licenses screenshot</summary>
<img width="1656" alt="licenses view change" src="https://user-images.githubusercontent.com/35524806/54689337-99540300-4b1f-11e9-90d7-24508670e0b2.png">
</details>

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #12446 
