### PR TITLE
i18n: Split translation strings to simplify translation

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -81,54 +81,46 @@ class WPSEO_Metabox_Formatter {
 				'labels' => array(
 					'content' => array(
 						'na'   => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'Readability: %1$sNot available%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to readability. */
+							__( 'Readability: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'Not available', 'wordpress-seo' ) . '</strong>'
 						),
 						'bad'  => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'Readability: %1$sNeeds improvement%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to readability. */
+							__( 'Readability: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
 						),
 						'ok'   => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'Readability: %1$sOK%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to readability. */
+							__( 'Readability: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
 						),
 						'good' => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'Readability: %1$sGood%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to readability. */
+							__( 'Readability: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
 						),
 					),
 					'keyword' => array(
 						'na'   => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'SEO: %1$sNot available%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to SEO. */
+							__( 'SEO: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'Not available', 'wordpress-seo' ) . '</strong>'
 						),
 						'bad'  => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'SEO: %1$sNeeds improvement%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to SEO. */
+							__( 'SEO: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
 						),
 						'ok'   => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'SEO: %1$sOK%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to SEO. */
+							__( 'SEO: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
 						),
 						'good' => sprintf(
-							/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag. */
-							__( 'SEO: %1$sGood%2$s', 'wordpress-seo' ),
-							'<strong>',
-							'</strong>'
+							/* translators: %s expands to SEO. */
+							__( 'SEO: %s', 'wordpress-seo' ),
+							'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
 						),
 					),
 				),

--- a/admin/statistics/class-statistics-service.php
+++ b/admin/statistics/class-statistics-service.php
@@ -201,21 +201,12 @@ class WPSEO_Statistics_Service {
 		return array(
 			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
 			WPSEO_Rank::NO_FOCUS => sprintf( __( 'Posts %1$swithout%2$s a focus keyphrase', 'wordpress-seo' ), '<strong>', '</strong>' ),
-			WPSEO_Rank::BAD => sprintf(
-				/* translators: %s expands to the score */
-				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
-				'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
-			),
-			WPSEO_Rank::OK => sprintf(
-				/* translators: %s expands to the score */
-				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
-				'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
-			),
-			WPSEO_Rank::GOOD => sprintf(
-				/* translators: %s expands to the score */
-				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
-				'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
-			),
+			/* translators: %s expands to the score */
+			WPSEO_Rank::BAD      => sprintf( __( 'Posts with the SEO score: %s', 'wordpress-seo' ), '<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>' ),
+			/* translators: %s expands to the score */
+			WPSEO_Rank::OK       => sprintf( __( 'Posts with the SEO score: %s', 'wordpress-seo' ), '<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>' ),
+			/* translators: %s expands to the score */
+			WPSEO_Rank::GOOD     => sprintf( __( 'Posts with the SEO score: %s', 'wordpress-seo' ), '<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>' ),
 			WPSEO_Rank::NO_INDEX => __( 'Posts that should not show up in search results', 'wordpress-seo' ),
 		);
 	}

--- a/admin/statistics/class-statistics-service.php
+++ b/admin/statistics/class-statistics-service.php
@@ -199,14 +199,26 @@ class WPSEO_Statistics_Service {
 	 */
 	private function labels() {
 		return array(
-			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
-			WPSEO_Rank::NO_FOCUS => sprintf( __( 'Posts %1$swithout%2$s a focus keyphrase', 'wordpress-seo' ), '<strong>', '</strong>' ),
-			/* translators: %s expands to the score */
-			WPSEO_Rank::BAD      => sprintf( __( 'Posts with the SEO score: %s', 'wordpress-seo' ), '<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>' ),
-			/* translators: %s expands to the score */
-			WPSEO_Rank::OK       => sprintf( __( 'Posts with the SEO score: %s', 'wordpress-seo' ), '<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>' ),
-			/* translators: %s expands to the score */
-			WPSEO_Rank::GOOD     => sprintf( __( 'Posts with the SEO score: %s', 'wordpress-seo' ), '<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>' ),
+			WPSEO_Rank::NO_FOCUS => sprintf(
+				/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
+				__( 'Posts %1$swithout%2$s a focus keyphrase', 'wordpress-seo' ),
+				'<strong>', '</strong>'
+			),
+			WPSEO_Rank::BAD => sprintf(
+				/* translators: %s expands to the score */
+				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
+				'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
+			),
+			WPSEO_Rank::OK => sprintf(
+				/* translators: %s expands to the score */
+				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
+				'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
+			),
+			WPSEO_Rank::GOOD => sprintf(
+				/* translators: %s expands to the score */
+				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
+				'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
+			),
 			WPSEO_Rank::NO_INDEX => __( 'Posts that should not show up in search results', 'wordpress-seo' ),
 		);
 	}

--- a/admin/statistics/class-statistics-service.php
+++ b/admin/statistics/class-statistics-service.php
@@ -201,12 +201,21 @@ class WPSEO_Statistics_Service {
 		return array(
 			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
 			WPSEO_Rank::NO_FOCUS => sprintf( __( 'Posts %1$swithout%2$s a focus keyphrase', 'wordpress-seo' ), '<strong>', '</strong>' ),
-			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
-			WPSEO_Rank::BAD      => sprintf( __( 'Posts with the SEO score: %1$sneeds improvement%2$s', 'wordpress-seo' ), '<strong>', '</strong>' ),
-			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
-			WPSEO_Rank::OK       => sprintf( __( 'Posts with the SEO score: %1$sOK%2$s', 'wordpress-seo' ), '<strong>', '</strong>' ),
-			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
-			WPSEO_Rank::GOOD     => sprintf( __( 'Posts with the SEO score: %1$sgood%2$s', 'wordpress-seo' ), '<strong>', '</strong>' ),
+			WPSEO_Rank::BAD => sprintf(
+				/* translators: %s expands to the score */
+				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
+				'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
+			),
+			WPSEO_Rank::OK => sprintf(
+				/* translators: %s expands to the score */
+				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
+				'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
+			),
+			WPSEO_Rank::GOOD => sprintf(
+				/* translators: %s expands to the score */
+				__( 'Posts with the SEO score: %s', 'wordpress-seo' ),
+				'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
+			),
 			WPSEO_Rank::NO_INDEX => __( 'Posts that should not show up in search results', 'wordpress-seo' ),
 		);
 	}

--- a/inc/class-wpseo-rank.php
+++ b/inc/class-wpseo-rank.php
@@ -138,11 +138,11 @@ class WPSEO_Rank {
 	 */
 	public function get_drop_down_label() {
 		$labels = array(
-			self::NO_FOCUS => __( 'SEO: No Focus Keyphrase', 'wordpress-seo' ),
-			self::BAD      => __( 'SEO: Needs improvement', 'wordpress-seo' ),
-			self::OK       => __( 'SEO: OK', 'wordpress-seo' ),
-			self::GOOD     => __( 'SEO: Good', 'wordpress-seo' ),
-			self::NO_INDEX => __( 'SEO: Post Noindexed', 'wordpress-seo' ),
+			self::NO_FOCUS => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'No Focus Keyphrase', 'wordpress-seo' ) ),
+			self::BAD      => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'Needs improvement', 'wordpress-seo' ) ),
+			self::OK       => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'OK', 'wordpress-seo' ) ),
+			self::GOOD     => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'Good', 'wordpress-seo' ) ),
+			self::NO_INDEX => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'Post Noindexed', 'wordpress-seo' ) ),
 		);
 
 		return $labels[ $this->rank ];
@@ -155,9 +155,9 @@ class WPSEO_Rank {
 	 */
 	public function get_drop_down_readability_labels() {
 		$labels = array(
-			self::BAD      => __( 'Readability: Needs improvement', 'wordpress-seo' ),
-			self::OK       => __( 'Readability: OK', 'wordpress-seo' ),
-			self::GOOD     => __( 'Readability: Good', 'wordpress-seo' ),
+			self::BAD      => sprintf( __( 'Readability: %s', 'wordpress-seo' ), __( 'Needs improvement', 'wordpress-seo' ) ),
+			self::OK       => sprintf( __( 'Readability: %s', 'wordpress-seo' ), __( 'OK', 'wordpress-seo' ) ),
+			self::GOOD     => sprintf( __( 'Readability: %s', 'wordpress-seo' ), __( 'Good', 'wordpress-seo' ) ),
 		);
 
 		return $labels[ $this->rank ];

--- a/inc/class-wpseo-rank.php
+++ b/inc/class-wpseo-rank.php
@@ -138,11 +138,30 @@ class WPSEO_Rank {
 	 */
 	public function get_drop_down_label() {
 		$labels = array(
-			self::NO_FOCUS => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'No Focus Keyphrase', 'wordpress-seo' ) ),
-			self::BAD      => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'Needs improvement', 'wordpress-seo' ) ),
-			self::OK       => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'OK', 'wordpress-seo' ) ),
-			self::GOOD     => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'Good', 'wordpress-seo' ) ),
-			self::NO_INDEX => sprintf( __( 'SEO: %s', 'wordpress-seo' ), __( 'Post Noindexed', 'wordpress-seo' ) ),
+			self::NO_FOCUS => sprintf(
+				/* translators: %s expands to the SEO score */
+				__( 'SEO: %s', 'wordpress-seo' ),
+				__( 'No Focus Keyphrase', 'wordpress-seo' )
+			),
+			self::BAD => sprintf(
+				/* translators: %s expands to the SEO score */
+				__( 'SEO: %s', 'wordpress-seo' ),
+				__( 'Needs improvement', 'wordpress-seo' )
+			),
+			self::OK => sprintf(
+				/* translators: %s expands to the SEO score */
+				__( 'SEO: %s', 'wordpress-seo' ),
+				__( 'OK', 'wordpress-seo' ) ),
+			self::GOOD => sprintf(
+				/* translators: %s expands to the SEO score */
+				__( 'SEO: %s', 'wordpress-seo' ),
+				__( 'Good', 'wordpress-seo' )
+			),
+			self::NO_INDEX => sprintf(
+				/* translators: %s expands to the SEO score */
+				__( 'SEO: %s', 'wordpress-seo' ),
+				__( 'Post Noindexed', 'wordpress-seo' )
+			),
 		);
 
 		return $labels[ $this->rank ];
@@ -155,9 +174,21 @@ class WPSEO_Rank {
 	 */
 	public function get_drop_down_readability_labels() {
 		$labels = array(
-			self::BAD      => sprintf( __( 'Readability: %s', 'wordpress-seo' ), __( 'Needs improvement', 'wordpress-seo' ) ),
-			self::OK       => sprintf( __( 'Readability: %s', 'wordpress-seo' ), __( 'OK', 'wordpress-seo' ) ),
-			self::GOOD     => sprintf( __( 'Readability: %s', 'wordpress-seo' ), __( 'Good', 'wordpress-seo' ) ),
+			self::BAD => sprintf(
+				/* translators: %s expands to the readability score */
+				__( 'Readability: %s', 'wordpress-seo' ),
+				__( 'Needs improvement', 'wordpress-seo' )
+			),
+			self::OK => sprintf(
+				/* translators: %s expands to the readability score */
+				__( 'Readability: %s', 'wordpress-seo' ),
+				__( 'OK', 'wordpress-seo' )
+			),
+			self::GOOD => sprintf(
+				/* translators: %s expands to the readability score */
+				__( 'Readability: %s', 'wordpress-seo' ),
+				__( 'Good', 'wordpress-seo' )
+			),
 		);
 
 		return $labels[ $this->rank ];


### PR DESCRIPTION
Three translation strings in translate.wordpress.org that can be simplified:

![yoast5](https://user-images.githubusercontent.com/576623/56832000-53533300-6873-11e9-91d0-68c41236960a.png)

The old strings:

* `Posts with the SEO score: %1$sgood%2$s`
* `Posts with the SEO score: %1$sneeds improvement%2$s`
* `Posts with the SEO score: %1$sOK%2$s`

The new string:

* `Posts with the SEO score: %s`

Notes:

The plugin already has the following strings: `OK`, `Good`, `Needs improvement`.

This PR actually simplifies the translations strings, merges similar strings and reduce the number of strings. 

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Split translation strings to simplify translation

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
