### PR TITLE
Noindex filter for feeds

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1337,9 +1337,9 @@ class WPSEO_Frontend {
 		/**
 		 * Allow switching the X-Robots-Tag header for feeds on or off.
 		 *
-		 * @api   boolean $noindex Whether the noindex header should get set (true) or not (false).
+		 * @api boolean $noindex Whether the noindex header should get set (true) or not (false). Defaults to true.
 		 *
-		 * @since 11.4
+		 * @since 11.5
 		 */
 		$noindex = apply_filters( 'wpseo_feed_noindex', true );
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1343,7 +1343,7 @@ class WPSEO_Frontend {
 		 */
 		$noindex = apply_filters( 'wpseo_feed_noindex', true );
 
-		if ( ( is_feed() || is_robots() ) && headers_sent() === false && $noindex === true ) {
+		if ( $noindex === true && headers_sent() === false && ( is_feed() || is_robots() ) ) {
 			header( 'X-Robots-Tag: noindex, follow', true );
 
 			return true;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1339,7 +1339,7 @@ class WPSEO_Frontend {
 		 *
 		 * @api boolean $noindex Whether the noindex header should get set (true) or not (false). Defaults to true.
 		 *
-		 * @since 11.5
+		 * @since 11.6
 		 */
 		$noindex = apply_filters( 'wpseo_feed_noindex', true );
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1332,9 +1332,18 @@ class WPSEO_Frontend {
 	 * @since 1.1.7
 	 * @return boolean Boolean indicating whether the noindex header was sent.
 	 */
-	public function noindex_feed() {
+	public function noindex_feed(  ) {
 
-		if ( ( is_feed() || is_robots() ) && headers_sent() === false ) {
+		/**
+		 * Allow switching the X-Robots-Tag header for feeds on or off.
+		 *
+		 * @api   boolean $noindex Whether the noindex header should get set (true) or not (false).
+		 *
+		 * @since 11.4
+		 */
+		$noindex = apply_filters( 'wpseo_feed_noindex', true );
+
+		if ( ( is_feed() || is_robots() ) && headers_sent() === false && $noindex === true ) {
 			header( 'X-Robots-Tag: noindex, follow', true );
 
 			return true;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1332,7 +1332,7 @@ class WPSEO_Frontend {
 	 * @since 1.1.7
 	 * @return boolean Boolean indicating whether the noindex header was sent.
 	 */
-	public function noindex_feed(  ) {
+	public function noindex_feed() {
 
 		/**
 		 * Allow switching the X-Robots-Tag header for feeds on or off.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds filter "wpseo_feed_noindex" to disable the noindex header on feeds.

## Relevant technical choices:

* With the rise of podcasts in Google, people want a way to disable the noindex header on feeds. We still want the default behavior to not change, so it can only be disabled via a filter.

## Test instructions
This PR can be tested by following these steps:

* Add the following `add_filter` to your functions.php:
```php
add_filter( 'wpseo_feed_noindex', '__return_false' );
```

* Send a curl request to the feed of your test site, reading only the headers:
```shell
curl -IL "wplatest.test/feed/"
```

* The return should read something like:
```
HTTP/1.1 200 OK
Server: nginx
Date: Thu, 06 Jun 2019 12:43:48 GMT
Content-Type: application/rss+xml; charset=UTF-8
Connection: keep-alive
Last-Modified: Thu, 06 Jun 2019 11:14:51 GMT
Link: <http://wplatest.test/wp-json/>; rel="https://api.w.org/"
```

* Note that the following header is not present:
```
X-Robots-Tag: noindex, follow
```

* Remove the filter from your `functions.php` and note that the header returns

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/10262
Fixes https://github.com/Yoast/wordpress-seo/issues/12857

Please note that this code contains a `<at>since` comment pointing to the expected 11.6 release. 