### PR TITLE
Fixed upgrade routine

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -674,7 +674,7 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_111() {
 		// Set company_or_person to company when it's an invalid value.
-		$company_or_person = WPSEO_Options::get( 'wpseo_titles', '' );
+		$company_or_person = WPSEO_Options::get( 'company_or_person', '' );
 
 		if ( ! in_array( $company_or_person, array( 'company', 'person' ), true ) ) {
 			WPSEO_Options::set( 'company_or_person', 'company' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Fixes bug where upgrade routine would set the site entity to company when person is selected.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install Yoast SEO 11.0
* Set site entity (`SEO` > `Search Appearance` > `General` ) to Person.
* Install Yoast SEO 11.1
* Check if site entity is still Person.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
