### PR TITLE
Add logic to remove defaults from options, remove Google+ defaults

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -706,8 +706,8 @@ class WPSEO_Upgrade {
 			'yoast-acf-analysis',
 		);
 
-		$this->remove_default_from_option( 'wpseo_social', 'google_plus_url' );
-		$this->remove_default_from_option( 'wpseo_social', 'plus-publisher' );
+		$this->remove_option_key( 'wpseo_social', 'google_plus_url' );
+		$this->remove_option_key( 'wpseo_social', 'plus-publisher' );
 
 		$center = Yoast_Notification_Center::get();
 		foreach ( $plugins as $plugin ) {
@@ -806,7 +806,7 @@ class WPSEO_Upgrade {
 	 *
 	 * @return void
 	 */
-	protected function remove_default_from_option( $option_name, $default_name ) {
+	protected function remove_option_key( $option_name, $default_name ) {
 		$data = get_option( $option_name, array() );
 		if ( ! is_array( $data ) || $data === array() ) {
 			return;

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -691,7 +691,10 @@ class WPSEO_Upgrade {
 	}
 
 	/**
+	 * Performs the 12.3 upgrade.
+	 *
 	 * Removes the about notice when its still in the database.
+	 * Removes the google plus defaults from the database.
 	 */
 	private function upgrade_123() {
 		$plugins = array(
@@ -702,6 +705,9 @@ class WPSEO_Upgrade {
 			'yoast-woocommerce-seo',
 			'yoast-acf-analysis',
 		);
+
+		$this->remove_default_from_option('wpseo_social', 'google_plus_url');
+		$this->remove_default_from_option('wpseo_social', 'plus-publisher');
 
 		$center = Yoast_Notification_Center::get();
 		foreach ( $plugins as $plugin ) {
@@ -789,6 +795,26 @@ class WPSEO_Upgrade {
 		 * The option framework will remove any settings that are not configured
 		 * for this option, removing any migrated settings.
 		 */
+		update_option( $option_name, $data );
+	}
+
+	/**
+	 * Removes old default from option.
+	 *
+	 * @param string $option_name Option name.
+	 * @param string $default_name Default name.
+	 *
+	 * @return void
+	 */
+	protected function remove_default_from_option( $option_name, $default_name ) {
+		$data = get_option( $option_name, array() );
+		if ( ! is_array( $data ) || $data === array() ) {
+			return;
+		}
+
+		unset( $data[$default_name] );
+
+		//Re-save the option without the removed default.
 		update_option( $option_name, $data );
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -721,8 +721,8 @@ class WPSEO_Upgrade {
 	 * Removes the Google plus defaults from the database.
 	 */
 	private function upgrade_124() {
-		$this->remove_option_key( 'wpseo_social', 'google_plus_url' );
-		$this->remove_option_key( 'wpseo_social', 'plus-publisher' );
+		$this->cleanup_option_data( 'wpseo_social', 'google_plus_url' );
+		$this->cleanup_option_data( 'wpseo_social', 'plus-publisher' );
 	}
 
 	/**
@@ -804,26 +804,6 @@ class WPSEO_Upgrade {
 		 * The option framework will remove any settings that are not configured
 		 * for this option, removing any migrated settings.
 		 */
-		update_option( $option_name, $data );
-	}
-
-	/**
-	 * Removes old default from option.
-	 *
-	 * @param string $option_name  Option name.
-	 * @param string $default_name Default name.
-	 *
-	 * @return void
-	 */
-	protected function remove_option_key( $option_name, $default_name ) {
-		$data = get_option( $option_name, array() );
-		if ( ! is_array( $data ) || $data === array() ) {
-			return;
-		}
-
-		unset( $data[ $default_name ] );
-
-		// Re-save the option without the removed default.
 		update_option( $option_name, $data );
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -706,8 +706,8 @@ class WPSEO_Upgrade {
 			'yoast-acf-analysis',
 		);
 
-		$this->remove_default_from_option('wpseo_social', 'google_plus_url');
-		$this->remove_default_from_option('wpseo_social', 'plus-publisher');
+		$this->remove_default_from_option( 'wpseo_social', 'google_plus_url' );
+		$this->remove_default_from_option( 'wpseo_social', 'plus-publisher' );
 
 		$center = Yoast_Notification_Center::get();
 		foreach ( $plugins as $plugin ) {
@@ -812,9 +812,9 @@ class WPSEO_Upgrade {
 			return;
 		}
 
-		unset( $data[$default_name] );
+		unset( $data[ $default_name ] );
 
-		//Re-save the option without the removed default.
+		// Re-save the option without the removed default.
 		update_option( $option_name, $data );
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -141,6 +141,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_123();
 		}
 
+		if ( version_compare( $version, '12.4-RC0', '<' ) ) {
+			$this->upgrade_124();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -694,7 +698,6 @@ class WPSEO_Upgrade {
 	 * Performs the 12.3 upgrade.
 	 *
 	 * Removes the about notice when its still in the database.
-	 * Removes the google plus defaults from the database.
 	 */
 	private function upgrade_123() {
 		$plugins = array(
@@ -706,14 +709,20 @@ class WPSEO_Upgrade {
 			'yoast-acf-analysis',
 		);
 
-		$this->remove_option_key( 'wpseo_social', 'google_plus_url' );
-		$this->remove_option_key( 'wpseo_social', 'plus-publisher' );
-
 		$center = Yoast_Notification_Center::get();
 		foreach ( $plugins as $plugin ) {
 			$center->remove_notification_by_id( 'wpseo-outdated-yoast-seo-plugin-' . $plugin );
-
 		}
+	}
+
+	/**
+	 * Performs the 12.4 upgrade.
+	 *
+	 * Removes the Google plus defaults from the database.
+	 */
+	private function upgrade_124() {
+		$this->remove_option_key( 'wpseo_social', 'google_plus_url' );
+		$this->remove_option_key( 'wpseo_social', 'plus-publisher' );
 	}
 
 	/**
@@ -801,7 +810,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Removes old default from option.
 	 *
-	 * @param string $option_name Option name.
+	 * @param string $option_name  Option name.
 	 * @param string $default_name Default name.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

Added the remove_default_from_option function to class-upgrade.php, which can be called on upgrade performs. This enables us to remove defaults from options in the database, for example when they're deprecated and removed, just like the Google Plus defaults.

Removed the 'google_plus_url' and 'plus-publisher' defaults from the social option, via the remove_default_from_option function.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where Google+ data would still be exported in the settings export.

## Relevant technical choices:

* Created remove_default_from_option function, which gets the option, removes a default and uploads it back to the database. Both the option and default are provided via the parameters.

* Called the remove_default_from_option function from the upgrade_123 function, which is initiated on the Yoast 12.3 version update. And removed the following defaults:
    * google_plus_url
    * plus-publisher

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install the Yoast Test Helper plugin from 'https://github.com/yoast/yoast-test-helper'
* Install a Yoast SEO version older than 10.0 (Before the Google+ fields were removed) (see all releases here: https://github.com/Yoast/wordpress-seo/releases)
* Checkout this branch.
* Now you should have 2 Yoast SEO's in your plugin folder; Yoast SEO < 10.0 & Yoast SEO (>) 12.3 (This branch).
    * First activate Yoast SEO 10.0.
    * Go to SEO -> Social and fill something in the 'Google+' input. And press 'Save changes'.
    * Go to SEO -> Tools -> import & export -> Export settings and press 'Export your Yoast SEO settings'. Scroll down and you will find the 'google_plus_url' and 'plus-publisher' defaults. The 'google_plus_url' should contain the input which you entered in the Google+ input.
    * Deactivate Yoast SEO 10.0 and activate Yoast SEO 12.3 with this branch.
    * Go to Tools -> Yoast Test. Go to Plugin options & database versions and set the DB version to something like 12.0, which will trigger the 12.3 Upgrade routine.
    * Go to SEO -> Tools -> import & export -> Export settings and press 'Export your Yoast SEO settings' 
    * The list should not contain the  'google_plus_url' and 'plus-publisher' defaults anymore. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/bugreports/issues/556
