### PR TITLE
[src] QA: consistently use `use` statements

### DIFF
--- a/src/exceptions/no-indexable-found.php
+++ b/src/exceptions/no-indexable-found.php
@@ -8,11 +8,12 @@
 namespace Yoast\WP\Free\Exceptions;
 
 use Yoast\WP\Free\Loggers\Logger;
+use OutOfRangeException;
 
 /**
  * The exception when no indexable could be found.
  */
-class No_Indexable_Found extends \OutOfRangeException {
+class No_Indexable_Found extends OutOfRangeException {
 
 	/**
 	 * Returns an exception when an indexable for a post is not found.

--- a/src/formatters/indexable-post-formatter.php
+++ b/src/formatters/indexable-post-formatter.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Free\Formatters;
 
+use WPSEO_Meta;
 use Yoast\WP\Free\Models\SEO_Meta;
 
 /**
@@ -184,7 +185,7 @@ class Indexable_Post_Formatter {
 	 * @return mixed The value of the indexable entry to use.
 	 */
 	protected function get_meta_value( $meta_key ) {
-		$value = \WPSEO_Meta::get_value( $meta_key, $this->post_id );
+		$value = WPSEO_Meta::get_value( $meta_key, $this->post_id );
 		if ( is_string( $value ) && $value === '' ) {
 			return null;
 		}

--- a/src/formatters/indexable-term-formatter.php
+++ b/src/formatters/indexable-term-formatter.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Free\Formatters;
 
+use WPSEO_Taxonomy_Meta;
 
 /**
  * Formats the term meta to indexable format.
@@ -174,7 +175,7 @@ class Indexable_Term_Formatter {
 	 * @return bool|array The meta data for the term.
 	 */
 	protected function get_meta_data() {
-		return \WPSEO_Taxonomy_Meta::get_term_meta( $this->term_id, $this->taxonomy );
+		return WPSEO_Taxonomy_Meta::get_term_meta( $this->term_id, $this->taxonomy );
 	}
 
 	/**

--- a/src/loaders/oauth.php
+++ b/src/loaders/oauth.php
@@ -5,6 +5,10 @@
  * @package Yoast\YoastSEO\Loaders
  */
 
+use Yoast\WP\Free\Config\Dependency_Management;
+use Yoast\WP\Free\Oauth\Client;
+use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
+
 if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'Status: 403 Forbidden' );
 	header( 'HTTP/1.1 403 Forbidden' );
@@ -23,8 +27,8 @@ if ( file_exists( dirname( WPSEO_FILE ) . '/vendor_prefixed/guzzlehttp/promises/
 	require_once dirname( WPSEO_FILE ) . '/vendor_prefixed/guzzlehttp/promises/src/functions.php';
 }
 
-$yoast_seo_dependecy_management = new \Yoast\WP\Free\Config\Dependency_Management();
+$yoast_seo_dependecy_management = new Dependency_Management();
 $yoast_seo_dependecy_management->initialize();
 
-class_alias( \Yoast\WP\Free\Oauth\Client::class, 'WPSEO_MyYoast_Client' );
-class_alias( \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface::class, 'WPSEO_MyYoast_AccessToken_Interface' );
+class_alias( Client::class, 'WPSEO_MyYoast_Client' );
+class_alias( AccessTokenInterface::class, 'WPSEO_MyYoast_AccessToken_Interface' );

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\Free\Oauth;
 
+use WPSEO_Options;
+use WPSEO_Utils;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessToken;
 
@@ -178,7 +180,7 @@ class Client {
 			[
 				'clientId'                => $this->config['clientId'],
 				'clientSecret'            => $this->config['secret'],
-				'redirectUri'             => ( \WPSEO_Utils::is_plugin_network_active() ) ? home_url( 'yoast/oauth/callback' ) : network_home_url( 'yoast/oauth/callback' ),
+				'redirectUri'             => ( WPSEO_Utils::is_plugin_network_active() ) ? home_url( 'yoast/oauth/callback' ) : network_home_url( 'yoast/oauth/callback' ),
 				'urlAuthorize'            => 'https://yoast.com/login/oauth/authorize',
 				'urlAccessToken'          => 'https://yoast.com/login/oauth/token',
 				'urlResourceOwnerDetails' => 'https://my.yoast.com/api/sites/current',
@@ -214,7 +216,7 @@ class Client {
 	 * @return array
 	 */
 	protected function get_option() {
-		$option_value = \WPSEO_Options::get( 'myyoast_oauth', false );
+		$option_value = WPSEO_Options::get( 'myyoast_oauth', false );
 
 		if ( $option_value ) {
 			return wp_parse_args(
@@ -234,9 +236,9 @@ class Client {
 	 * @return void
 	 */
 	protected function update_option() {
-		\WPSEO_Options::set(
+		WPSEO_Options::set(
 			'myyoast_oauth',
-			\WPSEO_Utils::format_json_encode(
+			WPSEO_Utils::format_json_encode(
 				[
 					'config'        => $this->config,
 					'access_tokens' => $this->access_tokens,

--- a/src/watchers/primary-term-watcher.php
+++ b/src/watchers/primary-term-watcher.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Free\Watchers;
 
+use WPSEO_Meta;
 use Yoast\WP\Free\Exceptions\No_Indexable_Found;
 use Yoast\WP\Free\Loggers\Logger;
 use Yoast\WP\Free\Models\Primary_Term as Primary_Term_Indexable;
@@ -225,7 +226,7 @@ class Primary_Term_Watcher implements Integration {
 	 * @return int The term ID.
 	 */
 	protected function get_posted_term_id( $taxonomy ) {
-		return filter_input( INPUT_POST, \WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_term', FILTER_SANITIZE_NUMBER_INT );
+		return filter_input( INPUT_POST, WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_term', FILTER_SANITIZE_NUMBER_INT );
 	}
 
 	/**
@@ -238,6 +239,6 @@ class Primary_Term_Watcher implements Integration {
 	 * @return bool Whether the referer is valid.
 	 */
 	protected function is_referer_valid( $taxonomy ) {
-		return check_admin_referer( 'save-primary-term', \WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_nonce' );
+		return check_admin_referer( 'save-primary-term', WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_nonce' );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

A lot of the time, the new files within `src` did used external classes, without importing them with `use` statements.

As it is good practice to always import all classes used within a namespaced file using `use` statements, this has now been fixed.

This is on the one hand about consistency across the classes, on the other hand about documenting which classes are used in a file.

Only one exception is made and that is for the PHP native `Exception` class as using that in its fully qualified form makes it unambiguous whether the PHP native `Exception` class or a userland `Exception` class has been used.

As for the order of the `use` statements, I've listed those as such:
* Functional classes first in alphabetic order.
* Test related classes after that, again in alphabetic order.
* [If applicable] PHP native classes in alphabetic order.

CS-wise, any arbitrary blank lines in the list of `use` statements have been removed.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.