### PR TITLE
CS: clean up after merges / namespaced files

### DIFF
--- a/config/dependency-injection/container-compiler.php
+++ b/config/dependency-injection/container-compiler.php
@@ -43,8 +43,8 @@ class Container_Compiler {
 					'namespace' => 'Yoast\WP\Free\Generated',
 				]
 			);
-			$code   = str_replace( 'Symfony\\Component\\DependencyInjection', 'YoastSEO_Vendor\\Symfony\\Component\\DependencyInjection', $code );
-			$code   = str_replace( 'Symfony\\\\Component\\\\DependencyInjection', 'YoastSEO_Vendor\\\\Symfony\\\\Component\\\\DependencyInjection', $code );
+			$code   = \str_replace( 'Symfony\\Component\\DependencyInjection', 'YoastSEO_Vendor\\Symfony\\Component\\DependencyInjection', $code );
+			$code   = \str_replace( 'Symfony\\\\Component\\\\DependencyInjection', 'YoastSEO_Vendor\\\\Symfony\\\\Component\\\\DependencyInjection', $code );
 
 			$cache->write( $code, $container_builder->getResources() );
 		}

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -24,7 +24,7 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Custom_Loader constructor.
 	 *
-	 * @param ContainerBuilder $container The ContainerBuilder to load classes for.
+	 * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container The ContainerBuilder to load classes for.
 	 */
 	public function __construct( ContainerBuilder $container ) {
 		parent::__construct( $container, new FileLocator( __DIR__ . '/../..' ) );
@@ -56,41 +56,43 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Registers a set of classes as services using PSR-4 for discovery.
 	 *
-	 * @param Definition $prototype A definition to use as template.
-	 * @param string     $namespace The namespace prefix of classes in the scanned directory.
-	 * @param string     $resource  The directory to look for classes, glob-patterns allowed.
-	 * @param string     $exclude   A globed path of files to exclude.
+	 * @param \Symfony\Component\DependencyInjection\Definition $prototype A definition to use as template.
+	 * @param string                                            $namespace The namespace prefix of classes
+	 *                                                                     in the scanned directory.
+	 * @param string                                            $resource  The directory to look for classes,
+	 *                                                                     glob-patterns allowed.
+	 * @param string                                            $exclude   A globed path of files to exclude.
 	 *
 	 * @throws InvalidArgumentException If invalid arguments are supplied.
 	 *
 	 * @return void
 	 */
 	public function registerClasses( Definition $prototype, $namespace, $resource, $exclude = null ) {
-		if ( '\\' !== substr( $namespace, -1 ) ) {
-			throw new InvalidArgumentException( sprintf( 'Namespace prefix must end with a "\\": %s.', $namespace ) );
+		if ( '\\' !== \substr( $namespace, -1 ) ) {
+			throw new InvalidArgumentException( \sprintf( 'Namespace prefix must end with a "\\": %s.', $namespace ) );
 		}
-		if ( ! preg_match( '/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\\\\)++$/', $namespace ) ) {
-			throw new InvalidArgumentException( sprintf( 'Namespace is not a valid PSR-4 prefix: %s.', $namespace ) );
+		if ( ! \preg_match( '/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\\\\)++$/', $namespace ) ) {
+			throw new InvalidArgumentException( \sprintf( 'Namespace is not a valid PSR-4 prefix: %s.', $namespace ) );
 		}
 
 		$classes = $this->findClasses( $namespace, $resource, $exclude );
 		// Prepare for deep cloning.
-		$serialized_prototype = serialize( $prototype );
+		$serialized_prototype = \serialize( $prototype );
 		$interfaces           = [];
 		$singly_implemented   = [];
 
 		foreach ( $classes as $class => $error_message ) {
-			if ( interface_exists( $class, false ) ) {
+			if ( \interface_exists( $class, false ) ) {
 				$interfaces[] = $class;
 			}
 			else {
-				$this->setDefinition( $class, $definition = unserialize( $serialized_prototype ) );
+				$this->setDefinition( $class, $definition = \unserialize( $serialized_prototype ) );
 				if ( null !== $error_message ) {
 					$definition->addError( $error_message );
 
 					continue;
 				}
-				foreach ( class_implements( $class, false ) as $interface ) {
+				foreach ( \class_implements( $class, false ) as $interface ) {
 					$singly_implemented[ $interface ] = isset( $singly_implemented[ $interface ] ) ? false : $class;
 				}
 			}
@@ -106,8 +108,8 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Registers a definition in the container with its instanceof-conditionals.
 	 *
-	 * @param string     $id         The ID of the definition.
-	 * @param Definition $definition The definition.
+	 * @param string                                            $id         The ID of the definition.
+	 * @param \Symfony\Component\DependencyInjection\Definition $definition The definition.
 	 *
 	 * @throws InvalidArgumentException If invalid arguments were supplied.
 	 *
@@ -119,7 +121,7 @@ class Custom_Loader extends PhpFileLoader {
 		// @codingStandardsIgnoreLine WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar This is from an inherited class not abiding by that standard.
 		if ( $this->isLoadingInstanceof ) {
 			if ( ! $definition instanceof ChildDefinition ) {
-				throw new InvalidArgumentException( sprintf( 'Invalid type definition "%s": ChildDefinition expected, "%s" given.', $id, \get_class( $definition ) ) );
+				throw new InvalidArgumentException( \sprintf( 'Invalid type definition "%s": ChildDefinition expected, "%s" given.', $id, \get_class( $definition ) ) );
 			}
 			$this->instanceof[ $id ] = $definition;
 		}
@@ -152,7 +154,7 @@ class Custom_Loader extends PhpFileLoader {
 				}
 
 				// Normalize Windows slashes.
-				$exclude_paths[ str_replace( '\\', '/', $path ) ] = true;
+				$exclude_paths[ \str_replace( '\\', '/', $path ) ] = true;
 			}
 		}
 
@@ -164,28 +166,28 @@ class Custom_Loader extends PhpFileLoader {
 			if ( null === $prefix_len ) {
 				$prefix_len = \strlen( $resource->getPrefix() );
 
-				if ( $exclude_prefix && 0 !== strpos( $exclude_prefix, $resource->getPrefix() ) ) {
-					throw new InvalidArgumentException( sprintf( 'Invalid "exclude" pattern when importing classes for "%s": make sure your "exclude" pattern (%s) is a subset of the "resource" pattern (%s)', $namespace, $exclude, $pattern ) );
+				if ( $exclude_prefix && 0 !== \strpos( $exclude_prefix, $resource->getPrefix() ) ) {
+					throw new InvalidArgumentException( \sprintf( 'Invalid "exclude" pattern when importing classes for "%s": make sure your "exclude" pattern (%s) is a subset of the "resource" pattern (%s)', $namespace, $exclude, $pattern ) );
 				}
 			}
 
-			if ( isset( $exclude_paths[ str_replace( '\\', '/', $path ) ] ) ) {
+			if ( isset( $exclude_paths[ \str_replace( '\\', '/', $path ) ] ) ) {
 				continue;
 			}
 
-			if ( ! preg_match( $ext_regexp, $path, $m ) || ! $info->isReadable() ) {
+			if ( ! \preg_match( $ext_regexp, $path, $m ) || ! $info->isReadable() ) {
 				continue;
 			}
 			$class = $this->getClassFromClassMap( $path );
 
-			if ( ! $class || ! preg_match( '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $class ) ) {
+			if ( ! $class || ! \preg_match( '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $class ) ) {
 				continue;
 			}
 
 			try {
 				$r = $this->container->getReflectionClass( $class );
 			} catch ( \ReflectionException $e ) {
-				$classes[ $class ] = sprintf(
+				$classes[ $class ] = \sprintf(
 					'While discovering services from namespace "%s", an error was thrown when processing the class "%s": "%s".',
 					$namespace,
 					$class,
@@ -195,7 +197,7 @@ class Custom_Loader extends PhpFileLoader {
 			}
 			// Check to make sure the expected class exists.
 			if ( ! $r ) {
-				throw new InvalidArgumentException( sprintf( 'Expected to find class "%s" in file "%s" while importing services from resource "%s", but it was not found! Check the namespace prefix used with the resource.', $class, $path, $pattern ) );
+				throw new InvalidArgumentException( \sprintf( 'Expected to find class "%s" in file "%s" while importing services from resource "%s", but it was not found! Check the namespace prefix used with the resource.', $class, $path, $pattern ) );
 			}
 
 			if ( $r->isInstantiable() || $r->isInterface() ) {

--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -55,17 +55,17 @@ class Loader_Pass implements CompilerPassInterface {
 	private function process_definition( Definition $definition, Definition $loader_definition ) {
 		$class = $definition->getClass();
 
-		if ( is_subclass_of( $class, Initializer::class ) ) {
+		if ( \is_subclass_of( $class, Initializer::class ) ) {
 			$loader_definition->addMethodCall( 'register_initializer', [ $class ] );
 			$definition->setPublic( true );
 		}
 
-		if ( is_subclass_of( $class, Integration::class ) ) {
+		if ( \is_subclass_of( $class, Integration::class ) ) {
 			$loader_definition->addMethodCall( 'register_integration', [ $class ] );
 			$definition->setPublic( true );
 		}
 
-		if ( is_subclass_of( $class, Conditional::class ) ) {
+		if ( \is_subclass_of( $class, Conditional::class ) ) {
 			$definition->setPublic( true );
 		}
 	}

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -38,7 +38,7 @@ $excluded_directories = [
 	'orm',
 ];
 
-$excluded = implode( ',', array_merge( $excluded_directories, $excluded_files ) );
+$excluded = \implode( ',', \array_merge( $excluded_directories, $excluded_files ) );
 
 $base_definition = new Definition();
 
@@ -50,6 +50,6 @@ $base_definition
 /* @var $loader \Yoast\WP\Free\Dependency_Injection\Custom_Loader */
 $loader->registerClasses( $base_definition, 'Yoast\\WP\\Free\\', 'src/*', 'src/{' . $excluded . '}' );
 
-if ( file_exists( __DIR__ . '/../../premium/config/dependency-injection/services.php' ) ) {
+if ( \file_exists( __DIR__ . '/../../premium/config/dependency-injection/services.php' ) ) {
 	include __DIR__ . '/../../premium/config/dependency-injection/services.php';
 }

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\Free\Builders;
 
 use Exception;
-use Yoast\WP\Free\Models\Indexable_Extension;
 use Yoast\WP\Free\Repositories\SEO_Meta_Repository;
 
 /**

--- a/src/conditionals/feature-flag-conditional.php
+++ b/src/conditionals/feature-flag-conditional.php
@@ -16,7 +16,7 @@ abstract class Feature_Flag_Conditional implements Conditional {
 	 * @inheritdoc
 	 */
 	public function is_met() {
-		$feature_flag = strtoupper( $this->get_feature_flag() );
+		$feature_flag = \strtoupper( $this->get_feature_flag() );
 
 		return \defined( 'YOAST_SEO_' . $feature_flag ) && \constant( 'YOAST_SEO_' . $feature_flag ) === true;
 	}

--- a/src/config/dependency-management.php
+++ b/src/config/dependency-management.php
@@ -89,6 +89,6 @@ class Dependency_Management {
 	 * @return bool True on successful alias.
 	 */
 	protected function class_alias( $base, $alias ) {
-		return class_alias( $base, $alias );
+		return \class_alias( $base, $alias );
 	}
 }

--- a/src/database/database-setup.php
+++ b/src/database/database-setup.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\Database;
 
-use YoastSEO_Vendor\Psr\Log\LoggerInterface;
 use Yoast\WP\Free\Conditionals\No_Conditionals;
 use Yoast\WP\Free\Loggers\Logger;
 use Yoast\WP\Free\WordPress\Initializer;
@@ -21,7 +20,7 @@ class Database_Setup implements Initializer {
 	use No_Conditionals;
 
 	/**
-	 * @var LoggerInterface
+	 * @var \YoastSEO_Vendor\Psr\Log\LoggerInterface
 	 */
 	protected $logger;
 

--- a/src/database/migration-runner.php
+++ b/src/database/migration-runner.php
@@ -40,7 +40,7 @@ class Migration_Runner implements Initializer {
 	const MIGRATION_ERROR_TRANSIENT_KEY = 'yoast_migration_problem_';
 
 	/**
-	 * @var Ruckusing_Framework
+	 * @var \Yoast\WP\Free\Database\Ruckusing_Framework
 	 */
 	protected $framework;
 
@@ -52,8 +52,8 @@ class Migration_Runner implements Initializer {
 	/**
 	 * Migrations constructor.
 	 *
-	 * @param Ruckusing_Framework $framework The Ruckusing framework runner.
-	 * @param Logger              $logger    A PSR compatible logger.
+	 * @param \Yoast\WP\Free\Database\Ruckusing_Framework $framework The Ruckusing framework runner.
+	 * @param \Yoast\WP\Free\Loggers\Logger               $logger    A PSR compatible logger.
 	 */
 	public function __construct( Ruckusing_Framework $framework, Logger $logger ) {
 		$this->framework = $framework;
@@ -105,7 +105,7 @@ class Migration_Runner implements Initializer {
 			// Something went wrong...
 			$this->set_failed_state( $name, $exception->getMessage() );
 
-			if ( defined( 'YOAST_ENVIRONMENT' ) && YOAST_ENVIRONMENT !== 'production' ) {
+			if ( \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT !== 'production' ) {
 				throw $exception;
 			}
 

--- a/src/database/ruckusing-framework.php
+++ b/src/database/ruckusing-framework.php
@@ -20,26 +20,27 @@ use YoastSEO_Vendor\Task_Db_Migrate;
 class Ruckusing_Framework {
 
 	/**
-	 * @var wpdb
+	 * @var \wpdb
 	 */
 	protected $wpdb;
 
 	/**
-	 * @var Dependency_Management
+	 * @var \Yoast\WP\Free\Config\Dependency_Management
 	 */
 	protected $dependency_management;
 
 	/**
-	 * @var Migration_Logger
+	 * @var \Yoast\WP\Free\Loggers\Migration_Logger
 	 */
 	protected $migration_logger;
 
 	/**
 	 * Ruckusing_Framework constructor.
 	 *
-	 * @param wpdb                  $wpdb                  The wpdb instance.
-	 * @param Dependency_Management $dependency_management The dependency management checker.
-	 * @param Migration_Logger      $migration_logger      The migration logger, extends the Ruckusing logger.
+	 * @param \wpdb                                       $wpdb                  The wpdb instance.
+	 * @param \Yoast\WP\Free\Config\Dependency_Management $dependency_management The dependency management checker.
+	 * @param \Yoast\WP\Free\Loggers\Migration_Logger     $migration_logger      The migration logger, extends the
+	 *                                                                           Ruckusing logger.
 	 */
 	public function __construct( wpdb $wpdb, Dependency_Management $dependency_management, Migration_Logger $migration_logger ) {
 		$this->wpdb                  = $wpdb;
@@ -53,7 +54,7 @@ class Ruckusing_Framework {
 	 * @param string $migrations_table_name The migrations table name.
 	 * @param string $migrations_directory  The migrations directory.
 	 *
-	 * @return Ruckusing_FrameworkRunner The framework runner.
+	 * @return \YoastSEO_Vendor\Ruckusing_FrameworkRunner The framework runner.
 	 */
 	public function get_framework_runner( $migrations_table_name, $migrations_directory ) {
 		$this->maybe_set_constant();
@@ -78,7 +79,7 @@ class Ruckusing_Framework {
 	 * @param string                                        $migrations_table_name The migrations table name.
 	 * @param string                                        $migrations_directory  The migrations directory.
 	 *
-	 * @return Ruckusing_Task_Manager The task manager.
+	 * @return \YoastSEO_Vendor\Ruckusing_Task_Manager The task manager.
 	 * @throws \YoastSEO_Vendor\Ruckusing_Exception If any of the arguments are invalid.
 	 */
 	public function get_framework_task_manager( $adapter, $migrations_table_name, $migrations_directory ) {
@@ -127,7 +128,7 @@ class Ruckusing_Framework {
 	 */
 	public function maybe_set_constant() {
 		$constant_name  = $this->dependency_management->prefixed_available() ? \YOAST_VENDOR_NS_PREFIX . '\RUCKUSING_BASE' : 'RUCKUSING_BASE';
-		$constant_value = \WPSEO_PATH . 'migrations' . DIRECTORY_SEPARATOR . 'ruckusing';
+		$constant_value = \WPSEO_PATH . 'migrations' . \DIRECTORY_SEPARATOR . 'ruckusing';
 
 		if ( \defined( $constant_name ) ) {
 			return \constant( $constant_name ) === $constant_value;

--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -18,7 +18,7 @@ class Logger implements LoggerInterface {
 	use LoggerTrait;
 
 	/**
-	 * @var LoggerInterface
+	 * @var \YoastSEO_Vendor\Psr\Log\LoggerInterface
 	 */
 	protected $wrapped_logger;
 
@@ -31,9 +31,9 @@ class Logger implements LoggerInterface {
 		/**
 		 * Gives the possibility to set override the logger interface.
 		 *
-		 * @api \Psr\Log\LoggerInterface $logger Instance of NullLogger.
+		 * @api \YoastSEO_Vendor\Psr\Log\LoggerInterface $logger Instance of NullLogger.
 		 *
-		 * @return \Psr\Log\LoggerInterface The logger object.
+		 * @return \YoastSEO_Vendor\Psr\Log\LoggerInterface The logger object.
 		 */
 		$this->wrapped_logger = \apply_filters( 'wpseo_logger', $this->wrapped_logger );
 	}

--- a/src/loggers/migration-logger.php
+++ b/src/loggers/migration-logger.php
@@ -15,7 +15,7 @@ use YoastSEO_Vendor\Ruckusing_Util_Logger;
 class Migration_Logger extends Ruckusing_Util_Logger {
 
 	/**
-	 * @var Logger
+	 * @var \Yoast\WP\Free\Loggers\Logger
 	 */
 	protected $logger;
 
@@ -24,7 +24,7 @@ class Migration_Logger extends Ruckusing_Util_Logger {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param Logger $logger The logger to wrap.
+	 * @param \Yoast\WP\Free\Loggers\Logger $logger The logger to wrap.
 	 */
 	public function __construct( Logger $logger ) {
 		$this->logger = $logger;

--- a/src/main.php
+++ b/src/main.php
@@ -11,22 +11,22 @@ use Yoast\WP\Free\Config\Dependency_Management;
 use Yoast\WP\Free\Dependency_Injection\Container_Compiler;
 use Yoast\WP\Free\Generated\Cached_Container;
 
-if ( ! defined( 'WPSEO_VERSION' ) ) {
-	header( 'Status: 403 Forbidden' );
-	header( 'HTTP/1.1 403 Forbidden' );
+if ( ! \defined( 'WPSEO_VERSION' ) ) {
+	\header( 'Status: 403 Forbidden' );
+	\header( 'HTTP/1.1 403 Forbidden' );
 	exit();
 }
 
 $dependency_management = new Dependency_Management();
 $dependency_management->initialize();
 
-$development = defined( 'YOAST_ENVIRONMENT' ) && YOAST_ENVIRONMENT === 'development';
-if ( $development && class_exists( '\Yoast\WP\Free\Dependency_Injection\Container_Compiler' ) ) {
+$development = \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT === 'development';
+if ( $development && \class_exists( '\Yoast\WP\Free\Dependency_Injection\Container_Compiler' ) ) {
 	// Exception here is unhandled as it will only occur in development.
 	Container_Compiler::compile( $development );
 }
 
-if ( file_exists( __DIR__ . '/generated/container.php' ) ) {
+if ( \file_exists( __DIR__ . '/generated/container.php' ) ) {
 	require_once __DIR__ . '/generated/container.php';
 	$container = new Cached_Container();
 	try {

--- a/src/models/indexable-extension.php
+++ b/src/models/indexable-extension.php
@@ -15,14 +15,14 @@ use Yoast\WP\Free\ORM\Yoast_Model;
 abstract class Indexable_Extension extends Yoast_Model {
 
 	/**
-	 * @var Indexable
+	 * @var \Yoast\WP\Free\Models\Indexable
 	 */
 	protected $indexable = null;
 
 	/**
 	 * Returns the indexable this extension belongs to.
 	 *
-	 * @return Indexable The indexable.
+	 * @return \Yoast\WP\Free\Models\Indexable The indexable.
 	 */
 	public function indexable() {
 		if ( $this->indexable === null ) {

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -65,7 +65,7 @@ class Indexable extends Yoast_Model {
 	/**
 	 * The loaded indexable extensions.
 	 *
-	 * @var Indexable_Extension[]
+	 * @var \Yoast\WP\Free\Models\Indexable_Extension[]
 	 */
 	protected $loaded_extensions = [];
 
@@ -91,8 +91,8 @@ class Indexable extends Yoast_Model {
 	 */
 	public function save() {
 		if ( $this->permalink ) {
-			$this->permalink      = trailingslashit( $this->permalink );
-			$this->permalink_hash = strlen( $this->permalink ) . ':' . md5( $this->permalink );
+			$this->permalink      = \trailingslashit( $this->permalink );
+			$this->permalink_hash = \strlen( $this->permalink ) . ':' . \md5( $this->permalink );
 		}
 
 		return parent::save();

--- a/src/orm/yoast-model.php
+++ b/src/orm/yoast-model.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\ORM;
 
-use YoastSEO_Vendor\Psr\Log\LoggerInterface;
 use Yoast\WP\Free\Exceptions\Missing_Method;
 
 /**
@@ -61,7 +60,7 @@ class Yoast_Model {
 	/**
 	 * Set a logger to use for all models.
 	 *
-	 * @var LoggerInterface $logger
+	 * @var \YoastSEO_Vendor\Psr\Log\LoggerInterface $logger
 	 */
 	public static $logger;
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -49,7 +49,7 @@ class Indexable_Repository extends ORMWrapper {
 	 * @param \Yoast\WP\Free\Builders\Indexable_Term_Builder   $term_builder   The term builder for creating missing indexables.
 	 * @param \Yoast\WP\Free\Loggers\Logger                    $logger         The logger.
 	 *
-	 * @return Indexable_Repository
+	 * @return \Yoast\WP\Free\Repositories\Indexable_Repository
 	 */
 	public static function get_instance(
 		Indexable_Author_Builder $author_builder,
@@ -77,8 +77,8 @@ class Indexable_Repository extends ORMWrapper {
 	 * @param string $url The indexable url.
 	 */
 	public function find_by_url( $url ) {
-		$url      = trailingslashit( $url );
-		$url_hash = strlen( $url ) . ':' . md5( $url );
+		$url      = \trailingslashit( $url );
+		$url_hash = \strlen( $url ) . ':' . \md5( $url );
 
 		// Find by both url_hash and url, url_hash is indexed so will be used first by the DB to optimize the query.
 		return $this->where( 'url_hash', $url_hash )

--- a/src/repositories/primary-term-repository.php
+++ b/src/repositories/primary-term-repository.php
@@ -20,7 +20,7 @@ class Primary_Term_Repository extends ORMWrapper {
 	/**
 	 * Returns the instance of this class constructed through the ORM Wrapper.
 	 *
-	 * @return Primary_Term_Repository
+	 * @return \Yoast\WP\Free\Repositories\Primary_Term_Repository
 	 */
 	public static function get_instance() {
 		ORMWrapper::$repositories[ Yoast_Model::get_table_name( 'Primary_Term' ) ] = self::class;

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -23,7 +23,7 @@ class SEO_Links_Repository extends ORMWrapper {
 	/**
 	 * Returns the instance of this class constructed through the ORM Wrapper.
 	 *
-	 * @return SEO_Links_Repository
+	 * @return \Yoast\WP\Free\Repositories\SEO_Links_Repository
 	 */
 	public static function get_instance() {
 		ORMWrapper::$repositories[ Yoast_Model::get_table_name( 'SEO_Links' ) ] = self::class;

--- a/src/repositories/seo-meta-repository.php
+++ b/src/repositories/seo-meta-repository.php
@@ -20,7 +20,7 @@ class SEO_Meta_Repository extends ORMWrapper {
 	/**
 	 * Returns the instance of this class constructed through the ORM Wrapper.
 	 *
-	 * @return SEO_Meta_Repository
+	 * @return \Yoast\WP\Free\Repositories\SEO_Meta_Repository
 	 */
 	public static function get_instance() {
 		ORMWrapper::$repositories[ Yoast_Model::get_table_name( 'SEO_Meta' ) ] = self::class;

--- a/src/watchers/indexable-post-watcher.php
+++ b/src/watchers/indexable-post-watcher.php
@@ -25,12 +25,12 @@ class Indexable_Post_Watcher implements Integration {
 	}
 
 	/**
-	 * @var Indexable_Repository
+	 * @var \Yoast\WP\Free\Repositories\Indexable_Repository
 	 */
 	protected $repository;
 
 	/**
-	 * @var Indexable_Post_Builder
+	 * @var \Yoast\WP\Free\Builders\Indexable_Post_Builder
 	 */
 	protected $builder;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\Free\Tests;
 
 use WPSEO_Options;
 use Brain\Monkey;
-use Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
@@ -52,12 +51,12 @@ abstract class TestCase extends BaseTestCase {
 
 		Monkey\Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
-			->with( call_user_func_array( 'Mockery::anyOf', $this->mocked_options ) )
+			->with( \call_user_func_array( 'Mockery::anyOf', $this->mocked_options ) )
 			->andReturn( [] );
 
 		Monkey\Functions\expect( 'get_site_option' )
 			->zeroOrMoreTimes()
-			->with( call_user_func_array( 'Mockery::anyOf', $this->mocked_options ) )
+			->with( \call_user_func_array( 'Mockery::anyOf', $this->mocked_options ) )
 			->andReturn( [] );
 	}
 

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -6,7 +6,6 @@ use WPSEO_Admin;
 use WPSEO_GSC;
 use WPSEO_Primary_Term_Admin;
 use Yoast_Dashboard_Widget;
-use Yoast_Notification;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\Free\Tests\Doubles\Shortlinker;

--- a/tests/admin/metabox/metabox-editor-test.php
+++ b/tests/admin/metabox/metabox-editor-test.php
@@ -2,9 +2,9 @@
 
 namespace Yoast\WP\Free\Tests\Admin\Metabox;
 
-use \WPSEO_Admin_Asset_Manager;
-use \WPSEO_Metabox_Editor;
-use \Brain\Monkey;
+use WPSEO_Admin_Asset_Manager;
+use WPSEO_Metabox_Editor;
+use Brain\Monkey;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
@@ -93,7 +93,7 @@ class Metabox_Editor_Test extends TestCase {
 				'other_property'  => 'hello world',
 			)
 		);
-		ksort( $actual );
+		\ksort( $actual );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/admin/metabox/metabox-section-additional-test.php
+++ b/tests/admin/metabox/metabox-section-additional-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\Free\Tests\Admin\Metabox;
 
 use Yoast\WP\Free\Tests\TestCase;
 use WPSEO_Metabox_Section_Additional;
-use Brain\Monkey;
 
 /**
  * Unit Test Class.

--- a/tests/admin/metabox/metabox-test.php
+++ b/tests/admin/metabox/metabox-test.php
@@ -66,9 +66,9 @@ class Metabox_Test extends TestCase {
 			] ] );
 
 		$actual = $this->instance->get_additional_meta_sections();
-		$this->assertSame( 1, count( $actual ) );
+		$this->assertSame( 1, \count( $actual ) );
 
-		$entry = array_pop( $actual );
+		$entry = \array_pop( $actual );
 		$this->assertInstanceOf( WPSEO_Metabox_Section_Additional::class, $entry );
 
 		$this->assertSame( "tab-name", $entry->name );
@@ -87,9 +87,9 @@ class Metabox_Test extends TestCase {
 			->andReturn( [ "not an array", [ "name" => "tab-name", "link_content" => "Testing Tab", "content" => "Testing 1 2 3" ], 123 ] );
 
 		$actual = $this->instance->get_additional_meta_sections();
-		$this->assertSame( 1, count( $actual ) );
+		$this->assertSame( 1, \count( $actual ) );
 
-		$entry = array_pop( $actual );
+		$entry = \array_pop( $actual );
 		$this->assertInstanceOf( WPSEO_Metabox_Section_Additional::class, $entry );
 
 		$this->assertSame( "tab-name", $entry->name );
@@ -108,6 +108,6 @@ class Metabox_Test extends TestCase {
 			->andReturn( [ [ "link_content" => "Testing Tab", "content" => "Testing 1 2 3" ] ] );
 
 		$actual = $this->instance->get_additional_meta_sections();
-		$this->assertSame( 0, count( $actual ) );
+		$this->assertSame( 0, \count( $actual ) );
 	}
 }

--- a/tests/database/migration-runner-test.php
+++ b/tests/database/migration-runner-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\Free\Tests\Database;
 
 use Brain\Monkey;
-use Exception;
 use Mockery;
 use Yoast\WP\Free\Conditionals\Indexables_Feature_Flag_Conditional;
 use Yoast\WP\Free\Database\Ruckusing_Framework;
@@ -201,7 +200,7 @@ class Migration_Runner_Test extends TestCase {
 	/**
 	 * Returns a wpdb mock.
 	 *
-	 * @return wpdb The wpdb mock.
+	 * @return \wpdb The wpdb mock.
 	 */
 	protected function get_wpdb_mock() {
 		$wpdb         = Mockery::mock( 'wpdb' );

--- a/tests/frontend/schema/schema-how-to-test.php
+++ b/tests/frontend/schema/schema-how-to-test.php
@@ -19,12 +19,12 @@ use Yoast\WP\Free\Tests\TestCase;
 class Schema_HowTo_Test extends TestCase {
 
 	/**
-	 * @var Schema_HowTo_Double
+	 * @var \Yoast\WP\Free\Tests\Doubles\Frontend\Schema\Schema_HowTo_Double
 	 */
 	private $instance;
 
 	/**
-	 * @var WPSEO_Schema_Context
+	 * @var \WPSEO_Schema_Context
 	 */
 	private $context;
 

--- a/tests/frontend/schema/schema-webpage-test.php
+++ b/tests/frontend/schema/schema-webpage-test.php
@@ -6,7 +6,6 @@ use Brain\Monkey;
 use Mockery;
 use WP_Post;
 use WPSEO_Schema_Context;
-use WPSEO_Schema_Utils;
 use WPSEO_Schema_WebPage;
 use Yoast\WP\Free\Tests\TestCase;
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Variety of fixes:
* Don't backslash prefix the class name in a `use` statement.
* Backslash prefix all global functions and constants.
* Use fully qualified names in docblocks.
* Remove unused `use` statements.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.

