### PR TITLE
Improve the WordPress Media Uploader Frame initialization.

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 151,
+			maxWarnings: 150,
 		},
 	},
 	tests: {

--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -1,4 +1,3 @@
-/* global wp */
 import React, { createRef } from "react";
 import PropTypes from "prop-types";
 import RaisedButton from "material-ui/RaisedButton";
@@ -13,14 +12,10 @@ class MediaUpload extends React.Component {
 
 		this.state = {
 			currentUpload: props.value,
-			mediaUpload: wp.media( {
-				title: this.props.translate( "Choose an image" ),
-				button: { text: this.props.translate( "Choose an image" ) },
-				multiple: false,
-			} ),
 		};
 
-		this.state.mediaUpload.on( "select", this.selectUpload.bind( this ) );
+		this.mediaUploaderFrame = null;
+		this.selectUpload = this.selectUpload.bind( this );
 		this.chooseButton = createRef();
 	}
 
@@ -48,14 +43,24 @@ class MediaUpload extends React.Component {
 	/**
 	 * Opens the media upload.
 	 *
-	 * @param {Event} evt The event that is triggered.
-	 *
 	 * @returns {void}
 	 */
-	chooseUpload( evt ) {
-		evt.preventDefault();
+	chooseUpload() {
+		// If the media upload frame already exists, open it and return.
+		if ( this.mediaUploaderFrame ) {
+			this.mediaUploaderFrame.open();
+			return;
+		}
 
-		this.state.mediaUpload.open();
+		// Set up the media upload frame.
+		this.mediaUploaderFrame = window.wp.media( {
+			title: this.props.translate( "Choose an image andreatest" ),
+			button: { text: this.props.translate( "Choose an image andreatest" ) },
+			multiple: false,
+		} );
+
+		this.mediaUploaderFrame.on( "select", this.selectUpload );
+		this.mediaUploaderFrame.open();
 	}
 
 	/**
@@ -64,7 +69,7 @@ class MediaUpload extends React.Component {
 	 * @returns {void}
 	 */
 	selectUpload() {
-		var attachment = this.state.mediaUpload.state().get( "selection" ).first().toJSON();
+		var attachment = this.mediaUploaderFrame.state().get( "selection" ).first().toJSON();
 
 		this.setState( {
 			currentUpload: attachment.url,

--- a/js/src/wp-seo-admin-media.js
+++ b/js/src/wp-seo-admin-media.js
@@ -8,71 +8,42 @@ jQuery( document ).ready(
 			return;
 		}
 
-		/**
-		 * Returns the target HTML id for this button element.
-		 *
-		 * @param {Object} $button The image select button.
-		 * @returns {string} The HTML id for the URL input field.
-		 */
-		function getTarget( $button ) {
-			$button = $( $button );
-
-			let target = $button.data( "target" );
-
-			// This is the implicit way to define which URL field to fill.
-			if ( ! target || target === "" ) {
-				target = $( $button ).attr( "id" ).replace( /_button$/, "" );
-			}
-
-			return target;
-		}
-
-		/**
-		 * Returns the hidden ID input element for this button.
-		 *
-		 * @param {Object} $button The image select button.
-		 * @returns {string} The HTML id for the ID input field.
-		 */
-		function getIdTarget( $button ) {
-			$button = $( $button );
-
-			return $button.data( "target-id" );
-		}
-
 		$( ".wpseo_image_upload_button" ).each( function( index, element ) {
-			const urlInputHtmlId = getTarget( element );
-			const idInputHtmlId = getIdTarget( element );
+			const $urlInput = $( "#" + $( element ).data( "target" ) );
+			const $idInput = $( "#" + $( element ).data( "target" ) + "-id" );
 
-			const $urlInput = $( "#" + urlInputHtmlId );
-			const $idInput = $( "#" + idInputHtmlId );
-
-			// eslint-disable-next-line
-			var wpseoCustomUploader = wp.media.frames.file_frame = wp.media( {
-				title: wpseoMediaL10n.choose_image,
-				button: { text: wpseoMediaL10n.choose_image },
-				multiple: false,
-			} );
-
-			wpseoCustomUploader.on( "select", function() {
-				var attachment = wpseoCustomUploader.state().get( "selection" ).first().toJSON();
-
-				$urlInput.val( attachment.url );
-				$idInput.val( attachment.id );
-			}
-			);
+			let wpseoCustomUploader;
 
 			const $uploadImageButton = $( element );
 
-			$uploadImageButton.click( function( e ) {
-				e.preventDefault();
+			$uploadImageButton.click( function() {
+				// If the media uploader frame for this button already exists, open it and return.
+				if ( wpseoCustomUploader ) {
+					wpseoCustomUploader.open();
+					return;
+				}
+
+				// Set up the media uploader frame for this button.
+				// eslint-disable-next-line
+				wpseoCustomUploader = wp.media.frames.file_frame = wp.media( {
+					title: wpseoMediaL10n.choose_image,
+					button: { text: wpseoMediaL10n.choose_image },
+					multiple: false,
+				} );
+
+				wpseoCustomUploader.on( "select", function() {
+					var attachment = wpseoCustomUploader.state().get( "selection" ).first().toJSON();
+
+					$urlInput.val( attachment.url );
+					$idInput.val( attachment.id );
+				} );
+
 				wpseoCustomUploader.open();
 			} );
 
 			$uploadImageButton
 				.siblings( ".wpseo_image_remove_button" )
-				.on( "click", ( e ) => {
-					e.preventDefault();
-
+				.on( "click", () => {
 					$urlInput.val( "" );
 					$idInput.val( "" );
 				} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve the WordPress Media Uploader Frame initialization

## Relevant technical choices:
In the Plugin we're calling the WordPress media uploader in 4 cases:
- featured image upload (to plug our `FeaturedImagePlugin` for the analysis)
- facebook image upload
- twitter image upload
- configuration wizard: organization image

In all these cases, the Media Uploader Frame is initialized on DOM ready, before it's actually used.

In WordPress core instead, some care has been taken to initialize it only when clicking on something, i.e. only when needed, to avoid running unnecessary JavaScript. For a simple example of the core usage, see https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/admin/custom-background.js?rev=43347&marks=86-143#L79

With this PR:
- the Media Uploader Frame is initialized only when clicking on the upload buttons
- rendering of some empty buttons in the DOM is avoided


## Test instructions

**First, test what happens on trunk**

The easier case to test is in the Configuration Wizard:

- be sure you've previously set your site to represent a _person_
- go in the Configuration Wizard > step 3
- open your dev tools and observe the rendered source, at the bottom before the closing body
- click the radio button `Organization`
- observe a new, hidden, button is injected in the DOM: `<button type="button" class="browser" style="display: none;"></button>`
- this means the Media Uploader Frame has been initialized and we're just ran some JS from the core media views

The same happens in the post meta box:
- use the Classic Editor
- edit a post or create a new one
- observe there are _three_ empty buttons at the end of the DOM
- this means we've just initialized three instances of the Media Uploader Frame

The same happens in Gutenberg, with the difference that Gutenberg initializes some additional Media Uploader Frames. When Yoast SEO is activated I've counted from 5 to 9 instances of the uploader (the varying amount depends on Gutenberg, not sure why).

**Then, thest this PR:**

Repeat the tests above and observe that the behavior is now different and the Media Uploader Frame is _not_ inizialized when there's no need for it:
- in the Configuration Wizard > step 3: click "Organization" and observe there's no hidden button 
- when clicking "Choose an image" the button is added and immediately replaced by the real uploader (the media views work this way...) so you'll see something like `<div id="__wp-uploader-id-2" class="supports-drag-drop"  ...`
- check setting and removing the image works as expected

Same in the post meta box;
- create a new post in the Classic Editor
- notice there are no hidden buttons at the end of the DOM
- in the meta box > Social: set images for Facebook and Twitter
- notice the Media Uploader Frame is initialized only when clicking on the "Upload Image" buttons
- clicking again the buttons and close the modal multiple times: notice the existing uploaders are reused: no new ``<div id="__wp-uploader- ...` are added to the DOM
- check setting and removing the images works as expected
- check the same for the post featured image
- check setting and removing the featured image works as expected

You can repeat these checks on Gutenberg: remind that Gutenberg add its own uploders (ignore them).

Note: for the featured image, I've slightly reorganized the code because some parts meant to run for the Classic Editor were unnecessarily running also on Gutenberg.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #6273 
