### PR TITLE
Remove the loadingSpinner import from metabox.scss

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -4,7 +4,6 @@
 /*rtl:begin:ignore*/
 @import "../../node_modules/draft-js/dist/Draft";
 /*rtl:end:ignore*/
-@import "../../node_modules/yoast-components/css/loadingSpinner";
 
 @function svg-icon-list($color) {
 	@return inline-svg('<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path fill="#{$color}" d="M384 1408q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm0-512q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm1408 416v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5zm-1408-928q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm1408 416v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5zm0-512v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5z"/></svg>');


### PR DESCRIPTION
## Summary

It seems that the classes provided in the loadingSpinner are not used in the wordpress-seo repo and since we are removing the file altogether we should remove the import.

This PR can be summarized in the following changelog entry:

* Remove the loadingSpinner.scss import from metabox.scss.

## Relevant technical choices:

* See Yoast/javascript#152

## Test instructions
This PR can be tested by following these steps:

* Check that the build works and everything looks the same.

Related Yoast/javascript#152
