### PR TITLE
Make sure the person always has a logo attribute

### DIFF
--- a/frontend/schema/class-schema-person.php
+++ b/frontend/schema/class-schema-person.php
@@ -194,6 +194,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 		if ( $person_logo_id ) {
 			$image         = new WPSEO_Schema_Image( $schema_id );
 			$data['image'] = $image->generate_from_attachment_id( $person_logo_id, $data['name'] );
+			$data['logo']  = array( '@id' => $schema_id );
 		}
 
 		return $data;


### PR DESCRIPTION
* In one case, the `Person` could be missing a `logo` attribute after we fixed that `Person` is always an `Organization`.

## Summary

This PR can be summarized in the following changelog entry:

* None needed.
