### PR TITLE
i18n: Merge two translation strings into one, in search appearance media tab

### DIFF
--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -11,9 +11,6 @@ $wpseo_post_type              = get_post_type_object( 'attachment' );
 $recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
 $editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
 $view_utils                   = new Yoast_View_Utils();
-?>
-<p><strong><?php esc_html_e( 'We recommend you set this to Yes.', 'wordpress-seo' ); ?></strong></p>
-<?php
 
 $yoast_free_disable_attachments_texts = array(
 	'on'  => __( 'Yes', 'wordpress-seo' ),
@@ -22,7 +19,7 @@ $yoast_free_disable_attachments_texts = array(
 $yform->toggle_switch(
 	'disable-attachment',
 	$yoast_free_disable_attachments_texts,
-	__( 'Redirect attachment URLs to the attachment itself?', 'wordpress-seo' )
+	__( 'Redirect attachment URLs to the attachment itself? (recommended)', 'wordpress-seo' )
 );
 
 ?>


### PR DESCRIPTION
with over 1200 translation strings, it's hard to translate the plugin. Some strings can be merged, here are two strings that can be replaced:

![yoast21a](https://user-images.githubusercontent.com/576623/56912630-525f1300-6ab8-11e9-8a9c-193e5c519494.png)

![yoast21b](https://user-images.githubusercontent.com/576623/56912635-568b3080-6ab8-11e9-936e-176ef4d67f32.png)


## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge two translation strings into one, in search appearance media tab

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
