### PR TITLE
Test documentation: fix @covers tags

### DIFF
--- a/integration-tests/admin/exceptions/test-file-size-exception.php
+++ b/integration-tests/admin/exceptions/test-file-size-exception.php
@@ -13,7 +13,7 @@
 class WPSEO_File_Size_Exception_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @covers WPSEO_File_Size_Exception::externally_hosted()
+	 * @covers WPSEO_File_Size_Exception::externally_hosted
 	 */
 	public function test_externally_hosted_exception() {
 		$expected_exception = WPSEO_File_Size_Exception::externally_hosted( 'https://external.im/age.jpg' );

--- a/integration-tests/admin/links/test-class-link-reindex-post-service.php
+++ b/integration-tests/admin/links/test-class-link-reindex-post-service.php
@@ -13,10 +13,10 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Testing the default situation without any unprocessed posts.
 	 *
-	 * @covers WPSEO_Link_Reindex_Post_Service::reindex()
-	 * @covers WPSEO_Link_Reindex_Post_Service::process_posts()
-	 * @covers WPSEO_Link_Reindex_Post_Service::is_processable()
-	 * @covers WPSEO_Link_Reindex_Post_Service::get_unprocessed_posts()
+	 * @covers WPSEO_Link_Reindex_Post_Service::reindex
+	 * @covers WPSEO_Link_Reindex_Post_Service::process_posts
+	 * @covers WPSEO_Link_Reindex_Post_Service::is_processable
+	 * @covers WPSEO_Link_Reindex_Post_Service::get_unprocessed_posts
 	 */
 	public function test_reindex() {
 		$class_instance = new WPSEO_Link_Reindex_Post_Service();
@@ -27,7 +27,7 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Testing the situation where the needed tables aren't accessible.
 	 *
-	 * @covers WPSEO_Link_Reindex_Post_Service::reindex()
+	 * @covers WPSEO_Link_Reindex_Post_Service::reindex
 	 */
 	public function test_reindex_with_inaccessible_tables() {
 		$class_instance = $this
@@ -48,10 +48,10 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the reindexing functionality with one 'unprocessed' post.
 	 *
-	 * @covers WPSEO_Link_Reindex_Post_Service::reindex()
-	 * @covers WPSEO_Link_Reindex_Post_Service::process_posts()
-	 * @covers WPSEO_Link_Reindex_Post_Service::is_processable()
-	 * @covers WPSEO_Link_Reindex_Post_Service::process_post()
+	 * @covers WPSEO_Link_Reindex_Post_Service::reindex
+	 * @covers WPSEO_Link_Reindex_Post_Service::process_posts
+	 * @covers WPSEO_Link_Reindex_Post_Service::is_processable
+	 * @covers WPSEO_Link_Reindex_Post_Service::process_post
 	 */
 	public function test_reindex_with_posts() {
 		$content_processor = $this->get_content_processor_mock();
@@ -92,7 +92,7 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the reindexing without any posts.
 	 *
-	 * @covers WPSEO_Link_Reindex_Post_Service::reindex()
+	 * @covers WPSEO_Link_Reindex_Post_Service::reindex
 	 */
 	public function test_reindex_without_posts() {
 		$content_processor = $this->get_content_processor_mock();

--- a/integration-tests/admin/links/test-class-link-watcher.php
+++ b/integration-tests/admin/links/test-class-link-watcher.php
@@ -63,7 +63,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Don't process trash posts.
 	 *
-	 * @covers WPSEO_Link_Watcher::save_post()
+	 * @covers WPSEO_Link_Watcher::save_post
 	 */
 	public function test_skip_trash_posts() {
 

--- a/integration-tests/admin/services/test-class-endpoint-indexable.php
+++ b/integration-tests/admin/services/test-class-endpoint-indexable.php
@@ -33,7 +33,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the get_indexable for an invalid post type.
 	 *
-	 * @covers WPSEO_Indexable_Service::get_indexable()
+	 * @covers WPSEO_Indexable_Service::get_indexable
 	 */
 	public function test_get_indexable_for_invalid_object_type() {
 		$request = $this
@@ -54,7 +54,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the get_indexable for a valid post type and a non indexable.
 	 *
-	 * @covers WPSEO_Indexable_Service::get_indexable()
+	 * @covers WPSEO_Indexable_Service::get_indexable
 	 */
 	public function test_get_indexable_for_valid_post_type_with_a_non_indexable_object() {
 		$provider = $this
@@ -100,7 +100,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the get_indexable for a valid post type and an indexable object.
 	 *
-	 * @covers WPSEO_Indexable_Service::get_indexable()
+	 * @covers WPSEO_Indexable_Service::get_indexable
 	 */
 	public function test_get_indexable_for_valid_post_type_with_an_indexable_object() {
 		$provider = $this
@@ -147,7 +147,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	 * Tests the return value of the get_provider.
 	 *
 	 * @expectedException WPSEO_Invalid_Argument_Exception
-	 * @covers            WPSEO_Indexable_Service::get_provider()
+	 * @covers            WPSEO_Indexable_Service::get_provider
 	 */
 	public function test_get_provider() {
 		$this->assertInstanceOf( 'WPSEO_Indexable_Service_Post_Provider', $this->service->get_provider( 'post' ) );
@@ -158,7 +158,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the handling of an unknown object type.
 	 *
-	 * @covers WPSEO_Indexable_Service::handle_unknown_object_type()
+	 * @covers WPSEO_Indexable_Service::handle_unknown_object_type
 	 */
 	public function test_handle_unknown_object_type() {
 		$this->assertInstanceOf( 'WP_REST_Response', $this->service->handle_unknown_object_type( 'unknown' ) );

--- a/integration-tests/admin/services/test-class-indexable-post-provider.php
+++ b/integration-tests/admin/services/test-class-indexable-post-provider.php
@@ -66,7 +66,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param mixed  $object_id   The object id.
 	 * @param string $description The test description.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable
 	 */
 	public function test_is_indexable_with_invalid_object_ids( $object_id, $description ) {
 		$this->assertFalse( $this->provider->is_indexable( $object_id ), $description );
@@ -75,7 +75,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the obtaining of a non indexable post.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable
 	 */
 	public function test_is_indexable_with_valid_object_ids_for_non_indexable_posts() {
 		$this->assertFalse( $this->provider->is_indexable( $this->get_revision() ) );
@@ -85,7 +85,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the post is indexable when having a valid object id.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable
 	 */
 	public function test_is_indexable() {
 		$this->assertTrue( $this->provider->is_indexable( self::factory()->post->create() ) );
@@ -99,7 +99,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param mixed  $object_id   The object id.
 	 * @param string $description The test description.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::get()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::get
 	 */
 	public function test_get_a_non_indexable_post_with_invalid_object_ids( $object_id, $description ) {
 		$this->assertEquals( array(), $this->provider->get( $object_id ), $description );
@@ -108,8 +108,8 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the obtaining of a non indexable post.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::get()
-	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::get
+	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable
 	 */
 	public function test_get_a_non_indexable_post() {
 		$this->assertEquals( array(), $this->provider->get( $this->get_revision() ) );
@@ -119,7 +119,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the getting of an indexable post.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::get()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::get
 	 */
 	public function test_get() {
 		$post = self::factory()->post->create_and_get();
@@ -186,7 +186,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param bool|null $expected       The expected conversion.
 	 * @param string    $description    Description of the test.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_indexable_data()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_indexable_data
 	 *
 	 * @dataProvider indexable_data_conversion_provider
 	 */
@@ -204,7 +204,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param bool|null $expected       The expected conversion.
 	 * @param string    $description    Description of the test.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_advanced()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_advanced
 	 *
 	 * @dataProvider advanced_indexable_data_conversion_provider
 	 */
@@ -222,7 +222,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param bool|null $expected          The expected conversion.
 	 * @param string    $description       Description of the test.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_cornerstone()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_cornerstone
 	 *
 	 * @dataProvider cornerstone_conversion_provider
 	 */
@@ -239,7 +239,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param bool|null $expected    The expected conversion.
 	 * @param string    $description Description of the test.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_cornerstone()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_cornerstone
 	 *
 	 * @dataProvider nofollow_conversion_provider
 	 */
@@ -256,7 +256,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param bool|null $expected    The expected conversion.
 	 * @param string    $description Description of the test.
 	 *
-	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_noindex()
+	 * @covers WPSEO_Indexable_Service_Post_Provider::convert_noindex
 	 *
 	 * @dataProvider noindex_conversion_provider
 	 */

--- a/integration-tests/admin/services/test-class-indexable-term-provider.php
+++ b/integration-tests/admin/services/test-class-indexable-term-provider.php
@@ -33,7 +33,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting non existing terms.
 	 *
-	 * @covers WPSEO_Indexable_Service_Term_Provider::get()
+	 * @covers WPSEO_Indexable_Service_Term_Provider::get
 	 */
 	public function test_get_non_existing_term() {
 		$this->assertEquals( array(), $this->provider->get( false ) );
@@ -45,7 +45,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the term is indexable in various situations.
 	 *
-	 * @covers WPSEO_Indexable_Service_Term_Provider::is_indexable()
+	 * @covers WPSEO_Indexable_Service_Term_Provider::is_indexable
 	 */
 	public function test_is_indexable() {
 		$this->assertFalse( $this->provider->is_indexable( false ) );
@@ -69,7 +69,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the getting of an indexable term.
 	 *
-	 * @covers WPSEO_Indexable_Service_Term_Provider::get()
+	 * @covers WPSEO_Indexable_Service_Term_Provider::get
 	 */
 	public function test_get() {
 		$term = $this
@@ -144,7 +144,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	 * @param bool|null $expected    The expected conversion.
 	 * @param string    $description Description of the test.
 	 *
-	 * @covers WPSEO_Indexable_Service_Term_Provider::convert_noindex()
+	 * @covers WPSEO_Indexable_Service_Term_Provider::convert_noindex
 	 *
 	 * @dataProvider noindex_conversion_provider
 	 */
@@ -157,7 +157,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the renaming of indexable data.
 	 *
-	 * @covers WPSEO_Indexable_Service_Term_Provider::rename_indexable_data()
+	 * @covers WPSEO_Indexable_Service_Term_Provider::rename_indexable_data
 	 */
 	public function test_rename_indexable_data() {
 		$supplied_values = array(
@@ -198,7 +198,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the conversion of the indexable data.
 	 *
-	 * @covers WPSEO_Indexable_Service_Term_Provider::convert_indexable_data()
+	 * @covers WPSEO_Indexable_Service_Term_Provider::convert_indexable_data
 	 */
 	public function test_convert_indexable_data() {
 		$instance = $this

--- a/integration-tests/admin/test-class-admin-asset-dev-server-location.php
+++ b/integration-tests/admin/test-class-admin-asset-dev-server-location.php
@@ -23,7 +23,7 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 	/**
 	 * Basic get_url test.
 	 *
-	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url()
+	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url
 	 */
 	public function test_get_url() {
 		$asset = new WPSEO_Admin_Asset( $this->asset_defaults );
@@ -38,7 +38,7 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 	/**
 	 * Tests that the constructor accepts a different dev server URL.
 	 *
-	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url()
+	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url
 	 */
 	public function test_get_url_different_url() {
 		$asset = new WPSEO_Admin_Asset( $this->asset_defaults );
@@ -55,8 +55,8 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 	 *
 	 * @integration_test
 	 *
-	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url()
-	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url()
+	 * @covers WPSEO_Admin_Asset_Dev_Server_Location::get_url
+	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url
 	 */
 	public function test_get_url_default() {
 		$asset_args        = $this->asset_defaults;

--- a/integration-tests/admin/test-class-admin-asset-seo-location.php
+++ b/integration-tests/admin/test-class-admin-asset-seo-location.php
@@ -13,7 +13,7 @@ final class Test_WPSEO_Admin_Asset_SEO_Location extends PHPUnit_Framework_TestCa
 	/**
 	 * Tests the get_url function.
 	 *
-	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url()
+	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url
 	 */
 	public function test_get_url() {
 		$asset_args = array(

--- a/integration-tests/admin/test-class-admin-editor-specific-replace-vars.php
+++ b/integration-tests/admin/test-class-admin-editor-specific-replace-vars.php
@@ -29,7 +29,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests adding replacement variables for page types.
 	 *
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::add_for_page_types()
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::add_for_page_types
 	 */
 	public function test_add_for_page_types() {
 		$this->class_instance->add_for_page_types(
@@ -46,7 +46,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test adding replacement variables for page types with given variables being an empty array.
 	 *
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::add_for_page_types()
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::add_for_page_types
 	 */
 	public function test_add_for_page_types_with_empty_array() {
 		$this->class_instance->add_for_page_types( array( 'post' ), array() );
@@ -61,9 +61,9 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * Tests that get_shared_replace_vars removes all replacement variables that occurs in the editor specific
 	 * replacement variables.
 	 *
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get_generic()
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get_unique_replacement_variables()
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::extract_names()
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get_generic
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get_unique_replacement_variables
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::extract_names
 	 */
 	public function test_get_shared_replace_vars_filters_editor_specific_replace_vars() {
 		$replace_vars_list = array(
@@ -252,7 +252,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * Tests that has_editor_specific_replace_vars returns true when it has recommended replacement
 	 * variables for the passed page type.
 	 *
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::has_for_page_type()
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::has_for_page_type
 	 */
 	public function test_has_editor_specific_replace_vars_existing() {
 		$this->assertEquals( true, $this->class_instance->has_for_page_type( 'post' ) );
@@ -286,7 +286,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the filter for the editor specific replacement variables.
 	 *
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get()
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get
 	 */
 	public function test_editor_specific_replacement_variables_filter() {
 		add_filter( 'wpseo_editor_specific_replace_vars', array( $this, 'filter_editor_specific_replacement_variables' ) );
@@ -314,7 +314,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the filter for the editor specific replacement variables.
 	 *
-	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get()
+	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get
 	 */
 	public function test_editor_specific_replacement_variables_filter_with_wrong_return_value() {
 		add_filter( 'wpseo_editor_specific_replace_vars', '__return_false' );

--- a/integration-tests/admin/test-class-database-proxy.php
+++ b/integration-tests/admin/test-class-database-proxy.php
@@ -79,7 +79,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests inserting a valid dataset into the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::insert()
+	 * @covers WPSEO_Database_Proxy::insert
 	 */
 	public function test_insert() {
 		$result = self::$proxy->insert(
@@ -96,7 +96,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests inserting a dataset with an existing ID into the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::insert()
+	 * @covers WPSEO_Database_Proxy::insert
 	 */
 	public function test_insert_exists() {
 		self::$proxy->insert(
@@ -122,7 +122,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests inserting an invalid dataset into the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::insert()
+	 * @covers WPSEO_Database_Proxy::insert
 	 */
 	public function test_insert_invalid() {
 		$result = self::$proxy->insert(
@@ -138,7 +138,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests updating a valid dataset in the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::update()
+	 * @covers WPSEO_Database_Proxy::update
 	 */
 	public function test_update() {
 		self::$proxy->insert(
@@ -166,7 +166,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests updating a not existing dataset in the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::update()
+	 * @covers WPSEO_Database_Proxy::update
 	 */
 	public function test_update_not_exists() {
 		$result = self::$proxy->update(
@@ -186,7 +186,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests updating an invalid dataset in the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::update()
+	 * @covers WPSEO_Database_Proxy::update
 	 */
 	public function test_update_invalid() {
 		$result = self::$proxy->update(
@@ -206,7 +206,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests inserting or otherwise updating a valid dataset in the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::upsert()
+	 * @covers WPSEO_Database_Proxy::upsert
 	 */
 	public function test_upsert_new() {
 		$result = self::$proxy->upsert(
@@ -227,7 +227,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests inserting or otherwise updating an existing dataset in the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::upsert()
+	 * @covers WPSEO_Database_Proxy::upsert
 	 */
 	public function test_upsert_existing() {
 		self::$proxy->insert(
@@ -278,7 +278,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests deleting a valid dataset from the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::delete()
+	 * @covers WPSEO_Database_Proxy::delete
 	 */
 	public function test_delete() {
 		self::$proxy->insert(
@@ -302,7 +302,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests deleting a not existing dataset from the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::delete()
+	 * @covers WPSEO_Database_Proxy::delete
 	 */
 	public function test_delete_not_exists() {
 		$result = self::$proxy->delete(
@@ -318,7 +318,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests deleting an invalid dataset from the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::delete()
+	 * @covers WPSEO_Database_Proxy::delete
 	 */
 	public function test_delete_invalid() {
 		$result = self::$proxy->delete(
@@ -334,7 +334,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests querying results from the database.
 	 *
-	 * @covers WPSEO_Database_Proxy::get_results()
+	 * @covers WPSEO_Database_Proxy::get_results
 	 */
 	public function test_get_results() {
 		$table_name = self::$proxy->get_table_name();
@@ -363,7 +363,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests creating a table in the database from columns definition.
 	 *
-	 * @covers WPSEO_Database_Proxy::create_table()
+	 * @covers WPSEO_Database_Proxy::create_table
 	 */
 	public function test_create_table() {
 		global $wpdb;
@@ -388,7 +388,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests checking whether the last database request resulted in an error.
 	 *
-	 * @covers WPSEO_Database_Proxy::has_error()
+	 * @covers WPSEO_Database_Proxy::has_error
 	 */
 	public function test_has_error() {
 		$this->assertFalse( self::$proxy->has_error() );
@@ -397,7 +397,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests correctness of the full prefixed table name for a regular table.
 	 *
-	 * @covers WPSEO_Database_Proxy::get_table_name()
+	 * @covers WPSEO_Database_Proxy::get_table_name
 	 */
 	public function test_get_table_name() {
 		global $wpdb;
@@ -411,7 +411,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests correctness of the full prefixed table name for a global table.
 	 *
-	 * @covers WPSEO_Database_Proxy::get_table_name()
+	 * @covers WPSEO_Database_Proxy::get_table_name
 	 */
 	public function test_get_table_name_global() {
 		global $wpdb;
@@ -428,7 +428,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests correct registration of a regular table with WordPress.
 	 *
-	 * @covers WPSEO_Database_Proxy::register_table()
+	 * @covers WPSEO_Database_Proxy::register_table
 	 */
 	public function test_register_table() {
 		global $wpdb;
@@ -442,7 +442,7 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests correct registration of a global table with WordPress.
 	 *
-	 * @covers WPSEO_Database_Proxy::register_table()
+	 * @covers WPSEO_Database_Proxy::register_table
 	 */
 	public function test_register_table_global() {
 		global $wpdb;

--- a/integration-tests/admin/test-class-extension-manager.php
+++ b/integration-tests/admin/test-class-extension-manager.php
@@ -29,7 +29,7 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the scenario when no active extensions are loaded.
 	 *
-	 * @covers WPSEO_Extension_Manager::is_activated()
+	 * @covers WPSEO_Extension_Manager::is_activated
 	 */
 	public function test_has_no_active_extensions_loaded() {
 		$extension_manager = $this
@@ -53,7 +53,7 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the scenario when no active extensions are loaded and the cache is considered faulty.
 	 *
-	 * @covers WPSEO_Extension_Manager::is_activated()
+	 * @covers WPSEO_Extension_Manager::is_activated
 	 */
 	public function test_has_no_active_extensions_loaded_and_cached_are_faulty() {
 

--- a/integration-tests/admin/test-class-option-tabs.php
+++ b/integration-tests/admin/test-class-option-tabs.php
@@ -13,7 +13,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the retrieval of the base.
 	 *
-	 * @covers WPSEO_Option_Tabs::get_base()
+	 * @covers WPSEO_Option_Tabs::get_base
 	 */
 	public function test_get_base() {
 		$option_tabs = new WPSEO_Option_Tabs( 'base' );
@@ -24,7 +24,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the addition of a new tab.
 	 *
-	 * @covers WPSEO_Option_Tabs::add_tab()
+	 * @covers WPSEO_Option_Tabs::add_tab
 	 */
 	public function test_add_tab() {
 		$option_tabs = new WPSEO_Option_Tabs( 'base' );
@@ -38,7 +38,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the retrieval of the tabs.
 	 *
-	 * @covers WPSEO_Option_Tabs::get_tabs()
+	 * @covers WPSEO_Option_Tabs::get_tabs
 	 */
 	public function test_get_tabs() {
 		$option_tab  = new WPSEO_Option_Tab( 'name', 'label' );
@@ -51,7 +51,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the given tab is active.
 	 *
-	 * @covers WPSEO_Option_Tabs::get_active_tab()
+	 * @covers WPSEO_Option_Tabs::get_active_tab
 	 */
 	public function test_is_active_tab() {
 		$option_tab  = new WPSEO_Option_Tab( 'name', 'label' );
@@ -64,7 +64,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests of the given tab is not active.
 	 *
-	 * @covers WPSEO_Option_Tabs::is_active_tab()
+	 * @covers WPSEO_Option_Tabs::is_active_tab
 	 */
 	public function test_is_active_tab_not_active() {
 		$option_tab  = new WPSEO_Option_Tab( 'name', 'label' );
@@ -77,7 +77,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests retrieval of an active tab without having any tabs.
 	 *
-	 * @covers WPSEO_Option_Tabs::is_active_tab()
+	 * @covers WPSEO_Option_Tabs::is_active_tab
 	 */
 	public function test_get_active_tab_without_any_active_tab_being_set() {
 		$option_tabs = new WPSEO_Option_Tabs( 'base' );
@@ -88,7 +88,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the retrieval of the active tab.
 	 *
-	 * @covers WPSEO_Option_Tabs::get_active_tab()
+	 * @covers WPSEO_Option_Tabs::get_active_tab
 	 */
 	public function test_get_active_tab() {
 		$option_tab  = new WPSEO_Option_Tab( 'name', 'label' );
@@ -101,7 +101,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the retrieval of the active tab without having any tabs.
 	 *
-	 * @covers WPSEO_Option_Tabs::get_active_tab()
+	 * @covers WPSEO_Option_Tabs::get_active_tab
 	 */
 	public function test_get_active_tab_WITH_nonexisting_tab_set_as_active() {
 		$option_tabs = new WPSEO_Option_Tabs( 'base', 'nonexisting' );
@@ -112,7 +112,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the retrieval of the active tab without having a active tab being set.
 	 *
-	 * @covers WPSEO_Option_Tabs::get_active_tab()
+	 * @covers WPSEO_Option_Tabs::get_active_tab
 	 */
 	public function test_get_active_tab_WITH_no_tab_set_as_active() {
 		$option_tabs = new WPSEO_Option_Tabs( 'base' );

--- a/integration-tests/admin/test-class-yoast-form.php
+++ b/integration-tests/admin/test-class-yoast-form.php
@@ -13,7 +13,7 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests setting the form option with a valid option having a `WPSEO_Option` class.
 	 *
-	 * @covers Yoast_Form::set_option()
+	 * @covers Yoast_Form::set_option
 	 */
 	public function test_properties_set_with_valid_option() {
 		$form = new Yoast_Form_Double();
@@ -30,7 +30,7 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests setting the form option with an invalid option that does not have a `WPSEO_Option` class.
 	 *
-	 * @covers Yoast_Form::set_option()
+	 * @covers Yoast_Form::set_option
 	 */
 	public function test_properties_set_with_invalid_option() {
 		$option_keys = array( 'key1', 'key2', 'key3' );
@@ -47,7 +47,7 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether a control is disabled with a valid option having a `WPSEO_Option` class.
 	 *
-	 * @covers Yoast_Form::is_control_disabled()
+	 * @covers Yoast_Form::is_control_disabled
 	 */
 	public function test_is_control_disabled_with_valid_option() {
 		$form = new Yoast_Form_Double();
@@ -59,7 +59,7 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether a control is disabled with an invalid option that does not have a `WPSEO_Option` class.
 	 *
-	 * @covers Yoast_Form::is_control_disabled()
+	 * @covers Yoast_Form::is_control_disabled
 	 */
 	public function test_is_control_disabled_with_invalid_option() {
 		$form = new Yoast_Form_Double();

--- a/integration-tests/admin/test-class-yoast-network-admin.php
+++ b/integration-tests/admin/test-class-yoast-network-admin.php
@@ -54,7 +54,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @covers Yoast_Network_Admin::get_site_choices()
+	 * @covers Yoast_Network_Admin::get_site_choices
 	 */
 	public function test_get_site_choices() {
 		$this->skipWithoutMultisite();
@@ -78,7 +78,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @group yoastnetwork
 	 * @group ms-required
 	 *
-	 * @covers Yoast_Network_Admin::get_site_choices()
+	 * @covers Yoast_Network_Admin::get_site_choices
 	 */
 	public function test_get_site_choices_output() {
 		$this->skipWithoutMultisite();
@@ -103,7 +103,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * Tests getting a site's states.
 	 *
 	 * @group  ms-required
-	 * @covers Yoast_Network_Admin::get_site_states()
+	 * @covers Yoast_Network_Admin::get_site_states
 	 */
 	public function test_get_site_states() {
 		$this->skipWithoutMultisite();
@@ -132,7 +132,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests handling a request to update options.
 	 *
-	 * @covers Yoast_Network_Admin::handle_update_options_request()
+	 * @covers Yoast_Network_Admin::handle_update_options_request
 	 */
 	public function test_handle_update_options_request() {
 		$admin = $this
@@ -155,7 +155,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests handling a request to restore a site's settings.
 	 *
-	 * @covers Yoast_Network_Admin::handle_restore_site_request()
+	 * @covers Yoast_Network_Admin::handle_restore_site_request
 	 */
 	public function test_handle_restore_site_request() {
 		$admin = $this
@@ -178,7 +178,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests output for hidden settings fields.
 	 *
-	 * @covers Yoast_Network_Admin::settings_fields()
+	 * @covers Yoast_Network_Admin::settings_fields
 	 */
 	public function test_settings_fields() {
 		$admin = new Yoast_Network_Admin();
@@ -198,7 +198,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests registering main hooks.
 	 *
-	 * @covers Yoast_Network_Admin::register_hooks()
+	 * @covers Yoast_Network_Admin::register_hooks
 	 */
 	public function test_register_hooks() {
 		$admin = $this->getMockBuilder( 'Yoast_Network_Admin' )
@@ -218,7 +218,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests registering AJAX hooks.
 	 *
-	 * @covers Yoast_Network_Admin::register_ajax_hooks()
+	 * @covers Yoast_Network_Admin::register_ajax_hooks
 	 */
 	public function test_register_ajax_hooks() {
 		$admin = new Yoast_Network_Admin();
@@ -231,7 +231,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests checking requirements for the network settings API.
 	 *
-	 * @covers Yoast_Network_Admin::meets_requirements()
+	 * @covers Yoast_Network_Admin::meets_requirements
 	 */
 	public function test_meets_requirements() {
 		$admin = new Yoast_Network_Admin();
@@ -243,7 +243,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests verifying a request with an invalid nonce.
 	 *
-	 * @covers Yoast_Network_Admin::verify_request()
+	 * @covers Yoast_Network_Admin::verify_request
 	 */
 	public function test_verify_request_with_invalid_nonce() {
 		$admin = new Yoast_Network_Admin();
@@ -263,7 +263,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests verifying a request with a valid nonce, but lacking capabilities.
 	 *
-	 * @covers Yoast_Network_Admin::verify_request()
+	 * @covers Yoast_Network_Admin::verify_request
 	 */
 	public function test_verify_request_with_valid_nonce_but_lacking_caps() {
 		$admin = new Yoast_Network_Admin();
@@ -278,7 +278,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests verifying a request with a valid nonce and the required capabilities.
 	 *
-	 * @covers Yoast_Network_Admin::verify_request()
+	 * @covers Yoast_Network_Admin::verify_request
 	 */
 	public function test_verify_request_with_valid_nonce_and_caps() {
 		$admin = new Yoast_Network_Admin();
@@ -301,7 +301,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests verifying an AJAX request with an invalid nonce.
 	 *
-	 * @covers Yoast_Network_Admin::verify_request()
+	 * @covers Yoast_Network_Admin::verify_request
 	 */
 	public function test_verify_request_ajax_with_invalid_nonce() {
 		$admin = new Yoast_Network_Admin();
@@ -318,7 +318,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests verifying an AJAX request with a valid nonce, but lacking capabilities.
 	 *
-	 * @covers Yoast_Network_Admin::verify_request()
+	 * @covers Yoast_Network_Admin::verify_request
 	 */
 	public function test_verify_request_ajax_with_valid_nonce_but_lacking_caps() {
 		$admin = new Yoast_Network_Admin();
@@ -335,7 +335,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests verifying an AJAX request with a valid nonce and the required capabilities.
 	 *
-	 * @covers Yoast_Network_Admin::verify_request()
+	 * @covers Yoast_Network_Admin::verify_request
 	 */
 	public function test_verify_request_ajax_with_valid_nonce_and_caps() {
 		$admin = new Yoast_Network_Admin();
@@ -360,7 +360,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests terminating a request.
 	 *
-	 * @covers Yoast_Network_Admin::terminate_request()
+	 * @covers Yoast_Network_Admin::terminate_request
 	 */
 	public function test_terminate_request() {
 		$admin = $this
@@ -383,7 +383,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests terminating an AJAX request.
 	 *
-	 * @covers Yoast_Network_Admin::terminate_request()
+	 * @covers Yoast_Network_Admin::terminate_request
 	 *
 	 * @throws \WPDieException For test purposes.
 	 */

--- a/integration-tests/admin/test-class-yoast-network-settings-api.php
+++ b/integration-tests/admin/test-class-yoast-network-settings-api.php
@@ -13,7 +13,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests registering a setting.
 	 *
-	 * @covers Yoast_Network_Settings_API::register_setting()
+	 * @covers Yoast_Network_Settings_API::register_setting
 	 */
 	public function test_register_setting() {
 		$api = new Yoast_Network_Settings_API();
@@ -31,7 +31,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting registered settings.
 	 *
-	 * @covers Yoast_Network_Settings_API::get_registered_settings()
+	 * @covers Yoast_Network_Settings_API::get_registered_settings
 	 */
 	public function test_get_registered_settings() {
 		$group = 'yst_ms_group';
@@ -53,7 +53,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting whitelisted options.
 	 *
-	 * @covers Yoast_Network_Settings_API::get_whitelist_options()
+	 * @covers Yoast_Network_Settings_API::get_whitelist_options
 	 */
 	public function test_get_whitelist_options() {
 		$registered_group   = 'yst_ms_group';
@@ -73,7 +73,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests filtering setting sanitization.
 	 *
-	 * @covers Yoast_Network_Settings_API::filter_sanitize_option()
+	 * @covers Yoast_Network_Settings_API::filter_sanitize_option
 	 */
 	public function test_filter_sanitize_option() {
 		$api = new Yoast_Network_Settings_API();
@@ -89,7 +89,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests filtering setting default.
 	 *
-	 * @covers Yoast_Network_Settings_API::filter_default_option()
+	 * @covers Yoast_Network_Settings_API::filter_default_option
 	 */
 	public function test_filter_default_option() {
 		$api = new Yoast_Network_Settings_API();
@@ -108,7 +108,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the singleton getter.
 	 *
-	 * @covers Yoast_Network_Settings_API::get()
+	 * @covers Yoast_Network_Settings_API::get
 	 */
 	public function test_get() {
 		$this->assertInstanceOf( 'Yoast_Network_Settings_API', Yoast_Network_Settings_API::get() );
@@ -117,7 +117,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests checking requirements for the network settings API.
 	 *
-	 * @covers Yoast_Network_Settings_API::meets_requirements()
+	 * @covers Yoast_Network_Settings_API::meets_requirements
 	 */
 	public function test_meets_requirements() {
 		$api = new Yoast_Network_Settings_API();

--- a/integration-tests/admin/watchers/test-class-slug-change-watcher.php
+++ b/integration-tests/admin/watchers/test-class-slug-change-watcher.php
@@ -67,7 +67,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests showing notification when a post is moved to trash.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_post_trash()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_post_trash
 	 */
 	public function test_detect_post_trash() {
 		$instance = $this
@@ -87,7 +87,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests showing notification when a non visible post is moved to trash.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_post_trash()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_post_trash
 	 */
 	public function test_detect_post_trash_no_visible_post_status() {
 
@@ -115,7 +115,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests showing notification when a post is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete
 	 */
 	public function test_detect_post_delete() {
 		$instance = $this
@@ -135,7 +135,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests not showing the notification when the nav menu item is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete
 	 */
 	public function test_detect_post_delete_menu_item() {
 		$instance = $this
@@ -155,7 +155,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests not showing the notification when a trashed post is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete
 	 */
 	public function test_detect_post_delete_trashed_post() {
 		// Make sure we're working with a trashed post.
@@ -182,7 +182,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests not showing the notification when a post revision is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete
 	 */
 	public function test_detect_post_delete_revision() {
 		$revision_id = wp_save_post_revision( self::$post_id );
@@ -204,7 +204,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests not showing the notification when a pending post is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_post_delete
 	 */
 	public function test_detect_post_delete_when_not_visible() {
 
@@ -232,7 +232,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests showing the notification when a term of a public taxonomy is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_term_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_term_delete
 	 */
 	public function test_detect_term_delete() {
 		$instance = $this
@@ -252,7 +252,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests showing the notification when a term of a non-public taxonomy is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_term_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_term_delete
 	 */
 	public function test_detect_term_delete_when_not_viewable() {
 		$instance = $this
@@ -272,7 +272,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests showing the notification when a non-existing term is deleted.
 	 *
-	 * @covers WPSEO_Slug_Change_Watcher::detect_term_delete()
+	 * @covers WPSEO_Slug_Change_Watcher::detect_term_delete
 	 */
 	public function test_detect_term_delete_when_not_exists() {
 		$instance = $this

--- a/integration-tests/capabilities/test-class-register-capabilities.php
+++ b/integration-tests/capabilities/test-class-register-capabilities.php
@@ -30,7 +30,7 @@ class WPSEO_Register_Capabilities_Tests extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider data_filter_user_has_wpseo_manage_options_cap
 	 *
-	 * @covers WPSEO_Register_Capabilities::filter_user_has_wpseo_manage_options_cap()
+	 * @covers WPSEO_Register_Capabilities::filter_user_has_wpseo_manage_options_cap
 	 *
 	 * @param string $role             Which role to test. 'network_administrator' is also allowed.
 	 * @param string $access           Access setting value to test. Either 'admin' or 'superadmin'.

--- a/integration-tests/config-ui/components/test-class-component-connect-gsc.php
+++ b/integration-tests/config-ui/components/test-class-component-connect-gsc.php
@@ -43,14 +43,14 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	}
 
 	/**
-	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::get_identifier()
+	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::get_identifier
 	 */
 	public function test_get_identifier() {
 		$this->assertEquals( 'ConnectGoogleSearchConsole', $this->component->get_identifier() );
 	}
 
 	/**
-	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::get_field()
+	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::get_field
 	 */
 	public function test_get_field() {
 		$this->assertEquals(
@@ -60,7 +60,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	}
 
 	/**
-	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::get_data()
+	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::get_data
 	 */
 	public function test_get_data() {
 		$expected = array(
@@ -77,7 +77,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	}
 
 	/**
-	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::set_data()
+	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::set_data
 	 */
 	public function test_set_data() {
 
@@ -95,7 +95,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	}
 
 	/**
-	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::set_data()
+	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::set_data
 	 */
 	public function test_set_data_empty_token() {
 
@@ -123,7 +123,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	}
 
 	/**
-	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::handle_profile_change()
+	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::handle_profile_change
 	 */
 	public function test_handle_profile_change() {
 		$current = array( 'profile' => 'a' );
@@ -135,7 +135,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console_Test extends PHPUnit_
 	}
 
 	/**
-	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::handle_profile_change()
+	 * @covers WPSEO_Config_Component_Connect_Google_Search_Console::handle_profile_change
 	 */
 	public function test_handle_profile_change_no_changes() {
 		$current = array( 'profile' => 'a' );

--- a/integration-tests/config-ui/components/test-class-component-mailchimp-signup.php
+++ b/integration-tests/config-ui/components/test-class-component-mailchimp-signup.php
@@ -13,7 +13,7 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the get_identifier.
 	 *
-	 * @covers WPSEO_Config_Component_Mailchimp_Signup::get_identifier()
+	 * @covers WPSEO_Config_Component_Mailchimp_Signup::get_identifier
 	 */
 	public function test_get_identifier() {
 		$mailchimp_signup = new WPSEO_Config_Component_Mailchimp_Signup();
@@ -24,7 +24,7 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the get_field.
 	 *
-	 * @covers WPSEO_Config_Component_Mailchimp_Signup::get_field()
+	 * @covers WPSEO_Config_Component_Mailchimp_Signup::get_field
 	 */
 	public function test_get_field() {
 		$mailchimp_signup = new WPSEO_Config_Component_Mailchimp_Signup();
@@ -35,7 +35,7 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting the data.
 	 *
-	 * @covers WPSEO_Config_Component_Mailchimp_Signup::get_data()
+	 * @covers WPSEO_Config_Component_Mailchimp_Signup::get_data
 	 */
 	public function test_get_data() {
 		$mailchimp_signup = new WPSEO_Config_Component_Mailchimp_Signup();
@@ -49,7 +49,7 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests setting the data.
 	 *
-	 * @covers WPSEO_Config_Component_Mailchimp_Signup::set_data()
+	 * @covers WPSEO_Config_Component_Mailchimp_Signup::set_data
 	 */
 	public function test_set_data() {
 		// We explicitly sets the current user ID, because set_data needs to have a current_user.

--- a/integration-tests/config-ui/components/test-class-factory-post-type.php
+++ b/integration-tests/config-ui/components/test-class-factory-post-type.php
@@ -11,7 +11,7 @@
 class WPSEO_Config_Factory_Post_Type_Test extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * @covers WPSEO_Config_Factory_Post_Type::get_fields()
+	 * @covers WPSEO_Config_Factory_Post_Type::get_fields
 	 */
 	public function test_get_fields() {
 

--- a/integration-tests/config-ui/fields/test-class-config-field-choice.php
+++ b/integration-tests/config-ui/fields/test-class-config-field-choice.php
@@ -28,7 +28,7 @@ class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Config_Field_Choice::add_choice()
+	 * @covers WPSEO_Config_Field_Choice::add_choice
 	 */
 	public function test_add_choice() {
 		$value              = 'yes';

--- a/integration-tests/config-ui/fields/test-class-config-field.php
+++ b/integration-tests/config-ui/fields/test-class-config-field.php
@@ -11,9 +11,9 @@
 class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * @covers WPSEO_Config_Field::__construct()
-	 * @covers WPSEO_Config_Field::get_identifier()
-	 * @covers WPSEO_Config_Field::get_component()
+	 * @covers WPSEO_Config_Field::__construct
+	 * @covers WPSEO_Config_Field::get_identifier
+	 * @covers WPSEO_Config_Field::get_component
 	 */
 	public function test_constructor() {
 
@@ -27,8 +27,8 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Config_Field::set_property()
-	 * @covers WPSEO_Config_Field::get_properties()
+	 * @covers WPSEO_Config_Field::set_property
+	 * @covers WPSEO_Config_Field::get_properties
 	 */
 	public function test_properties() {
 		$property       = 'p';
@@ -46,7 +46,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Config_Field::get_data()
+	 * @covers WPSEO_Config_Field::get_data
 	 */
 	public function test_get_data() {
 		$data = 'test';
@@ -58,8 +58,8 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Config_Field::set_requires()
-	 * @covers WPSEO_Config_Field::get_requires()
+	 * @covers WPSEO_Config_Field::set_requires
+	 * @covers WPSEO_Config_Field::get_requires
 	 */
 	public function test_set_requires() {
 		$field_b = 'field_b';
@@ -79,7 +79,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Config_Field::to_array()
+	 * @covers WPSEO_Config_Field::to_array
 	 */
 	public function test_to_array() {
 		$field = new WPSEO_Config_Field( 'a', 'b' );
@@ -91,7 +91,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Config_Field::to_array()
+	 * @covers WPSEO_Config_Field::to_array
 	 */
 	public function test_to_array_requires() {
 		$field = new WPSEO_Config_Field( 'a', 'b' );
@@ -105,7 +105,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Config_Field::to_array()
+	 * @covers WPSEO_Config_Field::to_array
 	 */
 	public function test_to_array_properties() {
 		$property       = 'p';

--- a/integration-tests/config-ui/test-class-configuration-components.php
+++ b/integration-tests/config-ui/test-class-configuration-components.php
@@ -27,7 +27,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Components::add_component()
+	 * @covers WPSEO_Configuration_Components::add_component
 	 */
 	public function test_add_component() {
 		$component = $this->getMockBuilder( 'WPSEO_Config_Component' )->getMock();
@@ -38,7 +38,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Components::set_adapter()
+	 * @covers WPSEO_Configuration_Components::set_adapter
 	 */
 	public function test_set_adapter() {
 		$adapter = $this
@@ -68,7 +68,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Components::set_storage()
+	 * @covers WPSEO_Configuration_Components::set_storage
 	 */
 	public function test_set_storage() {
 		$storage = $this
@@ -90,7 +90,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Components::set_storage()
+	 * @covers WPSEO_Configuration_Components::set_storage
 	 */
 	public function test_set_storage_on_field() {
 		$component = $this

--- a/integration-tests/config-ui/test-class-configuration-endpoint.php
+++ b/integration-tests/config-ui/test-class-configuration-endpoint.php
@@ -29,7 +29,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Endpoint::set_service()
+	 * @covers WPSEO_Configuration_Endpoint::set_service
 	 */
 	public function test_set_service() {
 		$service = $this->getMockBuilder( 'WPSEO_Configuration_Service' )->getMock();
@@ -39,7 +39,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Endpoint::can_retrieve_data()
+	 * @covers WPSEO_Configuration_Endpoint::can_retrieve_data
 	 */
 	public function test_can_retrieve_data_fail() {
 		$user_id = $this->factory->user->create();
@@ -50,7 +50,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Endpoint::can_retrieve_data()
+	 * @covers WPSEO_Configuration_Endpoint::can_retrieve_data
 	 */
 	public function test_can_retrieve_data_pass() {
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
@@ -61,7 +61,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Endpoint::can_save_data()
+	 * @covers WPSEO_Configuration_Endpoint::can_save_data
 	 */
 	public function test_can_save_data_fail() {
 		$user_id = $this->factory->user->create();
@@ -72,7 +72,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Endpoint::can_save_data()
+	 * @covers WPSEO_Configuration_Endpoint::can_save_data
 	 */
 	public function test_can_save_data_pass() {
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
@@ -83,7 +83,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Endpoint::register()
+	 * @covers WPSEO_Configuration_Endpoint::register
 	 *
 	 */
 	public function test_register() {

--- a/integration-tests/config-ui/test-class-configuration-options-adapter.php
+++ b/integration-tests/config-ui/test-class-configuration-options-adapter.php
@@ -27,7 +27,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::add_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_lookup
 	 */
 	public function test_add_lookup() {
 		$class_name = 'c';
@@ -46,7 +46,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup
 	 */
 	public function test_add_custom_lookup() {
 		$class_name   = 'stdClass';
@@ -68,7 +68,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup
 	 *
 	 * @expectedException        InvalidArgumentException
 	 * @expectedExceptionMessage Custom option must be callable.
@@ -78,7 +78,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup
 	 *
 	 * @expectedException        InvalidArgumentException
 	 * @expectedExceptionMessage Custom option must be callable.
@@ -88,7 +88,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::add_option_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_option_lookup
 	 */
 	public function test_add_yoast_lookup() {
 		$class_name = 'stdClass';
@@ -106,7 +106,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::add_wordpress_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_wordpress_lookup
 	 */
 	public function test_add_wordpress_lookup() {
 		$class_name = 'stdClass';
@@ -124,7 +124,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::add_wordpress_lookup()
+	 * @covers WPSEO_Configuration_Options_Adapter::add_wordpress_lookup
 	 *
 	 * @expectedException        InvalidArgumentException
 	 * @expectedExceptionMessage WordPress option must be a string.
@@ -134,7 +134,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::get_option_type()
+	 * @covers WPSEO_Configuration_Options_Adapter::get_option_type
 	 */
 	public function test_get_option_type() {
 		$class_name = 'stdClass';
@@ -147,7 +147,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::get_option()
+	 * @covers WPSEO_Configuration_Options_Adapter::get_option
 	 */
 	public function test_get_option() {
 		$class_name = 'stdClass';
@@ -160,7 +160,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::get()
+	 * @covers WPSEO_Configuration_Options_Adapter::get
 	 */
 	public function test_get_wordpress_option() {
 		$option   = 'blogname';
@@ -176,7 +176,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::get()
+	 * @covers WPSEO_Configuration_Options_Adapter::get
 	 */
 	public function test_get_yoast_option() {
 		$key      = 'version';
@@ -192,7 +192,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::get()
+	 * @covers WPSEO_Configuration_Options_Adapter::get
 	 */
 	public function test_get_custom_option() {
 		$get = array( $this, 'custom_option_get' );
@@ -209,7 +209,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::get()
+	 * @covers WPSEO_Configuration_Options_Adapter::get
 	 */
 	public function test_get_unknown_type() {
 
@@ -225,7 +225,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::set()
+	 * @covers WPSEO_Configuration_Options_Adapter::set
 	 */
 	public function test_set_wordpress_option() {
 		$option = uniqid( 'ut' );
@@ -240,7 +240,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::set()
+	 * @covers WPSEO_Configuration_Options_Adapter::set
 	 */
 	public function test_set_yoast_option() {
 		$option = 'wpseo_titles';
@@ -261,7 +261,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::set()
+	 * @covers WPSEO_Configuration_Options_Adapter::set
 	 */
 	public function test_set_yoast_option_same_value() {
 		$option = 'wpseo_titles';
@@ -281,7 +281,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::set()
+	 * @covers WPSEO_Configuration_Options_Adapter::set
 	 */
 	public function test_set_option_unknown_type() {
 		$field = new WPSEO_Config_Field( 'field', 'component' );
@@ -291,7 +291,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Options_Adapter::set()
+	 * @covers WPSEO_Configuration_Options_Adapter::set
 	 */
 	public function test_set_custom_option() {
 		$catcher = $this

--- a/integration-tests/config-ui/test-class-configuration-service.php
+++ b/integration-tests/config-ui/test-class-configuration-service.php
@@ -48,7 +48,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test set storage.
 	 *
-	 * @covers WPSEO_Configuration_Service::set_storage()
+	 * @covers WPSEO_Configuration_Service::set_storage
 	 */
 	public function test_set_storage() {
 		$service = new WPSEO_Configuration_Service_Mock();
@@ -61,7 +61,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test set endpoint.
 	 *
-	 * @covers WPSEO_Configuration_Service::set_endpoint()
+	 * @covers WPSEO_Configuration_Service::set_endpoint
 	 */
 	public function test_set_endpoint() {
 		$service  = new WPSEO_Configuration_Service_Mock();
@@ -74,7 +74,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test set options adapter.
 	 *
-	 * @covers WPSEO_Configuration_Service::set_options_adapter()
+	 * @covers WPSEO_Configuration_Service::set_options_adapter
 	 */
 	public function test_set_options_adapter() {
 		$service = new WPSEO_Configuration_Service_Mock();
@@ -87,7 +87,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test set components.
 	 *
-	 * @covers WPSEO_Configuration_Service::set_components()
+	 * @covers WPSEO_Configuration_Service::set_components
 	 */
 	public function test_set_components() {
 		$service    = new WPSEO_Configuration_Service_Mock();
@@ -100,7 +100,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test set structure.
 	 *
-	 * @covers WPSEO_Configuration_Service::set_structure()
+	 * @covers WPSEO_Configuration_Service::set_structure
 	 */
 	public function test_set_structure() {
 		$service   = new WPSEO_Configuration_Service_Mock();
@@ -113,7 +113,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test retrieving configuration.
 	 *
-	 * @covers WPSEO_Configuration_Service::get_configuration()
+	 * @covers WPSEO_Configuration_Service::get_configuration
 	 */
 	public function test_get_configuration() {
 		$storage   = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->setMethods( array( 'retrieve' ) )->getMock();
@@ -153,7 +153,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test saving configuration function calls.
 	 *
-	 * @covers WPSEO_Configuration_Service::set_configuration()
+	 * @covers WPSEO_Configuration_Service::set_configuration
 	 */
 	public function test_set_configuration() {
 
@@ -188,7 +188,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Make sure all providers are set with default providers call.
 	 *
-	 * @covers WPSEO_Configuration_Service::set_default_providers()
+	 * @covers WPSEO_Configuration_Service::set_default_providers
 	 */
 	public function test_set_default_providers() {
 		$configuration_service = new WPSEO_Configuration_Service_Mock();

--- a/integration-tests/config-ui/test-class-configuration-storage.php
+++ b/integration-tests/config-ui/test-class-configuration-storage.php
@@ -27,7 +27,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Storage::add_field()
+	 * @covers WPSEO_Configuration_Storage::add_field
 	 */
 	public function test_add_field() {
 		$field = $this
@@ -40,8 +40,8 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Storage::set_adapter()
-	 * @covers WPSEO_Configuration_Storage::get_adapter()
+	 * @covers WPSEO_Configuration_Storage::set_adapter
+	 * @covers WPSEO_Configuration_Storage::get_adapter
 	 */
 	public function test_set_adapter() {
 		$adapter = new WPSEO_Configuration_Options_Adapter();
@@ -51,7 +51,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Storage::is_not_null()
+	 * @covers WPSEO_Configuration_Storage::is_not_null
 	 */
 	public function test_is_not_null() {
 		$this->assertTrue( $this->storage->is_not_null( '1' ) );
@@ -61,7 +61,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test get field data with string.
 	 *
-	 * @covers WPSEO_Configuration_Storage::get_field_data()
+	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_null() {
 		$data = null;
@@ -90,7 +90,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test get field data default Field value.
 	 *
-	 * @covers WPSEO_Configuration_Storage::get_field_data()
+	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_field_default() {
 		$data    = null;
@@ -125,7 +125,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test get field data with string.
 	 *
-	 * @covers WPSEO_Configuration_Storage::get_field_data()
+	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_string() {
 		$data = 'data';
@@ -154,7 +154,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test get field data with string.
 	 *
-	 * @covers WPSEO_Configuration_Storage::get_field_data()
+	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_array() {
 		$data    = array( 'a' => '1' );
@@ -196,7 +196,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Storage::retrieve()
+	 * @covers WPSEO_Configuration_Storage::retrieve
 	 */
 	public function test_retrieve() {
 		$field          = 'f';

--- a/integration-tests/config-ui/test-class-configuration-structure.php
+++ b/integration-tests/config-ui/test-class-configuration-structure.php
@@ -27,7 +27,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Structure::initialize()
+	 * @covers WPSEO_Configuration_Structure::initialize
 	 */
 	public function test_constructor() {
 		$this->structure->initialize();
@@ -52,7 +52,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Structure::add_step()
+	 * @covers WPSEO_Configuration_Structure::add_step
 	 */
 	public function test_add_step() {
 
@@ -64,7 +64,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Configuration_Structure::retrieve()
+	 * @covers WPSEO_Configuration_Structure::retrieve
 	 */
 	public function test_retrieve() {
 		$identifier = 'i';

--- a/integration-tests/frontend/test-class-front-end-page-type.php
+++ b/integration-tests/frontend/test-class-front-end-page-type.php
@@ -22,8 +22,8 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where nothing has been done to manipulate the result.
 	 *
-	 * @covers WPSEO_Frontend_Page_Type::is_simple_page()
-	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id()
+	 * @covers WPSEO_Frontend_Page_Type::is_simple_page
+	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id
 	 */
 	public function test_simple_page_default_state() {
 		$this->assertFalse( WPSEO_Frontend_Page_Type::is_simple_page() );
@@ -33,8 +33,8 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where a single post will be visited.
 	 *
-	 * @covers WPSEO_Frontend_Page_Type::is_simple_page()
-	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id()
+	 * @covers WPSEO_Frontend_Page_Type::is_simple_page
+	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id
 	 */
 	public function test_simple_page_with_a_post_being_visited() {
 		$post = $this->factory()->post->create_and_get();
@@ -47,8 +47,8 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where a page that is set as home will be visited.
 	 *
-	 * @covers WPSEO_Frontend_Page_Type::is_simple_page()
-	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id()
+	 * @covers WPSEO_Frontend_Page_Type::is_simple_page
+	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id
 	 */
 	public function test_simple_page_with_a_page_set_as_home_page_being_visited() {
 		$current_page_for_posts = get_option( 'page_for_posts' );
@@ -70,8 +70,8 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where a filter hook has been set.
 	 *
-	 * @covers WPSEO_Frontend_Page_Type::is_simple_page()
-	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id()
+	 * @covers WPSEO_Frontend_Page_Type::is_simple_page
+	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id
 	 */
 	public function test_simple_page_without_a_set_filter_for_the_id() {
 		$this->assertFalse( WPSEO_Frontend_Page_Type::is_simple_page() );
@@ -81,8 +81,8 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where a filter hook has been set.
 	 *
-	 * @covers WPSEO_Frontend_Page_Type::is_simple_page()
-	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id()
+	 * @covers WPSEO_Frontend_Page_Type::is_simple_page
+	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id
 	 */
 	public function test_simple_page_with_a_set_filter_for_the_id() {
 		add_filter( 'wpseo_frontend_page_type_simple_page_id', array( $this, 'simple_page_hook' ) );

--- a/integration-tests/frontend/test-class-opengraph.php
+++ b/integration-tests/frontend/test-class-opengraph.php
@@ -801,7 +801,7 @@ EXPECTED;
 	/**
 	 * Tests the rendering of article:section for a post with two categories.
 	 *
-	 * @covers WPSEO_OpenGraph::category()
+	 * @covers WPSEO_OpenGraph::category
 	 */
 	public function test_get_category() {
 		$post_id = $this->create_post_with_categories();
@@ -823,7 +823,7 @@ EXPECTED;
 	 * Tests the rendering of article:section for a post with two categories where the first
 	 * set category will be removed via a filter.
 	 *
-	 * @covers WPSEO_OpenGraph::category()
+	 * @covers WPSEO_OpenGraph::category
 	 */
 	public function test_get_category_with_first_value_removed_by_filter() {
 		add_filter( 'get_the_categories', array( $this, 'remove_first_category' ) );

--- a/integration-tests/frontend/test-class-twitter.php
+++ b/integration-tests/frontend/test-class-twitter.php
@@ -285,7 +285,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Twitter::image()
+	 * @covers WPSEO_Twitter::image
 	 */
 	public function test_homepage_image() {
 		// Test default image.
@@ -302,7 +302,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Twitter::image()
+	 * @covers WPSEO_Twitter::image
 	 */
 	public function test_default_image() {
 		// Create and go to post.
@@ -338,7 +338,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Twitter::image()
+	 * @covers WPSEO_Twitter::image
 	 */
 	public function test_meta_value_image() {
 		// Create and go to post.
@@ -355,7 +355,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Twitter::image()
+	 * @covers WPSEO_Twitter::image
 	 */
 	public function test_post_thumbnail_image() {
 		$post_id         = $this->factory->post->create();
@@ -375,7 +375,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Twitter::image()
+	 * @covers WPSEO_Twitter::image
 	 */
 	public function test_post_content_image() {
 		$url     = 'http://example.com/example.jpg';
@@ -438,7 +438,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Twitter::gallery_images_output()
+	 * @covers WPSEO_Twitter::gallery_images_output
 	 */
 	public function test_gallery_images() {
 

--- a/integration-tests/frontend/test-class-woocommerce-shop-page.php
+++ b/integration-tests/frontend/test-class-woocommerce-shop-page.php
@@ -13,7 +13,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation when WooCommerce isn't activated.
 	 *
-	 * @covers WPSEO_WooCommerce_Shop_Page::get_shop_page_id()
+	 * @covers WPSEO_WooCommerce_Shop_Page::get_shop_page_id
 	 */
 	public function test_get_shop_page_id() {
 		$woocommerce_shop_page = new WPSEO_WooCommerce_Shop_Page();
@@ -24,7 +24,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation when WooCommerce isn't activated.
 	 *
-	 * @covers WPSEO_WooCommerce_Shop_Page::is_shop_page()
+	 * @covers WPSEO_WooCommerce_Shop_Page::is_shop_page
 	 */
 	public function test_is_shop_page() {
 		$woocommerce_shop_page = new WPSEO_WooCommerce_Shop_Page();
@@ -35,7 +35,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where the currently opened page isn't a shop page.
 	 *
-	 * @covers WPSEO_WooCommerce_Shop_Page::get_page_id()
+	 * @covers WPSEO_WooCommerce_Shop_Page::get_page_id
 	 */
 	public function test_get_page_id_for_non_shop_page() {
 		/** @var $woocommerce_shop_page WPSEO_WooCommerce_Shop_Page */
@@ -59,7 +59,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where the currently opened page isn't a shop page.
 	 *
-	 * @covers WPSEO_WooCommerce_Shop_Page::get_page_id()
+	 * @covers WPSEO_WooCommerce_Shop_Page::get_page_id
 	 */
 	public function test_get_page_id_for_shop_page() {
 		/** @var $woocommerce_shop_page WPSEO_WooCommerce_Shop_Page */
@@ -84,8 +84,8 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where the currently opened page isn't a shop page.
 	 *
-	 * @covers WPSEO_WooCommerce_Shop_Page::get_page_id()
-	 * @covers WPSEO_WooCommerce_Shop_Page::get_shop_page_id()
+	 * @covers WPSEO_WooCommerce_Shop_Page::get_page_id
+	 * @covers WPSEO_WooCommerce_Shop_Page::get_shop_page_id
 	 */
 	public function test_get_page_id_for_shop_page_with_missing_get_page_id_function() {
 		/** @var $woocommerce_shop_page WPSEO_WooCommerce_Shop_Page */

--- a/integration-tests/frontend/test-class-wpseo-content-images.php
+++ b/integration-tests/frontend/test-class-wpseo-content-images.php
@@ -15,7 +15,7 @@ class WPSEO_Content_Images_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test getting the image from post content.
 	 *
-	 * @covers WPSEO_Content_Images::get_images_from_content()
+	 * @covers WPSEO_Content_Images::get_images_from_content
 	 */
 	public function test_get_only_valid_images_from_content() {
 		$class_instance = new WPSEO_Content_Images_Double();

--- a/integration-tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -65,7 +65,7 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests the situation where the archive redirect has been redirected.
 	 *
-	 * @covers WPSEO_Frontend::archive_redirect()
+	 * @covers WPSEO_Frontend::archive_redirect
 	 */
 	public function test_archive_redirect_being_redirected() {
 		global $wp_query;

--- a/integration-tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-robots.php
@@ -33,7 +33,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 *
 	 * @todo Test post type archives.
 	 * @todo Test with page_for_posts option.
@@ -49,7 +49,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_robots_on_private_blog() {
 		// Go to home.
@@ -64,7 +64,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_with_replytocom_attribute() {
 		// Go to home.
@@ -80,7 +80,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_subpages_with_robots_using_default_state() {
 		// Go to home.
@@ -93,7 +93,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_post_robots_default_state() {
 		WPSEO_Options::set( 'noindex-post', false );
@@ -108,7 +108,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_post_noindex() {
 		// Create and go to post.
@@ -121,7 +121,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_private_post() {
 		// Create and go to post.
@@ -133,7 +133,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_category() {
 		// Go to category page.
@@ -152,7 +152,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_category_noindex() {
 		// Go to category page.
@@ -175,7 +175,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_author_archive() {
 		// Go to author page.
@@ -188,7 +188,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	}
 
 	/**
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_author_archive_noindex() {
 		// Go to author page.
@@ -207,7 +207,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests whether an author, when set to not appear in search results, gets a noindex.
 	 *
-	 * @covers WPSEO_Frontend::robots()
+	 * @covers WPSEO_Frontend::robots
 	 */
 	public function test_individual_archive_noindex() {
 		// Go to author page.

--- a/integration-tests/frontend/test-class-wpseo-frontend-title.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-title.php
@@ -105,7 +105,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests if pagination is added to the title.
 	 *
-	 * @covers WPSEO_Frontend::add_paging_to_title()
+	 * @covers WPSEO_Frontend::add_paging_to_title
 	 */
 	public function test_add_paging_to_title() {
 		$input = 'Initial title';
@@ -123,7 +123,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests the add to title behaviour.
 	 *
-	 * @covers WPSEO_Frontend::add_to_title()
+	 * @covers WPSEO_Frontend::add_to_title
 	 */
 	public function test_add_to_title() {
 		$title      = 'Title';
@@ -140,7 +140,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests post type archive title.
 	 *
-	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 * @covers WPSEO_Frontend::get_post_type_archive_title
 	 */
 	public function test_get_post_type_archive_title() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
@@ -163,7 +163,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests if the post type archive has a menu title fallback.
 	 *
-	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 * @covers WPSEO_Frontend::get_post_type_archive_title
 	 */
 	public function test_get_post_type_archive_title_menu_title_fallback() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
@@ -194,7 +194,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests if the post type archive has a post type name fallback.
 	 *
-	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 * @covers WPSEO_Frontend::get_post_type_archive_title
 	 */
 	public function test_get_post_type_archive_title_name_fallback() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
@@ -225,7 +225,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests if the post type archive title falls back on post type name.
 	 *
-	 * @covers WPSEO_Frontend::get_post_type_archive_title()
+	 * @covers WPSEO_Frontend::get_post_type_archive_title
 	 */
 	public function test_get_post_type_archive_title_empty_fallback() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
@@ -256,7 +256,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests if the seo title is a 404 title when an invalid object is presented.
 	 *
-	 * @covers WPSEO_Frontend::get_seo_title()
+	 * @covers WPSEO_Frontend::get_seo_title
 	 */
 	public function test_get_seo_title_no_valid_object() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
@@ -274,7 +274,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests for normal behaviour of the seo title with expected input.
 	 *
-	 * @covers WPSEO_Frontend::get_seo_title()
+	 * @covers WPSEO_Frontend::get_seo_title
 	 */
 	public function test_get_seo_title_with_valid_object() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
@@ -295,7 +295,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Test if seo title applies replace vars as expected.
 	 *
-	 * @covers WPSEO_Frontend::get_seo_title()
+	 * @covers WPSEO_Frontend::get_seo_title
 	 */
 	public function test_get_seo_title_use_replace_vars() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
@@ -320,7 +320,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * Tests if the global queried object is being used with no supplied input.
 	 *
-	 * @covers WPSEO_Frontend::get_seo_title()
+	 * @covers WPSEO_Frontend::get_seo_title
 	 */
 	public function test_get_seo_title_use_queried_object() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )

--- a/integration-tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
@@ -38,7 +38,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the is_shop_page conditional is being respected.
 	 *
-	 * @covers WPSEO_Frontend::generate_title()
+	 * @covers WPSEO_Frontend::generate_title
 	 */
 	public function test_get_shop_page_title() {
 		$post = self::factory()->post->create_and_get();
@@ -62,7 +62,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the post type archive fallback is being used.
 	 *
-	 * @covers WPSEO_Frontend::generate_title()
+	 * @covers WPSEO_Frontend::generate_title
 	 */
 	public function test_get_shop_page_title_post_archive_title_fallback() {
 		$post = self::factory()->post->create_and_get();
@@ -90,7 +90,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the metadescription is being used on the shop page.
 	 *
-	 * @covers WPSEO_Frontend::generate_metadesc()
+	 * @covers WPSEO_Frontend::generate_metadesc
 	 */
 	public function test_get_shop_page_meta_description() {
 		$post = self::factory()->post->create_and_get();
@@ -125,7 +125,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests expected behaviour for an empty post type archive template.
 	 *
-	 * @covers WPSEO_Frontend::generate_metadesc()
+	 * @covers WPSEO_Frontend::generate_metadesc
 	 */
 	public function test_get_shop_page_meta_description_empty_template() {
 		$post = self::factory()->post->create_and_get();
@@ -154,7 +154,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests expected behaviour for an undetermined post type.
 	 *
-	 * @covers WPSEO_Frontend::generate_metadesc()
+	 * @covers WPSEO_Frontend::generate_metadesc
 	 */
 	public function test_get_shop_page_meta_description_empty_post_type() {
 		$post = self::factory()->post->create_and_get();

--- a/integration-tests/frontend/test-class-wpseo-frontend.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend.php
@@ -538,7 +538,7 @@ Page 3/3
 	/**
 	 * Checks the value of the debug mark getter when the premium version is 'active'.
 	 *
-	 * @covers WPSEO_Frontend::head_product_name()
+	 * @covers WPSEO_Frontend::head_product_name
 	 */
 	public function test_head_get_debug_mark_for_premium() {
 		/** @var $frontend WPSEO_Frontend_Double */
@@ -558,7 +558,7 @@ Page 3/3
 	/**
 	 * Checks the value of the debug mark getter when the free version is 'active'.
 	 *
-	 * @covers WPSEO_Frontend::head_product_name()
+	 * @covers WPSEO_Frontend::head_product_name
 	 */
 	public function test_head_get_debug_mark_for_free() {
 		/** @var $frontend WPSEO_Frontend_Double */
@@ -790,7 +790,7 @@ Page 3/3
 	/**
 	 * Tests if the queried post type is fetched properly.
 	 *
-	 * @covers WPSEO_Frontend::get_queried_post_type()
+	 * @covers WPSEO_Frontend::get_queried_post_type
 	 *
 	 * @return void
 	 */
@@ -814,7 +814,7 @@ Page 3/3
 	/**
 	 * Tests for post type when given as multiple items.
 	 *
-	 * @covers WPSEO_Frontend::get_queried_post_type()
+	 * @covers WPSEO_Frontend::get_queried_post_type
 	 *
 	 * @return void
 	 */

--- a/integration-tests/frontend/test-class-wpseo-image-utils.php
+++ b/integration-tests/frontend/test-class-wpseo-image-utils.php
@@ -74,7 +74,7 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 * @param integer $attachment_id The attachment id.
 	 * @param string  $message       Message to show when test fails.
 	 *
-	 * @covers WPSEO_Image_Utils::get_data()
+	 * @covers WPSEO_Image_Utils::get_data
 	 */
 	public function test_get_data( $image, $expected, $attachment_id, $message ) {
 		$this->assertEquals(

--- a/integration-tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/integration-tests/frontend/test-class-wpseo-opengraph-image.php
@@ -432,8 +432,8 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test getting the image from post content.
 	 *
-	 * @covers WPSEO_OpenGraph_Image::set_images()
-	 * @covers WPSEO_OpenGraph_Image::add_first_usable_content_image()
+	 * @covers WPSEO_OpenGraph_Image::set_images
+	 * @covers WPSEO_OpenGraph_Image::add_first_usable_content_image
 	 */
 	public function test_get_images_from_content() {
 		$image_url    = 'https://cdn.yoast.com/app/uploads/2018/03/Caroline_Blog_SEO_FI-600x314.jpg';

--- a/integration-tests/inc/indexables/test-class-indexable.php
+++ b/integration-tests/inc/indexables/test-class-indexable.php
@@ -20,7 +20,7 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 	 * @param string    $description Description of the test.
 	 *
 	 * @dataProvider noindex_conversion_provider
-	 * @covers       WPSEO_Indexable::get_robots_noindex_value()
+	 * @covers       WPSEO_Indexable::get_robots_noindex_value
 	 */
 	public function test_get_robots_noindex_value( $value, $expected, $description ) {
 		$data = WPSEO_Indexable_Double::get_robots_noindex_value( $value );
@@ -31,7 +31,7 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the retrieval of data as an array.
 	 *
-	 * @covers WPSEO_Indexable::to_array()
+	 * @covers WPSEO_Indexable::to_array
 	 */
 	public function test_to_array() {
 		$instance = $this
@@ -52,7 +52,7 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the filtering of updateable data.
 	 *
-	 * @covers WPSEO_Indexable::filter_updateable_data()
+	 * @covers WPSEO_Indexable::filter_updateable_data
 	 */
 	public function test_filter_updateable_data() {
 		$instance = $this

--- a/integration-tests/inc/indexables/test-class-post-indexable.php
+++ b/integration-tests/inc/indexables/test-class-post-indexable.php
@@ -15,7 +15,7 @@ class WPSEO_Post_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the creation of a new Post Indexable object.
 	 *
-	 * @covers WPSEO_Post_Indexable::from_object()
+	 * @covers WPSEO_Post_Indexable::from_object
 	 */
 	public function test_from_object() {
 		$post = $this
@@ -35,7 +35,7 @@ class WPSEO_Post_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the creation of an invalid Post Indexable object.
 	 *
-	 * @covers            WPSEO_Post_Indexable::from_object()
+	 * @covers            WPSEO_Post_Indexable::from_object
 	 * @expectedException WPSEO_Invalid_Argument_Exception
 	 */
 	public function test_from_object_invalid_post() {
@@ -45,7 +45,7 @@ class WPSEO_Post_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the updating of an existing Post Indexable object.
 	 *
-	 * @covers WPSEO_Post_Indexable::update()
+	 * @covers WPSEO_Post_Indexable::update
 	 */
 	public function test_update() {
 		$post = $this

--- a/integration-tests/inc/indexables/test-class-term-indexable.php
+++ b/integration-tests/inc/indexables/test-class-term-indexable.php
@@ -19,7 +19,7 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 	 * @param bool|null $expected      The expected converted value.
 	 * @param string    $description   Description of the test.
 	 *
-	 * @covers WPSEO_Term_Indexable::get_robots_noindex_value()
+	 * @covers WPSEO_Term_Indexable::get_robots_noindex_value
 	 *
 	 * @dataProvider robots_noindex_provider
 	 */
@@ -32,7 +32,7 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the creation of a new Term Indexable object.
 	 *
-	 * @covers WPSEO_Term_Indexable::from_object()
+	 * @covers WPSEO_Term_Indexable::from_object
 	 */
 	public function test_from_object() {
 		$term = $this
@@ -52,7 +52,7 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the creation of an invalid Term Indexable object.
 	 *
-	 * @covers            WPSEO_Term_Indexable::from_object()
+	 * @covers            WPSEO_Term_Indexable::from_object
 	 * @expectedException WPSEO_Invalid_Argument_Exception
 	 */
 	public function test_from_object_invalid_term() {
@@ -62,7 +62,7 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the updating of an existing Term Indexable object.
 	 *
-	 * @covers WPSEO_Term_Indexable::update()
+	 * @covers WPSEO_Term_Indexable::update
 	 */
 	public function test_update() {
 		$term = $this

--- a/integration-tests/inc/options/test-class-wpseo-option-social.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-social.php
@@ -18,7 +18,7 @@ class WPSEO_Option_Social_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider validate_option_provider
 	 *
-	 * @covers WPSEO_Option_Social::validate_option()
+	 * @covers WPSEO_Option_Social::validate_option
 	 */
 	public function test_validate_option( $expected, $dirty, $clean, $old ) {
 		$instance = new WPSEO_Option_Social_Double();

--- a/integration-tests/inc/options/test-class-wpseo-option-titles.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-titles.php
@@ -14,7 +14,7 @@ class WPSEO_Option_Titles_Test extends WPSEO_UnitTestCase {
 	 * Tests if the enrich_defaults() cache is properly invalidated
 	 * when a new post type or taxonomy is registered.
 	 *
-	 * @covers WPSEO_Option_Titles::enrich_defaults()
+	 * @covers WPSEO_Option_Titles::enrich_defaults
 	 */
 	public function test_enrich_defaults_cache_invalidation() {
 		$wpseo_option_titles = WPSEO_Option_Titles::get_instance();

--- a/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
@@ -30,8 +30,8 @@ class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 	 * Tests that disabled 'wpseo' feature variables return false.
 	 *
 	 * @group  ms-required
-	 * @covers WPSEO_Option::validate()
-	 * @covers WPSEO_Option::prevent_disabled_options_update()
+	 * @covers WPSEO_Option::validate
+	 * @covers WPSEO_Option::prevent_disabled_options_update
 	 */
 	public function test_verify_features_against_network() {
 		$this->skipWithoutMultisite();

--- a/integration-tests/inc/options/test-class-wpseo-option.php
+++ b/integration-tests/inc/options/test-class-wpseo-option.php
@@ -14,8 +14,8 @@ class WPSEO_Option_Test extends WPSEO_UnitTestCase {
 	 * Tests that disabled variables cannot be updated.
 	 *
 	 * @group  ms-required
-	 * @covers WPSEO_Option::validate()
-	 * @covers WPSEO_Option::prevent_disabled_options_update()
+	 * @covers WPSEO_Option::validate
+	 * @covers WPSEO_Option::prevent_disabled_options_update
 	 */
 	public function test_prevent_disabled_options_update() {
 		$this->skipWithoutMultisite();

--- a/integration-tests/inc/options/test-class-wpseo-options.php
+++ b/integration-tests/inc/options/test-class-wpseo-options.php
@@ -106,7 +106,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the get() function returns a valid result.
 	 *
-	 * @covers WPSEO_Options::get()
+	 * @covers WPSEO_Options::get
 	 */
 	public function test_get_returns_valid_result() {
 		$option                            = WPSEO_Options::get_option( 'wpseo' );
@@ -124,7 +124,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the get() function returns a valid result.
 	 *
-	 * @covers WPSEO_Options::get()
+	 * @covers WPSEO_Options::get
 	 */
 	public function test_get_returns_null_result() {
 		$result = WPSEO_Options::get( 'non_existent_value' );
@@ -134,7 +134,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the get() function returns a valid result.
 	 *
-	 * @covers WPSEO_Options::get()
+	 * @covers WPSEO_Options::get
 	 */
 	public function test_get_returns_default_result() {
 		$result = WPSEO_Options::get( 'non_existent_value', array() );
@@ -144,7 +144,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the get() function returns a valid result.
 	 *
-	 * @covers WPSEO_Options::get()
+	 * @covers WPSEO_Options::get
 	 */
 	public function test_set_works() {
 		$option_before                            = WPSEO_Options::get_option( 'wpseo' );
@@ -188,8 +188,8 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @covers WPSEO_Options::get()
-	 * @covers WPSEO_Options::add_ms_option()
+	 * @covers WPSEO_Options::get
+	 * @covers WPSEO_Options::add_ms_option
 	 */
 	public function test_ms_options_included_in_get_in_multisite() {
 		$this->skipWithoutMultisite();
@@ -217,8 +217,8 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-excluded
 	 *
-	 * @covers WPSEO_Options::get()
-	 * @covers WPSEO_Options::add_ms_option()
+	 * @covers WPSEO_Options::get
+	 * @covers WPSEO_Options::add_ms_option
 	 */
 	public function test_ms_options_excluded_in_get_non_multisite() {
 		$this->skipWithMultisite();

--- a/integration-tests/inc/options/test-class-wpseo-taxonomy-meta.php
+++ b/integration-tests/inc/options/test-class-wpseo-taxonomy-meta.php
@@ -13,7 +13,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the method without a term object.
 	 *
-	 * @covers WPSEO_Taxonomy_Meta::get_meta_without_term()
+	 * @covers WPSEO_Taxonomy_Meta::get_meta_without_term
 	 */
 	public function test_get_meta_without_term_when_no_term_is_set() {
 		$this->assertFalse( WPSEO_Taxonomy_Meta::get_meta_without_term( 'meta_field' ) );
@@ -22,7 +22,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the method with a term object that has no taxonomy.
 	 *
-	 * @covers WPSEO_Taxonomy_Meta::get_meta_without_term()
+	 * @covers WPSEO_Taxonomy_Meta::get_meta_without_term
 	 */
 	public function test_get_meta_without_term_when_taxonomy_is_missing() {
 		$GLOBALS['wp_query']->queried_object = self::factory()
@@ -39,7 +39,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the method with a valid term object.
 	 *
-	 * @covers WPSEO_Taxonomy_Meta::get_meta_without_term()
+	 * @covers WPSEO_Taxonomy_Meta::get_meta_without_term
 	 */
 	public function test_get_meta_with_valid_term() {
 		$GLOBALS['wp_query']->queried_object = self::factory()
@@ -56,7 +56,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if data with backslashes and double quotes remains the same after validating.
 	 *
-	 * @covers WPSEO_Taxonomy_Meta::validate_term_meta_data()
+	 * @covers WPSEO_Taxonomy_Meta::validate_term_meta_data
 	 */
 	public function test_validate_term_meta_data() {
 		/*
@@ -92,7 +92,7 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if data gets validated as expected.
 	 *
-	 * @covers WPSEO_Taxonomy_Meta::validate_term_meta_data()
+	 * @covers WPSEO_Taxonomy_Meta::validate_term_meta_data
 	 */
 	public function test_validation_of_term_meta_data() {
 		/*

--- a/integration-tests/inc/test-class-post-type.php
+++ b/integration-tests/inc/test-class-post-type.php
@@ -24,7 +24,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the default situation with no custom post types being added.
 	 *
-	 * @covers WPSEO_Post_Type::get_accessible_post_types()
+	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types() {
 		$post_types = WPSEO_Post_Type::get_accessible_post_types();
@@ -36,7 +36,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a custom public post type.
 	 *
-	 * @covers WPSEO_Post_Type::get_accessible_post_types()
+	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_a_custom_post_type() {
 		register_post_type( 'custom-post-type', array( 'public' => true ) );
@@ -47,7 +47,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a custom public post type that is not publicly queryable.
 	 *
-	 * @covers WPSEO_Post_Type::get_accessible_post_types()
+	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_a_custom_post_type_that_is_noy_publicly_queryable() {
 		register_post_type(
@@ -64,7 +64,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a custom private post post type.
 	 *
-	 * @covers WPSEO_Post_Type::get_accessible_post_types()
+	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_a_custom_private_post_type() {
 		register_post_type( 'custom-post-type', array( 'public' => false ) );
@@ -75,7 +75,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a post type that is set to robots noindex.
 	 *
-	 * @covers WPSEO_Post_Type::get_accessible_post_types()
+	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_a_non_indexable_post_type() {
 		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
@@ -89,7 +89,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a post type that isn't set to robots noindex.
 	 *
-	 * @covers WPSEO_Post_Type::get_accessible_post_types()
+	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_an_indexable_post_type() {
 		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
@@ -124,7 +124,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a post type that isn't set to robots noindex.
 	 *
-	 * @covers WPSEO_Post_Type::is_post_type_indexable()
+	 * @covers WPSEO_Post_Type::is_post_type_indexable
 	 */
 	public function test_is_post_type_indexable_with_indexable_post_type() {
 		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
@@ -137,7 +137,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a post type that is set to robots noindex.
 	 *
-	 * @covers WPSEO_Post_Type::is_post_type_indexable()
+	 * @covers WPSEO_Post_Type::is_post_type_indexable
 	 */
 	public function test_is_post_type_indexable_with_non_indexable_post_type() {
 		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
@@ -150,7 +150,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test the situation where the attachment post type will be filtered.
 	 *
-	 * @covers WPSEO_Post_Type::filter_attachment_post_type()
+	 * @covers WPSEO_Post_Type::filter_attachment_post_type
 	 */
 	public function test_filter_attachment_post_type() {
 		$this->assertNotContains(
@@ -180,7 +180,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether or (custom) post types are enabled in the REST API.
 	 *
-	 * @covers WPSEO_Post_Type::is_rest_enabled()
+	 * @covers WPSEO_Post_Type::is_rest_enabled
 	 */
 	public function test_rest_enabled_post_types() {
 		$this->assertTrue( WPSEO_Post_Type::is_rest_enabled( 'post' ) );

--- a/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -70,7 +70,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests adding the admin bar menu, lacking general capabilities.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::add_menu()
+	 * @covers WPSEO_Admin_Bar_Menu::add_menu
 	 */
 	public function test_add_menu_lacking_capabilities() {
 		$admin_bar_menu = $this
@@ -105,7 +105,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests adding the admin bar menu.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::add_menu()
+	 * @covers WPSEO_Admin_Bar_Menu::add_menu
 	 */
 	public function test_add_menu() {
 		wp_set_current_user( self::$wpseo_manager );
@@ -148,7 +148,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests enqueuing assets when the admin bar is not shown.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::enqueue_assets()
+	 * @covers WPSEO_Admin_Bar_Menu::enqueue_assets
 	 */
 	public function test_enqueue_assets_without_admin_bar() {
 		add_filter( 'show_admin_bar', '__return_false' );
@@ -170,7 +170,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests enqueuing assets.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::enqueue_assets()
+	 * @covers WPSEO_Admin_Bar_Menu::enqueue_assets
 	 */
 	public function test_enqueue_assets() {
 		add_filter( 'show_admin_bar', '__return_true' );
@@ -194,7 +194,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests registering main hooks.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::register_hooks()
+	 * @covers WPSEO_Admin_Bar_Menu::register_hooks
 	 */
 	public function test_register_hooks() {
 		$admin_bar_menu = $this->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
@@ -216,7 +216,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests checking requirements.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::meets_requirements()
+	 * @covers WPSEO_Admin_Bar_Menu::meets_requirements
 	 */
 	public function test_meets_requirements() {
 		$admin_bar_menu = new WPSEO_Admin_Bar_Menu( $this->get_asset_manager() );
@@ -238,7 +238,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where everything is going well.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword
 	 */
 	public function test_get_post_focus_keyword() {
 		$post = self::factory()->post->create_and_get();
@@ -253,7 +253,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation with a non object given as argument.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword
 	 */
 	public function test_get_post_focus_keyword_with_invalid_object() {
 		$instance = new WPSEO_Admin_Bar_Menu_Double();
@@ -264,7 +264,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where the given object doesn't have an ID.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword
 	 */
 	public function test_get_post_focus_keyword_with_valid_object_but_no_id_property() {
 		$post     = new stdClass();
@@ -276,7 +276,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the situation where the page analysis is disabled by filter.
 	 *
-	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword()
+	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword
 	 */
 	public function test_get_post_focus_keyword_with_page_analysis_filter_disabled() {
 		add_filter( 'wpseo_use_page_analysis', '__return_false' );

--- a/integration-tests/inc/test-language-utils.php
+++ b/integration-tests/inc/test-language-utils.php
@@ -13,7 +13,7 @@ class WPSEO_Language_Utils_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test the get_language function with no argument.
 	 *
-	 * @covers WPSEO_Language_Utils::get_language()
+	 * @covers WPSEO_Language_Utils::get_language
 	 */
 	public function test_get_language_no_argument() {
 		$language = WPSEO_Language_Utils::get_language();
@@ -24,7 +24,7 @@ class WPSEO_Language_Utils_Test extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test the get_language with the en_GB argument.
 	 *
-	 * @covers WPSEO_Language_Utils::get_language()
+	 * @covers WPSEO_Language_Utils::get_language
 	 */
 	public function test_get_language_english() {
 		$language = WPSEO_Language_Utils::get_language( 'en_GB' );

--- a/integration-tests/notifications/test-class-yoast-notification-center.php
+++ b/integration-tests/notifications/test-class-yoast-notification-center.php
@@ -497,7 +497,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @covers Yoast_Notification_Center::dismiss_notification()
+	 * @covers Yoast_Notification_Center::dismiss_notification
 	 */
 	public function test_dismiss_notification_is_per_site() {
 		$this->skipWithoutMultisite();
@@ -525,7 +525,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @covers Yoast_Notification_Center::restore_notification()
+	 * @covers Yoast_Notification_Center::restore_notification
 	 */
 	public function test_restore_notification_is_per_site() {
 		$this->skipWithoutMultisite();
@@ -559,7 +559,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @covers Yoast_Notification_Center::is_notification_dismissed()
+	 * @covers Yoast_Notification_Center::is_notification_dismissed
 	 */
 	public function test_is_notification_dismissed_is_per_site() {
 		$this->skipWithoutMultisite();
@@ -591,7 +591,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that checking for dismissed notifications falls back to user meta if no user options.
 	 *
-	 * @covers Yoast_Notification_Center::is_notification_dismissed()
+	 * @covers Yoast_Notification_Center::is_notification_dismissed
 	 */
 	public function test_is_notification_dismissed_falls_back_to_user_meta() {
 
@@ -613,7 +613,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that restoring a notification also clears old user metadata.
 	 *
-	 * @covers Yoast_Notification_Center::restore_notification()
+	 * @covers Yoast_Notification_Center::restore_notification
 	 */
 	public function test_restore_notification_clears_user_meta() {
 
@@ -630,7 +630,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that nonces are stripped when notifications are fetched from the database.
 	 *
-	 * @covers Yoast_Notification_Center::retrieve_notifications_from_storage()
+	 * @covers Yoast_Notification_Center::retrieve_notifications_from_storage
 	 */
 	public function test_retrieve_notifications_from_storage_strips_nonces() {
 		$notification_center = Yoast_Notification_Center::get();
@@ -663,7 +663,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that nonces are not stored in the database when persisting notifications.
 	 *
-	 * @covers Yoast_Notification_Center::update_storage()
+	 * @covers Yoast_Notification_Center::update_storage
 	 */
 	public function test_update_storage_strips_nonces() {
 		$notification_center = Yoast_Notification_Center::get();
@@ -685,7 +685,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests removal of a notification when there isn't any with given ID.
 	 *
-	 * @covers Yoast_Notification_Center::remove_notification_by_id()
+	 * @covers Yoast_Notification_Center::remove_notification_by_id
 	 */
 	public function test_remove_notification_by_id_when_no_notification_is_found() {
 		$notification_center = $this
@@ -704,7 +704,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests removal of a notification.
 	 *
-	 * @covers Yoast_Notification_Center::remove_notification_by_id()
+	 * @covers Yoast_Notification_Center::remove_notification_by_id
 	 */
 	public function test_remove_notification_by_id_when_notification_is_found() {
 		$notification_center = $this

--- a/integration-tests/notifiers/test-class-configuration-notifier.php
+++ b/integration-tests/notifiers/test-class-configuration-notifier.php
@@ -13,7 +13,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the notify method when the Onboarding Wizard notice won't be shown.
 	 *
-	 * @covers WPSEO_Configuration_Notifier::notify()
+	 * @covers WPSEO_Configuration_Notifier::notify
 	 */
 	public function test_notify_when_onboarding_wizard_notice_wont_be_shown() {
 		WPSEO_Options::set( 'show_onboarding_notice', false );
@@ -25,7 +25,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the notify method when the Onboarding Wizard notice will be shown.
 	 *
-	 * @covers WPSEO_Configuration_Notifier::notify()
+	 * @covers WPSEO_Configuration_Notifier::notify
 	 */
 	public function test_notify_when_onboarding_wizard_notice_will_be_shown() {
 		WPSEO_Options::set( 'show_onboarding_notice', true );
@@ -37,7 +37,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the listen method when the notification will be shown and dismissal trigger is on.
 	 *
-	 * @covers WPSEO_Configuration_Notifier::listen()
+	 * @covers WPSEO_Configuration_Notifier::listen
 	 */
 	public function test_listen_when_notification_will_be_shown_and_dismissal_trigger_is_on() {
 		$notifier = $this
@@ -66,7 +66,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the listen method when the notification is not shown.
 	 *
-	 * @covers WPSEO_Configuration_Notifier::listen()
+	 * @covers WPSEO_Configuration_Notifier::listen
 	 */
 	public function test_listen_when_notification_is_not_shown() {
 		$notifier = $this
@@ -94,7 +94,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the listen method when notification is shown, but the dismissed trigger isn't on.
 	 *
-	 * @covers WPSEO_Configuration_Notifier::listen()
+	 * @covers WPSEO_Configuration_Notifier::listen
 	 */
 	public function test_listen_when_notification_is_show_but_trigger_is_not_on() {
 		$notifier = $this

--- a/integration-tests/notifiers/test-class-dismissible-notification.php
+++ b/integration-tests/notifiers/test-class-dismissible-notification.php
@@ -57,7 +57,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the handler when the situation is applicable for showing it.
 	 *
-	 * @covers WPSEO_Dismissible_Notification::handle()
+	 * @covers WPSEO_Dismissible_Notification::handle
 	 */
 	public function test_handle_where_situation_is_applicable() {
 		$notification_center = $this
@@ -86,7 +86,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the handler when the situation is not applicable for showing it.
 	 *
-	 * @covers WPSEO_Dismissible_Notification::handle()
+	 * @covers WPSEO_Dismissible_Notification::handle
 	 */
 	public function test_handle_where_situation_is_not_applicable() {
 		$notification_center = $this
@@ -115,7 +115,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the dismissal method.
 	 *
-	 * @covers WPSEO_Dismissible_Notification::dismiss()
+	 * @covers WPSEO_Dismissible_Notification::dismiss
 	 */
 	public function test_dismiss() {
 		$handler = $this
@@ -137,7 +137,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests is_applicable when notices has been dismissed.
 	 *
-	 * @covers WPSEO_Dismissible_Notification::is_applicable()
+	 * @covers WPSEO_Dismissible_Notification::is_applicable
 	 */
 	public function test_is_applicable_with_dismissed_notice() {
 		$instance = $this
@@ -156,7 +156,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests is_applicable when notices has not been dismissed.
 	 *
-	 * @covers WPSEO_Dismissible_Notification::is_applicable()
+	 * @covers WPSEO_Dismissible_Notification::is_applicable
 	 */
 	public function test_is_applicable_with_non_dismissed_notice() {
 		$instance = $this

--- a/integration-tests/notifiers/test-class-post-type-archive-notifier.php
+++ b/integration-tests/notifiers/test-class-post-type-archive-notifier.php
@@ -15,7 +15,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the handler when the situation is not applicable for showing it.
 	 *
-	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable()
+	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable
 	 */
 	public function test_is_applicable_notice_dismissed() {
 		$handler = $this
@@ -34,7 +34,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the handler when the situation is not applicable for showing it.
 	 *
-	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable()
+	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable
 	 */
 	public function test_is_applicable_new_install() {
 		$handler = $this
@@ -58,7 +58,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the handler when the situation is not applicable for showing it.
 	 *
-	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable()
+	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable
 	 */
 	public function test_is_applicable_with_empty_post_types() {
 		$handler = $this
@@ -87,7 +87,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the handler when the situation is not applicable for showing it.
 	 *
-	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable()
+	 * @covers WPSEO_Post_Type_Archive_Notification_Handler::is_applicable
 	 */
 	public function test_is_applicable_with_post_types() {
 		$handler = $this

--- a/integration-tests/onpage/test-class-onpage.php
+++ b/integration-tests/onpage/test-class-onpage.php
@@ -234,7 +234,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if active is based on the option.
 	 *
-	 * @covers WPSEO_OnPage::is_active()
+	 * @covers WPSEO_OnPage::is_active
 	 */
 	public function test_is_active() {
 		WPSEO_Options::set( 'onpage_indexability', true );
@@ -245,9 +245,9 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the cronjob is scheduled when enabled.
 	 *
-	 * @covers WPSEO_OnPage::activate_hooks()
-	 * @covers WPSEO_OnPage::schedule_cron()
-	 * @covers WPSEO_OnPage::unschedule_cron()
+	 * @covers WPSEO_OnPage::activate_hooks
+	 * @covers WPSEO_OnPage::schedule_cron
+	 * @covers WPSEO_OnPage::unschedule_cron
 	 */
 	public function test_cron_scheduling() {
 		WPSEO_Options::set( 'onpage_indexability', true );

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -190,7 +190,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the excluded posts with the usage of the filter.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_excluded_posts()
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_excluded_posts
 	 */
 	public function test_get_excluded_posts_with_set_filter() {
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
@@ -213,7 +213,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the excluded posts with the usage of a filter that returns an invalid value.
 	 *
-	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_excluded_posts()
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_excluded_posts
 	 */
 	public function test_get_excluded_posts_with_set_filter_that_has_invalid_return_value() {
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache-data.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache-data.php
@@ -30,8 +30,8 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test getting/setting sitemap.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap()
-	 * @covers WPSEO_Sitemap_Cache_Data::get_sitemap()
+	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap
+	 * @covers WPSEO_Sitemap_Cache_Data::get_sitemap
 	 */
 	public function test_get_set_sitemap() {
 		$sitemap = 'this is a sitemap';
@@ -43,8 +43,8 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Setting a sitemap that is not a string.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::get_sitemap()
-	 * @covers WPSEO_Sitemap_Cache_Data::is_usable()
+	 * @covers WPSEO_Sitemap_Cache_Data::get_sitemap
+	 * @covers WPSEO_Sitemap_Cache_Data::is_usable
 	 */
 	public function test_set_sitemap_not_string() {
 		$sitemap         = new StdClass();
@@ -58,7 +58,7 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test with invalid status.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::get_status()
+	 * @covers WPSEO_Sitemap_Cache_Data::get_status
 	 */
 	public function test_set_invalid_status() {
 		$status = 'invalid';
@@ -71,7 +71,7 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test status of sitemap without setting anything.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::get_status()
+	 * @covers WPSEO_Sitemap_Cache_Data::get_status
 	 */
 	public function test_sitemap_status_unset() {
 		$this->assertEquals( WPSEO_Sitemap_Cache_Data::UNKNOWN, $this->subject->get_status() );
@@ -80,8 +80,8 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test setting empty sitemap - status.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap()
-	 * @covers WPSEO_Sitemap_Cache_Data::get_status()
+	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap
+	 * @covers WPSEO_Sitemap_Cache_Data::get_status
 	 */
 	public function test_set_empty_sitemap_status() {
 		$sitemap = '';
@@ -93,8 +93,8 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test is_usable with status.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::get_status()
-	 * @covers WPSEO_Sitemap_Cache_Data::is_usable()
+	 * @covers WPSEO_Sitemap_Cache_Data::get_status
+	 * @covers WPSEO_Sitemap_Cache_Data::is_usable
 	 */
 	public function test_set_status_is_usable() {
 		$this->subject->set_status( WPSEO_Sitemap_Cache_Data::OK );
@@ -107,8 +107,8 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test setting status string/constant.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::set_status()
-	 * @covers WPSEO_Sitemap_Cache_Data::get_status()
+	 * @covers WPSEO_Sitemap_Cache_Data::set_status
+	 * @covers WPSEO_Sitemap_Cache_Data::get_status
 	 */
 	public function test_set_status_string() {
 		$this->subject->set_status( WPSEO_Sitemap_Cache_Data::OK );

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -25,7 +25,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test sitemap cache not set.
 	 *
-	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data()
+	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data
 	 */
 	public function test_transient_not_set() {
 
@@ -38,9 +38,9 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test if the transient cache is set as a cache data object.
 	 *
-	 * @covers WPSEO_Sitemaps_Cache::store_sitemap()
-	 * @covers WPSEO_Sitemaps_Cache::get_sitemap()
-	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data()
+	 * @covers WPSEO_Sitemaps_Cache::store_sitemap
+	 * @covers WPSEO_Sitemaps_Cache::get_sitemap
+	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data
 	 */
 	public function test_transient_cache_data_object() {
 
@@ -63,9 +63,9 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test sitemap cache XML set as string not being validated.
 	 *
-	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data()
-	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap()
-	 * @covers WPSEO_Sitemap_Cache_Data::is_usable()
+	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data
+	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap
+	 * @covers WPSEO_Sitemap_Cache_Data::is_usable
 	 */
 	public function test_transient_string_to_cache_data() {
 

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -91,7 +91,7 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting the fallback url if the plugin is loaded from a different domain.
 	 *
-	 * @covers WPSEO_Sitemaps_Renderer_Double::get_xsl_url()
+	 * @covers WPSEO_Sitemaps_Renderer_Double::get_xsl_url
 	 */
 	public function test_is_home_url_returned_correctly() {
 		$class_instance = new WPSEO_Sitemaps_Renderer_Double();

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -70,7 +70,7 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether the current request should be redirected to sitemap_index.xml.
 	 *
-	 * @covers       WPSEO_Sitemaps_Router::needs_sitemap_index_redirect()
+	 * @covers       WPSEO_Sitemaps_Router::needs_sitemap_index_redirect
 	 * @dataProvider data_needs_sitemap_index_redirect
 	 *
 	 * @param array    $server_vars Associative array of `$_SERVER` vars to set.

--- a/integration-tests/test-class-primary-term-admin.php
+++ b/integration-tests/test-class-primary-term-admin.php
@@ -75,7 +75,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 * - css/metabox-primary-category.css;
 	 * - js/dist/wp-seo-metabox-category.js.
 	 *
-	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
+	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets
 	 */
 	public function test_enqueue_assets_EMPTY_taxonomies_DO_NOT_enqueue_scripts() {
 		$this->class_instance->enqueue_assets();
@@ -89,7 +89,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 * - css/metabox-primary-category.css;
 	 * - js/dist/wp-seo-metabox-category.js.
 	 *
-	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
+	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets
 	 */
 	public function test_enqueue_assets_DO_NOT_enqueue_scripts() {
 		$this->class_instance
@@ -107,7 +107,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 * - css/metabox-primary-category.css;
 	 * - js/dist/wp-seo-metabox-category.js.
 	 *
-	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets()
+	 * @covers WPSEO_Primary_Term_Admin::enqueue_assets
 	 */
 	public function test_enqueue_assets_WITH_taxonomies_DO_enqueue_scripts() {
 		global $pagenow;
@@ -141,7 +141,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Make sure the primary terms are saved.
 	 *
-	 * @covers WPSEO_Primary_Term_Admin::save_primary_terms()
+	 * @covers WPSEO_Primary_Term_Admin::save_primary_terms
 	 */
 	public function test_save_primary_terms_CALLS_save_primary_term() {
 		$taxonomies = array(

--- a/integration-tests/test-class-wpseo-breadcrumbs.php
+++ b/integration-tests/test-class-wpseo-breadcrumbs.php
@@ -54,7 +54,7 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting the url for a private post.
 	 *
-	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id()
+	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id
 	 */
 	public function test_getting_url_of_private_post() {
 		$breadcrumbs = new WPSEO_Breadcrumbs_Double();
@@ -66,7 +66,7 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting the url for a public post.
 	 *
-	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id()
+	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id
 	 */
 	public function test_getting_url_of_public_post() {
 		$breadcrumbs = new WPSEO_Breadcrumbs_Double();
@@ -78,7 +78,7 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests getting the url for a non existing post id.
 	 *
-	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id()
+	 * @covers WPSEO_Breadcrumbs::get_link_url_for_id
 	 */
 	public function test_getting_url_of_a_non_existing_post() {
 		$breadcrumbs = new WPSEO_Breadcrumbs_Double();

--- a/integration-tests/test-class-wpseo-meta-columns.php
+++ b/integration-tests/test-class-wpseo-meta-columns.php
@@ -271,7 +271,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Meta_Columns::column_heading()
+	 * @covers WPSEO_Meta_Columns::column_heading
 	 */
 	public function test_column_heading_has_score() {
 		self::$class_instance->set_current_post_type( 'post' );
@@ -281,7 +281,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Meta_Columns::column_heading()
+	 * @covers WPSEO_Meta_Columns::column_heading
 	 */
 	public function test_column_heading_has_focuskw() {
 		self::$class_instance->set_current_post_type( 'post' );
@@ -291,7 +291,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Meta_Columns::column_heading()
+	 * @covers WPSEO_Meta_Columns::column_heading
 	 */
 	public function test_column_heading_has_metadesc() {
 		self::$class_instance->set_current_post_type( 'post' );
@@ -303,7 +303,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that column_hidden returns the columns to hide so that WordPress hides them.
 	 *
-	 * @covers WPSEO_Meta_Columns::column_hidden()
+	 * @covers WPSEO_Meta_Columns::column_hidden
 	 */
 	public function test_column_hidden_HIDE_COLUMNS() {
 		$user = $this->getMockBuilder( 'WP_User' )
@@ -325,7 +325,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 *
 	 * This is so the user can still set the columns they want to hide.
 	 *
-	 * @covers WPSEO_Meta_Columns::column_hidden()
+	 * @covers WPSEO_Meta_Columns::column_hidden
 	 */
 	public function test_column_hidden_KEEP_OPTION() {
 		// Option shouldn't be touched if the user has set it already.
@@ -345,7 +345,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if column_hidden can deal with non array values returned from WordPress.
 	 *
-	 * @covers WPSEO_Meta_Columns::column_hidden()
+	 * @covers WPSEO_Meta_Columns::column_hidden
 	 */
 	public function test_column_hidden_UNEXPECTED_VALUE() {
 		$user = $this->getMockBuilder( 'WP_User' )
@@ -365,14 +365,14 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Meta_Columns::is_valid_filter()
+	 * @covers WPSEO_Meta_Columns::is_valid_filter
 	 */
 	public function test_is_valid_filter() {
 		$this->assertTrue( self::$class_instance->is_valid_filter( 'needs improvement' ) );
 	}
 
 	/**
-	 * @covers WPSEO_Meta_Columns::is_valid_filter()
+	 * @covers WPSEO_Meta_Columns::is_valid_filter
 	 */
 	public function test_is_invalid_filter() {
 		$this->assertFalse( self::$class_instance->is_valid_filter( '' ) );
@@ -385,7 +385,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @param array  $expected The resulting SEO score filter.
 	 *
 	 * @dataProvider determine_seo_filters_dataprovider
-	 * @covers       WPSEO_Meta_Columns::determine_seo_filters()
+	 * @covers       WPSEO_Meta_Columns::determine_seo_filters
 	 */
 	public function test_determine_seo_filters( $filter, $expected ) {
 		$result = self::$class_instance->determine_seo_filters( $filter );
@@ -398,7 +398,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @param array  $expected The Readability score filter.
 	 *
 	 * @dataProvider determine_readability_filters_dataprovider
-	 * @covers       WPSEO_Meta_Columns::determine_readability_filters()
+	 * @covers       WPSEO_Meta_Columns::determine_readability_filters
 	 */
 	public function test_determine_readability_filters( $filter, $expected ) {
 		$result = self::$class_instance->determine_readability_filters( $filter );
@@ -412,7 +412,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @param array $expected Array containing the complete filter query.
 	 *
 	 * @dataProvider build_filter_query_dataprovider
-	 * @covers       WPSEO_Meta_Columns::build_filter_query()
+	 * @covers       WPSEO_Meta_Columns::build_filter_query
 	 */
 	public function test_build_filter_query( $vars, $filters, $expected ) {
 		$result = self::$class_instance->build_filter_query( $vars, $filters );
@@ -423,7 +423,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether the default indexing is being used.
 	 *
-	 * @covers WPSEO_Meta_Columns::uses_default_indexing()
+	 * @covers WPSEO_Meta_Columns::uses_default_indexing
 	 */
 	public function test_is_using_default_indexing() {
 		$post = $this->factory()->post->create_and_get( array() );
@@ -439,7 +439,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether the default indexing is not being used.
 	 *
-	 * @covers WPSEO_Meta_Columns::uses_default_indexing()
+	 * @covers WPSEO_Meta_Columns::uses_default_indexing
 	 */
 	public function test_is_not_using_default_indexing() {
 		$post = $this->factory()->post->create_and_get( array() );
@@ -455,7 +455,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether a hard set indexing value on a post, is considered indexable.
 	 *
-	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 * @covers WPSEO_Meta_Columns::is_indexable
 	 */
 	public function test_is_indexable_when_set_on_post() {
 		$post = $this->factory()->post->create_and_get( array() );
@@ -471,7 +471,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether a not hard set indexing value on a post, is considered indexable based on the default setting.
 	 *
-	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 * @covers WPSEO_Meta_Columns::is_indexable
 	 */
 	public function test_is_indexable_when_using_default() {
 		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
@@ -488,7 +488,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether a not hard set indexing value on a post, is considered not indexable based on the default setting.
 	 *
-	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 * @covers WPSEO_Meta_Columns::is_indexable
 	 */
 	public function test_is_not_indexable_when_using_default() {
 		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
@@ -505,7 +505,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether a malformed post object defaults to true.
 	 *
-	 * @covers WPSEO_Meta_Columns::is_indexable()
+	 * @covers WPSEO_Meta_Columns::is_indexable
 	 */
 	public function test_is_indexable_when_using_malformed_post_object() {
 		$post         = '';

--- a/integration-tests/test-class-wpseo-meta.php
+++ b/integration-tests/test-class-wpseo-meta.php
@@ -15,7 +15,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if data can be stored.
 	 *
-	 * @covers WPSEO_Meta::set_value()
+	 * @covers WPSEO_Meta::set_value
 	 */
 	public function test_set_value() {
 		// Create and go to post.
@@ -29,7 +29,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if data can be retrieved.
 	 *
-	 * @covers WPSEO_Meta::get_value()
+	 * @covers WPSEO_Meta::get_value
 	 */
 	public function test_get_value() {
 
@@ -55,8 +55,8 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @see self::test_get_value_unregistered_field_serialized()
 	 *
-	 * @covers WPSEO_Meta::set_value()
-	 * @covers WPSEO_Meta::get_value()
+	 * @covers WPSEO_Meta::set_value
+	 * @covers WPSEO_Meta::get_value
 	 */
 	public function test_get_value_non_registered_field() {
 
@@ -80,7 +80,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 * data cannot be confirmed to be expected and thus an empty string will
 	 * be returned.
 	 *
-	 * @covers WPSEO_Meta::get_value()
+	 * @covers WPSEO_Meta::get_value
 	 */
 	public function test_get_value_unregistered_field_serialized() {
 
@@ -100,7 +100,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if a non existing key returns an empty string.
 	 *
-	 * @covers WPSEO_Meta::get_value()
+	 * @covers WPSEO_Meta::get_value
 	 */
 	public function test_get_value_non_existing_key() {
 
@@ -116,7 +116,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if data with slashes remains the same after storing.
 	 *
-	 * @covers WPSEO_Meta::get_value()
+	 * @covers WPSEO_Meta::get_value
 	 */
 	public function test_set_value_slashed() {
 		$post_id = $this->factory->post->create();
@@ -135,8 +135,8 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 * Tests if data, registered as serialized, with slashes remains the same
 	 * after storing.
 	 *
-	 * @covers WPSEO_Meta::set_value()
-	 * @covers WPSEO_Meta::get_value()
+	 * @covers WPSEO_Meta::set_value
+	 * @covers WPSEO_Meta::get_value
 	 */
 	public function test_get_and_set_value_slashed_array() {
 		$post_id = $this->factory->post->create();
@@ -155,8 +155,8 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 * Tests if serialized data, registered as serialized, with slashes remains
 	 * the same after storing.
 	 *
-	 * @covers WPSEO_Meta::set_value()
-	 * @covers WPSEO_Meta::get_value()
+	 * @covers WPSEO_Meta::set_value
+	 * @covers WPSEO_Meta::get_value
 	 */
 	public function test_get_and_set_value_serialized_and_slashed_array() {
 		$post_id = $this->factory->post->create();

--- a/integration-tests/test-class-wpseo-metabox.php
+++ b/integration-tests/test-class-wpseo-metabox.php
@@ -29,7 +29,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that on certain pages, assets are not enqueued.
 	 *
-	 * @covers WPSEO_Metabox::enqueue()
+	 * @covers WPSEO_Metabox::enqueue
 	 */
 	public function test_enqueue_not_firing_on_options_page() {
 		global $pagenow;
@@ -45,7 +45,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests that enqueuing the necessary assets, works.
 	 *
-	 * @covers WPSEO_Metabox::enqueue()
+	 * @covers WPSEO_Metabox::enqueue
 	 */
 	public function test_enqueue_firing_on_new_post_page() {
 		global $pagenow;

--- a/integration-tests/test-class-wpseo-utils.php
+++ b/integration-tests/test-class-wpseo-utils.php
@@ -41,7 +41,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Utils::is_apache()
+	 * @covers WPSEO_Utils::is_apache
 	 */
 	public function test_wpseo_is_apache() {
 		$_SERVER['SERVER_SOFTWARE'] = 'Apache/2.2.22';
@@ -52,7 +52,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Utils::is_nginx()
+	 * @covers WPSEO_Utils::is_nginx
 	 */
 	public function test_wpseo_is_nginx() {
 		$_SERVER['SERVER_SOFTWARE'] = 'nginx/1.5.11';
@@ -63,7 +63,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Utils::trim_nbsp_from_string()
+	 * @covers WPSEO_Utils::trim_nbsp_from_string
 	 */
 	public function test_wpseo_trim_nbsp_from_string() {
 		$old_string = ' This is an old string with&nbsp;as spaces.&nbsp;';
@@ -94,7 +94,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 * Tests translate_score function.
 	 *
 	 * @dataProvider translate_score_provider
-	 * @covers       WPSEO_Utils::translate_score()
+	 * @covers       WPSEO_Utils::translate_score
 	 *
 	 * @param int    $score     The decimal score to translate.
 	 * @param bool   $css_value Whether to return the i18n translated score or the CSS class value.
@@ -171,7 +171,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether the plugin is network-active or not.
 	 *
-	 * @covers WPSEO_Utils::is_plugin_network_active()
+	 * @covers WPSEO_Utils::is_plugin_network_active
 	 */
 	public function test_is_plugin_network_active() {
 		$this->assertFalse( WPSEO_Utils::is_plugin_network_active() );

--- a/integration-tests/test-wpseo-functions.php
+++ b/integration-tests/test-wpseo-functions.php
@@ -11,7 +11,7 @@
 class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * @covers wpseo_replace_vars
+	 * @covers ::wpseo_replace_vars
 	 */
 	public function test_wpseo_replace_vars() {
 

--- a/tests/admin/admin-asset-analysis-worker-location-test.php
+++ b/tests/admin/admin-asset-analysis-worker-location-test.php
@@ -14,7 +14,7 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 	/**
 	 * Tests the get_url function.
 	 *
-	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
+	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url
 	 */
 	public function test_get_url() {
 		$version          = 'test-version';
@@ -39,7 +39,7 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 	/**
 	 * Tests the get_url function when we pass a name.
 	 *
-	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url()
+	 * @covers WPSEO_Admin_Asset_Analysis_Worker_Location::get_url
 	 */
 	public function test_get_url_with_name() {
 		$custom_file_name = 'custom-name';

--- a/tests/admin/myyoast-proxy-test.php
+++ b/tests/admin/myyoast-proxy-test.php
@@ -16,7 +16,7 @@ use Yoast\WP\Free\Tests\TestCase;
 class MyYoast_Proxy_Test extends TestCase {
 
 	/**
-	 * @covers WPSEO_MyYoast_Proxy::determine_proxy_options()
+	 * @covers WPSEO_MyYoast_Proxy::determine_proxy_options
 	 */
 	public function test_determine_proxy_options_for_the_research_webworker_file() {
 		/** @var \Yoast\Tests\Doubles\MyYoast_Proxy_Double $instance */
@@ -42,8 +42,8 @@ class MyYoast_Proxy_Test extends TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
-	 * @covers WPSEO_MyYoast_Proxy::determine_proxy_options()
+	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page
+	 * @covers WPSEO_MyYoast_Proxy::determine_proxy_options
 	 */
 	public function test_render_proxy_page_for_an_unknown_file() {
 		/** @var \WPSEO_MyYoast_Proxy $instance */
@@ -68,7 +68,7 @@ class MyYoast_Proxy_Test extends TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
+	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page
 	 */
 	public function test_render_proxy_page_for_the_research_webworker_file() {
 		/** @var \WPSEO_MyYoast_Proxy $instance */
@@ -113,7 +113,7 @@ class MyYoast_Proxy_Test extends TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
+	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page
 	 */
 	public function test_render_proxy_page_for_the_research_webworker_file_errored_and_wordpress_not_found() {
 		Monkey\Functions\expect( 'wp_remote_get' )
@@ -183,7 +183,7 @@ class MyYoast_Proxy_Test extends TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
+	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page
 	 */
 	public function test_render_proxy_page_via_wordpress() {
 		Monkey\Functions\expect( 'wp_remote_get' )
@@ -228,7 +228,7 @@ class MyYoast_Proxy_Test extends TestCase {
 	}
 
 	/**
-	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page()
+	 * @covers WPSEO_MyYoast_Proxy::render_proxy_page
 	 */
 	public function test_render_proxy_page_via_wordpress_errored() {
 		$wp_error_mock = Mockery::mock( '\WP_Error' );

--- a/tests/config/database-migration-test.php
+++ b/tests/config/database-migration-test.php
@@ -160,7 +160,7 @@ class Database_Migration_Test extends TestCase {
 	/**
 	 * Tests the initializing with an exception being thrown.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Database_Migration::run_migrations()
+	 * @covers \Yoast\WP\Free\Config\Database_Migration::run_migrations
 	 */
 	public function test_initialize_with_exception_thrown() {
 		$instance = $this
@@ -195,7 +195,7 @@ class Database_Migration_Test extends TestCase {
 	/**
 	 * Tests the retrieval of the charset.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_charset()
+	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_charset
 	 */
 	public function test_get_charset() {
 		$instance = new Database_Migration_Double(
@@ -209,7 +209,7 @@ class Database_Migration_Test extends TestCase {
 	/**
 	 * Tests the retrieval of the migration configuration.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_configuration()
+	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_configuration
 	 */
 	public function test_get_configuration() {
 		$instance = new Database_Migration_Double(
@@ -221,7 +221,7 @@ class Database_Migration_Test extends TestCase {
 	}
 
 	/**
-	 * @covers \Yoast\WP\Free\Config\Database_Migration::set_defines()
+	 * @covers \Yoast\WP\Free\Config\Database_Migration::set_defines
 	 */
 	public function test_set_define_success() {
 		$instance = $this
@@ -247,7 +247,7 @@ class Database_Migration_Test extends TestCase {
 	}
 
 	/**
-	 * @covers \Yoast\WP\Free\Config\Database_Migration::set_defines()
+	 * @covers \Yoast\WP\Free\Config\Database_Migration::set_defines
 	 */
 	public function test_set_define_failed() {
 		$instance = $this
@@ -275,7 +275,7 @@ class Database_Migration_Test extends TestCase {
 	/**
 	 * Tests if the defines are configured correctly when we are using prefixed dependencies.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_defines()
+	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_defines
 	 */
 	public function test_get_defines() {
 		$dependency_management = $this
@@ -301,7 +301,7 @@ class Database_Migration_Test extends TestCase {
 	/**
 	 * Tests if the defines are configured correctly when we are not using prefixed dependencies.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_defines()
+	 * @covers \Yoast\WP\Free\Config\Database_Migration::get_defines
 	 */
 	public function test_get_defines_not_prefixed() {
 		$dependency_management = $this

--- a/tests/config/dependency-management-test.php
+++ b/tests/config/dependency-management-test.php
@@ -17,7 +17,7 @@ class Dependency_Management_Test extends TestCase {
 	/**
 	 * Tests if the alias is created with ideal conditions.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias()
+	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias
 	 */
 	public function test_ensure_class_alias() {
 		$instance = $this
@@ -48,7 +48,7 @@ class Dependency_Management_Test extends TestCase {
 	/**
 	 * Tests if no alias is created for unrelated class.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias()
+	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias
 	 */
 	public function test_ensure_class_alias_unrelated_class() {
 		$instance = $this
@@ -75,7 +75,7 @@ class Dependency_Management_Test extends TestCase {
 	/**
 	 * Tests if alias is not created when prefixed dependencies are present.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias()
+	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias
 	 */
 	public function test_ensure_class_alias_prefix_available() {
 		$instance = $this
@@ -103,7 +103,7 @@ class Dependency_Management_Test extends TestCase {
 	/**
 	 * Tests if class alias is not created when base class does not exist.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias()
+	 * @covers \Yoast\WP\Free\Config\Dependency_Management::ensure_class_alias
 	 */
 	public function test_ensure_class_alias_base_class_does_not_exist() {
 		$instance = $this
@@ -133,7 +133,7 @@ class Dependency_Management_Test extends TestCase {
 	/**
 	 * Tests to make sure the autoloader is registered during initialization.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Dependency_Management::initialize()
+	 * @covers \Yoast\WP\Free\Config\Dependency_Management::initialize
 	 */
 	public function test_registration_of_autoloader() {
 		$instance = new Dependency_Management();

--- a/tests/config/plugin-test.php
+++ b/tests/config/plugin-test.php
@@ -24,7 +24,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests adding an integration.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::add_integration()
+	 * @covers \Yoast\WP\Free\Config\Plugin::add_integration
 	 */
 	public function test_add_integration() {
 		$instance = new Plugin_Double( $this->get_dependency_management_mock(), $this->get_database_migration_mock() );
@@ -41,7 +41,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests for default dependeny management class.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::__construct()
+	 * @covers \Yoast\WP\Free\Config\Plugin::__construct
 	 */
 	public function test_default_dependency_management() {
 		$instance = new Plugin_Double( null, $this->get_database_migration_mock() );
@@ -52,7 +52,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests for default database migration class.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::__construct()
+	 * @covers \Yoast\WP\Free\Config\Plugin::__construct
 	 */
 	public function test_default_database_migration() {
 		$instance = new Plugin_Double( null, null );
@@ -63,7 +63,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests if the initialize calls the expected methods.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::initialize()
+	 * @covers \Yoast\WP\Free\Config\Plugin::initialize
 	 */
 	public function test_initialize() {
 		$dependency_management = $this->get_dependency_management_mock();
@@ -99,7 +99,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests early return if dependency management could not complete.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::initialize()
+	 * @covers \Yoast\WP\Free\Config\Plugin::initialize
 	 */
 	public function test_initialize_dependency_management_not_initialized() {
 		$dependency_management = $this->get_dependency_management_mock();
@@ -134,7 +134,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests if initialize failed if migration failed.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::initialize()
+	 * @covers \Yoast\WP\Free\Config\Plugin::initialize
 	 */
 	public function test_initialize_db_migration_not_initialized() {
 		$dependency_management = $this->get_dependency_management_mock();
@@ -163,8 +163,8 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests if the expected methods are called during register hooks.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::register_hooks()
-	 * @covers \Yoast\WP\Free\Config\Plugin::trigger_integration_hook()
+	 * @covers \Yoast\WP\Free\Config\Plugin::register_hooks
+	 * @covers \Yoast\WP\Free\Config\Plugin::trigger_integration_hook
 	 */
 	public function test_register_hooks() {
 		$methods  = array(
@@ -215,8 +215,8 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests if the action is called during register hooks.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::register_hooks()
-	 * @covers \Yoast\WP\Free\Config\Plugin::trigger_integration_hook()
+	 * @covers \Yoast\WP\Free\Config\Plugin::register_hooks
+	 * @covers \Yoast\WP\Free\Config\Plugin::trigger_integration_hook
 	 */
 	public function test_register_hooks_action_is_called() {
 		$instance = new Plugin_Double();
@@ -232,7 +232,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests if get integration group is not called on failed initialize.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::register_hooks()
+	 * @covers \Yoast\WP\Free\Config\Plugin::register_hooks
 	 */
 	public function test_register_hooks_not_initialzed() {
 		$instance = $this
@@ -252,7 +252,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests if frontend integration returns a Frontend object.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::add_frontend_integrations()
+	 * @covers \Yoast\WP\Free\Config\Plugin::add_frontend_integrations
 	 */
 	public function test_add_frontend_integrations() {
 		$instance = $this
@@ -271,7 +271,7 @@ class Plugin_Test extends TestCase {
 	/**
 	 * Tests if add admin integrations returns an Admin object.
 	 *
-	 * @covers \Yoast\WP\Free\Config\Plugin::add_admin_integrations()
+	 * @covers \Yoast\WP\Free\Config\Plugin::add_admin_integrations
 	 */
 	public function test_add_admin_integrations() {
 		$instance = $this

--- a/tests/exceptions/no-indexable-found-test.php
+++ b/tests/exceptions/no-indexable-found-test.php
@@ -47,8 +47,8 @@ class No_Indexable_Found_Test extends TestCase {
 	/**
 	 * Tests the exception for a non existing post.
 	 *
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_post_id()
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_post_id
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception
 	 *
 	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
@@ -67,8 +67,8 @@ class No_Indexable_Found_Test extends TestCase {
 	/**
 	 * Tests the exception for a non existing term.
 	 *
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_term_id()
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_term_id
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception
 	 *
 	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
@@ -87,8 +87,8 @@ class No_Indexable_Found_Test extends TestCase {
 	/**
 	 * Tests the exception for a non existing term.
 	 *
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_primary_term()
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_primary_term
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception
 	 *
 	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
@@ -107,8 +107,8 @@ class No_Indexable_Found_Test extends TestCase {
 	/**
 	 * Tests the exception for a non existing post.
 	 *
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_author_id()
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_author_id
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception
 	 *
 	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */
@@ -127,8 +127,8 @@ class No_Indexable_Found_Test extends TestCase {
 	/**
 	 * Tests the exception for a non existing indexable meta.
 	 *
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_meta_key()
-	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception()
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::from_meta_key
+	 * @covers \Yoast\WP\Free\Exceptions\No_Indexable_Found::create_and_log_exception
 	 *
 	 * @throws \Yoast\WP\Free\Exceptions\No_Indexable_Found For test purposes.
 	 */

--- a/tests/formatters/indexable-post-formatter-test.php
+++ b/tests/formatters/indexable-post-formatter-test.php
@@ -102,7 +102,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests retreiving a meta value.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_meta_value()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_meta_value
 	 */
 	public function test_get_meta_value() {
 		Monkey\Functions\expect( 'update_post_meta' )
@@ -128,7 +128,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests the robots noindex lookup method.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_robots_noindex()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_robots_noindex
 	 */
 	public function test_get_robots_noindex() {
 		$instance = new Indexable_Post_Double( 1 );
@@ -148,7 +148,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests if robot options returns the expected type of data.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_robots_options()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_robots_options
 	 */
 	public function test_get_robots_options() {
 		$instance = new Indexable_Post_Double( 1 );
@@ -158,7 +158,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests retrieval of keyword scrore with keyword being set.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_keyword_score()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_keyword_score
 	 */
 	public function test_get_keyword_score() {
 		$instance = new Indexable_Post_Double( 1 );
@@ -169,7 +169,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests retrieval of keyword scrore with no keyword being set.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_keyword_score()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_keyword_score
 	 */
 	public function test_get_keyword_score_with_no_keyword() {
 		$instance = new Indexable_Post_Double( 1 );
@@ -180,7 +180,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests if the meta lookup returns the expected type of data.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_indexable_lookup()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_indexable_lookup
 	 */
 	public function test_get_indexable_lookup() {
 		$instance = new Indexable_Post_Double( 1 );
@@ -190,7 +190,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests if the meta lookup returns the expected type of data.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_indexable_meta_lookup()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::get_indexable_meta_lookup
 	 */
 	public function test_get_indexable_meta_lookup() {
 		$instance = new Indexable_Post_Double( 1 );
@@ -200,7 +200,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests setting the link count for an indexable.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::set_link_count()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::set_link_count
 	 */
 	public function test_set_link_count() {
 		$formatter = $this
@@ -228,7 +228,7 @@ class Indexable_Post_Formatter_Test extends TestCase {
 	/**
 	 * Tests setting the link count for an indexable.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::set_link_count()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Post_Formatter::set_link_count
 	 */
 	public function test_set_link_count_with_thrown_exception() {
 		$formatter = $this

--- a/tests/formatters/indexable-term-formatter-test.php
+++ b/tests/formatters/indexable-term-formatter-test.php
@@ -110,7 +110,7 @@ class Indexable_Term_Formatter_Test extends TestCase {
 	/**
 	 * Tests the noindex expected outcome.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_noindex_value()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_noindex_value
 	 */
 	public function test_get_noindex_value() {
 		$this->assertTrue( $this->instance->get_noindex_value( 'noindex' ) );
@@ -124,7 +124,7 @@ class Indexable_Term_Formatter_Test extends TestCase {
 	/**
 	 * Tests retrieval of keyword scrore with keyword being set.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_keyword_score()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_keyword_score
 	 */
 	public function test_get_keyword_score() {
 		$this->assertSame( 100, $this->instance->get_keyword_score( 'keyword', 100 ) );
@@ -133,7 +133,7 @@ class Indexable_Term_Formatter_Test extends TestCase {
 	/**
 	 * Tests retrieval of keyword scrore with no keyword being set.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_keyword_score()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_keyword_score
 	 */
 	public function test_get_keyword_score_with_no_keyword() {
 		$this->assertNull( $this->instance->get_keyword_score( '', 100 ) );
@@ -142,7 +142,7 @@ class Indexable_Term_Formatter_Test extends TestCase {
 	/**
 	 * Tests if the meta lookup returns the expected type of data.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_indexable_lookup()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_indexable_lookup
 	 */
 	public function test_get_indexable_lookup() {
 		$this->assertInternalType( 'array', $this->instance->get_indexable_lookup() );
@@ -151,7 +151,7 @@ class Indexable_Term_Formatter_Test extends TestCase {
 	/**
 	 * Tests if the meta lookup returns the expected type of data.
 	 *
-	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_indexable_meta_lookup()
+	 * @covers \Yoast\WP\Free\Formatters\Indexable_Term_Formatter::get_indexable_meta_lookup
 	 */
 	public function test_get_indexable_meta_lookup() {
 		$this->assertInternalType( 'array', $this->instance->get_indexable_meta_lookup() );

--- a/tests/watchers/indexable-author-watcher-test.php
+++ b/tests/watchers/indexable-author-watcher-test.php
@@ -19,7 +19,7 @@ class Indexable_Author_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the expected hooks are registered.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::register_hooks()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::register_hooks
 	 */
 	public function test_register_hooks() {
 		$instance = new Indexable_Author_Watcher();
@@ -32,7 +32,7 @@ class Indexable_Author_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the indexable is being deleted.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::delete_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::delete_meta
 	 */
 	public function test_delete_meta() {
 		$instance = $this
@@ -67,7 +67,7 @@ class Indexable_Author_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the indexable is being deleted.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::delete_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::delete_meta
 	 */
 	public function test_delete_meta_exception() {
 		$instance = $this
@@ -86,7 +86,7 @@ class Indexable_Author_Watcher_Test extends TestCase {
 	/**
 	 * Tests the save meta functionality.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::save_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::save_meta
 	 */
 	public function test_save_meta() {
 		$indexable_mock = $this
@@ -142,7 +142,7 @@ class Indexable_Author_Watcher_Test extends TestCase {
 	/**
 	 * Tests the save meta functionality.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::save_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Author_Watcher::save_meta
 	 */
 	public function test_save_meta_exception() {
 		$instance = $this

--- a/tests/watchers/indexable-post-watcher-test.php
+++ b/tests/watchers/indexable-post-watcher-test.php
@@ -20,7 +20,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the expected hooks are registered.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::register_hooks()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::register_hooks
 	 */
 	public function test_register_hooks() {
 		$instance = new Indexable_Post_Watcher();
@@ -33,7 +33,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the indexable is being deleted.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::delete_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::delete_meta
 	 */
 	public function test_delete_meta() {
 		$instance = $this
@@ -68,7 +68,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the indexable is being deleted.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::delete_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::delete_meta
 	 */
 	public function test_delete_meta_exception() {
 		$instance = $this
@@ -87,7 +87,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	/**
 	 * Tests the save meta functionality.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::save_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::save_meta
 	 */
 	public function test_save_meta() {
 		$indexable_mock = $this
@@ -149,7 +149,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	/**
 	 * Tests the early return for non-indexable post.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::save_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::save_meta
 	 */
 	public function test_save_meta_is_post_not_indexable() {
 		$instance = $this
@@ -172,7 +172,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	/**
 	 * Tests the save meta functionality.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::save_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Post_Watcher::save_meta
 	 */
 	public function test_save_meta_exception() {
 		Monkey\Functions\expect( 'wp_is_post_revision' )

--- a/tests/watchers/indexable-term-watcher-test.php
+++ b/tests/watchers/indexable-term-watcher-test.php
@@ -19,7 +19,7 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the expected hooks are registered.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::register_hooks()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::register_hooks
 	 */
 	public function test_register_hooks() {
 		$instance = new Indexable_Term_Watcher();
@@ -32,7 +32,7 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the indexable is being deleted.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::delete_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::delete_meta
 	 */
 	public function test_delete_meta() {
 		$instance = $this
@@ -66,7 +66,7 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	/**
 	 * Tests if the indexable is being deleted.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::delete_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::delete_meta
 	 */
 	public function test_delete_meta_exception() {
 		$instance = $this
@@ -85,7 +85,7 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	/**
 	 * Tests the save meta.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::save_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::save_meta
 	 */
 	public function test_save_meta() {
 		$taxonomy_id = 1;
@@ -140,7 +140,7 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	/**
 	 * Tests the save meta functionality.
 	 *
-	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::save_meta()
+	 * @covers \Yoast\WP\Free\Watchers\Indexable_Term_Watcher::save_meta
 	 */
 	public function test_save_meta_exception() {
 		$instance = $this

--- a/tests/wordpress/integration-group-test.php
+++ b/tests/wordpress/integration-group-test.php
@@ -19,7 +19,7 @@ class Integration_Group_Test extends TestCase {
 	/**
 	 * Tests the addition of an integration.
 	 *
-	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::add_integration()
+	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::add_integration
 	 */
 	public function test_add_integrations() {
 		$instance = new Integration_Group();
@@ -36,7 +36,7 @@ class Integration_Group_Test extends TestCase {
 	/**
 	 * Tests ensure integration is called on constructor.
 	 *
-	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::__construct()
+	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::__construct
 	 */
 	public function test_construct() {
 		$classname = '\Yoast\WP\Free\WordPress\Integration_Group';
@@ -61,7 +61,7 @@ class Integration_Group_Test extends TestCase {
 	/**
 	 * Tests to make sure only Integration instances are used in the Integration Group.
 	 *
-	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::ensure_integration()
+	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::ensure_integration
 	 */
 	public function test_ensure_integration() {
 		$integration = $this
@@ -88,7 +88,7 @@ class Integration_Group_Test extends TestCase {
 	/**
 	 * Tests that register hooks is called on the integration.
 	 *
-	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::register_hooks()
+	 * @covers \Yoast\WP\Free\WordPress\Integration_Group::register_hooks
 	 */
 	public function test_register_hooks() {
 		$integration = $this


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

`@covers` tags are used to indicate what class/method/function a test covers when calculating code coverage of the tests.

Some rules of thumbs when adding these:
* Global functions should be preceded by a double colon `::`.
* There should be no parenthesis `()`  at the end of the function name.
* If the `@covers` tag is in one block with other tags, the content should be aligned at one space past the longest tag name.

This commit fixes all tags regarding the first two bullets.

Ref:
* https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.covers
* https://github.com/Yoast/yoastcs/issues/123

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is an annotation-only change and should have no effect on the functionality.
