### PR TITLE
Makes "old WP version notice" dynamic

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -449,7 +449,7 @@ class WPSEO_Admin_Init {
 				'wordpress-seo'
 			),
 			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/old-wp-support' ) . '" target="_blank" rel="nofollow">',
-			'</a>'
+			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
 		);
 
 		$notification = new Yoast_Notification(

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -392,12 +392,12 @@ class WPSEO_Admin_Init {
 	 *
 	 * @return string $latest_major_wp_version The latest released major WordPress version.
 	 */
-	private function get_latest_major_wordpress_version(){
+	private function get_latest_major_wordpress_version() {
 		$stability_check_api_url = 'http://api.wordpress.org/core/stable-check/1.0/';
 		$wp_version_stability_json = file_get_contents( $stability_check_api_url );
 		$wp_version_stability_object = json_decode( $wp_version_stability_json );
-		$wp_version_stability_array = ( array )$wp_version_stability_object;;
-		$latest_wp_version_string = array_search ( 'latest', $wp_version_stability_array );
+		$wp_version_stability_array = (array) $wp_version_stability_object;
+		$latest_wp_version_string = array_search( 'latest', $wp_version_stability_array, true );
 		$latest_major_wp_version = floatval( $latest_wp_version_string );
 
 		return $latest_major_wp_version;
@@ -417,11 +417,11 @@ class WPSEO_Admin_Init {
 		 * Calculate the next major WordPress version and convert it to a string.
 		 */
 		$latest_wp_version_number = floor( $latest_major_wp_version );
-		$latest_wp_version_decimal = $latest_major_wp_version - $latest_wp_version_number;
+		$latest_wp_version_decimal = ( $latest_major_wp_version - $latest_wp_version_number );
 
 		$next_major_wp_version = bcadd( $latest_major_wp_version, 0.1, 1 );
 
-		if ( $latest_wp_version_decimal == .9 ) {
+		if ( $latest_wp_version_decimal === .9 ) {
 			$next_major_wp_version = bcadd( $latest_major_wp_version, 1, 1 );
 		}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -390,17 +390,14 @@ class WPSEO_Admin_Init {
 	/**
 	 * Gets the latest released major WordPress version from the WordPress stable-check api.
 	 *
-	 * @return string $latest_major_wp_version The latest released major WordPress version.
+	 * @return float The latest released major WordPress version.
 	 */
 	private function get_latest_major_wordpress_version() {
-		$stability_check_api_url = 'http://api.wordpress.org/core/stable-check/1.0/';
-		$wp_version_stability_json = file_get_contents( $stability_check_api_url );
-		$wp_version_stability_object = json_decode( $wp_version_stability_json );
-		$wp_version_stability_array = (array) $wp_version_stability_object;
-		$latest_wp_version_string = array_search( 'latest', $wp_version_stability_array, true );
-		$latest_major_wp_version = floatval( $latest_wp_version_string );
+		$wp_version_stability     = json_decode( file_get_contents( 'http://api.wordpress.org/core/stable-check/1.0/' ) );
+		$latest_wp_version_string = array_search( 'latest', (array) $wp_version_stability, true );
 
-		return $latest_major_wp_version;
+		// Strip the patch version and convert to a float.
+		return floatval( $latest_wp_version_string );
 	}
 
 	/**
@@ -412,20 +409,9 @@ class WPSEO_Admin_Init {
 		global $wp_version;
 
 		$latest_major_wp_version = $this->get_latest_major_wordpress_version();
+		$next_major_wp_version   = number_format( ( $latest_major_wp_version + 0.1 ), 1 );
 
-		/**
-		 * Calculate the next major WordPress version and convert it to a string.
-		 */
-		$latest_wp_version_number = floor( $latest_major_wp_version );
-		$latest_wp_version_decimal = ( $latest_major_wp_version - $latest_wp_version_number );
-
-		$next_major_wp_version = bcadd( $latest_major_wp_version, 0.1, 1 );
-
-		if ( $latest_wp_version_decimal === .9 ) {
-			$next_major_wp_version = bcadd( $latest_major_wp_version, 1, 1 );
-		}
-
-		$wp_less_than_50 = version_compare( $wp_version, '5.0', '<' );
+		$wp_less_than_50             = version_compare( $wp_version, '5.0', '<' );
 		$wp_less_than_latest_version = version_compare( $wp_version, $latest_major_wp_version, '<' );
 
 		$notification_center = Yoast_Notification_Center::get();

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -393,7 +393,7 @@ class WPSEO_Admin_Init {
 	 * @return float The latest released major WordPress version. 0 The stable-check api doesn't respond.
 	 */
 	private function get_latest_major_wordpress_version() {
-		$response  = wp_remote_get( 'http://api.wordpress.org/core/stable-check/1.0/' );
+		$response = wp_remote_get( 'http://api.wordpress.org/core/stable-check/1.0/' );
 		if ( is_wp_error( $response ) ) {
 			return 0;
 		}
@@ -465,7 +465,7 @@ class WPSEO_Admin_Init {
 		);
 
 		if ( $wp_less_than_latest_version ) {
-			// if the latest WordPress version is not known, do not initiate the WordPress upgrade notice.
+			// If the latest WordPress version is not known, do not initiate the WordPress upgrade notice.
 			if ( $this->get_latest_major_wordpress_version() === 0 ) {
 				$notification_center->remove_notification( $notification );
 				return;

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -390,9 +390,9 @@ class WPSEO_Admin_Init {
 	/**
 	 * Gets the latest released major WordPress version from the WordPress stable-check api.
 	 *
-	 * @return string $latest_released_major_wp_version The latest released major WordPress version.
+	 * @return string $latest_major_wp_version The latest released major WordPress version.
 	 */
-	private function get_latest_released_major_wordpress_version(){
+	private function get_latest_major_wordpress_version(){
 		$stability_check_api_url = 'http://api.wordpress.org/core/stable-check/1.0/';
 		$wp_version_stability_json = file_get_contents( $stability_check_api_url );
 		$wp_version_stability_object = json_decode( $wp_version_stability_json );
@@ -411,7 +411,7 @@ class WPSEO_Admin_Init {
 	public function wordpress_upgrade_notice() {
 		global $wp_version;
 
-		$latest_major_wp_version = $this->get_latest_released_major_wordpress_version();
+		$latest_major_wp_version = $this->get_latest_major_wordpress_version();
 
 		/**
 		 * Calculate the next major WordPress version and convert it to a string.

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -419,10 +419,10 @@ class WPSEO_Admin_Init {
 		$latest_major_wp_version_number = floor( $latest_major_wp_version );
 		$latest_major_wp_version_decimal = $latest_major_wp_version - $latest_major_wp_version_number;
 
+		$next_major_wp_version = bcadd( $latest_major_wp_version, 0.1, 1 );
+
 		if ( $latest_major_wp_version_decimal == .9 ) {
 			$next_major_wp_version = bcadd( $latest_major_wp_version, 1, 1 );
-		} else {
-			$next_major_wp_version = bcadd( $latest_major_wp_version, 0.1, 1 );
 		}
 
 		$wp_less_than_50 = version_compare( $wp_version, '5.0', '<' );

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -416,17 +416,17 @@ class WPSEO_Admin_Init {
 		/**
 		 * Calculate the next major WordPress version and convert it to a string.
 		 */
-		$latest_major_wp_version_number = floor( $latest_major_wp_version );
-		$latest_major_wp_version_decimal = $latest_major_wp_version - $latest_major_wp_version_number;
+		$latest_wp_version_number = floor( $latest_major_wp_version );
+		$latest_wp_version_decimal = $latest_major_wp_version - $latest_wp_version_number;
 
 		$next_major_wp_version = bcadd( $latest_major_wp_version, 0.1, 1 );
 
-		if ( $latest_major_wp_version_decimal == .9 ) {
+		if ( $latest_wp_version_decimal == .9 ) {
 			$next_major_wp_version = bcadd( $latest_major_wp_version, 1, 1 );
 		}
 
 		$wp_less_than_50 = version_compare( $wp_version, '5.0', '<' );
-		$wp_less_than_latest_major_version = version_compare( $wp_version, $latest_major_wp_version, '<' );
+		$wp_less_than_latest_version = version_compare( $wp_version, $latest_major_wp_version, '<' );
 
 		$notification_center = Yoast_Notification_Center::get();
 
@@ -474,7 +474,7 @@ class WPSEO_Admin_Init {
 			)
 		);
 
-		if ( $wp_less_than_latest_major_version ) {
+		if ( $wp_less_than_latest_version ) {
 			$notification_center->add_notification( $notification );
 			return;
 		}


### PR DESCRIPTION
## Summary

* Enhances the old WP version notice, by getting and calculating the current and next WP version.
* Added the function "get_latest_major_wordpress_version", which gets the latest WP version.
* Calculates current and next major WP version, to be shown in the old WP version notice.


<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances the old WP version notice, by getting and calculating the current and next WP version.

## Relevant technical choices:

* I imported the latest WordPress version from the 'stable-check' API from WordPress (http://api.wordpress.org/core/stable-check/1.0/).
CR: Please check if this is done safely!

* I converted the JSON object to a PHP object and the PHP object to an array and took the latest wp version from that array. 

* I used `bcadd()` to calculate the next major WP version. I did this because `round()`, `floor()` and `ceil()` all change the value, while `bcadd()` (if applicable) cuts the remaining decimals off. `bcadd()` also converts the `floats` to `strings`, which is needed to use them in the notice text.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out [this PR](https://github.com/Yoast/wordpress-seo/pull/12956) on how to install different wp versions.

* Go to the SEO dashboard to check the notifications.
There should also be a notice if you are not on the latest WP version.

It looks like this:

![image](https://user-images.githubusercontent.com/42736463/65602939-09e34d00-dfa5-11e9-91ec-fd705977b1d1.png)


* Make sure the text (in the notice) displays the versions correctly in this bit: 
> When the next version of WordPress comes out, that means that we will support WordPress [CURRENT_VERSION] and [NEXT_VERSION]. 

In the following format: 
CURRENT_VERSION: `5.2`
NEXT_VERSION: `5.3`

or

CURRENT_VERSION: `5.9`
NEXT_VERSION: `6.0`

Check which WordPress version is the latest [here](http://api.wordpress.org/core/stable-check/1.0/)

To manually change the latest version, for example to test a version change from 5.9 to 6.0:
Change `$latest_major_wp_version = $this->get_latest_major_wordpress_version();` on line 414 in the `admin/clas-admin-init.php` file to `$latest_major_wp_version = 5.9;`

* If you are on the latest wordpress version, there should be no notice at all.

* Make sure the versions outputted in the text always contain one decimal (such as 5.2, NOT 5.2.3 or 5.34).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12952 
