### PR TITLE
Remove colons from labels in option form fields

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -364,7 +364,7 @@ class Yoast_Form {
 		}
 
 		$this->label(
-			$label . ':',
+			$label,
 			array(
 				'for'   => $var,
 				'class' => 'textinput',
@@ -406,7 +406,7 @@ class Yoast_Form {
 		$val      = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
 
 		$this->label(
-			$label . ':',
+			$label,
 			array(
 				'for'   => $var,
 				'class' => 'textinput',
@@ -455,7 +455,7 @@ class Yoast_Form {
 
 		if ( $show_label ) {
 			$this->label(
-				$label . ':',
+				$label,
 				array(
 					'for'   => $var,
 					'class' => 'select',
@@ -505,7 +505,7 @@ class Yoast_Form {
 
 		$var_esc = esc_attr( $var );
 		$this->label(
-			$label . ':',
+			$label,
 			array(
 				'for'   => $var,
 				'class' => 'select',
@@ -544,7 +544,7 @@ class Yoast_Form {
 		$var_esc = esc_attr( $var );
 
 		$this->label(
-			$label . ':',
+			$label,
 			array(
 				'for'   => 'wpseo_' . $var,
 				'class' => 'select',


### PR DESCRIPTION
## Summary
As discussed and confirmed in #local-seo channel by @luckickken and @omarreiss we decided to remove the colon at the and of the settings form fields.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.

If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* [wordpress-seo] Removed the colon from admin form labels
* [wordpress-seo-local] Fixes a regression where admin form labels looked odd, because of the colon.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Check all the settings pages in Yoast SEO, and see the colon is removed at the end of each label.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance
* [ ] I have tested this code to the best of my abilities

Fixes #13499 