### PR TITLE
Change the shortlinker's days_active to not contain HTML characters

### DIFF
--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -116,7 +116,7 @@ class WPSEO_Shortlinker {
 				$cohort = '6-30';
 				break;
 			default:
-				$cohort = '>30';
+				$cohort = '30plus';
 		}
 		return $cohort;
 	}


### PR DESCRIPTION
This was giving trouble with output escaping

## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Change the shortlinker's `days_active` from `>30` to `30plus` to avoid output escaping trouble.

## Relevant technical choices:

* This change has been communicated with Annelieke and Jono (because of UTM tags).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use WordPress 4.9.10
* See the issue.
* The notice when you trash a post in free was also broken for the same reason.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2495
