### PR TITLE
Don't output an author to pages, not even when the site is not represented.

### DIFF
--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -68,10 +68,10 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			$this->add_image( $data );
 
 			$post = get_post( $this->context->id );
-			if ( $post instanceof WP_Post ) {
-				$data['datePublished'] = mysql2date( DATE_W3C, $post->post_date_gmt, false );
-				$data['dateModified']  = mysql2date( DATE_W3C, $post->post_modified_gmt, false );
+			$data['datePublished'] = mysql2date( DATE_W3C, $post->post_date_gmt, false );
+			$data['dateModified']  = mysql2date( DATE_W3C, $post->post_modified_gmt, false );
 
+			if ( get_post_type( $post ) === 'post' ) {
 				$data = $this->add_author( $data, $post );
 			}
 		}

--- a/tests/frontend/schema/class-schema-webpage-test.php
+++ b/tests/frontend/schema/class-schema-webpage-test.php
@@ -119,6 +119,78 @@ class WPSEO_Schema_WebPage_Test extends TestCase {
 	}
 
 	/**
+	 * Tests if no author is set for a page.
+	 *
+	 * @covers \WPSEO_Schema_WebPage::generate
+	 * @covers \WPSEO_Schema_WebPage::add_breadcrumbs
+	 * @covers \WPSEO_Schema_WebPage::determine_page_type
+	 * @covers \WPSEO_Frontend_Page_Type::is_posts_page
+	 * @covers \WPSEO_Frontend_Page_Type::is_home_posts_page
+	 */
+	public function test_do_not_add_author_for_page() {
+		Monkey\Functions\stubs( [
+			'is_singular' => true,
+
+		] );
+
+		$this->context->site_represents = false;
+
+		$post = Mockery::mock('WP_Post' );
+		$post->post_date_gmt = '';
+		$post->post_modified_gmt = '';
+
+		Monkey\Functions\expect( 'get_post' )
+			->andReturn( $post );
+
+		Monkey\Functions\expect( 'get_post_type' )
+			->andReturn( 'page' );
+
+		$actual = $this->instance->generate();
+
+		$this->assertArrayNotHasKey( 'author', $actual );
+	}
+
+	/**
+	 * Tests if an author is set for a post when the site is not represented.
+	 *
+	 * @covers \WPSEO_Schema_WebPage::generate
+	 * @covers \WPSEO_Schema_WebPage::add_breadcrumbs
+	 * @covers \WPSEO_Schema_WebPage::determine_page_type
+	 * @covers \WPSEO_Frontend_Page_Type::is_posts_page
+	 * @covers \WPSEO_Frontend_Page_Type::is_home_posts_page
+	 * @covers \WPSEO_Schema_WebPage::add_author
+	 */
+	public function test_add_author_for_post() {
+		Monkey\Functions\stubs( [
+			'is_singular' => true,
+
+		] );
+
+		$this->context->site_represents = false;
+
+		$post = Mockery::mock('WP_Post' );
+		$post->post_date_gmt = '';
+		$post->post_modified_gmt = '';
+		$post->post_author = 'author';
+
+		Monkey\Functions\expect( 'get_post' )
+			->andReturn( $post );
+
+		Monkey\Functions\expect( 'get_post_type' )
+			->andReturn( 'post' );
+
+		Monkey\Functions\expect( 'get_userdata' )
+			->andReturn( (object) [ 'user_login' => 'user_login' ] );
+
+		Monkey\Functions\expect( 'wp_hash' )
+			->andReturn( 'user_hash' );
+
+		$actual = $this->instance->generate();
+
+		$this->assertArrayHasKey( 'author', $actual );
+	}
+
+	/**
 	 * Tests if the add_author adds the author when the site is not represented.
 	 *
 	 * @covers \WPSEO_Schema_WebPage::add_author


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A (fixes a regression).

## Relevant technical choices:

* Although the original issue was only about pages, I verified with Jono that an author should never be output for everything that is not a post (= pages, attachment pages, etc).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* View the following singular posts/pages and check the schema output:
- Post -> should have author.
- Post with FAQ -> should have author.
- Post with HowTo -> should have author.
- Page -> shouldn't have author.
- Static homepage -> shouldn't have author.
- Custom post type -> shouldn't have author.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13224
