### PR TITLE
Output escaping class export

### DIFF
--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -27,13 +27,6 @@ class WPSEO_Export {
 	private $export = '';
 
 	/**
-	 * Holds the export error message.
-	 *
-	 * @var string
-	 */
-	private $error = '';
-
-	/**
 	 * Holds whether the export was a success.
 	 *
 	 * @var boolean
@@ -72,28 +65,6 @@ class WPSEO_Export {
 		);
 		echo '</p>';
 		echo '<textarea id="wpseo-export" rows="20" cols="100">' . esc_textarea( $this->export ) . '</textarea>';
-	}
-
-	/**
-	 * Returns true when the property error has a value.
-	 *
-	 * @return bool
-	 */
-	public function has_error() {
-		return ( $this->error !== '' );
-	}
-
-	/**
-	 * Sets the error hook, to display the error to the user.
-	 */
-	public function set_error_hook() {
-		/* translators: %1$s expands to Yoast SEO */
-		$message = sprintf( esc_html__( 'Error creating %1$s export: ', 'wordpress-seo' ), 'Yoast SEO' ) . $this->error;
-
-		printf(
-			'<div class="notice notice-error"><p>%1$s</p></div>',
-			$message
-		);
 	}
 
 	/**
@@ -172,5 +143,33 @@ class WPSEO_Export {
 			$val = '"' . $val . '"';
 		}
 		$this->write_line( $key . ' = ' . $val );
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * Returns true when the property error has a value.
+	 *
+	 * @deprecated 11.9 Obsolete since the export setting refactor in 9.2.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool
+	 */
+	public function has_error() {
+		_deprecated_function( __METHOD__, 'WPSEO 11.9' );
+
+		return false;
+	}
+
+	/**
+	 * Sets the error hook, to display the error to the user.
+	 *
+	 * @deprecated 11.9 Obsolete since the export setting refactor in 9.2.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function set_error_hook() {
+		_deprecated_function( __METHOD__, 'WPSEO 11.9' );
 	}
 }

--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -71,7 +71,7 @@ class WPSEO_Export {
 			)
 		);
 		echo '</p>';
-		echo '<textarea id="wpseo-export" rows="20" cols="100">' . $this->export . '</textarea>';
+		echo '<textarea id="wpseo-export" rows="20" cols="100">' . esc_textarea( $this->export ) . '</textarea>';
 	}
 
 	/**
@@ -88,7 +88,7 @@ class WPSEO_Export {
 	 */
 	public function set_error_hook() {
 		/* translators: %1$s expands to Yoast SEO */
-		$message = sprintf( __( 'Error creating %1$s export: ', 'wordpress-seo' ), 'Yoast SEO' ) . $this->error;
+		$message = sprintf( esc_html__( 'Error creating %1$s export: ', 'wordpress-seo' ), 'Yoast SEO' ) . $this->error;
 
 		printf(
 			'<div class="notice notice-error"><p>%1$s</p></div>',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping.

## Relevant technical choices:
* All error-related things from this class became obsolete in  https://github.com/Yoast/wordpress-seo/pull/4975/files#diff-e9ef37a839756dcbe1e776428c21fb98L97. Therefore, I 
	* removed `private $error`
    * deprecated `has_error`
    * deprecated `set_error_hook`
* I've added `esc_textarea` around `$this->export` to output escape the exported data.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to Yoast SEO > Tools > Import and Export
* Click the `Export settings tab`
* Export the settings.
* Do the same on `trunk`, compare the exports, and see that they are the same.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
