### PR TITLE
Bumped Yoast javascript package dependencies after release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,13 +103,13 @@
     "@wordpress/is-shallow-equal": "^1.2.0",
     "@wordpress/rich-text": "^3.2.2",
     "@wordpress/url": "^2.5.0",
-    "@yoast/algolia-search-box": "^1.7.0-rc.0",
-    "@yoast/analysis-report": "^0.8.0-rc.0",
-    "@yoast/components": "^0.8.0-rc.0",
-    "@yoast/configuration-wizard": "^1.7.0-rc.0",
-    "@yoast/helpers": "^0.6.0-rc.0",
-    "@yoast/search-metadata-previews": "^1.10.0-rc.0",
-    "@yoast/style-guide": "^0.6.0-rc.0",
+    "@yoast/algolia-search-box": "^1.7.0",
+    "@yoast/analysis-report": "^0.8.0",
+    "@yoast/components": "^0.8.0",
+    "@yoast/configuration-wizard": "^1.7.0",
+    "@yoast/helpers": "^0.3.0",
+    "@yoast/search-metadata-previews": "^1.10.1",
+    "@yoast/style-guide": "^0.5.0",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
     "draft-js": "^0.10.5",
@@ -132,8 +132,8 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^4.2.0",
-    "yoast-components": "^4.34.0-rc.0",
-    "yoastseo": "^1.61.0-rc.0"
+    "yoast-components": "^4.34.1",
+    "yoastseo": "^1.61.0"
   },
   "yoast": {
     "pluginVersion": "12.3-RC2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,14 +649,14 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
-"@yoast/algolia-search-box@^1.7.0-rc.0":
-  version "1.7.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@yoast/algolia-search-box/-/algolia-search-box-1.7.0-rc.0.tgz#3c238bbf09f1be515d740a727c4ef6be2919fc95"
-  integrity sha512-FiMiEfUbU5KrM8dsr75rAy4otidRk2eTcYPni2A8SajqTluhugSc8wdVrfn1sJyOUQww4KEVYvhM7m1bQ3IaBw==
+"@yoast/algolia-search-box@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@yoast/algolia-search-box/-/algolia-search-box-1.7.0.tgz#32bebb797ebf1d638b3b23322ae4c503fa6d57c2"
+  integrity sha512-2fD68pGUAy+Ujax44p/Rn/LfDuUulrjRfo6qfQbczK5rix8FuHQKiN1RuVlKiLziVwe3KqKnlLr/JN6FjitWHw==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
-    "@yoast/components" "^0.8.0-rc.0"
+    "@yoast/components" "^0.8.0"
     "@yoast/helpers" "^0.6.0-rc.0"
     "@yoast/style-guide" "^0.6.0-rc.0"
     algoliasearch "^3.22.3"
@@ -665,13 +665,13 @@
     react "16.6.3"
     styled-components "^4.2.0"
 
-"@yoast/analysis-report@^0.8.0-rc.0":
-  version "0.8.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@yoast/analysis-report/-/analysis-report-0.8.0-rc.0.tgz#8f0c0c2b1f4504510ead219bb6311c3c52fc6d8f"
-  integrity sha512-syHTuP1dt000nYDAxQLqsQtBtLe7WfIGlvGHEwG06408hCTymgU4AHnplGqY5Vud0NMae/ZwO7xfWmxLDjNjNw==
+"@yoast/analysis-report@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@yoast/analysis-report/-/analysis-report-0.8.0.tgz#4a71b63e7f3fbf5be1f15794d17a467fc462bd9d"
+  integrity sha512-Qug2z/fGhFCDGRC2eH/iIAvqILxR7nxCOJf+DqJPWIXqraK02xfkQ1ZrRfOGM+cQpQ8MkSKW6Hjt9hYHIAyJAg==
   dependencies:
     "@wordpress/i18n" "^1.1.0"
-    "@yoast/components" "^0.8.0-rc.0"
+    "@yoast/components" "^0.8.0"
     "@yoast/helpers" "^0.6.0-rc.0"
     "@yoast/style-guide" "^0.6.0-rc.0"
     lodash "^4.17.11"
@@ -680,10 +680,10 @@
     react-dom "16.6.3"
     styled-components "^4.2.0"
 
-"@yoast/components@^0.8.0-rc.0":
-  version "0.8.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@yoast/components/-/components-0.8.0-rc.0.tgz#1120411974a76e458bdaac3e2afd1315acffed25"
-  integrity sha512-irM3Fw2hfNKBoAz8XySpf6lhQuwfFgQsTHDT5Y63f1f+yzIZ8jswy70IMzH2cU3yG2jurRSsDd2c0Ca1CkMqIw==
+"@yoast/components@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@yoast/components/-/components-0.8.0.tgz#57f8af6cc4c7c9b6922074f86c464c62aa28f204"
+  integrity sha512-J7QvwbKZ1kzShuHe+sOR1MoqZ0YNma0AZPAwhLnWYUA+XHYcvOYwQpU9kuXI8DhgNWJRqfgGhxy8SDWNZSOIlg==
   dependencies:
     "@wordpress/a11y" "^1.1.3"
     "@wordpress/i18n" "^1.2.3"
@@ -696,13 +696,13 @@
     react-tabs "^2.3.0"
     styled-components "^4.2.0"
 
-"@yoast/configuration-wizard@^1.7.0-rc.0":
-  version "1.7.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@yoast/configuration-wizard/-/configuration-wizard-1.7.0-rc.0.tgz#bb6d7e9306cb85e9fd92cd54de52204df6a5027b"
-  integrity sha512-us3CWLRkL0xo6VIhVVu+jGFK4mUA+ton/KfWOHhJhJDYlqfS9Duh3yQn+9pK3xmX8sLL618qWs99NjXHNXANOg==
+"@yoast/configuration-wizard@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@yoast/configuration-wizard/-/configuration-wizard-1.7.0.tgz#e43ca8662241a21e07ced58bf766fa83e0892809"
+  integrity sha512-BYIdwB0TEuxLSj/Uw+QY+/nUHlST8axj96Kp5gRMS07//i6G6jxcDsGxxj0LIkMiRhwwCMZgRsilIfgsg4TBQA==
   dependencies:
     "@wordpress/i18n" "^1.1.0"
-    "@yoast/components" "^0.8.0-rc.0"
+    "@yoast/components" "^0.8.0"
     "@yoast/helpers" "^0.6.0-rc.0"
     "@yoast/style-guide" "^0.6.0-rc.0"
     interpolate-components "^1.1.1"
@@ -748,6 +748,16 @@
     node-sass "^4.12.0"
     time-grunt "^1.0.0"
 
+"@yoast/helpers@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@yoast/helpers/-/helpers-0.3.0.tgz#0102d1c16c16ecafb5997e6ca241b7eb9e872f0e"
+  integrity sha512-xu2pAnVjpwbHh1688GWc4FDaRpDFz1/67+V97fS9ksUd/S2iwrsWVQ1hbOavCuN24fAwJTqWpgzNHwWgA9Brwg==
+  dependencies:
+    "@wordpress/i18n" "^1.2.3"
+    prop-types "^15.7.2"
+    styled-components "^2.4.1"
+    whatwg-fetch "1.1.1"
+
 "@yoast/helpers@^0.6.0-rc.0":
   version "0.6.0-rc.0"
   resolved "https://registry.yarnpkg.com/@yoast/helpers/-/helpers-0.6.0-rc.0.tgz#33701c2a83cd5c1b1dd92d5999952b1c923a4b9e"
@@ -758,14 +768,14 @@
     styled-components "^2.4.1"
     whatwg-fetch "1.1.1"
 
-"@yoast/search-metadata-previews@^1.10.0-rc.0":
-  version "1.10.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.10.0-rc.0.tgz#284a3eb0f6154bd4e114283a48698c8e7447a12b"
-  integrity sha512-Owwan0zN5vb41gf2ahQkrQebvpiQcqjvvWbMnfOBsZlwhHS9gA+xt0Ut6ZhUrZrenz2Aw1gQTz1kReMvnC2W4Q==
+"@yoast/search-metadata-previews@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.10.1.tgz#e779053ed7a1d42046fcfcd690707bc82fadda7e"
+  integrity sha512-xcoV5pJKVIUkUQo/h612PM5X4cUoesK+2sR4Jd+nDQ/dutwpJRkZVWkqn98FsmhS1eyYV7dE4wJBPumDoRYLLg==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
-    "@yoast/components" "^0.8.0-rc.0"
+    "@yoast/components" "^0.8.0"
     "@yoast/helpers" "^0.6.0-rc.0"
     "@yoast/style-guide" "^0.6.0-rc.0"
     draft-js "^0.10.5"
@@ -777,7 +787,12 @@
     prop-types "^15.6.0"
     react-transition-group "^2.7.1"
     styled-components "^4.2.0"
-    yoastseo "^1.61.0-rc.0"
+    yoastseo "^1.61.0"
+
+"@yoast/style-guide@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@yoast/style-guide/-/style-guide-0.5.0.tgz#36cc88f8a22f86df8a504203f79eecaad8443294"
+  integrity sha512-3uJt4g06Y7y6Yc7B2hdyb7k2nFx/PMmOX1wXc/+tajfxw9TtFmcBED/byuVIVd+EQmX5Jve0aTisdQQKzCJ6/w==
 
 "@yoast/style-guide@^0.6.0-rc.0":
   version "0.6.0-rc.0"
@@ -13110,19 +13125,19 @@ yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yoast-components@^4.34.0-rc.0:
-  version "4.34.0-rc.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.34.0-rc.0.tgz#e51213971b08eb53e5577c5fb7dc5f050162bcf4"
-  integrity sha512-yKGlX/F4I3UpdPw3ajGTP+UDfPSxNRDi+j6nw/ZHHOdeyBeNn/n0qO+lT0tlW6KMXj376l4u1F/s30hkzFEPnA==
+yoast-components@^4.34.1:
+  version "4.34.1"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.34.1.tgz#e95eeacd0d72526e68a6e94d6325314889e539ad"
+  integrity sha512-vh2s1qSZnkzLe/DE77K65ZwiAnDvmkQVwi5qIxQv8vx0pLt37Gt1JtPJIrkIxnFbqUEwOd6Wv01JngIjmGEzPA==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
-    "@yoast/algolia-search-box" "^1.7.0-rc.0"
-    "@yoast/analysis-report" "^0.8.0-rc.0"
-    "@yoast/components" "^0.8.0-rc.0"
-    "@yoast/configuration-wizard" "^1.7.0-rc.0"
+    "@yoast/algolia-search-box" "^1.7.0"
+    "@yoast/analysis-report" "^0.8.0"
+    "@yoast/components" "^0.8.0"
+    "@yoast/configuration-wizard" "^1.7.0"
     "@yoast/helpers" "^0.6.0-rc.0"
-    "@yoast/search-metadata-previews" "^1.10.0-rc.0"
+    "@yoast/search-metadata-previews" "^1.10.1"
     "@yoast/style-guide" "^0.6.0-rc.0"
     algoliasearch "^3.22.3"
     clipboard "^1.5.15"
@@ -13142,12 +13157,12 @@ yoast-components@^4.34.0-rc.0:
     styled-components "^4.2.0"
     whatwg-fetch "^1.0.0"
     wicked-good-xpath "^1.3.0"
-    yoastseo "^1.61.0-rc.0"
+    yoastseo "^1.61.0"
 
-yoastseo@^1.61.0-rc.0:
-  version "1.61.0-rc.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.61.0-rc.0.tgz#7d2714ac67a8d38decdda7d867116667602ceb01"
-  integrity sha512-hdZ4c5ijxhjeb+1wk30nHVpQp9F9SPlI2QGglRJEo0ZTxzDsRMibyI5iPB9FY9TcoogS5F0sHLLYKeWOUuAxFw==
+yoastseo@^1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.61.0.tgz#7edd811d26b61a571ca4d01515286f252b9201d1"
+  integrity sha512-KB86HCjU/w3F7Mhe2Y3ubIWjbHmvPMUEQJGVGOK1dzwQwKm3v2sFCljQBdMe33qEimlvNuYU5q1N9S4R8erXRQ==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     "@yoast/feature-flag" "^0.3.0-rc.1"


### PR DESCRIPTION
## Summary

Bumps the JavaScript monorepo packages for release 12.3. 
