### PR TITLE
Add a method to the indexable repository class to extract multiple indexables with one request

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -122,6 +122,9 @@
 		<exclude-pattern>*/src/*.php$</exclude-pattern>
 		<exclude-pattern>*/config/*.php$</exclude-pattern>
 	</rule>
+	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.array_columnFound">
+		<exclude-pattern>*/src/*.php$</exclude-pattern>
+	</rule>
 
 	<!-- These usages of PHP > 5.2 code are surrounded by the correct safeguards. -->
 	<rule ref="PHPCompatibility.FunctionUse.NewFunctionParameters.parse_ini_file_scanner_modeFound">

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -108,6 +108,36 @@ class Indexable_Repository extends ORMWrapper {
 	}
 
 	/**
+	 * Retrieves multiple indexables at once by their IDs and type.
+	 *
+	 * @param int[]  $object_ids  The array of indexable object IDs.
+	 * @param string $object_type The indexable object type.
+	 * @param bool   $auto_create Optional. Create the indexable if it does not exist.
+	 *
+	 * @return \Yoast\WP\Free\Models\Indexable[] An array of indexables.
+	 */
+	public function find_by_multiple_ids_and_type( $object_ids, $object_type, $auto_create = true ) {
+		$indexables = $this
+			->where_in( 'object_id', $object_ids )
+			->where( 'object_type', $object_type )
+			->find_many();
+
+		if ( $auto_create ) {
+			$indexables_available = array_column( $indexables, 'object_id' );
+			$indexables_to_create = array_diff( $object_ids, $indexables_available );
+
+			foreach ( $indexables_to_create as $indexable_to_create ) {
+				$indexable = $this->create_for_id_and_type( $indexable_to_create, $object_type );
+				$indexable->save();
+
+				$indexables[] = $indexable;
+			}
+		}
+
+		return $indexables;
+	}
+
+	/**
 	 * Creates an indexable by its ID and type.
 	 *
 	 * @param int    $object_id   The indexable object ID.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a method to the Indexable_Repository class that allows simultaneous extraction of multiple indexables by an array of `object_id`s, and `object_type`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Please see the Premium PR https://github.com/Yoast/wordpress-seo-premium/pull/2521 for testing instructions.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2349
