### PR TITLE
Don't allow all HTML tags in the schema description

### DIFF
--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -77,7 +77,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 		}
 
 		if ( ! empty( $this->context->description ) ) {
-			$data['description'] = $this->context->description;
+			$data['description'] = strip_tags( $this->context->description, '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><b><strong><i><em>' );
 		}
 
 		if ( $this->add_breadcrumbs() ) {

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1191,6 +1191,7 @@ SVG;
 			return false;
 		}
 
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Escaping happens in WPSEO_Utils::schema_tag, which should be whitelisted.
 		echo self::schema_tag( $graph, $class );
 		return true;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -112,9 +112,10 @@ Find out all about Yoast SEO 11.8 in [our 11.8 release post](https://yoa.st/rele
 
 Enhancements:
 
-* Moved advanced SEO settings to a collapsible in the SEO tab.
+* Moves advanced SEO settings to a collapsible in the SEO tab.
 * Social settings tab in the metabox now contains collapsibles instead of tabs.
 * Adds style for padding to the metabox menu to avoid it being overwritten by custom editor styles. Props to [@emilyatmobtown](https://github.com/emilyatmobtown).
+* Improves sanitization of the schema output.
 
 Bugfixes:
 

--- a/tests/frontend/schema/class-schema-webpage-test.php
+++ b/tests/frontend/schema/class-schema-webpage-test.php
@@ -226,4 +226,35 @@ class WPSEO_Schema_WebPage_Test extends TestCase {
 
 		$this->assertArrayNotHasKey( 'author', $data );
 	}
+
+	/**
+	 * Tests if the description in the schema output gets stripped from script tags.
+	 *
+	 * @covers \WPSEO_Schema_WebPage::generate
+	 */
+	public function test_schema_output_strips_script_tags_from_description() {
+		$this->context->description = '<script>this is a malicious script</script>';
+
+		$actual = $this->instance->generate();
+
+		$expected = 'this is a malicious script';
+
+		$this->assertEquals( $actual['description'], $expected );
+	}
+
+	/**
+	 * Tests if the description in the schema output gets stripped from script tags.
+	 *
+	 * @covers \WPSEO_Schema_WebPage::generate
+	 */
+	public function test_schema_output_leaves_h1_tags_in_description() {
+		$this->context->description = '<h1>this is a title</h1>';
+
+		$actual = $this->instance->generate();
+
+		$expected = '<h1>this is a title</h1>';
+
+		$this->assertEquals( $actual['description'], $expected );
+	}
+
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where too many HTML tags were allowed in the description in the Schema output.

## Relevant technical choices:

* I've allowed the same tags as in https://github.com/Yoast/wordpress-seo/pull/13204/files.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See https://github.com/Yoast/bugreports/issues/502.
* Also put tags that don't get stripped in the description, for example `<h1>`.
* After this and https://github.com/Yoast/wordpress-seo/issues/13327 have been merged, please create new RCs.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/502
