### PR TITLE
Replace xsl variable with yoast_xsl

### DIFF
--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -29,11 +29,11 @@ class WPSEO_Sitemaps_Router {
 
 		$wp->add_query_var( 'sitemap' );
 		$wp->add_query_var( 'sitemap_n' );
-		$wp->add_query_var( 'yoast_xsl' );
+		$wp->add_query_var( 'yoast-sitemap-xsl' );
 
 		add_rewrite_rule( 'sitemap_index\.xml$', 'index.php?sitemap=1', 'top' );
 		add_rewrite_rule( '([^/]+?)-sitemap([0-9]+)?\.xml$', 'index.php?sitemap=$matches[1]&sitemap_n=$matches[2]', 'top' );
-		add_rewrite_rule( '([a-z]+)?-?sitemap\.xsl$', 'index.php?yoast_xsl=$matches[1]', 'top' );
+		add_rewrite_rule( '([a-z]+)?-?sitemap\.xsl$', 'index.php?yoast-sitemap-xsl=$matches[1]', 'top' );
 	}
 
 	/**
@@ -45,7 +45,7 @@ class WPSEO_Sitemaps_Router {
 	 */
 	public function redirect_canonical( $redirect ) {
 
-		if ( get_query_var( 'sitemap' ) || get_query_var( 'yoast_xsl' ) ) {
+		if ( get_query_var( 'sitemap' ) || get_query_var( 'yoast-sitemap-xsl' ) ) {
 			return false;
 		}
 

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -29,11 +29,11 @@ class WPSEO_Sitemaps_Router {
 
 		$wp->add_query_var( 'sitemap' );
 		$wp->add_query_var( 'sitemap_n' );
-		$wp->add_query_var( 'xsl' );
+		$wp->add_query_var( 'yoast_xsl' );
 
 		add_rewrite_rule( 'sitemap_index\.xml$', 'index.php?sitemap=1', 'top' );
 		add_rewrite_rule( '([^/]+?)-sitemap([0-9]+)?\.xml$', 'index.php?sitemap=$matches[1]&sitemap_n=$matches[2]', 'top' );
-		add_rewrite_rule( '([a-z]+)?-?sitemap\.xsl$', 'index.php?xsl=$matches[1]', 'top' );
+		add_rewrite_rule( '([a-z]+)?-?sitemap\.xsl$', 'index.php?yoast_xsl=$matches[1]', 'top' );
 	}
 
 	/**
@@ -45,7 +45,7 @@ class WPSEO_Sitemaps_Router {
 	 */
 	public function redirect_canonical( $redirect ) {
 
-		if ( get_query_var( 'sitemap' ) || get_query_var( 'xsl' ) ) {
+		if ( get_query_var( 'sitemap' ) || get_query_var( 'yoast_xsl' ) ) {
 			return false;
 		}
 

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -175,7 +175,7 @@ class WPSEO_Sitemaps {
 	public function register_xsl( $name, $function, $rewrite = '' ) {
 		add_action( 'wpseo_xsl_' . $name, $function );
 		if ( ! empty( $rewrite ) ) {
-			add_rewrite_rule( $rewrite, 'index.php?yoast_xsl=' . $name, 'top' );
+			add_rewrite_rule( $rewrite, 'index.php?yoast-sitemap-xsl=' . $name, 'top' );
 		}
 	}
 
@@ -230,9 +230,9 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
-		$yoast_xsl = get_query_var( 'yoast_xsl' );
+		$yoast_sitemap_xsl = get_query_var( 'yoast-sitemap-xsl' );
 
-		if ( ! empty( $yoast_xsl ) ) {
+		if ( ! empty( $yoast_sitemap_xsl ) ) {
 			/*
 			 * This is a method to provide the XSL via the home_url.
 			 * Needed when the site_url and home_url are not the same.
@@ -240,7 +240,7 @@ class WPSEO_Sitemaps {
 			 *
 			 * Whenever home_url and site_url are the same, the file can be loaded directly.
 			 */
-			$this->xsl_output( $yoast_xsl );
+			$this->xsl_output( $yoast_sitemap_xsl );
 			$this->sitemap_close();
 
 			return;

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -175,7 +175,7 @@ class WPSEO_Sitemaps {
 	public function register_xsl( $name, $function, $rewrite = '' ) {
 		add_action( 'wpseo_xsl_' . $name, $function );
 		if ( ! empty( $rewrite ) ) {
-			add_rewrite_rule( $rewrite, 'index.php?xsl=' . $name, 'top' );
+			add_rewrite_rule( $rewrite, 'index.php?yoast_xsl=' . $name, 'top' );
 		}
 	}
 
@@ -230,9 +230,9 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
-		$xsl = get_query_var( 'xsl' );
+		$yoast_xsl = get_query_var( 'yoast_xsl' );
 
-		if ( ! empty( $xsl ) ) {
+		if ( ! empty( $yoast_xsl ) ) {
 			/*
 			 * This is a method to provide the XSL via the home_url.
 			 * Needed when the site_url and home_url are not the same.
@@ -240,7 +240,7 @@ class WPSEO_Sitemaps {
 			 *
 			 * Whenever home_url and site_url are the same, the file can be loaded directly.
 			 */
-			$this->xsl_output( $xsl );
+			$this->xsl_output( $yoast_xsl );
 			$this->sitemap_close();
 
 			return;

--- a/tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -47,7 +47,7 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 		set_query_var( 'sitemap', 'sitemap_value' );
 		$this->assertFalse( self::$class_instance->redirect_canonical( $url ) );
 
-		set_query_var( 'xsl', 'xsl_value' );
+		set_query_var( 'yoast_xsl', 'xsl_value' );
 		$this->assertFalse( self::$class_instance->redirect_canonical( $url ) );
 	}
 

--- a/tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -47,7 +47,7 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 		set_query_var( 'sitemap', 'sitemap_value' );
 		$this->assertFalse( self::$class_instance->redirect_canonical( $url ) );
 
-		set_query_var( 'yoast_xsl', 'xsl_value' );
+		set_query_var( '$yoast_sitemap_xsl', 'xsl_value' );
 		$this->assertFalse( self::$class_instance->redirect_canonical( $url ) );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where URLs with a non-Yoast SEO related xsl query string parameter would result in a blank page. Props [@stodorovic](https://github.com/stodorovic) and [@yiska](https://github.com/yiska).

## Relevant technical choices:

* We have changed query variable to avoid possible conflicts with other plugins.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Apply changes from this PR. 
* Save Permalinks to flush new rewrite rules.
*  Test xsl style-sheets:
_https&#58;//example&#46;com/main-sitemap.xsl_ 
_https&#58;//example&#46;com/?yoast-sitemap-xsl=main_ 
* Install and activate _Yoast SEO: News_
*  Test xsl style-sheets:
_https&#58;//example&#46;com/news-sitemap.xsl_ 
_https&#58;//example&#46;com/?yoast-sitemap-xsl=news_ 
* Test that YoastSEO is not hijacking all urls with an "xsl" parameter anymore:
 _https&#58;//example&#46;com/?xsl=blabla_ shouldn't result in a blank page. 


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12558 
