### PR TITLE
Fixes metabox when Classic Editor and Gutenberg plugins are active

### DIFF
--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -100,10 +100,8 @@ function scheduleAnnotationQueueApplication() {
  * @returns {boolean} Whether or not annotations are available in Gutenberg.
  */
 export function isAnnotationAvailable() {
-	return ! isUndefined( select( "core/editor" ) ) &&
-		isFunction( select( "core/editor" ).getBlocks ) &&
-		! isUndefined( select( "core/annotations" ) ) &&
-		isFunction( dispatch( "core/annotations" ).__experimentalAddAnnotation );
+	return select( "core/editor" ) && isFunction( select( "core/editor" ).getBlocks ) &&
+		select( "core/annotations" ) && isFunction( dispatch( "core/annotations" ).__experimentalAddAnnotation );
 }
 
 /**

--- a/js/src/decorator/gutenberg.js
+++ b/js/src/decorator/gutenberg.js
@@ -1,6 +1,5 @@
 /* External dependencies */
 import isFunction from "lodash/isFunction";
-import isUndefined from "lodash/isUndefined";
 import flatMap from "lodash/flatMap";
 import { create } from "@wordpress/rich-text";
 import { select, dispatch } from "@wordpress/data";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the metabox would be empty when both the classic editor plugin as well as the Gutenberg plugin were installed.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install an instance of WordPress `4.9.8` + 5.0 + 5.1 + 5.2.
* For all those versions:
   * Check if the metabox is working on a post edit page.
   * Check if the metabox is working on a taxonomy edit page.
   * Check if the metabox is working on a page edit page.
   * Check if the metabox is working on a custom post type edit page.
* Check the same for all installations + classic editor plugin.
* Check the same for all installations + Gutenberg plugin.
* Check the same for all installations + Gutenberg + classic editor plugin.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/bugreports#345
