### PR TITLE
[tests] QA: call global functions using a fully qualified name

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,7 +33,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 				},
 				'wp_slash'       => null,
 				'absint'         => function( $value ) {
-					return abs( intval( $value ) );
+					return \abs( \intval( $value ) );
 				},
 			]
 		);

--- a/tests/config/dependency-management-test.php
+++ b/tests/config/dependency-management-test.php
@@ -138,7 +138,7 @@ class Dependency_Management_Test extends \Yoast\WP\Free\Tests\TestCase {
 		$instance = new Dependency_Management();
 		$instance->initialize();
 
-		$registered_autoloaders = spl_autoload_functions();
+		$registered_autoloaders = \spl_autoload_functions();
 
 		$this->assertContains( array( $instance, 'ensure_class_alias' ), $registered_autoloaders );
 	}

--- a/tests/config/plugin-test.php
+++ b/tests/config/plugin-test.php
@@ -224,11 +224,11 @@ class Plugin_Test extends \Yoast\WP\Free\Tests\TestCase {
 		$instance = new Plugin_Double();
 		$instance->set_initialize_success( true );
 
-		$action_count = did_action( 'wpseo_load_integrations' );
+		$action_count = \did_action( 'wpseo_load_integrations' );
 
 		$instance->register_hooks();
 
-		$this->assertEquals( ( $action_count + 1 ), did_action( 'wpseo_load_integrations' ) );
+		$this->assertEquals( ( $action_count + 1 ), \did_action( 'wpseo_load_integrations' ) );
 	}
 
 	/**

--- a/tests/config/upgrade-test.php
+++ b/tests/config/upgrade-test.php
@@ -40,7 +40,7 @@ class Upgrade_Test extends \Yoast\WP\Free\Tests\TestCase {
 		$upgrade = new Upgrade( $migration );
 		$upgrade->register_hooks();
 
-		$actual = has_action( 'wpseo_run_upgrade', array( $upgrade, 'do_upgrade' ) );
+		$actual = \has_action( 'wpseo_run_upgrade', array( $upgrade, 'do_upgrade' ) );
 
 		$this->assertEquals( 10, $actual );
 	}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

When PHP encounters an unqualified function call in a namespaced file, it will first try and find the function within the namespace and only when it can not find it in the namespace, fall-back to the global function.

Using fully qualified function names when calling a global function ensures that PHP will bypass the search within the namespace and call the global function directly.

It also ensures that optimal use is made of the PHP7 opcodes on VM level which have been implemented for a select group of PHP internal functions resulting in faster code execution.

Ref: https://www.php.net/manual/en/language.namespaces.fallback.php

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-code-only change and should have no effect on the functionality.
    If the tests still run & pass without PHP errors being thrown, we're good (and yes, they do, I tested).