### PR TITLE
Implements the OpenGraph site name meta tag via the front-end integration

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -13,6 +13,7 @@ use WPSEO_Replace_Vars;
 use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
 use Yoast\WP\Free\Helpers\Schema\ID_Helper;
+use Yoast\WP\Free\Helpers\Site_Helper;
 use Yoast\WP\Free\Helpers\Url_Helper;
 use Yoast\WP\Free\Models\Indexable;
 use Yoast\WP\Free\Presentations\Abstract_Presentation;
@@ -83,10 +84,16 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @var ID_Helper
 	 */
 	private $id_helper;
+
 	/**
 	 * @var WPSEO_Replace_Vars
 	 */
 	private $replace_vars_helper;
+
+	/**
+	 * @var Site_Helper
+	 */
+	private $site_helper;
 
 	/**
 	 * Meta_Tags_Context constructor.
@@ -96,19 +103,22 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @param Image_Helper       $image_helper        The image helper.
 	 * @param ID_Helper          $id_helper           The schema id helper.
 	 * @param WPSEO_Replace_Vars $replace_vars_helper The replace vars helper.
+	 * @param Site_Helper        $site_helper         The site helper.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,
 		Url_Helper $url_helper,
 		Image_Helper $image_helper,
 		ID_Helper $id_helper,
-		WPSEO_Replace_Vars $replace_vars_helper
+		WPSEO_Replace_Vars $replace_vars_helper,
+		Site_Helper $site_helper
 	) {
 		$this->options_helper      = $options_helper;
 		$this->url_helper          = $url_helper;
 		$this->image_helper        = $image_helper;
 		$this->id_helper           = $id_helper;
 		$this->replace_vars_helper = $replace_vars_helper;
+		$this->site_helper         = $site_helper;
 	}
 
 	/**
@@ -159,6 +169,15 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		}
 
 		return \get_bloginfo( 'name' );
+	}
+
+	/**
+	 * Generates the site name from the WordPress options.
+	 *
+	 * @return string The site name.
+	 */
+	public function generate_wordpress_site_name() {
+		return $this->site_helper->get_site_name();
 	}
 
 	/**
@@ -229,12 +248,14 @@ class Meta_Tags_Context extends Abstract_Presentation {
 				if ( $this->company_logo_id < 1 ) {
 					$this->site_represents = false;
 				}
+
 				return 'company';
 			case 'person':
 				// Do not use a non-existing user.
 				if ( $this->site_user_id !== false && \get_user_by( 'id', $this->site_user_id ) === false ) {
 					return false;
 				}
+
 				return 'person';
 		}
 
@@ -253,6 +274,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		if ( $this->site_represents === 'company' ) {
 			return [ '@id' => $this->site_url . $this->id_helper->organization_hash ];
 		}
+
 		return false;
 	}
 
@@ -266,6 +288,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		if ( ! $breadcrumbs_enabled ) {
 			$breadcrumbs_enabled = $this->options_helper->get( 'breadcrumbs-enable', false );
 		}
+
 		return $breadcrumbs_enabled;
 	}
 

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -13,6 +13,7 @@ use Yoast\WP\Free\Models\Indexable;
  * Class Robots_Helper
  */
 class Robots_Helper {
+
 	/**
 	 * Gets the default robots settings applicable for all types of pages.
 	 *

--- a/src/helpers/site-helper.php
+++ b/src/helpers/site-helper.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * A helper object for site options.
+ *
+ * @package Yoast\WP\Free\Helpers
+ */
+
+namespace Yoast\WP\Free\Helpers;
+
+use WPSEO_Utils;
+
+/**
+ * Class Site_Helper
+ */
+class Site_Helper {
+
+	/**
+	 * Retrieves the site name.
+	 *
+	 * @return string
+	 */
+	public function get_site_name() {
+		return WPSEO_Utils::get_site_name();
+	}
+}

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -7,8 +7,6 @@
 
 namespace Yoast\WP\Free\Helpers;
 
-use \WP_Term;
-
 /**
  * Class Taxonomy_Helper
  */

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -208,6 +208,7 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	private function get_context( Indexable $indexable ) {
 		$blocks = [];
+		$post   = null;
 		if ( $indexable->object_type === 'post' ) {
 			$post   = \get_post( $indexable->object_id );
 			$blocks = $this->blocks_helper->get_all_blocks_from_content( $post->post_content );

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -282,6 +282,15 @@ class Indexable_Presentation extends Abstract_Presentation {
 	}
 
 	/**
+	 * Generates the open graph site name.
+	 *
+	 * @return string The open graph site name.
+	 */
+	public function generate_og_site_name() {
+		return $this->context->wordpress_site_name;
+	}
+
+	/**
 	 * Generates the Twitter card type.
 	 *
 	 * @return string The Twitter card type.
@@ -404,7 +413,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return '';
 		}
 
-		$default_image_id  = $this->options_helper->get( 'og_default_image_id', '' );
+		$default_image_id = $this->options_helper->get( 'og_default_image_id', '' );
 		if ( $default_image_id ) {
 			$attachment_url = $this->get_attachment_url_by_id( $default_image_id );
 			if ( $attachment_url ) {

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -7,10 +7,8 @@
 
 namespace Yoast\WP\Free\Presenters\Open_Graph;
 
-use Yoast\WP\Free\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
-use Yoast\WP\Free\Values\Open_Graph\Images;
 
 /**
  * Class Image_Presenter

--- a/src/presenters/open-graph/site-name-presenter.php
+++ b/src/presenters/open-graph/site-name-presenter.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Presenter class for the OpenGraph site name.
+ *
+ * @package Yoast\YoastSEO\Presenters\Open_Graph
+ */
+
+namespace Yoast\WP\Free\Presenters\Open_Graph;
+
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
+
+/**
+ * Class Site_Name_Presenter
+ */
+class Site_Name_Presenter extends Abstract_Indexable_Presenter {
+
+	/**
+	 * Returns the site name.
+	 *
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 *
+	 * @return string The title tag.
+	 */
+	public function present( Indexable_Presentation $presentation ) {
+		$site_name = $this->filter( $presentation->og_site_name );
+
+		if ( is_string( $site_name ) && $site_name !== '' ) {
+			return sprintf( '<meta property="og:site_name" content="%s" />', \esc_attr( $site_name ) );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Run the site name through the `wpseo_opengraph_site_name` filter.
+	 *
+	 * @param string $site_name The site_name to filter.
+	 *
+	 * @return string $site_name The filtered site_name.
+	 */
+	private function filter( $site_name ) {
+		/**
+		 * Filter: 'wpseo_opengraph_site_name' - Allow changing the Yoast SEO generated OpenGraph site name.
+		 *
+		 * @api string $site_name The site_name.
+		 */
+		return (string) trim( \apply_filters( 'wpseo_opengraph_site_name', $site_name ) );
+	}
+}

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -26,7 +26,7 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		$title = $this->filter( $this->replace_vars( $presentation->og_title, $presentation ) );
 
 		if ( is_string( $title ) && $title !== '' ) {
-			return '<meta property="og:title" value="' . \esc_attr( \wp_strip_all_tags( \stripslashes( $title ) ) ) . '"/>';
+			return '<meta property="og:title" content="' . \esc_attr( \wp_strip_all_tags( \stripslashes( $title ) ) ) . '"/>';
 		}
 
 		return '';

--- a/src/presenters/twitter/card-presenter.php
+++ b/src/presenters/twitter/card-presenter.php
@@ -24,7 +24,7 @@ class Card_Presenter extends Abstract_Indexable_Presenter {
 	public function present( Indexable_Presentation $presentation ) {
 		$card_type = $this->filter( $presentation->twitter_card );
 		if ( is_string( $card_type ) && $card_type !== '' ) {
-			return sprintf( '<meta name="twitter:card" content="%s" />', $card_type );
+			return sprintf( '<meta name="twitter:card" content="%s" />', \esc_attr( $card_type ) );
 		}
 
 		return '';

--- a/src/presenters/twitter/title-presenter.php
+++ b/src/presenters/twitter/title-presenter.php
@@ -25,7 +25,7 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		$twitter_title = (string) $this->filter( $this->replace_vars( $presentation->twitter_title, $presentation ) );
 
 		if ( $twitter_title !== '' ) {
-			return \sprintf( '<meta name="twitter:title" content="%s" />', $twitter_title );
+			return \sprintf( '<meta name="twitter:title" content="%s" />', \esc_attr( $twitter_title ) );
 		}
 
 		return '';

--- a/tests/_mocks/meta-tags-context.php
+++ b/tests/_mocks/meta-tags-context.php
@@ -63,6 +63,11 @@ class Meta_Tags_Context extends \Yoast\WP\Free\Context\Meta_Tags_Context {
 	/**
 	 * @var string
 	 */
+	public $wordpress_site_name;
+
+	/**
+	 * @var string
+	 */
 	public $site_url;
 
 	/**

--- a/tests/presentations/indexable-presentation/og-site-name-test.php
+++ b/tests/presentations/indexable-presentation/og-site-name-test.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class WordPress_Site_Name_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
+ *
+ * @group presentations
+ * @group open-graph
+ */
+class WordPress_Site_Name_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the OpenGraph site name is given.
+	 *
+	 * @covers ::generate_og_site_name
+	 */
+	public function test_generate_og_site_name() {
+		$this->context->wordpress_site_name = 'My Site';
+
+		$this->assertEquals( 'My Site', $this->instance->generate_og_site_name() );
+	}
+
+	/**
+	 * Tests the situation where an empty value is returned.
+	 *
+	 * @covers ::generate_og_site_name
+	 */
+	public function test_generate_title_with_empty_return_value() {
+		$this->assertEmpty( $this->instance->generate_og_site_name() );
+	}
+}

--- a/tests/presentations/indexable-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-presentation/presentation-instance-builder.php
@@ -77,16 +77,16 @@ trait Presentation_Instance_Builder {
 		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 		$this->og_image_helper     = Mockery::mock( OG_Image_Helper::class );
 
-		$this->context             = Mockery::mock( Meta_Tags_Context::class )->makePartial();
+		$this->context = Mockery::mock( Meta_Tags_Context::class );
 
-		$this->og_image_generator  = Mockery::mock(
+		$this->og_image_generator = Mockery::mock(
 			OG_Image_Generator::class,
 			[
 				$this->og_image_helper,
 				$this->image_helper,
 				$this->options_helper,
 			]
-		)->makePartial();
+		);
 
 		$instance = Mockery::mock( Indexable_Presentation::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/presenters/open-graph/image-presenter-test.php
+++ b/tests/presenters/open-graph/image-presenter-test.php
@@ -3,11 +3,8 @@
 namespace Yoast\WP\Free\Tests\Presenters\Open_Graph;
 
 use Mockery;
-use Yoast\WP\Free\Helpers\Image_Helper;
-use Yoast\WP\Free\Helpers\Url_Helper;
 use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Open_Graph\Image_Presenter;
-use Yoast\WP\Free\Tests\Doubles\Presenters\Open_Graph\Image_Presenter_Double;
 use Yoast\WP\Free\Tests\TestCase;
 use Brain\Monkey;
 
@@ -23,7 +20,7 @@ use Brain\Monkey;
 class Image_Presenter_Test extends TestCase {
 
 	/**
-	 * @var Image_Presenter_Double|Mockery\MockInterface
+	 * @var Image_Presenter|Mockery\MockInterface
 	 */
 	protected $instance;
 

--- a/tests/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/presenters/open-graph/site-name-presenter-test.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presenters;
+
+use Brain\Monkey;
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Open_Graph\Site_Name_Presenter;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Site_Name_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presenters\Open_Graph\Site_Name_Presenter
+ *
+ * @group presenters
+ * @group open-graph
+ */
+class Site_Name_Presenter_Test extends TestCase {
+
+	/**
+	 * @var Site_Name_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * @var Indexable_Presentation
+	 */
+	protected $presentation;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->instance     = new Site_Name_Presenter();
+		$this->presentation = new Indexable_Presentation();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$this->presentation->og_site_name = 'My Site';
+
+		$expected = '<meta property="og:site_name" content="My Site" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests the presenter with an empty site name.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_empty_site_name() {
+		$this->presentation->og_site_name = '';
+
+		$expected = '';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title, when the `wpseo_title` filter is applied.
+	 *
+	 * @covers ::present
+	 * @covers ::filter
+	 */
+	public function test_present_filter() {
+		$this->presentation->og_site_name = 'My Site';
+
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_site_name' )
+			->once()
+			->with( 'My Site' )
+			->andReturn( 'My Site' );
+
+		$expected = '<meta property="og:site_name" content="My Site" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements the OpenGraph site name meta tag via the front-end integration.

## Relevant technical choices:

* Adds a site helper with the method to get the site name. This differs from the already existing site name in the context object. Created an issue to address this: https://github.com/Yoast/wordpress-seo/issues/13598

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the front-end of a post/page/category/whatever.
* Ensure the head has a meta tag with `og:site_name`. The value should be the same as you have entered in the WordPress settings.
* Adapt your site name and check if it has changed in the front-end.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
