### PR TITLE
Move header output to its own function and make it filterable

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -271,7 +271,6 @@ class WPSEO_Sitemaps {
 			return;
 		}
 
-		$this->send_headers( $type );
 		$this->output();
 		$this->sitemap_close();
 	}
@@ -443,6 +442,7 @@ class WPSEO_Sitemaps {
 	 * Spit out the generated sitemap.
 	 */
 	public function output() {
+		$this->send_headers();
 		echo $this->renderer->get_output( $this->sitemap, $this->transient );
 	}
 
@@ -616,11 +616,9 @@ class WPSEO_Sitemaps {
 	}
 
 	/**
-	 * Sends all the required HTTP Headers
-	 *
-	 * @param string $type Provide a type for a post_type sitemap, SITEMAP_INDEX_TYPE for the root sitemap.
+	 * Sends all the required HTTP Headers.
 	 */
-	private function send_headers( $type ) {
+	private function send_headers() {
 		$headers = array(
 			$this->http_protocol . ' 200 OK'                                                       => 200,
 			// Prevent the search engines from indexing the XML Sitemap.
@@ -632,9 +630,8 @@ class WPSEO_Sitemaps {
 		 * Filter the HTTP headers we send before an XML sitemap.
 		 *
 		 * @param array  $headers The HTTP headers we're going to send out.
-		 * @param string $type    Post type or SITEMAP_INDEX_TYPE.
 		 */
-		$headers = apply_filters( 'wpseo_sitemap_http_headers', $headers, $type );
+		$headers = apply_filters( 'wpseo_sitemap_http_headers', $headers );
 
 		foreach ( $headers as $header => $status ) {
 			if ( is_numeric( $status ) ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -619,6 +619,10 @@ class WPSEO_Sitemaps {
 	 * Sends all the required HTTP Headers.
 	 */
 	private function send_headers() {
+		if ( headers_sent() ) {
+			return;
+		}
+
 		$headers = array(
 			$this->http_protocol . ' 200 OK'                                                       => 200,
 			// Prevent the search engines from indexing the XML Sitemap.

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -104,6 +104,7 @@ class WPSEO_Sitemaps {
 	public function __construct() {
 
 		add_action( 'after_setup_theme', array( $this, 'init_sitemaps_providers' ) );
+		add_action( 'after_setup_theme', array( $this, 'reduce_query_load' ), 99 );
 		add_action( 'pre_get_posts', array( $this, 'redirect' ), 1 );
 		add_action( 'wpseo_hit_sitemap_index', array( $this, 'hit_sitemap_index' ) );
 		add_action( 'wpseo_ping_search_engines', array( __CLASS__, 'ping_search_engines' ) );
@@ -137,6 +138,20 @@ class WPSEO_Sitemaps {
 			if ( is_object( $provider ) && $provider instanceof WPSEO_Sitemap_Provider ) {
 				$this->providers[] = $provider;
 			}
+		}
+	}
+
+	/**
+	 * Check the current request URI, if we can determine it's probably an XML sitemap, kill loading the widgets.
+	 */
+	public function reduce_query_load() {
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+		$request_uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$extension   = substr( $request_uri, -4 );
+		if ( false !== stripos( $request_uri, 'sitemap' ) && in_array( $extension, array( '.xml', '.xsl' ), true ) ) {
+			remove_all_actions( 'widgets_init' );
 		}
 	}
 


### PR DESCRIPTION
Make the HTTP headers output before the XML sitemap filterable. Should help team Local fix https://github.com/Yoast/bugreports/issues/564

## Summary

This PR can be summarized in the following changelog entry:

* Introduces a new filter `wpseo_sitemap_http_headers` which allows filtering the HTTP headers we send for XML sitemaps.

## Relevant technical choices:

* Decided to move the XML sitemap request hijack to earlier in the process, as that way we are hijacking the request before WordPress sends any HTTP headers.

## Test instructions
This PR can be tested by following these steps:

* This should leave the XML sitemap output unharmed.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

