### PR TITLE
Added "Strong" parameter to Light Switch component

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -304,8 +304,9 @@ class Yoast_Form {
 	 * @param array  $buttons Array of two visual labels for the buttons (defaults Disabled/Enabled).
 	 * @param bool   $reverse Reverse order of buttons (default true).
 	 * @param string $help    Inline Help that will be printed out before the visible toggles text.
+	 * @param bool   $strong  The visual label displayed in strong text.
 	 */
-	public function light_switch( $var, $label, $buttons = array(), $reverse = true, $help = '' ) {
+	public function light_switch( $var, $label, $buttons = array(), $reverse = true, $help = '', $strong = false ) {
 
 		if ( ! isset( $this->options[ $var ] ) ) {
 			$this->options[ $var ] = false;
@@ -332,8 +333,10 @@ class Yoast_Form {
 
 		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
 
+		$strong_class = ( $strong ) ? ' switch-light-visual-label__strong': '';
+
 		echo '<div class="switch-container', $help_class, '">',
-		'<span class="switch-light-visual-label" id="', esc_attr( $var . '-label' ), '">', esc_html( $label ), '</span>' . $help,
+		'<span class="switch-light-visual-label' . $strong_class . '" id="', esc_attr( $var . '-label' ), '">', esc_html( $label ), '</span>' . $help,
 		'<label class="', $class, '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>',
 		'<input type="checkbox" aria-labelledby="', esc_attr( $var . '-label' ), '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $this->options[ $var ], 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>',
 		'<span aria-hidden="true">

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -304,7 +304,7 @@ class Yoast_Form {
 	 * @param array  $buttons Array of two visual labels for the buttons (defaults Disabled/Enabled).
 	 * @param bool   $reverse Reverse order of buttons (default true).
 	 * @param string $help    Inline Help that will be printed out before the visible toggles text.
-	 * @param bool   $strong  The visual label displayed in strong text.
+	 * @param bool   $strong  Whether the visual label is displayed in strong text. Default is false.
 	 */
 	public function light_switch( $var, $label, $buttons = array(), $reverse = true, $help = '', $strong = false ) {
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -333,7 +333,7 @@ class Yoast_Form {
 
 		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
 
-		$strong_class = ( $strong ) ? ' switch-light-visual-label__strong': '';
+		$strong_class = ( $strong ) ? ' switch-light-visual-label__strong' : '';
 
 		echo '<div class="switch-container', $help_class, '">',
 		'<span class="switch-light-visual-label' . $strong_class . '" id="', esc_attr( $var . '-label' ), '">', esc_html( $label ), '</span>' . $help,

--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -21,7 +21,7 @@ printf(
 	esc_html__( 'Twitter uses Open Graph metadata just like Facebook, so be sure to keep the Open Graph checkbox on the Facebook tab checked if you want to optimize your site for Twitter.', 'wordpress-seo' )
 );
 
-$yform->light_switch( 'twitter', __( 'Add Twitter card meta data', 'wordpress-seo' ) );
+$yform->light_switch( 'twitter', __( 'Add Twitter card meta data', 'wordpress-seo' ), array(), true, '', true );
 
 echo '<p>';
 esc_html_e( 'Enable this feature if you want Twitter to display a preview with images and a text excerpt when a link to your site is shared.', 'wordpress-seo' );

--- a/css/src/toggle-switch.scss
+++ b/css/src/toggle-switch.scss
@@ -18,30 +18,30 @@
 
 /* Only target browsers with support for media queries. */
 @media only screen {
- 	.switch-light,
+	.switch-light,
 	.switch-toggle {
 		position: relative;
 		display: block;
 		padding: 0 !important;
 	}
 
-    .switch-light::after,
+	.switch-light::after,
 	.switch-toggle::after {
 		clear: both;
 		content: "";
 		display: table;
 	}
 
-    .switch-light *,
-    .switch-light *:before,
-    .switch-light *:after,
-    .switch-toggle *,
-    .switch-toggle *:before,
-    .switch-toggle *:after {
+	.switch-light *,
+	.switch-light *:before,
+	.switch-light *:after,
+	.switch-toggle *,
+	.switch-toggle *:before,
+	.switch-toggle *:after {
 		box-sizing: border-box;
 	}
 
-    .switch-light a,
+	.switch-light a,
 	.switch-toggle a {
 		display: block;
 		-webkit-transition: all 0.2s ease-out;
@@ -49,10 +49,10 @@
 		transition: all 0.2s ease-out;
 	}
 
-    .switch-light label,
-    .switch-light > span,
-    .switch-toggle label,
-    .switch-toggle > span,
+	.switch-light label,
+	.switch-light > span,
+	.switch-toggle label,
+	.switch-toggle > span,
 	.switch-light-visual-label {
 		line-height: 2;
 		vertical-align: middle;
@@ -89,27 +89,27 @@
 	}
 
 	.switch-light span span {
-	    position: relative;
-	    z-index: 2;
-	    display: block;
-	    float: left;
-	    width: 50%;
-	    text-align: center;
-	    -webkit-user-select: none;
-	    -moz-user-select: none;
-	    -ms-user-select: none;
-	    user-select: none;
+		position: relative;
+		z-index: 2;
+		display: block;
+		float: left;
+		width: 50%;
+		text-align: center;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
 	}
 
 	.switch-light a {
-	    position: absolute;
-	    right: 50%;
-	    top: 0;
-	    z-index: 1;
-	    display: block;
-	    width: 50%;
-	    height: 100%;
-	    padding: 0;
+		position: absolute;
+		right: 50%;
+		top: 0;
+		z-index: 1;
+		display: block;
+		width: 50%;
+		height: 100%;
+		padding: 0;
 	}
 
 	.switch-toggle input {

--- a/css/src/toggle-switch.scss
+++ b/css/src/toggle-switch.scss
@@ -433,6 +433,10 @@
 		margin: 8px 0;
 		font-weight: 400;
 		line-height: 2;
+
+		&__strong {
+			font-weight: 600;
+		}
 	}
 
 	.switch-container {


### PR DESCRIPTION
## Summary

A notice about Twitter using OpenGraph was added to the Twitter social tab (in [this](https://github.com/Yoast/wordpress-seo/pull/13635) PR). To make sure the label of the light switch below it stands out, a `strong` parameter was added to the light switch component. 
For more info on this decision, see: https://github.com/Yoast/wordpress-seo/issues/13631#issuecomment-542170823

* See #13631 for the initial issue.
* See #13635 for the PR about the Twitter OpenGraph notice text.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds OpenGraph notice to the user in the Twitter social tab. Props to @stevenfranks.

## Relevant technical choices:

* The strong parameter was added to the light switch component, so it would stand out with a text above.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See that the label of the Light Switch in the Twitter social tab is `strong` (SEO --> Social --> Twitter).
* Make sure the labels of other Light Switches are not `strong` e.g. Facebook (in same tab menu) and Breadcrumbs (SEO --> Search Appearances --> Breadcrumbs).

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13631
