### PR TITLE
CS: update Premium to use YoastCS 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -247,9 +247,9 @@ script:
   if [[ "$PHPCS" == "1" ]]; then
     travis_fold start "PHP.code-style" && travis_time_start
     if [[ -d "premium" ]]; then
-      composer premium-check-cs
+      composer premium-check-cs -- -n
     else
-      vendor/bin/phpcs -q --runtime-set ignore_warnings_on_exit 1
+      vendor/bin/phpcs -qn
     fi
     travis_time_finish && travis_fold end "PHP.code-style"
   fi

--- a/composer.json
+++ b/composer.json
@@ -81,9 +81,9 @@
 		],
 		"premium-check-cs": [
 			"@before-premium-cs",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,*/tests/load/wp-seo-premium.php --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,*/tests/load/wp-seo-premium.php,*/tests/premium/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
 		],
 		"check-cs-errors": [
@@ -98,7 +98,7 @@
 			"@after-premium-cs"
 		],
 		"before-premium-cs": [
-			"composer require --dev yoast/yoastcs:~1.2.1 --update-with-dependencies --no-suggest --no-interaction"
+			"composer require --dev yoast/yoastcs:~1.3.0 --update-with-dependencies --no-suggest --no-interaction"
 		],
 		"after-premium-cs": [
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This is the sister-PR to the ruleset update pulled in the Premium repo - https://github.com/Yoast/wordpress-seo-premium/pull/2567.

This makes it so the `premium-check-cs` script will now use YoastCS 1.3.0.

It also ensures that files in the new `/tests/premium/` will be scanned and scanned against the correct PHP version (5.6+).

Lastly, it addresses the previously discussed issue that - as both repos currently still allow warnings -, errors can be hard to find in the report displayed by Travis. So for the Travis runs, CS `warning`s will now be hidden.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a build-script-only change and should have no effect on the functionality.

