### PR TITLE
Slightly change yoa.st query params

### DIFF
--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -9,7 +9,6 @@
  * Helps with creating shortlinks in the plugin
  */
 class WPSEO_Shortlinker {
-
 	/**
 	 * Collects the additional data necessary for the shortlink.
 	 *
@@ -22,7 +21,6 @@ class WPSEO_Shortlinker {
 			'platform_version' => $GLOBALS['wp_version'],
 			'software'         => $this->get_software(),
 			'software_version' => WPSEO_VERSION,
-			'role'             => $this->get_filtered_user_role(),
 			'days_active'      => $this->get_days_active(),
 		);
 	}
@@ -79,7 +77,7 @@ class WPSEO_Shortlinker {
 	private function get_php_version() {
 		$version = explode( '.', PHP_VERSION );
 
-		return (int) $version[0] . '.' . (int) $version[1] . '.' . (int) $version[2];
+		return (int) $version[0] . '.' . (int) $version[1];
 	}
 
 	/**
@@ -96,31 +94,6 @@ class WPSEO_Shortlinker {
 	}
 
 	/**
-	 * Gets the current user's role without leaking roles that shouldn't be public.
-	 *
-	 * @return string The filtered user role.
-	 */
-	private function get_filtered_user_role() {
-		$user           = wp_get_current_user();
-		$built_in_roles = array(
-			'administrator',
-			'wpseo_manager',
-			'wpseo_editor',
-			'editor',
-			'author',
-			'contributor',
-			'subscriber',
-		);
-		$filtered_roles = array_intersect( $built_in_roles, $user->roles );
-
-		$role = current( $filtered_roles );
-		if ( ! $role ) {
-			$role = 'unknown';
-		}
-		return $role;
-	}
-
-	/**
 	 * Gets the number of days the plugin has been active.
 	 *
 	 * @return int The number of days the plugin is active.
@@ -128,7 +101,21 @@ class WPSEO_Shortlinker {
 	private function get_days_active() {
 		$date_activated = WPSEO_Options::get( 'first_activated_on' );
 		$datediff       = ( time() - $date_activated );
-
-		return (int) round( $datediff / DAY_IN_SECONDS );
+		$days           = (int) round( $datediff / DAY_IN_SECONDS );
+		switch( $days ) {
+			case 0:
+			case 1:
+				$cohort = '0-1';
+				break;
+			case ( $days < 5 ):
+				$cohort = '2-5';
+				break;
+			case ( $days < 30 ):
+				$cohort = '6-30';
+				break;
+			default:
+				$cohort = '>30';
+		}
+		return $cohort;
 	}
 }

--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -102,7 +102,7 @@ class WPSEO_Shortlinker {
 		$date_activated = WPSEO_Options::get( 'first_activated_on' );
 		$datediff       = ( time() - $date_activated );
 		$days           = (int) round( $datediff / DAY_IN_SECONDS );
-		switch( $days ) {
+		switch ( $days ) {
 			case 0:
 			case 1:
 				$cohort = '0-1';


### PR DESCRIPTION
## Summary

In order to increase cache efficiency for `yoa.st` links, I'm slightly changing some parameters.

- We add a `role` parameter to `yoa.st` links that we don't use, so we're removing that.
- PHP now is only `x.y` instead of `x.y.z`
- `days_active` is now divided into 4 cohorts, instead of outputting the specific number of days.

This PR can be summarized in the following changelog entry:

* no changelog needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See any yoa.st link in the plugin, see that it changed.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

