### PR TITLE
Make sure the person always has a logo attribute

### DIFF
--- a/frontend/schema/class-schema-person.php
+++ b/frontend/schema/class-schema-person.php
@@ -194,6 +194,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 		if ( $person_logo_id ) {
 			$image         = new WPSEO_Schema_Image( $schema_id );
 			$data['image'] = $image->generate_from_attachment_id( $person_logo_id, $data['name'] );
+			$data['logo']  = array( '@id' => $schema_id );
 		}
 
 		return $data;


### PR DESCRIPTION
Copied from https://github.com/Yoast/wordpress-seo/pull/12969, which as based on `trunk`.

* In one case, the `Person` could be missing a `logo` attribute after we fixed that `Person` is always an `Organization`.

## Test instruction

* Set site to represent a Person on the SEO -> Search Appearance page.
* Set an image for that Person on the same settings page.
* See that `logo` attribute exists with this patch.

## Summary

This PR can be summarized in the following changelog entry:

* None needed.
