### PR TITLE
[src] QA: use global constants with a fully qualified name

### DIFF
--- a/src/config/database-migration.php
+++ b/src/config/database-migration.php
@@ -139,7 +139,7 @@ class Database_Migration {
 	 */
 	protected function set_failed_state( $message ) {
 		// @todo do something with the message.
-		\set_transient( $this->get_error_transient_key(), self::MIGRATION_STATE_ERROR, DAY_IN_SECONDS );
+		\set_transient( $this->get_error_transient_key(), self::MIGRATION_STATE_ERROR, \DAY_IN_SECONDS );
 	}
 
 	/**
@@ -195,16 +195,16 @@ class Database_Migration {
 			'db'             => array(
 				'production' => array(
 					'type'      => 'mysql',
-					'host'      => DB_HOST,
+					'host'      => \DB_HOST,
 					'port'      => 3306,
-					'database'  => DB_NAME,
-					'user'      => DB_USER,
-					'password'  => DB_PASSWORD,
+					'database'  => \DB_NAME,
+					'user'      => \DB_USER,
+					'password'  => \DB_PASSWORD,
 					'charset'   => $this->get_charset(),
 					'directory' => '', // This needs to be set, to use the migrations folder as base folder.
 				),
 			),
-			'migrations_dir' => array( 'default' => WPSEO_PATH . 'migrations' ),
+			'migrations_dir' => array( 'default' => \WPSEO_PATH . 'migrations' ),
 			// This needs to be set but is not used.
 			'db_dir'         => true,
 			// This needs to be set but is not used.
@@ -239,13 +239,13 @@ class Database_Migration {
 	protected function get_defines( $table_name ) {
 		if ( $this->dependency_management->prefixed_available() ) {
 			return array(
-				YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_BASE' => WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY . '/ruckusing',
-				YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_TS_SCHEMA_TBL_NAME' => $table_name,
+				\YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_BASE' => \WPSEO_PATH . \YOAST_VENDOR_PREFIX_DIRECTORY . '/ruckusing',
+				\YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_TS_SCHEMA_TBL_NAME' => $table_name,
 			);
 		}
 
 		return array(
-			'RUCKUSING_BASE'               => WPSEO_PATH . 'vendor/ruckusing/ruckusing-migrations',
+			'RUCKUSING_BASE'               => \WPSEO_PATH . 'vendor/ruckusing/ruckusing-migrations',
 			'RUCKUSING_TS_SCHEMA_TBL_NAME' => $table_name,
 		);
 	}

--- a/src/config/dependency-management.php
+++ b/src/config/dependency-management.php
@@ -34,11 +34,11 @@ class Dependency_Management {
 	 */
 	public function ensure_class_alias( $class ) {
 		// If the namespace beings with the dependency class prefix, make an alias for regular class.
-		if ( \strpos( $class, YOAST_VENDOR_NS_PREFIX ) !== 0 || $this->prefixed_available() ) {
+		if ( \strpos( $class, \YOAST_VENDOR_NS_PREFIX ) !== 0 || $this->prefixed_available() ) {
 			return;
 		}
 
-		$base = \substr( $class, ( \strlen( YOAST_VENDOR_NS_PREFIX ) + 1 ) );
+		$base = \substr( $class, ( \strlen( \YOAST_VENDOR_NS_PREFIX ) + 1 ) );
 		if ( ! $this->class_exists( $base ) ) {
 			return;
 		}
@@ -57,7 +57,7 @@ class Dependency_Management {
 		static $available = null;
 
 		if ( $available === null ) {
-			$available = \is_file( WPSEO_PATH . YOAST_VENDOR_PREFIX_DIRECTORY . '/dependencies-prefixed.txt' );
+			$available = \is_file( \WPSEO_PATH . \YOAST_VENDOR_PREFIX_DIRECTORY . '/dependencies-prefixed.txt' );
 		}
 
 		return $available;

--- a/src/config/plugin.php
+++ b/src/config/plugin.php
@@ -163,9 +163,9 @@ class Plugin implements Integration {
 	 * @return void
 	 */
 	protected function configure_orm() {
-		ORM::configure( 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME );
-		ORM::configure( 'username', DB_USER );
-		ORM::configure( 'password', DB_PASSWORD );
+		ORM::configure( 'mysql:host=' . \DB_HOST . ';dbname=' . \DB_NAME );
+		ORM::configure( 'username', \DB_USER );
+		ORM::configure( 'password', \DB_PASSWORD );
 
 		Yoast_Model::$auto_prefix_models = '\\Yoast\\WP\\Free\\Models\\';
 	}

--- a/src/watchers/indexable-author-watcher.php
+++ b/src/watchers/indexable-author-watcher.php
@@ -23,7 +23,7 @@ class Indexable_Author_Watcher implements Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'profile_update', array( $this, 'save_meta' ), PHP_INT_MAX );
+		\add_action( 'profile_update', array( $this, 'save_meta' ), \PHP_INT_MAX );
 		\add_action( 'deleted_user', array( $this, 'delete_meta' ) );
 	}
 

--- a/src/watchers/indexable-post-watcher.php
+++ b/src/watchers/indexable-post-watcher.php
@@ -23,7 +23,7 @@ class Indexable_Post_Watcher implements Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'wp_insert_post', array( $this, 'save_meta' ), PHP_INT_MAX );
+		\add_action( 'wp_insert_post', array( $this, 'save_meta' ), \PHP_INT_MAX );
 		\add_action( 'delete_post', array( $this, 'delete_meta' ) );
 	}
 

--- a/src/watchers/indexable-term-watcher.php
+++ b/src/watchers/indexable-term-watcher.php
@@ -23,8 +23,8 @@ class Indexable_Term_Watcher implements Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'edited_term', array( $this, 'save_meta' ), PHP_INT_MAX, 3 );
-		\add_action( 'delete_term', array( $this, 'delete_meta' ), PHP_INT_MAX, 3 );
+		\add_action( 'edited_term', array( $this, 'save_meta' ), \PHP_INT_MAX, 3 );
+		\add_action( 'delete_term', array( $this, 'delete_meta' ), \PHP_INT_MAX, 3 );
 	}
 
 	/**

--- a/src/watchers/primary-term-watcher.php
+++ b/src/watchers/primary-term-watcher.php
@@ -227,7 +227,7 @@ class Primary_Term_Watcher implements Integration {
 	 * @return int The term ID.
 	 */
 	protected function get_posted_term_id( $taxonomy ) {
-		return \filter_input( INPUT_POST, WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_term', FILTER_SANITIZE_NUMBER_INT );
+		return \filter_input( \INPUT_POST, WPSEO_Meta::$form_prefix . 'primary_' . $taxonomy . '_term', \FILTER_SANITIZE_NUMBER_INT );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

When PHP encounters an unqualified constant in a namespaced file, it will first try and find the constant within the namespace and only when it can not find it in the namespace, fall-back to the global constant.

Using fully qualified constant names when using a global constant ensures that PHP will bypass the search within the namespace and use the global constant directly.

Ref: https://www.php.net/manual/en/language.namespaces.fallback.php

## Test instructions

This PR can be tested by following these steps:

* _N/A_
    This is a code-only change and should have no effect on the functionality.

