### PR TITLE
Test documentation: add some missing property docblocks

### DIFF
--- a/tests/inc/options/test-class-wpseo-option-wpseo.php
+++ b/tests/inc/options/test-class-wpseo-option-wpseo.php
@@ -10,6 +10,11 @@
  */
 class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 
+	/**
+	 * Features which can be disabled via the network settings.
+	 *
+	 * @var array
+	 */
 	protected $feature_vars = array(
 		'disableadvanced_meta',
 		'onpage_indexability',

--- a/tests/inc/test-class-wpseo-upgrade-history.php
+++ b/tests/inc/test-class-wpseo-upgrade-history.php
@@ -8,6 +8,11 @@
  */
 class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 
+	/**
+	 * Option name.
+	 *
+	 * @var string
+	 */
 	private static $option_name = 'wpseo_history_test';
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.