### PR TITLE
Fix configuration wizard error

### DIFF
--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -232,6 +232,10 @@ class Yoast_Input_Validation {
 	public static function add_dirty_value_to_settings_errors( $error_code, $dirty_value ) {
 		global $wp_settings_errors;
 
+		if ( ! is_array( $wp_settings_errors ) ) {
+			return;
+		}
+
 		foreach ( $wp_settings_errors as $index => $error ) {
 			if ( $error['code'] === $error_code ) {
 				$wp_settings_errors[ $index ]['yoast_dirty_value'] = $dirty_value;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the configuration wizard would error on step 3 when in WordPress `4.9.10`.

## Relevant technical choices:

* Only added a safety check for now.
* The actual validation is still happening.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Reproduce:
1. Use WP 4.9.10
1. Install and activate Yoast SEO 12.1 RC3.
1. Configure the social profile as in the issue: `https://www.facebook.com/hohoho`.
1. Configure the knowledge graph as in the issue: organization name & logo filled in.
1. Go to step 3 in the configuration wizard.
1. Click next and you get an error at the top.

Test this branch:
1. Build and activate the code in this branch.
1. Go to step 3 in the configuration wizard.
1. Click next and do not get an error.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13471
