### PR TITLE
i18n: Merge similar translation strings in help center

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -109,7 +109,7 @@ class WPSEO_Help_Center {
 
 		if ( $is_premium === false ) {
 			$formatted_data['videoDescriptions'][] = array(
-				'title'       => __( 'Need some help?', 'wordpress-seo' ),
+				'title'       => __( 'Need help?', 'wordpress-seo' ),
 				'description' => __( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/seo-premium-vt' ),
 				'linkText'    => __( 'Get Yoast SEO Premium now »', 'wordpress-seo' ),


### PR DESCRIPTION
Two translation strings in translate.wordpress.org that can be merged:

![yoast18](https://user-images.githubusercontent.com/576623/56850128-dd98a700-6906-11e9-8f7b-9526f2d4ccc8.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in help center

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
