### PR TITLE
Exclude term ids from xml sitemap filter

### DIFF
--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -75,7 +75,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$term_args = array(
 			'hide_empty' => $hide_empty,
 			'fields'     => 'ids',
-			'exclude'	 => $exclude_term_ids
+			'exclude'    => $exclude_term_ids
 		);
 
 		foreach ( $taxonomy_names as $taxonomy_name ) {

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -75,7 +75,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$term_args = array(
 			'hide_empty' => $hide_empty,
 			'fields'     => 'ids',
-			'exclude'    => $exclude_term_ids
+			'exclude'    => $exclude_term_ids,
 		);
 
 		foreach ( $taxonomy_names as $taxonomy_name ) {

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -62,11 +62,20 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		 */
 		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, $taxonomy_names );
 
+		/**
+		 * Filter to exclude term ids from the XML sitemap.
+		 *
+		 * @param array   $exclude        Defaults to an empty array.
+		 * @param array   $taxonomy_names Array of names for the taxonomies being processed.
+		 */
+		$exclude_term_ids = apply_filters( 'wpseo_sitemap_exclude_term_ids', array(), $taxonomy_names );
+
 		$all_taxonomies = array();
 
 		$term_args = array(
 			'hide_empty' => $hide_empty,
 			'fields'     => 'ids',
+			'exclude'	 => $exclude_term_ids
 		);
 
 		foreach ( $taxonomy_names as $taxonomy_name ) {
@@ -165,7 +174,10 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		/** This filter is documented in inc/sitemaps/class-taxonomy-sitemap-provider.php */
 		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, array( $taxonomy->name ) );
-		$terms      = get_terms( $taxonomy->name, array( 'hide_empty' => $hide_empty ) );
+		/** This filter is documented in inc/sitemaps/class-taxonomy-sitemap-provider.php */
+		$exclude_term_ids = apply_filters( 'wpseo_sitemap_exclude_term_ids', array(), array( $taxonomy->name ) );
+
+		$terms      = get_terms( $taxonomy->name, array( 'hide_empty' => $hide_empty, 'exclude' => $exclude_term_ids ) );
 
 		// If the total term count is lower than the offset, we are on an invalid page.
 		if ( count( $terms ) < $offset ) {


### PR DESCRIPTION
## Summary

Adds a filter to exclude term IDs from the XML sitemap, using the filter `wpseo_sitemap_exclude_term_ids`

This PR can be summarized in the following changelog entry:

* No user-facing changes

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* In code, add a filter for `wpseo_sitemap_exclude_term_ids` and return an array of term IDs to exclude from the taxonomy XML sitemap.

Example:
```
add_filter( 'wpseo_sitemap_exclude_term_ids', 'exclude_my_term_ids_from_sitemap', 10, 2);

function exclude_my_term_ids_from_sitemap( $term_ids_to_exclude, $taxonomies ) {
	if(in_array('category', $taxonomies)) {
               $term_ids_to_exclude = array( 5, 13, 26 );
        }
	
	return $term_ids_to_exclude;
}
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12656
