### PR TITLE
Travis: only one command per condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,6 +191,7 @@ before_script:
     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
     chmod +x ./cc-test-reporter
     ./cc-test-reporter before-build
+    mkdir -p /tmp/coverage
   fi
 - export -f travis_fold
 - export -f travis_time_start
@@ -269,11 +270,18 @@ script:
 - |
   if [[ "$COVERAGE" == "1" ]]; then
     travis_fold start "PHP.coverage" && travis_time_start
-    mkdir -p /tmp/coverage
     vendor/bin/phpunit -c phpunit-integration.xml.dist --coverage-php /tmp/coverage/integration-tests.cov
-    vendor/bin/phpunit --coverage-php /tmp/coverage/tests.cov
-    ./vendor/bin/phpcov merge /tmp/coverage --clover build/logs/clover.xml
     travis_time_finish && travis_fold end "PHP.coverage"
+  fi
+- |
+  if [[ "$COVERAGE" == "1" ]]; then
+    travis_fold start "PHP.coverage" && travis_time_start
+    vendor/bin/phpunit --coverage-php /tmp/coverage/tests.cov
+    travis_time_finish && travis_fold end "PHP.coverage"
+  fi
+- |
+  if [[ "$COVERAGE" == "1" ]]; then
+    ./vendor/bin/phpcov merge /tmp/coverage --clover build/logs/clover.xml
   fi
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

When there are several commands within the same condition, Travis will only look at the exit code of the last command to determine whether the build should pass/fail.

For commands not in the `script` section, this is normally not an issue as if something goes wrong there, the commands in `script` will likely fail too.

For the commands in the `script` section, however, we do want the build to fail, so we cannot have more than one command per condition.

The problem condition was the `$COVERAGE` check.
I have now:
* Moved the creating of the temporary directory to `before_script`.
* Split the remaining two unit test run commands and the command to merge the log files each into their own condition.

## Test instructions

This PR can be tested by following these steps:
* Check the code coverage report to see that the coverage has not changed.

