### PR TITLE
Add output escaping to select attributes

### DIFF
--- a/admin/views/form/select.php
+++ b/admin/views/form/select.php
@@ -18,7 +18,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 ?>
-<select <?php echo $attributes; ?>name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $id ); ?>">
+<select <?php echo esc_attr( $attributes ); ?>name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $id ); ?>">
 	<?php foreach ( $options as $option_attribute_value => $option_html_value ) : ?>
 	<option value="<?php echo esc_attr( $option_attribute_value ); ?>"<?php echo selected( $selected, $option_attribute_value, false ); ?>><?php echo esc_html( $option_html_value ); ?></option>
 	<?php endforeach; ?>

--- a/admin/views/form/select.php
+++ b/admin/views/form/select.php
@@ -18,7 +18,8 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 ?>
-<select <?php echo esc_attr( $attributes ); ?>name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $id ); ?>">
+<?php /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $attributes is properly escaped in parse_attribute via get_attributes in class-yoast-input-select.php. */ ?>
+<select <?php echo $attributes; ?>name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $id ); ?>">
 	<?php foreach ( $options as $option_attribute_value => $option_html_value ) : ?>
 	<option value="<?php echo esc_attr( $option_attribute_value ); ?>"<?php echo selected( $selected, $option_attribute_value, false ); ?>><?php echo esc_html( $option_html_value ); ?></option>
 	<?php endforeach; ?>

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -638,7 +638,7 @@ function yoast_wpseo_missing_filter_notice() {
  * @param string $message Message string.
  */
 function yoast_wpseo_activation_failed_notice( $message ) {
-	echo '<div class="error"><p>' . esc_html__( 'Activation failed:', 'wordpress-seo' ) . ' ' . $message . '</p></div>';
+	echo '<div class="error"><p>' . esc_html__( 'Activation failed:', 'wordpress-seo' ) . ' ' . strip_tags( $message, '<a>' ) . '</p></div>';
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A Improves output escaping

## Relevant technical choices:

* 	Added an ignore comment because $attributes is properly escaped in parse_attribute via get_attributes in class-yoast-input-select.php.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
- Not needed. There are no code changes.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
