### PR TITLE
Add missing argument to deprecated filter to avoid fatal error

### DIFF
--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -36,7 +36,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 		 *
 		 * @api mixed If false or an empty array is returned, disable our output.
 		 */
-		$return = apply_filters( 'wpseo_json_ld_output', $deprecated_data );
+		$return = apply_filters( 'wpseo_json_ld_output', $deprecated_data, '' );
 		if ( $return === array() || $return === false ) {
 			return;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ Release Date: May 6th, 2019
 Bugfixes:
 
 * Fixes a bug where an empty width and height would be outputted in the image schema when there was no retrievable width and height.
+* Fixes a bug where using the `$context` argument in the deprecated `wpseo_json_ld_output` filter would result in a fatal error when using PHP 7.1 or higher.
 
 Other
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where using the `$context` argument in the deprecated `wpseo_json_ld_output` filter would result in a fatal error when using PHP 7.1 or higher.

## Relevant technical choices:

* I've added an empty string because the `$context` parameter in the filter before the deprecation was a string as well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have query monitor installed.
* Add the following to your theme's functions.php:
```
add_filter( 'wpseo_json_ld_output', function( $data, $context ) {
	 return $data;
}, 10, 2 );
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12846 
