### PR TITLE
Adds logic for having the values in case of noindex and nosnippet

### DIFF
--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -55,7 +55,7 @@ class Robots_Helper {
 			unset( $robots['index'], $robots['follow'] );
 		}
 
-		if ( ! empty( $robots['nosnippet'] ) && ! empty( $robots['noindex'] ) ) {
+		if ( ! empty( $robots['nosnippet'] ) && ! empty( $robots['index'] ) && $robots['index'] === 'noindex' ) {
 			$robots['max-snippet']       = 'max-snippet:-1';
 			$robots['max-image-preview'] = 'max-image-preview:large';
 			$robots['max-video-preview'] = 'max-video-preview:-1';

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -49,16 +49,16 @@ class Robots_Helper {
 		// Remove null values.
 		$robots = array_filter( $robots );
 
+		if ( empty( $robots['nosnippet'] ) && ! empty( $robots['index'] ) && $robots['index'] !== 'noindex' ) {
+			$robots['max-snippet']       = 'max-snippet:-1';
+			$robots['max-image-preview'] = 'max-image-preview:large';
+			$robots['max-video-preview'] = 'max-video-preview:-1';
+		}
+
 		// If robots index and follow are set, they can be excluded because they are default values.
 		if ( ! empty( $robots['index'] ) && $robots['index'] === 'index' &&
 		     ! empty( $robots['follow'] ) && $robots['follow'] === 'follow' ) {
 			unset( $robots['index'], $robots['follow'] );
-		}
-
-		if ( ! empty( $robots['nosnippet'] ) && ! empty( $robots['index'] ) && $robots['index'] === 'noindex' ) {
-			$robots['max-snippet']       = 'max-snippet:-1';
-			$robots['max-image-preview'] = 'max-image-preview:large';
-			$robots['max-video-preview'] = 'max-video-preview:-1';
 		}
 
 		return $robots;

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -50,8 +50,15 @@ class Robots_Helper {
 		$robots = array_filter( $robots );
 
 		// If robots index and follow are set, they can be excluded because they are default values.
-		if ( $robots['index'] === 'index' && $robots['follow'] === 'follow' ) {
+		if ( ! empty( $robots['index'] ) && $robots['index'] === 'index' &&
+		     ! empty( $robots['follow'] ) && $robots['follow'] === 'follow' ) {
 			unset( $robots['index'], $robots['follow'] );
+		}
+
+		if ( ! empty( $robots['nosnippet'] ) && ! empty( $robots['noindex'] ) ) {
+			$robots['max-snippet']       = 'max-snippet:-1';
+			$robots['max-image-preview'] = 'max-image-preview:large';
+			$robots['max-video-preview'] = 'max-video-preview:-1';
 		}
 
 		return $robots;

--- a/tests/helpers/robots-helper-test.php
+++ b/tests/helpers/robots-helper-test.php
@@ -88,7 +88,11 @@ class Robots_Helper_Test extends TestCase {
 			'follow' => 'follow',
 		] );
 
-		$expected = [];
+		$expected = [
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
+		];
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -165,31 +169,7 @@ class Robots_Helper_Test extends TestCase {
 		] );
 
 		$expected = [
-			'noimageindex' => 'noimageindex',
-		];
-
-		$this->assertEquals( $expected, $actual );
-	}
-
-	/**
-	 * Tests if additional values are set when noindex and nosnippet are set.
-	 *
-	 * @covers ::after_generate
-	 */
-	public function test_after_generate_with_no_index_and_nosnippet() {
-		Monkey\Functions\expect( 'get_option' )
-			->once()
-			->with( 'blog_public' )
-			->andReturn( '1' );
-
-		$actual = $this->instance->after_generate( [
-			'index'     => 'noindex',
-			'nosnippet' => 'nosnippet',
-		] );
-
-		$expected = [
-			'index'             => 'noindex',
-			'nosnippet'         => 'nosnippet',
+			'noimageindex'      => 'noimageindex',
 			'max-snippet'       => 'max-snippet:-1',
 			'max-image-preview' => 'max-image-preview:large',
 			'max-video-preview' => 'max-video-preview:-1',

--- a/tests/helpers/robots-helper-test.php
+++ b/tests/helpers/robots-helper-test.php
@@ -44,7 +44,7 @@ class Robots_Helper_Test extends TestCase {
 		$actual = $this->instance->get_base_values( $indexable );
 
 		$expected = [
-			'index' => 'noindex',
+			'index'  => 'noindex',
 			'follow' => 'nofollow',
 		];
 
@@ -65,7 +65,7 @@ class Robots_Helper_Test extends TestCase {
 		$actual = $this->instance->get_base_values( $indexable );
 
 		$expected = [
-			'index' => 'index',
+			'index'  => 'index',
 			'follow' => 'follow',
 		];
 
@@ -84,7 +84,7 @@ class Robots_Helper_Test extends TestCase {
 			->andReturn( '1' );
 
 		$actual = $this->instance->after_generate( [
-			'index' => 'index',
+			'index'  => 'index',
 			'follow' => 'follow',
 		] );
 
@@ -109,12 +109,12 @@ class Robots_Helper_Test extends TestCase {
 			->andReturn( '0' );
 
 		$actual = $this->instance->after_generate( [
-			'index' => 'index',
+			'index'  => 'index',
 			'follow' => 'follow',
 		] );
 
 		$expected = [
-			'index' => 'noindex',
+			'index'  => 'noindex',
 			'follow' => 'follow',
 		];
 
@@ -135,12 +135,12 @@ class Robots_Helper_Test extends TestCase {
 		$_GET['replytocom'] = '123';
 
 		$actual = $this->instance->after_generate( [
-			'index' => 'index',
+			'index'  => 'index',
 			'follow' => 'follow',
 		] );
 
 		$expected = [
-			'index' => 'noindex',
+			'index'  => 'noindex',
 			'follow' => 'follow',
 		];
 
@@ -161,11 +161,11 @@ class Robots_Helper_Test extends TestCase {
 			->andReturn( '1' );
 
 		$actual = $this->instance->after_generate( [
-			'index' => 'index',
-			'follow' => 'follow',
+			'index'        => 'index',
+			'follow'       => 'follow',
 			'noimageindex' => 'noimageindex',
-			'nosnippet' => null,
-			'noarchive' => null,
+			'nosnippet'    => null,
+			'noarchive'    => null,
 		] );
 
 		$expected = [

--- a/tests/helpers/robots-helper-test.php
+++ b/tests/helpers/robots-helper-test.php
@@ -170,4 +170,31 @@ class Robots_Helper_Test extends TestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * Tests if additional values are set when noindex and nosnippet are set.
+	 *
+	 * @covers ::after_generate
+	 */
+	public function test_after_generate_with_no_index_and_nosnippet() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'blog_public' )
+			->andReturn( '1' );
+
+		$actual = $this->instance->after_generate( [
+			'noindex'   => 'noindex',
+			'nosnippet' => 'nosnippet',
+		] );
+
+		$expected = [
+			'noindex'           => 'noindex',
+			'nosnippet'         => 'nosnippet',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
 }

--- a/tests/helpers/robots-helper-test.php
+++ b/tests/helpers/robots-helper-test.php
@@ -183,12 +183,12 @@ class Robots_Helper_Test extends TestCase {
 			->andReturn( '1' );
 
 		$actual = $this->instance->after_generate( [
-			'noindex'   => 'noindex',
+			'index'     => 'noindex',
 			'nosnippet' => 'nosnippet',
 		] );
 
 		$expected = [
-			'noindex'           => 'noindex',
+			'index'             => 'noindex',
 			'nosnippet'         => 'nosnippet',
 			'max-snippet'       => 'max-snippet:-1',
 			'max-image-preview' => 'max-image-preview:large',


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set the noindex and nosnippet value for a post and verify that the additional robots values are rendered.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
