### PR TITLE
Introduce feature flag to prevent loading the code in src

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -342,10 +342,13 @@ function wpseo_init() {
 	$wpseo_onpage = new WPSEO_OnPage();
 	$wpseo_onpage->register_hooks();
 
-	// When namespaces are not available, stop further execution.
-	if ( version_compare( PHP_VERSION, '5.6.0', '>=' ) ) {
-		require_once WPSEO_PATH . 'src/main.php';
-		// require_once WPSEO_PATH . 'src/loaders/oauth.php'; Temporarily disabled.
+	// Feature flag introduced to resolve problems with composer installation in 11.8.
+	if ( defined( 'WPSEO_EXPERIMENTAL_PHP56' ) && WPSEO_EXPERIMENTAL_PHP56 ) {
+		// When namespaces are not available, stop further execution.
+		if ( version_compare( PHP_VERSION, '5.6.0', '>=' ) ) {
+			require_once WPSEO_PATH . 'src/main.php';
+			// require_once WPSEO_PATH . 'src/loaders/oauth.php'; Temporarily disabled.
+		}
 	}
 }
 


### PR DESCRIPTION
This feature flag prevents loading the code in the `src` folder.
The code is currently breaking composer installations, thus we can't ship this way.

This change needs to be merged in the premium release branch to make sure we can acceptance test on Yoast.com