### PR TITLE
Update URLs to ping Google and Bing

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -570,8 +570,8 @@ class WPSEO_Sitemaps {
 		}
 
 		// Ping Google and Bing.
-		wp_remote_get( 'http://www.google.com/webmasters/tools/ping?sitemap=' . $url, array( 'blocking' => false ) );
-		wp_remote_get( 'http://www.bing.com/ping?sitemap=' . $url, array( 'blocking' => false ) );
+		wp_remote_get( 'https://www.google.com/ping?sitemap=' . $url, array( 'blocking' => false ) );
+		wp_remote_get( 'https://www.bing.com/ping?sitemap=' . $url, array( 'blocking' => false ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updates URLs to ping Google and Bing with a sitemap.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* URLs can be verified against official documents here:
https://developers.google.com/search/docs/guides/submit-URLs
https://www.bing.com/webmaster/help/how-to-submit-sitemaps-82a15bd4

* Opening the following URLs in a browser confirm that the requested HTTPS versions work as expected:
https://www.google.com/ping?sitemap=https://www.example.org/sitemap_index.xml
https://www.bing.com/ping?sitemap=https://www.example.org/sitemap_index.xml


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #11570 