### PR TITLE
Return attachment url instead of entire attachment array

### DIFF
--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -190,7 +190,7 @@ class Image_Helper {
 	}
 
 	/**
-	 * Retrieves the attachment variations for given attachments.
+	 * Retrieves the best attachment variation for the given attachment.
 	 *
 	 * @codeCoverageIgnore - We have to write test when this method contains own code.
 	 *
@@ -199,7 +199,7 @@ class Image_Helper {
 	 *
 	 * @return bool|string The attachment url or false when no variations found.
 	 */
-	public function get_attachment_variations( $attachment_id, $image_params = [] ) {
+	public function get_best_attachment_variation( $attachment_id, $image_params = [] ) {
 		$variations = \WPSEO_Image_Utils::get_variations( $attachment_id );
 		$variations = \WPSEO_Image_Utils::filter_usable_dimensions( $image_params, $variations );
 		$variations = \WPSEO_Image_Utils::filter_usable_file_size( $variations );

--- a/src/helpers/open-graph/image-helper.php
+++ b/src/helpers/open-graph/image-helper.php
@@ -132,6 +132,6 @@ class Image_Helper {
 			return $this->image_helper->get_image( $attachment_id, $override_image_size );
 		}
 
-		return $this->image_helper->get_attachment_variations( $attachment_id, $this->image_params );
+		return $this->image_helper->get_best_attachment_variation( $attachment_id, $this->image_params );
 	}
 }

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -392,7 +392,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->image_helper->get_image( $attachment_id, $override_image_size );
 		}
 
-		return $this->image_helper->get_attachment_variations(
+		$attachment = $this->image_helper->get_best_attachment_variation(
 			$attachment_id,
 			[
 				'min_width'  => 200,
@@ -401,6 +401,8 @@ class Indexable_Presentation extends Abstract_Presentation {
 				'max_height' => 2000,
 			]
 		);
+
+		return $attachment['url'];
 	}
 
 	/**

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -48,7 +48,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 
 			// Adds secure URL if detected. Not all services implement this, so the regular one also needs to be rendered.
 			if ( strpos( $image_url, 'https://' ) === 0 ) {
-				$return .= '<meta property="og:image:secure_url" value="' . esc_url( $image_url ) . '"/>';
+				$return .= PHP_EOL . '<meta property="og:image:secure_url" value="' . esc_url( $image_url ) . '"/>';
 			}
 
 			foreach ( static::$image_tags as $key => $value ) {
@@ -56,7 +56,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 					continue;
 				}
 
-				$return .= '<meta property="og:image:' . esc_attr( $key ) . '" value="' . $image_meta[ $key ] . '"/>';
+				$return .= PHP_EOL . '<meta property="og:image:' . esc_attr( $key ) . '" value="' . $image_meta[ $key ] . '"/>';
 			}
 		}
 

--- a/tests/presentations/indexable-presentation-test.php
+++ b/tests/presentations/indexable-presentation-test.php
@@ -91,7 +91,7 @@ class Indexable_Presentation_Test extends TestCase {
 			->andReturn( null );
 
 		$this->image_helper
-			->expects( 'get_attachment_variations' )
+			->expects( 'get_best_attachment_variation' )
 			->once()
 			->with(
 				1337,
@@ -102,7 +102,7 @@ class Indexable_Presentation_Test extends TestCase {
 					'max_height' => 2000,
 				]
 			)
-			->andReturn( 'image.jpg' );
+			->andReturn( [ 'url' => 'image.jpg' ] );
 
 		$this->assertEquals( 'image.jpg', $this->instance->get_attachment_url_by_id( 1337 ) );
 	}

--- a/tests/presenters/open-graph/image-presenter-test.php
+++ b/tests/presenters/open-graph/image-presenter-test.php
@@ -61,7 +61,7 @@ class Image_Presenter_Test extends TestCase {
 		$presentation->og_images = [ $image ];
 
 		$this->assertEquals(
-			'<meta property="og:image" value="https://example.com/image.jpg"/><meta property="og:image:secure_url" value="https://example.com/image.jpg"/><meta property="og:image:width" value="100"/><meta property="og:image:height" value="100"/>',
+			'<meta property="og:image" value="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:secure_url" value="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:width" value="100"/>' . PHP_EOL . '<meta property="og:image:height" value="100"/>',
 			$this->instance->present( $presentation )
 		);
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Let `get_attachment_url_by_id` return a single URL instead of an entire image data array. 
* Renamed `get_attachment_variations` to `get_best_attachment_variation` to let the name better reflect what the function is doing. 
* Changed the test accordingly
* Added PHP_EOL to the list of `og:image` tags to make sure each of them is printed on a new line.
* Changed the test accordingly

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to Yoast SEO > Social > Facebook
	* Have open graph enabled
	* Upload a default image.
* Write a post without Twitter image, without Facebook image, without featured image, without image gallery and without post content image.
* Inspect the source of the post on the frontend.
* On the feature branch, you'll see `http://Array` as `twitter:image`.
* On this branch, you'll see the correct default image url as `twitter:image`.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
