### PR TITLE
[integration-tests] QA/PHPUnit 7: fix faulty unit test

### DIFF
--- a/integration-tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-robots.php
@@ -284,6 +284,9 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_noindex_page() {
 		$expected = '<meta name="robots" content="noindex" />' . "\n";
-		$this->expectOutput( $expected, self::$class_instance->noindex_page() );
+
+		self::$class_instance->noindex_page();
+
+		$this->expectOutput( $expected );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

The `WPSEO_UnitTestCase::expectOutput()` method expects two parameters, the first the `$expected` output, the second a `$description` for when the test fails.

The method was being incorrectly called from within this test, causing the unit test to error out on the stricter PHPUnit7,

## Test instructions

This PR can be tested by following these steps:

* If the tests pass in Travis we're good.
