### PR TITLE
Fix the heading structure of the readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -101,20 +101,20 @@ For more info on search engine optimization and WordPress SEO in specific, check
 == Installation ==
 Starting with Yoast SEO consists of just two steps: installing and setting up the plugin. Yoast SEO is designed to work with your site’s specific needs, so don’t forget to go through the Yoast SEO configuration wizard as explained in the ‘after activation’ step!
 
-= INSTALL YOAST SEO FROM WITHIN WORDPRESS =
+### INSTALL YOAST SEO FROM WITHIN WORDPRESS
 
 1. Visit the plugins page within your dashboard and select ‘Add New’;
 1. Search for ‘Yoast SEO’;
 1. Activate Yoast SEO from your Plugins page;
 1. Go to ‘after activation’ below.
 
-= INSTALL YOAST SEO MANUALLY =
+### INSTALL YOAST SEO MANUALLY
 
 1. Upload the ‘wordpress-seo’ folder to the /wp-content/plugins/ directory;
 1. Activate the Yoast SEO plugin through the ‘Plugins’ menu in WordPress;
 1. Go to ‘after activation’ below.
 
-= AFTER ACTIVATION =
+### AFTER ACTIVATION
 
 1. You should see (a notice to start) the Yoast SEO configuration wizard;
 1. Go through the configuration wizard and set up the plugin for your site;
@@ -123,10 +123,12 @@ Starting with Yoast SEO consists of just two steps: installing and setting up th
 == Frequently Asked Questions ==
 
 = How do the XML Sitemaps in the Yoast SEO plugin work? =
+
 Having an XML sitemap can be beneficial for SEO, as Google can retrieve essential pages of a website very fast, even if the internal linking of a site isn’t flawless.
 The sitemap index and individual sitemaps are updated automatically as you add or remove content and will include the post types you want search engines to index. Post Types marked as noindex will not appear in the sitemap. [Learn more about XML Sitemaps](https://yoa.st/3qt).
 
 = How can I add my website to Google Search Console? =
+
 It is straightforward to add your website to Google Search Console. 
 1. Create a Google Search Console account and login into your account.
 1. Click ‘Add a property’ under the search drop-down.
@@ -143,6 +145,7 @@ It is straightforward to add your website to Google Search Console.
 If you want more details steps, please visit [our article on our knowledge base](https://yoa.st/3qu).
 
 = How do I implement Yoast SEO breadcrumbs? =
+
 The steps below are a temporary solution as manual edits made to theme files may be overwritten with future theme updates. Please contact the theme developer for a permanent solution. We’ve written an article about the [importance of breadcrumbs for SEO](https://yoa.st/3qv). 
 
 To implement the [breadcrumbs]https://yoa.st/3qw) function in Yoast SEO, you will have to edit your theme. We recommend that prior to any editing of the theme files, a backup is taken. Your host provider can help you take a backup.
@@ -164,23 +167,27 @@ Alternatively, you can manually add the breadcrumb shortcode to individual posts
 If you need more details or a step by step guide, read our [Implementation guide for Yoast SEO breadcrumbs](https://yoa.st/3qx).
 
 = How do I noindex URLS? =
+
 Yoast SEO provides multiple options for setting a URL or group of URLs to noindex. [Read more about how to do this in this guide](https://yoa.st/3qy/).
 
 = Google shows the wrong description, how do I fix this? =
+
 If you’ve crafted nice meta descriptions for your blog posts, nothing is more annoying than Google showing another description for your site completely in the search result snippet. 
 
 Possible causes could be:
 1. wrong description in code
-1. Google cache is outdated
-1. Search term manipulation
-1. Google ignored the meta description
+2. Google cache is outdated
+3. Search term manipulation
+4. Google ignored the meta description
 
 You can [read more here on how to solve the issue with the wrong description](https://yoa.st/3qz).
 
 = How often is Yoast SEO updated? =
+
 Yoast SEO is updated every two weeks. If you want to know why, please read [this post on why we release every two weeks](https://yoa.st/3q-)!
 
 = How do I get support? =
+
 As our free plugin is used by millions of people worldwide, we cannot offer you all one on one support. If you have trouble with the Yoast SEO for WordPress plugin, you can get help on the support forums here at [wordpress.org](https://wordpress.org/support/plugin/wordpress-seo/) or by checking out or knowledge base at [kb.yoast.com](https://yoa.st/3r1). 
 
 The plugins you buy at Yoast are called ‘premium plugins’ (even if Premium isn’t in its name) and include a complete year of free updates and premium support. This means you can contact our support team if you have any questions about that plugin.
@@ -188,6 +195,7 @@ The plugins you buy at Yoast are called ‘premium plugins’ (even if Premium i
 [Read more on how to get support](https://yoa.st/3r2)
 
 = I have a different question than listed here =
+
 Your question has most likely been answered on our knowledge base: [kb.yoast.com](https://yoa.st/1va).
 
 == Screenshots ==


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* I've used the example in https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/ to fix the readme.
   * I've changed `=` to `###` in headings we came up with. Only 'official' WordPress headings can have `=` or `==`.
   * I've added a newline between the question and the answer in the FAQ.
   * Just to be sure, I used increasing numbers in the ordered list.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12121
