### PR TITLE
[src] QA: remove unused `use` statement

### DIFF
--- a/src/config/dependency-management.php
+++ b/src/config/dependency-management.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\Free\Config;
 
 use Composer\Script\Event;
-use Composer\Installer\PackageEvent;
 
 /**
  * Sets up class aliases and defines required constants.

--- a/src/formatters/indexable-author-formatter.php
+++ b/src/formatters/indexable-author-formatter.php
@@ -7,8 +7,6 @@
 
 namespace Yoast\WP\Free\Formatters;
 
-use Yoast\WP\Free\Models\Indexable;
-
 /**
  * Formats the term meta to indexable format.
  */

--- a/src/formatters/indexable-post-formatter.php
+++ b/src/formatters/indexable-post-formatter.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\Formatters;
 
-use Yoast\WP\Free\Models\Indexable;
 use Yoast\WP\Free\Models\SEO_Meta;
 
 /**

--- a/src/formatters/indexable-term-formatter.php
+++ b/src/formatters/indexable-term-formatter.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\Formatters;
 
-use Yoast\WP\Free\Models\Indexable;
 
 /**
  * Formats the term meta to indexable format.

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -9,7 +9,6 @@ namespace Yoast\WP\Free\Oauth;
 
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessToken;
-use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
 
 /**
  * Represents the oAuth client.

--- a/src/watchers/primary-term-watcher.php
+++ b/src/watchers/primary-term-watcher.php
@@ -9,7 +9,6 @@ namespace Yoast\WP\Free\Watchers;
 
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Loggers\Logger;
-use Yoast\WP\Free\Models\Indexable;
 use Yoast\WP\Free\Models\Primary_Term as Primary_Term_Indexable;
 use Yoast\WP\Free\WordPress\Integration;
 

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\Free;
 
 use Yoast\WP\Free\Exceptions\Missing_Method;
-use YoastSEO_Vendor\ORM;
 
 /**
  * Make Model compatible with WordPress.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

If a class is not used in a file, it shouldn't be imported.

Note: use within documentation or as text strings, for instance for a `instanceOf` test, does not mean the class needs to be imported.

## Test instructions

This PR can be tested by following these steps:
* Good question... the unit tests covering this code don't throw any errors, so we should be good providing the code is tested in depth. If not, then ask @atimmer or @herregroen how to test this.