### PR TITLE
Restore classname

### DIFF
--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -163,6 +163,7 @@ class DashboardWidget extends React.Component {
 		}
 
 		return <WordpressFeed
+			className="wordpress-feed"
 			key="yoast-seo-blog-feed"
 			title={ wpseoDashboardWidgetL10n.feed_header }
 			feed={ this.state.feed }


### PR DESCRIPTION
Partially fixes https://github.com/Yoast/javascript/issues/205
## Summary

The WordPress Feed component's classname was changed. This PR restores it.


OLD
---
![image](https://user-images.githubusercontent.com/5352634/55705658-8d9d8300-59df-11e9-88ab-ef73a4b2b5d9.png)

NEW
---
![image](https://user-images.githubusercontent.com/5352634/55705560-57f89a00-59df-11e9-8d5b-98e78e6818b0.png)

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* I choose to overwrite the new classname with the old classname so we can maintain BC (and it's the easiest solution).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Verify that the dashboard widget looks like in the screenshot.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

