### PR TITLE
Set company or person in upgrade routine

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -128,6 +128,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_100();
 		}
 
+		if ( version_compare( $version, '11.1-RC0', '<' ) ) {
+			$this->upgrade_111();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -661,6 +665,20 @@ class WPSEO_Upgrade {
 		// Removes recalibration options.
 		WPSEO_Options::clean_up( 'wpseo' );
 		delete_option( 'wpseo_recalibration_beta_mailinglist_subscription' );
+	}
+
+	/**
+	 * Performs the 11.1 upgrade.
+	 *
+	 * @return void
+	 */
+	private function upgrade_111() {
+		// Set company_or_person to company if empty.
+		$company_or_person = WPSEO_Options::get( 'wpseo_titles', '' );
+
+		if ( $company_or_person === '' ) {
+			WPSEO_Options::set( 'company_or_person', 'company' );
+		}
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -676,7 +676,7 @@ class WPSEO_Upgrade {
 		// Set company_or_person to company if empty.
 		$company_or_person = WPSEO_Options::get( 'wpseo_titles', '' );
 
-		if ( $company_or_person === '' ) {
+		if ( ! in_array( $company_or_person, array( 'company', 'person' ), true ) ) {
 			WPSEO_Options::set( 'company_or_person', 'company' );
 		}
 	}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -673,7 +673,7 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_111() {
-		// Set company_or_person to company if empty.
+		// Set company_or_person to company when it's an invalid value.
 		$company_or_person = WPSEO_Options::get( 'wpseo_titles', '' );
 
 		if ( ! in_array( $company_or_person, array( 'company', 'person' ), true ) ) {

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -357,8 +357,10 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					if ( isset( $dirty[ $key ] ) ) {
 						if ( in_array( $dirty[ $key ], array( 'company', 'person' ), true ) ) {
 							$clean[ $key ] = $dirty[ $key ];
-						} else {
-							$clean[ $key ] = $this->get_defaults()[ 'company_or_person' ];
+						}
+						else {
+							$defaults = $this->get_defaults();
+							$clean[ $key ] = $defaults['company_or_person'];
 						}
 					}
 					break;

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -358,7 +358,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 						if ( in_array( $dirty[ $key ], array( 'company', 'person' ), true ) ) {
 							$clean[ $key ] = $dirty[ $key ];
 						} else {
-							$clean[ $key ] = 'company';
+							$clean[ $key ] = $this->get_defaults()[ 'company_or_person' ];
 						}
 					}
 					break;

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -354,9 +354,11 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					break;
 
 				case 'company_or_person':
-					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
+					if ( isset( $dirty[ $key ] ) ) {
 						if ( in_array( $dirty[ $key ], array( 'company', 'person' ), true ) ) {
 							$clean[ $key ] = $dirty[ $key ];
+						} else {
+							$clean[ $key ] = 'company';
 						}
 					}
 					break;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Fixes edgecase where you could set the site entity to "".

## Relevant technical choices:

* Added upgrade routine that will set `company_or_person` to company when an invalid value is stored at the moment of upgrading.
* Added validation for `company_or_person` in `class-wpseo-option-titles.php`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reproduce steps in #12725 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12725
