### PR TITLE
[tests] QA: use global constants with a fully qualified name

### DIFF
--- a/tests/admin/admin-asset-analysis-worker-location-test.php
+++ b/tests/admin/admin-asset-analysis-worker-location-test.php
@@ -20,11 +20,11 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 		$version          = 'test-version';
 
 		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $version );
-		$suffix   = ( YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
+		$suffix   = ( \YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->once()
-			->with( $location->get_asset()->get_src(), PHP_URL_SCHEME )
+			->with( $location->get_asset()->get_src(), \PHP_URL_SCHEME )
 			->andReturnNull();
 
 		Monkey\Functions\expect( 'plugins_url' )
@@ -46,11 +46,11 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 		$version          = 'test-version';
 
 		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $version, $custom_file_name );
-		$suffix   = ( YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
+		$suffix   = ( \YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->once()
-			->with( $location->get_asset()->get_src(), PHP_URL_SCHEME )
+			->with( $location->get_asset()->get_src(), \PHP_URL_SCHEME )
 			->andReturnNull();
 
 		Monkey\Functions\expect( 'plugins_url' )

--- a/tests/config/database-migration-test.php
+++ b/tests/config/database-migration-test.php
@@ -31,7 +31,7 @@ class Database_Migration_Test extends TestCase {
 	public function test_initialize_with_set_defines_failing() {
 		Monkey\Functions\expect( 'set_transient' )
 			->once()
-			->with( Database_Migration::MIGRATION_ERROR_TRANSIENT_KEY, Database_Migration::MIGRATION_STATE_ERROR, DAY_IN_SECONDS )
+			->with( Database_Migration::MIGRATION_ERROR_TRANSIENT_KEY, Database_Migration::MIGRATION_STATE_ERROR, \DAY_IN_SECONDS )
 			->andReturn( true );
 
 		$instance = $this
@@ -292,8 +292,8 @@ class Database_Migration_Test extends TestCase {
 
 		$defines = $instance->get_defines( 'table_name' );
 
-		$this->assertArrayHasKey( YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_BASE', $defines );
-		$this->assertArrayHasKey( YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_TS_SCHEMA_TBL_NAME', $defines );
+		$this->assertArrayHasKey( \YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_BASE', $defines );
+		$this->assertArrayHasKey( \YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_TS_SCHEMA_TBL_NAME', $defines );
 
 		$this->assertContains( 'table_name', $defines );
 	}

--- a/tests/config/dependency-management-test.php
+++ b/tests/config/dependency-management-test.php
@@ -38,11 +38,11 @@ class Dependency_Management_Test extends TestCase {
 		$instance
 			->expects( $this->once() )
 			->method( 'class_alias' )
-			->with( 'My_Class', YOAST_VENDOR_NS_PREFIX . '\My_Class' )
+			->with( 'My_Class', \YOAST_VENDOR_NS_PREFIX . '\My_Class' )
 			->will( $this->returnValue( true ) );
 
 		/** @var \Yoast\WP\Free\Config\Dependency_Management $instance */
-		$instance->ensure_class_alias( YOAST_VENDOR_NS_PREFIX . '\My_Class' );
+		$instance->ensure_class_alias( \YOAST_VENDOR_NS_PREFIX . '\My_Class' );
 	}
 
 	/**
@@ -97,7 +97,7 @@ class Dependency_Management_Test extends TestCase {
 			->method( 'class_alias' );
 
 		/** @var \Yoast\WP\Free\Config\Dependency_Management $instance */
-		$instance->ensure_class_alias( YOAST_VENDOR_NS_PREFIX . '\Some_Class' );
+		$instance->ensure_class_alias( \YOAST_VENDOR_NS_PREFIX . '\Some_Class' );
 	}
 
 	/**
@@ -127,7 +127,7 @@ class Dependency_Management_Test extends TestCase {
 			->method( 'class_alias' );
 
 		/** @var \Yoast\WP\Free\Config\Dependency_Management $instance */
-		$instance->ensure_class_alias( YOAST_VENDOR_NS_PREFIX . '\Some_Class' );
+		$instance->ensure_class_alias( \YOAST_VENDOR_NS_PREFIX . '\Some_Class' );
 	}
 
 	/**

--- a/tests/metabox/metabox-editor-test.php
+++ b/tests/metabox/metabox-editor-test.php
@@ -30,13 +30,13 @@ class Metabox_Editor_Test extends TestCase {
 	public function get_flat_version() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 
-		return $asset_manager->flatten_version( WPSEO_VERSION );
+		return $asset_manager->flatten_version( \WPSEO_VERSION );
 	}
 
 	public function test_add_css_inside_editor_empty() {
 		Monkey\Functions\expect('plugins_url' )
 			->once()
-			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . "/../../wp-seo.php" ) )
+			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . "/../../wp-seo.php" ) )
 			->andReturn( 'example.org' );
 
 		$actual = $this->subject->add_css_inside_editor( '' );
@@ -48,7 +48,7 @@ class Metabox_Editor_Test extends TestCase {
 	public function test_add_css_inside_editor_preexisting() {
 		Monkey\Functions\expect('plugins_url' )
 			->once()
-			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . "/../../wp-seo.php" ) )
+			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . "/../../wp-seo.php" ) )
 			->andReturn( 'example.org' );
 
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

When PHP encounters an unqualified constant in a namespaced file, it will first try and find the constant within the namespace and only when it can not find it in the namespace, fall-back to the global constant.

Using fully qualified constant names when using a global constant ensures that PHP will bypass the search within the namespace and use the global constant directly.

Ref: https://www.php.net/manual/en/language.namespaces.fallback.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
