### PR TITLE
Travis: run PHP 7.4 against WP master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
     - php: "7.4snapshot"
-      env: WP_VERSION=latest PHPUNIT=1
+      env: WP_VERSION=master PHPUNIT=1
     - stage: 🚀 deployment
       name: "Deploy to S3"
       if: branch = deploy # Only build when on the `deploy` branch, this functionality is not used yet and is taking a long time to complete.
@@ -97,7 +97,7 @@ jobs:
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-      env: WP_VERSION=latest PHPUNIT=1
+      env: WP_VERSION=master PHPUNIT=1
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
 cache:


### PR DESCRIPTION


## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

To get an honest impression about how PHP 7.4 ready the plugin is, the PHP 7.4 build needs to be run against the `trunk` version of WP (WP 5.3) as earlier WP versions weren't ready for PHP 7.4, so you would never get a passing build.

By running against `master`, any failures remaining should be PHP 7.4 issues in the plugin, not in WP itself.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a build-script-only change and should have no effect on the functionality.

