### PR TITLE
Adapt the max inner width to match our previous of 600px

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -244,7 +244,7 @@ tr.yst_row.even {
 		}
 
 		&.search-appearance {
-			max-width: 600px;
+			max-width: 632px; // Width of 600px + 2 times padding of 16px making the inner max width the wanted 600px.
 			box-shadow: 0 1px 2px rgba( #000, 0.2 );
 			background-color: #fff;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Makes the inner width of the search appearance's papers are 600px, as before.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to Yoast search appearance.
* Check that the papers' elements get moved to the next line just as in `11.7`, see the issue for a screenshot example.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13327 
