### PR TITLE
updates robots() to have an echo param like other frontend methods

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -687,8 +687,8 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * This function normally outputs the robots meta tag but is also used in other places to retrieve
-	 * the meta robots value 
+	 * This function normally outputs the robots meta tag but is also used in other places to retrieve the meta robots value.
+	 *
 	 * @param bool $echo Whether or not to output the meta robots element.
 	 *
 	 * @return string $robotsstr
@@ -790,13 +790,14 @@ class WPSEO_Frontend {
 		if ( strpos( $robotsstr, 'noindex' ) !== false ) {
 			remove_action( 'wpseo_head', array( $this, 'canonical' ), 20 );
 		}
-		
+
 		if ( $echo === false ) {
 			return $robotsstr;
 		}
 
 		if ( is_string( $robotsstr ) && $robotsstr !== '' ) {
-			echo '<meta name="robots" content="', esc_attr( $robotsstr ), '"/>', "\n";
+      echo '<meta name="robots" content="', esc_attr( $robotsstr ), '"/>', "\n";
+      return $robotsstr;
 		}
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -687,11 +687,13 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * Output the meta robots value.
+	 * This function normally outputs the robots meta tag but is also used in other places to retrieve
+	 * the meta robots value 
+	 * @param bool $echo Whether or not to output the meta robots element.
 	 *
-	 * @return string
+	 * @return string $robotsstr
 	 */
-	public function robots() {
+	public function robots( $echo = true ) {
 		global $wp_query, $post;
 
 		$robots           = array();
@@ -784,16 +786,18 @@ class WPSEO_Frontend {
 		 */
 		$robotsstr = apply_filters( 'wpseo_robots', $robotsstr );
 
-		if ( is_string( $robotsstr ) && $robotsstr !== '' ) {
-			echo '<meta name="robots" content="', esc_attr( $robotsstr ), '"/>', "\n";
-		}
-
 		// If a page has a noindex, it should _not_ have a canonical, as these are opposing indexing directives.
 		if ( strpos( $robotsstr, 'noindex' ) !== false ) {
 			remove_action( 'wpseo_head', array( $this, 'canonical' ), 20 );
 		}
+		
+		if ( $echo === false ) {
+			return $robotsstr;
+		}
 
-		return $robotsstr;
+		if ( is_string( $robotsstr ) && $robotsstr !== '' &&  ) {
+			echo '<meta name="robots" content="', esc_attr( $robotsstr ), '"/>', "\n";
+		}
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -796,8 +796,8 @@ class WPSEO_Frontend {
 		}
 
 		if ( is_string( $robotsstr ) && $robotsstr !== '' ) {
-      echo '<meta name="robots" content="', esc_attr( $robotsstr ), '"/>', "\n";
-      return $robotsstr;
+			echo '<meta name="robots" content="', esc_attr( $robotsstr ), '"/>', "\n";
+			return $robotsstr;
 		}
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -795,7 +795,7 @@ class WPSEO_Frontend {
 			return $robotsstr;
 		}
 
-		if ( is_string( $robotsstr ) && $robotsstr !== '' &&  ) {
+		if ( is_string( $robotsstr ) && $robotsstr !== '' ) {
 			echo '<meta name="robots" content="', esc_attr( $robotsstr ), '"/>', "\n";
 		}
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* updates robots() to have an echo param like other frontend methods

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Verify meta robots tag doesn't render as usual if index,follow
* verify meta robots tag renders correctly if noindexed, etc
* $wpseo_frontend = WPSEO_Frontend::get_instance();
* $robots = $wpseo_frontend->robots( false );
* ensure no echo on page
* var_dump($robots) returns correct robots info


## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13291 

