### PR TITLE
Add a filter to allow disabling the structured data blocks

### DIFF
--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -9,7 +9,6 @@
  * Class to load assets required for structured data blocks.
  */
 class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
-
 	/**
 	 * An instance of the WPSEO_Admin_Asset_Manager class.
 	 *
@@ -21,6 +20,10 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 	 * WPSEO_Structured_Data_Blocks constructor.
 	 */
 	public function __construct() {
+		if ( ! $this->check_enabled() ) {
+			return;
+		}
+
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 	}
 
@@ -28,8 +31,28 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 	 * Registers hooks for Structured Data Blocks with WordPress.
 	 */
 	public function register_hooks() {
+		if ( ! $this->check_enabled() ) {
+			return;
+		}
+
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_categories', array( $this, 'add_block_category' ) );
+	}
+
+	/**
+	 * Checks whether the Structured Data Blocks are disabled.
+	 *
+	 * @return boolean
+	 */
+	private function check_enabled() {
+		/**
+		 * Filter: 'wpseo_enable_structured_data_blocks' - Allows disabling Yoast's schema blocks entirely.
+		 *
+		 * @api bool If false, our structured data blocks won't show.
+		 */
+		$enabled = apply_filters( 'wpseo_enable_structured_data_blocks', true );
+
+		return $enabled;
 	}
 
 	/**
@@ -51,7 +74,7 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 		$categories[] = array(
 			'slug'  => 'yoast-structured-data-blocks',
 			'title' => sprintf(
-				/* translators: %1$s expands to Yoast. */
+			/* translators: %1$s expands to Yoast. */
 				__( '%1$s Structured Data Blocks', 'wordpress-seo' ),
 				'Yoast'
 			),

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -74,7 +74,7 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 		$categories[] = array(
 			'slug'  => 'yoast-structured-data-blocks',
 			'title' => sprintf(
-			/* translators: %1$s expands to Yoast. */
+				/* translators: %1$s expands to Yoast. */
 				__( '%1$s Structured Data Blocks', 'wordpress-seo' ),
 				'Yoast'
 			),

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -17,24 +17,9 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 	protected $asset_manager;
 
 	/**
-	 * WPSEO_Structured_Data_Blocks constructor.
-	 */
-	public function __construct() {
-		if ( ! $this->check_enabled() ) {
-			return;
-		}
-
-		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
-	}
-
-	/**
 	 * Registers hooks for Structured Data Blocks with WordPress.
 	 */
 	public function register_hooks() {
-		if ( ! $this->check_enabled() ) {
-			return;
-		}
-
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'block_categories', array( $this, 'add_block_category' ) );
 	}
@@ -59,6 +44,14 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 	 * Enqueue Gutenberg block assets for backend editor.
 	 */
 	public function enqueue_block_editor_assets() {
+		if ( ! $this->check_enabled() ) {
+			return;
+		}
+
+		if ( ! $this->asset_manager ) {
+			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
+		}
+
 		$this->asset_manager->enqueue_script( 'structured-data-blocks' );
 		$this->asset_manager->enqueue_style( 'structured-data-blocks' );
 	}
@@ -71,14 +64,16 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 	 * @return array The updated categories.
 	 */
 	public function add_block_category( $categories ) {
-		$categories[] = array(
-			'slug'  => 'yoast-structured-data-blocks',
-			'title' => sprintf(
+		if ( $this->check_enabled() ) {
+			$categories[] = array(
+				'slug'  => 'yoast-structured-data-blocks',
+				'title' => sprintf(
 				/* translators: %1$s expands to Yoast. */
-				__( '%1$s Structured Data Blocks', 'wordpress-seo' ),
-				'Yoast'
-			),
-		);
+					__( '%1$s Structured Data Blocks', 'wordpress-seo' ),
+					'Yoast'
+				),
+			);
+		}
 
 		return $categories;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a filter, `wpseo_enable_structured_data_blocks`, to allow disabling Yoast's Structured Data block editor blocks.

## Test instructions

This PR can be tested by following these steps:

* Use the latest version of granular control plugin, check "Disable Gutenberg blocks" under "General".

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


