### PR TITLE
Output escaping: class-shortcode-filter

### DIFF
--- a/admin/ajax/class-shortcode-filter.php
+++ b/admin/ajax/class-shortcode-filter.php
@@ -36,6 +36,7 @@ class WPSEO_Shortcode_Filter {
 			);
 		}
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: WPSEO_Utils::format_json_encode is considered safe.
 		wp_die( WPSEO_Utils::format_json_encode( $parsed_shortcodes ) );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping

## Relevant technical choices:

* Add phpcs:ignore comment above things that are already escaped using `WPSEO_Utils::format_json_encode`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer before-premium-cs`. This installs the latest Yoast CS.
* Run the `WordPress.Security.EscapeOutput` sniff on the touched files:
```
vendor/bin/phpcs -p --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./ ./admin/ajax/class-shortcode-filter.php
```
* Run `composer after-premium-cs`. This reverts the PHP packages back to normal.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
