### PR TITLE
i18n: Merge similar translation strings - standard button text

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -112,7 +112,8 @@ class WPSEO_Help_Center {
 				'title'       => __( 'Need help?', 'wordpress-seo' ),
 				'description' => __( 'Go Premium and our experts will be there for you to answer any questions you might have about the setup and use of the plugin.', 'wordpress-seo' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/seo-premium-vt' ),
-				'linkText'    => __( 'Get Yoast SEO Premium now »', 'wordpress-seo' ),
+				/* translators: %s expands to Yoast SEO Premium */
+				'linkText'    => sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ),
 			);
 
 			$formatted_data['videoDescriptions'][] = array(


### PR DESCRIPTION
All over the code, we see the button `Get Yoast SEO Premium`. In all the places (9 occurrences) the plugin uses standard button text `Get %s`. Only one place is different:

![yoast24](https://user-images.githubusercontent.com/576623/57078344-c555cd00-6cf6-11e9-9775-9abfc51eb9c6.png)

This PR merge similar translation strings. Replacing the string in the screenshot with the standard `Get %s`.

This will further reduce the total number of translation strings. And standardize the button text.

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings - standard button strings

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
