### PR TITLE
Mention that training is free

### DIFF
--- a/admin/class-help-center.php
+++ b/admin/class-help-center.php
@@ -118,10 +118,10 @@ class WPSEO_Help_Center {
 				/* translators: %s expands to Yoast SEO */
 				'title'       => sprintf( __( 'Want to be a %s Expert?', 'wordpress-seo' ), 'Yoast SEO' ),
 				/* translators: %1$s expands to Yoast SEO */
-				'description' => sprintf( __( 'Follow our %1$s for WordPress training and become a certified %1$s Expert!', 'wordpress-seo' ), 'Yoast SEO' ),
+				'description' => sprintf( __( 'Follow our free %1$s for WordPress training and become a certified %1$s Expert!', 'wordpress-seo' ), 'Yoast SEO' ),
 				'link'        => WPSEO_Shortlinker::get( 'https://yoa.st/wordpress-training-vt' ),
 				/* translators: %s expands to Yoast SEO */
-				'linkText'    => sprintf( __( 'Enroll in the %s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' ),
+				'linkText'    => sprintf( __( 'Enroll in the free %s for WordPress training', 'wordpress-seo' ), 'Yoast SEO' ),
 			);
 		}
 

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -58,6 +58,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				</div>
 				<div class="wp-clearfix">
 					<p>
+						<strong><?php echo esc_html_x( 'Free:', 'course', 'wordpress-seo' ); ?></strong>
 						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jv' ); ?>" target="_blank">
 							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/yoast_seo_for_wp_2.svg' ); ?>" alt="">
 							<strong>


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes mentions of the Yoast SEO for WordPress training, which is now free.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In the sidebar, the word **`Free:`** (in boldface) should appear before `Yoast SEO for WordPress training`.

<img width="259" alt="Screenshot 2019-09-17 at 09 52 38" src="https://user-images.githubusercontent.com/20280513/65030095-3a8d0c00-d93f-11e9-97a2-cf0c2f1a06df.png">

* In the help center, the word `free` (not in boldface, see [here](https://github.com/Yoast/wordpress-seo-premium/issues/2530#issuecomment-532133904)) should appear in the text and hyperlink of `Want to be a Yoast SEO expert?`

<img width="901" alt="Screenshot 2019-09-17 at 11 35 49" src="https://user-images.githubusercontent.com/20280513/65030151-54c6ea00-d93f-11e9-9e15-a38748a3b0e0.png">

When merging this PR, please check the relevant boxes in [#2530](https://github.com/Yoast/wordpress-seo-premium/issues/2530).

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [#2530](https://github.com/Yoast/wordpress-seo-premium/issues/2530) (in premium)
