### PR TITLE
Add head metadata support for AMP Stories via amp_story_head action

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -90,6 +90,7 @@ class WPSEO_Frontend {
 
 		add_action( 'wp_head', array( $this, 'front_page_specific_init' ), 0 );
 		add_action( 'wp_head', array( $this, 'head' ), 1 );
+		add_action( 'amp_story_head', array( $this, 'head' ), 1 );
 
 		// The head function here calls action wpseo_head, to which we hook all our functionality.
 		add_action( 'wpseo_head', array( $this, 'debug_mark' ), 2 );
@@ -100,10 +101,13 @@ class WPSEO_Frontend {
 
 		// Remove actions that we will handle through our wpseo_head call, and probably change the output of.
 		remove_action( 'wp_head', 'rel_canonical' );
+		remove_action( 'amp_story_head', 'rel_canonical' );
 		remove_action( 'wp_head', 'index_rel_link' );
 		remove_action( 'wp_head', 'start_post_rel_link' );
 		remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head' );
+		remove_action( 'amp_story_head', 'adjacent_posts_rel_link_wp_head' );
 		remove_action( 'wp_head', 'noindex', 1 );
+		remove_action( 'amp_story_head', 'noindex', 1 );
 
 		// When using WP 4.4, just use the new hook.
 		add_filter( 'pre_get_document_title', array( $this, 'title' ), 15 );

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -73,6 +73,13 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		$data = $this->add_keywords( $data );
 		$data = $this->add_sections( $data );
 
+		// If using the amp plugin, use amp_get_schemaorg_metadata function to generate ld data and merge with article data.
+		if ( is_singular('amp_story') && function_exists( 'amp_get_schemaorg_metadata' ) ) {
+			$amp_metadata = amp_get_schemaorg_metadata();
+			unset( $amp_metadata['@context'] );
+			$data = wp_parse_args( $amp_metadata, $data );
+		}
+
 		return $data;
 	}
 
@@ -93,7 +100,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		 *
 		 * @api string[] $post_types The post types for which we output Article.
 		 */
-		$post_types = apply_filters( 'wpseo_schema_article_post_types', array( 'post' ) );
+		$post_types = apply_filters( 'wpseo_schema_article_post_types', array( 'post', 'amp_story' ) );
 
 		return in_array( $post_type, $post_types );
 	}

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -150,6 +150,9 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			case is_archive():
 				$type = 'CollectionPage';
 				break;
+			case is_singular( 'amp_story' ):
+				$type = 'BlogPosting';
+				break;
 			default:
 				$type = 'WebPage';
 		}

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -150,9 +150,6 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			case is_archive():
 				$type = 'CollectionPage';
 				break;
-			case is_singular( 'amp_story' ):
-				$type = 'BlogPosting';
-				break;
 			default:
 				$type = 'WebPage';
 		}


### PR DESCRIPTION
## Summary

In https://github.com/ampproject/amp-wp/pull/3039 a new `amp_story_head` action was added for plugins to output additional metadata in AMP Stories (https://github.com/ampproject/amp-wp/issues/2968). This hook is analogous to `wp_head` and `embed_head` in core. Support for AMP Stories was submitted for Jetpack's opengraph logic in https://github.com/Automattic/jetpack/pull/13416. This PR does the same for Yoast. (Additional core metadata is being added to Stories in https://github.com/ampproject/amp-wp/pull/3175.)

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add support for adding metadata to AMP Stories (the `amp_story` post type) from the [official AMP plugin](https://wordpress.org/plugins/amp/).

## Relevant technical choices:

* In the same way that `wp_head` is hooked/unhooked, the same is done for the `amp_story_head` action.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Generate a build of the AMP plugin from the `develop` branch.
2. Activate the Stories experience in the AMP settings screen.
3. Publish a story.
4. The `head` on the frontend story should have its output modified as follows with this change:

```diff
6a7,18
> 	<meta property="og:locale" content="en_US">
> 	<meta property="og:type" content="article">
> 	<meta property="og:title" content="Bison2 - WordPressDevs">
> 	<meta property="og:url" content="https://wordpressdev.lndo.site/stories/bison-2/">
> 	<meta property="og:site_name" content="WordPressDevs">
> 	<meta property="og:image" content="https://wordpressdev.lndo.site/content/uploads/2019/08/American_bison_k5680-1-4-1024x668.jpg">
> 	<meta property="og:image:secure_url" content="https://wordpressdev.lndo.site/content/uploads/2019/08/American_bison_k5680-1-4-1024x668.jpg">
> 	<meta property="og:image:width" content="1024">
> 	<meta property="og:image:height" content="668">
> 	<meta name="twitter:card" content="summary_large_image">
> 	<meta name="twitter:title" content="Bison2 - WordPressDevs">
> 	<meta name="twitter:image" content="https://wordpressdev.lndo.site/content/uploads/2019/08/American_bison_k5680-1-4.jpg">
86a99,140
> 	<!-- This site is optimized with the Yoast SEO plugin v12.0 - https://yoast.com/wordpress/plugins/seo/ -->
> 	<!-- Admin only notice: this page does not show a meta description because it does not have one, either write it for this page specifically or go into the [SEO - Search Appearance] menu and set up a template. -->
> 	<link rel="canonical" href="https://wordpressdev.lndo.site/stories/bison-2/">
> 	<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--main">{
> 		"@context": "https://schema.org",
> 		"@graph": [
> 			{
> 				"@type": "WebSite",
> 				"@id": "https://wordpressdev.lndo.site/#website",
> 				"url": "https://wordpressdev.lndo.site/",
> 				"name": "WordPressDevs",
> 				"potentialAction": {
> 					"@type": "SearchAction",
> 					"target": "https://wordpressdev.lndo.site/?s={search_term_string}",
> 					"query-input": "required name=search_term_string"
> 				}
> 			},
> 			{
> 				"@type": "ImageObject",
> 				"@id": "https://wordpressdev.lndo.site/stories/bison-2/#primaryimage",
> 				"url": "https://wordpressdev.lndo.site/content/uploads/2019/08/American_bison_k5680-1-4.jpg",
> 				"width": 2700,
> 				"height": 1761,
> 				"caption": "Bizon!!"
> 			},
> 			{
> 				"@type": "WebPage",
> 				"@id": "https://wordpressdev.lndo.site/stories/bison-2/#webpage",
> 				"url": "https://wordpressdev.lndo.site/stories/bison-2/",
> 				"inLanguage": "en-US",
> 				"name": "Bison2 - WordPressDevs",
> 				"isPartOf": {
> 					"@id": "https://wordpressdev.lndo.site/#website"
> 				},
> 				"primaryImageOfPage": {
> 					"@id": "https://wordpressdev.lndo.site/stories/bison-2/#primaryimage"
> 				},
> 				"datePublished": "2019-08-28T00:00:11+00:00",
> 				"dateModified": "2019-09-03T18:53:24+00:00"
> 			}
> 		]
> 	}</script><!-- / Yoast SEO plugin. -->
92,93d145
< 	<link rel="prev" title="Test" href="https://wordpressdev.lndo.site/stories/test-5/">
< 	<link rel="canonical" href="https://wordpressdev.lndo.site/stories/bison-2/">
100,122d151
< 	<script type="application/ld+json">{
< 		"@context": "http:\/\/schema.org",
< 		"publisher": {
< 			"@type": "Organization",
< 			"name": "WordPressDevs",
< 			"logo": "https:\/\/wordpressdev.lndo.site\/content\/uploads\/2019\/02\/cropped-Security-Photo-4.png"
< 		},
< 		"@type": "BlogPosting",
< 		"mainEntityOfPage": "https:\/\/wordpressdev.lndo.site\/stories\/bison-2\/",
< 		"headline": "Bison2",
< 		"datePublished": "2019-08-28T00:00:11+00:00",
< 		"dateModified": "2019-09-03T18:53:24+00:00",
< 		"author": {
< 			"@type": "Person",
< 			"name": "ˈwɛsˌtn̩ \\o\/ ˈɹuːˌɾɚ (Рутер)"
< 		},
< 		"image": [
< 			"https:\/\/wordpressdev.lndo.site\/content\/uploads\/2019\/08\/American_bison_k5680-1-4-696x928.jpg",
< 			"https:\/\/wordpressdev.lndo.site\/content\/uploads\/2019\/08\/American_bison_k5680-1-4-928x928.jpg",
< 			"https:\/\/wordpressdev.lndo.site\/content\/uploads\/2019\/08\/American_bison_k5680-1-4-928x696.jpg",
< 			"https:\/\/wordpressdev.lndo.site\/content\/uploads\/2019\/08\/American_bison_k5680-1-4.jpg"
< 		]
< 	}</script>
```

## Outstanding Issues

⚠️ The `image` metadata being generated by Yoast is not including the sizes that Google Search is looking for. See https://github.com/ampproject/amp-wp/pull/2930 for background on this. In particular, the `image` should be an array containing:

1. The portrait image size.
2. The square image size.
3. The landscape image size.
4. The normal featured image.

Google Search would then pick the right image aspect ratio based on the needs of the given context. This PR needs to be amended to also ensure that these image sizes are included.

⚠️ Additionally, Yoast does not seem to be including the publisher logo. Search needs there to be logo provided, even falling back to the WordPress logo. Again, refer to https://github.com/ampproject/amp-wp/pull/2930

👉 Please feel free to amend the PR with the required changes!

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended