### PR TITLE
Fix WP_Query usage

### DIFF
--- a/admin/links/class-link-columns.php
+++ b/admin/links/class-link-columns.php
@@ -214,7 +214,7 @@ class WPSEO_Link_Columns {
 	public function set_count_objects() {
 		global $wp_query;
 
-		$posts    = $wp_query->get_posts();
+		$posts    = empty( $wp_query->posts ) ? $wp_query->get_posts() : $wp_query->posts;
 		$post_ids = array();
 
 		// Post lists return a list of objects.


### PR DESCRIPTION
The `WP_Query::get_posts()` method must not be called several times for the same object, otherwise
the results of the second call may be wrong. This is the case if the query includes several taxonomy terms. 

Here is an experiment to demonstrate the issue that you can do with WordPress without any plugin:

```php
$query = new WP_Query(
  array(
    'post_type' => 'post',
    'tag'       => 'tag1,tag2',
  )
);
$query->get_posts();
$query->get_posts();
```

The first corresponding SQL query looks like: 

```
SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts LEFT JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id) WHERE 1=1 AND ( 
wp_term_relationships.term_taxonomy_id IN (127,128)
) AND wp_posts.post_type = 'post' AND (wp_posts.post_status = 'publish' OR wp_posts.post_status = 'future' OR wp_posts.post_status = 'draft' OR wp_posts.post_status = 'pending' OR wp_posts.post_status = 'private') GROUP BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
```

The second corresponding SQL query looks like: 

```
SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts LEFT JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id) LEFT JOIN wp_term_relationships AS tt1 ON (wp_posts.ID = tt1.object_id) WHERE 1=1 AND ( 
wp_term_relationships.term_taxonomy_id IN (127) 
AND 
tt1.term_taxonomy_id IN (127,128)
) AND wp_posts.post_type = 'post' AND (wp_posts.post_status = 'publish' OR wp_posts.post_status = 'future' OR wp_posts.post_status = 'draft' OR wp_posts.post_status = 'pending' OR wp_posts.post_status = 'private') GROUP BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
```

Note the two ( the first being wrong) tax query in the second SQL query. 

For the context, the issue was reported by a developer wanting to programmatically filter the posts list table by 2 custom taxonomy terms. It works when Yoast SEO is not active, but fails when Yoast SEO i active. 