### PR TITLE
Escape output in paper-collapsible.php

### DIFF
--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -42,7 +42,8 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 				$help_text->get_button_html(),
 				wp_kses_post( $collapsible_config['toggle_icon'] ),
 				esc_attr( $collapsible_config['expanded'] ),
-				esc_attr( $button_id_attr )
+				// phpcs:ignore WordPress.Security.EscapeOutput -- $button_id_attr is escaped above.
+				$button_id_attr
 			);
 		}
 		else {

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -36,15 +36,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 			}
 
 			printf(
-				'<h2 class="%6$s"><button%5$s type="button" class="toggleable-container-trigger" aria-expanded="%4$s">%1$s%2$s <span class="toggleable-container-icon dashicons %3$s" aria-hidden="true"></span></button></h2>',
-				esc_html( $title ) . wp_kses_post( $title_after ),
-				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
-				$help_text->get_button_html(),
-				wp_kses_post( $collapsible_config['toggle_icon'] ),
-				esc_attr( $collapsible_config['expanded'] ),
+				'<h2 class="%1$s"><button%2$s type="button" class="toggleable-container-trigger" aria-expanded="%3$s">%4$s%5$s <span class="toggleable-container-icon dashicons %6$s" aria-hidden="true"></span></button></h2>',
+				esc_attr( 'collapsible-header ' . $collapsible_header_class ),
 				// phpcs:ignore WordPress.Security.EscapeOutput -- $button_id_attr is escaped above.
 				$button_id_attr,
-				esc_attr( 'collapsible-header ' . $collapsible_header_class )
+				esc_attr( $collapsible_config['expanded'] ),
+				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
+				$help_text->get_button_html(),
+				esc_html( $title ) . wp_kses_post( $title_after ),
+				wp_kses_post( $collapsible_config['toggle_icon'] )
 			);
 		}
 		else {

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -37,7 +37,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 			printf(
 				'<h2 class="collapsible-header"><button%5$s type="button" class="toggleable-container-trigger" aria-expanded="%4$s">%1$s%2$s <span class="toggleable-container-icon dashicons %3$s" aria-hidden="true"></span></button></h2>',
-				esc_html( $title ) . $title_after,
+				esc_html( $title ) . wp_kses_post( $title_after ),
 				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
 				$help_text->get_button_html(),
 				wp_kses_post( $collapsible_config['toggle_icon'] ),

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -36,14 +36,15 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 			}
 
 			printf(
-				'<h2 class="collapsible-header"><button%5$s type="button" class="toggleable-container-trigger" aria-expanded="%4$s">%1$s%2$s <span class="toggleable-container-icon dashicons %3$s" aria-hidden="true"></span></button></h2>',
+				'<h2 class="%6$s"><button%5$s type="button" class="toggleable-container-trigger" aria-expanded="%4$s">%1$s%2$s <span class="toggleable-container-icon dashicons %3$s" aria-hidden="true"></span></button></h2>',
 				esc_html( $title ) . wp_kses_post( $title_after ),
 				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
 				$help_text->get_button_html(),
 				wp_kses_post( $collapsible_config['toggle_icon'] ),
 				esc_attr( $collapsible_config['expanded'] ),
 				// phpcs:ignore WordPress.Security.EscapeOutput -- $button_id_attr is escaped above.
-				$button_id_attr
+				$button_id_attr,
+				esc_attr( 'collapsible-header ' . $collapsible_header_class )
 			);
 		}
 		else {

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -36,22 +36,13 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 			}
 
 			printf(
-<<<<<<< HEAD
-				'<h2 class="collapsible-header %5$s"><button%4$s type="button" class="toggleable-container-trigger" aria-expanded="%3$s">%1$s <span class="toggleable-container-icon dashicons %2$s" aria-hidden="true"></span></button></h2>',
-				esc_html( $title ) . $title_after . $help_text->get_button_html(),
-				$collapsible_config['toggle_icon'],
-				$collapsible_config['expanded'],
-				$button_id_attr,
-				esc_attr( $collapsible_header_class )
-=======
 				'<h2 class="collapsible-header"><button%5$s type="button" class="toggleable-container-trigger" aria-expanded="%4$s">%1$s%2$s <span class="toggleable-container-icon dashicons %3$s" aria-hidden="true"></span></button></h2>',
-				esc_html( $title ) . wp_kses_post( $title_after ),
+				esc_html( $title ) . $title_after,
 				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
 				$help_text->get_button_html(),
 				wp_kses_post( $collapsible_config['toggle_icon'] ),
 				esc_attr( $collapsible_config['expanded'] ),
 				esc_attr( $button_id_attr )
->>>>>>> Escape output in paper-collapsible.php
 			);
 		}
 		else {
@@ -74,12 +65,19 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		$container_id_attr = sprintf( ' id="%s"', esc_attr( $paper_id_prefix . $paper_id . '-container' ) );
 	}
 
+	add_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_forms' ) );
+	add_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_a11y' ) );
+	$content = wp_kses_post( $content );
+	remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_forms' ) );
+	remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_a11y' ) );
+
 	printf(
 		'<div%1$s class="%2$s">%3$s</div>',
 		// phpcs:ignore WordPress.Security.EscapeOutput -- $container_id_attr is escaped above.
 		$container_id_attr,
 		esc_attr( 'paper-container ' . $collapsible_config['class'] ),
-		wp_kses_post( $content )
+		// phpcs:ignore WordPress.Security.EscapeOutput -- $content is escaped above.
+		$content
 	);
 	?>
 

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -27,6 +27,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 	<?php
 	if ( ! empty( $title ) ) {
+
 		if ( ! empty( $collapsible ) ) {
 
 			$button_id_attr = '';
@@ -35,21 +36,37 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 			}
 
 			printf(
+<<<<<<< HEAD
 				'<h2 class="collapsible-header %5$s"><button%4$s type="button" class="toggleable-container-trigger" aria-expanded="%3$s">%1$s <span class="toggleable-container-icon dashicons %2$s" aria-hidden="true"></span></button></h2>',
 				esc_html( $title ) . $title_after . $help_text->get_button_html(),
 				$collapsible_config['toggle_icon'],
 				$collapsible_config['expanded'],
 				$button_id_attr,
 				esc_attr( $collapsible_header_class )
+=======
+				'<h2 class="collapsible-header"><button%5$s type="button" class="toggleable-container-trigger" aria-expanded="%4$s">%1$s%2$s <span class="toggleable-container-icon dashicons %3$s" aria-hidden="true"></span></button></h2>',
+				esc_html( $title ) . wp_kses_post( $title_after ),
+				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
+				$help_text->get_button_html(),
+				wp_kses_post( $collapsible_config['toggle_icon'] ),
+				esc_attr( $collapsible_config['expanded'] ),
+				esc_attr( $button_id_attr )
+>>>>>>> Escape output in paper-collapsible.php
 			);
 		}
 		else {
-			printf( '<div class="paper-title"><h2 class="help-button-inline">' . esc_html( $title ) . $title_after . $help_text->get_button_html() . '</h2></div>' );
+			echo '<div class="paper-title"><h2 class="help-button-inline">',
+				esc_html( $title ),
+				wp_kses_post( $title_after ),
+				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
+				$help_text->get_button_html(),
+				'</h2></div>';
 		}
 	}
 	?>
 	<?php
 
+	// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
 	echo $help_text->get_panel_html();
 
 	$container_id_attr = '';
@@ -59,9 +76,10 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 	printf(
 		'<div%1$s class="%2$s">%3$s</div>',
+		// phpcs:ignore WordPress.Security.EscapeOutput -- $container_id_attr is escaped above.
 		$container_id_attr,
 		esc_attr( 'paper-container ' . $collapsible_config['class'] ),
-		$content
+		wp_kses_post( $content )
 	);
 	?>
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1230,6 +1230,7 @@ SVG;
 			$a11y_tags = array(
 				'button'   => array(
 					'aria-expanded' => true,
+					'aria-controls' => true,
 				),
 				'div'      => array(
 					'tabindex' => true,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Adds proper escaping to `paper-collapsible.php`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the search appearance pages and the metabox are still working.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
