### PR TITLE
Fix snippet preview image bug.

### DIFF
--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -102,6 +102,8 @@ class ClassicEditorData {
 	getFeaturedImage() {
 		var postThumbnail = $( ".attachment-post-thumbnail" );
 		if ( postThumbnail.length > 0 ) {
+			this.featuredImageIsSet = true;
+
 			return $( postThumbnail.get( 0 ) ).attr( "src" );
 		}
 

--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -103,14 +103,15 @@ class ClassicEditorData {
 	/**
 	 * Gets the featured image source from the DOM.
 	 *
-	 * @returns {string} The url to the featured image.
+	 * @returns {string|null} The url to the featured image.
 	 */
 	getFeaturedImage() {
-		var postThumbnail = $( ".attachment-post-thumbnail" );
-		if ( postThumbnail.length > 0 ) {
+		const postThumbnail = $( "#set-post-thumbnail img" ).attr( "src" );
+
+		if ( postThumbnail ) {
 			this.featuredImageIsSet = true;
 
-			return $( postThumbnail.get( 0 ) ).attr( "src" );
+			return postThumbnail;
 		}
 
 		this.featuredImageIsSet = false;

--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -70,19 +70,25 @@ class ClassicEditorData {
 
 		const url = this.getFeaturedImage() || this.getContentImage() || null;
 
-		this.setFeaturedImageInSnippetPreview( url );
+		this.setImageInSnippetPreview( url );
 
 		$( "#postimagediv" ).on( "click", "#remove-post-thumbnail", () => {
 			this.featuredImageIsSet = false;
 
-			this.setFeaturedImageInSnippetPreview( this.getContentImage() );
+			this.setImageInSnippetPreview( this.getContentImage() );
 		} );
 
 		const featuredImage = wp.media.featuredImage.frame();
 
 		featuredImage.on( "select", () => {
 			const newUrl = featuredImage.state().get( "selection" ).first().attributes.url;
-			this.setFeaturedImageInSnippetPreview( newUrl );
+
+			if ( ! newUrl ) {
+				return;
+			}
+
+			this.featuredImageIsSet = true;
+			this.setImageInSnippetPreview( newUrl );
 		} );
 
 		tmceHelper.addEventHandler( tmceId, [ "change" ], debounce( () => {
@@ -90,7 +96,7 @@ class ClassicEditorData {
 				return;
 			}
 
-			this.setFeaturedImageInSnippetPreview( this.getContentImage() );
+			this.setImageInSnippetPreview( this.getContentImage() );
 		}, 1000 ) );
 	}
 
@@ -119,7 +125,7 @@ class ClassicEditorData {
 	 *
 	 * @returns {void}
 	 */
-	setFeaturedImageInSnippetPreview( url ) {
+	setImageInSnippetPreview( url ) {
 		this._store.dispatch( updateData( { snippetPreviewImageURL: url } ) );
 	}
 
@@ -330,7 +336,7 @@ class ClassicEditorData {
 		}
 		// Handle image change.
 		if ( this._previousData.snippetPreviewImageURL !== newData.snippetPreviewImageURL ) {
-			this.setFeaturedImageInSnippetPreview( newData.snippetPreviewImageURL );
+			this.setImageInSnippetPreview( newData.snippetPreviewImageURL );
 		}
 	}
 
@@ -365,7 +371,6 @@ class ClassicEditorData {
 			excerpt_only: this.getExcerpt( false ),
 			slug: this.getSlug(),
 			content: this.getContent(),
-			snippetPreviewImageURL: this.getFeaturedImage() || this.getContentImage(),
 		};
 	}
 
@@ -381,7 +386,6 @@ class ClassicEditorData {
 			excerpt: this.getExcerpt(),
 			// eslint-disable-next-line
 			excerpt_only: this.getExcerpt( false ),
-			snippetPreviewImageURL: this.getFeaturedImage() || this.getContentImage(),
 		};
 	}
 }

--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -1,4 +1,4 @@
-/* global wp */
+/* global wp jQuery */
 
 /* External dependencies */
 import analysis from "yoastseo";
@@ -32,7 +32,7 @@ class ClassicEditorData {
 	 *
 	 * @returns {void}
 	 */
-	constructor( refresh, store, settings = { tinyMceId: "" } ) {
+	constructor( refresh, store, settings = { tinyMceId: tmceId } ) {
 		this._refresh = refresh;
 		this._store = store;
 		this._initialData = {};
@@ -68,10 +68,6 @@ class ClassicEditorData {
 			return;
 		}
 
-		const url = this.getFeaturedImage() || this.getContentImage() || null;
-
-		this.setImageInSnippetPreview( url );
-
 		$( "#postimagediv" ).on( "click", "#remove-post-thumbnail", () => {
 			this.featuredImageIsSet = false;
 
@@ -91,7 +87,13 @@ class ClassicEditorData {
 			this.setImageInSnippetPreview( newUrl );
 		} );
 
-		tmceHelper.addEventHandler( tmceId, [ "change" ], debounce( () => {
+		tmceHelper.addEventHandler( this._settings.tinyMceId, [ "init" ], () => {
+			const url = this.getFeaturedImage() || this.getContentImage() || null;
+
+			this.setImageInSnippetPreview( url );
+		} );
+
+		tmceHelper.addEventHandler( this._settings.tinyMceId, [ "change" ], debounce( () => {
 			if ( this.featuredImageIsSet ) {
 				return;
 			}
@@ -216,11 +218,7 @@ class ClassicEditorData {
 	 * @returns {string} The content of the document.
 	 */
 	getContent() {
-		let tinyMceId = this._settings.tinyMceId;
-
-		if ( tinyMceId === "" ) {
-			tinyMceId = tmceId;
-		}
+		const tinyMceId = this._settings.tinyMceId;
 
 		return removeMarks( tmceHelper.getContentTinyMce( tinyMceId ) );
 	}


### PR DESCRIPTION
Fixed bug where snippet preview image was set to content image when featured image was set

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

In the **classic editor** and **Gutenberg**
With **storefront** and **twentynineteen** theme.
For **post** and **term** edit pages.

* Add a featured image.
* Mobile snippet preview image should be the featured image.
* Add a content image.
* Make sure the mobile snippet preview image is not overwritten with the content image.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
