### PR TITLE
Use get_core_updates to get the latest major WordPress version

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -393,15 +393,21 @@ class WPSEO_Admin_Init {
 	 * @return float The latest released major WordPress version. 0 The stable-check api doesn't respond.
 	 */
 	private function get_latest_major_wordpress_version() {
-		$response = wp_remote_get( 'http://api.wordpress.org/core/stable-check/1.0/' );
-		if ( is_wp_error( $response ) ) {
+		$core_updates = get_core_updates( array( 'dismissed' => true ) );
+
+		if ( $core_updates === false ) {
 			return 0;
 		}
 
-		$wp_version_latest = (array) json_decode( $response['body'] );
+		$wp_version_latest = get_bloginfo( 'version' );
+		foreach ( $core_updates as $update ) {
+			if ( $update->response === 'upgrade' && version_compare( $update->version, $wp_version_latest, '>' ) ) {
+				$wp_version_latest = $update->version;
+			}
+		}
 
 		// Strip the patch version and convert to a float.
-		return (float) array_search( 'latest', $wp_version_latest, true );
+		return (float) $wp_version_latest;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Use the core transient to get the latest version update instead of sending requests to wordpress.org.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Change your WordPress version in `wp-includes/version.php` to something old.
* Be sure to visit the updates page to make WordPress check for updates
* You should see a notification in the Yoast notification center that you're not running the latest version.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/635