### PR TITLE
Improve the import and export settings textarea labels and descriptions.

### DIFF
--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -51,7 +51,7 @@ class WPSEO_Export {
 			return;
 		}
 
-		echo '<p>';
+		echo '<p id="wpseo-settings-export-desc">';
 		printf(
 			/* translators: %1$s expands to Import settings */
 			esc_html__(
@@ -64,7 +64,9 @@ class WPSEO_Export {
 			)
 		);
 		echo '</p>';
-		echo '<textarea id="wpseo-export" rows="20" cols="100">' . esc_textarea( $this->export ) . '</textarea>';
+		/* translators: %1$s expands to Yoast SEO */
+		echo '<label for="wpseo-settings-export" class="yoast-inline-label">' . sprintf( __( 'Your %1$s settings:', 'wordpress-seo' ), 'Yoast SEO' ) . '</label><br />';
+		echo '<textarea id="wpseo-settings-export" rows="20" cols="100" aria-describedby="wpseo-settings-export-desc">' . esc_textarea( $this->export ) . '</textarea>';
 	}
 
 	/**

--- a/admin/views/tabs/tool/wpseo-import.php
+++ b/admin/views/tabs/tool/wpseo-import.php
@@ -16,11 +16,12 @@ if ( ! defined( 'WPSEO_NAMESPACES' ) || ! WPSEO_NAMESPACES ) {
 	return;
 }
 ?>
-<p>
+<p id="settings-import-desc">
 	<?php
 	printf(
-		/* translators: 1: Import settings button string from below. */
-		esc_html__( 'Import settings by pasting the settings you copied from another site here and clicking "%s".', 'wordpress-seo' ),
+		/* translators: 1: expands to Yoast SEO, 2: expands to Import settings. */
+		esc_html__( 'Import settings from another %1$s installation by pasting them here and clicking "%2$s".', 'wordpress-seo' ),
+		'Yoast SEO',
 		esc_html__( 'Import settings', 'wordpress-seo' )
 	);
 	?>
@@ -31,15 +32,15 @@ if ( ! defined( 'WPSEO_NAMESPACES' ) || ! WPSEO_NAMESPACES ) {
 	method="post"
 	accept-charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 	<?php wp_nonce_field( WPSEO_Import_Settings::NONCE_ACTION ); ?>
-	<label class="screen-reader-text" for="settings-import">
+	<label class="yoast-inline-label" for="settings-import">
 		<?php
 		printf(
 			/* translators: %s expands to Yoast SEO */
-			esc_html__( 'Paste your settings from another %s installation.', 'wordpress-seo' ),
+			esc_html__( '%s settings to import:', 'wordpress-seo' ),
 			'Yoast SEO'
 		);
 		?>
-	</label>
-	<textarea id="settings-import" rows="10" cols="140" name="settings_import"></textarea><br/>
+	</label><br />
+	<textarea id="settings-import" rows="10" cols="140" name="settings_import" aria-describedby="settings-import-desc"></textarea><br/>
 	<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Import settings', 'wordpress-seo' ); ?>"/>
 </form>

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -165,13 +165,13 @@ else {
 	else {
 		echo '<form action="', esc_url( $action_url ), '" method="post" id="robotstxtform">';
 		wp_nonce_field( 'wpseo-robotstxt', '_wpnonce', true, true );
-		echo '<p><label for="robotsnew" class="yoast-inline-label">';
+		echo '<label for="robotsnew" class="yoast-inline-label">';
 		printf(
 			/* translators: %s expands to robots.txt. */
 			esc_html__( 'Edit the content of your %s:', 'wordpress-seo' ),
 			'robots.txt'
 		);
-		echo '</label></p>';
+		echo '</label>';
 		echo '<textarea class="large-text code" rows="15" name="robotsnew" id="robotsnew">', esc_textarea( $content ), '</textarea><br/>';
 		printf(
 			'<div class="submit"><input class="button" type="submit" name="submitrobots" value="%s" /></div>',
@@ -215,13 +215,13 @@ if ( ! WPSEO_Utils::is_nginx() ) {
 		else {
 			echo '<form action="', esc_url( $action_url ), '" method="post" id="htaccessform">';
 			wp_nonce_field( 'wpseo-htaccess', '_wpnonce', true, true );
-			echo '<p><label for="htaccessnew" class="yoast-inline-label">';
+			echo '<label for="htaccessnew" class="yoast-inline-label">';
 			printf(
 				/* translators: %s expands to ".htaccess". */
 				esc_html__( 'Edit the content of your %s:', 'wordpress-seo' ),
 				'.htaccess'
 			);
-			echo '</label></p>';
+			echo '</label>';
 			echo '<textarea class="large-text code" rows="15" name="htaccessnew" id="htaccessnew">', esc_textarea( $contentht ), '</textarea><br/>';
 			printf(
 				'<div class="submit"><input class="button" type="submit" name="submithtaccess" value="%s" /></div>',

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -53,7 +53,8 @@ tr.yst_row.even {
 
 	.yoast-inline-label {
 		float: none;
-		margin: 0;
+		display: inline-block;
+		margin: 0 0 8px;
 	}
 
 	input.textinput,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

- https://github.com/Yoast/bugreports/issues/623


## Relevant technical choices:

- adds missing label to the export settings textarea
- makes the import settings textarea label visible
- changes the import settings description text by merging into it some text that was used for the visually hidden label
- associates the descriptions to the textareas with `aria-describedby`
- adds a 8px bottom margin to the `yoast-inline-label` CSS class
- makes the robots.txt and htaccess textarea labels use the same bottom margin for consistency

## Test instructions
This PR can be tested by following these steps:

- go to SEO > Tools > Import and Export
- on the Import settings tab: see the new text description
- click the textarea label and verify the textarea receives focus
- on the Export settings tab: click the "Export your Yoast SEO settings" button
- see the new textarea label 
- click the textarea label and verify the textarea receives focus
- go to SEO > Tools > File editor
- see the robots.txt textarea label "Edit the content of your robots.txt:" has a slightly bigger bottom margin

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
N/A

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Screenshots

Import before: 

<img width="752" alt="import before" src="https://user-images.githubusercontent.com/1682452/66745630-d008b680-ee7f-11e9-8a7b-95e7a9c06804.png">

Import after:

<img width="760" alt="import after" src="https://user-images.githubusercontent.com/1682452/66745631-d0a14d00-ee7f-11e9-835d-aab6beed3766.png">

Export before:

<img width="703" alt="export before" src="https://user-images.githubusercontent.com/1682452/66745653-e0b92c80-ee7f-11e9-8b25-4dc7e4e78e54.png">

Export after:

<img width="705" alt="export after" src="https://user-images.githubusercontent.com/1682452/66745654-e0b92c80-ee7f-11e9-8f1a-a55ba74dfe98.png">

Robots.txt textarea: unchanged but with a slightly increased bottom margin:

<img width="843" alt="robots" src="https://user-images.githubusercontent.com/1682452/66745696-034b4580-ee80-11e9-90ec-584472290cff.png">


Fixes https://github.com/Yoast/bugreports/issues/623
