### PR TITLE
Add feature flag package import

### DIFF
--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -1,5 +1,7 @@
 /* Browser:true */
-/* global wpseoSelect2Locale */
+/* global wpseoSelect2Locale, wpseoFeaturesL10n */
+
+import { enableFeatures } from "@yoast/feature-toggle";
 
 ( function( $ ) {
 	/**
@@ -8,6 +10,9 @@
 	 * @returns {void}
 	 */
 	function wpseoInitTabs() {
+		// Enable features using the feature-toggle package.
+		enableFeatures( wpseoFeaturesL10n );
+
 		// When there's only one add-on tab, change its link to a span element.
 		var addonsTabsLinks = jQuery( "#wpseo-meta-section-addons .wpseo_tablink" );
 		if ( addonsTabsLinks.length === 1 ) {

--- a/js/src/wp-seo-metabox.js
+++ b/js/src/wp-seo-metabox.js
@@ -1,7 +1,7 @@
 /* Browser:true */
 /* global wpseoSelect2Locale, wpseoFeaturesL10n */
 
-import { enableFeatures } from "@yoast/feature-toggle";
+import { enableFeatures } from "@yoast/feature-flag";
 
 ( function( $ ) {
 	/**


### PR DESCRIPTION
Reverts Yoast/wordpress-seo#12813 for `feature/internal-linking`.

## Summary
* [non-user-facing] Enables feature-flag functionality for `metabox`.

## Testing instructions
* Add a new feature-flag feature in your `wp-config`
```
define( 'YOAST_SEO_ENABLED_FEATURES', 'some_feature' );
```
* Add an import for `enabledFeatures()` from `@yoast/feature-flag` and a `console.log` that calls `enabledFeatures()` in the [`Free metabox`](https://github.com/Yoast/wordpress-seo/blob/de6ea6d2e06c37f248d5ff8450b367896446efbf/js/src/wp-seo-metabox.js) to check if `some_feature` is enabled.