### PR TITLE
i18n: Merge 6 similar translation strings in gsc category filters to one string

### DIFF
--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -113,15 +113,15 @@ class WPSEO_GSC_Category_Filters {
 	 * Setting the values for the filter.
 	 */
 	private function set_filter_values() {
-		$this->set_filter_value( 'access_denied', __( 'Access denied', 'wordpress-seo' ), __( 'Server requires authentication or is blocking Googlebot from accessing the site.', 'wordpress-seo' ), __( 'Show information about errors in category \'Access Denied\'', 'wordpress-seo' ) );
+		$this->set_filter_value( 'access_denied', __( 'Access denied', 'wordpress-seo' ), __( 'Server requires authentication or is blocking Googlebot from accessing the site.', 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Access denied', 'wordpress-seo' ) ) );
 		$this->set_filter_value( 'faulty_redirects', __( 'Faulty redirects', 'wordpress-seo' ) );
 		$this->set_filter_value( 'not_followed', __( 'Not followed', 'wordpress-seo' ) );
-		$this->set_filter_value( 'not_found', __( 'Not found', 'wordpress-seo' ), __( 'URL points to a non-existent page.', 'wordpress-seo' ), __( 'Show information about errors in category \'Not Found\'', 'wordpress-seo' ) );
-		$this->set_filter_value( 'other', __( 'Other', 'wordpress-seo' ), __( 'Google was unable to crawl this URL due to an undetermined issue.', 'wordpress-seo' ), __( 'Show information about errors in category \'Other\'', 'wordpress-seo' ) );
+		$this->set_filter_value( 'not_found', __( 'Not found', 'wordpress-seo' ), __( 'URL points to a non-existent page.', 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Not found', 'wordpress-seo' ) ) );
+		$this->set_filter_value( 'other', __( 'Other', 'wordpress-seo' ), __( 'Google was unable to crawl this URL due to an undetermined issue.', 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Other', 'wordpress-seo' ) ) );
 		/* Translators: %1$s: expands to '<code>robots.txt</code>'. */
-		$this->set_filter_value( 'roboted', __( 'Blocked', 'wordpress-seo' ), sprintf( __( 'Googlebot could access your site, but certain URLs are blocked for Googlebot in your %1$s file. This block could either be for all Googlebots or even specifically for Googlebot-mobile.', 'wordpress-seo' ), '<code>robots.txt</code>' ), __( 'Show information about errors in category \'Blocked\'', 'wordpress-seo' ) );
-		$this->set_filter_value( 'server_error', __( 'Server Error', 'wordpress-seo' ), __( 'Request timed out or site is blocking Google.', 'wordpress-seo' ), __( 'Show information about errors in category \'Server\'', 'wordpress-seo' ) );
-		$this->set_filter_value( 'soft_404', __( 'Soft 404', 'wordpress-seo' ), __( "The target URL doesn't exist, but your server is not returning a 404 (file not found) error.", 'wordpress-seo' ), __( 'Show information about errors in category \'Soft 404\'', 'wordpress-seo' ) );
+		$this->set_filter_value( 'roboted', __( 'Blocked', 'wordpress-seo' ), sprintf( __( 'Googlebot could access your site, but certain URLs are blocked for Googlebot in your %1$s file. This block could either be for all Googlebots or even specifically for Googlebot-mobile.', 'wordpress-seo' ), '<code>robots.txt</code>' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Blocked', 'wordpress-seo' ) ) );
+		$this->set_filter_value( 'server_error', __( 'Server Error', 'wordpress-seo' ), __( 'Request timed out or site is blocking Google.', 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Server', 'wordpress-seo' ) ) );
+		$this->set_filter_value( 'soft_404', __( 'Soft 404', 'wordpress-seo' ), __( "The target URL doesn't exist, but your server is not returning a 404 (file not found) error.", 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Soft 404', 'wordpress-seo' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
![yoast6](https://user-images.githubusercontent.com/576623/56834311-c069c700-6879-11e9-9e0e-3fb0a1d9739c.png)

All the 6 strings can be merged to 1 string with `%s` placeholder:

`Show information about errors in category %s`

Instead of `%s` placeholder we use a category names, this translations string is already exist.

This way we reduce the total amount of translations strings.

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in gsc category filters

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
