### PR TITLE
CS: clean up after merges

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -276,7 +276,7 @@ class WPSEO_Admin {
 		$contactmethods['tumblr']     = __( 'Tumblr profile URL', 'wordpress-seo' );
 		$contactmethods['twitter']    = __( 'Twitter username (without @)', 'wordpress-seo' );
 		$contactmethods['youtube']    = __( 'YouTube profile URL', 'wordpress-seo' );
-		$contactmethods['wikipedia']    = __( 'Wikipedia page about you', 'wordpress-seo' ) . '<br/><small>' . __( '(if one exists)', 'wordpress-seo' ) . '</small>';
+		$contactmethods['wikipedia']  = __( 'Wikipedia page about you', 'wordpress-seo' ) . '<br/><small>' . __( '(if one exists)', 'wordpress-seo' ) . '</small>';
 
 		return $contactmethods;
 	}

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -158,8 +158,8 @@ class WPSEO_Admin_Pages {
 	private function should_show_local_seo_upsell() {
 		$addon_manager = new WPSEO_Addon_Manager();
 
-		return ! WPSEO_Utils::is_yoast_seo_premium() &&
-			   ! $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::LOCAL_SLUG );
+		return ! WPSEO_Utils::is_yoast_seo_premium()
+			&& ! $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::LOCAL_SLUG );
 	}
 
 	/**

--- a/admin/class-schema-person-upgrade-notification.php
+++ b/admin/class-schema-person-upgrade-notification.php
@@ -55,11 +55,11 @@ class WPSEO_Schema_Person_Upgrade_Notification implements WPSEO_WordPress_Integr
 	 */
 	protected function get_notification() {
 		$message = sprintf(
-				/* translators: %1$s is a link start tag to the Configuration Wizard, %2$s is the link closing tag. */
-				__( 'You have previously set your site to represent a person. We’ve improved our functionality around Schema and the Knowledge Graph, so you should go in and %1$scomplete those settings%2$s.', 'wordpress-seo' ),
-			'<a href="' . admin_url( 'admin.php?page=wpseo_titles' ) . '">',
+			/* translators: %1$s is a link start tag to the Configuration Wizard, %2$s is the link closing tag. */
+			__( 'You have previously set your site to represent a person. We’ve improved our functionality around Schema and the Knowledge Graph, so you should go in and %1$scomplete those settings%2$s.', 'wordpress-seo' ),
+			'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles' ) ) . '">',
 			'</a>'
-			);
+		);
 
 		$notification = new Yoast_Notification(
 			$message,

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -343,17 +343,17 @@ class Yoast_Form {
 	public function textinput( $var, $label, $attr = array() ) {
 		if ( ! is_array( $attr ) ) {
 			$attr = array(
-				'class' => $attr,
+				'class'    => $attr,
 				'disabled' => false,
 			);
 		}
 
-		$defaults     = array(
+		$defaults   = array(
 			'placeholder' => '',
 			'class'       => '',
 		);
-		$attr         = wp_parse_args( $attr, $defaults );
-		$val          = isset( $this->options[ $var ] ) ? $this->options[ $var ] : '';
+		$attr       = wp_parse_args( $attr, $defaults );
+		$val        = isset( $this->options[ $var ] ) ? $this->options[ $var ] : '';
 		$attributes = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';
 		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
 			$attributes .= ' disabled';

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -11,7 +11,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	'search-appearance-knowledge-graph',
 	__( 'Learn more about the knowledge graph setting', 'wordpress-seo' ),
 	sprintf(
-	/* translators: %1$s opens the link to the Yoast.com article about Google's Knowledge Graph, %2$s closes the link, */
+		/* translators: %1$s opens the link to the Yoast.com article about Google's Knowledge Graph, %2$s closes the link, */
 		__( 'This data is shown as metadata in your site. It is intended to appear in %1$sGoogle\'s Knowledge Graph%2$s. You can be either an organization, or a person.', 'wordpress-seo' ),
 		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1-p' ) ) . '" target="_blank" rel="noopener noreferrer">',
 		'</a>'

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -69,9 +69,18 @@ if ( $company_or_person === 'person' ) {
 	echo '<p>';
 	$user_id = WPSEO_Options::get( 'company_or_person_user_id', '' );
 	$person  = get_userdata( $user_id );
-	printf( esc_html__( 'To change the social accounts used for your site, update the details for %1$s.', 'wordpress-seo' ), '<a href="' . admin_url( 'user-edit.php?user_id=' . $user_id ) . '">' . $person->display_name . '</a>' );
+	printf(
+		/* translators: 1: link to edit user page. */
+		esc_html__( 'To change the social accounts used for your site, update the details for %1$s.', 'wordpress-seo' ),
+		'<a href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_id ) ) . '">' . esc_html( $person->display_name ) . '</a>'
+	);
 	echo ' ';
-	printf( esc_html__( 'To make your site represent a Company or Organization go to %1$sSearch Appearance%2$s and set Organization or Person to "Organization".', 'wordpress-seo' ), '<a href="' . admin_url( 'admin.php?page=wpseo_titles' ) . '">', '</a>' );
+	printf(
+		/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
+		esc_html__( 'To make your site represent a Company or Organization go to %1$sSearch Appearance%2$s and set Organization or Person to "Organization".', 'wordpress-seo' ),
+		'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles' ) ) . '">',
+		'</a>'
+	);
 	echo '</p></div>';
 
 	// Organization social fields should still be rendered, because other wise the values are lost on save.

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1914,6 +1914,7 @@ class WPSEO_Frontend {
 	 * Output the rel=publisher code on every page of the site.
 	 *
 	 * @deprecated 10.1.3
+	 * @codeCoverageIgnore
 	 *
 	 * @return boolean Boolean indicating whether the publisher link was printed.
 	 */

--- a/frontend/schema/class-schema-author.php
+++ b/frontend/schema/class-schema-author.php
@@ -54,7 +54,6 @@ class WPSEO_Schema_Author extends WPSEO_Schema_Person implements WPSEO_Graph_Pie
 		return false;
 	}
 
-
 	/**
 	 * Builds our array of Schema Person data for a given user ID.
 	 *
@@ -105,7 +104,7 @@ class WPSEO_Schema_Author extends WPSEO_Schema_Person implements WPSEO_Graph_Pie
 				$user_id = get_queried_object_id();
 				break;
 			default:
-				$post = get_post( $this->context->id );
+				$post    = get_post( $this->context->id );
 				$user_id = (int) $post->post_author;
 				break;
 		}

--- a/frontend/schema/class-schema-breadcrumb.php
+++ b/frontend/schema/class-schema-breadcrumb.php
@@ -140,9 +140,12 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	 */
 	private function add_paginated_state() {
 		$this->index++;
-		return $this->add_breadcrumb( $this->index, array(
-			'url'  => $this->context->canonical,
-			'text' => $this->context->title,
-		) );
+		return $this->add_breadcrumb(
+			$this->index,
+			array(
+				'url'  => $this->context->canonical,
+				'text' => $this->context->title,
+			)
+		);
 	}
 }

--- a/frontend/schema/class-schema-image.php
+++ b/frontend/schema/class-schema-image.php
@@ -123,8 +123,6 @@ class WPSEO_Schema_Image {
 		if ( ! empty( $caption ) ) {
 			$this->data['caption'] = $caption;
 		}
-
-		return;
 	}
 
 	/**

--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -13,6 +13,7 @@
  * @since 1.8
  */
 class WPSEO_Schema implements WPSEO_WordPress_Integration {
+
 	/**
 	 * Registers the hooks.
 	 */

--- a/frontend/schema/interface-wpseo-graph-piece.php
+++ b/frontend/schema/interface-wpseo-graph-piece.php
@@ -12,6 +12,7 @@ if ( ! interface_exists( 'WPSEO_Graph_Piece' ) ) {
 	 * @since 10.2
 	 */
 	interface WPSEO_Graph_Piece {
+
 		/**
 		 * Add your piece of the graph.
 		 *

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -110,7 +110,6 @@ class WPSEO_Addon_Manager {
 		}
 
 		return $this->get_site_information_default();
-
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1179,7 +1179,6 @@ SVG;
 		return wp_json_encode( $data, $flags );
 	}
 
-
 	/**
 	 * Output a Schema blob.
 	 *

--- a/tests/admin/test-class-schema-person-upgrade-notification.php
+++ b/tests/admin/test-class-schema-person-upgrade-notification.php
@@ -11,13 +11,14 @@
  * @group Person_Schema
  */
 class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
+
 	/**
 	 * Remove the notification when Person is not selected.
 	 */
 	public function test_remove_notification_not_person() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
-						 ->setMethods( array( 'remove_notification' ) )
-						 ->getMock();
+			->setMethods( array( 'remove_notification' ) )
+			->getMock();
 
 		WPSEO_Options::set( 'company_or_person', 'company' );
 
@@ -31,8 +32,8 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_remove_notification_user_id_set() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
-						 ->setMethods( array( 'remove_notification' ) )
-						 ->getMock();
+			->setMethods( array( 'remove_notification' ) )
+			->getMock();
 
 		WPSEO_Options::set( 'company_or_person', 'person' );
 		WPSEO_Options::set( 'company_or_person_user_id', '1' );
@@ -47,8 +48,8 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_notification() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
-						 ->setMethods( array( 'add_notification' ) )
-						 ->getMock();
+			->setMethods( array( 'add_notification' ) )
+			->getMock();
 
 		WPSEO_Options::set( 'company_or_person', 'person' );
 		WPSEO_Options::set( 'company_or_person_user_id', '' );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Mixed bag of fixes:
* Various whitespace fixes;
* Added missing translators comments x 2;
* Added missing output escape around a URL x 3;
* Added missing output escaping for link text x 1;
* Removed an unnecessary empty return at end of function;
* Added missing `@codeCoverageIgnore` tag for deprecated method.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.