### PR TITLE
12540 fix gutenberg type check

### DIFF
--- a/js/src/helpers/isGutenbergAvailable.js
+++ b/js/src/helpers/isGutenbergAvailable.js
@@ -1,6 +1,6 @@
 /* global wp */
 
-import isUndefined from "lodash/isUndefined";
+import isNil from "lodash/isNil";
 import isFunction from "lodash/isFunction";
 
 /**
@@ -10,9 +10,9 @@ import isFunction from "lodash/isFunction";
  */
 export const isGutenbergDataAvailable = () => {
 	return (
-		! isUndefined( window.wp ) &&
-		! isUndefined( wp.data ) &&
-		! isUndefined( wp.data.select( "core/editor" ) ) &&
+		! isNil( window.wp ) &&
+		! isNil( wp.data ) &&
+		! isNil( wp.data.select( "core/editor" ) ) &&
 		isFunction( wp.data.select( "core/editor" ).getEditedPostAttribute )
 	);
 };

--- a/js/src/helpers/isGutenbergDataAvailable.js
+++ b/js/src/helpers/isGutenbergDataAvailable.js
@@ -1,6 +1,6 @@
 /* global wp */
 
-import isUndefined from "lodash/isUndefined";
+import isNil from "lodash/isNil";
 import isFunction from "lodash/isFunction";
 
 /**
@@ -10,10 +10,10 @@ import isFunction from "lodash/isFunction";
  */
 const isGutenbergDataAvailable = () => {
 	return (
-		! isUndefined( window.wp ) &&
-		! isUndefined( wp.data ) &&
-		! isUndefined( wp.data.select( "core/edit-post" ) ) &&
-		! isUndefined( wp.data.select( "core/editor" ) ) &&
+		! isNil( window.wp ) &&
+		! isNil( wp.data ) &&
+		! isNil( wp.data.select( "core/edit-post" ) ) &&
+		! isNil( wp.data.select( "core/editor" ) ) &&
 		isFunction( wp.data.select( "core/editor" ).getEditedPostAttribute )
 	);
 };

--- a/js/tests/isGutenbergAvailable.test.js
+++ b/js/tests/isGutenbergAvailable.test.js
@@ -26,4 +26,10 @@ describe( "isGutenbergDataAvailable", () => {
 		const actual = isGutenbergDataAvailable();
 		expect( actual ).toBe( false );
 	} );
+
+	it( "returns false if wp.data is available but the required selectors not registered", () => {
+		window.wp = { data: { select: () => null } };
+		const actual = isGutenbergDataAvailable();
+		expect( actual ).toBe( false );
+	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where the metabox would not display on term edit pages when running the development build of Gutenberg.

## Relevant technical choices:

* In the development build of Gutenberg `wp.data` is loaded on term edit pages but the `core/editor` selectors are not registered. This causes `null` to be returned which is then compared to `undefined` causing us to wrongly assume Gutenberg is fully available.

## Test instructions
This PR can be tested by following these steps:

* Checkout Gutenberg master, build plugin and activate it.
* Go to create new Category.
* You should see the metabox and it should work as expected.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #12540

Replaces https://github.com/Yoast/wordpress-seo/pull/12613