### PR TITLE
Output escaping: class-admin-init

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -720,13 +720,19 @@ class WPSEO_Admin_Init {
 		global $pagenow;
 
 		if ( $pagenow === 'options-permalink.php' ) {
-			$warning = esc_html__( 'WARNING:', 'wordpress-seo' );
-			/* translators: %1$s and %2$s expand to <i> items to emphasize the word in the middle. */
-			$message = esc_html__( 'Changing your permalinks settings can seriously impact your search engine visibility. It should almost %1$s never %2$s be done on a live website.', 'wordpress-seo' );
-			$link    = esc_html__( 'Learn about why permalinks are important for SEO.', 'wordpress-seo' );
-			$url     = WPSEO_Shortlinker::get( 'https://yoa.st/why-permalinks/' );
-
-			echo '<div class="notice notice-warning"><p><strong>' . $warning . '</strong><br>' . sprintf( $message, '<i>', '</i>' ) . '<br><a href="' . $url . '" target="_blank">' . $link . '</a></p></div>';
+			printf(
+				'<div class="notice notice-warning"><p><strong>%1$s</strong><br>%2$s<br><a href="%3$s" target="_blank">%4$s</a></p></div>',
+				esc_html__( 'WARNING:', 'wordpress-seo' ),
+				sprintf(
+					/* translators: %1$s and %2$s expand to <em> items to emphasize the word in the middle. */
+					esc_html__( 'Changing your permalinks settings can seriously impact your search engine visibility. It should almost %1$s never %2$s be done on a live website.', 'wordpress-seo' ),
+					'<em>',
+					'</em>'
+				),
+				esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/why-permalinks/' ) ),
+				// The link's content.
+				esc_html__( 'Learn about why permalinks are important for SEO.', 'wordpress-seo' )
+			);
 		}
 	}
 }

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -694,11 +694,13 @@ class WPSEO_Admin_Init {
 		// Show notice for each deprecated filter or action that has been registered.
 		foreach ( $deprecated_notices as $deprecated_filter ) {
 			$deprecation_info = $deprecated_filters[ $deprecated_filter ];
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- only uses the hardcoded values from above.
 			_deprecated_hook(
 				$deprecated_filter,
 				'WPSEO ' . $deprecation_info['version'],
 				$deprecation_info['alternative']
 			);
+			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -679,22 +679,6 @@ class WPSEO_Admin_Init {
 
 		// WordPress hooks that have been deprecated since a Yoast SEO version.
 		$deprecated_filters = array(
-			'wpseo_metakey' => array(
-				'version'     => '6.3',
-				'alternative' => null,
-			),
-			'wpseo_metakeywords' => array(
-				'version'     => '6.3',
-				'alternative' => null,
-			),
-			'wpseo_stopwords' => array(
-				'version'     => '7.0',
-				'alternative' => null,
-			),
-			'wpseo_redirect_orphan_attachment' => array(
-				'version'     => '7.0',
-				'alternative' => null,
-			),
 			'wpseo_genesis_force_adjacent_rel_home' => array(
 				'version'     => '9.4',
 				'alternative' => null,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Fix output escaping in `class-admin-init`.

## Relevant technical choices:

* Added PHPCS ignore to the first error in this file because it uses only hardcoded values.
* Added `esc_url` around the `Shortlinker` URL.
* Removed entries from deprecated notifications because they are too old.
* Refactored long `echo` line to `printf` multiline.
* Replaced `<i>` with `<em>`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

The notice for permalink settings still has to work:
* Go to the WP permalink settings and change it to something that does not include the `postname`.
* Go to the Yoast SEO dashboard.
* Ensure there is now a notice: `You do not have your postname in the URL of your posts and pages, it is highly recommended that you do. Consider setting your permalink structure to /%postname%/.`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
