### PR TITLE
Fixes various quirks in the floating save changes button

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -161,7 +161,7 @@ class Yoast_Form {
 			$settings_changed_listener->show_success_message();
 			echo '</div>';
 
-			echo '<div id="wpseo-submit-container-fixed" class="wpseo-admin-submit wpseo-admin-submit-fixed">';
+			echo '<div id="wpseo-submit-container-fixed" class="wpseo-admin-submit wpseo-admin-submit-fixed" style="display: none;">';
 			submit_button( __( 'Save changes', 'wordpress-seo' ) );
 			$settings_changed_listener->show_success_message();
 			echo '</div>';

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -520,6 +520,16 @@ td.column-wpseo-linked {
 	}
 }
 
+body.folded {
+	.wpseo-admin-submit-fixed {
+		left: 36px;
+
+		@media screen and (max-width: 782px) {
+			left: 0;
+		}
+	}
+}
+
 .wpseo-admin-submit {
 	z-index: 5;
 	display: flex;

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -242,6 +242,14 @@ import { debounce } from "lodash";
 		}
 
 		jQuery( window ).on( "resize scroll", debounce( onViewportChange, 100 ) );
+		jQuery( window ).on( "yoast-seo-tab-change", onViewportChange );
+
+		const messages = jQuery( ".wpseo-message" );
+		if ( messages.length ) {
+			window.setTimeout( () => {
+				messages.fadeOut();
+			}, 5000 );
+		}
 
 		onViewportChange();
 	}
@@ -327,6 +335,8 @@ import { debounce } from "lodash";
 			} else {
 				jQuery( "#wpseo-submit-container" ).show();
 			}
+
+			jQuery( window ).trigger( "yoast-seo-tab-change" );
 		} );
 
 		// Handle the Company or Person select.
@@ -367,9 +377,10 @@ import { debounce } from "lodash";
 				.find( "span" ).toggleClass( "dashicons-arrow-up-alt2 dashicons-arrow-down-alt2" );
 		} );
 
-		setFixedSubmitButtonVisibility();
 		wpseoCopyHomeMeta();
 		setInitialActiveTab();
 		initSelect2();
+		// Should be called after the initial active tab has been set.
+		setFixedSubmitButtonVisibility();
 	} );
 }() );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the following behaviour described in #13558 
  - Floating button does not exist on page (re)load
  - "Settings saved" text visible after changes
  - Switching tabs leaves the button on screen
  - Different screen-width events (with colapsed menu)

## Relevant technical choices:

* Hide/Show button on tab initialization.
* Remove "Settings saved." message after 5 seconds.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13558 
