### PR TITLE
Deprecate do_tab and add phpcs:ignore about get_content_sections

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1060,7 +1060,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	/**
 	 * Output a tab in the Yoast SEO Metabox.
 	 *
-	 * @deprecated         11.9
+	 * @deprecated         12.2
 	 * @codeCoverageIgnore
 	 *
 	 * @param string $id      CSS ID of the tab.
@@ -1068,7 +1068,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @param string $content Content of the tab. This content should be escaped.
 	 */
 	public function do_tab( $id, $heading, $content ) {
-		_deprecated_function( __METHOD__, '11.9' );
+		_deprecated_function( __METHOD__, '12.2' );
 
 		?>
 		<div id="<?php echo esc_attr( 'wpseo_' . $id ); ?>" class="wpseotab wpseo-form <?php echo esc_attr( $id ); ?>">

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -256,24 +256,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
-	 * Output a tab in the Yoast SEO Metabox.
-	 *
-	 * @param string $id      CSS ID of the tab.
-	 * @param string $heading Heading for the tab.
-	 * @param string $content Content of the tab. This content should be escaped.
-	 */
-	public function do_tab( $id, $heading, $content ) {
-		?>
-		<div id="<?php echo esc_attr( 'wpseo_' . $id ); ?>" class="wpseotab wpseo-form <?php echo esc_attr( $id ); ?>">
-			<?php echo $content; ?>
-		</div>
-		<?php
-	}
-
-	/**
 	 * Output the meta box.
 	 */
 	public function meta_box() {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title is considered safe.
 		$content_sections = $this->get_content_sections();
 
 		echo '<div class="wpseo-metabox-content">';
@@ -1069,5 +1055,25 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	public function setup_page_analysis() {
 		_deprecated_function( __METHOD__, 'WPSEO 9.6' );
+	}
+
+	/**
+	 * Output a tab in the Yoast SEO Metabox.
+	 *
+	 * @deprecated         11.9
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $id      CSS ID of the tab.
+	 * @param string $heading Heading for the tab.
+	 * @param string $content Content of the tab. This content should be escaped.
+	 */
+	public function do_tab( $id, $heading, $content ) {
+		_deprecated_function( __METHOD__, '11.9' );
+
+		?>
+		<div id="<?php echo esc_attr( 'wpseo_' . $id ); ?>" class="wpseotab wpseo-form <?php echo esc_attr( $id ); ?>">
+			<?php echo $content; ?>
+		</div>
+		<?php
 	}
 }

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -259,10 +259,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * Output the meta box.
 	 */
 	public function meta_box() {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title is considered safe.
 		$content_sections = $this->get_content_sections();
 
 		echo '<div class="wpseo-metabox-content">';
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title is considered safe.
 		printf( '<div class="wpseo-metabox-menu"><ul role="tablist" class="yoast-aria-tabs" aria-label="%s">', $this->get_product_title() );
 
 		foreach ( $content_sections as $content_section ) {
@@ -1072,7 +1072,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		?>
 		<div id="<?php echo esc_attr( 'wpseo_' . $id ); ?>" class="wpseotab wpseo-form <?php echo esc_attr( $id ); ?>">
-			<?php echo $content; ?>
+			<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: deprecated function.
+			echo $content;
+			?>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A Deprecates do_tab and improves output escaping.

## Relevant technical choices:

* Deprecating do_tab is a remnant from https://github.com/Yoast/wpseo-video/pull/700/files and https://github.com/Yoast/wpseo-news/pull/518.
* I searched for occurrences in our plugins, which were absent: https://github.com/search?q=org%3AYoast+-repo%3AYoast%2Fprivate-archive+-repo%3AYoast%2Fyoast-release-helper+do_tab&type=Code

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See that the metabox including the News and Video addons are still functioning and no deprecation warnings are being thrown.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
