### PR TITLE
Introduce generate indexables command

### DIFF
--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -15,6 +15,7 @@ use Yoast\WP\Free\Conditionals\Conditional;
 use Yoast\WP\Free\Loader;
 use Yoast\WP\Free\WordPress\Initializer;
 use Yoast\WP\Free\WordPress\Integration;
+use Yoast\WP\Free\WordPress\WP_CLI_Command;
 
 /**
  * A pass is a step in the compilation process of the container.
@@ -62,6 +63,11 @@ class Loader_Pass implements CompilerPassInterface {
 
 		if ( \is_subclass_of( $class, Integration::class ) ) {
 			$loader_definition->addMethodCall( 'register_integration', [ $class ] );
+			$definition->setPublic( true );
+		}
+
+		if ( \is_subclass_of( $class, WP_CLI_Command::class ) ) {
+			$loader_definition->addMethodCall( 'register_command', [ $class ] );
 			$definition->setPublic( true );
 		}
 

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -20,12 +20,6 @@ use Yoast\WP\Free\WordPress\Wrapper;
 $container->register( 'wpdb', 'wpdb' )->setFactory( [ Wrapper::class, 'get_wpdb' ] );
 $container->register( 'wp_query', 'WP_Query' )->setFactory( [ Wrapper::class, 'get_wp_query' ] );
 
-// Model repository factory functions.
-$container->register( Indexable_Repository::class, Indexable_Repository::class )->setFactory( [ Indexable_Repository::class, 'get_instance' ] )->setAutowired( true );
-$container->register( Primary_Term_Repository::class, Primary_Term_Repository::class )->setFactory( [ Primary_Term_Repository::class, 'get_instance' ] )->setAutowired( true );
-$container->register( SEO_Meta_Repository::class, SEO_Meta_Repository::class )->setFactory( [ SEO_Meta_Repository::class, 'get_instance' ] )->setAutowired( true );
-$container->register( SEO_Links_Repository::class, SEO_Links_Repository::class )->setFactory( [ SEO_Links_Repository::class, 'get_instance' ] )->setAutowired( true );
-
 $excluded_files = [
 	'main.php',
 ];

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -8,10 +8,6 @@
 namespace Yoast\WP\Free\Dependency_Injection;
 
 use Symfony\Component\DependencyInjection\Definition;
-use Yoast\WP\Free\Repositories\Indexable_Repository;
-use Yoast\WP\Free\Repositories\Primary_Term_Repository;
-use Yoast\WP\Free\Repositories\SEO_Links_Repository;
-use Yoast\WP\Free\Repositories\SEO_Meta_Repository;
 use Yoast\WP\Free\WordPress\Wrapper;
 
 /* @var $container \Symfony\Component\DependencyInjection\ContainerBuilder */

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -454,6 +454,8 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 			$term_id = $term->term_id;
 		}
 		else {
+			var_dump( $term, is_object( $term ) );
+			exit;
 			return false;
 		}
 

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -15,17 +15,30 @@ class Indexable_Term_Builder {
 	/**
 	 * Formats the data.
 	 *
-	 * @param int                             $term_id  ID of the term to save data for.
+	 * @param int                             $term_id   ID of the term to save data for.
 	 * @param \Yoast\WP\Free\Models\Indexable $indexable The indexable to format.
 	 *
 	 * @return \Yoast\WP\Free\Models\Indexable The extended indexable.
+	 *
+	 * @throws \Exception If the term could not be found.
 	 */
 	public function build( $term_id, $indexable ) {
-		$term      = \get_term( $term_id );
-		$taxonomy  = $term->taxonomy;
-		$term_meta = \WPSEO_Taxonomy_Meta::get_term_meta( $term_id, $taxonomy );
+		$term = \get_term( $term_id );
 
-		$indexable->permalink       = \get_term_link( $term_id, $taxonomy );
+		if ( is_wp_error( $term ) ) {
+			throw new \Exception( array_key_first( $term->errors ) );
+		}
+
+		$taxonomy  = $term->taxonomy;
+		$term_link = \get_term_link( $term_id, $taxonomy );
+
+		if ( is_wp_error( $term_link ) ) {
+			throw new \Exception( array_key_first( $term_link->errors ) );
+		}
+
+		$term_meta = \WPSEO_Taxonomy_Meta::get_term_meta( $term, $taxonomy );
+
+		$indexable->permalink       = $term_link;
 		$indexable->object_sub_type = $taxonomy;
 
 		$indexable->primary_focus_keyword_score = $this->get_keyword_score(

--- a/src/commands/generate-indexables-command.php
+++ b/src/commands/generate-indexables-command.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\Free\Commands;
 
 use wpdb;
-use Yoast\WP\Free\Watchers\Indexable_Author_Watcher;
 use Yoast\WP\Free\Watchers\Indexable_Post_Watcher;
 use Yoast\WP\Free\Watchers\Indexable_Term_Watcher;
 use Yoast\WP\Free\WordPress\WP_CLI_Command;
@@ -29,24 +28,24 @@ class Generate_Indexables_Command implements WP_CLI_Command {
 	private $term_watcher;
 
 	/**
-	 * @var Indexable_Author_Watcher
-	 */
-	private $author_watcher;
-
-	/**
 	 * @var wpdb
 	 */
 	private $wpdb;
 
+	/**
+	 * Generate_Indexables_Command constructor.
+	 *
+	 * @param Indexable_Post_Watcher   $post_watcher The post watcher, used to build/update indexables for posts.
+	 * @param Indexable_Term_Watcher   $term_watcher The term watcher, used to build/update indexables for posts.
+	 * @param wpdb                     $wpdb         The wpdb instance, used to get lists of all posts and terms.
+	 */
 	public function __construct(
 		Indexable_Post_Watcher $post_watcher,
 		Indexable_Term_Watcher $term_watcher,
-		Indexable_Author_Watcher $author_watcher,
 		wpdb $wpdb
 	) {
 		$this->post_watcher = $post_watcher;
 		$this->term_watcher = $term_watcher;
-		$this->author_watcher = $author_watcher;
 		$this->wpdb = $wpdb;
 	}
 
@@ -74,10 +73,15 @@ class Generate_Indexables_Command implements WP_CLI_Command {
 	 * @return void
 	 */
 	public function execute() {
-		//$this->generate_for_posts();
+		$this->generate_for_posts();
 		$this->generate_for_terms();
 	}
 
+	/**
+	 * Generates indexables for all posts.
+	 *
+	 * @return void
+	 */
 	private function generate_for_posts() {
 		$page     = 0;
 		$total    = $this->wpdb->get_var( "SELECT COUNT(ID) FROM {$this->wpdb->posts};" );
@@ -101,6 +105,11 @@ class Generate_Indexables_Command implements WP_CLI_Command {
 		$progress->finish();
 	}
 
+	/**
+	 * Generates indexables for all terms.
+	 *
+	 * @return void
+	 */
 	private function generate_for_terms() {
 		$page     = 0;
 		$total    = $this->wpdb->get_var( "SELECT COUNT(term_id) FROM {$this->wpdb->terms};" );

--- a/src/commands/generate-indexables-command.php
+++ b/src/commands/generate-indexables-command.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Command to generate indexables for all posts and terms.
+ *
+ * @package Yoast\YoastSEO\Commands
+ */
+
+namespace Yoast\WP\Free\Commands;
+
+use wpdb;
+use Yoast\WP\Free\Watchers\Indexable_Author_Watcher;
+use Yoast\WP\Free\Watchers\Indexable_Post_Watcher;
+use Yoast\WP\Free\Watchers\Indexable_Term_Watcher;
+use Yoast\WP\Free\WordPress\WP_CLI_Command;
+
+/**
+ * Formats the term meta to indexable format.
+ */
+class Generate_Indexables_Command implements WP_CLI_Command {
+
+	/**
+	 * @var Indexable_Post_Watcher
+	 */
+	private $post_watcher;
+
+	/**
+	 * @var Indexable_Term_Watcher
+	 */
+	private $term_watcher;
+
+	/**
+	 * @var Indexable_Author_Watcher
+	 */
+	private $author_watcher;
+
+	/**
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	public function __construct(
+		Indexable_Post_Watcher $post_watcher,
+		Indexable_Term_Watcher $term_watcher,
+		Indexable_Author_Watcher $author_watcher,
+		wpdb $wpdb
+	) {
+		$this->post_watcher = $post_watcher;
+		$this->term_watcher = $term_watcher;
+		$this->author_watcher = $author_watcher;
+		$this->wpdb = $wpdb;
+	}
+
+	/**
+	 * Returns the name of this command.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return 'yoast indexables generate';
+	}
+
+	/**
+	 * Returns the configuration of this command.
+	 *
+	 * @return array
+	 */
+	public function get_config() {
+		return [ 'shortdesc' => __( 'Generates indexables for all posts and terms.', 'wordpress-seo' ) ];
+	}
+
+	/**
+	 * Executes this command.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$this->generate_for_posts();
+		$this->generate_for_terms();
+	}
+
+	private function generate_for_posts() {
+		$page     = 0;
+		$total    = $this->wpdb->get_var( "SELECT COUNT(ID) FROM {$this->wpdb->posts};" );
+		$progress = \WP_CLI\Utils\make_progress_bar( __( 'Indexing posts', 'wordpress-seo' ), $total );
+
+		while ( true ) {
+			$post_ids = $this->wpdb->get_col( $this->wpdb->prepare( "SELECT ID FROM {$this->wpdb->posts} ORDER BY ID ASC LIMIT %d, 25;", $page * 25 ) );
+
+			if ( empty( $post_ids ) ) {
+				break;
+			}
+
+			foreach( $post_ids as $post_id ) {
+				$this->post_watcher->build_indexable( $post_id );
+				$progress->tick();
+			}
+
+			$page += 1;
+		}
+
+		$progress->finish();
+	}
+
+	private function generate_for_terms() {
+		$page     = 0;
+		$total    = $this->wpdb->get_var( "SELECT COUNT(ID) FROM {$this->wpdb->terms};" );
+		$progress = \WP_CLI\Utils\make_progress_bar( __( 'Indexing terms', 'wordpress-seo' ), $total );
+
+		while ( true ) {
+			$term_ids = $this->wpdb->get_col( $this->wpdb->prepare( "SELECT ID FROM {$this->wpdb->terms} ORDER BY ID ASC LIMIT %d, 25;", $page * 25 ) );
+
+			if ( empty( $term_ids ) ) {
+				break;
+			}
+
+			foreach( $term_ids as $term_id ) {
+				$this->term_watcher->build_indexable( $term_id );
+				$progress->tick();
+			}
+
+			$page += 1;
+		}
+
+		$progress->finish();
+	}
+}

--- a/src/commands/generate-indexables-command.php
+++ b/src/commands/generate-indexables-command.php
@@ -74,7 +74,7 @@ class Generate_Indexables_Command implements WP_CLI_Command {
 	 * @return void
 	 */
 	public function execute() {
-		$this->generate_for_posts();
+		//$this->generate_for_posts();
 		$this->generate_for_terms();
 	}
 
@@ -103,11 +103,11 @@ class Generate_Indexables_Command implements WP_CLI_Command {
 
 	private function generate_for_terms() {
 		$page     = 0;
-		$total    = $this->wpdb->get_var( "SELECT COUNT(ID) FROM {$this->wpdb->terms};" );
+		$total    = $this->wpdb->get_var( "SELECT COUNT(term_id) FROM {$this->wpdb->terms};" );
 		$progress = \WP_CLI\Utils\make_progress_bar( __( 'Indexing terms', 'wordpress-seo' ), $total );
 
 		while ( true ) {
-			$term_ids = $this->wpdb->get_col( $this->wpdb->prepare( "SELECT ID FROM {$this->wpdb->terms} ORDER BY ID ASC LIMIT %d, 25;", $page * 25 ) );
+			$term_ids = $this->wpdb->get_col( $this->wpdb->prepare( "SELECT term_id FROM {$this->wpdb->terms} ORDER BY term_id ASC LIMIT %d, 25;", $page * 25 ) );
 
 			if ( empty( $term_ids ) ) {
 				break;

--- a/src/orm/yoast-orm-wrapper.php
+++ b/src/orm/yoast-orm-wrapper.php
@@ -31,11 +31,6 @@ use YoastSEO_Vendor\ORM;
 class ORMWrapper extends ORM {
 
 	/**
-	 * @var array
-	 */
-	public static $repositories = [];
-
-	/**
 	 * The wrapped find_one and find_many classes will return an instance or
 	 * instances of this class.
 	 *
@@ -90,11 +85,6 @@ class ORMWrapper extends ORM {
 	 */
 	public static function for_table( $table_name, $connection_name = parent::DEFAULT_CONNECTION ) {
 		static::_setup_db( $connection_name );
-
-		if ( self::$repositories[ $table_name ] ) {
-			return new self::$repositories[ $table_name ]( $table_name, [], $connection_name );
-		}
-
 		return new static( $table_name, [], $connection_name );
 	}
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -11,7 +11,6 @@ use Yoast\WP\Free\Builders\Indexable_Author_Builder;
 use Yoast\WP\Free\Builders\Indexable_Post_Builder;
 use Yoast\WP\Free\Builders\Indexable_Term_Builder;
 use Yoast\WP\Free\Loggers\Logger;
-use Yoast\WP\Free\ORM\ORMWrapper;
 use Yoast\WP\Free\ORM\Yoast_Model;
 
 /**
@@ -19,7 +18,7 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  *
  * @package Yoast\WP\Free\ORM\Repositories
  */
-class Indexable_Repository extends ORMWrapper {
+class Indexable_Repository {
 
 	/**
 	 * @var \Yoast\WP\Free\Builders\Indexable_Author_Builder
@@ -51,24 +50,25 @@ class Indexable_Repository extends ORMWrapper {
 	 *
 	 * @return \Yoast\WP\Free\Repositories\Indexable_Repository
 	 */
-	public static function get_instance(
+	public function __construct(
 		Indexable_Author_Builder $author_builder,
 		Indexable_Post_Builder $post_builder,
 		Indexable_Term_Builder $term_builder,
 		Logger $logger
 	) {
-		ORMWrapper::$repositories[ Yoast_Model::get_table_name( 'Indexable' ) ] = self::class;
+		$this->author_builder = $author_builder;
+		$this->post_builder   = $post_builder;
+		$this->term_builder   = $term_builder;
+		$this->logger         = $logger;
+	}
 
-		/**
-		 * @var $instance self
-		 */
-		$instance                 = Yoast_Model::of_type( 'Indexable' );
-		$instance->author_builder = $author_builder;
-		$instance->post_builder   = $post_builder;
-		$instance->term_builder   = $term_builder;
-		$instance->logger         = $logger;
-
-		return $instance;
+	/**
+	 * Starts a query for this repository.
+	 *
+	 * @return \Yoast\WP\Free\ORM\ORMWrapper
+	 */
+	public function query() {
+		return Yoast_Model::of_type( 'Indexable' );
 	}
 
 	/**
@@ -81,7 +81,8 @@ class Indexable_Repository extends ORMWrapper {
 		$url_hash = \strlen( $url ) . ':' . \md5( $url );
 
 		// Find by both url_hash and url, url_hash is indexed so will be used first by the DB to optimize the query.
-		return $this->where( 'url_hash', $url_hash )
+		return $this->query()
+					->where( 'url_hash', $url_hash )
 					->where( 'url', $url )
 					->find_one();
 	}
@@ -96,9 +97,10 @@ class Indexable_Repository extends ORMWrapper {
 	 * @return bool|\Yoast\WP\Free\Models\Indexable Instance of indexable.
 	 */
 	public function find_by_id_and_type( $object_id, $object_type, $auto_create = true ) {
-		$indexable = $this->where( 'object_id', $object_id )
-			->where( 'object_type', $object_type )
-			->find_one();
+		$indexable = $this->query()
+						  ->where( 'object_id', $object_id )
+						  ->where( 'object_type', $object_type )
+						  ->find_one();
 
 		if ( $auto_create && ! $indexable ) {
 			$indexable = $this->create_for_id_and_type( $object_id, $object_type );
@@ -117,10 +119,10 @@ class Indexable_Repository extends ORMWrapper {
 	 * @return \Yoast\WP\Free\Models\Indexable[] An array of indexables.
 	 */
 	public function find_by_multiple_ids_and_type( $object_ids, $object_type, $auto_create = true ) {
-		$indexables = $this
-			->where_in( 'object_id', $object_ids )
-			->where( 'object_type', $object_type )
-			->find_many();
+		$indexables = $this->query()
+						   ->where_in( 'object_id', $object_ids )
+						   ->where( 'object_type', $object_type )
+						   ->find_many();
 
 		if ( $auto_create ) {
 			$indexables_available = array_column( $indexables, 'object_id' );
@@ -151,7 +153,7 @@ class Indexable_Repository extends ORMWrapper {
 		 *
 		 * @var \Yoast\WP\Free\Models\Indexable $indexable
 		 */
-		$indexable              = $this->create();
+		$indexable              = $this->query()->create();
 		$indexable->object_id   = $object_id;
 		$indexable->object_type = $object_type;
 

--- a/src/repositories/primary-term-repository.php
+++ b/src/repositories/primary-term-repository.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\Repositories;
 
-use Yoast\WP\Free\ORM\ORMWrapper;
 use Yoast\WP\Free\ORM\Yoast_Model;
 
 /**
@@ -15,16 +14,14 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  *
  * @package Yoast\WP\Free\ORM\Repositories
  */
-class Primary_Term_Repository extends ORMWrapper {
+class Primary_Term_Repository {
 
 	/**
-	 * Returns the instance of this class constructed through the ORM Wrapper.
+	 * Starts a query for this repository.
 	 *
-	 * @return \Yoast\WP\Free\Repositories\Primary_Term_Repository
+	 * @return \Yoast\WP\Free\ORM\ORMWrapper
 	 */
-	public static function get_instance() {
-		ORMWrapper::$repositories[ Yoast_Model::get_table_name( 'Primary_Term' ) ] = self::class;
-
+	public function query() {
 		return Yoast_Model::of_type( 'Primary_Term' );
 	}
 
@@ -39,9 +36,10 @@ class Primary_Term_Repository extends ORMWrapper {
 	 */
 	public function find_by_postid_and_taxonomy( $post_id, $taxonomy, $auto_create = true ) {
 		/** @var \Yoast\WP\Free\Models\Primary_Term $primary_term */
-		$primary_term = $this->where( 'post_id', $post_id )
-			->where( 'taxonomy', $taxonomy )
-			->find_one();
+		$primary_term = $this->query()
+							 ->where( 'post_id', $post_id )
+							 ->where( 'taxonomy', $taxonomy )
+							 ->find_one();
 
 		if ( $auto_create && ! $primary_term ) {
 			$primary_term = $this->create();

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\Repositories;
 
-use Yoast\WP\Free\ORM\ORMWrapper;
 use Yoast\WP\Free\ORM\Yoast_Model;
 
 /**
@@ -18,16 +17,14 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  *
  * @package Yoast\WP\Free\ORM\Repositories
  */
-class SEO_Links_Repository extends ORMWrapper {
+class SEO_Links_Repository {
 
 	/**
-	 * Returns the instance of this class constructed through the ORM Wrapper.
+	 * Starts a query for this repository.
 	 *
-	 * @return \Yoast\WP\Free\Repositories\SEO_Links_Repository
+	 * @return \Yoast\WP\Free\ORM\ORMWrapper
 	 */
-	public static function get_instance() {
-		ORMWrapper::$repositories[ Yoast_Model::get_table_name( 'SEO_Links' ) ] = self::class;
-
+	public function query() {
 		return Yoast_Model::of_type( 'SEO_Links' );
 	}
 }

--- a/src/repositories/seo-meta-repository.php
+++ b/src/repositories/seo-meta-repository.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\Repositories;
 
-use Yoast\WP\Free\ORM\ORMWrapper;
 use Yoast\WP\Free\ORM\Yoast_Model;
 
 /**
@@ -15,16 +14,14 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  *
  * @package Yoast\WP\Free\ORM\Repositories
  */
-class SEO_Meta_Repository extends ORMWrapper {
+class SEO_Meta_Repository {
 
 	/**
-	 * Returns the instance of this class constructed through the ORM Wrapper.
+	 * Starts a query for this repository.
 	 *
-	 * @return \Yoast\WP\Free\Repositories\SEO_Meta_Repository
+	 * @return \Yoast\WP\Free\ORM\ORMWrapper
 	 */
-	public static function get_instance() {
-		ORMWrapper::$repositories[ Yoast_Model::get_table_name( 'SEO_Meta' ) ] = self::class;
-
+	public function query() {
 		return Yoast_Model::of_type( 'SEO_Meta' );
 	}
 
@@ -36,7 +33,8 @@ class SEO_Meta_Repository extends ORMWrapper {
 	 * @return \Yoast\WP\Free\Models\SEO_Meta The SEO meta.
 	 */
 	public function find_by_post_id( $post_id ) {
-		return $this->where( 'object_id', $post_id )
+		return $this->query()
+					->where( 'object_id', $post_id )
 					->find_one();
 	}
 }

--- a/src/watchers/indexable-term-watcher.php
+++ b/src/watchers/indexable-term-watcher.php
@@ -85,7 +85,11 @@ class Indexable_Term_Watcher implements Integration {
 		$indexable = $this->repository->find_by_id_and_type( $term_id, 'term', false );
 
 		// If we haven't found an existing indexable, create it. Otherwise update it.
-		$indexable = ( $indexable === false ) ? $this->repository->create_for_id_and_type( $term_id, 'term' ) : $this->builder->build( $term_id, $indexable );
+		try {
+			$indexable = ( $indexable === false ) ? $this->repository->create_for_id_and_type( $term_id, 'term' ) : $this->builder->build( $term_id, $indexable );
+		} catch ( \Exception $exception ) {
+			return;
+		}
 
 		$indexable->save();
 	}

--- a/src/wordpress/wp-cli-command.php
+++ b/src/wordpress/wp-cli-command.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * WP CLI command interface definition.
+ *
+ * @package Yoast\YoastSEO\WordPress
+ */
+
+namespace Yoast\WP\Free\WordPress;
+
+/**
+ * An interface for registering integrations with WordPress
+ */
+interface WP_CLI_Command {
+
+	/**
+	 * Returns the name of this command.
+	 *
+	 * @return string
+	 */
+	public function get_name();
+
+	/**
+	 * Returns the configuration of this command.
+	 *
+	 * @return array
+	 */
+	public function get_config();
+
+	/**
+	 * Executes this command.
+	 *
+	 * @return void
+	 */
+	public function execute();
+}


### PR DESCRIPTION
## Summary

Adds a command that generates indexables for all posts and terms `wp yoast indexables generate`.
This PR can be summarized in the following changelog entry:

* Adds a WP CLI command to generate indexables for all posts and term `wp yoast indexables generate`.

## Relevant technical choices:

* No indexables are generated for authors as the way roles are stored in WordPress would make this extremely performance intensive.

## Test instructions
This PR can be tested by following these steps:

* Delete all entries in your `wp_yoast_indexables` table.
* run `wp yoast indexables generate`
* Your indexables table should be filled with indexables.
* Check that SEO settings such as the title are also set on your indexables.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13068
