### PR TITLE
Remove two notifications

### DIFF
--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -36,15 +36,7 @@ class WPSEO_Product_Upsell_Notice {
 	 * Checks if the notice should be added or removed.
 	 */
 	public function initialize() {
-		if ( $this->is_notice_dismissed() ) {
-			$this->remove_notification();
-
-			return;
-		}
-
-		if ( $this->should_add_notification() ) {
-			$this->add_notification();
-		}
+		$this->remove_notification();
 	}
 
 	/**

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -82,13 +82,7 @@ class WPSEO_GSC implements WPSEO_WordPress_Integration {
 	public function register_gsc_notification() {
 		$notification        = $this->get_profile_notification();
 		$notification_center = Yoast_Notification_Center::get();
-
-		if ( $this->has_profile() ) {
-			$notification_center->remove_notification( $notification );
-
-			return;
-		}
-		$notification_center->add_notification( $notification );
+		$notification_center->remove_notification( $notification );
 	}
 
 	/**


### PR DESCRIPTION
The "please rate this plugin" and "connect your GSC" notifications should not be shown anymore.

## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Disabled the "please rate" notification & the "connect to Google Search Console" notification

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Google Search Console:
* Make sure you don't see the Google Search Console-connect notification, even when not connected to Google Search Console.

5-star rating:
* Make sure you meet all the conditions to show the `5-star rating` notification:
  * Have the following database option settings:
    * `wpseo` -> `wpseofirst_activated_on` - timestamp larger than two weeks in the past (`1491392325`)
    * User meta option: `wpseo-remove-upsell-notice` should be removed if present
* Don't see the notification being displayed on the dashboard

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12599
