### PR TITLE
Set traffic light icon default to grey bullets.

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -946,9 +946,9 @@ class WPSEO_Utils {
 				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
 			</g>
 			<g class="traffic-light-color traffic-light-init">
-				<ellipse fill="#5B2942" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
-				<ellipse fill="#5B2942" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
-				<ellipse fill="#5B2942" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
 			</g>
 		</g>
 	</g>

--- a/js/src/ui/trafficLight.js
+++ b/js/src/ui/trafficLight.js
@@ -9,10 +9,11 @@ function updateTrafficLight( indicator ) {
 	var trafficLight = jQuery( ".yst-traffic-light" );
 	var trafficLightLink = trafficLight.closest( ".wpseo-meta-section-link" );
 	var trafficLightDesc = jQuery( "#wpseo-traffic-light-desc" );
+	var cssClass = indicator.className || "na";
 
 	// Update the traffic light image.
 	trafficLight
-		.attr( "class", "yst-traffic-light " + indicator.className );
+		.attr( "class", "yst-traffic-light " + cssClass );
 
 	// Update the traffic light link.
 	trafficLightLink.attr( "aria-describedby", "wpseo-traffic-light-desc" );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Set the Traffic Light icon to show grey bullets when the readability and keyword analysis are disabled/

## Relevant technical choices:

- When the readability and keyword analysis are disabled, `indicator.className` is an empty string so the icon doesn't get a CSS class to show any bullet. Simplest fix: default to `na`.
- The initial CSS class applied to the Traffic Light icon displays bullets with a darker grey. This produced a "flash effect" when the bullets change from dark grey to light grey (see animated GIF below for clarity). As I couldn't think of a reason why the default bullets should be darker, I've changed them to use the light grey, avoiding the flash.

Bullets changing grey on page load:

![color flash](https://user-images.githubusercontent.com/1682452/58020517-a59d1200-7b08-11e9-8e02-c3188482a874.gif)


## Test instructions
- disable the readability and keyword analysis
- edit a post and check the Traffic Light bullets are grey
- same when editing a taxonomy term
- try different combinations of disabled / enabled readability and keyword analysis and check the bullets display the correct color depending on the score
- try also a post with an empty keyphrase

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Note: technically, this PR changes the UI but it's a barely noticeable change.

Fixes #11524
