### PR TITLE
Test documentation: add some missing @covers tags

### DIFF
--- a/tests/admin/test-class-admin-editor-specific-replace-vars.php
+++ b/tests/admin/test-class-admin-editor-specific-replace-vars.php
@@ -231,6 +231,9 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 'fallback_archive', $this->class_instance->determine_for_archive( 'non-existing-archive', 'fallback_archive' ) );
 	}
 
+	/**
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::determine_for_archive
+	 */
 	public function test_determine_for_archive_with_a_existing_archive() {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Admin_Editor_Specific_Replace_Vars' )

--- a/tests/test-class-wpseo-rank.php
+++ b/tests/test-class-wpseo-rank.php
@@ -29,6 +29,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @dataProvider provider_get_css_class
+	 * @covers       WPSEO_Rank::get_css_class
 	 *
 	 * @param int    $rank     Ranking.
 	 * @param string $expected Expected CSS class.
@@ -56,6 +57,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @dataProvider provider_get_label
+	 * @covers       WPSEO_Rank::get_label
 	 *
 	 * @param int    $rank     Ranking.
 	 * @param string $expected Expected label.
@@ -83,6 +85,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @dataProvider provider_get_drop_down_label
+	 * @covers       WPSEO_Rank::get_drop_down_label
 	 *
 	 * @param int    $rank     Ranking.
 	 * @param string $expected Expected drop-down label.
@@ -110,6 +113,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @dataProvider provider_get_starting_score
+	 * @covers       WPSEO_Rank::get_starting_score
 	 *
 	 * @param int    $rank     Ranking.
 	 * @param string $expected Expected start score.
@@ -137,6 +141,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @dataProvider provider_get_end_score
+	 * @covers       WPSEO_Rank::get_end_score
 	 *
 	 * @param int    $rank     Ranking.
 	 * @param string $expected Expected end score.
@@ -164,6 +169,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @dataProvider provider_from_numeric_score
+	 * @covers       WPSEO_Rank::from_numeric_score
 	 *
 	 * @param int $score    Numeric score.
 	 * @param int $expected Expected ranking.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.