### PR TITLE
Apply wp_kses_post to allowed html if needed

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -211,6 +211,9 @@ class WPSEO_Taxonomy {
 
 		foreach ( $filters as $filter ) {
 			remove_filter( $filter, 'wp_filter_kses' );
+			if ( ! current_user_can( 'unfiltered_html' ) ) {
+				add_filter( $filter, 'wp_filter_post_kses' );
+			}
 		}
 		remove_filter( 'term_description', 'wp_kses_data' );
 	}


### PR DESCRIPTION
Replaces https://github.com/Yoast/wordpress-seo/pull/13219 because that one was based on trunk.

Fixes Yoast/wordpress-seo-premium#2470

See issue for details.