### PR TITLE
Bump packages to newest RC version

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@yoast/algolia-search-box": "^1.0.0-rc.7",
     "@yoast/components": "^0.1.0-rc.7",
     "@yoast/configuration-wizard": "^1.0.0-rc.7",
-    "@yoast/search-metadata-previews": "^1.0.0-rc.9",
+    "@yoast/search-metadata-previews": "^1.0.0-rc.10",
     "@yoast/style-guide": "^0.1.0-rc.5",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
@@ -151,8 +151,8 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^4.2.0",
-    "yoast-components": "^4.24.0-rc.10",
-    "yoastseo": "^1.51.0-rc.7"
+    "yoast-components": "^4.24.0-rc.11",
+    "yoastseo": "^1.51.0-rc.8"
   },
   "yoast": {
     "pluginVersion": "11.1-RC1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,10 +700,10 @@
     styled-components "^2.4.1"
     whatwg-fetch "1.1.1"
 
-"@yoast/search-metadata-previews@^1.0.0-rc.9":
-  version "1.0.0-rc.9"
-  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.0.0-rc.9.tgz#79f69c08d3f461f2670efdbd3fcf952aa150bb50"
-  integrity sha512-JLm+EDylDRxgs93rR8Yf+ZoizczNDmGTLP+9gI8R/NgE/pjyvleaFBnV2Na4MBOP3My8IphgXf7YqXQ2K9gFbg==
+"@yoast/search-metadata-previews@^1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.0.0-rc.10.tgz#dab0df881e61a5058600fbd4a3552e6243de0ccb"
+  integrity sha512-edghLmRcmley2+FsjKa8CDZVJdy9F/8gkRFqg82QptenBevGKo8uGmhKqhGr4QacRHFZ7qrOw37Ql4edOk0jiw==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -719,7 +719,7 @@
     prop-types "^15.6.0"
     react-transition-group "^2.7.1"
     styled-components "^4.2.0"
-    yoastseo "^1.51.0-rc.7"
+    yoastseo "^1.51.0-rc.8"
 
 "@yoast/style-guide@^0.1.0-rc.5":
   version "0.1.0-rc.5"
@@ -12790,10 +12790,10 @@ yauzl@^2.2.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yoast-components@^4.24.0-rc.10:
-  version "4.24.0-rc.10"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.24.0-rc.10.tgz#b05911252fda4ebea08d46db12ba68585acbfee2"
-  integrity sha512-rnnoB1rsZJVk5vegHlRH16jb3V4p/ekSdYhXgwwdsNNNgQOjR6OhMqCYhKQSCHoyRJGO/f7SUDDwu4loSGqdoQ==
+yoast-components@^4.24.0-rc.11:
+  version "4.24.0-rc.11"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.24.0-rc.11.tgz#83240068ed0ca2d4e5699c74b309752a16e0accb"
+  integrity sha512-nf3wdhUIkG7t9HtBXJlPpU7Fjd3W3u9bLBMzCGFzTr6TwbrTSoeEc5u28ov5iCkfW8pE147dBHUoQGq+2slcFQ==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -12802,7 +12802,7 @@ yoast-components@^4.24.0-rc.10:
     "@yoast/components" "^0.1.0-rc.7"
     "@yoast/configuration-wizard" "^1.0.0-rc.7"
     "@yoast/helpers" "^0.1.0-rc.4"
-    "@yoast/search-metadata-previews" "^1.0.0-rc.9"
+    "@yoast/search-metadata-previews" "^1.0.0-rc.10"
     "@yoast/style-guide" "^0.1.0-rc.5"
     algoliasearch "^3.22.3"
     clipboard "^1.5.15"
@@ -12822,12 +12822,12 @@ yoast-components@^4.24.0-rc.10:
     styled-components "^4.2.0"
     whatwg-fetch "^1.0.0"
     wicked-good-xpath "^1.3.0"
-    yoastseo "^1.51.0-rc.7"
+    yoastseo "^1.51.0-rc.8"
 
-yoastseo@^1.51.0-rc.7:
-  version "1.51.0-rc.7"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.51.0-rc.7.tgz#76abebe972b67f908b0d3f29b1978cadce784da3"
-  integrity sha512-j/fSPfJ44mVOEU+cO626fRRhWPsnb97OAolEcoPKvVHo8hyW+OfY35aqNRTWy7QbPFVfGnPsiF9kgOSvX4jfaQ==
+yoastseo@^1.51.0-rc.8:
+  version "1.51.0-rc.8"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.51.0-rc.8.tgz#398ac1091cdc0bcb1f7f52fe79f4a3ee60846f7f"
+  integrity sha512-kzvXiOS+rx4EZ7/syxmIaeFvqSs7/8stuBCxebqYd6HkE6PeWhaVSRfPQfDAtzwMkA5mnZPwxZWWtFP28f1Inw==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     htmlparser2 "^3.9.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Updates dependencies for `yoastseo` and `yoast-components` and `search-metadatea-previews` for release 11.0.


## Relevant technical choices:

* There only was a change in yoastseo. `yoast-components` and `search-metadatea-previews` were bumped because they also include `yoastseo` as a dependency.

## Test instructions
This PR can be tested by following these steps:

* See https://github.com/Yoast/javascript/pull/247

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
