### PR TITLE
i18n: Merge similar translation strings in help center

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -214,7 +214,7 @@ class WPSEO_Help_Center {
 		$popup_content .= '<li>' . sprintf(
 			// We don't use strong text here, but we do use it in the "Add keyword" popup, this is just to have the same translatable strings.
 			/* translators: %1$s expands to a 'strong' start tag, %2$s to a 'strong' end tag. */
-			__( '%1$sSocial media preview%2$s: Facebook &amp; Twitter', 'wordpress-seo' ),
+			__( '%1$sSocial media preview%2$s: Facebook & Twitter', 'wordpress-seo' ),
 			'',
 			''
 		) . '</li>';


### PR DESCRIPTION
Translation strings in translate.wordpress.org that can be merged:

![yoast11](https://user-images.githubusercontent.com/576623/56848301-dca84b00-68ef-11e9-82b9-a1aec925ab38.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in help center

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
