### PR TITLE
Output escaping class yoast form fieldset

### DIFF
--- a/admin/views/form/fieldset.php
+++ b/admin/views/form/fieldset.php
@@ -11,6 +11,8 @@
  * @uses string $content           The fieldset content, i.e. a set of logically grouped form controls.
  */
 
+_deprecated_file( __FILE__, '11.9' );
+
 if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'Status: 403 Forbidden' );
 	header( 'HTTP/1.1 403 Forbidden' );

--- a/deprecated/admin/config-ui/fields/class-field-profile-url-googleplus.php
+++ b/deprecated/admin/config-ui/fields/class-field-profile-url-googleplus.php
@@ -20,7 +20,7 @@ class WPSEO_Config_Field_Profile_URL_GooglePlus extends WPSEO_Config_Field {
 	 * @deprecated 10.1
 	 */
 	public function __construct() {
-		_deprecated_constructor( 'WPSEO_Config_Field_Profile_URL_GooglePlus', '10.1' );
+		_deprecated_function( __METHOD__, '10.1' );
 	}
 
 	/**

--- a/deprecated/class-cornerstone.php
+++ b/deprecated/class-cornerstone.php
@@ -32,7 +32,7 @@ class WPSEO_Cornerstone {
 	 * @deprecated 8.4
 	 */
 	public function __construct() {
-		_deprecated_constructor( 'WPSEO_Cornerstone', '8.4' );
+		_deprecated_function( __METHOD__, '8.4' );
 	}
 
 	/**

--- a/deprecated/class-metabox-addon-section.php
+++ b/deprecated/class-metabox-addon-section.php
@@ -25,7 +25,7 @@ class WPSEO_Metabox_Addon_Tab_Section extends WPSEO_Metabox_Tab_Section {
 	 * @param array  $options      Optional link attributes.
 	 */
 	public function __construct( $name, $link_content, array $tabs = array(), array $options = array() ) {
-		_deprecated_constructor( 'WPSEO_Metabox_Addon_Tab_Section', '11.9' );
+		_deprecated_function( __METHOD__, '11.9' );
 		parent::__construct( $name, $link_content, $tabs, $options );
 	}
 

--- a/deprecated/class-recalibration-beta-notification.php
+++ b/deprecated/class-recalibration-beta-notification.php
@@ -29,7 +29,7 @@ class WPSEO_Recalibration_Beta_Notification implements WPSEO_WordPress_Integrati
 	 * @deprecated 9.6
 	 */
 	public function __construct() {
-		_deprecated_constructor( 'WPSEO_Recalibration_Beta_Notification', 'WPSEO 9.6' );
+		_deprecated_function( __METHOD__, '9.6' );
 	}
 
 	/**

--- a/deprecated/class-recalibration-beta.php
+++ b/deprecated/class-recalibration-beta.php
@@ -40,7 +40,7 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		_deprecated_constructor( 'WPSEO_Recalibration_Beta', 'WPSEO 10.0' );
+		_deprecated_function( __METHOD__, '10.0' );
 	}
 
 	/**

--- a/deprecated/class-wpseo-option-permalinks.php
+++ b/deprecated/class-wpseo-option-permalinks.php
@@ -40,7 +40,7 @@ class WPSEO_Option_Permalinks {
 	 * @return void
 	 */
 	protected function __construct() {
-		_deprecated_constructor( __CLASS__, 'WPSEO 7.0' );
+		_deprecated_function( __METHOD__, '7.0' );
 	}
 
 	/**

--- a/deprecated/class-yoast-form-fieldset.php
+++ b/deprecated/class-yoast-form-fieldset.php
@@ -134,6 +134,7 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 	public function html() {
 		_deprecated_function( __METHOD__, '11.9' );
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: This is deprecated.
 		echo $this->get_html();
 	}
 

--- a/deprecated/class-yoast-form-fieldset.php
+++ b/deprecated/class-yoast-form-fieldset.php
@@ -52,11 +52,16 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 	/**
 	 * Constructor.
 	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
+	 *
 	 * @param string $id             ID for the fieldset.
 	 * @param string $legend_content The translatable legend text.
 	 * @param string $content        The grouped form elements for the fieldset.
 	 */
 	public function __construct( $id, $legend_content, $content ) {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		$this->id             = $id;
 		$this->legend_content = $legend_content;
 		$this->content        = $content;
@@ -64,8 +69,13 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 
 	/**
 	 * Render the view.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 */
 	public function render_view() {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		/*
 		 * Extract because we want values accessible via variables for later use
 		 * in the view instead of accessing them as an array.
@@ -77,24 +87,39 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 
 	/**
 	 * Start output buffering to catch the form elements to wrap in the fieldset.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 */
 	public function start() {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		ob_start();
 	}
 
 	/**
 	 * Return output buffering with the form elements to wrap in the fieldset.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 */
 	public function end() {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		$this->content = ob_get_clean();
 	}
 
 	/**
 	 * Return the rendered view.
 	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
+	 *
 	 * @return string
 	 */
 	public function get_html() {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		ob_start();
 		$this->render_view();
 		return ob_get_clean();
@@ -102,33 +127,53 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 
 	/**
 	 * Output the rendered view.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 */
 	public function html() {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		echo $this->get_html();
 	}
 
 	/**
 	 * Add attributes to the fieldset default attributes.
 	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
+	 *
 	 * @param array $attributes Array of attributes names and values to merge with the defaults.
 	 */
 	public function add_attributes( $attributes ) {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		$this->attributes = wp_parse_args( $attributes, $this->attributes );
 	}
 
 	/**
 	 * Add attributes to the fieldset legend default attributes.
 	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
+	 *
 	 * @param array $attributes Array of attributes names and values to merge with the defaults.
 	 */
 	public function legend_add_attributes( $attributes ) {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		$this->legend_attributes = wp_parse_args( $attributes, $this->legend_attributes );
 	}
 
 	/**
 	 * Visually hide the fieldset legend but keep it available to assistive technologies.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 */
 	public function legend_hide() {
+		_deprecated_function( __METHOD__, '11.9' );
+
 		$this->legend_attributes = wp_parse_args(
 			array( 'class' => 'screen-reader-text' ),
 			$this->legend_attributes
@@ -137,6 +182,9 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 
 	/**
 	 * Return the set of attributes and content for the fieldset.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 *
 	 * @return array
 	 */
@@ -152,6 +200,9 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 
 	/**
 	 * Return HTML formatted attributes as a string, when there are attributes set.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 *
 	 * @param array $attributes Fieldset or legend attributes.
 	 *
@@ -170,6 +221,9 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 
 	/**
 	 * Escape and format an attribute as an HTML attribute.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
 	 *
 	 * @param string $value     The value of the attribute.
 	 * @param string $attribute The attribute to look for.

--- a/deprecated/class-yoast-modal.php
+++ b/deprecated/class-yoast-modal.php
@@ -21,7 +21,7 @@ class Yoast_Modal {
 	 * @deprecated 9.2
 	 */
 	public function __construct() {
-		_deprecated_constructor( 'Yoast_Modal', '9.2' );
+		_deprecated_function( __METHOD__, '9.2' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Improves output escaping

## Relevant technical choices:

* Deprecated the whole class and related view file because it is not used.
* Replaced other `_deprecated_constructor` calls because I learned this is only for PHP4 style constructors (see commit message).
* Add phpcs:ignore comment instead of fixing it to save time.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer before-premium-cs`. This installs the latest Yoast CS.
* Run the `WordPress.Security.EscapeOutput` sniff on the touched files:
```
vendor/bin/phpcs -p --standard=WordPress --sniffs=WordPress.Security.EscapeOutput --report=full,summary,source --basepath=./ deprecated/class-yoast-form-fieldset.php
```
* Run `composer after-premium-cs`. This reverts the PHP packages back to normal.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
