### PR TITLE
CS: enforce consistent array format

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -142,4 +142,30 @@
 	<rule ref="PHPCompatibility.FunctionUse.NewFunctionParameters.array_unique_sort_flagsFound">
 		<exclude-pattern>*/inc/sitemaps/class-sitemap-image-parser\.php$</exclude-pattern>
 	</rule>
+
+	<!--
+	#############################################################################
+	TEMPORARY TWEAK
+	YoastCS will demand short arrays, but until support for WP < 5.2 has been
+	dropped, this can - for now - only be allowed (and enforced) for the folders
+	containing PHP 5.6+ code.
+	#############################################################################
+	-->
+
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
+		<exclude-pattern>*/config/*\.php$</exclude-pattern>
+		<exclude-pattern>*/src/*\.php$</exclude-pattern>
+		<exclude-pattern>*/tests/*\.php$</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
+		<exclude-pattern>*/wp-seo-main\.php$</exclude-pattern>
+		<exclude-pattern>*/admin/*\.php$</exclude-pattern>
+		<exclude-pattern>*/cli/*\.php$</exclude-pattern>
+		<exclude-pattern>*/frontend/*\.php$</exclude-pattern>
+		<exclude-pattern>*/inc/*\.php$</exclude-pattern>
+		<exclude-pattern>*/integration-tests/*\.php$</exclude-pattern>
+		<exclude-pattern>*/migrations/*\.php$</exclude-pattern>
+		<exclude-pattern>*/scripts/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -47,7 +47,7 @@ class Logger implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function log( $level, $message, array $context = array() ) {
+	public function log( $level, $message, array $context = [] ) {
 		$this->wrapped_logger->log( $level, $message, $context );
 	}
 }

--- a/src/orm/yoast-model.php
+++ b/src/orm/yoast-model.php
@@ -481,11 +481,11 @@ class Yoast_Model {
 			->select( "{$associated_table_name}.*" )
 			->join(
 				$join_table_name,
-				array(
+				[
 					"{$associated_table_name}.{$associated_table_id_column}",
 					'=',
 					"{$join_table_name}.{$key_to_associated_table}",
-				)
+				]
 			)
 			->where( "{$join_table_name}.{$key_to_base_table}", $this->{$base_table_id_column} );
 	}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -113,7 +113,7 @@ abstract class TestCase extends BaseTestCase {
 		\ob_clean();
 
 		if ( ! \is_array( $expected ) ) {
-			$expected = array( $expected );
+			$expected = [ $expected ];
 		}
 
 		foreach ( $expected as $needle ) {
@@ -132,7 +132,7 @@ abstract class TestCase extends BaseTestCase {
 		\ob_clean();
 
 		if ( ! \is_array( $needles ) ) {
-			$needles = array( $needles );
+			$needles = [ $needles ];
 		}
 
 		foreach ( $needles as $needle ) {

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -48,11 +48,11 @@ class Admin_Features_Test extends TestCase {
 
 		$class_instance = $this->get_admin_with_expectations();
 
-		$admin_features = array(
+		$admin_features = [
 			'google_search_console'  => new WPSEO_GSC(),
 			'primary_category'       => new WPSEO_Primary_Term_Admin(),
 			'dashboard_widget'       => new Yoast_Dashboard_Widget(),
-		);
+		];
 
 		$this->assertEquals( $admin_features, $class_instance->get_admin_features() );
 	}
@@ -68,10 +68,10 @@ class Admin_Features_Test extends TestCase {
 
 		$class_instance = $this->get_admin_with_expectations();
 
-		$admin_features = array(
+		$admin_features = [
 			'google_search_console' => new WPSEO_GSC(),
 			'dashboard_widget'      => new Yoast_Dashboard_Widget(),
-		);
+		];
 
 		$this->assertEquals( $admin_features, $class_instance->get_admin_features() );
 	}
@@ -81,11 +81,11 @@ class Admin_Features_Test extends TestCase {
 	 */
 	public function test_update_contactmethods() {
 		$class_instance = $this->get_admin_with_expectations();
-		$result         = $class_instance->update_contactmethods( array() );
+		$result         = $class_instance->update_contactmethods( [] );
 		\ksort( $result );
 
 		$this->assertSame(
-			array(
+			[
 				'facebook'   => 'Facebook profile URL',
 				'instagram'  => 'Instagram profile URL',
 				'linkedin'   => 'LinkedIn profile URL',
@@ -96,7 +96,7 @@ class Admin_Features_Test extends TestCase {
 				'twitter'    => 'Twitter username (without @)',
 				'wikipedia'  => 'Wikipedia page about you<br/><small>(if one exists)</small>',
 				'youtube'    => 'YouTube profile URL',
-			),
+			],
 			$result
 		);
 	}

--- a/tests/admin/formatter/term-metabox-formatter-test.php
+++ b/tests/admin/formatter/term-metabox-formatter-test.php
@@ -44,7 +44,7 @@ class Term_Metabox_Formatter_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->taxonomy           = (object) array();
+		$this->taxonomy           = (object) [];
 		$this->mock_term          = Mockery::mock( '\WP_Term' )->makePartial();
 		$this->mock_term->term_id = 1;
 

--- a/tests/admin/metabox/metabox-editor-test.php
+++ b/tests/admin/metabox/metabox-editor-test.php
@@ -62,36 +62,36 @@ class Metabox_Editor_Test extends TestCase {
 	}
 
 	public function test_add_custom_element() {
-		$expected = array(
+		$expected = [
 			'custom_elements' => '~yoastmark',
-		);
+		];
 
-		$actual = $this->subject->add_custom_element( array() );
+		$actual = $this->subject->add_custom_element( [] );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_add_custom_element_preexisting() {
-		$expected = array(
+		$expected = [
 			'custom_elements' => 'div,~yoastmark',
-		);
+		];
 
-		$actual = $this->subject->add_custom_element( array( 'custom_elements' => 'div' ) );
+		$actual = $this->subject->add_custom_element( [ 'custom_elements' => 'div' ] );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_add_custom_element_other_properties() {
-		$expected = array(
+		$expected = [
 			'custom_elements' => '~yoastmark',
 			'other_property'  => 'hello world',
-		);
+		];
 
 		$actual = $this->subject->add_custom_element(
-			array(
+			[
 				'custom_elements' => '',
 				'other_property'  => 'hello world',
-			)
+			]
 		);
 		\ksort( $actual );
 

--- a/tests/admin/myyoast-proxy-test.php
+++ b/tests/admin/myyoast-proxy-test.php
@@ -25,7 +25,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/** @var \Yoast\WP\Free\Tests\Doubles\Admin\MyYoast_Proxy_Double $instance */
 		$instance = $this
 			->getMockBuilder( MyYoast_Proxy_Double::class )
-			->setMethods( array( 'get_proxy_file', 'get_plugin_version' ) )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -36,10 +36,10 @@ class MyYoast_Proxy_Test extends TestCase {
 				->method( 'get_plugin_version' )
 				->will( $this->returnValue( '1.0' ) );
 
-		$expected = array(
+		$expected = [
 			'content_type' => 'text/javascript; charset=UTF-8',
 			'url'          => 'https://my.yoast.com/api/downloads/file/analysis-worker?plugin_version=1.0',
-		);
+		];
 
 		$this->assertEquals( $expected, $instance->determine_proxy_options() );
 	}
@@ -52,7 +52,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/** @var \WPSEO_MyYoast_Proxy $instance */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( array( 'get_proxy_file', 'get_plugin_version', 'set_header' ) )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'set_header' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -77,7 +77,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/** @var \WPSEO_MyYoast_Proxy $instance */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( array( 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ) )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
 			->getMock();
 
 		$instance
@@ -132,7 +132,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/** @var \WPSEO_MyYoast_Proxy $instance */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( array( 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ) )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
 			->getMock();
 
 		$instance
@@ -207,7 +207,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/** @var \WPSEO_MyYoast_Proxy $instance */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( array( 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ) )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
 			->getMock();
 
 		$instance
@@ -244,7 +244,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/** @var \WPSEO_MyYoast_Proxy $instance */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( array( 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ) )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
 			->getMock();
 
 		$instance

--- a/tests/admin/roles/role-manager-test.php
+++ b/tests/admin/roles/role-manager-test.php
@@ -17,7 +17,7 @@ class Role_Manager_Test extends TestCase {
 
 		$this->assertNotContains( 'role', $instance->get_roles() );
 
-		$instance->register( 'role', 'My Role', array() );
+		$instance->register( 'role', 'My Role', [] );
 
 		$this->assertContains( 'role', $instance->get_roles() );
 	}
@@ -28,7 +28,7 @@ class Role_Manager_Test extends TestCase {
 		Monkey\Functions\expect( 'get_role' )
 			->once()
 			->with( 'administrator' )
-			->andReturn( (object) array( 'capabilities' => array( 'manage_options' => true ) ) );
+			->andReturn( (object) [ 'capabilities' => [ 'manage_options' => true ] ] );
 
 		$capabilities = $instance->get_capabilities( 'administrator' );
 
@@ -46,12 +46,12 @@ class Role_Manager_Test extends TestCase {
 			->andReturn( false );
 
 		$result = $instance->get_capabilities( false );
-		$this->assertSame( array(), $result );
+		$this->assertSame( [], $result );
 
 		$result = $instance->get_capabilities( new stdClass() );
-		$this->assertSame( array(), $result );
+		$this->assertSame( [], $result );
 
 		$result = $instance->get_capabilities( 'fake_role' );
-		$this->assertSame( array(), $result );
+		$this->assertSame( [], $result );
 	}
 }

--- a/tests/admin/watchers/indexable-author-watcher-test.php
+++ b/tests/admin/watchers/indexable-author-watcher-test.php
@@ -47,8 +47,8 @@ class Indexable_Author_Watcher_Test extends TestCase {
 		$instance = new Indexable_Author_Watcher( $repository_mock, new Indexable_Author_Builder() );
 		$instance->register_hooks();
 
-		$this->assertNotFalse( \has_action( 'profile_update', array( $instance, 'build_indexable' ) ) );
-		$this->assertNotFalse( \has_action( 'deleted_user', array( $instance, 'delete_indexable' ) ) );
+		$this->assertNotFalse( \has_action( 'profile_update', [ $instance, 'build_indexable' ] ) );
+		$this->assertNotFalse( \has_action( 'deleted_user', [ $instance, 'delete_indexable' ] ) );
 	}
 
 	/**

--- a/tests/admin/watchers/indexable-post-watcher-test.php
+++ b/tests/admin/watchers/indexable-post-watcher-test.php
@@ -49,8 +49,8 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		$instance = new Indexable_Post_Watcher( $repository_mock, $builder_mock );
 		$instance->register_hooks();
 
-		$this->assertNotFalse( \has_action( 'wp_insert_post', array( $instance, 'build_indexable' ) ) );
-		$this->assertNotFalse( \has_action( 'delete_post', array( $instance, 'delete_indexable' ) ) );
+		$this->assertNotFalse( \has_action( 'wp_insert_post', [ $instance, 'build_indexable' ] ) );
+		$this->assertNotFalse( \has_action( 'delete_post', [ $instance, 'delete_indexable' ] ) );
 	}
 
 	/**

--- a/tests/admin/watchers/indexable-term-watcher-test.php
+++ b/tests/admin/watchers/indexable-term-watcher-test.php
@@ -48,8 +48,8 @@ class Indexable_Term_Watcher_Test extends TestCase {
 		$instance = new Indexable_Term_Watcher( $repository_mock, $builder_mock );
 		$instance->register_hooks();
 
-		$this->assertNotFalse( \has_action( 'edited_term', array( $instance, 'build_indexable' ) ) );
-		$this->assertNotFalse( \has_action( 'delete_term', array( $instance, 'delete_indexable' ) ) );
+		$this->assertNotFalse( \has_action( 'edited_term', [ $instance, 'build_indexable' ] ) );
+		$this->assertNotFalse( \has_action( 'delete_term', [ $instance, 'delete_indexable' ] ) );
 	}
 
 	/**

--- a/tests/frontend/schema/schema-faq-questions-test.php
+++ b/tests/frontend/schema/schema-faq-questions-test.php
@@ -50,10 +50,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => 'This is an answer',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -80,10 +80,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => '',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => 'This is an answer',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -110,10 +110,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => '',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -140,10 +140,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => '',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => '',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -172,10 +172,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => '<h1>This is an answer<h1>',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -204,10 +204,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => 'This is an answer',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -236,10 +236,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => '<h1>This is an answer</h1>',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -268,10 +268,10 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
-			'acceptedAnswer'   => array(
+			'acceptedAnswer'   => [
 				'@type' => 'Answer',
 				'text'  => 'This is an answer',
-			),
+			],
 		];
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/frontend/schema/schema-webpage-test.php
+++ b/tests/frontend/schema/schema-webpage-test.php
@@ -36,7 +36,7 @@ class Schema_WebPage_Test extends TestCase {
 
 		Monkey\Functions\stubs(
 			[
-				'get_bloginfo'  => array( $this, 'get_bloginfo' ),
+				'get_bloginfo'  => [ $this, 'get_bloginfo' ],
 				'is_search'     => false,
 				'is_author'     => false,
 				'is_home'       => false,

--- a/tests/inc/class-wpseo-content-images-test.php
+++ b/tests/inc/class-wpseo-content-images-test.php
@@ -57,7 +57,7 @@ class Content_Images_Test extends TestCase {
 
 		$images_array = $this->instance->get_images_from_content( $post_content );
 
-		$expected = array( $external_image1, $external_image2, $non_attachment_image );
+		$expected = [ $external_image1, $external_image2, $non_attachment_image ];
 
 		$this->assertEquals( $expected, $images_array );
 	}
@@ -73,7 +73,7 @@ class Content_Images_Test extends TestCase {
 
 		$images_array = $this->instance->get_images_from_content( $post_content );
 
-		$expected = array();
+		$expected = [];
 
 		$this->assertEquals( $expected, $images_array );
 	}

--- a/tests/inc/options/option-social-test.php
+++ b/tests/inc/options/option-social-test.php
@@ -83,56 +83,56 @@ class Option_Social_Test extends TestCase {
 	 * @return array The test data.
 	 */
 	public function validate_option_valid_data_provider() {
-		return array(
-			array(
-				'expected' => array( 'og_default_image_id' => 'value' ),
-				'dirty'    => array(),
-				'clean'    => array( 'og_default_image_id' => 'value' ),
-				'old'      => array(),
-			),
-			array(
-				'expected' => array( 'og_frontpage_image_id' => 'value' ),
-				'dirty'    => array(),
-				'clean'    => array( 'og_frontpage_image_id' => 'value' ),
-				'old'      => array(),
-			),
-			array(
-				'expected' => array( 'og_default_image_id' => '' ),
-				'dirty'    => array( 'og_default_image_id' => '' ),
-				'clean'    => array( 'og_default_image_id' => '' ),
-				'old'      => array(),
-			),
-			array(
-				'expected' => array( 'og_frontpage_image_id' => '' ),
-				'dirty'    => array( 'og_frontpage_image_id' => '' ),
-				'clean'    => array( 'og_frontpage_image_id' => '' ),
-				'old'      => array(),
-			),
-			array(
-				'expected' => array( 'og_default_image_id' => 123 ),
-				'dirty'    => array( 'og_default_image_id' => '123' ),
-				'clean'    => array( 'og_default_image_id' => '' ),
-				'old'      => array(),
-			),
-			array(
-				'expected' => array( 'og_frontpage_image_id' => 0 ),
-				'dirty'    => array( 'og_frontpage_image_id' => 'testen' ),
-				'clean'    => array( 'og_frontpage_image_id' => '' ),
-				'old'      => array(),
-			),
-			array(
-				'expected' => array( 'youtube_url' => 'https://www.youtube.com/yoast' ),
-				'dirty'    => array( 'youtube_url' => 'https://www.youtube.com/yoast' ),
-				'clean'    => array( 'youtube_url' => 'https://www.youtube.com/yoast' ),
-				'old'      => array(),
-			),
-			array(
-				'expected' => array( 'youtube_url' => 'https://www.youtube.com/yoasttube' ),
-				'dirty'    => array( 'youtube_url' => 'https://www.youtube.com/yoasttube' ),
-				'clean'    => array( 'youtube_url' => 'https://www.youtube.com/yoast' ),
-				'old'      => array(),
-			),
-		);
+		return [
+			[
+				'expected' => [ 'og_default_image_id' => 'value' ],
+				'dirty'    => [],
+				'clean'    => [ 'og_default_image_id' => 'value' ],
+				'old'      => [],
+			],
+			[
+				'expected' => [ 'og_frontpage_image_id' => 'value' ],
+				'dirty'    => [],
+				'clean'    => [ 'og_frontpage_image_id' => 'value' ],
+				'old'      => [],
+			],
+			[
+				'expected' => [ 'og_default_image_id' => '' ],
+				'dirty'    => [ 'og_default_image_id' => '' ],
+				'clean'    => [ 'og_default_image_id' => '' ],
+				'old'      => [],
+			],
+			[
+				'expected' => [ 'og_frontpage_image_id' => '' ],
+				'dirty'    => [ 'og_frontpage_image_id' => '' ],
+				'clean'    => [ 'og_frontpage_image_id' => '' ],
+				'old'      => [],
+			],
+			[
+				'expected' => [ 'og_default_image_id' => 123 ],
+				'dirty'    => [ 'og_default_image_id' => '123' ],
+				'clean'    => [ 'og_default_image_id' => '' ],
+				'old'      => [],
+			],
+			[
+				'expected' => [ 'og_frontpage_image_id' => 0 ],
+				'dirty'    => [ 'og_frontpage_image_id' => 'testen' ],
+				'clean'    => [ 'og_frontpage_image_id' => '' ],
+				'old'      => [],
+			],
+			[
+				'expected' => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'dirty'    => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'clean'    => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'old'      => [],
+			],
+			[
+				'expected' => [ 'youtube_url' => 'https://www.youtube.com/yoasttube' ],
+				'dirty'    => [ 'youtube_url' => 'https://www.youtube.com/yoasttube' ],
+				'clean'    => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'old'      => [],
+			],
+		];
 	}
 
 	/**
@@ -141,22 +141,22 @@ class Option_Social_Test extends TestCase {
 	 * @return array The test data.
 	 */
 	public function validate_option_invalid_data_provider() {
-		return array(
-			array(
-				'expected'  => array( 'facebook_site' => '' ),
-				'dirty'     => array( 'facebook_site' => 'invalidurl' ),
-				'clean'     => array( 'facebook_site' => '' ),
-				'old'       => array(),
+		return [
+			[
+				'expected'  => [ 'facebook_site' => '' ],
+				'dirty'     => [ 'facebook_site' => 'invalidurl' ],
+				'clean'     => [ 'facebook_site' => '' ],
+				'old'       => [],
 				'slug_name' => 'facebook_site',
-			),
-			array(
-				'expected'  => array( 'youtube_url' => 'https://www.youtube.com/yoast' ),
-				'dirty'     => array( 'youtube_url' => 'invalidurl' ),
-				'clean'     => array( 'youtube_url' => 'https://www.youtube.com/yoast' ),
-				'old'       => array( 'youtube_url' => 'https://www.youtube.com/yoast' ),
+			],
+			[
+				'expected'  => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'dirty'     => [ 'youtube_url' => 'invalidurl' ],
+				'clean'     => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'old'       => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
 				'slug_name' => 'youtube_url',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -177,14 +177,14 @@ class Option_Social_Test extends TestCase {
 		Monkey\Functions\stubs( [
 			'wp_remote_retrieve_body' => function () {
 				return WPSEO_Utils::format_json_encode(
-					array(
-						'error' => array(
+					[
+						'error' => [
 							'message'    => '(#803) Some of the aliases you requested do not exist: yoastInvalidFBAppID',
 							'type'       => 'OAuthException',
 							'code'       => 803,
 							'fbtrace_id' => 'AbXND56LRJ0FDXHfdJUuVIr',
-						)
-					)
+						]
+					]
 				);
 			},
 		] );
@@ -202,10 +202,10 @@ class Option_Social_Test extends TestCase {
 			return true;
 		} );
 		$instance = new Option_Social_Double();
-		$clean = array( 'fbadminapp' => '246554168145' );
-		$dirty = array( 'fbadminapp' => 'yoastInvalidFBAppID' );
+		$clean = [ 'fbadminapp' => '246554168145' ];
+		$dirty = [ 'fbadminapp' => 'yoastInvalidFBAppID' ];
 		$instance->validate_facebook_app_id( 'fbadminapp', $dirty, '246554168145', $clean );
-		$this->assertEquals( array( 'fbadminapp' => '246554168145' ), $clean );
+		$this->assertEquals( [ 'fbadminapp' => '246554168145' ], $clean );
 
 		unset( $GLOBALS['wp_settings_errors'] );
 	}
@@ -231,12 +231,12 @@ class Option_Social_Test extends TestCase {
 		Monkey\Functions\stubs( [
 			'wp_remote_retrieve_body' => function () {
 				return WPSEO_Utils::format_json_encode(
-					array(
+					[
 						'category' => 'Just For Fun',
 						'link'     => 'http://www.ilikealot.com/auth/start/facebook/',
 						'name'     => 'Ilikealot',
 						'id'       => '246554168145',
-					)
+					]
 				);
 			},
 		] );
@@ -248,10 +248,10 @@ class Option_Social_Test extends TestCase {
 			return true;
 		});
 		$instance = new Option_Social_Double();
-		$clean = array( 'fbadminapp' => '' );
-		$dirty = array( 'fbadminapp' => '246554168145' );
+		$clean = [ 'fbadminapp' => '' ];
+		$dirty = [ 'fbadminapp' => '246554168145' ];
 		$instance->validate_facebook_app_id( 'fbadminapp', $dirty, '', $clean );
-		$this->assertEquals( array( 'fbadminapp' => '246554168145' ), $clean );
+		$this->assertEquals( [ 'fbadminapp' => '246554168145' ], $clean );
 		unset( $GLOBALS['wp_settings_errors'] );
 	}
 
@@ -272,21 +272,21 @@ class Option_Social_Test extends TestCase {
 		Monkey\Functions\stubs( [
 			'wp_remote_retrieve_body' => function () {
 				return WPSEO_Utils::format_json_encode(
-					array(
-						'error' => array(
+					[
+						'error' => [
 							'message'    => '(#803) Some of the aliases you requested do not exist: yoastInvalidFBAppID',
 							'type'       => 'OAuthException',
 							'code'       => 803,
 							'fbtrace_id' => 'AbXND56LRJ0FDXHfdJUuVIr',
-						)
-					)
+						]
+					]
 				);
 			},
 		] );
 
 		$instance = new Option_Social_Double();
-		$clean    = array( 'fbadminapp' => '' );
-		$dirty    = array( 'fbadminapp' => 'yoastInvalidFBAppID' );
+		$clean    = [ 'fbadminapp' => '' ];
+		$dirty    = [ 'fbadminapp' => 'yoastInvalidFBAppID' ];
 
 		$GLOBALS['wp_settings_errors'] = [[
 			'setting' => 'yoast_wpseo_social_options',


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

WordPressCS will demand long arrays and forbid the use of short arrays as of WPCS 2.2.0.
See: https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/

For YoastCS, however, a choice has been made to demand short arrays.

For now, while WP 4.9, and therefore PHP 5.2 still needs to be supported, this is only possible in the directories containing files with PHP 5.6+ code.
So in this interim period, we will enforce short arrays in the PHP 5.6+ code and long arrays everywhere else.

Once the minimum supported WP version has moved up to WP 5.2 / PHP 5.6, short arrays will be enforced for all code and the change-over can be done automatically using the auto-fixer included in the relevant sniff.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.

