### PR TITLE
Output escaping: class-recalculate-scores-ajax

### DIFF
--- a/admin/ajax/class-recalculate-scores-ajax.php
+++ b/admin/ajax/class-recalculate-scores-ajax.php
@@ -28,6 +28,7 @@ class WPSEO_Recalculate_Scores_Ajax {
 		check_ajax_referer( 'wpseo_recalculate', 'nonce' );
 
 		wp_die(
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: WPSEO_Utils::format_json_encode is considered safe.
 			WPSEO_Utils::format_json_encode(
 				array(
 					'posts' => $this->calculate_posts(),
@@ -49,6 +50,7 @@ class WPSEO_Recalculate_Scores_Ajax {
 			$response = $fetch_object->get_items_to_recalculate( $paged );
 
 			if ( ! empty( $response ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: WPSEO_Utils::format_json_encode is considered safe.
 				wp_die( WPSEO_Utils::format_json_encode( $response ) );
 			}
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping

## Relevant technical choices:

* Add phpcs:ignore comment above things that are already escaped using `WPSEO_Utils::format_json_encode`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer before-premium-cs`. This installs the latest Yoast CS.
* Run the `WordPress.Security.EscapeOutput` sniff on the touched files:
```
vendor/bin/phpcs -p --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./ ./admin/ajax/class-recalculate-scores-ajax.php
```
* Run `composer after-premium-cs`. This reverts the PHP packages back to normal.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
