### PR TITLE
Move output to a util function for re-usability

### DIFF
--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -18,7 +18,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 */
 	public function register_hooks() {
 		add_action( 'wpseo_head', array( $this, 'json_ld' ), 91 );
-		add_action( 'wpseo_json_ld', array( $this, 'output' ), 1 );
+		add_action( 'wpseo_json_ld', array( $this, 'generate' ), 1 );
 	}
 
 	/**
@@ -37,7 +37,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 *
 	 * @return void
 	 */
-	public function output() {
+	public function generate() {
 		$graph = array();
 
 		foreach ( $this->get_graph_pieces() as $piece ) {
@@ -59,14 +59,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 			}
 		}
 
-		if ( is_array( $graph ) && ! empty( $graph ) ) {
-			$output = array(
-				'@context' => 'https://schema.org',
-				'@graph'   => $graph,
-			);
-
-			echo "<script type='application/ld+json' class='yoast-schema-graph yoast-schema-graph--main'>", WPSEO_Utils::format_json_encode( $output ), '</script>', "\n";
-		}
+		WPSEO_Utils::schema_output( $graph, 'yoast-schema-graph yoast-schema-graph--main' );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1179,6 +1179,24 @@ SVG;
 		return wp_json_encode( $data, $flags );
 	}
 
+
+	/**
+	 * Output a Schema blob.
+	 *
+	 * @param array  $graph The Schema graph array to output.
+	 * @param string $class The (optional) class to add to the script tag.
+	 */
+	public static function schema_output( $graph, $class = 'yoast-schema-graph' ) {
+		if ( is_array( $graph ) && ! empty( $graph ) ) {
+			$output = array(
+				'@context' => 'https://schema.org',
+				'@graph'   => $graph,
+			);
+
+			echo "<script type='application/ld+json' class='", $class, "'>", self::format_json_encode( $output ), '</script>', "\n";
+		}
+	}
+
 	/* ********************* DEPRECATED METHODS ********************* */
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* No changelog needed.

## Relevant technical choices:

* Moved the output part of the function to a separate utils function so it can be reused.
