### PR TITLE
Add @yoast/configuration-wizard and @yoast/style-guide to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
   "devDependencies": {
     "@wordpress/babel-plugin-makepot": "^1.0.0",
     "@wordpress/babel-preset-default": "^1.1.3",
+    "@yoast/configuration-wizard": "^0.1.0",
     "@yoast/grunt-plugin-tasks": "^1.0.0",
+    "@yoast/style-guide": "^0.1.0",
     "algoliasearch": "^3.16.0",
     "autoprefixer": "^6.3.1",
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Adds two missing dependencies.
However, these packages *aren't released yet*! 
So, we cannot run `yarn install` on this branch yet.

## what needs to be done:
1. `@yoast/configuration-wizard` and `@yoast/style-guide` must be released to npm.
1. `yarn install` must be executed with this branch checked out.
1. The yarn.lock file must be committed.