### PR TITLE
Add a more specifc filter to make the hide or show empty terms decision per taxonomy

### DIFF
--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -15,6 +15,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 * @var WPSEO_Sitemap_Image_Parser
 	 */
 	protected static $image_parser;
+
 	/**
 	 * Determines whether images should be included in the XML sitemap.
 	 *
@@ -118,7 +119,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			$last_modified_gmt = WPSEO_Sitemaps::get_last_modified_gmt( $tax->object_type );
 
-			for ( $page_counter = 0; $page_counter < $max_pages; $page_counter ++ ) {
+			for ( $page_counter = 0; $page_counter < $max_pages; $page_counter++ ) {
 
 				$current_page = ( $max_pages > 1 ) ? ( $page_counter + 1 ) : '';
 
@@ -148,7 +149,8 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 				if ( $query->have_posts() ) {
 					$date = $query->posts[0]->post_modified_gmt;
-				} else {
+				}
+				else {
 					$date = $last_modified_gmt;
 				}
 

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -83,12 +83,19 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		$all_taxonomies = array();
 
-		$term_args = array(
-			'hide_empty' => $hide_empty,
-			'fields'     => 'ids',
-		);
-
 		foreach ( $taxonomy_names as $taxonomy_name ) {
+			/**
+			 * Filter the setting of excluding empty terms from the XML sitemap for a specific taxonomy.
+			 *
+			 * @param boolean $exclude       Defaults to the sitewide setting.
+			 * @param string  $taxonomy_name The name of the taxonomy being processed.
+			 */
+			$hide_empty_tax = apply_filters( 'wpseo_sitemap_exclude_empty_terms_taxonomy', $hide_empty, $taxonomy_name );
+
+			$term_args = array(
+				'hide_empty' => $hide_empty_tax,
+				'fields'     => 'ids',
+			);
 			$taxonomy_terms = get_terms( $taxonomy_name, $term_args );
 
 			if ( count( $taxonomy_terms ) > 0 ) {

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -9,14 +9,12 @@
  * Sitemap provider for author archives.
  */
 class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
-
 	/**
 	 * Holds image parser instance.
 	 *
 	 * @var WPSEO_Sitemap_Image_Parser
 	 */
 	protected static $image_parser;
-
 	/**
 	 * Determines whether images should be included in the XML sitemap.
 	 *
@@ -92,7 +90,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			 */
 			$hide_empty_tax = apply_filters( 'wpseo_sitemap_exclude_empty_terms_taxonomy', $hide_empty, $taxonomy_name );
 
-			$term_args = array(
+			$term_args      = array(
 				'hide_empty' => $hide_empty_tax,
 				'fields'     => 'ids',
 			);
@@ -120,7 +118,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 			$last_modified_gmt = WPSEO_Sitemaps::get_last_modified_gmt( $tax->object_type );
 
-			for ( $page_counter = 0; $page_counter < $max_pages; $page_counter++ ) {
+			for ( $page_counter = 0; $page_counter < $max_pages; $page_counter ++ ) {
 
 				$current_page = ( $max_pages > 1 ) ? ( $page_counter + 1 ) : '';
 
@@ -150,8 +148,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 				if ( $query->have_posts() ) {
 					$date = $query->posts[0]->post_modified_gmt;
-				}
-				else {
+				} else {
 					$date = $last_modified_gmt;
 				}
 
@@ -191,7 +188,9 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		/** This filter is documented in inc/sitemaps/class-taxonomy-sitemap-provider.php */
 		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, array( $taxonomy->name ) );
-		$terms      = get_terms( $taxonomy->name, array( 'hide_empty' => $hide_empty ) );
+		/** This filter is documented in inc/sitemaps/class-taxonomy-sitemap-provider.php */
+		$hide_empty_tax = apply_filters( 'wpseo_sitemap_exclude_empty_terms_taxonomy', $hide_empty, $taxonomy->name );
+		$terms          = get_terms( $taxonomy->name, array( 'hide_empty' => $hide_empty_tax ) );
 
 		// If the total term count is lower than the offset, we are on an invalid page.
 		if ( count( $terms ) < $offset ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add a more specifc filter (`wpseo_sitemap_exclude_empty_terms_taxonomy`) to make the hide or show empty terms decision _per taxonomy_.

## Test instructions
This PR can be tested by following these steps:

* Use the granular control plugin, latest version.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
