### PR TITLE
Apply the same premium logic for the taxonomy social tabs as for posts

### DIFF
--- a/admin/class-social-admin.php
+++ b/admin/class-social-admin.php
@@ -132,11 +132,11 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 			$tab_content .= $this->do_meta_box( $meta_field_defs[ $field_name ], $field_name );
 		}
 
-		$features = new WPSEO_Features();
 		/**
 		 * If premium hide the form to show the social preview instead, we still need the fields to be output because
 		 * the values of the social preview are saved in the hidden field.
 		 */
+		$features = new WPSEO_Features();
 		if ( $features->is_premium() ) {
 			return $this->hide_form( $tab_content );
 		}
@@ -151,7 +151,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 *
 	 * @return string The content.
 	 */
-	public function hide_form( $tab_content ) {
+	private function hide_form( $tab_content ) {
 		return '<div class="hidden">' . $tab_content . '</div>';
 	}
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -202,13 +202,34 @@ class WPSEO_Taxonomy_Metabox {
 		}
 
 		$meta_fields = $this->taxonomy_social_fields->get_by_network( $network );
+		$content     = $this->taxonomy_tab_content->html( $meta_fields );
+
+		/**
+		 * If premium hide the form to show the social preview instead, we still need the fields to be output because
+		 * the values of the social preview are saved in the hidden field.
+		 */
+		$features = new WPSEO_Features();
+		if ( $features->is_premium() ) {
+			$content = $this->hide_form( $content );
+		}
 
 		$tab_settings = new WPSEO_Metabox_Collapsible(
 			$name,
-			$this->social_admin->get_premium_notice( $network ) . $this->taxonomy_tab_content->html( $meta_fields ),
+			$this->social_admin->get_premium_notice( $network ) . $content,
 			$label
 		);
 
 		return $tab_settings;
+	}
+
+	/**
+	 * Hides the given output when rendered to HTML.
+	 *
+	 * @param string $tab_content The social tab content.
+	 *
+	 * @return string The content.
+	 */
+	private function hide_form( $tab_content ) {
+		return '<div class="hidden">' . $tab_content . '</div>';
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the duplicate social previews in Premium.


## Relevant technical choices:

* Used the same logic as for posts/pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On free & premium, check the following:
  * On categories, tags, posts, pages and custom post types, check the following:
    1. Go to the SEO tab's advanced collapsible. The content should not be empty anymore.
    1. Go to the Social tab. The content of the Facebook and Twitter collapsibles should not be duplicated anymore.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/514
