### PR TITLE
Add filter for company_name and company_logo_id

### DIFF
--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -193,7 +193,13 @@ class WPSEO_Schema_Context {
 					break;
 				}
 
-				$this->company_logo_id = apply_filters( 'wpseo_schema_company_logo_id', WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' ) );
+				/**
+				 * Filter: 'wpseo_schema_company_logo_id' - Allows filtering company logo id
+				 *
+				 * @api integer $company_logo_id.
+				 */
+				$company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
+				$this->company_logo_id = apply_filters( 'wpseo_schema_company_logo_id', $company_logo_id );
 
 				/*
 				 * Do not use a company without a logo.

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -180,7 +180,7 @@ class WPSEO_Schema_Context {
 
 		switch ( $this->site_represents ) {
 			case 'company':
-				$this->company_name = WPSEO_Options::get( 'company_name' );
+				$this->company_name = apply_filters( 'wpseo_schema_company_name', WPSEO_Options::get( 'company_name' ) );
 				// Do not use a non-named company.
 				if ( empty( $this->company_name ) ) {
 					$this->site_represents = false;

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -180,7 +180,13 @@ class WPSEO_Schema_Context {
 
 		switch ( $this->site_represents ) {
 			case 'company':
-				$this->company_name = apply_filters( 'wpseo_schema_company_name', WPSEO_Options::get( 'company_name' ) );
+				/**
+				 * Filter: 'wpseo_schema_company_name' - Allows filtering company name
+				 *
+				 * @api string $company_name.
+				 */
+				$company_name = WPSEO_Options::get( 'company_name' );
+				$this->company_name = apply_filters( 'wpseo_schema_company_name', $company_name );
 				// Do not use a non-named company.
 				if ( empty( $this->company_name ) ) {
 					$this->site_represents = false;

--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -187,7 +187,7 @@ class WPSEO_Schema_Context {
 					break;
 				}
 
-				$this->company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
+				$this->company_logo_id = apply_filters( 'wpseo_schema_company_logo_id', WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' ) );
 
 				/*
 				 * Do not use a company without a logo.


### PR DESCRIPTION
## Summary

Example scenario - Yoast Organization schema is not generated when either the company name or logo is not set in Yoast settings. As a user/theme developer, often name and/or logo is set separately in Theme Options or similar settings. I propose adding a filter for the company name and the company logo to allow developers to filter in Company Name or Company Logo from their options so the user doesn't need to set them in both theme options and yoast options.

This PR can be summarized in the following changelog entry:

*Add filter **wpseo_schema_company_name** - allows filtering Yoast company name setting
*Add filter **wpseo_schema_company_logo_id** - allows filtering Yoast company logo setting

## Documentation
* [x ] I have written documentation for this change.

## Quality assurance

* [x ] I have tested this code to the best of my abilities
