### PR TITLE
Deprecate unused wpseo_ajax_replace_vars

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -83,25 +83,6 @@ function wpseo_dismiss_tagline_notice() {
 add_action( 'wp_ajax_wpseo_dismiss_tagline_notice', 'wpseo_dismiss_tagline_notice' );
 
 /**
- * Used in the editor to replace vars for the snippet preview.
- */
-function wpseo_ajax_replace_vars() {
-	global $post;
-	check_ajax_referer( 'wpseo-replace-vars' );
-
-	$post = get_post( intval( filter_input( INPUT_POST, 'post_id' ) ) );
-	global $wp_query;
-	$wp_query->queried_object    = $post;
-	$wp_query->queried_object_id = $post->ID;
-
-	$omit = array( 'excerpt', 'excerpt_only', 'title' );
-	echo wpseo_replace_vars( stripslashes( filter_input( INPUT_POST, 'string' ) ), $post, $omit );
-	die;
-}
-
-add_action( 'wp_ajax_wpseo_replace_vars', 'wpseo_ajax_replace_vars' );
-
-/**
  * Save an individual SEO title from the Bulk Editor.
  */
 function wpseo_save_title() {
@@ -397,4 +378,26 @@ function wpseo_add_fb_admin() {
 	}
 	_deprecated_function( __FUNCTION__, 'WPSEO 7.0', 'This method is deprecated.' );
 	wpseo_ajax_json_echo_die( '' );
+}
+
+/**
+ * Used in the editor to replace vars for the snippet preview.
+ *
+ * @deprecated 11.9
+ * @codeCoverageIgnore
+ */
+function wpseo_ajax_replace_vars() {
+	_deprecated_function( __METHOD__, 'WPSEO 11.9' );
+
+	global $post;
+	check_ajax_referer( 'wpseo-replace-vars' );
+
+	$post = get_post( intval( filter_input( INPUT_POST, 'post_id' ) ) );
+	global $wp_query;
+	$wp_query->queried_object    = $post;
+	$wp_query->queried_object_id = $post->ID;
+
+	$omit = array( 'excerpt', 'excerpt_only', 'title' );
+	echo wpseo_replace_vars( stripslashes( filter_input( INPUT_POST, 'string' ) ), $post, $omit );
+	die;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping.

## Relevant technical choices:

* I've searched for both `wpseo-replace-vars`, `wp_ajax_wpseo_replace_vars` and `wpseo_replace_vars` in the entire codebase of the Yoast organization on GitHub, and didn't find any uses.
* I also didn't see the ajax request in the Network tab anywhere.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test if the replace vars are still working, either in the backend as well as the frontend:
    * All fields in the snippet editor on posts, pages, categories, tags, CPTs: check both the replacement in the editor itself, as well as the output on the frontend. Please compare to a previous Yoast SEO version because not all replace vars are functioning correctly.
    * All replacevar fields in the social previews (Free + Premium!). Check the result on the frontend. Again, compare to a previous Yoast SEO version
    * All replacevar fields in the Search appearance settings. Check the result on the frontend. Again, compare to a previous Yoast SEO version.
    * If you can think of any more fields with replacevars (maybe in add ons?), test those as well.
* Make sure the deprecation version is still up-to-date when you merge this PR.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
