### PR TITLE
Fix capitalization for Yoast i18n-module 3.1.0 release

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -544,7 +544,7 @@ class WPSEO_Admin_Init {
 	 */
 	private function register_i18n_promo_class() {
 		// BC, because an older version of the i18n-module didn't have this class.
-		$i18n_module = new Yoast_I18n_WordPressOrg_v3(
+		$i18n_module = new Yoast_I18n_WordPressOrg_V3(
 			array(
 				'textdomain'  => 'wordpress-seo',
 				'plugin_name' => 'Yoast SEO',


### PR DESCRIPTION
The commit that changed the capitalization: https://github.com/Yoast/i18n-module/commit/87aef6aa623a5076293064ebcd85de720d6e5fe5

## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Fixes class capitalization because the Yoast i18n-module update to `3.1.0` changed its capitalization.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Without this code get a fatal PHP error (I got this on the search-appearance page).
* With this code it works fine.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
