### PR TITLE
Fix automated tests by ensuring that the correct branch is checked out.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=latest PHPLINT=1 PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION=lts/*
+      env: WP_VERSION=latest PHPLINT=1 PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION=lts/* AUTO_CHECKOUT_MONOREPO_BRANCH=1
     - php: 7.3
       env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
     - php: 5.6

--- a/scripts/link_monorepo_to_plugin.js
+++ b/scripts/link_monorepo_to_plugin.js
@@ -4,7 +4,7 @@ const path = require( "path" );
 const readlineSync = require( "readline-sync" );
 const execSync = require( "child_process" ).execSync;
 
-const IS_TRAVIS = process.env.CI === "true";
+const AUTO_CHECKOUT = process.env.AUTO_CHECKOUT_MONOREPO_BRANCH;
 const TRAVIS_BRANCH = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH;
 
 let monorepoLocation;
@@ -190,7 +190,7 @@ log( `Your monorepo is located in "${ getMonorepoLocationFromFile() }". ` );
 
 log( "Fetching branches of the monorepo." );
 execMonorepoNoOutput( "git fetch" );
-if ( IS_TRAVIS ) {
+if ( AUTO_CHECKOUT ) {
 	const monorepoBranch = checkoutMonorepoBranch( TRAVIS_BRANCH );
 	log( "Checking out " + monorepoBranch + " on the monorepo." );
 }
@@ -198,7 +198,7 @@ if ( IS_TRAVIS ) {
 log( "Pulling the latest monorepo changes." );
 try {
 	execMonorepoNoOutput( "git pull 2>/dev/null" );
-} catch( error ) {
+} catch ( error ) {
 	// No remote is specified.
 	warning( "git could not pull changes from the remote repo.\nIf you are working on a local version of the javascript branch, this is expected behaviour.\nContinuing..." )
 }


### PR DESCRIPTION
## Summary
The automated tests are currently failing because the tests are running on the `master` branch. Due to the changes introduced in #13036, `link-monorepo` now actually tries to checkout the branch on which it is running when run inside Travis. Thus, the link-monorepo script checks out the `master` branch of the monorepo when running the automated tests on the master branch.

This PR can be summarised in the following changelog entry:

* This PR adds an additional environment variable that can be set to allow Travis to automatically set the monorepo branch. If `AUTO_CHECKOUT_MONOREPO_BRANCH` is set to `1`, `link_monorepo_to_plugin.js` will automatically try to checkout a branch based on the branch on which it is currently running.

## Relevant technical choices:

* #13036 was created to hopefully fix the difference in snapshots between the `release` branches and the `master` branch. This PR tries to work around those changes and add an additional variable to prevent us from always trying to check out a different branch.

## Test instructions
[non-user-facing]

This PR can be tested by following these steps:
* See that the automated tests are failing because the `master` branch of the monorepo is used.
* Run the tests again after merging this PR in `trunk`. See that `develop` is now used instead of `master`.
* The automated tests should work again.

Fixes #13077 
