### PR TITLE
i18n: Merge similar translation strings in author archive settings

### DIFF
--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -35,7 +35,7 @@ $author_archives_help = new WPSEO_Admin_Help_Panel(
 
 $yform->index_switch(
 	'noindex-author-wpseo',
-	__( 'author archives', 'wordpress-seo' ),
+	__( 'Author archives', 'wordpress-seo' ),
 	$author_archives_help->get_button_html() . $author_archives_help->get_panel_html()
 );
 


### PR DESCRIPTION
Two translation strings in translate.wordpress.org that can be merged:

![yoast2](https://user-images.githubusercontent.com/576623/56823577-f64c8280-685c-11e9-9d08-c6b658a0266a.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in author archive settings

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
