### PR TITLE
Tests: improve test skipping

### DIFF
--- a/integration-tests/notifications/test-class-yoast-notification.php
+++ b/integration-tests/notifications/test-class-yoast-notification.php
@@ -289,7 +289,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	private function add_cap( $capability ) {
 		// Capabilities have been changed in 4.2: code doesn't fail, just the test.
 		if ( version_compare( $GLOBALS['wp_version'], '4.2', '<' ) ) {
-			$this->markTestSkipped();
+			$this->markTestSkipped( 'Test requires WP 4.2 or higher' );
 		}
 
 		$me = wp_get_current_user();
@@ -306,7 +306,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	private function remove_cap( $capability ) {
 		// Capabilities have been changed in 4.2: code doesn't fail, just the test.
 		if ( version_compare( $GLOBALS['wp_version'], '4.2', '<' ) ) {
-			$this->markTestSkipped();
+			$this->markTestSkipped( 'Test requires WP 4.2 or higher' );
 		}
 
 		$me = wp_get_current_user();


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* Made sure skipped tests will always have an explanation on why the test has been skipped.

**Note**: as this skipping of the test applies to a WP version which is no longer supported, it would also be a very valid choice to remove this test skip logic completely.

Let me know if that change is desired.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
* Ok, if you really want to test it:
    - Check out the `trunk` branch & make sure your WP install for the unit tests is at WP < 4.2.
    - Run `phpunit -c phpunit-integration.xml.dist --verbose` and take note of the notices at the bottom of the run showing why tests are being skipped and two tests not having any notices.
    - Check out this branch & make sure your WP install is still at WP < 4.2.
    - Run `phpunit -c phpunit-integration.xml.dist --verbose` and take note of the notices at the bottom of the run showing why tests are being skipped and that the two tests which previously had no notice about why they were being skipped, now have an explanation.