### PR TITLE
Escape the option_tab_content output

### DIFF
--- a/admin/class-option-tabs-formatter.php
+++ b/admin/class-option-tabs-formatter.php
@@ -64,7 +64,7 @@ class WPSEO_Option_Tabs_Formatter {
 			 */
 			$option_tab_content = apply_filters( 'wpseo_option_tab-' . $tab_filter_name, null, $option_tabs, $tab );
 			if ( ! empty( $option_tab_content ) ) {
-				echo $option_tab_content;
+				echo wp_kses_post( $option_tab_content );
 			}
 
 			if ( empty( $option_tab_content ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A Improves output escaping.

## Relevant technical choices:

* The only place where we use the filter to add a tab is in the search index purge plugin: https://github.com/Yoast/search-index-purge/pull/27/files. All HTML in that file can be used with `wp_kses_post`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install the Search Index Purge plugin.
* Navigate to Yoast SEO > Search appearance > Media.
* See that the entire content from the Search Index Purge plugin is still there. See https://github.com/Yoast/search-index-purge/pull/27/files#diff-3af5e6ebf1e0d76175c1d63505acd3c0R17.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
