### PR TITLE
Fixed CS Error in `class-yoast-alerts.php`

### DIFF
--- a/admin/class-yoast-alerts.php
+++ b/admin/class-yoast-alerts.php
@@ -141,12 +141,14 @@ class Yoast_Alerts {
 	private function output_ajax_response( $type ) {
 
 		$html = $this->get_view_html( $type );
+		// phpcs:disable WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
 		echo WPSEO_Utils::format_json_encode(
 			array(
 				'html'  => $html,
 				'total' => self::get_active_alert_count(),
 			)
 		);
+		// phpcs:enable
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer before-premium-cs`. This installs the latest Yoast CS.
* Run the `WordPress.Security.EscapeOutput` sniff on the touched files:
```
vendor/bin/phpcs -p ./admin/class-yoast-alerts.php --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #