### PR TITLE
Don't throw error in case of no-upstream when using yarn link-monorepo.

### DIFF
--- a/scripts/link_monorepo_to_plugin.js
+++ b/scripts/link_monorepo_to_plugin.js
@@ -167,7 +167,9 @@ function log( message ) {
 /**
  * Console logs with yellow font for warnings.
  *
- * @param message The message to log.
+ * @param {string} message The message to log.
+ *
+ * @returns {void}
  */
 function warning( message ) {
 	// eslint-disable-next-line no-console

--- a/scripts/link_monorepo_to_plugin.js
+++ b/scripts/link_monorepo_to_plugin.js
@@ -164,6 +164,16 @@ function log( message ) {
 	console.log( "\x1b[1m" + message + "\x1b[0m" );
 }
 
+/**
+ * Console logs with yellow font for warnings.
+ *
+ * @param message The message to log.
+ */
+function warning( message ) {
+	// eslint-disable-next-line no-console
+	console.log( "\x1b[33m%s\x1b[0m", message );
+}
+
 // Start the script.
 log( `Your monorepo is located in "${ getMonorepoLocationFromFile() }". ` );
 
@@ -175,7 +185,12 @@ if ( IS_TRAVIS ) {
 }
 
 log( "Pulling the latest monorepo changes." );
-execMonorepoNoOutput( "git pull" );
+try {
+	execMonorepoNoOutput( "git pull 2>/dev/null" );
+} catch( error ) {
+	// No remote is specified.
+	warning( "git could not pull changes from the remote repo.\nIf you are working on a local version of the javascript branch, this is expected behaviour.\nContinuing..." )
+}
 
 log( "Unlinking previously linked Yoast packages from Yarn." );
 unlinkAllYoastPackages();


### PR DESCRIPTION
## Summary
Don't throw error in case of no-upstream when using yarn link-monorepo but instead display a warning notifying the user of the error and continuing the script.

This PR can be summarized in the following changelog entry:

* Ensure that `yarn link-monorepo` also works on branches that only exist locally.

## Test instructions
This PR can be tested by following these steps:
1. Run `git checkout -b random-branch` in your monorepo location.
2. Run `yarn link-monorepo`, this should give a warning message notifying you that `git pull` was not successful. The script should continue running.

Fixes Yoast/javascript#273
