### PR TITLE
Fix development of monorepo in plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/js/tests/setupTests.js",
     "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\](?!yoast-components|yoastseo|lodash-es).+\\.js$"
+      "[/\\\\]node_modules[/\\\\](?!yoast-components|yoastseo|lodash-es|@yoast).+\\.js$"
     ],
     "testPathIgnorePatterns": [
       "/js/tests/edit.test.js"

--- a/scripts/link_monorepo_to_plugin.sh
+++ b/scripts/link_monorepo_to_plugin.sh
@@ -46,13 +46,13 @@ yarn link-all
 cd ..
 
 # Get all the packages inside the yoastseo package.json that are scoped using @yoast
-packages=($(cat package.json | tr '"' '\n' | grep -w @yoast))
+packages=($(ls javascript/packages))
 
 for package in ${packages[@]}
 do
-   echo -e "Linking ${package}\n"
+   echo -e "Linking @yoast/${package}\n"
    # We don't want to exit on errors since there are some packages that we simply can't link (yet).
-   yarn link ${package} || true
+   yarn link @yoast/${package} || true
 done
 
 # Manually link yoast-components and yoastseo because they don't adhere to the new naming conventions (yet).

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -74,7 +74,7 @@ module.exports = function( env = { environment: "production" } ) {
 			rules: [
 				{
 					test: /.jsx?$/,
-					exclude: /node_modules[/\\](?!(yoast-components|gutenberg|yoastseo|@wordpress)[/\\]).*/,
+					exclude: /node_modules[/\\](?!(yoast-components|gutenberg|yoastseo|@wordpress|@yoast)[/\\]).*/,
 					use: [
 						{
 							loader: "babel-loader",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

This fixes two things:

* Link all packages inside the monorepo instead of only the ones in the package.json. Because of how webpack builds the files, we cannot build on the packages required in `package.json`. Because a package we require could have a different dependency and then that dependency is not linked. If it is not linked then webpack cannot find it.
* Run babel over the `@yoast` packages because we are running those from source in the monorepo.

## Relevant technical choices:

* :point_up:

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn link-monorepo`
* Run grunt build:js
* You should have a limited amount of errors. Before this PR you had errors that `@yoast/components`, `@yoast/helpers` were missing. After this PR you don't have the same errors.

These errors are expected, because the imports are incorrect in the plugin:

```
    ERROR in ./js/src/components/modals/Container.js
    Module not found: Error: Can't resolve 'yoast-components/composites/Plugin/Shared/components/Icon' in '/Users/antontimmermans/VVV/www/wordpress-default/public_html/wp-content/plugins/wordpress-seo-2/js/src/components/modals'
     @ ./js/src/components/modals/Container.js 12:12-80
     @ ./js/src/components/modals/RedirectUpsell.js
     @ ./js/src/wp-seo-admin-gsc.js

    ERROR in ./js/src/components/contentAnalysis/SeoAnalysis.js
    Module not found: Error: Can't resolve 'yoast-components/composites/basic/YoastSeoIcon' in '/Users/antontimmermans/VVV/www/wordpress-default/public_html/wp-content/plugins/wordpress-seo-2/js/src/components/contentAnalysis'
     @ ./js/src/components/contentAnalysis/SeoAnalysis.js 57:20-77
     @ ./js/src/components/Metabox.js
     @ ./js/src/containers/Metabox.js
     @ ./js/src/components/MetaboxPortal.js
     @ ./js/src/helpers/classicEditor.js
     @ ./js/src/wp-seo-term-scraper.js

    ERROR in ./js/src/components/modals/RedirectUpsell.js
    Module not found: Error: Can't resolve 'yoast-components/composites/basic/YoastSeoIcon' in '/Users/antontimmermans/VVV/www/wordpress-default/public_html/wp-content/plugins/wordpress-seo-2/js/src/components/modals'
     @ ./js/src/components/modals/RedirectUpsell.js 21:20-77
     @ ./js/src/wp-seo-admin-gsc.js
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended