### PR TITLE
Added ms_is_switched check to terms

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -166,6 +166,10 @@ class WPSEO_Taxonomy {
 	 * @param string $taxonomy The taxonomy the term belongs to.
 	 */
 	public function update_term( $term_id, $tt_id, $taxonomy ) {
+		if ( ms_is_switched() ) {
+			return;
+		}
+
 		/* Create post array with only our values. */
 		$new_meta_data = array();
 		foreach ( WPSEO_Taxonomy_Meta::$defaults_per_term as $key => $default ) {


### PR DESCRIPTION
## Summary

Fixes a bug when working in a MultilingualPress environment and editing the Snippet Preview's values (including the keyword) for a *term*. Before this fix, any changes made would be synced across all additional languages.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug for terms where keywords and snippet preview data would be synced across all languages in a MultilingualPress multisite environment.

## Relevant technical choices:

* The reason that we need to add this is due to limitations within WordPress and its handling of data across multiple sites in a multisite environment. This isn't necessarily an issue with MLP itself; Every plugin that runs in a multisite environment can potentially have similar issues.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*Note: To acquire a copy of MLP, login to LastPass -> Shared-licenses vault. There's a login there for MultilingualPress so you can download the latest version.*

* Ensure you have a multisite environment with MultilingualPress and Yoast SEO installed.
* Configure at least two languages in MultilingualPress.
* Create a new category and ensure you set it to sync with the secondary language in the MLP metabox (`Create a new term, and use it as translation in <language>.`).
* Edit the keyword and other values in the Snippet Preview and save the category.
* Open up the newly created, translated category. See that the keyword and other changes are identical to the 'main' language's values.
* Checkout this PR.
* Make more changes to the keyword and/or Snippet Preview's values.
* Save the changes and open up (or refresh) the secondary language's translated version of the category.
* Notice that the changes made to the values, haven't been synced.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/153
