### PR TITLE
Add keyword to admin bar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,9 @@
 		"check-cs-errors": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --error-severity=1 --warning-severity=6"
 		],
+		"check-staged-cs": [
+			"Yoast\\WP\\Free\\Composer\\Actions::check_staged_cs"
+		],
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcbf"
 		],

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -62,4 +62,21 @@ class Actions {
 
 		$io->write( 'The dependency injection container has been compiled.' );
 	}
+
+	/**
+	 * Runs PHPCS on the staged files.
+	 *
+	 * Used the composer check-staged-cs command.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	public static function check_staged_cs() {
+		\exec( 'git diff --staged --name-only', $files );
+		$files = array_filter( $files, function ( $file ) {
+			return substr( $file, -4 ) === '.php';
+		} );
+		\system( 'composer check-cs -- ' . implode( ' ', $files ) );
+	}
 }

--- a/css/src/adminbar.scss
+++ b/css/src/adminbar.scss
@@ -48,6 +48,11 @@
 	color: #f18500;
 }
 
+.yoast-hidden,
+:not(.wp-admin) .wpseo-focus-keyphrase-empty + #wp-admin-bar-wpseo-focus-keyphrase {
+	display: none;
+}
+
 @media screen and ( max-width: 782px ) {
 	.adminbar-seo-score {
 		margin: 16px 10px 0 2px !important;

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -158,15 +158,15 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	protected function add_root_menu( WP_Admin_Bar $wp_admin_bar ) {
 		$title = $this->get_title();
 
-		$score        	= '';
-		$focus_keyword	= '';
-		$settings_url 	= '';
-		$counter      	= '';
-		$alert_popup  	= '';
+		$score         = '';
+		$focus_keyword = '';
+		$settings_url  = '';
+		$counter       = '';
+		$alert_popup   = '';
 
 		$post = $this->get_singular_post();
 		if ( $post ) {
-			$score = $this->get_post_score( $post );
+			$score         = $this->get_post_score( $post );
 			$focus_keyword = $this->get_post_focus_keyword( $post );
 		}
 
@@ -195,12 +195,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$wp_admin_bar->add_menu( $admin_bar_menu_args );
 
 		if ( $post ) {
-			$focus_keyword_span = '<span class="ab-item wpseo-focus-keyphrase-ab-item">' . $focus_keyword . '</span>';
-
+			if ( empty( $focus_keyword ) ) {
+				$focus_keyword = '<em>not set</em>';
+			}
 			$admin_bar_menu_args = array(
 				'parent' => self::MENU_IDENTIFIER,
 				'id'     => 'wpseo-focus-keyphrase',
-				'title'  => sprintf( __( 'Focus keyphrase: %s', 'wordpress-seo' ) , $focus_keyword_span ),
+				'title'  => sprintf( __( 'Focus keyphrase: %s', 'wordpress-seo' ), '<span class="ab-item wpseo-focus-keyphrase-ab-item">' . $focus_keyword . '</span>' ),
 			);
 			$wp_admin_bar->add_menu( $admin_bar_menu_args );
 		}
@@ -257,19 +258,19 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 
 		$submenu_items = array(
 			array(
-				'id'     => 'wpseo-kwresearchtraining',
-				'title'  => __( 'Keyword research training', 'wordpress-seo' ),
-				'href'   => WPSEO_Shortlinker::get( 'https://yoa.st/wp-admin-bar' ),
+				'id'    => 'wpseo-kwresearchtraining',
+				'title' => __( 'Keyword research training', 'wordpress-seo' ),
+				'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/wp-admin-bar' ),
 			),
 			array(
-				'id'     => 'wpseo-adwordsexternal',
-				'title'  => __( 'Google Ads', 'wordpress-seo' ),
-				'href'   => $adwords_url,
+				'id'    => 'wpseo-adwordsexternal',
+				'title' => __( 'Google Ads', 'wordpress-seo' ),
+				'href'  => $adwords_url,
 			),
 			array(
-				'id'     => 'wpseo-googleinsights',
-				'title'  => __( 'Google Trends', 'wordpress-seo' ),
-				'href'   => $trends_url,
+				'id'    => 'wpseo-googleinsights',
+				'title' => __( 'Google Trends', 'wordpress-seo' ),
+				'href'  => $trends_url,
 			),
 		);
 
@@ -316,60 +317,60 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$encoded_url   = urlencode( $url );
 		$submenu_items = array(
 			array(
-				'id'     => 'wpseo-inlinks',
-				'title'  => __( 'Check links to this URL', 'wordpress-seo' ),
-				'href'   => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . $encoded_url . '&domain=',
+				'id'    => 'wpseo-inlinks',
+				'title' => __( 'Check links to this URL', 'wordpress-seo' ),
+				'href'  => 'https://search.google.com/search-console/links/drilldown?resource_id=' . urlencode( get_option( 'siteurl' ) ) . '&type=EXTERNAL&target=' . $encoded_url . '&domain=',
 			),
 			array(
-				'id'     => 'wpseo-kwdensity',
-				'title'  => __( 'Check Keyphrase Density', 'wordpress-seo' ),
+				'id'    => 'wpseo-kwdensity',
+				'title' => __( 'Check Keyphrase Density', 'wordpress-seo' ),
 				// HTTPS not available.
-				'href'   => 'http://www.zippy.co.uk/keyworddensity/index.php?url=' . $encoded_url . '&keyword=' . urlencode( $focus_keyword ),
+				'href'  => 'http://www.zippy.co.uk/keyworddensity/index.php?url=' . $encoded_url . '&keyword=' . urlencode( $focus_keyword ),
 			),
 			array(
-				'id'     => 'wpseo-cache',
-				'title'  => __( 'Check Google Cache', 'wordpress-seo' ),
-				'href'   => '//webcache.googleusercontent.com/search?strip=1&q=cache:' . $encoded_url,
+				'id'    => 'wpseo-cache',
+				'title' => __( 'Check Google Cache', 'wordpress-seo' ),
+				'href'  => '//webcache.googleusercontent.com/search?strip=1&q=cache:' . $encoded_url,
 			),
 			array(
-				'id'     => 'wpseo-header',
-				'title'  => __( 'Check Headers', 'wordpress-seo' ),
-				'href'   => '//quixapp.com/headers/?r=' . urlencode( $url ),
+				'id'    => 'wpseo-header',
+				'title' => __( 'Check Headers', 'wordpress-seo' ),
+				'href'  => '//quixapp.com/headers/?r=' . urlencode( $url ),
 			),
 			array(
-				'id'     => 'wpseo-structureddata',
-				'title'  => __( 'Google Structured Data Test', 'wordpress-seo' ),
-				'href'   => 'https://search.google.com/structured-data/testing-tool#url=' . $encoded_url,
+				'id'    => 'wpseo-structureddata',
+				'title' => __( 'Google Structured Data Test', 'wordpress-seo' ),
+				'href'  => 'https://search.google.com/structured-data/testing-tool#url=' . $encoded_url,
 			),
 			array(
-				'id'     => 'wpseo-facebookdebug',
-				'title'  => __( 'Facebook Debugger', 'wordpress-seo' ),
-				'href'   => '//developers.facebook.com/tools/debug/og/object?q=' . $encoded_url,
+				'id'    => 'wpseo-facebookdebug',
+				'title' => __( 'Facebook Debugger', 'wordpress-seo' ),
+				'href'  => '//developers.facebook.com/tools/debug/og/object?q=' . $encoded_url,
 			),
 			array(
-				'id'     => 'wpseo-pinterestvalidator',
-				'title'  => __( 'Pinterest Rich Pins Validator', 'wordpress-seo' ),
-				'href'   => 'https://developers.pinterest.com/tools/url-debugger/?link=' . $encoded_url,
+				'id'    => 'wpseo-pinterestvalidator',
+				'title' => __( 'Pinterest Rich Pins Validator', 'wordpress-seo' ),
+				'href'  => 'https://developers.pinterest.com/tools/url-debugger/?link=' . $encoded_url,
 			),
 			array(
-				'id'     => 'wpseo-htmlvalidation',
-				'title'  => __( 'HTML Validator', 'wordpress-seo' ),
-				'href'   => '//validator.w3.org/check?uri=' . $encoded_url,
+				'id'    => 'wpseo-htmlvalidation',
+				'title' => __( 'HTML Validator', 'wordpress-seo' ),
+				'href'  => '//validator.w3.org/check?uri=' . $encoded_url,
 			),
 			array(
-				'id'     => 'wpseo-cssvalidation',
-				'title'  => __( 'CSS Validator', 'wordpress-seo' ),
-				'href'   => '//jigsaw.w3.org/css-validator/validator?uri=' . $encoded_url,
+				'id'    => 'wpseo-cssvalidation',
+				'title' => __( 'CSS Validator', 'wordpress-seo' ),
+				'href'  => '//jigsaw.w3.org/css-validator/validator?uri=' . $encoded_url,
 			),
 			array(
-				'id'     => 'wpseo-pagespeed',
-				'title'  => __( 'Google Page Speed Test', 'wordpress-seo' ),
-				'href'   => '//developers.google.com/speed/pagespeed/insights/?url=' . $encoded_url,
+				'id'    => 'wpseo-pagespeed',
+				'title' => __( 'Google Page Speed Test', 'wordpress-seo' ),
+				'href'  => '//developers.google.com/speed/pagespeed/insights/?url=' . $encoded_url,
 			),
 			array(
-				'id'     => 'wpseo-google-mobile-friendly',
-				'title'  => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
-				'href'   => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . $encoded_url,
+				'id'    => 'wpseo-google-mobile-friendly',
+				'title' => __( 'Mobile-Friendly Test', 'wordpress-seo' ),
+				'href'  => 'https://www.google.com/webmasters/tools/mobile-friendly/?url=' . $encoded_url,
 			),
 		);
 
@@ -483,10 +484,10 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Gets the current post if in a singular post context.
 	 *
-	 * @global string       $pagenow Current page identifier.
+	 * @return WP_Post|null Post object, or null if not in singular context.
 	 * @global WP_Post|null $post    Current post object, or null if none available.
 	 *
-	 * @return WP_Post|null Post object, or null if not in singular context.
+	 * @global string       $pagenow Current page identifier.
 	 */
 	protected function get_singular_post() {
 		global $pagenow, $post;
@@ -559,11 +560,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Gets the current term if in a singular term context.
 	 *
-	 * @global string       $pagenow  Current page identifier.
+	 * @return WP_Term|null Term object, or null if not in singular context.
 	 * @global WP_Query     $wp_query Current query object.
 	 * @global WP_Term|null $tag      Current term object, or null if none available.
 	 *
-	 * @return WP_Term|null Term object, or null if not in singular context.
+	 * @global string       $pagenow  Current page identifier.
 	 */
 	protected function get_singular_term() {
 		global $pagenow, $wp_query, $tag;

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -164,26 +164,16 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$counter      = '';
 		$alert_popup  = '';
 
-		$term = $this->get_singular_term();
-		if ( $term ) {
-			$score = $this->get_term_score( $term );
-		}
-
 		$can_manage_options = $this->can_manage_options();
 
 		if ( $can_manage_options ) {
 			$settings_url = $this->get_settings_page_url();
 		}
 
+		$score = $this->get_score();
 		if ( empty( $score ) && ! is_network_admin() && $can_manage_options ) {
 			$counter     = $this->get_notification_counter();
 			$alert_popup = $this->get_notification_alert_popup();
-		}
-
-		$score   = '';
-		$post_id = $this->get_singular_post_id();
-		if ( $post_id ) {
-			$score = $this->get_post_score( $post_id );
 		}
 
 		$admin_bar_menu_args = array(
@@ -569,11 +559,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 
 		if ( $analysis_seo->is_enabled() ) {
-			return $this->get_score( WPSEO_Meta::get_value( 'linkdex', $post_id ) );
+			return $this->get_score_element( WPSEO_Meta::get_value( 'linkdex', $post_id ) );
 		}
 
 		if ( $analysis_readability->is_enabled() ) {
-			return $this->get_score( WPSEO_Meta::get_value( 'content_score', $post_id ) );
+			return $this->get_score_element( WPSEO_Meta::get_value( 'content_score', $post_id ) );
 		}
 
 		return '';
@@ -618,11 +608,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 
 		if ( $analysis_seo->is_enabled() ) {
-			return $this->get_score( WPSEO_Taxonomy_Meta::get_term_meta( $term->term_id, $term->taxonomy, 'linkdex' ) );
+			return $this->get_score_element( WPSEO_Taxonomy_Meta::get_term_meta( $term->term_id, $term->taxonomy, 'linkdex' ) );
 		}
 
 		if ( $analysis_readability->is_enabled() ) {
-			return $this->get_score( WPSEO_Taxonomy_Meta::get_term_meta( $term->term_id, $term->taxonomy, 'content_score' ) );
+			return $this->get_score_element( WPSEO_Taxonomy_Meta::get_term_meta( $term->term_id, $term->taxonomy, 'content_score' ) );
 		}
 
 		return '';
@@ -635,7 +625,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * @return string Score markup.
 	 */
-	protected function get_score( $score ) {
+	protected function get_score_element( $score ) {
 		$score_class      = WPSEO_Utils::translate_score( $score );
 		$translated_score = WPSEO_Utils::translate_score( $score, false );
 		/* translators: %s expands to the SEO score. */
@@ -708,5 +698,26 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 */
 	protected function can_manage_options() {
 		return is_network_admin() && current_user_can( 'wpseo_manage_network_options' ) || ! is_network_admin() && WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Determine the score for the current content.
+	 *
+	 * @return string
+	 */
+	protected function get_score() {
+		$score = '';
+
+		$term = $this->get_singular_term();
+		if ( $term ) {
+			$score = $this->get_term_score( $term );
+		}
+
+		$post_id = $this->get_singular_post_id();
+		if ( $post_id ) {
+			$score = $this->get_post_score( $post_id );
+		}
+
+		return $score;
 	}
 }

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -230,31 +230,46 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		);
 
 		$focus_keyword = $this->get_post_focus_keyword( $post_id );
+
+		$admin_bar_keyphrase_menu_item_args = array(
+			'parent' => 'wpseo_post_info',
+			'id'     => 'wpseo-focus-keyphrase',
+			'title'  => '<span class="ab-item wpseo-focus-keyphrase-ab-item">' . $focus_keyword . '</span>',
+		);
+
+		/* translators: %s expands to the post type. */
+		$focus_keyword_is_set_text     = sprintf( __( 'Focus keyphrase for this %s:', 'wordpress-seo' ), get_post_type() );
+		/* translators: %s expands to the post type. */
+		$focus_keyword_is_not_set_text = sprintf( __( 'Focus keyphrase for this %s not set', 'wordpress-seo' ), get_post_type() );
+
+		$hidden_text_strings = '<span class="wpseo-focus-keyphrase-is-set-text yoast-hidden">' . $focus_keyword_is_set_text . '</span>' .
+			'<span class="wpseo-focus-keyphrase-is-not-set-text yoast-hidden">' . $focus_keyword_is_not_set_text . '</span>';
+
 		if ( empty( $focus_keyword ) ) {
 			$admin_bar_menu_args = array(
 				'parent' => 'wpseo_post_info',
 				'id'     => 'wpseo-focus-keyphrase-heading',
-				/* translators: %s expands to the post type. */
-				'title'  => sprintf( __( 'Focus keyphrase for this %s not set.', 'wordpress-seo' ), get_post_type() ),
+				'title'  => $focus_keyword_is_not_set_text,
+				'meta'   => array(
+					'html'  => $hidden_text_strings,
+					'class' => 'wpseo-focus-keyphrase-empty',
+				),
 			);
 			$wp_admin_bar->add_menu( $admin_bar_menu_args );
+			$wp_admin_bar->add_menu( $admin_bar_keyphrase_menu_item_args );
 			return;
 		}
 
 		$admin_bar_menu_args = array(
 			'parent' => 'wpseo_post_info',
 			'id'     => 'wpseo-focus-keyphrase-heading',
-			/* translators: %s expands to the post type. */
-			'title'  => sprintf( __( 'Focus keyphrase for this %s:', 'wordpress-seo' ), get_post_type() ),
+			'title'  => $focus_keyword_is_set_text,
+			'meta'   => array(
+				'html' => $hidden_text_strings,
+			),
 		);
 		$wp_admin_bar->add_menu( $admin_bar_menu_args );
-
-		$admin_bar_menu_args = array(
-			'parent' => 'wpseo_post_info',
-			'id'     => 'wpseo-focus-keyphrase',
-			'title'  => '<span class="ab-item wpseo-focus-keyphrase-ab-item">' . $focus_keyword . '</span>',
-		);
-		$wp_admin_bar->add_menu( $admin_bar_menu_args );
+		$wp_admin_bar->add_menu( $admin_bar_keyphrase_menu_item_args );
 	}
 
 	/**

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -508,11 +508,10 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Gets the current post if in a singular post context.
 	 *
-	 * @return bool|int False when not singular, Post ID when it is.
-	 *
 	 * @global WP_Post|null $post    Current post object, or null if none available.
-	 *
 	 * @global string       $pagenow Current page identifier.
+	 *
+	 * @return bool|int False when not singular, Post ID when it is.
 	 */
 	protected function get_singular_post_id() {
 		global $pagenow, $post;
@@ -579,11 +578,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Gets the current term if in a singular term context.
 	 *
-	 * @return WP_Term|null Term object, or null if not in singular context.
 	 * @global WP_Query     $wp_query Current query object.
 	 * @global WP_Term|null $tag      Current term object, or null if none available.
-	 *
 	 * @global string       $pagenow  Current page identifier.
+	 *
+	 * @return WP_Term|null Term object, or null if not in singular context.
 	 */
 	protected function get_singular_term() {
 		global $pagenow, $wp_query, $tag;

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -219,11 +219,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		$focus_keyword = $this->get_post_focus_keyword( $post_id );
-		if ( empty( $focus_keyword ) ) {
-			$focus_keyword = '<em>not set</em>';
-		}
-
 		$wp_admin_bar->add_group(
 			array(
 				'parent' => self::MENU_IDENTIFIER,
@@ -233,6 +228,18 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				),
 			)
 		);
+
+		$focus_keyword = $this->get_post_focus_keyword( $post_id );
+		if ( empty( $focus_keyword ) ) {
+			$admin_bar_menu_args = array(
+				'parent' => 'wpseo_post_info',
+				'id'     => 'wpseo-focus-keyphrase-heading',
+				/* translators: %s expands to the post type. */
+				'title'  => sprintf( __( 'Focus keyphrase for this %s not set.', 'wordpress-seo' ), get_post_type() ),
+			);
+			$wp_admin_bar->add_menu( $admin_bar_menu_args );
+			return;
+		}
 
 		$admin_bar_menu_args = array(
 			'parent' => 'wpseo_post_info',

--- a/integration-tests/admin/exceptions/test-file-size-exception.php
+++ b/integration-tests/admin/exceptions/test-file-size-exception.php
@@ -7,8 +7,6 @@
 
 /**
  * Unit Test Class.
- *
- * @group test
  */
 class WPSEO_File_Size_Exception_Test extends WPSEO_UnitTestCase {
 

--- a/integration-tests/doubles/class-admin-bar-menu-double.php
+++ b/integration-tests/doubles/class-admin-bar-menu-double.php
@@ -13,7 +13,7 @@ class WPSEO_Admin_Bar_Menu_Double extends WPSEO_Admin_Bar_Menu {
 	/**
 	 * @inheritdoc
 	 */
-	public function get_post_focus_keyword( $post ) {
-		return parent::get_post_focus_keyword( $post );
+	public function get_post_focus_keyword() {
+		return parent::get_post_focus_keyword();
 	}
 }

--- a/integration-tests/doubles/class-admin-bar-menu-double.php
+++ b/integration-tests/doubles/class-admin-bar-menu-double.php
@@ -13,7 +13,7 @@ class WPSEO_Admin_Bar_Menu_Double extends WPSEO_Admin_Bar_Menu {
 	/**
 	 * @inheritdoc
 	 */
-	public function get_post_focus_keyword() {
-		return parent::get_post_focus_keyword();
+	public function get_post_focus_keyword( $post_id ) {
+		return parent::get_post_focus_keyword( $post_id );
 	}
 }

--- a/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -34,6 +34,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 		'add_keyword_research_submenu',
 		'add_analysis_submenu',
 		'add_settings_submenu',
+		'add_focus_keyword_submenu',
 		'add_network_settings_submenu',
 	);
 
@@ -136,6 +137,11 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 		$admin_bar_menu
 			->expects( $this->once() )
 			->method( 'add_settings_submenu' )
+			->with( $wp_admin_bar );
+
+		$admin_bar_menu
+			->expects( $this->once() )
+			->method( 'add_focus_keyword_submenu' )
 			->with( $wp_admin_bar );
 
 		$admin_bar_menu

--- a/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -247,7 +247,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 
 		$instance = new WPSEO_Admin_Bar_Menu_Double();
 
-		$this->assertEquals( 'focus keyword', $instance->get_post_focus_keyword() );
+		$this->assertEquals( 'focus keyword', $instance->get_post_focus_keyword( $post->ID ) );
 	}
 
 	/**
@@ -262,18 +262,6 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests the situation where the given object doesn't have an ID.
-	 *
-	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword
-	 */
-	public function test_get_post_focus_keyword_with_valid_object_but_no_id_property() {
-		$post     = new stdClass();
-		$instance = new WPSEO_Admin_Bar_Menu_Double();
-
-		$this->assertEquals( '', $instance->get_post_focus_keyword( $post ) );
-	}
-
-	/**
 	 * Tests the situation where the page analysis is disabled by filter.
 	 *
 	 * @covers WPSEO_Admin_Bar_Menu::get_post_focus_keyword
@@ -284,7 +272,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 		$post     = self::factory()->post->create_and_get();
 		$instance = new WPSEO_Admin_Bar_Menu_Double();
 
-		$this->assertEquals( '', $instance->get_post_focus_keyword( $post ) );
+		$this->assertEquals( '', $instance->get_post_focus_keyword( $post->ID ) );
 	}
 
 	/**

--- a/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -106,7 +106,14 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests adding the admin bar menu.
 	 *
+	 * @group test
+	 *
 	 * @covers WPSEO_Admin_Bar_Menu::add_menu
+	 * @covers WPSEO_Admin_Bar_Menu::add_root_menu
+	 * @covers WPSEO_Admin_Bar_Menu::add_analysis_submenu
+	 * @covers WPSEO_Admin_Bar_Menu::add_focus_keyword_submenu
+	 * @covers WPSEO_Admin_Bar_Menu::add_keyword_research_submenu
+	 * @covers WPSEO_Admin_Bar_Menu::add_settings_submenu
 	 */
 	public function test_add_menu() {
 		wp_set_current_user( self::$wpseo_manager );

--- a/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -247,7 +247,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 
 		$instance = new WPSEO_Admin_Bar_Menu_Double();
 
-		$this->assertEquals( 'focus keyword', $instance->get_post_focus_keyword( $post ) );
+		$this->assertEquals( 'focus keyword', $instance->get_post_focus_keyword() );
 	}
 
 	/**

--- a/js/src/ui/adminBar.js
+++ b/js/src/ui/adminBar.js
@@ -2,7 +2,7 @@
  * Updates the admin bar for the page.
  *
  * @param {Object} indicator The indicator for the keyword score.
- * @param {string} keyword The focus keyphrase for the post.
+ * @param {string} keyword   The focus keyphrase for the post.
  *
  * @returns {void}
  */
@@ -12,7 +12,7 @@ function updateAdminBar( indicator, keyword ) {
 		.attr( "class", "wpseo-score-icon adminbar-seo-score " + indicator.className )
 		.find( ".adminbar-seo-score-text" ).text( indicator.screenReaderText );
 
-	// Updates the focus keyhprase in the menu
+	// Updates the focus keyphrase in the menu
 	const keywordMenuElement = jQuery( "#wp-admin-bar-wpseo-focus-keyphrase" );
 
 	if ( keyword === "" ) {

--- a/js/src/ui/adminBar.js
+++ b/js/src/ui/adminBar.js
@@ -12,17 +12,22 @@ function updateAdminBar( indicator, keyword ) {
 		.attr( "class", "wpseo-score-icon adminbar-seo-score " + indicator.className )
 		.find( ".adminbar-seo-score-text" ).text( indicator.screenReaderText );
 
-	// Updates the focus keyphrase in the menu
+	const keywordHeading     = jQuery( "#wp-admin-bar-wpseo-focus-keyphrase-heading" );
 	const keywordMenuElement = jQuery( "#wp-admin-bar-wpseo-focus-keyphrase" );
 
+	// Updates the focus keyphrase in the menu
+	keywordMenuElement.find( ".wpseo-focus-keyphrase-ab-item" ).text( keyword );
+
 	if ( keyword === "" ) {
+		const notSetText = keywordHeading.find( ".wpseo-focus-keyphrase-is-not-set-text" ).text();
+		keywordHeading.find( ".ab-item" ).text( notSetText );
 		keywordMenuElement.hide();
 	}
 
 	if ( keyword !== "" && typeof keyword !== "undefined" ) {
-		keywordMenuElement
-			.show()
-			.find( ".wpseo-focus-keyphrase-ab-item" ).text( keyword );
+		const setText = keywordHeading.find( ".wpseo-focus-keyphrase-is-set-text" ).text();
+		keywordHeading.find( ".ab-item" ).text( setText );
+		keywordMenuElement.show();
 	}
 }
 


### PR DESCRIPTION
## Summary

Example:

<img width="852" alt="Screen Shot 2019-10-07 at 16 21 12" src="https://user-images.githubusercontent.com/487629/66407662-e0d3ab00-e9ed-11e9-9781-38de8eb6cf06.png">

This PR can be summarized in the following changelog entry:

* Adds the focus keyphrase to the Yoast SEO menu in the frontend admin bar. Props [emilyatmobtown](https://github.com/emilyatmobtown)

## Relevant technical choices:

* Cleaned up a bit of `inc/class-wpseo-admin-bar-menu.php` as it was a bit weird.

## Test instructions

This PR can be tested by following these steps:

* Set a focus keyphrase on a post
* View this post on the frontend
* See that the Yoast SEO admin bar menu now has a bit saying "Focus keyphrase for this post: `<focus keyphrase you set>`"

* Go to a post without a focus keyword, on the frontend, see that the Yoast SEO admin bar menu now has a bit saying "Focus keyphrase for this post: _not set_"


## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Closes #13248
Fixes #8327
