### PR TITLE
[src] QA: don't use leading backslash on `false`

### DIFF
--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -67,7 +67,7 @@ class Yoast_Model {
 	 *
 	 * @var bool $short_table_names
 	 */
-	public static $short_table_names = \false;
+	public static $short_table_names = false;
 
 	/**
 	 * The ORM instance used by this model instance to communicate with the database.

--- a/src/yoast-orm-wrapper.php
+++ b/src/yoast-orm-wrapper.php
@@ -98,8 +98,8 @@ class ORMWrapper extends ORM {
 	 * @return bool|Yoast_Model Instance of the model class.
 	 */
 	protected function create_model_instance( $orm ) {
-		if ( $orm === \false ) {
-			return \false;
+		if ( $orm === false ) {
+			return false;
 		}
 
 		/** @var Yoast_Model $model */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

`false` and `true` are a special kind of global constant and using a leading backslash with them is unnecessary.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.