### PR TITLE
Remove Free from default addons list

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -65,8 +65,6 @@ class WPSEO_Addon_Manager {
 	 * @var array
 	 */
 	protected static $addons = array(
-		// Yoast SEO Free isn't an addon actually, but we needed it in some cases.
-		'wp-seo.php'            => self::FREE_SLUG,
 		'wp-seo-premium.php'    => self::PREMIUM_SLUG,
 		'wpseo-news.php'        => self::NEWS_SLUG,
 		'video-seo.php'         => self::VIDEO_SLUG,
@@ -336,7 +334,14 @@ class WPSEO_Addon_Manager {
 	 * @return string The slug when found or empty string when not.
 	 */
 	protected function get_slug_by_plugin_file( $plugin_file ) {
-		foreach ( self::$addons as $addon => $addon_slug ) {
+		$addons = self::$addons;
+
+		// Yoast SEO Free isn't an addon, but we needed it in Premium to fetch translations.
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+			$addons['wp-seo.php'] = self::FREE_SLUG;
+		}
+
+		foreach ( $addons as $addon => $addon_slug ) {
 			if ( strpos( $plugin_file, $addon ) !== false ) {
 				return $addon_slug;
 			}


### PR DESCRIPTION
Only add it conditionally when Premium is active.
This is needed for the translations updates of the free translations.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes the situation where Yoast SEO would contact Yoast.com for license checks even when no Yoast addons are installed.

## Relevant technical choices:

* Conditionally add the Free plugin as addon when relevant (in Premium to make sure we can fetch the Free translation file updates from WordPress.org)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12571
