### PR TITLE
Add strip_tags to activation failed message

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -638,7 +638,7 @@ function yoast_wpseo_missing_filter_notice() {
  * @param string $message Message string.
  */
 function yoast_wpseo_activation_failed_notice( $message ) {
-	echo '<div class="error"><p>' . esc_html__( 'Activation failed:', 'wordpress-seo' ) . ' ' . $message . '</p></div>';
+	echo '<div class="error"><p>' . esc_html__( 'Activation failed:', 'wordpress-seo' ) . ' ' . strip_tags( $message, '<a>' ) . '</p></div>';
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A Improves output escaping

## Relevant technical choices:

* Currently, $message is one of two messages. One is a string, the other is a string with an `<a>`. Therefore, I chose to strip all tags except for `<a>`s.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On line 488 of wp-seo-main.php, change the existing if statement to:
```
if ( $spl_autoload_exists ) {
	add_action( 'admin_init', 'yoast_wpseo_missing_spl', 1 );
	add_action( 'admin_init', 'yoast_wpseo_missing_autoload', 1 );

}
```
* Deactivate and activate the plugin.
* See the following intact notifications:
<img width="807" alt="Schermafbeelding 2019-08-02 om 09 10 13" src="https://user-images.githubusercontent.com/17744553/62351521-07fd9000-b506-11e9-85f8-5283b4e1e84e.png">

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
