### PR TITLE
i18n: Replace %s with %d to merge similar translation string

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -260,8 +260,8 @@ class WPSEO_Help_Center {
 			'searchResultDetail.searchResult'    => __( 'Search result', 'wordpress-seo' ),
 			'searchResult.noResultsText'         => __( 'No results found.', 'wordpress-seo' ),
 			'searchResult.foundResultsText'      => sprintf(
-				/* translators: %s expands to the number of results found . */
-				__( 'Number of results found: %s', 'wordpress-seo' ),
+				/* translators: %d expands to the number of results found . */
+				__( 'Number of results found: %d', 'wordpress-seo' ),
 				'{ resultsCount }'
 			),
 			'searchResult.searchResultsHeading'  => __( 'Search results', 'wordpress-seo' ),


### PR DESCRIPTION
Two translation strings in translate.wordpress.org that can be merged:

![yoast3](https://user-images.githubusercontent.com/576623/56830649-8b587700-686f-11e9-9d1e-2235beb584d8.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Replace %s with %d to merge similar translation string

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
