### PR TITLE
Ensure the same capability is required for the admin widget and the `ryte` REST endpoint

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -15,6 +15,8 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	 */
 	const CACHE_TRANSIENT_KEY = 'wpseo-dashboard-totals';
 
+	const DISPLAY_CAPABILITY = 'edit_posts';
+
 	/**
 	 * @var WPSEO_Admin_Asset_Manager
 	 */
@@ -150,6 +152,6 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	private function show_widget() {
 		$analysis_seo = new WPSEO_Metabox_Analysis_SEO();
 
-		return $analysis_seo->is_enabled() && current_user_can( 'edit_posts' );
+		return $analysis_seo->is_enabled() && current_user_can( self::DISPLAY_CAPABILITY );
 	}
 }

--- a/admin/endpoints/class-endpoint-ryte.php
+++ b/admin/endpoints/class-endpoint-ryte.php
@@ -21,11 +21,6 @@ class WPSEO_Endpoint_Ryte implements WPSEO_Endpoint {
 	const ENDPOINT_RETRIEVE = 'ryte';
 
 	/**
-	 * @var string
-	 */
-	const CAPABILITY_RETRIEVE = 'manage_options';
-
-	/**
 	 * Service to use.
 	 *
 	 * @var WPSEO_Ryte_Service
@@ -60,6 +55,6 @@ class WPSEO_Endpoint_Ryte implements WPSEO_Endpoint {
 	 * @return bool Whether or not data can be retrieved.
 	 */
 	public function can_retrieve_data() {
-		return current_user_can( self::CAPABILITY_RETRIEVE );
+		return current_user_can( Yoast_Dashboard_Widget::DISPLAY_CAPABILITY );
 	}
 }

--- a/tests/admin/endpoints/test-class-enpoint-ryte.php
+++ b/tests/admin/endpoints/test-class-enpoint-ryte.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin\Endpoints
+ */
+class WPSEO_Endpoint_Ryte_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * @test
+	 *
+	 * @see https://github.com/Yoast/wordpress-seo/issues/12621
+	 */
+	public function it_can_retrieve_data_depending_on_capability() {
+
+		$service = $this->createMock( 'WPSEO_Ryte_Service' );
+		$subject = new WPSEO_Endpoint_Ryte( $service );
+
+		$current_user = wp_get_current_user();
+		$has_cap      = $current_user->has_cap( Yoast_Dashboard_Widget::DISPLAY_CAPABILITY );
+
+		if ( ! $has_cap ) {
+			$current_user->add_cap( Yoast_Dashboard_Widget::DISPLAY_CAPABILITY );
+		}
+
+		$this->assertTrue(
+			$subject->can_retrieve_data(),
+			'The current user should have capability:' . Yoast_Dashboard_Widget::DISPLAY_CAPABILITY
+		);
+
+		$current_user->remove_cap( Yoast_Dashboard_Widget::DISPLAY_CAPABILITY );
+
+		$this->assertFalse(
+			$subject->can_retrieve_data(),
+			'The current user should NOT have capability:' . Yoast_Dashboard_Widget::DISPLAY_CAPABILITY
+		);
+
+		if ( $has_cap ) {
+			$current_user->add_cap( Yoast_Dashboard_Widget::DISPLAY_CAPABILITY );
+		}
+	}
+}


### PR DESCRIPTION
https://github.com/Yoast/wordpress-seo/issues/12621

## Summary

This PR can be summarized in the following changelog entry:

* Fixed a console error on WP Dashboard when accessed by a non-admin.

## Relevant technical choices:

* I believe it's relevant to allow editors to see the dashboard widget, so I made the REST endpoint follow the same capability for displaying the widget (that is `edit_posts`).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*Fresh install + WP SEO Activated
*Create an editor account and login with this account
*Navigate to the WordPress Dashboard
=> No console error

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
