### PR TITLE
Show site icon as favicon in mobile snippet preview

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -70,6 +70,7 @@ class WPSEO_Metabox_Formatter {
 			'isPremium'                 => WPSEO_Utils::is_yoast_seo_premium(),
 			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
 			'wordFormRecognitionActive' => ( WPSEO_Language_Utils::get_language( get_locale() ) === 'en' ),
+			'siteIconUrl'               => get_site_icon_url(),
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -133,6 +133,7 @@ export function mapStateToProps( state ) {
 		baseUrl: state.settings.snippetEditor.baseUrl,
 		date: state.settings.snippetEditor.date,
 		recommendedReplacementVariables: state.settings.snippetEditor.recommendedReplacementVariables,
+		faviconSrc: state.settings.snippetEditor.siteIconUrl,
 	};
 }
 

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -73,6 +73,7 @@ class Edit {
 				baseUrl: this._args.snippetEditorBaseUrl,
 				date: this._args.snippetEditorDate,
 				recommendedReplacementVariables: this._args.recommendedReplaceVars,
+				siteIconUrl: this._localizedData.siteIconUrl,
 			},
 		} ) );
 	}


### PR DESCRIPTION
## Summary
If a site icon is set, it will be used as favicon in the snippet preview.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances the favicon in the snippet preview, uses the site icon as favicon, if set.

## Relevant technical choices:

* Added the siteIconUrl to the PostScraper and TermScraper store. 
* Mapped the siteIconUrl (as faviconSrc) to the snippet editor component.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to Appearance -> Customize.
    * Go to Site identity -> Site icon and upload an icon.
* Add and edit a post.
     * Scroll down to the snippet preview.
     * Check if the site icon shows as favicon (example screenshot below). 
* Also check if it shows when editing a tag and category.

![image](https://user-images.githubusercontent.com/42736463/63361846-2b7f6200-c371-11e9-82b0-546927b5d439.png)

* Remove the site icon, and check if the default site icon shows in the snippet preview (example below)
    * In Post
    * In Tag
    * In Category

![image](https://user-images.githubusercontent.com/42736463/63362048-844efa80-c371-11e9-80d2-04d96b58153f.png)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13059 
