### PR TITLE
Add twitter title presenter

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -89,22 +89,6 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	/**
 	 * @inheritDoc
 	 */
-	public function generate_twitter_title() {
-		if ( $this->model->twitter_title ) {
-			return $this->model->twitter_title;
-		}
-
-		$title = $this->meta_helper->get_value( 'twitter-title', $this->current_page_helper->get_simple_page_id() );
-		if ( ! is_string( $title ) ) {
-			return '';
-		}
-
-		return $this->title;
-	}
-
-	/**
-	 * @inheritDoc
-	 */
 	public function generate_replace_vars_object() {
 		return \get_post( $this->model->object_id );
 	}

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -411,18 +411,18 @@ class Indexable_Presentation extends Abstract_Presentation {
 	}
 
 	/**
-	 * Generates the twitter card type.
+	 * Generates the Twitter card type.
 	 *
-	 * @return string The twitter card type.
+	 * @return string The Twitter card type.
 	 */
 	public function generate_twitter_card() {
 		return '';
 	}
 
 	/**
-	 * Generates the twitter title.
+	 * Generates the Twitter title.
 	 *
-	 * @return string The twitter title.
+	 * @return string The Twitter title.
 	 */
 	public function generate_twitter_title() {
 		if ( $this->model->twitter_title ) {
@@ -437,9 +437,9 @@ class Indexable_Presentation extends Abstract_Presentation {
 	}
 
 	/**
-	 * Generates the twitter description.
+	 * Generates the Twitter description.
 	 *
-	 * @return string The twitter description.
+	 * @return string The Twitter description.
 	 */
 	public function generate_twitter_description() {
 		if ( $this->model->twitter_description ) {
@@ -454,9 +454,9 @@ class Indexable_Presentation extends Abstract_Presentation {
 	}
 
 	/**
-	 * Generates the twitter image.
+	 * Generates the Twitter image.
 	 *
-	 * @return string The twitter image.
+	 * @return string The Twitter image.
 	 */
 	public function generate_twitter_image() {
 		if ( $this->model->twitter_image ) {

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -429,6 +429,10 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_title;
 		}
 
+		if ( $this->title ) {
+			return $this->title;
+		}
+
 		return '';
 	}
 

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -22,10 +22,11 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	 * @return string The document title tag.
 	 */
 	public function present( Indexable_Presentation $presentation ) {
-		$title = $this->filter( $this->replace_vars( $presentation->title, $presentation ) );
+		$title = (string) $this->filter( $this->replace_vars( $presentation->title, $presentation ) );
+		$title = \wp_strip_all_tags( \stripslashes( $title ) );
 
-		if ( is_string( $title ) && $title !== '' ) {
-			return '<title>' . \esc_html( \wp_strip_all_tags( \stripslashes( $title ) ) ) . '</title>';
+		if ( $title !== '' ) {
+			return '<title>' . \esc_html( $title ) . '</title>';
 		}
 
 		return '';
@@ -44,6 +45,6 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		 *
 		 * @api string $title The title.
 		 */
-		return (string) trim( \apply_filters( 'wpseo_title', $title ) );
+		return \trim( \apply_filters( 'wpseo_title', $title ) );
 	}
 }

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -15,11 +15,11 @@ use Yoast\WP\Free\Presentations\Indexable_Presentation;
 class Title_Presenter extends Abstract_Indexable_Presenter {
 
 	/**
-	 * Returns the meta description for a post.
+	 * Returns the document title.
 	 *
 	 * @param Indexable_Presentation $presentation The presentation of an indexable.
 	 *
-	 * @return string The meta description tag.
+	 * @return string The document title tag.
 	 */
 	public function present( Indexable_Presentation $presentation ) {
 		$title = $this->filter( $this->replace_vars( $presentation->title, $presentation ) );
@@ -32,11 +32,11 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	}
 
 	/**
-	 * Run the meta description content through the `wpseo_metadesc` filter.
+	 * Run the document title through the `wpseo_title` filter.
 	 *
-	 * @param string $title The meta description to filter.
+	 * @param string $title The document title to filter.
 	 *
-	 * @return string $title The filtered meta description.
+	 * @return string $title The filtered document title.
 	 */
 	private function filter( $title ) {
 		/**

--- a/src/presenters/twitter/card-presenter.php
+++ b/src/presenters/twitter/card-presenter.php
@@ -11,7 +11,7 @@ use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
 
 /**
- * Class Twitter_Card_Presenter
+ * Class Card_Presenter
  */
 class Card_Presenter extends Abstract_Indexable_Presenter {
 	/**

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -12,7 +12,7 @@ use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
 
 /**
- * Class Twitter_Image_Presenter
+ * Class Image_Presenter
  */
 class Image_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/twitter/title-presenter.php
+++ b/src/presenters/twitter/title-presenter.php
@@ -22,7 +22,7 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	 * @return string The Twitter title tag.
 	 */
 	public function present( Indexable_Presentation $presentation ) {
-		$twitter_title = (string) $this->filter( $presentation->twitter_title );
+		$twitter_title = (string) $this->filter( $this->replace_vars( $presentation->twitter_title, $presentation ) );
 
 		if ( $twitter_title !== '' ) {
 			return \sprintf( '<meta name="twitter:title" content="%s" />', $twitter_title );

--- a/src/presenters/twitter/title-presenter.php
+++ b/src/presenters/twitter/title-presenter.php
@@ -25,7 +25,7 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		$twitter_title = (string) $this->filter( $presentation->twitter_title );
 
 		if ( $twitter_title !== '' ) {
-			return sprintf( '<meta name="twitter:title" content="%s" />', $twitter_title );
+			return \sprintf( '<meta name="twitter:title" content="%s" />', $twitter_title );
 		}
 
 		return '';

--- a/src/presenters/twitter/title-presenter.php
+++ b/src/presenters/twitter/title-presenter.php
@@ -22,9 +22,9 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	 * @return string The Twitter title tag.
 	 */
 	public function present( Indexable_Presentation $presentation ) {
-		$twitter_title = $this->filter( $presentation->twitter_title );
+		$twitter_title = (string) $this->filter( $presentation->twitter_title );
 
-		if ( is_string( $twitter_title ) && $twitter_title !== '' ) {
+		if ( $twitter_title !== '' ) {
 			return sprintf( '<meta name="twitter:title" content="%s" />', $twitter_title );
 		}
 
@@ -44,6 +44,6 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		 *
 		 * @api string $twitter_title The Twitter title.
 		 */
-		return (string) trim( \apply_filters( 'wpseo_twitter_title', $twitter_title ) );
+		return \trim( \apply_filters( 'wpseo_twitter_title', $twitter_title ) );
 	}
 }

--- a/src/presenters/twitter/title-presenter.php
+++ b/src/presenters/twitter/title-presenter.php
@@ -11,7 +11,7 @@ use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
 
 /**
- * Class Twitter_Title_Presenter
+ * Class Title_Presenter
  */
 class Title_Presenter extends Abstract_Indexable_Presenter {
 	/**

--- a/tests/presentations/indexable-post-type-presentation/robots-test.php
+++ b/tests/presentations/indexable-post-type-presentation/robots-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Post_Type_Presentation
+ */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
 
@@ -6,13 +11,11 @@ use Brain\Monkey;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
- * Class WPSEO_Schema_FAQ_Questions_Test.
- *
- * @group schema
+ * Class Robots_Test
  *
  * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Post_Type_Presentation
  *
- * @package Yoast\Tests\Frontend\Schema
+ * @group robots
  */
 class Robots_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-post-type-presentation/robots-test.php
+++ b/tests/presentations/indexable-post-type-presentation/robots-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Post_Type_Presentation
- */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
 

--- a/tests/presentations/indexable-post-type-presentation/twitter-description-test.php
+++ b/tests/presentations/indexable-post-type-presentation/twitter-description-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Post_Type_Presentation
+ */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
 
@@ -6,7 +11,7 @@ use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
 
 /**
- * Class Abstract_Robots_Presenter_Test
+ * Class Twitter_Description_Test
  *
  * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Post_Type_Presentation
  *

--- a/tests/presentations/indexable-post-type-presentation/twitter-description-test.php
+++ b/tests/presentations/indexable-post-type-presentation/twitter-description-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Post_Type_Presentation
- */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
 

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -26,7 +26,7 @@ class Robots_Test extends TestCase {
 	/**
 	 * @var Indexable_Presentation
 	 */
-	private $instance;
+	protected $instance;
 
 	/**
 	 * Sets up the test class.

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Presentation
- */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
 

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Presentation
+ */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
 
@@ -10,11 +15,11 @@ use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
- * Class WPSEO_Schema_FAQ_Questions_Test.
+ * Class Robots_Test
  *
- * @group schema
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
  *
- * @package Yoast\Tests\Frontend\Schema
+ * @group robots
  */
 class Robots_Test extends TestCase {
 
@@ -45,12 +50,12 @@ class Robots_Test extends TestCase {
 
 		$robots_helper->expects( 'get_base_values' )
 			->andReturn( [
-				'index' =>  'index',
+				'index' => 'index',
 				'follow' => 'follow',
 			] );
 		$robots_helper->expects( 'after_generate' )
 			->with( [
-				'index' =>  'index',
+				'index' => 'index',
 				'follow' => 'follow',
 			] )
 			->andReturnUsing( function( $robots ) {
@@ -63,7 +68,7 @@ class Robots_Test extends TestCase {
 
 		$actual = $this->instance->generate_robots();
 		$expected = [
-			'index' =>  'noindex',
+			'index' => 'noindex',
 			'follow' => 'follow',
 		];
 

--- a/tests/presentations/indexable-presentation/title-test.php
+++ b/tests/presentations/indexable-presentation/title-test.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Presentation
+ */
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Tests\Mocks\Indexable;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Title_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
+ *
+ * @group title-test
+ */
+class Title_Test extends TestCase {
+
+	/**
+	 * @var Options_Helper|Mockery\MockInterface
+	 */
+	protected $option_helper;
+
+	/**
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * @var Indexable_Presentation
+	 */
+	protected $instance;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		$this->option_helper = Mockery::mock( Options_Helper::class );
+		$this->indexable     = new Indexable();
+
+		$presentation   = Mockery::mock( Indexable_Presentation::class )->makePartial();
+		$this->instance = $presentation->of( $this->indexable );
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the title is given.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_generate_title_with_set_title() {
+		$this->indexable->title = 'Title';
+
+		$this->assertEquals( 'Title', $this->instance->generate_title() );
+	}
+
+	/**
+	 * Tests the situation where an empty value is returned.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_generate_title_with_empty_return_value() {
+		$this->assertEmpty( $this->instance->generate_title() );
+	}
+}

--- a/tests/presentations/indexable-presentation/title-test.php
+++ b/tests/presentations/indexable-presentation/title-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Presentation
- */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
 

--- a/tests/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-presentation/twitter-title-test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Presentation
+ */
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Tests\Mocks\Indexable;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Twitter_Title_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
+ *
+ * @group presentations
+ * @group twitter
+ * @group twitter-title
+ */
+class Twitter_Title_Test extends TestCase {
+
+	/**
+	 * @var Options_Helper|Mockery\MockInterface
+	 */
+	protected $option_helper;
+
+	/**
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * @var Indexable_Presentation
+	 */
+	protected $instance;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		$this->option_helper = Mockery::mock( Options_Helper::class );
+		$this->indexable     = new Indexable();
+
+		$presentation   = Mockery::mock( Indexable_Presentation::class )->makePartial();
+		$this->instance = $presentation->of( $this->indexable );
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the Twitter title is given.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_generate_twitter_title_with_set_twitter_title() {
+		$this->indexable->twitter_title = 'Twitter title';
+
+		$this->assertEquals( 'Twitter title', $this->instance->generate_twitter_title() );
+	}
+
+	/**
+	 * Tests the situation where an empty value is returned.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_generate_twitter_title_with_empty_return_value() {
+		$this->assertEmpty( $this->instance->generate_twitter_title() );
+	}
+}

--- a/tests/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-presentation/twitter-title-test.php
@@ -64,6 +64,17 @@ class Twitter_Title_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the situation where no Twitter title is given, but the general title has been set.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_generate_twitter_title_with_set_general_title() {
+		$this->indexable->title = 'General title';
+
+		$this->assertEquals( 'General title', $this->instance->generate_twitter_title() );
+	}
+
+	/**
 	 * Tests the situation where an empty value is returned.
 	 *
 	 * @covers ::generate_twitter_title

--- a/tests/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-presentation/twitter-title-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presentations\Indexable_Presentation
- */
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
 

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -6,7 +6,6 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Robots_Presenter;
-use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -63,7 +63,7 @@ class Robots_Presenter_Test extends TestCase {
 
 		Monkey\Filters\expectApplied( 'wpseo_robots' )
 			->once()
-			->with( 'index,nofollow')
+			->with( 'index,nofollow' )
 			->andReturn( 'noindex' );
 
 		$actual = $this->instance->present( $indexable_presentation );

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presenters
+ */
 
 namespace Yoast\WP\Free\Tests\Presenters;
 

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presenters
- */
 
 namespace Yoast\WP\Free\Tests\Presenters;
 

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presenters
+ */
+
+namespace Yoast\WP\Free\Tests\Presenters;
+
+use Mockery;
+use Brain\Monkey;
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Title_Presenter;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Title_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presenters\Title_Presenter
+ *
+ * @group twitter-title
+ */
+class Title_Presenter_Test extends TestCase {
+	/**
+	 * @var Indexable_Presentation
+	 */
+	protected $indexable_presentation;
+
+	/**
+	 * @var Title_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 */
+	protected $replace_vars;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+
+		$this->instance = new Title_Presenter();
+		$this->instance->set_replace_vars_helper( $this->replace_vars );
+
+		$this->indexable_presentation = new Indexable_Presentation();
+		$this->indexable_presentation->replace_vars_object = [];
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$this->indexable_presentation->title = 'example_title';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing( function( $str ) {
+				return $str;
+			} );
+
+		Monkey\Functions\expect( 'wp_strip_all_tags' )
+			->andReturn( 'example_title' );
+
+		$expected = '<title>example_title</title>';
+		$actual = $this->instance->present( $this->indexable_presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns an empty title when the title is empty.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_title_is_empty() {
+		$this->indexable_presentation->title = '';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing( function( $str ) {
+				return $str;
+			} );
+
+		Monkey\Functions\expect( 'wp_strip_all_tags' )
+			->andReturn( '' );
+
+		$expected = '';
+		$actual = $this->instance->present( $this->indexable_presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title, when the `wpseo_title` filter is applied.
+	 *
+	 * @covers ::present
+	 * @covers ::filter
+	 */
+	public function test_present_filter() {
+		$this->indexable_presentation->title = 'example_title';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing( function( $str ) {
+				return $str;
+			} );
+
+		Monkey\Filters\expectApplied( 'wpseo_title' )
+			->once()
+			->with( 'example_title' )
+			->andReturn( 'exampletitle' );
+
+		Monkey\Functions\expect( 'wp_strip_all_tags' )
+			->andReturn( 'exampletitle' );
+
+		$expected = '<title>exampletitle</title>';
+		$actual = $this->instance->present( $this->indexable_presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -75,7 +75,7 @@ class Title_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the presenter returns an empty title when the title is empty.
+	 * Tests whether the presenter returns an empty string when the title is empty.
 	 *
 	 * @covers ::present
 	 */
@@ -91,10 +91,9 @@ class Title_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_strip_all_tags' )
 			->andReturn( '' );
 
-		$expected = '';
 		$actual = $this->instance->present( $this->indexable_presentation );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEmpty( $actual );
 	}
 
 	/**

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -13,6 +13,7 @@ use Yoast\WP\Free\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\Free\Presenters\Title_Presenter
  *
+ * @group presenters
  * @group title-presenter
  */
 class Title_Presenter_Test extends TestCase {

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presenters
- */
 
 namespace Yoast\WP\Free\Tests\Presenters;
 

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -18,7 +18,7 @@ use Yoast\WP\Free\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\Free\Presenters\Title_Presenter
  *
- * @group twitter-title
+ * @group title-presenter
  */
 class Title_Presenter_Test extends TestCase {
 	/**

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\Free\Presenters\Twitter\Description_Presenter;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
- * Class Twitter_Image_Presenter_Test.
+ * Class Description_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\Free\Presenters\Twitter\Description_Presenter
  *
@@ -65,7 +65,7 @@ class Description_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the presentation of a relative image.
+	 * Tests the presentation of an empty description.
 	 *
 	 * @covers ::present
 	 * @covers ::filter

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Presenters\Twitter
- */
 
 namespace Yoast\WP\Free\Tests\Presenters\Twitter;
 

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Presenters\Twitter
  */
 
 namespace Yoast\WP\Free\Tests\Presenters\Twitter;

--- a/tests/presenters/twitter/image-presenter-test.php
+++ b/tests/presenters/twitter/image-presenter-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\Free\Tests\Presenters\Twitter;
 

--- a/tests/presenters/twitter/image-presenter-test.php
+++ b/tests/presenters/twitter/image-presenter-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
 
 /**
- * Class Twitter_Image_Presenter_Test.
+ * Class Image_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\Free\Presenters\Twitter\Image_Presenter
  *

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\YoastSEO\Tests\Twitter\Presenters
+ */
+
+namespace Yoast\WP\Free\Tests\Twitter\Presenters;
+
+use Brain\Monkey;
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Twitter\Title_Presenter;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Title_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presenters\Twitter\Title_Presenter
+ *
+ * @group twitter-title
+ */
+class Title_Presenter_Test extends TestCase {
+	/**
+	 * @var Indexable_Presentation
+	 */
+	protected $indexable_presentation;
+
+	/**
+	 * @var Title_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->instance = new Title_Presenter();
+		$this->indexable_presentation = new Indexable_Presentation();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct Twitter title.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$this->indexable_presentation->twitter_title = 'twitter_example_title';
+
+		$expected = '<meta name="twitter:title" content="twitter_example_title" />';
+		$actual = $this->instance->present( $this->indexable_presentation );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns an empty string when the Twitter title is empty.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_twitter_title_is_empty() {
+		$this->indexable_presentation->twitter_title = '';
+
+		$actual = $this->instance->present( $this->indexable_presentation );
+		$this->assertEmpty( $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct Twitter title, when the `wpseo_twitter_title` filter is applied.
+	 *
+	 * @covers ::present
+	 * @covers ::filter
+	 */
+	public function test_present_filter() {
+		$this->indexable_presentation->twitter_title = 'twitter_example_title';
+
+		Monkey\Filters\expectApplied( 'wpseo_twitter_title' )
+			->once()
+			->with( 'twitter_example_title' )
+			->andReturn( 'twitterexampletitle' );
+
+		$expected = '<meta name="twitter:title" content="twitterexampletitle" />';
+		$actual = $this->instance->present( $this->indexable_presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\YoastSEO\Tests\Twitter\Presenters
- */
 
 namespace Yoast\WP\Free\Tests\Twitter\Presenters;
 

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\Free\Tests\Twitter\Presenters;
 
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Twitter\Title_Presenter;
 use Yoast\WP\Free\Tests\TestCase;
@@ -31,11 +32,19 @@ class Title_Presenter_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 */
+	protected $replace_vars;
+
+	/**
 	 * Sets up the test class.
 	 */
 	public function setUp() {
 		$this->instance = new Title_Presenter();
 		$this->indexable_presentation = new Indexable_Presentation();
+		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->instance->set_replace_vars_helper( $this->replace_vars );
+		$this->indexable_presentation->replace_vars_object = [];
 
 		return parent::setUp();
 	}
@@ -47,6 +56,12 @@ class Title_Presenter_Test extends TestCase {
 	 */
 	public function test_present() {
 		$this->indexable_presentation->twitter_title = 'twitter_example_title';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing( function( $str ) {
+				return $str;
+			} );
 
 		$expected = '<meta name="twitter:title" content="twitter_example_title" />';
 		$actual = $this->instance->present( $this->indexable_presentation );
@@ -61,6 +76,12 @@ class Title_Presenter_Test extends TestCase {
 	public function test_present_twitter_title_is_empty() {
 		$this->indexable_presentation->twitter_title = '';
 
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing( function( $str ) {
+				return $str;
+			} );
+
 		$actual = $this->instance->present( $this->indexable_presentation );
 		$this->assertEmpty( $actual );
 	}
@@ -73,6 +94,12 @@ class Title_Presenter_Test extends TestCase {
 	 */
 	public function test_present_filter() {
 		$this->indexable_presentation->twitter_title = 'twitter_example_title';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->andReturnUsing( function( $str ) {
+				return $str;
+			} );
 
 		Monkey\Filters\expectApplied( 'wpseo_twitter_title' )
 			->once()


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ..
. (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Implemented `twitter_title`, including unit tests
* Also added unit tests for `title`, since they were missing and `twitter_title` is based on this
* Fixed CS and documentation in unrelated files when I came across problems

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* The page source should show an indented `twitter-title` tag with the correct title. This is the example for a simple post:
<img width="695" alt="Screenshot 2019-10-01 at 15 02 07" src="https://user-images.githubusercontent.com/20280513/65964144-8fab4080-e45c-11e9-922a-452882d026f4.png">

* When testing, (also) use snippet variables in your `twitter-title`, for example `%%date%%`. Make sure they are output correctly (this example should be output as a formatted date, for example `"September 26, 2019"`).

* You should check whether the `twitter-title` tag is present for the following types of content
    * Post 
        * Create a post (`Posts` --> `Add new` --> `Social` (in metabox) --> add a `Twitter title`)
        * `Publish` --> `View post`
        * Right click --> `View page source` (this bullet point also applies to all examples below, and will be left out from now on)
    * Page
        * Create a page (`Pages` --> `Add new` --> `Social` (in metabox) --> add a `Twitter title`)
        * `Publish` --> `View page`
    * Attachment page
        * STATUS :heavy_multiplication_x:: `twitter-title` tag is shown, but contents are incorrect
        * In the menu on the left, click `SEO` --> `Search appearance` --> `Media`
        * Set `Redirect attachment URLs to the attachment itself?` to `No`, set `Yoast SEO Meta Box` to `Show`, then click `Save changes`
        * In the menu on the left, click `Media`
        * Click on an image (or first add an image if the media library is empty), then click `View attachment page`
        * In the top menu, click `Edit media`. This will show the metabox, click `Social` --> add a `Twitter title` --> `Update`
        * View the attachment page again (it seems that for this, you need to follow the first two above steps again)
    * Another public and publicly queryable post type
        * Activate the `Yoast Test Helper` plugin; `Books` and `Movies` will now appear in the menu on the left.
        * `Books` --> `Add new` --> `Social` (in metabox) --> add a `Twitter title`
        * `Publish` --> `View post`
    * Post type archive for posts
        * In the menu on the left, click `Settings` --> `Reading`
        * Set `Your homepage displays` to `A static page`
        * For `Posts page`, set a random page, then `Save changes`
        * Through the menu on the left, navigate to the page you just set as homepage, `Edit` --> `Social` (in metabox) --> add a `Twitter title`
        * `Update` and `View page`
        * This page now represents a post type archive for posts
    * Post type archive for another public and publicly queryable post type
        * View a book post (see above how to create such a post)
        * In the bread crumb, click `Book` to go to the archive
        * `twitter-title` should be output in the page source, but its contents default to the general `title`, since there is no way to set `twitter-title`. 
    * Term archive for categories
        * Go to `Posts`, and add categories to a few posts (to add a category, create/edit a post; in the right menu there is a `Categories` collapsible)
        * In the left menu, click `Posts` --> `Categories`
        * Hoover over a category name, then click `Edit` and set a Twitter title
        * Go back, hoover over the category name again, then click `View`
    * Term archive for tags
        * Exactly the same as for `Categories`, but for `Tags`
    * Term archive for another public and publicly queryable post type
        * Hoover over `Books` in the left menu, there you see `Categories` and `Genres` (these genres correspond to `Tags`)
        * Follow the steps described above for `Categories` and `Tags`
    * Author archives
        * STATUS :heavy_multiplication_x:: `twitter-title` is not shown
        * Navigate to an author archive, for example `http://one.wordpress.test/author/admin/` (potentially replace `one` with the name of your installation`)
    * Date archives
        * STATUS :heavy_multiplication_x:: `twitter-title` is not shown
        * Navigate to a date archive, for example `http://one.wordpress.test/2019/09/13/` 
    * Home page
        * Navigate to the homepage
    * Error page
        * STATUS :heavy_multiplication_x:: `twitter-title` is not shown
        * Navigate to a page that can't be found, for example `http://one.wordpress.test/aaa`
    * Search result page
        * STATUS :heavy_multiplication_x:: `twitter-title` is not shown
        * Navigate to a search result page, for example `http://one.wordpress.test/?s=gutenberg`
    * Site wide default
        * STATUS ❓ : how to navigate to a site wide default?

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
