### PR TITLE
Always load the Addon Manager

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -111,7 +111,6 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_Expose_Shortlinks();
 		$integrations[] = new WPSEO_MyYoast_Proxy();
 		$integrations[] = new WPSEO_MyYoast_Route();
-		$integrations[] = new WPSEO_Addon_Manager();
 		$integrations[] = $this->admin_features['google_search_console'];
 		$integrations   = array_merge( $integrations, $this->initialize_seo_links(), $this->initialize_cornerstone_content() );
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -499,6 +499,9 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 
 		new Yoast_Alerts();
 
+		$yoast_addon_manager = new WPSEO_Addon_Manager();
+		$yoast_addon_manager->register_hooks();
+
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			require_once WPSEO_PATH . 'admin/ajax.php';
 


### PR DESCRIPTION
Instead of only when doing AJAX and `inline-save`

## Summary

This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

* Always register the Addon Manager hooks, these were not hooked on AJAX requests.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2316
