### PR TITLE
CS: Move multi-line function call out of embedded PHP

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -101,6 +101,11 @@ class WPSEO_Configuration_Page {
 	public function show_wizard() {
 		$this->enqueue_assets();
 		$dashboard_url = admin_url( '/admin.php?page=wpseo_dashboard' );
+		$wizard_title  = sprintf(
+			/* translators: %s expands to Yoast SEO. */
+			__( '%s &rsaquo; Configuration Wizard', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
 		?>
 		<!DOCTYPE html>
 		<!--[if IE 9]>
@@ -112,12 +117,7 @@ class WPSEO_Configuration_Page {
 		<head>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-			<title><?php
-				printf(
-					/* translators: %s expands to Yoast SEO. */
-					esc_html__( '%s &rsaquo; Configuration Wizard', 'wordpress-seo' ),
-					'Yoast SEO' );
-			?></title>
+			<title><?php echo esc_html( $wizard_title ); ?></title>
 			<?php
 			wp_print_head_scripts();
 			wp_print_styles( 'yoast-seo-yoast-components' );

--- a/admin/views/js-templates-primary-term.php
+++ b/admin/views/js-templates-primary-term.php
@@ -33,11 +33,13 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 </script>
 
 <script type="text/html" id="tmpl-primary-term-screen-reader">
-	<span class="screen-reader-text wpseo-primary-category-label"><?php
-		printf(
-			/* translators: %s is the taxonomy title. This will be shown to screenreaders */
-			'(' . esc_html__( 'Primary %s', 'wordpress-seo' ) . ')',
-			'{{data.taxonomy.title}}'
-		);
-		?></span>
+	<?php
+	/* translators: %s is the taxonomy title. This will be shown to screenreaders */
+	$yoast_free_js_taxonomy_title = __( 'Primary %s', 'wordpress-seo' );
+	$yoast_free_js_taxonomy_title = sprintf(
+		'(' . $yoast_free_js_taxonomy_title . ')',
+		'{{data.taxonomy.title}}'
+	);
+	?>
+	<span class="screen-reader-text wpseo-primary-category-label"><?php echo esc_html( $yoast_free_js_taxonomy_title ); ?></span>
 </script>

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -155,7 +155,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				<?php if ( $has_valid_premium_subscription ) : ?>
 					<div class="yoast-button yoast-button--noarrow yoast-button--extension yoast-button--extension-activated"><?php esc_html_e( 'Activated', 'wordpress-seo' ); ?></div>
 					<a target="_blank" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/13k' ); ?>"
-						class="yoast-link--license"><?php
+						class="yoast-link--license">
+						<?php
 						/* translators: %s expands to the extension title */
 						printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
@@ -209,14 +210,16 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 		<hr class="yoast-hr" aria-hidden="true"/>
 
 		<section class="yoast-promo-extensions">
-			<h2><?php
+			<h2>
+				<?php
 				/* translators: %1$s expands to Yoast SEO */
 				$yoast_seo_extensions = sprintf( __( '%1$s extensions', 'wordpress-seo' ), 'Yoast SEO' );
 				$yoast_seo_extensions = '<span class="yoast-heading-highlight">' . $yoast_seo_extensions . '</span>';
 
 				/* translators: %1$s expands to Yoast SEO extensions */
 				printf( esc_html__( '%1$s to optimize your site even further', 'wordpress-seo' ), $yoast_seo_extensions );
-				?></h2>
+				?>
+			</h2>
 
 			<?php foreach ( $extensions as $slug => $extension ) : ?>
 				<section class="yoast-promoblock secondary yoast-promo-extension">


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Multi-line embedded PHP should have the PHP open and close tags on a line by themselves.

Depending on the HTML tags in which the code is embedded, adding these additional line-breaks may or may not influence how things display on screen. For block elements, it should normally have no influence. For inline HTML elements, like `<span>` or `<a>`, it will add a space to the displayed text on screen.

For most cases addressed in this PR, moving the multi-line function call to a variable declared before the HTML section starts and only echo-ing the variable in the embedded PHP is the simplest solution around this.

In one case, adding the above mentioned line-breaks should be just fine.

Includes output escaping of the texts where it was missing and could be safely added.

## Test instructions

This PR can be tested by following these steps:
* Verify that the on-screen output for the affected views looks the same before/after.