### PR TITLE
Moves the retrieve_enabled_features function out of the area of deprecated functions

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1364,6 +1364,22 @@ SVG;
 		return array_merge_recursive( $allowed_post_tags, $input_tags );
 	}
 
+	/**
+	 * Gets an array of enabled features.
+	 *
+	 * @return string[] The array of enabled features.
+	 */
+	public static function retrieve_enabled_features() {
+		$enabled_features = array();
+		if ( defined( 'YOAST_SEO_ENABLED_FEATURES' ) ) {
+			$enabled_features = preg_split( '/,\W*/', YOAST_SEO_ENABLED_FEATURES );
+		}
+		// Make the array of enabled features filterable, so features can be enabled at will.
+		$enabled_features = apply_filters( 'wpseo_enable_feature', $enabled_features );
+
+		return $enabled_features;
+	}
+
 	/* ********************* DEPRECATED METHODS ********************* */
 
 	/**
@@ -1403,21 +1419,5 @@ SVG;
 		_deprecated_function( __METHOD__, 'WPSEO 9.5', 'WPSEO_Language_Utils::get_user_locale' );
 
 		return WPSEO_Language_Utils::get_user_locale();
-	}
-
-	/**
-	 * Gets an array of enabled features.
-	 *
-	 * @return string[] The array of enabled features.
-	 */
-	public static function retrieve_enabled_features() {
-		$enabled_features = array();
-		if ( defined( 'YOAST_SEO_ENABLED_FEATURES' ) ) {
-			$enabled_features = preg_split( '/,\W*/', YOAST_SEO_ENABLED_FEATURES );
-		}
-		// Make the array of enabled features filterable, so features can be enabled at will.
-		$enabled_features = apply_filters( 'wpseo_enable_feature', $enabled_features );
-
-		return $enabled_features;
 	}
 }


### PR DESCRIPTION

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The `retrieve_enabled_features` function was incorrectly marked as deprecated.

## Relevant technical choices:

* The function was added below the 'deprecated methods' comment in `WPSEO_Utils`, erroneously marking it as deprecated.
It is now moved above the comment, within the same file.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
