### PR TITLE
i18n: Merge similar translation strings in sidebar

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -218,7 +218,7 @@ class WPSEO_Help_Center {
 			'',
 			''
 		) . '</li>';
-		$popup_content .= '<li>' . __( '24/7 support', 'wordpress-seo' ) . '</li>';
+		$popup_content .= '<li>' . __( '24/7 email support', 'wordpress-seo' ) . '</li>';
 		$popup_content .= '<li>' . __( 'No ads!', 'wordpress-seo' ) . '</li>';
 		$popup_content .= '</ul>';
 

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -57,7 +57,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 			'<strong>' . esc_html__( 'No more dead links', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Easy redirect manager', 'wordpress-seo' ),
 			'<strong>' . esc_html__( 'Superfast internal linking suggestions', 'wordpress-seo' ) . '</strong>',
 			'<strong>' . esc_html__( 'Social media preview', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Facebook & Twitter', 'wordpress-seo' ),
-			'<strong>' . esc_html__( '24/7 support', 'wordpress-seo' ) . '</strong>',
+			'<strong>' . esc_html__( '24/7 email support', 'wordpress-seo' ) . '</strong>',
 			'<strong>' . esc_html__( 'No ads!', 'wordpress-seo' ) . '</strong>',
 		);
 

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -29,8 +29,8 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				<li><strong><?php esc_html_e( 'Preview your page in Facebook and Twitter', 'wordpress-seo' ); ?></strong></li>
 				<li><strong><?php esc_html_e( 'Get real-time suggestions for internal links', 'wordpress-seo' ); ?></strong></li>
 				<li><strong><?php esc_html_e( 'No more dead links a.k.a. 404 pages', 'wordpress-seo' ); ?></strong></li>
-				<li><strong><?php esc_html_e( '24/7 email support', 'wordpress-seo' ); ?></strong></li>
-				<li><strong><?php esc_html_e( 'No ads', 'wordpress-seo' ); ?></strong></li>
+				<li><strong><?php esc_html_e( '24/7 support', 'wordpress-seo' ); ?></strong></li>
+				<li><strong><?php esc_html_e( 'No ads!', 'wordpress-seo' ); ?></strong></li>
 			</ul>
 
 			<a id="wpseo-premium-button" class="yoast-button-upsell" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jj' ); ?>" target="_blank">

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -29,7 +29,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				<li><strong><?php esc_html_e( 'Preview your page in Facebook and Twitter', 'wordpress-seo' ); ?></strong></li>
 				<li><strong><?php esc_html_e( 'Get real-time suggestions for internal links', 'wordpress-seo' ); ?></strong></li>
 				<li><strong><?php esc_html_e( 'No more dead links a.k.a. 404 pages', 'wordpress-seo' ); ?></strong></li>
-				<li><strong><?php esc_html_e( '24/7 support', 'wordpress-seo' ); ?></strong></li>
+				<li><strong><?php esc_html_e( '24/7 email support', 'wordpress-seo' ); ?></strong></li>
 				<li><strong><?php esc_html_e( 'No ads!', 'wordpress-seo' ); ?></strong></li>
 			</ul>
 

--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -42,7 +42,7 @@ const KeywordSynonyms = ( props ) => {
 			"<strong>",
 			"</strong>"
 		),
-		`<strong>${ __( "24/7 support", "wordpress-seo" ) }</strong>`,
+		`<strong>${ __( "24/7 email support", "wordpress-seo" ) }</strong>`,
 		`<strong>${ __( "No ads!", "wordpress-seo" ) }</strong>`,
 	];
 

--- a/js/src/components/modals/MultipleKeywords.js
+++ b/js/src/components/modals/MultipleKeywords.js
@@ -35,7 +35,7 @@ const MultipleKeywords = ( props ) => {
 			"<strong>",
 			"</strong>"
 		),
-		`<strong>${__( "24/7 support", "wordpress-seo" )}</strong>`,
+		`<strong>${__( "24/7 email support", "wordpress-seo" )}</strong>`,
 		`<strong>${__( "No ads!", "wordpress-seo" )}</strong>`,
 	];
 


### PR DESCRIPTION
translation strings in translate.wordpress.org that can be merged:

![yoast17](https://user-images.githubusercontent.com/576623/56849518-2304a680-68fe-11e9-8acc-f6c86a5fb59c.png)

![yoast16](https://user-images.githubusercontent.com/576623/56849519-24ce6a00-68fe-11e9-8f84-c29cbdeacc1f.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in sidebar

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
