### PR TITLE
Checks if class has identifier property and use that as the class name.

### DIFF
--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -82,6 +82,9 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 
 		foreach ( $pieces as $piece ) {
 			$class = str_replace( 'wpseo_schema_', '', strtolower( get_class( $piece ) ) );
+			if ( property_exists( $piece, 'identifier' ) ) {
+				$class = $piece->identifier;
+			}
 
 			/**
 			 * Filter: 'wpseo_schema_needs_<class name>' - Allows changing which graph pieces we output.

--- a/frontend/schema/class-schema.php
+++ b/frontend/schema/class-schema.php
@@ -81,17 +81,17 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 		$this->parse_blocks();
 
 		foreach ( $pieces as $piece ) {
-			$class = str_replace( 'wpseo_schema_', '', strtolower( get_class( $piece ) ) );
+			$identifier = str_replace( 'wpseo_schema_', '', strtolower( get_class( $piece ) ) );
 			if ( property_exists( $piece, 'identifier' ) ) {
-				$class = $piece->identifier;
+				$identifier = $piece->identifier;
 			}
 
 			/**
-			 * Filter: 'wpseo_schema_needs_<class name>' - Allows changing which graph pieces we output.
+			 * Filter: 'wpseo_schema_needs_<identifier>' - Allows changing which graph pieces we output.
 			 *
 			 * @api bool $is_needed Whether or not to show a graph piece.
 			 */
-			$is_needed = apply_filters( 'wpseo_schema_needs_' . $class, $piece->is_needed() );
+			$is_needed = apply_filters( 'wpseo_schema_needs_' . $identifier, $piece->is_needed() );
 			if ( ! $is_needed ) {
 				continue;
 			}
@@ -99,11 +99,11 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 			$graph_piece = $piece->generate();
 
 			/**
-			 * Filter: 'wpseo_schema_<class name>' - Allows changing graph piece output.
+			 * Filter: 'wpseo_schema_<identifier>' - Allows changing graph piece output.
 			 *
 			 * @api array $graph_piece The graph piece to filter.
 			 */
-			$graph_piece = apply_filters( 'wpseo_schema_' . $class, $graph_piece );
+			$graph_piece = apply_filters( 'wpseo_schema_' . $identifier, $graph_piece );
 			if ( is_array( $graph_piece ) ) {
 				$graph[] = $graph_piece;
 			}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the possibility to declare an identifier when integrating with schema output.

## Relevant technical choices:

* This pull is looking for a public class property named `identifier` and will use that. This makes it possible to integrate in a situation where the class isn't named `WPSEO_Schema_*` or is using a namespace. 

A temporary fix was class aliasing the namespaced class to meet the class name requirement used in the code:
```
class_alias( \My\Namespace\Schema::class, 'WPSEO_Schema_Review' );
```

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* For testing this I recommend using my private spare time project: https://github.com/andizer/review-block - This plugin adds a review block to the block editor. Clone this project, do a `yarn install` (or `npm install`) and than just `npm build` which builds the production files. When you've done this just do `composer install` for getting the autoloader.
* Checkout the branch for this pull and add a 'andizer review block' to a post, fill in some scoring values and press save. Go to your post and view its source and check if schema.org output is generated.
* Now checkout `use-identifier-property` from the review block repo. Refresh the contents of your post and make sure the schema.org output is generated.
* Verify that our own schema is unchanged.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
