### PR TITLE
Strip tags in the PHP and allow tags for FAQ answers

### DIFF
--- a/frontend/schema/class-schema-faq-questions.php
+++ b/frontend/schema/class-schema-faq-questions.php
@@ -81,7 +81,7 @@ class WPSEO_Schema_FAQ_Questions {
 			'answerCount'    => 1,
 			'acceptedAnswer' => array(
 				'@type' => 'Answer',
-				'text'  => strip_tags( $question['jsonAnswer'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'br', 'ol', 'ul', 'li', 'a', 'p', 'b', 'strong', 'i', 'em' ) ),
+				'text'  => strip_tags( $question['jsonAnswer'], '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><b><strong><i><em>' ),
 			),
 		);
 	}

--- a/frontend/schema/class-schema-faq-questions.php
+++ b/frontend/schema/class-schema-faq-questions.php
@@ -77,11 +77,11 @@ class WPSEO_Schema_FAQ_Questions {
 			'@id'            => $this->context->canonical . '#' . $question['id'],
 			'position'       => $this->position ++,
 			'url'            => $this->context->canonical . '#' . $question['id'],
-			'name'           => $question['jsonQuestion'],
+			'name'           => strip_tags( $question['jsonQuestion'] ),
 			'answerCount'    => 1,
 			'acceptedAnswer' => array(
 				'@type' => 'Answer',
-				'text'  => $question['jsonAnswer'],
+				'text'  => strip_tags( $question['jsonAnswer'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'br', 'ol', 'ul', 'li', 'a', 'p', 'b', 'strong', 'i', 'em' ) ),
 			),
 		);
 	}

--- a/js/src/structured-data-blocks/faq/components/FAQ.js
+++ b/js/src/structured-data-blocks/faq/components/FAQ.js
@@ -104,8 +104,8 @@ export default class FAQ extends Component {
 			id: questions[ index ].id,
 			question: newQuestion,
 			answer: newAnswer,
-			jsonQuestion: stripHTML( renderToString( newQuestion ) ),
-			jsonAnswer: stripHTML( renderToString( newAnswer ) ),
+			jsonQuestion: renderToString( newQuestion ),
+			jsonAnswer: renderToString( newAnswer ),
 		};
 
 		const imageSrc = Question.getImageSrc( newAnswer );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Allows a subset of HTML tags in FAQ answer schema output.

## Relevant technical choices:

* Moves all HTML stripping to the PHP to allow more future compatibility.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13113.
