### PR TITLE
Fix copy-pasta in constructor comment

### DIFF
--- a/frontend/schema/class-schema-person.php
+++ b/frontend/schema/class-schema-person.php
@@ -19,7 +19,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	private $context;
 
 	/**
-	 * WPSEO_Schema_Breadcrumb constructor.
+	 * WPSEO_Schema_Person constructor.
 	 *
 	 * @param WPSEO_Schema_Context $context A value object with context variables.
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes copy-pasta in `WPSEO_Schema_Person` constructor comment.
