### PR TITLE
i18n: Merge similar translation strings in Google Search Console

### DIFF
--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -44,10 +44,9 @@ switch ( $platform_tabs->current_tab() ) {
 			// Print auth screen.
 			echo '<p>';
 			printf(
-				/* Translators: %1$s: expands to Yoast SEO, %2$s expands to Google Search Console. */
-				esc_html__( 'To allow %1$s to fetch your %2$s information, please enter your Google Authorization Code. Clicking the button below will open a new window.', 'wordpress-seo' ),
+				/* Translators: %s: expands to Yoast SEO. */
+				esc_html__( 'To allow %s to fetch your Google Search Console information, please enter your Google Authorization Code. Clicking the button below will open a new window.', 'wordpress-seo' ),
 				'Yoast SEO',
-				'Google Search Console'
 			);
 			echo "</p>\n";
 			echo '<input type="hidden" id="gsc_auth_url" value="', esc_url( $this->service->get_client()->createAuthUrl() ) , '" />';

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -46,7 +46,7 @@ switch ( $platform_tabs->current_tab() ) {
 			printf(
 				/* Translators: %s: expands to Yoast SEO. */
 				esc_html__( 'To allow %s to fetch your Google Search Console information, please enter your Google Authorization Code. Clicking the button below will open a new window.', 'wordpress-seo' ),
-				'Yoast SEO',
+				'Yoast SEO'
 			);
 			echo "</p>\n";
 			echo '<input type="hidden" id="gsc_auth_url" value="', esc_url( $this->service->get_client()->createAuthUrl() ) , '" />';


### PR DESCRIPTION
Translation strings in translate.wordpress.org that can be merged:

![yoast10](https://user-images.githubusercontent.com/576623/56847695-10cb3e00-68e7-11e9-94d0-c21bb2158fe8.png)

In one string the plugin uses `%s` placeholder, in the other it uses the `Google Search Console` string. The placeholder is not translatable white the string can be translated. Not consistent. The PR removes the `%s` placeholder.

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in Google Search Console

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
