### PR TITLE
Apply lodash.unescape to term names in TaxonomyPicker

### DIFF
--- a/js/src/components/TaxonomyPicker.js
+++ b/js/src/components/TaxonomyPicker.js
@@ -2,6 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import { unescape } from "lodash";
 
 const SelectContainer = styled.div`
 	padding-top: 6px;
@@ -41,7 +42,7 @@ const TaxonomyPicker = ( props ) => {
 								key={ term.id }
 								value={ term.id }
 							>
-								{ term.name }
+								{ unescape( term.name ) }
 							</option>
 						);
 					} )


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the primary term selector would not display HTML entities properly. Props to [@dlh01](https://github.com/dlh01).

## Relevant technical choices:

* The use of `lodash.unescape` mirrors the handling of term names in the Gutenberg repo:

https://github.com/WordPress/gutenberg/blob/c148164001ef981c4b903672cb5449da30737a10/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js#L330

https://github.com/WordPress/gutenberg/blob/c148164001ef981c4b903672cb5449da30737a10/packages/editor/src/components/post-taxonomies/flat-term-selector.js#L39-L52

## Test instructions

This PR can be tested by following these steps:

* Follow the replication steps in #13356.
* Observe that the term name displays as expected in step (3) of the replication steps.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13356
