### PR TITLE
Make sure error-code is a number

### DIFF
--- a/inc/class-my-yoast-api-request.php
+++ b/inc/class-my-yoast-api-request.php
@@ -152,7 +152,7 @@ class WPSEO_MyYoast_Api_Request {
 		$response          = wp_remote_request( $url, $request_arguments );
 
 		if ( is_wp_error( $response ) ) {
-			throw new WPSEO_MyYoast_Bad_Request_Exception( $response->get_error_message(), $response->get_error_code() );
+			throw new WPSEO_MyYoast_Bad_Request_Exception( $response->get_error_message() );
 		}
 
 		$response_code    = wp_remote_retrieve_response_code( $response );
@@ -168,7 +168,7 @@ class WPSEO_MyYoast_Api_Request {
 			throw new WPSEO_MyYoast_Authentication_Exception( esc_html( $response_message ), 401 );
 		}
 
-		throw new WPSEO_MyYoast_Bad_Request_Exception( esc_html( $response_message ), $response_code );
+		throw new WPSEO_MyYoast_Bad_Request_Exception( esc_html( $response_message ), (int) $response_code );
 	}
 
 	/**

--- a/tests/doubles/class-my-yoast-api-request-double.php
+++ b/tests/doubles/class-my-yoast-api-request-double.php
@@ -11,15 +11,16 @@
 class WPSEO_MyYoast_Api_Request_Double extends WPSEO_MyYoast_Api_Request {
 
 	/**
-	 * Checks if MyYoast tokens are allowed and adds the token to the request body.
-	 *
-	 * When tokens are disallowed it will add the url to the request body.
-	 *
-	 * @param array $request_arguments The arguments to enrich.
-	 *
-	 * @return array The enriched arguments.
+	 * @inheritdoc
 	 */
 	public function enrich_request_arguments( array $request_arguments ) {
 		return parent::enrich_request_arguments( $request_arguments );
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function do_request( $url, $request_arguments ) {
+		return parent::do_request( $url, $request_arguments );
 	}
 }

--- a/tests/inc/test-class-myyoast-api-request.php
+++ b/tests/inc/test-class-myyoast-api-request.php
@@ -310,4 +310,23 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			$instance->enrich_request_arguments( array() )
 		);
 	}
+
+	/**
+	 * Test Exception is being called correctly.
+	 *
+	 * Unit test to make sure this is fixed: https://github.com/Yoast/wordpress-seo/issues/12560
+	 *
+	 * @expectedException        WPSEO_MyYoast_Bad_Request_Exception
+	 * @expectedExceptionMessage Error
+	 */
+	public function test_exception_arguments() {
+		add_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
+
+		$instance = new WPSEO_MyYoast_Api_Request_Double( 'some_url', array() );
+		$instance->do_request( 'some_url', array() );
+	}
+
+	public function return_error_object() {
+		return new WP_Error( 'error-code', 'Error' );
+	}
 }

--- a/tests/inc/test-class-myyoast-api-request.php
+++ b/tests/inc/test-class-myyoast-api-request.php
@@ -324,6 +324,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 
 		$instance = new WPSEO_MyYoast_Api_Request_Double( 'some_url', array() );
 		$instance->do_request( 'some_url', array() );
+
+		remove_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
 	}
 
 	public function return_error_object() {

--- a/tests/inc/test-class-myyoast-api-request.php
+++ b/tests/inc/test-class-myyoast-api-request.php
@@ -328,6 +328,11 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 		remove_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
 	}
 
+	/**
+	 * Helper function for the `test_exception_arguments` test
+	 *
+	 * @return WP_Error
+	 */
 	public function return_error_object() {
 		return new WP_Error( 'error-code', 'Error' );
 	}

--- a/tests/inc/test-class-myyoast-api-request.php
+++ b/tests/inc/test-class-myyoast-api-request.php
@@ -320,12 +320,12 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	 * @expectedExceptionMessage Error
 	 */
 	public function test_exception_arguments() {
-		add_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
+		add_filter( 'pre_http_request', array( $this, 'return_error_object' ) );
 
 		$instance = new WPSEO_MyYoast_Api_Request_Double( 'some_url', array() );
 		$instance->do_request( 'some_url', array() );
 
-		remove_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
+		remove_filter( 'pre_http_request', array( $this, 'return_error_object' ) );
 	}
 
 	/**


### PR DESCRIPTION
Instead of a string, as most error codes in WordPress are.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error can occur on license requests which return an unexpected result.


## Relevant technical choices:

* Make sure the Exception second argument is always a number or not given at all

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Trigger a `WP_Error` in the license request (`$response = new WP_Error( 'error-code', 'Error' );`)
* Go to either: Dashboard, Yoast SEO Dashboard, Plugin page or Premium page.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #12560 
