### PR TITLE
Make sure twitter image id is set when building indexable

### DIFF
--- a/src/builders/indexable-home-page-builder.php
+++ b/src/builders/indexable-home-page-builder.php
@@ -61,6 +61,7 @@ class Indexable_Home_Page_Builder {
 
 		$indexable->og_title       = $this->options_helper->get( 'og_frontpage_title' );
 		$indexable->og_image       = $this->options_helper->get( 'og_frontpage_image' );
+		$indexable->og_image_id    = $this->options_helper->get( 'og_frontpage_image_id' );
 		$indexable->og_description = $this->options_helper->get( 'og_frontpage_desc' );
 
 		return $indexable;

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -143,6 +143,7 @@ class Indexable_Post_Builder {
 			'opengraph-description' => 'og_description',
 			'twitter-title'         => 'twitter_title',
 			'twitter-image'         => 'twitter_image',
+			'twitter-image-id'      => 'twitter_image_id',
 			'twitter-description'   => 'twitter_description',
 		];
 	}

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -125,6 +125,7 @@ class Indexable_Term_Builder {
 			'wpseo_twitter-title'         => 'twitter_title',
 			'wpseo_twitter-description'   => 'twitter_description',
 			'wpseo_twitter-image'         => 'twitter_image',
+			'wpseo_twitter-image-id'      => 'twitter_image_id',
 		];
 	}
 

--- a/tests/builders/indexable-home-page-builder-test.php
+++ b/tests/builders/indexable-home-page-builder-test.php
@@ -37,6 +37,7 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_title' )->andReturn( 'home_og_title' );
 		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_desc' )->andReturn( 'home_og_description' );
 		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_image' )->andReturn( 'home_og_image' );
+		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_image_id' )->andReturn( 1337 );
 
 		$url_helper_mock = Mockery::mock( Url_Helper::class );
 		$url_helper_mock->expects( 'home' )->once()->with()->andReturn( 'https://permalink' );
@@ -56,6 +57,7 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', false );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_title', 'home_og_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_image', 'home_og_image' );
+		$indexable_mock->orm->expects( 'set' )->with( 'og_image_id', 1337 );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_description', 'home_og_description' );
 
 		$builder = new Indexable_Home_Page_Builder( $options_helper_mock, $url_helper_mock );
@@ -75,6 +77,7 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_title' )->andReturn( 'home_og_title' );
 		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_desc' )->andReturn( 'home_og_description' );
 		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_image' )->andReturn( 'home_og_image' );
+		$options_helper_mock->expects( 'get' )->with( 'og_frontpage_image_id' )->andReturn( 1337 );
 
 		$url_helper_mock = Mockery::mock( Url_Helper::class );
 		$url_helper_mock->expects( 'home' )->once()->with()->andReturn( 'https://permalink' );
@@ -94,6 +97,7 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', false );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_title', 'home_og_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_image', 'home_og_image' );
+		$indexable_mock->orm->expects( 'set' )->with( 'og_image_id', 1337 );
 		$indexable_mock->orm->expects( 'set' )->with( 'og_description', 'home_og_description' );
 
 		$builder = new Indexable_Home_Page_Builder( $options_helper_mock, $url_helper_mock );

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -87,7 +87,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'twitter_image' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'twitter_image.jpg' );
-		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_id', null );
+		$indexable_mock->orm->expects( 'set' )->times( 2 )->with( 'twitter_image_id', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_id', 1 );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'featured-image' );

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -89,7 +89,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'twitter_image' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'image.jpg' );
-		$indexable_mock->orm->expects( 'set' )->times(2 )->with( 'twitter_image_id', null );
+		$indexable_mock->orm->expects( 'set' )->times( 2 )->with( 'twitter_image_id', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'first-content-image' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_description', 'twitter_description' );

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -89,7 +89,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'twitter_image' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'image.jpg' );
-		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_id', null );
+		$indexable_mock->orm->expects( 'set' )->times(2 )->with( 'twitter_image_id', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'first-content-image' );
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_description', 'twitter_description' );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set a twitter image for a post and verify in the indexables db table that the twitter_image_id is set.
* Do the same for a term
* Set an opengraph image for the homepage and make sure that in the record (db) for the homepage indexable the og-image-id is set

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
