### PR TITLE
CS: clean up after merges

### DIFF
--- a/admin/ajax/class-yoast-dismissable-notice.php
+++ b/admin/ajax/class-yoast-dismissable-notice.php
@@ -32,7 +32,6 @@ class Yoast_Dismissable_Notice_Ajax {
 	 */
 	const FOR_SITE = 'option';
 
-
 	/**
 	 * Name of the notice that will be dismissed.
 	 *

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -9,6 +9,7 @@
  * Class that holds most of the admin functionality for Yoast SEO.
  */
 class WPSEO_Admin {
+
 	/**
 	 * The page identifier used in WordPress to register the admin page.
 	 *
@@ -17,6 +18,7 @@ class WPSEO_Admin {
 	 * @var string
 	 */
 	const PAGE_IDENTIFIER = 'wpseo_dashboard';
+
 	/**
 	 * Array of classes that add admin functionality.
 	 *

--- a/admin/class-bulk-title-editor-list-table.php
+++ b/admin/class-bulk-title-editor-list-table.php
@@ -18,7 +18,6 @@ class WPSEO_Bulk_Title_Editor_List_Table extends WPSEO_Bulk_List_Table {
 	 */
 	protected $page_type = 'title';
 
-
 	/**
 	 * Settings with are used in __construct.
 	 *

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -118,21 +118,21 @@ class WPSEO_Metabox_Formatter {
 							'<strong>' . __( 'Not available', 'wordpress-seo' ) . '</strong>'
 						),
 						'bad'  => sprintf(
-						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
 							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',
 							'<strong>' . __( 'Needs improvement', 'wordpress-seo' ) . '</strong>'
 						),
 						'ok'   => sprintf(
-						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
 							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',
 							'<strong>' . __( 'OK', 'wordpress-seo' ) . '</strong>'
 						),
 						'good' => sprintf(
-						/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
+							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
 							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',

--- a/admin/metabox/class-metabox-section-readability.php
+++ b/admin/metabox/class-metabox-section-readability.php
@@ -9,6 +9,7 @@
  * Generates and displays the React root element for a metabox section.
  */
 class WPSEO_Metabox_Section_Readability implements WPSEO_Metabox_Section {
+
 	/**
 	 * Name of the section, used as an identifier in the HTML.
 	 *

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -11,6 +11,7 @@
  * @since 10.2
  */
 class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
+
 	/**
 	 * A value object with context variables.
 	 *

--- a/frontend/schema/class-schema-author.php
+++ b/frontend/schema/class-schema-author.php
@@ -13,12 +13,14 @@
  * @property WPSEO_Schema_Context $context A value object with context variables.
  */
 class WPSEO_Schema_Author extends WPSEO_Schema_Person implements WPSEO_Graph_Piece {
+
 	/**
 	 * A value object with context variables.
 	 *
 	 * @var WPSEO_Schema_Context
 	 */
 	private $context;
+
 	/**
 	 * The Schema type we use for this class.
 	 *

--- a/frontend/schema/class-schema-breadcrumb.php
+++ b/frontend/schema/class-schema-breadcrumb.php
@@ -11,12 +11,14 @@
  * @since 10.2
  */
 class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
+
 	/**
 	 * A value object with context variables.
 	 *
 	 * @var WPSEO_Schema_Context
 	 */
 	private $context;
+
 	/**
 	 * Current position in the List.
 	 *

--- a/frontend/schema/class-schema-faq-question-list.php
+++ b/frontend/schema/class-schema-faq-question-list.php
@@ -17,24 +17,28 @@
  * @property int                     count
  */
 class WPSEO_Schema_FAQ_Question_List {
+
 	/**
 	 * The Schema array.
 	 *
 	 * @var array
 	 */
 	private $data = array();
+
 	/**
 	 * All the blocks of this block-type.
 	 *
 	 * @var WP_Block_Parser_Block
 	 */
 	private $blocks;
+
 	/**
 	 * Number of questions on the page.
 	 *
 	 * @var int
 	 */
 	private $count;
+
 	/**
 	 * IDs of the questions on the page.
 	 *

--- a/frontend/schema/class-schema-faq-questions.php
+++ b/frontend/schema/class-schema-faq-questions.php
@@ -16,18 +16,21 @@
  * @property int                   $position The position in the list.
  */
 class WPSEO_Schema_FAQ_Questions {
+
 	/**
 	 * The Schema array.
 	 *
 	 * @var array
 	 */
 	private $data;
+
 	/**
 	 * All the blocks of this block-type.
 	 *
 	 * @var WP_Block_Parser_Block
 	 */
 	private $block;
+
 	/**
 	 * Position in the list.
 	 *

--- a/frontend/schema/class-schema-faq.php
+++ b/frontend/schema/class-schema-faq.php
@@ -11,6 +11,7 @@
  * @since 11.3
  */
 class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
+
 	/**
 	 * Determine whether this graph piece is needed or not.
 	 *

--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -11,6 +11,7 @@
  * @since 11.5
  */
 class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
+
 	/**
 	 * Determine whether this graph piece is needed or not.
 	 *
@@ -165,7 +166,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 					$schema_step['text'] = $step['jsonText'];
 				}
 			}
-			else if ( empty( $step['jsonText'] ) ) {
+			elseif ( empty( $step['jsonText'] ) ) {
 				$schema_step['text'] = $step['jsonName'];
 			}
 			else {

--- a/frontend/schema/class-schema-organization.php
+++ b/frontend/schema/class-schema-organization.php
@@ -11,6 +11,7 @@
  * @since 10.2
  */
 class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
+
 	/**
 	 * A value object with context variables.
 	 *

--- a/frontend/schema/class-schema-person.php
+++ b/frontend/schema/class-schema-person.php
@@ -11,6 +11,7 @@
  * @since 10.2
  */
 class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
+
 	/**
 	 * A value object with context variables.
 	 *

--- a/frontend/schema/class-schema-utils.php
+++ b/frontend/schema/class-schema-utils.php
@@ -11,6 +11,7 @@
  * @since 11.6
  */
 class WPSEO_Schema_Utils {
+
 	/**
 	 * Retrieve a users Schema ID.
 	 *

--- a/frontend/schema/class-schema-website.php
+++ b/frontend/schema/class-schema-website.php
@@ -11,6 +11,7 @@
  * @since 10.2
  */
 class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
+
 	/**
 	 * A value object with context variables.
 	 *

--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -13,6 +13,7 @@
  * @since 1.8
  */
 class WPSEO_Schema implements WPSEO_WordPress_Integration {
+
 	/**
 	 * Holds the parsed blocks for the current page.
 	 *

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -40,14 +40,12 @@ class WPSEO_Meta {
 	 */
 	public static $meta_prefix = '_yoast_wpseo_';
 
-
 	/**
 	 * Prefix for all WPSEO meta value form field names and ids.
 	 *
 	 * @var string
 	 */
 	public static $form_prefix = 'yoast_wpseo_';
-
 
 	/**
 	 * Allowed length of the meta description.
@@ -56,14 +54,12 @@ class WPSEO_Meta {
 	 */
 	public static $meta_length = 156;
 
-
 	/**
 	 * Reason the meta description is not the default length.
 	 *
 	 * @var string
 	 */
 	public static $meta_length_reason = '';
-
 
 	/**
 	 * Meta box field definitions for the meta box form.
@@ -206,7 +202,6 @@ class WPSEO_Meta {
 		),
 	);
 
-
 	/**
 	 * Helper property - reverse index of the definition array.
 	 *
@@ -217,7 +212,6 @@ class WPSEO_Meta {
 	 * @var array
 	 */
 	public static $fields_index = array();
-
 
 	/**
 	 * Helper property - array containing only the defaults in the format:

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -297,7 +297,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		}
 
 		$this->enriched_defaults = $enriched_defaults;
-		$this->defaults += $enriched_defaults;
+		$this->defaults         += $enriched_defaults;
 	}
 
 	/**

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -411,7 +411,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	protected function get_post_type_archive_link( $post_type ) {
 
-		$pt_archive_page_id  = -1;
+		$pt_archive_page_id = -1;
 
 		if ( $post_type === 'post' ) {
 

--- a/integration-tests/taxonomy/test-class-taxonomy-presenter.php
+++ b/integration-tests/taxonomy/test-class-taxonomy-presenter.php
@@ -10,7 +10,6 @@
  */
 class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 
-
 	/**
 	 * Holds the instance of the class being tested.
 	 *

--- a/src/loaders/indexable.php
+++ b/src/loaders/indexable.php
@@ -20,4 +20,3 @@ if ( $has_feature_flag && class_exists( '\Yoast\WP\Free\Config\Plugin' ) ) {
 	$bootstrap->initialize();
 	$bootstrap->register_hooks();
 }
-

--- a/tests/admin/admin-asset-analysis-worker-location-test.php
+++ b/tests/admin/admin-asset-analysis-worker-location-test.php
@@ -11,14 +11,14 @@ use Yoast\WP\Free\Tests\TestCase;
  * Tests WPSEO_Admin_Asset.
  */
 final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
+
 	/**
 	 * Tests the get_url function.
 	 *
 	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
 	 */
 	public function test_get_url() {
-		$version          = 'test-version';
-
+		$version  = 'test-version';
 		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $version );
 		$suffix   = ( \YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
 
@@ -29,7 +29,7 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 
 		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'js/dist/wp-seo-analysis-worker-' . $version . $suffix . '.js', \realpath( __DIR__ . "/../../wp-seo.php" ) )
+			->with( 'js/dist/wp-seo-analysis-worker-' . $version . $suffix . '.js', \realpath( __DIR__ . '/../../wp-seo.php' ) )
 			->andReturn( 'asset_location' );
 
 		$actual = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
@@ -55,7 +55,7 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 
 		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'js/dist/wp-seo-' . $custom_file_name . '-' . $version . $suffix . '.js', \realpath( __DIR__ . "/../../wp-seo.php" ) )
+			->with( 'js/dist/wp-seo-' . $custom_file_name . '-' . $version . $suffix . '.js', \realpath( __DIR__ . '/../../wp-seo.php' ) )
 			->andReturn( 'asset_location' );
 
 		$actual = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );

--- a/tests/doubles/class-schema-how-to-double.php
+++ b/tests/doubles/class-schema-how-to-double.php
@@ -9,6 +9,7 @@
  * Test Helper Class.
  */
 class WPSEO_Schema_HowTo_Double extends WPSEO_Schema_HowTo {
+
 	/**
 	 * Determine whether we're part of an article or a webpage.
 	 *

--- a/tests/doubles/onpage-option-mock.php
+++ b/tests/doubles/onpage-option-mock.php
@@ -11,7 +11,9 @@
 class OnPage_Option_Mock extends WPSEO_OnPage_Option {
 
 	private $enabled;
+
 	private $status;
+
 	private $can_fetch;
 
 	public function __construct( $enabled, $status, $can_fetch ) {

--- a/tests/frontend/schema/class-schema-how-to-test.php
+++ b/tests/frontend/schema/class-schema-how-to-test.php
@@ -15,6 +15,7 @@ use \Mockery;
  * @package Yoast\Tests\Frontend\Schema
  */
 class WPSEO_Schema_HowTo_Test extends TestCase {
+
 	/**
 	 * @var \WPSEO_Schema_HowTo_Double
 	 */
@@ -53,15 +54,15 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 			[
 				'attrs' => [
 					'jsonDescription' => 'description',
-					'name' => 'title',
-					'steps' => [],
+					'name'            => 'title',
+					'steps'           => [],
 				],
 			]
 		);
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -69,7 +70,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 				'name'             => 'title',
 				'mainEntityOfPage' => [ '@id' => 'https://example.com/#article' ],
 				'description'      => 'description',
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );
@@ -105,7 +106,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -115,18 +116,18 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 				'description'      => 'description',
 				'step'             => [
 					[
-						'@type' => 'HowToStep',
-						'url'   => 'example.com#step-id-1',
-						'name'  => 'How to step 1',
+						'@type'           => 'HowToStep',
+						'url'             => 'example.com#step-id-1',
+						'name'            => 'How to step 1',
 						'itemListElement' => [
 							[
 								'@type' => 'HowToDirection',
 								'text'  => 'How to step 1 description',
-							]
+							],
 						],
 					],
 				],
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );
@@ -175,7 +176,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -185,19 +186,19 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 				'description'      => 'description',
 				'step'             => [
 					[
-						'@type' => 'HowToStep',
-						'url'   => 'example.com#step-id-1',
-						'name'  => 'How to step 1',
-						'image' => 'https://example.com/image.png',
+						'@type'           => 'HowToStep',
+						'url'             => 'example.com#step-id-1',
+						'name'            => 'How to step 1',
+						'image'           => 'https://example.com/image.png',
 						'itemListElement' => [
 							[
 								'@type' => 'HowToDirection',
 								'text'  => 'How to step 1 description',
-							]
+							],
 						],
 					],
 				],
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );
@@ -233,7 +234,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -248,7 +249,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 						'text'  => 'How to step 1',
 					],
 				],
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );
@@ -277,7 +278,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 						[
 							'id'       => 'step-id-1',
 							'jsonText' => 'How to step 1 description.',
-							'text' => [
+							'text'     => [
 								'How to step 1 description.',
 							],
 						],
@@ -288,7 +289,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -303,7 +304,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 						'text'  => 'How to step 1 description.',
 					],
 				],
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );
@@ -330,7 +331,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 						[
 							'id'       => 'step-id-1',
 							'jsonText' => '',
-							'text' => [
+							'text'     => [
 								[
 									'type'   => 'img',
 									'key'    => 1,
@@ -350,7 +351,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -366,7 +367,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 						'text'  => '',
 					],
 				],
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );
@@ -399,7 +400,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -407,7 +408,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 				'name'             => 'title',
 				'mainEntityOfPage' => [ '@id' => 'https://example.com/#article' ],
 				'description'      => 'description',
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );
@@ -450,7 +451,7 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$expected = [
 			[
-				'@id' => 'OtherGraphPiece'
+				'@id' => 'OtherGraphPiece',
 			],
 			[
 				'@type'            => 'HowTo',
@@ -461,18 +462,18 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 				'totalTime'        => 'P1DT12H30M',
 				'step'             => [
 					[
-						'@type' => 'HowToStep',
-						'url'   => 'example.com#step-id-1',
-						'name'  => 'How to step 1',
+						'@type'           => 'HowToStep',
+						'url'             => 'example.com#step-id-1',
+						'name'            => 'How to step 1',
 						'itemListElement' => [
 							[
 								'@type' => 'HowToDirection',
 								'text'  => 'How to step 1 description',
-							]
+							],
 						],
 					],
 				],
-			]
+			],
 		];
 
 		$this->assertEquals( $actual, $expected );

--- a/tests/frontend/schema/class-schema-webpage-test.php
+++ b/tests/frontend/schema/class-schema-webpage-test.php
@@ -18,6 +18,7 @@ use Yoast\WP\Free\Tests\TestCase;
  * @package Yoast\Tests\Frontend\Schema
  */
 class WPSEO_Schema_WebPage_Test extends TestCase {
+
 	/**
 	 * @var \WPSEO_Schema_WebPage
 	 */
@@ -34,15 +35,17 @@ class WPSEO_Schema_WebPage_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		Monkey\Functions\stubs( [
-			'get_bloginfo'  => array( $this, 'get_bloginfo' ),
-			'is_search'     => false,
-			'is_author'     => false,
-			'is_home'       => false,
-			'is_archive'    => false,
-			'is_front_page' => false,
-			'is_singular'   => false,
-		] );
+		Monkey\Functions\stubs(
+			[
+				'get_bloginfo'  => array( $this, 'get_bloginfo' ),
+				'is_search'     => false,
+				'is_author'     => false,
+				'is_home'       => false,
+				'is_archive'    => false,
+				'is_front_page' => false,
+				'is_singular'   => false,
+			]
+		);
 
 		$this->context = Mockery::mock( WPSEO_Schema_Context::class )->makePartial();
 
@@ -78,9 +81,7 @@ class WPSEO_Schema_WebPage_Test extends TestCase {
 	 * @covers \WPSEO_Frontend_Page_Type::is_posts_page
 	 */
 	public function test_schema_output_type_is_collection_page_on_static_posts_page() {
-		Monkey\Functions\stubs( [
-			'is_home' => true,
-		] );
+		Monkey\Functions\stubs( [ 'is_home' => true ] );
 
 		Monkey\Functions\expect( 'get_option' )
 			->with( 'show_on_front' )
@@ -103,9 +104,7 @@ class WPSEO_Schema_WebPage_Test extends TestCase {
 	 * @covers \WPSEO_Frontend_Page_Type::is_home_posts_page
 	 */
 	public function test_schema_output_type_is_collection_page_on_homepage_with_posts() {
-		Monkey\Functions\stubs( [
-			'is_home' => true,
-		] );
+		Monkey\Functions\stubs( [ 'is_home' => true ] );
 
 		Monkey\Functions\expect( 'get_option' )
 			->with( 'show_on_front' )

--- a/tests/frontend/schema/mainimage-test.php
+++ b/tests/frontend/schema/mainimage-test.php
@@ -55,11 +55,13 @@ class MainImage_Test extends TestCase {
 		];
 
 		$this->instance = $this->getMockBuilder( WPSEO_Schema_MainImage_Double::class )
-			->setMethods( [
-				'get_first_usable_content_image_for_post',
-				'generate_image_schema_from_attachment_id',
-				'generate_image_schema_from_url'
-			] )
+			->setMethods(
+				[
+					'get_first_usable_content_image_for_post',
+					'generate_image_schema_from_attachment_id',
+					'generate_image_schema_from_url',
+				]
+			)
 			->setConstructorArgs( [ $this->context ] )
 			->getMock();
 	}

--- a/tests/metabox/metabox-editor-test.php
+++ b/tests/metabox/metabox-editor-test.php
@@ -34,21 +34,21 @@ class Metabox_Editor_Test extends TestCase {
 	}
 
 	public function test_add_css_inside_editor_empty() {
-		Monkey\Functions\expect('plugins_url' )
+		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . "/../../wp-seo.php" ) )
+			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . '/../../wp-seo.php' ) )
 			->andReturn( 'example.org' );
 
-		$actual = $this->subject->add_css_inside_editor( '' );
+		$actual   = $this->subject->add_css_inside_editor( '' );
 		$expected = 'example.org';
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_add_css_inside_editor_preexisting() {
-		Monkey\Functions\expect('plugins_url' )
+		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . "/../../wp-seo.php" ) )
+			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . '/../../wp-seo.php' ) )
 			->andReturn( 'example.org' );
 
 

--- a/tests/roles/role-manager-test.php
+++ b/tests/roles/role-manager-test.php
@@ -23,12 +23,12 @@ class Role_Manager_Test extends TestCase {
 	}
 
 	public function test_get_capabilities() {
-		$instance     = new WPSEO_Role_Manager_Mock();
+		$instance = new WPSEO_Role_Manager_Mock();
 
-		Monkey\Functions\expect('get_role' )
+		Monkey\Functions\expect( 'get_role' )
 			->once()
 			->with( 'administrator' )
-			->andReturn( (object) array( "capabilities" => array( "manage_options" => true ) ) );
+			->andReturn( (object) array( 'capabilities' => array( 'manage_options' => true ) ) );
 
 		$capabilities = $instance->get_capabilities( 'administrator' );
 
@@ -40,7 +40,7 @@ class Role_Manager_Test extends TestCase {
 	public function test_get_capabilities_bad_input() {
 		$instance = new WPSEO_Role_Manager_Mock();
 
-		Monkey\Functions\expect('get_role' )
+		Monkey\Functions\expect( 'get_role' )
 			->once()
 			->with( 'fake_role' )
 			->andReturn( false );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Mostly whitespace.

Fixes issues related to:
* One blank line before each property declaration. (YoastCS 1.3.0)
* One blank line before each method declaration.
* One blank line after a namespace declaration.
* Single quoted strings vs double quoted strings.
* Code indentation.
* Multiple statement alignment of the equal signs.
* Spacing on the inside of parentheses.
* Comma after last array item.
* Array double arrow alignment.
* Multi-line function call layout.
* Use elseif.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
