### PR TITLE
Remove invalid organization nodes

### DIFF
--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -37,6 +37,10 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 			return false;
 		}
 
+		if ( $this->context->site_represents === false ) {
+			return false;
+		}
+
 		return self::is_article_post_type( get_post_type() );
 	}
 

--- a/frontend/schema/class-schema-author.php
+++ b/frontend/schema/class-schema-author.php
@@ -128,17 +128,6 @@ class WPSEO_Schema_Author extends WPSEO_Schema_Person implements WPSEO_Graph_Pie
 	}
 
 	/**
-	 * Returns the string to use in Schema's `@id`.
-	 *
-	 * @param int $user_id The user ID if we're on a user page.
-	 *
-	 * @return string The `@id` string value.
-	 */
-	protected function determine_schema_id( $user_id ) {
-		return get_author_posts_url( $user_id ) . WPSEO_Schema_IDs::AUTHOR_HASH;
-	}
-
-	/**
 	 * Gets the Schema type we use for this class.
 	 *
 	 * @return string[] The schema type.

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -178,27 +178,31 @@ class WPSEO_Schema_Context {
 	private function set_site_represents_variables() {
 		$this->site_represents = WPSEO_Options::get( 'company_or_person', false );
 
-		if ( $this->site_represents === 'company' ) {
-			$this->company_name = WPSEO_Options::get( 'company_name' );
-			// Do not use a non-named company.
-			if ( empty( $this->company_name ) ) {
-				$this->site_represents = false;
-			}
-			else {
+		switch ( $this->site_represents ) {
+			case 'company':
+				$this->company_name = WPSEO_Options::get( 'company_name' );
+				// Do not use a non-named company.
+				if ( empty( $this->company_name ) ) {
+					$this->site_represents = false;
+					break;
+				}
+
 				$this->company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
-				// This is not a false check due to how `get_attachment_id_from_settings` works.
+				/*
+				 * Do not use a company without a logo.
+				 * This is not a false check due to how `get_attachment_id_from_settings` works.
+				 */
 				if ( $this->company_logo_id < 1 ) {
 					$this->site_represents = false;
 				}
-			}
-		}
-
-		if ( $this->site_represents === 'person' ) {
-			$this->site_user_id = WPSEO_Options::get( 'company_or_person_user_id', false );
-			// Do not use a non-existing user.
-			if ( $this->site_user_id !== false && get_user_by( 'id', $this->site_user_id ) === false ) {
-				$this->site_represents = false;
-			}
+				break;
+			case 'person':
+				$this->site_user_id = WPSEO_Options::get( 'company_or_person_user_id', false );
+				// Do not use a non-existing user.
+				if ( $this->site_user_id !== false && get_user_by( 'id', $this->site_user_id ) === false ) {
+					$this->site_represents = false;
+				}
+				break;
 		}
 	}
 

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -10,11 +10,12 @@
  *
  * @property string $canonical                 The current page's canonical.
  * @property string $company_name              Holds the company name, if the site represents a company.
+ * @property int    $company_logo_id           Holds the company logo's ID, if the site represents a company.
  * @property int    $id                        The post ID, if there is one.
  * @property string $site_name                 The site's name.
  * @property string $site_represents           Whether this site represents a `company` or a `person`.
  * @property string $site_url                  The site's URL.
- * @property int    $site_user_id              The site's User ID if a site represents a `person`.
+ * @property int    $site_user_id              The site's user ID if a site represents a `person`.
  * @property string $title                     Page title.
  * @property string $description               Page description.
  * @property bool   $breadcrumbs_enabled       Whether or not this site has breadcrumbs enabled.
@@ -38,6 +39,13 @@ class WPSEO_Schema_Context {
 	 * @var string
 	 */
 	public $company_name;
+
+	/**
+	 * Holds the company logo's ID, if the site represents a company.
+	 *
+	 * @var int
+	 */
+	public $company_logo_id;
 
 	/**
 	 * The queried object ID, if there is one.
@@ -172,6 +180,15 @@ class WPSEO_Schema_Context {
 
 		if ( $this->site_represents === 'company' ) {
 			$this->company_name = WPSEO_Options::get( 'company_name' );
+			// Do not use a non-named company.
+			if ( empty( $this->company_name ) ) {
+				$this->site_represents = false;
+			} else {
+				$this->company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
+				if ( $this->company_logo_id === false ) {
+					$this->site_represents = false;
+				}
+			}
 		}
 
 		if ( $this->site_represents === 'person' ) {

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -185,7 +185,8 @@ class WPSEO_Schema_Context {
 				$this->site_represents = false;
 			} else {
 				$this->company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
-				if ( $this->company_logo_id === false ) {
+				// This is not a false check due to how `get_attachment_id_from_settings` works.
+				if ( $this->company_logo_id < 1 ) {
 					$this->site_represents = false;
 				}
 			}

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -183,7 +183,8 @@ class WPSEO_Schema_Context {
 			// Do not use a non-named company.
 			if ( empty( $this->company_name ) ) {
 				$this->site_represents = false;
-			} else {
+			}
+			else {
 				$this->company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
 				// This is not a false check due to how `get_attachment_id_from_settings` works.
 				if ( $this->company_logo_id < 1 ) {

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -188,6 +188,7 @@ class WPSEO_Schema_Context {
 				}
 
 				$this->company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
+
 				/*
 				 * Do not use a company without a logo.
 				 * This is not a false check due to how `get_attachment_id_from_settings` works.

--- a/frontend/schema/class-schema-organization.php
+++ b/frontend/schema/class-schema-organization.php
@@ -62,14 +62,9 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @return array $data The Organization schema.
 	 */
 	private function add_logo( $data ) {
-		$logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
-
-		if ( empty( $logo_id ) ) {
-			return $data;
-		}
 		$schema_id     = $this->context->site_url . WPSEO_Schema_IDs::ORGANIZATION_LOGO_HASH;
 		$schema_image  = new WPSEO_Schema_Image( $schema_id );
-		$data['logo']  = $schema_image->generate_from_attachment_id( $logo_id, $this->context->company_name );
+		$data['logo']  = $schema_image->generate_from_attachment_id( $this->context->company_logo_id, $this->context->company_name );
 		$data['image'] = array( '@id' => $schema_id );
 
 		return $data;

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -82,8 +82,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 
 		if ( $this->add_breadcrumbs() ) {
 			$data['breadcrumb'] = array(
-				'@type' => 'Person',
-				'@id'   => $this->context->canonical . WPSEO_Schema_IDs::BREADCRUMB_HASH,
+				'@id' => $this->context->canonical . WPSEO_Schema_IDs::BREADCRUMB_HASH,
 			);
 		}
 

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -98,11 +98,22 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 *
 	 * @return array The WebPage schema.
 	 */
-	private function add_author( $data, $post ) {
+	public function add_author( $data, $post ) {
 		if ( $this->context->site_represents === false ) {
 			$data['author'] = array( '@id' => WPSEO_Schema_Utils::get_user_schema_id( $post->post_author, $this->context ) );
 		}
 		return $data;
+	}
+
+	/**
+	 * If we have an image, make it the primary image of the page.
+	 *
+	 * @param array $data WebPage schema data.
+	 */
+	public function add_image( &$data ) {
+		if ( $this->context->has_image ) {
+			$data['primaryImageOfPage'] = array( '@id' => $this->context->canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH );
+		}
 	}
 
 	/**
@@ -150,16 +161,5 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 		 * @api string $type The WebPage type.
 		 */
 		return apply_filters( 'wpseo_schema_webpage_type', $type );
-	}
-
-	/**
-	 * If we have an image, make it the primary image of the page.
-	 *
-	 * @param array $data WebPage schema data.
-	 */
-	public function add_image( &$data ) {
-		if ( $this->context->has_image ) {
-			$data['primaryImageOfPage'] = array( '@id' => $this->context->canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH );
-		}
 	}
 }

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -90,7 +90,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	}
 
 	/**
-	 * Determine if we should add an author attribute.
+	 * Adds an author property to the $data if the WebPage is not represented.
 	 *
 	 * @param array   $data The WebPage schema.
 	 * @param WP_Post $post The post the context is representing.

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -396,9 +396,12 @@ class WPSEO_Image_Utils {
 	/**
 	 * Retrieves an attachment ID for an image uploaded in the settings.
 	 *
+	 * Due to self::get_attachment_by_url returning 0 instead of false.
+	 * 0 is also a possibility when no ID is available.
+	 *
 	 * @param string $setting The setting the image is stored in.
 	 *
-	 * @return int|bool The attachment id, or false if no id is available.
+	 * @return int|bool The attachment id, or false or 0 if no ID is available.
 	 */
 	public static function get_attachment_id_from_settings( $setting ) {
 		$image_id = WPSEO_Options::get( $setting . '_id', false );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,6 +37,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 				'absint'         => function( $value ) {
 					return \abs( \intval( $value ) );
 				},
+				'mysql2date'     => null,
 			]
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `Organization` and `Article` Schema nodes would incorrectly be output when a website had not set their organization's name and/or logo.  

## Relevant technical choices:

* Codescout: Removed `WPSEO_Schema_Author->determine_schema_id` because it isn't used (I think it was replaced by `WPSEO_Schema_Utils::get_user_schema_id`).
* Added setting the company logo to `WPSEO_Schema_Context` so the `site_represents` is set to `false` when the `Organization` has no name and/or logo.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to your `SEO -> Search Appearance` settings. Set the knowledge graph to `Organization` without a name and logo.
* Check the output of the Schema (use [GSDTT](https://search.google.com/structured-data/testing-tool/) too):
	- There should not be an `Organization` graph piece.
	- There should not be an `Article` graph piece.
	- The `WebPage` should have an `Author` that is pointing to the `Author` of the page (previously `Article`).
* Repeat the above but without a name, with a logo.
* Repeat again with a name, without a logo.
* Repeat again with a name and logo and verify it does have the graph pieces.
* Repeat all steps again on another type of page. For example a `CollectionPage` (archive).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13168 
