### PR TITLE
Fix rtlcss ignore directive for the Draft.js stylesheet.

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -1,8 +1,8 @@
 @import "yoastseo";
 @import "../../node_modules/draft-js-mention-plugin/lib/plugin";
-/*rtl:begin:ignore*/
+/*!rtl:begin:ignore*/
 @import "../../node_modules/draft-js/dist/Draft";
-/*rtl:end:ignore*/
+/*!rtl:end:ignore*/
 
 @function svg-icon-list($color) {
 	@return inline-svg('<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path fill="#{$color}" d="M384 1408q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm0-512q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm1408 416v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5zm-1408-928q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm1408 416v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5zm0-512v192q0 13-9.5 22.5t-22.5 9.5h-1216q-13 0-22.5-9.5t-9.5-22.5v-192q0-13 9.5-22.5t22.5-9.5h1216q13 0 22.5 9.5t9.5 22.5z"/></svg>');


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixe the Snippet Title and Meta fields style for right-to-left languages.

## Relevant technical choices:
- looks like the `rtl:ignore` control directive doesn't work as expected any longer for imported stylesheets
- two possible causes:
  - either `postcss`, which runs before `rtlcss` now strips out the comments e.g. `/*rtl:begin:ignore*/` so the imported file is not ignored
  - or maybe related: https://github.com/MohammadYounes/rtlcss/issues/137

This PR seeks to fix the bug by adding an exclamation mark to the comment, as suggested on the [cssnano documentation](https://cssnano.co/optimisations/discardcomments). 

The comments need to be written exactly as follows, without spaces:
```
/*!rtl:begin:ignore*/
@import "../../node_modules/draft-js/dist/Draft";
/*!rtl:end:ignore*/
```

## Test instructions
- test on trunk
- change site language to an RTL
- change the author language to an RTL
- go to post
- click Edit Snippet to show the meta and title fields
- see the fields are incorrectly styled for LTR:

<img width="729" alt="Screenshot 2019-07-24 at 16 30 29" src="https://user-images.githubusercontent.com/1682452/61802221-6654af80-ae30-11e9-864d-4258e8ef8e26.png">

- switch to this branch
- run `yarn && grunt build:css && grunt build:js && grunt webpack:buildProd`
- repeat the steps above
- see the fields are correctly styled for RTL:

<img width="729" alt="Screenshot 2019-07-24 at 16 29 27" src="https://user-images.githubusercontent.com/1682452/61802165-5046ef00-ae30-11e9-828e-0fb26a620264.png">


Fixes https://github.com/Yoast/bugreports/issues/482
