### PR TITLE
[integration-tests] QA: remove the `checkRequirements()` method

### DIFF
--- a/integration-tests/admin/test-class-yoast-network-admin.php
+++ b/integration-tests/admin/test-class-yoast-network-admin.php
@@ -57,6 +57,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Admin::get_site_choices()
 	 */
 	public function test_get_site_choices() {
+		$this->skipWithoutMultisite();
+
 		$admin = new Yoast_Network_Admin();
 
 		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );
@@ -79,6 +81,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Admin::get_site_choices()
 	 */
 	public function test_get_site_choices_output() {
+		$this->skipWithoutMultisite();
+
 		$admin = new Yoast_Network_Admin();
 
 		$site = get_site();
@@ -102,6 +106,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Network_Admin::get_site_states()
 	 */
 	public function test_get_site_states() {
+		$this->skipWithoutMultisite();
+
 		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
 			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
 

--- a/integration-tests/capabilities/test-class-register-capabilities.php
+++ b/integration-tests/capabilities/test-class-register-capabilities.php
@@ -37,6 +37,8 @@ class WPSEO_Register_Capabilities_Tests extends WPSEO_UnitTestCase {
 	 * @param bool   $expected_has_cap Whether the expected capability check result is true or false.
 	 */
 	public function test_filter_user_has_wpseo_manage_options_cap( $role, $access, $expected_has_cap ) {
+		$this->skipWithoutMultisite();
+
 		WPSEO_Options::get_instance();
 
 		$options           = get_site_option( 'wpseo_ms', array() );

--- a/integration-tests/framework/class-wpseo-unit-test-case.php
+++ b/integration-tests/framework/class-wpseo-unit-test-case.php
@@ -65,36 +65,4 @@ abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 			$this->assertTrue( $found !== false, sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
 		}
 	}
-
-	/**
-	 * Allows tests to be skipped on single or multisite installs by using @group annotations.
-	 *
-	 * This is a custom extension of the PHPUnit and WordPress requirements handling.
-	 */
-	protected function checkRequirements() {
-		parent::checkRequirements();
-
-		$annotations = $this->getAnnotations();
-
-		$groups = array();
-		if ( ! empty( $annotations['class']['group'] ) ) {
-			$groups = array_merge( $groups, $annotations['class']['group'] );
-		}
-
-		if ( ! empty( $annotations['method']['group'] ) ) {
-			$groups = array_merge( $groups, $annotations['method']['group'] );
-		}
-
-		if ( empty( $groups ) ) {
-			return;
-		}
-
-		if ( in_array( 'ms-required', $groups, true ) ) {
-			$this->skipWithoutMultisite();
-		}
-
-		if ( in_array( 'ms-excluded', $groups, true ) ) {
-			$this->skipWithMultisite();
-		}
-	}
 }

--- a/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
@@ -34,6 +34,8 @@ class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Option::prevent_disabled_options_update()
 	 */
 	public function test_verify_features_against_network() {
+		$this->skipWithoutMultisite();
+
 		$options  = WPSEO_Options::get_option( 'wpseo' );
 		$expected = array_fill_keys( $this->feature_vars, true );
 		$this->assertEqualSets( $expected, array_intersect_key( $options, $expected ) );

--- a/integration-tests/inc/options/test-class-wpseo-option.php
+++ b/integration-tests/inc/options/test-class-wpseo-option.php
@@ -18,6 +18,8 @@ class WPSEO_Option_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Option::prevent_disabled_options_update()
 	 */
 	public function test_prevent_disabled_options_update() {
+		$this->skipWithoutMultisite();
+
 		$option_vars = array(
 			'enable_admin_bar_menu',
 			'enable_cornerstone_content',

--- a/integration-tests/inc/options/test-class-wpseo-options.php
+++ b/integration-tests/inc/options/test-class-wpseo-options.php
@@ -192,6 +192,8 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::add_ms_option()
 	 */
 	public function test_ms_options_included_in_get_in_multisite() {
+		$this->skipWithoutMultisite();
+
 		$ms_option_keys = array(
 			'access',
 			'defaultblog',
@@ -219,6 +221,8 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::add_ms_option()
 	 */
 	public function test_ms_options_excluded_in_get_non_multisite() {
+		$this->skipWithMultisite();
+
 		$ms_option_keys = array(
 			'access',
 			'defaultblog',

--- a/integration-tests/notifications/test-class-yoast-notification-center.php
+++ b/integration-tests/notifications/test-class-yoast-notification-center.php
@@ -500,6 +500,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::dismiss_notification()
 	 */
 	public function test_dismiss_notification_is_per_site() {
+		$this->skipWithoutMultisite();
+
 		$site2 = self::factory()->blog->create();
 
 		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
@@ -526,6 +528,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::restore_notification()
 	 */
 	public function test_restore_notification_is_per_site() {
+		$this->skipWithoutMultisite();
+
 		$site2 = self::factory()->blog->create();
 
 		$notification  = new Yoast_Notification( 'notification', $this->fake_notification_defaults );
@@ -558,6 +562,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::is_notification_dismissed()
 	 */
 	public function test_is_notification_dismissed_is_per_site() {
+		$this->skipWithoutMultisite();
+
 		if ( version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) ) {
 			$this->markTestSkipped( 'Skipped because since WordPress 5.1 the hook wpmu_new_blog is deprecated' );
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

### [integration-tests] QA: remove the `checkRequirements()` method

First off, it looks like this code made it into WP Core as of v 3.5.0, so there is no need to have this duplicate method around.

Secondly, as of PHPUnit 7.0, the upstream method has become private, so this method isn't called anymore.
This is problematic as it means that the test skipping via `@group` annotations will no longer work in combination with PHPUnit 7.0. However, this is a problem which should primarily be fixed upstream in WP Core, not locally in WPSEO.

Ref: https://github.com/sebastianbergmann/phpunit/commit/932238a6a3018cdfac6c2a7d8f1d5d49e65f5dc0

### [integration-tests] PHPUnit 7: Work-around for multisite test skipping

As the test skipping via custom `@group` annotations no longer works as of PHPUnit 7.0, this is a (temporary?) work around.

Instead of relying on the `@group` annotations to be respected, we now call the WP native `skipWithMultisite()` and `skipWithoutMultisite()` methods directly to handle the test skipping if the test method is called _in spite of_ the `@group` annotation.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-code-only change and should have no effect on the functionality. If the unit tests pass the build, we're good.