### PR TITLE
Fixed bu where posts wouldn't receive noindex when they should

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -91,7 +91,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 		);
 
 		$private           = \get_post_status( $this->model->object_id ) === 'private';
-		$post_type_noindex = ! $this->post_type_helper->is_indexable( $this->model->object_id );
+		$post_type_noindex = ! $this->post_type_helper->is_indexable( $this->model->object_sub_type );
 
 		if ( $private || $post_type_noindex ) {
 			$robots['index'] = 'noindex';

--- a/tests/presentations/indexable-post-type-presentation/robots-test.php
+++ b/tests/presentations/indexable-post-type-presentation/robots-test.php
@@ -49,6 +49,7 @@ class Robots_Test extends TestCase {
 		$this->indexable->is_robots_noarchive    = true;
 		$this->indexable->is_robots_noimageindex = true;
 		$this->indexable->object_id              = 1337;
+		$this->indexable->object_sub_type        = 'post';
 
 		Monkey\Functions\expect( 'get_post_status' )
 			->once()
@@ -57,7 +58,7 @@ class Robots_Test extends TestCase {
 
 		$this->post_type_helper->expects( 'is_indexable' )
 							   ->once()
-							   ->with( 1337 )
+							   ->with( 'post' )
 							   ->andReturn( true );
 
 		$actual   = $this->instance->generate_robots();
@@ -78,7 +79,8 @@ class Robots_Test extends TestCase {
 	 * @covers ::generate_robots
 	 */
 	public function test_generate_robots_private_post() {
-		$this->indexable->object_id = 1337;
+		$this->indexable->object_id       = 1337;
+		$this->indexable->object_sub_type = 'post';
 
 		Monkey\Functions\expect( 'get_post_status' )
 			->once()
@@ -88,7 +90,7 @@ class Robots_Test extends TestCase {
 		$this->post_type_helper
 			->expects( 'is_indexable' )
 			->once()
-			->with( 1337 )
+			->with( 'post' )
 			->andReturn( true );
 
 		$actual   = $this->instance->generate_robots();
@@ -106,7 +108,8 @@ class Robots_Test extends TestCase {
 	 * @covers ::generate_robots
 	 */
 	public function test_generate_robots_post_type_not_indexable() {
-		$this->indexable->object_id = 1337;
+		$this->indexable->object_id       = 1337;
+		$this->indexable->object_sub_type = 'post';
 
 		Monkey\Functions\expect( 'get_post_status' )
 			->once()
@@ -116,7 +119,7 @@ class Robots_Test extends TestCase {
 		$this->post_type_helper
 			->expects( 'is_indexable' )
 			->once()
-			->with( 1337 )
+			->with( 'post' )
 			->andReturn( false );
 
 		$actual   = $this->instance->generate_robots();


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Fixed a booboo.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set `SEO` > `Search Appearance` > `Content types` > `Posts` > `Show Posts in search results?` to **No**.
* Create a post and make sure it has a robots `noindex` directive.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
