### PR TITLE
Use importScripts inside the worker instead of module imports to replicate webpack external behavior

### DIFF
--- a/js/src/wp-seo-analysis-worker.js
+++ b/js/src/wp-seo-analysis-worker.js
@@ -1,5 +1,11 @@
-import "babel-polyfill";
-import AnalysisWebWorker from "yoastseo/src/worker/AnalysisWebWorker";
+// Ensure the global window is set, our dependencies use it.
+self.window = self;
 
-const worker = new AnalysisWebWorker( self );
+// We only know the URL of the worker script, so base all other files names on that.
+self.importScripts( self.location.href.replace( "wp-seo-analysis-worker", "commons" ) );
+self.importScripts( self.location.href.replace( "wp-seo-analysis-worker", "analysis" ) );
+
+import "babel-polyfill";
+
+const worker = new self.yoast.analysis.AnalysisWebWorker( self );
 worker.register();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Use importScripts inside the worker instead of module imports to replicate webpack external behavior.

## Relevant technical choices:

* This change ensures that code is not duplicated in the distributed ZIP.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In Free:
	* Go to the edit page. See no console errors.
    * Test *all* assessments for posts and make sure the outcomes are as expected. 
* In premium: test all word-form related assessments. 
* Local + video + woo: test all assessments they add.
* Free + premium: Build a zip, see that the zipsize has decreased.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
