### PR TITLE
Add wpseo_should_index_links filter

### DIFF
--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -43,7 +43,6 @@ class WPSEO_Link_Watcher {
 	 * @return void
 	 */
 	public function save_post( $post_id, WP_Post $post ) {
-
 		/**
 		 * Filter: 'wpseo_should_index_links' - Allows disabling of Yoast's links indexation.
 		 *

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -30,16 +30,8 @@ class WPSEO_Link_Watcher {
 	 * @returns void
 	 */
 	public function register_hooks() {
-
-		/**
-		 * Filter: 'wpseo_should_index_links' - Allows disabling of Yoast's links indexation.
-		 *
-		 * @api bool To disable the indexation, return false.
-		 */
-		if ( apply_filters( 'wpseo_should_index_links', true ) ) {
 			add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
 			add_action( 'delete_post', array( $this, 'delete_post' ) );
-		}
 	}
 
 	/**
@@ -51,6 +43,16 @@ class WPSEO_Link_Watcher {
 	 * @return void
 	 */
 	public function save_post( $post_id, WP_Post $post ) {
+
+		/**
+		 * Filter: 'wpseo_should_index_links' - Allows disabling of Yoast's links indexation.
+		 *
+		 * @api bool To disable the indexation, return false.
+		 */
+		if ( ! apply_filters( 'wpseo_should_index_links', true ) ) {
+			return;
+		}
+
 		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			return;
 		}
@@ -82,6 +84,11 @@ class WPSEO_Link_Watcher {
 	 * @return void
 	 */
 	public function delete_post( $post_id ) {
+		/** This filter is documented in admin/links/class-link-watcher.php */
+		if ( ! apply_filters( 'wpseo_should_index_links', true ) ) {
+			return;
+		}
+
 		if ( ! WPSEO_Link_Table_Accessible::is_accessible() || ! WPSEO_Meta_Table_Accessible::is_accessible() ) {
 			return;
 		}

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -30,8 +30,16 @@ class WPSEO_Link_Watcher {
 	 * @returns void
 	 */
 	public function register_hooks() {
-		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
-		add_action( 'delete_post', array( $this, 'delete_post' ) );
+
+		/**
+		 * Filter: 'wpseo_should_index_links' - Allows disabling of Yoast's links indexation.
+		 *
+		 * @api bool To disable the indexation, return false.
+		 */
+		if ( apply_filters( 'wpseo_should_index_links', true ) ) {
+			add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
+			add_action( 'delete_post', array( $this, 'delete_post' ) );
+		}
 	}
 
 	/**

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -30,8 +30,8 @@ class WPSEO_Link_Watcher {
 	 * @returns void
 	 */
 	public function register_hooks() {
-			add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
-			add_action( 'delete_post', array( $this, 'delete_post' ) );
+		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
+		add_action( 'delete_post', array( $this, 'delete_post' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add the `wpseo_should_index_links` filter that can be used to disable the link indexation.

## Relevant technical choices:

Currently, the link counter feature toggle only disables the UI: the link count columns on the post overview are hidden (as well as the orphaned content filter in Premium). However, all 'calculations' in the background are still done. These could lead to a slow backend as described in #9474. 

The first option was to stop doing those calculations when the feature is disabled and remove the link indexation data from the database. This would lead to a clean database, but would also mean that when a user would disable the toggle temporarily, a complete reindexation of possibly thousands of posts would need to take place when the feature is enabled again (also for people who disabled the feature just to see what the toggle does). 

The second option was to stop doing those calculations when the feature is disabled and stop editing the database, but leave the current database data as is. This would be challenging when the user would enable the toggle again later. In that case, we would be dealing with an out-of-date database, and our current reindexing algorithm cannot deal with that (because it only reindexes posts that never had been indexed, which means that updated posts with new links would be untouched by the algorithm).

Another thing to consider is that we might build functionality that depends on the link data in the future. We did that with the orphaned content filter before (which is now disabled as well when the text link counter is toggled off, without any notification/explanation). If we would stop the calculations, that would mean that, when adding this new functionality, we would need to add an update routine to reindex all posts for all sites that have the text link counter toggled off. This would be a very expensive upgrade routine for large sites.

With all these pieces of content in mind, we've decided to add a filter that can be used to stop the calculations. That way, people who really want to stop them can stop them, but we don't make a technical decision that could be costly in the future on a larger scale.

_About the location of the `apply_filters`_
In my first try, I added the `apply_filters` to `register_hooks` around the add_actions. However, when testing with the filter in my theme's `functions.php`, I noticed that `register_hooks` was called before the theme's `functions.php` was loaded. Therefore, I decided to move the `apply_filters` to within `save_post` and `delete_post`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build this branch.
* Add the following line to your theme's functions.php:
```
add_filter( 'wpseo_should_index_links', function() {
	return false;
} );
```
* Set breakpoints within `save_post` and `delete_post` after the filter.
* Start your debugger, save a post, and see that the breakpoints are not reached.
* Start your debugger, delete a post, and see that the breakpoints are not reached.
* Replace the filter call in your theme's functions.php by:
```
add_filter( 'wpseo_should_index_links', function() {
	return true;
} );
```
* Start your debugger, save a post, and see that the breakpoints are reached.
* Start your debugger, delete a post, and see that the breakpoints are reached.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9474 
