### PR TITLE
Introduce `WPSEO_Utils::format_json_encode`

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -21,7 +21,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
  * @param array $results Results array for encoding.
  */
 function wpseo_ajax_json_echo_die( $results ) {
-	echo wp_json_encode( $results );
+	echo WPSEO_Utils::format_json_encode( $results );
 	die();
 }
 
@@ -297,7 +297,7 @@ function ajax_get_keyword_usage() {
 	}
 
 	wp_die(
-		wp_json_encode( WPSEO_Meta::keyword_usage( $keyword, $post_id ) )
+		WPSEO_Utils::format_json_encode( WPSEO_Meta::keyword_usage( $keyword, $post_id ) )
 	);
 }
 
@@ -327,7 +327,7 @@ function ajax_get_term_keyword_usage() {
 	$usage = $usage[ $keyword ];
 
 	wp_die(
-		wp_json_encode( $usage )
+		WPSEO_Utils::format_json_encode( $usage )
 	);
 }
 

--- a/admin/ajax/class-recalculate-scores-ajax.php
+++ b/admin/ajax/class-recalculate-scores-ajax.php
@@ -28,7 +28,7 @@ class WPSEO_Recalculate_Scores_Ajax {
 		check_ajax_referer( 'wpseo_recalculate', 'nonce' );
 
 		wp_die(
-			wp_json_encode(
+			WPSEO_Utils::format_json_encode(
 				array(
 					'posts' => $this->calculate_posts(),
 					'terms' => $this->calculate_terms(),
@@ -49,7 +49,7 @@ class WPSEO_Recalculate_Scores_Ajax {
 			$response = $fetch_object->get_items_to_recalculate( $paged );
 
 			if ( ! empty( $response ) ) {
-				wp_die( wp_json_encode( $response ) );
+				wp_die( WPSEO_Utils::format_json_encode( $response ) );
 			}
 		}
 

--- a/admin/ajax/class-shortcode-filter.php
+++ b/admin/ajax/class-shortcode-filter.php
@@ -36,6 +36,6 @@ class WPSEO_Shortcode_Filter {
 			);
 		}
 
-		wp_die( wp_json_encode( $parsed_shortcodes ) );
+		wp_die( WPSEO_Utils::format_json_encode( $parsed_shortcodes ) );
 	}
 }

--- a/admin/class-collector.php
+++ b/admin/class-collector.php
@@ -45,6 +45,6 @@ class WPSEO_Collector {
 	 * @return false|string The encode string.
 	 */
 	public function get_as_json() {
-		return wp_json_encode( $this->collect() );
+		return WPSEO_Utils::format_json_encode( $this->collect() );
 	}
 }

--- a/admin/class-yoast-alerts.php
+++ b/admin/class-yoast-alerts.php
@@ -139,7 +139,7 @@ class Yoast_Alerts {
 	private function output_ajax_response( $type ) {
 
 		$html = $this->get_view_html( $type );
-		echo wp_json_encode(
+		echo WPSEO_Utils::format_json_encode(
 			array(
 				'html'  => $html,
 				'total' => self::get_active_alert_count(),

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -370,7 +370,7 @@ class Yoast_Notification_Center {
 				$notification_json[] = $notification->render();
 			}
 
-			echo wp_json_encode( $notification_json );
+			echo WPSEO_Utils::format_json_encode( $notification_json );
 
 			return;
 		}

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -350,7 +350,7 @@ class Yoast_Notification {
 			return '';
 		}
 
-		return wp_json_encode( $this->options['data_json'] );
+		return WPSEO_Utils::format_json_encode( $this->options['data_json'] );
 	}
 
 	/**

--- a/admin/google_search_console/class-gsc-ajax.php
+++ b/admin/google_search_console/class-gsc-ajax.php
@@ -105,6 +105,6 @@ class WPSEO_GSC_Ajax {
 	private function get_profiles() {
 		$component = new WPSEO_Config_Component_Connect_Google_Search_Console();
 
-		wp_die( wp_json_encode( $component->get_data() ) );
+		wp_die( WPSEO_Utils::format_json_encode( $component->get_data() ) );
 	}
 }

--- a/admin/import/plugins/class-import-seopressor.php
+++ b/admin/import/plugins/class-import-seopressor.php
@@ -121,7 +121,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Plugin_Importer {
 		}
 
 		if ( $focus_keywords !== array() ) {
-			$this->maybe_save_post_meta( 'focuskeywords', wp_json_encode( $focus_keywords ), $post_id );
+			$this->maybe_save_post_meta( 'focuskeywords', WPSEO_Utils::format_json_encode( $focus_keywords ), $post_id );
 		}
 	}
 

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -119,7 +119,7 @@ function wpseo_get_rendered_tab( $table, $id ) {
 
 ?>
 <script>
-	var wpseoBulkEditorNonce = <?php echo wp_json_encode( wp_create_nonce( 'wpseo-bulk-editor' ) ); ?>;
+	var wpseoBulkEditorNonce = <?php echo WPSEO_Utils::format_json_encode( wp_create_nonce( 'wpseo-bulk-editor' ) ); ?>;
 
 	// eslint-disable-next-line
 	var wpseo_bulk_editor_nonce = wpseoBulkEditorNonce;

--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -65,28 +65,8 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 				'@graph'   => $graph,
 			);
 
-			echo "<script type='application/ld+json'>", $this->format_data( $output ), '</script>', "\n";
+			echo "<script type='application/ld+json'>", WPSEO_Utils::format_json_encode( $output ), '</script>', "\n";
 		}
-	}
-
-	/**
-	 * Prepares the data for outputting.
-	 *
-	 * @param array $data The data to format.
-	 *
-	 * @return false|string The prepared string.
-	 */
-	public function format_data( $data ) {
-		$flags = 0;
-		if ( version_compare( PHP_VERSION, '5.4', '>=' ) ) {
-			// @codingStandardsIgnoreLine This is used in the wp_json_encode call, which checks for this.
-			$flags = ( $flags | JSON_UNESCAPED_SLASHES );
-		}
-		if ( defined( 'WPSEO_DEBUG' ) && WPSEO_DEBUG ) {
-			$flags = ( $flags | JSON_PRETTY_PRINT );
-		}
-
-		return wp_json_encode( $data, $flags );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1152,6 +1152,26 @@ SVG;
 		return class_exists( 'WPSEO_MyYoast_Client' );
 	}
 
+	/**
+	 * Prepares data for outputting as JSON.
+	 *
+	 * @param array $data The data to format.
+	 *
+	 * @return false|string The prepared JSON string.
+	 */
+	public static function format_json_encode( $data ) {
+		$flags = 0;
+		if ( version_compare( PHP_VERSION, '5.4', '>=' ) ) {
+			// @codingStandardsIgnoreLine This is used in the wp_json_encode call, which checks for this.
+			$flags = ( $flags | JSON_UNESCAPED_SLASHES );
+		}
+		if ( defined( 'WPSEO_DEBUG' ) && WPSEO_DEBUG ) {
+			$flags = ( $flags | JSON_PRETTY_PRINT );
+		}
+
+		return wp_json_encode( $data, $flags );
+	}
+
 	/* ********************* DEPRECATED METHODS ********************* */
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1165,8 +1165,15 @@ SVG;
 			// @codingStandardsIgnoreLine This is used in the wp_json_encode call, which checks for this.
 			$flags = ( $flags | JSON_UNESCAPED_SLASHES );
 		}
-		if ( defined( 'WPSEO_DEBUG' ) && WPSEO_DEBUG ) {
+		if ( self::is_development_mode() ) {
 			$flags = ( $flags | JSON_PRETTY_PRINT );
+
+			/**
+			 * Filter the Yoast SEO development mode.
+			 *
+			 * @api array $data Allows filtering of the JSON data for debug purposes.
+			 */
+			$data = apply_filters( 'wpseo_debug_json_data', $data );
 		}
 
 		return wp_json_encode( $data, $flags );

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -295,7 +295,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 						// The data is stringified JSON. Use `json_decode` and `json_encode` around the sanitation.
 						$input         = json_decode( $meta_data[ $key ], true );
 						$sanitized     = array_map( array( 'WPSEO_Utils', 'sanitize_text_field' ), $input );
-						$clean[ $key ] = wp_json_encode( $sanitized );
+						$clean[ $key ] = WPSEO_Utils::format_json_encode( $sanitized );
 					}
 					elseif ( isset( $old_meta[ $key ] ) ) {
 						// Retain old value if field currently not in use.
@@ -317,7 +317,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 							);
 						}
 
-						$clean[ $key ] = wp_json_encode( $sanitized );
+						$clean[ $key ] = WPSEO_Utils::format_json_encode( $sanitized );
 					}
 					elseif ( isset( $old_meta[ $key ] ) ) {
 						// Retain old value if field currently not in use.

--- a/inc/structured-data-blocks/class-faq-block.php
+++ b/inc/structured-data-blocks/class-faq-block.php
@@ -44,7 +44,7 @@ class WPSEO_FAQ_Block implements WPSEO_WordPress_Integration {
 
 		$json_ld = $this->get_json_ld( $attributes );
 
-		return '<script type="application/ld+json">' . wp_json_encode( $json_ld ) . '</script>' . $content;
+		return '<script type="application/ld+json">' . WPSEO_Utils::format_json_encode( $json_ld ) . '</script>' . $content;
 	}
 
 	/**

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -44,7 +44,7 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 
 		$json_ld = $this->get_json_ld( $attributes );
 
-		return '<script type="application/ld+json">' . WPSEO_Schema( $json_ld ) . '</script>' . $content;
+		return '<script type="application/ld+json">' . WPSEO_Utils::format_json_encode( $json_ld ) . '</script>' . $content;
 	}
 
 	/**

--- a/inc/structured-data-blocks/class-how-to-block.php
+++ b/inc/structured-data-blocks/class-how-to-block.php
@@ -44,7 +44,7 @@ class WPSEO_How_To_Block implements WPSEO_WordPress_Integration {
 
 		$json_ld = $this->get_json_ld( $attributes );
 
-		return '<script type="application/ld+json">' . wp_json_encode( $json_ld ) . '</script>' . $content;
+		return '<script type="application/ld+json">' . WPSEO_Schema( $json_ld ) . '</script>' . $content;
 	}
 
 	/**

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -237,7 +237,7 @@ class Client {
 	protected function update_option() {
 		\WPSEO_Options::set(
 			'myyoast_oauth',
-			WPSEO_Utils::format_json_encode(
+			\WPSEO_Utils::format_json_encode(
 				[
 					'config'        => $this->config,
 					'access_tokens' => $this->access_tokens,

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -237,7 +237,7 @@ class Client {
 	protected function update_option() {
 		\WPSEO_Options::set(
 			'myyoast_oauth',
-			wp_json_encode(
+			WPSEO_Utils::format_json_encode(
 				[
 					'config'        => $this->config,
 					'access_tokens' => $this->access_tokens,

--- a/tests/config-ui/test-class-configuration-service.php
+++ b/tests/config-ui/test-class-configuration-service.php
@@ -171,7 +171,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 		$data = new WP_REST_Request();
 		$data->set_header( 'content-type', 'application/json' );
 
-		$data->set_body( wp_json_encode( $expected ) );
+		$data->set_body( WPSEO_Utils::format_json_encode( $expected ) );
 
 		$storage
 			->expects( $this->once() )

--- a/tests/formatter/test-metabox-formatter.php
+++ b/tests/formatter/test-metabox-formatter.php
@@ -50,7 +50,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		wp_mkdir_p( plugin_dir_path( WPSEO_FILE ) . 'languages' );
 		file_put_contents(
 			$file_name,
-			wp_json_encode( array( 'key' => 'value' ) )
+			WPSEO_Utils::format_json_encode( array( 'key' => 'value' ) )
 		);
 
 		$class_instance = new WPSEO_Metabox_Formatter(

--- a/tests/inc/options/test-class-wpseo-taxonomy-meta.php
+++ b/tests/inc/options/test-class-wpseo-taxonomy-meta.php
@@ -68,7 +68,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 			'wpseo_noindex'         => 'index',
 			'wpseo_canonical'       => 'https://yoast.com/',
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
-			'wpseo_focuskeywords'   => wp_json_encode(
+			'wpseo_focuskeywords'   => WPSEO_Utils::format_json_encode(
 				array(
 					array(
 						'keyword' => '\"test\"',
@@ -80,7 +80,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 					),
 				)
 			),
-			'wpseo_keywordsynonyms' => wp_json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( array( '""TESTING""', '""""' ) ),
 			'wpseo_focuskw'         => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_title'           => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" and \backslashes\.',
@@ -103,7 +103,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 		$expected = array(
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
 			'wpseo_canonical'       => 'https://yoast.com/test%20space',
-			'wpseo_focuskeywords'   => wp_json_encode(
+			'wpseo_focuskeywords'   => WPSEO_Utils::format_json_encode(
 				array(
 					array(
 						'keyword' => '\"test\"',
@@ -115,7 +115,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 					),
 				)
 			),
-			'wpseo_keywordsynonyms' => wp_json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( array( '""TESTING""', '""""' ) ),
 			'wpseo_focuskw'         => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_title'           => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" and \backslashes\.',
@@ -126,7 +126,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 			'wpseo_noindex'         => 'extra something',
 			'wpseo_canonical'       => 'https://yoast.com/test space',
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
-			'wpseo_focuskeywords'   => wp_json_encode(
+			'wpseo_focuskeywords'   => WPSEO_Utils::format_json_encode(
 				array(
 					array(
 						'keyword' => '\"test\"',
@@ -139,7 +139,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 					),
 				)
 			),
-			'wpseo_keywordsynonyms' => wp_json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( array( '""TESTING""', '""""' ) ),
 			'wpseo_focuskw'         => '  &quotdouble quotes" `>&lt;&gt;&#96<`and \backslashes\.  ',
 			'wpseo_title'           => '&quotdouble quotes"			and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" <>and<> \backslashes\.',

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -762,7 +762,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	protected function get_subscriptions() {
 		return json_decode(
-			wp_json_encode(
+			WPSEO_Utils::format_json_encode(
 				array(
 					'wp-seo-premium.php' => array(
 						'expiry_date' => $this->get_future_date(),

--- a/tests/inc/test-class-myyoast-api-request.php
+++ b/tests/inc/test-class-myyoast-api-request.php
@@ -197,7 +197,7 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 		$instance
 			->expects( $this->once() )
 			->method( 'do_request' )
-			->will( $this->returnValue( wp_json_encode( $response ) ) );
+			->will( $this->returnValue( WPSEO_Utils::format_json_encode( $response ) ) );
 
 		$this->assertTrue( $instance->fire() );
 		$this->assertAttributeEquals( (object) $response, 'response', $instance );

--- a/tests/notifications/test-class-yoast-notification.php
+++ b/tests/notifications/test-class-yoast-notification.php
@@ -110,7 +110,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 		$data = array( 'bla' );
 
 		$subject = new Yoast_Notification( 'message', array( 'data_json' => $data ) );
-		$this->assertEquals( $subject->get_json(), wp_json_encode( $data ) );
+		$this->assertEquals( $subject->get_json(), WPSEO_Utils::format_json_encode( $data ) );
 
 		$subject = new Yoast_Notification( 'message', array( 'data_json' => '' ) );
 		$this->assertEquals( $subject->get_json(), '' );


### PR DESCRIPTION
This introduces `WPSEO_Utils::format_json_encode` which has two advantages:

* we use unescaped slashes everywhere when possible, which improves readability and makes our JSON strings smaller.
* we always output JSON nicely when we can and `WPSEO_DEBUG` is on.

Because these advantages both seem useful _everywhere_, at the suggestion of @omarreiss  I've made this change everywhere we called `wp_json_encode` and replaced it with this new util. This new function also replaces the `format_data` function we had previously introduce in `WPSEO_Schema`.

Would like some dev and architect feedback on this, @atimmer @IreneStr @moorscode 