### PR TITLE
Check if we are in Premium first

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -220,7 +220,7 @@ class WPSEO_Admin {
 		}
 
 		$addon_manager = new WPSEO_Addon_Manager();
-		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) && WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( WPSEO_Utils::is_yoast_seo_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
 			return $links;
 		}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -188,7 +188,7 @@ class Yoast_Form {
 	public function admin_sidebar() {
 		// No banners in Premium.
 		$addon_manager = new WPSEO_Addon_Manager();
-		if ( $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) && WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( WPSEO_Utils::is_yoast_seo_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
 			return;
 		}
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -105,7 +105,7 @@ if ( WPSEO_Utils::is_woocommerce_active() ) {
 }
 
 $addon_manager                  = new WPSEO_Addon_Manager();
-$has_valid_premium_subscription = $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG );
+$has_valid_premium_subscription = WPSEO_Utils::is_yoast_seo_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG );
 
 /* translators: %1$s expands to Yoast SEO. */
 $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );


### PR DESCRIPTION
Before doing a license check on the Premium slug, this avoids doing calls to MyYoast.

## Summary

This PR can be summarized in the following changelog entry:

* tbd

## Relevant technical choices:

* Doing a check if Premium is activated before additional checks on the license.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install Yoast SEO on a site where no other addons (or Premium) is present
* Visiting any page in site should not trigger an HTTP request to MyYoast
  * The previous patch has removed this request from -most- pages, this PR removes it from the `Plugins`, `Premium` and settings pages (which have upsells).
  * Makes sure to check: Post overview, Post edit, Taxonomy overview, Taxonomy edit, Yoast SEO settings pages, Configuration Wizard, Plugin overview, dashboard, WordPress Core updates pages.
  * Checking this can be done using the Query Monitor plugin (or any other plugin that will show you what HTTP requests are being done.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12571
