### PR TITLE
Documentation: improve class docblock short vs long description layout

### DIFF
--- a/admin/ajax/class-yoast-dismissable-notice.php
+++ b/admin/ajax/class-yoast-dismissable-notice.php
@@ -6,8 +6,8 @@
  */
 
 /**
- * This class will catch the request to dismiss the target notice (set by notice_name) and will store the dismiss status as an user meta
- * in the database
+ * This class will catch the request to dismiss the target notice (set by notice_name)
+ * and will store the dismiss status as an user meta in the database
  */
 class Yoast_Dismissable_Notice_Ajax {
 

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -6,7 +6,10 @@
  */
 
 /**
- * This class registers all the necessary styles and scripts. Also has methods for the enqueing of scripts and styles. It automatically adds a prefix to the handle.
+ * This class registers all the necessary styles and scripts.
+ *
+ * Also has methods for the enqueing of scripts and styles.
+ * It automatically adds a prefix to the handle.
  */
 class WPSEO_Admin_Asset_Manager {
 

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -11,14 +11,14 @@
  *
  * Some guidelines:
  * - To update a meta value, you can just use update_post_meta() with the full (prefixed) meta key
- *        or the convenience method WPSEO_Meta::set_value() with the internal key.
- *        All updates will be automatically validated.
- *        Meta values will only be saved to the database if they are *not* the same as the default to
- *        keep database load low.
+ *   or the convenience method WPSEO_Meta::set_value() with the internal key.
+ *   All updates will be automatically validated.
+ *   Meta values will only be saved to the database if they are *not* the same as the default to
+ *   keep database load low.
  * - To retrieve a WPSEO meta value, you **must** use WPSEO_Meta::get_value() which will always return a
- *        string value, either the saved value or the default.
- *        This method can also retrieve a complete set of WPSEO meta values for one specific post, see
- *        the method documentation for the parameters.
+ *   string value, either the saved value or the default.
+ *   This method can also retrieve a complete set of WPSEO meta values for one specific post, see
+ *   the method documentation for the parameters.
  *
  * {@internal Unfortunately there isn't a filter available to hook into before returning the results
  *            for get_post_meta(), get_post_custom() and the likes. That would have been the

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -12,48 +12,48 @@
  * Some guidelines:
  * [Retrieving options]
  * - Use the normal get_option() to retrieve an option. You will receive a complete array for the option.
- *    Any subkeys which were not set, will have their default values in place.
+ *   Any subkeys which were not set, will have their default values in place.
  * - In other words, you will normally not have to check whether a subkey isset() as they will *always* be set.
- *    They will also *always* be of the correct variable type.
- *    The only exception to this are the options with variable option names based on post_type or taxonomy
- *    as those will not always be available before the taxonomy/post_type is registered.
- *    (they will be available if a value was set, they won't be if it wasn't as the class won't know
- *    that a default needs to be injected).
+ *   They will also *always* be of the correct variable type.
+ *   The only exception to this are the options with variable option names based on post_type or taxonomy
+ *   as those will not always be available before the taxonomy/post_type is registered.
+ *   (they will be available if a value was set, they won't be if it wasn't as the class won't know
+ *   that a default needs to be injected).
  *
  * [Updating/Adding options]
  * - For multisite site_options, please use the WPSEO_Options::update_site_option() method.
  * - For normal options, use the normal add/update_option() functions. As long a the classes here
  *   are instantiated, validation for all options and their subkeys will be automatic.
  * - On (succesfull) update of a couple of options, certain related actions will be run automatically.
- *    Some examples:
- *      - on change of wpseo[yoast_tracking], the cron schedule will be adjusted accordingly
- *      - on change of wpseo and wpseo_title, some caches will be cleared
+ *   Some examples:
+ *   - on change of wpseo[yoast_tracking], the cron schedule will be adjusted accordingly
+ *   - on change of wpseo and wpseo_title, some caches will be cleared
  *
  *
  * [Important information about add/updating/changing these classes]
  * - Make sure that option array key names are unique across options. The WPSEO_Options::get_all()
- *    method merges most options together. If any of them have non-unique names, even if they
- *    are in a different option, they *will* overwrite each other.
+ *   method merges most options together. If any of them have non-unique names, even if they
+ *   are in a different option, they *will* overwrite each other.
  * - When you add a new array key in an option: make sure you add proper defaults and add the key
- *    to the validation routine in the proper place or add a new validation case.
- *    You don't need to do any upgrading as any option returned will always be merged with the
- *    defaults, so new options will automatically be available.
- *    If the default value is a string which need translating, add this to the concrete class
- *    translate_defaults() method.
+ *   to the validation routine in the proper place or add a new validation case.
+ *   You don't need to do any upgrading as any option returned will always be merged with the
+ *   defaults, so new options will automatically be available.
+ *   If the default value is a string which need translating, add this to the concrete class
+ *   translate_defaults() method.
  * - When you remove an array key from an option: if it's important that the option is really removed,
- *    add the WPSEO_Option::clean_up( $option_name ) method to the upgrade run.
- *    This will re-save the option and automatically remove the array key no longer in existance.
+ *   add the WPSEO_Option::clean_up( $option_name ) method to the upgrade run.
+ *   This will re-save the option and automatically remove the array key no longer in existance.
  * - When you rename a sub-option: add it to the clean_option() routine and run that in the upgrade run.
  * - When you change the default for an option sub-key, make sure you verify that the validation routine will
- *    still work the way it should.
- *    Example: changing a default from '' (empty string) to 'text' with a validation routine with tests
- *    for an empty string will prevent a user from saving an empty string as the real value. So the
- *    test for '' with the validation routine would have to be removed in that case.
+ *   still work the way it should.
+ *   Example: changing a default from '' (empty string) to 'text' with a validation routine with tests
+ *   for an empty string will prevent a user from saving an empty string as the real value. So the
+ *   test for '' with the validation routine would have to be removed in that case.
  * - If an option needs specific actions different from defined in this abstract class, you can just overrule
- *    a method by defining it in the concrete class.
+ *   a method by defining it in the concrete class.
  *
- * @todo       - [JRF => testers] Double check that validation will not cause errors when called
- *               from upgrade routine (some of the WP functions may not yet be available).
+ * @todo [JRF => testers] Double check that validation will not cause errors when called
+ *       from upgrade routine (some of the WP functions may not yet be available).
  */
 abstract class WPSEO_Option {
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

A _short description_ should normally be a short sentence, while an additional _long description_ can be used to expand on that.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.