### PR TITLE
Make sure that the configuration-wizard has access to its own scss.

### DIFF
--- a/css/src/alerts.scss
+++ b/css/src/alerts.scss
@@ -1,3 +1,4 @@
+@import "../../node_modules/@yoast/style-guide/src/colors";
 @import "../../node_modules/yoast-components/css/all.scss";
 
 $breakpoint_mobile: '768px';

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -1,7 +1,8 @@
-/* This file is meant to be used exclusively for the Onboarding Wizard. */
+/* This file is meant to be used exclusively for the Configuration Wizard. */
 @import "../../node_modules/sassdash/scss/sassdash";
 @import "wp";
-@import "../../node_modules/yoast-components/css/all.scss";
+@import "../../node_modules/@yoast/configuration-wizard/src/configuration-wizard";
+@import "../../node_modules/@yoast/style-guide/src/colors";
 
 #wizard {
 	overflow: hidden;

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -3,11 +3,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 // Required to make Material UI work with touch screens.
-import { OnboardingWizard } from "yoast-components";
-import { MessageBox } from "yoast-components";
+import ConfigurationWizard, { MessageBox, MailchimpSignup, ConnectGoogleSearchConsole } from "@yoast/configuration-wizard";
 
-import MailchimpSignup from "./components/MailchimpSignup";
-import ConnectGoogleSearchConsole from "./components/ConnectGoogleSearchConsole";
 import MediaUpload from "./components/MediaUpload";
 import Suggestions from "./components/Suggestions";
 import FinalStep from "./components/FinalStep";
@@ -124,7 +121,7 @@ class App extends React.Component {
 		if ( typeof( this.state.config ) !== "undefined" && this.state.config !== {} ) {
 			return (
 				<div>
-					<OnboardingWizard { ...this.state.config } headerIcon={ YoastIcon } />
+					<ConfigurationWizard { ...this.state.config } headerIcon={ YoastIcon } />
 				</div>
 			);
 		}

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -3,8 +3,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 // Required to make Material UI work with touch screens.
-import ConfigurationWizard, { MessageBox, MailchimpSignup, ConnectGoogleSearchConsole } from "@yoast/configuration-wizard";
+import ConfigurationWizard, { MessageBox } from "@yoast/configuration-wizard";
 
+
+import MailchimpSignup from "./components/MailchimpSignup";
+import ConnectGoogleSearchConsole from "./components/ConnectGoogleSearchConsole";
 import MediaUpload from "./components/MediaUpload";
 import Suggestions from "./components/Suggestions";
 import FinalStep from "./components/FinalStep";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* We moved the configuration-wizard to its own package. As a result, it lost access to its `scss`. This PR makes sure that the configuration-wizard contains its own sass.

## Test instructions
Make sure that the configuration-wizard can still be build and looks the same.

## UI changes
This PR should not create any UI changes. If that happens, please reject this PR.

Related Yoast/javascript#141
Related Yoast/javascript#148