### PR TITLE
Introduces method get_post_statuses in sitemaps

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -593,7 +593,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$join   = " LEFT JOIN {$wpdb->posts} AS p2 ON ({$wpdb->posts}.post_parent = p2.ID) ";
 
 			$parent_statuses = array_diff( $post_statuses, array( 'inherit' ) );
-			$status_where    = "p2.post_status IN ('" . implode( "','", $post_statuses ) . "') AND p2.post_password = ''";
+			$status_where    = "p2.post_status IN ('" . implode( "','", $parent_statuses ) . "') AND p2.post_password = ''";
 		}
 
 		$where_clause = "

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -586,18 +586,19 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$join   = '';
 
 		$post_statuses = array_map( 'esc_sql', WPSEO_Sitemaps::get_post_statuses( $post_type ) );
-
-		$status = "{$wpdb->posts}.post_status IN ('" . implode( "','", $post_statuses ) . "')";
+		$status_where  = "{$wpdb->posts}.post_status IN ('" . implode( "','", $post_statuses ) . "')";
 
 		// Based on WP_Query->get_posts(). R.
 		if ( 'attachment' === $post_type ) {
 			$join   = " LEFT JOIN {$wpdb->posts} AS p2 ON ({$wpdb->posts}.post_parent = p2.ID) ";
-			$status = "p2.post_status IN ('" . implode( "','", $post_statuses ) . "') AND p2.post_password = ''";
+
+			$parent_statuses = array_diff( $post_statuses, array( 'inherit' ) );
+			$status_where    = "p2.post_status IN ('" . implode( "','", $post_statuses ) . "') AND p2.post_password = ''";
 		}
 
 		$where_clause = "
 			{$join}
-			WHERE {$status}
+			WHERE {$status_where}
 				AND {$wpdb->posts}.post_type = %s
 				AND {$wpdb->posts}.post_password = ''
 				AND {$wpdb->posts}.post_date != '0000-00-00 00:00:00'

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -495,20 +495,17 @@ class WPSEO_Sitemaps {
 			$post_type_names = get_post_types( array( 'public' => true ) );
 
 			if ( ! empty( $post_type_names ) ) {
-				/**
-				 * Filter post status list for sitemap query for the post type.
-				 *
-				 * @param Array $post_status_names      Post status list, defaults to array( 'publish', 'inherit' ).
-				 */
-				$post_status_names = apply_filters( 'wpseo_sitemap_poststatus_lastmodified' , array( 'publish', 'inherit' ) );
+
+				$post_statuses = array_map( 'esc_sql', self::get_post_statuses() );
+
 				$sql = "
-				SELECT post_type, MAX(post_modified_gmt) AS date
-				FROM $wpdb->posts
-				WHERE post_status IN ('" . implode( "','", array_map( 'esc_sql', $post_status_names ) ) . "')
-					AND post_type IN ('" . implode( "','", $post_type_names ) . "')
-				GROUP BY post_type
-				ORDER BY post_modified_gmt DESC
-			";
+					SELECT post_type, MAX(post_modified_gmt) AS date
+					FROM $wpdb->posts
+					WHERE post_status IN ('" . implode( "','", $post_statuses ) . "')
+						AND post_type IN ('" . implode( "','", $post_type_names ) . "')
+					GROUP BY post_type
+					ORDER BY post_modified_gmt DESC
+				";
 
 				foreach ( $wpdb->get_results( $sql ) as $obj ) {
 					$post_type_dates[ $obj->post_type ] = $obj->date;
@@ -587,5 +584,36 @@ class WPSEO_Sitemaps {
 		$entries = (int) apply_filters( 'wpseo_sitemap_entries_per_page', 1000 );
 
 		return $entries;
+	}
+
+	/**
+	 * Get post statuses for post_type or the root sitemap.
+	 *
+	 * @param string $type Provide a type for a post_type sitemap, SITEMAP_INDEX_TYPE for the root sitemap.
+	 *
+	 * @since 10.2
+	 *
+	 * @return array List of post statuses.
+	 */
+	public static function get_post_statuses( $type = self::SITEMAP_INDEX_TYPE ) {
+		/**
+		 * Filter post status list for sitemap query for the post type.
+		 *
+	         * @param array  $post_statuses Post status list, defaults to array( 'publish' ).
+	         * @param string $type          Post type or SITEMAP_INDEX_TYPE.
+		 */
+		$post_statuses = apply_filters( 'wpseo_sitemap_post_statuses' , array( 'publish' ), $type );
+
+		if ( ! is_array( $post_statuses ) || empty( $post_statuses ) ) {
+			$post_statuses = array( 'publish' );
+		}
+
+		if ( ( $type === self::SITEMAP_INDEX_TYPE || $type === 'attachment' )
+			&& ! in_array( 'inherit', $post_statuses, true )
+		) {
+			$post_statuses[] = 'inherit';
+		}
+
+		return $post_statuses;
 	}
 }

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -168,6 +168,8 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$terms = array();
 		}
 
+		$post_statuses = array_map( 'esc_sql', self::get_post_statuses() );
+
 		// Grab last modified date.
 		$sql = "
 			SELECT MAX(p.post_modified_gmt) AS lastmod
@@ -178,7 +180,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				ON		term_tax.term_taxonomy_id = term_rel.term_taxonomy_id
 				AND		term_tax.taxonomy = %s
 				AND		term_tax.term_id = %d
-			WHERE	p.post_status IN ('publish','inherit')
+			WHERE	p.post_status IN ('" . implode( "','", $post_type_names ) . "')
 				AND		p.post_password = ''
 		";
 

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -168,7 +168,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$terms = array();
 		}
 
-		$post_statuses = array_map( 'esc_sql', self::get_post_statuses() );
+		$post_statuses = array_map( 'esc_sql', WPSEO_Sitemaps::get_post_statuses() );
 
 		// Grab last modified date.
 		$sql = "
@@ -180,7 +180,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				ON		term_tax.term_taxonomy_id = term_rel.term_taxonomy_id
 				AND		term_tax.taxonomy = %s
 				AND		term_tax.term_id = %d
-			WHERE	p.post_status IN ('" . implode( "','", $post_type_names ) . "')
+			WHERE	p.post_status IN ('" . implode( "','", $post_statuses ) . "')
 				AND		p.post_password = ''
 		";
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Use unique filter _wpseo_sitemap_post_statuses_ for the root sitemap or a CPT sitemap. Props to [stodorovic](https://github.com/stodorovic) and [tolnem](https://github.com/tolnem)
* Populates correct _post_status_ in post object (sitemaps) Props to [stodorovic](https://github.com/stodorovic)

## Relevant technical choices:

* Create new method _get_post_statuses_ in _class WPSEO_Sitemaps_ which returns post statuses

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a custom post type
* Enable Edit Flow plugin or otherwise create custom post status for the custom post type
* Create one or more posts with the custom post status
* Add a filter for `wpseo_sitemap_post_statuses` to include custom post status into CPT sitemap.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
