### PR TITLE
Add alert when organization info is missing

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -144,7 +144,7 @@ class WPSEO_Admin_Pages {
 			'showLocalSEOUpsell'       => $this->should_show_local_seo_upsell(),
 			'localSEOUpsellURL'        => WPSEO_Shortlinker::get( 'https://yoa.st/3mp' ),
 		);
-		$search_appearance_l10n['knowledgeGraphCompanyInfoMissing'] = WPSEO_Utils::get_knowledge_graph_company_info_missing_l10n();
+		$search_appearance_l10n['knowledgeGraphCompanyInfoMissing'] = WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n();
 
 		return $search_appearance_l10n;
 	}

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -137,13 +137,16 @@ class WPSEO_Admin_Pages {
 	 * @return array The search appearance variables.
 	 */
 	public function localize_search_appearance_script() {
-		return array(
+		$search_appearance_l10n                    = array(
 			'isRtl'                    => is_rtl(),
 			'userEditUrl'              => add_query_arg( 'user_id', '{user_id}', admin_url( 'user-edit.php' ) ),
 			'brushstrokeBackgroundURL' => plugins_url( 'images/brushstroke_background.svg', WPSEO_FILE ),
 			'showLocalSEOUpsell'       => $this->should_show_local_seo_upsell(),
 			'localSEOUpsellURL'        => WPSEO_Shortlinker::get( 'https://yoa.st/3mp' ),
 		);
+		$search_appearance_l10n['knowledgeGraphCompanyInfoMissing'] = WPSEO_Utils::get_knowledge_graph_company_info_missing_l10n();
+
+		return $search_appearance_l10n;
 	}
 
 	/**

--- a/admin/config-ui/class-configuration-storage.php
+++ b/admin/config-ui/class-configuration-storage.php
@@ -49,6 +49,7 @@ class WPSEO_Configuration_Storage {
 			new WPSEO_Config_Field_Profile_URL_YouTube(),
 			new WPSEO_Config_Field_Profile_URL_Wikipedia(),
 			new WPSEO_Config_Field_Company_Or_Person(),
+			new WPSEO_Config_Field_Company_Info_Missing(),
 			new WPSEO_Config_Field_Company_Name(),
 			new WPSEO_Config_Field_Company_Logo(),
 			new WPSEO_Config_Field_Person(),

--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -31,6 +31,7 @@ class WPSEO_Configuration_Structure {
 		'publishingEntity'           => array(
 			'publishingEntity',
 			'publishingEntityType',
+			'publishingEntityCompanyInfo',
 			'publishingEntityCompanyName',
 			'publishingEntityCompanyLogo',
 			'publishingEntityPersonId',

--- a/admin/config-ui/fields/class-field-company-info-missing.php
+++ b/admin/config-ui/fields/class-field-company-info-missing.php
@@ -12,11 +12,13 @@ class WPSEO_Config_Field_Company_Info_Missing extends WPSEO_Config_Field {
 
 	/**
 	 * WPSEO_Config_Field_Company_Info_Missing constructor.
+	 *
+	 * @codeCoverageIgnore This is only using WPSEO_Config_Field and WPSEO_Utils functionality.
 	 */
 	public function __construct() {
 		parent::__construct( 'publishingEntityCompanyInfo', 'CompanyInfoMissing' );
 
-		$l10n_data = WPSEO_Utils::get_knowledge_graph_company_info_missing_l10n();
+		$l10n_data = WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n();
 
 		$this->set_property( 'message', $l10n_data['message'] );
 		$this->set_property( 'link', $l10n_data['URL'] );

--- a/admin/config-ui/fields/class-field-company-info-missing.php
+++ b/admin/config-ui/fields/class-field-company-info-missing.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Configurator
+ */
+
+/**
+ * Class WPSEO_Config_Field_Company_Info_Missing.
+ */
+class WPSEO_Config_Field_Company_Info_Missing extends WPSEO_Config_Field {
+
+	/**
+	 * WPSEO_Config_Field_Company_Info_Missing constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'publishingEntityCompanyInfo', 'CompanyInfoMissing' );
+
+		$l10n_data = WPSEO_Utils::get_knowledge_graph_company_info_missing_l10n();
+
+		$this->set_property( 'message', $l10n_data['message'] );
+		$this->set_property( 'link', $l10n_data['URL'] );
+
+		$this->set_requires( 'publishingEntityType', 'company' );
+	}
+}

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -44,6 +44,17 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	$yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-seo' ), $yoast_free_kg_select_options, 'styled', false );
 	?>
 	<div id="knowledge-graph-company">
+		<?php
+		/*
+		* Render the `knowledge-graph-company-warning` div when the company name or logo are not set.
+		* This div is used as React render root in `js/src/search-appearance.js`.
+		*/
+		$is_company_info_missing = empty( $yform->options['company_name'] ) || empty( $yform->options['company_logo'] );
+		if ( $is_company_info_missing ) :
+		?>
+		<div id="knowledge-graph-company-warning"></div>
+		<?php endif; ?>
+
 		<h3><?php esc_html_e( 'Organization', 'wordpress-seo' ); ?></h3>
 		<?php
 		$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), array( 'autocomplete' => 'organization' ) );

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -45,6 +45,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	?>
 	<div id="knowledge-graph-company">
 		<?php
+
 		/*
 		* Render the `knowledge-graph-company-warning` div when the company name or logo are not set.
 		* This div is used as React render root in `js/src/search-appearance.js`.

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1081,6 +1081,22 @@ SVG;
 	}
 
 	/**
+	 * Returns the l10n array for the knowledge graph company info missing.
+	 *
+	 * @return array The l10n array.
+	 */
+	public static function get_knowledge_graph_company_info_missing_l10n() {
+		return array(
+			'URL'     => esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3r3' ) ),
+			/* translators: 1: expands to a link opening tag; 2: expands to a link closing tag */
+			'message' => esc_html__(
+				'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
+				'wordpress-seo'
+			),
+		);
+	}
+
+	/**
 	 * Retrieves the analysis worker log level. Defaults to errors only.
 	 *
 	 * Uses bool YOAST_SEO_DEBUG as flag to enable logging. Off equals ERROR.

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1081,22 +1081,6 @@ SVG;
 	}
 
 	/**
-	 * Returns the l10n array for the knowledge graph company info missing.
-	 *
-	 * @return array The l10n array.
-	 */
-	public static function get_knowledge_graph_company_info_missing_l10n() {
-		return array(
-			'URL'     => esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3r3' ) ),
-			/* translators: 1: expands to a link opening tag; 2: expands to a link closing tag */
-			'message' => esc_html__(
-				'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
-				'wordpress-seo'
-			),
-		);
-	}
-
-	/**
 	 * Retrieves the analysis worker log level. Defaults to errors only.
 	 *
 	 * Uses bool YOAST_SEO_DEBUG as flag to enable logging. Off equals ERROR.

--- a/inc/language-utils.php
+++ b/inc/language-utils.php
@@ -17,7 +17,7 @@ class WPSEO_Language_Utils {
 	 *
 	 * @param string $locale The locale to get the language of.
 	 *
-	 * @returns string The language part of the locale.
+	 * @return string The language part of the locale.
 	 */
 	public static function get_language( $locale = null ) {
 		$language = 'en';
@@ -44,7 +44,7 @@ class WPSEO_Language_Utils {
 	 * Can be removed when support for WordPress 4.6 will be dropped, in favor
 	 * of WordPress get_user_locale() that already fallbacks to the site's locale.
 	 *
-	 * @returns string The locale.
+	 * @return string The locale.
 	 */
 	public static function get_user_locale() {
 		if ( function_exists( 'get_user_locale' ) ) {
@@ -67,5 +67,21 @@ class WPSEO_Language_Utils {
 		$language     = isset( $translations[ $locale ] ) ? $translations[ $locale ]['native_name'] : 'English (US)';
 
 		return $language;
+	}
+
+	/**
+	 * Returns the l10n array for the knowledge graph company info missing.
+	 *
+	 * @return array The l10n array.
+	 */
+	public static function get_knowledge_graph_company_info_missing_l10n() {
+		return array(
+			'URL'     => esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3r3' ) ),
+			/* translators: 1: expands to a link opening tag; 2: expands to a link closing tag */
+			'message' => esc_html__(
+				'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
+				'wordpress-seo'
+			),
+		);
 	}
 }

--- a/js/src/components/CompanyInfoMissing.js
+++ b/js/src/components/CompanyInfoMissing.js
@@ -1,0 +1,43 @@
+/* External dependencies */
+import { sprintf } from "@wordpress/i18n";
+import interpolateComponents from "interpolate-components";
+import PropTypes from "prop-types";
+import React from "react";
+
+/* Yoast dependencies */
+import { Alert } from "@yoast/components";
+import { makeOutboundLink } from "@yoast/helpers";
+
+const OutboundLink = makeOutboundLink();
+
+/**
+ * Shows an alert with a message and a link.
+ *
+ * @constructor
+ *
+ * @param {Object} props The properties to use.
+ *
+ * @returns {React.Component} The Alert component.
+ */
+const CompanyInfoMissing = ( props ) => {
+	return <Alert type={ props.type }>
+		{ [
+			interpolateComponents( {
+				mixedString: sprintf( props.message, "{{link}}", "{{/link}}" ),
+				components: { link: <OutboundLink href={ props.link } /> },
+			} ),
+		] }
+	</Alert>;
+};
+
+CompanyInfoMissing.propTypes = {
+	type: PropTypes.oneOf( [ "error", "info", "success", "warning" ] ),
+	message: PropTypes.string.isRequired,
+	link: PropTypes.string.isRequired,
+};
+
+CompanyInfoMissing.defaultProps = {
+	type: "warning",
+};
+
+export default CompanyInfoMissing;

--- a/js/src/components/CompanyInfoMissingOnboardingWizard.js
+++ b/js/src/components/CompanyInfoMissingOnboardingWizard.js
@@ -1,0 +1,40 @@
+/* External dependencies */
+import { isEmpty } from "lodash";
+import PropTypes from "prop-types";
+import React from "react";
+
+/* Yoast dependencies */
+import CompanyInfoMissing from "./CompanyInfoMissing";
+
+/**
+ * Shows an alert when the company name or logo are empty.
+ *
+ * @constructor
+ *
+ * @param {Object} props The properties to use.
+ *
+ * @returns {React.Component} The Alert component.
+ */
+const CompanyInfoMissingOnboardingWizard = ( { properties, stepState } ) => {
+	const isCompanyInfoMissing = isEmpty( stepState.fieldValues[ "publishing-entity" ].publishingEntityCompanyName ) ||
+		isEmpty( stepState.fieldValues[ "publishing-entity" ].publishingEntityCompanyLogo );
+
+	return isCompanyInfoMissing && <CompanyInfoMissing { ...properties } />;
+};
+
+CompanyInfoMissingOnboardingWizard.propTypes = {
+	properties: PropTypes.shape( {
+		message: PropTypes.string.isRequired,
+		link: PropTypes.string.isRequired,
+	} ).isRequired,
+	stepState: PropTypes.shape( {
+		fieldValues: PropTypes.shape( {
+			"publishing-entity": PropTypes.shape( {
+				publishingEntityCompanyName: PropTypes.string.isRequired,
+				publishingEntityCompanyLogo: PropTypes.string.isRequired,
+			} ),
+		} ).isRequired,
+	} ).isRequired,
+};
+
+export default CompanyInfoMissingOnboardingWizard;

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -14,6 +14,7 @@ import MediaUpload from "./components/MediaUpload";
 import Suggestions from "./components/Suggestions";
 import FinalStep from "./components/FinalStep";
 import WordPressUserSelectorOnboardingWizard from "./components/WordPressUserSelectorOnboardingWizard";
+import CompanyInfoMissingOnboardingWizard from "./components/CompanyInfoMissingOnboardingWizard";
 import YoastIcon from "../../images/Yoast_SEO_Icon.svg";
 import { setYoastComponentsL10n } from "./helpers/i18n";
 
@@ -75,6 +76,7 @@ class App extends React.Component {
 				Suggestions,
 				FinalStep,
 				WordPressUserSelector: WordPressUserSelectorOnboardingWizard,
+				CompanyInfoMissing: CompanyInfoMissingOnboardingWizard,
 			},
 		} );
 

--- a/js/src/search-appearance.js
+++ b/js/src/search-appearance.js
@@ -6,7 +6,7 @@ import forEach from "lodash/forEach";
 import { Provider } from "react-redux";
 import { createStore, combineReducers } from "redux";
 
-/* Internal dependencies */
+/* Yoast dependencies */
 import SettingsReplacementVariableEditors from "./components/SettingsReplacementVariableEditors";
 import snippetEditorReducer from "./redux/reducers/snippetEditor";
 import configureEnhancers from "./redux/utils/configureEnhancers";
@@ -15,6 +15,7 @@ import { updateReplacementVariable } from "./redux/actions/snippetEditor";
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 import { ThemeProvider } from "styled-components";
 import WordPressUserSelectorSearchAppearance from "./components/WordPressUserSelectorSearchAppearance";
+import CompanyInfoMissing from "./components/CompanyInfoMissing";
 import LocalSEOUpsell from "./components/LocalSEOUpsell";
 
 setYoastComponentsL10n();
@@ -54,6 +55,7 @@ const editorElements = document.querySelectorAll( "[data-react-replacevar-editor
 const singleFieldElements = document.querySelectorAll( "[data-react-replacevar-field]" );
 const wpUserSelector = document.getElementById( "wpseo-person-selector" );
 const localSEOElement = document.getElementById( "wpseo-local-seo-upsell" );
+const companyInfoMissingElement = document.getElementById( "knowledge-graph-company-warning" );
 
 const element = document.createElement( "div" );
 document.body.appendChild( element );
@@ -68,6 +70,7 @@ const {
 	showLocalSEOUpsell,
 	localSEOUpsellURL,
 	brushstrokeBackgroundURL,
+	knowledgeGraphCompanyInfoMissing,
 } = wpseoSearchAppearance;
 
 render(
@@ -79,6 +82,13 @@ render(
 					editorElements={ editorElements }
 				/>
 				{ createPortal( <WordPressUserSelectorSearchAppearance />, wpUserSelector ) }
+				{ companyInfoMissingElement && createPortal(
+					<CompanyInfoMissing
+						message={ knowledgeGraphCompanyInfoMissing.message }
+						link={ knowledgeGraphCompanyInfoMissing.URL }
+					/>,
+					companyInfoMissingElement
+				) }
 				{ showLocalSEOUpsell && createPortal(
 					<LocalSEOUpsell
 						url={ localSEOUpsellURL }

--- a/js/tests/components/CompanyInfoMissing.test.js
+++ b/js/tests/components/CompanyInfoMissing.test.js
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import CompanyInfoMissing from "../../src/components/CompanyInfoMissing";
+
+describe( "CompanyInfoMissing", () => {
+	it( "matches the snapshot", () => {
+		const component = renderer.create(
+			<CompanyInfoMissing message="Testing." link="https://example.com/" />,
+		);
+
+		const tree = component.toJSON();
+
+		expect( tree.props.className.startsWith( "Alert" ) ).toBe( true );
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/js/tests/components/CompanyInfoMissingOnboardingWizard.test.js
+++ b/js/tests/components/CompanyInfoMissingOnboardingWizard.test.js
@@ -1,0 +1,25 @@
+import { mount } from "enzyme";
+import CompanyInfoMissingOnboardingWizard from "../../src/components/CompanyInfoMissingOnboardingWizard";
+
+describe( "CompanyInfoMissingOnboardingWizard", () => {
+	it( "matches the snapshot", () => {
+		const tree = mount(
+			<CompanyInfoMissingOnboardingWizard
+				properties={ {
+					message: "Testing.",
+					link: "https://example.com/",
+				} }
+				stepState={ {
+					fieldValues: {
+						"publishing-entity": {
+							publishingEntityCompanyName: "company",
+							publishingEntityCompanyLogo: "https://example.com/logo.png",
+						},
+					},
+				} }
+			/>,
+		);
+
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/js/tests/components/__snapshots__/CompanyInfoMissing.test.js.snap
+++ b/js/tests/components/__snapshots__/CompanyInfoMissing.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CompanyInfoMissing matches the snapshot 1`] = `
+<div
+  className="Alert__AlertContainer-sc-13lb81i-0 lfexDP"
+>
+  <svg
+    aria-hidden={true}
+    className="yoast-svg-icon yoast-svg-icon-alert-warning Alert__AlertIcon-sc-13lb81i-2 camkTq createSvgIconComponent__StyledSvg-sc-1h4gl3a-0 cPnaHk"
+    fill="#674e00"
+    focusable="false"
+    role="img"
+    size="16px"
+    viewBox="0 0 576 512"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+    />
+  </svg>
+  <div
+    className="Alert__AlertContent-sc-13lb81i-1 jJuGwm"
+  >
+    Testing.
+  </div>
+</div>
+`;

--- a/js/tests/components/__snapshots__/CompanyInfoMissingOnboardingWizard.test.js.snap
+++ b/js/tests/components/__snapshots__/CompanyInfoMissingOnboardingWizard.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CompanyInfoMissingOnboardingWizard matches the snapshot 1`] = `
+<CompanyInfoMissingOnboardingWizard
+  properties={
+    Object {
+      "link": "https://example.com/",
+      "message": "Testing.",
+    }
+  }
+  stepState={
+    Object {
+      "fieldValues": Object {
+        "publishing-entity": Object {
+          "publishingEntityCompanyLogo": "https://example.com/logo.png",
+          "publishingEntityCompanyName": "company",
+        },
+      },
+    }
+  }
+/>
+`;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,6 +43,7 @@ abstract class TestCase extends BaseTestCase {
 				'esc_html__'          => null,
 				'esc_html_x'          => null,
 				'esc_attr_x'          => null,
+				'esc_url'             => null,
 				'esc_url_raw'         => null,
 				'sanitize_text_field' => null,
 				'is_admin'            => false,

--- a/tests/inc/language-utils-test.php
+++ b/tests/inc/language-utils-test.php
@@ -1,17 +1,20 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package WPSEO\Tests\Inc
- */
+
+namespace Yoast\WP\Free\Tests\Inc;
+
+use Mockery;
+use WPSEO_Language_Utils;
+use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Unit Test Class.
+ *
+ * @group language-utils
  */
-class WPSEO_Language_Utils_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Language_Utils_Test extends TestCase {
 
 	/**
-	 * Test the get_language function with no argument.
+	 * Tests the get_language function with no argument.
 	 *
 	 * @covers WPSEO_Language_Utils::get_language
 	 */
@@ -22,7 +25,7 @@ class WPSEO_Language_Utils_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Test the get_language with the en_GB argument.
+	 * Tests the get_language with the en_GB argument.
 	 *
 	 * @covers WPSEO_Language_Utils::get_language
 	 */
@@ -32,6 +35,11 @@ class WPSEO_Language_Utils_Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'en', $language );
 	}
 
+	/**
+	 * Tests the get_language with other languages.
+	 *
+	 * @covers WPSEO_Language_Utils::get_language
+	 */
 	public function test_get_language() {
 		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( '' ) );
 		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( 'a' ) );
@@ -43,5 +51,23 @@ class WPSEO_Language_Utils_Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( 'xxxx' ) );
 		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( 'xxxx_XX' ) );
 		$this->assertEquals( 'en', WPSEO_Language_Utils::get_language( '_XX' ) );
+	}
+
+	/**
+	 * Tests the l10n object for the knowledge graph missing company info.
+	 *
+	 * @covers WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n
+	 */
+	public function test_get_knowledge_graph_company_info_missing_l10n() {
+		$shortlinker = Mockery::mock( 'alias:WPSEO_Shortlinker' )->makePartial();
+		$shortlinker->expects( 'get' )
+			->once()
+			->with( 'https://yoa.st/3r3' )
+			->andReturn( 'https://yoast.com' );
+
+		$this->assertEquals( [
+			'URL'     => 'https://yoast.com',
+			'message' => 'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
+		], WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n() );
 	}
 }

--- a/tests/inc/language-utils-test.php
+++ b/tests/inc/language-utils-test.php
@@ -2,8 +2,10 @@
 
 namespace Yoast\WP\Free\Tests\Inc;
 
+use Brain\Monkey;
 use Mockery;
 use WPSEO_Language_Utils;
+use Yoast\WP\Free\Tests\Doubles\Shortlinker;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
@@ -59,10 +61,11 @@ class WPSEO_Language_Utils_Test extends TestCase {
 	 * @covers WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n
 	 */
 	public function test_get_knowledge_graph_company_info_missing_l10n() {
-		$shortlinker = Mockery::mock( 'alias:WPSEO_Shortlinker' )->makePartial();
-		$shortlinker->expects( 'get' )
-			->once()
-			->with( 'https://yoa.st/3r3' )
+		$shortlinker = new Shortlinker();
+
+		Monkey\Functions\expect( 'add_query_arg' )
+			->times( 1 )
+			->with( $shortlinker->get_additional_shortlink_data(), Mockery::pattern( '/https:\/\/yoa.st\/*/' ) )
 			->andReturn( 'https://yoast.com' );
 
 		$this->assertEquals( [

--- a/tests/inc/options/option-social-test.php
+++ b/tests/inc/options/option-social-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\Free\Tests\Admin\Metabox;
+namespace Yoast\WP\Free\Tests\Inc\Options;
 
 use Brain\Monkey;
 use WPSEO_Option_Social;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an alert when organization information is missing.

## Relevant technical choices:

* Adds a component for the configuration wizard in order to detect on the fly changes to the company fields.
* On the search appearance in JS: use the existence of the div as toggle whether to show the alert. As all the data is readily available in the view.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the search appearance settings, general tab.
* Set the knowledge graph to represent an organization.
* The following situations need to be tested (save in between):
  1. _No alert_ when the name and logo are set.
  1. _Alert_ when the name is not set and the logo is set.
  1. _Alert_ when the name is set and the logo is not set.
  1. _Alert_ when the name and logo are not set.
* Open the configuration wizard and go to step 3.
* Test the same situations again. Here the alert should be shown/hidden on the fly when changing the name and logo.
* The text and link should be as specified in the issue:
  * Copy should be: `A company name and logo need to be set for structured data to work properly.`
  * Copy of the link should be: `Learn more about the importance of structured data.`
  * Link should be the shortlink: `https://yoa.st/3r3`. Which goes to the page: `https://yoast.com/what-is-structured-data/`

## Screenshots
<img width="615" alt="search-appearance" src="https://user-images.githubusercontent.com/35524806/64234173-0acd1580-cef6-11e9-8fa5-d3f3fc5f683c.png">
<img width="606" alt="configuration-wizard" src="https://user-images.githubusercontent.com/35524806/64234176-0d2f6f80-cef6-11e9-80bd-76d959830141.png">

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Requires https://github.com/Yoast/javascript/pull/349
Fixes #13440 
