### PR TITLE
Adds abstract WPSEO Health Check class

### DIFF
--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -173,7 +173,7 @@ abstract class WPSEO_Health_Check {
 	}
 
 	/**
-	 * WordPress converts the underscore in dashed, just to prevent issues we have
+	 * WordPress converts the underscores to dashes. To prevent issues we have
 	 * to do it as well.
 	 *
 	 * @return string The formatted testname.

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -152,11 +152,11 @@ abstract class WPSEO_Health_Check {
 			$this->badge = array();
 		}
 
-		if ( empty( $this->badge['label'] )  ) {
+		if ( empty( $this->badge['label'] ) ) {
 			$this->badge['label'] = __( 'SEO', 'wordpress-seo' );
 		}
 
-		if ( empty( $this->badge['color'] )  ) {
+		if ( empty( $this->badge['color'] ) ) {
 			$this->badge['color'] = 'green';
 		}
 

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Internals
+ */
+
+/**
+ * Represents the abstract class for the health check.
+ */
+abstract class WPSEO_Health_Check {
+
+	const STATUS_GOOD = 'good';
+	const STATUS_RECOMMENDED = 'recommended';
+	const STATUS_CRITICAL = 'critical';
+
+	/**
+	 * Name of the test.
+	 *
+	 * @var string
+	 */
+	protected $name = '';
+
+	/**
+	 * The value of the section header in the Health check.
+	 *
+	 * @var string
+	 */
+	protected $label = '';
+
+	/**
+	 * Section the result should be displayed in.
+	 *
+	 * @var string
+	 */
+	protected $status = '';
+
+	/**
+	 * What the badge should say with a color.
+	 *
+	 * @var array
+	 */
+	protected $badge = array(
+		'label' => '',
+		'color' => '',
+	);
+
+	/**
+	 * Additional details about the results of the test.
+	 *
+	 * @var string
+	 */
+	protected $description = '';
+
+	/**
+	 * A link or button to allow the end user to take action on the result.
+	 *
+	 * @var string
+	 */
+	protected $actions = '';
+
+	/**
+	 * The name of the test.
+	 *
+	 * @var string
+	 */
+	protected $test = '';
+
+	/**
+	 * Whether or not the test should be ran on AJAX as well.
+	 *
+	 * @var bool True when is async, default false.
+	 */
+	protected $async = false;
+
+	/**
+	 * Runs the test and returns the result.
+	 *
+	 * @return array The result.
+	 */
+	abstract public function test();
+
+	/**
+	 * Registers the test to WordPress.
+	 */
+	public function register_test() {
+		if ( $this->async ) {
+			add_filter( 'wp_ajax_site_status_tests', array( $this, 'add_async_test' ) );
+
+			return;
+		}
+
+		add_filter( 'site_status_tests', array( $this, 'add_test' ) );
+
+	}
+
+	/**
+	 * Runs the test.
+	 *
+	 * @param array $tests Array with the current tests.
+	 *
+	 * @return array The extended array.
+	 */
+	public function add_test( $tests ) {
+		$tests['direct'][ $this->name ] = array(
+			'test' => array( $this, 'get_test_result' ),
+			'name' => $this->name,
+		);
+
+		return $tests;
+	}
+
+	/**
+	 * Runs the test in async mode.
+	 *
+	 * @param array $tests Array with the current tests.
+	 *
+	 * @return array The extended array.
+	 */
+	public function add_async_test( $tests ) {
+		$tests['async'][ $this->name ] = array(
+			'test' => array( $this, 'get_test_result' ),
+			'name' => $this->name,
+		);
+
+		return $tests;
+	}
+
+	/**
+	 * Formats the test result as an array.
+	 *
+	 * @return array The formatted test result.
+	 */
+	public function get_test_result() {
+		$this->test();
+
+		return array(
+			'label'       => $this->label,
+			'status'      => $this->status,
+			'badge'       => $this->get_badge(),
+			'description' => $this->description,
+			'actions'     => $this->actions,
+		);
+	}
+
+	/**
+	 * Retrieves the badge and ensure usable values are set.
+	 *
+	 * @return array The proper formatted badge.
+	 */
+	protected function get_badge() {
+		if ( ! is_array( $this->badge ) ) {
+			$this->badge = array();
+		}
+
+		if ( empty( $this->badge['label'] )  ) {
+			$this->badge['label'] = __( 'SEO', 'wordpress-seo' );
+		}
+
+		if ( empty( $this->badge['color'] )  ) {
+			$this->badge['color'] = 'green';
+		}
+
+		return $this->badge;
+	}
+}

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -91,7 +91,6 @@ abstract class WPSEO_Health_Check {
 		}
 
 		add_filter( 'site_status_tests', array( $this, 'add_test' ) );
-
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added the basis for adding checks in the WordPress Site Health page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch
* Create the following class and make sure to run `composer dump-autoload` 
```php
class WPSEO_Example_Check extends WPSEO_Health_Check {

	protected $test = 'yoast_test_health_check';
	protected $name = 'test_health_check';
	
	public function run() {
		$this->label = __( 'Your site failed the test check!' );
		$this->status = self::STATUS_CRITICAL;
		$this->description = __( 'Lorum ipsum' );
		$this->actions = '<a href="https://yoa.st/test-check-failed">Click here!</a>';
	}
}
```
* Add the following lines to the end of the `wp-seo-main.php` file
```php
add_action( 'init', function() {
     $check = new WPSEO_Example_Check();
     $check->register_test();
} );
```
* Go to the Site Health page (Tools > Site Health) and see our notice.
* In the example class add the next property:
```php
   protected $async = true;
```
* Again visit the Site Health page and verify the error is loaded by AJAX.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12903
