### PR TITLE
Fix search-appearance React error

### DIFF
--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -241,13 +241,12 @@ class WordPressUserSelector extends Component {
 	}
 }
 
-WordPressUserSelector.propTypes = {
+export const WordPressUserSelectorPropTypes = {
 	name: PropTypes.string.isRequired,
 	value: PropTypes.number.isRequired,
-	properties: PropTypes.shape( {
-		user: PropTypes.number,
-	} ).isRequired,
 	onChange: PropTypes.func.isRequired,
 };
+
+WordPressUserSelector.propTypes = WordPressUserSelectorPropTypes;
 
 export default WordPressUserSelector;

--- a/js/src/components/WordPressUserSelectorOnboardingWizard.js
+++ b/js/src/components/WordPressUserSelectorOnboardingWizard.js
@@ -5,8 +5,8 @@ import { Label } from "@yoast/components";
 import styled from "styled-components";
 
 /* Internal dependencies */
-import WordPressUserSelector from "./WordPressUserSelector";
 import valueToNativeEvent from "./higherorder/valueToNativeEvent";
+import WordPressUserSelector, { WordPressUserSelectorPropTypes } from "./WordPressUserSelector";
 
 /**
  * Container for the user selector.
@@ -60,5 +60,9 @@ class WordPressUserSelectorOnboardingWizard extends Component {
 		);
 	}
 }
+
+WordPressUserSelectorOnboardingWizard.propTypes = {
+	...WordPressUserSelectorPropTypes,
+};
 
 export default valueToNativeEvent( WordPressUserSelectorOnboardingWizard );

--- a/js/src/redux/utils/configureEnhancers.js
+++ b/js/src/redux/utils/configureEnhancers.js
@@ -1,7 +1,6 @@
 /* External dependencies */
 import { applyMiddleware } from "redux";
 import thunk from "redux-thunk";
-import logger from "redux-logger";
 import flowRight from "lodash/flowRight";
 
 /**
@@ -13,10 +12,6 @@ export default function configureEnhancers() {
 	const middleware = [
 		thunk,
 	];
-
-	if ( process.env.NODE_ENV !== "production" ) {
-		middleware.push( logger );
-	}
 
 	const enhancers = [
 		applyMiddleware( ...middleware ),

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "jest-styled-components": "^6.3.1",
     "load-grunt-config": "^0.19.2",
     "raf": "^3.4.0",
-    "redux-logger": "^3.0.6",
     "request": "^2.88.0",
     "sassdash": "^0.9.0",
     "shusher": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,11 +3747,6 @@ decorate-component-with-props@^1.0.2:
   resolved "https://registry.yarnpkg.com/decorate-component-with-props/-/decorate-component-with-props-1.1.0.tgz#b496c814c6a2aba0cf2ad26e44cbedb8ead42f15"
   integrity sha512-tTYQojixN64yK3/WBODMfvss/zbmyUx9HQXhzSxZiSiofeekVeRyyuToy9BCiTMrVEIKWxTcla2t3y5qdaUF7Q==
 
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
-  integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
-
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -10293,13 +10288,6 @@ reduce@^1.0.1:
   integrity sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==
   dependencies:
     object-keys "^1.1.0"
-
-redux-logger@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
-  dependencies:
-    deep-diff "^0.3.5"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing because only in the trunk so far] Fixes a console error due to incorrect PropTypes in the WordPressUserSelector component.
* [non-userfacing] Removes development dependency of `redux-logger`, that was used on the search-appearance page.

## Relevant technical choices:

* Added a PropTypes export in the WordPressUserSelector file.
* Added the WordPressUserSelectorPropTypes in the WordPressUserSelectorOnboardingWizard.
* Removed `redux-logger` middleware; used only in the search-appearance store. Please use the Redux development tool browser extension instead.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Replicate the issue by activating the plugin of `release/11.1`.
* Go to the `SEO -> Search Appearance` page.
* Check the console for the following error:
<img width="884" alt="WordPressUserSelect-properties-error" src="https://user-images.githubusercontent.com/35524806/56349944-f4821f80-61c9-11e9-8ada-b8b67c701cdb.png">

* Activate the plugin of this branch.
* Go to the `SEO -> Search Appearance` page.
* Verify the console error is no longer there.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
