### PR TITLE
Fix Prev and Next URLs on site search pages

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1105,14 +1105,16 @@ class WPSEO_Frontend {
 
 		// Maybe output the prev link.
 		if ( $paged > 1 ) {
-			$this->adjacent_rel_link( 'prev', previous_posts( false ), ( $paged - 1 ), 'page' );
+			// Pass a "page" of -1 to prevent duplicate addition of query arg
+			$this->adjacent_rel_link( 'prev', previous_posts( false ), -1 );
 		}
 
 		$nextpage = ( intval( $paged ) + 1 );
 
 		// Maybe output the next link.
 		if ( $nextpage <= $max_page ) {
-			$this->adjacent_rel_link( 'next', next_posts( $max_page, false ), ( $paged + 1 ), 'page' );
+			// Pass a "page" of -1 to prevent duplicate addition of query arg
+			$this->adjacent_rel_link( 'next', next_posts( $max_page, false ), -1 );
 		}
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1107,14 +1107,14 @@ class WPSEO_Frontend {
 			$paged = 1;
 		}
 
-		// Maybe output the prev link
+		// Maybe output the prev link.
 		if ( $paged > 1 ) {
 			$this->adjacent_rel_link( 'prev', previous_posts( false ), ( $page - 1 ), 'page' );
 		}
 
-		$nextpage = intval( $paged ) + 1;
+		$nextpage = ( intval( $paged ) + 1 );
 
-		// Maybe output the next link
+		// Maybe output the next link.
 		if ( $nextpage <= $max_page ) {
 			$this->adjacent_rel_link( 'next', next_posts( $max_page, false ), ( $page + 1 ), 'page' );
 		}

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1095,13 +1095,9 @@ class WPSEO_Frontend {
 	 * @return void
 	 */
 	protected function rel_links_search() {
-		$num_pages = 1;
-
 		global $paged, $wp_query;
 
-		if ( ! $max_page ) {
-			$max_page = $wp_query->max_num_pages;
-		}
+		$max_page = $wp_query->max_num_pages;
 
 		if ( ! $paged ) {
 			$paged = 1;

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1052,6 +1052,11 @@ class WPSEO_Frontend {
 			return;
 		}
 
+		if ( is_search() ) {
+			$this->rel_links_search();
+			return;
+		}
+
 		$this->rel_links_archive();
 	}
 
@@ -1081,6 +1086,37 @@ class WPSEO_Frontend {
 
 		if ( $page < $num_pages ) {
 			$this->adjacent_rel_link( 'next', $url, ( $page + 1 ), 'page' );
+		}
+	}
+
+	/**
+	 * Output the rel prev/next links for a search result page.
+	 *
+	 * @return void
+	 */
+	protected function rel_links_search() {
+		$num_pages = 1;
+
+		global $paged, $wp_query;
+
+		if ( ! $max_page ) {
+			$max_page = $wp_query->max_num_pages;
+		}
+
+		if ( ! $paged ) {
+			$paged = 1;
+		}
+
+		// Maybe output the prev link
+		if ( $paged > 1 ) {
+			$this->adjacent_rel_link( 'prev', previous_posts( false ), ( $page - 1 ), 'page' );
+		}
+
+		$nextpage = intval( $paged ) + 1;
+
+		// Maybe output the next link
+		if ( $nextpage <= $max_page ) {
+			$this->adjacent_rel_link( 'next', next_posts( $max_page, false ), ( $page + 1 ), 'page' );
 		}
 	}
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1105,14 +1105,14 @@ class WPSEO_Frontend {
 
 		// Maybe output the prev link.
 		if ( $paged > 1 ) {
-			$this->adjacent_rel_link( 'prev', previous_posts( false ), ( $page - 1 ), 'page' );
+			$this->adjacent_rel_link( 'prev', previous_posts( false ), ( $paged - 1 ), 'page' );
 		}
 
 		$nextpage = ( intval( $paged ) + 1 );
 
 		// Maybe output the next link.
 		if ( $nextpage <= $max_page ) {
-			$this->adjacent_rel_link( 'next', next_posts( $max_page, false ), ( $page + 1 ), 'page' );
+			$this->adjacent_rel_link( 'next', next_posts( $max_page, false ), ( $paged + 1 ), 'page' );
 		}
 	}
 


### PR DESCRIPTION
Add `rel_links_search()` to explicitly support search results page, similar to `rel_links_single()`

Based search result pagination logic off of WP Core's implementation in `wp-includes/link-template.php`, `get_previous_posts_link()` and` get_next_posts_link()`. 

https://core.trac.wordpress.org/browser/tags/5.2.3/src/wp-includes/link-template.php#L2467

(The existing `rel_links_archive()` implementation relies on the canonical URL, which leads to the URL generation problem discussed in #13407.)

Fixes #13407

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the previous & next URLs on search results pages were incorrect. (The issue did not impact the search results page pagination, only the metadata URLs provided to search engine crawlers.)

## Relevant technical choices:

* Split `is_search()` into a dedicated function similar to the way `is_single()` is handled. The existing archive prev/next handler relies on the `$url = $this->canonical( false, true, true );`, which was the root cause of the URLs getting mangled. A dedicated function seemed like a cleaner choice.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out trunk and activate the plugin
* Generate a minimum of 21 posts with shared keywords to generate 3 pages of search results
* Search for the shared term
* View the source of the search results page 1, 2, and 3. Verify the HTML head `<link rel=` prev & next elements have the wrong URL
* Check out this branch
* Refresh the view source for all 3 search results pages.
* Verify the prev & next URLs in the head are correct
* Verify prev/next handling on archive pages is not broken.
* Verify prev/next on single records is not broken.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended