### PR TITLE
Bump yoast components to v. 4.23.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^4.2.0",
-    "yoast-components": "^4.23.1-rc.0",
+    "yoast-components": "^4.23.1",
     "yoastseo": "^1.50.0"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12639,10 +12639,10 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yoast-components@^4.23.1-rc.0:
-  version "4.23.1-rc.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.23.1-rc.0.tgz#0834782fa76342052f44d56e7406738d6d42d7af"
-  integrity sha512-vwIV7d/PJHswmt26TZAz8mzg6HbyvErksGdddhS4HbDA1pbSVD1rl/YjHaL7EDF8Ldjio1JyPpMBk3TNLVWAmA==
+yoast-components@^4.23.1:
+  version "4.23.1"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.23.1.tgz#a6a7cffeba7fd010190275fcdfc49851dc491076"
+  integrity sha512-xQ1iCLRAZINWHdFjV6mPbQgv/DPh5gNFnb39oIcBHY87ZkVMf7dx013zwgPQQnjtC41EfmavvkXsTEqL4U8qzA==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Updates `yoast-components` to 4.23.1.

## Relevant technical choices:


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build the files and check whether nothing breaks.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
