### PR TITLE
Remove two notifications

### DIFF
--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -36,6 +36,11 @@ class WPSEO_Product_Upsell_Notice {
 	 * Checks if the notice should be added or removed.
 	 */
 	public function initialize() {
+		// Joost de Valk, April 6 2019.
+		// Temporarily override the entire system and remove the notification.
+		$this->remove_notification();
+		return;
+
 		if ( $this->is_notice_dismissed() ) {
 			$this->remove_notification();
 

--- a/admin/google_search_console/class-gsc.php
+++ b/admin/google_search_console/class-gsc.php
@@ -67,7 +67,7 @@ class WPSEO_GSC implements WPSEO_WordPress_Integration {
 			$this->request_handler();
 		}
 
-		add_action( 'admin_init', array( $this, 'register_gsc_notification' ) );
+		add_action( 'admin_init', array( $this, 'unregister_gsc_notification' ) );
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 	}
 
@@ -79,16 +79,10 @@ class WPSEO_GSC implements WPSEO_WordPress_Integration {
 	 *
 	 * @return void
 	 */
-	public function register_gsc_notification() {
+	public function unregister_gsc_notification() {
 		$notification        = $this->get_profile_notification();
 		$notification_center = Yoast_Notification_Center::get();
-
-		if ( $this->has_profile() ) {
-			$notification_center->remove_notification( $notification );
-
-			return;
-		}
-		$notification_center->add_notification( $notification );
+		$notification_center->remove_notification( $notification );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove notification for Google Search Console connection. It doesn't directly affect your rankings and we should therefor not throw a notification for it.
* Remove notification that requests giving a rating on wordpress.org, we're going to find a better way of doing this.

## Relevant technical choices:

* Code still exists, it's only short-circuited, let's clean it up better for 11.1.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* You should no longer have notifications for Google Search Console and for giving a plugin rating.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
