### PR TITLE
i18n: Update wrong category name in Google Search Console

### DIFF
--- a/admin/google_search_console/class-gsc-category-filters.php
+++ b/admin/google_search_console/class-gsc-category-filters.php
@@ -120,7 +120,7 @@ class WPSEO_GSC_Category_Filters {
 		$this->set_filter_value( 'other', __( 'Other', 'wordpress-seo' ), __( 'Google was unable to crawl this URL due to an undetermined issue.', 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Other', 'wordpress-seo' ) ) );
 		/* Translators: %1$s: expands to '<code>robots.txt</code>'. */
 		$this->set_filter_value( 'roboted', __( 'Blocked', 'wordpress-seo' ), sprintf( __( 'Googlebot could access your site, but certain URLs are blocked for Googlebot in your %1$s file. This block could either be for all Googlebots or even specifically for Googlebot-mobile.', 'wordpress-seo' ), '<code>robots.txt</code>' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Blocked', 'wordpress-seo' ) ) );
-		$this->set_filter_value( 'server_error', __( 'Server Error', 'wordpress-seo' ), __( 'Request timed out or site is blocking Google.', 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Server', 'wordpress-seo' ) ) );
+		$this->set_filter_value( 'server_error', __( 'Server Error', 'wordpress-seo' ), __( 'Request timed out or site is blocking Google.', 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Server Error', 'wordpress-seo' ) ) );
 		$this->set_filter_value( 'soft_404', __( 'Soft 404', 'wordpress-seo' ), __( "The target URL doesn't exist, but your server is not returning a 404 (file not found) error.", 'wordpress-seo' ), sprintf( __( 'Show information about errors in category %s', 'wordpress-seo' ), __( 'Soft 404', 'wordpress-seo' ) ) );
 	}
 


### PR DESCRIPTION
The name of the category is not `Server`, its `Server Error`.

The problem is that the new `Server` translation string is a new string, not used in any other place, inflating the total number of translation strings.

This PR fixes the category name in Google Search Console filters, and reduces the total number of translation strings.

Related: #12782

## Summary

This PR can be summarized in the following changelog entry:

* i18n: Update wrong category name in Google Search Console

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
