### PR TITLE
i18n: Move "Yoast SEO" out of translation string

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -304,7 +304,8 @@ class WPSEO_Admin {
 			'variable_warning'        => sprintf( __( 'Warning: the variable %s cannot be used in this template. See the help center for more info.', 'wordpress-seo' ), '<code>%s</code>' ),
 			'dismiss_about_url'       => $this->get_dismiss_url( 'wpseo-dismiss-about' ),
 			'dismiss_tagline_url'     => $this->get_dismiss_url( 'wpseo-dismiss-tagline-notice' ),
-			'help_video_iframe_title' => __( 'Yoast SEO video tutorial', 'wordpress-seo' ),
+			/* translators: %s: expends to Yoast SEO */
+			'help_video_iframe_title' => sprintf( __( '%s video tutorial', 'wordpress-seo' ), 'Yoast SEO' ),
 			'scrollable_table_hint'   => __( 'Scroll to see the table content.', 'wordpress-seo' ),
 		);
 	}

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -119,8 +119,8 @@ class WPSEO_Help_Center {
 			$formatted_data['videoDescriptions'][] = array(
 				/* translators: %s expands to Yoast SEO */
 				'title'       => sprintf( __( 'Want to be a %s Expert?', 'wordpress-seo' ), 'Yoast SEO' ),
-				/* translators: %s expands to Yoast SEO */
-				'description' => sprintf( __( 'Follow our %s for WordPress training and become a certified %s Expert!', 'wordpress-seo' ), 'Yoast SEO' ),
+				/* translators: %1$s expands to Yoast SEO */
+				'description' => sprintf( __( 'Follow our %1$s for WordPress training and become a certified %1$s Expert!', 'wordpress-seo' ), 'Yoast SEO' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/wordpress-training-vt' ),
 				/* translators: %s expands to Yoast SEO */
 				'linkText'    => sprintf( __( 'Enroll in the %s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' ),

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -120,7 +120,7 @@ class WPSEO_Help_Center {
 				/* translators: %s expands to Yoast SEO */
 				'title'       => sprintf( __( 'Want to be a %s Expert?', 'wordpress-seo' ), 'Yoast SEO' ),
 				/* translators: %s expands to Yoast SEO */
-				'description' => __( 'Follow our %s for WordPress training and become a certified %s Expert!', 'wordpress-seo' ), 'Yoast SEO' ),
+				'description' => sprintf( __( 'Follow our %s for WordPress training and become a certified %s Expert!', 'wordpress-seo' ), 'Yoast SEO' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/wordpress-training-vt' ),
 				/* translators: %s expands to Yoast SEO */
 				'linkText'    => sprintf( __( 'Enroll in the %s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' ),

--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -117,10 +117,13 @@ class WPSEO_Help_Center {
 			);
 
 			$formatted_data['videoDescriptions'][] = array(
-				'title'       => __( 'Want to be a Yoast SEO Expert?', 'wordpress-seo' ),
-				'description' => __( 'Follow our Yoast SEO for WordPress training and become a certified Yoast SEO Expert!', 'wordpress-seo' ),
+				/* translators: %s expands to Yoast SEO */
+				'title'       => sprintf( __( 'Want to be a %s Expert?', 'wordpress-seo' ), 'Yoast SEO' ),
+				/* translators: %s expands to Yoast SEO */
+				'description' => __( 'Follow our %s for WordPress training and become a certified %s Expert!', 'wordpress-seo' ), 'Yoast SEO' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/wordpress-training-vt' ),
-				'linkText'    => __( 'Enroll in the Yoast SEO for WordPress training »', 'wordpress-seo' ),
+				/* translators: %s expands to Yoast SEO */
+				'linkText'    => sprintf( __( 'Enroll in the %s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' ),
 			);
 		}
 

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -114,8 +114,12 @@ class Yoast_Feature_Toggles {
 				/* translators: %s: Ryte */
 				'name'            => sprintf( __( '%s integration', 'wordpress-seo' ), 'Ryte' ),
 				'setting'         => 'onpage_indexability',
-				/* translators: 1: Ryte */
-				'label'           => sprintf( __( '%1$s will check weekly if your site is still indexable by search engines and Yoast SEO will notify you when this is not the case.', 'wordpress-seo' ), 'Ryte' ),
+				'label'           => sprintf(
+					/* translators: 1: Ryte, 2: Yoast SEO */
+					__( '%1$s will check weekly if your site is still indexable by search engines and %2$s will notify you when this is not the case.', 'wordpress-seo' ),
+					'Ryte',
+					'Yoast SEO'
+				),
 				/* translators: %s: Ryte */
 				'read_more_label' => sprintf( __( 'Read more about how %s works.', 'wordpress-seo' ), 'Ryte ' ),
 				'read_more_url'   => 'https://yoa.st/2an',

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -20,7 +20,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 		<div class="yoast-sidebar__section">
 			<h2>
 				<?php
-				/* translators: %s expands to the plugin name */
+				/* translators: %s expands to Yoast SEO Premium */
 				printf( esc_html__( 'Upgrade to %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 				?>
 			</h2>
@@ -35,7 +35,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 
 			<a id="wpseo-premium-button" class="yoast-button-upsell" href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jj' ); ?>" target="_blank">
 				<?php
-				/* translators: %s is replaced by the plugin name */
+				/* translators: %s expands to Yoast SEO Premium */
 				printf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 				echo $new_tab_message;
 				echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
@@ -82,7 +82,12 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 			</div>
 		</div>
 		<div class="yoast-sidebar__section">
-			<h2><?php esc_html_e( 'Extend Yoast SEO', 'wordpress-seo' ); ?></h2>
+			<h2>
+				<?php
+					/* translators: %s expands to Yoast SEO */
+					printf( esc_html__( 'Extend %s', 'wordpress-seo' ), 'Yoast SEO' );
+				?>
+			</h2>
 			<div class="wp-clearfix">
 				<p>
 					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jq' ); ?>" target="_blank">
@@ -129,7 +134,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 			<p>
 				<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jy' ); ?>" target="_blank">
 					<?php
-						/* translators: %s expands to Yoast SEO Premium. */
+						/* translators: %s expands to Yoast SEO Premium */
 						printf( esc_html__( 'Upgrade to %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 						echo $new_tab_message;
 					?>

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -62,9 +62,9 @@ function wpseo_import_external_select( $name, $plugins ) {
 	<h3><?php esc_html_e( 'Step 2: Import', 'wordpress-seo' ); ?></h3>
 	<p>
 		<?php
-		/* translators: %s expands to Yoast SEO */
+		/* translators: %1$s expands to Yoast SEO */
 		printf(
-			esc_html__( 'This will import the post metadata like SEO titles and descriptions into your %s metadata. It will only do this when there is no existing %s metadata yet. The original data will remain in place.', 'wordpress-seo' ),
+			esc_html__( 'This will import the post metadata like SEO titles and descriptions into your %1$s metadata. It will only do this when there is no existing %1$s metadata yet. The original data will remain in place.', 'wordpress-seo' ),
 			'Yoast SEO'
 		);
 		?>

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -17,7 +17,11 @@ $import_check->detect();
 if ( count( $import_check->needs_import ) === 0 ) {
 	echo '<h2>', esc_html__( 'Import from other SEO plugins', 'wordpress-seo' ), '</h2>';
 	echo '<p>';
-	esc_html_e( 'Yoast SEO did not detect any plugin data from plugins it can import from.', 'wordpress-seo' );
+	printf(
+		/* translators: %s expands to Yoast SEO */
+		esc_html__( '%s did not detect any plugin data from plugins it can import from.', 'wordpress-seo' ),
+		'Yoast SEO'
+	);
 	echo '</p>';
 
 	return;
@@ -57,7 +61,13 @@ function wpseo_import_external_select( $name, $plugins ) {
 <div class="tab-block">
 	<h3><?php esc_html_e( 'Step 2: Import', 'wordpress-seo' ); ?></h3>
 	<p>
-		<?php esc_html_e( 'This will import the post metadata like SEO titles and descriptions into your Yoast SEO metadata. It will only do this when there is no existing Yoast SEO metadata yet. The original data will remain in place.', 'wordpress-seo' ); ?>
+		<?php
+		/* translators: %s expands to Yoast SEO */
+		printf(
+			esc_html__( 'This will import the post metadata like SEO titles and descriptions into your %s metadata. It will only do this when there is no existing %s metadata yet. The original data will remain in place.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
+		?>
 	</p>
 	<form action="<?php echo esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#import-seo' ) ); ?>"
 		method="post" accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -31,7 +31,15 @@ if ( ! defined( 'WPSEO_NAMESPACES' ) || ! WPSEO_NAMESPACES ) {
 	method="post"
 	accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php wp_nonce_field( WPSEO_Import_Settings::NONCE_ACTION ); ?>
-	<label class="screen-reader-text" for="settings-import"><?php esc_html_e( 'Paste your settings from another Yoast SEO installation.', 'wordpress-seo' ); ?></label>
+	<label class="screen-reader-text" for="settings-import">
+		<?php
+		printf(
+			/* translators: %s expands to Yoast SEO */
+			esc_html__( 'Paste your settings from another %s installation.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
+		?>
+	</label>
 	<textarea id="settings-import" rows="10" cols="140" name="settings_import"></textarea><br/>
 	<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Import settings', 'wordpress-seo' ); ?>"/>
 </form>


### PR DESCRIPTION
This PR replaces the `Yoast SEO` string with `%s` placeholder. To match the convention in other translation strings.

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Move `Yoast SEO` out of translation string

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
