### PR TITLE
Renamed filters to use the old wpseo_ prefix

### DIFF
--- a/frontend/schema/class-schema-context.php
+++ b/frontend/schema/class-schema-context.php
@@ -183,11 +183,11 @@ class WPSEO_Schema_Context {
 				$company_name = WPSEO_Options::get( 'company_name' );
 
 				/**
-				 * Filter: 'yoast_free_schema_company_name' - Allows filtering company name
+				 * Filter: 'wpseo_schema_company_name' - Allows filtering company name
 				 *
 				 * @api string $company_name.
 				 */
-				$this->company_name = apply_filters( 'yoast_free_schema_company_name', $company_name );
+				$this->company_name = apply_filters( 'wpseo_schema_company_name', $company_name );
 
 				// Do not use a non-named company.
 				if ( empty( $this->company_name ) ) {
@@ -198,11 +198,11 @@ class WPSEO_Schema_Context {
 				$company_logo_id = WPSEO_Image_Utils::get_attachment_id_from_settings( 'company_logo' );
 
 				/**
-				 * Filter: 'yoast_free_schema_company_logo_id' - Allows filtering company logo id
+				 * Filter: 'wpseo_schema_company_logo_id' - Allows filtering company logo id
 				 *
 				 * @api integer $company_logo_id.
 				 */
-				$this->company_logo_id = apply_filters( 'yoast_free_schema_company_logo_id', $company_logo_id );
+				$this->company_logo_id = apply_filters( 'wpseo_schema_company_logo_id', $company_logo_id );
 
 				/*
 				 * Do not use a company without a logo.

--- a/frontend/schema/class-schema-organization.php
+++ b/frontend/schema/class-schema-organization.php
@@ -102,12 +102,12 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 		}
 
 		/**
-		 * Filter: 'yoast_free_schema_organization_social_profiles' - Allows filtering social profiles for the
+		 * Filter: 'wpseo_schema_organization_social_profiles' - Allows filtering social profiles for the
 		 * represented organization.
 		 *
 		 * @api string[] $profiles
 		 */
-		$profiles = apply_filters( 'yoast_free_schema_organization_social_profiles', $profiles );
+		$profiles = apply_filters( 'wpseo_schema_organization_social_profiles', $profiles );
 
 		return $profiles;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -114,8 +114,9 @@ Enhancements:
 
 * Updates desktop snippet preview to match Google's new font sizes.
 * Adds collapsible around the hidden problems and notifications on the Yoast dashboard.
-* Adds a filter `yoast_free_schema_company_name` that allows filtering Yoast company name setting. Props to [@andrewgillingham](https://github.com/andrewgillingham).
-* Adds a filter `yoast_free_schema_company_logo_id` that allows filtering Yoast company logo setting. Props to [@andrewgillingham](https://github.com/andrewgillingham).
+* Adds a filter `wpseo_schema_organization_social_profiles` that allows filtering an organizations social profiles in schema. Props to [juliquiron](https://github.com/juliquiron).
+* Adds a filter `wpseo_schema_company_name` that allows filtering Yoast company name setting. Props to [@andrewgillingham](https://github.com/andrewgillingham).
+* Adds a filter `wpseo_free_schema_company_logo_id` that allows filtering Yoast company logo setting. Props to [@andrewgillingham](https://github.com/andrewgillingham).
 * Adds a filter `wpseo_sitemap_exclude_empty_terms_taxonomy` to control hiding empty terms per taxonomy.
 * Adds a filter `wpseo_enable_structured_data_blocks` to allow disabling Yoast's Structured Data block editor blocks.
 * Adds a `get_robots` method to retrieve the robot HTML without it being output. Props to [@bradymwilliams](https://github.com/bradymwilliams).


### PR DESCRIPTION
Renamed filters to use the old `wpseo_` prefix, adjusted documentation changelog and added a changelog item for `wpseo_schema_organization_social_profiles`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Renamed filters to use the old `wpseo_` prefix, adjusted documentation changelog and added a changelog item for `wpseo_schema_organization_social_profiles`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test the filters with the new names instead of the old ones.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13452 
