### PR TITLE
i18n: replace &raquo; with a period at the end of a sentence

### DIFF
--- a/admin/views/tabs/metas/paper-content/general/homepage.php
+++ b/admin/views/tabs/metas/paper-content/general/homepage.php
@@ -38,7 +38,7 @@
 		echo '<p>';
 		printf(
 			/* translators: 1: link open tag; 2: link close tag. */
-			esc_html__( 'You can determine the title and description for the front page by %1$sediting the front page itself &raquo;%2$s', 'wordpress-seo' ),
+			esc_html__( 'You can determine the title and description for the front page by %1$sediting the front page itself%2$s.', 'wordpress-seo' ),
 			'<a href="' . esc_url( get_edit_post_link( get_option( 'page_on_front' ) ) ) . '">',
 			'</a>'
 		);
@@ -47,7 +47,7 @@
 			echo '<p>';
 			printf(
 				/* translators: 1: link open tag; 2: link close tag. */
-				esc_html__( 'You can determine the title and description for the blog page by %1$sediting the blog page itself &raquo;%2$s', 'wordpress-seo' ),
+				esc_html__( 'You can determine the title and description for the blog page by %1$sediting the blog page itself%2$s.', 'wordpress-seo' ),
 				'<a href="' . esc_url( get_edit_post_link( get_option( 'page_for_posts' ) ) ) . '">',
 				'</a>'
 			);


### PR DESCRIPTION
Current:

![yoast23a](https://user-images.githubusercontent.com/576623/56934041-28771200-6af3-11e9-9502-4bfdc3fec6ba.png)

New:

![yoast23b](https://user-images.githubusercontent.com/576623/56934044-2a40d580-6af3-11e9-8ae0-65ce27d97e4b.png)

## Summary

This PR can be summarized in the following changelog entry:

* i18n: replace `&raquo;` with a period at the end of a sentence

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
