### PR TITLE
Show installation default title when SEO title is not set for posts

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -147,9 +147,9 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			/**
 			 * Filter: 'wpseo_opengraph_show_publish_date' - Allow showing publication date for other post types.
 			 *
-			 * @param string $post_type The current URL's post type.
-			 *
 			 * @api bool Whether or not to show publish date.
+			 *
+			 * @param string $post_type The current URL's post type.
 			 */
 			if ( ! apply_filters( 'wpseo_opengraph_show_publish_date', false, $this->post_type->get_post_type( $this->context->post ) ) ) {
 				return '';

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -29,7 +29,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 * Indexable_Post_Type_Presentation constructor.
 	 *
 	 * @param Post_Type_Helper $post_type The post type helper.
-	 * @param User_Helper      $user             The user helper.
+	 * @param User_Helper      $user      The user helper.
 	 */
 	public function __construct( Post_Type_Helper $post_type, User_Helper $user ) {
 		$this->post_type = $post_type;
@@ -44,7 +44,15 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			return $this->model->title;
 		}
 
-		return $this->options_helper->get( 'title-' . $this->model->object_sub_type );
+		// Get SEO title as entered in Search appearance.
+		$post_type = $this->model->object_sub_type;
+		$title     = $this->options_helper->get( 'title-' . $this->model->object_sub_type );
+		if ( $title ) {
+			return $title;
+		}
+
+		// Get installation default title.
+		return $this->options_helper->get_title_default( 'title-' . $post_type );
 	}
 
 	/**
@@ -139,9 +147,9 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			/**
 			 * Filter: 'wpseo_opengraph_show_publish_date' - Allow showing publication date for other post types.
 			 *
-			 * @api bool Whether or not to show publish date.
-			 *
 			 * @param string $post_type The current URL's post type.
+			 *
+			 * @api bool Whether or not to show publish date.
 			 */
 			if ( ! apply_filters( 'wpseo_opengraph_show_publish_date', false, $this->post_type->get_post_type( $this->context->post ) ) ) {
 				return '';

--- a/tests/presentations/indexable-post-type-presentation/title-test.php
+++ b/tests/presentations/indexable-post-type-presentation/title-test.php
@@ -25,31 +25,56 @@ class Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the title is set.
+	 * Tests the situation where the specific post's SEO title is set.
 	 *
 	 * @covers ::generate_title
 	 */
-	public function test_with_title() {
-		$this->indexable->title = 'Title';
+	public function test_with_specific_post_seo_title() {
+		$this->indexable->title = 'Specific post SEO title';
 
-		$this->assertEquals( 'Title', $this->instance->generate_title() );
+		$this->assertEquals( 'Specific post SEO title', $this->instance->generate_title() );
 	}
 
 	/**
-	 * Tests the situation where the title is not set and we fall back to the options title.
+	 * Tests the situation where the specific post's SEO title is not set,
+	 * but the SEO title for posts in general is set.
 	 *
 	 * @covers ::generate_title
 	 */
-	public function test_with_default_fallback() {
+	public function test_with_general_post_seo_title() {
 		$this->indexable->object_sub_type = 'post';
 
 		$this->options_helper
 			->expects( 'get' )
 			->once()
 			->with( 'title-post' )
-			->andReturn( 'This is the title' );
+			->andReturn( 'General post SEO title' );
 
-		$this->assertEquals( 'This is the title', $this->instance->generate_title() );
+		$this->assertEquals( 'General post SEO title', $this->instance->generate_title() );
 	}
 
+	/**
+	 * Tests the situation where the specific post's SEO title is not set,
+	 * and the SEO title for posts in general is not set,
+	 * and therefore we fall back to the installation default title for posts.
+	 *
+	 * @covers ::generate_title
+	 */
+	public function test_with_post_installation_default_title() {
+		$this->indexable->object_sub_type = 'post';
+
+		$this->options_helper
+			->expects( 'get' )
+			->once()
+			->with( 'title-post' )
+			->andReturn( '' );
+
+		$this->options_helper
+			->expects( 'get_title_default' )
+			->once()
+			->with( 'title-post' )
+			->andReturn( 'Post installation default title' );
+
+		$this->assertEquals( 'Post installation default title', $this->instance->generate_title() );
+	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where no title meta tag was output for posts and pages in case the `SEO title` field was empty in the backend

## Relevant technical choices:

* In case the `SEO title` field is empty at the level of a specific post or page, and also is empty in `Search appearance` --> `Content Types` --> `Posts`/`Pages`, we now output the installation default title.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post
* Set a 'post-specific' `SEO title` (in the snippet editor)
* Check whether a 'general' `SEO title` is also set in `Search appearance` --> `Content Types` --> `Posts` (if not, set it)
* In the frontend, check whether the post-specific title is output under the `title` tag
* Now delete the post-specific title in the backend
* In the frontend, check whether the general title is output under the `title` tag
* Now delete the general title in the backend
* In the frontend, check whether the installation default title is output under the `title` tag.
    * It should look like: `%%title%% %%page%% %%sep%% %%sitename%%`

* Repeat the above steps for a page

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
