### PR TITLE
Show ads and `FAQ` and `Premium Support` links when Premium is not active

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -220,7 +220,7 @@ class WPSEO_Admin {
 		}
 
 		$addon_manager = new WPSEO_Addon_Manager();
-		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) && WPSEO_Utils::is_yoast_seo_premium() ) {
 			return $links;
 		}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -188,7 +188,7 @@ class Yoast_Form {
 	public function admin_sidebar() {
 		// No banners in Premium.
 		$addon_manager = new WPSEO_Addon_Manager();
-		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) && WPSEO_Utils::is_yoast_seo_premium() ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Fixes a bug where the premium ads and `FAQ` and `Premium Support` links would not be shown when a site has a valid premium license but not an active premium plugin.

## Relevant technical choices:

* Adds a check whether the premium plugin is active to the check that there is a valid license.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have a website that does have a valid premium license (local.wordpress.test does have one. I'm not sure about one.wordpress.test. When in doubt, check with team platform).
* On release/10.1: 
    * Install and activate wordpress-seo (free!)
    * Click `Yoast SEO` in the sidebar to go to our notification center.
    * See that there are no upsells for premium on the righthand side.
    * Go to the plugin overview. Check Yoast SEO, and see that the following links are missing:
<img width="583" alt="54687709-812eb480-4b1c-11e9-871b-b1604df866c6" src="https://user-images.githubusercontent.com/17744553/54817641-b6abdd00-4c97-11e9-9dd9-3b676a25a4e9.png">

* Switch to this branch:
    * Repeat the steps and see the ads and the links.
* Merge this branch into premium.
* Repeat the steps and don't see the ads and the links.
* Repeat the steps for a site without a valid premium subscription.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
