### PR TITLE
Don't bump @yoast/grunt-plugin-tasks when updating monorepo packages

### DIFF
--- a/scripts/bump_monorepo_packages.js
+++ b/scripts/bump_monorepo_packages.js
@@ -41,8 +41,8 @@ function errorlog( message ) {
  *
  * @returns {boolean} Whether or not a package is a Yoast package.
  */
-function isYoastPackage( packageName ) {
-	return packageName.includes( "@yoast" ) || legacyYoastPackages.includes( packageName );
+function isYoastMonorepoPackage( packageName ) {
+	return ( packageName.includes( "@yoast" ) && packageName !== "@yoast/grunt-plugin-tasks" ) || legacyYoastPackages.includes( packageName );
 }
 
 /**
@@ -107,8 +107,8 @@ function addPackagesWithFailsafe( packageNames, version = "", flags = "" ) {
 function bumpVersions( args ) {
 	const packages = JSON.parse( fs.readFileSync( "package.json", "utf8" ) ) || {};
 
-	const installedYoastPackages = Object.keys( packages.dependencies || {} ).filter( isYoastPackage );
-	const installedDevYoastPackages = Object.keys( packages.devDependencies || {} ).filter( isYoastPackage );
+	const installedYoastPackages = Object.keys( packages.dependencies || {} ).filter( isYoastMonorepoPackage );
+	const installedDevYoastPackages = Object.keys( packages.devDependencies || {} ).filter( isYoastMonorepoPackage );
 
 	const version = args[ 0 ];
 	addPackagesWithFailsafe( installedYoastPackages, version );


### PR DESCRIPTION
## Summary
The day before the release, we use `yarn bump-monorepo-packages` to update all monorepo packages in the release branch. Until now, this script updated all packages from the package.json starting with `@yoast` plus a limited list of defined legacy packages. However, we also have a package starting with `@yoast` that is not part of the monorepo: @yoast/grunt-plugin-tasks. 

In https://github.com/Yoast/wordpress-seo/pull/13127/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R51 `yarn bump-monorepo-packages` was used, but as a result, @yoast/grunt-plugin-tasks was updated as well. This meant that changes from that package, which were not tested during RC testing, became part of the 11.4 release. We need to prevent that situation in the feature. 

This PR can be summarized in the following changelog entry:

* [not-userfacing] Fixes a bug where the `yarn bump-monorepo-packages` script would update all packages starting with `@yoast/` instead of only the monorepo packages.

## Relevant technical choices:

* I've renamed `isYoastPackage` to `isYoastMonorepoPackage` to better reflect the behavior.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Trunk**
* Run `yarn bump-monorepo-packages`. 
* The first output will be something like
`yarn add @yoast/algolia-search-box @yoast/analysis-report @yoast/components @yoast/configuration-wizard @yoast/helpers @yoast/search-metadata-previews @yoast/style-guide yoast-components yoastseo`.
* After that part is done, the following output is shown:
`yarn add @yoast/grunt-plugin-tasks eslint-config-yoast --dev`. 

**This branch**
* Run `yarn bump-monorepo-packages`. 
* The first output will be something like
`yarn add @yoast/algolia-search-box @yoast/analysis-report @yoast/components @yoast/configuration-wizard @yoast/helpers @yoast/search-metadata-previews @yoast/style-guide yoast-components yoastseo`
* After that part is done, the following output is shown:
`yarn add eslint-config-yoast --dev`. 
* Notice that `@yoast/grunt-plugin-tasks` is no longer part of the above output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
