### PR TITLE
Fix external URL check

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -24,7 +24,11 @@ class WPSEO_Image_Utils {
 		 */
 		$url = preg_replace( '/(.*)-\d+x\d+\.(jpg|png|gif)$/', '$1.$2', $url );
 		
-		$uploads = wp_get_upload_dir();
+		static $uploads;
+
+		if ( $uploads === null ) {
+			$uploads = wp_get_upload_dir();
+		}
 
 		// Don't try to do this for external URLs.
 		if ( strpos( $url, $uploads['baseurl'] ) !== 0 ) {

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -23,9 +23,11 @@ class WPSEO_Image_Utils {
 		 * we strip out the size part of an image URL.
 		 */
 		$url = preg_replace( '/(.*)-\d+x\d+\.(jpg|png|gif)$/', '$1.$2', $url );
+		
+		$uploads = wp_get_upload_dir();
 
 		// Don't try to do this for external URLs.
-		if ( strpos( $url, get_site_url() ) !== 0 ) {
+		if ( strpos( $url, $uploads['baseurl'] ) !== 0 ) {
 			return 0;
 		}
 

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -23,7 +23,7 @@ class WPSEO_Image_Utils {
 		 * we strip out the size part of an image URL.
 		 */
 		$url = preg_replace( '/(.*)-\d+x\d+\.(jpg|png|gif)$/', '$1.$2', $url );
-		
+
 		static $uploads;
 
 		if ( $uploads === null ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
 * Fixes an edge case bug when people use external URLs for their images. Props to [	gr8shivam](https://github.com/gr8shivam)

Fixes the edge cases for external image URL check in https://github.com/Yoast/wordpress-seo/blob/trunk/inc/class-wpseo-image-utils.php#L28

The current `get_site_url()` works for cases where a user is using the Logo URL like
- http://example.com/wp-content/uploads/..
- http://example.com/mydata/uploads/..

But it misses out and treats as external URL when a user is using a different upload path like
- http://img.example.com/..

_Matching with the Upload directory base URL fixes this._

## Test instructions
This PR can be tested by following these steps:
* Change default media path to a subdomain like img.example.com either manually or using [WP Original Media Path plugin](https://wordpress.org/plugins/wp-original-media-path/)
* Use an attachment image url directly in Organization Logo URL path (Only for users continuing from previous versions since newer version picks up the Attachment ID directly and doesn't come in `get_attachment_by_url()` function)

## Others
* UI Changes: None 
* [.] I have tested this code to the best of my abilities

EDIT: For Issue #13586, refer #13600 (case when user is using non wp uploads directory.)