### PR TITLE
Add additional logging for travis.

### DIFF
--- a/scripts/link_monorepo_to_plugin.js
+++ b/scripts/link_monorepo_to_plugin.js
@@ -4,7 +4,7 @@ const path = require( "path" );
 const readlineSync = require( "readline-sync" );
 const execSync = require( "child_process" ).execSync;
 
-const IS_TRAVIS = process.env.CI === "1";
+const IS_TRAVIS = process.env.CI === "true";
 const TRAVIS_BRANCH = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH;
 
 let monorepoLocation;
@@ -151,9 +151,15 @@ function unlinkAllYoastPackages() {
  * @returns {string} The checked out monorepo branch.
  */
 function checkoutMonorepoBranch( yoastSEOBranch ) {
-	const monorepoBranch = yoastSEOBranch === "trunk" ? "develop" : yoastSEOBranch;
+	let monorepoBranch = yoastSEOBranch === "trunk" ? "develop" : yoastSEOBranch;
 
-	execMonorepoNoOutput( `git checkout ${ monorepoBranch }` );
+	try {
+		execMonorepoNoOutput( `git checkout ${ monorepoBranch }` );
+	} catch ( error ) {
+		monorepoBranch = "master";
+		execMonorepoNoOutput( `git checkout master` );
+	}
+
 	return monorepoBranch;
 }
 
@@ -186,7 +192,7 @@ log( "Fetching branches of the monorepo." );
 execMonorepoNoOutput( "git fetch" );
 if ( IS_TRAVIS ) {
 	const monorepoBranch = checkoutMonorepoBranch( TRAVIS_BRANCH );
-	log( "Checking out " + monorepoBranch + "on the monorepo." );
+	log( "Checking out " + monorepoBranch + " on the monorepo." );
 }
 
 log( "Pulling the latest monorepo changes." );

--- a/scripts/link_monorepo_to_plugin.js
+++ b/scripts/link_monorepo_to_plugin.js
@@ -156,8 +156,8 @@ function checkoutMonorepoBranch( yoastSEOBranch ) {
 	try {
 		execMonorepoNoOutput( `git checkout ${ monorepoBranch }` );
 	} catch ( error ) {
-		monorepoBranch = "master";
-		execMonorepoNoOutput( `git checkout master` );
+		monorepoBranch = "develop";
+		execMonorepoNoOutput( `git checkout ${ monorepoBranch }` );
 	}
 
 	return monorepoBranch;


### PR DESCRIPTION
## Summary
Changed 
```javascript
const IS_TRAVIS = process.env.CI === "1";
``` 
to 
```javascript
const IS_TRAVIS = process.env.CI === "true";
```
Add an additional try/catch to have a fallback for when there is no remote branch.

This should be done because we want to test Travis against the same version of the monorepo as we test it locally whenever that is possible. By adding this integration, we ensure that users can enforce this by creating equally named branches on `wordpress-seo` and `javascript`.

This PR can be summarized in the following changelog entry:
* [non-user-facing] Travis should try to checkout the same branch on the monorepo.

## Test instructions
This PR can be tested by following these steps:
**Travis was not doing what we expected it to do. Now, we should be able to check that Travis checkouts the expected branch.**
1. Push a branch to github and ensure that a Travis build is started.
2. If the same branch exists on the monorepo, and the branch is a non-release branch with release tags, then Travis should checkout the same branch on the monorepo. This should be visible in the Travis logs where it states which branch it tries to check out.
3. Ensure that Travis still works when there is no matching monorepo branch and that it fallbacks to `develop`.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes N/A.
