### PR TITLE
[src] QA: call global functions using a fully qualified name

### DIFF
--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -222,11 +222,11 @@ class Database_Migration {
 	 * @return bool True if the define has the value we want it to be.
 	 */
 	protected function set_define( $define, $value ) {
-		if ( defined( $define ) ) {
-			return constant( $define ) === $value;
+		if ( \defined( $define ) ) {
+			return \constant( $define ) === $value;
 		}
 
-		return define( $define, $value );
+		return \define( $define, $value );
 	}
 
 	/**

--- a/src/config/dependency-management.php
+++ b/src/config/dependency-management.php
@@ -34,11 +34,11 @@ class Dependency_Management {
 	 */
 	public function ensure_class_alias( $class ) {
 		// If the namespace beings with the dependency class prefix, make an alias for regular class.
-		if ( strpos( $class, YOAST_VENDOR_NS_PREFIX ) !== 0 || $this->prefixed_available() ) {
+		if ( \strpos( $class, YOAST_VENDOR_NS_PREFIX ) !== 0 || $this->prefixed_available() ) {
 			return;
 		}
 
-		$base = substr( $class, ( strlen( YOAST_VENDOR_NS_PREFIX ) + 1 ) );
+		$base = \substr( $class, ( \strlen( YOAST_VENDOR_NS_PREFIX ) + 1 ) );
 		if ( ! $this->class_exists( $base ) ) {
 			return;
 		}
@@ -57,7 +57,7 @@ class Dependency_Management {
 		static $available = null;
 
 		if ( $available === null ) {
-			$available = is_file( WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY . '/dependencies-prefixed.txt' );
+			$available = \is_file( WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY . '/dependencies-prefixed.txt' );
 		}
 
 		return $available;
@@ -99,7 +99,7 @@ class Dependency_Management {
 	 * @return bool True if the class exists.
 	 */
 	protected function class_exists( $class ) {
-		return class_exists( $class ) || interface_exists( $class );
+		return \class_exists( $class ) || \interface_exists( $class );
 	}
 
 	/**

--- a/src/config/plugin.php
+++ b/src/config/plugin.php
@@ -125,7 +125,7 @@ class Plugin implements Integration {
 	 * @return bool
 	 */
 	protected function is_admin() {
-		return is_admin();
+		return \is_admin();
 	}
 
 	/**
@@ -134,7 +134,7 @@ class Plugin implements Integration {
 	 * @return bool
 	 */
 	protected function is_frontend() {
-		return ! is_admin();
+		return ! \is_admin();
 	}
 
 	/**
@@ -192,6 +192,6 @@ class Plugin implements Integration {
 		 *
 		 * @api \Yoast\WP\Free\Config\Plugin The Plugin object to register integrations on.
 		 */
-		do_action( 'wpseo_load_integrations', $this );
+		\do_action( 'wpseo_load_integrations', $this );
 	}
 }

--- a/src/config/upgrade.php
+++ b/src/config/upgrade.php
@@ -38,7 +38,7 @@ class Upgrade implements Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		add_action( 'wpseo_run_upgrade', array( $this, 'do_upgrade' ) );
+		\add_action( 'wpseo_run_upgrade', array( $this, 'do_upgrade' ) );
 	}
 
 	/**

--- a/src/exceptions/missing-method.php
+++ b/src/exceptions/missing-method.php
@@ -22,9 +22,9 @@ class Missing_Method extends \Exception {
 	 */
 	public static function for_class( $method, $class_name ) {
 		return new static(
-			sprintf(
+			\sprintf(
 				/* translators: %1$s expands to the method name. %2$s expands to the class name */
-				__( 'Method %1$s() does not exist in class %2$s', 'wordpress-seo' ),
+				\__( 'Method %1$s() does not exist in class %2$s', 'wordpress-seo' ),
 				$method,
 				$class_name
 			)

--- a/src/formatters/indexable-author-formatter.php
+++ b/src/formatters/indexable-author-formatter.php
@@ -95,7 +95,7 @@ class Indexable_Author_Formatter {
 	 */
 	protected function get_author_meta( $key ) {
 		$value = \get_the_author_meta( $key, $this->user_id );
-		if ( is_string( $value ) && $value === '' ) {
+		if ( \is_string( $value ) && $value === '' ) {
 			return null;
 		}
 

--- a/src/formatters/indexable-post-formatter.php
+++ b/src/formatters/indexable-post-formatter.php
@@ -56,9 +56,9 @@ class Indexable_Post_Formatter {
 
 		// Set additional meta-robots values.
 		$noindex_advanced = $this->get_meta_value( 'meta-robots-adv' );
-		$meta_robots      = explode( ',', $noindex_advanced );
+		$meta_robots      = \explode( ',', $noindex_advanced );
 		foreach ( $this->get_robots_options() as $meta_robots_option ) {
-			$indexable->{ 'is_robots_' . $meta_robots_option } = in_array( $meta_robots_option, $meta_robots, true ) ? 1 : null;
+			$indexable->{ 'is_robots_' . $meta_robots_option } = \in_array( $meta_robots_option, $meta_robots, true ) ? 1 : null;
 		}
 
 		foreach ( $this->get_indexable_lookup() as $meta_key => $indexable_key ) {
@@ -186,7 +186,7 @@ class Indexable_Post_Formatter {
 	 */
 	protected function get_meta_value( $meta_key ) {
 		$value = WPSEO_Meta::get_value( $meta_key, $this->post_id );
-		if ( is_string( $value ) && $value === '' ) {
+		if ( \is_string( $value ) && $value === '' ) {
 			return null;
 		}
 

--- a/src/formatters/indexable-term-formatter.php
+++ b/src/formatters/indexable-term-formatter.php
@@ -155,12 +155,12 @@ class Indexable_Term_Formatter {
 	 * @return null|string The meta value.
 	 */
 	protected function get_meta_value( $meta_key, $term_meta ) {
-		if ( ! array_key_exists( $meta_key, $term_meta ) ) {
+		if ( ! \array_key_exists( $meta_key, $term_meta ) ) {
 			return null;
 		}
 
 		$value = $term_meta[ $meta_key ];
-		if ( is_string( $value ) && $value === '' ) {
+		if ( \is_string( $value ) && $value === '' ) {
 			return null;
 		}
 

--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -44,7 +44,7 @@ class Logger {
 			 *
 			 * @return \YoastSEO_Vendor\Psr\Log\LoggerInterface The logger object.
 			 */
-			$logger = apply_filters( 'wpseo_logger', $logger );
+			$logger = \apply_filters( 'wpseo_logger', $logger );
 		}
 
 		if ( ! $logger instanceof LoggerInterface ) {

--- a/src/models/indexable-meta.php
+++ b/src/models/indexable-meta.php
@@ -55,13 +55,13 @@ class Indexable_Meta extends Yoast_Model {
 		$indexable_meta->meta_key     = $meta_key;
 
 		Logger::get_logger()->debug(
-			sprintf(
+			\sprintf(
 				/* translators: 1: ID; 2: value of a meta key. */
-				__( 'Indexable meta created for indexable id %1$s with meta key %2$s', 'wordpress-seo' ),
+				\__( 'Indexable meta created for indexable id %1$s with meta key %2$s', 'wordpress-seo' ),
 				$indexable_id,
 				$meta_key
 			),
-			get_object_vars( $indexable_meta )
+			\get_object_vars( $indexable_meta )
 		);
 
 		return $indexable_meta;
@@ -83,24 +83,24 @@ class Indexable_Meta extends Yoast_Model {
 	 */
 	public function save() {
 		if ( ! $this->created_at ) {
-			$this->created_at = gmdate( 'Y-m-d H:i:s' );
+			$this->created_at = \gmdate( 'Y-m-d H:i:s' );
 		}
 
 		if ( $this->updated_at ) {
-			$this->updated_at = gmdate( 'Y-m-d H:i:s' );
+			$this->updated_at = \gmdate( 'Y-m-d H:i:s' );
 		}
 
 		$saved = parent::save();
 
 		if ( $saved ) {
 			Logger::get_logger()->debug(
-				sprintf(
+				\sprintf(
 					/* translators: 1: ID; 2: value of a meta key. */
-					__( 'Indexable meta saved for indexable id %1$s with meta key %2$s', 'wordpress-seo' ),
+					\__( 'Indexable meta saved for indexable id %1$s with meta key %2$s', 'wordpress-seo' ),
 					$this->indexable_id,
 					$this->meta_key
 				),
-				get_object_vars( $this )
+				\get_object_vars( $this )
 			);
 		}
 
@@ -117,8 +117,8 @@ class Indexable_Meta extends Yoast_Model {
 
 		if ( $deleted ) {
 			Logger::get_logger()->debug(
-				__( 'Indexable meta deleted.', 'wordpress-seo' ),
-				get_object_vars( $this )
+				\__( 'Indexable meta deleted.', 'wordpress-seo' ),
+				\get_object_vars( $this )
 			);
 		}
 

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -96,13 +96,13 @@ class Indexable extends Yoast_Model {
 		$indexable->object_type = $object_type;
 
 		Logger::get_logger()->debug(
-			sprintf(
+			\sprintf(
 				/* translators: 1: object ID; 2: object type. */
-				__( 'Indexable created for object %1$s with type %2$s', 'wordpress-seo' ),
+				\__( 'Indexable created for object %1$s with type %2$s', 'wordpress-seo' ),
 				$object_id,
 				$object_type
 			),
-			get_object_vars( $indexable )
+			\get_object_vars( $indexable )
 		);
 
 		return $indexable;
@@ -131,29 +131,29 @@ class Indexable extends Yoast_Model {
 	 */
 	public function save() {
 		if ( ! $this->created_at ) {
-			$this->created_at = gmdate( 'Y-m-d H:i:s' );
+			$this->created_at = \gmdate( 'Y-m-d H:i:s' );
 		}
 
 		if ( $this->updated_at ) {
-			$this->updated_at = gmdate( 'Y-m-d H:i:s' );
+			$this->updated_at = \gmdate( 'Y-m-d H:i:s' );
 		}
 
 		$saved = parent::save();
 
 		if ( $saved ) {
 			Logger::get_logger()->debug(
-				sprintf(
+				\sprintf(
 					/* translators: 1: object ID; 2: object type. */
-					__( 'Indexable saved for object %1$s with type %2$s', 'wordpress-seo' ),
+					\__( 'Indexable saved for object %1$s with type %2$s', 'wordpress-seo' ),
 					$this->object_id,
 					$this->object_type
 				),
-				get_object_vars( $this )
+				\get_object_vars( $this )
 			);
 
 			$this->save_meta();
 
-			do_action( 'wpseo_indexable_saved', $this );
+			\do_action( 'wpseo_indexable_saved', $this );
 		}
 
 		return $saved;
@@ -169,16 +169,16 @@ class Indexable extends Yoast_Model {
 
 		if ( $deleted ) {
 			Logger::get_logger()->debug(
-				sprintf(
+				\sprintf(
 					/* translators: 1: object ID; 2: object type. */
-					__( 'Indexable deleted for object %1$s with type %2$s', 'wordpress-seo' ),
+					\__( 'Indexable deleted for object %1$s with type %2$s', 'wordpress-seo' ),
 					$this->object_id,
 					$this->object_type
 				),
-				get_object_vars( $this )
+				\get_object_vars( $this )
 			);
 
-			do_action( 'wpseo_indexable_deleted', $this );
+			\do_action( 'wpseo_indexable_deleted', $this );
 		}
 
 		return $deleted;
@@ -240,7 +240,7 @@ class Indexable extends Yoast_Model {
 	protected function get_meta( $meta_key, $auto_create = true ) {
 		$this->initialize_meta();
 
-		if ( array_key_exists( $meta_key, $this->meta_data ) ) {
+		if ( \array_key_exists( $meta_key, $this->meta_data ) ) {
 			return $this->meta_data[ $meta_key ];
 		}
 

--- a/src/models/primary-term.php
+++ b/src/models/primary-term.php
@@ -53,11 +53,11 @@ class Primary_Term extends Yoast_Model {
 	public function save() {
 
 		if ( ! $this->created_at ) {
-			$this->created_at = gmdate( 'Y-m-d H:i:s' );
+			$this->created_at = \gmdate( 'Y-m-d H:i:s' );
 		}
 
 		if ( $this->updated_at ) {
-			$this->updated_at = gmdate( 'Y-m-d H:i:s' );
+			$this->updated_at = \gmdate( 'Y-m-d H:i:s' );
 		}
 
 		return parent::save();

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -75,7 +75,7 @@ class Client {
 	public function save_configuration( array $config ) {
 		$allowed_config_keys = array( 'clientId', 'secret' );
 		foreach ( $allowed_config_keys as $allowed_config_key ) {
-			if ( ! array_key_exists( $allowed_config_key, $config ) ) {
+			if ( ! \array_key_exists( $allowed_config_key, $config ) ) {
 				continue;
 			}
 
@@ -143,7 +143,7 @@ class Client {
 	 */
 	public function get_access_token( $user_id = null ) {
 		if ( $user_id === null ) {
-			return reset( $this->access_tokens );
+			return \reset( $this->access_tokens );
 		}
 
 		if ( ! isset( $this->access_tokens[ $user_id ] ) ) {
@@ -180,7 +180,7 @@ class Client {
 			[
 				'clientId'                => $this->config['clientId'],
 				'clientSecret'            => $this->config['secret'],
-				'redirectUri'             => ( WPSEO_Utils::is_plugin_network_active() ) ? home_url( 'yoast/oauth/callback' ) : network_home_url( 'yoast/oauth/callback' ),
+				'redirectUri'             => ( WPSEO_Utils::is_plugin_network_active() ) ? \home_url( 'yoast/oauth/callback' ) : \network_home_url( 'yoast/oauth/callback' ),
 				'urlAuthorize'            => 'https://yoast.com/login/oauth/authorize',
 				'urlAccessToken'          => 'https://yoast.com/login/oauth/token',
 				'urlResourceOwnerDetails' => 'https://my.yoast.com/api/sites/current',
@@ -196,7 +196,7 @@ class Client {
 	 * @return \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface[] The formatted access tokens.
 	 */
 	protected function format_access_tokens( $access_tokens ) {
-		if ( ! is_array( $access_tokens ) || $access_tokens === [] ) {
+		if ( ! \is_array( $access_tokens ) || $access_tokens === [] ) {
 			return [];
 		}
 
@@ -219,8 +219,8 @@ class Client {
 		$option_value = WPSEO_Options::get( 'myyoast_oauth', false );
 
 		if ( $option_value ) {
-			return wp_parse_args(
-				json_decode( $option_value, true ),
+			return \wp_parse_args(
+				\json_decode( $option_value, true ),
 				$this->get_default_option()
 			);
 		}

--- a/src/watchers/primary-term-watcher.php
+++ b/src/watchers/primary-term-watcher.php
@@ -126,9 +126,9 @@ class Primary_Term_Watcher implements Integration {
 	 * @return array The taxonomies.
 	 */
 	protected function generate_primary_term_taxonomies( $post_id ) {
-		$post_type      = get_post_type( $post_id );
-		$all_taxonomies = get_object_taxonomies( $post_type, 'objects' );
-		$all_taxonomies = array_filter( $all_taxonomies, array( $this, 'filter_hierarchical_taxonomies' ) );
+		$post_type      = \get_post_type( $post_id );
+		$all_taxonomies = \get_object_taxonomies( $post_type, 'objects' );
+		$all_taxonomies = \array_filter( $all_taxonomies, array( $this, 'filter_hierarchical_taxonomies' ) );
 
 		/**
 		 * Filters which taxonomies for which the user can choose the primary term.
@@ -139,7 +139,7 @@ class Primary_Term_Watcher implements Integration {
 		 * @param array  $all_taxonomies All taxonomies for this post types, even ones that don't have primary term
 		 *                               enabled.
 		 */
-		$taxonomies = (array) apply_filters( 'wpseo_primary_term_taxonomies', $all_taxonomies, $post_type, $all_taxonomies );
+		$taxonomies = (array) \apply_filters( 'wpseo_primary_term_taxonomies', $all_taxonomies, $post_type, $all_taxonomies );
 
 		return $taxonomies;
 	}
@@ -203,7 +203,7 @@ class Primary_Term_Watcher implements Integration {
 	 * @return integer The post ID.
 	 */
 	protected function get_current_id() {
-		return get_the_ID();
+		return \get_the_ID();
 	}
 
 	/**
@@ -214,7 +214,7 @@ class Primary_Term_Watcher implements Integration {
 	 * @return bool Whether the method is a post request.
 	 */
 	protected function is_post_request() {
-		return isset( $_SERVER['REQUEST_METHOD'] ) && strtolower( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) === 'post';
+		return isset( $_SERVER['REQUEST_METHOD'] ) && \strtolower( \wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) === 'post';
 	}
 
 	/**
@@ -227,7 +227,7 @@ class Primary_Term_Watcher implements Integration {
 	 * @return int The term ID.
 	 */
 	protected function get_posted_term_id( $taxonomy ) {
-		return filter_input( INPUT_POST, WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_term', FILTER_SANITIZE_NUMBER_INT );
+		return \filter_input( INPUT_POST, WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_term', FILTER_SANITIZE_NUMBER_INT );
 	}
 
 	/**
@@ -240,6 +240,6 @@ class Primary_Term_Watcher implements Integration {
 	 * @return bool Whether the referer is valid.
 	 */
 	protected function is_referer_valid( $taxonomy ) {
-		return check_admin_referer( 'save-primary-term', WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_nonce' );
+		return \check_admin_referer( 'save-primary-term', WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_nonce' );
 	}
 }

--- a/src/wordpress/integration-group.php
+++ b/src/wordpress/integration-group.php
@@ -51,7 +51,7 @@ class Integration_Group implements Integration {
 			$integration->register_hooks();
 		};
 
-		array_map( $register_hooks, $this->integrations );
+		\array_map( $register_hooks, $this->integrations );
 	}
 
 	/**
@@ -66,6 +66,6 @@ class Integration_Group implements Integration {
 			return $integration instanceof Integration;
 		};
 
-		return array_filter( $integrations, $is_integration );
+		return \array_filter( $integrations, $is_integration );
 	}
 }

--- a/src/yoast-model.php
+++ b/src/yoast-model.php
@@ -127,7 +127,7 @@ class Yoast_Model {
 			$table_name = 'yoast_' . $table_name;
 		}
 
-		return $wpdb->prefix . strtolower( $table_name );
+		return $wpdb->prefix . \strtolower( $table_name );
 	}
 
 	/**
@@ -430,13 +430,13 @@ class Yoast_Model {
 		if ( $join_class_name === null ) {
 			$base_model      = \explode( '\\', $base_class_name );
 			$base_model_name = \end( $base_model );
-			if ( 0 === strpos( $base_model_name, static::$auto_prefix_models ) ) {
+			if ( 0 === \strpos( $base_model_name, static::$auto_prefix_models ) ) {
 				$base_model_name = \substr( $base_model_name, \strlen( static::$auto_prefix_models ), \strlen( $base_model_name ) );
 			}
 			// Paris wasn't checking the name settings for the associated class.
 			$associated_model      = \explode( '\\', $associated_class_name );
 			$associated_model_name = \end( $associated_model );
-			if ( 0 === strpos( $associated_model_name, static::$auto_prefix_models ) ) {
+			if ( 0 === \strpos( $associated_model_name, static::$auto_prefix_models ) ) {
 				$associated_model_name = \substr( $associated_model_name, \strlen( static::$auto_prefix_models ), \strlen( $associated_model_name ) );
 			}
 			$class_names = array( $base_model_name, $associated_model_name );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

When PHP encounters an unqualified function call in a namespaced file, it will first try and find the function within the namespace and only when it can not find it in the namespace, fall-back to the global function.

Using fully qualified function names when calling a global function ensures that PHP will bypass the search within the namespace and call the global function directly.

It also ensures that optimal use is made of the PHP7 opcodes on VM level which have been implemented for a select group of PHP internal functions resulting in faster code execution.

Ref: https://www.php.net/manual/en/language.namespaces.fallback.php

## Test instructions

This PR can be tested by following these steps:

* _N/A_
    This is a code-only change and should have no effect on the functionality.
