### PR TITLE
Add webpack bundle analyzer to all bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "test": "jest",
     "build": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --progress",
-    "webpack-analyze-bundle": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json js/dist",
+    "webpack-analyze-bundle": "cross-env BUNDLE_ANALYZER=1 NODE_ENV=production webpack --config ./webpack/webpack.config.js --progress",
     "i18n-yoast-components": "cross-env NODE_ENV=production babel node_modules/yoast-components --ignore node_modules/yoast-components/node_modules,tests/*Test.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",
     "prestart": "grunt build:css && grunt webpack:buildDev",

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -6,6 +6,7 @@ const isString = require( "lodash/isString" );
 
 const paths = require( "./paths" );
 const pkg = require( "../package.json" );
+const BundleAnalyzerPlugin = require( "webpack-bundle-analyzer" ).BundleAnalyzerPlugin;
 
 const pluginVersionSlug = paths.flattenVersionForFile( pkg.yoast.pluginVersion );
 
@@ -37,6 +38,33 @@ const defaultAllowedHosts = [
 	"build.wordpress-develop.test",
 	"src.wordpress-develop.test",
 ];
+
+let bundleAnalyzerPort = 8888;
+
+/**
+ * Creates a new bundle analyzer on a unique port number.
+ *
+ * @returns {BundleAnalyzerPlugin} bundle analyzer.
+ */
+function createBundleAnalyzer() {
+	return new BundleAnalyzerPlugin( {
+		analyzerPort: bundleAnalyzerPort++,
+	} );
+}
+
+/**
+ * Adds a bundle analyzer to a list of webpack plugins.
+ *
+ * @param {Array} plugins Current list of plugins.
+ * @returns {Array} List of plugins including the webpack bundle analyzer.
+ */
+function addBundleAnalyzer( plugins ) {
+	if ( process.env.BUNDLE_ANALYZER ) {
+		return [ ...plugins, createBundleAnalyzer() ];
+	}
+
+	return plugins;
+}
 
 module.exports = function( env = { environment: "production" } ) {
 	const mode = env.environment || process.env.NODE_ENV || "production";
@@ -134,7 +162,7 @@ module.exports = function( env = { environment: "production" } ) {
 
 				"styled-components": "window.yoast.styledComponents",
 			},
-			plugins: [
+			plugins: addBundleAnalyzer( [
 				...plugins,
 				new CopyWebpackPlugin( [
 					{
@@ -148,7 +176,7 @@ module.exports = function( env = { environment: "production" } ) {
 						to: "../vendor/react-dom.min.js",
 					},
 				] ),
-			],
+			] ),
 		},
 
 		// Config for components, which doesn't need all '@yoast' externals.
@@ -170,9 +198,9 @@ module.exports = function( env = { environment: "production" } ) {
 
 				"styled-components": "window.yoast.styledComponents",
 			},
-			plugins: [
+			plugins: addBundleAnalyzer( [
 				...plugins,
-			],
+			] ),
 			optimization: {
 				runtimeChunk: false,
 			},
@@ -215,7 +243,7 @@ module.exports = function( env = { environment: "production" } ) {
 				compose: "./node_modules/@wordpress/compose",
 				richText: "./node_modules/@wordpress/rich-text",
 			},
-			plugins,
+			plugins: addBundleAnalyzer( plugins ),
 			optimization: {
 				runtimeChunk: false,
 			},
@@ -231,7 +259,7 @@ module.exports = function( env = { environment: "production" } ) {
 			entry: {
 				"babel-polyfill": "./js/src/babel-polyfill.js",
 			},
-			plugins,
+			plugins: addBundleAnalyzer( plugins ),
 			optimization: {
 				runtimeChunk: false,
 			},
@@ -247,7 +275,7 @@ module.exports = function( env = { environment: "production" } ) {
 			entry: {
 				"wp-seo-analysis-worker": "./js/src/wp-seo-analysis-worker.js",
 			},
-			plugins,
+			plugins: addBundleAnalyzer( plugins ),
 			optimization: {
 				runtimeChunk: false,
 			},
@@ -259,7 +287,7 @@ module.exports = function( env = { environment: "production" } ) {
 			entry: {
 				"wp-seo-used-keywords-assessment": "./js/src/wp-seo-used-keywords-assessment.js",
 			},
-			plugins,
+			plugins: addBundleAnalyzer( plugins ),
 			optimization: {
 				runtimeChunk: false,
 			},


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* This makes is so all different bundles can be analyzed, even the ones
we generate to duplicate WordPress behavior.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn webpack-analyze-bundle` to analyze the JavaScript bundles and see 6 browser tabs opened that contain a size analysis of the different bundles.