### PR TITLE
Fix an empty post title from changing a breadcrumb SD schema url

### DIFF
--- a/frontend/schema/class-schema-breadcrumb.php
+++ b/frontend/schema/class-schema-breadcrumb.php
@@ -120,7 +120,7 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 		}
 
 		if ( empty( $breadcrumb['text'] ) ) {
-			$breadcrumb['url'] = $this->context->title;
+			$breadcrumb['text'] = $this->context->title;
 		}
 
 		return array(


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an empty page title would cause the breadcrumbs schema to set a wrong url.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Enable breadcrumbs in SEO -> Search Appearance -> Breadcrumbs (no inclusion in theme or shortcode needed)
* Create a post, save it, remove the title and save it again
* Check the post on the frontend, specifically the HTML
* Note that all "url" references in the breadcrumbs schema are actually  valid URLs. Without this fix, the item referring to this post had the title set as the url.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13616