### PR TITLE
Add search result page and error page presentations with robots output

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -219,6 +219,8 @@ class Front_End_Integration implements Integration_Interface {
 		switch ( true ) {
 			case $this->current_page_helper->is_attachment():
 				return 'Attachment';
+			case $this->current_page_helper->is_search_result():
+				return 'Search_Result_Page';
 			case $this->current_page_helper->is_simple_page() || $this->current_page_helper->is_home_static_page():
 				return 'Post_Type';
 			case $this->current_page_helper->is_post_type_archive():
@@ -231,8 +233,6 @@ class Front_End_Integration implements Integration_Interface {
 				return 'Date_Archive';
 			case $this->current_page_helper->is_home_posts_page():
 				return 'Home_Page';
-			case $this->current_page_helper->is_search_result():
-				return 'Search_Result_Page';
 			case $this->current_page_helper->is_error_page():
 				return 'Error_Page';
 		}

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -53,6 +53,7 @@ class Front_End_Integration implements Integration_Interface {
 		'Debug\Marker_Open',
 		'Title',
 		'Meta_Description',
+		'Robots',
 	];
 
 	/**
@@ -62,7 +63,6 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	protected $indexing_directive_presenters = [
 		'Canonical',
-		'Robots',
 	];
 
 	/**
@@ -232,7 +232,7 @@ class Front_End_Integration implements Integration_Interface {
 			case $this->current_page_helper->is_home_posts_page():
 				return 'Home_Page';
 			case $this->current_page_helper->is_search_result():
-				return 'Search_Result';
+				return 'Search_Result_Page';
 			case $this->current_page_helper->is_error_page():
 				return 'Error_Page';
 		}

--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -33,7 +33,7 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 	protected $post_type_helper;
 
 	/**
-	 * Indexable_Post_Type_Presentation constructor.
+	 * Indexable_Author_Archive_Presentation constructor.
 	 *
 	 * @param WP_Query_Wrapper $wp_query_wrapper The wp query wrapper.
 	 * @param User_Helper      $user_helper      The user helper.

--- a/src/presentations/indexable-error-page-presentation.php
+++ b/src/presentations/indexable-error-page-presentation.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Presentation object for indexables.
+ *
+ * @package Yoast\YoastSEO\Presentations
+ */
+
+namespace Yoast\WP\Free\Presentations;
+
+/**
+ * Class Indexable_Error_Page_Presentation
+ */
+class Indexable_Error_Page_Presentation extends Indexable_Presentation {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_robots() {
+		$robots = $this->robots_helper->get_base_values( $this->model );
+
+		$robots['index'] = 'noindex';
+
+		return $this->robots_helper->after_generate( $robots );
+	}
+}

--- a/src/presentations/indexable-search-result-page-presentation.php
+++ b/src/presentations/indexable-search-result-page-presentation.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Presentation object for indexables.
+ *
+ * @package Yoast\YoastSEO\Presentations
+ */
+
+namespace Yoast\WP\Free\Presentations;
+
+/**
+ * Class Indexable_Search_Result_Page_Presentation
+ */
+class Indexable_Search_Result_Page_Presentation extends Indexable_Presentation {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_robots() {
+		$robots = $this->robots_helper->get_base_values( $this->model );
+
+		$robots['index'] = 'noindex';
+
+		return $this->robots_helper->after_generate( $robots );
+	}
+}

--- a/tests/presentations/indexable-error-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-error-page-presentation/presentation-instance-builder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Error_Page_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Image_Helper;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Robots_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Error_Page_Presentation;
+use Yoast\WP\Free\Tests\Mocks\Indexable;
+
+/**
+ * Trait Presentation_Instance_Builder
+ */
+trait Presentation_Instance_Builder {
+
+	/**
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * @var Indexable_Error_Page_Presentation
+	 */
+	protected $instance;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $options_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $robots_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $image_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $current_page_helper;
+
+	/**
+	 * Builds an instance of Indexable_Error_Page_Presentation.
+	 */
+	protected function setInstance() {
+		$this->indexable = new Indexable();
+
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->image_helper        = Mockery::mock( Image_Helper::class );
+		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
+
+		$instance = new Indexable_Error_Page_Presentation();
+
+		$this->instance = $instance->of( $this->indexable );
+		$this->instance->set_helpers(
+			$this->robots_helper,
+			$this->image_helper,
+			$this->options_helper,
+			$this->current_page_helper
+		);
+	}
+}

--- a/tests/presentations/indexable-error-page-presentation/robots-test.php
+++ b/tests/presentations/indexable-error-page-presentation/robots-test.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Error_Page_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Robots_Test.
+ *
+ * @group presentations
+ * @group robots
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Error_Page_Presentation
+ */
+class Robots_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setInstance();
+
+		$this->robots_helper
+			->expects( 'get_base_values' )
+			->once()
+			->andReturn( [
+				'index'  => 'index',
+				'follow' => 'follow',
+			] );
+
+		$this->robots_helper
+			->expects( 'after_generate' )
+			->once()
+			->andReturnUsing( function ( $robots ) {
+				return array_filter( $robots );
+			} );
+	}
+
+	/**
+	 * Tests that the robots is set to no index.
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots_dont_index() {
+		$actual   = $this->instance->generate_robots();
+		$expected = [
+			'index'  => 'noindex',
+			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/tests/presentations/indexable-search-result-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-search-result-page-presentation/presentation-instance-builder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Search_Result_Page_Presentation;
+
+use Mockery;
+use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Image_Helper;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Robots_Helper;
+use Yoast\WP\Free\Presentations\Indexable_Search_Result_Page_Presentation;
+use Yoast\WP\Free\Tests\Mocks\Indexable;
+
+/**
+ * Trait Presentation_Instance_Builder
+ */
+trait Presentation_Instance_Builder {
+
+	/**
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * @var Indexable_Search_Result_Page_Presentation
+	 */
+	protected $instance;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $options_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $robots_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $image_helper;
+
+	/**
+	 * @var Mockery\Mock
+	 */
+	protected $current_page_helper;
+
+	/**
+	 * Builds an instance of Indexable_Search_Result_Page_Presentation.
+	 */
+	protected function setInstance() {
+		$this->indexable = new Indexable();
+
+		$this->options_helper      = Mockery::mock( Options_Helper::class );
+		$this->image_helper        = Mockery::mock( Image_Helper::class );
+		$this->robots_helper       = Mockery::mock( Robots_Helper::class );
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
+
+		$instance = new Indexable_Search_Result_Page_Presentation();
+
+		$this->instance = $instance->of( $this->indexable );
+		$this->instance->set_helpers(
+			$this->robots_helper,
+			$this->image_helper,
+			$this->options_helper,
+			$this->current_page_helper
+		);
+	}
+}

--- a/tests/presentations/indexable-search-result-page-presentation/robots-test.php
+++ b/tests/presentations/indexable-search-result-page-presentation/robots-test.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Search_Result_Page_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Robots_Test.
+ *
+ * @group presentations
+ * @group robots
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Search_Result_Page_Presentation
+ */
+class Robots_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setInstance();
+
+		$this->robots_helper
+			->expects( 'get_base_values' )
+			->once()
+			->andReturn( [
+				'index'  => 'index',
+				'follow' => 'follow',
+			] );
+
+		$this->robots_helper
+			->expects( 'after_generate' )
+			->once()
+			->andReturnUsing( function ( $robots ) {
+				return array_filter( $robots );
+			} );
+	}
+
+	/**
+	 * Tests that the robots is set to no index.
+	 *
+	 * @covers ::generate_robots
+	 */
+	public function test_generate_robots_dont_index() {
+		$actual   = $this->instance->generate_robots();
+		$expected = [
+			'index'  => 'noindex',
+			'follow' => 'follow',
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add search result page and error page presentations with robots output.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to a search page and ensure that the robots meta has `noindex,follow`.
* Go to a 404 page and ensure that the robots meta has `noindex,follow`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
