### PR TITLE
Made company default entity and removed option to select no entity

### DIFF
--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -38,7 +38,6 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	</p>
 	<?php
 	$yoast_free_kg_select_options = array(
-		''        => __( 'Choose whether you\'re an organization or a person', 'wordpress-seo' ),
 		'company' => __( 'Organization', 'wordpress-seo' ),
 		'person'  => __( 'Person', 'wordpress-seo' ),
 	);

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -69,7 +69,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'alternate_website_name'        => '',
 		'company_logo'                  => '',
 		'company_name'                  => '',
-		'company_or_person'             => '',
+		'company_or_person'             => 'company',
 		'company_or_person_user_id'     => false,
 
 		'stripcategorybase'             => false,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Make `company` the default entity type on a new installation.
* Removed option to choose on entity type on the search appearance page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new WordPress site.
* Install the plugin from this PR. You can take my word for it or build it yourself:
[wordpress-seo-test.zip](https://github.com/Yoast/wordpress-seo/files/3088524/wordpress-seo-test.zip)
* Don't go through the configuration wizard, check `SEO` > `Search Appearance` first to see whether the site entity is set to `Organization`. Be sure you can no longer select `Choose whether this site represents a person or an organization...`.
* Go through the configuration wizard and make sure everything works as intended.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
