### PR TITLE
How-to and FAQ blocks CSS issues with latest Gutenberg

### DIFF
--- a/css/src/metabox.scss
+++ b/css/src/metabox.scss
@@ -25,6 +25,8 @@
 }
 
 // Reset margins inherited from Gutenberg.
+// Fixed in Gutenberg https://github.com/WordPress/gutenberg/pull/16207
+// Can be removed in future versions.
 .DraftEditor-root [data-block] {
 	margin: 0;
 }

--- a/css/src/structured-data-blocks.scss
+++ b/css/src/structured-data-blocks.scss
@@ -35,12 +35,20 @@
 	font-weight: 600;
 }
 
-.schema-how-to-description,
-.schema-how-to-step-name,
-.schema-how-to-step-text,
-.schema-faq-question,
-.schema-faq-answer {
+// Override Gutenberg styles.
+.schema-how-to .schema-how-to-steps,
+.schema-how-to .schema-how-to-description,
+.schema-how-to .schema-how-to-step-name,
+.schema-how-to .schema-how-to-step-text,
+.schema-faq .schema-faq-question,
+.schema-faq .schema-faq-answer {
+	margin: 0;
 	line-height: inherit;
+}
+
+// Override Gutenberg styles.
+.schema-how-to .schema-how-to-steps {
+	padding-top: 0;
 }
 
 .schema-how-to-step-button-container,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves the How-to and FAQ blocks styling for better compatibility with latest version of the WordPress blocks editor.

## Relevant technical choices:
- this PR addresses only the CSS part from https://github.com/Yoast/bugreports/issues/471
- the other issues related to the blocks functionality will be investigated upstream

## Test instructions
This PR can be tested by following these steps:
- activate Yoast SEO trunk
- activate the Gutenberg plugin: current version is 6.4.0
- create a post and add How-to and FAQ blocks 
- see the text fields are misaligned:

<img width="1001" alt="misaligned" src="https://user-images.githubusercontent.com/1682452/64709795-249ec780-d4b7-11e9-8179-d0c6e9e92cd3.png">


- switch to this branch and build all the things
- refresh the page
- see the text field have a nice alignment:

<img width="1000" alt="aligned" src="https://user-images.githubusercontent.com/1682452/64709806-28324e80-d4b7-11e9-8953-8cb7a377997d.png">

Note: the spacing between post title and first blocks, and the spacing between blocks is slightly different on latest Gutenberg and it's an intentional change from the Gutenteam.

See https://github.com/Yoast/bugreports/issues/471
