### PR TITLE
Remove Gutenberg CSS classes and adjust CSS accordingly.

### DIFF
--- a/css/src/structured-data-blocks.scss
+++ b/css/src/structured-data-blocks.scss
@@ -10,7 +10,8 @@
 
 .schema-how-to-buttons,
 .schema-faq-buttons {
-	text-align: center;
+	display: flex;
+	justify-content: center;
 
 	button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
 		box-shadow: none;
@@ -44,7 +45,7 @@
 
 .schema-how-to-step-button-container,
 .schema-faq-section-button-container {
-	display: inline-block;
+	display: inline-flex;
 	text-align: right;
 
 	button.components-icon-button:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 175,
+			maxWarnings: 172,
 		},
 	},
 	tests: {

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -281,7 +281,7 @@ export default class FAQ extends Component {
 			<IconButton
 				icon="insert"
 				onClick={ this.onAddQuestionButtonClick }
-				className="editor-inserter__toggle schema-faq-add-question"
+				className="schema-faq-add-question"
 			>
 				{ __( "Add question", "wordpress-seo" ) }
 			</IconButton>

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -49,7 +49,7 @@ export default class Question extends Component {
 	getMediaUploadButton( props ) {
 		return (
 			<IconButton
-				className="schema-faq-section-button editor-inserter__toggle faq-section-add-media"
+				className="schema-faq-section-button faq-section-add-media"
 				icon="insert"
 				onClick={ props.open }
 			>
@@ -211,13 +211,13 @@ export default class Question extends Component {
 				render={ this.getMediaUploadButton }
 			/>
 			<IconButton
-				className="schema-faq-section-button editor-inserter__toggle"
+				className="schema-faq-section-button"
 				icon="trash"
 				label={ __( "Delete question", "wordpress-seo" ) }
 				onClick={ this.onRemoveQuestion }
 			/>
 			<IconButton
-				className="schema-faq-section-button editor-inserter__toggle"
+				className="schema-faq-section-button"
 				icon="insert"
 				label={ __( "Insert question", "wordpress-seo" ) }
 				onClick={ this.onInsertQuestion }

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -13,7 +13,7 @@ import buildDurationString from "../utils/buildDurationString";
 import appendSpace from "../../../components/higherorder/appendSpace";
 
 const { RichText, InspectorControls } = window.wp.editor;
-const { Button, IconButton, Dashicon, PanelBody, TextControl, ToggleControl } = window.wp.components;
+const { IconButton, PanelBody, TextControl, ToggleControl } = window.wp.components;
 const { Component, renderToString, createRef } = window.wp.element;
 
 const RichTextWithAppendedSpace = appendSpace( RichText.Content );
@@ -509,7 +509,7 @@ export default class HowTo extends Component {
 			<IconButton
 				icon="insert"
 				onClick={ this.onAddStepButtonClick }
-				className="editor-inserter__toggle schema-how-to-add-step"
+				className="schema-how-to-add-step"
 			>
 				{ __( "Add step", "wordpress-seo" ) }
 			</IconButton>
@@ -651,15 +651,14 @@ export default class HowTo extends Component {
 
 		if ( ! attributes.hasDuration ) {
 			return (
-				// Use a `Button` because at the moment `IconButton` doesn't support refs.
-				<Button
+				<IconButton
 					onClick={ this.addDuration }
-					className="components-icon-button schema-how-to-duration-button editor-inserter__toggle"
+					className="schema-how-to-duration-button"
 					ref={ this.addDurationButton }
+					icon="insert"
 				>
-					<Dashicon icon="insert" />
 					{ __( "Add total time", "wordpress-seo" ) }
-				</Button>
+				</IconButton>
 			);
 		}
 
@@ -717,7 +716,7 @@ export default class HowTo extends Component {
 							placeholder="MM"
 						/>
 						<IconButton
-							className="schema-how-to-duration-delete-button editor-inserter__toggle"
+							className="schema-how-to-duration-delete-button"
 							icon="trash"
 							label={ __( "Delete total time", "wordpress-seo" ) }
 							onClick={ this.removeDuration }

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -171,7 +171,7 @@ export default class HowToStep extends Component {
 	getMediaUploadButton( props ) {
 		return (
 			<IconButton
-				className="schema-how-to-step-button editor-inserter__toggle how-to-step-add-media"
+				className="schema-how-to-step-button how-to-step-add-media"
 				icon="insert"
 				onClick={ props.open }
 			>
@@ -200,13 +200,13 @@ export default class HowToStep extends Component {
 			/>
 			}
 			<IconButton
-				className="schema-how-to-step-button editor-inserter__toggle"
+				className="schema-how-to-step-button"
 				icon="trash"
 				label={ __( "Delete step", "wordpress-seo" ) }
 				onClick={ this.onRemoveStep }
 			/>
 			<IconButton
-				className="schema-how-to-step-button editor-inserter__toggle"
+				className="schema-how-to-step-button"
 				icon="insert"
 				label={ __( "Insert step", "wordpress-seo" ) }
 				onClick={ this.onInsertStep }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix the buttons position in the structured data blocks.

## Relevant technical choices:
- Gutenberg moved some components from `editor` to `block-editor`
- as a consequence, also some Gutenberg CSS classes have now different names e.g. `editor-inserter__toggle` became `block-editor-inserter__toggle`
- we shouldn't use Gutenberg CSS class names in our components to start with, as they're not part of a formalized API (or so they _dixit_)
- this PR removes any usage of `editor-inserter__toggle`
- removes `components-icon-button` from the JS, though it's still used in our stylesheet
- changes the "Add total time" Button component to IconButton: this was a hack made necessary by the IconButton lack of support for `ref`s. So we used a Button and manually added the CSS class `components-icon-button`. Since https://github.com/WordPress/gutenberg/pull/14163, IconButton now is able to get a ref thus we can use an IconButton


## Test instructions
- activate the Gutenberg plugin, at the moment latest master is 5.3.0 https://github.com/WordPress/gutenberg/commit/95642a40ca5dddbaf93a565d9a78a554974a3e0e
- create a post
- add a How-to block with some steps
- add a FAQ block with some QA
- check all the buttons are properly positioned
  - How-to: Add total time
  - both blocks: Add Image, Delete, Insert, and the "Add step / question" at the bottom
- press the How-to "Add total time" button using the keyboard
- tab to the "Delete total time" trash icon button and press it
- verify focus is moved back to the "Add total time" button

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #12496 
