### PR TITLE
Add a filter that allows excluding a term by ID

### DIFF
--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -193,7 +193,18 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				AND		p.post_password = ''
 		";
 
+		/**
+		 * Filter: 'wpseo_exclude_from_sitemap_by_term_ids' - Allow excluding terms by ID.
+		 *
+		 * @api array $terms_to_exclude The terms to exclude.
+		 */
+		$terms_to_exclude = apply_filters( 'wpseo_exclude_from_sitemap_by_term_ids', array() );
+
 		foreach ( $terms as $term ) {
+
+			if ( in_array( $term->term_id, $terms_to_exclude, true ) ) {
+				continue;
+			}
 
 			$url = array();
 


### PR DESCRIPTION
## Summary
Add a filter,  `wpseo_exclude_from_sitemap_by_term_ids`, that allows excluding a term by ID.

This PR can be summarized in the following changelog entry:

* Add a filter,  `wpseo_exclude_from_sitemap_by_term_ids`, that allows excluding a term by ID.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

