### PR TITLE
[doubles] QA: remove unused `use` statement

### DIFF
--- a/tests/doubles/oauth/client.php
+++ b/tests/doubles/oauth/client.php
@@ -7,8 +7,6 @@
 
 namespace Yoast\WP\Free\Tests\Doubles\Oauth;
 
-use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
-
 /**
  * Test Helper Class.
  */
@@ -19,7 +17,7 @@ class Client extends \Yoast\WP\Free\Oauth\Client {
 	 *
 	 * @param array $access_tokens Access tokens to format.
 	 *
-	 * @return AccessTokenInterface[] Formatted AccessTokens.
+	 * @return \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface[] Formatted AccessTokens.
 	 */
 	public function format_access_tokens( $access_tokens ) {
 		return parent::format_access_tokens( $access_tokens );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

If a class is not used in a file, it shouldn't be imported.

Note: use within documentation or as text strings, for instance for a `instanceOf` test, does not mean the class needs to be imported.

Also: use FQCN name in the documentation.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-code-only change and should have no effect on the functionality.
    If the tests still run & pass without PHP errors being thrown, we're good (and yes, they do, I tested).