### PR TITLE
Don't suppress builtin taxonomies.

### DIFF
--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -69,7 +69,6 @@ echo '<br/>';
 $taxonomies = get_taxonomies(
 	array(
 		'public'   => true,
-		'_builtin' => false,
 	),
 	'objects'
 );


### PR DESCRIPTION
Hello,

This patch is to fix the 'Content type archive to show in breadcrumbs for taxonomies' section re-enabling the builtin taxonomies for Category, Tag, Format so users can specify the Blog archive as it's parent.

Without this change the breadcrumbs for these builtin taxonomies aren't able to contain 'Blog' or the parent Blog archive page.

Thanks

## Summary

This PR can be summarized in the following changelog entry:

* Enable builtin Taxonomies for the 'Content type archive to show in breadcrumbs for taxonomies' section to allow the Blog archive page be added to the breadcrumbs.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Navigate to the Breadcrumb settings and find the 'Category', 'Tag', 'Format' entries are now present under 'Content type archive to show in breadcrumbs for taxonomies', update their settings to use your Blog page. Then navigate to a term page to find the updated breadcrumbs

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
