### PR TITLE
Fixed user check which caused a false 404

### DIFF
--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -157,8 +157,8 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		$users = $this->get_users( $user_criteria );
 
-		// Determine max page based on the total number of users.
-		if ( $user_criteria['offset'] > count( $users ) ) {
+		// Throw an exception when there are no users in the sitemap.
+		if ( count( $users ) === 0 ) {
 			throw new OutOfBoundsException( 'Invalid sitemap page requested' );
 		}
 

--- a/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -33,14 +33,14 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if a user is excluded from the sitemap when there are no posts.
-     *
-     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
-     *
-     * @expectedException OutOfBoundsException
-     * @expectedExceptionMessage Invalid sitemap page requested
 	 *
-     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
-     */
+	 * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
+	 *
+	 * @expectedException        OutOfBoundsException
+	 * @expectedExceptionMessage Invalid sitemap page requested
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 */
 	public function test_author_excluded_from_sitemap_by_zero_posts() {
 		// Removes authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
@@ -48,14 +48,14 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		// Creates a user, without any posts.
 		$this->factory->user->create( array( 'role' => 'author' ) );
 
-        // Checks which users are in the sitemap, there should be none.
-        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+		// Checks which users are in the sitemap, there should be none.
+		self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 	}
 
 	/**
 	 * Tests if a user is NOT excluded from the sitemap when there are posts.
-     *
-     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_not_excluded_from_sitemap_non_zero_posts() {
 		// Removes authors with no posts.
@@ -67,7 +67,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		// Creates posts.
 		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
 
-        // Checks which users are in the sitemap.
+		// Checks which users are in the sitemap.
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 
 		// User should now be in the XML sitemap as user now has 3 posts.
@@ -79,8 +79,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if a user is NOT excluded from the sitemap when there are no posts.
-     *
-     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_not_excluded_from_sitemap_by_zero_posts() {
 		// Doesn't remove authors with no posts.
@@ -91,13 +91,13 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		$admin_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 
-        // Checks which users are in the sitemap.
+		// Checks which users are in the sitemap.
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 
 		// There should be 3 users in the sitemap.
 		$this->assertCount( 3, $sitemap_links );
 
-        // Makes sure it are the users we expected.
+		// Makes sure it are the users we expected.
 		$sitemap_urls = wp_list_pluck( $sitemap_links, 'loc' );
 		$this->assertContains( get_author_posts_url( $author_id ), $sitemap_urls );
 		$this->assertContains( get_author_posts_url( $admin_id ), $sitemap_urls );
@@ -106,13 +106,13 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests whether setting a user to not be visible in search results excludes user from XML sitemap.
-     *
-     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
-     *
-     * @expectedException OutOfBoundsException
-     * @expectedExceptionMessage Invalid sitemap page requested
-     *
-     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 *
+	 * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
+	 *
+	 * @expectedException        OutOfBoundsException
+	 * @expectedExceptionMessage Invalid sitemap page requested
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_exclusion() {
 		// Creates a user with 3 posts.
@@ -122,8 +122,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		// Excludes the user from the sitemaps.
 		update_user_meta( $user_id, 'wpseo_noindex_author', 'on' );
 
-        // Checks which authors are in the sitemap, there should be none.
-        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+		// Checks which authors are in the sitemap, there should be none.
+		self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 	}
 
 	/**
@@ -132,10 +132,10 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
 	 */
 	public function test_get_index_links_empty_sitemap() {
-        // Doesn't remove authors with no posts.
+		// Doesn't remove authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
 
-        // Makes sure the author archives are enabled.
+		// Makes sure the author archives are enabled.
 		WPSEO_Options::set( 'disable-author', false );
 
 		// Fetches the global sitemap.
@@ -158,7 +158,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
 	 */
 	public function test_get_index_links_disabled_archive() {
-	    // Disables the author archive.
+		// Disables the author archive.
 		WPSEO_Options::set( 'disable-author', true );
 
 		// Fetches the global sitemap.
@@ -175,42 +175,42 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		$this->expectOutput( '' );
 	}
 
-    /**
-     * Tests if there is no exception thrown on the second sitemap, when the amount of entries (users) exceeds
-     * the max entries limit (thus a second sitemap is created).
-     *
-     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
-     */
+	/**
+	 * Tests if there is no exception thrown on the second sitemap, when the amount of entries (users) exceeds
+	 * the max entries limit (thus a second sitemap is created).
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 */
 	public function test_throw_no_exception_on_second_sitemap() {
 		// Creates two users, without any posts.
-		$author_id         = $this->factory->user->create( array( 'role' => 'author' ) );
-		$second_author_id  = $this->factory->user->create( array( 'role' => 'author' ) );
-		$third_author_id   = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_id        = $this->factory->user->create( array( 'role' => 'author' ) );
+		$second_author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$third_author_id  = $this->factory->user->create( array( 'role' => 'author' ) );
 
 		// Creates posts.
 		$this->factory->post->create_many( 3, array( 'post_author' => $author_id ) );
 		$this->factory->post->create_many( 3, array( 'post_author' => $second_author_id ) );
 		$this->factory->post->create_many( 3, array( 'post_author' => $third_author_id ) );
 
-		// Checks which users are in the second sitemap.
+		// Collects the author links for the third sitemap.
 		$third_sitemap_links = self::$class_instance->get_sitemap_links( 'author', 1, 3 );
 
 		// Third user should be in the third sitemap, as the max_entries limit is 1 user.
 		$this->assertCount( 1, $third_sitemap_links );
 	}
 
-    /**
-     * Tests whether the author sitemap is empty, when there are no users.
-     *
-     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
-     *
-     * @expectedException OutOfBoundsException
-     * @expectedExceptionMessage Invalid sitemap page requested
-     *
-     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
-     */
-    public function test_no_users_empty_author_sitemap() {
-        // Checks which users are in the sitemap, there should be none.
-        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
-    }
+	/**
+	 * Tests whether the author sitemap is empty, when there are no users.
+	 *
+	 * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
+	 *
+	 * @expectedException        OutOfBoundsException
+	 * @expectedExceptionMessage Invalid sitemap page requested
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 */
+	public function test_no_users_empty_author_sitemap() {
+		// Checks which users are in the sitemap, there should be none.
+		self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+	}
 }

--- a/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -31,21 +31,6 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		self::$class_instance = new WPSEO_Author_Sitemap_Provider();
 	}
 
-    /**
-     * Tests whether the author sitemap is empty, when there are no users.
-     *
-     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
-     *
-     * @expectedException OutOfBoundsException
-     * @expectedExceptionMessage Invalid sitemap page requested
-     *
-     * @covers WPSEO_Author_Sitemap_Provider::get_index_links
-     */
-    public function test_get_index_links_sitemap() {
-        // Checks which users are in the sitemap, there should be none.
-        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
-    }
-
 	/**
 	 * Tests if a user is excluded from the sitemap when there are no posts.
      *
@@ -139,7 +124,10 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
 	 */
 	public function test_get_index_links_empty_sitemap() {
+        // Doesn't remove authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
+
+        // Makes sure the author archives are enabled.
 		WPSEO_Options::set( 'disable-author', false );
 
 		// Fetches the global sitemap.
@@ -162,6 +150,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
 	 */
 	public function test_get_index_links_disabled_archive() {
+	    // Disables the author archive.
 		WPSEO_Options::set( 'disable-author', true );
 
 		// Fetches the global sitemap.
@@ -196,5 +185,20 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
         // Second user should now be in the second sitemap, as the max_entries limit is 1 user.
         $this->assertCount( 1, $second_sitemap_links );
+    }
+
+    /**
+     * Tests whether the author sitemap is empty, when there are no users.
+     *
+     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
+     *
+     * @expectedException OutOfBoundsException
+     * @expectedExceptionMessage Invalid sitemap page requested
+     *
+     * @covers WPSEO_Author_Sitemap_Provider::get_index_links
+     */
+    public function test_no_users_empty_author_sitemap() {
+        // Checks which users are in the sitemap, there should be none.
+        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
     }
 }

--- a/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -38,7 +38,9 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
      *
      * @expectedException OutOfBoundsException
      * @expectedExceptionMessage Invalid sitemap page requested
-	 */
+	 *
+     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+     */
 	public function test_author_excluded_from_sitemap_by_zero_posts() {
 		// Removes authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
@@ -52,6 +54,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if a user is NOT excluded from the sitemap when there are posts.
+     *
+     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_not_excluded_from_sitemap_non_zero_posts() {
 		// Removes authors with no posts.
@@ -75,6 +79,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if a user is NOT excluded from the sitemap when there are no posts.
+     *
+     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_not_excluded_from_sitemap_by_zero_posts() {
 		// Doesn't remove authors with no posts.
@@ -105,6 +111,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
      *
      * @expectedException OutOfBoundsException
      * @expectedExceptionMessage Invalid sitemap page requested
+     *
+     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_exclusion() {
 		// Creates a user with 3 posts.
@@ -170,6 +178,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
     /**
      * Tests if there is no exception thrown on the second sitemap, when the amount of entries (users) exceeds
      * the max entries limit (thus a second sitemap is created).
+     *
+     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
      */
     public function test_throw_no_exception_on_second_sitemap() {
         // Creates two users, without any posts.
@@ -195,7 +205,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
      * @expectedException OutOfBoundsException
      * @expectedExceptionMessage Invalid sitemap page requested
      *
-     * @covers WPSEO_Author_Sitemap_Provider::get_index_links
+     * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
      */
     public function test_no_users_empty_author_sitemap() {
         // Checks which users are in the sitemap, there should be none.

--- a/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -20,73 +20,93 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	private static $class_instance;
 
 	/**
-	 * Set up our double class.
+	 * Sets up our double class.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		// Make sure the author archives are enabled.
+		// Makes sure the author archives are enabled.
 		WPSEO_Options::set( 'disable-author', false );
 
 		self::$class_instance = new WPSEO_Author_Sitemap_Provider();
 	}
 
+    /**
+     * Tests whether the author sitemap is empty, when there are no users.
+     *
+     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
+     *
+     * @expectedException OutOfBoundsException
+     * @expectedExceptionMessage Invalid sitemap page requested
+     *
+     * @covers WPSEO_Author_Sitemap_Provider::get_index_links
+     */
+    public function test_get_index_links_sitemap() {
+        // Checks which users are in the sitemap, there should be none.
+        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+    }
+
 	/**
-	 * Test if a user is excluded from the sitemap when there are no posts.
+	 * Tests if a user is excluded from the sitemap when there are no posts.
+     *
+     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
+     *
+     * @expectedException OutOfBoundsException
+     * @expectedExceptionMessage Invalid sitemap page requested
 	 */
 	public function test_author_excluded_from_sitemap_by_zero_posts() {
-		// Remove authors with no posts.
+		// Removes authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
 
-		// Create a user, without any posts.
+		// Creates a user, without any posts.
 		$this->factory->user->create( array( 'role' => 'author' ) );
 
-		// Check which authors are in the sitemap.
-		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
-
-		// User should not be in the list.
-		$this->assertEmpty( $sitemap_links );
+        // Checks which users are in the sitemap, there should be none.
+        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 	}
 
 	/**
 	 * Tests if a user is NOT excluded from the sitemap when there are posts.
 	 */
 	public function test_author_not_excluded_from_sitemap_non_zero_posts() {
-		// Remove authors with no posts.
+		// Removes authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
 
-		// Create a user, without any posts.
+		// Creates a user, without any posts.
 		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
 
-		// Create posts.
+		// Creates posts.
 		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
 
+        // Checks which users are in the sitemap.
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 
 		// User should now be in the XML sitemap as user now has 3 posts.
 		$this->assertCount( 1, $sitemap_links );
 
-		// Make sure it's the user we expected.
+		// Makes sure it's the user we expected.
 		$this->assertContains( get_author_posts_url( $user_id ), wp_list_pluck( $sitemap_links, 'loc' ) );
 	}
 
 	/**
-	 * Test if a user is NOT excluded from the sitemap when there are no posts.
+	 * Tests if a user is NOT excluded from the sitemap when there are no posts.
 	 */
 	public function test_author_not_excluded_from_sitemap_by_zero_posts() {
-		// Don't remove authors with no posts.
+		// Doesn't remove authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
 
-		// Add three more users (of different types) without posts.
+		// Adds three more users (of different types) without posts.
 		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
 		$admin_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 
+        // Checks which users are in the sitemap.
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 
-		// We should now have three in the XML sitemap.
+		// There should be 3 users in the sitemap.
 		$this->assertCount( 3, $sitemap_links );
 
+        // Makes sure it are the users we expected.
 		$sitemap_urls = wp_list_pluck( $sitemap_links, 'loc' );
 		$this->assertContains( get_author_posts_url( $author_id ), $sitemap_urls );
 		$this->assertContains( get_author_posts_url( $admin_id ), $sitemap_urls );
@@ -94,20 +114,23 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Test whether setting a user to not be visible in search results excludes user from XML sitemap.
+	 * Tests whether setting a user to not be visible in search results excludes user from XML sitemap.
+     *
+     * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
+     *
+     * @expectedException OutOfBoundsException
+     * @expectedExceptionMessage Invalid sitemap page requested
 	 */
 	public function test_author_exclusion() {
-		// Create a user with 3 posts.
+		// Creates a user with 3 posts.
 		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
 		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
 
-		// Exclude the user from the sitemaps.
+		// Excludes the user from the sitemaps.
 		update_user_meta( $user_id, 'wpseo_noindex_author', 'on' );
 
-		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
-
-		// User should not be in the XML sitemap.
-		$this->assertEmpty( $sitemap_links );
+        // Checks which authors are in the sitemap, there should be none.
+        self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 	}
 
 	/**
@@ -119,17 +142,17 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
 		WPSEO_Options::set( 'disable-author', false );
 
-		// Fetch the global sitemap.
+		// Fetches the global sitemap.
 		set_query_var( 'sitemap', 'author' );
 
-		// Set the page to the second one, which should not contain an entry, and should not exist.
+		// Sets the page to the second one, which should not contain an entry, and should not exist.
 		set_query_var( 'sitemap_n', '2' );
 
-		// Load the sitemap.
+		// Loads the sitemap.
 		$sitemaps = new WPSEO_Sitemaps_Double();
 		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
 
-		// Expect an empty page (404) to be returned.
+		// Expects an empty page (404) to be returned.
 		$this->expectOutput( '' );
 	}
 
@@ -141,27 +164,37 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	public function test_get_index_links_disabled_archive() {
 		WPSEO_Options::set( 'disable-author', true );
 
-		// Fetch the global sitemap.
+		// Fetches the global sitemap.
 		set_query_var( 'sitemap', 'author' );
 
-		// Set the page to the second one, which should not contain an entry, and should not exist.
+		// Sets the page to the second one, which should not contain an entry, and should not exist.
 		set_query_var( 'sitemap_n', '1' );
 
-		// Load the sitemap.
+		// Loads the sitemap.
 		$sitemaps = new WPSEO_Sitemaps_Double();
 		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
 
-		// Expect an empty page (404) to be returned.
+		// Expects an empty page (404) to be returned.
 		$this->expectOutput( '' );
 	}
 
-	/**
-	 * Makes sure the filtered out entries do not cause a sitemap index link to return a 404.
-	 *
-	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
-	 */
-	public function test_get_index_links_sitemap() {
-		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
-		$this->assertEquals( array(), $sitemap_links );
-	}
+    /**
+     * Tests if there is no exception thrown on the second sitemap, when the amount of entries (users) exceeds
+     * the max entries limit (thus a second sitemap is created).
+     */
+    public function test_throw_no_exception_on_second_sitemap() {
+        // Creates two users, without any posts.
+        $author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+        $second_author_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+
+        // Creates posts.
+        $this->factory->post->create_many( 3, array( 'post_author' => $author_id ) );
+        $this->factory->post->create_many( 3, array( 'post_author' => $second_author_id ) );
+
+        // Checks which users are in the second sitemap.
+        $second_sitemap_links = self::$class_instance->get_sitemap_links( 'author', 1, 2 );
+
+        // Second user should now be in the second sitemap, as the max_entries limit is 1 user.
+        $this->assertCount( 1, $second_sitemap_links );
+    }
 }

--- a/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -181,21 +181,23 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
      *
      * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
      */
-    public function test_throw_no_exception_on_second_sitemap() {
-        // Creates two users, without any posts.
-        $author_id = $this->factory->user->create( array( 'role' => 'author' ) );
-        $second_author_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+	public function test_throw_no_exception_on_second_sitemap() {
+		// Creates two users, without any posts.
+		$author_id         = $this->factory->user->create( array( 'role' => 'author' ) );
+		$second_author_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+		$third_author_id   = $this->factory->user->create( array( 'role' => 'author' ) );
 
-        // Creates posts.
-        $this->factory->post->create_many( 3, array( 'post_author' => $author_id ) );
-        $this->factory->post->create_many( 3, array( 'post_author' => $second_author_id ) );
+		// Creates posts.
+		$this->factory->post->create_many( 3, array( 'post_author' => $author_id ) );
+		$this->factory->post->create_many( 3, array( 'post_author' => $second_author_id ) );
+		$this->factory->post->create_many( 3, array( 'post_author' => $third_author_id ) );
 
-        // Checks which users are in the second sitemap.
-        $second_sitemap_links = self::$class_instance->get_sitemap_links( 'author', 1, 2 );
+		// Checks which users are in the second sitemap.
+		$third_sitemap_links = self::$class_instance->get_sitemap_links( 'author', 1, 3 );
 
-        // Second user should now be in the second sitemap, as the max_entries limit is 1 user.
-        $this->assertCount( 1, $second_sitemap_links );
-    }
+		// Third user should be in the third sitemap, as the max_entries limit is 1 user.
+		$this->assertCount( 1, $third_sitemap_links );
+	}
 
     /**
      * Tests whether the author sitemap is empty, when there are no users.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a 404 error would be shown for half of the author sitemaps in case of multiple author sitemaps.

When the number of authors (users) passes the maximum amount of entries set for a sitemap (offset), the second author sitemap (local.wordpress.test/author-sitemap2.xml) gives a 404.

This PR changes the logic for when an exception should be thrown. Before, we would check if the offset was greater than the number of users (thus an exception should be thrown), but we assumed the `count( $users )` would contain the total amount of users. But it contains the amount of users in the _current offset_.

So if there are `200` users, and the offset is `150`, we would always expect the `count( $user )` to be `200`, in reality, however, the second offset would result in a `count( $users )` of `50`.

With the `count( $user )` being the number of users in the _current_ offset, we can just check if an offset is empty and throw an exception if it is.

## Relevant technical choices:

* Changed `if ( $user_criteria['offset'] > count( $users ) ) {` to `if ( count( $users ) === 0 ) {`

Copied from a comment by @moorscode in [the issue](https://github.com/Yoast/wordpress-seo/issues/13200#issuecomment-510044301):

> The assumption was made that count( $users ) would always contain the total amount of users.
> This turns out to be the number of users in the current offset provided by the argument above the mentioned logic.
> 
> `if ( $user_criteria['offset'] > count( $users ) ) {`
> Which logically concludes that we should check if the number of users returned for the offset + limit query is not zero.
> 
> So the line can be changed to check against that:
> 
> `if ( count( $users ) === 0 ) {`
> This also requires some unit tests to confirm.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to your local WordPress environment
* Add a maximum number of sitemap entries of 1, with the `max_entries_per_sitemap` filter:
    * Go to Appearance -> Theme Editor
    * In the Theme Files menu, go to Functions.php
    * Add a maximum number of sitemap entries with the following filter: `add_filter( 'wpseo_sitemap_entries_per_page', 'max_entries_per_sitemap' );
 function max_entries_per_sitemap() {
    return 1;
}`
* Toggle the Yoast XML sitemaps Off, save, and On again, to process the filter.
    * Go SEO -> General
    * In the menu bar go to Features
    * Find the (currently) 5th item in the toggle list, XML sitemaps, and toggle it to Off.
    * Save the settings at the bottom of the page.
    * Toggle it back On and save the settings again.
* Add 2 authors and publish a post one both of them, also post on the admin user
    * Publish a post on your admin profile
    * Go to Users in the main menu
    * Add a new user with the Add New button
    * Fill in username, email and password, and select under Role: Author, then save by pressing the Add New User button.
    * Log out of your current profile by hovering over the `Howdy, [username]` text in the upper right corner 
    * Log in to your newly created profile.
    * Publish a post
    * Do this again for a second new author profile.

If correct, you will have three different posts under three different profiles. 

* Go to `local.wordpress.test/author-sitemap.xml`, this should show a sitemap with 2 author profiles in it
* Go to `local.wordpress.test/author-sitemap2.xml`, this should show a sitemap one author profile in it.
* Go to `local.wordpress.test/author-sitemap3.xml`, this should show a sitemap one author profile in it.
* Go to `local.wordpress.test/author-sitemap4.xml`, if you only have 3 author accounts with published posts, this should display a 404.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes ##13200
