### PR TITLE
Plugin installation flow

### DIFF
--- a/admin/class-plugin-installation.php
+++ b/admin/class-plugin-installation.php
@@ -24,6 +24,19 @@ class WPSEO_Plugin_Installation implements WPSEO_WordPress_Integration {
 	public function enqueue_scripts() {
 		if ( 'wpseo_licenses' === filter_input( INPUT_GET, 'page' ) ) {
 			$asset_manager = new WPSEO_Admin_Asset_Manager();
+			wp_localize_script(
+				WPSEO_Admin_Asset_Manager::PREFIX . 'plugin-installation',
+				'wpseoPluginInstallationL10n',
+				array(
+					'pluginNames' => array(
+						'yoast-seo-wordpress-premium' => 'Yoast SEO Premium',
+						'yoast-seo-local'             => 'Yoast Local SEO',
+						'yoast-seo-video'             => 'Yoast Video SEO',
+						'yoast-seo-news'              => 'Yoast News SEO',
+						'yoast-seo-woocommerce'       => 'Yoast Woocommerce SEO',
+					),
+				)
+			);
 			$asset_manager->enqueue_script( 'plugin-installation' );
 		}
 	}

--- a/admin/class-plugin-installation.php
+++ b/admin/class-plugin-installation.php
@@ -29,7 +29,7 @@ class WPSEO_Plugin_Installation implements WPSEO_WordPress_Integration {
 				'wpseoPluginInstallationL10n',
 				array(
 					'target'  => array(
-						'domain' =>'http://two.wordpress.test',
+						'domain' => 'http://two.wordpress.test',
 						'path'   => '/wp-admin/admin.php?page=wpseo_popup_page&url=' . esc_html( home_url() ) . '&plugin=',
 					),
 					'pluginNames' => array(

--- a/admin/class-plugin-installation.php
+++ b/admin/class-plugin-installation.php
@@ -29,8 +29,8 @@ class WPSEO_Plugin_Installation implements WPSEO_WordPress_Integration {
 				'wpseoPluginInstallationL10n',
 				array(
 					'target'  => array(
-						'domain' =>'https://my.yoast.com',
-						'path'   => '/addsite?url=' . esc_html( home_url() ) . '&plugins=',
+						'domain' =>'http://two.wordpress.test',
+						'path'   => '/wp-admin/admin.php?page=wpseo_popup_page&url=' . esc_html( home_url() ) . '&plugin=',
 					),
 					'pluginNames' => array(
 						'yoast-seo-wordpress-premium' => 'Yoast SEO Premium',

--- a/admin/class-plugin-installation.php
+++ b/admin/class-plugin-installation.php
@@ -29,8 +29,8 @@ class WPSEO_Plugin_Installation implements WPSEO_WordPress_Integration {
 				'wpseoPluginInstallationL10n',
 				array(
 					'target'  => array(
-						'domain' => 'http://two.wordpress.test',
-						'path'   => '/wp-admin/admin.php?page=wpseo_popup_page&url=' . esc_html( home_url() ) . '&plugin=',
+						'domain' => 'https://my.yoast.com',
+						'path'   => '/addsite?url=' . esc_html( home_url() ) . '&plugin=',
 					),
 					'pluginNames' => array(
 						'yoast-seo-wordpress-premium' => 'Yoast SEO Premium',

--- a/admin/class-plugin-installation.php
+++ b/admin/class-plugin-installation.php
@@ -32,13 +32,7 @@ class WPSEO_Plugin_Installation implements WPSEO_WordPress_Integration {
 						'domain' => 'https://my.yoast.com',
 						'path'   => '/addsite?url=' . esc_html( home_url() ) . '&plugin=',
 					),
-					'pluginNames' => array(
-						'yoast-seo-wordpress-premium' => 'Yoast SEO Premium',
-						'yoast-seo-local'             => 'Yoast Local SEO',
-						'yoast-seo-video'             => 'Yoast Video SEO',
-						'yoast-seo-news'              => 'Yoast News SEO',
-						'yoast-seo-woocommerce'       => 'Yoast Woocommerce SEO',
-					),
+					'pluginNames' => WPSEO_Addon_Manager::get_addon_names(),
 				)
 			);
 			$asset_manager->enqueue_script( 'plugin-installation' );

--- a/admin/class-plugin-installation.php
+++ b/admin/class-plugin-installation.php
@@ -28,6 +28,10 @@ class WPSEO_Plugin_Installation implements WPSEO_WordPress_Integration {
 				WPSEO_Admin_Asset_Manager::PREFIX . 'plugin-installation',
 				'wpseoPluginInstallationL10n',
 				array(
+					'target'  => array(
+						'domain' =>'https://my.yoast.com',
+						'path'   => '/addsite?url=' . esc_html( home_url() ) . '&plugins=',
+					),
 					'pluginNames' => array(
 						'yoast-seo-wordpress-premium' => 'Yoast SEO Premium',
 						'yoast-seo-local'             => 'Yoast Local SEO',

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -186,6 +186,15 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 					?>
 				</a>
 
+				<a class="yoast-link--already-bought" href="#" id="<?php echo esc_attr( 'wpseo-already-bought-yoast-seo-wordpress-premium', 'wordpress-seo' ); ?>">
+					<?php
+					/* translators: %s expands to Yoast SEO Premium */
+					printf( esc_html__( 'I\'ve already bought %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+					echo $new_tab_message;
+					?>
+				</a>
+				<br />
+
 				<a target="_blank" href="<?php echo esc_url( $premium_extension->get_info_url() ); ?>"
 					class="yoast-link--more-info">
 					<?php
@@ -273,7 +282,6 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								/* translators: %s expands to the product name */
 								printf( esc_html__( 'I\'ve already bought %s', 'wordpress-seo' ), $extension->get_buy_button() );
 								echo $new_tab_message;
-								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 								?>
 							</a>
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -268,7 +268,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								?>
 							</a>
 
-							<a href="#" id="<?php esc_attr_e( 'wpseo-already-bought-' . $slug ); ?>">
+							<a class="yoast-link--already-bought" href="#" id="<?php esc_attr_e( 'wpseo-already-bought-' . $slug ); ?>">
 								<?php
 								/* translators: %s expands to the product name */
 								printf( esc_html__( 'I\'ve already bought %s', 'wordpress-seo' ), $extension->get_buy_button() );

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -268,7 +268,7 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								?>
 							</a>
 
-							<a class="yoast-link--already-bought" href="#" id="<?php esc_attr_e( 'wpseo-already-bought-' . $slug ); ?>">
+							<a class="yoast-link--already-bought" href="#" id="<?php echo esc_attr( 'wpseo-already-bought-' . $slug, 'wordpress-seo' ); ?>">
 								<?php
 								/* translators: %s expands to the product name */
 								printf( esc_html__( 'I\'ve already bought %s', 'wordpress-seo' ), $extension->get_buy_button() );

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -268,6 +268,15 @@ $new_tab_message         = '<span class="screen-reader-text">' . esc_html__( '(O
 								?>
 							</a>
 
+							<a href="#" id="<?php esc_attr_e( 'wpseo-already-bought-' . $slug ); ?>">
+								<?php
+								/* translators: %s expands to the product name */
+								printf( esc_html__( 'I\'ve already bought %s', 'wordpress-seo' ), $extension->get_buy_button() );
+								echo $new_tab_message;
+								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
+								?>
+							</a>
+
 							<a target="_blank" class="yoast-link--more-info"
 								href="<?php echo esc_url( $extension->get_info_url() ); ?>">
 								<?php

--- a/css/src/extensions.scss
+++ b/css/src/extensions.scss
@@ -96,7 +96,6 @@
 
 		&-upsell {
 			width: 100%;
-			margin-bottom: 1em;
 
 			@media only screen and (min-width: $page-width-small) {
 				width: auto;
@@ -250,6 +249,17 @@
 			margin: 0;
 			background-position: left center;
 		}
+	}
+
+	&-link--already-bought {
+		font-family: "Open Sans",Arial,sans-serif;
+		font-size: 1rem;
+		line-height: 1.88;
+		letter-spacing: 0.01em;
+		text-align: center;
+		display: block;
+		margin-bottom: 16px;
+		margin-top: 8px;
 	}
 
 	&-heading-highlight {

--- a/css/src/extensions.scss
+++ b/css/src/extensions.scss
@@ -232,13 +232,14 @@
 		}
 	}
 
-
 	&-link--more-info {
 		background: url(svg-icon-info($color-pink-dark));
 		padding-left: calc( 1em + 5px );
 		background-size: 1em;
 		background-repeat: no-repeat;
 		background-position: left center;
+		display: inline-block;
+		margin-top: 16px;
 
 		&:after {
 			content: " \00BB";
@@ -257,7 +258,7 @@
 		line-height: 1.88;
 		letter-spacing: 0.01em;
 		text-align: center;
-		display: block;
+		display: inline-block;
 		margin-bottom: 16px;
 		margin-top: 8px;
 	}

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -73,6 +73,21 @@ class WPSEO_Addon_Manager {
 	);
 
 	/**
+	 * Retrieves the list of addon names.
+	 *
+	 * @return array The list of addons.
+	 */
+	public static function get_addon_names() {
+		return array(
+			'yoast-seo-wordpress-premium' => 'Yoast SEO Premium',
+			'yoast-seo-local'             => 'Yoast Local SEO',
+			'yoast-seo-video'             => 'Yoast Video SEO',
+			'yoast-seo-news'              => 'Yoast News SEO',
+			'yoast-seo-woocommerce'       => 'Yoast Woocommerce SEO',
+		);
+	}
+
+	/**
 	 * Hooks into WordPress.
 	 *
 	 * @codeCoverageIgnore

--- a/js/src/components/PluginInstallation.js
+++ b/js/src/components/PluginInstallation.js
@@ -30,6 +30,43 @@ class PluginInstallation extends Component {
 	 * @returns {void}
 	 */
 	componentDidMount() {
+		this.registerPopUpListeners();
+		this.registerMessageListener();
+		this.checkUrlForInstallation();
+	}
+
+	registerPopUpListeners() {
+		const pluginSlugs = Object.keys( wpseoPluginInstallationL10n.pluginNames );
+		const target      = wpseoPluginInstallationL10n.target;
+
+		for ( let i = 0; i < pluginSlugs.length; i++ ) {
+			const linkElement = document.getElementById( `wpseo-already-bought-${ pluginSlugs[ i ] }` );
+
+			if ( ! linkElement ) {
+				continue;
+			}
+
+			linkElement.onclick = () => {
+				window.open(
+					target.domain + target.path + pluginSlugs[ i ],
+					"myyoast",
+					"height=700,width=500,menubar=no"
+				);
+			};
+		}
+	}
+
+	registerMessageListener() {
+		window.addEventListener( "message", event => {
+			if ( event.origin !== "https://my.yoast.com" ) {
+				return;
+			}
+
+			
+		} );
+	}
+
+	checkUrlForInstallation() {
 		const urlParams = new URLSearchParams( window.location.search );
 
 		if ( ! urlParams.has( "install_plugins" ) ) {

--- a/js/src/components/PluginInstallation.js
+++ b/js/src/components/PluginInstallation.js
@@ -19,6 +19,10 @@ const CloseButton = styled.a`
 	cursor: pointer;
 `;
 
+const AlertWithMarginTop = styled( Alert )`
+	margin-top: 16px;
+`;
+
 /**
  * Plugin installation modal.
  */
@@ -184,7 +188,7 @@ class PluginInstallation extends Component {
 		}
 
 		return (
-			<Alert
+			<AlertWithMarginTop
 				type="success"
 			>
 				{
@@ -196,7 +200,7 @@ class PluginInstallation extends Component {
 						)
 						: __( "Congratulations! Your products are successfully installed on your website!", "wordpress-seo" )
 				}
-			</Alert>
+			</AlertWithMarginTop>
 		);
 	}
 

--- a/js/src/install-plugin/actions.js
+++ b/js/src/install-plugin/actions.js
@@ -4,19 +4,40 @@ import apiFetch from "@wordpress/api-fetch";
 /**
  * Set tasks queue.
  *
- * @param {array} tasks The tasks.
+ * @param {array} tasks  The tasks.
+ * @param {bool}  single Whether or not this is a single plugin installation queue.
  *
  * @returns {Object} Redux action.
  */
-export function setQueue( tasks ) {
-	for ( let i = 0; i < tasks.length; i++ ) {
-		tasks[ i ].status = "pending";
-	}
-
+function setQueue( tasks, single ) {
 	return {
 		type: "SET_QUEUE",
+		singlePluginInstallation: single,
 		tasks,
 	};
+}
+
+export function queueMultiplePluginInstallations( pluginSlugs ) {
+	const queue = [];
+
+	for ( let i = 0; i < pluginSlugs.length; i++ ) {
+		queue.push( {
+			status: "pending",
+			type: "INSTALL_PLUGIN",
+			plugin: pluginSlugs[ i ],
+		} );
+		queue.push( {
+			status: "pending",
+			type: "ACTIVATE_PLUGIN",
+			plugin: pluginSlugs[ i ],
+		} );
+	}
+
+	return setQueue( queue, pluginSlugs.length === 1 ? pluginSlugs[ 0 ] : false );
+}
+
+export function queuePluginInstallation( pluginSlug ) {
+	return queueMultiplePluginInstallations( [ pluginSlug ] );
 }
 
 /**
@@ -26,7 +47,7 @@ export function setQueue( tasks ) {
  *
  * @returns {void}
  */
-async function installPlugin( pluginSlug ) {
+async function installPluginCall( pluginSlug ) {
 	await apiFetch( {
 		path: `/yoast/v1/myyoast/download/install?slug=${ pluginSlug }`,
 	} );
@@ -39,7 +60,7 @@ async function installPlugin( pluginSlug ) {
  *
  * @returns {void}
  */
-async function activatePlugin( pluginSlug ) {
+async function activatePluginCall( pluginSlug ) {
 	await apiFetch( {
 		path: `/yoast/v1/myyoast/download/activate?slug=${ pluginSlug }`,
 	} );
@@ -64,10 +85,10 @@ async function runTask( dispatch, task, taskIndex ) {
 	try {
 		switch ( task.type ) {
 			case "ACTIVATE_PLUGIN":
-				await activatePlugin( task.plugin );
+				await activatePluginCall( task.plugin );
 				break;
 			case "INSTALL_PLUGIN":
-				await installPlugin( task.plugin );
+				await installPluginCall( task.plugin );
 				break;
 		}
 	} catch ( e ) {

--- a/js/src/install-plugin/actions.js
+++ b/js/src/install-plugin/actions.js
@@ -17,6 +17,13 @@ function setQueue( tasks, single ) {
 	};
 }
 
+/**
+ * Que multiple plugins for installation and activation.
+ *
+ * @param {array<string>} pluginSlugs The plugin slugs.
+ *
+ * @returns {Object} Redux action.
+ */
 export function queueMultiplePluginInstallations( pluginSlugs ) {
 	const queue = [];
 
@@ -36,6 +43,13 @@ export function queueMultiplePluginInstallations( pluginSlugs ) {
 	return setQueue( queue, pluginSlugs.length === 1 ? pluginSlugs[ 0 ] : false );
 }
 
+/**
+ * Queue a single plugin for installation and activation.
+ *
+ * @param {string} pluginSlug The plugin slugs.
+ *
+ * @returns {Object} Redux action.
+ */
 export function queuePluginInstallation( pluginSlug ) {
 	return queueMultiplePluginInstallations( [ pluginSlug ] );
 }

--- a/js/src/install-plugin/reducer.js
+++ b/js/src/install-plugin/reducer.js
@@ -1,5 +1,6 @@
 const INITIAL_STATE = {
 	installing: false,
+	singlePluginInstallation: false,
 	tasks: [],
 };
 
@@ -33,6 +34,7 @@ export default ( state = INITIAL_STATE, action ) => {
 			return {
 				...INITIAL_STATE,
 				tasks: action.tasks,
+				singlePluginInstallation: action.singlePluginInstallation,
 			};
 		case "SET_INSTALLING":
 			return {

--- a/js/src/plugin-installation.js
+++ b/js/src/plugin-installation.js
@@ -1,6 +1,5 @@
 import { render } from "@wordpress/element";
 import { Provider } from "react-redux";
-import { Modal } from "@yoast/components";
 import configureStore from "./install-plugin/configureStore";
 import PluginInstallation from "./components/PluginInstallation";
 

--- a/js/src/plugin-installation.js
+++ b/js/src/plugin-installation.js
@@ -1,11 +1,13 @@
 import { render } from "@wordpress/element";
 import { Provider } from "react-redux";
+import { Modal } from "@yoast/components";
 import configureStore from "./install-plugin/configureStore";
 import PluginInstallation from "./components/PluginInstallation";
 
 const store = configureStore();
 
 const el = document.createElement( "div" );
+el.setAttribute( "id", "wpseo-app-element" );
 document.getElementById( "extensions" ).append( el );
 
 window.onbeforeunload = () => {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a way for plugins to be installed from MyYoast.

## Relevant technical choices:

* We expect an object from the popup in the following form:
```js
{
  success: true,
  url: 'http://your-domain.wordpress.test',
  plugins: [ 'the-slug' ],
}
```
* Multiple plugins can be installed at once. The texts change based on whether you install one or more plugin at a time. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

MyYoast plugin slugs:
Premium: `yoast-seo-wordpress-premium`
Local: `yoast-seo-local`
News: `yoast-seo-news`
Video: `yoast-seo-video`
WooCommerce: `yoast-seo-woocommerce`

* Link https://github.com/Yoast/javascript/pull/359
* Test plugin installation from URL:
  * Go to `/wp-admin/admin.php?page=wpseo_licenses&install_plugins=` + a comma separated list of plugin slugs from myyoast.
  * All plugins provided in the url should be installed.

* Test plugin installation from popup:
  * Install the following URL on a different environment (with a different host URL).
[popup.zip](https://github.com/Yoast/wordpress-seo/files/3626639/popup.zip)
  * In `/admin/class-plugin-installation` change the `target.domain` and `target.path` localized variables.
    * `domain`: `your.domain.test` < domain chosen in step 1.
    * `path` : `'/wp-admin/admin.php?page=wpseo_popup_page&url=' . esc_html( home_url() ) . '&plugin='`
  * Make sure the plugin you want to install isn't installed.
  * Go to the licenses page and click on `I've already bought ...`
  * A popup should open on the domain specified in step 1.
  * Click the `Install pluginslug` button.
  * The plugin should be installed.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13434 
