### PR TITLE
Add a notification to encourage people to upgrade WordPress if on a v…

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -446,7 +446,7 @@ class WPSEO_Admin_Init {
 		$notification_center = Yoast_Notification_Center::get();
 
 		$message = sprintf(
-			/* translators: 1: opening strong tag 2: closing strong tag 3: html break 4: Yoast 5: Yoast SEO 6: 5.2 7: 5.3 */
+			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag, %3$s expands to a html break, %4$s expands to Yoast, %5$s expands to Yoast SEO, %6$s expands to 5.2, %7$s expands to 5.3 */
 			__(
 				'%1$sUpgrade WordPress to the most recent version%2$s%3$sWe’ve noticed that you’re not on the latest WordPress version, which might cause an issue soon. %4$s (for reasons of security and stability) only supports the current and previous version of WordPress. When the next version of WordPress comes out, that means that we will support WordPress %6$s and %7$s. This means you will not get any updates to %5$s until you update your WordPress, so please make sure to upgrade to the latest WordPress version soon!%3$s%3$s',
 				'wordpress-seo'
@@ -461,7 +461,7 @@ class WPSEO_Admin_Init {
 		);
 		if ( $wordpress_less_than_50 ) {
 			$message .= sprintf(
-				/* translators: 1: Yoast SEO 2: 5.0 */
+				/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.0 */
 				__(
 					'If you’ve held off on updating to %2$s and higher because of the new Gutenberg editor, please install the Classic editor plugin. It will give you the same editing experience you have now, but also the security of newer versions of WordPress and %1$s.',
 					'wordpress-seo'
@@ -472,7 +472,7 @@ class WPSEO_Admin_Init {
 		}
 		$message .= '<br/><br/>';
 		$message .= sprintf(
-			/* translators: 1: opening anchor tag 2: closing anchor tag */
+			/* translators: %1$s expands to an opening anchor tag, %2$s expands to a closing anchor tag */
 			__(
 				'Read %1$sthis post for more information about why we’re not supporting older versions.%2$s',
 				'wordpress-seo'

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -44,6 +44,7 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_init', array( $this, 'yoast_plugin_suggestions_notification' ), 15 );
 		add_action( 'admin_init', array( $this, 'recalculate_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'unsupported_php_notice' ), 15 );
+		add_action( 'admin_init', array( $this, 'wordpress_upgrade_notice' ), 15 );
 		add_action( 'admin_init', array( $this->asset_manager, 'register_assets' ) );
 		add_action( 'admin_init', array( $this, 'show_hook_deprecation_warnings' ) );
 		add_action( 'admin_init', array( 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ) );
@@ -429,6 +430,70 @@ class WPSEO_Admin_Init {
 	public function unsupported_php_notice() {
 		$notification_center = Yoast_Notification_Center::get();
 		$notification_center->remove_notification_by_id( 'wpseo-dismiss-unsupported-php' );
+	}
+
+	/**
+	 * Creates a WordPress upgrade notification in the notification center.
+	 *
+	 * @return void
+	 */
+	public function wordpress_upgrade_notice() {
+		global $wp_version;
+
+		$wordpress_less_than_50 = version_compare( $wp_version, '5.0', '<' );
+		$wordpress_less_than_52 = version_compare( $wp_version, '5.2', '<' );
+
+		$notification_center = Yoast_Notification_Center::get();
+
+		$message = sprintf(
+			/* translators: 1: opening strong tag 2: closing strong tag 3: html break 4: Yoast 5: Yoast SEO 6: 5.2 7: 5.3 */
+			__(
+				'%1$sUpgrade WordPress to the most recent version%2$s%3$sWe’ve noticed that you’re not on the latest WordPress version, which might cause an issue soon. %4$s (for reasons of security and stability) only supports the current and previous version of WordPress. When the next version of WordPress comes out, that means that we will support WordPress %6$s and %7$s. This means you will not get any updates to %5$s until you update your WordPress, so please make sure to upgrade to the latest WordPress version soon!%3$s%3$s',
+				'wordpress-seo'
+			),
+			'<strong>',
+			'</strong>',
+			'<br/>',
+			'Yoast',
+			'Yoast SEO',
+			'5.2',
+			'5.3'
+		);
+		if ( $wordpress_less_than_50 ) {
+			$message .= sprintf(
+				/* translators: 1: Yoast SEO 2: 5.0 */
+				__(
+					'If you’ve held off on updating to %2$s and higher because of the new Gutenberg editor, please install the Classic editor plugin. It will give you the same editing experience you have now, but also the security of newer versions of WordPress and %1$s.',
+					'wordpress-seo'
+				),
+				'Yoast SEO',
+				'5.0'
+			);
+		}
+		$message .= '<br/><br/>';
+		$message .= sprintf(
+			/* translators: 1: opening anchor tag 2: closing anchor tag */
+			__(
+				'Read %1$sthis post for more information about why we’re not supporting older versions.%2$s',
+				'wordpress-seo'
+			),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/old-wp-support' ) . '" target="_blank" rel="nofollow">',
+			'</a>'
+		);
+
+		$notification = new Yoast_Notification(
+			$message,
+			array(
+				'type' => Yoast_Notification::ERROR,
+				'id'   => 'wpseo-dismiss-wordpress-upgrade',
+			)
+		);
+
+		if ( $wordpress_less_than_52 ) {
+			$notification_center->add_notification( $notification );
+			return;
+		}
+		$notification_center->remove_notification( $notification );
 	}
 
 	/**


### PR DESCRIPTION
…ersion lower than 5.2

## Summary

This PR can be summarized in the following changelog entry:

* Introduces a notification that encourages updating to the latest WordPress version.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

<details><summary>For VVV; to get the different versions of WordPress I use the following in the `vvv-custom.yml`</summary>

```
  wordpress-49:
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    hosts:
      - 49.wordpress.test
    custom:
      wp_version: 4.9.10

  wordpress-50:
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    hosts:
      - 50.wordpress.test
    custom:
      wp_version: 5.0.4

  wordpress-51:
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    hosts:
      - 51.wordpress.test
    custom:
      wp_version: 5.1.1
```
</details>

Go to the SEO dashboard to check the notifications.
There should also be a notification about this new error.

* Test on WordPress 5.2 or higher: there should be no new notification.
* Test on WordPress 5.1.1: there should be a notification without the paragraph about `5.0`.
* Test on WordPress 5.0.4: same as `5.1.1`.
* Test on WordPress 4.9.10 or lower: there should be a notification with the full text (see issue).
* Test that upgrading removes the notification.

## Screenshots
<details><summary>4.9.10 or lower</summary><img width="1511" alt="4 9 10" src="https://user-images.githubusercontent.com/35524806/57842821-926b0900-77cd-11e9-8caf-79fdeff619ee.png"></details>
<details><summary>5.1.1 or lower but higher than 4.9.10</summary><img width="1507" alt="5 1 1" src="https://user-images.githubusercontent.com/35524806/57842836-96972680-77cd-11e9-939d-b88f095f36e0.png"></details>

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12951 
