### PR TITLE
Fallback to first content image when no featured image is available

### DIFF
--- a/frontend/class-opengraph-image.php
+++ b/frontend/class-opengraph-image.php
@@ -317,7 +317,7 @@ class WPSEO_OpenGraph_Image {
 			return;
 		}
 
-		$this->add_first_usable_content_image( get_post( $post_id ) );
+		$this->add_first_usable_content_image( $post_id );
 	}
 
 	/**
@@ -685,20 +685,14 @@ class WPSEO_OpenGraph_Image {
 	/**
 	 * Adds the first usable attachment image from the post content.
 	 *
-	 * @param WP_Post $post The post object.
+	 * @param int $post_id The post id.
 	 *
 	 * @return void
 	 */
-	private function add_first_usable_content_image( $post ) {
-		$image_finder = new WPSEO_Content_Images();
-		$images       = $image_finder->get_images( $post->ID, $post );
+	private function add_first_usable_content_image( $post_id ) {
+		$image_url = WPSEO_Image_Utils::get_first_usable_content_image_for_post( $post_id );
 
-		if ( ! is_array( $images ) || $images === array() ) {
-			return;
-		}
-
-		$image_url = reset( $images );
-		if ( ! $image_url ) {
+		if ( $image_url === null || empty( $image_url ) ) {
 			return;
 		}
 

--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -630,15 +630,9 @@ class WPSEO_Twitter {
 	 * @return bool True when images output succeeded.
 	 */
 	private function image_from_content_output( $post_id ) {
-		$image_finder = new WPSEO_Content_Images();
-		$images       = $image_finder->get_images( $post_id );
+		$image_url = WPSEO_Image_Utils::get_first_usable_content_image_for_post( $post_id );
 
-		if ( ! is_array( $images ) || $images === array() ) {
-			return false;
-		}
-
-		$image_url = reset( $images );
-		if ( ! $image_url ) {
+		if ( $image_url === null || empty( $image_url ) ) {
 			return false;
 		}
 

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -154,7 +154,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			return $data;
 		}
 
-		$data['image']              = $image_schema;
+		$data['image'] = $image_schema;
 		$data['primaryImageOfPage'] = array(
 			'@id' => $image_id,
 		);
@@ -185,7 +185,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @param int    $post_id  The post id.
 	 * @param string $image_id The image schema id.
 	 *
-	 * @return array|null The image schema object and null if there is no image in teh content.
+	 * @return array|null The image schema object and null if there is no image in the content.
 	 */
 	private function get_first_content_image( $post_id, $image_id ) {
 		$image_url = WPSEO_Image_Utils::get_first_usable_content_image_for_post( $post_id );

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -69,7 +69,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 		}
 
 		if ( is_singular() ) {
-			$data = $this->add_featured_image( $data );
+			$data = $this->add_image( $data );
 
 			$post                  = get_post( $this->context->id );
 			$data['datePublished'] = mysql2date( DATE_W3C, $post->post_date_gmt, false );
@@ -135,24 +135,66 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	}
 
 	/**
-	 * Adds a featured image to the schema if there is one.
+	 * Adds a featured image to the schema if there is one, if not falls back to the first image on the page.
 	 *
 	 * @param array $data WebPage Schema.
 	 *
 	 * @return array $data WebPage Schema.
 	 */
-	private function add_featured_image( $data ) {
-		if ( ! has_post_thumbnail( $this->context->id ) ) {
+	private function add_image( $data ) {
+		$image_id = $this->context->canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH;
+
+		$image_schema = $this->get_featured_image( $this->context->id, $image_id );
+
+		if ( $image_schema === null ) {
+			$image_schema = $this->get_first_content_image( $this->context->id, $image_id );
+		}
+
+		if ( $image_schema === null ) {
 			return $data;
 		}
 
-		$id                         = $this->context->canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH;
-		$schema_image               = new WPSEO_Schema_Image( $id );
-		$data['image']              = $schema_image->generate_from_attachment_id( get_post_thumbnail_id() );
+		$data['image']              = $image_schema;
 		$data['primaryImageOfPage'] = array(
-			'@id' => $id,
+			'@id' => $image_id,
 		);
 
 		return $data;
+	}
+
+	/**
+	 * Gets the image schema for the web page based on the featured image.
+	 *
+	 * @param int    $post_id  The post id.
+	 * @param string $image_id The image schema id.
+	 *
+	 * @return array|null The image schema object and null if there is no featured image.
+	 */
+	private function get_featured_image( $post_id, $image_id ) {
+		if ( ! has_post_thumbnail( $post_id ) ) {
+			return null;
+		}
+
+		$schema_image = new WPSEO_Schema_Image( $image_id );
+		return $schema_image->generate_from_attachment_id( get_post_thumbnail_id() );
+	}
+
+	/**
+	 * Gets the image schema for the web page based on the first content image image.
+	 *
+	 * @param int    $post_id  The post id.
+	 * @param string $image_id The image schema id.
+	 *
+	 * @return array|null The image schema object and null if there is no image in teh content.
+	 */
+	private function get_first_content_image( $post_id, $image_id ) {
+		$image_url = WPSEO_Image_Utils::get_first_usable_content_image_for_post( $post_id );
+
+		if ( $image_url === null ) {
+			return null;
+		}
+
+		$schema_image = new WPSEO_Schema_Image( $image_id );
+		return $schema_image->generate_from_url( $image_url );
 	}
 }

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -362,7 +362,7 @@ class WPSEO_Image_Utils {
 	/**
 	 * Gets the post's first usable content image. Null if none is available.
 	 *
-	 * @param integer $post_id The post id.
+	 * @param int $post_id The post id.
 	 *
 	 * @return string|null The image URL.
 	 */

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -372,7 +372,7 @@ class WPSEO_Image_Utils {
 		$image_finder = new WPSEO_Content_Images();
 		$images       = $image_finder->get_images( $post->ID, $post );
 
-		if ( ! is_array( $images ) || $images === array() ) {
+		if ( ! is_array( $images ) || empty( $images ) ) {
 			return null;
 		}
 

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -358,4 +358,29 @@ class WPSEO_Image_Utils {
 
 		return true;
 	}
+
+	/**
+	 * Gets the post's first usable content image. Null if none is available.
+	 *
+	 * @param integer $post_id The post id.
+	 *
+	 * @return string|null The image URL.
+	 */
+	public static function get_first_usable_content_image_for_post( $post_id = null ) {
+		$post = get_post( $post_id );
+
+		$image_finder = new WPSEO_Content_Images();
+		$images       = $image_finder->get_images( $post->ID, $post );
+
+		if ( ! is_array( $images ) || $images === array() ) {
+			return null;
+		}
+
+		$image_url = reset( $images );
+		if ( ! $image_url ) {
+			return null;
+		}
+
+		return $image_url;
+	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fallback to first image in content for schema when no featured image is set.

## Relevant technical choices:

* Created helper function `get_first_usable_content_image_for_post`.
* Didn't write unit tests because the code relies heavily on wp functions.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* When a post/page has a featured image, check whether the same image is used for `og:image`, `twitter:image` and the `WebPage` graph's `image` object.
* When a post/page has no featured image, but other images, check whether the first  image is used for `og:image`, `twitter:image` and the `WebPage` graph's `image` object.
* When a post/page has no featured image, and no images, check whether there are no `og:image` or `twitter:image` meta tags, and the `WebPage` graph part has no `image` propery.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12706 
