### PR TITLE
No longer execute the link-monorepo scripts using a shebang (#!)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",
     "prestart": "grunt build:css && grunt webpack:buildDev",
     "start": "webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
-    "link-monorepo": "./scripts/link_monorepo_to_plugin.js",
-    "unlink-monorepo": "./scripts/unlink_monorepo.js"
+    "link-monorepo": "node scripts/link_monorepo_to_plugin.js",
+    "unlink-monorepo": "node scripts/unlink_monorepo.js"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/js/tests/setupTests.js",

--- a/scripts/link_monorepo_to_plugin.js
+++ b/scripts/link_monorepo_to_plugin.js
@@ -1,4 +1,3 @@
-#!/usr/local/bin/node
 const fs = require( "fs" );
 const readlineSync = require( "readline-sync" );
 const execSync = require( "child_process" ).execSync;

--- a/scripts/link_monorepo_to_plugin.js
+++ b/scripts/link_monorepo_to_plugin.js
@@ -167,6 +167,11 @@ checkout_branch_and_pull( javascriptBranch );
 const packages = execMonorepo( `ls packages` ).toString().split( "\n" ).filter( value => value !== "" );
 unlink_all_yoast_packages();
 
+// Just to be sure.
+execMonorepoNoOutput( `
+	yarn install
+` );
+
 execMonorepoNoOutput( `
 	yarn link-all
 ` );


### PR DESCRIPTION
This *probably* fixes the problems Daria has. Also, it ensures that those commands can be used on other filesystems as long as node is installed.
