### PR TITLE
CS/QA: use `wp_strip_all_tags()` [2]

### DIFF
--- a/frontend/schema/class-schema-faq-questions.php
+++ b/frontend/schema/class-schema-faq-questions.php
@@ -80,7 +80,7 @@ class WPSEO_Schema_FAQ_Questions {
 			'@id'            => $this->context->canonical . '#' . $question['id'],
 			'position'       => $this->position ++,
 			'url'            => $this->context->canonical . '#' . $question['id'],
-			'name'           => strip_tags( $question['jsonQuestion'] ),
+			'name'           => wp_strip_all_tags( $question['jsonQuestion'] ),
 			'answerCount'    => 1,
 			'acceptedAnswer' => array(
 				'@type' => 'Answer',

--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -156,7 +156,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 			);
 
 			$json_text = strip_tags( $step['jsonText'], $this->allowed_json_text_tags );
-			$json_name = strip_tags( $step['jsonName'] );
+			$json_name = wp_strip_all_tags( $step['jsonName'] );
 
 			if ( empty( $json_name ) ) {
 				if ( empty( $step['text'] ) ) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,6 +62,16 @@ abstract class TestCase extends BaseTestCase {
 				'wp_parse_args'       => function ( $settings, $defaults ) {
 					return \array_merge( $defaults, $settings );
 				},
+				'wp_strip_all_tags'   => function ( $string, $remove_breaks = false ) {
+					$string = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
+					$string = strip_tags( $string );
+
+					if ( $remove_breaks ) {
+						$string = preg_replace( '/[\r\n\t ]+/', ' ', $string );
+					}
+
+					return trim( $string );
+				},
 			]
 		);
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

The `wp_strip_all_tags()` function is more comprehensive than the PHP native `strip_tags()` function.

The advantage of `wp_strip_all_tags()` over `strip_tags()` is that it does not leave the content of removed `<script>` and `<style>` tags behind.

> This differs from `strip_tags()` because it removes the contents of the `<script>` and `<style>` tags. E.g. `strip_tags( '<script>something</script>' )` will return ‘something’. `wp_strip_all_tags()` will return ”

It can also remove superfluous whitespace within the string which may be left behind after removing the tags. For this, the second parameter `$remove_breaks` needs to be passed and set to `true`.

Refs:
* https://developer.wordpress.org/reference/functions/wp_strip_all_tags/
* http://php.net/manual/en/function.strip-tags.php

Includes mocking this function for the unit tests.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
