### PR TITLE
Whitelist more attributes in the wp_kses_post filters

### DIFF
--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -100,22 +100,19 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 	 * @return void
 	 */
 	public function display_content() {
-		$html  = sprintf(
-			'<div role="tabpanel" id="wpseo-meta-section-%1$s" aria-labelledby="wpseo-meta-tab-%1$s" tabindex="0" class="wpseo-meta-section">',
-			esc_attr( $this->name )
-		);
-		$html .= $this->content;
-		$html .= '<div id="wpseo-metabox-root" class="wpseo-metabox-root"></div>';
-		$html .= $this->html_after;
-		$html .= '</div>';
-
 		add_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_forms' ) );
 		add_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_a11y' ) );
 
-		echo wp_kses_post( $html );
+		printf(
+			'<div role="tabpanel" id="wpseo-meta-section-%1$s" aria-labelledby="wpseo-meta-tab-%1$s" tabindex="0" class="wpseo-meta-section">',
+			esc_attr( $this->name )
+		);
+		echo wp_kses_post( $this->content );
+		echo '<div id="wpseo-metabox-root" class="wpseo-metabox-root"></div>';
+		echo wp_kses_post( $this->html_after );
+		echo '</div>';
 
 		remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_forms' ) );
 		remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_a11y' ) );
-
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1229,11 +1229,24 @@ SVG;
 
 		if ( isset( $a11y_tags ) === false ) {
 			$a11y_tags = array(
-				'button' => array(
+				'button'   => array(
 					'aria-expanded' => true,
 				),
-				'div' => array(
+				'div'      => array(
 					'tabindex' => true,
+				),
+				// Below are attributes that are needed for backwards compatibility (WP < 5.1).
+				'span'     => array(
+					'aria-hidden' => true,
+				),
+				'input'    => array(
+					'aria-describedby' => true,
+				),
+				'select'   => array(
+					'aria-describedby' => true,
+				),
+				'textarea' => array(
+					'aria-describedby' => true,
 				),
 			);
 
@@ -1298,6 +1311,14 @@ SVG;
 					'type'            => true,
 					'value'           => true,
 					'width'           => true,
+
+					/*
+					 * Below are attributes that are needed for backwards compatibility (WP < 5.1).
+					 * They are used for the social media image in the metabox.
+					 * These can be removed once we move to the React versions of the social previews.
+					 */
+					'data-target'     => true,
+					'data-target-id'  => true,
 				),
 				'select' => array(
 					'accesskey'       => true,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Adds aria and data attributes to the filters we use for `wp_kses_post`. This is to support WordPress < 5.1. This affects only the tab content of the React tabs (SEO & Readability) and the collapsible sections, since this is where we currently apply the filters before using `wp_kses_post`.

In WordPress 5.1 support was added for:
	- `data-*` attributes: https://github.com/WordPress/WordPress/commit/a0309e80b6a4d805e4f230649be07b4bfb1a56a5
	- (a couple of) `aria-` attributes: https://github.com/WordPress/WordPress/commit/32e9dea3ea0a0a27ecae89b40c274420ea49a8ff

As of writing we also support WordPress 4.9.10 and 5.0.4.

## Relevant technical choices:

* Refactored `display_content` in `metabox-section-react` to surround the content and after_html with `wp_kses_post` instead of everything since the other output is already escaped or hardcoded. And it prevented the need to also whitelist `aria-labelledby` for a `div`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Issue test
* Test in 4.9 or 5.0
* See the issue's reproduce steps. However, locally I was only able to reproduce it once. With Jannes, we found the exact database leftover that is made possible because of this bug.
* Go to Yoast SEO > Social and chose a default Facebook image. 
* Put the created post in the state of having its own Facebook image.
* Open your database editor of choice.
* Look up the `post_id` of your post in the `wp_posts` table.
* Find the `post_id` and remove the row with the `meta_key` in the `wp_postmeta` table: `_yoast_wpseo_opengraph-image` (resulting in this post still having a `_yoast_wpseo_opengraph-image-id`).
* Refresh the source of the front of the post. This should now be the problem as described in the issue.
* Edit the post: press the `Clear Image` button and update the post.
* Verify the front of the post has the default images again.

### Output escaping test
* View the source of the edit page of your post in this branch and in a build of `trunk`.
* `data-target="yoast_wpseo_opengraph-image" data-target-id="yoast_wpseo_opengraph-image-id"` should be present in the source.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13338 
