### PR TITLE
Limit targets for force rewrite titles option to title tags in head tag

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1574,11 +1574,17 @@ class WPSEO_Frontend {
 			$debug_mark = $this->get_debug_mark();
 
 			/*
-			 * Find all titles, strip them out and add the new one in within the debug marker,
+			 * Find title in head, strip it out and add the new one in within the debug marker,
 			 * so it's easily identified whether a site uses force rewrite.
 			 */
-			$content = preg_replace( '/<title.*?\/title>/i', '', $content );
-			$content = str_replace( $debug_mark, $debug_mark . "\n" . '<title>' . esc_html( $title ) . '</title>', $content );
+			preg_match_all( '/<head.*?\/head>/is', $content, $matches );
+			if ( count( $matches ) && count( $matches[0] ) ) {
+				foreach( $matches[0] as $head ) {
+					$head_without_title = preg_replace( '/<title.*?\/title>/is', '', $head );
+					$content = str_replace( $head, $head_without_title, $content );
+				}
+				$content = str_replace( $debug_mark, $debug_mark . "\n" . '<title>' . esc_html( $title ) . '</title>', $content );
+			}
 		}
 
 		$GLOBALS['wp_query'] = $old_wp_query;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1579,7 +1579,7 @@ class WPSEO_Frontend {
 			 */
 			preg_match_all( '/<head.*?\/head>/is', $content, $matches );
 			if ( count( $matches ) && count( $matches[0] ) ) {
-				foreach( $matches[0] as $head ) {
+				foreach ( $matches[0] as $head ) {
 					$head_without_title = preg_replace( '/<title.*?\/title>/is', '', $head );
 					$content = str_replace( $head, $head_without_title, $content );
 				}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* Fixes a bug where the "force rewrite titles" option would removes title tag in svg tags.

## Test instructions
This PR can be tested by following these steps:
1. Write a svg tag including a title tag in some theme template.
```html
<svg>
  <title>SVG title should not be removed</title>
</svg>
```
2. Access the page that uses the above template.
3. Open developer tool of your browser, and check the followings
  * Before: The title tag in the svg tag is removed.
  * After: The title tag in the svg tag remains.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #6770