### PR TITLE
Add premium/src folder to rules in premium-check-cs script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,9 +81,9 @@
 		],
 		"premium-check-cs": [
 			"@before-premium-cs",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,*/tests/load/wp-seo-premium.php,*/tests/premium/,*/src/premium/ --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,*/tests/load/wp-seo-premium.php,*/tests/premium/,*/premium/src/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ ./src/premium/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ ./premium/src/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
 		],
 		"check-cs-errors": [

--- a/composer.json
+++ b/composer.json
@@ -81,9 +81,9 @@
 		],
 		"premium-check-cs": [
 			"@before-premium-cs",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,*/tests/load/wp-seo-premium.php,*/tests/premium/ --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,*/tests/load/wp-seo-premium.php,*/tests/premium/,*/src/premium/ --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ ./src/premium/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
 		],
 		"check-cs-errors": [


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

* Adds the `premium/src` folder to the phpcs checks for 5.6 and explicitly ignores it for the 5.2 tests

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
