### PR TITLE
QA: make text translatable

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -158,7 +158,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 						class="yoast-link--license">
 						<?php
 						/* translators: %s expands to the extension title */
-						printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
+						printf( esc_html__( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
 						?>
 					</a>
@@ -168,7 +168,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 						class="yoast-link--license">
 						<?php
 						/* translators: %s expands to the extension title */
-						printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
+						printf( esc_html__( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $premium_extension->get_title() );
 						echo $new_tab_message;
 						?>
 					</a>
@@ -242,7 +242,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 									class="yoast-link--license">
 									<?php
 									/* translators: %s expands to the extension title */
-									printf( esc_html( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
+									printf( esc_html__( 'Manage your %s subscription on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
 									?>
 								</a>
@@ -252,7 +252,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 									class="yoast-link--license">
 									<?php
 									/* translators: %s expands to the extension title */
-									printf( esc_html( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
+									printf( esc_html__( 'Activate %s for your site on MyYoast', 'wordpress-seo' ), $extension->get_title() );
 									echo $new_tab_message;
 									?>
 								</a>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _Improved I18n support_

## Relevant technical choices:

Fix some output escaping function calls to make sure they use the "translate + escape" variant instead of just escape the (untranslated) text.

## Test instructions

This PR can be tested by following these steps:

On `trunk`:
* Select a non-English language which is 100% translated for your admin interface.
* Go to the `licenses` page and see that four text strings are still in English.
* Switch to this branch and see the difference.
