### PR TITLE
Bump yoastseo to 1.50 and yoast-components to 4.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,8 +143,8 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^3.2.6",
-    "yoast-components": "^4.23.0-rc.6",
-    "yoastseo": "^1.50.0-rc.6"
+    "yoast-components": "^4.23.0",
+    "yoastseo": "^1.50.0"
   },
   "yoast": {
     "pluginVersion": "10.1-RC5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12343,10 +12343,10 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yoast-components@^4.23.0-rc.6:
-  version "4.23.0-rc.6"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.23.0-rc.6.tgz#dce7a24ba7700a710352d605166fe878e75cf549"
-  integrity sha512-s4NxYMqhcvQMUxdzbMXahdYmh4JqvqBDGpo+Y2N4Se9VujsmIHkEeFnjDu5C00oMaCFLQx40E8ipkDr1eWidxg==
+yoast-components@^4.23.0:
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.23.0.tgz#c7a55e2c2f0ac59eadbdafe49cbde0a49b001897"
+  integrity sha512-UZQWLuCykRzfZXmTkt/gSKsdhSRFb8Plf2f2ig/VNvU8hxzeT2ARRNEVLGjhhpsCgB642s8DqZbhVmPySoLGTA==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -12368,14 +12368,14 @@ yoast-components@^4.23.0-rc.6:
     styled-components "^2.1.2"
     whatwg-fetch "^1.0.0"
     wicked-good-xpath "^1.3.0"
-    yoastseo "^1.50.0-rc.6"
+    yoastseo "^1.50.0"
   optionalDependencies:
     grunt-scss-to-json "^1.0.1"
 
-yoastseo@^1.50.0-rc.6:
-  version "1.50.0-rc.6"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.50.0-rc.6.tgz#780af268268efe0d1caaf28968968b7835179bbe"
-  integrity sha512-YBxGDudVncelNMYQYDp37HxrPfnF/LfaCNhPpzhh/0x23VXYa2XiZwGfwoM7c5jYksIzzJHC2freHm2BKyXFaQ==
+yoastseo@^1.50.0:
+  version "1.50.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.50.0.tgz#dba63d3902d3e04954bfb02624903466db22348f"
+  integrity sha512-0V7wbNsWiuBpz7zV3esScu1fI/k0uMmjy2RVnEkeBgL4ktk1EBCbbYmdkG5Sg8Bg3dfmtjzpEAzifQWsJYV1lA==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     htmlparser2 "^3.9.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Version bump for YoastSEO (to 1.50.0)
[non-user-facing] Version bump for Yoast Components (to 4.23.0)

## Test instructions
This PR can be tested by following these steps:

* Build the files, see no errors. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as 