### PR TITLE
Override CSS margins inherited from Gutenberg.

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -22,11 +22,11 @@
 	*, *:before, *:after {
 		box-sizing: inherit;
 	}
+}
 
-	// Reset margins inherited from Gutenberg.
-	& [data-block] {
-		margin: 0;
-	}
+// Reset margins inherited from Gutenberg.
+.DraftEditor-root [data-block] {
+	margin: 0;
 }
 
 /* Hide the taxonomy metabox rich editor when it's first inserted in the form. */

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -22,6 +22,11 @@
 	*, *:before, *:after {
 		box-sizing: inherit;
 	}
+
+	// Reset margins inherited from Gutenberg.
+	& [data-block] {
+		margin: 0;
+	}
 }
 
 /* Hide the taxonomy metabox rich editor when it's first inserted in the form. */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Override CSS rules inherited from Gutenberg that break the Snippet Editor title and description

## Test instructions
- install and activate the Gutenberg plugin, current version: 5.9.2 
- on Yoast SEO trunk, edit a post, go to the metabox and open the snippet editor
- see the SEO title and description fields display some unexpected spacing, e.g.:

<img width="716" alt="before" src="https://user-images.githubusercontent.com/1682452/59666977-3c1b2c80-91b6-11e9-9496-b624e9605fb5.png">

- switch to this branch and build the CSS
- refresh the page
- see the SEO title and description fields look as expected, e.g.:

<img width="713" alt="after" src="https://user-images.githubusercontent.com/1682452/59667053-5ce38200-91b6-11e9-83e3-c8985b466505.png">

Note: a PR has been submitted upstream to better scope the offending CSS selector, see https://github.com/WordPress/gutenberg/pull/16207

Fixes #13145
