### PR TITLE
Use inline-block to display ok checkmark

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -982,7 +982,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 
 .wpseo-checkmark-ok-icon {
-	float: left;
+	display: inline-block;
 	width: 18px;
 	margin-right: 5px;
 	height: 18px;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `inline-block` property to the `wpseo-checkmark-ok-icon` to make sure the text after the checkmark gets aligned properly.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Please see https://github.com/Yoast/wordpress-seo-premium/pull/2570 for testing instructions.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/wordpress-seo-premium/issues/2560
