### PR TITLE
Fix namespaces in the tests directory

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests;
+namespace Yoast\WP\Free\Tests;
 
 use PHPUnit_Framework_TestCase;
 use Brain\Monkey;

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Yoast\Tests\Admin;
+namespace Yoast\WP\Free\Tests\Admin;
 
 use Brain\Monkey;
-use Yoast\Tests\Doubles\Shortlinker;
+use Yoast\WP\Free\Tests\Doubles\Shortlinker;
 
 /**
  * Class Admin_Features.
  *
  * @package Yoast\Tests\Admin
  */
-class Admin_Features extends \Yoast\Tests\TestCase {
+class Admin_Features extends \Yoast\WP\Free\Tests\TestCase {
 
 	private function get_admin_with_expectations() {
 		$shortlinker = new Shortlinker();

--- a/tests/config/admin-test.php
+++ b/tests/config/admin-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Config;
+namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Admin;
 
@@ -9,7 +9,7 @@ use Yoast\WP\Free\Config\Admin;
  *
  * @package Yoast\Tests\Config
  */
-class Admin_Test extends \Yoast\Tests\TestCase {
+class Admin_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Tests if the class is based upon the Integration interface.

--- a/tests/config/database-migration-test.php
+++ b/tests/config/database-migration-test.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Yoast\Tests\Config;
+namespace Yoast\WP\Free\Tests\Config;
 
-use Yoast\Tests\Doubles\Database_Migration;
-use Yoast\Tests\Doubles\Database_Migration as Database_Migration_Double;
+use Yoast\WP\Free\Tests\Doubles\Database_Migration;
+use Yoast\WP\Free\Tests\Doubles\Database_Migration as Database_Migration_Double;
 use Yoast\WP\Free\Config\Dependency_Management;
 
 use Brain\Monkey;
@@ -15,7 +15,7 @@ use Brain\Monkey;
  *
  * @package Yoast\Tests
  */
-class Database_Migration_Test extends \Yoast\Tests\TestCase {
+class Database_Migration_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	public function setUp() {
 		parent::setUp();
@@ -35,7 +35,7 @@ class Database_Migration_Test extends \Yoast\Tests\TestCase {
 			->andReturn( true );
 
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Database_Migration' )
 			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods( array( 'set_defines' ) )
 			->getMock();
@@ -53,7 +53,7 @@ class Database_Migration_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_is_usable() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Database_Migration' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'get_migration_state' ) )
 			->getMock();
@@ -70,7 +70,7 @@ class Database_Migration_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_is_not_usable() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Database_Migration' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'get_migration_state' ) )
 			->getMock();
@@ -132,7 +132,7 @@ class Database_Migration_Test extends \Yoast\Tests\TestCase {
 			->andReturn( true );
 
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Database_Migration' )
 			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods(
 				array(
@@ -162,7 +162,7 @@ class Database_Migration_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_initialize_with_exception_thrown() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Database_Migration' )
 			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods(
 				array(
@@ -223,7 +223,7 @@ class Database_Migration_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_set_define_success() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Database_Migration' )
 			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods(
 				array( 'set_define', 'get_defines' )
@@ -249,7 +249,7 @@ class Database_Migration_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_set_define_failed() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Database_Migration' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Database_Migration' )
 			->setConstructorArgs( array( null, new Dependency_Management() ) )
 			->setMethods(
 				array( 'set_define', 'get_defines' )

--- a/tests/config/dependency-management-test.php
+++ b/tests/config/dependency-management-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Config;
+namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Dependency_Management;
 
@@ -11,7 +11,7 @@ use Yoast\WP\Free\Config\Dependency_Management;
  *
  * @package Yoast\Tests
  */
-class Dependency_Management_Test extends \Yoast\Tests\TestCase {
+class Dependency_Management_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Tests if the alias is created with ideal conditions.

--- a/tests/config/frontend-test.php
+++ b/tests/config/frontend-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Config;
+namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Frontend;
 
@@ -9,7 +9,7 @@ use Yoast\WP\Free\Config\Frontend;
  *
  * @package Yoast\Tests\Config
  */
-class Frontend_Test extends \Yoast\Tests\TestCase {
+class Frontend_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Tests if the class is based upon the Integration interface.

--- a/tests/config/plugin-test.php
+++ b/tests/config/plugin-test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Yoast\Tests\Config;
+namespace Yoast\WP\Free\Tests\Config;
 
-use Yoast\Tests\Doubles\Plugin as Plugin_Double;
+use Yoast\WP\Free\Tests\Doubles\Plugin as Plugin_Double;
 use Yoast\WP\Free\Config\Database_Migration;
 use Yoast\WP\Free\Config\Dependency_Management;
 use Yoast\WP\Free\WordPress\Integration_Group;
@@ -14,7 +14,7 @@ use Yoast\WP\Free\WordPress\Integration_Group;
  *
  * @package Yoast\Tests\Config
  */
-class Plugin_Test extends \Yoast\Tests\TestCase {
+class Plugin_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Tests if the class is based upon the Integration interface.
@@ -177,7 +177,7 @@ class Plugin_Test extends \Yoast\Tests\TestCase {
 			'get_integration_group',
 		);
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Plugin' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Plugin' )
 			->setMethods( $methods )
 			->getMock();
 
@@ -238,7 +238,7 @@ class Plugin_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_register_hooks_not_initialzed() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Plugin' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Plugin' )
 			->setMethods( array( 'get_integration_group' ) )
 			->getMock();
 
@@ -258,7 +258,7 @@ class Plugin_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_add_frontend_integrations() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Plugin' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Plugin' )
 			->setMethods( array( 'add_integration' ) )
 			->getMock();
 
@@ -277,7 +277,7 @@ class Plugin_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_add_admin_integrations() {
 		$instance = $this
-			->getMockBuilder( 'Yoast\Tests\Doubles\Plugin' )
+			->getMockBuilder( 'Yoast\WP\Free\Tests\Doubles\Plugin' )
 			->setMethods( array( 'add_integration' ) )
 			->getMock();
 

--- a/tests/config/upgrade-test.php
+++ b/tests/config/upgrade-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Config;
+namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Upgrade;
 
@@ -9,7 +9,7 @@ use Yoast\WP\Free\Config\Upgrade;
  *
  * @package Yoast\Tests\Config
  */
-class Upgrade_Test extends \Yoast\Tests\TestCase {
+class Upgrade_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	public function test_do_upgrade() {
 		$migration = $this

--- a/tests/doubles/database-migration.php
+++ b/tests/doubles/database-migration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Doubles;
+namespace Yoast\WP\Free\Tests\Doubles;
 
 /**
  * Test Helper Class.

--- a/tests/doubles/indexable-author-formatter-double.php
+++ b/tests/doubles/indexable-author-formatter-double.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Doubles;
+namespace Yoast\WP\Free\Tests\Doubles;
 
 use Yoast\WP\Free\Formatters\Indexable_Author_Formatter;
 

--- a/tests/doubles/indexable-post-formatter-double.php
+++ b/tests/doubles/indexable-post-formatter-double.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Doubles;
+namespace Yoast\WP\Free\Tests\Doubles;
 
 use Yoast\WP\Free\Formatters\Indexable_Post_Formatter;
 

--- a/tests/doubles/indexable-term-formatter-double.php
+++ b/tests/doubles/indexable-term-formatter-double.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Doubles;
+namespace Yoast\WP\Free\Tests\Doubles;
 
 use Yoast\WP\Free\Formatters\Indexable_Term_Formatter;
 

--- a/tests/doubles/oauth/client.php
+++ b/tests/doubles/oauth/client.php
@@ -5,7 +5,7 @@
  * @package Yoast\Tests\Doubles\Oauth
  */
 
-namespace Yoast\Tests\Doubles\Oauth;
+namespace Yoast\WP\Free\Tests\Doubles\Oauth;
 
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
 

--- a/tests/doubles/plugin.php
+++ b/tests/doubles/plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Doubles;
+namespace Yoast\WP\Free\Tests\Doubles;
 
 /**
  * Test Helper Class.

--- a/tests/doubles/wpseo-shortlinker-double.php
+++ b/tests/doubles/wpseo-shortlinker-double.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Doubles;
+namespace Yoast\WP\Free\Tests\Doubles;
 
 /**
  * Class Shortlinker.

--- a/tests/exceptions/no-indexable-found-test.php
+++ b/tests/exceptions/no-indexable-found-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Exceptions;
+namespace Yoast\WP\Free\Tests\Exceptions;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Loggers\Logger;
@@ -13,7 +13,7 @@ use Yoast\WP\Free\Loggers\Logger;
  *
  * @package Yoast\Tests\Exceptions
  */
-class No_Indexable_Found_Test extends \Yoast\Tests\TestCase {
+class No_Indexable_Found_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Sets up the test fixtures for each test.

--- a/tests/formatters/indexable-author-formatter-test.php
+++ b/tests/formatters/indexable-author-formatter-test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Yoast\Tests\Formatters;
+namespace Yoast\WP\Free\Tests\Formatters;
 
-use Yoast\Tests\Doubles\Indexable_Author_Formatter_Double;
+use Yoast\WP\Free\Tests\Doubles\Indexable_Author_Formatter_Double;
 
 /**
  * Class Indexable_Author_Test.
@@ -12,7 +12,7 @@ use Yoast\Tests\Doubles\Indexable_Author_Formatter_Double;
  *
  * @package Yoast\Tests\Formatters
  */
-class Indexable_Author_Formatter_Test extends \Yoast\Tests\TestCase {
+class Indexable_Author_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * @covers \Yoast\WP\Free\Formatters\Indexable_Author_Formatter::format

--- a/tests/formatters/indexable-post-formatter-test.php
+++ b/tests/formatters/indexable-post-formatter-test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Yoast\Tests\Formatters;
+namespace Yoast\WP\Free\Tests\Formatters;
 
-use Yoast\Tests\Doubles\Indexable_Post_Formatter_Double as Indexable_Post_Double;
+use Yoast\WP\Free\Tests\Doubles\Indexable_Post_Formatter_Double as Indexable_Post_Double;
 
 use Brain\Monkey;
 
@@ -14,7 +14,7 @@ use Brain\Monkey;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Post_Formatter_Test extends \Yoast\Tests\TestCase {
+class Indexable_Post_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::format
@@ -202,7 +202,7 @@ class Indexable_Post_Formatter_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_set_link_count() {
 		$formatter = $this
-			->getMockBuilder( '\Yoast\Tests\Doubles\Indexable_Post_Formatter_Double' )
+			->getMockBuilder( '\Yoast\WP\Free\Tests\Doubles\Indexable_Post_Formatter_Double' )
 			->setConstructorArgs( array( 1 ) )
 			->setMethods( array( 'get_seo_meta' ) )
 			->getMock();
@@ -230,7 +230,7 @@ class Indexable_Post_Formatter_Test extends \Yoast\Tests\TestCase {
 	 */
 	public function test_set_link_count_with_thrown_exception() {
 		$formatter = $this
-			->getMockBuilder( '\Yoast\Tests\Doubles\Indexable_Post_Formatter_Double' )
+			->getMockBuilder( '\Yoast\WP\Free\Tests\Doubles\Indexable_Post_Formatter_Double' )
 			->setConstructorArgs( array( 1 ) )
 			->setMethods( array( 'get_seo_meta' ) )
 			->getMock();

--- a/tests/formatters/indexable-term-formatter-test.php
+++ b/tests/formatters/indexable-term-formatter-test.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Yoast\Tests\Formatters;
+namespace Yoast\WP\Free\Tests\Formatters;
 
-use Yoast\Tests\Doubles\Indexable_Term_Formatter_Double;
+use Yoast\WP\Free\Tests\Doubles\Indexable_Term_Formatter_Double;
 
 /**
  * Class Indexable_Term_Test.
@@ -12,7 +12,7 @@ use Yoast\Tests\Doubles\Indexable_Term_Formatter_Double;
  *
  * @package Yoast\Tests\Formatters
  */
-class Indexable_Term_Formatter_Test extends \Yoast\Tests\TestCase {
+class Indexable_Term_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Holds the instance of the class being tested.

--- a/tests/oauth/client-test.php
+++ b/tests/oauth/client-test.php
@@ -5,7 +5,7 @@
  * @package Yoast\Tests\Oauth
  */
 
-namespace Yoast\Tests\Oauth;
+namespace Yoast\WP\Free\Tests\Oauth;
 
 use Yoast\WP\Free\Oauth\Client;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
@@ -18,7 +18,7 @@ Use Brain\Monkey;
  *
  * @group oauth
  */
-class Oauth_Client_Test extends \Yoast\Tests\TestCase {
+class Oauth_Client_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Holds the instance of the class being tested.
@@ -53,7 +53,7 @@ class Oauth_Client_Test extends \Yoast\Tests\TestCase {
 	 * @covers \Yoast\WP\Free\Oauth\Client::format_access_tokens
 	 */
 	public function test_format_access_tokens() {
-		$class_instance = new \Yoast\Tests\Doubles\Oauth\Client();
+		$class_instance = new \Yoast\WP\Free\Tests\Doubles\Oauth\Client();
 
 		$access_tokens = [
 			1 => [ 'access_token' => 'this-is-a-token' ],
@@ -73,7 +73,7 @@ class Oauth_Client_Test extends \Yoast\Tests\TestCase {
 	 * @covers \Yoast\WP\Free\Oauth\Client::format_access_tokens
 	 */
 	public function test_format_access_tokens_with_invalid_argument() {
-		$class_instance = new \Yoast\Tests\Doubles\Oauth\Client();
+		$class_instance = new \Yoast\WP\Free\Tests\Doubles\Oauth\Client();
 
 		$this->assertEquals( [], $class_instance->format_access_tokens( false ) );
 	}
@@ -84,7 +84,7 @@ class Oauth_Client_Test extends \Yoast\Tests\TestCase {
 	 * @covers \Yoast\WP\Free\Oauth\Client::format_access_tokens
 	 */
 	public function test_format_access_tokens_with_empty_array_as_argument() {
-		$class_instance = new \Yoast\Tests\Doubles\Oauth\Client();
+		$class_instance = new \Yoast\WP\Free\Tests\Doubles\Oauth\Client();
 
 		$this->assertEquals( [], $class_instance->format_access_tokens( [] ) );
 	}

--- a/tests/watchers/indexable-author-watcher-test.php
+++ b/tests/watchers/indexable-author-watcher-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Watchers;
+namespace Yoast\WP\Free\Tests\Watchers;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Watchers\Indexable_Author_Watcher;
@@ -13,7 +13,7 @@ use Yoast\WP\Free\Watchers\Indexable_Author_Watcher;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Author_Watcher_Test extends \Yoast\Tests\TestCase {
+class Indexable_Author_Watcher_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Tests if the expected hooks are registered.

--- a/tests/watchers/indexable-post-watcher-test.php
+++ b/tests/watchers/indexable-post-watcher-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Watchers;
+namespace Yoast\WP\Free\Tests\Watchers;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Watchers\Indexable_Post_Watcher;
@@ -15,7 +15,7 @@ use Brain\Monkey;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Post_Watcher_Test extends \Yoast\Tests\TestCase {
+class Indexable_Post_Watcher_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Sets up the environment for each test.

--- a/tests/watchers/indexable-term-watcher-test.php
+++ b/tests/watchers/indexable-term-watcher-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\Watchers;
+namespace Yoast\WP\Free\Tests\Watchers;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Watchers\Indexable_Term_Watcher;
@@ -13,7 +13,7 @@ use Yoast\WP\Free\Watchers\Indexable_Term_Watcher;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Term_Watcher_Test extends \Yoast\Tests\TestCase {
+class Indexable_Term_Watcher_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Tests if the expected hooks are registered.

--- a/tests/wordpress/integration-group-test.php
+++ b/tests/wordpress/integration-group-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\Tests\WordPress;
+namespace Yoast\WP\Free\Tests\WordPress;
 
 use Yoast\WP\Free\WordPress\Integration_Group;
 
@@ -11,7 +11,7 @@ use Yoast\WP\Free\WordPress\Integration_Group;
  *
  * @package Yoast\Tests
  */
-class Integration_Group_Test extends \Yoast\Tests\TestCase {
+class Integration_Group_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 	/**
 	 * Tests the addition of an integration.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* No user facing changes

## Relevant technical choices:
Updates the namespaces used in the tests directory to match our standards.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer test`. It should pass.
* All namespaces in `tests` should start with `Yoast\WP\Free\Tests`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
