### PR TITLE
Fix TypeError when attempting to set focus on the How-to add duration button

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 172,
+			maxWarnings: 170,
 		},
 	},
 	tests: {

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -602,7 +602,21 @@ export default class HowTo extends Component {
 	 */
 	removeDuration() {
 		this.props.setAttributes( { hasDuration: false } );
-		setTimeout( () => this.addDurationButton.current.focus() );
+		// Wait for the Add Duration button to mount.
+		setTimeout( () => {
+			/*
+			 * Prior to Gutenberg 5.3 the IconButton doesn't support refs. The ref
+			 * returns the Component instance and attempting to set focus on it
+			 * triggers a TypeError. To keep it simple, we accepct a focus loss.
+			 * Starting from WordPress 5.2, Iconbutton does support refs so this
+			 * check can be removed in the future.
+			 */
+			if ( this.addDurationButton.current instanceof Component ) {
+				return;
+			}
+
+			this.addDurationButton.current.focus();
+		} );
 	}
 
 	/**

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -607,7 +607,7 @@ export default class HowTo extends Component {
 			/*
 			 * Prior to Gutenberg 5.3 the IconButton doesn't support refs. The ref
 			 * returns the Component instance and attempting to set focus on it
-			 * triggers a TypeError. To keep it simple, we accepct a focus loss.
+			 * triggers a TypeError. To keep it simple, we accept a focus loss.
 			 * Starting from WordPress 5.2, Iconbutton does support refs so this
 			 * check can be removed in the future.
 			 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed TypeError when attempting to set focus on the How-to add duration button

## Relevant technical choices:
Prior to Gutenberg 5.3 the IconButton doesn't support refs. The ref returns the Component instance and attempting to set focus on it triggers a TypeError.

I guess we could fix this by using ReactDOM / findDOMNode for Gutenberg 5.3 and previous but that wouldn't be great.
Considering the how-to block is going to be refactored and to keep it simple, I'd propose we accept a focus loss in WordPress 5.1.

Starting from WordPress 5.2, Iconbutton does support refs and everything will work correctly.

## Test instructions
- build the plugin
- add a How-To block
- click on "Add total time"
- then click on the trash icon ("Delete total time")
- in WordPress trunk 5.2: focus is moved back to the "Add total time" button
- in WordPress 5.1: focus is not moved back (actually there's a focus loss)
- verify there are no JS errors

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #12628 
