### PR TITLE
All remaining title metatags

### DIFF
--- a/src/presentations/indexable-error-page-presentation.php
+++ b/src/presentations/indexable-error-page-presentation.php
@@ -31,8 +31,6 @@ class Indexable_Error_Page_Presentation extends Indexable_Presentation {
 			return $this->model->title;
 		}
 
-		$title = $this->options_helper->get_title_default( 'title-404-wpseo' );
-
-		return $title;
+		return $this->options_helper->get_title_default( 'title-404-wpseo' );
 	}
 }

--- a/src/presentations/indexable-error-page-presentation.php
+++ b/src/presentations/indexable-error-page-presentation.php
@@ -22,4 +22,17 @@ class Indexable_Error_Page_Presentation extends Indexable_Presentation {
 
 		return $this->robots_helper->after_generate( $robots );
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_title() {
+		if ( $this->model->title ) {
+			return $this->model->title;
+		}
+
+		$title = $this->options_helper->get_title_default( 'title-404-wpseo' );
+
+		return $title;
+	}
 }

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -31,7 +31,6 @@ class Indexable_Home_Page_Presentation extends Indexable_Presentation {
 			return $this->model->title;
 		}
 
-		// @todo Fill in the correct fallback title
-		return 'Fallback title';
+		return $this->options_helper->get_title_default( 'title-home-wpseo' );
 	}
 }

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -22,4 +22,16 @@ class Indexable_Home_Page_Presentation extends Indexable_Presentation {
 
 		return $this->options_helper->get( 'metadesc-home-wpseo' );
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_title() {
+		if ( $this->model->title ) {
+			return $this->model->title;
+		}
+
+		// @todo Fill in the correct fallback title
+		return 'Fallback title';
+	}
 }

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -24,4 +24,16 @@ class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 
 		return $this->robots_helper->after_generate( $robots );
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_title() {
+		if ( $this->model->title ) {
+			return $this->model->title;
+		}
+
+		// @todo Fill in the correct fallback title
+		return 'Fallback title';
+	}
 }

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -33,7 +33,9 @@ class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 			return $this->model->title;
 		}
 
-		// @todo Fill in the correct fallback title
-		return 'Fallback title';
+		$post_type = $this->model->object_sub_type;
+		$title     = $this->options_helper->get_title_default( 'title-ptarchive-' . $post_type );
+
+		return $title;
 	}
 }

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -319,6 +319,10 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_title;
 		}
 
+		if ( $this->model->og_title ) {
+			return $this->model->og_title;
+		}
+
 		if ( $this->title ) {
 			return $this->title;
 		}

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -86,6 +86,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		 */
 		if ( $this->current_page->is_multiple_terms_page() ) {
 			$robots['index'] = 'noindex';
+
 			return $this->robots_helper->after_generate( $robots );
 		}
 
@@ -110,5 +111,17 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		}
 
 		return $this->robots_helper->after_generate( $robots );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function generate_title() {
+		if ( $this->model->title ) {
+			return $this->model->title;
+		}
+
+		// @todo Fill in the correct fallback title
+		return 'Fallback title';
 	}
 }

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -12,6 +12,8 @@ use Yoast\WP\Free\Wrappers\WP_Query_Wrapper;
 
 /**
  * Class Indexable_Presentation
+ *
+ * @property \WP_Term $replace_vars_object
  */
 class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 
@@ -91,15 +93,10 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		}
 
 		/**
-		 * @var \WP_Term $term
-		 */
-		$term = $this->wp_query_wrapper->get_query()->get_queried_object();
-
-		/**
 		 * First we get the no index option for this taxonomy, because it can be overwritten the indexable value for
 		 * this specific term.
 		 */
-		if ( ! $this->taxonomy_helper->is_indexable( $term->taxonomy ) ) {
+		if ( ! $this->taxonomy_helper->is_indexable( $this->replace_vars_object->taxonomy ) ) {
 			$robots['index'] = 'noindex';
 		}
 
@@ -121,7 +118,8 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 			return $this->model->title;
 		}
 
-		// @todo Fill in the correct fallback title
-		return 'Fallback title';
+		$title = $this->options_helper->get_title_default( 'title-tax-' . $this->replace_vars_object->taxonomy );
+
+		return $title;
 	}
 }

--- a/tests/presentations/indexable-error-page-presentation/title-test.php
+++ b/tests/presentations/indexable-error-page-presentation/title-test.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Error_Page_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Title_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Error_Page_Presentation
+ *
+ * @group presentations
+ * @group title
+ *
+ * @package Yoast\Tests\Presentations\Indexable_Error_Page_Presentation
+ */
+class Title_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setInstance();
+	}
+
+	/**
+	 * Tests whether the title is returned when it is set.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_title() {
+		$this->indexable->title = 'Error page title';
+
+		$this->assertEquals( 'Error page title', $this->instance->generate_title() );
+	}
+
+	/**
+	 * Tests whether the default title is returned when no title is set.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_title_without_set_title() {
+		$this->options_helper
+			->expects( 'get_title_default' )
+			->once()
+			->with( 'title-404-wpseo' )
+			->andReturn( 'Default error page title' );
+
+		$this->assertEquals( 'Default error page title', $this->instance->generate_title() );
+	}
+}

--- a/tests/presentations/indexable-home-page-presentation/title-test.php
+++ b/tests/presentations/indexable-home-page-presentation/title-test.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Home_Page_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Title_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Home_Page_Presentation
+ *
+ * @group presentations
+ * @group title
+ */
+class Title_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the title is set.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_with_title() {
+		$this->indexable->title = 'Homepage title';
+
+		$this->assertEquals( 'Homepage title', $this->instance->generate_title() );
+	}
+
+	/**
+	 * Tests the situation where the title is not set and we fall back to the options title.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_with_default_fallback() {
+		$this->options_helper
+			->expects( 'get_title_default' )
+			->once()
+			->with( 'title-home-wpseo' )
+			->andReturn( 'The homepage title' );
+
+		$this->assertEquals( 'The homepage title', $this->instance->generate_title() );
+	}
+
+}

--- a/tests/presentations/indexable-post-type-archive-presentation/title-test.php
+++ b/tests/presentations/indexable-post-type-archive-presentation/title-test.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Archive_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Title_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Post_Type_Archive_Presentation
+ *
+ * @group presentations
+ * @group title
+ */
+class Title_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the title is set.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_with_title() {
+		$this->indexable->title = 'Title';
+
+		$this->assertEquals( 'Title', $this->instance->generate_title() );
+	}
+
+	/**
+	 * Tests the situation where the title is not set and we fall back to the options title.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_with_default_fallback() {
+		$this->indexable->object_sub_type = 'posttype';
+
+		$this->options_helper
+			->expects( 'get_title_default' )
+			->once()
+			->with( 'title-ptarchive-posttype' )
+			->andReturn( 'This is the title' );
+
+		$this->assertEquals( 'This is the title', $this->instance->generate_title() );
+	}
+
+}

--- a/tests/presentations/indexable-post-type-presentation/title-test.php
+++ b/tests/presentations/indexable-post-type-presentation/title-test.php
@@ -25,7 +25,7 @@ class Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the title is given.
+	 * Tests the situation where the title is set.
 	 *
 	 * @covers ::generate_title
 	 */
@@ -36,11 +36,11 @@ class Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the title is not set and we fall back to the template.
+	 * Tests the situation where the title is not set and we fall back to the options title.
 	 *
 	 * @covers ::generate_title
 	 */
-	public function test_with_template_fallback() {
+	public function test_with_default_fallback() {
 		$this->indexable->object_sub_type = 'post';
 
 		$this->options_helper

--- a/tests/presentations/indexable-presentation/og-site-name-test.php
+++ b/tests/presentations/indexable-presentation/og-site-name-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\Free\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
  *
  * @group presentations
- * @group open-graph
+ * @group opengraph
  */
 class WordPress_Site_Name_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-presentation/og-title-test.php
+++ b/tests/presentations/indexable-presentation/og-title-test.php
@@ -10,8 +10,8 @@ use Yoast\WP\Free\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
  *
  * @group presentations
- * @group og
- * @group og_title
+ * @group opengraph
+ * @group opengraph-title
  */
 class OG_Title_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-presentation/og-title-test.php
+++ b/tests/presentations/indexable-presentation/og-title-test.php
@@ -10,6 +10,8 @@ use Yoast\WP\Free\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
  *
  * @group presentations
+ * @group og
+ * @group og_title
  */
 class OG_Title_Test extends TestCase {
 	use Presentation_Instance_Builder;
@@ -24,23 +26,23 @@ class OG_Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the OG title is given.
+	 * Tests the situation where the OG title is set.
 	 *
 	 * ::covers generate_og_title
 	 */
-	public function test_generate_og_title_when_og_title_is_given() {
+	public function test_generate_og_title_when_og_title_is_set() {
 		$this->indexable->og_title = 'Example of OG title';
 
 		$this->assertEquals( 'Example of OG title', $this->instance->generate_og_title() );
 	}
 
 	/**
-	 * Tests the situation where the OG title is not given, and the general title is returned.
+	 * Tests the situation where the OG title is not set, and the SEO title is returned.
 	 *
 	 * ::covers generate_og_title
 	 */
-	public function test_generate_og_title_with_general_title() {
-		$this->indexable->title = 'Example of general title';
-		$this->assertEquals( 'Example of general title', $this->instance->generate_og_title() );
+	public function test_generate_og_title_with_seo_title() {
+		$this->indexable->title = 'Example of SEO title';
+		$this->assertEquals( 'Example of SEO title', $this->instance->generate_og_title() );
 	}
 }

--- a/tests/presentations/indexable-presentation/title-test.php
+++ b/tests/presentations/indexable-presentation/title-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\Free\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Presentation
  *
  * @group presentations
- * @group title-test
+ * @group title
  */
 class Title_Test extends TestCase {
 
@@ -47,14 +47,14 @@ class Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the title is given.
+	 * Tests the situation where the SEO title is given.
 	 *
 	 * @covers ::generate_title
 	 */
 	public function test_generate_title_with_set_title() {
-		$this->indexable->title = 'Title';
+		$this->indexable->title = 'SEO title';
 
-		$this->assertEquals( 'Title', $this->instance->generate_title() );
+		$this->assertEquals( 'SEO title', $this->instance->generate_title() );
 	}
 
 	/**

--- a/tests/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-presentation/twitter-title-test.php
@@ -48,7 +48,7 @@ class Twitter_Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the Twitter title is given.
+	 * Tests the situation where the Twitter title is set.
 	 *
 	 * @covers ::generate_twitter_title
 	 */
@@ -59,14 +59,25 @@ class Twitter_Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where no Twitter title is given, but the general title has been set.
+	 * Tests the situation where no Twitter title is set, but the OG title is set.
 	 *
 	 * @covers ::generate_twitter_title
 	 */
-	public function test_generate_twitter_title_with_set_general_title() {
-		$this->indexable->title = 'General title';
+	public function test_generate_twitter_title_with_set_og_title() {
+		$this->indexable->og_title = 'OG title';
 
-		$this->assertEquals( 'General title', $this->instance->generate_twitter_title() );
+		$this->assertEquals( 'OG title', $this->instance->generate_twitter_title() );
+	}
+
+	/**
+	 * Tests the situation where no Twitter and OG titles are set, but the SEO title is set.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_generate_twitter_title_with_set_seo_title() {
+		$this->indexable->title = 'SEO title';
+
+		$this->assertEquals( 'SEO title', $this->instance->generate_twitter_title() );
 	}
 
 	/**

--- a/tests/presentations/indexable-term-archive-presentation/robots-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/robots-test.php
@@ -27,7 +27,7 @@ class Robots_Test extends TestCase {
 		$this->robots_helper
 			->expects( 'after_generate' )
 			->once()
-			->andReturnUsing( function ( $robots ) {
+			->andReturnUsing( function( $robots ) {
 				return $robots;
 			} );
 	}
@@ -38,7 +38,12 @@ class Robots_Test extends TestCase {
 	 * @covers ::generate_robots
 	 */
 	public function test_generate_robots() {
-		$this->setup_wp_query_wrapper();
+		$this->instance
+			->expects( 'generate_replace_vars_object' )
+			->once()
+			->andReturn( (object) [
+				'taxonomy' => 'category',
+			] );
 
 		$this->robots_helper
 			->expects( 'get_base_values' )
@@ -74,7 +79,12 @@ class Robots_Test extends TestCase {
 	 * @covers ::generate_robots
 	 */
 	public function test_generate_robots_taxonomy_not_indexable() {
-		$this->setup_wp_query_wrapper();
+		$this->instance
+			->expects( 'generate_replace_vars_object' )
+			->once()
+			->andReturn( (object) [
+				'taxonomy' => 'category',
+			] );
 
 		$this->robots_helper
 			->expects( 'get_base_values' )
@@ -111,7 +121,12 @@ class Robots_Test extends TestCase {
 	 * @covers ::generate_robots
 	 */
 	public function test_generate_robots_taxonomy_not_indexable_term_indexable() {
-		$this->setup_wp_query_wrapper();
+		$this->instance
+			->expects( 'generate_replace_vars_object' )
+			->once()
+			->andReturn( (object) [
+				'taxonomy' => 'category',
+			] );
 
 		$this->robots_helper
 			->expects( 'get_base_values' )
@@ -150,7 +165,12 @@ class Robots_Test extends TestCase {
 	 * @covers ::generate_robots
 	 */
 	public function test_generate_robots_taxonomy_indexable_term_not_indexable() {
-		$this->setup_wp_query_wrapper();
+		$this->instance
+			->expects( 'generate_replace_vars_object' )
+			->once()
+			->andReturn( (object) [
+				'taxonomy' => 'category',
+			] );
 
 		$this->robots_helper
 			->expects( 'get_base_values' )

--- a/tests/presentations/indexable-term-archive-presentation/title-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/title-test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Presentations\Indexable_Term_Archive_Presentation;
+
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Class Title_Test
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Presentations\Indexable_Term_Archive_Presentation
+ *
+ * @group presentations
+ * @group title
+ */
+class Title_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		$this->setInstance();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the title is set.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_with_title() {
+		$this->indexable->title = 'Title';
+
+		$this->assertEquals( 'Title', $this->instance->generate_title() );
+	}
+
+	/**
+	 * Tests the situation where the title is not set and we fall back to the options title.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_with_default_fallback() {
+		$this->instance
+			->expects( 'generate_replace_vars_object' )
+			->once()
+			->andReturn( (object) [
+				'taxonomy' => 'category',
+			] );
+
+		$this->options_helper
+			->expects( 'get_title_default' )
+			->once()
+			->with( 'title-tax-category' )
+			->andReturn( 'This is the title' );
+
+		$this->assertEquals( 'This is the title', $this->instance->generate_title() );
+	}
+
+}

--- a/tests/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/presenters/open-graph/site-name-presenter-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\Free\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\Free\Presenters\Open_Graph\Site_Name_Presenter
  *
  * @group presenters
- * @group open-graph
+ * @group opengraph
  */
 class Site_Name_Presenter_Test extends TestCase {
 

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\Free\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\Free\Presenters\Open_Graph\Title_Presenter
  *
  * @group presenters
- * @group open-graph
+ * @group opengraph
  */
 class Title_Presenter_Test extends TestCase {
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds meta tags for `title`, makes `twitter-title` fall back to `og-title`, and makes `og-title` fall back to `title`.

## Relevant technical choices:

* In consultation with @jdevalk, it was decided to fall back to the option title defaults in case no title is set by the user (rather than using the more complex fallback logic from `class-frontend`).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

For `term archive`:
* In the backend you should enter an `SEO title`, an `OG title` and a `Twitter title`
    * `Posts` --> `Categories` --> Hoover over a category --> `Edit` --> `Edit snippet` --> `SEO title`
    * `Posts` --> `Categories` --> Hoover over a category --> `Edit` --> `Social` --> `Facebook title`
    * `Posts` --> `Categories` --> Hoover over a category --> `Edit` --> `Twitter` --> `Twitter title`
* In the frontend, check whether the meta tags are rendered with the titles you just entered.
* Now delete the `Twitter title` in the backend, and check in the frontend whether `twitter-title` contains the same value as `og-title`.
* Now delete the `OG title` in the backend, and check in the frontend whether `twitter-title` and `og-title` contain the same value as `title`.
* Now delete the `SEO title` in the backend, and check in the frontend whether `twitter-title`, `og-title` and `title` contain the fallback title.
* The fallback titles can be found in `class-wpseo-option-titles.php`.
    * For term archive it is: `%%term_title%% Archive %%page%% %%sep%% %%sitename%%`

For `homepage`, `post type archive` and `error page`:
* In the backend you should enter an `SEO title`
    * Homepage: `SEO` --> `Search appearance` --> `General` --> `Homepage` --> `SEO title` (social titles cannot be set for homepage)
    * Post type archive: `SEO` --> `Search appearance` --> `Content types` --> `Books` --> `SEO title` (for `Books` to be there, Yoast Test Helper has to be activated)
    * Error page: `SEO` --> `Search appearance` --> `Archives` --> `Special pages` --> `404 pages` --> `SEO title`
* For each of the page types, check in the frontend whether the `title` meta tag is rendered with the title you just entered.
* For each of the page types, delete the `SEO title` in the backend, and check in the frontend whether `title` contains the fallback title.
* The fallback titles can be found in `class-wpseo-option-titles.php`.
    * For `home page` it is: `%%sitename%% %%page%% %%sep%% %%sitedesc%%`
    * For `post type archive` it is: `%%pt_plural%% Archive %%page%% %%sep%% %%sitename%%`
    * For `error page` it is: `Page not found ' %%sep%% %%sitename%%`

(FYI, the pages types `author archive`, `date archive`, `attachment` and `search page` were already handled in [this PR](https://github.com/Yoast/wordpress-seo/pull/13618), and `post` and `page` in [this PR](https://github.com/Yoast/wordpress-seo/pull/13560)).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
