### PR TITLE
Premium cs only checkout outside travis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
 		],
 		"after-premium-cs": [
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
-			"git checkout composer.lock",
+			"if [[ -z $TRAVIS ]] then; git checkout composer.lock; fi;",
 			"composer config-yoastcs"
 		],
 		"prefix-dependencies": [

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
 		],
 		"after-premium-cs": [
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
-			"@php ./scripts/maybe_restore_composer_lock.php",
+			"@php ./scripts/maybe-restore-composer-lock.php",
 			"composer config-yoastcs"
 		],
 		"prefix-dependencies": [

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
 		],
 		"after-premium-cs": [
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",
-			"if [[ -z $TRAVIS ]] then; git checkout composer.lock; fi;",
+			"@php ./scripts/maybe_restore_composer_lock.php",
 			"composer config-yoastcs"
 		],
 		"prefix-dependencies": [

--- a/scripts/maybe-restore-composer-lock.php
+++ b/scripts/maybe-restore-composer-lock.php
@@ -1,5 +1,5 @@
 <?php
-/** Windows compatible way of executing this conditionally. **/
+// Windows compatible way of executing this conditionally.
 if ( ! getenv( 'TRAVIS' ) ) {
 	exec( 'git checkout composer.lock' );
 }

--- a/scripts/maybe-restore-composer-lock.php
+++ b/scripts/maybe-restore-composer-lock.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Scripts
+ */
+
 // Windows compatible way of executing this conditionally.
 if ( ! getenv( 'TRAVIS' ) ) {
 	exec( 'git checkout composer.lock' );

--- a/scripts/maybe-restore-composer-lock.php
+++ b/scripts/maybe-restore-composer-lock.php
@@ -1,0 +1,5 @@
+<?php
+// Windows compatible way of executing this conditionally.
+if ( ! getenv( 'TRAVIS' ) ) {
+	exec( 'git checkout composer.lock' );
+}

--- a/scripts/maybe-restore-composer-lock.php
+++ b/scripts/maybe-restore-composer-lock.php
@@ -1,5 +1,5 @@
 <?php
-// Windows compatible way of executing this conditionally.
+/** Windows compatible way of executing this conditionally. **/
 if ( ! getenv( 'TRAVIS' ) ) {
 	exec( 'git checkout composer.lock' );
 }

--- a/scripts/maybe_restore_composer_lock.php
+++ b/scripts/maybe_restore_composer_lock.php
@@ -1,0 +1,5 @@
+<?php
+// Windows compatible way of executing this conditionally.
+if ( ! getenv( "TRAVIS" ) ) {
+	exec( "git checkout composer.lock" );
+}

--- a/scripts/maybe_restore_composer_lock.php
+++ b/scripts/maybe_restore_composer_lock.php
@@ -1,5 +1,0 @@
-<?php
-// Windows compatible way of executing this conditionally.
-if ( ! getenv( "TRAVIS" ) ) {
-	exec( "git checkout composer.lock" );
-}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Don't checkout composer.lock on Travis. This breaks the build because the composer.json is changed as well, which results in a mismatch.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Travis should pass without problems. Locally, the composer.lock should be checked out during `after-premium-cs`. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
