### PR TITLE
Fix the Customizer checkbox to match the Search Appearance toggle for introducing the Blog in breadcrumbs

### DIFF
--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -66,7 +66,7 @@ class WPSEO_Customizer {
 		$this->wp_customize = $wp_customize;
 
 		$this->breadcrumbs_section();
-		$this->breadcrumbs_blog_remove_setting();
+		$this->breadcrumbs_blog_show_setting();
 		$this->breadcrumbs_separator_setting();
 		$this->breadcrumbs_home_setting();
 		$this->breadcrumbs_prefix_setting();
@@ -99,25 +99,25 @@ class WPSEO_Customizer {
 	}
 
 	/**
-	 * Adds the breadcrumbs remove blog checkbox.
+	 * Adds the breadcrumbs show blog checkbox.
 	 */
-	private function breadcrumbs_blog_remove_setting() {
+	private function breadcrumbs_blog_show_setting() {
 		$index        = 'breadcrumbs-display-blog-page';
 		$control_args = array(
-			'label'           => __( 'Remove blog page from breadcrumbs', 'wordpress-seo' ),
+			'label'           => __( 'Show blog page in breadcrumbs', 'wordpress-seo' ),
 			'type'            => 'checkbox',
-			'active_callback' => array( $this, 'breadcrumbs_blog_remove_active_cb' ),
+			'active_callback' => array( $this, 'breadcrumbs_blog_show_active_cb' ),
 		);
 
 		$this->add_setting_and_control( $index, $control_args );
 	}
 
 	/**
-	 * Returns whether or not to show the breadcrumbs blog remove option.
+	 * Returns whether or not to show the breadcrumbs blog show option.
 	 *
 	 * @return bool
 	 */
-	public function breadcrumbs_blog_remove_active_cb() {
+	public function breadcrumbs_blog_show_active_cb() {
 		return 'page' === get_option( 'show_on_front' );
 	}
 


### PR DESCRIPTION
## Summary
Update Customizer 'Remove blog page from breadcrumbs' to be 'Show blog page in breadcrumbs' to match the Search Appearance 'Show blog page' setting as the two are married.

Previously;
<img width="1607" alt="Screen Shot 2019-05-24 at 3 57 09 PM" src="https://user-images.githubusercontent.com/8726005/59131702-ee860080-8927-11e9-9e59-3125c8d59991.png">

With the PR;
<img width="1616" alt="Screen Shot 2019-06-07 at 1 27 23 PM" src="https://user-images.githubusercontent.com/8726005/59131740-0a89a200-8928-11e9-86c8-6b975725b178.png">


This PR can be summarized in the following changelog entry:
* Updated Customizer Breadcrumbs settings to change the verbiage of the checkbox enabling the display of the Blog page in breadcrumbs.

## Relevant technical choices:
* I kept the Search Appearance as is since the toggle introduces the blog page and updated the married Customizer setting to have more appropriate verbiage.

## Test instructions
This PR can be tested by following these steps:
1. Update the General > Reading settings setting a Home page and Posts page.
2. Add breadcrumbs to theme.
3. Update Search Apperance 'Show blog page' toggle. Check it introduces the Blog page to breadcrumbs as well as updated the Customizer checkbox.
4. Update Customizer > Breadcrumbs to disable the 'Show blog page in breadcrumbs' and confirm the blog page is no longer available on breadcrumbs.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Note: I'm unsure how to add unittests for this, assistance place.