### PR TITLE
[src] Documentation: use FQCN in docblocks

### DIFF
--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -40,15 +40,15 @@ class Database_Migration {
 	protected $wpdb;
 
 	/**
-	 * @var \Dependency_Management
+	 * @var \Yoast\WP\Free\Config\Dependency_Management
 	 */
 	protected $dependency_management;
 
 	/**
 	 * Migrations constructor.
 	 *
-	 * @param \wpdb                 $wpdb                  Database class to use.
-	 * @param Dependency_Management $dependency_management Dependency Management to use.
+	 * @param \wpdb                                       $wpdb                  Database class to use.
+	 * @param \Yoast\WP\Free\Config\Dependency_Management $dependency_management Dependency Management to use.
 	 */
 	public function __construct( $wpdb, Dependency_Management $dependency_management ) {
 		$this->wpdb                  = $wpdb;
@@ -163,7 +163,7 @@ class Database_Migration {
 	/**
 	 * Retrieves the Ruckusing instance to run migrations with.
 	 *
-	 * @return Ruckusing_FrameworkRunner Framework runner to use.
+	 * @return \YoastSEO_Vendor\Ruckusing_FrameworkRunner Framework runner to use.
 	 */
 	protected function get_framework_runner() {
 		$main = new Ruckusing_FrameworkRunner(

--- a/src/config/dependency-management.php
+++ b/src/config/dependency-management.php
@@ -70,7 +70,7 @@ class Dependency_Management {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param Event $event Composer event that triggered this script.
+	 * @param \Composer\Script\Event $event Composer event that triggered this script.
 	 *
 	 * @return void
 	 */

--- a/src/config/plugin.php
+++ b/src/config/plugin.php
@@ -34,22 +34,22 @@ class Plugin implements Integration {
 	/**
 	 * The dependency manager to use.
 	 *
-	 * @var Dependency_Management $dependency_management
+	 * @var \Yoast\WP\Free\Config\Dependency_Management $dependency_management
 	 */
 	protected $dependency_management;
 
 	/**
 	 * The database migration to use.
 	 *
-	 * @var Database_Migration $database_migration
+	 * @var \Yoast\WP\Free\Config\Database_Migration $database_migration
 	 */
 	protected $database_migration;
 
 	/**
 	 * Creates a new plugin instance.
 	 *
-	 * @param Dependency_Management|null $dependency_management Class to manage dependency prefixing.
-	 * @param Database_Migration|null    $database_migration    Class to manage database migrations.
+	 * @param \Yoast\WP\Free\Config\Dependency_Management|null $dependency_management Class to manage dependency prefixing.
+	 * @param \Yoast\WP\Free\Config\Database_Migration|null    $database_migration    Class to manage database migrations.
 	 */
 	public function __construct( Dependency_Management $dependency_management = null, Database_Migration $database_migration = null ) {
 		// @codingStandardsIgnoreStart
@@ -61,7 +61,7 @@ class Plugin implements Integration {
 	/**
 	 * Adds an integration to the stack
 	 *
-	 * @param Integration $integration Integration to add.
+	 * @param \Yoast\WP\Free\WordPress\Integration $integration Integration to add.
 	 *
 	 * @return void
 	 */
@@ -175,7 +175,7 @@ class Plugin implements Integration {
 	 *
 	 * @param array $integrations Integrations to load into the group.
 	 *
-	 * @return Integration_Group.
+	 * @return \Yoast\WP\Free\WordPress\Integration_Group
 	 */
 	protected function get_integration_group( array $integrations = array() ) {
 		return new Integration_Group( $integrations );

--- a/src/config/upgrade.php
+++ b/src/config/upgrade.php
@@ -17,14 +17,14 @@ class Upgrade implements Integration {
 	/**
 	 * The database migration to use.
 	 *
-	 * @var Database_Migration $database_migration
+	 * @var \Yoast\WP\Free\Config\Database_Migration $database_migration
 	 */
 	protected $database_migration;
 
 	/**
 	 * Upgrade constructor.
 	 *
-	 * @param Database_Migration $database_migration Database Migration to use.
+	 * @param \Yoast\WP\Free\Config\Database_Migration $database_migration Database Migration to use.
 	 */
 	public function __construct( Database_Migration $database_migration ) {
 		$this->database_migration = $database_migration;

--- a/src/exceptions/no-indexable-found.php
+++ b/src/exceptions/no-indexable-found.php
@@ -19,7 +19,7 @@ class No_Indexable_Found extends \OutOfRangeException {
 	 *
 	 * @param integer $post_id Post ID for the non existing indexable.
 	 *
-	 * @return No_Indexable_Found The exception.
+	 * @return \Yoast\WP\Free\Exceptions\No_Indexable_Found The exception.
 	 */
 	public static function from_post_id( $post_id ) {
 		$message = \sprintf(
@@ -37,7 +37,7 @@ class No_Indexable_Found extends \OutOfRangeException {
 	 * @param int    $term_id  The term the indexable is based upon.
 	 * @param string $taxonomy The taxonomy the indexable belongs to.
 	 *
-	 * @return No_Indexable_Found The exception.
+	 * @return \Yoast\WP\Free\Exceptions\No_Indexable_Found The exception.
 	 */
 	public static function from_term_id( $term_id, $taxonomy ) {
 		$message = \sprintf(
@@ -56,7 +56,7 @@ class No_Indexable_Found extends \OutOfRangeException {
 	 * @param integer $post_id  The post ID.
 	 * @param string  $taxonomy The taxonomy for the given Post ID.
 	 *
-	 * @return No_Indexable_Found The exception.
+	 * @return \Yoast\WP\Free\Exceptions\No_Indexable_Found The exception.
 	 */
 	public static function from_primary_term( $post_id, $taxonomy ) {
 		$message = \sprintf(
@@ -74,7 +74,7 @@ class No_Indexable_Found extends \OutOfRangeException {
 	 *
 	 * @param int $user_id The user to retrieve the indexable for.
 	 *
-	 * @return No_Indexable_Found The exception.
+	 * @return \Yoast\WP\Free\Exceptions\No_Indexable_Found The exception.
 	 */
 	public static function from_author_id( $user_id ) {
 		$message = \sprintf(
@@ -92,7 +92,7 @@ class No_Indexable_Found extends \OutOfRangeException {
 	 * @param string $meta_key     The meta key.
 	 * @param int    $indexable_id The ID of the indexable.
 	 *
-	 * @return No_Indexable_Found The exception.
+	 * @return \Yoast\WP\Free\Exceptions\No_Indexable_Found The exception.
 	 */
 	public static function from_meta_key( $meta_key, $indexable_id ) {
 		$message = \sprintf(
@@ -110,7 +110,7 @@ class No_Indexable_Found extends \OutOfRangeException {
 	 *
 	 * @param string $message The error message.
 	 *
-	 * @return No_Indexable_Found Instance of the exception.
+	 * @return \Yoast\WP\Free\Exceptions\No_Indexable_Found Instance of the exception.
 	 */
 	protected static function create_and_log_exception( $message ) {
 		Logger::get_logger()->notice( $message );

--- a/src/formatters/indexable-author-formatter.php
+++ b/src/formatters/indexable-author-formatter.php
@@ -33,9 +33,9 @@ class Indexable_Author_Formatter {
 	/**
 	 * Formats the data.
 	 *
-	 * @param Indexable $indexable The indexable to format.
+	 * @param \Yoast\WP\Free\Models\Indexable $indexable The indexable to format.
 	 *
-	 * @return Indexable The extended indexable.
+	 * @return \Yoast\WP\Free\Models\Indexable The extended indexable.
 	 */
 	public function format( $indexable ) {
 		$meta_data = $this->get_meta_data();

--- a/src/formatters/indexable-post-formatter.php
+++ b/src/formatters/indexable-post-formatter.php
@@ -35,9 +35,9 @@ class Indexable_Post_Formatter {
 	/**
 	 * Formats the data.
 	 *
-	 * @param Indexable $indexable The indexable to format.
+	 * @param \Yoast\WP\Free\Models\Indexable $indexable The indexable to format.
 	 *
-	 * @return Indexable The extended indexable.
+	 * @return \Yoast\WP\Free\Models\Indexable The extended indexable.
 	 */
 	public function format( $indexable ) {
 		$indexable->permalink       = $this->get_permalink();
@@ -154,9 +154,9 @@ class Indexable_Post_Formatter {
 	/**
 	 * Updates the link count from existing data.
 	 *
-	 * @param Indexable $indexable The indexable to extend.
+	 * @param \Yoast\WP\Free\Models\Indexable $indexable The indexable to extend.
 	 *
-	 * @return Indexable The extended indexable.
+	 * @return \Yoast\WP\Free\Models\Indexable The extended indexable.
 	 */
 	protected function set_link_count( $indexable ) {
 		try {
@@ -219,7 +219,7 @@ class Indexable_Post_Formatter {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return SEO_Meta The SEO meta for current post id.
+	 * @return \Yoast\WP\Free\Models\SEO_Meta The SEO meta for current post id.
 	 */
 	protected function get_seo_meta() {
 		return SEO_Meta::find_by_post_id( $this->post_id );

--- a/src/formatters/indexable-term-formatter.php
+++ b/src/formatters/indexable-term-formatter.php
@@ -43,9 +43,9 @@ class Indexable_Term_Formatter {
 	/**
 	 * Formats the data.
 	 *
-	 * @param Indexable $indexable The indexable to format.
+	 * @param \Yoast\WP\Free\Models\Indexable $indexable The indexable to format.
 	 *
-	 * @return Indexable The extended indexable.
+	 * @return \Yoast\WP\Free\Models\Indexable The extended indexable.
 	 */
 	public function format( $indexable ) {
 		$term_meta = $this->get_meta_data();

--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -18,14 +18,14 @@ class Logger {
 	/**
 	 * The instance of the logger.
 	 *
-	 * @var LoggerInterface|null
+	 * @var \YoastSEO_Vendor\Psr\Log\LoggerInterface|null
 	 */
 	protected static $logger;
 
 	/**
 	 * Retrieves an instance of the logger.
 	 *
-	 * @return LoggerInterface The logger.
+	 * @return \YoastSEO_Vendor\Psr\Log\LoggerInterface The logger.
 	 */
 	public static function get_logger() {
 		static $logger;
@@ -40,9 +40,9 @@ class Logger {
 			/**
 			 * Gives the possibility to set override the logger interface.
 			 *
-			 * @api LoggerInterface $logger Instance of NullLogger.
+			 * @api \YoastSEO_Vendor\Psr\Log\LoggerInterface $logger Instance of NullLogger.
 			 *
-			 * @return LoggerInterface The logger object.
+			 * @return \YoastSEO_Vendor\Psr\Log\LoggerInterface The logger object.
 			 */
 			$logger = apply_filters( 'wpseo_logger', $logger );
 		}
@@ -57,7 +57,7 @@ class Logger {
 	/**
 	 * Sets the logger object.
 	 *
-	 * @param LoggerInterface|null $logger The logger to use.
+	 * @param \YoastSEO_Vendor\Psr\Log\LoggerInterface|null $logger The logger to use.
 	 */
 	public static function set_logger( LoggerInterface $logger = null ) {
 		if ( ! $logger instanceof LoggerInterface ) {

--- a/src/models/indexable-meta.php
+++ b/src/models/indexable-meta.php
@@ -27,7 +27,7 @@ class Indexable_Meta extends Yoast_Model {
 	 * @param int    $indexable_id The indexable ID.
 	 * @param string $meta_key     The meta key.
 	 *
-	 * @return bool|Indexable_Meta Indexable meta object.
+	 * @return bool|\Yoast\WP\Free\Models\Indexable_Meta Indexable meta object.
 	 */
 	public static function find_meta_for_indexable( $indexable_id, $meta_key ) {
 		return Yoast_Model::of_type( 'Indexable_Meta' )
@@ -42,13 +42,13 @@ class Indexable_Meta extends Yoast_Model {
 	 * @param int    $indexable_id The indexable ID.
 	 * @param string $meta_key     The meta key.
 	 *
-	 * @return bool|Indexable_Meta Indexable meta object.
+	 * @return bool|\Yoast\WP\Free\Models\Indexable_Meta Indexable meta object.
 	 */
 	public static function create_meta_for_indexable( $indexable_id, $meta_key ) {
 		/**
 		 * Indexable instance for the post.
 		 *
-		 * @var Indexable_Meta $indexable_meta
+		 * @var \Yoast\WP\Free\Models\Indexable_Meta $indexable_meta
 		 */
 		$indexable_meta               = Yoast_Model::of_type( 'Indexable_Meta' )->create();
 		$indexable_meta->indexable_id = $indexable_id;

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -51,7 +51,7 @@ class Indexable extends Yoast_Model {
 	/**
 	 * The Indexable meta data.
 	 *
-	 * @var Indexable_Meta[]
+	 * @var \Yoast\WP\Free\Models\Indexable_Meta[]
 	 */
 	protected $meta_data;
 
@@ -62,7 +62,7 @@ class Indexable extends Yoast_Model {
 	 * @param string $object_type The indexable object type.
 	 * @param bool   $auto_create Optional. Create the indexable if it does not exist.
 	 *
-	 * @return bool|Indexable Instance of indexable.
+	 * @return bool|\Yoast\WP\Free\Models\Indexable Instance of indexable.
 	 */
 	public static function find_by_id_and_type( $object_id, $object_type, $auto_create = true ) {
 		$indexable = Yoast_Model::of_type( 'Indexable' )
@@ -83,13 +83,13 @@ class Indexable extends Yoast_Model {
 	 * @param int    $object_id   The indexable object ID.
 	 * @param string $object_type The indexable object type.
 	 *
-	 * @return bool|Indexable Instance of indexable.
+	 * @return bool|\Yoast\WP\Free\Models\Indexable Instance of indexable.
 	 */
 	public static function create_for_id_and_type( $object_id, $object_type ) {
 		/*
 		 * Indexable instance.
 		 *
-		 * @var Indexable $indexable
+		 * @var \Yoast\WP\Free\Models\Indexable $indexable
 		 */
 		$indexable              = Yoast_Model::of_type( 'Indexable' )->create();
 		$indexable->object_id   = $object_id;
@@ -111,7 +111,7 @@ class Indexable extends Yoast_Model {
 	/**
 	 * Returns the related meta model.
 	 *
-	 * @return Indexable_Meta Array of meta objects.
+	 * @return \Yoast\WP\Free\Models\Indexable_Meta Array of meta objects.
 	 */
 	public function meta() {
 		try {
@@ -233,9 +233,9 @@ class Indexable extends Yoast_Model {
 	 * @param string $meta_key    The meta key to get object for.
 	 * @param bool   $auto_create Optional. Create the indexable if it does not exist.
 	 *
-	 * @return Indexable_Meta
+	 * @return \Yoast\WP\Free\Models\Indexable_Meta
 	 *
-	 * @throws No_Indexable_Found Exception when no Indexable entry could be found.
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found Exception when no Indexable entry could be found.
 	 */
 	protected function get_meta( $meta_key, $auto_create = true ) {
 		$this->initialize_meta();

--- a/src/models/primary-term.php
+++ b/src/models/primary-term.php
@@ -29,7 +29,7 @@ class Primary_Term extends Yoast_Model {
 	 * @param string $taxonomy    The taxonomy the indexable belongs to.
 	 * @param bool   $auto_create Optional. Creates an indexable if it does not exist yet.
 	 *
-	 * @return bool|Indexable Instance of indexable.
+	 * @return bool|\Yoast\WP\Free\Models\Indexable Instance of indexable.
 	 */
 	public static function find_by_postid_and_taxonomy( $post_id, $taxonomy, $auto_create = true ) {
 		/** @var \Yoast\WP\Free\Models\Primary_Term $indexable */

--- a/src/models/seo-meta.php
+++ b/src/models/seo-meta.php
@@ -30,7 +30,7 @@ class SEO_Meta extends Yoast_Model {
 	 *
 	 * @param int $post_id The post ID.
 	 *
-	 * @return SEO_Meta The SEO meta.
+	 * @return \Yoast\WP\Free\Models\SEO_Meta The SEO meta.
 	 */
 	public static function find_by_post_id( $post_id ) {
 		return Yoast_Model::of_type( 'SEO_Meta' )

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -25,7 +25,7 @@ class Client {
 	/**
 	 * Contains the set access tokens.
 	 *
-	 * @var AccessTokenInterface[]
+	 * @var \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface[]
 	 */
 	private $access_tokens;
 
@@ -53,7 +53,7 @@ class Client {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return Client Instance of this class.
+	 * @return \Yoast\WP\Free\Oauth\Client Instance of this class.
 	 */
 	public static function get_instance() {
 		if ( static::$instance === null ) {
@@ -122,8 +122,8 @@ class Client {
 	/**
 	 * Saves the access token for the given user.
 	 *
-	 * @param int                  $user_id      User ID to receive token for.
-	 * @param AccessTokenInterface $access_token The access token to save.
+	 * @param int                                                              $user_id      User ID to receive token for.
+	 * @param \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface $access_token The access token to save.
 	 *
 	 * @return void
 	 */
@@ -137,7 +137,7 @@ class Client {
 	 *
 	 * @param null|int $user_id User ID to receive token for.
 	 *
-	 * @return bool|AccessTokenInterface False if not found. Token when found.
+	 * @return bool|\YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface False if not found. Token when found.
 	 */
 	public function get_access_token( $user_id = null ) {
 		if ( $user_id === null ) {
@@ -171,7 +171,7 @@ class Client {
 	/**
 	 * Returns an instance of the oAuth provider.
 	 *
-	 * @return GenericProvider The provider.
+	 * @return \YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider The provider.
 	 */
 	public function get_provider() {
 		return new GenericProvider(
@@ -191,7 +191,7 @@ class Client {
 	 *
 	 * @param array $access_tokens The access tokens to format.
 	 *
-	 * @return AccessTokenInterface[] The formatted access tokens.
+	 * @return \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface[] The formatted access tokens.
 	 */
 	protected function format_access_tokens( $access_tokens ) {
 		if ( ! is_array( $access_tokens ) || $access_tokens === [] ) {

--- a/src/watchers/indexable-author-watcher.php
+++ b/src/watchers/indexable-author-watcher.php
@@ -72,9 +72,10 @@ class Indexable_Author_Watcher implements Integration {
 	 * @param int  $user_id     The user to retrieve the indexable for.
 	 * @param bool $auto_create Optional. Create the indexable when it does not exist yet.
 	 *
-	 * @return Indexable The indexable for the suppied user ID.
+	 * @return \Yoast\WP\Free\Models\Indexable The indexable for the suppied user ID.
 	 *
-	 * @throws No_Indexable_Found Exception when no Indexable could be found for the supplied user.
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found Exception when no Indexable could
+	 *                                                      be found for the supplied user.
 	 */
 	protected function get_indexable( $user_id, $auto_create = true ) {
 		$indexable = Indexable::find_by_id_and_type( $user_id, 'user', $auto_create );
@@ -93,7 +94,7 @@ class Indexable_Author_Watcher implements Integration {
 	 *
 	 * @param int $user_id The user ID.
 	 *
-	 * @return Indexable_Author_Formatter Instance.
+	 * @return \Yoast\WP\Free\Formatters\Indexable_Author_Formatter Instance.
 	 */
 	protected function get_formatter( $user_id ) {
 		return new Indexable_Author_Formatter( $user_id );

--- a/src/watchers/indexable-post-watcher.php
+++ b/src/watchers/indexable-post-watcher.php
@@ -77,9 +77,9 @@ class Indexable_Post_Watcher implements Integration {
 	 * @param int  $post_id     Post to fetch indexable for.
 	 * @param bool $auto_create Optional. Create the indexable if it does not exist.
 	 *
-	 * @return Indexable
+	 * @return \Yoast\WP\Free\Models\Indexable
 	 *
-	 * @throws No_Indexable_Found Exception when no Indexable entry could be found.
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found Exception when no Indexable entry could be found.
 	 */
 	protected function get_indexable( $post_id, $auto_create = true ) {
 		$indexable = Indexable::find_by_id_and_type( $post_id, 'post', $auto_create );
@@ -132,7 +132,7 @@ class Indexable_Post_Watcher implements Integration {
 	 *
 	 * @param int $post_id The post ID.
 	 *
-	 * @return Indexable_Post_Formatter Instance.
+	 * @return \Yoast\WP\Free\Formatters\Indexable_Post_Formatter Instance.
 	 */
 	protected function get_formatter( $post_id ) {
 		return new Indexable_Post_Formatter( $post_id );

--- a/src/watchers/indexable-term-watcher.php
+++ b/src/watchers/indexable-term-watcher.php
@@ -81,9 +81,10 @@ class Indexable_Term_Watcher implements Integration {
 	 * @param string $taxonomy    The taxonomy the indexable belongs to.
 	 * @param bool   $auto_create Optional. Creates an indexable if it does not exist yet.
 	 *
-	 * @return Indexable The indexable found for the supplied term.
+	 * @return \Yoast\WP\Free\Models\Indexable The indexable found for the supplied term.
 	 *
-	 * @throws No_Indexable_Found Exception when no indexable could be found for the supplied term.
+	 * @throws \Yoast\WP\Free\Models\No_Indexable_Found Exception when no indexable could be found
+	 *                                                  for the supplied term.
 	 */
 	protected function get_indexable( $term_id, $taxonomy, $auto_create = true ) {
 		$indexable = Indexable::find_by_id_and_type( $term_id, 'term', $auto_create );
@@ -103,7 +104,7 @@ class Indexable_Term_Watcher implements Integration {
 	 * @param int    $term_id  ID of the term to save data for.
 	 * @param string $taxonomy The taxonomy the term belongs to.
 	 *
-	 * @return Indexable_Term_Formatter Instance.
+	 * @return \Yoast\WP\Free\Formatters\Indexable_Term_Formatter Instance.
 	 */
 	protected function get_formatter( $term_id, $taxonomy ) {
 		return new Indexable_Term_Formatter( $term_id, $taxonomy );

--- a/src/watchers/primary-term-watcher.php
+++ b/src/watchers/primary-term-watcher.php
@@ -163,9 +163,10 @@ class Primary_Term_Watcher implements Integration {
 	 * @param string $taxonomy    The taxonomy the indexable belongs to.
 	 * @param bool   $auto_create Optional. Creates an indexable if it does not exist yet.
 	 *
-	 * @return Indexable Instance of the indexable.
+	 * @return \Yoast\WP\Free\Models\Indexable Instance of the indexable.
 	 *
-	 * @throws No_Indexable_Found Exception when no indexable could be found for the supplied post.
+	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found Exception when no indexable could be found
+	 *                                                      for the supplied post.
 	 */
 	protected function get_indexable( $post_id, $taxonomy, $auto_create = true ) {
 		$indexable = Primary_Term_Indexable::find_by_postid_and_taxonomy( $post_id, 'post', $auto_create );
@@ -180,7 +181,7 @@ class Primary_Term_Watcher implements Integration {
 	/**
 	 * Deletes the given indexable.
 	 *
-	 * @param Indexable $indexable The indexable to delete.
+	 * @param \Yoast\WP\Free\Models\Indexable $indexable The indexable to delete.
 	 *
 	 * @return void
 	 */

--- a/src/wordpress/integration-group.php
+++ b/src/wordpress/integration-group.php
@@ -15,14 +15,14 @@ class Integration_Group implements Integration {
 	/**
 	 * List of integrations.
 	 *
-	 * @var Integration[]
+	 * @var \Yoast\WP\Free\WordPress\Integration[]
 	 */
 	protected $integrations = array();
 
 	/**
 	 * Integration_Group constructor.
 	 *
-	 * @param Integration[] $integrations List of integrations to load.
+	 * @param \Yoast\WP\Free\WordPress\Integration[] $integrations List of integrations to load.
 	 *
 	 * @return void
 	 */
@@ -33,7 +33,7 @@ class Integration_Group implements Integration {
 	/**
 	 * Adds an integration to the group.
 	 *
-	 * @param Integration $integration The integration to add.
+	 * @param \Yoast\WP\Free\WordPress\Integration $integration The integration to add.
 	 *
 	 * @return void
 	 */

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -71,7 +71,7 @@ class Yoast_Model {
 	/**
 	 * The ORM instance used by this model instance to communicate with the database.
 	 *
-	 * @var ORM $orm
+	 * @var \YoastSEO_Vendor\ORM $orm
 	 */
 	public $orm;
 
@@ -88,7 +88,7 @@ class Yoast_Model {
 	 * @param string $class_name   Type of Model to load.
 	 * @param bool   $yoast_prefix Optional. True to prefix the table name with the Yoast prefix.
 	 *
-	 * @return ORMWrapper Wrapper to use.
+	 * @return \Yoast\WP\Free\ORMWrapper Wrapper to use.
 	 */
 	public static function of_type( $class_name, $yoast_prefix = true ) {
 		// Prepend namespace to the class name.
@@ -105,7 +105,7 @@ class Yoast_Model {
 	 *
 	 * @param string $class_name Type of Model to load.
 	 *
-	 * @return ORMWrapper
+	 * @return \Yoast\WP\Free\ORMWrapper
 	 */
 	public static function of_wp_type( $class_name ) {
 		return static::of_type( $class_name, false );
@@ -291,7 +291,7 @@ class Yoast_Model {
 	 * @param string      $class_name      The target class name.
 	 * @param null|string $connection_name The name of the connection.
 	 *
-	 * @return ORMWrapper Instance of the ORM wrapper.
+	 * @return \Yoast\WP\Free\ORMWrapper Instance of the ORM wrapper.
 	 */
 	public static function factory( $class_name, $connection_name = null ) {
 		$class_name = static::$auto_prefix_models . $class_name;
@@ -317,7 +317,7 @@ class Yoast_Model {
 	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 * @param null|string $connection_name                          The name of the connection.
 	 *
-	 * @return ORMWrapper
+	 * @return \Yoast\WP\Free\ORMWrapper
 	 * @throws \Exception When ID of urrent model has a null value.
 	 */
 	protected function has_one_or_many( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null, $connection_name = null ) {
@@ -349,7 +349,7 @@ class Yoast_Model {
 	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 * @param null|string $connection_name                          The name of the connection.
 	 *
-	 * @return ORMWrapper Instance of the ORM.
+	 * @return \Yoast\WP\Free\ORMWrapper Instance of the ORM.
 	 * @throws \Exception  When ID of current model has a null value.
 	 */
 	protected function has_one( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null, $connection_name = null ) {
@@ -365,7 +365,7 @@ class Yoast_Model {
 	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 * @param null|string $connection_name                          The name of the connection.
 	 *
-	 * @return ORMWrapper Instance of the ORM.
+	 * @return \Yoast\WP\Free\ORMWrapper Instance of the ORM.
 	 * @throws \Exception When ID has a null value.
 	 */
 	protected function has_many( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null, $connection_name = null ) {
@@ -417,7 +417,7 @@ class Yoast_Model {
 	 * @param null|string $key_in_associated_table The key in the associated table.
 	 * @param null|string $connection_name         The name of the connection.
 	 *
-	 * @return ORMWrapper Instance of the ORM.
+	 * @return \Yoast\WP\Free\ORMWrapper Instance of the ORM.
 	 */
 	protected function has_many_through( $associated_class_name, $join_class_name = null, $key_to_base_table = null, $key_to_associated_table = null, $key_in_base_table = null, $key_in_associated_table = null, $connection_name = null ) {
 		$base_class_name = \get_class( $this );
@@ -479,7 +479,7 @@ class Yoast_Model {
 	/**
 	 * Set the wrapped ORM instance associated with this Model instance.
 	 *
-	 * @param ORM $orm The ORM instance to set.
+	 * @param \YoastSEO_Vendor\ORM $orm The ORM instance to set.
 	 *
 	 * @return void
 	 */
@@ -673,9 +673,9 @@ class Yoast_Model {
 	 * @param string $name      The method to call.
 	 * @param array  $arguments The arguments to use.
 	 *
-	 * @throws Missing_Method When the method does not exist.
+	 * @throws \Yoast\WP\Free\Exceptions\Missing_Method When the method does not exist.
 	 *
-	 * @return bool|ORMWrapper Result of the call.
+	 * @return bool|\Yoast\WP\Free\ORMWrapper Result of the call.
 	 */
 	public function __call( $name, $arguments ) {
 		$method = \strtolower( \preg_replace( '/([a-z])([A-Z])/', '$1_$2', $name ) );

--- a/src/yoast-orm-wrapper.php
+++ b/src/yoast-orm-wrapper.php
@@ -58,7 +58,7 @@ class ORMWrapper extends ORM {
 	 * the name of the filter will be passed to the called filter function as
 	 * arguments after the ORM class.
 	 *
-	 * @return ORMWrapper Instance of the ORM wrapper.
+	 * @return \Yoast\WP\Free\ORMWrapper Instance of the ORM wrapper.
 	 */
 	public function filter() {
 		$args            = \func_get_args();
@@ -81,7 +81,7 @@ class ORMWrapper extends ORM {
 	 * @param string $table_name      The table to create instance for.
 	 * @param string $connection_name The connection name.
 	 *
-	 * @return ORMWrapper Instance of the ORM wrapper.
+	 * @return \Yoast\WP\Free\ORMWrapper Instance of the ORM wrapper.
 	 */
 	public static function for_table( $table_name, $connection_name = parent::DEFAULT_CONNECTION ) {
 		static::_setup_db( $connection_name );
@@ -93,16 +93,16 @@ class ORMWrapper extends ORM {
 	 * Method to create an instance of the model class associated with this
 	 * wrapper and populate it with the supplied Idiorm instance.
 	 *
-	 * @param ORMWrapper|ORM $orm The ORM used by model.
+	 * @param \Yoast\WP\Free\ORMWrapper|\YoastSEO_Vendor\ORM $orm The ORM used by model.
 	 *
-	 * @return bool|Yoast_Model Instance of the model class.
+	 * @return bool|\Yoast\WP\Free\Yoast_Model Instance of the model class.
 	 */
 	protected function create_model_instance( $orm ) {
 		if ( $orm === false ) {
 			return false;
 		}
 
-		/** @var Yoast_Model $model */
+		/** @var \Yoast\WP\Free\Yoast_Model $model */
 		$model = new $this->class_name();
 		$model->set_orm( $orm );
 
@@ -115,7 +115,7 @@ class ORMWrapper extends ORM {
 	 *
 	 * @param null|integer $id The ID to lookup.
 	 *
-	 * @return Yoast_Model Instance of the model.
+	 * @return \Yoast\WP\Free\Yoast_Model Instance of the model.
 	 */
 	public function find_one( $id = null ) {
 		return $this->create_model_instance( parent::find_one( $id ) );
@@ -142,7 +142,7 @@ class ORMWrapper extends ORM {
 	 *
 	 * @param null|mixed $data The data to pass.
 	 *
-	 * @return ORMWrapper|bool Instance of the ORM.
+	 * @return \Yoast\WP\Free\ORMWrapper|bool Instance of the ORM.
 	 */
 	public function create( $data = null ) {
 		return $this->create_model_instance( parent::create( $data ) );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Best practice: using fully qualified class names in annotations results in unambiguous phpDocs.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
