### PR TITLE
fix notice showing

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -243,7 +243,11 @@ class WPSEO_Image_Utils {
 		// If the file size for the file is over our limit, we're going to go for a smaller version.
 		// @todo Save the filesize to the image metadata.
 		// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- If file size doesn't properly return, we'll not fail.
-		return @filesize( self::get_absolute_path( $image['path'] ) );
+		if(file_exists(self::get_absolute_path( $image['path'] ))) {
+			return @filesize( self::get_absolute_path( $image['path'] ) );
+		}
+		
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Notice: Trying to get property of non-object in /var/www/montreal.webpublisherpro.com/htdocs/wp-content/plugins/wordpress-seo/frontend/schema/class-schema-utils.php on line 26

Notice fixed.

## Summary

This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13307
