### PR TITLE
Registers a new DB migrations folder for premium with ruckusing.

### DIFF
--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -204,7 +204,10 @@ class Database_Migration {
 					'directory' => '', // This needs to be set, to use the migrations folder as base folder.
 				),
 			),
-			'migrations_dir' => array( 'default' => WPSEO_PATH . 'migrations' ),
+			'migrations_dir' => array(
+				'default' => WPSEO_PATH . 'migrations',
+				'premium' => WPSEO_PATH . 'premium/migrations'
+			),
 			// This needs to be set but is not used.
 			'db_dir'         => true,
 			// This needs to be set but is not used.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Registers a separate database migration directory for Yoast Premium.

## Relevant technical choices:
* The DB migrations for premium will be located in `premium/migrations`. 
* When the directory `premium/migrations` does not exist, the DB migrations are still run but a new directory `premium/migrations` is made by Ruckusing (the DB migration library we use).
  * I do not think this is a big issue, since it will always be an empty directory.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Start the development version of the plugin.
* Go to a random admin page.
* Everything should run as expected.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
