### PR TITLE
rename "titleWidth" to "titleLength"

### DIFF
--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -5,7 +5,7 @@ import get from "lodash/get";
 import analysis from "yoastseo";
 
 /* Internal dependencies */
-import measureTextWidth from "../helpers/measureTextWidth";
+import measureTextLength from "../helpers/measureTextLength";
 import { update as updateAdminBar } from "../ui/adminBar";
 import publishBox from "../ui/publishBox";
 import { update as updateTrafficLight } from "../ui/trafficLight";
@@ -60,7 +60,7 @@ PostDataCollector.prototype.getData = function() {
 		searchUrl: this.getSearchUrl(),
 		postUrl: this.getPostUrl(),
 		permalink: this.getPermalink(),
-		titleWidth: measureTextWidth( this.getSnippetTitle() ),
+		titleLength: measureTextLength( this.getSnippetTitle() ),
 	};
 
 	const snippetData = {

--- a/js/src/analysis/TermDataCollector.js
+++ b/js/src/analysis/TermDataCollector.js
@@ -10,7 +10,7 @@ import { termsTmceId as tmceId } from "../wp-seo-tinymce";
 import getIndicatorForScore from "../analysis/getIndicatorForScore";
 import { update as updateTrafficLight } from "../ui/trafficLight";
 import { update as updateAdminBar } from "../ui/adminBar";
-import measureTextWidth from "../helpers/measureTextWidth";
+import measureTextLength from "../helpers/measureTextLength";
 
 const $ = jQuery;
 
@@ -48,7 +48,7 @@ TermDataCollector.prototype.getData = function() {
 		name: this.getName(),
 		baseUrl: this.getBaseUrl(),
 		pageTitle: this.getPageTitle(),
-		titleWidth: measureTextWidth( this.getTitle() ),
+		titleLength: measureTextLength( this.getTitle() ),
 	};
 
 	const state = this._store.getState();

--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -1,7 +1,7 @@
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 
-import measureTextWidth from "../helpers/measureTextWidth";
+import measureTextLength from "../helpers/measureTextLength";
 import getContentLocale from "./getContentLocale";
 
 import { Paper } from "yoastseo";
@@ -50,7 +50,7 @@ export default function collectAnalysisData( edit, store, customAnalysisData, pl
 		data.text = pluggable._applyModifications( "content", data.text );
 	}
 
-	data.titleWidth = measureTextWidth( data.title );
+	data.titleLength = measureTextLength( data.title );
 	data.locale = getContentLocale();
 
 	return Paper.parse( data );

--- a/js/src/helpers/measureTextLength.js
+++ b/js/src/helpers/measureTextLength.js
@@ -30,7 +30,7 @@ function createMeasurementElement() {
  * @param {string} text The text to measure the width for.
  * @returns {number} The width in pixels.
  */
-export default function measureTextWidth( text ) {
+export default function measureTextLength( text ) {
 	let element = document.getElementById( elementId );
 	if ( ! element ) {
 		element = createMeasurementElement();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* https://github.com/Yoast/wordpress-seo/issues/13269

## Relevant technical choices:

* Refactored all `titleWidth` to `titleLength`, including file names

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On a post, check the SEO Analysis section in the Yoast metabox. `SEO title length` should be used as a "key" in the analysis results instead of `SEO title width`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have ~added~ modified unittests to verify the code works as intended

Fixes #
* Minor refactoring