### PR TITLE
i18n: Merge similar translation strings in KeywordSynonyms.js

### DIFF
--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -17,8 +17,8 @@ const PremiumLandingPageLink = makeOutboundLink();
  */
 const KeywordSynonyms = ( props ) => {
 	const intro = sprintf(
-		/* translators: %s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
-		__( "Great news: you can, with %s!", "wordpress-seo" ),
+		/* translators: %1$s expands to a 'Yoast SEO Premium' text linked to the yoast.com website. */
+		__( "Great news: you can, with %1$s!", "wordpress-seo" ),
 		"{{link}}Yoast SEO Premium{{/link}}"
 	);
 


### PR DESCRIPTION

![yoast27](https://user-images.githubusercontent.com/576623/57283105-0e22d280-70b7-11e9-8ec2-b8c2a3dd661e.png)

* `Great news: you can, with %1$s!` - **5 strings**
* `Great news: you can, with %s!` - **1 string**

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Merge similar translation strings in KeywordSynonyms.js

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
