### PR TITLE
Reverted backport wordpress externals

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -190,7 +190,14 @@ module.exports = function( env = { environment: "production" } ) {
 
 				lodash: "lodash",
 
-				...wordpressExternals,
+				// Don't reference window.wp.* externals in this config!
+				"@wordpress/element": [ "wp", "element" ],
+				"@wordpress/data": [ "wp", "data" ],
+				"@wordpress/components": [ "wp",  "components" ],
+				"@wordpress/i18n": [ "wp", "i18n" ],
+				"@wordpress/api-fetch": [ "wp", "apiFetch" ],
+				"@wordpress/rich-text": [ "wp", "richText" ],
+				"@wordpress/compose": [ "wp", "compose" ],
 			},
 			output: {
 				path: paths.jsDist,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the metabox would be empty on WordPress versions below 5.0.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install an instance of WordPress `4.9.8` + 5.0 + 5.1 + 5.2.
* For all those versions:
   * Check if the metabox is working on a post edit page.
   * Check if the metabox is working on a taxonomy edit page.
   * Check if the metabox is working on a page edit page.
   * Check if the metabox is working on a custom post type edit page.
* Check the same for all installations + classic editor plugin.
* Check the same for all installations + Gutenberg plugin.
* Check the same for all installations + Gutenberg + classic editor plugin.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12950 
