### PR TITLE
Apply esc_attr on import export tool message

### DIFF
--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -74,7 +74,9 @@ if ( $import ) {
 			$status = 'updated';
 		}
 
-		echo '<div id="message" class="message ', $status, '"><p>', esc_html( $msg ), '</p></div>';
+		$class = 'message ' . $status;
+
+		echo '<div id="message" class="', esc_attr( $status ), '"><p>', esc_html( $msg ), '</p></div>';
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Apply proper escaping in `tool-import-export.php`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the import export message (when importing or exporting a file) is still working.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
