### PR TITLE
Revert the escaping of content collapsible paper because it stripped too much

### DIFF
--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -67,12 +67,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		$container_id_attr = sprintf( ' id="%s"', esc_attr( $paper_id_prefix . $paper_id . '-container' ) );
 	}
 
-	add_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_forms' ) );
-	add_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_a11y' ) );
-	$content = wp_kses_post( $content );
-	remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_forms' ) );
-	remove_filter( 'wp_kses_allowed_html', array( 'WPSEO_Utils', 'extend_kses_post_with_a11y' ) );
-
 	printf(
 		'<div%1$s class="%2$s">%3$s</div>',
 		// phpcs:ignore WordPress.Security.EscapeOutput -- $container_id_attr is escaped above.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts the output escaping of the collapsible paper content.

## Relevant technical choices:

* There is something going wrong with the filters. Even though those filters should allow `<input>`, `aria-describedby` and more, those elements were still stripped from the $content. We chose to revert this change for now, to fix trunk, but will look in a real solution soon. 

Output differences:
<img width="1650" alt="Schermafbeelding 2019-10-11 om 10 37 32" src="https://user-images.githubusercontent.com/17744553/66637361-2a510f80-ec13-11e9-8561-e33a95185163.png">
Left: after this revert, right: before this revert.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the metabox
* Open the social tab
* See the facebook title input, facebook image input, twitter title input and twitter image input.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13627
