### PR TITLE
Let free do the tracking, default off.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -111,6 +111,7 @@ class WPSEO_Admin {
 		$integrations[] = new WPSEO_MyYoast_Proxy();
 		$integrations[] = new WPSEO_MyYoast_Route();
 		$integrations[] = new WPSEO_Schema_Person_Upgrade_Notification();
+		$integrations[] = new WPSEO_Tracking( 'https://tracking.yoast.com', ( WEEK_IN_SECONDS * 2 ) );
 
 		$integrations = array_merge(
 			$integrations,

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -14,14 +14,14 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 	 * @var array $anonymous_settings contains all of the option_names which need to be
 	 * anonimized before they can be sent elsewhere.
 	 */
-	private $anonymous_settings = [
+	private $anonymous_settings = array(
 		"baiduverify", "googleverify", "msverify", "yandexverify", "website_name",
 		"alternate_website_name", "company_logo", "company_name", "person_name",
 		"person_logo", "person_logo_id", "company_logo_id", "facebook_site",
 		"instagram_url", "linkedin_url", "myspace_url", "pinterest_url",
 		"pinterestverify", "twitter_site", "youtube_url", "wikipedia_url",
 		"fbadminapp",
-	];
+	);
 
 	/**
 	 * Returns the collection data.

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -81,7 +81,7 @@ class WPSEO_Tracking extends WPSEO_WordPress_Integration {
 		 *
 		 * @api string $is_disabled The disabled state. Default is false.
 		 */
-		if ( apply_filters( 'wpseo_disable_tracking', true ) === true ) {
+		if ( apply_filters( 'wpseo_enable_tracking', false ) === false ) {
 			return false;
 		}
 

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -8,7 +8,7 @@
 /**
  * This class handles the tracking routine.
  */
-class WPSEO_Tracking {
+class WPSEO_Tracking extends WPSEO_WordPress_Integration {
 
 	/**
 	 * The tracking option name.
@@ -45,10 +45,15 @@ class WPSEO_Tracking {
 	/**
 	 * Registers all hooks to WordPress.
 	 */
-	public function send() {
+	public function register_hooks() {
+		add_action( 'admin_init', array( $this, 'send' ), 1 );
+	}
 
-		$current_time = time();
-		if ( ! $this->should_send_tracking( $current_time ) ) {
+	/**
+	 * Sends the tracking data.
+	 */
+	public function send() {
+		if ( ! $this->should_send_tracking() ) {
 			return;
 		}
 
@@ -68,7 +73,24 @@ class WPSEO_Tracking {
 	 *
 	 * @return bool True when tracking data should be send.
 	 */
-	protected function should_send_tracking( $current_time ) {
+	protected function should_send_tracking() {
+		global $pagenow;
+
+		/**
+		 * Filter: 'wpseo_disable_tracking' - Disables the data tracking of Yoast SEO Premium.
+		 *
+		 * @api string $is_disabled The disabled state. Default is false.
+		 */
+		if ( apply_filters( 'wpseo_disable_tracking', true ) === true ) {
+			return false;
+		}
+
+		// Because we don't want to possibly block plugin actions with our routines.
+		if ( in_array( $pagenow, array( 'plugins.php', 'plugin-install.php', 'plugin-editor.php' ), true ) ) {
+			return false;
+		}
+
+		$current_time = time();
 		$last_time = get_option( $this->option_name );
 
 		// When there is no data being set.

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -8,7 +8,7 @@
 /**
  * This class handles the tracking routine.
  */
-class WPSEO_Tracking extends WPSEO_WordPress_Integration {
+class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 
 	/**
 	 * The tracking option name.


### PR DESCRIPTION
## Summary

Made WPSEO_Tracking an integration.

`should_send_tracking()` now checks for everything that might impact if we should send or not. Default off. Can be enabled through a filter.