### PR TITLE
Fix for issue #10002

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -196,7 +196,7 @@ class WPSEO_Image_Utils {
 		}
 
 		// Add the uploads basedir if the path does not start with it.
-		if ( empty( $uploads['error'] ) && strpos( $path, $uploads['basedir'] . DIRECTORY_SEPARATOR ) !== 0 ) {
+		if ( empty( $uploads['error'] ) && strpos( $path, $uploads['basedir'] ) !== 0 ) {
 			return $uploads['basedir'] . DIRECTORY_SEPARATOR . ltrim( $path, DIRECTORY_SEPARATOR );
 		}
 


### PR DESCRIPTION
In `get_absolute_path` remove the concatenation of `DIRECTORY_SEPARATOR` to `$uploads['basedir']` in the `strpos` since this character may not match the character in the `$path`. The DIRECTORY_SEPARATOR in Windows is '\', but the `$path` may contain a forward slash ( '/' ).

I haven't developed an automated test for this simple function change.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug on Windows filesystems where a PHP filesize warning was raised for image metadata on a post.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On a Linux server, set a Facebook image on the Yoast Social tab for a post.
* Clone the site from the Linux server to Windows by exporting and importing the database
and copying all the files.
* Visit the post. 

Without the fix I get the following warning

Warning: filesize(): stat failed for C:\apache\htdocs\susancowemiller/wp-content/uploads/sites/2\C:\apache\htdocs\susancowemiller/wp-content/uploads/sites/2/2014/12/butterfly11-e1456339559137.jpg

With the fix applied the warning is not issued. 


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #10002 
