### PR TITLE
Travis: run the "non-unit test" build against PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ stages:
 jobs:
   fast_finish: true
   include:
+    - php: 7.2
+      env: WP_VERSION=latest PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION=lts/* AUTO_CHECKOUT_MONOREPO_BRANCH=1
     - php: 7.3
-      env: WP_VERSION=latest PHPLINT=1 PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION=lts/* AUTO_CHECKOUT_MONOREPO_BRANCH=1
-    - php: 7.3
-      env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
+      env: WP_VERSION=latest PHPLINT=1 WP_MULTISITE=1 COVERAGE=1
     - php: 5.6
       env: WP_VERSION=latest PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

The "non-unit test" build was doing:
* Linting against PHP 7.3
* Running PHPCS
* Running a security check
* Running a JS check.

For the security check and the JS check, the PHP version doesn't matter.

For the PHPCS check, it also doesn't matter, other than that the PHPCS version used by WPSEO is a very old version which is not fully compatible with PHP 7.3, resulting in a lot of noise in the Travis output due to deprecations warnings and such coming from PHPCS.

With that in mind, I'm proposing changing the "non-unit test" build to run on PHP 7.2 which gets rid of the noise.

The only thing which was running on that build which really should be run against PHP 7.3, is the `lint` check, so moving that check to another PHP 7.3 build takes care of that.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a build-script-only change and should have no effect on the functionality.
