### PR TITLE
Backport transient updates form Premium patch

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -90,7 +90,11 @@ class WPSEO_Addon_Manager {
 	 * @return stdClass The site information.
 	 */
 	public function get_site_information() {
-		$site_information = $this->get_site_information_transient();
+		static $site_information = null;
+
+		if ( $site_information === null ) {
+			$site_information = $this->get_site_information_transient();
+		}
 
 		if ( $site_information ) {
 			return $site_information;
@@ -392,7 +396,31 @@ class WPSEO_Addon_Manager {
 	 * @return stdClass|false The transient value.
 	 */
 	protected function get_site_information_transient() {
+		global $pagenow;
+
+		// Force re-check on license & dashboard pages.
+		$current_page = $this->get_current_page();
+		// Check whether the licenses are valid or whether we need to show notifications.
+		$exclude_cache = ( $current_page === 'wpseo_licenses' || $current_page === 'wpseo_dashboard' );
+
+		// Also do a fresh request on Plugins & Core Update pages.
+		$exclude_cache = $exclude_cache || $pagenow === 'plugins.php';
+		$exclude_cache = $exclude_cache || $pagenow === 'update-core.php';
+
+		if ( $exclude_cache ) {
+			return false;
+		}
+
 		return get_transient( self::SITE_INFORMATION_TRANSIENT );
+	}
+
+	/**
+	 * Returns the current page.
+	 *
+	 * @return string The current page.
+	 */
+	protected function get_current_page() {
+		return filter_input( INPUT_GET, 'page' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,13 @@ You'll find answers to many of your questions on [kb.yoast.com](https://yoa.st/1
 
 == Changelog ==
 
+= 10.1.3 =
+Release Date: ?
+
+Bugfixes:
+
+* Fixes a bug where the license information from MyYoast is being saved aggressively, causing updates in MyYoast to take 24 hours to show up in the site.
+
 = 10.1.2 =
 Release Date: April 3rd, 2019
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the license information from MyYoast is being saved aggressively, causing updates in MyYoast to take 24 hours to show up in the site.

## Relevant technical choices:

* Statically cache the response on the current request
* Early return `false` for the transient content on certain pages in the admin, because the upgrade notification needs the information on all pages and we don't want to do the request on all the pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
