### PR TITLE
Make AMP pages output Yoast SEO Schema

### DIFF
--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -20,6 +20,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	public function register_hooks() {
 		add_action( 'wpseo_head', array( $this, 'json_ld' ), 91 );
 		add_action( 'wpseo_json_ld', array( $this, 'generate' ), 1 );
+		add_action( 'amp_post_template_head', array( $this, 'json_ld' ), 9 );
 	}
 
 	/**
@@ -42,6 +43,8 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 			return;
 		}
 
+		// Remove the AMP hook that also outputs Schema metadata on AMP pages.
+		remove_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
 		do_action( 'wpseo_json_ld' );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Yoast SEO now takes control of the Schema output on pages generated by the [AMP plugin](https://wordpress.org/plugins/amp/). 

## Relevant technical choices:

* Removed the AMP schema metadata.

## Test instructions
This PR can be tested by following these steps:

* Go to an AMP page with the AMP plugin active, see that we have nice Yoast SEO schema.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12862

Replaces https://github.com/Yoast/wordpress-seo/pull/12864