### PR TITLE
Implement focus style for the notification center buttons

### DIFF
--- a/css/src/alerts.scss
+++ b/css/src/alerts.scss
@@ -81,10 +81,28 @@ $yoast-alerts-active-margin: 20px;
 }
 
 .yoast-alerts .button.restore:hover,
-.yoast-alerts .button.dismiss:hover,
+.yoast-alerts .button.dismiss:hover {
+	background: transparent;
+}
+
 .yoast-alerts .button.restore:focus,
 .yoast-alerts .button.dismiss:focus {
 	background: transparent;
+
+	&::before {
+		content: "";
+		display: block;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		box-shadow: 0 0 0 1px #007cba;
+		/* Only visible in Windows High Contrast mode */
+		outline: 2px solid transparent;
+	}
 }
 
 .yoast-container .separator {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the notification center dismiss and restore buttons had no focus style.

## Relevant technical choices:
- I'd like to propose to use the "rounded focus style" that is an established pattern in WordPress, see screenshots below

## Test instructions
- before this patch
- go to SE) > General
- make sure you have Problems and Notifications showing up in the Notification center
- use the Tab key to navigate
- observe there's no focus style on the dismiss and restore buttons (the ones with the eyes icons)
- switch to this branch
- build the CSS
- repeat the steps above
- see the new focus style
- check the buttons can still be clicked with mouse and activated with keyboard
- check there are no layout glitches in the responsive view

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/641