### PR TITLE
Fix KeywordInput duplicate IDs

### DIFF
--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -13,6 +13,7 @@ import styled from "styled-components";
 import { setFocusKeyword } from "../../redux/actions/focusKeyword";
 import { setMarkerPauseStatus } from "../../redux/actions/markerPauseStatus";
 import HelpLink from "./HelpLink";
+import { LocationConsumer } from "../contexts/location";
 
 const KeywordInputContainer = styled( StyledContainerTopLevel )`
 	padding: 16px;
@@ -46,17 +47,21 @@ class KeywordInput extends Component {
 	 * @returns {ReactElement} The component.
 	 */
 	render() {
-		return <KeywordInputContainer>
-			<KeywordInputComponent
-				id="focus-keyword-input"
-				onChange={ this.props.onFocusKeywordChange }
-				keyword={ this.props.keyword }
-				label={ __( "Focus keyphrase", "wordpress-seo" ) }
-				helpLink={ KeywordInput.renderHelpLink() }
-				onBlurKeyword={ this.props.onBlurKeyword }
-				onFocusKeyword={ this.props.onFocusKeyword }
-			/>
-		</KeywordInputContainer>;
+		return <LocationConsumer>
+			{ context => (
+				<KeywordInputContainer>
+					<KeywordInputComponent
+						id={ `focus-keyword-input-${ context }` }
+						onChange={ this.props.onFocusKeywordChange }
+						keyword={ this.props.keyword }
+						label={ __( "Focus keyphrase", "wordpress-seo" ) }
+						helpLink={ KeywordInput.renderHelpLink() }
+						onBlurKeyword={ this.props.onBlurKeyword }
+						onFocusKeyword={ this.props.onFocusKeyword }
+					/>
+				</KeywordInputContainer>
+			) }
+		</LocationConsumer>;
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes duplicate IDs for the "Focus keyphrase" input field

## Test instructions
- build the JS
- edit a post
- open the plugin sidebar
- verify the "Focus keyphrase" input field in the sidebar and the one in the metabox have different IDs
- click on the "Focus keyphrase" **label** in the Sidebar and verify the field below the label gets focused
- verify the same in the metabox

See https://github.com/Yoast/wordpress-seo-premium/pull/2407 for Premium.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #13002

