### PR TITLE
Adjust the Configuration Wizard user selector styling for WP 5.3.

### DIFF
--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -30,6 +30,12 @@ const Styles = createGlobalStyle`
 			&__input input {
 				box-shadow: none;
 				margin: 0;
+				min-height: 0;
+				line-height: 1.4;
+
+				&:focus {
+					box-shadow: none;
+				}
 			}
 
 			&__menu {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improved the Configuration Wizard user selector styling for better compatibility with WordPress 5.3.

## Relevant technical choices:

*

## Test instructions
- built all the things
- go to SEO > General > Configuration Wizard > step 3
- choose "Person": the user selector appears
- verify its height is the same as in WordPress 5.2
- click it
- verify the focus style looks like in WordPress 5.2 

Screenshot before:

<img width="721" alt="before" src="https://user-images.githubusercontent.com/1682452/67370087-66bd2d80-f57a-11e9-930e-bcc5c6a6f764.png">

Screenshot after:

<img width="716" alt="after" src="https://user-images.githubusercontent.com/1682452/67370105-6ae94b00-f57a-11e9-90f3-7d439ff9a2a9.png">

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/658