### PR TITLE
Reinstate wpseo_json_ld_output filter

### DIFF
--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -27,15 +27,20 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 * @since 1.8
 	 */
 	public function json_ld() {
+		$deprecated_data = array(
+			'_deprecated' => 'Please use the "wpseo_schema_*" filters to extend the Yoast SEO schema data - see the WPSEO_Schema class.'
+		);
+
 		/**
 		 * Filter: 'wpseo_json_ld_output' - Allows disabling Yoast's schema output entirely.
 		 *
 		 * @api mixed If false or an empty array is returned, disable our output.
 		 */
-		$return = apply_filters( 'wpseo_json_ld_output', 'test' );
+		$return = apply_filters( 'wpseo_json_ld_output', $deprecated_data );
 		if ( $return === array() || $return === false ) {
 			return;
 		}
+
 		do_action( 'wpseo_json_ld' );
 	}
 

--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -28,7 +28,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 */
 	public function json_ld() {
 		$deprecated_data = array(
-			'_deprecated' => 'Please use the "wpseo_schema_*" filters to extend the Yoast SEO schema data - see the WPSEO_Schema class.'
+			'_deprecated' => 'Please use the "wpseo_schema_*" filters to extend the Yoast SEO schema data - see the WPSEO_Schema class.',
 		);
 
 		/**

--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -27,6 +27,15 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 * @since 1.8
 	 */
 	public function json_ld() {
+		/**
+		 * Filter: 'wpseo_json_ld_output' - Allows disabling Yoast's schema output entirely.
+		 *
+		 * @api mixed If false or an empty array is returned, disable our output.
+		 */
+		$return = apply_filters( 'wpseo_json_ld_output', 'test' );
+		if ( $return === array() || $return === false ) {
+			return;
+		}
 		do_action( 'wpseo_json_ld' );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* No changelog needed.

## Relevant technical choices:

* Brought the filter `wpseo_json_ld_output` back, return `false` or an empty array on it and it will disable all Schema output. Done after a search on WPDirectory.net showed too many plugins use that filter to disable our output.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12619 
