### PR TITLE
CS: clean up after merges

### DIFF
--- a/admin/admin-settings-changed-listener.php
+++ b/admin/admin-settings-changed-listener.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * A Wordpress integration that listens for whether the SEO changes have been saved successfully.
+ * A WordPress integration that listens for whether the SEO changes have been saved successfully.
  */
 class WPSEO_Admin_Settings_Changed_Listener implements WPSEO_WordPress_Integration {
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -686,6 +686,7 @@ class WPSEO_Admin_Init {
 	}
 
 	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Add an alert if outdated versions of Yoast SEO plugins are running.
 	 *

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -137,13 +137,14 @@ class WPSEO_Admin_Pages {
 	 * @return array The search appearance variables.
 	 */
 	public function localize_search_appearance_script() {
-		$search_appearance_l10n                    = array(
+		$search_appearance_l10n = array(
 			'isRtl'                    => is_rtl(),
 			'userEditUrl'              => add_query_arg( 'user_id', '{user_id}', admin_url( 'user-edit.php' ) ),
 			'brushstrokeBackgroundURL' => plugins_url( 'images/brushstroke_background.svg', WPSEO_FILE ),
 			'showLocalSEOUpsell'       => $this->should_show_local_seo_upsell(),
 			'localSEOUpsellURL'        => WPSEO_Shortlinker::get( 'https://yoa.st/3mp' ),
 		);
+
 		$search_appearance_l10n['knowledgeGraphCompanyInfoMissing'] = WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n();
 
 		return $search_appearance_l10n;

--- a/admin/class-plugin-compatibility.php
+++ b/admin/class-plugin-compatibility.php
@@ -38,6 +38,7 @@ class WPSEO_Plugin_Compatibility {
 	 * WPSEO_Plugin_Compatibility constructor.
 	 *
 	 * @deprecated 12.3
+	 * @codeCoverageIgnore
 	 *
 	 * @param string     $version              The version to check against.
 	 * @param null|class $availability_checker The checker to use.
@@ -55,6 +56,7 @@ class WPSEO_Plugin_Compatibility {
 	 * Retrieves the availability checker.
 	 *
 	 * @deprecated 12.3
+	 * @codeCoverageIgnore
 	 *
 	 * @param null|object $checker The checker to set.
 	 *
@@ -75,6 +77,7 @@ class WPSEO_Plugin_Compatibility {
 	 * Wraps the availability checker's get_installed_plugins method.
 	 *
 	 * @deprecated 12.3
+	 * @codeCoverageIgnore
 	 *
 	 * @return array Array containing all the installed plugins.
 	 */
@@ -88,6 +91,7 @@ class WPSEO_Plugin_Compatibility {
 	 * Creates a list of installed plugins and whether or not they are compatible.
 	 *
 	 * @deprecated 12.3
+	 * @codeCoverageIgnore
 	 *
 	 * @return array Array containing the installed plugins and compatibility.
 	 */
@@ -106,6 +110,7 @@ class WPSEO_Plugin_Compatibility {
 	 * Checks whether or not a plugin is compatible.
 	 *
 	 * @deprecated 12.3
+	 * @codeCoverageIgnore
 	 *
 	 * @param string $plugin The plugin to look for and match.
 	 *
@@ -129,6 +134,7 @@ class WPSEO_Plugin_Compatibility {
 	 * Gets the major/minor version of the plugin for easier comparing.
 	 *
 	 * @deprecated 12.3
+	 * @codeCoverageIgnore
 	 *
 	 * @param string $version The version to trim.
 	 *

--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -13,6 +13,15 @@
 class Yoast_Input_Validation {
 
 	/**
+	 * The error descriptions.
+	 *
+	 * @since 12.1
+	 *
+	 * @var array
+	 */
+	private static $error_descriptions = array();
+
+	/**
 	 * Check whether an option group is a Yoast SEO setting.
 	 *
 	 * The normal pattern is 'yoast' . $option_name . 'options'.
@@ -84,14 +93,6 @@ class Yoast_Input_Validation {
 	}
 
 	/**
-	 * The error descriptions.
-	 *
-	 * @since 12.1
-	 * @var array
-	 */
-	private static $_error_descriptions = array();
-
-	/**
 	 * Sets the error descriptions.
 	 *
 	 * @since 12.1
@@ -100,7 +101,7 @@ class Yoast_Input_Validation {
 	 *                            each entry, the key must be the setting variable.
 	 */
 	public static function set_error_descriptions( $descriptions = array() ) {
-		$defaults     = array(
+		$defaults = array(
 			'baiduverify'     => sprintf(
 				/* translators: %s: additional message with the submitted invalid value */
 				esc_html__( 'Baidu verification codes can only contain letters, numbers, hyphens, and underscores. %s', 'wordpress-seo' ),
@@ -175,7 +176,7 @@ class Yoast_Input_Validation {
 
 		$descriptions = wp_parse_args( $descriptions, $defaults );
 
-		self::$_error_descriptions = $descriptions;
+		self::$error_descriptions = $descriptions;
 	}
 
 	/**
@@ -186,7 +187,7 @@ class Yoast_Input_Validation {
 	 * @return array An associative array of error descriptions.
 	 */
 	public static function get_error_descriptions() {
-		return self::$_error_descriptions;
+		return self::$error_descriptions;
 	}
 
 	/**
@@ -198,11 +199,11 @@ class Yoast_Input_Validation {
 	 * @return string The error description.
 	 */
 	public static function get_error_description( $error_code ) {
-		if ( ! isset( self::$_error_descriptions[ $error_code ] ) ) {
+		if ( ! isset( self::$error_descriptions[ $error_code ] ) ) {
 			return null;
 		}
 
-		return self::$_error_descriptions[ $error_code ];
+		return self::$error_descriptions[ $error_code ];
 	}
 
 	/**
@@ -311,7 +312,8 @@ class Yoast_Input_Validation {
 
 		if ( $dirty_value ) {
 			return sprintf(
-				__( 'The submitted value was: %s', 'wordpress-seo' ),
+				/* translators: %s: form value as submitted. */
+				esc_html__( 'The submitted value was: %s', 'wordpress-seo' ),
 				$dirty_value
 			);
 		}

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -380,7 +380,7 @@ class Yoast_Notification {
 	 * @param string $value Attribute value.
 	 * @param string $key   Attribute name.
 	 */
-	private function parse_attributes( & $value, $key ) {
+	private function parse_attributes( &$value, $key ) {
 		$value = sprintf( '%s="%s"', $key, esc_attr( $value ) );
 	}
 }

--- a/admin/config-ui/fields/class-field-success-message.php
+++ b/admin/config-ui/fields/class-field-success-message.php
@@ -27,10 +27,10 @@ class WPSEO_Config_Field_Success_Message extends WPSEO_Config_Field {
 		$this->set_property( 'href', WPSEO_Shortlinker::get( 'https://yoa.st/3rp' ) );
 
 		/* translators: %1$s expands to Yoast SEO. */
-		$img_alt = __( '%1$s video tutorial', 'wordpress-seo' );
-		$img_args  = array(
-			'src' 	=> plugin_dir_url( WPSEO_FILE ) . ( 'images/Yoast_Academy_video.png' ),
-			'alt' 	=> sprintf( $img_alt, 'Yoast SEO' ),
+		$img_alt  = __( '%1$s video tutorial', 'wordpress-seo' );
+		$img_args = array(
+			'src' => plugin_dir_url( WPSEO_FILE ) . ( 'images/Yoast_Academy_video.png' ),
+			'alt' => sprintf( $img_alt, 'Yoast SEO' ),
 		);
 
 		$this->set_property( 'image', $img_args );

--- a/admin/import/plugins/class-import-wpseo.php
+++ b/admin/import/plugins/class-import-wpseo.php
@@ -213,7 +213,7 @@ class WPSEO_Import_WPSEO extends WPSEO_Plugin_Importer {
 	 *
 	 * @return void
 	 */
-	private function import_taxonomy_description( & $tax_meta, $taxonomy, $term_id ) {
+	private function import_taxonomy_description( &$tax_meta, $taxonomy, $term_id ) {
 		$description = get_option( 'wpseo_' . $taxonomy . '_' . $term_id, false );
 		if ( $description !== false ) {
 			// Import description.
@@ -230,7 +230,7 @@ class WPSEO_Import_WPSEO extends WPSEO_Plugin_Importer {
 	 *
 	 * @return void
 	 */
-	private function import_taxonomy_robots( & $tax_meta, $taxonomy, $term_id ) {
+	private function import_taxonomy_robots( &$tax_meta, $taxonomy, $term_id ) {
 		$wpseo_robots = get_option( 'wpseo_' . $taxonomy . '_' . $term_id . '_robots', false );
 		if ( $wpseo_robots === false ) {
 			return;

--- a/admin/notifiers/class-configuration-notifier.php
+++ b/admin/notifiers/class-configuration-notifier.php
@@ -153,7 +153,7 @@ class WPSEO_Configuration_Notifier implements WPSEO_Listener {
 		);
 		$notification .= '<div class="yoast-container__configuration-wizard--content">';
 		$notification .= sprintf(
-		    '<h3>%s<span class="dashicons dashicons-yes"></span></h3>',
+			'<h3>%s<span class="dashicons dashicons-yes"></span></h3>',
 			esc_html( $title )
 		);
 

--- a/admin/tracking/class-tracking-plugin-data.php
+++ b/admin/tracking/class-tracking-plugin-data.php
@@ -38,7 +38,7 @@ class WPSEO_Tracking_Plugin_Data implements WPSEO_Collection {
 
 		$plugin_data = array();
 		foreach ( $plugins as $plugin ) {
-			$plugin_key = sanitize_title( $plugin['name'] );
+			$plugin_key                 = sanitize_title( $plugin['name'] );
 			$plugin_data[ $plugin_key ] = $plugin;
 		}
 

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -45,8 +45,8 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 	 * @param int    $threshold The limit for the option.
 	 */
 	public function __construct( $endpoint, $threshold ) {
-		$this->endpoint  = $endpoint;
-		$this->threshold = $threshold;
+		$this->endpoint     = $endpoint;
+		$this->threshold    = $threshold;
 		$this->current_time = time();
 	}
 

--- a/admin/views/class-yoast-input-select.php
+++ b/admin/views/class-yoast-input-select.php
@@ -134,7 +134,7 @@ class Yoast_Input_Select {
 	 * @param string $value     The value of the attribute.
 	 * @param string $attribute The attribute to look for.
 	 */
-	private function parse_attribute( & $value, $attribute ) {
+	private function parse_attribute( &$value, $attribute ) {
 		$value = sprintf( '%s="%s"', esc_html( $attribute ), esc_attr( $value ) );
 	}
 }

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -47,12 +47,12 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		<?php
 
 		/*
-		* Render the `knowledge-graph-company-warning` div when the company name or logo are not set.
-		* This div is used as React render root in `js/src/search-appearance.js`.
-		*/
+		 * Render the `knowledge-graph-company-warning` div when the company name or logo are not set.
+		 * This div is used as React render root in `js/src/search-appearance.js`.
+		 */
 		$is_company_info_missing = empty( $yform->options['company_name'] ) || empty( $yform->options['company_logo'] );
 		if ( $is_company_info_missing ) :
-		?>
+			?>
 		<div id="knowledge-graph-company-warning"></div>
 		<?php endif; ?>
 

--- a/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
@@ -16,6 +16,7 @@ use PhpParser\NodeVisitorAbstract;
  * Class Vendor_Prefixing_Visitor
  */
 class Remove_Vendor_Prefixing_Array_Key_Visitor extends NodeVisitorAbstract {
+
 	/**
 	 * @param \PhpParser\Node $node The node being visited.
 	 *

--- a/config/php-codeshift/remove-vendor-prefixing-codemod.php
+++ b/config/php-codeshift/remove-vendor-prefixing-codemod.php
@@ -13,6 +13,7 @@ use Codeshift\AbstractCodemod;
  * Class Vendor_Prefixing_Codemod
  */
 class Remove_Vendor_Prefixing_Codemod extends AbstractCodemod {
+
 	/**
 	 * Sets up the environment required to do the code modifications.
 	 */
@@ -23,8 +24,8 @@ class Remove_Vendor_Prefixing_Codemod extends AbstractCodemod {
 		\define( 'YOAST_VENDOR_DEFINE_PREFIX', 'YOASTSEO_VENDOR__' );
 		\define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
-		$visitor = new Remove_Vendor_Prefixing_Visitor();
-		$comment_visitor = new Remove_Vendor_Prefixing_Comment_Visitor();
+		$visitor           = new Remove_Vendor_Prefixing_Visitor();
+		$comment_visitor   = new Remove_Vendor_Prefixing_Comment_Visitor();
 		$array_key_visitor = new Remove_Vendor_Prefixing_Array_Key_Visitor();
 		$this->addTraversalTransform( $visitor, $comment_visitor, $array_key_visitor );
 	}

--- a/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
@@ -15,6 +15,7 @@ use PhpParser\NodeVisitorAbstract;
  * Class Vendor_Prefixing_Visitor
  */
 class Remove_Vendor_Prefixing_Comment_Visitor extends NodeVisitorAbstract {
+
 	/**
 	 * @param \PhpParser\Node $node The node being visited.
 	 *

--- a/config/php-codeshift/remove-vendor-prefixing-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-visitor.php
@@ -15,6 +15,7 @@ use PhpParser\NodeVisitorAbstract;
  * Class Vendor_Prefixing_Visitor
  */
 class Remove_Vendor_Prefixing_Visitor extends NodeVisitorAbstract {
+
 	/**
 	 * @param \PhpParser\Node $node The node being visited.
 	 *

--- a/deprecated/class-yoast-form-fieldset.php
+++ b/deprecated/class-yoast-form-fieldset.php
@@ -229,7 +229,7 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 	 * @param string $value     The value of the attribute.
 	 * @param string $attribute The attribute to look for.
 	 */
-	private function parse_attribute( & $value, $attribute ) {
+	private function parse_attribute( &$value, $attribute ) {
 		$value = sprintf( '%s="%s"', esc_html( $attribute ), esc_attr( $value ) );
 	}
 }

--- a/inc/class-structured-data-blocks.php
+++ b/inc/class-structured-data-blocks.php
@@ -9,6 +9,7 @@
  * Class to load assets required for structured data blocks.
  */
 class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
+
 	/**
 	 * An instance of the WPSEO_Admin_Asset_Manager class.
 	 *
@@ -68,7 +69,7 @@ class WPSEO_Structured_Data_Blocks implements WPSEO_WordPress_Integration {
 			$categories[] = array(
 				'slug'  => 'yoast-structured-data-blocks',
 				'title' => sprintf(
-				/* translators: %1$s expands to Yoast. */
+					/* translators: %1$s expands to Yoast. */
 					__( '%1$s Structured Data Blocks', 'wordpress-seo' ),
 					'Yoast'
 				),

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -10,8 +10,19 @@
  */
 abstract class WPSEO_Health_Check {
 
+	/**
+	 * @var string
+	 */
 	const STATUS_GOOD = 'good';
+
+	/**
+	 * @var string
+	 */
 	const STATUS_RECOMMENDED = 'recommended';
+
+	/**
+	 * @var string
+	 */
 	const STATUS_CRITICAL = 'critical';
 
 	/**

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -29,7 +29,6 @@
  *   - on change of wpseo[yoast_tracking], the cron schedule will be adjusted accordingly
  *   - on change of wpseo and wpseo_title, some caches will be cleared
  *
- *
  * [Important information about add/updating/changing these classes]
  * - Make sure that option array key names are unique across options. The WPSEO_Options::get_all()
  *   method merges most options together. If any of them have non-unique names, even if they
@@ -376,7 +375,7 @@ abstract class WPSEO_Option {
 		}
 	}
 
- 	/**
+	/**
 	 * Validates a Facebook App ID.
 	 *
 	 * @param string $key   Key to check, in this case: the Facebook App ID field name.
@@ -388,14 +387,14 @@ abstract class WPSEO_Option {
 		if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 			$url = 'https://graph.facebook.com/' . $dirty[ $key ];
 
-			$response        = wp_remote_get( $url );
+			$response = wp_remote_get( $url );
 			// These filters are used in the tests.
 			/**
 			 * Filter: 'validate_facebook_app_id_api_response_code' - Allows to filter the Faceboook API response code.
 			 *
 			 * @api int $response_code The Facebook API response header code.
 			 */
-			$response_code   = apply_filters( 'validate_facebook_app_id_api_response_code', wp_remote_retrieve_response_code( $response ) );
+			$response_code = apply_filters( 'validate_facebook_app_id_api_response_code', wp_remote_retrieve_response_code( $response ) );
 			/**
 			 * Filter: 'validate_facebook_app_id_api_response_body' - Allows to filter the Faceboook API response body.
 			 *
@@ -423,7 +422,7 @@ abstract class WPSEO_Option {
 					$this->group_name, // Slug title of the setting.
 					$key, // Suffix-ID for the error message box. WordPress prepends `setting-error-`.
 					sprintf(
-					/* translators: %s expands to an invalid Facebook App ID. */
+						/* translators: %s expands to an invalid Facebook App ID. */
 						__( '%s does not seem to be a valid Facebook App ID. Please correct.', 'wordpress-seo' ),
 						'<strong>' . esc_html( $dirty[ $key ] ) . '</strong>'
 					), // The error message.
@@ -775,7 +774,7 @@ abstract class WPSEO_Option {
 		$options = (array) $options;
 
 		/*
-		$filtered = array();
+			$filtered = array();
 
 			if ( $defaults !== array() ) {
 				foreach ( $defaults as $key => $default_value ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -624,9 +624,9 @@ class WPSEO_Sitemaps {
 		}
 
 		$headers = array(
-			$this->http_protocol . ' 200 OK'                                                       => 200,
+			$this->http_protocol . ' 200 OK' => 200,
 			// Prevent the search engines from indexing the XML Sitemap.
-			'X-Robots-Tag: noindex, follow'                                                        => '',
+			'X-Robots-Tag: noindex, follow'  => '',
 			'Content-Type: text/xml; charset=' . esc_attr( $this->renderer->get_output_charset() ) => '',
 		);
 

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -9,6 +9,7 @@
  * Sitemap provider for author archives.
  */
 class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
+
 	/**
 	 * Holds image parser instance.
 	 *

--- a/integration-tests/config-ui/test-class-configuration-endpoint.php
+++ b/integration-tests/config-ui/test-class-configuration-endpoint.php
@@ -84,7 +84,6 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * @covers WPSEO_Configuration_Endpoint::register
-	 *
 	 */
 	public function test_register() {
 

--- a/integration-tests/doubles/frontend-double.php
+++ b/integration-tests/doubles/frontend-double.php
@@ -35,7 +35,7 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	}
 
 	/**
-	 * @param WPSEO_WooCommerce_Shop_Page $woocommerce_shop_page
+	 * @param WPSEO_WooCommerce_Shop_Page $woocommerce_shop_page Shop page object.
 	 */
 	public function set_woocommerce_shop_page( WPSEO_WooCommerce_Shop_Page $woocommerce_shop_page ) {
 		$this->woocommerce_shop_page = $woocommerce_shop_page;

--- a/src/orm/yoast-model.php
+++ b/src/orm/yoast-model.php
@@ -332,7 +332,7 @@ class Yoast_Model {
 	 * @param null|string $connection_name                          The name of the connection.
 	 *
 	 * @return \Yoast\WP\Free\ORM\ORMWrapper
-	 * @throws \Exception When ID of urrent model has a null value.
+	 * @throws \Exception When ID of current model has a null value.
 	 */
 	protected function has_one_or_many( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null, $connection_name = null ) {
 		$base_table_name  = static::get_table_name_for_class( \get_class( $this ) );

--- a/tests/admin/input-validation-test.php
+++ b/tests/admin/input-validation-test.php
@@ -22,20 +22,20 @@ class Input_Validation_Test extends TestCase {
 	public function test_document_title_updated_with_error() {
 		$admin_title = 'Original title';
 
-		Monkey\Functions\stubs( [
-			'add_settings_error' => null,
-		] );
+		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
-			->andReturn( [
+			->andReturn(
 				[
-					'setting' => 'yoast-setting-group-name',
-					'code'    => 'code',
-					'message' => 'This is the error message',
-					'type'    => 'error',
-				],
-			] );
+					[
+						'setting' => 'yoast-setting-group-name',
+						'code'    => 'code',
+						'message' => 'This is the error message',
+						'type'    => 'error',
+					],
+				]
+			);
 
 		$title_with_error_message = Yoast_Input_Validation::add_yoast_admin_document_title_errors( $admin_title );
 
@@ -51,27 +51,26 @@ class Input_Validation_Test extends TestCase {
 	public function test_document_title_updated_with_errors() {
 		$admin_title = 'Original title';
 
-		Monkey\Functions\stubs( [
-			'add_settings_error' => null,
-		] );
+		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
-			->andReturn( [
+			->andReturn(
 				[
-					'setting' => 'yoast-setting-first-group-name',
-					'code'    => 'first-code',
-					'message' => 'This is the first error message',
-					'type'    => 'error',
-				],
-				[
-					'setting' => 'yoast-setting-second-group-name',
-					'code'    => 'second-code',
-					'message' => 'This is the second error message',
-					'type'    => 'error',
-				],
-			] );
-
+					[
+						'setting' => 'yoast-setting-first-group-name',
+						'code'    => 'first-code',
+						'message' => 'This is the first error message',
+						'type'    => 'error',
+					],
+					[
+						'setting' => 'yoast-setting-second-group-name',
+						'code'    => 'second-code',
+						'message' => 'This is the second error message',
+						'type'    => 'error',
+					],
+				]
+			);
 
 		$title_with_error_message = Yoast_Input_Validation::add_yoast_admin_document_title_errors( $admin_title );
 
@@ -87,20 +86,20 @@ class Input_Validation_Test extends TestCase {
 	public function test_document_title_not_updated_with_non_yoast_errors() {
 		$admin_title = 'Original title';
 
-		Monkey\Functions\stubs( [
-			'add_settings_error' => null,
-		] );
+		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
-			->andReturn( [
+			->andReturn(
 				[
-					'setting' => 'new_admin_email',
-					'code'    => 'invalid_new_admin_email',
-					'message' => 'This is the error message',
-					'type'    => 'error',
-				],
-			] );
+					[
+						'setting' => 'new_admin_email',
+						'code'    => 'invalid_new_admin_email',
+						'message' => 'This is the error message',
+						'type'    => 'error',
+					],
+				]
+			);
 
 		$title_with_error_message = Yoast_Input_Validation::add_yoast_admin_document_title_errors( $admin_title );
 
@@ -116,20 +115,20 @@ class Input_Validation_Test extends TestCase {
 	public function test_document_title_not_updated_with_settings_updated_error() {
 		$admin_title = 'Original title';
 
-		Monkey\Functions\stubs( [
-			'add_settings_error' => null,
-		] );
+		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
-			->andReturn( [
+			->andReturn(
 				[
-					'setting' => 'new_admin_email',
-					'code'    => 'settings_updated',
-					'message' => 'This is the error message',
-					'type'    => 'error',
-				],
-			] );
+					[
+						'setting' => 'new_admin_email',
+						'code'    => 'settings_updated',
+						'message' => 'This is the error message',
+						'type'    => 'error',
+					],
+				]
+			);
 
 		$title_with_error_message = Yoast_Input_Validation::add_yoast_admin_document_title_errors( $admin_title );
 
@@ -152,21 +151,21 @@ class Input_Validation_Test extends TestCase {
 			],
 		];
 
-		Monkey\Functions\stubs( [
-			'add_settings_error' => null,
-		] );
+		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
-			->andReturn( [
+			->andReturn(
 				[
-					'setting'           => 'name_of_input_field_with_error',
-					'code'              => 'name_of_input_field_with_error',
-					'message'           => 'This is the error message',
-					'type'              => 'error',
-					'yoast_dirty_value' => 'Invalid submitted value',
-				],
-			] );
+					[
+						'setting'           => 'name_of_input_field_with_error',
+						'code'              => 'name_of_input_field_with_error',
+						'message'           => 'This is the error message',
+						'type'              => 'error',
+						'yoast_dirty_value' => 'Invalid submitted value',
+					],
+				]
+			);
 
 		Yoast_Input_Validation::add_dirty_value_to_settings_errors( 'name_of_input_field_with_error', 'Invalid submitted value' );
 
@@ -192,21 +191,21 @@ class Input_Validation_Test extends TestCase {
 			],
 		];
 
-		Monkey\Functions\stubs( [
-			'add_settings_error' => null,
-		] );
+		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
-			->andReturn( [
+			->andReturn(
 				[
-					'setting'           => 'name_of_input_field_with_error',
-					'code'              => 'name_of_input_field_with_error',
-					'message'           => 'This is the error message',
-					'type'              => 'error',
-					'yoast_dirty_value' => 'Invalid submitted value',
-				],
-			] );
+					[
+						'setting'           => 'name_of_input_field_with_error',
+						'code'              => 'name_of_input_field_with_error',
+						'message'           => 'This is the error message',
+						'type'              => 'error',
+						'yoast_dirty_value' => 'Invalid submitted value',
+					],
+				]
+			);
 
 		Yoast_Input_Validation::add_dirty_value_to_settings_errors( 'name_of_input_field_with_error', 'Invalid submitted value' );
 

--- a/tests/doubles/inc/options/option-social-double.php
+++ b/tests/doubles/inc/options/option-social-double.php
@@ -31,7 +31,6 @@ class Option_Social_Double extends WPSEO_Option_Social {
 		return parent::validate_option( $dirty, $clean, $old );
 	}
 
-
 	/**
 	 * Validates a Facebook App ID.
 	 *

--- a/tests/inc/class-wpseo-image-utils-test.php
+++ b/tests/inc/class-wpseo-image-utils-test.php
@@ -41,8 +41,8 @@ class Image_Utils_Test extends TestCase {
 		$term_descr =
 			'<p>This is a term description. It has several images:</p>
 			<img src=""/>
-			<img src="' . 'https://example.com/media/first_image.jpg' . '"/>
-			<img src="' . 'https://example.com/media/second_image.jpg' . '"/>
+			<img src="https://example.com/media/first_image.jpg"/>
+			<img src="https://example.com/media/second_image.jpg"/>
 			<p> That were all the images. Done! </p>';
 
 		Monkey\Functions\expect( 'term_description' )

--- a/tests/inc/language-utils-test.php
+++ b/tests/inc/language-utils-test.php
@@ -68,9 +68,12 @@ class WPSEO_Language_Utils_Test extends TestCase {
 			->with( $shortlinker->get_additional_shortlink_data(), Mockery::pattern( '/https:\/\/yoa.st\/*/' ) )
 			->andReturn( 'https://yoast.com' );
 
-		$this->assertEquals( [
-			'URL'     => 'https://yoast.com',
-			'message' => 'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
-		], WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n() );
+		$this->assertEquals(
+			[
+				'URL'     => 'https://yoast.com',
+				'message' => 'A company name and logo need to be set for structured data to work properly. %1$sLearn more about the importance of structured data.%2$s',
+			],
+			WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n()
+		);
 	}
 }

--- a/tests/inc/options/option-social-test.php
+++ b/tests/inc/options/option-social-test.php
@@ -39,10 +39,11 @@ class Option_Social_Test extends TestCase {
 	/**
 	 * Tests validate_option with invalid data.
 	 *
-	 * @param string $expected The expected value.
-	 * @param array  $dirty    New value for the option.
-	 * @param array  $clean    Clean value for the option, normally the defaults.
-	 * @param array  $old      Old value of the option.
+	 * @param string $expected  The expected value.
+	 * @param array  $dirty     New value for the option.
+	 * @param array  $clean     Clean value for the option, normally the defaults.
+	 * @param array  $old       Old value of the option.
+	 * @param string $slug_name The option key.
 	 *
 	 * @dataProvider validate_option_invalid_data_provider
 	 *
@@ -164,29 +165,33 @@ class Option_Social_Test extends TestCase {
 	 * @covers Yoast_Input_Validation::validate_facebook_app_id
 	 */
 	public function test_facebook_app_id_is_invalid() {
-		Monkey\Functions\stubs( [
-			'wp_remote_get' => null,
-			'add_settings_error' => null,
-			'wp_remote_retrieve_response_code' => function () {
-				return 200;
-			},
-		] );
+		Monkey\Functions\stubs(
+			[
+				'wp_remote_get'                    => null,
+				'add_settings_error'               => null,
+				'wp_remote_retrieve_response_code' => function () {
+					return 200;
+				},
+			]
+		);
 
 		// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
-		Monkey\Functions\stubs( [
-			'wp_remote_retrieve_body' => function () {
-				return WPSEO_Utils::format_json_encode(
-					[
-						'error' => [
-							'message'    => '(#803) Some of the aliases you requested do not exist: yoastInvalidFBAppID',
-							'type'       => 'OAuthException',
-							'code'       => 803,
-							'fbtrace_id' => 'AbXND56LRJ0FDXHfdJUuVIr',
+		Monkey\Functions\stubs(
+			[
+				'wp_remote_retrieve_body' => function () {
+					return WPSEO_Utils::format_json_encode(
+						[
+							'error' => [
+								'message'    => '(#803) Some of the aliases you requested do not exist: yoastInvalidFBAppID',
+								'type'       => 'OAuthException',
+								'code'       => 803,
+								'fbtrace_id' => 'AbXND56LRJ0FDXHfdJUuVIr',
+							],
 						]
-					]
-				);
-			},
-		] );
+					);
+				},
+			]
+		);
 
 		$GLOBALS['wp_settings_errors'] = [
 			[
@@ -197,12 +202,16 @@ class Option_Social_Test extends TestCase {
 			],
 		];
 
-		\add_filter( 'validate_facebook_app_id_api_response_body', function() {
-			return true;
-		} );
+		\add_filter(
+			'validate_facebook_app_id_api_response_body',
+			function() {
+				return true;
+			}
+		);
+
 		$instance = new Option_Social_Double();
-		$clean = [ 'fbadminapp' => '246554168145' ];
-		$dirty = [ 'fbadminapp' => 'yoastInvalidFBAppID' ];
+		$clean    = [ 'fbadminapp' => '246554168145' ];
+		$dirty    = [ 'fbadminapp' => 'yoastInvalidFBAppID' ];
 		$instance->validate_facebook_app_id( 'fbadminapp', $dirty, '246554168145', $clean );
 		$this->assertEquals( [ 'fbadminapp' => '246554168145' ], $clean );
 
@@ -216,39 +225,50 @@ class Option_Social_Test extends TestCase {
 	 */
 	public function test_facebook_app_id_is_valid() {
 		$GLOBALS['wp_settings_errors'] = [];
-		$response_code = 200;
+		$response_code                 = 200;
 
-		Monkey\Functions\stubs( [
-			'wp_remote_get' => null,
-			'add_settings_error' => null,
-			'wp_remote_retrieve_response_code' => function () use ( $response_code ) {
-				return $response_code;
-			},
-		] );
+		Monkey\Functions\stubs(
+			[
+				'wp_remote_get'                    => null,
+				'add_settings_error'               => null,
+				'wp_remote_retrieve_response_code' => function () use ( $response_code ) {
+					return $response_code;
+				},
+			]
+		);
 
 		// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
-		Monkey\Functions\stubs( [
-			'wp_remote_retrieve_body' => function () {
-				return WPSEO_Utils::format_json_encode(
-					[
-						'category' => 'Just For Fun',
-						'link'     => 'http://www.ilikealot.com/auth/start/facebook/',
-						'name'     => 'Ilikealot',
-						'id'       => '246554168145',
-					]
-				);
-			},
-		] );
+		Monkey\Functions\stubs(
+			[
+				'wp_remote_retrieve_body' => function () {
+					return WPSEO_Utils::format_json_encode(
+						[
+							'category' => 'Just For Fun',
+							'link'     => 'http://www.ilikealot.com/auth/start/facebook/',
+							'name'     => 'Ilikealot',
+							'id'       => '246554168145',
+						]
+					);
+				},
+			]
+		);
 
-		\add_filter( 'validate_facebook_app_id_api_response_code', function () use ( $response_code ) {
-			return $response_code;
-		} );
-		\add_filter( 'validate_facebook_app_id_api_response_body', function() {
-			return true;
-		});
+		\add_filter(
+			'validate_facebook_app_id_api_response_code',
+			function () use ( $response_code ) {
+				return $response_code;
+			}
+		);
+		\add_filter(
+			'validate_facebook_app_id_api_response_body',
+			function() {
+				return true;
+			}
+		);
+
 		$instance = new Option_Social_Double();
-		$clean = [ 'fbadminapp' => '' ];
-		$dirty = [ 'fbadminapp' => '246554168145' ];
+		$clean    = [ 'fbadminapp' => '' ];
+		$dirty    = [ 'fbadminapp' => '246554168145' ];
 		$instance->validate_facebook_app_id( 'fbadminapp', $dirty, '', $clean );
 		$this->assertEquals( [ 'fbadminapp' => '246554168145' ], $clean );
 		unset( $GLOBALS['wp_settings_errors'] );
@@ -260,39 +280,45 @@ class Option_Social_Test extends TestCase {
 	 * @covers WPSEO_Option_Social::validate_facebook_app_id
 	 */
 	public function test_validate_facebook_app_id_adds_settings_error() {
-		Monkey\Functions\stubs( [
-			'wp_remote_get' => null,
-			'wp_remote_retrieve_response_code' => function () {
-				return 200;
-			},
-		] );
+		Monkey\Functions\stubs(
+			[
+				'wp_remote_get'                    => null,
+				'wp_remote_retrieve_response_code' => function () {
+					return 200;
+				},
+			]
+		);
 
 		// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
-		Monkey\Functions\stubs( [
-			'wp_remote_retrieve_body' => function () {
-				return WPSEO_Utils::format_json_encode(
-					[
-						'error' => [
-							'message'    => '(#803) Some of the aliases you requested do not exist: yoastInvalidFBAppID',
-							'type'       => 'OAuthException',
-							'code'       => 803,
-							'fbtrace_id' => 'AbXND56LRJ0FDXHfdJUuVIr',
+		Monkey\Functions\stubs(
+			[
+				'wp_remote_retrieve_body' => function () {
+					return WPSEO_Utils::format_json_encode(
+						[
+							'error' => [
+								'message'    => '(#803) Some of the aliases you requested do not exist: yoastInvalidFBAppID',
+								'type'       => 'OAuthException',
+								'code'       => 803,
+								'fbtrace_id' => 'AbXND56LRJ0FDXHfdJUuVIr',
+							],
 						]
-					]
-				);
-			},
-		] );
+					);
+				},
+			]
+		);
 
 		$instance = new Option_Social_Double();
 		$clean    = [ 'fbadminapp' => '' ];
 		$dirty    = [ 'fbadminapp' => 'yoastInvalidFBAppID' ];
 
-		$GLOBALS['wp_settings_errors'] = [[
-			'setting' => 'yoast_wpseo_social_options',
-			'code'    => 'fbadminapp',
-			'message' =>'<strong>yoastInvalidFBAppID</strong> does not seem to be a valid Facebook App ID. Please correct.',
-			'type'    => 'notice-error',
-		]];
+		$GLOBALS['wp_settings_errors'] = [
+			[
+				'setting' => 'yoast_wpseo_social_options',
+				'code'    => 'fbadminapp',
+				'message' => '<strong>yoastInvalidFBAppID</strong> does not seem to be a valid Facebook App ID. Please correct.',
+				'type'    => 'notice-error',
+			],
+		];
 
 		Monkey\Functions\expect( 'add_settings_error' )
 			->once()


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Mixed bag of fixes.

[Whitespace and code layout]
* Align the assignment operators in assignment blocks.
* Use tabs to indent, not spaces.
* Use spaces for inline alignment.
* Exactly one blank line above each function declaration.
* Exactly one blank line above each property declaration.
* No space between the `&` reference operator and the variable it applies to in function declarations.
* Each parameter in a multi-line function call should start on its own line.
* Arrays: align double arrows.
* Arrays: One space between the array double arrow and the value.
* Arrays: comma after each array item.
* Arrays: each item should start on its own line for multi-line arrays.
* List properties at the top of a class.
* Don't use an underscore prefix to indicate `private`. That's PHP-4 style code. PHP 5+ has the visibility modifiers.
* No unnecessary string concatenation.

[Functional]
* I18n: Add missing translators comment.

[Documentation]
* Spell `WordPress` correctly.
* Minor miscellaneous spelling fix.
* Docs: Deprecated methods should be ignored for test code coverage.
* Docs: Add perfunctory docblocks to class `const` declarations.
* Docs: Minor comment format fixes.
* Docs: Add missing `@param` comment.
* Docs: Add missing `@param` description.
* Docs: No two blank lines in a row in docblocks.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
