### PR TITLE
Bump packages for 11.7 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,13 +97,13 @@
     "@wordpress/is-shallow-equal": "^1.2.0",
     "@wordpress/rich-text": "^3.2.2",
     "@wordpress/url": "^2.5.0",
-    "@yoast/algolia-search-box": "^1.5.0-rc.0",
-    "@yoast/analysis-report": "^0.6.0-rc.0",
-    "@yoast/components": "^0.6.0-rc.0",
-    "@yoast/configuration-wizard": "^1.5.0-rc.0",
-    "@yoast/helpers": "^0.4.0-rc.2",
-    "@yoast/search-metadata-previews": "^1.6.0-rc.0",
-    "@yoast/style-guide": "^0.4.0-rc.1",
+    "@yoast/algolia-search-box": "^1.4.0",
+    "@yoast/analysis-report": "^0.5.0",
+    "@yoast/components": "^0.5.0",
+    "@yoast/configuration-wizard": "^1.4.0",
+    "@yoast/helpers": "^0.3.0",
+    "@yoast/search-metadata-previews": "^1.6.0",
+    "@yoast/style-guide": "^0.2.0",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
     "draft-js": "^0.10.5",
@@ -126,8 +126,8 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^4.2.0",
-    "yoast-components": "^4.30.0-rc.0",
-    "yoastseo": "^1.57.0-rc.0"
+    "yoast-components": "^4.30.0",
+    "yoastseo": "^1.57.0"
   },
   "yoast": {
     "pluginVersion": "11.7-RC2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,6 +649,22 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
+"@yoast/algolia-search-box@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@yoast/algolia-search-box/-/algolia-search-box-1.4.0.tgz#b7c79466200e351aa6a1add869e05816b922761d"
+  integrity sha512-cfysw/W8Y0CgAxjFxZ69ekgJ/GwsePOQcrqk0jJ84O2/M2fWfL2KVDIdaJ1XcC1dFr7br70TkhrPA5Q/m7MfVg==
+  dependencies:
+    "@wordpress/a11y" "^1.0.7"
+    "@wordpress/i18n" "^1.1.0"
+    "@yoast/components" "^0.5.0"
+    "@yoast/helpers" "^0.4.0-rc.2"
+    "@yoast/style-guide" "^0.4.0-rc.1"
+    algoliasearch "^3.22.3"
+    lodash "^4.17.4"
+    prop-types "^15.6.0"
+    react "16.6.3"
+    styled-components "^4.2.0"
+
 "@yoast/algolia-search-box@^1.5.0-rc.0":
   version "1.5.0-rc.0"
   resolved "https://registry.yarnpkg.com/@yoast/algolia-search-box/-/algolia-search-box-1.5.0-rc.0.tgz#6c89958772f41b24e60d839991903c644bf44f53"
@@ -663,6 +679,21 @@
     lodash "^4.17.4"
     prop-types "^15.6.0"
     react "16.6.3"
+    styled-components "^4.2.0"
+
+"@yoast/analysis-report@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@yoast/analysis-report/-/analysis-report-0.5.0.tgz#edf6e7f99bc1fee81028c6da76a00cbf2291fdd2"
+  integrity sha512-f0hLUyDj4FGHbFEbyL4cb2usX5MB2Q9FtZoCMEdcTRfezhr4tx9RYADs87ZD95UeZPSKu5LPzGp20z3bUa2ebw==
+  dependencies:
+    "@wordpress/i18n" "^1.1.0"
+    "@yoast/components" "^0.5.0"
+    "@yoast/helpers" "^0.4.0-rc.2"
+    "@yoast/style-guide" "^0.4.0-rc.1"
+    lodash "^4.17.11"
+    prop-types "^15.6.0"
+    react "16.6.3"
+    react-dom "16.6.3"
     styled-components "^4.2.0"
 
 "@yoast/analysis-report@^0.6.0-rc.0":
@@ -680,6 +711,22 @@
     react-dom "16.6.3"
     styled-components "^4.2.0"
 
+"@yoast/components@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@yoast/components/-/components-0.5.0.tgz#0f0b077666d670d3cd16c041aaf7ee9e9f1c13c5"
+  integrity sha512-aU/Hr5OeCohKJZils0QM+fmLvhGvqrfqn7JcBXNeim48hbnfEkEHS8FA/uAbbrUwZC1l19CFlgfl79R3JlgapQ==
+  dependencies:
+    "@wordpress/a11y" "^1.1.3"
+    "@wordpress/i18n" "^1.2.3"
+    "@yoast/helpers" "^0.4.0-rc.2"
+    "@yoast/style-guide" "^0.4.0-rc.1"
+    interpolate-components "^1.1.1"
+    lodash "^4.17.11"
+    prop-types "^15.7.2"
+    react-modal "^3.8.1"
+    react-tabs "^2.3.0"
+    styled-components "^4.2.0"
+
 "@yoast/components@^0.6.0-rc.0":
   version "0.6.0-rc.0"
   resolved "https://registry.yarnpkg.com/@yoast/components/-/components-0.6.0-rc.0.tgz#a2b471dcd2383a7ae6f27f5035bde4339293a23e"
@@ -695,6 +742,19 @@
     react-modal "^3.8.1"
     react-tabs "^2.3.0"
     styled-components "^4.2.0"
+
+"@yoast/configuration-wizard@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@yoast/configuration-wizard/-/configuration-wizard-1.4.0.tgz#b795b4c243df548aea2041ca32c47a18f5909e21"
+  integrity sha512-vfOd5S7bLixAi+YXhGNbO3Vc8tyYPbTGEa+vNW7G4AaNaWZpQwPTpHlBlposbicP/VA/+lRb9ywILQYn5ws7/w==
+  dependencies:
+    "@wordpress/i18n" "^1.1.0"
+    "@yoast/components" "^0.5.0"
+    "@yoast/helpers" "^0.4.0-rc.2"
+    "@yoast/style-guide" "^0.4.0-rc.1"
+    interpolate-components "^1.1.1"
+    lodash "^4.17.11"
+    prop-types "^15.7.2"
 
 "@yoast/configuration-wizard@^1.5.0-rc.0":
   version "1.5.0-rc.0"
@@ -748,6 +808,16 @@
     node-sass "^4.12.0"
     time-grunt "^1.0.0"
 
+"@yoast/helpers@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@yoast/helpers/-/helpers-0.3.0.tgz#0102d1c16c16ecafb5997e6ca241b7eb9e872f0e"
+  integrity sha512-xu2pAnVjpwbHh1688GWc4FDaRpDFz1/67+V97fS9ksUd/S2iwrsWVQ1hbOavCuN24fAwJTqWpgzNHwWgA9Brwg==
+  dependencies:
+    "@wordpress/i18n" "^1.2.3"
+    prop-types "^15.7.2"
+    styled-components "^2.4.1"
+    whatwg-fetch "1.1.1"
+
 "@yoast/helpers@^0.4.0-rc.2":
   version "0.4.0-rc.2"
   resolved "https://registry.yarnpkg.com/@yoast/helpers/-/helpers-0.4.0-rc.2.tgz#f91fc0004b2a9e67750b69b373a7e7b2dd2ab111"
@@ -758,10 +828,10 @@
     styled-components "^2.4.1"
     whatwg-fetch "1.1.1"
 
-"@yoast/search-metadata-previews@^1.6.0-rc.0":
-  version "1.6.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.6.0-rc.0.tgz#37b0bca3877913ec68c596c6234931c656766a89"
-  integrity sha512-7Whzdc3hZLOOPpoZRnR3AFGpzA+Q1waXy84vNFWywZeNBLopBTtXpDvbf3qmksgtvBnLignw8HiCnPW0ckGHyg==
+"@yoast/search-metadata-previews@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.6.0.tgz#e8bf490cbbb7bc1bb3265a6592bb91332bd3b149"
+  integrity sha512-HBgzh23GbVpFluQkIMmsCa+HPg1vXV9viA2P8pYZY+qH0q5rLESyLfuAVgzOA/LOQEZwlkMD3CmVOTnPVTKh0Q==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -777,7 +847,12 @@
     prop-types "^15.6.0"
     react-transition-group "^2.7.1"
     styled-components "^4.2.0"
-    yoastseo "^1.57.0-rc.0"
+    yoastseo "^1.57.0"
+
+"@yoast/style-guide@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@yoast/style-guide/-/style-guide-0.2.0.tgz#fc18da12d42e308f99a5af731d492c1369020d86"
+  integrity sha512-u8KQtBKJT6ea8UwZ1PB6Zun6zEGVYwBFXGUmI21ks66slJcIvWg1Gj49CtbV/Olk00RgcjAl2/Gek3xRlmwY+A==
 
 "@yoast/style-guide@^0.4.0-rc.1":
   version "0.4.0-rc.1"
@@ -13110,10 +13185,10 @@ yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yoast-components@^4.30.0-rc.0:
-  version "4.30.0-rc.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.30.0-rc.0.tgz#42216f3f1d0aa35f7e676e8bee5993947e0ce328"
-  integrity sha512-2w6FPB9vCroF3j++50ueSoiKGtZHakz8kdaA/2VE33hFj2dWd3XvGXRZXbrYpqSwF5EViKH7LTj6G4dzOKweXw==
+yoast-components@^4.30.0:
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.30.0.tgz#b3989e12987fa37c6ea47cb24a801058a2a97685"
+  integrity sha512-Zi1w3Y3MVFXtK0sWQ9dF097clTSkFEP9L6KG/N1XSiPVr7JrvjBj1Rd0JikavFhR4d63ouwe1zIXwK+IqUdvQw==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -13122,7 +13197,7 @@ yoast-components@^4.30.0-rc.0:
     "@yoast/components" "^0.6.0-rc.0"
     "@yoast/configuration-wizard" "^1.5.0-rc.0"
     "@yoast/helpers" "^0.4.0-rc.2"
-    "@yoast/search-metadata-previews" "^1.6.0-rc.0"
+    "@yoast/search-metadata-previews" "^1.6.0"
     "@yoast/style-guide" "^0.4.0-rc.1"
     algoliasearch "^3.22.3"
     clipboard "^1.5.15"
@@ -13142,12 +13217,12 @@ yoast-components@^4.30.0-rc.0:
     styled-components "^4.2.0"
     whatwg-fetch "^1.0.0"
     wicked-good-xpath "^1.3.0"
-    yoastseo "^1.57.0-rc.0"
+    yoastseo "^1.57.0"
 
-yoastseo@^1.57.0-rc.0:
-  version "1.57.0-rc.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.57.0-rc.0.tgz#1c4d7eacf8090d72ebfaf1549079570491f067a4"
-  integrity sha512-Kswfn92m3fUm6kus2+zVqRMWIUfdVvjkZLB/jdImyTs4Sg3jXrNbZrfgLUyUnoGMlCa3YjXU/s517jHDmaJjDw==
+yoastseo@^1.57.0:
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.57.0.tgz#457558603f6f69e58bdbf58ea612f657b70646e5"
+  integrity sha512-gW4TTwd2/lqYGE9lIJp4VwYJ3euAXmOZfJQwLAcp3LMHvbcQD4T0OjXfBHha0tBtKs5fIyCVQgGGi1M7pezgQg==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     "@yoast/feature-flag" "^0.3.0-rc.1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Updates all Yoast packages to the stable release versions for 11.7.


## Relevant technical choices:

* n/a

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* n/a

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
