### PR TITLE
Don't output author URL when those are disabled

### DIFF
--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -105,7 +105,24 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 			return $this->context->site_url . WPSEO_Schema_IDs::PERSON_HASH;
 		}
 
-		return get_author_posts_url( $post->post_author ) . WPSEO_Schema_IDs::AUTHOR_HASH;
+		return $this->get_author_posts_url( $post->post_author ) . WPSEO_Schema_IDs::AUTHOR_HASH;
+	}
+
+	/**
+	 * Retrieves the author post URL based on our author archives settings.
+	 *
+	 * @param int $user_id
+	 *
+	 * @return string unsigned Author posts URL.
+	 */
+	private function get_author_posts_url( $user_id ) {
+		if ( WPSEO_Options::get( 'disable-author', false ) === false ) {
+			return get_author_posts_url( $user_id );
+		}
+		$user = get_userdata( $user_id );
+		$slug = sanitize_title( $user->display_name );
+
+		return $this->context->site_url . 'person/' . $slug . '/';
 	}
 
 	/**

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -111,7 +111,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	/**
 	 * Retrieves the author post URL based on our author archives settings.
 	 *
-	 * @param int $user_id
+	 * @param int $user_id The author's user ID.
 	 *
 	 * @return string unsigned Author posts URL.
 	 */

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -122,7 +122,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		$user = get_userdata( $user_id );
 		$slug = sanitize_title( $user->display_name );
 
-		return $this->context->site_url . 'person/' . $slug . '/';
+		return $this->context->site_url . 'schema/person/' . $slug . '/';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Don't output author URLs in Schema when author archives are disabled.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Disable author archives in the Yoast SEO settings, see the author `@id` changes.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12718 
