### PR TITLE
[tests] Documentation: use FQCN in docblocks

### DIFF
--- a/tests/config/database-migration-test.php
+++ b/tests/config/database-migration-test.php
@@ -327,7 +327,7 @@ class Database_Migration_Test extends \Yoast\WP\Free\Tests\TestCase {
 	/**
 	 * Retrieves a class to mock a FrameworkRunner.
 	 *
-	 * @return FrameworkRunner
+	 * @return \FrameworkRunner
 	 */
 	protected function get_framework_runner_mock() {
 		return $this

--- a/tests/config/dependency-management-test.php
+++ b/tests/config/dependency-management-test.php
@@ -40,7 +40,7 @@ class Dependency_Management_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->with( 'My_Class', YOAST_VENDOR_NS_PREFIX . '\My_Class' )
 			->will( $this->returnValue( true ) );
 
-		/** @var Dependency_Management $instance */
+		/** @var \Yoast\WP\Free\Config\Dependency_Management $instance */
 		$instance->ensure_class_alias( YOAST_VENDOR_NS_PREFIX . '\My_Class' );
 	}
 
@@ -67,7 +67,7 @@ class Dependency_Management_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->expects( $this->never() )
 			->method( 'prefixed_available' );
 
-		/** @var Dependency_Management $instance */
+		/** @var \Yoast\WP\Free\Config\Dependency_Management $instance */
 		$instance->ensure_class_alias( 'Unrelated_Class' );
 	}
 
@@ -95,7 +95,7 @@ class Dependency_Management_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->expects( $this->never() )
 			->method( 'class_alias' );
 
-		/** @var Dependency_Management $instance */
+		/** @var \Yoast\WP\Free\Config\Dependency_Management $instance */
 		$instance->ensure_class_alias( YOAST_VENDOR_NS_PREFIX . '\Some_Class' );
 	}
 
@@ -125,7 +125,7 @@ class Dependency_Management_Test extends \Yoast\WP\Free\Tests\TestCase {
 			->expects( $this->never() )
 			->method( 'class_alias' );
 
-		/** @var Dependency_Management $instance */
+		/** @var \Yoast\WP\Free\Config\Dependency_Management $instance */
 		$instance->ensure_class_alias( YOAST_VENDOR_NS_PREFIX . '\Some_Class' );
 	}
 

--- a/tests/config/plugin-test.php
+++ b/tests/config/plugin-test.php
@@ -309,7 +309,7 @@ class Plugin_Test extends \Yoast\WP\Free\Tests\TestCase {
 	/**
 	 * Mocks a Dependency Management.
 	 *
-	 * @return Dependency_Management
+	 * @return \Yoast\WP\Free\Config\Dependency_Management
 	 */
 	protected function get_dependecy_management_mock() {
 		return $this
@@ -321,7 +321,7 @@ class Plugin_Test extends \Yoast\WP\Free\Tests\TestCase {
 	/**
 	 * Mocks a Database Migration.
 	 *
-	 * @return Database_Migration
+	 * @return \Yoast\WP\Free\Config\Database_Migration
 	 */
 	protected function get_database_migration_mock() {
 		return $this
@@ -336,7 +336,7 @@ class Plugin_Test extends \Yoast\WP\Free\Tests\TestCase {
 	 *
 	 * @param array $integrations List of integrations to load.
 	 *
-	 * @return Integration_Group
+	 * @return \Yoast\WP\Free\WordPress\Integration_Group
 	 */
 	protected function get_integration_group_mock( array $integrations = array() ) {
 		return $this

--- a/tests/formatters/indexable-term-formatter-test.php
+++ b/tests/formatters/indexable-term-formatter-test.php
@@ -17,7 +17,7 @@ class Indexable_Term_Formatter_Test extends \Yoast\WP\Free\Tests\TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var Indexable_Term_Formatter_Double
+	 * @var \Yoast\WP\Free\Tests\Doubles\Indexable_Term_Formatter_Double
 	 */
 	protected $instance;
 

--- a/tests/oauth/client-test.php
+++ b/tests/oauth/client-test.php
@@ -23,7 +23,7 @@ class Oauth_Client_Test extends \Yoast\WP\Free\Tests\TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var Client
+	 * @var \Yoast\WP\Free\Oauth\Client
 	 */
 	protected $class_instance;
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Best practice: using fully qualified class names in annotations results in unambiguous phpDocs.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.