### PR TITLE
Expose default title to use in internal linking suggestions

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -172,6 +172,7 @@ class WPSEO_Frontend {
 	 * Resets the entire class so canonicals, titles etc can be regenerated.
 	 */
 	public function reset() {
+		self::$instance = null;
 		foreach ( get_class_vars( __CLASS__ ) as $name => $default ) {
 			switch ( $name ) {
 				// Clear the class instance to be re-initialized.
@@ -181,6 +182,7 @@ class WPSEO_Frontend {
 
 				// Exclude these properties from being reset.
 				case 'woocommerce_shop_page':
+				case 'default_title':
 					break;
 
 				// Reset property to the class default.

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -71,6 +71,13 @@ class WPSEO_Frontend {
 	protected $woocommerce_shop_page;
 
 	/**
+	 * Default title with replace-vars.
+	 *
+	 * @var object
+	 */
+	public static $default_title = '%%title%% %%sep%% %%sitename%%';
+
+	/**
 	 * Class constructor.
 	 *
 	 * Adds and removes a lot of filters.
@@ -303,7 +310,7 @@ class WPSEO_Frontend {
 		$template = WPSEO_Options::get( $index, '' );
 		if ( $template === '' ) {
 			if ( is_singular() ) {
-				return $this->replace_vars( '%%title%% %%sep%% %%sitename%%', $var_source );
+				return $this->replace_vars( self::$default_title, $var_source );
 			}
 
 			return '';

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -73,7 +73,7 @@ class WPSEO_Frontend {
 	/**
 	 * Default title with replace-vars.
 	 *
-	 * @var object
+	 * @var string
 	 */
 	public static $default_title = '%%title%% %%sep%% %%sitename%%';
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Exposes the default SEO title to make sure that we can use it in the internal linking functionality.

## Relevant technical choices:

*

## Test instructions
See [this PR](https://github.com/Yoast/wordpress-seo-premium/pull/2472) for testing instructions.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/wordpress-seo-premium/issues/2464
