### PR TITLE
QA: remove useless override methods

### DIFF
--- a/integration-tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/integration-tests/frontend/test-class-wpseo-opengraph-image.php
@@ -13,13 +13,6 @@
 class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * Set up class instance.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-	}
-
-	/**
 	 * Provision tests.
 	 */
 	public function setUp() {

--- a/integration-tests/test-wpseo-functions.php
+++ b/integration-tests/test-wpseo-functions.php
@@ -11,13 +11,6 @@
 class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * Provision some options.
-	 */
-	public function setUp() {
-		parent::setUp();
-	}
-
-	/**
 	 * @covers wpseo_replace_vars
 	 */
 	public function test_wpseo_replace_vars() {

--- a/tests/watchers/indexable-post-watcher-test.php
+++ b/tests/watchers/indexable-post-watcher-test.php
@@ -18,13 +18,6 @@ use Brain\Monkey;
 class Indexable_Post_Watcher_Test extends \Yoast\Tests\TestCase {
 
 	/**
-	 * Sets up the environment for each test.
-	 */
-	public function setUp() {
-		parent::setUp();
-	}
-
-	/**
 	 * Tests if the expected hooks are registered.
 	 *
 	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::register_hooks()


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

The parent method will automatically be called by PHP/PHPUnit if the `setUp(BeforeClass)()` method is defined in the parent and not in the child, so there is absolutely no need to redeclare the method when all it does is call the parent.


## Test instructions
This PR can be tested by following these steps:

* _N/A_

