### PR TITLE
Documentation: improve miscellaneous tag alignment and grouping

### DIFF
--- a/admin/capabilities/class-capability-manager-integration.php
+++ b/admin/capabilities/class-capability-manager-integration.php
@@ -60,7 +60,7 @@ class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integratio
 	/**
 	 * Add capabilities to its own group in the Members plugin.
 	 *
-	 * @see  members_register_cap_group()
+	 * @see members_register_cap_group()
 	 */
 	public function action_members_register_cap_group() {
 		if ( ! function_exists( 'members_register_cap_group' ) ) {
@@ -80,7 +80,7 @@ class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integratio
 	/**
 	 * Adds Yoast SEO capability group in the User Role Editor plugin.
 	 *
-	 * @see    URE_Capabilities_Groups_Manager::get_groups_tree()
+	 * @see URE_Capabilities_Groups_Manager::get_groups_tree()
 	 *
 	 * @param array $groups Current groups.
 	 *
@@ -101,7 +101,7 @@ class WPSEO_Capability_Manager_Integration implements WPSEO_WordPress_Integratio
 	/**
 	 * Adds capabilities to the Yoast SEO group in the User Role Editor plugin.
 	 *
-	 * @see    URE_Capabilities_Groups_Manager::get_cap_groups()
+	 * @see URE_Capabilities_Groups_Manager::get_cap_groups()
 	 *
 	 * @param array  $groups Current capability groups.
 	 * @param string $cap_id Capability identifier.

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -180,6 +180,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @link https://developers.facebook.com/blog/post/2013/06/19/platform-updates--new-open-graph-tags-for-media-publishers-and-more/
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
+	 *
 	 * @return boolean
 	 */
 	public function website_facebook() {
@@ -262,6 +263,7 @@ class WPSEO_OpenGraph {
 	 * Outputs the canonical URL as OpenGraph URL, which consolidates likes and shares.
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
+	 *
 	 * @return boolean
 	 */
 	public function url() {
@@ -298,7 +300,6 @@ class WPSEO_OpenGraph {
 	 * Last update/compare with FB list done on 2015-03-16 by Rarst.
 	 *
 	 * @link http://www.facebook.com/translations/FacebookLocales.xml for the list of supported locales.
-	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
 	 *
 	 * @param bool $echo Whether to echo or return the locale.
@@ -664,6 +665,7 @@ class WPSEO_OpenGraph {
 	 * Output the article tags as article:tag tags.
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
+	 *
 	 * @return boolean
 	 */
 	public function tags() {
@@ -688,6 +690,7 @@ class WPSEO_OpenGraph {
 	 * Output the article category as an article:section tag.
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
+	 *
 	 * @return boolean;
 	 */
 	public function category() {
@@ -727,6 +730,7 @@ class WPSEO_OpenGraph {
 	 * Output the article publish and last modification date.
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
+	 *
 	 * @return boolean;
 	 */
 	public function publish_date() {
@@ -778,6 +782,7 @@ class WPSEO_OpenGraph {
 	 * Outputs the site owner.
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
+	 *
 	 * @return void
 	 *
 	 * @deprecated 7.1

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -57,7 +57,7 @@ class WPSEO_Utils {
 	 *
 	 * {@internal current_user_can() checks internally whether a user is on wp-ms and adjusts accordingly.}}
 	 *
-	 * @since    1.8.0
+	 * @since 1.8.0
 	 *
 	 * @return bool
 	 */
@@ -316,7 +316,7 @@ class WPSEO_Utils {
 	 * Sanitize a url for saving to the database.
 	 * Not to be confused with the old native WP function.
 	 *
-	 * @todo  [JRF => whomever] Check/improve url verification.
+	 * @todo [JRF => whomever] Check/improve url verification.
 	 *
 	 * @since 1.8.0
 	 *
@@ -1204,7 +1204,7 @@ SVG;
 	/**
 	 * Returns the language part of a given locale, defaults to english when the $locale is empty.
 	 *
-	 * @see        WPSEO_Language_Utils::get_language()
+	 * @see WPSEO_Language_Utils::get_language()
 	 *
 	 * @deprecated 9.5
 	 * @codeCoverageIgnore
@@ -1227,7 +1227,7 @@ SVG;
 	 * Can be removed when support for WordPress 4.6 will be dropped, in favor
 	 * of WordPress get_user_locale() that already fallbacks to the site's locale.
 	 *
-	 * @see        WPSEO_Language_Utils::get_user_locale()
+	 * @see WPSEO_Language_Utils::get_user_locale()
 	 *
 	 * @deprecated 9.5
 	 * @codeCoverageIgnore

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -22,7 +22,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	 *
 	 * {@internal Shouldn't be requested directly, use $this->get_defaults();}}
 	 *
-	 * @var  array
+	 * @var array
 	 */
 	protected $defaults = array(
 		// Non-form fields, set via (ajax) function.

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -150,7 +150,7 @@ function wpseo_register_var_replacement( $var, $replace_function, $type = 'advan
  * title-ptarchive and metadesc-ptarchive fields translation.
  * Documentation: http://wpml.org/documentation/support/language-configuration-files/
  *
- * @global      $sitepress
+ * @global $sitepress
  *
  * @param array $config WPML configuration data to filter.
  *

--- a/src/models/primary-term.php
+++ b/src/models/primary-term.php
@@ -17,8 +17,8 @@ use Yoast\WP\Free\Yoast_Model;
  * @property int    $term_id  Term ID.
  * @property string $taxonomy Taxonomy.
  *
- * @property string  $created_at
- * @property string  $updated_at
+ * @property string $created_at
+ * @property string $updated_at
  */
 class Primary_Term extends Yoast_Model {
 

--- a/tests/admin/services/test-class-endpoint-indexable.php
+++ b/tests/admin/services/test-class-endpoint-indexable.php
@@ -147,7 +147,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	 * Tests the return value of the get_provider.
 	 *
 	 * @expectedException WPSEO_Invalid_Argument_Exception
-	 * @covers WPSEO_Indexable_Service::get_provider()
+	 * @covers            WPSEO_Indexable_Service::get_provider()
 	 */
 	public function test_get_provider() {
 		$this->assertInstanceOf( 'WPSEO_Indexable_Service_Post_Provider', $this->service->get_provider( 'post' ) );

--- a/tests/admin/services/test-class-indexable-post-provider.php
+++ b/tests/admin/services/test-class-indexable-post-provider.php
@@ -66,7 +66,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param mixed  $object_id   The object id.
 	 * @param string $description The test description.
 	 *
-	 * @covers       WPSEO_Indexable_Service_Post_Provider::is_indexable()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable()
 	 */
 	public function test_is_indexable_with_invalid_object_ids( $object_id, $description ) {
 		$this->assertFalse( $this->provider->is_indexable( $object_id ), $description );
@@ -99,7 +99,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param mixed  $object_id   The object id.
 	 * @param string $description The test description.
 	 *
-	 * @covers       WPSEO_Indexable_Service_Post_Provider::get()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::get()
 	 */
 	public function test_get_a_non_indexable_post_with_invalid_object_ids( $object_id, $description ) {
 		$this->assertEquals( array(), $this->provider->get( $object_id ), $description );

--- a/tests/admin/test-class-admin-recommended-replace-vars.php
+++ b/tests/admin/test-class-admin-recommended-replace-vars.php
@@ -191,7 +191,7 @@ class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * @param string $page_type The page type to get the recommended replacement variables for.
 	 * @param array  $expected  The expected recommended replacement variables.
 	 *
-	 * @covers       WPSEO_Admin_Recommended_Replace_Vars::get_recommended_replacevars_for
+	 * @covers WPSEO_Admin_Recommended_Replace_Vars::get_recommended_replacevars_for
 	 */
 	public function test_get_recommended_replacevars( $page_type, $expected ) {
 		$this->assertEquals( $expected, $this->class_instance->get_recommended_replacevars_for( $page_type ) );

--- a/tests/admin/test-class-yoast-network-admin.php
+++ b/tests/admin/test-class-yoast-network-admin.php
@@ -74,8 +74,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * Tests getting site choices output.
 	 *
 	 * @group yoastnetwork
-	 *
 	 * @group ms-required
+	 *
 	 * @covers Yoast_Network_Admin::get_site_choices()
 	 */
 	public function test_get_site_choices_output() {
@@ -98,7 +98,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting a site's states.
 	 *
-	 * @group ms-required
+	 * @group  ms-required
 	 * @covers Yoast_Network_Admin::get_site_states()
 	 */
 	public function test_get_site_states() {

--- a/tests/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/config-ui/test-class-configuration-options-adapter.php
@@ -68,9 +68,9 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers                   WPSEO_Configuration_Options_Adapter::add_custom_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup()
 	 *
-	 * @expectedException InvalidArgumentException
+	 * @expectedException        InvalidArgumentException
 	 * @expectedExceptionMessage Custom option must be callable.
 	 */
 	public function test_add_custom_lookup_not_a_callback_get() {
@@ -78,9 +78,9 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers                   WPSEO_Configuration_Options_Adapter::add_custom_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup()
 	 *
-	 * @expectedException InvalidArgumentException
+	 * @expectedException        InvalidArgumentException
 	 * @expectedExceptionMessage Custom option must be callable.
 	 */
 	public function test_add_custom_lookup_not_a_callback_set() {
@@ -124,9 +124,9 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers                   WPSEO_Configuration_Options_Adapter::add_wordpress_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_wordpress_lookup()
 	 *
-	 * @expectedException InvalidArgumentException
+	 * @expectedException        InvalidArgumentException
 	 * @expectedExceptionMessage WordPress option must be a string.
 	 */
 	public function test_add_wordpress_lookup_option_non_string() {

--- a/tests/inc/indexables/test-class-indexable.php
+++ b/tests/inc/indexables/test-class-indexable.php
@@ -20,7 +20,7 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 	 * @param string    $description Description of the test.
 	 *
 	 * @dataProvider noindex_conversion_provider
-	 * @covers WPSEO_Indexable::get_robots_noindex_value()
+	 * @covers       WPSEO_Indexable::get_robots_noindex_value()
 	 */
 	public function test_get_robots_noindex_value( $value, $expected, $description ) {
 		$data = WPSEO_Indexable_Double::get_robots_noindex_value( $value );

--- a/tests/inc/indexables/test-class-post-indexable.php
+++ b/tests/inc/indexables/test-class-post-indexable.php
@@ -35,7 +35,7 @@ class WPSEO_Post_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the creation of an invalid Post Indexable object.
 	 *
-	 * @covers WPSEO_Post_Indexable::from_object()
+	 * @covers            WPSEO_Post_Indexable::from_object()
 	 * @expectedException WPSEO_Invalid_Argument_Exception
 	 */
 	public function test_from_object_invalid_post() {

--- a/tests/inc/indexables/test-class-term-indexable.php
+++ b/tests/inc/indexables/test-class-term-indexable.php
@@ -52,7 +52,7 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the creation of an invalid Term Indexable object.
 	 *
-	 * @covers WPSEO_Term_Indexable::from_object()
+	 * @covers            WPSEO_Term_Indexable::from_object()
 	 * @expectedException WPSEO_Invalid_Argument_Exception
 	 */
 	public function test_from_object_invalid_term() {

--- a/tests/inc/options/test-class-wpseo-option-wpseo.php
+++ b/tests/inc/options/test-class-wpseo-option-wpseo.php
@@ -29,7 +29,7 @@ class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that disabled 'wpseo' feature variables return false.
 	 *
-	 * @group ms-required
+	 * @group  ms-required
 	 * @covers WPSEO_Option::validate()
 	 * @covers WPSEO_Option::prevent_disabled_options_update()
 	 */

--- a/tests/inc/options/test-class-wpseo-option.php
+++ b/tests/inc/options/test-class-wpseo-option.php
@@ -13,7 +13,7 @@ class WPSEO_Option_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that disabled variables cannot be updated.
 	 *
-	 * @group ms-required
+	 * @group  ms-required
 	 * @covers WPSEO_Option::validate()
 	 * @covers WPSEO_Option::prevent_disabled_options_update()
 	 */

--- a/tests/inc/test-class-addon-manager.php
+++ b/tests/inc/test-class-addon-manager.php
@@ -420,7 +420,7 @@ class WPSEO_Addon_Manager_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider check_for_updates_provider
 	 *
-	 * @covers       WPSEO_Addon_Manager::check_for_updates
+	 * @covers WPSEO_Addon_Manager::check_for_updates
 	 *
 	 * @param array  $addons   The 'installed' addons.
 	 * @param array  $data     Data being send to the method.

--- a/tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -68,7 +68,7 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether the current request should be redirected to sitemap_index.xml.
 	 *
-	 * @covers WPSEO_Sitemaps_Router::needs_sitemap_index_redirect()
+	 * @covers       WPSEO_Sitemaps_Router::needs_sitemap_index_redirect()
 	 * @dataProvider data_needs_sitemap_index_redirect
 	 *
 	 * @param array    $server_vars Associative array of `$_SERVER` vars to set.

--- a/tests/test-class-admin-asset-manager.php
+++ b/tests/test-class-admin-asset-manager.php
@@ -367,7 +367,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the flatten_version function.
 	 *
-	 * @covers WPSEO_Admin_Asset_Manager::flatten_version
+	 * @covers       WPSEO_Admin_Asset_Manager::flatten_version
 	 * @dataProvider flatten_version_provider
 	 *
 	 * @param string $original Version number.

--- a/tests/test-class-wpseo-meta-columns.php
+++ b/tests/test-class-wpseo-meta-columns.php
@@ -385,7 +385,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @param array  $expected The resulting SEO score filter.
 	 *
 	 * @dataProvider determine_seo_filters_dataprovider
-	 * @covers WPSEO_Meta_Columns::determine_seo_filters()
+	 * @covers       WPSEO_Meta_Columns::determine_seo_filters()
 	 */
 	public function test_determine_seo_filters( $filter, $expected ) {
 		$result = self::$class_instance->determine_seo_filters( $filter );
@@ -398,7 +398,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @param array  $expected The Readability score filter.
 	 *
 	 * @dataProvider determine_readability_filters_dataprovider
-	 * @covers WPSEO_Meta_Columns::determine_readability_filters()
+	 * @covers       WPSEO_Meta_Columns::determine_readability_filters()
 	 */
 	public function test_determine_readability_filters( $filter, $expected ) {
 		$result = self::$class_instance->determine_readability_filters( $filter );
@@ -412,7 +412,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @param array $expected Array containing the complete filter query.
 	 *
 	 * @dataProvider build_filter_query_dataprovider
-	 * @covers WPSEO_Meta_Columns::build_filter_query()
+	 * @covers       WPSEO_Meta_Columns::build_filter_query()
 	 */
 	public function test_build_filter_query( $vars, $filters, $expected ) {
 		$result = self::$class_instance->build_filter_query( $vars, $filters );

--- a/tests/test-class-wpseo-utils.php
+++ b/tests/test-class-wpseo-utils.php
@@ -94,7 +94,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 * Tests translate_score function.
 	 *
 	 * @dataProvider translate_score_provider
-	 * @covers WPSEO_Utils::translate_score()
+	 * @covers       WPSEO_Utils::translate_score()
 	 *
 	 * @param int    $score     The decimal score to translate.
 	 * @param bool   $css_value Whether to return the i18n translated score or the CSS class value.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

Tag alignment and grouping fixes:
* Tags of the same kind should be grouped without blank lines between them.
* Different tags may sometimes be grouped, but not always.
* The content of grouped tags should start one space after the longest tag.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.