### PR TITLE
WPSEO_Statistics: bug fix

### DIFF
--- a/inc/class-wpseo-statistics.php
+++ b/inc/class-wpseo-statistics.php
@@ -57,6 +57,6 @@ class WPSEO_Statistics {
 
 		$posts = new WP_Query( $posts );
 
-		return $posts->found_posts;
+		return (int) $posts->found_posts;
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This is primarily a bug in WP Core which states that `$found_posts` will be an integer, but then doesn't necessarily ensure that it is

All the same, this bug in WP Core does not need to have any effect in WPSEO and a simple cast to `int` will negate the effect of the bug.

Bug discovered while reviewing the unit tests.

Refs:
* https://developer.wordpress.org/reference/classes/wp_query/
* https://developer.wordpress.org/reference/classes/wp_query/set_found_posts/



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no significant effect on the functionality.
