### PR TITLE
Fix fatal by adding multisite check

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -166,7 +166,7 @@ class WPSEO_Taxonomy {
 	 * @param string $taxonomy The taxonomy the term belongs to.
 	 */
 	public function update_term( $term_id, $tt_id, $taxonomy ) {
-		if ( ms_is_switched() ) {
+		if ( is_multisite() && ms_is_switched() ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Fix for PR https://github.com/Yoast/wordpress-seo/pull/13676

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where saving taxonomies would result in a fatal error in non-multisite environments.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to a single-site environment.
* Checkout trunk.
* Edit a taxonomy and save it.
* Observe the fatal error.
* Checkout this branch.
* Edit a taxonomy and save it.
* Observe there is no longer a fatal error.

You could check if the original PR implementation still works. See the test-instructions there https://github.com/Yoast/wordpress-seo/pull/13676

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
