### PR TITLE
Uses WPSEO_Utils::home_url() if home page shows latest posts

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -25,50 +25,10 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	protected static $classifier;
 
 	/**
-	 * Static front page ID.
-	 *
-	 * @var int
-	 */
-	protected static $page_on_front_id;
-
-	/**
-	 * Posts page ID.
-	 *
-	 * @var int
-	 */
-	protected static $page_for_posts_id;
-
-	/**
 	 * Set up object properties for data reuse.
 	 */
 	public function __construct() {
 		add_filter( 'save_post', array( $this, 'save_post' ) );
-	}
-
-	/**
-	 * Get front page ID.
-	 *
-	 * @return int
-	 */
-	protected function get_page_on_front_id() {
-		if ( ! isset( self::$page_on_front_id ) ) {
-			self::$page_on_front_id = (int) get_option( 'page_on_front' );
-		}
-
-		return self::$page_on_front_id;
-	}
-
-	/**
-	 * Get page for posts ID.
-	 *
-	 * @return int
-	 */
-	protected function get_page_for_posts_id() {
-		if ( ! isset( self::$page_for_posts_id ) ) {
-			self::$page_for_posts_id = (int) get_option( 'page_for_posts' );
-		}
-
-		return self::$page_for_posts_id;
 	}
 
 	/**
@@ -313,8 +273,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	protected function get_excluded_posts( $post_type ) {
 		$excluded_posts_ids = array();
 
-		if ( $post_type === 'page' && $this->get_page_for_posts_id() ) {
-			$excluded_posts_ids[] = $this->get_page_for_posts_id();
+		$page_on_front_id = ( $post_type === 'page' ) ? (int) get_option( 'page_on_front' ) : 0;
+		if ( $page_on_front_id > 0 ) {
+			$excluded_posts_ids[] = $page_on_front_id;
 		}
 
 		/**
@@ -329,8 +290,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		$excluded_posts_ids = array_map( 'intval', $excluded_posts_ids );
 
-		if ( $post_type === 'page' && $this->get_page_on_front_id() ) {
-			$excluded_posts_ids[] = $this->get_page_on_front_id();
+		$page_for_posts_id = ( $post_type === 'page' ) ? (int) get_option( 'page_for_posts' ) : 0;
+		if ( $page_for_posts_id > 0 ) {
+			$excluded_posts_ids[] = $page_for_posts_id;
 		}
 
 		return array_unique( $excluded_posts_ids );
@@ -692,5 +654,33 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		_deprecated_function( __METHOD__, 'WPSEO 11.5', 'WPSEO_Utils::home_url' );
 
 		return WPSEO_Utils::home_url();
+	}
+
+	/**
+	 * Get front page ID.
+	 *
+	 * @deprecated 11.5
+	 * @codeCoverageIgnore
+	 *
+	 * @return int
+	 */
+	protected function get_page_on_front_id() {
+		_deprecated_function( __METHOD__, 'WPSEO 11.5' );
+
+		return (int) get_option( 'page_on_front' );
+	}
+
+	/**
+	 * Get page for posts ID.
+	 *
+	 * @deprecated 11.5
+	 * @codeCoverageIgnore
+	 *
+	 * @return int
+	 */
+	protected function get_page_for_posts_id() {
+		_deprecated_function( __METHOD__, 'WPSEO 11.5' );
+
+		return (int) get_option( 'page_for_posts' );
 	}
 }

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -390,9 +390,10 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		if ( $post_type === 'page' ) {
 
-			if ( $this->get_page_on_front_id() ) {
+			$page_on_front_id = (int) get_option( 'page_on_front' );
+			if ( $page_on_front_id > 0 ) {
 				$front_page = $this->get_url(
-					get_post( $this->get_page_on_front_id() )
+					get_post( $page_on_front_id )
 				);
 			}
 
@@ -476,12 +477,12 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 *
 	 * @since 11.5
 	 *
-	 * @param string $post_type Post type.
-	 * @param int    $page_id   The page id.
+	 * @param string $post_type       Post type.
+	 * @param int    $archive_page_id The page id.
 	 *
 	 * @return bool True when post type archive is indexable.
 	 */
-	protected function is_post_type_archive_indexable( $post_type, $page_id = -1 ) {
+	protected function is_post_type_archive_indexable( $post_type, $archive_page_id = -1 ) {
 
 		if ( WPSEO_Options::get( 'noindex-ptarchive-' . $post_type, false ) ) {
 			return false;
@@ -492,12 +493,12 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 *
 		 * @since 9.3
 		 *
-		 * @param string $pt_archive_page_id The post_id of the page.
-		 * @param string $post_type          The post type this archive is for.
+		 * @param string $archive_page_id The post_id of the page.
+		 * @param string $post_type       The post type this archive is for.
 		 */
-		$page_id = (int) apply_filters( 'wpseo_sitemap_page_for_post_type_archive', $page_id, $post_type );
+		$archive_page_id = (int) apply_filters( 'wpseo_sitemap_page_for_post_type_archive', $archive_page_id, $post_type );
 
-		if ( $page_id > 0 && WPSEO_Meta::get_value( 'meta-robots-noindex', $page_id ) === '1' ) {
+		if ( $archive_page_id > 0 && WPSEO_Meta::get_value( 'meta-robots-noindex', $archive_page_id ) === '1' ) {
 			return false;
 		}
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -11,13 +11,6 @@
 class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 	/**
-	 * Holds the home_url() value.
-	 *
-	 * @var string
-	 */
-	protected static $home_url;
-
-	/**
 	 * Holds image parser instance.
 	 *
 	 * @var WPSEO_Sitemap_Image_Parser
@@ -107,17 +100,12 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	/**
 	 * Get Home URL.
 	 *
-	 * This has been moved from the constructor because wp_rewrite is not available on plugins_loaded in multisite.
-	 * It will now be requested on need and not on initialization.
+	 * This wrapper method keeps up the compatibility with WPML. It returns "original home URL".
 	 *
 	 * @return string
 	 */
 	protected function get_home_url() {
-		if ( ! isset( self::$home_url ) ) {
-			self::$home_url = WPSEO_Utils::home_url();
-		}
-
-		return self::$home_url;
+		return WPSEO_Utils::home_url();
 	}
 
 	/**

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -91,21 +91,10 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	protected function get_classifier() {
 		if ( ! isset( self::$classifier ) ) {
-			self::$classifier = new WPSEO_Link_Type_Classifier( $this->get_home_url() );
+			self::$classifier = new WPSEO_Link_Type_Classifier( home_url() );
 		}
 
 		return self::$classifier;
-	}
-
-	/**
-	 * Get Home URL.
-	 *
-	 * This wrapper method keeps up the compatibility with WPML. It returns "original home URL".
-	 *
-	 * @return string
-	 */
-	protected function get_home_url() {
-		return WPSEO_Utils::home_url();
 	}
 
 	/**
@@ -688,5 +677,19 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	protected function get_options() {
 		_deprecated_function( __METHOD__, 'WPSEO 7.0', 'WPSEO_Options::get' );
+	}
+
+	/**
+	 * Get Home URL.
+	 *
+	 * @deprecated 11.5
+	 * @codeCoverageIgnore
+	 *
+	 * @return string
+	 */
+	protected function get_home_url() {
+		_deprecated_function( __METHOD__, 'WPSEO 11.5', 'WPSEO_Utils::home_url' );
+
+		return WPSEO_Utils::home_url();
 	}
 }

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -266,24 +266,20 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$current_home     = get_option( 'home' );
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
 
-		add_filter( 'wpseo_xml_sitemap_post_url', array( $this, 'set_post_sitemap_url' ) );
+		$post_object = $this->factory()->post->create_and_get();
+		$post_url    = $sitemap_provider->get_url( $post_object );
 
-		update_option( 'home', $this->set_post_sitemap_url( null ) );
-		$this->assertFalse( $sitemap_provider->get_url( $this->factory()->post->create_and_get() ) );
+		$this->assertContains( $current_home, $post_url['loc'] );
+
+		// Change home URL.
+		update_option( 'home', 'http://example.com' );
+		wp_cache_delete( 'alloptions', 'options' );
+
+		$this->assertFalse( $sitemap_provider->get_url( $post_object ) );
+
+		// Revert original home URL.
 		update_option( 'home', $current_home );
-
-		remove_filter( 'wpseo_xml_sitemap_post_url', array( $this, 'set_post_sitemap_url' ) );
-	}
-
-	/**
-	 * Helper function to mock sitemap URL.
-	 *
-	 * @param string $url URL to mock.
-	 *
-	 * @return string URL to use.
-	 */
-	public function set_post_sitemap_url( $url ) {
-		return 'http://example.com';
+		wp_cache_delete( 'alloptions', 'options' );
 	}
 
 	/**

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -263,21 +263,14 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_url
 	 */
 	public function test_get_url() {
-		$instance = $this
-			->getMockBuilder( 'WPSEO_Post_Type_Sitemap_Provider_Double' )
-			->setMethods( array( 'get_home_url' ) )
-			->getMock();
-
-		$instance
-			->expects( $this->once() )
-			->method( 'get_home_url' )
-			->will( $this->returnValue( 'http://example.org' ) );
+		$current_home     = get_option( 'home' );
+		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
 
 		add_filter( 'wpseo_xml_sitemap_post_url', array( $this, 'set_post_sitemap_url' ) );
 
-		/** @var WPSEO_Post_Type_Sitemap_Provider_Double $instance */
-		$instance->set_classifier( null );
-		$this->assertFalse( $instance->get_url( $this->factory->post->create() ) );
+		update_option( 'home', $this->set_post_sitemap_url( null ) );
+		$this->assertFalse( $sitemap_provider->get_url( $this->factory()->post->create_and_get() ) );
+		update_option( 'home', $current_home );
 
 		remove_filter( 'wpseo_xml_sitemap_post_url', array( $this, 'set_post_sitemap_url' ) );
 	}

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -169,7 +169,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->assertContains( get_permalink( $front_page->ID ), $sitemap_links[0] );
 
 		$sitemap_links = $sitemap_provider->get_sitemap_links( 'post', 2, 1 );
-		$this->assertContains( get_post_type_archive_link( 'post' ), $sitemap_links[0] );
+		$this->assertContains( WPSEO_Utils::home_url(), $sitemap_links[0] );
 		$this->assertContains( get_permalink( $posts_page->ID ), $sitemap_links[0] );
 		$this->assertContains( get_permalink( $post_id ), $sitemap_links[1] );
 

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -169,7 +169,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->assertContains( get_permalink( $front_page->ID ), $sitemap_links[0] );
 
 		$sitemap_links = $sitemap_provider->get_sitemap_links( 'post', 2, 1 );
-		$this->assertContains( WPSEO_Utils::home_url(), $sitemap_links[0] );
+		$this->assertContains( get_post_type_archive_link( 'post' ), $sitemap_links[0] );
 		$this->assertContains( get_permalink( $posts_page->ID ), $sitemap_links[0] );
 		$this->assertContains( get_permalink( $post_id ), $sitemap_links[1] );
 
@@ -182,7 +182,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->assertContains( WPSEO_Utils::home_url(), $sitemap_links[0] );
 
 		$sitemap_links = $sitemap_provider->get_sitemap_links( 'post', 2, 1 );
-		$this->assertContains( get_post_type_archive_link( 'post' ), $sitemap_links[0] );
+		$this->assertContains( WPSEO_Utils::home_url(), $sitemap_links[0] );
 		$this->assertContains( get_permalink( $post_id ), $sitemap_links[1] );
 
 		update_option( 'show_on_front', $current_show_on_front );

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -151,7 +151,6 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $front_page->ID );
 		update_option( 'page_for_posts', 0 );
-		$sitemap_provider->reset();
 
 		$sitemap_links = $sitemap_provider->get_sitemap_links( 'page', 1, 1 );
 		$this->assertContains( get_permalink( $front_page->ID ), $sitemap_links[0] );
@@ -162,7 +161,6 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $front_page->ID );
 		update_option( 'page_for_posts', $posts_page->ID );
-		$sitemap_provider->reset();
 
 		$sitemap_links = $sitemap_provider->get_sitemap_links( 'page', 1, 1 );
 		$this->assertContains( WPSEO_Utils::home_url(), $sitemap_links[0] );
@@ -176,7 +174,6 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		update_option( 'show_on_front', 'posts' );
 		update_option( 'page_on_front', 0 );
 		update_option( 'page_for_posts', 0 );
-		$sitemap_provider->reset();
 
 		$sitemap_links = $sitemap_provider->get_sitemap_links( 'page', 1, 1 );
 		$this->assertContains( WPSEO_Utils::home_url(), $sitemap_links[0] );

--- a/tests/doubles/class-wpseo-post-type-sitemap-provider-double.php
+++ b/tests/doubles/class-wpseo-post-type-sitemap-provider-double.php
@@ -14,7 +14,6 @@ class WPSEO_Post_Type_Sitemap_Provider_Double extends WPSEO_Post_Type_Sitemap_Pr
 	 * Reset static variables.
 	 */
 	public function reset() {
-		self::$home_url          = null;
 		self::$page_on_front_id  = null;
 		self::$page_for_posts_id = null;
 	}

--- a/tests/doubles/class-wpseo-post-type-sitemap-provider-double.php
+++ b/tests/doubles/class-wpseo-post-type-sitemap-provider-double.php
@@ -11,14 +11,6 @@
 class WPSEO_Post_Type_Sitemap_Provider_Double extends WPSEO_Post_Type_Sitemap_Provider {
 
 	/**
-	 * Reset static variables.
-	 */
-	public function reset() {
-		self::$page_on_front_id  = null;
-		self::$page_for_posts_id = null;
-	}
-
-	/**
 	 * @inheritdoc
 	 */
 	public function get_url( $post ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes missing trailing slash  for the homepage on post sitemap.

## Relevant technical choices:

* Uses method _WPSEO_Utils::home_url()_ to retrieve the homepage URL for post and page sitemaps.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set the homepage to show the latest posts in Settings → Reading.
* Check post and page sitemaps. They should shown same URL for the homepage.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have updated unittests to verify the code works as intended

Fixes #12190
Partially fixes #6926
