### PR TITLE
Fixed user selector in 4.9.8

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -339,7 +339,7 @@ class WPSEO_Admin_Asset_Manager {
 				'name' => 'search-appearance',
 				'src'  => 'search-appearance-' . $flat_version,
 				'deps' => array(
-					'wp-api-fetch',
+					'wp-api',
 					self::PREFIX . 'components',
 					self::PREFIX . 'commons',
 				),
@@ -549,7 +549,7 @@ class WPSEO_Admin_Asset_Manager {
 					'jquery',
 					'wp-element',
 					'wp-i18n',
-					'wp-api-fetch',
+					'wp-api',
 					self::PREFIX . 'components',
 					self::PREFIX . 'commons',
 				),

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -1,11 +1,11 @@
 import Select from "react-select/lib/Async";
 import { Component, Fragment } from "@wordpress/element";
-import apiFetch from "@wordpress/api-fetch";
 import PropTypes from "prop-types";
 import { debounce } from "lodash";
 import { createGlobalStyle } from "styled-components";
 import { __ } from "@wordpress/i18n";
 import { SvgIcon } from "yoast-components";
+import { sendRequest } from "@yoast/helpers";
 
 /**
  * Styles to overwrite react-select styles.
@@ -49,6 +49,10 @@ const Styles = createGlobalStyle`
 		}
 	}
 `;
+
+const HEADERS = {
+	"X-WP-NONCE": wpApiSettings.nonce,
+};
 
 /**
  * Component to replace the react-select dropdown icon.
@@ -179,9 +183,7 @@ class WordPressUserSelector extends Component {
 	 * @returns {void}
 	 */
 	async fetchUser( id ) {
-		const user = await apiFetch( {
-			path: `/wp/v2/users/${ id }`,
-		} );
+		const user = await sendRequest( `/wp-json/wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } );
 
 		if ( ! user ) {
 			this.setState( { loading: false } );
@@ -207,9 +209,7 @@ class WordPressUserSelector extends Component {
 			search: input,
 		} );
 
-		apiFetch( {
-			path: `/wp/v2/users?${ queryParameters }`,
-		} ).then( users => {
+		sendRequest( `/wp-json/wp/v2/users?${ queryParameters }`, { method: "GET", headers: HEADERS } ).then( users => {
 			const mappedUsers = users.map( this.mapUserToSelectOption );
 
 			callback( mappedUsers );

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -134,7 +134,7 @@ class WordPressUserSelector extends Component {
 	}
 
 	/**
-	 * Creates a query string from a params object.
+	 * Adds additional query parameters to an existing URL. Also encodes existing query parameters.
 	 *
 	 * @param {string} url    The URL.
 	 * @param {Object} params Params for in the query string.

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -1,3 +1,4 @@
+/* global wpApiSettings */
 import Select from "react-select/lib/Async";
 import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
@@ -53,6 +54,8 @@ const Styles = createGlobalStyle`
 const HEADERS = {
 	"X-WP-NONCE": wpApiSettings.nonce,
 };
+
+const REST_ROUTE = wpApiSettings.root;
 
 /**
  * Component to replace the react-select dropdown icon.
@@ -209,7 +212,7 @@ class WordPressUserSelector extends Component {
 			search: input,
 		} );
 
-		sendRequest( `/wp-json/wp/v2/users?${ queryParameters }`, { method: "GET", headers: HEADERS } ).then( users => {
+		sendRequest( `${ REST_ROUTE }wp/v2/users?${ queryParameters }`, { method: "GET", headers: HEADERS } ).then( users => {
 			const mappedUsers = users.map( this.mapUserToSelectOption );
 
 			callback( mappedUsers );

--- a/js/src/components/WordPressUserSelectorSearchAppearance.js
+++ b/js/src/components/WordPressUserSelectorSearchAppearance.js
@@ -126,7 +126,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 				<WordPressUserSelector
 					hasLabel={ false }
 					name={ "wpseo-person-selector-name" }
-					properties={ { user: this.state.value } }
+					value={ this.state.value }
 					onChange={ this.onChange }
 				/>
 				<p>{ this.renderAuthorInfo() }</p>

--- a/js/tests/components/WordPressUserSelector.test.js
+++ b/js/tests/components/WordPressUserSelector.test.js
@@ -1,0 +1,14 @@
+import WordPressUserSelector from "../../src/components/WordPressUserSelector";
+
+describe( "addQueryParams", () => {
+	it( "adds an additional parameter", () => {
+		// Decoded: http://local.wordpress.test?search=test post&rest_route=/wp/v2/posts
+		const expected = "http://local.wordpress.test?search=test%20post&rest_route=%2Fwp%2Fv2%2Fposts";
+
+		const actual = WordPressUserSelector.addQueryParams( "http://local.wordpress.test?rest_route=/wp/v2/posts", {
+			search: "test post",
+		} );
+
+		expect( actual ).toBe( expected );
+	} );
+} );

--- a/js/tests/components/WordPressUserSelector.test.js
+++ b/js/tests/components/WordPressUserSelector.test.js
@@ -1,6 +1,17 @@
 import WordPressUserSelector from "../../src/components/WordPressUserSelector";
 
 describe( "addQueryParams", () => {
+	it( "adds a first parameter", () => {
+		// Decoded: http://local.wordpress.test?search=test post
+		const expected = "http://local.wordpress.test?search=test%20post";
+
+		const actual = WordPressUserSelector.addQueryParams( "http://local.wordpress.test", {
+			search: "test post",
+		} );
+
+		expect( actual ).toBe( expected );
+	} );
+
 	it( "adds an additional parameter", () => {
 		// Decoded: http://local.wordpress.test?search=test post&rest_route=/wp/v2/posts
 		const expected = "http://local.wordpress.test?search=test%20post&rest_route=%2Fwp%2Fv2%2Fposts";

--- a/js/tests/setupTests.js
+++ b/js/tests/setupTests.js
@@ -14,3 +14,8 @@ setLocaleData( {
 		/* eslint-enable */
 	},
 }, "wordpress-seo" );
+
+global.wpApiSettings = {
+	nonce: "nonce",
+	root: "http://example.com",
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Fixes bug where person selector didn't work in version prior to WordPress `5.*`.

## Relevant technical choices:

* Replaced `wp-api-fetch` with `@yoast/helpers`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test the person selector in WordPress `4.9.8`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12630 
