### PR TITLE
Reuse existing apply_filter in class-schema-article.php in class-schema-author.php

### DIFF
--- a/frontend/schema/class-schema-author.php
+++ b/frontend/schema/class-schema-author.php
@@ -91,13 +91,7 @@ class WPSEO_Schema_Author extends WPSEO_Schema_Person implements WPSEO_Graph_Pie
 	 * @return bool
 	 */
 	protected function is_post_author() {
-		/**
-		 * Filter: 'wpseo_schema_article_post_type' - Allow changing for which post types we output Article schema.
-		 *
-		 * @api array $post_types The post types for which we output Article.
-		 */
-		$post_types = apply_filters( 'wpseo_schema_article_post_type', array( 'post' ) );
-		if ( is_singular( $post_types ) ) {
+		if ( is_singular() && WPSEO_Schema_Article::is_article_post_type() ) {
 			return true;
 		}
 


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where news-article pages and custom post-types included in the news sitemap would not receive an author in their schema.

## Relevant technical choices:

* Reuse `WPSEO_Schema_Article::is_article_post_type` in `WPSEO_Schema_Author::is_post_author` to avoid applying the same filter twice.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Include pages in the News sitemap under `SEO` > `News SEO`.
* Create a page and inspect it's schema. Make sure it has an author.
* Note: to properly output article schema you your site has to represent a person or a company including a name and a logo.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/bugreports#454
