### PR TITLE
Added presenter and presentation for single page twitter creator metatag

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -156,4 +156,29 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 
 		return (string) $this->get_default_og_image();
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_twitter_creator() {
+		$twitter_creator = \ltrim( \trim( \get_the_author_meta( 'twitter', $this->context->post->post_author ) ), '@' );
+
+		/**
+		 * Filter: 'wpseo_twitter_creator_account' - Allow changing the Twitter account as output in the Twitter card by Yoast SEO.
+		 *
+		 * @api string $twitter The twitter account name string.
+		 */
+		$twitter_creator = \apply_filters( 'wpseo_twitter_creator_account', $twitter_creator );
+
+		if ( \is_string( $twitter_creator ) && $twitter_creator !== '' ) {
+			return '@' . $twitter_creator;
+		}
+
+		$site_twitter = $this->options_helper->get( 'twitter_site', '' );
+		if ( \is_string( $site_twitter ) && $site_twitter !== '' ) {
+			return '@' . $site_twitter;
+		}
+
+		return '';
+	}
 }

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -39,6 +39,7 @@ use Yoast\WP\Free\Presentations\Generators\Schema_Generator;
  * @property string twitter_title
  * @property string twitter_description
  * @property string twitter_image
+ * @property string twitter_creator
  * @property array  replace_vars_object
  */
 class Indexable_Presentation extends Abstract_Presentation {
@@ -334,6 +335,15 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_image;
 		}
 
+		return '';
+	}
+
+	/**
+	 * Generates the Twitter creator.
+	 *
+	 * @return string The Twitter creator.
+	 */
+	public function generate_twitter_creator() {
 		return '';
 	}
 

--- a/src/presenters/twitter/creator-presenter.php
+++ b/src/presenters/twitter/creator-presenter.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Presenter class for the OpenGraph title.
+ *
+ * @package Yoast\YoastSEO\Presenters\Twitter
+ */
+
+namespace Yoast\WP\Free\Presenters\Twitter;
+
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
+
+/**
+ * Class Creator_Presenter
+ */
+class Creator_Presenter extends Abstract_Indexable_Presenter {
+	/**
+	 * Presents the Twitter creator meta tag.
+	 *
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 *
+	 * @return string The Twitter creator tag.
+	 */
+	public function present( Indexable_Presentation $presentation ) {
+		$twitter_creator = $presentation->twitter_creator;
+
+		if ( is_string( $twitter_creator ) && $twitter_creator !== '' ) {
+			return sprintf( '<meta name="twitter:creator" content="%s" />', esc_attr( $twitter_creator ) );
+		}
+
+		return '';
+	}
+}

--- a/tests/presentations/indexable-post-type-presentation/twitter-creator-test.php
+++ b/tests/presentations/indexable-post-type-presentation/twitter-creator-test.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+use Brain\Monkey;
+
+/**
+ * Class Twitter_Creator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Post_Type_Presentation
+ *
+ * @group presentations
+ * @group twitter
+ * @group twitter-creator
+ */
+class Twitter_Creator_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		$this->context->post = (object) [ 'post_author' => 1337 ];
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests that the author's twitter handle is correctly output.
+	 *
+	 * @covers ::generate_twitter_creator
+	 */
+	public function test_author_meta_twitter() {
+		Monkey\Functions\expect( 'get_the_author_meta' )
+			->once()
+			->with( 'twitter', 1337 )
+			->andReturn( '@TwitterHandle' );
+
+		Monkey\Filters\expectApplied( 'wpseo_twitter_creator_account' )
+			->with( 'TwitterHandle' )
+			->once();
+
+		$this->options_helper
+			->expects( 'get' )
+			->never();
+
+		$expected = '@TwitterHandle';
+		$actual   = $this->instance->generate_twitter_creator();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests that the twitter handle falls back to the site twitter option, when no author twitter
+	 * handle is available.
+	 *
+	 * @covers ::generate_twitter_creator
+	 */
+	public function test_fallback_to_twitter_site() {
+		Monkey\Functions\expect( 'get_the_author_meta' )
+			->once()
+			->with( 'twitter', 1337 )
+			->andReturn( '' );
+
+		Monkey\Filters\expectApplied( 'wpseo_twitter_creator_account' )
+			->with( '' )
+			->once();
+
+		$this->options_helper
+			->expects( 'get' )
+			->once()
+			->with( 'twitter_site', '' )
+			->andReturn( 'SiteTwitterHandle' );
+
+		$expected = '@SiteTwitterHandle';
+		$actual   = $this->instance->generate_twitter_creator();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests that the twitter handle is empty when no author or site twitter handle are available.
+	 *
+	 * @covers ::generate_twitter_creator
+	 */
+	public function test_empty_no_author_twitter_no_site_twitter() {
+		Monkey\Functions\expect( 'get_the_author_meta' )
+			->once()
+			->with( 'twitter', 1337 )
+			->andReturn( '' );
+
+		Monkey\Filters\expectApplied( 'wpseo_twitter_creator_account' )
+			->with( '' )
+			->once();
+
+		$this->options_helper
+			->expects( 'get' )
+			->once()
+			->with( 'twitter_site', '' )
+			->andReturn( '' );
+
+		$expected = '';
+		$actual   = $this->instance->generate_twitter_creator();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests that the `wpseo_twitter_creator_account` is properly applied.
+	 *
+	 * @covers ::generate_twitter_creator
+	 */
+	public function test_filter() {
+		Monkey\Functions\expect( 'get_the_author_meta' )
+			->once()
+			->with( 'twitter', 1337 )
+			->andReturn( '@TwitterHandle' );
+
+		Monkey\Filters\expectApplied( 'wpseo_twitter_creator_account' )
+			->with( 'TwitterHandle' )
+			->once()
+			->andReturn( 'yoast' );
+
+		$this->options_helper
+			->expects( 'get' )
+			->never();
+
+		$expected = '@yoast';
+		$actual   = $this->instance->generate_twitter_creator();
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/tests/presenters/twitter/creator-presenter-test.php
+++ b/tests/presenters/twitter/creator-presenter-test.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presenters\Twitter;
+
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Twitter\Creator_Presenter;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Creator_Presenter_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presenters\Twitter\Creator_Presenter
+ *
+ * @group presenters
+ * @group twitter
+ * @group twitter-creator
+ */
+class Creator_Presenter_Test extends TestCase {
+
+	/**
+	 * @var Creator_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Setup of the tests.
+	 */
+	public function setUp() {
+		$this->instance = new Creator_Presenter();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the presentation for a set twitter creator.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$presentation = new Indexable_Presentation();
+		$presentation->twitter_creator = '@TwitterHandle';
+
+		$this->assertEquals(
+			'<meta name="twitter:creator" content="@TwitterHandle" />',
+			$this->instance->present( $presentation )
+		);
+	}
+
+	/**
+	 * Tests the presentation of an empty creator.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_empty_twitter_description() {
+		$presentation = new Indexable_Presentation();
+		$presentation->twitter_creator = '';
+
+		$this->assertEmpty( $this->instance->present( $presentation ) );
+	}
+
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Removed support for twitter URLs. Decided internally: https://yoast.slack.com/archives/C5SUKMF2T/p1570517299281300

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### No twitter handle
* Create a new user, only give him a username and a password.
* Set `SEO` > `Social` > `Accounts` > `Twitter username` to be **empty**.
* Create a post with the new user, inspect it, make sure he has not `twitter:creator` tag.

### Site twitter handle
* Set `SEO` > `Social` > `Accounts` > `Twitter username` to be **SiteTwitterHandle**.
* Inspect the post you created with your new user, make sure there is a `twitter:creator` meta tag with the value `@SiteTwitterHandle`.

### User twitter handle
* Edit your user and give him a twitter handle (without `@`).
* Inspect the post you created with your new user, make sure there is a `twitter:creator` meta tag with the value `@<your-twitter-handle>`.

### Filter twitter handle
* Add a `wpseo_twitter_creator_account` filter, and return and empty string in the callback function.
* Inspect the post you created with your new user, make sure there is a `twitter:creator` meta tag with the value `@SiteTwitterHandle`. This is the case because it falls back to your site's twitter handle, that you set in `SEO` > `Social` > `Accounts` > `Twitter username`.
* Alter the filter to return a different twitter handle and make sure it is reflected on the frontend.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
