### PR TITLE
Documentation: some method docblock format improvements

### DIFF
--- a/inc/sitemaps/class-sitemap-cache-data.php
+++ b/inc/sitemaps/class-sitemap-cache-data.php
@@ -106,9 +106,11 @@ class WPSEO_Sitemap_Cache_Data implements WPSEO_Sitemap_Cache_Data_Interface, Se
 	/**
 	 * String representation of object
 	 *
-	 * @link  http://php.net/manual/en/serializable.serialize.php
-	 * @return string the string representation of the object or null
+	 * @link http://php.net/manual/en/serializable.serialize.php
+	 *
 	 * @since 5.1.0
+	 *
+	 * @return string The string representation of the object or null.
 	 */
 	public function serialize() {
 
@@ -123,12 +125,13 @@ class WPSEO_Sitemap_Cache_Data implements WPSEO_Sitemap_Cache_Data_Interface, Se
 	/**
 	 * Constructs the object
 	 *
-	 * @link  http://php.net/manual/en/serializable.unserialize.php
+	 * @link http://php.net/manual/en/serializable.unserialize.php
+	 *
+	 * @since 5.1.0
 	 *
 	 * @param string $serialized The string representation of the object.
 	 *
 	 * @return void
-	 * @since 5.1.0
 	 */
 	public function unserialize( $serialized ) {
 

--- a/src/config/admin.php
+++ b/src/config/admin.php
@@ -19,9 +19,9 @@ class Admin implements Integration {
 	/**
 	 * Initializes the integration.
 	 *
-	 * @codeCoverageIgnore
-	 *
 	 * This is the place to register hooks and filters.
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

A method/function docblock has guidelines for information order and such. It is typically laid out like:
```php
/**
 * Short description.
 *
 * Long description....
 *
 * @tag Tag description.
 * @tag Tag description.
 *
 * @param type $name Parameter description.
 *
 * @return type Description.
 */
```

While the order of some of these is not 100% clearly defined, the short and long description _have_ to be at the top and the `@param` and `@return` tags have to be at the bottom and shouldn't be combined in a block with other tags.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.