### PR TITLE
Configuration wizard onboarding image: Add missing empty alt attribute

### DIFF
--- a/admin/notifiers/class-configuration-notifier.php
+++ b/admin/notifiers/class-configuration-notifier.php
@@ -146,7 +146,7 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 	private function notification( $title, $content, $show_dismissal = false ) {
 		$notification  = '<div class="yoast-container yoast-container__configuration-wizard">';
 		$notification .= sprintf(
-			'<img src="%1$s" height="%2$s" width="%3$d" />',
+			'<img src="%1$s" height="%2$s" width="%3$d" alt="" />',
 			esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/new-to-configuration-notice.svg' ),
 			60,
 			60

--- a/integration-tests/notifiers/test-class-configuration-notifier.php
+++ b/integration-tests/notifiers/test-class-configuration-notifier.php
@@ -19,7 +19,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'show_onboarding_notice', false );
 		$notifier = new WPSEO_Configuration_Notifier();
 
-		$this->assertEquals( '<div class="yoast-container yoast-container__configuration-wizard"><img src="http://example.org/wp-content/plugins/wordpress-seo/images/new-to-configuration-notice.svg" height="60" width="60" /><div class="yoast-container__configuration-wizard--content"><h3>Check SEO configuration</h3><p>Want to make sure your Yoast SEO settings are still OK? <a href="http://example.org/wp-admin/admin.php?page=wpseo_configurator">Open the configuration wizard again</a> to validate them.</p></div></div>', $notifier->notify() );
+		$this->assertEquals( '<div class="yoast-container yoast-container__configuration-wizard"><img src="http://example.org/wp-content/plugins/wordpress-seo/images/new-to-configuration-notice.svg" height="60" width="60" alt="" /><div class="yoast-container__configuration-wizard--content"><h3>Check SEO configuration</h3><p>Want to make sure your Yoast SEO settings are still OK? <a href="http://example.org/wp-admin/admin.php?page=wpseo_configurator">Open the configuration wizard again</a> to validate them.</p></div></div>', $notifier->notify() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add missing empty alt attribute to the Configuration wizard onboarding image

## Relevant technical choices:

Quick PR to fix the Configuration wizard onboarding image:

<img width="726" alt="Screenshot 2019-07-22 at 18 16 06" src="https://user-images.githubusercontent.com/1682452/61648751-5ada7a80-acb0-11e9-84ad-aae829d69350.png">

It misses an empty alt attribute `alt=""`. In absence of an alt attribute, screen readers will try to announce _something_, in most of the cases: part of the image URL, which is far from ideal.

Decorative images just need an empty `alt=""`.

Noticed while working on https://github.com/Yoast/bugreports/issues/400 and validating the HTML source.