### PR TITLE
13350 add internal linking columns to indexables table

### DIFF
--- a/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
+++ b/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
@@ -27,6 +27,13 @@ class WpYoastProminentWordIndexableColumns extends Ruckusing_Migration_Base {
 		) );
 
 		$this->add_column( $table_name, 'prominent_words_vector_length', 'float' );
+		$this->add_index(
+			$table_name,
+			'prominent_words_version',
+			array(
+				'name' => 'prominent_words_version'
+			)
+		);
 	}
 
 	/**
@@ -37,6 +44,7 @@ class WpYoastProminentWordIndexableColumns extends Ruckusing_Migration_Base {
 
 		$this->remove_column( $table_name, 'prominent_words_version' );
 		$this->remove_column( $table_name, 'prominent_words_vector_length' );
+		$this->remove_index( $table_name, 'prominent_words_version' );
 	}
 
 	/**

--- a/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
+++ b/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
@@ -23,7 +23,7 @@ class WpYoastProminentWordIndexableColumns extends Ruckusing_Migration_Base {
 			'null'     => true,
 			'limit'    => 11,
 			'unsigned' => true,
-			'default'  => null
+			'default'  => null,
 		) );
 
 		$this->add_column( $table_name, 'prominent_words_vector_length', 'float' );

--- a/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
+++ b/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
@@ -31,7 +31,7 @@ class WpYoastProminentWordIndexableColumns extends Ruckusing_Migration_Base {
 			$table_name,
 			'prominent_words_version',
 			array(
-				'name' => 'prominent_words_version'
+				'name' => 'prominent_words_version',
 			)
 		);
 	}
@@ -44,7 +44,6 @@ class WpYoastProminentWordIndexableColumns extends Ruckusing_Migration_Base {
 
 		$this->remove_column( $table_name, 'prominent_words_version' );
 		$this->remove_column( $table_name, 'prominent_words_vector_length' );
-		$this->remove_index( $table_name, 'prominent_words_version' );
 	}
 
 	/**

--- a/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
+++ b/migrations/20190813111111_WpYoastProminentWordIndexableColumns.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\Free\ORM\Yoast_Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * Class WpYoastProminentWordIndexableColumns
+ */
+class WpYoastProminentWordIndexableColumns extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$table_name = $this->get_table_name();
+
+		$this->add_column( $table_name, 'prominent_words_version', 'integer', array(
+			'null'     => true,
+			'limit'    => 11,
+			'unsigned' => true,
+			'default'  => null
+		) );
+
+		$this->add_column( $table_name, 'prominent_words_vector_length', 'float' );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		$table_name = $this->get_table_name();
+
+		$this->remove_column( $table_name, 'prominent_words_version' );
+		$this->remove_column( $table_name, 'prominent_words_vector_length' );
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Yoast_Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -52,6 +52,9 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  * @property string  $twitter_title
  * @property string  $twitter_description
  * @property string  $twitter_image
+ *
+ * @property int     $prominent_words_version
+ * @property float   $prominent_words_vector_length
  */
 class Indexable extends Yoast_Model {
 
@@ -70,7 +73,7 @@ class Indexable extends Yoast_Model {
 	protected $loaded_extensions = [];
 
 	/**
-	 * Returns an Indexable_Extension by it's name.
+	 * Returns an Indexable_Extension by its name.
 	 *
 	 * @param string $class_name The class name of the extension to load.
 	 *


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added prominent_words_version column and index to indexables table.
* Added prominent_words_vector_length to indexables table.

## Relevant technical choices:

* Added a prominent words version index as per https://github.com/Yoast/wordpress-seo/issues/13350#issuecomment-521667771

## Test instructions
This PR can be tested by following these steps:

* Checkout branch, build plugin.
* Go to your VVV wordpress/wp-admin.
* View your database, and verify that the `prominent_words_version` and `prominent_words_vector_length` columns exist (e.g. by viewing the structure tab in SQLPro) and verify that there is an index called `prominent_words_version` too.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13350 
