### PR TITLE
Resolves issue #12558: Moved check for sitemap parameter up so that only sitemaps are target…

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -230,6 +230,12 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
+		$type = get_query_var( 'sitemap' );
+
+		if ( empty( $type ) ) {
+			return;
+		}
+
 		$xsl = get_query_var( 'xsl' );
 
 		if ( ! empty( $xsl ) ) {
@@ -243,12 +249,6 @@ class WPSEO_Sitemaps {
 			$this->xsl_output( $xsl );
 			$this->sitemap_close();
 
-			return;
-		}
-
-		$type = get_query_var( 'sitemap' );
-
-		if ( empty( $type ) ) {
 			return;
 		}
 


### PR DESCRIPTION
…ted for redirection

## Summary

This PR can be summarized in the following changelog entry:

* Moved check for sitemap parameter up so that only sitemaps are targeted for redirection

## Relevant technical choices:

* Short circuiting the logic used to determine whether a redirect should apply. Check for targeting a sitemap first, then the xsl parameter.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Go to any website with Yoast installed and activated.
2. Navigate to almost any page where Yoast's hooks may run.
3. Add "?xsl=whatever" to the end of the URL
4. Observe a blank page

Examples:
https://yoast.com/?xsl=lolwat
https://www.whitehouse.gov/?xsl=itseverywhere
https://www.clockwork.com/impact/?xsl=whatever
https://uwosh.edu/admissions/?xsl=omg



## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12558