### PR TITLE
Update i18n-module version to 3.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"php": "^5.6.0||^7.0",
 		"composer/installers": "~1.0",
 		"yoast/license-manager": "1.6.0",
-		"yoast/i18n-module": "^3.0",
+		"yoast/i18n-module": "^3.1.1",
 		"yoast/api-libs": "^2.0",
 		"xrstf/composer-php52": "^1.0.20",
 		"j4mie/idiorm": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f3a641da6e35307b69aaaff10e1549e",
+    "content-hash": "718fa394340316f4212093be04f8bf1c",
     "packages": [
         {
             "name": "composer/installers",
@@ -845,16 +845,16 @@
         },
         {
             "name": "yoast/i18n-module",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/i18n-module.git",
-                "reference": "50c69961805a8d79699eed745a65e9e4a76538eb"
+                "reference": "9d0a2f6daea6fb42376b023e7778294d19edd85d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/50c69961805a8d79699eed745a65e9e4a76538eb",
-                "reference": "50c69961805a8d79699eed745a65e9e4a76538eb",
+                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/9d0a2f6daea6fb42376b023e7778294d19edd85d",
+                "reference": "9d0a2f6daea6fb42376b023e7778294d19edd85d",
                 "shasum": ""
             },
             "require": {
@@ -886,7 +886,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2019-05-06T08:29:33+00:00"
+            "time": "2019-05-07T06:45:05+00:00"
         },
         {
             "name": "yoast/license-manager",


### PR DESCRIPTION
i18n-module 3.1.1 reverts the capitalization of class names, which solves fatal errors.

