### PR TITLE
Add script to bump all installed @yoast packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "prestart": "grunt build:css && grunt webpack:buildDev",
     "start": "webpack-dev-server --config ./webpack/webpack.config.js --progress --env.environment=development",
     "link-monorepo": "node scripts/link_monorepo_to_plugin.js",
-    "unlink-monorepo": "node scripts/unlink_monorepo.js"
+    "unlink-monorepo": "node scripts/unlink_monorepo.js",
+    "bump-monorepo-packages": "node scripts/bump_monorepo_packages.js"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/js/tests/setupTests.js",

--- a/scripts/bump_monorepo_packages.js
+++ b/scripts/bump_monorepo_packages.js
@@ -1,0 +1,118 @@
+#!/usr/local/bin/node
+const fs = require( "fs" );
+const execSync = require( "child_process" ).execSync;
+
+// Non-@yoast packages.
+const legacyYoastPackages = [ "yoast-components", "yoastseo", "eslint-config-yoast" ];
+
+// Console colors.
+const bright = "\x1b[1m";
+const red = "\x1b[31m";
+const reset = "\x1b[0m";
+
+/**
+ * Console logs with a bright font.
+ *
+ * @param {string} message The message to log.
+ *
+ * @returns {void}
+ */
+function log( message ) {
+	// eslint-disable-next-line no-console
+	console.log( bright + message + reset );
+}
+
+/**
+ * Console logs with a bright red font.
+ *
+ * @param {string} message The message to log.
+ *
+ * @returns {void}
+ */
+function errorlog( message ) {
+	// eslint-disable-next-line no-console
+	console.log( bright + red + message + reset );
+}
+
+/**
+ * Checks whether a package is a Yoast monorepo package.
+ *
+ * @param {string} packageName A package name.
+ *
+ * @returns {boolean} Whether or not a package is a Yoast package.
+ */
+function isYoastPackage( packageName ) {
+	return packageName.includes( "@yoast" ) || legacyYoastPackages.includes( packageName );
+}
+
+/**
+ * Get a yarn add version string for a version number or constraint. Prefixes with "@" if a version is given.
+ *
+ * @param {string} version A version number or constraint.
+ *
+ * @returns {string} An @-prefixed version string
+ */
+function getVersionString( version = "" ) {
+	return version ? "@" + version : "";
+}
+
+/**
+ * Installs Yarn packages.
+ *
+ * @param {string[]} packageNames The package names to install.
+ * @param {string} version The version to install.
+ * @param {string} flags A string of flags to pass to the Yarn add command.
+ *
+ * @returns {void}
+ */
+function addPackages( packageNames, version = "", flags = "" ) {
+	const packageVersions = packageNames.map( packageName => packageName + getVersionString( version ) ).join( " " );
+	const cmd = `yarn add ${ packageVersions } ${ flags }`;
+	log( cmd );
+	execSync( cmd );
+}
+
+/**
+ * Installs Yarn packages. And retries each package individually on failure.
+ * This is useful for when a single package fail to install.
+ *
+ * @param {string[]} packageNames The package names to install.
+ * @param {string} version The version to install.
+ * @param {string} flags A string of flags to pass to the Yarn add command.
+ *
+ * @returns {void}
+ */
+function addPackagesWithFailsafe( packageNames, version = "", flags = "" ) {
+	try {
+		addPackages( packageNames, version, flags );
+	} catch ( e ) {
+		errorlog( "Failed to install one of the packages. Trying to install packages individually" );
+		packageNames.forEach( packageName => {
+			try {
+				addPackages( [ packageName ], version, flags );
+			} catch ( err ) {
+				errorlog( `Failed to install ${ packageName }${ getVersionString( version ) }` );
+			}
+		} );
+	}
+}
+
+/**
+ * Bumps the version all installed Yoast monorepo packages to the specified or latest version
+ *
+ * @param {array} args CLI arguments, the first arg being the version number.
+ *
+ * @returns {void}
+ */
+function bumpVersions( args ) {
+	const packages = JSON.parse( fs.readFileSync( "package.json", "utf8" ) ) || {};
+
+	const installedYoastPackages = Object.keys( packages.dependencies || {} ).filter( isYoastPackage );
+	const installedDevYoastPackages = Object.keys( packages.devDependencies || {} ).filter( isYoastPackage );
+
+	const version = args[ 0 ];
+	addPackagesWithFailsafe( installedYoastPackages, version );
+	addPackagesWithFailsafe( installedDevYoastPackages, version, "--dev" );
+}
+
+bumpVersions( process.argv.slice( 2 ) );

--- a/scripts/bump_monorepo_packages.js
+++ b/scripts/bump_monorepo_packages.js
@@ -6,9 +6,9 @@ const execSync = require( "child_process" ).execSync;
 const legacyYoastPackages = [ "yoast-components", "yoastseo", "eslint-config-yoast" ];
 
 // Console colors.
-const bright = "\x1b[1m";
-const red = "\x1b[31m";
-const reset = "\x1b[0m";
+const CONSOLE_STYLE_BRIGHT = "\x1b[1m";
+const CONSOLE_STYLE_RED = "\x1b[31m";
+const CONSOLE_STYLE_RESET = "\x1b[0m";
 
 /**
  * Console logs with a bright font.
@@ -19,7 +19,7 @@ const reset = "\x1b[0m";
  */
 function log( message ) {
 	// eslint-disable-next-line no-console
-	console.log( bright + message + reset );
+	console.log( CONSOLE_STYLE_BRIGHT + message + CONSOLE_STYLE_RESET );
 }
 
 /**
@@ -31,7 +31,7 @@ function log( message ) {
  */
 function errorlog( message ) {
 	// eslint-disable-next-line no-console
-	console.log( bright + red + message + reset );
+	console.log( CONSOLE_STYLE_BRIGHT + CONSOLE_STYLE_RED + message + CONSOLE_STYLE_RESET );
 }
 
 /**
@@ -50,7 +50,7 @@ function isYoastPackage( packageName ) {
  *
  * @param {string} version A version number or constraint.
  *
- * @returns {string} An @-prefixed version string
+ * @returns {string} An @-prefixed version string.
  */
 function getVersionString( version = "" ) {
 	return version ? "@" + version : "";
@@ -98,7 +98,7 @@ function addPackagesWithFailsafe( packageNames, version = "", flags = "" ) {
 }
 
 /**
- * Bumps the version all installed Yoast monorepo packages to the specified or latest version
+ * Bumps the version all installed Yoast monorepo packages to the specified or latest version.
  *
  * @param {array} args CLI arguments, the first arg being the version number.
  *


### PR DESCRIPTION
## Summary
Adds a script with which all monorepo packages can be updated at once.
`yarn bump-monorepo-packages` or `yarn bump-monorepo-packages ${version}`. (e.g. `yarn bump-monorepo-packages rc`)

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* The script tries to update all packages at once (first the dependencies, then the devDependencies). This is faster than every package on its own. If the installation fails, it falls back on updating every package one by one. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn bump-monorepo-packages` from the root with different version constraints and see if the monorepo packages are all properly updated. 

you can expect output like this:
![image](https://user-images.githubusercontent.com/5352634/56670659-8d75d680-66b3-11e9-89eb-e6314fe4a3a0.png)


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/javascript/issues/238
