### PR TITLE
i18n: simpler translation string

### DIFF
--- a/admin/notifiers/class-post-type-archive-notification-handler.php
+++ b/admin/notifiers/class-post-type-archive-notification-handler.php
@@ -73,12 +73,7 @@ class WPSEO_Post_Type_Archive_Notification_Handler extends WPSEO_Dismissible_Not
 			implode( ', ', $post_types )
 		);
 		$message .= PHP_EOL . PHP_EOL;
-		$message .= sprintf(
-			/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
-			__( '%1$sRemove this message%2$s', 'wordpress-seo' ),
-			'<a class="button" href="' . admin_url( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=' . $this->notification_identifier ) . '">',
-			'</a>'
-		);
+		$message .= '<a class="button" href="' . admin_url( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=' . $this->notification_identifier ) . '">' . __( 'Remove this message', 'wordpress-seo' ) . '</a>';
 
 		$notification_options = array(
 			'type'         => Yoast_Notification::WARNING,


### PR DESCRIPTION
![yoast1](https://user-images.githubusercontent.com/576623/56822771-bdaba980-685a-11e9-9fe2-880050cad581.png)

Current string in translate.wordpress.org has two placeholders `%1$s` and `%2$s` that should not be part of the translation string.

This PR replaces the current translation string with the placeholders `%1$sRemove this message%2$s`
with a simpler string without placeholders `Remove this message`.

## Summary

This PR can be summarized in the following changelog entry:

* i18n: simpler translation string

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
