### PR TITLE
Documentation: don't use docblocks for inline comments

### DIFF
--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -156,7 +156,8 @@ class WPSEO_Option_Social extends WPSEO_Option {
 				case 'twitter_site':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 						$twitter_id = sanitize_text_field( ltrim( $dirty[ $key ], '@' ) );
-						/**
+
+						/*
 						 * From the Twitter documentation about twitter screen names:
 						 * Typically a maximum of 15 characters long, but some historical accounts
 						 * may exist with longer names.

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -251,7 +251,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 			array( '%d', '%s', '%s' )
 		);
 
-		/**
+		/*
 		 * The result of Upsert is the number of affected rows.
 		 * As it internally does an Insert and then an Update, it will count as 2 rows.
 		 *


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

See #12390



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.