### PR TITLE
Documentation: use multi-line comment format for long inline comments

### DIFF
--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -180,7 +180,7 @@ abstract class WPSEO_Option {
 		/*
 		 * Make sure the option will always get validated, independently of register_setting()
 		 * (only available on back-end).
-		*/
+		 */
 		add_filter( 'sanitize_option_' . $this->option_name, array( $this, 'validate' ) );
 
 		// Flushes the rewrite rules when option is updated.

--- a/tests/admin/test-class-database-proxy.php
+++ b/tests/admin/test-class-database-proxy.php
@@ -256,7 +256,8 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		 * As it internally does an Insert and then an Update, it will count as 2 rows.
 		 *
 		 * {@link https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html}
-		 * "With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if the row is inserted as a new row and 2 if an existing row is updated."
+		 * "With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if the row
+		 *  is inserted as a new row and 2 if an existing row is updated."
 		 */
 		$this->assertSame( 2, $result );
 

--- a/tests/frontend/test-class-wpseo-frontend.php
+++ b/tests/frontend/test-class-wpseo-frontend.php
@@ -255,7 +255,10 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 		$category_id = wp_create_category( 'Yoast SEO Plugins' );
 		$this->factory->post->create_many( 3, array( 'post_category' => array( $category_id ) ) );
 
-		// This shouldn't be necessary but apparently multisite's rewrites are borked when you create a category and you don't flush (on 4.0 only).
+		/*
+		 * This shouldn't be necessary but apparently multisite's rewrites are borked
+		 * when you create a category and you don't flush (on 4.0 only).
+		 */
 		flush_rewrite_rules();
 
 		$category_link = get_category_link( $category_id );

--- a/tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/tests/frontend/test-class-wpseo-opengraph-image.php
@@ -220,7 +220,10 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = $this->setup_class();
 
-		// With a static frontpage, the image should be the default image, or the image from the static front page itself, not the frontpage image.
+		/*
+		 * With a static frontpage, the image should be the default image, or the
+		 * image from the static front page itself, not the frontpage image.
+		 */
 		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
 
 		update_option( 'show_on_front', $current_show_on_front );

--- a/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -139,7 +139,11 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		$index_cache_key = WPSEO_Sitemaps_Cache_Validator::get_storage_key();
 		set_transient( $index_cache_key, $test_index_content );
 
-		// De cache invalidator is based on time so if there isn't enough time difference between the two generations we will end up with the same cache invalidator, failing this test.
+		/*
+		 * The cache invalidator is based on time so if there isn't enough time
+		 * difference between the two generations we will end up with the same
+		 * cache invalidator, failing this test.
+		 */
 		usleep( 10000 );
 
 		// Act.

--- a/tests/test-class-rewrite.php
+++ b/tests/test-class-rewrite.php
@@ -64,7 +64,10 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 			$category_base = 'category';
 		}
 
-		// Remove initial slash, if there is one (we remove the trailing slash in the regex replacement and don't want to end up short a slash).
+		/*
+		 * Remove initial slash, if there is one (we remove the trailing slash in
+		 * the regex replacement and don't want to end up short a slash).
+		 */
 		if ( '/' === substr( $category_base, 0, 1 ) ) {
 			$category_base = substr( $category_base, 1 );
 		}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

Includes two minor tweaks to existing inline block comments.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.