### PR TITLE
Filter the media modals to show only images.

### DIFF
--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -17,6 +17,9 @@ class MediaUpload extends React.Component {
 				title: this.props.translate( "Choose an image" ),
 				button: { text: this.props.translate( "Choose an image" ) },
 				multiple: false,
+				library: {
+					type: "image",
+				},
 			} ),
 		};
 

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -206,7 +206,7 @@ export default class Question extends Component {
 		return <div className="schema-faq-section-button-container">
 			<MediaUpload
 				onSelect={ this.onSelectImage }
-				type="image"
+				allowedTypes={ [ "image" ] }
 				value={ attributes.id }
 				render={ this.getMediaUploadButton }
 			/>

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -194,7 +194,7 @@ export default class HowToStep extends Component {
 			{ ! HowToStep.getImageSrc( step.text ) &&
 			<MediaUpload
 				onSelect={ this.onSelectImage }
-				type="image"
+				allowedTypes={ [ "image" ] }
 				value={ step.id }
 				render={ this.getMediaUploadButton }
 			/>

--- a/js/src/wp-seo-admin-media.js
+++ b/js/src/wp-seo-admin-media.js
@@ -51,6 +51,9 @@ jQuery( document ).ready(
 				title: wpseoMediaL10n.choose_image,
 				button: { text: wpseoMediaL10n.choose_image },
 				multiple: false,
+				library: {
+					type: "image",
+				},
 			} );
 
 			wpseoCustomUploader.on( "select", function() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Filter the Media Modals to show only images.

## Test instructions
Check in the following places:

SEO > Search appearance > Knowledge Graph & Schema.org > Organization > Upload image
SEO > General > Configuration wizard step 3 > Organization > Choose an image
FAQ block > Question > Add image 
How-to block > Step > Add image 

When the media modal opens, check it's displaying only images and not other attachment types.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13074
