### PR TITLE
Escaped all output of class-yoast-form.php

### DIFF
--- a/admin/class-admin-help-panel.php
+++ b/admin/class-admin-help-panel.php
@@ -70,7 +70,7 @@ class WPSEO_Admin_Help_Panel {
 		return sprintf(
 			' <button type="button" class="yoast_help yoast-help-button dashicons" id="%1$s-help-toggle" aria-expanded="false" aria-controls="%1$s-help"><span class="yoast-help-icon" aria-hidden="true"></span><span class="screen-reader-text">%2$s</span></button>',
 			esc_attr( $this->id ),
-			$this->help_button_text
+			esc_html( $this->help_button_text )
 		);
 	}
 
@@ -97,7 +97,7 @@ class WPSEO_Admin_Help_Panel {
 			'%1$s<p id="%2$s-help" class="yoast-help-panel">%3$s</p>%4$s',
 			$wrapper_start,
 			esc_attr( $this->id ),
-			$this->help_content,
+			wp_kses_post( $this->help_content ),
 			$wrapper_end
 		);
 	}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -280,7 +280,7 @@ class Yoast_Form {
 	 * @param WPSEO_Admin_Help_Panel $help    Inline Help that will be printed out before the visible toggles text.
 	 * @param bool                   $strong  Whether the visual label is displayed in strong text. Default is false.
 	 */
-	public function light_switch( $var, $label, $buttons = array(), $reverse = true, $help = null, $strong = false ) {
+	public function light_switch( $var, $label, $buttons = [], $reverse = true, $help = null, $strong = false ) {
 		$val = WPSEO_Options::get( $var, false );
 
 		if ( $val === true ) {
@@ -302,7 +302,7 @@ class Yoast_Form {
 		$container_class = 'switch-container';
 		$help_toggle     = '';
 
-		if ( $help instanceof WPSEO_Admin_Help_Panel ) {
+		if ( $help !== null ) {
 			$container_class .= ' switch-container__has-help';
 			$help_toggle      = $help->get_button_html() . $help->get_panel_html();
 		}
@@ -643,7 +643,7 @@ class Yoast_Form {
 	 * @param WPSEO_Admin_Help_Panel $help   Inline Help that will be printed out before the visible toggles text.
 	 */
 	public function toggle_switch( $var, $values, $label, $help = null ) {
-		if ( ! is_array( $values ) || $values === array() ) {
+		if ( ! is_array( $values ) || $values === [] ) {
 			return;
 		}
 		$val = WPSEO_Options::get( $var, false );
@@ -657,7 +657,7 @@ class Yoast_Form {
 		$container_class = 'switch-container';
 		$help_toggle     = '';
 
-		if ( $help instanceof WPSEO_Admin_Help_Panel ) {
+		if ( $help !== null ) {
 			$container_class .= ' switch-container__has-help';
 			$help_toggle      = $help->get_button_html() . $help->get_panel_html();
 		}

--- a/admin/views/class-view-utils.php
+++ b/admin/views/class-view-utils.php
@@ -83,7 +83,7 @@ class Yoast_View_Utils {
 		$this->form->index_switch(
 			$noindex_option_name,
 			$post_type->labels->name,
-			$show_post_type_help->get_button_html() . $show_post_type_help->get_panel_html()
+			$show_post_type_help
 		);
 
 		$this->form->show_hide_switch(

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -53,7 +53,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 				'off' => __( 'Off', 'wordpress-seo' ),
 			],
 			'<strong>' . $feature->name . '</strong>',
-			$feature_help->get_button_html() . $feature_help->get_panel_html()
+			$feature_help
 		);
 	}
 	?>

--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -36,7 +36,7 @@ $author_archives_help = new WPSEO_Admin_Help_Panel(
 $yform->index_switch(
 	'noindex-author-wpseo',
 	__( 'author archives', 'wordpress-seo' ),
-	$author_archives_help->get_button_html() . $author_archives_help->get_panel_html()
+	$author_archives_help
 );
 
 ?>
@@ -59,7 +59,7 @@ $author_archives_no_posts_help = new WPSEO_Admin_Help_Panel(
 $yform->index_switch(
 	'noindex-author-noposts-wpseo',
 	__( 'archives for authors without posts', 'wordpress-seo' ),
-	$author_archives_no_posts_help->get_button_html() . $author_archives_no_posts_help->get_panel_html()
+	$author_archives_no_posts_help
 );
 
 ?>

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -34,7 +34,7 @@ $yform->toggle_switch(
 	$yform->index_switch(
 		'noindex-archive-wpseo',
 		__( 'date archives', 'wordpress-seo' ),
-		$date_archives_help->get_button_html() . $date_archives_help->get_panel_html()
+		$date_archives_help
 	);
 
 	$recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -40,7 +40,7 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 			__( 'the archive for %s', 'wordpress-seo' ),
 			$plural_label
 		),
-		$custom_post_type_archive_help->get_button_html() . $custom_post_type_archive_help->get_panel_html()
+		$custom_post_type_archive_help
 	);
 
 	$page_type = $recommended_replace_vars->determine_for_archive( $wpseo_post_type->name );

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -18,7 +18,7 @@ $noindex_option_name = 'noindex-' . $wpseo_post_type->name;
 $yform->index_switch(
 	$noindex_option_name,
 	$wpseo_post_type->labels->name,
-	$show_post_type_help->get_button_html() . $show_post_type_help->get_panel_html()
+	$show_post_type_help
 );
 
 $yform->show_hide_switch(

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -28,7 +28,7 @@ $taxonomies_help = $view_utils->search_results_setting_help( $wpseo_taxonomy );
 $yform->index_switch(
 	'noindex-tax-' . $wpseo_taxonomy->name,
 	$title,
-	$taxonomies_help->get_button_html() . $taxonomies_help->get_panel_html()
+	$taxonomies_help
 );
 
 

--- a/admin/views/tabs/metas/taxonomies/category-url.php
+++ b/admin/views/tabs/metas/taxonomies/category-url.php
@@ -24,5 +24,5 @@ $yform->light_switch(
 	__( 'Remove the categories prefix', 'wordpress-seo' ),
 	$remove_buttons,
 	false,
-	$stripcategorybase_help->get_button_html() . $stripcategorybase_help->get_panel_html()
+	$stripcategorybase_help
 );

--- a/admin/views/tabs/network/features.php
+++ b/admin/views/tabs/network/features.php
@@ -53,7 +53,7 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 				'off' => __( 'Disable', 'wordpress-seo' ),
 			],
 			'<strong>' . $feature->name . '</strong>',
-			$feature_help->get_button_html() . $feature_help->get_panel_html()
+			$feature_help
 		);
 	}
 	?>

--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -21,7 +21,7 @@ printf(
 	esc_html__( 'Twitter uses Open Graph metadata just like Facebook, so be sure to keep the "Add Open Graph meta data" setting on the Facebook tab enabled if you want to optimize your site for Twitter.', 'wordpress-seo' )
 );
 
-$yform->light_switch( 'twitter', __( 'Add Twitter card meta data', 'wordpress-seo' ), [], true, '', true );
+$yform->light_switch( 'twitter', __( 'Add Twitter card meta data', 'wordpress-seo' ), [], true, null, true );
 
 echo '<p>';
 esc_html_e( 'Enable this feature if you want Twitter to display a preview with images and a text excerpt when a link to your site is shared.', 'wordpress-seo' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Changed the method signature of `Yoast_Form::light_switch`, `Yoast_Form::toggle_switch` and `Yoast_Form::index_switch`. I double-checked that the parameter that was changed was not used by any of our plugins.
* Also added output escaping to `WPSEO_Admin_Help_Panel::get_button_html` and `WPSEO_Admin_Help_Panel::get_panel_html` in order to make sure all data output by `class-yoast-form` is escaped.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the settings on the admin pages can still be saved.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
