### PR TITLE
Remove AMP glue suggestion notification

### DIFF
--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -111,24 +111,6 @@ class WPSEO_Plugin_Availability {
 				),
 				'version_sync'  => false,
 			),
-
-			'yoastseo-amp' => array(
-				'url'           => 'https://wordpress.org/plugins/glue-for-yoast-seo-amp/',
-				'title'         => 'Yoast SEO AMP Glue',
-				'description'   => sprintf(
-					/* translators: %1$s expands to Yoast SEO */
-					__( 'Seamlessly integrate %1$s into your AMP pages!', 'wordpress-seo' ),
-					'Yoast SEO'
-				),
-				'installed'     => false,
-				'slug'          => 'glue-for-yoast-seo-amp/yoastseo-amp.php',
-				'_dependencies' => array(
-					'AMP' => array(
-						'slug' => 'amp/amp.php',
-					),
-				),
-				'version_sync'  => false,
-			),
 		);
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -132,6 +132,11 @@ class WPSEO_Upgrade {
 			$this->upgrade_111();
 		}
 
+		if ( version_compare( $version, '12.1-RC0', '<' ) ) {
+			/** Reset notifications because we removed the AMP Glue plugin notification */
+			$this->clean_all_notifications();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();


### PR DESCRIPTION
**NOTE:** If this is not merged before the 12.1 RC's are created, make sure to update the upgrade routine or rebase this on the release branch.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the AMP Glue plugin suggestion from the SEO dashboard when AMP and Yoast SEO are installed. The AMP Glue plugin by Yoast is being discontinued.

## Relevant technical choices:

* Reset notifications on upgrade to 12.1 or higher.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install `AMP` and `Yoast SEO` plugin.
* Go to SEO dashboard.
* Make the AMP glue plugin is not being suggested.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13415 
