### PR TITLE
Don't always output the image width and height

### DIFF
--- a/frontend/schema/class-schema-image.php
+++ b/frontend/schema/class-schema-image.php
@@ -146,6 +146,9 @@ class WPSEO_Schema_Image {
 	 */
 	private function add_image_size() {
 		$image_meta           = wp_get_attachment_metadata( $this->attachment_id );
+		if ( empty( $image_meta['width'] ) || empty( $image_meta['height'] ) ) {
+			return;
+		}
 		$this->data['width']  = $image_meta['width'];
 		$this->data['height'] = $image_meta['height'];
 	}


### PR DESCRIPTION
# This PR is based on master. Please don't merge until we've decided whether we're going to do a patch

When the wp_get_attachment_metadata filter is used and the result is a metadata object without width or height, we don't want to output the width and height in the schema (because we don't know it). Before this fix, we would output `"width":null,"height":null`.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where an empty width and height would be outputted in the image schema when there was no retrievable width and height. 

## Relevant technical choices:

* I've discussed this with @jono-alderson and came to the following conclusions:
    * When we don't know the width and the height of the image, we don't want to output them in the schema.
    * When we only know the width OR the height, we output neither.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* On trunk:
   * In your theme's functions.php, add `add_filter( 'wp_get_attachment_metadata', '__return_false' );`. As a result `wp_get_attachment_metadata( $this->attachment_id );` (on line 146) will return a metadata object without an width and height. 
   * Create a post, set a featured image, and save it.
   * Go to the front end, view the source, and see `"width":null,"height":null` in the schema.
* On this branch:
   * Also have the above filter in place. 
   * Go to frontend, view the source, and don't see `"width":null,"height":null` in the schema.
   * Replace the above filter by the following: 
```
add_filter( 'wp_get_attachment_metadata', function( $data ) {
		return array( 'width' => 120 );
} );
```
   * Go to frontend, view the source, and don't see the width and height outputted.
   * Replace the above filter by the following: 
```
add_filter( 'wp_get_attachment_metadata', function( $data ) {
		return array( 'width' => 120, 'height' => 120 );
} );
``` 
   * Go to frontend, view the source, and see the width and height outputted (120 and 120).
   * Remove the filter.
   * Go to frontend, view the source, and see the actual width and height in the schema.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12811
