### PR TITLE
Add schema and google keyword to Gutenblocks

### DIFF
--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -16,6 +16,8 @@ export default () => {
 		keywords: [
 			__( "FAQ", "wordpress-seo" ),
 			__( "Frequently Asked Questions", "wordpress-seo" ),
+			"Google",
+			__( "Schema", "wordpress-seo" ),
 		],
 		// Allow only one FAQ block per post.
 		supports: {

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -54,6 +54,8 @@ export default () => {
 		keywords: [
 			__( "How-to", "wordpress-seo" ),
 			__( "How to", "wordpress-seo" ),
+			"Google",
+			__( "Schema", "wordpress-seo" ),
 		],
 		// Allow only one How-To block per post.
 		supports: {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add 'Google' and 'schema' as keywords to the structured data Gutenberg blocks to make them show up for those search terms in the block search as well.

## Relevant technical choices:

* I didn't make Google translatable. I posted a question on the Yoast Translate slack to make sure this is the way to go for non-Latin-script languages. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Search in the block search on 'Google' and 'schema' and see both of our blocks show up.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
