### PR TITLE
Add a rankmath importer

### DIFF
--- a/admin/import/plugins/class-import-rankmath.php
+++ b/admin/import/plugins/class-import-rankmath.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * File with the class to handle data from RankMath.
+ *
+ * @package WPSEO\Admin\Import\Plugins
+ */
+
+/**
+ * Class with functionality to import RankMath post metadata.
+ */
+class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
+
+	/**
+	 * The plugin name.
+	 *
+	 * @var string
+	 */
+	protected $plugin_name = 'RankMath';
+
+	/**
+	 * Meta key, used in SQL LIKE clause for delete query.
+	 *
+	 * @var string
+	 */
+	protected $meta_key = 'rank_math_%';
+
+	/**
+	 * Array of meta keys to detect and import.
+	 *
+	 * @var array
+	 */
+	protected $clone_keys = array(
+		array(
+			'old_key' => 'rank_math_description',
+			'new_key' => 'metadesc',
+		),
+		array(
+			'old_key' => 'rank_math_title',
+			'new_key' => 'title',
+		),
+		array(
+			'old_key' => 'rank_math_canonical_url',
+			'new_key' => 'canonical',
+		),
+		array(
+			'old_key' => 'rank_math_primary_category',
+			'new_key' => 'primary_category',
+		),
+		array(
+			'old_key' => 'rank_math_facebook_title',
+			'new_key' => 'opengraph-title',
+		),
+		array(
+			'old_key' => 'rank_math_facebook_description',
+			'new_key' => 'opengraph-description',
+		),
+		array(
+			'old_key' => 'rank_math_facebook_image',
+			'new_key' => 'opengraph-image',
+		),
+		array(
+			'old_key' => 'rank_math_facebook_image_id',
+			'new_key' => 'opengraph-image-id',
+		),
+		array(
+			'old_key' => 'rank_math_twitter_title',
+			'new_key' => 'twitter-title',
+		),
+		array(
+			'old_key' => 'rank_math_twitter_description',
+			'new_key' => 'twitter-description',
+		),
+		array(
+			'old_key' => 'rank_math_twitter_image',
+			'new_key' => 'twitter-image',
+		),
+		array(
+			'old_key' => 'rank_math_twitter_image_id',
+			'new_key' => 'twitter-image-id',
+		),
+	);
+
+	/**
+	 * Handles post meta data to import.
+	 *
+	 * @return bool Import success status.
+	 */
+	protected function import() {
+		global $wpdb;
+		// Replace % with %% as their variables are the same except for that.
+		$wpdb->query( "UPDATE $wpdb->postmeta SET meta_value = REPLACE( meta_value, '%', '%%' ) WHERE meta_key IN ( 'rank_math_description', 'rank_math_title' )" );
+
+		$this->import_meta_robots();
+		$return = $this->meta_keys_clone( $this->clone_keys );
+
+		// Return %% to % so our import is non-destructive.
+		$wpdb->query( "UPDATE $wpdb->postmeta SET meta_value = REPLACE( meta_value, '%%', '%' ) WHERE meta_key IN ( 'rank_math_description', 'rank_math_title' )" );
+
+		return $return;
+	}
+
+	/**
+	 * RankMath stores robots meta quite differently, so we have to parse it out.
+	 */
+	private function import_meta_robots() {
+		global $wpdb;
+		$post_metas = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'rank_math_robots'" );
+		foreach ( $post_metas as $post_meta ) {
+			$post_meta->meta_value = unserialize( $post_meta->meta_value );
+			foreach ( array( 'noindex', 'nofollow' ) as $directive ) {
+				$directive_key = array_search( $directive, $post_meta->meta_value );
+				if ( $directive_key !== false ) {
+					update_post_meta( $post_meta->post_id, '_yoast_wpseo_meta-robots-' . $directive, 1 );
+					unset( $post_meta->meta_value[ $directive_key ] );
+				}
+			}
+			if ( count( $post_meta->meta_value ) > 0 ) {
+				$value = implode( ',', $post_meta->meta_value );
+				update_post_meta( $post_meta->post_id, '_yoast_wpseo_meta-robots-adv', $value );
+			}
+		}
+	}
+}

--- a/admin/import/plugins/class-import-rankmath.php
+++ b/admin/import/plugins/class-import-rankmath.php
@@ -114,16 +114,16 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 		global $wpdb;
 		$post_metas = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = 'rank_math_robots'" );
 		foreach ( $post_metas as $post_meta ) {
-			$post_meta->meta_value = unserialize( $post_meta->meta_value );
+			$robots_values = unserialize( $post_meta->meta_value );
 			foreach ( array( 'noindex', 'nofollow' ) as $directive ) {
-				$directive_key = array_search( $directive, $post_meta->meta_value );
+				$directive_key = array_search( $directive, $robots_values );
 				if ( $directive_key !== false ) {
 					update_post_meta( $post_meta->post_id, '_yoast_wpseo_meta-robots-' . $directive, 1 );
-					unset( $post_meta->meta_value[ $directive_key ] );
+					unset( $robots_values[ $directive_key ] );
 				}
 			}
-			if ( count( $post_meta->meta_value ) > 0 ) {
-				$value = implode( ',', $post_meta->meta_value );
+			if ( count( $robots_values ) > 0 ) {
+				$value = implode( ',', $robots_values );
 				update_post_meta( $post_meta->post_id, '_yoast_wpseo_meta-robots-adv', $value );
 			}
 		}
@@ -145,10 +145,12 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 		$options  = get_option( 'rank-math-options-titles' );
 
 		foreach ( $settings as $import_setting_key => $setting_key ) {
-			$value = $options[ $import_setting_key ];
-			// Make sure replace vars work.
-			$value = str_replace( '%', '%%', $value );
-			WPSEO_Options::set( $setting_key, $value );
+			if ( ! empty( $options[ $import_setting_key ] ) ) {
+				$value = $options[ $import_setting_key ];
+				// Make sure replace vars work.
+				$value = str_replace( '%', '%%', $value );
+				WPSEO_Options::set( $setting_key, $value );
+			}
 		}
 	}
 

--- a/admin/import/plugins/class-import-rankmath.php
+++ b/admin/import/plugins/class-import-rankmath.php
@@ -141,6 +141,8 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 			'date_archive_title'   => 'title-archive-wpseo',
 			'search_title'         => 'title-search-wpseo',
 			'404_title'            => 'title-404-wpseo',
+			'pt_post_title'        => 'title-post',
+			'pt_page_title'        => 'title-page',
 		);
 		$options  = get_option( 'rank-math-options-titles' );
 
@@ -166,6 +168,7 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 			$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'rank-math-%'" );
 			$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE '%rank_math%'" );
 		}
+
 		return $return;
 	}
 }

--- a/admin/import/plugins/class-import-rankmath.php
+++ b/admin/import/plugins/class-import-rankmath.php
@@ -78,6 +78,10 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 			'old_key' => 'rank_math_twitter_image_id',
 			'new_key' => 'twitter-image-id',
 		),
+		array(
+			'old_key' => 'rank_math_focus_keyword',
+			'new_key' => 'focuskw'
+		)
 	);
 
 	/**
@@ -95,6 +99,10 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 
 		// Return %% to % so our import is non-destructive.
 		$wpdb->query( "UPDATE $wpdb->postmeta SET meta_value = REPLACE( meta_value, '%%', '%' ) WHERE meta_key IN ( 'rank_math_description', 'rank_math_title' )" );
+
+		if ( $return ) {
+			$this->import_settings();
+		}
 
 		return $return;
 	}
@@ -118,6 +126,29 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 				$value = implode( ',', $post_meta->meta_value );
 				update_post_meta( $post_meta->post_id, '_yoast_wpseo_meta-robots-adv', $value );
 			}
+		}
+	}
+
+	/**
+	 * Imports some of the RankMath settings.
+	 */
+	private function import_settings() {
+		$settings = array(
+			'title_separator'      => 'separator',
+			'homepage_title'       => 'title-home-wpseo',
+			'homepage_description' => 'metadesc-home-wpseo',
+			'author_archive_title' => 'title-author-wpseo',
+			'date_archive_title'   => 'title-archive-wpseo',
+			'search_title'         => 'title-search-wpseo',
+			'404_title'            => 'title-404-wpseo'
+		);
+		$options  = get_option( 'rank-math-options-titles' );
+
+		foreach ( $settings as $import_setting_key => $setting_key ) {
+			$value = $options[ $import_setting_key ];
+			// Make sure replace vars work
+			$value = str_replace( '%', '%%', $value );
+			WPSEO_Options::set( $setting_key, $value );
 		}
 	}
 }

--- a/admin/import/plugins/class-import-rankmath.php
+++ b/admin/import/plugins/class-import-rankmath.php
@@ -80,8 +80,8 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 		),
 		array(
 			'old_key' => 'rank_math_focus_keyword',
-			'new_key' => 'focuskw'
-		)
+			'new_key' => 'focuskw',
+		),
 	);
 
 	/**
@@ -140,15 +140,30 @@ class WPSEO_Import_RankMath extends WPSEO_Plugin_Importer {
 			'author_archive_title' => 'title-author-wpseo',
 			'date_archive_title'   => 'title-archive-wpseo',
 			'search_title'         => 'title-search-wpseo',
-			'404_title'            => 'title-404-wpseo'
+			'404_title'            => 'title-404-wpseo',
 		);
 		$options  = get_option( 'rank-math-options-titles' );
 
 		foreach ( $settings as $import_setting_key => $setting_key ) {
 			$value = $options[ $import_setting_key ];
-			// Make sure replace vars work
+			// Make sure replace vars work.
 			$value = str_replace( '%', '%%', $value );
 			WPSEO_Options::set( $setting_key, $value );
 		}
+	}
+
+	/**
+	 * Removes the plugin data from the database.
+	 *
+	 * @return bool Cleanup status.
+	 */
+	protected function cleanup() {
+		$return = parent::cleanup();
+		if ( $return ) {
+			global $wpdb;
+			$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'rank-math-%'" );
+			$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE '%rank_math%'" );
+		}
+		return $return;
 	}
 }

--- a/admin/import/plugins/class-importers.php
+++ b/admin/import/plugins/class-importers.php
@@ -25,6 +25,7 @@ class WPSEO_Plugin_Importers {
 		'WPSEO_Import_WP_Meta_SEO',
 		'WPSEO_Import_Platinum_SEO',
 		'WPSEO_Import_Premium_SEO_Pack',
+		'WPSEO_Import_RankMath',
 		'WPSEO_Import_SEOPressor',
 		'WPSEO_Import_SEO_Framework',
 		'WPSEO_Import_Smartcrawl_SEO',

--- a/integration-tests/admin/import/test-class-import-rankmath.php
+++ b/integration-tests/admin/import/test-class-import-rankmath.php
@@ -96,8 +96,9 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$twitter_title   = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'twitter-title', true );
 		$twitter_desc    = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'twitter-description', true );
 
-		$homepage_title = WPSEO_Options::get( 'title-home-wpseo' );
-		$homepage_desc  = WPSEO_Options::get( 'metadesc-home-wpseo' );
+		$homepage_title      = WPSEO_Options::get( 'title-home-wpseo' );
+		$homepage_desc       = WPSEO_Options::get( 'metadesc-home-wpseo' );
+		$post_title_template = WPSEO_Options::get( 'title-post' );
 
 		$this->assertEquals( 1, $robots_noindex );
 		$this->assertEquals( 1, $robots_nofollow );
@@ -109,6 +110,7 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( 'Test homepage title', $homepage_title );
 		$this->assertEquals( 'Test homepage description', $homepage_desc );
+		$this->assertEquals( 'Test post title template %%sep%% %%sitename%%', $post_title_template );
 	}
 
 	/**
@@ -177,6 +179,7 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		update_option( 'rank-math-options-titles', array(
 			'homepage_title'       => 'Test homepage title',
 			'homepage_description' => 'Test homepage description',
+			'pt_post_title'        => 'Test post title template %sep% %sitename%',
 		) );
 	}
 }

--- a/integration-tests/admin/import/test-class-import-rankmath.php
+++ b/integration-tests/admin/import/test-class-import-rankmath.php
@@ -163,7 +163,7 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$post_id = $this->factory()->post->create();
 		update_post_meta( $post_id, 'rank_math_title', 'Test title' );
 		update_post_meta( $post_id, 'rank_math_description', 'Test description' );
-		update_post_meta( $post_id, 'rank_math_robots', array( 'noindex', 'follow' ) );
+		update_post_meta( $post_id, 'rank_math_robots', array( 'noindex', 'nofollow' ) );
 		update_post_meta( $post_id, 'rank_math_twitter_title', 'Test Twitter title' );
 		update_post_meta( $post_id, 'rank_math_twitter_description', 'Test Twitter description' );
 

--- a/integration-tests/admin/import/test-class-import-rankmath.php
+++ b/integration-tests/admin/import/test-class-import-rankmath.php
@@ -152,7 +152,7 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$post_id = $this->factory()->post->create();
 		update_post_meta( $post_id, 'rank_math_title', 'Test title' );
 		update_post_meta( $post_id, 'rank_math_description', 'Test description' );
-		update_post_meta( $post_id, 'rank_math_robots', 'noindex,nofollow' );
+		update_post_meta( $post_id, 'rank_math_robots', 'a:2:{i:0;s:7:"noindex";i:1;s:8:"nofollow";}' );
 		update_post_meta( $post_id, 'rank_math_twitter_title', 'Test Twitter title' );
 		update_post_meta( $post_id, 'rank_math_twitter_description', 'Test Twitter description' );
 

--- a/integration-tests/admin/import/test-class-import-rankmath.php
+++ b/integration-tests/admin/import/test-class-import-rankmath.php
@@ -82,10 +82,12 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Import_RankMath::import
 	 * @covers WPSEO_Import_RankMath::meta_key_clone
 	 * @covers WPSEO_Import_RankMath::meta_keys_clone
+	 * @covers WPSEO_Import_RankMath::import_settings
 	 */
 	public function test_import() {
 		$post_id = $this->setup_post();
-		$result  = $this->class_instance->run_import();
+		$this->setup_options();
+		$result = $this->class_instance->run_import();
 
 		$seo_title       = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'title', true );
 		$seo_desc        = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'metadesc', true );
@@ -94,6 +96,9 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$twitter_title   = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'twitter-title', true );
 		$twitter_desc    = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'twitter-description', true );
 
+		$homepage_title = WPSEO_Options::get( 'title-home-wpseo' );
+		$homepage_desc  = WPSEO_Options::get( 'metadesc-home-wpseo' );
+
 		$this->assertEquals( 1, $robots_noindex );
 		$this->assertEquals( 1, $robots_nofollow );
 		$this->assertEquals( 'Test title', $seo_title );
@@ -101,6 +106,9 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 'Test Twitter title', $twitter_title );
 		$this->assertEquals( 'Test Twitter description', $twitter_desc );
 		$this->assertEquals( $this->status( 'import', true ), $result );
+
+		$this->assertEquals( 'Test homepage title', $homepage_title );
+		$this->assertEquals( 'Test homepage description', $homepage_desc );
 	}
 
 	/**
@@ -125,6 +133,9 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$seo_title = get_post_meta( $post_id, 'rank_math_title', true );
 		$seo_desc  = get_post_meta( $post_id, 'rank_math_description', true );
 
+		$title_option = get_option( 'rank-math-options-titles' );
+
+		$this->assertEquals( $title_option, false );
 		$this->assertEquals( $seo_title, false );
 		$this->assertEquals( $seo_desc, false );
 		$this->assertEquals( $this->status( 'cleanup', true ), $result );
@@ -152,10 +163,20 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$post_id = $this->factory()->post->create();
 		update_post_meta( $post_id, 'rank_math_title', 'Test title' );
 		update_post_meta( $post_id, 'rank_math_description', 'Test description' );
-		update_post_meta( $post_id, 'rank_math_robots', 'a:2:{i:0;s:7:"noindex";i:1;s:8:"nofollow";}' );
+		update_post_meta( $post_id, 'rank_math_robots', array( 'noindex', 'follow' ) );
 		update_post_meta( $post_id, 'rank_math_twitter_title', 'Test Twitter title' );
 		update_post_meta( $post_id, 'rank_math_twitter_description', 'Test Twitter description' );
 
 		return $post_id;
+	}
+
+	/**
+	 * Sets up a fake RankMath settings array.
+	 */
+	private function setup_options() {
+		update_option( 'rank-math-options-titles', array(
+			'homepage_title'       => 'Test homepage title',
+			'homepage_description' => 'Test homepage description',
+		) );
 	}
 }

--- a/integration-tests/admin/import/test-class-import-rankmath.php
+++ b/integration-tests/admin/import/test-class-import-rankmath.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin\Import\Plugins
+ */
+
+/**
+ * Test importing meta data from SEO Framework.
+ */
+class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
+
+	/**
+	 * Holds the class instance.
+	 *
+	 * @var WPSEO_Import_RankMath
+	 */
+	private $class_instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->class_instance = new WPSEO_Import_RankMath();
+	}
+
+	/**
+	 * Tests the plugin name function.
+	 *
+	 * @covers WPSEO_Import_RankMath::get_plugin_name
+	 */
+	public function test_plugin_name() {
+		$this->assertEquals( 'RankMath', $this->class_instance->get_plugin_name() );
+	}
+
+	/**
+	 * Tests whether this importer has been registered.
+	 *
+	 * @covers WPSEO_Plugin_Importers::get
+	 */
+	public function test_importer_registered() {
+		$this->assertContains( 'WPSEO_Import_RankMath', WPSEO_Plugin_Importers::get() );
+	}
+
+	/**
+	 * Tests whether we can return false when there's no detectable data.
+	 *
+	 * @covers WPSEO_Import_RankMath::run_detect
+	 * @covers WPSEO_Import_RankMath::detect
+	 */
+	public function test_detect_no_data() {
+		$this->assertEquals( $this->status( 'detect', false ), $this->class_instance->run_detect() );
+	}
+
+	/**
+	 * Tests whether we can detect data.
+	 *
+	 * @covers WPSEO_Import_RankMath::__construct
+	 * @covers WPSEO_Import_RankMath::run_detect
+	 * @covers WPSEO_Import_RankMath::detect
+	 */
+	public function test_detect() {
+		$this->setup_post();
+		$this->assertEquals( $this->status( 'detect', true ), $this->class_instance->run_detect() );
+	}
+
+	/**
+	 * Tests whether we can return properly when there's nothing to import.
+	 *
+	 * @covers WPSEO_Import_RankMath::run_import
+	 */
+	public function test_import_no_data() {
+		$this->assertEquals( $this->status( 'import', false ), $this->class_instance->run_import() );
+	}
+
+	/**
+	 * Tests whether we can properly import data.
+	 *
+	 * @covers WPSEO_Import_RankMath::run_import
+	 * @covers WPSEO_Import_RankMath::import
+	 * @covers WPSEO_Import_RankMath::meta_key_clone
+	 * @covers WPSEO_Import_RankMath::meta_keys_clone
+	 */
+	public function test_import() {
+		$post_id = $this->setup_post();
+		$result  = $this->class_instance->run_import();
+
+		$seo_title       = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'title', true );
+		$seo_desc        = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'metadesc', true );
+		$robots_noindex  = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'meta-robots-noindex', true );
+		$robots_nofollow = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'meta-robots-nofollow', true );
+		$twitter_title   = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'twitter-title', true );
+		$twitter_desc    = get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'twitter-description', true );
+
+		$this->assertEquals( 1, $robots_noindex );
+		$this->assertEquals( 1, $robots_nofollow );
+		$this->assertEquals( 'Test title', $seo_title );
+		$this->assertEquals( 'Test description', $seo_desc );
+		$this->assertEquals( 'Test Twitter title', $twitter_title );
+		$this->assertEquals( 'Test Twitter description', $twitter_desc );
+		$this->assertEquals( $this->status( 'import', true ), $result );
+	}
+
+	/**
+	 * Tests whether we can properly return an error when there is no data to clean.
+	 *
+	 * @covers WPSEO_Import_RankMath::run_cleanup
+	 */
+	public function test_cleanup_no_data() {
+		$this->assertEquals( $this->status( 'cleanup', false ), $this->class_instance->run_cleanup() );
+	}
+
+	/**
+	 * Tests whether we can properly clean up.
+	 *
+	 * @covers WPSEO_Import_RankMath::run_cleanup
+	 * @covers WPSEO_Import_RankMath::cleanup
+	 */
+	public function test_cleanup() {
+		$post_id = $this->setup_post();
+		$result  = $this->class_instance->run_cleanup();
+
+		$seo_title = get_post_meta( $post_id, 'rank_math_title', true );
+		$seo_desc  = get_post_meta( $post_id, 'rank_math_description', true );
+
+		$this->assertEquals( $seo_title, false );
+		$this->assertEquals( $seo_desc, false );
+		$this->assertEquals( $this->status( 'cleanup', true ), $result );
+		$this->assertEquals( $this->status( 'detect', false ), $this->class_instance->run_detect() );
+	}
+
+	/**
+	 * Returns a WPSEO_Import_Status object to check against.
+	 *
+	 * @param string $action The action to return.
+	 * @param bool   $bool   The status.
+	 *
+	 * @return WPSEO_Import_Status Import status object.
+	 */
+	private function status( $action, $bool ) {
+		return new WPSEO_Import_Status( $action, $bool );
+	}
+
+	/**
+	 * Sets up a test post.
+	 *
+	 * @return int $post_id ID for the post created.
+	 */
+	private function setup_post() {
+		$post_id = $this->factory()->post->create();
+		update_post_meta( $post_id, 'rank_math_title', 'Test title' );
+		update_post_meta( $post_id, 'rank_math_description', 'Test description' );
+		update_post_meta( $post_id, 'rank_math_robots', 'noindex,nofollow' );
+		update_post_meta( $post_id, 'rank_math_twitter_title', 'Test Twitter title' );
+		update_post_meta( $post_id, 'rank_math_twitter_description', 'Test Twitter description' );
+
+		return $post_id;
+	}
+}

--- a/integration-tests/admin/import/test-class-importers.php
+++ b/integration-tests/admin/import/test-class-importers.php
@@ -16,6 +16,6 @@ class WPSEO_Plugin_Importers_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Plugin_Importers::get
 	 */
 	public function test_importers() {
-		$this->assertCount( 14, WPSEO_Plugin_Importers::get() );
+		$this->assertCount( 15, WPSEO_Plugin_Importers::get() );
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a RankMath post meta value importer.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new site, create some posts.
* Install RankMath, add some meta data to those posts.
* Activate Yoast SEO, deactivate RankMath.
* Go to Tools → Import → Import from other SEO plugins, it should detect RankMath
* Run the import, see the data is correctly imported.
* Run the clean, see all `rank_math_` prefixed meta values are deleted from the database tables and the plugin no longer finds RankMath to import from.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #12067
