### PR TITLE
Update i18n-module version to 3.1.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -845,17 +845,24 @@
         },
         {
             "name": "yoast/i18n-module",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/i18n-module.git",
-                "reference": "76b1645aaf8cf9a07dc06ec0bbe2a6838feeed4c"
+                "reference": "50c69961805a8d79699eed745a65e9e4a76538eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/76b1645aaf8cf9a07dc06ec0bbe2a6838feeed4c",
-                "reference": "76b1645aaf8cf9a07dc06ec0bbe2a6838feeed4c",
+                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/50c69961805a8d79699eed745a65e9e4a76538eb",
+                "reference": "50c69961805a8d79699eed745a65e9e4a76538eb",
                 "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "roave/security-advisories": "dev-master",
+                "yoast/yoastcs": "^1.2.2"
             },
             "type": "library",
             "autoload": {
@@ -865,7 +872,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -879,7 +886,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2017-09-06T07:17:52+00:00"
+            "time": "2019-05-06T08:29:33+00:00"
         },
         {
             "name": "yoast/license-manager",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a 'You're using WordPress in a language we don't support yet.' notice would be shown for formal and informal locales when the locale actually was supported.


## Relevant technical choices:

* Update i18n-module version to 3.1.0

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
