### PR TITLE
 Escape the outputted notifications and add ignore above format_json_encode

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
  * @param array $results Results array for encoding.
  */
 function wpseo_ajax_json_echo_die( $results ) {
-	// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe
+	// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
 	echo WPSEO_Utils::format_json_encode( $results );
 	die();
 }
@@ -275,7 +275,7 @@ function ajax_get_keyword_usage() {
 	}
 
 	wp_die(
-		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
 		WPSEO_Utils::format_json_encode( WPSEO_Meta::keyword_usage( $keyword, $post_id ) )
 	);
 }
@@ -306,7 +306,7 @@ function ajax_get_term_keyword_usage() {
 	$usage = $usage[ $keyword ];
 
 	wp_die(
-		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
 		WPSEO_Utils::format_json_encode( $usage )
 	);
 }

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -369,6 +369,7 @@ class Yoast_Notification_Center {
 				$notification_json[] = $notification->render();
 			}
 
+			// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
 			echo WPSEO_Utils::format_json_encode( $notification_json );
 
 			return;

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -376,7 +376,7 @@ class Yoast_Notification_Center {
 		}
 
 		foreach ( $notifications as $notification ) {
-			echo $notification;
+			echo wp_kses_post( $notification );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A: improves output escaping.

## Relevant technical choices:

* A $notification contains html. An example is: 
`<div class="yoast-alert"><p>Yoast SEO: Local needs a Google Maps browser key to show Google Maps on your website. You haven't set a Google Maps browser key yet. Go to the <a href="http://local.wordpress.test/wp-admin/admin.php?page=wpseo_local#top#api_keys">Yoast SEO: Local API keys page</a> to set the key, or <a href="https://yoa.st/gm-api-browser-key" target="_blank">visit the knowledge base</a> for more information.</p></div>`
* Therefore, I chose for `wp_kses_post`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to `Yoast SEO > General` and look at the notification center. See that all notifications are still present and look good (compare with `trunk`).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
