### PR TITLE
i18n: Merge similar translation strings in licenses

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -179,8 +179,8 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 				<a target="_blank" href="<?php echo esc_url( $premium_extension->get_buy_url() ); ?>"
 					class="yoast-button-upsell">
 					<?php
-					/* translators: $1$s expands to Yoast SEO Premium */
-					printf( esc_html__( 'Buy %1$s', 'wordpress-seo' ), $premium_extension->get_title() );
+					/* translators: $s expands to Yoast SEO Premium */
+					printf( esc_html__( 'Buy %s', 'wordpress-seo' ), $premium_extension->get_title() );
 					echo $new_tab_message;
 					echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 					?>


### PR DESCRIPTION
Translation strings in translate.wordpress.org that can be merged:

![yoast12](https://user-images.githubusercontent.com/576623/56848477-3f9ae180-68f2-11e9-85b7-bc10f0252b7d.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in licenses

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
