### PR TITLE
i18n: simpler translation string

### DIFF
--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -149,12 +149,7 @@ class WPSEO_Product_Upsell_Notice {
 
 		$message .= $this->get_premium_upsell_section() . "\n\n";
 
-		$message .= sprintf(
-			/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
-			__( '%1$sPlease don\'t show me this notification anymore%2$s', 'wordpress-seo' ),
-			'<a class="button" href="' . admin_url( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=upsell' ) . '">',
-			'</a>'
-		);
+		$message .= '<a class="button" href="' . admin_url( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=upsell' ) . '">' . __( 'Please don\'t show me this notification anymore', 'wordpress-seo' ) . '</a>';
 
 		$notification = new Yoast_Notification(
 			$message,


### PR DESCRIPTION
![yoast9](https://user-images.githubusercontent.com/576623/56840765-f9159a80-6891-11e9-867e-039cb323e961.png)

Current string in translate.wordpress.org has two placeholders `%1$s` and `%2$s` that should not be part of the translation string.

This PR replaces the current translation string with the placeholders
`%1$sPlease don't show me this notification anymore%2$s`

with a simpler string without placeholders
`Please don't show me this notification anymore`

See related PR #12776

## Summary

This PR can be summarized in the following changelog entry:

* i18n: simpler translation string

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
