### PR TITLE
Move the WPSEO_Replace_Vars::setup_statics_once call

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -1446,9 +1446,3 @@ class WPSEO_Replace_Vars {
 		return apply_filters( 'wpseo_terms', $output, $taxonomy );
 	}
 } /* End of class WPSEO_Replace_Vars */
-
-
-/**
- * Setup the class statics when the file is first loaded.
- */
-WPSEO_Replace_Vars::setup_statics_once();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -530,6 +530,8 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 	}
 
 	add_filter( 'phpcompat_whitelist', 'yoast_free_phpcompat_whitelist' );
+
+	add_action( 'init', 'WPSEO_Replace_Vars::setup_statics_once' );
 }
 
 // Activation and deactivation hook.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -531,7 +531,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 
 	add_filter( 'phpcompat_whitelist', 'yoast_free_phpcompat_whitelist' );
 
-	add_action( 'init', 'WPSEO_Replace_Vars::setup_statics_once' );
+	add_action( 'init', array( 'WPSEO_Replace_Vars', 'setup_statics_once' ) );
 }
 
 // Activation and deactivation hook.


### PR DESCRIPTION
Call it on WordPress's `init` to have it run after all the plugins and themes are loaded.
This is to make the extra replacement variables action working again.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where custom replacement variables would not be replaced in some implementations.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the code to the theme's function.php file (copied from the issue for convenience):
```
// define the custom replacement callback
function get_myname() {
    return 'My name is Moses';
}
// define the action for register yoast_variable replacments
function register_custom_yoast_variables() {
    wpseo_register_var_replacement( '%%myname%%', 'get_myname', 'advanced', 'some help text' );
}
// Add action
add_action('wpseo_register_extra_replacements', 'register_custom_yoast_variables');
```

* Check the following in free AND premium:
  * Edit a post (like Hello World) and add `%%myname%%` to the title and description. Update post.
  * View source code for the post front-end. See the variable output `My name is Moses`: title, description, og:title, og:description, twitter:title and twitter:description.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/570
