### PR TITLE
CSS autoprefixer drop support for IE less than 11.

### DIFF
--- a/grunt/config/postcss.js
+++ b/grunt/config/postcss.js
@@ -4,7 +4,7 @@ var autoprefixer = require( "autoprefixer" );
 module.exports = {
 	options: {
 		processors: [
-			autoprefixer( { browsers: "last 2 versions, IE >= 9" } ),
+			autoprefixer( { browsers: "last 2 versions, IE >= 11" } ),
 		],
 	},
 	build: {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Update the CSS autoprefixer configuration to drop support for old Internet Explorer versions.

## Test instructions
No special testing necessary. This change saves a few KB in the built CSS files.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11149 
