### PR TITLE
Don't check for active local license but for active local plugin

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -163,7 +163,7 @@ class WPSEO_Admin_Pages {
 		$addon_manager = new WPSEO_Addon_Manager();
 
 		return ! WPSEO_Utils::is_yoast_seo_premium()
-			&& ! $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::LOCAL_SLUG );
+			&& ! ( defined( 'WPSEO_LOCAL_FILE' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unnecessary API calls related to the Local SEO upsell on the search appearance settings page.

## Relevant technical choices:

* Instead of checking for an active license, we now check for an active plugin. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use Free, not Premium.
* Don't have Local SEO active.
* Go to the search appearance page.
* Set your Knowledge graph to Organization
* See the Local SEO upsell.
* Install and activate Local SEO.
* See no Local SEO upsell on the search appearance page.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/649
