### PR TITLE
HowTo and FAQ Schema: fix errors without an article piece

### DIFF
--- a/frontend/schema/class-schema-faq-question-list.php
+++ b/frontend/schema/class-schema-faq-question-list.php
@@ -78,7 +78,7 @@ class WPSEO_Schema_FAQ_Question_List {
 	 * @return string A reference URL.
 	 */
 	private function get_schema_id() {
-		if ( WPSEO_Schema_Article::is_article_post_type() ) {
+		if ( $this->context->site_represents !== false && WPSEO_Schema_Article::is_article_post_type() ) {
 			return $this->context->canonical . WPSEO_Schema_IDs::ARTICLE_HASH;
 		}
 

--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -117,7 +117,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * @codeCoverageIgnore
 	 */
 	protected function get_main_schema_id() {
-		if ( WPSEO_Schema_Article::is_article_post_type() ) {
+		if ( $this->context->site_represents !== false && WPSEO_Schema_Article::is_article_post_type() ) {
 			return $this->context->canonical . WPSEO_Schema_IDs::ARTICLE_HASH;
 		}
 

--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -113,8 +113,6 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * Determines whether we're part of an article or a webpage.
 	 *
 	 * @return string A reference URL.
-	 *
-	 * @codeCoverageIgnore
 	 */
 	protected function get_main_schema_id() {
 		if ( $this->context->site_represents !== false && WPSEO_Schema_Article::is_article_post_type() ) {

--- a/tests/frontend/schema/class-schema-how-to-test.php
+++ b/tests/frontend/schema/class-schema-how-to-test.php
@@ -98,6 +98,43 @@ class WPSEO_Schema_HowTo_Test extends TestCase {
 
 		$this->assertEquals( $actual, $expected );
 	}
+
+	/**
+	 * Tests the HowTo schema output with steps without json name and text.
+	 *
+	 * @covers WPSEO_Schema_HowTo::render
+	 * @covers WPSEO_Schema_HowTo::get_main_schema_id
+	 * @covers WPSEO_Schema_HowTo::add_steps
+	 * @covers WPSEO_Schema_HowTo::add_step_description
+	 */
+	public function test_schema_output_with_steps_without_json_name_and_text() {
+		$actual = $this->instance->render(
+			[
+				[ '@id' => 'OtherGraphPiece' ],
+			],
+			[
+				'attrs' => [
+					'jsonDescription' => 'description',
+					'name'            => 'title',
+					'steps'           => [
+						[
+							'id'       => 'step-id-1',
+							'text'     => [ 'How to step 1 text line' ],
+						],
+					],
+				],
+			]
+		);
+
+		$expected = [
+			[
+				'@id' => 'OtherGraphPiece'
+			],
+			[
+				'@type'            => 'HowTo',
+				'@id'              => 'example.com#howto-1',
+				'name'             => 'title',
+				'mainEntityOfPage' => [ '@id' => 'example.com#article' ],
 				'description'      => 'description',
 			]
 		];


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing (only in the release branch)] Fixes a bug where the HowTo and FAQ Schema is not stitched correctly when the site is not represented (company but no name/logo or person with an invalid user account).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Before
1. See the issue steps to reproduce.
1. Keep the knowledge graph settings (SEO -> Search Appearance) but update Yoast SEO to the code of this branch.

#### HowTo
1. Create a post or page with a HowTo block and publish it.
1. Go to the frontend of that post/page and view the source.
1. Copy the `<script type='application/ld+json' class='yoast-schema-graph yoast-schema-graph--main'>` script content and check it in the [GSDTT](https://search.google.com/structured-data/testing-tool).
1. There should only be one entry: `HowTo`.
1. Check in the JSON output: the `mainEntityOfPage` of the `HowTo` piece should be `WebPage` (you can click on `mainEntityOfPage` itself in GSDTT).

#### FAQ
1. Create a post or page with a FAQ block and publish it.
1. Go to the frontend of that post/page and view the source.
1. Copy the `<script type='application/ld+json' class='yoast-schema-graph yoast-schema-graph--main'>` script content and check it in the [GSDTT](https://search.google.com/structured-data/testing-tool).
1. There should only be one entry: `ItemList`.
1. Check in the JSON output: the `mainEntityOfPage` of the `ItemList` piece should be `WebPage` (you can click on `mainEntityOfPage` itself in GSDTT).

### Regression test: before
1. Change the knowledge graph settings to Organization and fill in the name and set a logo.

#### HowTo
1. Refresh the source of the earlier HowTo post/page and use the Schema output in GSDTT.
1. There should only be one entry: `HowTo`.
1. Check in the JSON output: the `mainEntityOfPage` of the `HowTo` piece should be `Article`.

#### FAQ
1. Refresh the source of the earlier FAQ post/page and use the Schema output in GSDTT.
1. There should only be one entry: `FAQ`.
1. Check in the JSON output: the `mainEntityOfPage` of the `ItemList` piece should be `Article`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #13197 
