### PR TITLE
Added filter to modify organization sameAs attributes.

### DIFF
--- a/frontend/schema/class-schema-organization.php
+++ b/frontend/schema/class-schema-organization.php
@@ -101,6 +101,8 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 			$profiles[] = 'https://twitter.com/' . WPSEO_Options::get( 'twitter_site' );
 		}
 
+		$profiles = apply_filters( 'wpseo_schema_organization_social_profiles', $profiles );
+
 		return $profiles;
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added filter to modify social profiles (sameAs attribute) in the Oranization schema object.

## Relevant technical choices:

* Keep naming of 'social profiles' despite sameAs stands for more generic links

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the filter `wpseo_schema_organization_social_profiles` and modify the array appending an element.

## UI changes
No UI changes.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
 - There is no test for Organization

