### PR TITLE
Add install and activation endpoints for addons.

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -376,12 +376,34 @@ class WPSEO_Addon_Manager {
 	 * @return bool|stdClass Object when request is successful. False if not.
 	 */
 	protected function request_current_sites() {
-		$api_request = new WPSEO_MyYoast_Api_Request( 'sites/current' );
+		$api_request = new WPSEO_MyYoast_Api_Request(
+			'sites/current',
+			array(
+				'headers' => $this->get_addon_headers()
+			)
+		);
+
 		if ( $api_request->fire() ) {
 			return $api_request->get_response();
 		}
 
 		return $this->get_site_information_default();
+	}
+
+	/**
+	 * Retrieves the addons as headers.
+	 *
+	 * @return array The addon headers
+	 */
+	protected function get_addon_headers() {
+		$addon_version_headers = $this->get_installed_addons_versions();
+
+		$headers = array();
+		foreach ( $addon_version_headers as $addon => $version ) {
+			$headers[ $addon . '-version' ] = $version;
+		}
+
+		return $headers;
 	}
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -281,12 +281,35 @@ class WPSEO_Addon_Manager {
 	}
 
 	/**
-	 * Retrieves the value of the static $addons property.
+	 * Finds the plugin file.
 	 *
-	 * @return array The addon mapping.
+	 * @param string $plugin_slug The plugin slug to search.
+	 *
+	 * @return boolean|string Plugin file when installed, False when plugin isn't installed.
+	 **/
+	public static function get_plugin_file( $plugin_slug ) {
+		$plugins            = get_plugins();
+		$plugin_files       = array_keys( $plugins );
+		$target_plugin_file = array_search( $plugin_slug, self::$addons, true );
+
+		foreach( $plugin_files as $plugin_file ) {
+			if ( false !== strpos( $plugin_file , $target_plugin_file ) ) {
+				return $plugin_file;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks is a plugin is installed.
+	 *
+	 * @param string $plugin_slug The plugin to check.
+	 *
+	 * @return bool True when plugin is installed.
 	 */
-	public static function get_addon_mapping() {
-		return self::$addons;
+	public static function is_installed( $plugin_slug ) {
+		return self::get_plugin_file( $plugin_slug ) !== false;
 	}
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -281,6 +281,15 @@ class WPSEO_Addon_Manager {
 	}
 
 	/**
+	 * Retrieves the value of the static $addons property.
+	 *
+	 * @return array The addon mapping.
+	 */
+	public static function get_addon_mapping() {
+		return self::$addons;
+	}
+
+	/**
 	 * Checks whether a plugin expiry date has been passed.
 	 *
 	 * @param stdClass $subscription Plugin subscription.

--- a/inc/class-my-yoast-api-request.php
+++ b/inc/class-my-yoast-api-request.php
@@ -200,14 +200,8 @@ class WPSEO_MyYoast_Api_Request {
 	 * @return array The enriched arguments.
 	 */
 	protected function enrich_request_arguments( array $request_arguments ) {
-		$request_arguments     = wp_parse_args( $request_arguments, array( 'headers' => array() ) );
-		$addon_version_headers = $this->get_installed_addon_versions();
-
-		foreach ( $addon_version_headers as $addon => $version ) {
-			$request_arguments['headers'][ $addon . '-version' ] = $version;
-		}
-
-		$request_body = $this->get_request_body();
+		$request_arguments = wp_parse_args( $request_arguments, array( 'headers' => array() ) );
+		$request_body      = $this->get_request_body();
 		if ( $request_body !== array() ) {
 			$request_arguments['body'] = $request_body;
 		}
@@ -332,19 +326,6 @@ class WPSEO_MyYoast_Api_Request {
 
 		// Remove the access token entirely.
 		$this->get_client()->remove_access_token( $user_id );
-	}
-
-	/**
-	 * Retrieves the installed addons as http headers.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @return array The installed addon versions.
-	 */
-	protected function get_installed_addon_versions() {
-		$addon_manager = new WPSEO_Addon_Manager();
-
-		return $addon_manager->get_installed_addons_versions();
 	}
 
 	/**

--- a/inc/class-my-yoast-plugin-installer-skin.php
+++ b/inc/class-my-yoast-plugin-installer-skin.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Inc
+ */
+
+/**
+ * Makes sure no output will be given during my yoast plugin install.
+ */
+class WPSEO_MyYoast_Plugin_Installer_Skin extends WP_Upgrader_Skin {
+
+	/**
+	 * Overrides the header method by doing nothing.
+	 */
+	public function header() {
+
+	}
+
+	/**
+	 * Overrides the footer method by doing nothing.
+	 */
+	public function footer() {
+
+	}
+
+	/**
+	 * Overrides the feedback method by doing nothing.
+	 *
+	 * @param string $string The value to give back as feedback.
+	 *
+	 */
+	public function feedback( $string ) {
+	}
+}

--- a/inc/class-my-yoast-plugin-installer-skin.php
+++ b/inc/class-my-yoast-plugin-installer-skin.php
@@ -28,8 +28,8 @@ class WPSEO_MyYoast_Plugin_Installer_Skin extends WP_Upgrader_Skin {
 	 * Overrides the feedback method by doing nothing.
 	 *
 	 * @param string $string The value to give back as feedback.
-	 *
 	 */
 	public function feedback( $string ) {
+
 	}
 }

--- a/inc/endpoints/class-myyoast-download-activate.php
+++ b/inc/endpoints/class-myyoast-download-activate.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Represents an implementation of the WPSEO_Endpoint interface to register one or multiple endpoints.
+ * Represents the endpoint for activating a specific Yoast Plugin on WordPress.
  */
 class WPSEO_Endpoint_MyYoast_Download_Activate implements WPSEO_Endpoint {
 	/**

--- a/inc/endpoints/class-myyoast-download-activate.php
+++ b/inc/endpoints/class-myyoast-download-activate.php
@@ -54,7 +54,7 @@ class WPSEO_Endpoint_MyYoast_Download_Activate implements WPSEO_Endpoint {
 
 		try {
 			$plugin_slug = $request->get_param( 'slug' );
-			$plugin_file = $this->find_plugin_file( $plugin_slug );
+			$plugin_file = $this->get_plugin_file( $plugin_slug );
 
 			return new WP_REST_Response( $this->activate_plugin( $plugin_file ) );
 		}
@@ -94,24 +94,20 @@ class WPSEO_Endpoint_MyYoast_Download_Activate implements WPSEO_Endpoint {
 	 *
 	 * @throws WPSEO_REST_Request_Exception When no subscription isn't found for given plugin.
 	 */
-	protected function find_plugin_file( $plugin_slug ) {
-		$plugins       = get_plugins();
-		$plugin_files  = array_keys( $plugins );
-		$target_plugin_file = array_search( $plugin_slug, WPSEO_Addon_Manager::get_addon_mapping(), true );
+	protected function get_plugin_file( $plugin_slug ) {
+		$plugin_file = WPSEO_Addon_Manager::get_plugin_file( $plugin_slug );
 
-		foreach( $plugin_files as $plugin_file ) {
-			if ( false !== strpos( $plugin_file , $target_plugin_file ) ) {
-				return $plugin_file;
-			}
+		if ( ! $plugin_file ) {
+			throw new WPSEO_REST_Request_Exception(
+				sprintf(
+				/* translators: %1$s expands to the plugin slug  */
+					esc_html__( 'Plugin %s is not installed', 'wordpress-seo' ),
+					$plugin_slug
+				)
+			);
 		}
 
-		throw new WPSEO_REST_Request_Exception(
-			sprintf(
-				/* translators: %1$s expands to the plugin slug  */
-				esc_html__( 'Plugin %s is not installed', 'wordpress-seo' ),
-				$plugin_slug
-			)
-		);
+		return $plugin_file;
 	}
 
 	/**

--- a/inc/endpoints/class-myyoast-download-activate.php
+++ b/inc/endpoints/class-myyoast-download-activate.php
@@ -58,7 +58,7 @@ class WPSEO_Endpoint_MyYoast_Download_Activate implements WPSEO_Endpoint {
 
 			return new WP_REST_Response( $this->activate_plugin( $plugin_file ) );
 		}
-		catch( WPSEO_REST_Request_Exception $exception ) {
+		catch ( WPSEO_REST_Request_Exception $exception ) {
 			return new WP_REST_Response(
 				$exception->getMessage(),
 				403

--- a/inc/endpoints/class-myyoast-download-activate.php
+++ b/inc/endpoints/class-myyoast-download-activate.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Endpoint
+ */
+
+/**
+ * Represents an implementation of the WPSEO_Endpoint interface to register one or multiple endpoints.
+ */
+class WPSEO_Endpoint_MyYoast_Download_Activate implements WPSEO_Endpoint {
+	/**
+	 * The namespace to use.
+	 *
+	 * @var string
+	 */
+	const REST_NAMESPACE = 'yoast/v1/myyoast/download';
+
+	/**
+	 * Registers the routes for the endpoints.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'activate',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'handle_request' ),
+				'permission_callback' => array( $this, 'can_retrieve_data' ),
+			)
+		);
+	}
+
+	/**
+	 * Determines whether or not data can be retrieved for the registered endpoints.
+	 *
+	 * @return bool Whether or not data can be retrieved.
+	 */
+	public function can_retrieve_data() {
+		return current_user_can( 'activate_plugins' );
+	}
+
+	/**
+	 * Handles the request by extracting the download url.
+	 *
+	 * @param WP_REST_Request $request The request to handle.
+	 *
+	 * @return WP_REST_Response The handle request as response.
+	 */
+	public function handle_request( WP_REST_Request $request ) {
+		$this->require_dependencies();
+
+		try {
+			$plugin_slug = $request->get_param( 'slug' );
+			$plugin_file = $this->find_plugin_file( $plugin_slug );
+
+			return new WP_REST_Response( $this->activate_plugin( $plugin_file ) );
+		}
+		catch( WPSEO_REST_Request_Exception $exception ) {
+			return new WP_REST_Response(
+				$exception->getMessage(),
+				403
+			);
+		}
+	}
+
+	/**
+	 * Activates the plugin based on the given plugin file.
+	 *
+	 * @param string $plugin_file The plugin to activate.
+	 *
+	 * @return bool True when activation is successful.
+	 *
+	 * @throws WPSEO_REST_Request_Exception When error occurred during activation.
+	 */
+	protected function activate_plugin( $plugin_file ) {
+
+		$result = activate_plugin( $plugin_file );
+		if ( $result !== null && is_wp_error( $result ) ) {
+			throw new WPSEO_REST_Request_Exception( $result->get_error_message() );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Formats the response.
+	 *
+	 * @param string $plugin_slug The plugin slug to get download url for.
+	 *
+	 * @return array|string Array when a list is requested, string when a plugin is request.
+	 *
+	 * @throws WPSEO_REST_Request_Exception When no subscription isn't found for given plugin.
+	 */
+	protected function find_plugin_file( $plugin_slug ) {
+		$plugins       = get_plugins();
+		$plugin_files  = array_keys( $plugins );
+		$target_plugin_file = array_search( $plugin_slug, WPSEO_Addon_Manager::get_addon_mapping(), true );
+
+		foreach( $plugin_files as $plugin_file ) {
+			if ( false !== strpos( $plugin_file , $target_plugin_file ) ) {
+				return $plugin_file;
+			}
+		}
+
+		throw new WPSEO_REST_Request_Exception(
+			sprintf(
+				/* translators: %1$s expands to the plugin slug  */
+				esc_html__( 'Plugin %s is not installed', 'wordpress-seo' ),
+				$plugin_slug
+			)
+		);
+	}
+
+	/**
+	 * Requires the files needed from WordPress itself.
+	 *
+	 * @return void
+	 */
+	private function require_dependencies() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
+	}
+}

--- a/inc/endpoints/class-myyoast-download-install.php
+++ b/inc/endpoints/class-myyoast-download-install.php
@@ -56,7 +56,7 @@ class WPSEO_Endpoint_MyYoast_Download_Install implements WPSEO_Endpoint {
 			$plugin_slug     = $request->get_param( 'slug' );
 			$plugin_download = $this->find_plugin_download( $plugin_slug );
 
-			return new WP_REST_Response( $this->install_plugin( $plugin_download ) );
+			return new WP_REST_Response( $this->install_plugin( $plugin_download, $plugin_slug ) );
 		}
 		catch( WPSEO_REST_Request_Exception $exception ) {
 			return new WP_REST_Response(
@@ -70,12 +70,17 @@ class WPSEO_Endpoint_MyYoast_Download_Install implements WPSEO_Endpoint {
 	 * Installs the plugin based on the given download.
 	 *
 	 * @param string $plugin_download The url to the download.
+	 * @param string $plugin_slug     The plugin slug to install.
 	 *
 	 * @return bool True when install is successful.
 	 *
 	 * @throws WPSEO_REST_Request_Exception When an WP_Error occurred.
 	 */
-	protected function install_plugin( $plugin_download ) {
+	protected function install_plugin( $plugin_download, $plugin_slug ) {
+		if ( $this->is_installed( $plugin_slug ) ) {
+			return true;
+		}
+
 		$upgrader = new Plugin_Upgrader( new WPSEO_MyYoast_Plugin_Installer_Skin() );
 		$result   = $upgrader->install( $plugin_download );
 		if ( is_wp_error( $result ) ) {
@@ -83,6 +88,17 @@ class WPSEO_Endpoint_MyYoast_Download_Install implements WPSEO_Endpoint {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Checks if the given plugin is installed.
+	 *
+	 * @param string $plugin_slug The plugin slug to check installation status for.
+	 *
+	 * @return bool True when plugin for plugin slug is installed.
+	 */
+	protected function is_installed( $plugin_slug ) {
+		return WPSEO_Addon_Manager::is_installed( $plugin_slug );
 	}
 
 	/**

--- a/inc/endpoints/class-myyoast-download-install.php
+++ b/inc/endpoints/class-myyoast-download-install.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Represents an implementation of the WPSEO_Endpoint interface to register one or multiple endpoints.
+ * Represents the endpoint for downloading and installing a zip-file from MyYoast.
  */
 class WPSEO_Endpoint_MyYoast_Download_Install implements WPSEO_Endpoint {
 	/**

--- a/inc/endpoints/class-myyoast-download-install.php
+++ b/inc/endpoints/class-myyoast-download-install.php
@@ -58,7 +58,7 @@ class WPSEO_Endpoint_MyYoast_Download_Install implements WPSEO_Endpoint {
 
 			return new WP_REST_Response( $this->install_plugin( $plugin_download, $plugin_slug ) );
 		}
-		catch( WPSEO_REST_Request_Exception $exception ) {
+		catch ( WPSEO_REST_Request_Exception $exception ) {
 			return new WP_REST_Response(
 				$exception->getMessage(),
 				403
@@ -171,7 +171,7 @@ class WPSEO_Endpoint_MyYoast_Download_Install implements WPSEO_Endpoint {
 			require_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 		}
 
-		if( ! class_exists( 'Plugin_Upgrader' ) ) {
+		if ( ! class_exists( 'Plugin_Upgrader' ) ) {
 			require_once( ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php' );
 		}
 

--- a/inc/endpoints/class-myyoast-download-install.php
+++ b/inc/endpoints/class-myyoast-download-install.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Endpoint
+ */
+
+/**
+ * Represents an implementation of the WPSEO_Endpoint interface to register one or multiple endpoints.
+ */
+class WPSEO_Endpoint_MyYoast_Download_Install implements WPSEO_Endpoint {
+	/**
+	 * The namespace to use.
+	 *
+	 * @var string
+	 */
+	const REST_NAMESPACE = 'yoast/v1/myyoast/download';
+
+	/**
+	 * Registers the routes for the endpoints.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'install',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'handle_request' ),
+				'permission_callback' => array( $this, 'can_retrieve_data' ),
+			)
+		);
+	}
+
+	/**
+	 * Determines whether or not data can be retrieved for the registered endpoints.
+	 *
+	 * @return bool Whether or not data can be retrieved.
+	 */
+	public function can_retrieve_data() {
+		return current_user_can( 'install_plugins' );
+	}
+
+	/**
+	 * Handles the request by extracting the download url.
+	 *
+	 * @param WP_REST_Request $request The request to handle.
+	 *
+	 * @return WP_REST_Response The handled request as response.
+	 */
+	public function handle_request( WP_REST_Request $request ) {
+		$this->require_dependencies();
+
+		try {
+			$plugin_slug     = $request->get_param( 'slug' );
+			$plugin_download = $this->find_plugin_download( $plugin_slug );
+
+			return new WP_REST_Response( $this->install_plugin( $plugin_download ) );
+		}
+		catch( WPSEO_REST_Request_Exception $exception ) {
+			return new WP_REST_Response(
+				$exception->getMessage(),
+				403
+			);
+		}
+	}
+
+	/**
+	 * Installs the plugin based on the given download.
+	 *
+	 * @param string $plugin_download The url to the download.
+	 *
+	 * @return bool True when install is successful.
+	 *
+	 * @throws WPSEO_REST_Request_Exception When an WP_Error occurred.
+	 */
+	protected function install_plugin( $plugin_download ) {
+		$upgrader = new Plugin_Upgrader( new WPSEO_MyYoast_Plugin_Installer_Skin() );
+		$result   = $upgrader->install( $plugin_download );
+		if ( is_wp_error( $result ) ) {
+			throw new WPSEO_REST_Request_Exception( $result->get_error_message() );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Formats the response.
+	 *
+	 * @param string $plugin_slug The plugin slug to get download url for.
+	 *
+	 * @return array|string Array when a list is requested, string when a plugin is request.
+	 *
+	 * @throws WPSEO_REST_Request_Exception When no subscription isn't found for given plugin.
+	 */
+	protected function find_plugin_download( $plugin_slug ) {
+		$download_urls = $this->get_plugin_downloads();
+
+		if ( ! $download_urls[ $plugin_slug ] ) {
+			throw new WPSEO_REST_Request_Exception(
+				sprintf(
+				/* translators: %1$s expands to the plugin slug  */
+					esc_html__( 'No subscription found for %s', 'wordpress-seo' ),
+					$plugin_slug
+				)
+			);
+		}
+
+		return $download_urls[ $plugin_slug ];
+	}
+
+	/**
+	 * Extracts the download urls from the given subscriptions.
+	 *
+	 * @return array Array with the download urls.
+	 */
+	protected function get_plugin_downloads() {
+		$subscriptions = $this->get_subscriptions();
+		$download_urls = array();
+		foreach ( $subscriptions as $subscription ) {
+			$download_urls[ $subscription->product->slug ] = $subscription->product->download;
+		}
+
+		return $download_urls;
+	}
+
+	/**
+	 * Retrieves the current subscriptions for the current website.
+	 *
+	 * @return array Subscriptions when set.
+	 */
+	protected function get_subscriptions() {
+		$request = new WPSEO_MyYoast_Api_Request( 'sites/current' );
+		if ( $request->fire() ) {
+			$response = $request->get_response();
+
+			if ( ! property_exists( $response, 'subscriptions' ) || empty( $response->subscriptions ) ) {
+				return array();
+			}
+
+			return (array) $response->subscriptions;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Requires the files needed from WordPress itself.
+	 *
+	 * @return void
+	 */
+	private function require_dependencies() {
+		if ( ! class_exists( 'WP_Upgrader' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
+		}
+
+		if( ! class_exists( 'Plugin_Upgrader' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php' );
+		}
+
+		if ( ! class_exists( 'WP_Upgrader_Skin' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' );
+		}
+
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
+
+		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		}
+	}
+}

--- a/integration-tests/inc/test-class-myyoast-api-request.php
+++ b/integration-tests/inc/test-class-myyoast-api-request.php
@@ -254,7 +254,7 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 				'body'    => array(
 					'This is' => 'the request body',
 				),
-				'headers' => [],
+				'headers' => array(),
 			),
 			$instance->enrich_request_arguments( array() )
 		);

--- a/integration-tests/inc/test-class-myyoast-api-request.php
+++ b/integration-tests/inc/test-class-myyoast-api-request.php
@@ -278,9 +278,9 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( array() ) );
 
 		$this->assertEquals(
-			[
+			array(
 				'headers' => array(),
-			],
+			),
 			$instance->enrich_request_arguments( array() )
 		);
 	}

--- a/integration-tests/inc/test-class-myyoast-api-request.php
+++ b/integration-tests/inc/test-class-myyoast-api-request.php
@@ -249,25 +249,12 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 				)
 			);
 
-		$instance
-			->expects( $this->once() )
-			->method( 'get_installed_addon_versions' )
-			->will(
-				$this->returnValue(
-					array(
-						'yoast-seo-wordpress-premium' => '10.0',
-					)
-				)
-			);
-
 		$this->assertEquals(
 			array(
 				'body'    => array(
 					'This is' => 'the request body',
 				),
-				'headers' => array(
-					'yoast-seo-wordpress-premium-version' => '10.0',
-				),
+				'headers' => [],
 			),
 			$instance->enrich_request_arguments( array() )
 		);
@@ -290,23 +277,10 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			->method( 'get_request_body' )
 			->will( $this->returnValue( array() ) );
 
-		$instance
-			->expects( $this->once() )
-			->method( 'get_installed_addon_versions' )
-			->will(
-				$this->returnValue(
-					array(
-						'yoast-seo-wordpress-premium' => '10.0',
-					)
-				)
-			);
-
 		$this->assertEquals(
-			array(
-				'headers' => array(
-					'yoast-seo-wordpress-premium-version' => '10.0',
-				),
-			),
+			[
+				'headers' => [],
+			],
 			$instance->enrich_request_arguments( array() )
 		);
 	}

--- a/integration-tests/inc/test-class-myyoast-api-request.php
+++ b/integration-tests/inc/test-class-myyoast-api-request.php
@@ -279,7 +279,7 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals(
 			[
-				'headers' => [],
+				'headers' => array(),
 			],
 			$instance->enrich_request_arguments( array() )
 		);

--- a/tests/inc/endpoints/myyoast-download-activate-test.php
+++ b/tests/inc/endpoints/myyoast-download-activate-test.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Inc\EndPoints;
+
+use Brain\Monkey;
+use Mockery;
+use Mockery\MockInterface;
+use WP_REST_Request;
+use WPSEO_Endpoint_MyYoast_Download_Activate;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @group myyoast
+ */
+class MyYoast_Download_Activate_Test extends TestCase {
+
+
+	/**
+	 * @var MockInterface Instance of target object.
+	 */
+	protected $instance;
+
+	/**
+	 * @var MockInterface request object;
+	 */
+	protected $request;
+
+	/**
+	 * Runs the setup.
+	 */
+	public function setUp() {
+		Mockery::mock( 'overload:WP_REST_Response' );
+
+		$this->request = Mockery::mock( WP_REST_Request::class );
+		$this->request
+			->expects( 'get_param' )
+			->once()
+			->with( 'slug' )
+			->andReturn( 'test-slug' );
+
+		$this->instance = Mockery::mock( WPSEO_Endpoint_MyYoast_Download_Activate::class )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+
+		$this->instance->shouldReceive( 'require_dependencies' )->once()->andReturnNull();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the handling of the request.
+	 */
+	public function test_handle_request() {
+		Monkey\Functions\expect( 'is_wp_error')->andReturn( false );
+
+		Mockery::mock('alias:WPSEO_Addon_Manager')
+			->shouldReceive('get_plugin_file')
+			->once()
+			->andReturn( 'test-slug.php' );
+
+		$this->instance
+			->shouldReceive( 'run_activation' )
+			->with( 'test-slug.php' )
+			->once();
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->handle_request( $this->request )
+		);
+	}
+
+	/**
+	 * Tests handling the request with a non existing plugin given as request argument.
+	 */
+	public function test_handle_request_with_no_plugin_file_found() {
+		Mockery::mock('alias:WPSEO_Addon_Manager')
+			->shouldReceive('get_plugin_file')
+			->once()
+			->andReturnFalse();
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->handle_request( $this->request )
+		);
+	}
+
+	/**
+	 * Tests handling the request with an error during plugin activation.
+	 */
+	public function test_handle_request_with_activation_going_wrong() {
+		Mockery::mock('alias:WPSEO_Addon_Manager')
+			->shouldReceive('get_plugin_file')
+			->once()
+			->andReturn( 'test-slug.php' );
+
+		$wp_error = Mockery::mock( \WP_Error::class );
+		$wp_error
+			->expects( 'get_error_message' )
+			->once()
+			->andReturn( 'Activation went wrong' );
+
+		Monkey\Functions\expect( 'is_wp_error' )
+			->with( $wp_error )
+			->andReturn( true );
+
+		$this->instance
+			->shouldReceive( 'run_activation' )
+			->once()
+			->andReturn( $wp_error );
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->handle_request( $this->request )
+		);
+	}
+}

--- a/tests/inc/endpoints/myyoast-download-install-test.php
+++ b/tests/inc/endpoints/myyoast-download-install-test.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Inc\EndPoints;
+
+use Brain\Monkey;
+use Mockery;
+use Mockery\MockInterface;
+use WP_REST_Request;
+use WPSEO_Endpoint_MyYoast_Download_Install;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @group myyoast
+ */
+class MyYoast_Download_Install_Test extends TestCase {
+
+	/**
+	 * @var MockInterface Instance of target object.
+	 */
+	protected $instance;
+
+	/**
+	 * @var MockInterface Request object;
+	 */
+	protected $request;
+
+	/**
+	 * Runs the setup.
+	 */
+	public function setUp() {
+		Mockery::mock( 'overload:WP_REST_Response' );
+
+		$this->request = Mockery::mock( WP_REST_Request::class );
+		$this->request
+			->expects( 'get_param' )
+			->once()
+			->with( 'slug' )
+			->andReturn( 'test-slug' );
+
+		$this->instance = Mockery::mock( WPSEO_Endpoint_MyYoast_Download_Install::class )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+
+		$this->instance->shouldReceive( 'require_dependencies' )->once()->andReturnNull();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the handling of the request.
+	 */
+	public function test_handle_request() {
+		Monkey\Functions\expect( 'is_wp_error')->andReturn( false );
+
+		Mockery::mock('alias:WPSEO_Addon_Manager')
+			->expects('is_installed' )
+			->andReturn( false );
+
+		$this->instance
+			->shouldReceive( 'request_current_subscriptions' )
+			->once()
+			->andReturn(
+				(object) [
+					(object) [
+						'product' => (object) [
+							'slug'     => 'test-slug',
+							'download' => 'test-slug.zip',
+						],
+					],
+				]
+			);
+
+		$this->instance
+			->shouldReceive( 'run_installation' )
+			->once()
+			->andReturn( false );
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->handle_request( $this->request )
+		);
+	}
+
+	/**
+	 * Tests the handling of the request for a plugin that has been installed already.
+	 */
+	public function test_handle_request_for_already_installed_plugin() {
+		Mockery::mock('alias:WPSEO_Addon_Manager')
+			->expects('is_installed' )
+			->andReturn( true );
+
+		$this->instance
+			->shouldNotReceive( 'run_installation' )
+			->never()
+			->andReturn( false );
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->handle_request( $this->request )
+		);
+	}
+
+	/**
+	 * Tests the handling of the request for a non existing plugin.
+	 */
+	public function test_handle_request_for_a_non_existing_plugin() {
+		Mockery::mock('alias:WPSEO_Addon_Manager')
+		        ->expects('is_installed' )
+		        ->andReturn( false );
+
+		Monkey\Functions\expect( 'is_wp_error')
+			->never()
+			->andReturn( false );
+
+		$this->instance
+			->shouldReceive( 'request_current_subscriptions' )
+			->once()
+			->andReturn(
+				(object) [
+					(object) [
+						'product' => (object) [
+							'slug'     => 'another-test-slug',
+							'download' => 'another-test-slug.zip',
+						],
+					],
+				]
+			);
+
+		$this->instance
+			->shouldReceive( 'run_installation' )
+			->never()
+			->andReturn( false );
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->handle_request( $this->request )
+		);
+	}
+
+	/**
+	 * Tests handling the request with an error during plugin activation.
+	 */
+	public function test_handle_request_with_installation_going_wrong() {
+		Mockery::mock('alias:WPSEO_Addon_Manager')
+		        ->expects('is_installed' )
+		        ->andReturn( false );
+
+		$wp_error = Mockery::mock( \WP_Error::class );
+		$wp_error
+			->expects( 'get_error_message' )
+			->once()
+			->andReturn( 'Installation went wrong' );
+
+		$this->instance
+			->shouldReceive( 'run_installation' )
+			->once()
+			->andReturn( $wp_error );
+
+		$this->instance
+			->shouldReceive( 'find_plugin_download' )
+			->once()
+			->andReturn( 'test-slug.zip' );
+
+		Monkey\Functions\expect( 'is_wp_error' )
+			->with( $wp_error )
+			->andReturn( true );
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->handle_request( $this->request )
+		);
+	}
+}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -375,6 +375,8 @@ function wpseo_init_rest_api() {
 	$endpoints[] = new WPSEO_Endpoint_File_Size( new WPSEO_File_Size_Service() );
 	$endpoints[] = new WPSEO_Endpoint_Statistics( $statistics_service );
 	$endpoints[] = new WPSEO_Endpoint_MyYoast_Connect();
+	$endpoints[] = new WPSEO_Endpoint_MyYoast_Download_Install();
+	$endpoints[] = new WPSEO_Endpoint_MyYoast_Download_Activate();
 
 	foreach ( $endpoints as $endpoint ) {
 		$endpoint->register();


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the ability to install the addons, in the Yoast SEO plugin, when they are bought via my-yoast.

## Relevant technical choices:

* I added the `WPSEO_MyYoast_Plugin_Installer_Skin` to make sure no output is given when installing the plugin via the api. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Make sure you are testing in an environment with active subscriptions. For example: `acceptance.test`. Also make sure you have no git repos for our plugins on these repos, otherwise they might get lost while following the test instructions.
1. Navigate to the dashboard and enter `wpApiSettings.nonce` in the javascript console. This nonce is needed when accessing the api endpoints.
1. Remove all other Yoast addons.
1. First of all navigate to http://acceptance.test/wp-json/yoast/v1/myyoast/download/install?slug=yoast-seo-wordpress-premium&_wpnonce=[the-nonce-from step 2]
1. Go to the plugins overview and verify that the addon is installed.
1. Navigate to http://acceptance.test/wp-json/yoast/v1/myyoast/download/activate?slug=yoast-seo-wordpress-premium&_wpnonce=[the-nonce-from step 2].
1. Go to the plugins overview and verify that the addon is activate.
1. Deactivate Premium and reactivate the free plugin (this is because Premium doesn't have the rest endpoints)
1. Test it for other addons by changing the slug to `yoast-seo-news`,  `yoast-seo-video`, `yoast-seo-woocommerce` and `yoast-seo-local`
1. Change the slug in the url for something that is different from all given examples e.g. `blabla`. You should get an error message.
1. Change the value of the nonce for something that isn't correct. You should get an error message.
1. Login as an non-admin user and try to access the endpoints - this should result in an error.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #13424
