### PR TITLE
Revert "Add clean:artifact after compress:artifact"

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -78,6 +78,7 @@ clean:build-assets:
   - 'copy:artifact'
   # Create a zip file
   - 'compress:artifact'
+  # There is no `clean:artifact` here because the `wp_deploy` needs the `artifact` folder.
   - 'restore-environment-after-artifact'
 
 'restore-environment-after-artifact':

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -78,8 +78,6 @@ clean:build-assets:
   - 'copy:artifact'
   # Create a zip file
   - 'compress:artifact'
-  # Remove build folder
-  - 'clean:artifact'
   - 'restore-environment-after-artifact'
 
 'restore-environment-after-artifact':


### PR DESCRIPTION
## Summary
The `wp_deploy` task needs the `artifact` folder. We found this out during the RC process.
The new plan (to be done on `trunk`) is to add the `clean:artifact` as step in the `deploy:trunk` and `deploy:master` tasks (after `wp_deploy` of course). Because it would still be nice to remove the `artifact` folder after releasing to have the environment ready for the next release. This means the `remove artifact folder` step can be removed from the release steps.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts Yoast/wordpress-seo#13531

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
