### PR TITLE
Metabox tabs: responsive, border and other box-shadow

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -90,6 +90,13 @@ ul.wpseo-metabox-tabs li.active {
 	vertical-align: top;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 	border-top: 1px solid #e8e8e8;
+
+	&.active {
+		background: #fff;
+		position: relative;
+		/* 1 higher than the active menu item: .wpseo-metabox-menu.active */
+		z-index: 12;
+	}
 }
 
 .wpseo-meta-section.active {
@@ -114,6 +121,7 @@ ul.wpseo-metabox-tabs li.active {
 		padding-left: 16px;
 		display: flex;
 		align-items: flex-end;
+		flex-wrap: wrap;
 
 		li:nth-child(1) {
 			z-index: 10;
@@ -135,9 +143,11 @@ ul.wpseo-metabox-tabs li.active {
 		}
 
 		li {
-			box-shadow: 0 0 2px rgba(0, 0, 0, .2);
+			box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
 			height: 32px;
-			margin-bottom: 0;
+			/* Negative margins are to not have double borders. */
+			margin-left: -1px;
+			margin-bottom: -1px;
 			text-align: center;
 			position: relative;
 			background-color: #f8f8f8;
@@ -146,6 +156,7 @@ ul.wpseo-metabox-tabs li.active {
 				color: #0073aa;
 				display: flex;
 				align-items: center;
+				border: 1px solid #ddd;
 			}
 
 			.yst-traffic-light {
@@ -172,20 +183,10 @@ ul.wpseo-metabox-tabs li.active {
 
 			&.active {
 				height: 36px;
-				z-index: 50;
+				/* 4 px is the difference in height with the inactive tabs. */
+				margin-top: -4px;
+				z-index: 11;
 				background-color: #ffffff;
-				box-shadow: 0 0 2px 1px rgba(0, 0, 0, .2);
-
-				&:after {
-					content: "";
-					display: block;
-					width: 100%;
-					position: absolute;
-					bottom: -4px;
-					background: #fff;
-					height: 4px;
-					left: 0;
-				}
 
 				a {
 					height: 36px;

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -122,6 +122,7 @@ ul.wpseo-metabox-tabs li.active {
 		display: flex;
 		align-items: flex-end;
 		flex-wrap: wrap;
+		flex-flow: wrap-reverse;
 
 		li:nth-child(1) {
 			z-index: 10;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Metabox tabs: wraps to multiple lines when the screen is not wide enough (starting from the bottom).
* [non-userfacing] Metabox tabs: adds a border and changes the box-shadow.

## Relevant technical choices:

* After some feedback changed the flow to `wrap-reverse` so the tabs start on the bottom.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the metabox and play around with the screen size. It should match the design:
![tabs-design](https://user-images.githubusercontent.com/35524806/59830074-25541180-933f-11e9-9ef0-b02865d4dcbc.png)
* Also check with an RTL language.


## Screenshot
<img width="461" alt="tabs-wrap-reverse" src="https://user-images.githubusercontent.com/35524806/59834843-fe9ad880-9348-11e9-9839-52dd94a077a3.png">


## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13123 
