### PR TITLE
Fix the Help Center video tab when clicking the skip links.

### DIFF
--- a/js/src/wp-seo-help-center.js
+++ b/js/src/wp-seo-help-center.js
@@ -78,6 +78,16 @@ class HelpCenter extends React.Component {
 	 * @returns {void}
 	 */
 	tabChanged() {
+		/*
+		 * Account for other URL fragment identifiers. For example, the "skip links"
+		 * `#wpbody-content` and `#wp-toolbar` used in WordPress. When the hash
+		 * changes and doesn't contain `#top#`, that means users didn't click on
+		 * one of the Yoast tabs.
+		 */
+		if ( location.hash.indexOf( "#top#" ) === -1 ) {
+			return;
+		}
+
 		const tabId = this.getTabIdFromUrlHash();
 		const videoUrl = this.getVideoUrl( tabId );
 		this.setState( { videoUrl } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where following links to page fragments made the Help Center video tab disappear.

## Test instructions

Test 1:
- go to any settings page e.g. SEO > General
- open the Help Center by clicking on the "Need Help?" button
- see the first Help Center tab is the Video Tutorial one
- see the loaded video is "General - Dashboard"
- refresh the page
- use the keyboard, navigate pressing the Tab key
- the two WordPress "skip links" appear in the tab order
- activate one of them by pressing the Enter key
- open the Help Center by clicking on the "Need Help?" button
- see the Help Center video tab is still visible and loads the correct video 


Test 2:
- go to (for example) SEO > Search Appearance
- open the Help Center by clicking on the "Need Help?" button
- see the Video Tutorial tab loads the video "Search Appearance - General"
- keep the Help Center open 
- click the "Taxonomies" tab 
- see the loaded video is "Search Appearance - Taxonomies"
- keep the Help Center open 
- use the keyboard, navigate pressing the Tab key until you reach the WordPress skip links
- click on one of them
- see the "Video tutorial" tab in the Help Center doesn't disappear and still loads the correct video 

== Note
Ideally, our implementation of the URL used for the tabs should be reviewed. Using a URL fragment identifier (`#...`) is prone to potential conflicts. I seem to recall a few bugs happened in the past because of the double hash character e.g. `#top#dashboard` or `#top#features`.

Also, changing the location hash makes browsers update their history entries but then trying to navigate the history doesn't do anything:

![Screenshot 2019-05-17 at 11 43 10](https://user-images.githubusercontent.com/1682452/57919705-a3814c00-7899-11e9-9c71-b6986c761bc2.jpg)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #12937 
