### PR TITLE
Add readability tab.

### DIFF
--- a/admin/metabox/class-metabox-section-readability.php
+++ b/admin/metabox/class-metabox-section-readability.php
@@ -23,7 +23,7 @@ class WPSEO_Metabox_Section_Readability implements WPSEO_Metabox_Section {
 		printf(
 			'<li role="tab"><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link">%2$s</a></li>',
 			esc_attr( $this->name ),
-			WPSEO_Utils::traffic_light_svg() . '<span>' . __( 'Readability', 'wordpress-seo' ) . '</span>'
+			'<div class="wpseo-score-icon-container" id="wpseo-readability-score-icon"></div><span>' . __( 'Readability', 'wordpress-seo' ) . '</span>'
 		);
 	}
 

--- a/admin/metabox/class-metabox-section-readability.php
+++ b/admin/metabox/class-metabox-section-readability.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Generates and displays the React root element for a metabox section.
+ */
+class WPSEO_Metabox_Section_Readability implements WPSEO_Metabox_Section {
+	/**
+	 * Name of the section, used as an identifier in the HTML.
+	 *
+	 * @var string
+	 */
+	public $name = 'readability';
+
+	/**
+	 * Outputs the section link.
+	 */
+	public function display_link() {
+		printf(
+			'<li role="tab"><a href="#wpseo-meta-section-%1$s" class="wpseo-meta-section-link">%2$s</a></li>',
+			esc_attr( $this->name ),
+			WPSEO_Utils::traffic_light_svg() . '<span>' . __( 'Readability', 'wordpress-seo' ) . '</span>'
+		);
+	}
+
+	/**
+	 * Outputs the section content.
+	 */
+	public function display_content() {
+		$html  = sprintf( '<div id="%1$s" class="wpseo-meta-section">', esc_attr( 'wpseo-meta-section-' . $this->name ) );
+		$html .= '<div id="wpseo-metabox-readability-root" class="wpseo-metabox-root"></div>';
+		$html .= '</div>';
+
+		echo $html;
+	}
+}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -337,7 +337,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		return new WPSEO_Metabox_Section_React(
 			'content',
-			WPSEO_Utils::traffic_light_svg() . '<span>' . __( 'SEO', 'wordpress-seo' ) . '</span>',
+			'<span class="wpseo-score-icon-container" id="wpseo-seo-score-icon"></span><span>' . __( 'SEO', 'wordpress-seo' ) . '</span>',
 			$content
 		);
 	}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -298,7 +298,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	private function get_content_sections() {
 		$content_sections = array();
 
-		$content_sections[] = $this->get_content_meta_section();
+		$content_sections[] = $this->get_seo_meta_section();
+
+		$content_sections[] = $this->get_readabilty_meta_section();
 
 		// Check if social_admin is an instance of WPSEO_Social_Admin.
 		if ( $this->social_admin instanceof WPSEO_Social_Admin ) {
@@ -317,11 +319,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
-	 * Returns the metabox section for the content analysis.
+	 * Returns the metabox section for the seo analysis.
 	 *
 	 * @return WPSEO_Metabox_Section
 	 */
-	private function get_content_meta_section() {
+	private function get_seo_meta_section() {
 		wp_nonce_field( 'yoast_free_metabox', 'yoast_free_metabox_nonce' );
 
 		$content = $this->get_tab_content( 'general' );
@@ -335,9 +337,18 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		return new WPSEO_Metabox_Section_React(
 			'content',
-			WPSEO_Utils::traffic_light_svg() . '<span>' . __( 'Content optimization', 'wordpress-seo' ) . '</span>',
+			WPSEO_Utils::traffic_light_svg() . '<span>' . __( 'SEO', 'wordpress-seo' ) . '</span>',
 			$content
 		);
+	}
+
+	/**
+	 * Returns the metabox section for the readability analysis.
+	 *
+	 * @return WPSEO_Metabox_Section
+	 */
+	private function get_readabilty_meta_section() {
+		return new WPSEO_Metabox_Section_Readability();
 	}
 
 	/**

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -299,8 +299,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$content_sections = array();
 
 		$content_sections[] = $this->get_seo_meta_section();
-
-		$content_sections[] = $this->get_readabilty_meta_section();
+		$content_sections[] = $this->get_readability_meta_section();
 
 		// Check if social_admin is an instance of WPSEO_Social_Admin.
 		if ( $this->social_admin instanceof WPSEO_Social_Admin ) {
@@ -347,7 +346,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @return WPSEO_Metabox_Section
 	 */
-	private function get_readabilty_meta_section() {
+	private function get_readability_meta_section() {
 		return new WPSEO_Metabox_Section_Readability();
 	}
 

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -639,39 +639,6 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 	}
 }
 
-// TODO: To be removed when the styled section will use the StyledSection component.
-.yoast-section {
-	box-shadow: 0 1px 2px rgba( 0, 0, 0, .2 );
-	position: relative;
-	background-color: #fff;
-	padding: 0 20px 15px;
-
-	&__heading {
-		padding: 8px 20px;
-		font-size: 1rem;
-		margin: 0 -20px 15px;
-		font-family: "Open Sans", sans-serif;
-		font-weight: 300;
-		color: #555;
-
-		&-icon {
-			padding-left: 44px; // 44 - 20 (icon width) = 24 for the 8px grid
-			background-repeat: no-repeat;
-			background-position: left 20px top 0.6em;
-			background-size: 16px;
-		}
-	}
-
-	*, & {
-		box-sizing: border-box;
-
-		&:before, &:after {
-			box-sizing: border-box;
-		}
-	}
-}
-
-
 .yoast-tooltip.yoast-tooltip-hidden::before,
 .yoast-tooltip.yoast-tooltip-hidden::after {
 	display: none;
@@ -726,4 +693,13 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 	.wpseotab.content {
 		padding: 16px 0;
 	}
+}
+
+.wpseo-score-icon-container {
+	height: 20px;
+	width: 20px;
+	margin-right: 8px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 151,
+			maxWarnings: 145,
 		},
 	},
 	tests: {

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
 import isNil from "lodash/isNil";
 
+import ScoreIconPortal from "./ScoreIconPortal";
 import Results from "./Results";
 import Collapsible from "../SidebarCollapsible";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
@@ -74,7 +75,6 @@ class ReadabilityAnalysis extends Component {
 			score.className = "loading";
 		}
 
-
 		return (
 			<LocationConsumer>
 				{ location => {
@@ -95,6 +95,10 @@ class ReadabilityAnalysis extends Component {
 					if ( location === "metabox" ) {
 						return createPortal(
 							<ReadabilityResultsTabContainer>
+								<ScoreIconPortal
+									scoreIndicator={ score.className }
+									elementId="wpseo-readability-score-icon"
+								/>
 								{ this.renderResults() }
 							</ReadabilityResultsTabContainer>,
 							document.getElementById( "wpseo-metabox-readability-root" )

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -1,5 +1,5 @@
-/* global wpseoPostScraperL10n wpseoTermScraperL10n wpseoAdminL10n */
-
+/* global wpseoPostScraperL10n, wpseoTermScraperL10n, wpseoAdminL10n */
+/* External components */
 import { Component, Fragment, createPortal } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
 import isNil from "lodash/isNil";
 
+/* Internal components */
 import ScoreIconPortal from "./ScoreIconPortal";
 import Results from "./Results";
 import Collapsible from "../SidebarCollapsible";
@@ -41,6 +42,11 @@ const StyledHelpLink = styled( HelpLink )`
  * Redux container for the readability analysis.
  */
 class ReadabilityAnalysis extends Component {
+	/**
+	 * Renders the Readability Analysis results.
+	 *
+	 * @returns {React.Element} The Readability Analysis results.
+	 */
 	renderResults() {
 		return (
 			<Fragment>
@@ -68,6 +74,11 @@ class ReadabilityAnalysis extends Component {
 		);
 	}
 
+	/**
+	 * Renders the Readability Analysis component.
+	 *
+	 * @returns {React.Element} The Readability Analysis component.
+	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );
 
@@ -111,10 +122,15 @@ class ReadabilityAnalysis extends Component {
 }
 
 ReadabilityAnalysis.propTypes = {
-	results: PropTypes.array,
-	marksButtonStatus: PropTypes.string,
-	hideMarksButtons: PropTypes.bool,
+	results: PropTypes.array.isRequired,
+	marksButtonStatus: PropTypes.string.isRequired,
+	/* eslint-disable-next-line react/no-unused-prop-types */
+	hideMarksButtons: PropTypes.bool.isRequired,
 	overallScore: PropTypes.number,
+};
+
+ReadabilityAnalysis.defaultProps = {
+	overallScore: null,
 };
 
 /**

--- a/js/src/components/contentAnalysis/ScoreIconPortal.js
+++ b/js/src/components/contentAnalysis/ScoreIconPortal.js
@@ -1,0 +1,31 @@
+/* External dependencies */
+import { createPortal } from "@wordpress/element";
+import { SvgIcon } from "@yoast/components";
+import PropTypes from "prop-types";
+
+/* Internal dependencies */
+import { getIconForScore } from "./mapResults";
+
+/**
+ * Renders a score icon in a specified dom element.
+ *
+ * @param {Object} props The component's props.
+ *
+ * @returns {React.Element} The score element.
+ */
+const ScoreIconPortal = ( { elementId, scoreIndicator } ) => {
+	const element = document.getElementById( elementId );
+
+	if ( ! element ) {
+		return null;
+	}
+
+	return createPortal( <SvgIcon { ...getIconForScore( scoreIndicator ) } />, element );
+};
+
+ScoreIconPortal.propTypes = {
+	elementId: PropTypes.string.isRequired,
+	scoreIndicator: PropTypes.string.isRequired,
+};
+
+export default ScoreIconPortal;

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -1,5 +1,5 @@
 /* global wpseoAdminL10n */
-
+/* External dependencies */
 import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -8,6 +8,9 @@ import { Slot } from "@wordpress/components";
 import { __, sprintf } from "@wordpress/i18n";
 import { YoastSeoIcon } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
+
+/* Internal dependencies */
+import ScoreIconPortal from "./ScoreIconPortal";
 import Collapsible from "../SidebarCollapsible";
 import Results from "./Results";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
@@ -218,6 +221,10 @@ class SeoAnalysis extends Component {
 							/>
 						</Collapsible>
 						{ this.props.shouldUpsell && this.renderKeywordUpsell( context ) }
+						<ScoreIconPortal
+							elementId="wpseo-seo-score-icon"
+							scoreIndicator={ score.className }
+						/>
 					</Fragment>
 				) }
 			</LocationConsumer>

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -171,12 +171,36 @@ class SeoAnalysis extends Component {
 	 * @returns {ReactElement} The AnalysisUpsell component.
 	 */
 	renderWordFormsUpsell( location ) {
-		return <AnalysisUpsell
-			url={ location === "sidebar"
-				? wpseoAdminL10n[ "shortlinks.upsell.sidebar.morphology_upsell_sidebar" ]
-				: wpseoAdminL10n[ "shortlinks.upsell.sidebar.morphology_upsell_metabox" ] }
-			alignment={ location === "sidebar" ? "vertical" : "horizontal" }
-		/>;
+		return (
+			<AnalysisUpsell
+				url={ location === "sidebar"
+					? wpseoAdminL10n[ "shortlinks.upsell.sidebar.morphology_upsell_sidebar" ]
+					: wpseoAdminL10n[ "shortlinks.upsell.sidebar.morphology_upsell_metabox" ] }
+				alignment={ location === "sidebar" ? "vertical" : "horizontal" }
+			/>
+		);
+	}
+
+	/**
+	 * Renders the ScoreIconPortal component, which displays a score indication icon in the SEO metabox tab.
+	 *
+	 * @param {string} location       Where this component is rendered.
+	 * @param {string} scoreIndicator String indicating the score.
+	 *
+	 * @returns {React.Element} The rendered score icone portal element.
+	 */
+	renderTabIcon( location, scoreIndicator ) {
+		// The tab icon should only be rendered for the metabox.
+		if ( location !== "metabox" ) {
+			return null;
+		}
+
+		return (
+			<ScoreIconPortal
+				elementId="wpseo-seo-score-icon"
+				scoreIndicator={ scoreIndicator }
+			/>
+		);
 	}
 
 	/**
@@ -194,7 +218,7 @@ class SeoAnalysis extends Component {
 
 		return (
 			<LocationConsumer>
-				{ context => (
+				{ location => (
 					<Fragment>
 						<Collapsible
 							title={ __( "SEO analysis", "wordpress-seo" ) }
@@ -202,14 +226,14 @@ class SeoAnalysis extends Component {
 							prefixIcon={ getIconForScore( score.className ) }
 							prefixIconCollapsed={ getIconForScore( score.className ) }
 							subTitle={ this.props.keyword }
-							id={ `yoast-seo-analysis-collapsible-${ context }` }
+							id={ `yoast-seo-analysis-collapsible-${ location }` }
 						>
-							<Slot name={ `yoast-synonyms-${ context }` } />
+							<Slot name={ `yoast-synonyms-${ location }` } />
 							{ this.props.shouldUpsell && <Fragment>
-								{ this.renderSynonymsUpsell( context ) }
-								{ this.renderMultipleKeywordsUpsell( context ) }
+								{ this.renderSynonymsUpsell( location ) }
+								{ this.renderMultipleKeywordsUpsell( location ) }
 							</Fragment> }
-							{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( context ) }
+							{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( location ) }
 							<AnalysisHeader>
 								{ __( "Analysis results", "wordpress-seo" ) }
 							</AnalysisHeader>
@@ -220,11 +244,8 @@ class SeoAnalysis extends Component {
 								marksButtonStatus={ this.props.marksButtonStatus }
 							/>
 						</Collapsible>
-						{ this.props.shouldUpsell && this.renderKeywordUpsell( context ) }
-						<ScoreIconPortal
-							elementId="wpseo-seo-score-icon"
-							scoreIndicator={ score.className }
-						/>
+						{ this.props.shouldUpsell && this.renderKeywordUpsell( location ) }
+						{ this.renderTabIcon( location, score.className ) }
 					</Fragment>
 				) }
 			</LocationConsumer>

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -206,7 +206,7 @@ class SeoAnalysis extends Component {
 	/**
 	 * Renders the SEO Analysis component.
 	 *
-	 * @returns {ReactElement} The SEO Analysis component.
+	 * @returns {React.Element} The SEO Analysis component.
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );


### PR DESCRIPTION
## Summary

**Note:** After merging this the `feature/horizontal-metabox-tabs` can be merged into trunk.

This PR can be summarized in the following changelog entry:

* Splits the content optimization into two separate SEO and Readability tabs.

#### Readability tab
<img width="746" alt="Screenshot 2019-06-18 at 11 15 07" src="https://user-images.githubusercontent.com/5389513/59669393-6969d980-91ba-11e9-8670-ca05655677cf.png">

#### SEO tab
<img width="744" alt="Screenshot 2019-06-18 at 11 17 43" src="https://user-images.githubusercontent.com/5389513/59669538-b77edd00-91ba-11e9-82e8-4f6795feeb81.png">

## Relevant technical choices:

* I used React portals to display the readability tab as well as the icons in the tabs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the tabs' appearance are according to https://github.com/Yoast/design/issues/383#issuecomment-492248230.
* That the tabs icon is initially blank is a bug that was introduced prior to this PR.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12916 
