### PR TITLE
[tests] QA: use the most specific PHPUnit assertion possible

### DIFF
--- a/tests/admin/admin-asset-analysis-worker-location-test.php
+++ b/tests/admin/admin-asset-analysis-worker-location-test.php
@@ -33,7 +33,7 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 			->andReturn( 'asset_location' );
 
 		$actual = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
-		$this->assertEquals( 'asset_location', $actual );
+		$this->assertSame( 'asset_location', $actual );
 	}
 
 	/**
@@ -59,6 +59,6 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 			->andReturn( 'asset_location' );
 
 		$actual = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
-		$this->assertEquals( 'asset_location', $actual );
+		$this->assertSame( 'asset_location', $actual );
 	}
 }

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -114,21 +114,23 @@ class Admin_Features_Test extends TestCase {
 	 */
 	public function test_update_contactmethods() {
 		$class_instance = $this->get_admin_with_expectations();
+		$result         = $class_instance->update_contactmethods( array() );
+		\ksort( $result );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'facebook'   => 'Facebook profile URL',
 				'instagram'  => 'Instagram profile URL',
 				'linkedin'   => 'LinkedIn profile URL',
-				'pinterest'  => 'Pinterest profile URL',
-				'twitter'    => 'Twitter username (without @)',
 				'myspace'    => 'MySpace profile URL',
+				'pinterest'  => 'Pinterest profile URL',
 				'soundcloud' => 'SoundCloud profile URL',
 				'tumblr'     => 'Tumblr profile URL',
-				'youtube'    => 'YouTube profile URL',
+				'twitter'    => 'Twitter username (without @)',
 				'wikipedia'  => 'Wikipedia page about you<br/><small>(if one exists)</small>',
+				'youtube'    => 'YouTube profile URL',
 			),
-			$class_instance->update_contactmethods( array() )
+			$result
 		);
 	}
 }

--- a/tests/config/database-migration-test.php
+++ b/tests/config/database-migration-test.php
@@ -203,7 +203,7 @@ class Database_Migration_Test extends TestCase {
 			new Dependency_Management()
 		);
 
-		$this->assertEquals( 'foo', $instance->get_charset() );
+		$this->assertSame( 'foo', $instance->get_charset() );
 	}
 
 	/**

--- a/tests/config/plugin-test.php
+++ b/tests/config/plugin-test.php
@@ -157,7 +157,7 @@ class Plugin_Test extends TestCase {
 
 		$instance->initialize();
 
-		$this->assertAttributeEquals( false, 'initialize_success', $instance );
+		$this->assertAttributeSame( false, 'initialize_success', $instance );
 	}
 
 	/**
@@ -226,7 +226,7 @@ class Plugin_Test extends TestCase {
 
 		$instance->register_hooks();
 
-		$this->assertEquals( ( $action_count + 1 ), \did_action( 'wpseo_load_integrations' ) );
+		$this->assertSame( ( $action_count + 1 ), \did_action( 'wpseo_load_integrations' ) );
 	}
 
 	/**

--- a/tests/config/upgrade-test.php
+++ b/tests/config/upgrade-test.php
@@ -43,6 +43,6 @@ class Upgrade_Test extends TestCase {
 
 		$actual = \has_action( 'wpseo_run_upgrade', array( $upgrade, 'do_upgrade' ) );
 
-		$this->assertEquals( 10, $actual );
+		$this->assertNotFalse( $actual );
 	}
 }

--- a/tests/exceptions/no-indexable-found-test.php
+++ b/tests/exceptions/no-indexable-found-test.php
@@ -57,7 +57,7 @@ class No_Indexable_Found_Test extends TestCase {
 			throw No_Indexable_Found::from_post_id( 1 );
 		}
 		catch ( No_Indexable_Found $e ) {
-			$this->assertEquals(
+			$this->assertSame(
 				'There is no indexable found for post id 1.',
 				$e->getMessage()
 			);
@@ -77,7 +77,7 @@ class No_Indexable_Found_Test extends TestCase {
 			throw No_Indexable_Found::from_term_id( 1, 'category' );
 		}
 		catch ( No_Indexable_Found $e ) {
-			$this->assertEquals(
+			$this->assertSame(
 				'There is no indexable found for term id 1 and taxonomy category.',
 				$e->getMessage()
 			);
@@ -97,7 +97,7 @@ class No_Indexable_Found_Test extends TestCase {
 			throw No_Indexable_Found::from_primary_term( 1, 'category' );
 		}
 		catch ( No_Indexable_Found $e ) {
-			$this->assertEquals(
+			$this->assertSame(
 				'There is no primary term found for post id 1 and taxonomy category.',
 				$e->getMessage()
 			);
@@ -117,7 +117,7 @@ class No_Indexable_Found_Test extends TestCase {
 			throw No_Indexable_Found::from_author_id( 1 );
 		}
 		catch ( No_Indexable_Found $e ) {
-			$this->assertEquals(
+			$this->assertSame(
 				'There is no indexable found for author id 1.',
 				$e->getMessage()
 			);
@@ -137,7 +137,7 @@ class No_Indexable_Found_Test extends TestCase {
 			throw No_Indexable_Found::from_meta_key( 'name', 1 );
 		}
 		catch ( No_Indexable_Found $e ) {
-			$this->assertEquals(
+			$this->assertSame(
 				'There is no meta found for indexable id 1 and meta key name.',
 				$e->getMessage()
 			);

--- a/tests/formatters/indexable-author-formatter-test.php
+++ b/tests/formatters/indexable-author-formatter-test.php
@@ -47,10 +47,10 @@ class Indexable_Author_Formatter_Test extends TestCase {
 		$indexable = new stdClass();
 		$indexable = $formatter->format( $indexable );
 
-		$this->assertAttributeEquals( 'https://permalink', 'permalink', $indexable );
-		$this->assertAttributeEquals( 'title', 'title', $indexable );
-		$this->assertAttributeEquals( 'description', 'description', $indexable );
-		$this->assertAttributeEquals( true, 'is_robots_noindex', $indexable );
+		$this->assertAttributeSame( 'https://permalink', 'permalink', $indexable );
+		$this->assertAttributeSame( 'title', 'title', $indexable );
+		$this->assertAttributeSame( 'description', 'description', $indexable );
+		$this->assertAttributeSame( true, 'is_robots_noindex', $indexable );
 	}
 
 	/**

--- a/tests/formatters/indexable-post-formatter-test.php
+++ b/tests/formatters/indexable-post-formatter-test.php
@@ -122,7 +122,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 
 		WPSEO_Meta::set_value( 'a', 'b', 1 );
 
-		$this->assertEquals( 'b', $instance->get_meta_value( 'a' ) );
+		$this->assertSame( 'b', $instance->get_meta_value( 'a' ) );
 	}
 
 	/**
@@ -163,7 +163,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	public function test_get_keyword_score() {
 		$instance = new Indexable_Post_Double( 1 );
 
-		$this->assertEquals( 100, $instance->get_keyword_score( 'keyword', 100 ) );
+		$this->assertSame( 100, $instance->get_keyword_score( 'keyword', 100 ) );
 	}
 
 	/**
@@ -221,8 +221,8 @@ class Indexable_Post_Formatter_Test extends TestCase {
 		$indexable = new stdClass();
 		$indexable = $formatter->set_link_count( $indexable );
 
-		$this->assertAttributeEquals( 404, 'link_count', $indexable );
-		$this->assertAttributeEquals( 1337, 'incoming_link_count', $indexable );
+		$this->assertAttributeSame( 404, 'link_count', $indexable );
+		$this->assertAttributeSame( 1337, 'incoming_link_count', $indexable );
 	}
 
 	/**

--- a/tests/formatters/indexable-term-formatter-test.php
+++ b/tests/formatters/indexable-term-formatter-test.php
@@ -127,7 +127,7 @@ class Indexable_Term_Formatter_Test extends TestCase {
 	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_keyword_score()
 	 */
 	public function test_get_keyword_score() {
-		$this->assertEquals( 100, $this->instance->get_keyword_score( 'keyword', 100 ) );
+		$this->assertSame( 100, $this->instance->get_keyword_score( 'keyword', 100 ) );
 	}
 
 	/**

--- a/tests/metabox/metabox-editor-test.php
+++ b/tests/metabox/metabox-editor-test.php
@@ -42,7 +42,7 @@ class Metabox_Editor_Test extends TestCase {
 		$actual = $this->subject->add_css_inside_editor( '' );
 		$expected = 'example.org';
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_add_css_inside_editor_preexisting() {
@@ -56,7 +56,7 @@ class Metabox_Editor_Test extends TestCase {
 
 		$actual = $this->subject->add_css_inside_editor( 'preexisting' );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_add_custom_element() {
@@ -66,7 +66,7 @@ class Metabox_Editor_Test extends TestCase {
 
 		$actual = $this->subject->add_custom_element( array() );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_add_custom_element_preexisting() {
@@ -76,13 +76,13 @@ class Metabox_Editor_Test extends TestCase {
 
 		$actual = $this->subject->add_custom_element( array( 'custom_elements' => 'div' ) );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_add_custom_element_other_properties() {
 		$expected = array(
-			'other_property'  => 'hello world',
 			'custom_elements' => '~yoastmark',
+			'other_property'  => 'hello world',
 		);
 
 		$actual = $this->subject->add_custom_element(
@@ -91,7 +91,8 @@ class Metabox_Editor_Test extends TestCase {
 				'other_property'  => 'hello world',
 			)
 		);
+		ksort( $actual );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 }

--- a/tests/oauth/client-test.php
+++ b/tests/oauth/client-test.php
@@ -75,7 +75,7 @@ class Client_Test extends TestCase {
 	public function test_format_access_tokens_with_invalid_argument() {
 		$class_instance = new Client_Double();
 
-		$this->assertEquals( [], $class_instance->format_access_tokens( false ) );
+		$this->assertSame( [], $class_instance->format_access_tokens( false ) );
 	}
 
 	/**
@@ -86,7 +86,7 @@ class Client_Test extends TestCase {
 	public function test_format_access_tokens_with_empty_array_as_argument() {
 		$class_instance = new Client_Double();
 
-		$this->assertEquals( [], $class_instance->format_access_tokens( [] ) );
+		$this->assertSame( [], $class_instance->format_access_tokens( [] ) );
 	}
 
 	/**
@@ -102,7 +102,7 @@ class Client_Test extends TestCase {
 	public function test_save_configuration( array $config, array $expected_config, $message ) {
 		$this->class_instance->save_configuration( $config );
 
-		$this->assertEquals(
+		$this->assertSame(
 			$expected_config,
 			$this->class_instance->get_configuration(),
 			$message
@@ -192,7 +192,7 @@ class Client_Test extends TestCase {
 	public function test_get_access_token_with_set_access_tokens() {
 		$this->class_instance->save_access_token( 1, new AccessToken( [ 'access_token' => 'this-is-a-token' ] ) );
 
-		$this->assertEquals( 'this-is-a-token', $this->class_instance->get_access_token() );
+		$this->assertSame( 'this-is-a-token', (string) $this->class_instance->get_access_token() );
 	}
 
 	/**
@@ -204,7 +204,7 @@ class Client_Test extends TestCase {
 	public function test_get_access_token_for_user() {
 		$this->class_instance->save_access_token( 1, new AccessToken( [ 'access_token' => 't0k3n' ] ) );
 
-		$this->assertEquals( 't0k3n', $this->class_instance->get_access_token( 1 ) );
+		$this->assertSame( 't0k3n', (string) $this->class_instance->get_access_token( 1 ) );
 	}
 
 	/**

--- a/tests/roles/role-manager-factory-test.php
+++ b/tests/roles/role-manager-factory-test.php
@@ -14,6 +14,6 @@ class Role_Manager_Factory_Test extends TestCase {
 		$instance  = WPSEO_Role_Manager_Factory::get();
 		$instance2 = WPSEO_Role_Manager_Factory::get();
 
-		$this->assertEquals( $instance, $instance2 );
+		$this->assertSame( $instance, $instance2 );
 	}
 }

--- a/tests/roles/role-manager-test.php
+++ b/tests/roles/role-manager-test.php
@@ -33,7 +33,7 @@ class Role_Manager_Test extends TestCase {
 		$capabilities = $instance->get_capabilities( 'administrator' );
 
 		$this->assertNotEmpty( $capabilities );
-		$this->assertContains( 'manage_options', array_keys( $capabilities ) );
+		$this->assertArrayHasKey( 'manage_options', $capabilities );
 		$this->assertTrue( $capabilities['manage_options'] );
 	}
 
@@ -46,12 +46,12 @@ class Role_Manager_Test extends TestCase {
 			->andReturn( false );
 
 		$result = $instance->get_capabilities( false );
-		$this->assertEquals( array(), $result );
+		$this->assertSame( array(), $result );
 
 		$result = $instance->get_capabilities( new stdClass() );
-		$this->assertEquals( array(), $result );
+		$this->assertSame( array(), $result );
 
 		$result = $instance->get_capabilities( 'fake_role' );
-		$this->assertEquals( array(), $result );
+		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/wordpress/integration-group-test.php
+++ b/tests/wordpress/integration-group-test.php
@@ -82,7 +82,7 @@ class Integration_Group_Test extends TestCase {
 		$constructor     = $reflected_class->getConstructor();
 		$constructor->invoke( $instance, array( $integration, $no_integration ) );
 
-		$this->assertAttributeEquals( array( $integration ), 'integrations', $instance );
+		$this->assertAttributeSame( array( $integration ), 'integrations', $instance );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available have been extended  hugely over the years.
To have the most reliable tests, the most specific assertion should be used.

This implements this for the new tests in the WPSEO plugin, while keeping in mind that at this time, PHPUnit 5.x should still be supported.

Refs:
* https://phpunit.de/manual/5.7/en/appendixes.assertions.html
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* As long as the unit tests pass in the Travis builds, we are good.
