### PR TITLE
Documentation: use @see tag

### DIFF
--- a/tests/test-class-wpseo-meta.php
+++ b/tests/test-class-wpseo-meta.php
@@ -53,7 +53,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 * When unserialized data is stored it will not be returned because the
 	 * field definition is missing which declares if the data is serialized.
 	 *
-	 * See self::test_get_value_unregistered_field_serialized()
+	 * @see self::test_get_value_unregistered_field_serialized()
 	 *
 	 * @covers WPSEO_Meta::set_value()
 	 * @covers WPSEO_Meta::get_value()


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

Ref: http://docs.phpdoc.org/references/phpdoc/tags/see.html

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.