### PR TITLE
Ignore the premium BrainMonkey tests folder for PHPCS for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
 		],
 		"premium-check-cs": [
 			"@before-premium-cs",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/ --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,tests/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
 		],


### PR DESCRIPTION
Related to https://github.com/Yoast/wordpress-seo-premium/pull/2392

## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Ignores the premium `tests` folder in the `composer premium-check-cs` command. This is to give us some time to fix the linting errors in the new tests.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test in combination with https://github.com/Yoast/wordpress-seo-premium/pull/2393 (test instructions are there).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
