### PR TITLE
Add safety check around the knowledge graph user

### DIFF
--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -169,6 +169,10 @@ class WPSEO_Schema_Context {
 
 		if ( $this->site_represents === 'person' ) {
 			$this->site_user_id = WPSEO_Options::get( 'company_or_person_user_id', false );
+			// Do no use a non-existing user.
+			if ( $this->site_user_id !== false && get_user_by( 'id', $this->site_user_id ) === false ) {
+				$this->site_user_id = false;
+			}
 		}
 
 		$this->id = get_queried_object_id();

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -169,7 +169,7 @@ class WPSEO_Schema_Context {
 
 		if ( $this->site_represents === 'person' ) {
 			$this->site_user_id = WPSEO_Options::get( 'company_or_person_user_id', false );
-			// Do no use a non-existing user.
+			// Do not use a non-existing user.
 			if ( $this->site_user_id !== false && get_user_by( 'id', $this->site_user_id ) === false ) {
 				$this->site_user_id = false;
 			}

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -26,25 +26,25 @@ const Styles = createGlobalStyle`
 				box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
 				min-height: 28px;
 			}
-			
+
 			&__input input {
 				box-shadow: none;
 				margin: 0;
 			}
-			
+
 			&__menu {
 				margin: 0;
 				border-radius: 0;
 			}
-			
+
 			&__menu-list {
 				padding: 0;
 			}
-			
+
 			&__option--is-selected {
 				background-color: #0085ba;
 			}
-			
+
 			&__indicators {
 				padding: 0 10px;
 			}

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -203,7 +203,7 @@ class WordPressUserSelector extends Component {
 	 *
 	 * @returns {void}
 	 */
-	async fetchUser( id ) {
+	fetchUser( id ) {
 		sendRequest( `${ REST_ROUTE }wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } )
 			.then( user => {
 				if ( user ) {

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -208,7 +208,7 @@ class WordPressUserSelector extends Component {
 			.then( user => {
 				if ( user ) {
 					this.onChange( this.mapUserToSelectOption( user ) );
-					// Setting the state to `loading: false` is already done.
+					// Setting the state to `loading: false` is already done in the `onChange` function.
 					return;
 				}
 				this.setState( { loading: false } );

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -204,15 +204,18 @@ class WordPressUserSelector extends Component {
 	 * @returns {void}
 	 */
 	async fetchUser( id ) {
-		const user = await sendRequest( `${ REST_ROUTE }wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } );
-
-		if ( ! user ) {
-			this.setState( { loading: false } );
-
-			return;
-		}
-
-		this.onChange( this.mapUserToSelectOption( user ) );
+		sendRequest( `${ REST_ROUTE }wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } )
+			.then( user => {
+				if ( user ) {
+					this.onChange( this.mapUserToSelectOption( user ) );
+					// Setting the state to `loading: false` is already done.
+					return;
+				}
+				this.setState( { loading: false } );
+			} )
+			.catch( () => {
+				this.setState( { loading: false } );
+			} );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where when having the knowledge graph user set as a deleted user it would no longer be possible to change this user. The schema output would be incorrect as well.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Point the knowledge graph user to a non-existing one
* Create a user (`Users -> Add new`).
* Set that user as knowledge graph person (`SEO -> Search Appearance`).
* Delete that user (`Users -> delete under that user`).

### Check frontend
* Go to the frontend of a post.
* Ensure you no longer get these errors (only output when `WP_DEBUG` is defined as true):
```
Notice: Trying to get property 'display_name' of non-object in /srv/www/wordpress-default/public_html/wp-content/plugins/wordpress-seo/frontend/schema/class-schema-person.php on line 133

Notice: Trying to get property 'user_email' of non-object in /srv/www/wordpress-default/public_html/wp-content/plugins/wordpress-seo/frontend/schema/class-schema-person.php on line 159

Notice: Trying to get property 'display_name' of non-object in /srv/www/wordpress-default/public_html/wp-content/plugins/wordpress-seo/frontend/schema/class-schema-person.php on line 166
```

### Check search appearance
* Go to `SEO -> Search Appearance`.
* Ensure you can still change the person here.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12842 
