### PR TITLE
Fixes the indexable repository tests.

### DIFF
--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Free\Tests\Repositories;
 
 use Mockery\Mock;
 use Yoast\WP\Free\Builders\Indexable_Author_Builder;
+use Yoast\WP\Free\Builders\Indexable_Date_Archive_Builder;
 use Yoast\WP\Free\Builders\Indexable_Home_Page_Builder;
 use Yoast\WP\Free\Builders\Indexable_Post_Builder;
 use Yoast\WP\Free\Builders\Indexable_Post_Type_Archive_Builder;
@@ -18,7 +19,7 @@ use YoastSEO_Vendor\ORM;
 /**
  * @group indexables
  */
-class Indexable_Post_Builder_Test extends TestCase {
+class Indexable_Repository_Test extends TestCase {
 
 	/**
 	 * @var Indexable_Repository
@@ -34,6 +35,10 @@ class Indexable_Post_Builder_Test extends TestCase {
 
 		global $wpdb;
 
+		if ( !isset( $wpdb ) ) {
+			$wpdb = new \stdClass();
+		}
+
 		/*
 		 * This cannot be `prefix_` because a different test might mess it up.
 		 * That is the disadvantage of globals.
@@ -48,11 +53,12 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$wpdb->prefix = 'custom_prefix_';
 
 		$this->repository = new Indexable_Repository(
-			\Mockery::mock(Indexable_Author_Builder::class ),
+			\Mockery::mock( Indexable_Author_Builder::class ),
 			\Mockery::mock( Indexable_Post_Builder::class ),
 			\Mockery::mock( Indexable_Term_Builder::class ),
 			\Mockery::mock( Indexable_Home_Page_Builder::class ),
 			\Mockery::mock( Indexable_Post_Type_Archive_Builder::class ),
+			\Mockery::mock( Indexable_Date_Archive_Builder::class ),
 			\Mockery::mock( Indexable_System_Page_Builder::class ),
 			\Mockery::mock( Current_Page_Helper::class ),
 			new Logger(),


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

 * Adds the missing indexable date archive builder mock argument to the tested indexable repo.
 * Makes sure that the wpdb mock is properly initialized when no global wpdb exists yet.
 * Renames the test class to Indexable_Repository_Test.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run the PHP tests on free (by running `composer test`).
* Check that no tests fail.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
