### PR TITLE
CS: clean up after merges

### DIFF
--- a/admin/config-ui/components/class-component-connect-google-search-console.php
+++ b/admin/config-ui/components/class-component-connect-google-search-console.php
@@ -148,7 +148,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console implements WPSEO_Conf
 		$profiles = array();
 		$sites    = $this->gsc_service->get_sites();
 		foreach ( $sites as $site_key => $site_value ) {
-			$profiles[ untrailingslashit( $site_key )  ] = untrailingslashit( $site_value );
+			$profiles[ untrailingslashit( $site_key ) ] = untrailingslashit( $site_value );
 		}
 
 		return $profiles;

--- a/admin/metabox/class-metabox-section-additional.php
+++ b/admin/metabox/class-metabox-section-additional.php
@@ -16,24 +16,28 @@ class WPSEO_Metabox_Section_Additional implements WPSEO_Metabox_Section {
 	 * @var string
 	 */
 	public $name;
+
 	/**
 	 * Content of the tab's section.
 	 *
 	 * @var string
 	 */
 	public $content;
+
 	/**
 	 * HTML to use in the tab header.
 	 *
 	 * @var string
 	 */
 	private $link_content;
+
 	/**
 	 * Class to add to the link.
 	 *
 	 * @var string
 	 */
 	private $link_class;
+
 	/**
 	 * Aria label to use for the link.
 	 *
@@ -84,7 +88,7 @@ class WPSEO_Metabox_Section_Additional implements WPSEO_Metabox_Section {
 	 * @return void
 	 */
 	public function display_content() {
-		$html = sprintf(
+		$html  = sprintf(
 			'<div role="tabpanel" id="wpseo-meta-section-%1$s" aria-labelledby="wpseo-meta-tab-%1$s" tabindex="0" class="wpseo-meta-section wpseo-form">',
 			esc_attr( $this->name )
 		);

--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -116,6 +116,5 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 
 		remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_forms' ) );
 		remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_a11y' ) );
-
 	}
 }

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -417,10 +417,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			if ( is_array( $section ) && array_key_exists( 'name', $section ) && array_key_exists( 'link_content', $section ) && array_key_exists( 'content', $section ) ) {
 				$options    = array_key_exists( 'options', $section ) ? $section['options'] : array();
 				$sections[] = new WPSEO_Metabox_Section_Additional(
-						$section['name'],
-						$section['link_content'],
-						$section['content'],
-						$options
+					$section['name'],
+					$section['link_content'],
+					$section['content'],
+					$options
 				);
 			}
 		}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,8 +12,16 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
  */
 abstract class TestCase extends BaseTestCase {
 
+	/**
+	 * Options being mocked.
+	 *
+	 * @var array
+	 */
 	protected $mocked_options = [ 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ];
 
+	/**
+	 * Set up the test fixtures.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
@@ -41,7 +49,7 @@ abstract class TestCase extends BaseTestCase {
 					return \abs( \intval( $value ) );
 				},
 				'mysql2date'     => null,
-				'wp_parse_args' => function( $settings, $defaults ) {
+				'wp_parse_args'  => function( $settings, $defaults ) {
 					return \array_merge( $defaults, $settings );
 				},
 			]
@@ -61,6 +69,9 @@ abstract class TestCase extends BaseTestCase {
 			->andReturn( [] );
 	}
 
+	/**
+	 * Tear down the test fixtures.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/admin/metabox/metabox-section-additional-test.php
+++ b/tests/admin/metabox/metabox-section-additional-test.php
@@ -24,11 +24,13 @@ class Metabox_Section_Additional extends TestCase {
 
 		$section->display_content();
 
-		$this->expectOutputContains( [
-			'Additional Content',
-			'id="wpseo-meta-section-additional-tab"',
-			'aria-labelledby="wpseo-meta-tab-additional-tab"'
-		] );
+		$this->expectOutputContains(
+			[
+				'Additional Content',
+				'id="wpseo-meta-section-additional-tab"',
+				'aria-labelledby="wpseo-meta-tab-additional-tab"',
+			]
+		);
 	}
 
 	/**
@@ -39,18 +41,28 @@ class Metabox_Section_Additional extends TestCase {
 	 * @covers WPSEO_Metabox_Section_Additional::display_link
 	 */
 	public function test_display_link() {
-		$section = new WPSEO_Metabox_Section_Additional( 'additional-tab', 'Additional Tab', 'Additional Content', [ 'link_class' => 'additional-class', 'link_aria_label' => 'additional-aria' ] );
+		$section = new WPSEO_Metabox_Section_Additional(
+			'additional-tab',
+			'Additional Tab',
+			'Additional Content',
+			[
+				'link_class'      => 'additional-class',
+				'link_aria_label' => 'additional-aria',
+			]
+		);
 
 		$section->display_link();
 
-		$this->expectOutputContains( [
-			'Additional Tab',
-			'id="wpseo-meta-tab-additional-tab"',
-			'href="#wpseo-meta-section-additional-tab"',
-			'aria-controls="wpseo-meta-section-additional-tab"',
-			'additional-class',
-			'aria-label="additional-aria"'
-		] );
+		$this->expectOutputContains(
+			[
+				'Additional Tab',
+				'id="wpseo-meta-tab-additional-tab"',
+				'href="#wpseo-meta-section-additional-tab"',
+				'aria-controls="wpseo-meta-section-additional-tab"',
+				'additional-class',
+				'aria-label="additional-aria"',
+			]
+		);
 	}
 
 	/**
@@ -64,8 +76,6 @@ class Metabox_Section_Additional extends TestCase {
 
 		$section->display_link();
 
-		$this->expectOutputNotContains( [
-			'aria-label'
-		] );
+		$this->expectOutputNotContains( [ 'aria-label' ] );
 	}
 }

--- a/tests/admin/metabox/metabox-test.php
+++ b/tests/admin/metabox/metabox-test.php
@@ -55,15 +55,19 @@ class Metabox_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'yoast_free_additional_metabox_sections' )
 			->once()
 			->with( [] )
-			->andReturn( [ [
-				"name" => "tab-name",
-				"link_content" => "Testing Tab",
-				"content" => "Testing 1 2 3",
-				"options" => [
-					'link_class' => 'tab-class',
-					'link_aria_label' => 'this-is-a-tab',
-				],
-			] ] );
+			->andReturn(
+				[
+					[
+						'name'         => 'tab-name',
+						'link_content' => 'Testing Tab',
+						'content'      => 'Testing 1 2 3',
+						'options'      => [
+							'link_class'      => 'tab-class',
+							'link_aria_label' => 'this-is-a-tab',
+						],
+					],
+				]
+			);
 
 		$actual = $this->instance->get_additional_meta_sections();
 		$this->assertSame( 1, count( $actual ) );
@@ -71,8 +75,8 @@ class Metabox_Test extends TestCase {
 		$entry = array_pop( $actual );
 		$this->assertInstanceOf( WPSEO_Metabox_Section_Additional::class, $entry );
 
-		$this->assertSame( "tab-name", $entry->name );
-		$this->assertSame( "Testing 1 2 3", $entry->content );
+		$this->assertSame( 'tab-name', $entry->name );
+		$this->assertSame( 'Testing 1 2 3', $entry->content );
 	}
 
 	/**
@@ -84,7 +88,17 @@ class Metabox_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'yoast_free_additional_metabox_sections' )
 			->once()
 			->with( [] )
-			->andReturn( [ "not an array", [ "name" => "tab-name", "link_content" => "Testing Tab", "content" => "Testing 1 2 3" ], 123 ] );
+			->andReturn(
+				[
+					'not an array',
+					[
+						'name'         => 'tab-name',
+						'link_content' => 'Testing Tab',
+						'content'      => 'Testing 1 2 3',
+					],
+					123,
+				]
+			);
 
 		$actual = $this->instance->get_additional_meta_sections();
 		$this->assertSame( 1, count( $actual ) );
@@ -92,8 +106,8 @@ class Metabox_Test extends TestCase {
 		$entry = array_pop( $actual );
 		$this->assertInstanceOf( WPSEO_Metabox_Section_Additional::class, $entry );
 
-		$this->assertSame( "tab-name", $entry->name );
-		$this->assertSame( "Testing 1 2 3", $entry->content );
+		$this->assertSame( 'tab-name', $entry->name );
+		$this->assertSame( 'Testing 1 2 3', $entry->content );
 	}
 
 	/**
@@ -105,7 +119,14 @@ class Metabox_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'yoast_free_additional_metabox_sections' )
 			->once()
 			->with( [] )
-			->andReturn( [ [ "link_content" => "Testing Tab", "content" => "Testing 1 2 3" ] ] );
+			->andReturn(
+				[
+					[
+						'link_content' => 'Testing Tab',
+						'content'      => 'Testing 1 2 3',
+					],
+				]
+			);
 
 		$actual = $this->instance->get_additional_meta_sections();
 		$this->assertSame( 0, count( $actual ) );

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -22,6 +22,11 @@ use Yoast\WP\Free\Tests\TestCase;
  */
 class Indexable_Term_Builder_Test extends TestCase {
 
+	/**
+	 * Options being mocked.
+	 *
+	 * @var array
+	 */
 	protected $mocked_options = [ 'wpseo', 'wpseo_titles', 'wpseo_social', 'wpseo_ms' ];
 
 	/**

--- a/tests/frontend/schema/schema-webpage-test.php
+++ b/tests/frontend/schema/schema-webpage-test.php
@@ -256,5 +256,4 @@ class Schema_WebPage_Test extends TestCase {
 
 		$this->assertEquals( $actual['description'], $expected );
 	}
-
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Variety of fixes, mostly whitespace related:
* Multi-line function call formatting.
* Don't unnecessarily use double quotes.
* Multi-item arrays containing associative keys should be multi-line.
* For multi-line arrays, have a comma after each entry, including the last one.
* Array arrow alignment.
* Assignment operator alignment.
* One blank line between properties and methods in a class.
* No blank line at the end of a function/method.
* No blank line at the end of a class.
* Some missing documentation.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.

