### PR TITLE
Revert "Replace 'SEO Available' with more descriptive text"

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -116,7 +116,7 @@ class WPSEO_Metabox_Formatter {
 							__( '%1$sSEO%2$s: %3$s', 'wordpress-seo' ),
 							'<a href="#yoast-seo-analysis-collapsible-metabox">',
 							'</a>',
-							'<strong>' . __( 'Focus Keyphrase not set', 'wordpress-seo' ) . '</strong>'
+							'<strong>' . __( 'Not available', 'wordpress-seo' ) . '</strong>'
 						),
 						'bad'  => sprintf(
 							/* translators: %1$s expands to the opening anchor tag, %2$s to the closing anchor tag, %3$s to the SEO score. */

--- a/inc/class-wpseo-rank.php
+++ b/inc/class-wpseo-rank.php
@@ -135,7 +135,7 @@ class WPSEO_Rank {
 	 */
 	public function get_label() {
 		$labels = array(
-			self::NO_FOCUS => __( 'Focus Keyphrase not set', 'wordpress-seo' ),
+			self::NO_FOCUS => __( 'Not available', 'wordpress-seo' ),
 			self::NO_INDEX => __( 'No index', 'wordpress-seo' ),
 			self::BAD      => __( 'Needs improvement', 'wordpress-seo' ),
 			self::OK       => __( 'OK', 'wordpress-seo' ),

--- a/integration-tests/test-class-wpseo-rank.php
+++ b/integration-tests/test-class-wpseo-rank.php
@@ -82,7 +82,7 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	 */
 	public function provider_get_label() {
 		return array(
-			array( WPSEO_Rank::NO_FOCUS, 'Focus Keyphrase not set' ),
+			array( WPSEO_Rank::NO_FOCUS, 'Not available' ),
 			array( WPSEO_Rank::NO_INDEX, 'No index' ),
 			array( WPSEO_Rank::BAD, 'Needs improvement' ),
 			array( WPSEO_Rank::OK, 'OK' ),

--- a/integration-tests/test-class-wpseo-utils.php
+++ b/integration-tests/test-class-wpseo-utils.php
@@ -129,7 +129,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 			array( 71, true, 'good' ),
 			array( 83, true, 'good' ),
 			array( 100, true, 'good' ),
-			array( 0, false, 'Focus Keyphrase not set' ),
+			array( 0, false, 'Not available' ),
 			array( 1, false, 'Needs improvement' ),
 			array( 23, false, 'Needs improvement' ),
 			array( 40, false, 'Needs improvement' ),


### PR DESCRIPTION
Reverts Yoast/wordpress-seo#13242

The change from 'Not available' to 'Focus Keyphrase not set' in `inc/class-wpseo-rank.php` had some unwanted consequences for the readability scores if they were not available. Since WPSEO_Rank is being used for both the readability score as well as the SEO score, the readability score aria-label in the post overview and the readability scores in the scores export (in Premium) were 'Focus Keyphrase not set'. However, the readability score is not dependent on a keyphrase being set.

Of course, it would be nicer if those two analyses could have their own score strings, but for now we chose for reverting the changes.