### PR TITLE
Enabled features are now also available on category and tag pages.

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -137,6 +137,7 @@ class WPSEO_Taxonomy {
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'replacevar-plugin', 'wpseoReplaceVarsL10n', $this->localize_replace_vars_script() );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoSelect2Locale', WPSEO_Language_Utils::get_language( WPSEO_Language_Utils::get_user_locale() ) );
 			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
+			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'metabox', 'wpseoFeaturesL10n', WPSEO_Utils::retrieve_enabled_features() );
 
 			$asset_manager->enqueue_script( 'admin-media' );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast SEO metabox on category and tag pages would not load. 

## Relevant technical choices:

* The list of feature flags is now also injected into the javascript side of the metabox on taxonomy and category pages. 

## Impact check
**High**: Can cause the entire metabox to not load on category and tag pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproducing the bug
* Checkout the `trunk` branch.
* Start your local `wordpress-seo` development environment.
* Go to a category or tag page.
* The page should have an empty Yoast SEO metabox.
* The browser's console should give this error:
  ```
  Uncaught ReferenceError: wpseoFeaturesL10n is not defined
  ```
### Checking if it is fixed
* Checkout this branch (`12745-wpseofeaturesl10n-is-not-defined`)
* Start your local `wordpress-seo` development environment.
* Go to a category or tag page.
* The Yoast SEO metabox should load.
* You should not see an error in the console.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12745