### PR TITLE
Use the "true" canonical, not the overridden one

### DIFF
--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -118,7 +118,7 @@ class WPSEO_Schema_Context {
 		}
 
 		$front             = WPSEO_Frontend::get_instance();
-		$this->canonical   = $front->canonical( false );
+		$this->canonical   = $front->canonical( false, false, true );
 		$this->title       = $front->title( '' );
 		$this->description = $front->metadesc( false );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Schema output now uses the "unoverridden" canonical, not the overridden one.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set a canonical on the advanced tab of the Yoast SEO metabox.
* See that the Schema output doesn't use that canonical but instead uses the "unoverridden" canonical.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12861
