### PR TITLE
Fix failing unit test by adding newly introduced robots string

### DIFF
--- a/integration-tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-robots.php
@@ -45,7 +45,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		$this->go_to( get_home_url() );
 
 		// Test home page with no special options.
-		$this->assertEquals( '', self::$class_instance->robots() );
+		$this->assertEquals( 'max-snippet:-1, max-image-preview:large, max-video-preview:-1', self::$class_instance->robots() );
 	}
 
 	/**
@@ -88,7 +88,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 
 		// Test 'paged' query var.
 		set_query_var( 'paged', 2 );
-		$this->assertEquals( '', self::$class_instance->robots() );
+		$this->assertEquals( 'max-snippet:-1, max-image-preview:large, max-video-preview:-1', self::$class_instance->robots() );
 		set_query_var( 'paged', 0 );
 	}
 
@@ -103,7 +103,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Test regular post with no special options.
-		$expected = '';
+		$expected = 'max-snippet:-1, max-image-preview:large, max-video-preview:-1';
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 	}
 
@@ -147,7 +147,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		$this->go_to( $category_link );
 
 		// Test regular category with no special options.
-		$expected = '';
+		$expected = 'max-snippet:-1, max-image-preview:large, max-video-preview:-1';
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 	}
 
@@ -183,7 +183,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		$this->go_to( get_author_posts_url( $user_id ) );
 
 		// Test author archive with no special options.
-		$expected = '';
+		$expected = 'max-snippet:-1, max-image-preview:large, max-video-preview:-1';
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 	}
 
@@ -221,7 +221,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		// Test that when this is _not_ set, we also do NOT have a noindex.
 		$user_id = $this->factory->user->create();
 		$this->go_to( get_author_posts_url( $user_id ) );
-		$expected = ''; // The default "index,follow" is automatically set to empty string.
+		$expected = 'max-snippet:-1, max-image-preview:large, max-video-preview:-1'; // The default "index,follow" is automatically set to empty string.
 		$this->assertEquals( $expected, self::$class_instance->robots() );
 	}
 

--- a/integration-tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-robots.php
@@ -123,6 +123,19 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	/**
 	 * @covers WPSEO_Frontend::robots
 	 */
+	public function test_post_nosnippet() {
+		// Create and go to post.
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Test nosnippet option.
+		WPSEO_Meta::set_value( 'meta-robots-adv', 'nosnippet', $post_id );
+		$this->assertEquals( 'nosnippet', self::$class_instance->robots() );
+	}
+
+	/**
+	 * @covers WPSEO_Frontend::robots
+	 */
 	public function test_private_post() {
 		// Create and go to post.
 		$post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See the tests pass

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
