### PR TITLE
Import the accessibility scss file in the Configuration Wizard

### DIFF
--- a/css/src/_wp.scss
+++ b/css/src/_wp.scss
@@ -1,4 +1,6 @@
 /* WordPress-specific styling to be used only for single-page apps like the Onboarding Wizard. */
+@import "../../node_modules/yoast-components/css/accessibility";
+
 body {
 	background: #f1f1f1;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Imports in the Configuration Wizard the scss file containing the `screen-reader-text` class 

Missed in https://github.com/Yoast/wordpress-seo/pull/12531


## Test instructions
- go to Configuration wizard > step 3 > click 'Choose image'.
- check the screen reader texts are hidden (see screenshot on the issue #12798)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #12798 
