### PR TITLE
Add date helper to wrap mysql2date

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\Free\Presentations\Generators\Schema;
 
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Article_Helper;
+use Yoast\WP\Free\Helpers\Date_Helper;
 
 /**
  * Returns schema Article data.
@@ -21,12 +22,19 @@ class Article extends Abstract_Schema_Piece {
 	private $article_helper;
 
 	/**
+	 * @var Date_Helper
+	 */
+	private $date_helper;
+
+	/**
 	 * Article constructor.
 	 *
 	 * @param Article_Helper $article_helper The article helper.
+	 * @param Date_Helper    $date_helper    The date helper.
 	 */
-	public function __construct( Article_Helper $article_helper ) {
+	public function __construct( Article_Helper $article_helper, Date_Helper $date_helper ) {
 		$this->article_helper = $article_helper;
+		$this->date_helper    = $date_helper;
 	}
 
 	/**
@@ -68,8 +76,8 @@ class Article extends Abstract_Schema_Piece {
 			'isPartOf'         => [ '@id' => $context->canonical . $this->id_helper->webpage_hash ],
 			'author'           => [ '@id' => $this->id_helper->get_user_schema_id( $context->post->post_author, $context ) ],
 			'headline'         => $context->title,
-			'datePublished'    => \mysql2date( DATE_W3C, $context->post->post_date_gmt, false ),
-			'dateModified'     => \mysql2date( DATE_W3C, $context->post->post_modified_gmt, false ),
+			'datePublished'    => $this->date_helper->mysql_date_to_w3c_format( $context->post->post_date_gmt ),
+			'dateModified'     => $this->date_helper->mysql_date_to_w3c_format( $context->post->post_modified_gmt ),
 			'commentCount'     => $comment_count['approved'],
 			'mainEntityOfPage' => [ '@id' => $context->canonical . $this->id_helper->webpage_hash ],
 		];

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\Free\Presentations\Generators\Schema;
 use WP_Post;
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Date_Helper;
 use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
 
 /**
@@ -30,17 +31,25 @@ class WebPage extends Abstract_Schema_Piece {
 	private $html_helper;
 
 	/**
+	 * @var Date_Helper
+	 */
+	private $date_helper;
+
+	/**
 	 * WebPage constructor.
 	 *
 	 * @param Current_Page_Helper $current_page_helper The current page helper.
 	 * @param HTML_Helper         $html_helper         The HTML helper.
+	 * @param Date_Helper         $date_helper         The Date helper.
 	 */
 	public function __construct(
 		Current_Page_Helper $current_page_helper,
-		HTML_Helper $html_helper
+		HTML_Helper $html_helper,
+		Date_Helper $date_helper
 	) {
 		$this->current_page = $current_page_helper;
 		$this->html_helper  = $html_helper;
+		$this->date_helper  = $date_helper;
 	}
 
 	/**
@@ -82,8 +91,8 @@ class WebPage extends Abstract_Schema_Piece {
 		if ( $context->indexable->object_type === 'post' ) {
 			$this->add_image( $data, $context );
 
-			$data['datePublished'] = \mysql2date( DATE_W3C, $context->post->post_date_gmt, false );
-			$data['dateModified']  = \mysql2date( DATE_W3C, $context->post->post_modified_gmt, false );
+			$data['datePublished'] = $this->date_helper->mysql_date_to_w3c_format( $context->post->post_date_gmt );
+			$data['dateModified']  = $this->date_helper->mysql_date_to_w3c_format( $context->post->post_modified_gmt );
 
 			if ( $context->indexable->object_sub_type === 'post' ) {
 				$data = $this->add_author( $data, $context->post, $context );

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * A helper object for dates.
+ *
+ * @package Yoast\YoastSEO\Helpers
+ */
+
+namespace Yoast\WP\Free\Helpers;
+
+
+/**
+ * Class Date_Helper
+ */
+class Date_Helper {
+	/**
+	 * Convert given date string to the W3C format.
+	 *
+	 * If $translate is true then the given date and format string will
+	 * be passed to date_i18n() for translation.
+	 *
+	 * @param string $date      Date string to convert.
+	 * @param bool   $translate Whether the return date should be translated. Default false.
+	 *
+	 * @return string Formatted date string.
+	 */
+	public function mysql_date_to_w3c_format( $date, $translate = false ) {
+		return \mysql2date( DATE_W3C, $date, $translate );
+	}
+}

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\Free\Presentations;
 
 use Yoast\WP\Free\Helpers\Post_Type_Helper;
 use Yoast\WP\Free\Helpers\User_Helper;
+use Yoast\WP\Free\Helpers\Date_Helper;
 
 /**
  * Class Indexable_Post_Type_Presentation
@@ -28,12 +29,14 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	/**
 	 * Indexable_Post_Type_Presentation constructor.
 	 *
-	 * @param Post_Type_Helper $post_type The post type helper.
-	 * @param User_Helper      $user             The user helper.
+	 * @param Post_Type_Helper $post_type  The post type helper.
+	 * @param User_Helper      $user       The user helper.
+	 * @param Date_Helper      $date       The date helper.
 	 */
-	public function __construct( Post_Type_Helper $post_type, User_Helper $user ) {
+	public function __construct( Post_Type_Helper $post_type, User_Helper $user, Date_Helper $date ) {
 		$this->post_type = $post_type;
 		$this->user      = $user;
+		$this->date      = $date;
 	}
 
 	/**
@@ -148,7 +151,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			}
 		}
 
-		return \mysql2date( DATE_W3C, $this->context->post->post_date_gmt, false );
+		return $this->date->mysql_date_to_w3c_format( $this->context->post->post_date_gmt );
 	}
 
 	/**
@@ -158,7 +161,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 */
 	public function generate_og_article_modified_time() {
 		if ( $this->context->post->post_modified_gmt !== $this->context->post->post_date_gmt ) {
-			return \mysql2date( DATE_W3C, $this->context->post->post_modified_gmt, false );
+			return $this->date->mysql_date_to_w3c_format( $this->context->post->post_modified_gmt );
 		}
 
 		return '';

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use stdClass;
 use Yoast\WP\Free\Helpers\Article_Helper;
+use Yoast\WP\Free\Helpers\Date_Helper;
 use Yoast\WP\Free\Helpers\Schema\ID_Helper;
 use Yoast\WP\Free\Presentations\Generators\Schema\Article;
 use Yoast\WP\Free\Tests\Mocks\Indexable;
@@ -32,6 +33,11 @@ class Article_Test extends TestCase {
 	private $article_helper_mock;
 
 	/**
+	 * @var Mockery\MockInterface|Date_Helper
+	 */
+	private $date_helper_mock;
+
+	/**
 	 * @var Article
 	 */
 	private $instance;
@@ -52,7 +58,8 @@ class Article_Test extends TestCase {
 		$this->id_helper_mock->webpage_hash       = '#webpage-hash';
 		$this->id_helper_mock->primary_image_hash = '#primary-image-hash';
 		$this->article_helper_mock                = Mockery::mock( Article_Helper::class );
-		$this->instance                           = new Article( $this->article_helper_mock );
+		$this->date_helper_mock                   = Mockery::mock( Date_Helper::class );
+		$this->instance                           = new Article( $this->article_helper_mock, $this->date_helper_mock );
 		$this->context_mock                       = new Meta_Tags_Context();
 		$this->context_mock->indexable            = new Indexable();
 		$this->context_mock->post                 = new stdClass();
@@ -167,6 +174,18 @@ class Article_Test extends TestCase {
 		$categories = [ (object) [ 'name' => 'Category1' ] ];
 		Monkey\Functions\expect( 'get_the_terms' )->with( 5, 'category' )->andReturn( $categories );
 		Monkey\Functions\expect( 'wp_list_pluck' )->once()->with( $categories, 'name' )->andReturn( [ 'Category1' ] );
+
+		$this->date_helper_mock
+			->expects( 'mysql_date_to_w3c_format' )
+			->once()
+			->with( '2345-12-12 12:12:12' )
+			->andReturn( '2345-12-12 12:12:12' );
+
+		$this->date_helper_mock
+			->expects( 'mysql_date_to_w3c_format' )
+			->once()
+			->with( '2345-12-12 23:23:23' )
+			->andReturn( '2345-12-12 23:23:23' );
 
 		$this->assertEquals(
 			[

--- a/tests/presentations/indexable-post-type-presentation/og-article-modified-time-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-article-modified-time-test.php
@@ -49,6 +49,12 @@ class OG_Article_Modified_Time_Test extends TestCase {
 			'post_modified_gmt' => '2019-11-09T12:34:56+00:00',
 		];
 
+		$this->date_helper
+			->expects( 'mysql_date_to_w3c_format' )
+			->with( '2019-11-09T12:34:56+00:00' )
+			->once()
+			->andReturn( '2019-11-09T12:34:56+00:00' );
+
 		$actual              = $this->instance->generate_og_article_modified_time();
 		$expected            = '2019-11-09T12:34:56+00:00';
 		$this->assertEquals( $expected, $actual );

--- a/tests/presentations/indexable-post-type-presentation/og-article-published-time-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-article-published-time-test.php
@@ -33,6 +33,13 @@ class OG_Article_Published_Time_Test extends TestCase {
 	public function test_generate_og_article_published_time_post() {
 		$this->indexable->object_sub_type = 'post';
 		$this->context->post = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
+
+		$this->date_helper
+			->expects( 'mysql_date_to_w3c_format' )
+			->with( '2019-10-08T12:26:31+00:00' )
+			->once()
+			->andReturn( '2019-10-08T12:26:31+00:00' );
+
 		$actual = $this->instance->generate_og_article_published_time();
 		$expected = '2019-10-08T12:26:31+00:00';
 
@@ -64,6 +71,12 @@ class OG_Article_Published_Time_Test extends TestCase {
 	public function test_generate_og_article_published_time_page_enabled() {
 		$this->context->post = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
 		$this->indexable->object_sub_type = 'page';
+
+		$this->date_helper
+			->expects( 'mysql_date_to_w3c_format' )
+			->with( '2019-10-08T12:26:31+00:00' )
+			->once()
+			->andReturn( '2019-10-08T12:26:31+00:00' );
 
 		$this->post_type_helper
 			->expects( 'get_post_type' )

--- a/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Free\Tests\Presentations\Indexable_Post_Type_Presentation;
 
 use Mockery;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
+use Yoast\WP\Free\Helpers\Date_Helper;
 use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Meta_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
@@ -69,6 +70,11 @@ trait Presentation_Instance_Builder {
 	protected $user_helper;
 
 	/**
+	 * @var Date_Helper|Mockery\MockInterface
+	 */
+	protected $date_helper;
+
+	/**
 	 * @var Meta_Tags_Context|Mockery\MockInterface
 	 */
 	protected $context;
@@ -87,12 +93,14 @@ trait Presentation_Instance_Builder {
 		$this->context             = Mockery::mock( Meta_Tags_Context::class )->makePartial();
 		$this->url_helper          = Mockery::mock( Url_Helper::class );
 		$this->user_helper         = Mockery::mock( User_Helper::class );
+		$this->date_helper         = Mockery::mock( Date_Helper::class );
 
 		$instance = Mockery::mock(
 			Indexable_Post_Type_Presentation::class,
 			[
 				$this->post_type_helper,
 				$this->user_helper,
+				$this->date_helper,
 			]
 		)
 			->shouldAllowMockingProtectedMethods()


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements a date helper to wrap mysql2date.

## Relevant technical choices:

* I've replaced all occurrences of `mysql2date` in the `src` folder by `mysql_date_to_w3c_format` from the new date helper class.  

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See that the tests still pass in Travis.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
