### PR TITLE
i18n: Merge similar translation strings in configuration page

### DIFF
--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -138,7 +138,7 @@ class WPSEO_Configuration_Page {
 			<a class="button yoast-wizard-return-link" href="<?php echo esc_url( $dashboard_url ); ?>">
 				<span aria-hidden="true" class="dashicons dashicons-no"></span>
 				<?php
-				esc_html_e( 'Close wizard', 'wordpress-seo' );
+				esc_html_e( 'Close the Wizard', 'wordpress-seo' );
 				?>
 			</a>
 		</div>


### PR DESCRIPTION
Translation strings in translate.wordpress.org that can be merged:

![yoast15](https://user-images.githubusercontent.com/576623/56848601-a7056100-68f3-11e9-9726-72b88fe5abd4.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in configuration page

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
