### PR TITLE
Bug fix: use the correct function

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,7 @@ define( 'DB_NAME', 'none' );
 define( 'DB_USER', 'nobody' );
 define( 'DB_PASSWORD', 'nothing' );
 
-if ( class_exists( 'opcache_reset' ) ) {
+if ( function_exists( 'opcache_reset' ) ) {
 	opcache_reset();
 }
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

`opcache_reset()` is a PHP function, not a class.

Ref: https://www.php.net/manual/en/function.opcache-reset.php



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no (significant) effect on the functionality.
