### PR TITLE
Output escaping: admin/metabox/class-metabox-section-readability.php

### DIFF
--- a/admin/metabox/class-metabox-section-readability.php
+++ b/admin/metabox/class-metabox-section-readability.php
@@ -22,9 +22,10 @@ class WPSEO_Metabox_Section_Readability implements WPSEO_Metabox_Section {
 	 */
 	public function display_link() {
 		printf(
-			'<li role="presentation"><a role="tab" href="#wpseo-meta-section-%1$s" id="wpseo-meta-tab-%1$s" aria-controls="wpseo-meta-section-%1$s" class="wpseo-meta-section-link">%2$s</a></li>',
+			'<li role="presentation"><a role="tab" href="#wpseo-meta-section-%1$s" id="wpseo-meta-tab-%1$s" aria-controls="wpseo-meta-section-%1$s" class="wpseo-meta-section-link">
+				<div class="wpseo-score-icon-container" id="wpseo-readability-score-icon"></div><span>%2$s</span></a></li>',
 			esc_attr( $this->name ),
-			'<div class="wpseo-score-icon-container" id="wpseo-readability-score-icon"></div><span>' . __( 'Readability', 'wordpress-seo' ) . '</span>'
+			esc_html__( 'Readability', 'wordpress-seo' )
 		);
 	}
 
@@ -32,13 +33,10 @@ class WPSEO_Metabox_Section_Readability implements WPSEO_Metabox_Section {
 	 * Outputs the section content.
 	 */
 	public function display_content() {
-		$html  = sprintf(
+		printf(
 			'<div role="tabpanel" id="wpseo-meta-section-%1$s" aria-labelledby="wpseo-meta-tab-%1$s" tabindex="0" class="wpseo-meta-section">',
 			esc_attr( $this->name )
 		);
-		$html .= '<div id="wpseo-metabox-readability-root" class="wpseo-metabox-root"></div>';
-		$html .= '</div>';
-
-		echo $html;
+		echo '<div id="wpseo-metabox-readability-root" class="wpseo-metabox-root"></div>', '</div>';
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping

## Relevant technical choices:

* `display_link`: Moved the HTML out of the replacement variable and into the `printf` format.
* `display_content`: Slight refactor to prevent a "PHPCS ignore" line.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer before-premium-cs`. This installs the latest Yoast CS.
* Run the `WordPress.Security.EscapeOutput` sniff on the touched files:
```
vendor/bin/phpcs -p --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./ ./admin/metabox/class-metabox-section-readability.php
```
* Run `composer after-premium-cs`. This reverts the PHP packages back to normal.
* Build this branch and check the `Readability` tab in the metabox, it should be unchanged.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
