### PR TITLE
[tests] QA: consistently use `use` statements

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,10 @@
 
 namespace Yoast\WP\Free\Tests;
 
-use PHPUnit_Framework_TestCase;
+use WPSEO_Options;
 use Brain\Monkey;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 /**
  * TestCase base class.
@@ -39,16 +41,16 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 		);
 
 		// This is required to ensure backfill and other statics are set.
-		\WPSEO_Options::get_instance();
+		WPSEO_Options::get_instance();
 
 		Monkey\Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
-			->with( \Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
 
 		Monkey\Functions\expect( 'get_site_option' )
 			->zeroOrMoreTimes()
-			->with( \Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
 	}
 

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -2,65 +2,72 @@
 
 namespace Yoast\WP\Free\Tests\Admin;
 
+use WPSEO_Admin;
+use WPSEO_GSC;
+use WPSEO_Primary_Term_Admin;
+use Yoast_Dashboard_Widget;
+use Yoast_Notification;
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\Free\Tests\Doubles\Shortlinker;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Admin_Features.
  *
  * @package Yoast\Tests\Admin
  */
-class Admin_Features extends \Yoast\WP\Free\Tests\TestCase {
+class Admin_Features extends TestCase {
 
 	private function get_admin_with_expectations() {
 		$shortlinker = new Shortlinker();
 
 		Monkey\Functions\expect( 'add_query_arg' )
 			->times( 4 )
-			->with( $shortlinker->get_additional_shortlink_data(), \Mockery::pattern( '/https:\/\/yoa.st\/*/' ) )
+			->with( $shortlinker->get_additional_shortlink_data(), Mockery::pattern( '/https:\/\/yoa.st\/*/' ) )
 			->andReturn( 'https://example.org' );
 
 		Monkey\Functions\expect( 'admin_url' )
 			->once()
-			->with( '?page=' . \WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=upsell' )
+			->with( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=upsell' )
 			->andReturn( 'https://example.org' );
 
 		Monkey\Functions\expect( 'wp_parse_args' )
 			->once()
 			->with(
 				array(
-					'type'         => \Yoast_Notification::WARNING,
+					'type'         => Yoast_Notification::WARNING,
 					'id'           => 'wpseo-upsell-notice',
 					'capabilities' => 'wpseo_manage_options',
 					'priority'     => 0.8,
 				),
 				array(
-					'type'             => \Yoast_Notification::UPDATED,
+					'type'             => Yoast_Notification::UPDATED,
 					'id'               => '',
 					'nonce'            => null,
 					'priority'         => 0.5,
 					'data_json'        => array(),
 					'dismissal_key'    => null,
 					'capabilities'     => array(),
-					'capability_check' => \Yoast_Notification::MATCH_ALL,
+					'capability_check' => Yoast_Notification::MATCH_ALL,
 					'yoast_branding'   => false,
 				)
 			)
 			->andReturn(
 				array(
-					'type'             => \Yoast_Notification::WARNING,
+					'type'             => Yoast_Notification::WARNING,
 					'id'               => 'wpseo-upsell-notice',
 					'nonce'            => null,
 					'priority'         => 0.8,
 					'data_json'        => array(),
 					'dismissal_key'    => null,
 					'capabilities'     => 'wpseo_manage_options',
-					'capability_check' => \Yoast_Notification::MATCH_ALL,
+					'capability_check' => Yoast_Notification::MATCH_ALL,
 					'yoast_branding'   => false,
 				)
 			);
 
-		return new \WPSEO_Admin();
+		return new WPSEO_Admin();
 	}
 
 	/**
@@ -75,9 +82,9 @@ class Admin_Features extends \Yoast\WP\Free\Tests\TestCase {
 		$class_instance = $this->get_admin_with_expectations();
 
 		$admin_features = array(
-			'google_search_console'  => new \WPSEO_GSC(),
-			'primary_category'       => new \WPSEO_Primary_Term_Admin(),
-			'dashboard_widget'       => new \Yoast_Dashboard_Widget(),
+			'google_search_console'  => new WPSEO_GSC(),
+			'primary_category'       => new WPSEO_Primary_Term_Admin(),
+			'dashboard_widget'       => new Yoast_Dashboard_Widget(),
 		);
 
 		$this->assertEquals( $admin_features, $class_instance->get_admin_features() );
@@ -95,8 +102,8 @@ class Admin_Features extends \Yoast\WP\Free\Tests\TestCase {
 		$class_instance = $this->get_admin_with_expectations();
 
 		$admin_features = array(
-			'google_search_console' => new \WPSEO_GSC(),
-			'dashboard_widget'      => new \Yoast_Dashboard_Widget(),
+			'google_search_console' => new WPSEO_GSC(),
+			'dashboard_widget'      => new Yoast_Dashboard_Widget(),
 		);
 
 		$this->assertEquals( $admin_features, $class_instance->get_admin_features() );

--- a/tests/config/admin-test.php
+++ b/tests/config/admin-test.php
@@ -3,13 +3,14 @@
 namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Admin;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Admin_Test.
  *
  * @package Yoast\Tests\Config
  */
-class Admin_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Admin_Test extends TestCase {
 
 	/**
 	 * Tests if the class is based upon the Integration interface.

--- a/tests/config/database-migration-test.php
+++ b/tests/config/database-migration-test.php
@@ -2,11 +2,11 @@
 
 namespace Yoast\WP\Free\Tests\Config;
 
+use Yoast\WP\Free\Config\Dependency_Management;
+use Brain\Monkey;
 use Yoast\WP\Free\Tests\Doubles\Database_Migration;
 use Yoast\WP\Free\Tests\Doubles\Database_Migration as Database_Migration_Double;
-use Yoast\WP\Free\Config\Dependency_Management;
-
-use Brain\Monkey;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Database_Migration_Test.
@@ -15,7 +15,7 @@ use Brain\Monkey;
  *
  * @package Yoast\Tests
  */
-class Database_Migration_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Database_Migration_Test extends TestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/config/dependency-management-test.php
+++ b/tests/config/dependency-management-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Dependency_Management;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Dependency_Management_Test.
@@ -11,7 +12,7 @@ use Yoast\WP\Free\Config\Dependency_Management;
  *
  * @package Yoast\Tests
  */
-class Dependency_Management_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Dependency_Management_Test extends TestCase {
 
 	/**
 	 * Tests if the alias is created with ideal conditions.

--- a/tests/config/frontend-test.php
+++ b/tests/config/frontend-test.php
@@ -3,13 +3,14 @@
 namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Frontend;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Frontend_Test.
  *
  * @package Yoast\Tests\Config
  */
-class Frontend_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Frontend_Test extends TestCase {
 
 	/**
 	 * Tests if the class is based upon the Integration interface.

--- a/tests/config/plugin-test.php
+++ b/tests/config/plugin-test.php
@@ -2,10 +2,11 @@
 
 namespace Yoast\WP\Free\Tests\Config;
 
-use Yoast\WP\Free\Tests\Doubles\Plugin as Plugin_Double;
 use Yoast\WP\Free\Config\Database_Migration;
 use Yoast\WP\Free\Config\Dependency_Management;
 use Yoast\WP\Free\WordPress\Integration_Group;
+use Yoast\WP\Free\Tests\Doubles\Plugin as Plugin_Double;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Plugin_Test.
@@ -14,7 +15,7 @@ use Yoast\WP\Free\WordPress\Integration_Group;
  *
  * @package Yoast\Tests\Config
  */
-class Plugin_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Plugin_Test extends TestCase {
 
 	/**
 	 * Tests if the class is based upon the Integration interface.

--- a/tests/config/upgrade-test.php
+++ b/tests/config/upgrade-test.php
@@ -3,13 +3,14 @@
 namespace Yoast\WP\Free\Tests\Config;
 
 use Yoast\WP\Free\Config\Upgrade;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Upgrade_Test.
  *
  * @package Yoast\Tests\Config
  */
-class Upgrade_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Upgrade_Test extends TestCase {
 
 	public function test_do_upgrade() {
 		$migration = $this

--- a/tests/exceptions/no-indexable-found-test.php
+++ b/tests/exceptions/no-indexable-found-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Free\Tests\Exceptions;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Loggers\Logger;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Indexable_Author_Test.
@@ -13,7 +14,7 @@ use Yoast\WP\Free\Loggers\Logger;
  *
  * @package Yoast\Tests\Exceptions
  */
-class No_Indexable_Found_Test extends \Yoast\WP\Free\Tests\TestCase {
+class No_Indexable_Found_Test extends TestCase {
 
 	/**
 	 * Sets up the test fixtures for each test.

--- a/tests/formatters/indexable-author-formatter-test.php
+++ b/tests/formatters/indexable-author-formatter-test.php
@@ -3,6 +3,8 @@
 namespace Yoast\WP\Free\Tests\Formatters;
 
 use Yoast\WP\Free\Tests\Doubles\Indexable_Author_Formatter_Double;
+use Yoast\WP\Free\Tests\TestCase;
+use stdClass;
 
 /**
  * Class Indexable_Author_Test.
@@ -12,7 +14,7 @@ use Yoast\WP\Free\Tests\Doubles\Indexable_Author_Formatter_Double;
  *
  * @package Yoast\Tests\Formatters
  */
-class Indexable_Author_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Indexable_Author_Formatter_Test extends TestCase {
 
 	/**
 	 * @covers \Yoast\WP\Free\Formatters\Indexable_Author_Formatter::format
@@ -42,7 +44,7 @@ class Indexable_Author_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 				)
 			);
 
-		$indexable = new \stdClass();
+		$indexable = new stdClass();
 		$indexable = $formatter->format( $indexable );
 
 		$this->assertAttributeEquals( 'https://permalink', 'permalink', $indexable );

--- a/tests/formatters/indexable-post-formatter-test.php
+++ b/tests/formatters/indexable-post-formatter-test.php
@@ -2,9 +2,11 @@
 
 namespace Yoast\WP\Free\Tests\Formatters;
 
-use Yoast\WP\Free\Tests\Doubles\Indexable_Post_Formatter_Double as Indexable_Post_Double;
-
+use WPSEO_Meta;
 use Brain\Monkey;
+use Yoast\WP\Free\Tests\Doubles\Indexable_Post_Formatter_Double as Indexable_Post_Double;
+use Yoast\WP\Free\Tests\TestCase;
+use stdClass;
 
 /**
  * Class Indexable_Post_Test.
@@ -14,7 +16,7 @@ use Brain\Monkey;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Post_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Indexable_Post_Formatter_Test extends TestCase {
 
 	/**
 	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::format
@@ -105,12 +107,12 @@ class Indexable_Post_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 	public function test_get_meta_value() {
 		Monkey\Functions\expect( 'update_post_meta' )
 			->once()
-			->with( 1, \WPSEO_Meta::$meta_prefix . 'a', 'b' )
+			->with( 1, WPSEO_Meta::$meta_prefix . 'a', 'b' )
 			->andReturn( true );
 		Monkey\Functions\expect( 'get_post_custom' )
 			->once()
 			->with( 1 )
-			->andReturn( [ \WPSEO_Meta::$meta_prefix . 'a' => 'b' ] );
+			->andReturn( [ WPSEO_Meta::$meta_prefix . 'a' => 'b' ] );
 		Monkey\Functions\expect( 'maybe_unserialize' )
 			->once()
 			->with( 'b' )
@@ -118,7 +120,7 @@ class Indexable_Post_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 
 		$instance = new Indexable_Post_Double( 1 );
 
-		\WPSEO_Meta::set_value( 'a', 'b', 1 );
+		WPSEO_Meta::set_value( 'a', 'b', 1 );
 
 		$this->assertEquals( 'b', $instance->get_meta_value( 'a' ) );
 	}
@@ -207,7 +209,7 @@ class Indexable_Post_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->setMethods( array( 'get_seo_meta' ) )
 			->getMock();
 
-		$seo_meta                      = new \stdClass();
+		$seo_meta                      = new stdClass();
 		$seo_meta->internal_link_count = 404;
 		$seo_meta->incoming_link_count = 1337;
 
@@ -216,7 +218,7 @@ class Indexable_Post_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->method( 'get_seo_meta' )
 			->will( $this->returnValue( $seo_meta ) );
 
-		$indexable = new \stdClass();
+		$indexable = new stdClass();
 		$indexable = $formatter->set_link_count( $indexable );
 
 		$this->assertAttributeEquals( 404, 'link_count', $indexable );
@@ -241,7 +243,7 @@ class Indexable_Post_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->method( 'get_seo_meta' )
 			->will( $this->throwException( new \Exception() ) );
 
-		$indexable = new \stdClass();
+		$indexable = new stdClass();
 		$indexable = $formatter->set_link_count( $indexable );
 	}
 }

--- a/tests/formatters/indexable-term-formatter-test.php
+++ b/tests/formatters/indexable-term-formatter-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Free\Tests\Formatters;
 
 use Yoast\WP\Free\Tests\Doubles\Indexable_Term_Formatter_Double;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Indexable_Term_Test.
@@ -12,7 +13,7 @@ use Yoast\WP\Free\Tests\Doubles\Indexable_Term_Formatter_Double;
  *
  * @package Yoast\Tests\Formatters
  */
-class Indexable_Term_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Indexable_Term_Formatter_Test extends TestCase {
 
 	/**
 	 * Holds the instance of the class being tested.

--- a/tests/oauth/client-test.php
+++ b/tests/oauth/client-test.php
@@ -10,15 +10,16 @@ namespace Yoast\WP\Free\Tests\Oauth;
 use Yoast\WP\Free\Oauth\Client;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessToken;
-
 use Brain\Monkey;
+use Yoast\WP\Free\Tests\Doubles\Oauth\Client as Client_Double;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Oauth_Test.
  *
  * @group oauth
  */
-class Oauth_Client_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Oauth_Client_Test extends TestCase {
 
 	/**
 	 * Holds the instance of the class being tested.
@@ -53,7 +54,7 @@ class Oauth_Client_Test extends \Yoast\WP\Free\Tests\TestCase {
 	 * @covers \Yoast\WP\Free\Oauth\Client::format_access_tokens
 	 */
 	public function test_format_access_tokens() {
-		$class_instance = new \Yoast\WP\Free\Tests\Doubles\Oauth\Client();
+		$class_instance = new Client_Double();
 
 		$access_tokens = [
 			1 => [ 'access_token' => 'this-is-a-token' ],
@@ -73,7 +74,7 @@ class Oauth_Client_Test extends \Yoast\WP\Free\Tests\TestCase {
 	 * @covers \Yoast\WP\Free\Oauth\Client::format_access_tokens
 	 */
 	public function test_format_access_tokens_with_invalid_argument() {
-		$class_instance = new \Yoast\WP\Free\Tests\Doubles\Oauth\Client();
+		$class_instance = new Client_Double();
 
 		$this->assertEquals( [], $class_instance->format_access_tokens( false ) );
 	}
@@ -84,7 +85,7 @@ class Oauth_Client_Test extends \Yoast\WP\Free\Tests\TestCase {
 	 * @covers \Yoast\WP\Free\Oauth\Client::format_access_tokens
 	 */
 	public function test_format_access_tokens_with_empty_array_as_argument() {
-		$class_instance = new \Yoast\WP\Free\Tests\Doubles\Oauth\Client();
+		$class_instance = new Client_Double();
 
 		$this->assertEquals( [], $class_instance->format_access_tokens( [] ) );
 	}

--- a/tests/watchers/indexable-author-watcher-test.php
+++ b/tests/watchers/indexable-author-watcher-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Free\Tests\Watchers;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Watchers\Indexable_Author_Watcher;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Indexable_Author_Test.
@@ -13,7 +14,7 @@ use Yoast\WP\Free\Watchers\Indexable_Author_Watcher;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Author_Watcher_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Indexable_Author_Watcher_Test extends TestCase {
 
 	/**
 	 * Tests if the expected hooks are registered.

--- a/tests/watchers/indexable-post-watcher-test.php
+++ b/tests/watchers/indexable-post-watcher-test.php
@@ -4,8 +4,8 @@ namespace Yoast\WP\Free\Tests\Watchers;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Watchers\Indexable_Post_Watcher;
-
 use Brain\Monkey;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Indexable_Post_Test.
@@ -15,7 +15,7 @@ use Brain\Monkey;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Post_Watcher_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Indexable_Post_Watcher_Test extends TestCase {
 
 	/**
 	 * Tests if the expected hooks are registered.

--- a/tests/watchers/indexable-term-watcher-test.php
+++ b/tests/watchers/indexable-term-watcher-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Free\Tests\Watchers;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Watchers\Indexable_Term_Watcher;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Indexable_Term_Test.
@@ -13,7 +14,7 @@ use Yoast\WP\Free\Watchers\Indexable_Term_Watcher;
  *
  * @package Yoast\Tests\Watchers
  */
-class Indexable_Term_Watcher_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Indexable_Term_Watcher_Test extends TestCase {
 
 	/**
 	 * Tests if the expected hooks are registered.

--- a/tests/wordpress/integration-group-test.php
+++ b/tests/wordpress/integration-group-test.php
@@ -3,6 +3,9 @@
 namespace Yoast\WP\Free\Tests\WordPress;
 
 use Yoast\WP\Free\WordPress\Integration_Group;
+use Yoast\WP\Free\Tests\TestCase;
+use ReflectionClass;
+use stdClass;
 
 /**
  * Class Database_Migration_Test.
@@ -11,7 +14,7 @@ use Yoast\WP\Free\WordPress\Integration_Group;
  *
  * @package Yoast\Tests
  */
-class Integration_Group_Test extends \Yoast\WP\Free\Tests\TestCase {
+class Integration_Group_Test extends TestCase {
 
 	/**
 	 * Tests the addition of an integration.
@@ -19,7 +22,7 @@ class Integration_Group_Test extends \Yoast\WP\Free\Tests\TestCase {
 	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::add_integration()
 	 */
 	public function test_add_integrations() {
-		$instance = new \Yoast\WP\Free\WordPress\Integration_Group();
+		$instance = new Integration_Group();
 
 		$integration = $this
 			->getMockBuilder( '\Yoast\WP\Free\WordPress\Integration' )
@@ -50,7 +53,7 @@ class Integration_Group_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->with( $this->equalTo( array( 'a', 'b' ) ) );
 
 		// Trigger the constructor to test the implicit method call.
-		$reflected_class = new \ReflectionClass( $classname );
+		$reflected_class = new ReflectionClass( $classname );
 		$constructor     = $reflected_class->getConstructor();
 		$constructor->invoke( $instance, array( 'a', 'b' ) );
 	}
@@ -72,10 +75,10 @@ class Integration_Group_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$no_integration = new \stdClass();
+		$no_integration = new stdClass();
 
 		// Trigger the constructor to test the implicit method call.
-		$reflected_class = new \ReflectionClass( $classname );
+		$reflected_class = new ReflectionClass( $classname );
 		$constructor     = $reflected_class->getConstructor();
 		$constructor->invoke( $instance, array( $integration, $no_integration ) );
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

A lot of the time, the new tests did used external classes, without importing them with `use` statements.

As it is good practice to always import all classes used within a namespaced file using `use` statements, this has now been fixed.

This is on the one hand about consistency across the classes, on the other hand about documenting which classes are used in a file.

Only one exception is made and that is for the PHP native `Exception` class as using that in its fully qualified form makes it unambiguous whether the PHP native `Exception` class or a userland `Exception` class has been used.

As for the order of the `use` statements, I've listed those as such:
* Functional classes first in alphabetic order.
* Test related classes after that, again in alphabetic order.
* [If applicable] PHP native classes in alphabetic order.

CS-wise, any arbitrary blank lines in the list of `use` statements have been removed.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-code-only change and should have no effect on the functionality.
    If the tests still run & pass without PHP errors being thrown, we're good (and yes, they do, I tested).