### PR TITLE
Improves wording for the configuration wizard notification

### DIFF
--- a/admin/notifiers/class-configuration-notifier.php
+++ b/admin/notifiers/class-configuration-notifier.php
@@ -107,10 +107,7 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 	 */
 	private function re_run_notification() {
 		/* translators: %1$s is a checkmark icon. */
-		$title = sprintf(
-			esc_html__( 'SEO settings configured%1$s', 'wordpress-seo' ),
-			'<span class="dashicons dashicons-yes"></span>'
-		);
+		$title = __( 'SEO settings configured', 'wordpress-seo' );
 
 		$content = sprintf(
 			/* translators: %1$s expands to Yoast SEO, %2$s is a link start tag to the Onboarding Wizard, %3$s is the link closing tag. */
@@ -160,7 +157,10 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 			60
 		);
 		$notification .= '<div class="yoast-container__configuration-wizard--content">';
-		$notification .= '<h3>' . $title . '</h3>';
+		$notification .= sprintf(
+		    '<h3>%s<span class="dashicons dashicons-yes"></span></h3>',
+            esc_html( $title )
+        );
 
 		$notification .= '<p>';
 		$notification .= $content;

--- a/admin/notifiers/class-configuration-notifier.php
+++ b/admin/notifiers/class-configuration-notifier.php
@@ -106,18 +106,15 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 	 * @return string The notification.
 	 */
 	private function re_run_notification() {
-		/* translators: %1$s is a checkmark icon. */
-		$title = __( 'SEO settings configured', 'wordpress-seo' );
-
 		$content = sprintf(
 			/* translators: %1$s expands to Yoast SEO, %2$s is a link start tag to the Onboarding Wizard, %3$s is the link closing tag. */
-			esc_html__( 'If you want to double-check your %1$s settings, or change something, you can always %2$sre-open the configuration wizard%3$s.', 'wordpress-seo' ),
+			esc_html__( 'If you want to double-check your %1$s settings, or change something, you can always %2$sreopen the configuration wizard%3$s.', 'wordpress-seo' ),
 			'Yoast SEO',
 			'<a href="' . esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ) . '">',
 			'</a>'
 		);
 
-		return $this->notification( $title, $content );
+		return $this->notification( __( 'SEO settings configured', 'wordpress-seo' ), $content );
 	}
 
 	/**
@@ -126,8 +123,6 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 	 * @return string The notification.
 	 */
 	private function first_time_notification() {
-		$title = __( 'First-time SEO configuration', 'wordpress-seo' );
-
 		$content = sprintf(
 			/* translators: %1$s expands to Yoast SEO, %2$s is a link start tag to the Onboarding Wizard, %3$s is the link closing tag. */
 			esc_html__( 'Get started quickly with the %1$s %2$sconfiguration wizard%3$s!', 'wordpress-seo' ),
@@ -136,7 +131,7 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 			'</a>'
 		);
 
-		return $this->notification( $title, $content, true );
+		return $this->notification( __( 'First-time SEO configuration', 'wordpress-seo' ), $content, true );
 	}
 
 	/**
@@ -159,8 +154,8 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 		$notification .= '<div class="yoast-container__configuration-wizard--content">';
 		$notification .= sprintf(
 		    '<h3>%s<span class="dashicons dashicons-yes"></span></h3>',
-            esc_html( $title )
-        );
+			esc_html( $title )
+		);
 
 		$notification .= '<p>';
 		$notification .= $content;

--- a/admin/notifiers/class-configuration-notifier.php
+++ b/admin/notifiers/class-configuration-notifier.php
@@ -106,15 +106,21 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 	 * @return string The notification.
 	 */
 	private function re_run_notification() {
+		/* translators: %1$s is a checkmark icon. */
+		$title = sprintf(
+			esc_html__( 'SEO settings configured%1$s', 'wordpress-seo' ),
+			'<span class="dashicons dashicons-yes"></span>'
+		);
+
 		$content = sprintf(
 			/* translators: %1$s expands to Yoast SEO, %2$s is a link start tag to the Onboarding Wizard, %3$s is the link closing tag. */
-			esc_html__( 'Want to make sure your %1$s settings are still OK? %2$sOpen the configuration wizard again%3$s to validate them.', 'wordpress-seo' ),
+			esc_html__( 'If you want to double-check your %1$s settings, or change something, you can always %2$sre-open the configuration wizard%3$s.', 'wordpress-seo' ),
 			'Yoast SEO',
 			'<a href="' . esc_url( admin_url( 'admin.php?page=' . WPSEO_Configuration_Page::PAGE_IDENTIFIER ) ) . '">',
 			'</a>'
 		);
 
-		return $this->notification( __( 'Check SEO configuration', 'wordpress-seo' ), $content );
+		return $this->notification( $title, $content );
 	}
 
 	/**
@@ -123,6 +129,8 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 	 * @return string The notification.
 	 */
 	private function first_time_notification() {
+		$title = __( 'First-time SEO configuration', 'wordpress-seo' );
+
 		$content = sprintf(
 			/* translators: %1$s expands to Yoast SEO, %2$s is a link start tag to the Onboarding Wizard, %3$s is the link closing tag. */
 			esc_html__( 'Get started quickly with the %1$s %2$sconfiguration wizard%3$s!', 'wordpress-seo' ),
@@ -131,7 +139,7 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 			'</a>'
 		);
 
-		return $this->notification( __( 'First-time SEO configuration', 'wordpress-seo' ), $content, true );
+		return $this->notification( $title, $content, true );
 	}
 
 	/**
@@ -152,7 +160,7 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 			60
 		);
 		$notification .= '<div class="yoast-container__configuration-wizard--content">';
-		$notification .= '<h3>' . esc_html( $title ) . '</h3>';
+		$notification .= '<h3>' . $title . '</h3>';
 
 		$notification .= '<p>';
 		$notification .= $content;

--- a/integration-tests/notifiers/test-class-configuration-notifier.php
+++ b/integration-tests/notifiers/test-class-configuration-notifier.php
@@ -19,7 +19,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'show_onboarding_notice', false );
 		$notifier = new WPSEO_Configuration_Notifier();
 
-		$this->assertEquals( '<div class="yoast-container yoast-container__configuration-wizard"><img src="http://example.org/wp-content/plugins/wordpress-seo/images/new-to-configuration-notice.svg" height="60" width="60"  alt=""/><div class="yoast-container__configuration-wizard--content"><h3>SEO settings configured<span class="dashicons dashicons-yes"></span></h3><p>If you want to double-check your Yoast SEO settings, or change something, you can always <a href="http://example.org/wp-admin/admin.php?page=wpseo_configurator">re-open the configuration wizard</a>.</p></div></div>', $notifier->notify() );
+		$this->assertEquals( '<div class="yoast-container yoast-container__configuration-wizard"><img src="http://example.org/wp-content/plugins/wordpress-seo/images/new-to-configuration-notice.svg" height="60" width="60" alt="" /><div class="yoast-container__configuration-wizard--content"><h3>SEO settings configured<span class="dashicons dashicons-yes"></span></h3><p>If you want to double-check your Yoast SEO settings, or change something, you can always <a href="http://example.org/wp-admin/admin.php?page=wpseo_configurator">reopen the configuration wizard</a>.</p></div></div>', $notifier->notify() );
 	}
 
 	/**

--- a/integration-tests/notifiers/test-class-configuration-notifier.php
+++ b/integration-tests/notifiers/test-class-configuration-notifier.php
@@ -19,7 +19,7 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'show_onboarding_notice', false );
 		$notifier = new WPSEO_Configuration_Notifier();
 
-		$this->assertEquals( '<div class="yoast-container yoast-container__configuration-wizard"><img src="http://example.org/wp-content/plugins/wordpress-seo/images/new-to-configuration-notice.svg" height="60" width="60" alt="" /><div class="yoast-container__configuration-wizard--content"><h3>Check SEO configuration</h3><p>Want to make sure your Yoast SEO settings are still OK? <a href="http://example.org/wp-admin/admin.php?page=wpseo_configurator">Open the configuration wizard again</a> to validate them.</p></div></div>', $notifier->notify() );
+		$this->assertEquals( '<div class="yoast-container yoast-container__configuration-wizard"><img src="http://example.org/wp-content/plugins/wordpress-seo/images/new-to-configuration-notice.svg" height="60" width="60"  alt=""/><div class="yoast-container__configuration-wizard--content"><h3>SEO settings configured<span class="dashicons dashicons-yes"></span></h3><p>If you want to double-check your Yoast SEO settings, or change something, you can always <a href="http://example.org/wp-admin/admin.php?page=wpseo_configurator">re-open the configuration wizard</a>.</p></div></div>', $notifier->notify() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the wording in the configuration wizard notification. Props [@emilyatmobtown](https://github.com/emilyatmobtown)

This PR replaces #13253, you can find more information in that PR.