### PR TITLE
CS: clean up after merges / namespaced files

### DIFF
--- a/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\PHP_CodeShift;
 
-use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
@@ -27,8 +26,8 @@ class Remove_Vendor_Prefixing_Array_Key_Visitor extends NodeVisitorAbstract {
 			return $node;
 		}
 
-		if ( $node->key instanceof String_ && strpos( $node->key->value, YOAST_VENDOR_NS_PREFIX ) !== false ) {
-			$node->key->value = str_replace( YOAST_VENDOR_NS_PREFIX . '\\', '', $node->key->value );
+		if ( $node->key instanceof String_ && \strpos( $node->key->value, \YOAST_VENDOR_NS_PREFIX ) !== false ) {
+			$node->key->value = \str_replace( \YOAST_VENDOR_NS_PREFIX . '\\', '', $node->key->value );
 		}
 
 		return $node;

--- a/config/php-codeshift/remove-vendor-prefixing-codemod.php
+++ b/config/php-codeshift/remove-vendor-prefixing-codemod.php
@@ -17,11 +17,11 @@ class Remove_Vendor_Prefixing_Codemod extends AbstractCodemod {
 	 * Sets up the environment required to do the code modifications.
 	 */
 	public function init() {
-		define( 'YoastSEO_Vendor\RUCKUSING_BASE', __DIR__ . '/../../fake-ruckusing' );
+		\define( 'YoastSEO_Vendor\RUCKUSING_BASE', __DIR__ . '/../../fake-ruckusing' );
 
-		define( 'YOAST_VENDOR_NS_PREFIX', 'YoastSEO_Vendor' );
-		define( 'YOAST_VENDOR_DEFINE_PREFIX', 'YOASTSEO_VENDOR__' );
-		define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
+		\define( 'YOAST_VENDOR_NS_PREFIX', 'YoastSEO_Vendor' );
+		\define( 'YOAST_VENDOR_DEFINE_PREFIX', 'YOASTSEO_VENDOR__' );
+		\define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
 		$visitor = new Remove_Vendor_Prefixing_Visitor();
 		$comment_visitor = new Remove_Vendor_Prefixing_Comment_Visitor();

--- a/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
@@ -23,8 +23,8 @@ class Remove_Vendor_Prefixing_Comment_Visitor extends NodeVisitorAbstract {
 	public function leaveNode( Node $node ) {
 		$comment = $node->getDocComment();
 
-		if ( $comment && strpos( $comment->getText(), YOAST_VENDOR_NS_PREFIX ) !== false ) {
-			$updated_text    = str_replace( YOAST_VENDOR_NS_PREFIX . '\\', '', $comment->getText() );
+		if ( $comment && \strpos( $comment->getText(), \YOAST_VENDOR_NS_PREFIX ) !== false ) {
+			$updated_text    = \str_replace( \YOAST_VENDOR_NS_PREFIX . '\\', '', $comment->getText() );
 			$updated_comment = new Doc( $updated_text, $comment->getLine(), $comment->getFilePos(), $comment->getTokenPos() );
 			$node->setDocComment( $updated_comment );
 		}

--- a/config/php-codeshift/remove-vendor-prefixing-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-visitor.php
@@ -25,7 +25,7 @@ class Remove_Vendor_Prefixing_Visitor extends NodeVisitorAbstract {
 			return $node;
 		}
 
-		if ( $node->getFirst() !== YOAST_VENDOR_NS_PREFIX ) {
+		if ( $node->getFirst() !== \YOAST_VENDOR_NS_PREFIX ) {
 			return $node;
 		}
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -123,8 +123,8 @@ class Indexable_Repository extends ORMWrapper {
 			->find_many();
 
 		if ( $auto_create ) {
-			$indexables_available = array_column( $indexables, 'object_id' );
-			$indexables_to_create = array_diff( $object_ids, $indexables_available );
+			$indexables_available = \array_column( $indexables, 'object_id' );
+			$indexables_to_create = \array_diff( $object_ids, $indexables_available );
 
 			foreach ( $indexables_to_create as $indexable_to_create ) {
 				$indexable = $this->create_for_id_and_type( $indexable_to_create, $object_type );

--- a/tests/admin/formatter/post-metabox-formatter-test.php
+++ b/tests/admin/formatter/post-metabox-formatter-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Admin\Formatter;
 
-use WPSEO_Post_Metabox_Formatter;
 use Yoast\WP\Free\Tests\Doubles\Admin\Formatter\Post_Metabox_Formatter_Double;
 use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
@@ -20,7 +19,7 @@ class Post_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var Post_Metabox_Formatter_Double
+	 * @var \Yoast\WP\Free\Tests\Doubles\Admin\Formatter\Post_Metabox_Formatter_Double
 	 */
 	private $instance;
 

--- a/tests/admin/formatter/term-metabox-formatter-test.php
+++ b/tests/admin/formatter/term-metabox-formatter-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Admin\Formatter;
 
-use WPSEO_Term_Metabox_Formatter;
 use Yoast\WP\Free\Tests\Doubles\Admin\Formatter\Term_Metabox_Formatter_Double;
 use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
@@ -20,14 +19,14 @@ class Term_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var Term_Metabox_Formatter_Double
+	 * @var \Yoast\WP\Free\Tests\Doubles\Admin\Formatter\Term_Metabox_Formatter_Double
 	 */
 	private $instance;
 
 	/**
 	 * Mocked stdClass.
 	 *
-	 * @var stdClass
+	 * @var \stdClass
 	 */
 	private $taxonomy;
 

--- a/tests/inc/class-wpseo-content-images-test.php
+++ b/tests/inc/class-wpseo-content-images-test.php
@@ -18,7 +18,7 @@ class Content_Images_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var WPSEO_Content_Images
+	 * @var \WPSEO_Content_Images
 	 */
 	private $instance;
 
@@ -43,7 +43,7 @@ class Content_Images_Test extends TestCase {
 
 		$external_image1      = 'https://example.com/media/first_image.jpg';
 		$external_image2      = 'https://example.com/media/second_image.jpg';
-		$non_attachment_image = get_home_url() . '/wp-content/plugins/wordpress-seo/integration-tests/assets/yoast.png';
+		$non_attachment_image = \get_home_url() . '/wp-content/plugins/wordpress-seo/integration-tests/assets/yoast.png';
 
 		$post_content =
 			'<p>This is a post. It has several images:</p>

--- a/tests/inc/class-wpseo-image-utils-test.php
+++ b/tests/inc/class-wpseo-image-utils-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\Free\Tests\Admin\Inc;
 
-use WPSEO_Image_Utils;
 use Yoast\WP\Free\Tests\Doubles\Inc\Image_Utils_Double;
 use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
@@ -19,7 +18,7 @@ class Image_Utils_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var Image_Utils_Double
+	 * @var \Yoast\WP\Free\Tests\Doubles\Inc\Image_Utils_Double
 	 */
 	private $instance;
 

--- a/tests/inc/options/option-social-test.php
+++ b/tests/inc/options/option-social-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\Free\Tests\Inc\Options;
 
 use Brain\Monkey;
-use WPSEO_Option_Social;
 use Yoast\WP\Free\Tests\Doubles\Inc\Options\Option_Social_Double;
 use Yoast\WP\Free\Tests\TestCase;
 use WPSEO_Utils;
@@ -198,7 +197,7 @@ class Option_Social_Test extends TestCase {
 			],
 		];
 
-		add_filter( 'validate_facebook_app_id_api_response_body', function() {
+		\add_filter( 'validate_facebook_app_id_api_response_body', function() {
 			return true;
 		} );
 		$instance = new Option_Social_Double();
@@ -241,10 +240,10 @@ class Option_Social_Test extends TestCase {
 			},
 		] );
 
-		add_filter( 'validate_facebook_app_id_api_response_code', function () use ( $response_code ) {
+		\add_filter( 'validate_facebook_app_id_api_response_code', function () use ( $response_code ) {
 			return $response_code;
 		} );
-		add_filter( 'validate_facebook_app_id_api_response_body', function() {
+		\add_filter( 'validate_facebook_app_id_api_response_body', function() {
 			return true;
 		});
 		$instance = new Option_Social_Double();


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Variety of fixes:
* Don't backslash prefix the class name in a `use` statement.
* Backslash prefix all global functions and constants.
* Use fully qualified names in docblocks.
* Remove unused `use` statements.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
