### PR TITLE
Add wp_version and php_version to the feed request

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -134,8 +134,8 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 			'ryte_analyze'     => __( 'Analyze entire site', 'wordpress-seo' ),
 			'ryte_fetch_url'   => esc_attr( add_query_arg( 'wpseo-redo-onpage', '1' ) ) . '#wpseo-dashboard-overview',
 			'ryte_landing_url' => WPSEO_Shortlinker::get( 'https://yoa.st/rytelp' ),
-			'wp_version'       => substr ( $GLOBALS['wp_version'], 0, 3 ) . '-' . ( is_plugin_active('classic-editor/classic-editor.php') ? '1' : '0' ),
-			'php_version'      => substr ( PHP_VERSION, 0, 3 ),
+			'wp_version'       => substr( $GLOBALS['wp_version'], 0, 3 ) . '-' . ( is_plugin_active( 'classic-editor/classic-editor.php' ) ? '1' : '0' ),
+			'php_version'      => substr( PHP_VERSION, 0, 3 ),
 		);
 	}
 

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -134,9 +134,8 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 			'ryte_analyze'     => __( 'Analyze entire site', 'wordpress-seo' ),
 			'ryte_fetch_url'   => esc_attr( add_query_arg( 'wpseo-redo-onpage', '1' ) ) . '#wpseo-dashboard-overview',
 			'ryte_landing_url' => WPSEO_Shortlinker::get( 'https://yoa.st/rytelp' ),
-			'wp_version'       => substr ( $GLOBALS['wp_version'], 0, 3 ),
+			'wp_version'       => substr ( $GLOBALS['wp_version'], 0, 3 ) . '-' . ( is_plugin_active('classic-editor/classic-editor.php') ? '1' : '0' ),
 			'php_version'      => substr ( PHP_VERSION, 0, 3 ),
-			'classic'          => is_plugin_active('classic-editor/classic-editor.php') ? 1 : 0,
 		);
 	}
 

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -135,7 +135,7 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 			'ryte_fetch_url'   => esc_attr( add_query_arg( 'wpseo-redo-onpage', '1' ) ) . '#wpseo-dashboard-overview',
 			'ryte_landing_url' => WPSEO_Shortlinker::get( 'https://yoa.st/rytelp' ),
 			'wp_version'       => substr( $GLOBALS['wp_version'], 0, 3 ) . '-' . ( is_plugin_active( 'classic-editor/classic-editor.php' ) ? '1' : '0' ),
-			'php_version'      => substr( PHP_VERSION, 0, 3 ),
+			'php_version'      => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
 		);
 	}
 

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -134,6 +134,9 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 			'ryte_analyze'     => __( 'Analyze entire site', 'wordpress-seo' ),
 			'ryte_fetch_url'   => esc_attr( add_query_arg( 'wpseo-redo-onpage', '1' ) ) . '#wpseo-dashboard-overview',
 			'ryte_landing_url' => WPSEO_Shortlinker::get( 'https://yoa.st/rytelp' ),
+			'wp_version'       => substr ( $GLOBALS['wp_version'], 0, 3 ),
+			'php_version'      => substr ( PHP_VERSION, 0, 3 ),
+			'classic'          => is_plugin_active('classic-editor/classic-editor.php') ? 1 : 0,
 		);
 	}
 

--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -99,8 +99,7 @@ class DashboardWidget extends React.Component {
 		// Developer note: this link should -not- be converted to a shortlink.
 		getPostFeed(
 			"https://yoast.com/feed/widget/?wp_version=" + wpseoDashboardWidgetL10n.wp_version +
-			"&php_version=" + wpseoDashboardWidgetL10n.php_version +
-			"&classic=" + wpseoDashboardWidgetL10n.classic,
+			"&php_version=" + wpseoDashboardWidgetL10n.php_version,
 			2
 		)
 			.then( ( feed ) => {

--- a/js/src/wp-seo-dashboard-widget.js
+++ b/js/src/wp-seo-dashboard-widget.js
@@ -97,7 +97,12 @@ class DashboardWidget extends React.Component {
 	 */
 	getFeed() {
 		// Developer note: this link should -not- be converted to a shortlink.
-		getPostFeed( "https://yoast.com/feed/widget/", 2 )
+		getPostFeed(
+			"https://yoast.com/feed/widget/?wp_version=" + wpseoDashboardWidgetL10n.wp_version +
+			"&php_version=" + wpseoDashboardWidgetL10n.php_version +
+			"&classic=" + wpseoDashboardWidgetL10n.classic,
+			2
+		)
 			.then( ( feed ) => {
 				feed.items = feed.items.map( ( item ) => {
 					item.description = jQuery( `<div>${ item.description }</div>` ).text();


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows showing specific dashboard feeds based on the wp_version and php_version of a site.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to WordPress dashboard
* Open network tab in inspector.
* See that the url contains the following structure:
yoast.com/feed/widget/?wp_version=`$wp_version`-`$with_classic_editor_active`&php_version=`$php_version`
* Test with classic editor and without.
* If possible, test with two different WordPress versions.
* If possible, test with two different PHP versions.

<img width="1641" alt="Dashboard_‹_one_wordpress_test_—_WordPress_and_Update_inschrijving_in_de_DBL_–_TBG_Dragons" src="https://user-images.githubusercontent.com/1488816/63772393-499d1300-c8d9-11e9-9fc9-ed756e29a600.png">

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities