### PR TITLE
Person image fixes

### DIFF
--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -55,6 +55,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		<h3><?php esc_html_e( 'Personal info', 'wordpress-seo' ); ?></h3>
 		<?php
 		echo '<div id="wpseo-person-selector"></div>';
+		$yform->media_input( 'person_logo', __( 'Person logo / avatar', 'wordpress-seo' ) );
 		$yform->hidden( 'company_or_person_user_id', 'person_id' );
 		?>
 	</div>

--- a/frontend/schema/class-schema-organization.php
+++ b/frontend/schema/class-schema-organization.php
@@ -62,14 +62,23 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @return array $data The Organization schema.
 	 */
 	private function add_logo( $data ) {
-		$logo = WPSEO_Options::get( 'company_logo', '' );
-		if ( empty( $logo ) ) {
+		$logo_id = WPSEO_Options::get( 'company_logo_id', false );
+		if ( ! $logo_id ) {
+			$company_logo = WPSEO_Options::get( 'company_logo', false );
+			if ( $company_logo ) {
+				// There is not an option to put a URL in this field in the settings, only to upload it through the media manager, so we just have to save this only once and never be here again.
+				$logo_id = WPSEO_Image_Utils::get_attachment_by_url( $company_logo );
+				WPSEO_Options::set( 'company_logo_id', $logo_id );
+			}
+		}
+
+		if ( empty( $logo_id ) ) {
 			return $data;
 		}
-		$id            = $this->context->site_url . WPSEO_Schema_IDs::ORGANIZATION_LOGO_HASH;
-		$schema_image  = new WPSEO_Schema_Image( $id );
-		$data['logo']  = $schema_image->generate_from_url( $logo, $this->context->company_name );
-		$data['image'] = array( '@id' => $id );
+		$schema_id     = $this->context->site_url . WPSEO_Schema_IDs::ORGANIZATION_LOGO_HASH;
+		$schema_image  = new WPSEO_Schema_Image( $schema_id );
+		$data['logo']  = $schema_image->generate_from_attachment_id( $logo_id, $this->context->company_name );
+		$data['image'] = array( '@schema_id' => $schema_id );
 
 		return $data;
 	}

--- a/frontend/schema/class-schema-organization.php
+++ b/frontend/schema/class-schema-organization.php
@@ -62,15 +62,7 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @return array $data The Organization schema.
 	 */
 	private function add_logo( $data ) {
-		$logo_id = WPSEO_Options::get( 'company_logo_id', false );
-		if ( ! $logo_id ) {
-			$company_logo = WPSEO_Options::get( 'company_logo', false );
-			if ( $company_logo ) {
-				// There is not an option to put a URL in this field in the settings, only to upload it through the media manager, so we just have to save this only once and never be here again.
-				$logo_id = WPSEO_Image_Utils::get_attachment_by_url( $company_logo );
-				WPSEO_Options::set( 'company_logo_id', $logo_id );
-			}
-		}
+		$logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
 
 		if ( empty( $logo_id ) ) {
 			return $data;
@@ -78,7 +70,7 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 		$schema_id     = $this->context->site_url . WPSEO_Schema_IDs::ORGANIZATION_LOGO_HASH;
 		$schema_image  = new WPSEO_Schema_Image( $schema_id );
 		$data['logo']  = $schema_image->generate_from_attachment_id( $logo_id, $this->context->company_name );
-		$data['image'] = array( '@schema_id' => $schema_id );
+		$data['image'] = array( '@id' => $schema_id );
 
 		return $data;
 	}

--- a/frontend/schema/class-schema-person.php
+++ b/frontend/schema/class-schema-person.php
@@ -162,6 +162,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 			return $data;
 		}
 
+		// If we don't have an image in our settings, fall back to an avatar, if we're allowed to.
 		$show_avatars = get_option( 'show_avatars' );
 		if ( ! $show_avatars ) {
 			return $data;
@@ -187,16 +188,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 * @return array    $data      The Person schema.
 	 */
 	private function set_image_from_options( $data, $schema_id ) {
-		$person_logo_id = WPSEO_Options::get( 'person_logo_id', false );
-
-		if ( ! $person_logo_id ) {
-			$person_logo = WPSEO_Options::get( 'person_logo', false );
-			if ( $person_logo ) {
-				// There is not an option to put a URL in this field in the settings, only to upload it through the media manager, so we just have to save this only once and never be here again.
-				$person_logo_id = WPSEO_Image_Utils::get_attachment_by_url( $person_logo );
-				WPSEO_Options::set( 'person_logo_id', $person_logo_id );
-			}
-		}
+		$person_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'person_logo' );
 
 		if ( $person_logo_id ) {
 			$image         = new WPSEO_Schema_Image( $schema_id );

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -389,7 +389,7 @@ class WPSEO_Image_Utils {
 	 *
 	 * @param string $setting The setting the image is stored in.
 	 *
-	 * @return int|bool
+	 * @return int|bool The attachment id, or false if no id is available.
 	 */
 	public static function get_attachment_id_from_settings( $setting ) {
 		$image_id = WPSEO_Options::get( $setting . '_id', false );

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -383,4 +383,26 @@ class WPSEO_Image_Utils {
 
 		return $image_url;
 	}
+
+	/**
+	 * Retrieves an attachment ID for an image uploaded in the settings.
+	 *
+	 * @param string $setting The setting the image is stored in.
+	 *
+	 * @return int|bool
+	 */
+	public static function get_attachment_id_from_settings( $setting ) {
+		$image_id = WPSEO_Options::get( $setting . '_id', false );
+		if ( ! $image_id ) {
+			$image = WPSEO_Options::get( $setting, false );
+			if ( $image ) {
+				// There is not an option to put a URL in an image field in the settings anymore, only to upload it through the media manager.
+				// This means an attachment always exists, so doing this is only needed once.
+				$image_id = self::get_attachment_by_url( $image );
+				WPSEO_Options::set( $setting . '_id', $image_id );
+			}
+		}
+
+		return $image_id;
+	}
 }

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -66,8 +66,11 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 		'website_name'                  => '',
 		'person_name'                   => '',
+		'person_logo'                   => '',
+		'person_logo_id'                => 0,
 		'alternate_website_name'        => '',
 		'company_logo'                  => '',
+		'company_logo_id'               => 0,
 		'company_name'                  => '',
 		'company_or_person'             => 'company',
 		'company_or_person_user_id'     => false,
@@ -366,6 +369,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					break;
 
 				case 'company_logo':
+				case 'person_logo':
 					$this->validate_url( $key, $dirty, $old, $clean );
 					break;
 
@@ -474,6 +478,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					break;
 
 				case 'company_or_person_user_id':
+				case 'company_logo_id':
+				case 'person_logo_id':
 				case 'title_test': /* Integer field - not in form. */
 					if ( isset( $dirty[ $key ] ) ) {
 						$int = WPSEO_Utils::validate_int( $dirty[ $key ] );


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* Performance optimization to how we retrieve logo images in schema.
* Add an avatar / logo input field to the settings for Person in the Company or Person choosing.
* Don't show avatars when the discussion settings don't allow it.

## Relevant technical choices:

* Made sure we store `company_logo_id` and `person_logo_id`, as that's much faster.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set site to Person, see the new input field.
* Use it, see the output uses it too.
* Set site to not use avatars (under Discussion), see we don't output anything if nothing is set in the above tested input field.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12717 
