### PR TITLE
Remove primary term cache, as it only slows down

### DIFF
--- a/src/watchers/primary-term-watcher.php
+++ b/src/watchers/primary-term-watcher.php
@@ -112,15 +112,7 @@ class Primary_Term_Watcher implements Integration {
 			$post_id = $this->get_current_id();
 		}
 
-		// @todo determine if caching is needed here, no database queries are used?
-		$taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_id, 'wpseo' );
-		if ( false !== $taxonomies ) {
-			return $taxonomies;
-		}
-
 		$taxonomies = $this->generate_primary_term_taxonomies( $post_id );
-
-		wp_cache_set( 'primary_term_taxonomies_' . $post_id, $taxonomies, 'wpseo' );
 
 		return $taxonomies;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removed redundant caching call for primary terms.

## Relevant technical choices:

* Seems that this causes a cache call to say a redis / memcached cache, when there is no database query that it prevents.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


