### PR TITLE
Set WebPage type to CollectionPage when page is any posts overview page

### DIFF
--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -108,6 +108,8 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @return string
 	 */
 	private function determine_page_type() {
+		$front_end_page_type = new WPSEO_Frontend_Page_Type();
+
 		switch ( true ) {
 			case is_search():
 				$type = 'SearchResultsPage';
@@ -115,6 +117,8 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			case is_author():
 				$type = 'ProfilePage';
 				break;
+			case $front_end_page_type->is_posts_page():
+			case $front_end_page_type->is_home_posts_page():
 			case is_archive():
 				$type = 'CollectionPage';
 				break;

--- a/tests/frontend/schema/class-schema-webpage-test.php
+++ b/tests/frontend/schema/class-schema-webpage-test.php
@@ -1,0 +1,111 @@
+<?php
+namespace Yoast\WP\Free\Tests\Frontend\Schema;
+
+use Yoast\WP\Free\Tests\TestCase;
+use \WPSEO_Schema_WebPage;
+use \WPSEO_Schema_Context;
+use \Mockery;
+use Brain\Monkey;
+
+/**
+* Class WPSEO_Schema_HowTo_Test.
+*
+* @group schema
+*
+* @package Yoast\Tests\Frontend\Schema
+*/
+class WPSEO_Schema_WebPage_Test extends TestCase {
+	/**
+	 * @var \WPSEO_Schema_WebPage
+	 */
+	private $instance;
+
+	/**
+	 * Test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		Monkey\Functions\stubs( [
+			'get_bloginfo'  => array( $this, 'get_bloginfo' ),
+			'is_search'     => false,
+			'is_author'     => false,
+			'is_home'       => false,
+			'is_archive'    => false,
+			'is_front_page' => false,
+			'is_singular'   => false,
+		] );
+
+		$context = Mockery::mock( WPSEO_Schema_Context::class )->makePartial();
+
+		$context->title     = 'title';
+		$context->canonical = 'example.com';
+
+		$this->instance = new WPSEO_Schema_WebPage( $context );
+	}
+
+	/**
+	 * Mock for get_bloginfo.
+	 *
+	 * @param string $type Blog info type.
+	 *
+	 * @return mixed Mocked get_bloginfo return value.
+	 */
+	public function get_bloginfo( $type ) {
+		switch ( $type ) {
+			case 'language':
+				return 'en-US';
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Tests if the WebPage type is CollectionPage if a static posts page is opened.
+	 *
+	 * @covers \WPSEO_Schema_WebPage::generate
+	 * @covers \WPSEO_Schema_WebPage::add_breadcrumbs
+	 * @covers \WPSEO_Schema_WebPage::determine_page_type
+	 * @covers \WPSEO_Frontend_Page_Type::is_posts_page
+	 */
+	public function test_schema_output_type_is_collection_page_on_static_posts_page() {
+		Monkey\Functions\stubs( [
+			'is_home' => true,
+		] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'show_on_front' )
+			->andReturn( 'page' );
+
+		$actual = $this->instance->generate();
+
+		$expected = 'CollectionPage';
+
+		$this->assertEquals( $actual['@type'], $expected );
+	}
+
+	/**
+	 * Tests if the WebPage type is CollectionPage if the homepage is set to display posts.
+	 *
+	 * @covers \WPSEO_Schema_WebPage::generate
+	 * @covers \WPSEO_Schema_WebPage::add_breadcrumbs
+	 * @covers \WPSEO_Schema_WebPage::determine_page_type
+	 * @covers \WPSEO_Frontend_Page_Type::is_posts_page
+	 * @covers \WPSEO_Frontend_Page_Type::is_home_posts_page
+	 */
+	public function test_schema_output_type_is_collection_page_on_homepage_with_posts() {
+		Monkey\Functions\stubs( [
+			'is_home' => true,
+		] );
+
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'show_on_front' )
+			->andReturn( 'posts' );
+
+		$actual = $this->instance->generate();
+
+		$expected = 'CollectionPage';
+
+		$this->assertEquals( $actual['@type'], $expected );
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Schema: Fixes a bug where static post pages and your homepage (if showing posts) were output as `WebPage` instead of `CollectionPage`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

#### Latests posts
* Go to `Settings` > `Reading`.
* Set `Your homepage displays` to `Your latest posts`.
* Go to you homepage. Make sure the page type is `CollectionPage` instead of `WebPage`.

#### Static posts page
* Create 2 pages, one named `Homepage` and on named `Posts page`.
* Go to `Settings` > `Reading`.
* Set `Your homepage displays` to `A static page`.
* Set `Homepage` to your `Homepage` page, and `Posts page` to your `Posts page` page.
* Go to you homepage. Make sure the page type is `WebPage`.
* Go to your `Posts page` page. Make sure the page type is `CollectionPage` instead of `WebPage`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12993 
