### PR TITLE
Fix person cannot be publisher

### DIFF
--- a/frontend/schema/class-schema-person.php
+++ b/frontend/schema/class-schema-person.php
@@ -128,7 +128,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	protected function build_person_data( $user_id ) {
 		$user_data = get_userdata( $user_id );
 		$data      = array(
-			'@type' => 'Person',
+			'@type' => array( 'Person', 'Organization' ),
 			'@id'   => $this->determine_schema_id( $user_id ),
 			'name'  => $user_data->display_name,
 		);
@@ -164,6 +164,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 		$id            = $this->context->site_url . WPSEO_Schema_IDs::PERSON_LOGO_HASH;
 		$schema_image  = new WPSEO_Schema_Image( $id );
 		$data['image'] = $schema_image->simple_image_object( $url, $user_data->display_name );
+		$data['logo']  = array( '@id' => $id );
 
 		return $data;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix `Person cannot be publisher` error in Google's Structured Data Testing Tool by making the `Person` node be a `[Person, Organization]` node.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12822 
