### PR TITLE
Fixed output sanitation errors in PHPCS regarding the bulk editor.

### DIFF
--- a/admin/class-bulk-description-editor-list-table.php
+++ b/admin/class-bulk-description-editor-list-table.php
@@ -70,6 +70,9 @@ class WPSEO_Bulk_Description_List_Table extends WPSEO_Bulk_List_Table {
 
 			case 'col_existing_yoast_seo_metadesc':
 				// @todo Inconsistent return/echo behavior R.
+				// I traced the escaping of the attributes to WPSEO_Bulk_List_Table::column_attributes. Alexander.
+				// The output of WPSEO_Bulk_List_Table::parse_meta_data_field is properly escaped.
+				// phpcs:ignore WordPress.Security.EscapeOutput
 				echo $this->parse_meta_data_field( $record->ID, $attributes );
 				break;
 		}

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -409,11 +409,12 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				);
 				printf(
 					'<select name="post_type_filter" id="%2$s">%1$s</select>',
+					// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $options is properly escaped.
 					$options,
 					esc_attr( 'post-type-filter-' . $instance_type )
 				);
 
-				submit_button( __( 'Filter', 'wordpress-seo' ), 'button', false, false, array( 'id' => 'post-query-submit' ) );
+				submit_button( esc_html__( 'Filter', 'wordpress-seo' ), 'button', false, false, array( 'id' => 'post-query-submit' ) );
 				echo '</div>';
 			}
 		}
@@ -770,7 +771,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		}
 
 		if ( ! empty( $class ) ) {
-			$attributes = 'class="' . implode( ' ', $class ) . '"';
+			$attributes = 'class="' . esc_attr( implode( ' ', $class ) ) . '"';
 		}
 
 		$attributes .= ' data-colname="' . esc_attr( $column_display_name ) . '"';
@@ -910,7 +911,11 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			$meta_value = $values[ $meta_value ];
 		}
 
-		return sprintf( '<td %2$s id="wpseo-existing-%4$s-%3$s">%1$s</td>', $meta_value, $attributes, $record_id, $this->target_db_field );
+		$id = "wpseo-existing-$record_id-$this->target_db_field";
+
+		// $attributes correctly escaped, verified by Alexander. See WPSEO_Bulk_Description_List_Table::parse_page_specific_column.
+		// phpcs:ignore WordPress.Security.EscapeOutput
+		return sprintf( '<td %2$s id="%3$s">%1$s</td>', esc_html( $meta_value ), $attributes, esc_attr( $id ) );
 	}
 
 	/**

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -409,7 +409,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 				);
 				printf(
 					'<select name="post_type_filter" id="%2$s">%1$s</select>',
-					// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $options is properly escaped.
+					// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $options is properly escaped above.
 					$options,
 					esc_attr( 'post-type-filter-' . $instance_type )
 				);

--- a/admin/class-bulk-title-editor-list-table.php
+++ b/admin/class-bulk-title-editor-list-table.php
@@ -69,7 +69,10 @@ class WPSEO_Bulk_Title_Editor_List_Table extends WPSEO_Bulk_List_Table {
 
 		switch ( $column_name ) {
 			case 'col_existing_yoast_seo_title':
-				// @todo Inconsistent echo/return behavior R.
+				// @todo Inconsistent return/echo behavior R.
+				// I traced the escaping of the attributes to WPSEO_Bulk_List_Table::column_attributes.
+				// The output of WPSEO_Bulk_List_Table::parse_meta_data_field is properly escaped.
+				// phpcs:ignore WordPress.Security.EscapeOutput
 				echo $this->parse_meta_data_field( $record->ID, $attributes );
 				break;
 


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer before-premium-cs`. This installs the latest Yoast CS.
* Run the `WordPress.Security.EscapeOutput` sniff on the touched files:
```
vendor/bin/phpcs -p ./admin/class-bulk-editor-list-table.php --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./
vendor/bin/phpcs -p ./admin/class-bulk-description-editor-list-table.php --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./
vendor/bin/phpcs -p ./admin/class-bulk-title-editor-list-table.php --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./
```
* Only 2 errors should be found in `class-bulk-editor-list-table.php`, this is harder to solve because of technical debt.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
