### PR TITLE
set maxwidth to 800

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -17,7 +17,6 @@
 }
 
 #wpseo_meta {
-	max-width: 800px;
 	box-sizing: border-box;
 
 	*, *:before, *:after {
@@ -110,6 +109,7 @@ ul.wpseo-metabox-tabs li.active {
 }
 
 .wpseo-metabox-content {
+	max-width: 800px;
 	padding-top: 16px;
 }
 

--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -17,6 +17,7 @@
 }
 
 #wpseo_meta {
+	max-width: 800px;
 	box-sizing: border-box;
 
 	*, *:before, *:after {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* https://github.com/Yoast/wordpress-seo/issues/13268

## Relevant technical choices:

* Set `max-width: 800px`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Edit any post, the Yoast metabox content shouldn't span the whole width

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
Set metabox max-width to 800px