### PR TITLE
Add a paper collapsible around the hidden Yoast alerts

### DIFF
--- a/admin/class-paper-presenter.php
+++ b/admin/class-paper-presenter.php
@@ -35,19 +35,22 @@ class WPSEO_Paper_Presenter {
 	 * WPSEO_presenter_paper constructor.
 	 *
 	 * @param string $title     The title of the paper.
-	 * @param string $view_file Optional. The path to the view file. Use the content setting if you do not wish to use a view file.
+	 * @param string $view_file Optional. The path to the view file. Use the content setting if you do not wish to use
+	 *                          a view file.
 	 * @param array  $settings  Optional. Settings for the paper.
 	 */
 	public function __construct( $title, $view_file = null, array $settings = array() ) {
 		$defaults = array(
-			'paper_id'     => null,
-			'collapsible'  => false,
-			'expanded'     => false,
-			'help_text'    => '',
-			'title_after'  => '',
-			'class'        => '',
-			'content'      => '',
-			'view_data'    => array(),
+			'paper_id'                 => null,
+			'paper_id_prefix'          => 'wpseo-',
+			'collapsible'              => false,
+			'collapsible_header_class' => '',
+			'expanded'                 => false,
+			'help_text'                => '',
+			'title_after'              => '',
+			'class'                    => '',
+			'content'                  => '',
+			'view_data'                => array(),
 		);
 
 		$this->settings  = wp_parse_args( $settings, $defaults );
@@ -91,15 +94,17 @@ class WPSEO_Paper_Presenter {
 		}
 
 		$view_variables = array(
-			'class'              => $this->settings['class'],
-			'collapsible'        => $this->settings['collapsible'],
-			'collapsible_config' => $this->collapsible_config(),
-			'title_after'        => $this->settings['title_after'],
-			'help_text'          => $this->settings['help_text'],
-			'view_file'          => $this->view_file,
-			'title'              => $this->title,
-			'paper_id'           => $this->settings['paper_id'],
-			'yform'              => Yoast_Form::get_instance(),
+			'class'                    => $this->settings['class'],
+			'collapsible'              => $this->settings['collapsible'],
+			'collapsible_config'       => $this->collapsible_config(),
+			'collapsible_header_class' => $this->settings['collapsible_header_class'],
+			'title_after'              => $this->settings['title_after'],
+			'help_text'                => $this->settings['help_text'],
+			'view_file'                => $this->view_file,
+			'title'                    => $this->title,
+			'paper_id'                 => $this->settings['paper_id'],
+			'paper_id_prefix'          => $this->settings['paper_id_prefix'],
+			'yform'                    => Yoast_Form::get_instance(),
 		);
 
 		return array_merge( $this->settings['view_data'], $view_variables );

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -4,13 +4,15 @@
  *
  * @package WPSEO\Admin\Views
  *
- * @uses string                 $paper_id           The ID of the paper.
- * @uses bool                   $collapsible        Whether the collapsible should be rendered.
- * @uses array                  $collapsible_config Configuration for the collapsible.
- * @uses string                 $title              The title.
- * @uses string                 $title_after        Additional content to render after the title.
- * @uses string                 $view_file          Path to the view file.
- * @uses WPSEO_Admin_Help_Panel $help_text          The help text.
+ * @uses    string                 $paper_id                  The ID of the paper.
+ * @uses    string                 $paper_id_prefix           The ID prefix of the paper.
+ * @uses    bool                   $collapsible               Whether the collapsible should be rendered.
+ * @uses    array                  $collapsible_config        Configuration for the collapsible.
+ * @uses    string                 $collapsible_header_class  Class for the collapsible header.
+ * @uses    string                 $title                     The title.
+ * @uses    string                 $title_after               Additional content to render after the title.
+ * @uses    string                 $view_file                 Path to the view file.
+ * @uses    WPSEO_Admin_Help_Panel $help_text                 The help text.
  */
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {
@@ -20,7 +22,8 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 ?>
-<div class="<?php echo esc_attr( 'paper tab-block ' . $class ); ?>"<?php echo ( $paper_id ) ? ' id="' . esc_attr( 'wpseo-' . $paper_id ) . '"' : ''; ?>>
+<div
+	class="<?php echo esc_attr( 'paper tab-block ' . $class ); ?>"<?php echo ( $paper_id ) ? ' id="' . esc_attr( $paper_id_prefix . $paper_id ) . '"' : ''; ?>>
 
 	<?php
 	if ( ! empty( $title ) ) {
@@ -28,15 +31,16 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 			$button_id_attr = '';
 			if ( ! empty( $paper_id ) ) {
-				$button_id_attr = sprintf( ' id="%s"', esc_attr( 'wpseo-' . $paper_id . '-button' ) );
+				$button_id_attr = sprintf( ' id="%s"', esc_attr( $paper_id_prefix . $paper_id . '-button' ) );
 			}
 
 			printf(
-				'<h2 class="collapsible-header"><button%4$s type="button" class="toggleable-container-trigger" aria-expanded="%3$s">%1$s <span class="toggleable-container-icon dashicons %2$s" aria-hidden="true"></span></button></h2>',
+				'<h2 class="collapsible-header %5$s"><button%4$s type="button" class="toggleable-container-trigger" aria-expanded="%3$s">%1$s <span class="toggleable-container-icon dashicons %2$s" aria-hidden="true"></span></button></h2>',
 				esc_html( $title ) . $title_after . $help_text->get_button_html(),
 				$collapsible_config['toggle_icon'],
 				$collapsible_config['expanded'],
-				$button_id_attr
+				$button_id_attr,
+				esc_attr( $collapsible_header_class )
 			);
 		}
 		else {
@@ -50,7 +54,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 	$container_id_attr = '';
 	if ( ! empty( $paper_id ) ) {
-		$container_id_attr = sprintf( ' id="%s"', esc_attr( 'wpseo-' . $paper_id . '-container' ) );
+		$container_id_attr = sprintf( ' id="%s"', esc_attr( $paper_id_prefix . $paper_id . '-container' ) );
 	}
 
 	printf(

--- a/admin/views/partial-alerts-errors.php
+++ b/admin/views/partial-alerts-errors.php
@@ -4,21 +4,26 @@
  *
  * @package WPSEO\Admin
  *
- * @uses array $alerts_data
+ * @uses    array $alerts_data
  */
 
-$type     = 'alerts';
+$type     = 'errors';
 $dashicon = 'warning';
+
+$active    = $alerts_data['errors']['active'];
+$dismissed = $alerts_data['errors']['dismissed'];
+
+$active_total    = count( $active );
+$dismissed_total = count( $dismissed );
+$total           = $alerts_data['metrics']['errors'];
 
 $i18n_title              = __( 'Problems', 'wordpress-seo' );
 $i18n_issues             = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
 $i18n_no_issues          = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
-$i18n_muted_issues_title = __( 'Muted problems:', 'wordpress-seo' );
-
-$active_total = count( $alerts_data['errors']['active'] );
-$total        = $alerts_data['metrics']['errors'];
-
-$active    = $alerts_data['errors']['active'];
-$dismissed = $alerts_data['errors']['dismissed'];
+$i18n_muted_issues_title = sprintf(
+	/* translators: %d expands the amount of hidden problems. */
+	_n( 'You have %d hidden problem:', 'You have %d hidden problems:', $dismissed_total, 'wordpress-seo' ),
+	$dismissed_total
+);
 
 require WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/admin/views/partial-alerts-template.php
+++ b/admin/views/partial-alerts-template.php
@@ -4,16 +4,17 @@
  *
  * @package WPSEO\Admin
  *
- * @uses string $type
- * @uses string $dashicon
- * @uses string $i18n_title
- * @uses string $i18n_issues
- * @uses string $i18n_no_issues
- * @uses string $i18n_muted_issues_title
- * @uses int    $active_total
- * @uses        $total
- * @uses array  $active
- * @uses array  $dismissed
+ * @uses    string $type
+ * @uses    string $dashicon
+ * @uses    string $i18n_title
+ * @uses    string $i18n_issues
+ * @uses    string $i18n_no_issues
+ * @uses    string $i18n_muted_issues_title
+ * @uses    int    $active_total
+ * @uses    int    $dismissed_total
+ * @uses    int    $total
+ * @uses    array  $active
+ * @uses    array  $dismissed
  */
 
 if ( ! function_exists( '_yoast_display_alerts' ) ) {
@@ -22,21 +23,31 @@ if ( ! function_exists( '_yoast_display_alerts' ) ) {
 	 *
 	 * @param array  $list   List of alerts.
 	 * @param string $status Status of the alerts (active/dismissed).
+	 *
+	 * @return string The output to render.
 	 */
 	function _yoast_display_alerts( $list, $status ) {
+		$alerts = '';
+
 		foreach ( $list as $notification ) {
 
 			switch ( $status ) {
 				case 'active':
-					$button = sprintf( '<button type="button" class="button dismiss"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-no-alt"></span></button>', esc_html__( 'Dismiss this item.', 'wordpress-seo' ) );
+					$button = sprintf(
+						'<button type="button" class="button dismiss"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-hidden"></span></button>',
+						esc_html__( 'Hide this item.', 'wordpress-seo' )
+					);
 					break;
 
 				case 'dismissed':
-					$button = sprintf( '<button type="button" class="button restore"><span class="screen-reader-text">%1$s</span><span class="dashicons dashicons-hidden"></span></button>', esc_html__( 'Restore this item.', 'wordpress-seo' ) );
+					$button = sprintf(
+						'<button type="button" class="button restore"><span class="screen-reader-text">%1$s</span><span class="dashicons yoast-svg-icon-eye"></span></button>',
+						esc_html__( 'Show this item.', 'wordpress-seo' )
+					);
 					break;
 			}
 
-			printf(
+			$alerts .= sprintf(
 				'<div class="yoast-alert-holder" id="%1$s" data-nonce="%2$s" data-json="%3$s">%4$s%5$s</div>',
 				esc_attr( $notification->get_id() ),
 				esc_attr( $notification->get_nonce() ),
@@ -45,6 +56,8 @@ if ( ! function_exists( '_yoast_display_alerts' ) ) {
 				$button
 			);
 		}
+
+		return $alerts;
 	}
 }
 
@@ -55,24 +68,35 @@ if ( ! $active ) {
 }
 
 ?>
-<h3><span class="dashicons <?php echo esc_attr( 'dashicons-' . $dashicon ); ?>"></span> <?php echo esc_html( $i18n_title ); ?> (<?php echo (int) $active_total; ?>)</h3>
+<h3 class="yoast-alerts-header" id="<?php echo esc_attr( 'yoast-' . $type . '-header' ); ?>">
+	<span class="dashicons <?php echo esc_attr( 'dashicons-' . $dashicon ); ?>"></span>
+	<?php echo esc_html( $i18n_title ); ?> (<?php echo (int) $active_total; ?>)
+</h3>
 
 <div id="<?php echo esc_attr( 'yoast-' . $type ); ?>">
 
 	<?php if ( $total ) : ?>
 		<p><?php echo esc_html( $wpseo_i18n_summary ); ?></p>
 
-		<div class="container" id="<?php echo esc_attr( 'yoast-' . $type . '-active' ); ?>">
-			<?php _yoast_display_alerts( $active, 'active' ); ?>
+		<div class="container yoast-alerts-active" id="<?php echo esc_attr( 'yoast-' . $type . '-active' ); ?>">
+			<?php echo _yoast_display_alerts( $active, 'active' ); ?>
 		</div>
 
-		<?php if ( $dismissed ) : ?>
-			<h4 class="yoast-muted-title"><?php echo esc_html( $i18n_muted_issues_title ); ?></h4>
-		<?php endif; ?>
-
-		<div class="container" id="<?php echo esc_attr( 'yoast-' . $type . '-dismissed' ); ?>">
-			<?php _yoast_display_alerts( $dismissed, 'dismissed' ); ?>
-		</div>
+		<?php if ( $dismissed ) {
+			$dismissed_paper = new WPSEO_Paper_Presenter(
+				esc_html( $i18n_muted_issues_title ),
+				null,
+				array(
+					'paper_id'                 => esc_attr( $type . '-dismissed' ),
+					'paper_id_prefix'          => 'yoast-',
+					'class'                    => 'yoast-alerts-dismissed',
+					'content'                  => _yoast_display_alerts( $dismissed, 'dismissed' ),
+					'collapsible'              => true,
+					'collapsible_header_class' => 'yoast-alert',
+				)
+			);
+			echo $dismissed_paper->get_output();
+		} ?>
 
 	<?php else : ?>
 

--- a/admin/views/partial-alerts-warnings.php
+++ b/admin/views/partial-alerts-warnings.php
@@ -4,21 +4,26 @@
  *
  * @package WPSEO\Admin
  *
- * @uses array $alerts_data
+ * @uses    array $alerts_data
  */
 
 $type     = 'warnings';
 $dashicon = 'flag';
 
+$active    = $alerts_data['warnings']['active'];
+$dismissed = $alerts_data['warnings']['dismissed'];
+
+$active_total    = count( $alerts_data['warnings']['active'] );
+$dismissed_total = count( $alerts_data['warnings']['dismissed'] );
+$total           = $alerts_data['metrics']['warnings'];
+
 $i18n_title              = __( 'Notifications', 'wordpress-seo' );
 $i18n_issues             = '';
 $i18n_no_issues          = __( 'No new notifications.', 'wordpress-seo' );
-$i18n_muted_issues_title = __( 'Muted notifications:', 'wordpress-seo' );
-
-$active_total = count( $alerts_data['warnings']['active'] );
-$total        = $alerts_data['metrics']['warnings'];
-
-$active    = $alerts_data['warnings']['active'];
-$dismissed = $alerts_data['warnings']['dismissed'];
+$i18n_muted_issues_title = sprintf(
+	/* translators: %d expands the amount of hidden notifications. */
+	_n( 'You have %d hidden notification:', 'You have %d hidden notifications:', $dismissed_total, 'wordpress-seo' ),
+	$dismissed_total
+);
 
 require WPSEO_PATH . 'admin/views/partial-alerts-template.php';

--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -30,7 +30,7 @@ $wpseo_contributors_phrase = sprintf(
 
 		<?php echo $notifier->notify(); ?>
 
-		<div class="yoast-container yoast-container__alert">
+		<div class="yoast-container yoast-container__error">
 			<?php require WPSEO_PATH . 'admin/views/partial-alerts-errors.php'; ?>
 		</div>
 

--- a/css/src/alerts.scss
+++ b/css/src/alerts.scss
@@ -1,37 +1,18 @@
 @import "../../node_modules/@yoast/style-guide/src/colors";
 @import "../../node_modules/yoast-components/css/all.scss";
+@import "../../node_modules/sassdash/index";
+@import "../../node_modules/yoastseo/css/icons";
 
 $breakpoint_mobile: '768px';
+$yoast-alerts-button-icon-width: 20px;
+$yoast-alerts-button-width: 52px;
+$yoast-alerts-active-margin: 20px;
 
 .yoast-alert {
 	padding: 0 12px;
 	border-left: 4px solid #fff;
 	background: #fff;
-	box-shadow: 0 1px 2px rgba( 0,0,0,.2 );
-}
-
-.yoast-alerts .yoast-alert-holder {
-	margin-bottom: 0.8em;
-}
-
-.yoast-alerts .yoast-alert {
-	width: 100%;
-}
-
-.yoast-container__alert .yoast-alert {
-	border-left-color: #dc3232;
-}
-
-#yoast-alerts-dismissed .yoast-alert {
-	border-left-color: #d93f69;
-}
-
-.yoast-container__warning .yoast-alert {
-	border-left-color: #5d237a;
-}
-
-#yoast-warnings-dismissed .yoast-alert {
-	border-left-color: #0075b3;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, .2);
 }
 
 .yoast-container {
@@ -41,7 +22,7 @@ $breakpoint_mobile: '768px';
 	padding: 20px 20px 0;
 	border: 1px solid #e5e5e5;
 	background-color: #fdfdfd;
-	box-shadow: 0 1px 1px rgba(0, 0, 0,.04);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
 }
 
 .yoast-alerts > h2:first-child {
@@ -60,10 +41,6 @@ $breakpoint_mobile: '768px';
 	font-size: 1.4em;
 }
 
-h3 .dashicons-warning {
-	color: #dc3232;
-}
-
 .yoast-container .container {
 	max-width: 980px;
 }
@@ -72,13 +49,14 @@ h3 .dashicons-warning {
 	display: -ms-flexbox;
 	display: -webkit-flex;
 	display: flex;
+	position: relative;
 }
 
 .restore .dashicons,
 .dismiss .dashicons {
-	font-size: 24px;
-	width: 24px;
-	height: 24px;
+	font-size: $yoast-alerts-button-icon-width;
+	width: $yoast-alerts-button-icon-width;
+	height: $yoast-alerts-button-icon-width;
 }
 
 .yoast-bottom-spacing {
@@ -88,17 +66,18 @@ h3 .dashicons-warning {
 /* These selectors need a higher specificity than .wp-core-ui .button */
 .yoast-alerts .button.restore,
 .yoast-alerts .button.dismiss {
-	flex: 0 0 45px;
-	width: 45px;
-	height: 45px;
-	margin-left: 10px;
+	position: absolute;
+	right: 0;
+	width: $yoast-alerts-button-width;
+	height: 100%;
 	line-height: inherit;
-
 	padding: 0;
 	outline: none;
 	cursor: pointer;
-
-
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	border-radius: 0;
 }
 
 .yoast-alerts .button.restore:hover,
@@ -115,11 +94,7 @@ h3 .dashicons-warning {
 }
 
 .yoast-container .dashicons-yes {
-	color: #77b227;
-}
-
-.yoast-container__warning .dashicons-flag {
-	color: #5d237a;
+	color: $color_green;
 }
 
 .yoast-container-disabled {
@@ -130,7 +105,7 @@ h3 .dashicons-warning {
 	bottom: 0;
 	left: 0;
 	border-radius: 4px;
-	background-color: rgba(232,232,232,0.7);
+	background-color: rgba(232, 232, 232, 0.7);
 }
 
 .yoast-no-issues {
@@ -155,15 +130,94 @@ h3 .dashicons-warning {
 	}
 }
 
+/* Shared style for the problems and notifications. */
+.yoast-alerts-header {
+}
+
+.yoast-alerts-active, .yoast-alerts-dismissed {
+	.yoast-alert {
+		padding-right: $yoast-alerts-button-width;
+		flex: 1;
+	}
+}
+
+.yoast-alerts-active {
+	.yoast-alert-holder {
+		margin-bottom: $yoast-alerts-active-margin;
+	}
+}
+
+.yoast-alerts-dismissed {
+	&.paper.tab-block {
+		margin: $yoast-alerts-active-margin 0 $yoast-alerts-active-margin 0;
+
+		.paper-container.toggleable-container {
+			padding: 0;
+
+			.yoast-alert-holder:nth-child(odd) {
+				background-color: $color_background_light;
+
+				.yoast-alert {
+					background-color: transparent;
+				}
+			}
+		}
+
+	}
+
+	.yoast-svg-icon-eye {
+		background: transparent url(svg-icon-eye($color_button_text)) no-repeat 0 0;
+		background-size: $yoast-alerts-button-icon-width;
+	}
+}
+
+/* Style only for errors / problems. */
+#yoast-errors-header {
+	.dashicons {
+		color: $color_red;
+	}
+}
+
+#yoast-errors-active {
+	.yoast-alert {
+		border-left-color: $color_red;
+	}
+}
+
+#yoast-errors-dismissed {
+	.yoast-alert {
+		border-left-color: #d93f69;
+	}
+}
+
+/* Style only for warnings / notifications. */
+#yoast-warnings-header {
+	.dashicons {
+		color: $color_purple;
+	}
+}
+
+#yoast-warnings-active {
+	.yoast-alert {
+		border-left-color: $color_purple;
+	}
+}
+
+#yoast-warnings-dismissed {
+	.yoast-alert {
+		border-left-color: #0075b3;
+	}
+}
+
 .yoast-alerts {
 
 	.yoast-container {
 		&__configuration-wizard {
 			display: flex;
 			align-items: center;
-			box-shadow:       0 1px 2px rgba(0, 0, 0, 0.2);
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 			background-color: $color_white;
-			min-height:       0;
+			min-height: 0;
 			padding-bottom: 20px;
 			margin-bottom: 15px;
 
@@ -195,7 +249,7 @@ h3 .dashicons-warning {
 					}
 				}
 
-				@media screen and ( max-width: $breakpoint_mobile ) {
+				@media screen and (max-width: $breakpoint_mobile) {
 					display: block;
 					position: relative;
 					padding: 16px;
@@ -205,7 +259,7 @@ h3 .dashicons-warning {
 			&--dismiss {
 				text-align: center;
 
-				@media screen and ( max-width: $breakpoint_mobile ) {
+				@media screen and (max-width: $breakpoint_mobile) {
 					width: 40px;
 					position: absolute;
 					top: 5px;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds collapsible around the hidden problems and notifications on the Yoast dashboard.

## Relevant technical choices:

* Fixed a confusing naming convention where the error alerts were called alerts in code, which is also used as the global name of them.
* Adds the `collapsible_header_class` option to the WPSEO_Paper_Presenter. Using this to add the `yoast-alert` class to the header (giving the colored border amongst other things).
* Adds the `paper_id_prefix` option to the paper collapsible view. This is to prevent the hardcoded default of `wpseo` in this case.
* Adds the `dismissed_total` variable to the partial alerts files. Which is used for the issue title translation.
* Moved CSS rules that where specific to the dashboard to clearer classes or ids. There is one class without style, I left it there.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the Yoast dashboard and check the problems and notifications.
  * Do they look like the design?
  * Do they work in different browsers?
  * Are they responsive?
* In order to check if this PR did not mess up the style of the existing alerts. Compare some of them with how they looked before, like these:
  * The remove post redirect notification.

## Screenshot
<img width="790" alt="hidden-alerts" src="https://user-images.githubusercontent.com/35524806/63751398-90761300-c8af-11e9-926c-b1c3425ef182.png">


## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12774 
