### PR TITLE
Added open graph type presenter

### DIFF
--- a/src/presenters/open-graph/type-presenter.php
+++ b/src/presenters/open-graph/type-presenter.php
@@ -11,7 +11,7 @@ use Yoast\WP\Free\Presentations\Indexable_Presentation;
 use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
 
 /**
- * Class Title_Presenter
+ * Class Type_Presenter
  */
 class Type_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/open-graph/type-presenter.php
+++ b/src/presenters/open-graph/type-presenter.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Presenter class for the OpenGraph type.
+ *
+ * @package Yoast\YoastSEO\Presenters\Open_Graph
+ */
+
+namespace Yoast\WP\Free\Presenters\Open_Graph;
+
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Abstract_Indexable_Presenter;
+
+/**
+ * Class Title_Presenter
+ */
+class Type_Presenter extends Abstract_Indexable_Presenter {
+
+	/**
+	 * Returns the opengraph type for a post.
+	 *
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 *
+	 * @return string The open graph type tag.
+	 */
+	public function present( Indexable_Presentation $presentation ) {
+		$og_type = $this->filter( $presentation->og_type );
+
+		if ( is_string( $og_type ) && $og_type !== '' ) {
+			return '<meta property="og:type" value="' . \esc_attr( $og_type ) . '"/>';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Run the opengraph type content through the `wpseo_opengraph_type` filter.
+	 *
+	 * @param string $type The type to filter.
+	 *
+	 * @return string $type The filtered type.
+	 */
+	private function filter( $type ) {
+		/**
+		 * Filter: 'wpseo_opengraph_type' - Allow changing the opengraph type.
+		 *
+		 * @api string $type The type.
+		 */
+		return (string) \apply_filters( 'wpseo_opengraph_type', $type );
+	}
+}

--- a/tests/presenters/open-graph/type-presenter-test.php
+++ b/tests/presenters/open-graph/type-presenter-test.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presenters\Open_Graph;
+
+use Mockery;
+use Brain\Monkey;
+use Yoast\WP\Free\Presentations\Indexable_Presentation;
+use Yoast\WP\Free\Presenters\Open_Graph\Type_Presenter;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Type_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presenters\Open_Graph\Type_Presenter
+ *
+ * @group presenters
+ * @group type-presenter
+ */
+class Type_Presenter_Test extends TestCase {
+	/**
+	 * @var Indexable_Presentation
+	 */
+	protected $indexable_presentation;
+
+	/**
+	 * @var Type_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->instance               = new Type_Presenter();
+		$this->indexable_presentation = new Indexable_Presentation();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct title.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$this->indexable_presentation->og_type = 'article';
+
+		$expected = '<meta property="og:type" value="article"/>';
+		$actual = $this->instance->present( $this->indexable_presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns an empty string when the title is empty.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_title_is_empty() {
+		$this->indexable_presentation->og_type = '';
+
+		$actual = $this->instance->present( $this->indexable_presentation );
+
+		$this->assertEmpty( $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct type, when the `wpseo_opengraph_type` filter
+	 * is applied.
+	 *
+	 * @covers ::present
+	 * @covers ::filter
+	 */
+	public function test_present_filter() {
+		$this->indexable_presentation->og_type = 'website';
+
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_type' )
+			->once()
+			->with( 'website' )
+			->andReturn( 'article' );
+
+		$expected = '<meta property="og:type" value="article"/>';
+		$actual = $this->instance->present( $this->indexable_presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/tests/presenters/open-graph/type-presenter-test.php
+++ b/tests/presenters/open-graph/type-presenter-test.php
@@ -38,7 +38,7 @@ class Type_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the presenter returns the correct title.
+	 * Tests whether the presenter returns the correct open graph type.
 	 *
 	 * @covers ::present
 	 */
@@ -52,11 +52,11 @@ class Type_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the presenter returns an empty string when the title is empty.
+	 * Tests whether the presenter returns an empty string when the open graph type is empty.
 	 *
 	 * @covers ::present
 	 */
-	public function test_present_title_is_empty() {
+	public function test_present_type_is_empty() {
 		$this->indexable_presentation->og_type = '';
 
 		$actual = $this->instance->present( $this->indexable_presentation );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N\A

## Relevant technical choices:

* Presentations were already implemented. Only created the presenter.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go throught all page types described in https://github.com/Yoast/wordpress-seo/issues/13475#issue-492414675.
* Make sure the corresponding `og:type` tag is output for each page type. But in short, the page type should always be website except for single post pages.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
