### PR TITLE
Scroll to the analysis when clicking the overall score in the publish box

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -81,45 +81,61 @@ class WPSEO_Metabox_Formatter {
 				'labels' => array(
 					'content' => array(
 						'na'   => sprintf(
-							/* translators: %s expands to readability. */
-							__( 'Readability: %s', 'wordpress-seo' ),
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the readability score. */
+							__( '%1$sReadability%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="#yoast-readability-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'Not available', 'wordpress-seo' ) . '</strong>'
 						),
 						'bad'  => sprintf(
-							/* translators: %s expands to readability. */
-							__( 'Readability: %s', 'wordpress-seo' ),
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the readability score. */
+							__( '%1$sReadability%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="#yoast-readability-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
 						),
 						'ok'   => sprintf(
-							/* translators: %s expands to readability. */
-							__( 'Readability: %s', 'wordpress-seo' ),
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the readability score. */
+							__( '%1$sReadability%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="#yoast-readability-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
 						),
 						'good' => sprintf(
-							/* translators: %s expands to readability. */
-							__( 'Readability: %s', 'wordpress-seo' ),
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the readability score. */
+							__( '%1$sReadability%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="#yoast-readability-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
 						),
 					),
 					'keyword' => array(
 						'na'   => sprintf(
-							/* translators: %s expands to SEO. */
-							__( 'SEO: %s', 'wordpress-seo' ),
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
+							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'Not available', 'wordpress-seo' ) . '</strong>'
 						),
 						'bad'  => sprintf(
-							/* translators: %s expands to SEO. */
-							__( 'SEO: %s', 'wordpress-seo' ),
+						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
+							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
 						),
 						'ok'   => sprintf(
-							/* translators: %s expands to SEO. */
-							__( 'SEO: %s', 'wordpress-seo' ),
+						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
+							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
 						),
 						'good' => sprintf(
-							/* translators: %s expands to SEO. */
-							__( 'SEO: %s', 'wordpress-seo' ),
+						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
+							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
+							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'</a>',
 							'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
 						),
 					),

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -113,28 +113,28 @@ class WPSEO_Metabox_Formatter {
 						'na'   => sprintf(
 							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
-							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',
 							'<strong>' . __( 'Not available', 'wordpress-seo' ) . '</strong>'
 						),
 						'bad'  => sprintf(
 						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
-							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',
 							'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
 						),
 						'ok'   => sprintf(
 						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
-							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',
 							'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
 						),
 						'good' => sprintf(
 						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
-							'<a href="##yoast-seo-analysis-collapsible-metabox">',
+							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',
 							'<strong>' . __( 'Good', 'wordpress-seo' ) . '</strong>'
 						),

--- a/js/src/ui/publishBox.js
+++ b/js/src/ui/publishBox.js
@@ -71,13 +71,46 @@ var imageScoreClass = "image yoast-logo svg";
 	}
 
 	/**
+	 * Scrolls to metabox collapsible and opens it when closed.
+	 *
+	 * @param {string} id Metabox collapsible id.
+	 *
+	 * @returns {void}
+	 */
+	function scrollToCollapsible( id ) {
+		const $adminbar = $( "#wpadminbar" );
+		const $collapsible = $( id );
+
+		if ( ! $adminbar || ! $collapsible ) {
+			return;
+		}
+
+		// The adminbar height depends on the viewport width.
+		const adminbarHeight = $adminbar.css( "position" ) === "fixed" ? $adminbar.height() : 0;
+
+		$( [ document.documentElement, document.body ] ).animate( {
+			scrollTop: $collapsible.offset().top - adminbarHeight,
+		}, 1000 );
+
+		// Move focus to the collapsible.
+		$collapsible.focus();
+
+		// The content of the analysis is a sibling of the h2 in the collapsible.
+		const $h2 = $collapsible.parent();
+
+		// If the sibling is not there, the collapsible is collapsed, so we should open it.
+		if ( $h2.siblings().length === 0 ) {
+			$collapsible.click();
+		}
+	}
+
+	/**
 	 * Initializes the publish box score indicators.
 	 *
 	 * @returns {void}
 	 */
 	function initialize() {
 		var notAvailableStatus = "na";
-		const $adminbar = $( "#wpadminbar" );
 
 		if ( wpseoPostScraperL10n.contentAnalysisActive === "1" ) {
 			createScoresInPublishBox( "content", notAvailableStatus );
@@ -89,52 +122,14 @@ var imageScoreClass = "image yoast-logo svg";
 
 		$( "#content-score" ).click( function( event ) {
 			event.preventDefault();
-			const $readabilityCollapsible = $( "#yoast-readability-analysis-collapsible-metabox" );
-			/*
- 			 * The adminbar height depends on the viewport width. Because people can change the viewport width whenever
- 			 * they want, we check the adminbar height within each of the .click functions.
- 			 */
-			const adminbarHeight = $adminbar.css( "position" ) === "fixed" ? $adminbar.height() : 0;
 
-			$( [ document.documentElement, document.body ] ).animate( {
-				scrollTop: $readabilityCollapsible.offset().top - adminbarHeight,
-			}, 1000 );
-
-			// Move focus to the collapsible.
-			$readabilityCollapsible.focus();
-
-			// The content of the analysis is a sibling of the h2 in the collapsible.
-			const $h2 = $readabilityCollapsible.parent();
-
-			// If the sibling is not there, the collapsible is collapsed, so we should open it.
-			if ( $h2.siblings().length === 0 ) {
-				$readabilityCollapsible.click();
-			}
+			scrollToCollapsible( "#yoast-readability-analysis-collapsible-metabox" );
 		} );
 
 		$( "#keyword-score" ).click( function( event ) {
 			event.preventDefault();
-			const $seoCollapsible = $( "#yoast-seo-analysis-collapsible-metabox" );
-			/*
-			 * The adminbar height depends on the viewport width. Because people can change the viewport width whenever
-			 * they want, we check the adminbar height within each of the .click functions.
-			 */
-			const adminbarHeight = $adminbar.css( "position" ) === "fixed" ? $adminbar.height() : 0;
 
-			$( [ document.documentElement, document.body ] ).animate( {
-				scrollTop: $seoCollapsible.offset().top - adminbarHeight,
-			}, 1000 );
-
-			// Move focus to the collapsible.
-			$seoCollapsible.focus();
-
-			// The content of the analysis is a sibling of the h2 in the collapsible.
-			const $h2 = $seoCollapsible.parent();
-
-			// If the sibling is not there, the collapsible is collapsed, so we should open it.
-			if ( $h2.siblings().length === 0 ) {
-				$seoCollapsible.click();
-			}
+			scrollToCollapsible( "#yoast-seo-analysis-collapsible-metabox" );
 		} );
 	}
 

--- a/js/src/ui/publishBox.js
+++ b/js/src/ui/publishBox.js
@@ -120,13 +120,15 @@ var imageScoreClass = "image yoast-logo svg";
 			createScoresInPublishBox( "keyword", notAvailableStatus );
 		}
 
-		$( "#content-score" ).click( function( event ) {
+		// Target only the link and use event delegation, as this link doesn't exist on dom ready yet.
+		$( "#content-score" ).on( "click", "[href='#yoast-readability-analysis-collapsible-metabox']", function( event ) {
 			event.preventDefault();
 
 			scrollToCollapsible( "#yoast-readability-analysis-collapsible-metabox" );
 		} );
 
-		$( "#keyword-score" ).click( function( event ) {
+		// Target only the link and use event delegation, as this link doesn't exist on dom ready yet.
+		$( "#keyword-score" ).on( "click", "[href='#yoast-seo-analysis-collapsible-metabox']", function( event ) {
 			event.preventDefault();
 
 			scrollToCollapsible( "#yoast-seo-analysis-collapsible-metabox" );

--- a/js/src/ui/publishBox.js
+++ b/js/src/ui/publishBox.js
@@ -23,8 +23,7 @@ var imageScoreClass = "image yoast-logo svg";
 	 * @returns {String} A string with label and description with correct text decoration.
 	 */
 	function createSEOScoreLabel( scoreType, status ) {
-		var label = wpseoPostScraperL10n.publish_box.labels[ scoreType ][ status ] || "";
-		return label;
+		return wpseoPostScraperL10n.publish_box.labels[ scoreType ][ status ] || "";
 	}
 
 	/**
@@ -78,6 +77,7 @@ var imageScoreClass = "image yoast-logo svg";
 	 */
 	function initialize() {
 		var notAvailableStatus = "na";
+		const $adminbar = $( "#wpadminbar" );
 
 		if ( wpseoPostScraperL10n.contentAnalysisActive === "1" ) {
 			createScoresInPublishBox( "content", notAvailableStatus );
@@ -86,6 +86,56 @@ var imageScoreClass = "image yoast-logo svg";
 		if ( wpseoPostScraperL10n.keywordAnalysisActive === "1" ) {
 			createScoresInPublishBox( "keyword", notAvailableStatus );
 		}
+
+		$( "#content-score" ).click( function( event ) {
+			event.preventDefault();
+			const $readabilityCollapsible = $( "#yoast-readability-analysis-collapsible-metabox" );
+			/*
+ 			 * The adminbar height depends on the viewport width. Because people can change the viewport width whenever
+ 			 * they want, we check the adminbar height within each of the .click functions.
+ 			 */
+			const adminbarHeight = $adminbar.css( "position" ) === "fixed" ? $adminbar.height() : 0;
+
+			$( [ document.documentElement, document.body ] ).animate( {
+				scrollTop: $readabilityCollapsible.offset().top - adminbarHeight,
+			}, 1000 );
+
+			// Move focus to the collapsible.
+			$readabilityCollapsible.focus();
+
+			// The content of the analysis is a sibling of the h2 in the collapsible.
+			const $h2 = $readabilityCollapsible.parent();
+
+			// If the sibling is not there, the collapsible is collapsed, so we should open it.
+			if ( $h2.siblings().length === 0 ) {
+				$readabilityCollapsible.click();
+			}
+		} );
+
+		$( "#keyword-score" ).click( function( event ) {
+			event.preventDefault();
+			const $seoCollapsible = $( "#yoast-seo-analysis-collapsible-metabox" );
+			/*
+			 * The adminbar height depends on the viewport width. Because people can change the viewport width whenever
+			 * they want, we check the adminbar height within each of the .click functions.
+			 */
+			const adminbarHeight = $adminbar.css( "position" ) === "fixed" ? $adminbar.height() : 0;
+
+			$( [ document.documentElement, document.body ] ).animate( {
+				scrollTop: $seoCollapsible.offset().top - adminbarHeight,
+			}, 1000 );
+
+			// Move focus to the collapsible.
+			$seoCollapsible.focus();
+
+			// The content of the analysis is a sibling of the h2 in the collapsible.
+			const $h2 = $seoCollapsible.parent();
+
+			// If the sibling is not there, the collapsible is collapsed, so we should open it.
+			if ( $h2.siblings().length === 0 ) {
+				$seoCollapsible.click();
+			}
+		} );
 	}
 
 	module.exports = {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds links to the SEO and readability scores in the classic editor publish box that make the page scroll to the corresponding analysis in the metabox.

## Relevant technical choices:

* I combined (1) adding `href`s with hashes to `SEO` and `Readbility` with (2) jQuery scrolling on element click to have both (1) a sensible, a11y-friendly `href` and (2) javascript-based scrolling that can take the admin bar height into account and sets focus.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use the classic editor.
* Go to a post, and click 'SEO' in the publish box. It should scroll to the SEO collapsible in the metabox, and open the collapsible. If the collapsible was already opened, it should stay open. Focus should move to the collapsible.
* Change your viewport width until you get the larger admin bar. Repeat the steps and see that the scrolling is still working correctly.
* Repeat the steps for 'Readability'. Also, combine clicking 'Readability' and 'SEO' multiple times, and change your viewport width in between. 
* Because all links are built separately, test with all possible readability and SEO scores.
* Test on pages and custom post types.
* Test in Premium

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #6939
