### PR TITLE
Only show compatibility notifications for active plugins

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -346,7 +346,7 @@ class WPSEO_Admin_Init {
 			$type         = ( $plugin['active'] ) ? Yoast_Notification::ERROR : Yoast_Notification::WARNING;
 			$notification = $this->get_yoast_seo_compatibility_notification( $name, $plugin, $type );
 
-			if ( $plugin['compatible'] === false ) {
+			if ( $plugin['active'] && $plugin['compatible'] === false ) {
 				$notification_center->add_notification( $notification );
 
 				continue;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes compatibility notifications to only show for active plugins.

## Relevant technical choices:

* I left the `$type` in there to still be able to remove any current warning notifications.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install old add-on versions but do not activate them.
* Go to the SEO Dashboard.
* There should no longer be notifications about updating the installed but inactive add-ons.
* Activate the add-ons.
* There should be an error notification about updating the active add-ons.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #12650 
