### PR TITLE
Restore timeout to more than 1 second

### DIFF
--- a/inc/class-my-yoast-api-request.php
+++ b/inc/class-my-yoast-api-request.php
@@ -24,7 +24,7 @@ class WPSEO_MyYoast_Api_Request {
 	 */
 	protected $args = array(
 		'method'    => 'GET',
-		'timeout'   => 1,
+		'timeout'   => 5,
 		'sslverify' => false,
 		'headers'   => array(
 			'Accept-Encoding' => '*',


### PR DESCRIPTION
As the response from MyYoast can be as large as 300kb (due to changelogs) - servers in areas that don't have good connection to MyYoast or CloudFlare can hit the timeout limit of 1 second.

## Summary

This PR can be summarized in the following changelog entry:

* Increased the MyYoast API request timeout from 1 to 5 seconds, to give servers with a less optimal connection to our services more room to fetch the data.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] ~I have tested this code to the best of my abilities~
* [ ] ~I have added unittests to verify the code works as intended~

Fixes #
