### PR TITLE
Remove publisher tag

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -86,7 +86,6 @@ class WPSEO_Frontend {
 		add_action( 'wpseo_head', array( $this, 'robots' ), 10 );
 		add_action( 'wpseo_head', array( $this, 'canonical' ), 20 );
 		add_action( 'wpseo_head', array( $this, 'adjacent_rel_links' ), 21 );
-		add_action( 'wpseo_head', array( $this, 'publisher' ), 22 );
 
 		// Remove actions that we will handle through our wpseo_head call, and probably change the output of.
 		remove_action( 'wp_head', 'rel_canonical' );
@@ -1148,22 +1147,6 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * Output the rel=publisher code on every page of the site.
-	 *
-	 * @return boolean Boolean indicating whether the publisher link was printed.
-	 */
-	public function publisher() {
-		$publisher = WPSEO_Options::get( 'plus-publisher', '' );
-		if ( $publisher !== '' ) {
-			echo '<link rel="publisher" href="', esc_url( $publisher ), '"/>', "\n";
-
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Outputs the meta description element or returns the description text.
 	 *
 	 * @param bool $echo Echo or return output flag.
@@ -1925,5 +1908,18 @@ class WPSEO_Frontend {
 		_deprecated_function( __METHOD__, 'WPSEO 9.6' );
 
 		return $title;
+	}
+
+	/**
+	 * Output the rel=publisher code on every page of the site.
+	 *
+	 * @deprecated 10.1.3
+	 *
+	 * @return boolean Boolean indicating whether the publisher link was printed.
+	 */
+	public function publisher() {
+		_deprecated_function( __METHOD__, 'WPSEO 10.1.3' );
+
+		return false;
 	}
 }

--- a/frontend/class-json-ld.php
+++ b/frontend/class-json-ld.php
@@ -251,7 +251,6 @@ class WPSEO_JSON_LD implements WPSEO_WordPress_Integration {
 			'facebook_site',
 			'instagram_url',
 			'linkedin_url',
-			'plus-publisher',
 			'myspace_url',
 			'youtube_url',
 			'pinterest_url',

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -34,7 +34,6 @@ class WPSEO_Option_Social extends WPSEO_Option {
 		'opengraph'             => true,
 		'pinterest_url'         => '',
 		'pinterestverify'       => '',
-		'plus-publisher'        => '', // Text field.
 		'twitter'               => true,
 		'twitter_site'          => '', // Text field.
 		'twitter_card_type'     => 'summary_large_image',
@@ -132,7 +131,6 @@ class WPSEO_Option_Social extends WPSEO_Option {
 				case 'linkedin_url':
 				case 'myspace_url':
 				case 'pinterest_url':
-				case 'plus-publisher':
 				case 'og_default_image':
 				case 'og_frontpage_image':
 				case 'youtube_url':

--- a/tests/frontend/test-class-wpseo-frontend.php
+++ b/tests/frontend/test-class-wpseo-frontend.php
@@ -383,25 +383,6 @@ Page 3/3
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::publisher
-	 */
-	public function test_publisher() {
-
-		// No publisher set.
-		$this->assertFalse( self::$class_instance->publisher() );
-
-		// Set publisher option.
-		$expected = 'https://plus.google.com/+JoostdeValk';
-		WPSEO_Options::set( 'plus-publisher', $expected );
-
-		// Publisher set, should echo.
-		$expected = '<link rel="publisher" href="' . esc_url( $expected ) . '"/>' . "\n";
-
-		$this->assertTrue( self::$class_instance->publisher() );
-		$this->expectOutput( $expected );
-	}
-
-	/**
 	 * @covers WPSEO_Frontend::nofollow_link
 	 */
 	public function test_nofollow_link() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `rel="publisher"` Google+ tag was being output on the frontend if that profile was provided in the past.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12588
