### PR TITLE
Add output escaping to tool desc and attr in admin/pages/tools.php

### DIFF
--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -54,8 +54,8 @@ if ( '' === $tool_page ) {
 		$attr = ( ! empty( $tool['attr'] ) ) ? $tool['attr'] : '';
 
 		echo '<li>';
-		echo '<strong><a href="', esc_url( $href ), '" ', $attr , '>', esc_html( $tool['title'] ), '</a></strong><br/>';
-		echo $tool['desc'];
+		echo '<strong><a href="', esc_url( $href ), '" ', esc_attr( $attr ) , '>', esc_html( $tool['title'] ), '</a></strong><br/>';
+		echo esc_html( $tool['desc'] );
 		echo '</li>';
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping

## Test instructions
* Go to Yoast SEO > Tools. 
* See that the tools and their descriptions are unchanged.

