### PR TITLE
Documentation: improve function docblock short vs long description layout

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -624,7 +624,8 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Heavily restricts the possible columns by which a user can order the table in the bulk editor, thereby preventing a possible CSRF vulnerability.
+	 * Heavily restricts the possible columns by which a user can order the table
+	 * in the bulk editor, thereby preventing a possible CSRF vulnerability.
 	 *
 	 * @param string $orderby The column by which we want to order.
 	 *
@@ -645,7 +646,8 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Makes sure the order clause is always ASC or DESC for the bulk editor table, thereby preventing a possible CSRF vulnerability.
+	 * Makes sure the order clause is always ASC or DESC for the bulk editor table,
+	 * thereby preventing a possible CSRF vulnerability.
 	 *
 	 * @param string $order Whether we want to sort ascending or descending.
 	 *

--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -186,7 +186,9 @@ class WPSEO_GSC_Category_Filters {
 	}
 
 	/**
-	 * Parsing the category counts. When there are 0 issues for a specific category, just remove that one from the array
+	 * Parsing the category counts.
+	 *
+	 * When there are 0 issues for a specific category, just remove that one from the array.
 	 *
 	 * @param array $category_counts Set of counts for categories.
 	 *

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -72,8 +72,10 @@ class WPSEO_GSC implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Handles the dashboard notification. If the Google Search Console has no credentials,
-	 * show a notification for the user to give him a heads up. This message is dismissable.
+	 * Handles the dashboard notification.
+	 *
+	 * If the Google Search Console has no credentials, show a notification
+	 * for the user to give him a heads up. This message is dismissable.
 	 *
 	 * @return void
 	 */

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -452,8 +452,8 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Updates the links for the link count when there is a difference between the site and home url. We've used the
-	 * site url instead of the home url.
+	 * Updates the links for the link count when there is a difference between the site and home url.
+	 * We've used the site url instead of the home url.
 	 *
 	 * @return void
 	 */

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -295,8 +295,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * Invalidates enrich_defaults() cache.
 	 *
 	 * Called from actions:
-	 *     (un)registered_post_type
-	 *     (un)registered_taxonomy
+	 * - (un)registered_post_type
+	 * - (un)registered_taxonomy
 	 *
 	 * @return void
 	 */

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -344,7 +344,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	}
 
 	/**
-	 * Gets the filter hook name and callback for adjusting the retrieved option value against the network-allowed features.
+	 * Gets the filter hook name and callback for adjusting the retrieved option value
+	 * against the network-allowed features.
 	 *
 	 * @return array Array where the first item is the hook name, the second is the hook callback,
 	 *               and the third is the hook priority.

--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -199,10 +199,9 @@ class WPSEO_Sitemaps_Cache_Validator {
 	 * Get the current cache validator
 	 *
 	 * Without the type the global validator is returned.
-	 *  This can invalidate -all- keys in cache at once
+	 * This can invalidate -all- keys in cache at once.
 	 *
-	 * With the type parameter the validator for that specific
-	 *  type can be invalidated
+	 * With the type parameter the validator for that specific type can be invalidated.
 	 *
 	 * @since 3.2
 	 *

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -29,7 +29,8 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 	/**
 	 * Renders the block.
 	 *
-	 * Because we can't save script tags in Gutenberg without sufficient user permissions, we render these server-side.
+	 * Because we can't save script tags in Gutenberg without sufficient user permissions,
+	 * we render these server-side.
 	 *
 	 * @param array  $attributes The attributes of the block.
 	 * @param string $content    The HTML content of the block.

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -29,7 +29,8 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 	/**
 	 * Renders the block.
 	 *
-	 * Because we can't save script tags in Gutenberg without sufficient user permissions, we render these server-side.
+	 * Because we can't save script tags in Gutenberg without sufficient user permissions,
+	 * we render these server-side.
 	 *
 	 * @param array  $attributes The attributes of the block.
 	 * @param string $content    The HTML content of the block.

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -145,7 +145,9 @@ function wpseo_register_var_replacement( $var, $replace_function, $type = 'advan
 
 /**
  * WPML plugin support: Set titles for custom types / taxonomies as translatable.
- * It adds new keys to a wpml-config.xml file for a custom post type title, metadesc, title-ptarchive and metadesc-ptarchive fields translation.
+ *
+ * It adds new keys to a wpml-config.xml file for a custom post type title, metadesc,
+ * title-ptarchive and metadesc-ptarchive fields translation.
  * Documentation: http://wpml.org/documentation/support/language-configuration-files/
  *
  * @global      $sitepress

--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache-validator.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache-validator.php
@@ -64,7 +64,8 @@ class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Key length should never be over 45 characters
 	 *
-	 * This would be 53 if we don't use a timeout, but we can't because all sitemaps would be autoloaded every request.
+	 * This would be 53 if we don't use a timeout, but we can't because all sitemaps would
+	 * be autoloaded every request.
 	 */
 	public function test_get_storage_key_very_long_type() {
 

--- a/tests/test-class-admin-asset-manager.php
+++ b/tests/test-class-admin-asset-manager.php
@@ -24,8 +24,8 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * This is the only way to tests the protected methods. The should really be constants, but we can't because we have
-	 * to support PHP5.5 and lower.
+	 * This is the only way to tests the protected methods. These should really be
+	 * constants, but we can't because we have to support PHP 5.5 and lower.
 	 *
 	 * @covers WPSEO_Admin_Asset_Manager::scripts_to_be_registered
 	 * @covers WPSEO_Admin_Asset_Manager::styles_to_be_registered

--- a/tests/test-class-primary-term-admin.php
+++ b/tests/test-class-primary-term-admin.php
@@ -70,7 +70,8 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * When there are no taxonomies, make sure the following files are not registered:
-	 * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
+	 * - css/metabox-primary-category.css;
+	 * - js/dist/wp-seo-metabox-category.js.
 	 *
 	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
 	 */
@@ -82,8 +83,9 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Do not enqueue the following scripts when the page is not post edit
-	 * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
+	 * Do not enqueue the following scripts when the page is not post edit:
+	 * - css/metabox-primary-category.css;
+	 * - js/dist/wp-seo-metabox-category.js.
 	 *
 	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
 	 */
@@ -100,7 +102,8 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * When there are taxonomies and the page is post-new, make sure the following files are registered:
-	 * css/metabox-primary-category.css, js/dist/wp-seo-metabox-category.js
+	 * - css/metabox-primary-category.css;
+	 * - js/dist/wp-seo-metabox-category.js.
 	 *
 	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
 	 */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

A _short description_ should normally be a short sentence, while an additional _long description_ can be used to expand on that.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
