### PR TITLE
Introduce filter to disable notifications in the notification center

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -302,16 +302,16 @@ class Yoast_Notification_Center {
 
 		$notification_id = $notification->get_id();
 
-		/**
-		 * Allow users to disable notifications
-		 *
-		 * @var bool   True to disable the notification, else false.
-		 * @var string Notification ID.
-		 */
-		$disable_notification = (bool) apply_filters( 'wpseo_disable_notification', false, $notification_id );
-
 		// Empty notifications are always added.
 		if ( $notification_id !== '' ) {
+
+			/**
+			 * Allow users to disable notifications
+			 *
+			 * @var bool   True to disable the notification, else false.
+			 * @var string Notification ID.
+			 */
+			$disable_notification = (bool) apply_filters( 'wpseo_disable_notification', false, $notification_id );
 
 			if ( $disable_notification ) {
 				$this->remove_notification_by_id( $notification_id, false );

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -289,17 +289,9 @@ class Yoast_Notification_Center {
 	 */
 	public function add_notification( Yoast_Notification $notification ) {
 
-		/**
-		 * Allow users to disable notifications
-		 *
-		 * @var bool   True to disable the notification, else false.
-		 * @var string Notification ID.
-		 */
-		$disable_notification = (bool) apply_filters( 'wpseo_disable_notification', false, $notification->get_id() );
-
 		$callback = array( $this, __METHOD__ );
 		$args     = func_get_args();
-		if ( $disable_notification || $this->queue_transaction( $callback, $args ) ) {
+		if ( $this->queue_transaction( $callback, $args ) ) {
 			return;
 		}
 
@@ -310,8 +302,21 @@ class Yoast_Notification_Center {
 
 		$notification_id = $notification->get_id();
 
+		/**
+		 * Allow users to disable notifications
+		 *
+		 * @var bool   True to disable the notification, else false.
+		 * @var string Notification ID.
+		 */
+		$disable_notification = (bool) apply_filters( 'wpseo_disable_notification', false, $notification_id );
+
 		// Empty notifications are always added.
 		if ( $notification_id !== '' ) {
+
+			if ( $disable_notification ) {
+				$this->remove_notification_by_id( $notification_id, false );
+				return;
+			}
 
 			// If notification ID exists in notifications, don't add again.
 			$present_notification = $this->get_notification_by_id( $notification_id );

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -289,9 +289,17 @@ class Yoast_Notification_Center {
 	 */
 	public function add_notification( Yoast_Notification $notification ) {
 
+		/**
+		 * Allow users to disable notifications
+		 *
+		 * @var bool   True to disable the notification, else false.
+		 * @var string Notification ID.
+		 */
+		$disable_notification = (bool) apply_filters( 'wpseo_disable_notification', false, $notification->get_id() );
+
 		$callback = array( $this, __METHOD__ );
 		$args     = func_get_args();
-		if ( $this->queue_transaction( $callback, $args ) ) {
+		if ( $disable_notification || $this->queue_transaction( $callback, $args ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduce a new filter (`wpseo_disable_notification`) to allow users to disable all, or specific, notification center notices.

## Relevant technical choices:

*  Filter named`wpseo_disable_notification` 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Test 1
* Install Gutenberg 6.4.0.
* From the dashboard, head into the notification center ('SEO > General').
* See the notice `Yoast SEO detected you are using version 6.4.0 of Gutenberg, please update to the latest version to prevent compatibility issues.`
![image](https://user-images.githubusercontent.com/5321364/66581117-88b3ba80-eb4d-11e9-9a29-d5e77905ebf3.png)
* Drop the following code into your themes `functions.php` file, a custom plugin, or an MU plugin file:
```php
/**
* Supress Yoast SEO admin notifications
*
* @param bool   True to disable notification, else false.
* @param string The notification ID.
*
* @return null
*/
function suppress_notifications( $bool, $notification_id ) {

	return ( 'wpseo-outdated-gutenberg-plugin' === $notification_id );

}
add_filter( 'wpseo_disable_notification', 'suppress_notifications', 10, 2 );
```
* Re-check the notification center. You should find that the Gutenberg outdated notice is no longer present.

### Test 2
* Install Gutenberg 6.4.0.
* From the dashboard, head into the notification center ('SEO > General').
* See the notice `Yoast SEO detected you are using version 6.4.0 of Gutenberg, please update to the latest version to prevent compatibility issues.` as well as any other notices you may see.
![image](https://user-images.githubusercontent.com/5321364/66582499-e77a3380-eb4f-11e9-8750-a25fc698e6b9.png)
* Drop the following code into your themes `functions.php` file, a custom plugin, or an MU plugin file:
```php
add_filter( 'wpseo_disable_notification', '__return_true', 10, 2 );
```
* Re-check the notification center. You should find that  **all** notices are no longer present.
![image](https://user-images.githubusercontent.com/5321364/66582470-d9c4ae00-eb4f-11e9-88c8-1f8d264cc2c0.png)

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended
