### PR TITLE
Change the URL for the courses feed

### DIFF
--- a/admin/courses-overview.php
+++ b/admin/courses-overview.php
@@ -25,19 +25,6 @@ class WPSEO_Courses_Overview implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Returns the Yoast SEO version the user currently is using.
-	 *
-	 * @return string The version: Free or Premium.
-	 */
-	private function get_version() {
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
-			return 'premium';
-		}
-
-		return 'free';
-	}
-
-	/**
 	 * Enqueue the relevant script.
 	 *
 	 * @return void
@@ -46,7 +33,6 @@ class WPSEO_Courses_Overview implements WPSEO_WordPress_Integration {
 		wp_enqueue_script( WPSEO_Admin_Asset_Manager::PREFIX . 'courses-overview' );
 
 		$localizations = array(
-			'version' => $this->get_version(),
 			'isRtl'   => is_rtl(),
 		);
 		wp_localize_script(

--- a/js/src/courses-overview.js
+++ b/js/src/courses-overview.js
@@ -38,19 +38,17 @@ class CoursesOverview extends React.Component {
 			courses: null,
 		};
 
-		this.getFeed( wpseoCoursesOverviewL10n.version );
+		this.getFeed();
 	}
 
 	/**
 	 * Fetches data from the yoast.com feed, parses it and sets it to the state.
 	 *
-	 * @param {String} version The active Yoast SEO version.
-	 *
 	 * @returns {void}
 	 */
-	getFeed( version ) {
+	getFeed() {
 		// Developer note: this link should -not- be converted to a shortlink.
-		getCourseFeed( "https://yoast.com/?feed=courses&license=" + version )
+		getCourseFeed( "https://yoast.com/feed/courses/" )
 			.then( ( feed ) => {
 				feed.items = feed.items.map( ( item ) => {
 					return item;


### PR DESCRIPTION
I see no reason for us to add the type of plugin to the courses feed. Updating the URL for caching reasons.

## Summary

This PR can be summarized in the following changelog entry:

* None needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Courses tab should still work.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
