### PR TITLE
i18n: simpler translation string in rss tab

### DIFF
--- a/admin/views/tabs/metas/paper-content/rss-content.php
+++ b/admin/views/tabs/metas/paper-content/rss-content.php
@@ -34,7 +34,7 @@ echo $rss_variables_help->get_panel_html();
 	<tbody>
 	<tr>
 		<td class="yoast-variable-name">%%AUTHORLINK%%</td>
-		<td class="yoast-variable-desc"><?php esc_html_e( 'A link to the archive for the post author, with the authors name as anchor text.', 'wordpress-seo' ); ?></td>
+		<td class="yoast-variable-desc"><?php esc_html_e( 'A link to the post author archive, with the authors name as anchor text.', 'wordpress-seo' ); ?></td>
 	</tr>
 	<tr>
 		<td class="yoast-variable-name">%%POSTLINK%%</td>
@@ -42,11 +42,11 @@ echo $rss_variables_help->get_panel_html();
 	</tr>
 	<tr>
 		<td class="yoast-variable-name">%%BLOGLINK%%</td>
-		<td class="yoast-variable-desc"><?php esc_html_e( "A link to your site, with your site's name as anchor text.", 'wordpress-seo' ); ?></td>
+		<td class="yoast-variable-desc"><?php esc_html_e( 'A link to the site, with the site name as anchor text.', 'wordpress-seo' ); ?></td>
 	</tr>
 	<tr>
 		<td class="yoast-variable-name">%%BLOGDESCLINK%%</td>
-		<td class="yoast-variable-desc"><?php esc_html_e( "A link to your site, with your site's name and description as anchor text.", 'wordpress-seo' ); ?></td>
+		<td class="yoast-variable-desc"><?php esc_html_e( 'A link to the site, with the site name and description as anchor text.', 'wordpress-seo' ); ?></td>
 	</tr>
 	</tbody>
 </table>


### PR DESCRIPTION

![yoast22a](https://user-images.githubusercontent.com/576623/56915044-378f9d00-6abe-11e9-9177-486d8af8e0a8.png)

![yoast22b](https://user-images.githubusercontent.com/576623/56915048-3a8a8d80-6abe-11e9-89a0-fb9c21a19fb9.png)


## Summary

This PR can be summarized in the following changelog entry:

* i18n: simpler translation string in rss tab

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
