### PR TITLE
Added `generate_robots` for term archive pages

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1626,7 +1626,6 @@ class WPSEO_Frontend {
 	 * @return bool
 	 */
 	protected function is_multiple_terms_query() {
-
 		global $wp_query;
 
 		if ( ! is_tax() && ! is_tag() && ! is_category() ) {

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -210,4 +210,26 @@ class Current_Page_Helper {
 
 		return $wp_query->is_404();
 	}
+
+	/**
+	 * Determine whether this page is an taxonomy archive page for multiple terms (url: /term-1,term2/).
+	 *
+	 * @return bool Whether or not the current page is an archive page for multiple terms.
+	 */
+	public function is_multiple_terms_page() {
+		$wp_query = $this->wp_query_wrapper->get_main_query();
+
+		if ( ! $this->is_term_archive() ) {
+			return false;
+		}
+
+		$term          = $wp_query->get_queried_object();
+		$queried_terms = $wp_query->tax_query->queried_terms;
+
+		if ( empty( $queried_terms[ $term->taxonomy ]['terms'] ) ) {
+			return false;
+		}
+
+		return \count( $queried_terms[ $term->taxonomy ]['terms'] ) > 1;
+	}
 }

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * A helper object for terms.
+ *
+ * @package Yoast\YoastSEO\Helpers
+ */
+
+namespace Yoast\WP\Free\Helpers;
+
+use \WP_Term;
+
+/**
+ * Class Taxonomy_Helper
+ */
+class Taxonomy_Helper {
+
+	/**
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * Taxonomy_Helper constructor.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct( Options_Helper $options_helper ) {
+		$this->options_helper = $options_helper;
+	}
+
+	/**
+	 * Checks if the requested term is indexable.
+	 *
+	 * @param string $taxonomy The taxonomy slug.
+	 *
+	 * @return bool True when taxonomy is set to index.
+	 */
+	public function is_indexable( $taxonomy ) {
+		return ! $this->options_helper->get( 'noindex-tax-' . $taxonomy, false );
+	}
+}

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -68,7 +68,7 @@ class Indexable extends Yoast_Model {
 	 *
 	 * @var array
 	 */
-	protected $boolean_columns = [  'is_robots_noindex', 'is_robots_nofollow', 'is_robots_noarchive', 'is_robots_noimageindex', 'is_robots_nosnippet' ];
+	protected $boolean_columns = [ 'is_robots_noindex', 'is_robots_nofollow', 'is_robots_noarchive', 'is_robots_noimageindex', 'is_robots_nosnippet' ];
 
 	/**
 	 * The loaded indexable extensions.

--- a/src/orm/yoast-model.php
+++ b/src/orm/yoast-model.php
@@ -535,7 +535,7 @@ class Yoast_Model {
 	 */
 	public function __set( $property, $value ) {
 		if ( $value !== null && \in_array( $property, $this->boolean_columns, true ) ) {
-			$value = $value ? '1' : '0';
+			$value = ( $value ) ? '1' : '0';
 		}
 
 		$this->orm->set( $property, $value );

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -8,6 +8,8 @@
 namespace Yoast\WP\Free\Presentations;
 
 use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Taxonomy_Helper;
+use Yoast\WP\Free\Wrappers\WP_Query_Wrapper;
 
 /**
  * Class Indexable_Presentation
@@ -20,14 +22,30 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	private $options_helper;
 
 	/**
+	 * @var WP_Query_Wrapper
+	 */
+	private $wp_query_wrapper;
+
+	/**
+	 * @var Taxonomy_Helper
+	 */
+	private $taxonomy_helper;
+
+	/**
 	 * Indexable_Post_Type_Presentation constructor.
 	 *
-	 * @param Options_Helper $options_helper The options helper.
+	 * @param Options_Helper   $options_helper   The options helper.
+	 * @param WP_Query_Wrapper $wp_query_wrapper The wp query wrapper.
+	 * @param Taxonomy_Helper  $taxonomy_helper  The Taxonomy helper.
 	 */
 	public function __construct(
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		WP_Query_Wrapper $wp_query_wrapper,
+		Taxonomy_Helper $taxonomy_helper
 	) {
-		$this->options_helper = $options_helper;
+		$this->options_helper   = $options_helper;
+		$this->wp_query_wrapper = $wp_query_wrapper;
+		$this->taxonomy_helper  = $taxonomy_helper;
 	}
 
 	/**
@@ -96,5 +114,42 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		}
 
 		return '';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_robots() {
+		$robots = $this->robots_helper->get_base_values( $this->model );
+
+		/**
+		 * If its a multiple terms archive page return a noindex.
+		 */
+		if ( $this->current_page_helper->is_multiple_terms_page() ) {
+			$robots['index'] = 'noindex';
+			return $this->robots_helper->after_generate( $robots );
+		}
+
+		/**
+		 * @var \WP_Term $term
+		 */
+		$term = $this->wp_query_wrapper->get_query()->get_queried_object();
+
+		/**
+		 * First we get the no index option for this taxonomy, because it can be overwritten the indexable value for
+		 * this specific term.
+		 */
+		if ( ! $this->taxonomy_helper->is_indexable( $term->taxonomy ) ) {
+			$robots['index'] = 'noindex';
+		}
+
+		/**
+		 * Overwrite the index directive when there is a term specific directive set.
+		 */
+		if ( $this->model->is_robots_noindex !== null ) {
+			$robots['index'] = ( $this->model->is_robots_noindex ) ? 'noindex' : 'index';
+		}
+
+		return $this->robots_helper->after_generate( $robots );
 	}
 }

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Robots_Helper;
+use Yoast\WP\Free\Helpers\Taxonomy_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation;
+use Yoast\WP\Free\Tests\Mocks\Indexable;
+use Yoast\WP\Free\Wrappers\WP_Query_Wrapper;
+
+/**
+ * Trait Presentation_Instance_Builder
+ */
+trait Presentation_Instance_Builder {
+
+	/**
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * @var Indexable_Term_Archive_Presentation
+	 */
+	protected $instance;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $options_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $robots_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $current_page_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $wp_query_wrapper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $taxonomy_helper;
+
+	/**
+	 * Builds an instance of Indexable_Post_Type_Presentation.
+	 */
+	protected function setInstance() {
+		$this->indexable = new Indexable();
+
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
+		$this->wp_query_wrapper    = Mockery::mock( WP_Query_Wrapper::class );
+		$this->taxonomy_helper     = Mockery::mock( Taxonomy_Helper::class );
+
+		$instance = new Indexable_Term_Archive_Presentation(
+			$this->options_helper,
+			$this->wp_query_wrapper,
+			$this->taxonomy_helper
+		);
+
+		$this->instance = $instance->of( $this->indexable );
+		$this->instance->set_helpers(
+			$this->robots_helper,
+			$this->current_page_helper
+		);
+	}
+}

--- a/tests/presentations/indexable-term-archive-presentation/robots-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/robots-test.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class WPSEO_Schema_FAQ_Questions_Test.
+ *
+ * @group schema
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation
+ *
+ * @package Yoast\Tests\Frontend\Schema
+ */
+class Robots_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setInstance();
+
+		$this->robots_helper->expects( 'after_generate' )
+			->once()
+			->andReturnUsing( function( $robots ) {
+				return $robots;
+			} );
+	}
+
+	/**
+	 * Tests the generate_robots with default settings.
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots() {
+		$this->setup_wp_query_wrapper();
+
+		$this->robots_helper
+			->expects( 'get_base_values' )
+			->once()
+			->with( $this->indexable )
+			->andReturn( [
+				'index'  => 'index',
+				'follow' => 'follow',
+			] );
+
+		$this->current_page_helper
+			->expects( 'is_multiple_terms_page' )
+			->once()
+			->andReturn( false );
+
+		$this->taxonomy_helper
+			->expects( 'is_indexable' )
+			->with( 'category' )
+			->andReturn( true );
+
+		$actual = $this->instance->generate_robots();
+		$expected = [
+			'index' =>  'index',
+			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $actual, $expected );
+	}
+
+	/**
+	 * Tests whether generate_robots sets noindex when a taxonomy is set to not be indexed.
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots_taxonomy_not_indexable() {
+		$this->setup_wp_query_wrapper();
+
+		$this->robots_helper
+			->expects( 'get_base_values' )
+			->once()
+			->with( $this->indexable )
+			->andReturn( [
+				'index'  => 'index',
+				'follow' => 'follow',
+			] );
+
+		$this->current_page_helper
+			->expects( 'is_multiple_terms_page' )
+			->once()
+			->andReturn( false );
+
+		$this->taxonomy_helper
+			->expects( 'is_indexable' )
+			->with( 'category' )
+			->andReturn( false );
+
+		$actual = $this->instance->generate_robots();
+		$expected = [
+			'index' =>  'noindex',
+			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $actual, $expected );
+	}
+
+	/**
+	 * Tests whether generate_robots sets index when a taxonomy is set to not be indexed, but the
+	 * queried term is.
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots_taxonomy_not_indexable_term_indexable() {
+		$this->setup_wp_query_wrapper();
+
+		$this->robots_helper
+			->expects( 'get_base_values' )
+			->once()
+			->with( $this->indexable )
+			->andReturn( [
+				'index'  => 'index',
+				'follow' => 'follow',
+			] );
+
+		$this->current_page_helper
+			->expects( 'is_multiple_terms_page' )
+			->once()
+			->andReturn( false );
+
+		$this->taxonomy_helper
+			->expects( 'is_indexable' )
+			->with( 'category' )
+			->andReturn( false );
+
+		$this->indexable->is_robots_noindex = false;
+
+		$actual = $this->instance->generate_robots();
+		$expected = [
+			'index' =>  'index',
+			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $actual, $expected );
+	}
+
+	/**
+	 * Tests whether generate_robots sets noindex when a taxonomy is set to be indexed, but the
+	 * queried term is not.
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots_taxonomy_indexable_term_not_indexable() {
+		$this->setup_wp_query_wrapper();
+
+		$this->robots_helper
+			->expects( 'get_base_values' )
+			->once()
+			->with( $this->indexable )
+			->andReturn( [
+				'index'  => 'noindex',
+				'follow' => 'follow',
+			] );
+
+		$this->current_page_helper
+			->expects( 'is_multiple_terms_page' )
+			->once()
+			->andReturn( false );
+
+		$this->taxonomy_helper
+			->expects( 'is_indexable' )
+			->with( 'category' )
+			->andReturn( true );
+
+		$this->indexable->is_robots_noindex = true;
+
+		$actual = $this->instance->generate_robots();
+		$expected = [
+			'index' =>  'noindex',
+			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $actual, $expected );
+	}
+
+	/**
+	 * Tests whether generate_robots sets noindex when multiple terms are being queried.
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots_multi_terms_page() {
+		$this->robots_helper
+			->expects( 'get_base_values' )
+			->once()
+			->with( $this->indexable )
+			->andReturn( [
+				'index'  => 'index',
+				'follow' => 'follow',
+			] );
+
+		$this->current_page_helper
+			->expects( 'is_multiple_terms_page' )
+			->once()
+			->andReturn( true );
+
+		$this->taxonomy_helper
+			->expects( 'is_indexable' )
+			->never();
+
+		$actual = $this->instance->generate_robots();
+		$expected = [
+			'index' =>  'noindex',
+			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $actual, $expected );
+	}
+
+	/**
+	 * Setup default WP_Query_Wrapper.
+	 */
+	private function setup_wp_query_wrapper() {
+		$wp_query = Mockery::mock( '\WP_Query' );
+		$wp_query
+			->expects( 'get_queried_object' )
+			->zeroOrMoreTimes()
+			->andReturn( (object) [
+				'taxonomy' => 'category',
+			] );
+		$this->wp_query_wrapper
+			->expects( 'get_query' )
+			->zeroOrMoreTimes()
+			->andReturn( $wp_query );
+	}
+}

--- a/tests/presentations/indexable-term-archive-presentation/twitter-description-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/twitter-description-test.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
 
-use Mockery;
-use Yoast\WP\Free\Helpers\Options_Helper;
-use Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation;
-use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
 
@@ -19,33 +15,15 @@ use Brain\Monkey;
  * @group twitter-description
  */
 class Twitter_Description_Test extends TestCase {
-
-	/**
-	 * @var Options_Helper|Mockery\MockInterface
-	 */
-	protected $option_helper;
-
-	/**
-	 * @var Indexable
-	 */
-	protected $indexable;
-
-	/**
-	 * @var Indexable_Term_Archive_Presentation
-	 */
-	protected $instance;
+	use Presentation_Instance_Builder;
 
 	/**
 	 * Does the setup for testing.
 	 */
 	public function setUp() {
-		$this->option_helper = Mockery::mock( Options_Helper::class );
-		$this->indexable     = new Indexable();
+		parent::setUp();
 
-		$presentation   = new Indexable_Term_Archive_Presentation( $this->option_helper );
-		$this->instance = $presentation->of( $this->indexable );
-
-		return parent::setUp();
+		$this->setInstance();
 	}
 
 	/**
@@ -65,7 +43,7 @@ class Twitter_Description_Test extends TestCase {
 	 * @covers ::generate_twitter_description
 	 */
 	public function test_with_term_description() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->andReturn( '' );
@@ -87,7 +65,7 @@ class Twitter_Description_Test extends TestCase {
 	 * @covers ::generate_twitter_description
 	 */
 	public function test_with_no_term_description() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->andReturn( '' );

--- a/tests/presentations/indexable-term-archive-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/twitter-image-test.php
@@ -2,11 +2,8 @@
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
 
-use Mockery;
-use Yoast\WP\Free\Helpers\Options_Helper;
-use Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation;
-use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
+use Brain\Monkey;
 
 /**
  * Class Abstract_Robots_Presenter_Test
@@ -18,33 +15,15 @@ use Yoast\WP\Free\Tests\TestCase;
  * @group twitter-image
  */
 class Twitter_Image_Test extends TestCase {
-
-	/**
-	 * @var Options_Helper|Mockery\MockInterface
-	 */
-	protected $option_helper;
-
-	/**
-	 * @var Indexable
-	 */
-	protected $indexable;
-
-	/**
-	 * @var Indexable_Term_Archive_Presentation
-	 */
-	protected $instance;
+	use Presentation_Instance_Builder;
 
 	/**
 	 * Does the setup for testing.
 	 */
 	public function setUp() {
-		$this->option_helper = Mockery::mock( Options_Helper::class );
-		$this->indexable     = new Indexable();
+		parent::setUp();
 
-		$presentation   = new Indexable_Term_Archive_Presentation( $this->option_helper );
-		$this->instance = $presentation->of( $this->indexable );
-
-		return parent::setUp();
+		$this->setInstance();
 	}
 
 	/**
@@ -64,7 +43,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_opengraph_disabled() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->with( 'opengraph' )
@@ -81,7 +60,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_opengraph_image() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->with( 'opengraph' )
@@ -98,12 +77,12 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_applied_filter_returning_false() {
-		\Brain\Monkey\Functions\expect( 'apply_filters' )
+		Monkey\Functions\expect( 'apply_filters' )
 			->once()
 			->with( 'wpseo_twitter_taxonomy_image', false )
 			->andReturn( false );
 
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->with( 'opengraph' )
 			->once()
@@ -118,7 +97,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_applied_filter() {
-		\Brain\Monkey\Functions\expect( 'apply_filters' )
+		Monkey\Functions\expect( 'apply_filters' )
 			->once()
 			->with( 'wpseo_twitter_taxonomy_image', false )
 			->andReturn( 'filtered_image.jpg' );
@@ -133,7 +112,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_default_image() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->andReturn( true, 'default_image.jpg' );
@@ -147,7 +126,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function _test_with_() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->andReturn( true, 'default_image.jpg' );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:


### Default settings
* Set `SEO` > `Search Appearance` > `Taxonomies` > `Categories` > `Show Categories in search results?` to `Yes`.
* Create a new category (use all default SEO settings).
* Visit the category page, make sure there is no robots meta tag.

### Taxonomies settings
* Set `SEO` > `Search Appearance` > `Taxonomies` > `Categories` > `Show Categories in search results?` to `No`.
* Create a new category (use all default SEO settings).
* Visit the category page, make sure there is a `noindex,follow` robots meta tag.

### Term settings precedence
* Set `SEO` > `Search Appearance` > `Taxonomies` > `Categories` > `Show Categories in search results?` to `No`.
* Create a new category, and edit it.
* In the Yoast SEO metabox set `SEO` > `Advanced` > `Allow search engines to show this Category in search results?` to `Yes`.
* Visit the category page, make sure there is no robots meta tag. This is because the term's SEO settings overrule the taxonomy settings.

### Multi term archive pages
* Set `SEO` > `Search Appearance` > `Taxonomies` > `Categories` > `Show Categories in search results?` to `Yes`.
* Create 2 new categories. Make sure you explicitely set their slug (e.g. `categoryterm1` and `categoryterm2` ). Use all default SEO settings.
* Go to a multi term archive page.
* By default this should be `http://one.wordpress.test/category/categoryterm1,categoryterm2/`.
* Make sure there is no robots meta tag.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
