### PR TITLE
Add an error notification on the Search Console page

### DIFF
--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -8,6 +8,56 @@
 // Admin header.
 Yoast_Form::get_instance()->admin_header( false, 'wpseo-gsc', false, 'yoast_wpseo_gsc_options' );
 
+// GSC Error notification.
+$gsc_profile = WPSEO_GSC_Settings::get_profile();
+$gsc_url     = 'https://search.google.com/search-console/index';
+if ( $gsc_profile !== '' ) {
+	$gsc_url = 'https://search.google.com/search-console/index?resource_id=' . rawurlencode( $gsc_profile );;
+}
+$gsc_post_url            = 'https://yoa.st/google-search-console-deprecated';
+$gsc_style_alert         = '
+	display: flex;
+	align-items: baseline;
+	position: relative;
+	padding: 16px;
+	border: 1px solid rgba(0, 0, 0, 0.2);
+	font-family: \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;
+	font-size: 14px;
+	font-weight: 400;
+	line-height: 1.5;
+	margin: 16px 0;
+	color: #450c11;
+	background: #f8d7da;
+';
+$gsc_style_alert_icon    = 'display: block; margin-right: 8px;';
+$gsc_style_alert_content = 'max-width: 600px;';
+$gsc_style_alert_link    = 'color: #004973;';
+$gsc_notification        = sprintf(
+/* Translators: %1$s: expands to opening anchor tag, %2$s expands to closing anchor tag. */
+	__( 'Google has discontinued its Crawl Errors API. Therefore, any possible crawl errors you might have cannot be displayed here anymore. %1$sRead our statement on this, for further information%2$s.', "wordpress-seo" ),
+	'<a style="' . $gsc_style_alert_link . '" href="' . WPSEO_Shortlinker::get( $gsc_post_url ) . '" target="_blank" rel="noopener">',
+	'</a>'
+);
+$gsc_notification        .= '<br/><br/>';
+$gsc_notification        .= sprintf(
+/* Translators: %1$s: expands to opening anchor tag, %2$s expands to closing anchor tag. */
+	__( 'To view your current crawl errors, %1$splease visit Google Search Console%2$s.', "wordpress-seo" ),
+	'<a style="' . $gsc_style_alert_link . '" href="' . $gsc_url . '" target="_blank" rel="noopener noreferrer">',
+	'</a>'
+);
+?>
+	<div style="<?php echo $gsc_style_alert; ?>">
+	<span style="<?php echo $gsc_style_alert_icon; ?>">
+		<svg xmlns="http://www.w3.org/2000/svg" width="12" height="14" viewBox="0 0 12 14" role="img" aria-hidden="true"
+		     focusable="false" fill="#450c11">
+			<path
+				d="M6 1q1.6 0 3 .8T11.2 4t.8 3-.8 3T9 12.2 6 13t-3-.8T.8 10 0 7t.8-3T3 1.8 6 1zm1 9.7V9.3 9L6.7 9H5l-.1.3V10.9l.3.1h1.6l.1-.3zm0-2.6L7 3.2v-.1L6.8 3H5 5l-.1.2.1 4.9.3.2h1.4l.2-.1Q7 8 6.9 8z"></path>
+		</svg>
+	</span>
+		<span style="<?php echo $gsc_style_alert_content; ?>"><?php echo $gsc_notification; ?></span>
+	</div>
+<?php
+
 $platform_tabs = new WPSEO_GSC_Platform_Tabs();
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG && WPSEO_GSC_Settings::get_profile() !== '' ) { ?>

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -34,7 +34,7 @@ $gsc_style_alert_content = 'max-width: 600px;';
 $gsc_style_alert_link    = 'color: #004973;';
 $gsc_notification        = sprintf(
 /* Translators: %1$s: expands to opening anchor tag, %2$s expands to closing anchor tag. */
-	__( 'Google has discontinued its Crawl Errors API. Therefore, any possible crawl errors you might have cannot be displayed here anymore. %1$sRead our statement on this, for further information%2$s.', "wordpress-seo" ),
+	__( 'Google has discontinued its Crawl Errors API. Therefore, any possible crawl errors you might have cannot be displayed here anymore. %1$sRead our statement on this, for further information%2$s.', 'wordpress-seo' ),
 	'<a style="' . $gsc_style_alert_link . '" href="' . WPSEO_Shortlinker::get( $gsc_post_url ) . '" target="_blank" rel="noopener">',
 	'</a>'
 );

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -12,7 +12,7 @@ Yoast_Form::get_instance()->admin_header( false, 'wpseo-gsc', false, 'yoast_wpse
 $gsc_profile = WPSEO_GSC_Settings::get_profile();
 $gsc_url     = 'https://search.google.com/search-console/index';
 if ( $gsc_profile !== '' ) {
-	$gsc_url = 'https://search.google.com/search-console/index?resource_id=' . rawurlencode( $gsc_profile );;
+	$gsc_url .= '?resource_id=' . rawurlencode( $gsc_profile );
 }
 $gsc_post_url            = 'https://yoa.st/google-search-console-deprecated';
 $gsc_style_alert         = '

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -21,7 +21,6 @@ $gsc_style_alert         = '
 	position: relative;
 	padding: 16px;
 	border: 1px solid rgba(0, 0, 0, 0.2);
-	font-family: \'Segoe UI\', Roboto, Oxygen-Sans, Ubuntu, Cantarell, \'Helvetica Neue\', sans-serif;
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 1.5;

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -41,7 +41,7 @@ $gsc_notification        = sprintf(
 $gsc_notification        .= '<br/><br/>';
 $gsc_notification        .= sprintf(
 /* Translators: %1$s: expands to opening anchor tag, %2$s expands to closing anchor tag. */
-	__( 'To view your current crawl errors, %1$splease visit Google Search Console%2$s.', "wordpress-seo" ),
+	__( 'To view your current crawl errors, %1$splease visit Google Search Console%2$s.', 'wordpress-seo' ),
 	'<a style="' . $gsc_style_alert_link . '" href="' . $gsc_url . '" target="_blank" rel="noopener noreferrer">',
 	'</a>'
 );

--- a/admin/google_search_console/views/gsc-display.php
+++ b/admin/google_search_console/views/gsc-display.php
@@ -33,7 +33,7 @@ $gsc_style_alert_content = 'max-width: 600px;';
 $gsc_style_alert_link    = 'color: #004973;';
 $gsc_notification        = sprintf(
 /* Translators: %1$s: expands to opening anchor tag, %2$s expands to closing anchor tag. */
-	__( 'Google has discontinued its Crawl Errors API. Therefore, any possible crawl errors you might have cannot be displayed here anymore. %1$sRead our statement on this, for further information%2$s.', 'wordpress-seo' ),
+	__( 'Google has discontinued its Crawl Errors API. Therefore, any possible crawl errors you might have cannot be displayed here anymore. %1$sRead our statement on this for further information%2$s.', 'wordpress-seo' ),
 	'<a style="' . $gsc_style_alert_link . '" href="' . WPSEO_Shortlinker::get( $gsc_post_url ) . '" target="_blank" rel="noopener">',
 	'</a>'
 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds an error notification on the Search Console page.

## Relevant technical choices:

* Inline HTML, CSS and SVG because this is a quick and temporary patch.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the `SEO -> Search Console` page.
* Verify you see the notification as per design (and screenshot below).
* Verify the `Read our statement on this, for further information.` link goes to `https://yoa.st/google-search-console-deprecated`.
* The `please visit Google Search Console` link can have 2 different values:
	* When you have no integration it should be `https://search.google.com/search-console/index`.
	* When you have an active integration it should be `https://search.google.com/search-console/index?resource_id=[SITE URL]`. This can be achieved by editing the database:
		* table: `wp_option`
		* `option_name`: `wpseo-gsc`
		* value: `a:1:{s:7:"profile";s:17:"https://yoast.com";}`

## Screenshot
<img width="1263" alt="GSC_integration_notification" src="https://user-images.githubusercontent.com/35524806/57074352-e4972f00-6ce3-11e9-927a-23fb39222d09.png">

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12830 
