### PR TITLE
Add facebook image presenter

### DIFF
--- a/migrations/20191001101822_WpYoastIndexablesAddOpenGraphImageID.php
+++ b/migrations/20191001101822_WpYoastIndexablesAddOpenGraphImageID.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+use Yoast\WP\Free\ORM\Yoast_Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+/**
+ * Class WpYoastIndexablesAddOpenGraphImageID
+ */
+class WpYoastIndexablesAddOpenGraphImageID extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$table_name = $this->get_table_name();
+		$this->add_column( $table_name, 'og_image_id', 'string', array( 'null' => true, 'limit' => 191 ) );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		$table_name = $this->get_table_name();
+		$this->remove_column( $table_name, 'og_image_id' );
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Yoast_Model::get_table_name( 'Indexable' );
+	}
+}

--- a/migrations/20191001101822_WpYoastIndexablesAddOpenGraphImageID.php
+++ b/migrations/20191001101822_WpYoastIndexablesAddOpenGraphImageID.php
@@ -4,8 +4,10 @@
  *
  * @package WPSEO\Migrations
  */
+
 use Yoast\WP\Free\ORM\Yoast_Model;
 use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
 /**
  * Class WpYoastIndexablesAddOpenGraphImageID
  */

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -129,6 +129,7 @@ class Indexable_Post_Builder {
 			'bctitle'               => 'breadcrumb_title',
 			'opengraph-title'       => 'og_title',
 			'opengraph-image'       => 'og_image',
+			'opengraph-image-id'    => 'og_image_id',
 			'opengraph-description' => 'og_description',
 			'twitter-title'         => 'twitter_title',
 			'twitter-image'         => 'twitter_image',

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -112,6 +112,7 @@ class Indexable_Term_Builder {
 			'wpseo_opengraph-title'       => 'og_title',
 			'wpseo_opengraph-description' => 'og_description',
 			'wpseo_opengraph-image'       => 'og_image',
+			'wpseo_opengraph-image-id'    => 'og_image_id',
 			'wpseo_twitter-title'         => 'twitter_title',
 			'wpseo_twitter-description'   => 'twitter_description',
 			'wpseo_twitter-image'         => 'twitter_image',

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -168,6 +168,17 @@ class Current_Page_Helper {
 	}
 
 	/**
+	 * Determine whether this is an attachment page.
+	 *
+	 * @return bool Whether nor not the current page is an attachment page.
+	 */
+	public function is_attachment() {
+		$wp_query = $this->wp_query_wrapper->get_main_query();
+
+		return $wp_query->is_attachment;
+	}
+
+	/**
 	 * Determine whether this is an author archive.
 	 *
 	 * @return bool Whether nor not the current page is an author archive.

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -19,14 +19,14 @@ class Image_Helper {
 	 *
 	 * @var array
 	 */
-	private static $valid_image_types = [ 'image/jpeg', 'image/gif', 'image/png' ];
+	protected static $valid_image_types = [ 'image/jpeg', 'image/gif', 'image/png' ];
 
 	/**
 	 * Image extensions that are supported by OpenGraph.
 	 *
 	 * @var array
 	 */
-	private static $valid_image_extensions = [ 'jpeg', 'jpg', 'gif', 'png' ];
+	protected static $valid_image_extensions = [ 'jpeg', 'jpg', 'gif', 'png' ];
 
 	/**
 	 * Gets an attachment page's attachment url.
@@ -78,9 +78,10 @@ class Image_Helper {
 
 	/**
 	 * Checks if the given extension is a valid extension
-	 * @param $image_extension
 	 *
-	 * @return bool
+	 * @param string $image_extension The image extension.
+	 *
+	 * @return bool True when valid.
 	 */
 	public function is_extension_valid( $image_extension ) {
 		return \in_array( $image_extension, static::$valid_image_extensions, true );

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -49,8 +49,10 @@ class Url_Helper {
 			return $url;
 		}
 
-		// If it's a relative URL, it's relative to the domain, not necessarily to the WordPress install, we
-		// want to preserve domain name and URL scheme (http / https) though.
+		/*
+			If it's a relative URL, it's relative to the domain, not necessarily to the WordPress install, we
+			want to preserve domain name and URL scheme (http / https) though.
+		*/
 		$parsed_url = \wp_parse_url( \home_url() );
 		$url        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $url;
 

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -36,4 +36,24 @@ class Url_Helper {
 	public function is_relative( $url ) {
 		return WPSEO_Utils::is_url_relative( $url );
 	}
+
+	/**
+	 * Get the relative path of the image.
+	 *
+	 * @param string $url Image URL.
+	 *
+	 * @return string The expanded image URL.
+	 */
+	public function get_relative_path( $url ) {
+		if ( $url[0] !== '/' ) {
+			return $url;
+		}
+
+		// If it's a relative URL, it's relative to the domain, not necessarily to the WordPress install, we
+		// want to preserve domain name and URL scheme (http / https) though.
+		$parsed_url = \wp_parse_url( \home_url() );
+		$url        = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $url;
+
+		return $url;
+	}
 }

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -217,6 +217,8 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	protected function get_page_type() {
 		switch ( true ) {
+			case $this->current_page_helper->is_attachment():
+				return 'Attachment';
 			case $this->current_page_helper->is_simple_page() || $this->current_page_helper->is_home_static_page():
 				return 'Post_Type';
 			case $this->current_page_helper->is_post_type_archive():

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -48,6 +48,7 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  * @property string  $og_title
  * @property string  $og_description
  * @property string  $og_image
+ * @property string  $og_image_id
  *
  * @property string  $twitter_title
  * @property string  $twitter_description

--- a/src/presentations/indexable-attachment-presentation.php
+++ b/src/presentations/indexable-attachment-presentation.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Presentation object for indexables.
+ *
+ * @package Yoast\YoastSEO\Presentations
+ */
+
+namespace Yoast\WP\Free\Presentations;
+
+/**
+ * Class Indexable_Attachment_Presentation
+ */
+class Indexable_Attachment_Presentation extends Indexable_Post_Type_Presentation {
+
+	/**
+	 * Generates the open graph images.
+	 *
+	 * @return array The open graph images.
+	 */
+	public function generate_og_images() {
+		if ( $this->model->og_image_id === null && $this->model->og_image ) {
+			return [ $this->model->og_image ];
+		}
+
+		if ( $this->model->og_image_id ) {
+			$attachment = $this->get_attachment_url_by_id( $this->model->og_image_id );
+			if ( $attachment ) {
+				return [ $attachment ];
+			}
+		}
+
+		if ( \wp_attachment_is_image( $this->model->object_id ) ) {
+			$attachment_image_url = $this->get_attachment_url_by_id( $this->model->object_id );
+			if ( $attachment_image_url ) {
+				return [ $attachment_image_url ];
+			}
+		}
+
+		$default_image = $this->get_default_og_image();
+		if ( $default_image ) {
+			return [ $default_image ];
+		}
+
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_twitter_image() {
+		if ( $this->model->twitter_image ) {
+			return $this->model->twitter_image;
+		}
+
+		// When OpenGraph image is set and the OpenGraph feature is enabled.
+		if ( $this->model->og_image && $this->options_helper->get( 'opengraph' ) === true ) {
+			return $this->model->og_image;
+		}
+
+		$image_url = $this->image_helper->get_attachment_image( $this->model->object_id );
+		if ( $image_url ) {
+			return $image_url;
+		}
+
+
+		return (string) $this->get_default_og_image();
+	}
+}

--- a/src/presentations/indexable-attachment-presentation.php
+++ b/src/presentations/indexable-attachment-presentation.php
@@ -18,15 +18,15 @@ class Indexable_Attachment_Presentation extends Indexable_Post_Type_Presentation
 	 * @return array The open graph images.
 	 */
 	public function generate_og_images() {
-		if ( $this->model->og_image_id === null && $this->model->og_image ) {
-			return [ $this->model->og_image ];
-		}
-
 		if ( $this->model->og_image_id ) {
 			$attachment = $this->get_attachment_url_by_id( $this->model->og_image_id );
 			if ( $attachment ) {
 				return [ $attachment ];
 			}
+		}
+
+		if ( $this->model->og_image ) {
+			return [ $this->model->og_image ];
 		}
 
 		if ( \wp_attachment_is_image( $this->model->object_id ) ) {

--- a/src/presentations/indexable-attachment-presentation.php
+++ b/src/presentations/indexable-attachment-presentation.php
@@ -62,7 +62,6 @@ class Indexable_Attachment_Presentation extends Indexable_Post_Type_Presentation
 			return $image_url;
 		}
 
-
 		return (string) $this->get_default_og_image();
 	}
 }

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -26,6 +26,37 @@ class Indexable_Home_Page_Presentation extends Indexable_Presentation {
 	/**
 	 * @inheritDoc
 	 */
+	public function generate_og_images() {
+		$images = parent::generate_og_images();
+
+		if ( ! empty( $images ) ) {
+			return $images;
+		}
+
+		$frontpage_image_id  = $this->options_helper->get( 'og_frontpage_image_id' );
+		if ( $frontpage_image_id ) {
+			$attachment_url = $this->get_attachment_url_by_id( $this->model->og_image_id );
+			if ( $attachment_url ) {
+				return [ $attachment_url ];
+			}
+		}
+
+		$frontpage_image_url = $this->options_helper->get( 'og_frontpage_image' );
+		if ( $frontpage_image_url ) {
+			return [ $frontpage_image_url ];
+		}
+
+		$default_image = $this->get_default_og_image();
+		if ( $default_image ) {
+			return [ $default_image ];
+		}
+
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public function generate_twitter_image() {
 		$twitter_image = parent::generate_twitter_image();
 

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -7,28 +7,10 @@
 
 namespace Yoast\WP\Free\Presentations;
 
-use Yoast\WP\Free\Helpers\Options_Helper;
-
 /**
  * Class Indexable_Presentation
  */
 class Indexable_Home_Page_Presentation extends Indexable_Presentation {
-
-	/**
-	 * @var Options_Helper
-	 */
-	protected $options_helper;
-
-	/**
-	 * Indexable_Home_Page_Presentation constructor.
-	 *
-	 * @param Options_Helper $options_helper The options helper.
-	 */
-	public function __construct(
-		Options_Helper $options_helper
-	) {
-		$this->options_helper = $options_helper;
-	}
 
 	/**
 	 * @inheritDoc

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -38,10 +38,6 @@ class Indexable_Home_Page_Presentation extends Indexable_Presentation {
 			return $this->model->og_image;
 		}
 
-		if ( $this->options_helper->get( 'opengraph' ) === true ) {
-			return (string) $this->options_helper->get( 'og_default_image', '' );
-		}
-
-		return '';
+		return (string) $this->get_default_og_image();
 	}
 }

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -15,22 +15,6 @@ use Yoast\WP\Free\Helpers\Options_Helper;
 class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 
 	/**
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
-	 * Indexable_Post_Type_Presentation constructor.
-	 *
-	 * @param Options_Helper $options_helper The options helper.
-	 */
-	public function __construct(
-		Options_Helper $options_helper
-	) {
-		$this->options_helper = $options_helper;
-	}
-
-	/**
 	 * @inheritDoc
 	 */
 	public function generate_robots() {

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -7,8 +7,6 @@
 
 namespace Yoast\WP\Free\Presentations;
 
-use Yoast\WP\Free\Helpers\Options_Helper;
-
 /**
  * Class Indexable_Presentation
  */

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -53,6 +53,39 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	}
 
 	/**
+	 * Generates the open graph images.
+	 *
+	 * @return array The open graph images.
+	 */
+	public function generate_og_images() {
+		$images = parent::generate_og_images();
+
+		if ( ! empty( $images ) ) {
+			return $images;
+		}
+
+		$featured_image_id = $this->image_helper->get_featured_image_id( $this->model->object_id );
+		if ( $featured_image_id ) {
+			$featured_image_url = $this->get_attachment_url_by_id( $featured_image_id );
+			if ( $featured_image_url ) {
+				return [ $featured_image_url ];
+			}
+		}
+
+		$content_image = $this->image_helper->get_post_content_image( $this->model->object_id );
+		if ( $content_image ) {
+			return [ $content_image ];
+		}
+
+		$default_image = $this->get_default_og_image();
+		if ( $default_image ) {
+			return [ $default_image ];
+		}
+
+		return [];
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public function generate_og_type() {

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -138,11 +138,6 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			return $this->model->og_image;
 		}
 
-		$image_url = $this->image_helper->get_attachment_image( $this->model->object_id );
-		if ( $image_url ) {
-			return $image_url;
-		}
-
 		/**
 		 * Filter: 'wpseo_twitter_image_size' - Allow changing the Twitter Card image size.
 		 *

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -7,9 +7,6 @@
 
 namespace Yoast\WP\Free\Presentations;
 
-use Yoast\WP\Free\Helpers\Meta_Helper;
-use Yoast\WP\Free\Helpers\Image_Helper;
-use Yoast\WP\Free\Helpers\Options_Helper;
 use Yoast\WP\Free\Helpers\Post_Type_Helper;
 
 /**
@@ -18,43 +15,19 @@ use Yoast\WP\Free\Helpers\Post_Type_Helper;
 class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 
 	/**
-	 * @var Image_Helper
-	 */
-	protected $image_helper;
-
-	/**
-	 * @var Options_Helper
-	 */
-	protected $options_helper;
-
-	/**
 	 * @var Post_Type_Helper
 	 */
 	protected $post_type_helper;
 
 	/**
-	 * @var Meta_Helper
-	 */
-	protected $meta_helper;
-
-	/**
 	 * Indexable_Post_Type_Presentation constructor.
 	 *
-	 * @param Options_Helper   $options_helper   The options helper.
 	 * @param Post_Type_Helper $post_type_helper The post type helper.
-	 * @param Meta_Helper      $meta_helper      The meta helper.
-	 * @param Image_Helper     $image_helper     The image helper.
 	 */
 	public function __construct(
-		Options_Helper $options_helper,
-		Post_Type_Helper $post_type_helper,
-		Meta_Helper $meta_helper,
-		Image_Helper $image_helper
+		Post_Type_Helper $post_type_helper
 	) {
-		$this->options_helper   = $options_helper;
 		$this->post_type_helper = $post_type_helper;
-		$this->meta_helper      = $meta_helper;
-		$this->image_helper     = $image_helper;
 	}
 
 	/**

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -159,10 +159,6 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			return $image_url;
 		}
 
-		if ( $this->options_helper->get( 'opengraph' ) === true ) {
-			return (string) $this->options_helper->get( 'og_default_image', '' );
-		}
-
-		return '';
+		return (string) $this->get_default_og_image();
 	}
 }

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -8,6 +8,8 @@
 namespace Yoast\WP\Free\Presentations;
 
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Image_Helper;
+use Yoast\WP\Free\Helpers\Options_Helper;
 use Yoast\WP\Free\Helpers\Robots_Helper;
 use Yoast\WP\Free\Models\Indexable;
 
@@ -52,16 +54,32 @@ class Indexable_Presentation extends Abstract_Presentation {
 	protected $current_page_helper;
 
 	/**
+	 * @var Image_Helper
+	 */
+	protected $image_helper;
+
+	/**
+	 * @var Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
 	 * @required
 	 *
 	 * Used by dependency injection container to inject the Robots_Helper.
 	 *
 	 * @param Robots_Helper       $robots_helper       The robots helper.
-	 * @param Current_Page_Helper $current_page_helper Current page helper.
+	 * @param Image_Helper        $image_helper        The image helper.
+	 * @param Options_Helper      $options_helper      The options helper.
 	 */
-	public function set_helpers( Robots_Helper $robots_helper, Current_Page_Helper $current_page_helper ) {
-		$this->robots_helper       = $robots_helper;
-		$this->current_page_helper = $current_page_helper;
+	public function set_helpers(
+		Robots_Helper $robots_helper,
+		Image_Helper $image_helper,
+		Options_Helper $options_helper
+	) {
+		$this->robots_helper  = $robots_helper;
+		$this->image_helper   = $image_helper;
+		$this->options_helper = $options_helper;
 	}
 
 	/**

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -71,15 +71,18 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @param Robots_Helper       $robots_helper       The robots helper.
 	 * @param Image_Helper        $image_helper        The image helper.
 	 * @param Options_Helper      $options_helper      The options helper.
+	 * @param Current_Page_Helper $current_page_helper The current page helper.
 	 */
 	public function set_helpers(
 		Robots_Helper $robots_helper,
 		Image_Helper $image_helper,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Current_Page_Helper $current_page_helper
 	) {
-		$this->robots_helper  = $robots_helper;
-		$this->image_helper   = $image_helper;
-		$this->options_helper = $options_helper;
+		$this->robots_helper       = $robots_helper;
+		$this->image_helper        = $image_helper;
+		$this->options_helper      = $options_helper;
+		$this->current_page_helper = $current_page_helper;
 	}
 
 	/**
@@ -170,15 +173,15 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @return array The open graph images.
 	 */
 	public function generate_og_images() {
-		if ( $this->model->og_image_id === null && $this->model->og_image ) {
-			return [ $this->model->og_image ];
-		}
-
 		if ( $this->model->og_image_id ) {
 			$attachment = $this->get_attachment_url_by_id( $this->model->og_image_id );
 			if ( $attachment ) {
 				return [ $attachment ];
 			}
+		}
+
+		if ( $this->model->og_image ) {
+			return [ $this->model->og_image ];
 		}
 
 		return [];

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -7,28 +7,10 @@
 
 namespace Yoast\WP\Free\Presentations;
 
-use Yoast\WP\Free\Helpers\Options_Helper;
-
 /**
  * Class Indexable_Presentation
  */
 class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
-
-	/**
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
-	 * Indexable_Post_Type_Presentation constructor.
-	 *
-	 * @param Options_Helper $options_helper The options helper.
-	 */
-	public function __construct(
-		Options_Helper $options_helper
-	) {
-		$this->options_helper = $options_helper;
-	}
 
 	/**
 	 * @inheritDoc

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -73,10 +73,6 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 			return $twitter_image;
 		}
 
-		if ( $this->options_helper->get( 'opengraph' ) === true ) {
-			return (string) $this->options_helper->get( 'og_default_image', '' );
-		}
-
-		return '';
+		return (string) $this->get_default_og_image();
 	}
 }

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -60,6 +60,24 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	/**
 	 * @inheritDoc
 	 */
+	public function generate_og_images() {
+		$images = parent::generate_og_images();
+
+		if ( ! empty( $images ) ) {
+			return $images;
+		}
+
+		$default_image = $this->get_default_og_image();
+		if ( $default_image ) {
+			return [ $default_image ];
+		}
+
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public function generate_twitter_description() {
 		$twitter_description = parent::generate_twitter_description();
 

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -38,6 +38,12 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		'mime-type' => 'type',
 	];
 
+	/**
+	 * Image_Presenter constructor.
+	 *
+	 * @param Image_Helper $image_helper The image helper.
+	 * @param Url_Helper   $url_helper   The url helper.
+	 */
 	public function __construct( Image_Helper $image_helper, Url_Helper $url_helper ) {
 		$this->image_helper = $image_helper;
 		$this->url_helper   = $url_helper;
@@ -62,13 +68,13 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 
 		$images = array_map( [ $this, 'filter' ], $images );
 		foreach ( $images as $image_index => $image_meta ) {
-			$image_url = $image_meta[ 'url' ];
+			$image_url = $image_meta['url'];
 
 			$return .= '<meta property="og:image" value="' . esc_url( $image_url ) . '"/>';
 
 			// Adds secure URL if detected. Not all services implement this, so the regular one also needs to be rendered.
 			if ( strpos( $image_meta['url'], 'https://' ) === 0 ) {
-				$return .= '<meta property="og:image:secure_url" value="' .esc_url( $image_url ) . '"/>';
+				$return .= '<meta property="og:image:secure_url" value="' . esc_url( $image_url ) . '"/>';
 			}
 
 			foreach ( static::$image_tags as $key => $value ) {
@@ -83,17 +89,24 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		return $return;
 	}
 
-	protected function format_image( $attachment ) {
+	/**
+	 * Formats the image. To have all images the same format.
+	 *
+	 * @param array|string $image The attachment to format.
+	 *
+	 * @return array|string The formatted attachment.
+	 */
+	protected function format_image( $image ) {
 		// In the past `add_image` accepted an image url, so leave this for backwards compatibility.
-		if ( is_string( $attachment ) && $attachment !== '' ) {
-			$attachment = [ 'url' => $attachment ];
+		if ( is_string( $image ) && $image !== '' ) {
+			$image = [ 'url' => $image ];
 		}
 
-		if ( $this->url_helper->is_relative( $attachment['url'] ) ) {
-			$attachment['url'] = $this->url_helper->get_relative_path( $attachment['url']);
+		if ( $this->url_helper->is_relative( $image['url'] ) ) {
+			$image['url'] = $this->url_helper->get_relative_path( $image['url'] );
 		}
 
-		return $attachment;
+		return $image;
 	}
 
 	/**
@@ -109,7 +122,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		}
 
 		$image_extension = $this->get_extension_from_url( $image['url'] );
-		$is_valid        =  $this->image_helper->is_extension_valid( $image_extension );
+		$is_valid        = $this->image_helper->is_extension_valid( $image_extension );
 
 		/**
 		 * Filter: 'wpseo_opengraph_is_valid_image_url' - Allows extra validation for an image url.
@@ -141,9 +154,6 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 
 		return $image;
 	}
-
-
-	// Na helper verplaatsen wat hieronder staat
 
 	/**
 	 * Determines the file extension of the passed URL.

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Presenter class for the OpenGraph image.
+ *
+ * @package Yoast\YoastSEO\Presenters\Open_Graph
+ */
+
+namespace Yoast\WP\Free\Presenters\Open_Graph;
+
+use Yoast\WP\Free\Helpers\Image_Helper;
+use Yoast\WP\Free\Helpers\Url_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
+
+/**
+ * Class Image_Presenter
+ */
+class Image_Presenter extends Abstract_Indexable_Presenter {
+
+	/**
+	 * @var Image_Helper
+	 */
+	protected $image_helper;
+
+	/**
+	 * @var Url_Helper
+	 */
+	protected $url_helper;
+
+	/**
+	 * Image tags that we output for each image.
+	 *
+	 * @var array
+	 */
+	protected static $image_tags = [
+		'width'     => 'width',
+		'height'    => 'height',
+		'mime-type' => 'type',
+	];
+
+	public function __construct( Image_Helper $image_helper, Url_Helper $url_helper ) {
+		$this->image_helper = $image_helper;
+		$this->url_helper   = $url_helper;
+	}
+
+	/**
+	 * Returns the image for a post.
+	 *
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 *
+	 * @return string The image tag.
+	 */
+	public function present( Indexable_Presentation $presentation ) {
+		if ( \post_password_required() ) {
+			return '';
+		}
+
+		$return = '';
+		$images = (array) $presentation->og_images;
+		$images = array_map( [ $this, 'format_image' ], $images );
+		$images = array_filter( $images, [ $this, 'is_image_url_valid' ] );
+
+		$images = array_map( [ $this, 'filter' ], $images );
+		foreach ( $images as $image_index => $image_meta ) {
+			$image_url = $image_meta[ 'url' ];
+
+			$return .= '<meta property="og:image" value="' . esc_url( $image_url ) . '"/>';
+
+			// Adds secure URL if detected. Not all services implement this, so the regular one also needs to be rendered.
+			if ( strpos( $image_meta['url'], 'https://' ) === 0 ) {
+				$return .= '<meta property="og:image:secure_url" value="' .esc_url( $image_url ) . '"/>';
+			}
+
+			foreach ( static::$image_tags as $key => $value ) {
+				if ( empty( $image_meta[ $key ] ) ) {
+					continue;
+				}
+
+				$return .= '<meta property="og:image:' . esc_attr( $key ) . '" value="' . $image_meta[ $key ] . '"/>';
+			}
+		}
+
+		return $return;
+	}
+
+	protected function format_image( $attachment ) {
+		// In the past `add_image` accepted an image url, so leave this for backwards compatibility.
+		if ( is_string( $attachment ) && $attachment !== '' ) {
+			$attachment = [ 'url' => $attachment ];
+		}
+
+		if ( $this->url_helper->is_relative( $attachment['url'] ) ) {
+			$attachment['url'] = $this->url_helper->get_relative_path( $attachment['url']);
+		}
+
+		return $attachment;
+	}
+
+	/**
+	 * Determines whether the passed URL is considered valid.
+	 *
+	 * @param array $image The image array.
+	 *
+	 * @return bool Whether or not the URL is a valid image.
+	 */
+	protected function is_image_url_valid( array $image ) {
+		if ( empty( $image['url'] ) || ! is_string( $image['url'] ) ) {
+			return false;
+		}
+
+		$image_extension = $this->get_extension_from_url( $image['url'] );
+		$is_valid        =  $this->image_helper->is_extension_valid( $image_extension );
+
+		/**
+		 * Filter: 'wpseo_opengraph_is_valid_image_url' - Allows extra validation for an image url.
+		 *
+		 * @api bool - Current validation result.
+		 *
+		 * @param string $url The image url to validate.
+		 */
+		return apply_filters( 'wpseo_opengraph_is_valid_image_url', $is_valid, $image['url'] );
+	}
+
+	/**
+	 * Run the image content through the `wpseo_opengraph_image` filter.
+	 *
+	 * @param array $image The image to filter.
+	 *
+	 * @return array The filtered image.
+	 */
+	private function filter( array $image ) {
+		/**
+		 * Filter: 'wpseo_opengraph_image' - Allow changing the OpenGraph image.
+		 *
+		 * @api string - The URL of the OpenGraph image.
+		 */
+		$image_url = \trim( \apply_filters( 'wpseo_opengraph_image', $image['url'] ) );
+		if ( ! empty( $image_url ) && \is_string( $image_url ) ) {
+			$image['url'] = $image_url;
+		}
+
+		return $image;
+	}
+
+
+	// Na helper verplaatsen wat hieronder staat
+
+	/**
+	 * Determines the file extension of the passed URL.
+	 *
+	 * @param string $url The URL.
+	 *
+	 * @return string The extension.
+	 */
+	protected function get_extension_from_url( $url ) {
+		$extension = '';
+		$path      = $this->get_image_url_path( $url );
+
+		if ( $path === '' ) {
+			return $extension;
+		}
+
+		$parts = explode( '.', $path );
+
+		if ( ! empty( $parts ) ) {
+			$extension = end( $parts );
+		}
+
+		return $extension;
+	}
+
+
+	/**
+	 * Gets the image path from the passed URL.
+	 *
+	 * @param string $url The URL to get the path from.
+	 *
+	 * @return string The path of the image URL. Returns an empty string if URL parsing fails.
+	 */
+	protected function get_image_url_path( $url ) {
+		return (string) wp_parse_url( $url, PHP_URL_PATH );
+	}
+}

--- a/tests/_mocks/Indexable.php
+++ b/tests/_mocks/Indexable.php
@@ -35,6 +35,7 @@ class Indexable extends \Yoast\WP\Free\Models\Indexable {
 	public $og_title;
 	public $og_description;
 	public $og_image;
+	public $og_image_id;
 	public $twitter_title;
 	public $twitter_description;
 	public $twitter_image;

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -47,6 +47,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 				'_yoast_wpseo_bctitle'               => [ 'breadcrumb_title' ],
 				'_yoast_wpseo_opengraph-title'       => [ 'og_title' ],
 				'_yoast_wpseo_opengraph-image'       => [ 'og_image' ],
+				'_yoast_wpseo_opengraph-image-id'    => [ 'og_image_id' ],
 				'_yoast_wpseo_opengraph-description' => [ 'og_description' ],
 				'_yoast_wpseo_twitter-title'         => [ 'twitter_title' ],
 				'_yoast_wpseo_twitter-image'         => [ 'twitter_image' ],
@@ -65,6 +66,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'description', 'description' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_title', 'og_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_image', 'og_image' );
+		$indexable_mock->orm->expects( 'set' )->with( 'og_image_id', 'og_image_id' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_description', 'og_description' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_title', 'twitter_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'twitter_image' );

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -54,6 +54,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 						'wpseo_bctitle'               => 'breadcrumb_title',
 						'wpseo_opengraph-title'       => 'og_title',
 						'wpseo_opengraph-image'       => 'og_image',
+						'wpseo_opengraph-image-id'    => 'og_image_id',
 						'wpseo_opengraph-description' => 'og_description',
 						'wpseo_twitter-title'         => 'twitter_title',
 						'wpseo_twitter-image'         => 'twitter_image',
@@ -73,6 +74,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'description', 'description' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_title', 'og_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_image', 'og_image' );
+		$indexable_mock->orm->expects( 'set' )->with( 'og_image_id', 'og_image_id' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_description', 'og_description' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_title', 'twitter_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'twitter_image' );

--- a/tests/presentations/indexable-attachment-presentation/og-images-test.php
+++ b/tests/presentations/indexable-attachment-presentation/og-images-test.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Attachment_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Abstract_Robots_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Attachment_Presentation
+ *
+ * @group presentations
+ * @group opengraph
+ * @group opengraph-image
+ */
+class OG_Image_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the og image is set.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_og_image() {
+		$this->indexable->og_image    = 'facebook_image.jpg';
+		$this->indexable->og_image_id = null;
+
+		$this->assertEquals( [ 'facebook_image.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where the og image id is set.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_og_image_id() {
+		$this->indexable->og_image    = null;
+		$this->indexable->og_image_id = 1;
+
+		$this->instance
+			->expects( 'get_attachment_url_by_id' )
+			->once()
+			->andReturn( 'facebook_image.jpg' );
+
+		$this->assertEquals( [ 'facebook_image.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where the attachment itself is given.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_attachment() {
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( true );
+
+		$this->instance
+			->expects( 'get_attachment_url_by_id' )
+			->once()
+			->andReturn( 'attachment.jpg' );
+
+		$this->assertEquals( [ 'attachment.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where the default og image is given.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_the_default_og_image() {
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'get_default_og_image' )
+			->once()
+			->andReturn( 'default_image.jpg' );
+
+		$this->assertEquals( [ 'default_image.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where no situation is applicable.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_no_applicable_situation() {
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'get_default_og_image' )
+			->once()
+			->andReturnFalse();
+
+		$this->assertEquals( [], $this->instance->generate_og_images() );
+	}
+
+}

--- a/tests/presentations/indexable-attachment-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-attachment-presentation/presentation-instance-builder.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Attachment_Presentation;
 
 use Mockery;
+use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Meta_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
@@ -52,6 +53,11 @@ trait Presentation_Instance_Builder {
 	protected $image_helper;
 
 	/**
+	 * @var Current_Page_Helper
+	 */
+	protected $current_page_helper;
+
+	/**
 	 * Builds an instance of Indexable_Attachment_Presentation.
 	 */
 	protected function setInstance() {
@@ -62,6 +68,7 @@ trait Presentation_Instance_Builder {
 		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
 		$this->meta_helper         = Mockery::mock( Meta_Helper::class );
 		$this->image_helper        = Mockery::mock( Image_Helper::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 
 		$instance = Mockery::mock(
 			Indexable_Attachment_Presentation::class,
@@ -72,7 +79,8 @@ trait Presentation_Instance_Builder {
 		$this->instance->set_helpers(
 			$this->robots_helper,
 			$this->image_helper,
-			$this->options_helper
+			$this->options_helper,
+			$this->current_page_helper
 		);
 	}
 }

--- a/tests/presentations/indexable-attachment-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-attachment-presentation/presentation-instance-builder.php
@@ -22,7 +22,7 @@ trait Presentation_Instance_Builder {
 	protected $indexable;
 
 	/**
-	 * @var Indexable_Attachment_Presentation
+	 * @var Indexable_Attachment_Presentation|Mockery\MockInterface
 	 */
 	protected $instance;
 
@@ -63,9 +63,10 @@ trait Presentation_Instance_Builder {
 		$this->meta_helper         = Mockery::mock( Meta_Helper::class );
 		$this->image_helper        = Mockery::mock( Image_Helper::class );
 
-		$instance = new Indexable_Attachment_Presentation(
-			$this->post_type_helper,
-		);
+		$instance = Mockery::mock(
+			Indexable_Attachment_Presentation::class,
+			[ $this->post_type_helper ]
+		)->shouldAllowMockingProtectedMethods()->makePartial();
 
 		$this->instance = $instance->of( $this->indexable );
 		$this->instance->set_helpers(

--- a/tests/presentations/indexable-attachment-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-attachment-presentation/presentation-instance-builder.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Attachment_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Helpers\Image_Helper;
+use Yoast\WP\Free\Helpers\Meta_Helper;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Post_Type_Helper;
+use Yoast\WP\Free\Helpers\Robots_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Attachment_Presentation;
+use Yoast\WP\Free\Tests\Mocks\Indexable;
+
+/**
+ * Trait Presentation_Instance_Builder
+ */
+trait Presentation_Instance_Builder {
+
+	/**
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * @var Indexable_Attachment_Presentation
+	 */
+	protected $instance;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $options_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $robots_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $post_type_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $meta_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $image_helper;
+
+	/**
+	 * Builds an instance of Indexable_Attachment_Presentation.
+	 */
+	protected function setInstance() {
+		$this->indexable = new Indexable();
+
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->post_type_helper    = Mockery::mock( Post_Type_Helper::class );
+		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
+		$this->meta_helper         = Mockery::mock( Meta_Helper::class );
+		$this->image_helper        = Mockery::mock( Image_Helper::class );
+
+		$instance = new Indexable_Attachment_Presentation(
+			$this->post_type_helper,
+		);
+
+		$this->instance = $instance->of( $this->indexable );
+		$this->instance->set_helpers(
+			$this->robots_helper,
+			$this->image_helper,
+			$this->options_helper
+		);
+	}
+}

--- a/tests/presentations/indexable-attachment-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-attachment-presentation/twitter-image-test.php
@@ -66,6 +66,11 @@ class Twitter_Image_Test extends TestCase {
 			->with( 'opengraph' )
 			->andReturnFalse();
 
+		$this->image_helper
+			->expects( 'get_attachment_image' )
+			->once()
+			->andReturn( '' );
+
 		$this->indexable->og_image = 'facebook_image.jpg';
 
 		$this->assertEmpty( $this->instance->generate_twitter_image() );
@@ -98,7 +103,7 @@ class Twitter_Image_Test extends TestCase {
 		$this->image_helper
 			->expects( 'get_attachment_image' )
 			->once()
-			->andReturnFalse( );
+			->andReturnFalse();
 
 		$this->assertEquals( 'default_image.jpg', $this->instance->generate_twitter_image() );
 	}

--- a/tests/presentations/indexable-attachment-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-attachment-presentation/twitter-image-test.php
@@ -59,7 +59,7 @@ class Twitter_Image_Test extends TestCase {
 	 *
 	 * @covers ::generate_twitter_image
 	 */
-	public function _test_with_opengraph_disabled() {
+	public function test_with_opengraph_disabled() {
 		$this->options_helper
 			->expects( 'get' )
 			->twice()

--- a/tests/presentations/indexable-attachment-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-attachment-presentation/twitter-image-test.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Attachment_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Abstract_Robots_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Attachment_Presentation
+ *
+ * @group presentations
+ * @group twitter
+ * @group twitter-image
+ */
+class Twitter_Image_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the twitter image is given.
+	 *
+	 * @covers ::generate_twitter_image
+	 */
+	public function test_with_set_twitter_image() {
+		$this->indexable->twitter_image = 'twitter_image.jpg';
+
+		$this->assertEquals( 'twitter_image.jpg', $this->instance->generate_twitter_image() );
+	}
+
+	/**
+	 * Tests the situation where the opengraph image is given.
+	 *
+	 * @covers ::generate_twitter_image
+	 */
+	public function test_with_opengraph_image() {
+		$this->options_helper
+			->expects( 'get' )
+			->once()
+			->with( 'opengraph' )
+			->andReturnTrue();
+
+		$this->indexable->og_image = 'facebook_image.jpg';
+
+		$this->assertEquals( 'facebook_image.jpg', $this->instance->generate_twitter_image() );
+	}
+
+
+	/**
+	 * Tests the situation where no twitter image is set and the opengraph is disabled.
+	 *
+	 * @covers ::generate_twitter_image
+	 */
+	public function _test_with_opengraph_disabled() {
+		$this->options_helper
+			->expects( 'get' )
+			->twice()
+			->with( 'opengraph' )
+			->andReturnFalse();
+
+		$this->indexable->og_image = 'facebook_image.jpg';
+
+		$this->assertEmpty( $this->instance->generate_twitter_image() );
+	}
+
+	/**
+	 * Tests the situation for an attachment.
+	 *
+	 * @covers ::generate_twitter_image
+	 */
+	public function test_for_an_attachment() {
+		$this->image_helper
+			->expects( 'get_attachment_image' )
+			->once()
+			->andReturn( 'attachment_image.jpg' );
+
+		$this->assertEquals( 'attachment_image.jpg', $this->instance->generate_twitter_image() );
+	}
+	/**
+	 * Tests the situation where the default image is given.
+	 *
+	 * @covers ::generate_twitter_image
+	 */
+	public function test_with_default_image() {
+		$this->options_helper
+			->expects( 'get' )
+			->times( 3 )
+			->andReturn( true, 0, 'default_image.jpg' );
+
+		$this->image_helper
+			->expects( 'get_attachment_image' )
+			->once()
+			->andReturnFalse( );
+
+		$this->assertEquals( 'default_image.jpg', $this->instance->generate_twitter_image() );
+	}
+	/**
+	 * Tests the situation where the default image is not given.
+	 *
+	 * @covers ::generate_twitter_image
+	 */
+	public function test_with_no_default_image_given() {
+		$this->options_helper
+			->expects( 'get' )
+			->once()
+			->andReturn( false );
+
+		$this->image_helper
+			->expects( 'get_attachment_image' )
+			->once()
+			->andReturnFalse( );
+
+
+		$this->assertEmpty( $this->instance->generate_twitter_image() );
+	}
+}

--- a/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Home_Page_Presentation;
 
 use Mockery;
+use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
 use Yoast\WP\Free\Helpers\Robots_Helper;
@@ -45,14 +46,20 @@ trait Presentation_Instance_Builder {
 	protected $image_helper;
 
 	/**
+	 * @var Current_Page_Helper
+	 */
+	protected $current_page_helper;
+
+	/**
 	 * Builds an instance of Indexable_Home_Page_Presentation.
 	 */
 	protected function setInstance() {
 		$this->indexable = new Indexable();
 
-		$this->options_helper = Mockery::mock( Options_Helper::class );
-		$this->robots_helper  = Mockery::mock( Robots_Helper::class );
-		$this->image_helper   = Mockery::mock( Image_Helper::class );
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
+		$this->image_helper        = Mockery::mock( Image_Helper::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 
 		$instance = new Indexable_Home_Page_Presentation();
 
@@ -60,7 +67,8 @@ trait Presentation_Instance_Builder {
 		$this->instance->set_helpers(
 			$this->robots_helper,
 			$this->image_helper,
-			$this->options_helper
+			$this->options_helper,
+			$this->current_page_helper
 		);
 	}
 }

--- a/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Home_Page_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Helpers\Image_Helper;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Robots_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Home_Page_Presentation;
+use Yoast\WP\Free\Tests\Mocks\Indexable;
+
+/**
+ * Trait Presentation_Instance_Builder
+ */
+trait Presentation_Instance_Builder {
+
+	/**
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * @var Indexable_Home_Page_Presentation
+	 */
+	protected $instance;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $options_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $robots_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $meta_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $image_helper;
+
+	/**
+	 * Builds an instance of Indexable_Home_Page_Presentation.
+	 */
+	protected function setInstance() {
+		$this->indexable = new Indexable();
+
+		$this->options_helper = Mockery::mock( Options_Helper::class );
+		$this->robots_helper  = Mockery::mock( Robots_Helper::class );
+		$this->image_helper   = Mockery::mock( Image_Helper::class );
+
+		$instance = new Indexable_Home_Page_Presentation();
+
+		$this->instance = $instance->of( $this->indexable );
+		$this->instance->set_helpers(
+			$this->robots_helper,
+			$this->image_helper,
+			$this->options_helper
+		);
+	}
+}

--- a/tests/presentations/indexable-home-page-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-home-page-presentation/twitter-image-test.php
@@ -2,11 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Home_Page_Presentation;
 
-use Mockery;
-use Yoast\WP\Free\Helpers\Current_Page_Helper;
-use Yoast\WP\Free\Helpers\Options_Helper;
-use Yoast\WP\Free\Presentations\Indexable_Home_Page_Presentation;
-use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
@@ -19,32 +14,13 @@ use Yoast\WP\Free\Tests\TestCase;
  * @group twitter-image
  */
 class Twitter_Image_Test extends TestCase {
-
-	/**
-	 * @var Options_Helper|Mockery\MockInterface
-	 */
-	protected $option_helper;
-
-	/**
-	 * @var Indexable
-	 */
-	protected $indexable;
-
-	/**
-	 * @var Indexable_Home_Page_Presentation
-	 */
-	protected $instance;
+	use Presentation_Instance_Builder;
 
 	/**
 	 * Does the setup for testing.
 	 */
 	public function setUp() {
-		$this->option_helper = Mockery::mock( Options_Helper::class );
-		$current_page_helper = Mockery::mock( Current_Page_Helper::class );
-		$this->indexable     = new Indexable();
-
-		$presentation   = new Indexable_Home_Page_Presentation( $this->option_helper, $current_page_helper );
-		$this->instance = $presentation->of( $this->indexable );
+		$this->setInstance();
 
 		return parent::setUp();
 	}
@@ -66,7 +42,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_opengraph_disabled() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->with( 'opengraph' )
@@ -83,7 +59,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_opengraph_image() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->with( 'opengraph' )
@@ -100,7 +76,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_default_image() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->andReturn( true, 'default_image.jpg' );
@@ -114,7 +90,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_no_default_image() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->andReturnFalse();

--- a/tests/presentations/indexable-home-page-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-home-page-presentation/twitter-image-test.php
@@ -78,8 +78,8 @@ class Twitter_Image_Test extends TestCase {
 	public function test_with_default_image() {
 		$this->options_helper
 			->expects( 'get' )
-			->twice()
-			->andReturn( true, 'default_image.jpg' );
+			->times( 3 )
+			->andReturn( true, 0, 'default_image.jpg' );
 
 		$this->assertEquals( 'default_image.jpg', $this->instance->generate_twitter_image() );
 	}

--- a/tests/presentations/indexable-post-type-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-archive-presentation/presentation-instance-builder.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Archive_Presenta
 
 use Mockery;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
 use Yoast\WP\Free\Helpers\Robots_Helper;
 use Yoast\WP\Free\Presentations\Indexable_Post_Type_Archive_Presentation;
@@ -40,6 +41,11 @@ trait Presentation_Instance_Builder {
 	protected $current_page_helper;
 
 	/**
+	 * @var Image_Helper
+	 */
+	protected $image_helper;
+
+	/**
 	 * Builds an instance of Indexable_Post_Type_Presentation.
 	 */
 	protected function setInstance() {
@@ -47,13 +53,16 @@ trait Presentation_Instance_Builder {
 
 		$this->options_helper      = Mockery::mock( Options_Helper::class );
 		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
+		$this->image_helper        = Mockery::mock( Image_Helper::class );
 		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 
-		$instance = new Indexable_Post_Type_Archive_Presentation( $this->options_helper );
+		$instance = new Indexable_Post_Type_Archive_Presentation();
 
 		$this->instance = $instance->of( $this->indexable );
 		$this->instance->set_helpers(
 			$this->robots_helper,
+			$this->image_helper,
+			$this->options_helper,
 			$this->current_page_helper
 		);
 	}

--- a/tests/presentations/indexable-post-type-presentation/og-images-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-images-test.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Yoast\WP\Free\Tests\Presentations\Indexable_Attachment_Presentation;
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
 
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
  * Class Abstract_Robots_Presenter_Test
  *
- * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Attachment_Presentation
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Post_Type_Presentation
  *
  * @group presentations
  * @group opengraph
@@ -55,32 +55,20 @@ class OG_Image_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the attachment itself is given.
-	 *
-	 * @covers ::generate_og_images
-	 */
-	public function test_with_attachment() {
-		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
-			->once()
-			->andReturn( true );
-
-		$this->instance
-			->expects( 'get_attachment_url_by_id' )
-			->once()
-			->andReturn( 'attachment.jpg' );
-
-		$this->assertEquals( [ 'attachment.jpg' ], $this->instance->generate_og_images() );
-	}
-
-	/**
 	 * Tests the situation where the default og image is given.
 	 *
 	 * @covers ::generate_og_images
 	 */
 	public function test_with_the_default_og_image() {
-		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+		$this->image_helper
+			->expects( 'get_featured_image_id' )
 			->once()
-			->andReturn( false );
+			->andReturnFalse();
+
+		$this->image_helper
+			->expects( 'get_post_content_image' )
+			->once()
+			->andReturnFalse();
 
 		$this->instance
 			->expects( 'get_default_og_image' )
@@ -96,9 +84,15 @@ class OG_Image_Test extends TestCase {
 	 * @covers ::generate_og_images
 	 */
 	public function test_with_no_applicable_situation() {
-		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+		$this->image_helper
+			->expects( 'get_featured_image_id' )
 			->once()
-			->andReturn( false );
+			->andReturnFalse();
+
+		$this->image_helper
+			->expects( 'get_post_content_image' )
+			->once()
+			->andReturnFalse();
 
 		$this->instance
 			->expects( 'get_default_og_image' )

--- a/tests/presentations/indexable-post-type-presentation/og-images-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-images-test.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Attachment_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Abstract_Robots_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Attachment_Presentation
+ *
+ * @group presentations
+ * @group opengraph
+ * @group opengraph-image
+ */
+class OG_Image_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the og image is set.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_og_image() {
+		$this->indexable->og_image    = 'facebook_image.jpg';
+		$this->indexable->og_image_id = null;
+
+		$this->assertEquals( [ 'facebook_image.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where the og image id is set.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_og_image_id() {
+		$this->indexable->og_image    = null;
+		$this->indexable->og_image_id = 1;
+
+		$this->instance
+			->expects( 'get_attachment_url_by_id' )
+			->once()
+			->andReturn( 'facebook_image.jpg' );
+
+		$this->assertEquals( [ 'facebook_image.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where the attachment itself is given.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_attachment() {
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( true );
+
+		$this->instance
+			->expects( 'get_attachment_url_by_id' )
+			->once()
+			->andReturn( 'attachment.jpg' );
+
+		$this->assertEquals( [ 'attachment.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where the default og image is given.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_the_default_og_image() {
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'get_default_og_image' )
+			->once()
+			->andReturn( 'default_image.jpg' );
+
+		$this->assertEquals( [ 'default_image.jpg' ], $this->instance->generate_og_images() );
+	}
+
+	/**
+	 * Tests the situation where no situation is applicable.
+	 *
+	 * @covers ::generate_og_images
+	 */
+	public function test_with_no_applicable_situation() {
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( false );
+
+		$this->instance
+			->expects( 'get_default_og_image' )
+			->once()
+			->andReturnFalse();
+
+		$this->assertEquals( [], $this->instance->generate_og_images() );
+	}
+
+}

--- a/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
@@ -23,7 +23,7 @@ trait Presentation_Instance_Builder {
 	protected $indexable;
 
 	/**
-	 * @var Indexable_Post_Type_Presentation
+	 * @var Indexable_Post_Type_Presentation|Mockery\MockInterface
 	 */
 	protected $instance;
 
@@ -53,6 +53,11 @@ trait Presentation_Instance_Builder {
 	protected $image_helper;
 
 	/**
+	 * @var Current_Page_Helper
+	 */
+	protected $current_page_helper;
+
+	/**
 	 * Builds an instance of Indexable_Post_Type_Presentation.
 	 */
 	protected function setInstance() {
@@ -63,16 +68,21 @@ trait Presentation_Instance_Builder {
 		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
 		$this->meta_helper         = Mockery::mock( Meta_Helper::class );
 		$this->image_helper        = Mockery::mock( Image_Helper::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 
-		$instance = new Indexable_Post_Type_Presentation(
-			$this->post_type_helper,
-		);
+		$instance = Mockery::mock(
+			Indexable_Post_Type_Presentation::class,
+			[ $this->post_type_helper ]
+		)
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
 
 		$this->instance = $instance->of( $this->indexable );
 		$this->instance->set_helpers(
 			$this->robots_helper,
 			$this->image_helper,
-			$this->options_helper
+			$this->options_helper,
+			$this->current_page_helper
 		);
 	}
 }

--- a/tests/presentations/indexable-post-type-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-post-type-presentation/twitter-image-test.php
@@ -136,8 +136,8 @@ class Twitter_Image_Test extends TestCase {
 	public function test_with_default_image() {
 		$this->options_helper
 			->expects( 'get' )
-			->twice()
-			->andReturn( true, 'default_image.jpg' );
+			->times( 3 )
+			->andReturn( true, 0, 'default_image.jpg' );
 
 		$this->image_helper
 			->expects( 'get_featured_image' )

--- a/tests/presentations/indexable-post-type-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-post-type-presentation/twitter-image-test.php
@@ -70,32 +70,12 @@ class Twitter_Image_Test extends TestCase {
 
 		$this->assertEmpty( $this->instance->generate_twitter_image() );
 	}
-
-	/**
-	 * Tests the situation for an attachment.
-	 *
-	 * @covers ::generate_twitter_image
-	 */
-	public function test_for_an_attachment() {
-		$this->image_helper
-			->expects( 'get_attachment_image' )
-			->once()
-			->andReturn( 'attachment_image.jpg' );
-
-		$this->assertEquals( 'attachment_image.jpg', $this->instance->generate_twitter_image() );
-	}
-
 	/**
 	 * Tests the situation where the featured image is given.
 	 *
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_a_featured_image() {
-		$this->image_helper
-			->expects( 'get_attachment_image' )
-			->once()
-			->andReturnFalse( );
-
 		$this->image_helper
 			->expects( 'get_featured_image' )
 			->once()
@@ -110,16 +90,11 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_a_gallery_image() {
-		$this->image_helper
-			->expects( 'get_attachment_image' )
-			->once()
-			->andReturnFalse( );
 
 		$this->image_helper
 			->expects( 'get_featured_image' )
 			->once()
 			->andReturnFalse();
-
 
 		$this->image_helper
 			->expects( 'get_gallery_image' )
@@ -135,11 +110,6 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_a_post_content_image() {
-		$this->image_helper
-			->expects( 'get_attachment_image' )
-			->once()
-			->andReturnFalse( );
-
 		$this->image_helper
 			->expects( 'get_featured_image' )
 			->once()
@@ -170,11 +140,6 @@ class Twitter_Image_Test extends TestCase {
 			->andReturn( true, 'default_image.jpg' );
 
 		$this->image_helper
-			->expects( 'get_attachment_image' )
-			->once()
-			->andReturnFalse( );
-
-		$this->image_helper
 			->expects( 'get_featured_image' )
 			->once()
 			->andReturnFalse();
@@ -201,11 +166,6 @@ class Twitter_Image_Test extends TestCase {
 			->expects( 'get' )
 			->once()
 			->andReturn( false );
-
-		$this->image_helper
-			->expects( 'get_attachment_image' )
-			->once()
-			->andReturnFalse( );
 
 		$this->image_helper
 			->expects( 'get_featured_image' )

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -4,6 +4,8 @@ namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
 
 use Mockery;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Image_Helper;
+use Yoast\WP\Free\Helpers\Options_Helper;
 use Yoast\WP\Free\Helpers\Robots_Helper;
 use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Tests\Mocks\Indexable;
@@ -41,6 +43,8 @@ class Robots_Test extends TestCase {
 	 */
 	public function test_generate_robots() {
 		$robots_helper       = Mockery::mock( Robots_Helper::class );
+		$image_helper        = Mockery::mock( Image_Helper::class );
+		$options_helper      = Mockery::mock( Options_Helper::class );
 		$current_page_helper = Mockery::mock( Current_Page_Helper::class );
 
 		$robots_helper->expects( 'get_base_values' )
@@ -59,7 +63,7 @@ class Robots_Test extends TestCase {
 				return $robots;
 			} );
 
-		$this->instance->set_helpers( $robots_helper, $current_page_helper );
+		$this->instance->set_helpers( $robots_helper, $image_helper, $options_helper, $current_page_helper );
 
 		$actual = $this->instance->generate_robots();
 		$expected = [

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
@@ -1,15 +1,13 @@
 <?php
 
-namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
 
 use Mockery;
-use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Meta_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
-use Yoast\WP\Free\Helpers\Post_Type_Helper;
 use Yoast\WP\Free\Helpers\Robots_Helper;
-use Yoast\WP\Free\Presentations\Indexable_Post_Type_Presentation;
+use Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation;
 use Yoast\WP\Free\Tests\Mocks\Indexable;
 
 /**
@@ -23,7 +21,7 @@ trait Presentation_Instance_Builder {
 	protected $indexable;
 
 	/**
-	 * @var Indexable_Post_Type_Presentation
+	 * @var Indexable_Term_Archive_Presentation
 	 */
 	protected $instance;
 
@@ -40,11 +38,6 @@ trait Presentation_Instance_Builder {
 	/**
 	 * @var Mockery\Mock
 	 */
-	protected $post_type_helper;
-
-	/**
-	 * @var Mockery\Mock
-	 */
 	protected $meta_helper;
 
 	/**
@@ -53,20 +46,17 @@ trait Presentation_Instance_Builder {
 	protected $image_helper;
 
 	/**
-	 * Builds an instance of Indexable_Post_Type_Presentation.
+	 * Builds an instance of Indexable_Term_Archive_Presentation.
 	 */
 	protected function setInstance() {
 		$this->indexable = new Indexable();
 
-		$this->options_helper      = Mockery::mock( Options_Helper::class );
-		$this->post_type_helper    = Mockery::mock( Post_Type_Helper::class );
-		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
-		$this->meta_helper         = Mockery::mock( Meta_Helper::class );
-		$this->image_helper        = Mockery::mock( Image_Helper::class );
+		$this->options_helper = Mockery::mock( Options_Helper::class );
+		$this->robots_helper  = Mockery::mock( Robots_Helper::class );
+		$this->meta_helper    = Mockery::mock( Meta_Helper::class );
+		$this->image_helper   = Mockery::mock( Image_Helper::class );
 
-		$instance = new Indexable_Post_Type_Presentation(
-			$this->post_type_helper,
-		);
+		$instance = new Indexable_Term_Archive_Presentation();
 
 		$this->instance = $instance->of( $this->indexable );
 		$this->instance->set_helpers(

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
 
 use Mockery;
 
+use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
 use Yoast\WP\Free\Helpers\Robots_Helper;
@@ -53,14 +54,20 @@ trait Presentation_Instance_Builder {
 	protected $taxonomy_helper;
 
 	/**
+	 * @var Current_Page_Helper
+	 */
+	protected $current_page_helper;
+
+	/**
 	 * Builds an instance of Indexable_Post_Type_Presentation.
 	 */
 	protected function setInstance() {
 		$this->indexable = new Indexable();
 
-		$this->options_helper   = Mockery::mock( Options_Helper::class );
-		$this->robots_helper    = Mockery::mock( Robots_Helper::class );
-		$this->image_helper     = Mockery::mock( Image_Helper::class );
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
+		$this->image_helper        = Mockery::mock( Image_Helper::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 
 		$this->wp_query_wrapper = Mockery::mock( WP_Query_Wrapper::class );
 		$this->taxonomy_helper  = Mockery::mock( Taxonomy_Helper::class );
@@ -74,7 +81,8 @@ trait Presentation_Instance_Builder {
 		$this->instance->set_helpers(
 			$this->robots_helper,
 			$this->image_helper,
-			$this->options_helper
+			$this->options_helper,
+			$this->current_page_helper
 		);
 	}
 }

--- a/tests/presentations/indexable-term-archive-presentation/twitter-description-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/twitter-description-test.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
 
-use Mockery;
-use Yoast\WP\Free\Helpers\Options_Helper;
-use Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation;
-use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
 
@@ -19,31 +15,13 @@ use Brain\Monkey;
  * @group twitter-description
  */
 class Twitter_Description_Test extends TestCase {
-
-	/**
-	 * @var Options_Helper|Mockery\MockInterface
-	 */
-	protected $option_helper;
-
-	/**
-	 * @var Indexable
-	 */
-	protected $indexable;
-
-	/**
-	 * @var Indexable_Term_Archive_Presentation
-	 */
-	protected $instance;
+	use Presentation_Instance_Builder;
 
 	/**
 	 * Does the setup for testing.
 	 */
 	public function setUp() {
-		$this->option_helper = Mockery::mock( Options_Helper::class );
-		$this->indexable     = new Indexable();
-
-		$presentation   = new Indexable_Term_Archive_Presentation( $this->option_helper );
-		$this->instance = $presentation->of( $this->indexable );
+		$this->setInstance();
 
 		return parent::setUp();
 	}
@@ -65,7 +43,7 @@ class Twitter_Description_Test extends TestCase {
 	 * @covers ::generate_twitter_description
 	 */
 	public function test_with_term_description() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->andReturn( '' );
@@ -87,7 +65,7 @@ class Twitter_Description_Test extends TestCase {
 	 * @covers ::generate_twitter_description
 	 */
 	public function test_with_no_term_description() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->andReturn( '' );

--- a/tests/presentations/indexable-term-archive-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/twitter-image-test.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
 
-use Mockery;
-use Yoast\WP\Free\Helpers\Options_Helper;
-use Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation;
-use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**
@@ -18,31 +14,13 @@ use Yoast\WP\Free\Tests\TestCase;
  * @group twitter-image
  */
 class Twitter_Image_Test extends TestCase {
-
-	/**
-	 * @var Options_Helper|Mockery\MockInterface
-	 */
-	protected $option_helper;
-
-	/**
-	 * @var Indexable
-	 */
-	protected $indexable;
-
-	/**
-	 * @var Indexable_Term_Archive_Presentation
-	 */
-	protected $instance;
+	use Presentation_Instance_Builder;
 
 	/**
 	 * Does the setup for testing.
 	 */
 	public function setUp() {
-		$this->option_helper = Mockery::mock( Options_Helper::class );
-		$this->indexable     = new Indexable();
-
-		$presentation   = new Indexable_Term_Archive_Presentation( $this->option_helper );
-		$this->instance = $presentation->of( $this->indexable );
+		$this->setInstance();
 
 		return parent::setUp();
 	}
@@ -64,7 +42,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_opengraph_disabled() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->with( 'opengraph' )
@@ -81,7 +59,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_opengraph_image() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->with( 'opengraph' )
@@ -103,7 +81,7 @@ class Twitter_Image_Test extends TestCase {
 			->with( 'wpseo_twitter_taxonomy_image', false )
 			->andReturn( false );
 
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->with( 'opengraph' )
 			->once()
@@ -133,7 +111,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function test_with_default_image() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->andReturn( true, 'default_image.jpg' );
@@ -147,7 +125,7 @@ class Twitter_Image_Test extends TestCase {
 	 * @covers ::generate_twitter_image
 	 */
 	public function _test_with_() {
-		$this->option_helper
+		$this->options_helper
 			->expects( 'get' )
 			->twice()
 			->andReturn( true, 'default_image.jpg' );

--- a/tests/presentations/indexable-term-archive-presentation/twitter-image-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/twitter-image-test.php
@@ -113,8 +113,8 @@ class Twitter_Image_Test extends TestCase {
 	public function test_with_default_image() {
 		$this->options_helper
 			->expects( 'get' )
-			->twice()
-			->andReturn( true, 'default_image.jpg' );
+			->times( 3 )
+			->andReturn( true, 0, 'default_image.jpg' );
 
 		$this->assertEquals( 'default_image.jpg', $this->instance->generate_twitter_image() );
 	}

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -6,7 +6,6 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Robots_Presenter;
-use Yoast\WP\Free\Tests\Mocks\Indexable;
 use Yoast\WP\Free\Tests\TestCase;
 
 /**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It just adds the first part of the facebook image presenters

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
