### PR TITLE
i18n: Merge similar translation strings in admin sidebar

### DIFF
--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -20,7 +20,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 		<div class="yoast-sidebar__section">
 			<h2>
 				<?php
-				/* translators: %1$s expands to the plugin name */
+				/* translators: %s expands to the plugin name */
 				printf( esc_html__( 'Upgrade to %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 				?>
 			</h2>
@@ -130,7 +130,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jy' ); ?>" target="_blank">
 					<?php
 						/* translators: %s expands to Yoast SEO Premium. */
-						printf( esc_html__( 'Upgrade to %s »', 'wordpress-seo' ), 'Yoast SEO Premium' );
+						printf( esc_html__( 'Upgrade to %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 						echo $new_tab_message;
 					?>
 				</a>

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -21,7 +21,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 			<h2>
 				<?php
 				/* translators: %1$s expands to the plugin name */
-				printf( esc_html__( 'Upgrade to %1$s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+				printf( esc_html__( 'Upgrade to %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 				?>
 			</h2>
 			<ul>


### PR DESCRIPTION
Translation strings in translate.wordpress.org that can be merged:

![yoast8](https://user-images.githubusercontent.com/576623/56835955-556ebf00-687e-11e9-8fe8-d2b98e85ea35.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in admin sidebar

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
