### PR TITLE
[src] QA: removed leading backslash from FQCN in `use` statements

### DIFF
--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -7,8 +7,8 @@
 
 namespace Yoast\WP\Free\Loggers;
 
-use \YoastSEO_Vendor\Psr\Log\LoggerInterface;
-use \YoastSEO_Vendor\Psr\Log\NullLogger;
+use YoastSEO_Vendor\Psr\Log\LoggerInterface;
+use YoastSEO_Vendor\Psr\Log\NullLogger;
 
 /**
  * Creates an instance of a logger object.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

As it states in the PHP documentation (emphasis is mine):

> Note that for namespaced names (fully qualified namespace names containing namespace separator, such as Foo\Bar as opposed to global names that do not, such as FooBar), **_the leading backslash is unnecessary and not recommended_**, as import names must be fully qualified, and are not processed relative to the current namespace.

Ref: https://www.php.net/manual/en/language.namespaces.importing.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.