### PR TITLE
fix enrich defaults

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -98,6 +98,13 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	);
 
 	/**
+	 * Used for "caching" during pageload.
+	 *
+	 * @var array
+	 */
+	protected $enriched_defaults = array();
+
+	/**
 	 * Array of variable option name patterns for the option.
 	 *
 	 * @var array
@@ -233,9 +240,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @return  void
 	 */
 	public function enrich_defaults() {
-		$cache_key = 'yoast_titles_rich_defaults_' . $this->option_name;
-
-		$enriched_defaults = wp_cache_get( $cache_key );
+		$enriched_defaults = $this->enriched_defaults;
 		if ( false !== $enriched_defaults ) {
 			$this->defaults += $enriched_defaults;
 			return;
@@ -291,7 +296,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 			}
 		}
 
-		wp_cache_set( $cache_key, $enriched_defaults );
+		$this->enriched_defaults = $enriched_defaults;
 		$this->defaults += $enriched_defaults;
 	}
 
@@ -305,7 +310,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 * @return void
 	 */
 	public function invalidate_enrich_defaults_cache() {
-		wp_cache_delete( 'yoast_titles_rich_defaults_' . $this->option_name );
+		$this->enriched_defaults = null;
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -102,7 +102,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 *
 	 * @var array
 	 */
-	protected $enriched_defaults = array();
+	protected $enriched_defaults = null;
 
 	/**
 	 * Array of variable option name patterns for the option.
@@ -241,7 +241,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	 */
 	public function enrich_defaults() {
 		$enriched_defaults = $this->enriched_defaults;
-		if ( false !== $enriched_defaults ) {
+		if ( null !== $enriched_defaults ) {
 			$this->defaults += $enriched_defaults;
 			return;
 		}

--- a/integration-tests/inc/options/test-class-wpseo-option-titles.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-titles.php
@@ -19,6 +19,12 @@ class WPSEO_Option_Titles_Test extends WPSEO_UnitTestCase {
 	public function test_enrich_defaults_cache_invalidation() {
 		$wpseo_option_titles = WPSEO_Option_Titles::get_instance();
 
+		// Register all actions again as they will have been removed in previous teardowns.
+		add_action( 'registered_post_type', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'unregistered_post_type', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'registered_taxonomy', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'unregistered_taxonomy', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
+
 		register_post_type( 'custom-post-type', array( 'public' => true ) );
 		$this->assertArrayHasKey( 'title-custom-post-type', $wpseo_option_titles->get_defaults() );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix over-enthusiastic use of `wp_cache` in `WPSEO_Option_Titles`.

## Relevant technical choices:

* Implemented suggestions by @herregroen in #12570

## Test instructions
This PR can be tested by following these steps:

* Everything everywhere (both in front and backend editing of posts) should keep working as it does.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12570 
Fixes #11976
