### PR TITLE
Decrease bundle size

### DIFF
--- a/js/src/components.js
+++ b/js/src/components.js
@@ -1,8 +1,9 @@
+// Don't change this order because some packages depend on each other.
 window.yoast = window.yoast || {};
-window.yoast.components = require( "yoast-components/index.js" );
-window.yoast.helpers = require( "@yoast/helpers" );
-window.yoast.configurationWizard = require( "@yoast/configuration-wizard" );
 window.yoast.styleGuide = require( "@yoast/style-guide" );
+window.yoast.helpers = require( "@yoast/helpers" );
 window.yoast.componentsNew = require( "@yoast/components" );
+window.yoast.configurationWizard = require( "@yoast/configuration-wizard" );
 window.yoast.algoliaSearchBox = require( "@yoast/algolia-search-box" );
 window.yoast.searchMetadataPreviews = require( "@yoast/search-metadata-previews" );
+window.yoast.components = require( "yoast-components/index.js" );

--- a/js/src/components.js
+++ b/js/src/components.js
@@ -1,2 +1,6 @@
 window.yoast = window.yoast || {};
 window.yoast.components = require( "yoast-components/index.js" );
+window.yoast.helpers = require( "@yoast/helpers" );
+window.yoast.configurationWizard = require( "@yoast/configuration-wizard" );
+window.yoast.styleGuide = require( "@yoast/style-guide" );
+window.yoast.componentsNew = require( "@yoast/components" );

--- a/js/src/components.js
+++ b/js/src/components.js
@@ -4,3 +4,5 @@ window.yoast.helpers = require( "@yoast/helpers" );
 window.yoast.configurationWizard = require( "@yoast/configuration-wizard" );
 window.yoast.styleGuide = require( "@yoast/style-guide" );
 window.yoast.componentsNew = require( "@yoast/components" );
+window.yoast.algoliaSearchBox = require( "@yoast/algolia-search-box" );
+window.yoast.searchMetadataPreview = require( "@yoast/search-metadata-preview" );

--- a/js/src/components.js
+++ b/js/src/components.js
@@ -5,4 +5,4 @@ window.yoast.configurationWizard = require( "@yoast/configuration-wizard" );
 window.yoast.styleGuide = require( "@yoast/style-guide" );
 window.yoast.componentsNew = require( "@yoast/components" );
 window.yoast.algoliaSearchBox = require( "@yoast/algolia-search-box" );
-window.yoast.searchMetadataPreview = require( "@yoast/search-metadata-preview" );
+window.yoast.searchMetadataPreviews = require( "@yoast/search-metadata-previews" );

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -116,7 +116,6 @@ module.exports = function( env = { environment: "production" } ) {
 				...mainEntry,
 				"styled-components": "./js/src/styled-components.js",
 				analysis: "./js/src/analysis.js",
-				components: "./js/src/components.js",
 			},
 			externals: {
 				...externals,
@@ -128,6 +127,10 @@ module.exports = function( env = { environment: "production" } ) {
 				"@wordpress/api-fetch": "window.wp.apiFetch",
 				"@wordpress/rich-text": "window.wp.richText",
 				"@wordpress/compose": "window.wp.compose",
+				"@yoast/helpers": "window.yoast.helpers",
+				"@yoast/components": "window.yoast.componentsNew",
+				"@yoast/configuration-wizard": "window.yoast.configurationWizard",
+				"@yoast/style-guide": "window.yoast.styleGuide",
 
 				"styled-components": "window.yoast.styledComponents",
 			},
@@ -147,6 +150,31 @@ module.exports = function( env = { environment: "production" } ) {
 				] ),
 			],
 		},
+
+		// Config for components, which doesn't need all '@yoast' externals.
+		{
+			...base,
+			entry: {
+				components: "./js/src/components.js",
+			},
+			externals: {
+				...externals,
+
+				"@wordpress/element": "window.wp.element",
+				"@wordpress/data": "window.wp.data",
+				"@wordpress/components": "window.wp.components",
+				"@wordpress/i18n": "window.wp.i18n",
+				"@wordpress/api-fetch": "window.wp.apiFetch",
+				"@wordpress/rich-text": "window.wp.richText",
+				"@wordpress/compose": "window.wp.compose",
+
+				"styled-components": "window.yoast.styledComponents",
+			},
+			plugins: [
+				...plugins,
+			],
+		},
+
 		// Config for wp packages files that are shipped for BC with WP 4.9.
 		{
 			...base,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not user-facing] Decrease bundle size by removing some bundle duplication.

## Relevant technical choices:

* I've added some `@yoast` packages to the externals in the main config.
* I've created a new config for the components bundle, which doesn't need those `@yoast` packages externals.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Don't forget to test https://github.com/Yoast/wordpress-seo-premium/pull/2327 as well. The main goal is to have a premium zip < 5 MB.
* Build a zip with this branch and make sure everything still works, especially things related to components and the `@yoast` packages: the configuration wizard, the metabox, the dashboard widget.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2322
