### PR TITLE
[tests] QA: remove unused `use` statement

### DIFF
--- a/tests/config/plugin-test.php
+++ b/tests/config/plugin-test.php
@@ -2,9 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Config;
 
-use Yoast\WP\Free\Config\Database_Migration;
-use Yoast\WP\Free\Config\Dependency_Management;
-use Yoast\WP\Free\WordPress\Integration_Group;
 use Yoast\WP\Free\Tests\Doubles\Plugin as Plugin_Double;
 use Yoast\WP\Free\Tests\TestCase;
 

--- a/tests/oauth/client-test.php
+++ b/tests/oauth/client-test.php
@@ -10,7 +10,6 @@ namespace Yoast\WP\Free\Tests\Oauth;
 use Yoast\WP\Free\Oauth\Client;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessToken;
-use Brain\Monkey;
 use Yoast\WP\Free\Tests\Doubles\Oauth\Client as Client_Double;
 use Yoast\WP\Free\Tests\TestCase;
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

If a class is not used in a file, it shouldn't be imported.

Note: use within documentation or as text strings, for instance for a `instanceOf` test, does not mean the class needs to be imported.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-code-only change and should have no effect on the functionality. If the unit tests pass the build, we're good.