### PR TITLE
13141 responsive banners sidebar

### DIFF
--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -42,93 +42,95 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				?>
 			</a><br>
 		</div>
-		<div class="yoast-sidebar__section">
-			<h2><?php esc_html_e( 'Improve your SEO skills', 'wordpress-seo' ); ?></h2>
-			<div class="wp-clearfix">
-				<p>
-					<strong><?php echo esc_html_x( 'Free:', 'course', 'wordpress-seo' ); ?></strong>
-					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/2oi' ); ?>" target="_blank">
-						<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/SEO_for_beginners.svg' ); ?>" alt="">
-						<strong><?php esc_html_e( 'SEO for Beginners training', 'wordpress-seo' ); ?></strong>
-						<?php echo $new_tab_message; ?>
-					</a><br>
-					<?php esc_html_e( 'Get quick wins to make your site rank higher in search engines.', 'wordpress-seo' ); ?>
-				</p>
-			</div>
-			<div class="wp-clearfix">
-				<p>
-					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jv' ); ?>" target="_blank">
-						<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/yoast_seo_for_wp_2.svg' ); ?>" alt="">
-						<strong>
-							<?php
-								/* translators: %s expands to Yoast SEO */
-								printf( esc_html__( '%s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' );
-							?>
-						</strong>
-						<?php echo $new_tab_message; ?>
-					</a><br>
-					<?php esc_html_e( 'Don’t waste time figuring out the best settings yourself.', 'wordpress-seo' ); ?>
-				</p>
-			</div>
-			<div class="wp-clearfix">
-				<p>
-					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/3lj' ); ?>" target="_blank">
-						<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/all-round-SEO.svg' ); ?>" alt="">
-						<strong><?php esc_html_e( 'All-around SEO training', 'wordpress-seo' ); ?></strong>
-						<?php echo $new_tab_message; ?>
-					</a><br>
-					<?php esc_html_e( 'Learn practical SEO skills to rank higher in Google.', 'wordpress-seo' ); ?>
-				</p>
-			</div>
-		</div>
-		<div class="yoast-sidebar__section">
-			<h2>
-				<?php
-					/* translators: %s expands to Yoast SEO */
-					printf( esc_html__( 'Extend %s', 'wordpress-seo' ), 'Yoast SEO' );
-				?>
-			</h2>
-			<div class="wp-clearfix">
-				<p>
-					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jq' ); ?>" target="_blank">
-						<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Local_SEO_Icon.svg' ); ?>" alt="">
-						<strong>Local SEO</strong>
-						<?php echo $new_tab_message; ?>
-					</a><br>
-					<?php esc_html_e( 'Be found in Google Maps and local results.', 'wordpress-seo' ); ?>
-				</p>
-			</div>
-			<div class="wp-clearfix">
-				<p>
-					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jo' ); ?>" target="_blank">
-						<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Video_SEO_Icon.svg' ); ?>" alt="">
-						<strong>Video SEO</strong>
-						<?php echo $new_tab_message; ?>
-					</a><br>
-					<?php esc_html_e( 'Be found in Google Video search and enhance your video sharing on social media.', 'wordpress-seo' ); ?>
-				</p>
-			</div>
-			<div class="wp-clearfix">
-				<p>
-					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jp' ); ?>" target="_blank">
-						<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Woo_SEO_Icon.svg' ); ?>" alt="">
-						<strong>WooCommerce SEO</strong>
-						<?php echo $new_tab_message; ?>
-					</a><br>
-					<?php esc_html_e( 'Optimize your shop\'s SEO and sell more products!', 'wordpress-seo' ); ?>
-				</p>
-			</div>
-			<div class="wp-clearfix">
-				<p>
-					<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jr' ); ?>" target="_blank">
-						<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/News_SEO_Icon.svg' ); ?>" alt="">
-						<strong>News SEO</strong>
-						<?php echo $new_tab_message; ?>
-					</a><br>
-					<?php esc_html_e( 'Optimize your site for Google News.', 'wordpress-seo' ); ?>
-				</p>
-			</div>
-		</div>
+        <div class="yoast-sidebar__product-list">
+            <div class="yoast-sidebar__section">
+                <h2><?php esc_html_e( 'Improve your SEO skills', 'wordpress-seo' ); ?></h2>
+                <div class="wp-clearfix">
+                    <p>
+                        <strong><?php echo esc_html_x( 'Free:', 'course', 'wordpress-seo' ); ?></strong>
+                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/2oi' ); ?>" target="_blank">
+                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/SEO_for_beginners.svg' ); ?>" alt="">
+                            <strong><?php esc_html_e( 'SEO for Beginners training', 'wordpress-seo' ); ?></strong>
+                            <?php echo $new_tab_message; ?>
+                        </a><br>
+                        <?php esc_html_e( 'Get quick wins to make your site rank higher in search engines.', 'wordpress-seo' ); ?>
+                    </p>
+                </div>
+                <div class="wp-clearfix">
+                    <p>
+                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jv' ); ?>" target="_blank">
+                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/yoast_seo_for_wp_2.svg' ); ?>" alt="">
+                            <strong>
+                                <?php
+                                    /* translators: %s expands to Yoast SEO */
+                                    printf( esc_html__( '%s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' );
+                                ?>
+                            </strong>
+                            <?php echo $new_tab_message; ?>
+                        </a><br>
+                        <?php esc_html_e( 'Don’t waste time figuring out the best settings yourself.', 'wordpress-seo' ); ?>
+                    </p>
+                </div>
+                <div class="wp-clearfix">
+                    <p>
+                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/3lj' ); ?>" target="_blank">
+                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/all-round-SEO.svg' ); ?>" alt="">
+                            <strong><?php esc_html_e( 'All-around SEO training', 'wordpress-seo' ); ?></strong>
+                            <?php echo $new_tab_message; ?>
+                        </a><br>
+                        <?php esc_html_e( 'Learn practical SEO skills to rank higher in Google.', 'wordpress-seo' ); ?>
+                    </p>
+                </div>
+            </div>
+            <div class="yoast-sidebar__section">
+                <h2>
+                    <?php
+                        /* translators: %s expands to Yoast SEO */
+                        printf( esc_html__( 'Extend %s', 'wordpress-seo' ), 'Yoast SEO' );
+                    ?>
+                </h2>
+                <div class="wp-clearfix">
+                    <p>
+                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jq' ); ?>" target="_blank">
+                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Local_SEO_Icon.svg' ); ?>" alt="">
+                            <strong>Local SEO</strong>
+                            <?php echo $new_tab_message; ?>
+                        </a><br>
+                        <?php esc_html_e( 'Be found in Google Maps and local results.', 'wordpress-seo' ); ?>
+                    </p>
+                </div>
+                <div class="wp-clearfix">
+                    <p>
+                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jo' ); ?>" target="_blank">
+                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Video_SEO_Icon.svg' ); ?>" alt="">
+                            <strong>Video SEO</strong>
+                            <?php echo $new_tab_message; ?>
+                        </a><br>
+                        <?php esc_html_e( 'Be found in Google Video search and enhance your video sharing on social media.', 'wordpress-seo' ); ?>
+                    </p>
+                </div>
+                <div class="wp-clearfix">
+                    <p>
+                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jp' ); ?>" target="_blank">
+                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Woo_SEO_Icon.svg' ); ?>" alt="">
+                            <strong>WooCommerce SEO</strong>
+                            <?php echo $new_tab_message; ?>
+                        </a><br>
+                        <?php esc_html_e( 'Optimize your shop\'s SEO and sell more products!', 'wordpress-seo' ); ?>
+                    </p>
+                </div>
+                <div class="wp-clearfix">
+                    <p>
+                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jr' ); ?>" target="_blank">
+                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/News_SEO_Icon.svg' ); ?>" alt="">
+                            <strong>News SEO</strong>
+                            <?php echo $new_tab_message; ?>
+                        </a><br>
+                        <?php esc_html_e( 'Optimize your site for Google News.', 'wordpress-seo' ); ?>
+                    </p>
+                </div>
+            </div>
+        </div>
 		<div class="yoast-sidebar__section">
 			<strong><?php esc_html_e( 'Remove these ads?', 'wordpress-seo' ); ?></strong>
 			<p>

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -42,95 +42,95 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				?>
 			</a><br>
 		</div>
-        <div class="yoast-sidebar__product-list">
-            <div class="yoast-sidebar__section">
-                <h2><?php esc_html_e( 'Improve your SEO skills', 'wordpress-seo' ); ?></h2>
-                <div class="wp-clearfix">
-                    <p>
-                        <strong><?php echo esc_html_x( 'Free:', 'course', 'wordpress-seo' ); ?></strong>
-                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/2oi' ); ?>" target="_blank">
-                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/SEO_for_beginners.svg' ); ?>" alt="">
-                            <strong><?php esc_html_e( 'SEO for Beginners training', 'wordpress-seo' ); ?></strong>
-                            <?php echo $new_tab_message; ?>
-                        </a><br>
-                        <?php esc_html_e( 'Get quick wins to make your site rank higher in search engines.', 'wordpress-seo' ); ?>
-                    </p>
-                </div>
-                <div class="wp-clearfix">
-                    <p>
-                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jv' ); ?>" target="_blank">
-                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/yoast_seo_for_wp_2.svg' ); ?>" alt="">
-                            <strong>
-                                <?php
-                                    /* translators: %s expands to Yoast SEO */
-                                    printf( esc_html__( '%s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' );
-                                ?>
-                            </strong>
-                            <?php echo $new_tab_message; ?>
-                        </a><br>
-                        <?php esc_html_e( 'Don’t waste time figuring out the best settings yourself.', 'wordpress-seo' ); ?>
-                    </p>
-                </div>
-                <div class="wp-clearfix">
-                    <p>
-                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/3lj' ); ?>" target="_blank">
-                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/all-round-SEO.svg' ); ?>" alt="">
-                            <strong><?php esc_html_e( 'All-around SEO training', 'wordpress-seo' ); ?></strong>
-                            <?php echo $new_tab_message; ?>
-                        </a><br>
-                        <?php esc_html_e( 'Learn practical SEO skills to rank higher in Google.', 'wordpress-seo' ); ?>
-                    </p>
-                </div>
-            </div>
-            <div class="yoast-sidebar__section">
-                <h2>
-                    <?php
-                        /* translators: %s expands to Yoast SEO */
-                        printf( esc_html__( 'Extend %s', 'wordpress-seo' ), 'Yoast SEO' );
-                    ?>
-                </h2>
-                <div class="wp-clearfix">
-                    <p>
-                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jq' ); ?>" target="_blank">
-                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Local_SEO_Icon.svg' ); ?>" alt="">
-                            <strong>Local SEO</strong>
-                            <?php echo $new_tab_message; ?>
-                        </a><br>
-                        <?php esc_html_e( 'Be found in Google Maps and local results.', 'wordpress-seo' ); ?>
-                    </p>
-                </div>
-                <div class="wp-clearfix">
-                    <p>
-                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jo' ); ?>" target="_blank">
-                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Video_SEO_Icon.svg' ); ?>" alt="">
-                            <strong>Video SEO</strong>
-                            <?php echo $new_tab_message; ?>
-                        </a><br>
-                        <?php esc_html_e( 'Be found in Google Video search and enhance your video sharing on social media.', 'wordpress-seo' ); ?>
-                    </p>
-                </div>
-                <div class="wp-clearfix">
-                    <p>
-                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jp' ); ?>" target="_blank">
-                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Woo_SEO_Icon.svg' ); ?>" alt="">
-                            <strong>WooCommerce SEO</strong>
-                            <?php echo $new_tab_message; ?>
-                        </a><br>
-                        <?php esc_html_e( 'Optimize your shop\'s SEO and sell more products!', 'wordpress-seo' ); ?>
-                    </p>
-                </div>
-                <div class="wp-clearfix">
-                    <p>
-                        <a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jr' ); ?>" target="_blank">
-                            <img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/News_SEO_Icon.svg' ); ?>" alt="">
-                            <strong>News SEO</strong>
-                            <?php echo $new_tab_message; ?>
-                        </a><br>
-                        <?php esc_html_e( 'Optimize your site for Google News.', 'wordpress-seo' ); ?>
-                    </p>
-                </div>
-            </div>
-        </div>
+		<div class="yoast-sidebar__product-list">
+			<div class="yoast-sidebar__section">
+				<h2><?php esc_html_e( 'Improve your SEO skills', 'wordpress-seo' ); ?></h2>
+				<div class="wp-clearfix">
+					<p>
+						<strong><?php echo esc_html_x( 'Free:', 'course', 'wordpress-seo' ); ?></strong>
+						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/2oi' ); ?>" target="_blank">
+							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/SEO_for_beginners.svg' ); ?>" alt="">
+							<strong><?php esc_html_e( 'SEO for Beginners training', 'wordpress-seo' ); ?></strong>
+							<?php echo $new_tab_message; ?>
+						</a><br>
+						<?php esc_html_e( 'Get quick wins to make your site rank higher in search engines.', 'wordpress-seo' ); ?>
+					</p>
+				</div>
+				<div class="wp-clearfix">
+					<p>
+						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jv' ); ?>" target="_blank">
+							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/yoast_seo_for_wp_2.svg' ); ?>" alt="">
+							<strong>
+								<?php
+									/* translators: %s expands to Yoast SEO */
+									printf( esc_html__( '%s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' );
+								?>
+							</strong>
+							<?php echo $new_tab_message; ?>
+						</a><br>
+						<?php esc_html_e( 'Don’t waste time figuring out the best settings yourself.', 'wordpress-seo' ); ?>
+					</p>
+				</div>
+				<div class="wp-clearfix">
+					<p>
+						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/3lj' ); ?>" target="_blank">
+							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/all-round-SEO.svg' ); ?>" alt="">
+							<strong><?php esc_html_e( 'All-around SEO training', 'wordpress-seo' ); ?></strong>
+							<?php echo $new_tab_message; ?>
+						</a><br>
+						<?php esc_html_e( 'Learn practical SEO skills to rank higher in Google.', 'wordpress-seo' ); ?>
+					</p>
+				</div>
+			</div>
+			<div class="yoast-sidebar__section">
+				<h2>
+					<?php
+						/* translators: %s expands to Yoast SEO */
+						printf( esc_html__( 'Extend %s', 'wordpress-seo' ), 'Yoast SEO' );
+					?>
+				</h2>
+				<div class="wp-clearfix">
+					<p>
+						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jq' ); ?>" target="_blank">
+							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Local_SEO_Icon.svg' ); ?>" alt="">
+							<strong>Local SEO</strong>
+							<?php echo $new_tab_message; ?>
+						</a><br>
+						<?php esc_html_e( 'Be found in Google Maps and local results.', 'wordpress-seo' ); ?>
+					</p>
+				</div>
+				<div class="wp-clearfix">
+					<p>
+						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jo' ); ?>" target="_blank">
+							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Video_SEO_Icon.svg' ); ?>" alt="">
+							<strong>Video SEO</strong>
+							<?php echo $new_tab_message; ?>
+						</a><br>
+						<?php esc_html_e( 'Be found in Google Video search and enhance your video sharing on social media.', 'wordpress-seo' ); ?>
+					</p>
+				</div>
+				<div class="wp-clearfix">
+					<p>
+						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jp' ); ?>" target="_blank">
+							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/Woo_SEO_Icon.svg' ); ?>" alt="">
+							<strong>WooCommerce SEO</strong>
+							<?php echo $new_tab_message; ?>
+						</a><br>
+						<?php esc_html_e( 'Optimize your shop\'s SEO and sell more products!', 'wordpress-seo' ); ?>
+					</p>
+				</div>
+				<div class="wp-clearfix">
+					<p>
+						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jr' ); ?>" target="_blank">
+							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/News_SEO_Icon.svg' ); ?>" alt="">
+							<strong>News SEO</strong>
+							<?php echo $new_tab_message; ?>
+						</a><br>
+						<?php esc_html_e( 'Optimize your site for Google News.', 'wordpress-seo' ); ?>
+					</p>
+				</div>
+			</div>
+		</div>
 		<div class="yoast-sidebar__section">
 			<strong><?php esc_html_e( 'Remove these ads?', 'wordpress-seo' ); ?></strong>
 			<p>

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -864,6 +864,29 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 		width: auto;
 		padding: 0;
 	}
+
+	/* Make the banners with product lists appear next to each other. */
+	.yoast-sidebar {
+
+		&__product-list {
+			display: flex;
+			border-bottom: 1px solid #ddd;
+
+			div p {
+				word-wrap: break-word;
+				width: calc( 100% - 50px );
+				//margin: 0;
+			}
+
+			.yoast-sidebar__section {
+				border-bottom: none;
+
+				&:first-child {
+					margin-right: 40px;
+				}
+			}
+		}
+	}
 }
 
 @media screen and ( max-width: 782px ) {
@@ -928,6 +951,26 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	/* Google Search Console: Reload crawl issues form. */
 	.wpseo-gsc-reload-crawl-issues-form {
 		margin-bottom: 0;
+	}
+
+	/* Make the banners with product lists appear below each other. */
+	.yoast-sidebar {
+
+		&__product-list {
+			display: block;
+			border-bottom: none;
+
+			.yoast-sidebar__section {
+				border-bottom: 1px solid #ddd;
+
+				p {
+					word-wrap: break-word;
+					width: calc( 100% - 50px );
+					margin: 0;
+					padding-left: 50px;
+				}
+			}
+		}
 	}
 }
 

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -875,7 +875,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 			div p {
 				word-wrap: break-word;
 				width: calc( 100% - 50px );
-				//margin: 0;
 			}
 
 			.yoast-sidebar__section {
@@ -966,7 +965,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 				p {
 					word-wrap: break-word;
 					width: calc( 100% - 50px );
-					margin: 0;
 					padding-left: 50px;
 				}
 			}

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -276,9 +276,9 @@ import a11ySpeak from "a11y-speak";
 			activeTab.addClass( "active" );
 			jQuery( this ).addClass( "nav-tab-active" );
 			if ( activeTab.hasClass( "nosave" ) ) {
-				jQuery( "#submit" ).hide();
+				jQuery( "#submit" ).parent().hide();
 			} else {
-				jQuery( "#submit" ).show();
+				jQuery( "#submit" ).parent().show();
 			}
 		} );
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the banners in the sidebar of Yoast SEO were no longer responsive.

## Relevant technical choices:

* Created a selector called `product-list` to capture the two banners that should appear next to each other. This is the reason that it seems like there are many changes in the `sidebar.php` file, but this is only caused by the indentation.
* Used `flex` to display the two banners next to each other.
* Because the images in the banners are `50px` but contribute to `p`'s width, the text width is calculated as `100% - 50px`.
* When shifting the screen width, the banner text wraps to the next line.
* Hid the submit button container on tabs that have no saveable options.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out this branch, and navigate to Yoast SEO in WP admin.
* When the screen width drops under `1025px`, the sidebar should shift from the right side of the screen to under the notifications, with `Improve your SEO skills` and `Extend Yoast SEO` appearing next to each other.
* When shifting the screen width, the text in these two banners should wrap to the next line.
* When the screen width drops under `601px`, `Improve your SEO skills` and `Extend Yoast SEO` should appear below each other.
* When shifting the screen width, the text in these two banners should still wrap to the next line.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13141
