### PR TITLE
Fix emptied organization social fields

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -338,8 +338,7 @@ class Yoast_Form {
 	 *
 	 * @param string       $var   The variable within the option to create the text input field for.
 	 * @param string       $label The label to show for the variable.
-	 * @param array|string $attr  Extra attributes to add to the input field. Can be class, disabled, autocomplete or
-	 *                            readonly.
+	 * @param array|string $attr  Extra attributes to add to the input field. Can be class, disabled, autocomplete.
 	 */
 	public function textinput( $var, $label, $attr = array() ) {
 		if ( ! is_array( $attr ) ) {
@@ -358,9 +357,6 @@ class Yoast_Form {
 		$attributes = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';
 		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
 			$attributes .= ' disabled';
-		}
-		if ( isset( $attr['readonly'] )  && $attr['readonly'] ) {
-			$attributes .= ' readonly';
 		}
 
 		$this->label(

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -338,7 +338,8 @@ class Yoast_Form {
 	 *
 	 * @param string       $var   The variable within the option to create the text input field for.
 	 * @param string       $label The label to show for the variable.
-	 * @param array|string $attr  Extra attributes to add to the input field.
+	 * @param array|string $attr  Extra attributes to add to the input field. Can be class, disabled, autocomplete or
+	 *                            readonly.
 	 */
 	public function textinput( $var, $label, $attr = array() ) {
 		if ( ! is_array( $attr ) ) {
@@ -360,7 +361,6 @@ class Yoast_Form {
 		}
 		if ( isset( $attr['readonly'] )  && $attr['readonly'] ) {
 			$attributes .= ' readonly';
-			$attr['class'] .= ' disabled';
 		}
 
 		$this->label(

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -338,7 +338,7 @@ class Yoast_Form {
 	 *
 	 * @param string       $var   The variable within the option to create the text input field for.
 	 * @param string       $label The label to show for the variable.
-	 * @param array|string $attr  Extra class to add to the input field.
+	 * @param array|string $attr  Extra attributes to add to the input field.
 	 */
 	public function textinput( $var, $label, $attr = array() ) {
 		if ( ! is_array( $attr ) ) {
@@ -357,6 +357,10 @@ class Yoast_Form {
 		$attributes = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';
 		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
 			$attributes .= ' disabled';
+		}
+		if ( isset( $attr['readonly'] )  && $attr['readonly'] ) {
+			$attributes .= ' readonly';
+			$attr['class'] .= ' disabled';
 		}
 
 		$this->label(

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -43,14 +43,19 @@ if ( $company_or_person === 'person' ) {
 echo '<h2 class="help-button-inline">' . esc_html__( 'Organization social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
 echo $social_profiles_help->get_panel_html();
 
+$readonly_attributes = array(
+	'readonly' => $read_only,
+	'class'    => $read_only ? 'disabled' : '',
+);
+
 $yform = Yoast_Form::get_instance();
-$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
-$yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
-$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
-$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
-$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
-$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
-$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
-$yform->textinput( 'wikipedia_url', __( 'Wikipedia URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'wikipedia_url', __( 'Wikipedia URL', 'wordpress-seo' ), $readonly_attributes );
 
 do_action( 'wpseo_admin_other_section' );

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -43,19 +43,19 @@ if ( $company_or_person === 'person' ) {
 echo '<h2 class="help-button-inline">' . esc_html__( 'Organization social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
 echo $social_profiles_help->get_panel_html();
 
-$readonly_attributes = array(
+$textinput_attributes = array(
 	'readonly' => $read_only,
-	'class'    => $read_only ? 'disabled' : '',
+	'class'    => ( $read_only ) ? 'disabled' : '',
 );
 
 $yform = Yoast_Form::get_instance();
-$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), $readonly_attributes );
-$yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ), $readonly_attributes );
-$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), $readonly_attributes );
-$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), $readonly_attributes );
-$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), $readonly_attributes );
-$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), $readonly_attributes );
-$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), $readonly_attributes );
-$yform->textinput( 'wikipedia_url', __( 'Wikipedia URL', 'wordpress-seo' ), $readonly_attributes );
+$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), $textinput_attributes );
+$yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ), $textinput_attributes );
+$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), $textinput_attributes );
+$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), $textinput_attributes );
+$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), $textinput_attributes );
+$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), $textinput_attributes );
+$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), $textinput_attributes );
+$yform->textinput( 'wikipedia_url', __( 'Wikipedia URL', 'wordpress-seo' ), $textinput_attributes );
 
 do_action( 'wpseo_admin_other_section' );

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -23,7 +23,7 @@ $social_profiles_help = new WPSEO_Admin_Help_Panel(
 
 $company_or_person = WPSEO_Options::get( 'company_or_person', '' );
 
-$disabled = false;
+$read_only = false;
 if ( $company_or_person === 'person' ) {
 	echo '<div class="paper tab-block">';
 	echo '<h2><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Your website is currently configured to represent a Person', 'wordpress-seo' ) . '</h2>';
@@ -37,20 +37,20 @@ if ( $company_or_person === 'person' ) {
 	echo ' ';
 	printf( esc_html__( 'To make your site represent a Company or Organization go to %1$sSearch Appearance%2$s and set Company or Person to "Company".', 'wordpress-seo' ), '<a href="' . admin_url( 'admin.php?page=wpseo_titles' ) . '">', '</a>' );
 	echo '</p></div>';
-	$disabled = true;
+	$read_only = 'readonly';
 }
 
-echo '<h2 class="help-button-inline">' . esc_html__( 'Company social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
+echo '<h2 class="help-button-inline">' . esc_html__( 'Organization social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
 echo $social_profiles_help->get_panel_html();
 
 $yform = Yoast_Form::get_instance();
-$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
-$yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
-$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
-$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
-$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
-$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
-$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
-$yform->textinput( 'wikipedia_url', __( 'Wikipedia URL', 'wordpress-seo' ), array( 'disabled' => $disabled ) );
+$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
+$yform->textinput( 'wikipedia_url', __( 'Wikipedia URL', 'wordpress-seo' ), array( 'readonly' => $read_only ) );
 
 do_action( 'wpseo_admin_other_section' );

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -23,7 +23,43 @@ $social_profiles_help = new WPSEO_Admin_Help_Panel(
 
 $company_or_person = WPSEO_Options::get( 'company_or_person', '' );
 
-$read_only = false;
+$organization_social_fields = array(
+	array(
+		'id'    => 'facebook_site',
+		'label' => __( 'Facebook Page URL', 'wordpress-seo' ),
+	),
+	array(
+		'id'    => 'twitter_site',
+		'label' => __( 'Twitter Username', 'wordpress-seo' ),
+	),
+	array(
+		'id'    => 'instagram_url',
+		'label' => __( 'Instagram URL', 'wordpress-seo' ),
+	),
+	array(
+		'id'    => 'linkedin_url',
+		'label' => __( 'LinkedIn URL', 'wordpress-seo' ),
+	),
+	array(
+		'id'    => 'myspace_url',
+		'label' => __( 'MySpace URL', 'wordpress-seo' ),
+	),
+	array(
+		'id'    => 'pinterest_url',
+		'label' => __( 'Pinterest URL', 'wordpress-seo' ),
+	),
+	array(
+		'id'    => 'youtube_url',
+		'label' => __( 'YouTube URL', 'wordpress-seo' ),
+	),
+	array(
+		'id'    => 'wikipedia_url',
+		'label' => __( 'Wikipedia URL', 'wordpress-seo' ),
+	),
+);
+
+$yform = Yoast_Form::get_instance();
+
 if ( $company_or_person === 'person' ) {
 	echo '<div class="paper tab-block">';
 	echo '<h2><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Your website is currently configured to represent a Person', 'wordpress-seo' ) . '</h2>';
@@ -37,25 +73,20 @@ if ( $company_or_person === 'person' ) {
 	echo ' ';
 	printf( esc_html__( 'To make your site represent a Company or Organization go to %1$sSearch Appearance%2$s and set Company or Person to "Company".', 'wordpress-seo' ), '<a href="' . admin_url( 'admin.php?page=wpseo_titles' ) . '">', '</a>' );
 	echo '</p></div>';
-	$read_only = 'readonly';
+
+	// Organization social fields should still be rendered, because other wise the values are lost on save.
+	foreach ( $organization_social_fields as $organization ) {
+		$yform->hidden( $organization['id'] );
+	}
 }
 
-echo '<h2 class="help-button-inline">' . esc_html__( 'Organization social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
-echo $social_profiles_help->get_panel_html();
+if ( $company_or_person === 'company' ) {
+	echo '<h2 class="help-button-inline">' . esc_html__( 'Organization social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
+	echo $social_profiles_help->get_panel_html();
 
-$textinput_attributes = array(
-	'readonly' => $read_only,
-	'class'    => ( $read_only ) ? 'disabled' : '',
-);
-
-$yform = Yoast_Form::get_instance();
-$yform->textinput( 'facebook_site', __( 'Facebook Page URL', 'wordpress-seo' ), $textinput_attributes );
-$yform->textinput( 'twitter_site', __( 'Twitter Username', 'wordpress-seo' ), $textinput_attributes );
-$yform->textinput( 'instagram_url', __( 'Instagram URL', 'wordpress-seo' ), $textinput_attributes );
-$yform->textinput( 'linkedin_url', __( 'LinkedIn URL', 'wordpress-seo' ), $textinput_attributes );
-$yform->textinput( 'myspace_url', __( 'MySpace URL', 'wordpress-seo' ), $textinput_attributes );
-$yform->textinput( 'pinterest_url', __( 'Pinterest URL', 'wordpress-seo' ), $textinput_attributes );
-$yform->textinput( 'youtube_url', __( 'YouTube URL', 'wordpress-seo' ), $textinput_attributes );
-$yform->textinput( 'wikipedia_url', __( 'Wikipedia URL', 'wordpress-seo' ), $textinput_attributes );
+	foreach ( $organization_social_fields as $organization ) {
+		$yform->textinput( $organization['id'], $organization['label'] );
+	}
+}
 
 do_action( 'wpseo_admin_other_section' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Fixes bug where organization social fields were cleared out when the site was representing a person.

## Relevant technical choices:

* Removed company social fields when person is represented by site.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open 2 tabs, one with the Onboarding wizard step 3, one on the social settings page (`SEO` > `Socials`).
* In the onboarding wizard select `Organization` and add some social links. Click `Next`.
* Refresh the socials settings page, see that your settings have taken effect.
* In the onboarding wizard, go back to step 3, select `Person` and select a user. Click `next`.
* Refresh the socials settings page, see that your settings have taken effect. The social fields should not be visible. For developers: you can inspect the HTML and still see them as hidden inputs.
* Click `Save`.
* In the onboarding wizard, refresh, go back to step 3, select `Organization`, and see that the social fields are unchanged. Click `Next`.
* Refresh the socials settings page, see that your organization social fields are unchanged.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12566
