### PR TITLE
Move wpml filter to integration

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1107,6 +1107,10 @@ SVG;
 	 * @return string The home url.
 	 */
 	public static function get_home_url() {
+
+		/**
+		 * Action: 'wpseo_home_url' - Allows overriding of the home URL.
+		 */
 		do_action( 'wpseo_home_url' );
 
 		// If the plugin is network activated, use the network home URL.

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1104,7 +1104,11 @@ SVG;
 	/**
 	 * In case WPML is installed, returns the original home_url and not the WPML version.
 	 *
+	 * In case of a multisite setup we return the network_home_url.
+	 *
 	 * @return string The home url.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public static function get_home_url() {
 
@@ -1113,7 +1117,7 @@ SVG;
 		 */
 		do_action( 'wpseo_home_url' );
 
-		// If the plugin is network activated, use the network home URL.
+		// If the plugin is network-activated, use the network home URL.
 		if ( WPSEO_Utils::is_plugin_network_active() ) {
 			return network_home_url();
 		}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1102,8 +1102,9 @@ SVG;
 	}
 
 	/**
-	 * In case WPML is installed, returns the original home_url and not the WPML version.
+	 * Returns the unfiltered home URL.
 	 *
+	 * In case WPML is installed, returns the original home_url and not the WPML version.
 	 * In case of a multisite setup we return the network_home_url.
 	 *
 	 * @return string The home url.

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1109,6 +1109,11 @@ SVG;
 	public static function get_home_url() {
 		do_action( 'wpseo_home_url' );
 
+		// If the plugin is network activated, use the network home URL.
+		if ( WPSEO_Utils::is_plugin_network_active() ) {
+			return network_home_url();
+		}
+
 		return home_url();
 	}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1102,44 +1102,14 @@ SVG;
 	}
 
 	/**
-	 * Returns the home url with the following modifications:
-	 *
-	 * In case of a multisite setup we return the network_home_url.
-	 * In case of no multisite setup we return the home_url while overriding the WPML filter.
-	 *
-	 * @codeCoverageIgnore
+	 * In case WPML is installed, returns the original home_url and not the WPML version.
 	 *
 	 * @return string The home url.
 	 */
 	public static function get_home_url() {
-		// Add a new filter to undo WPML's changing of home url.
-		add_filter( 'wpml_get_home_url', array( 'WPSEO_Utils', 'wpml_get_home_url' ), 10, 2 );
+		do_action( 'wpseo_home_url' );
 
-		$url = home_url();
-
-		// If the plugin is network activated, use the network home URL.
-		if ( self::is_plugin_network_active() ) {
-			$url = network_home_url();
-		}
-
-		remove_filter( 'wpml_get_home_url', array( 'WPSEO_Utils', 'wpml_get_home_url' ), 10 );
-
-		return $url;
-	}
-
-	/**
-	 * Returns the original URL instead of the language-enriched URL.
-	 * This method gets automatically triggered by the wpml_get_home_url filter.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @param string $home_url The url altered by WPML. Unused.
-	 * @param string $url      The url that isn't altered by WPML.
-	 *
-	 * @return string The original url.
-	 */
-	public static function wpml_get_home_url( $home_url, $url ) {
-		return $url;
+		return home_url();
 	}
 
 	/**

--- a/src/conditionals/wpml-conditional.php
+++ b/src/conditionals/wpml-conditional.php
@@ -1,0 +1,17 @@
+<?php namespace Yoast\WP\Free\Conditionals;
+
+/**
+ * Class WPML_Conditional
+ * @package Yoast\WP\Free\Conditionals
+ */
+class WPML_Conditional implements Conditional {
+
+	/**
+	 * Returns whether or not this conditional is met.
+	 *
+	 * @return boolean Whether or not the conditional is met.
+	 */
+	public function is_met() {
+		return function_exists( 'icl_object_id' );
+	}
+}

--- a/src/conditionals/wpml-conditional.php
+++ b/src/conditionals/wpml-conditional.php
@@ -1,7 +1,15 @@
-<?php namespace Yoast\WP\Free\Conditionals;
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\YoastSEO\Conditionals
+ */
+
+namespace Yoast\WP\Free\Conditionals;
 
 /**
  * Class WPML_Conditional
+ *
  * @package Yoast\WP\Free\Conditionals
  */
 class WPML_Conditional implements Conditional {
@@ -12,6 +20,6 @@ class WPML_Conditional implements Conditional {
 	 * @return boolean Whether or not the conditional is met.
 	 */
 	public function is_met() {
-		return function_exists( 'icl_object_id' );
+		return defined( 'WPML_PLUGIN_FILE' );
 	}
 }

--- a/src/integrations/compatibility/wpml.php
+++ b/src/integrations/compatibility/wpml.php
@@ -33,19 +33,14 @@ class WPML implements Integration_Interface {
 	}
 
 	/**
-	 * Returns the home url with the following modifications:
-	 *
-	 * In case of a multisite setup we return the network_home_url.
-	 * In case of no multisite setup we return the home_url while overriding the WPML filter.
-	 *
-	 * @codeCoverageIgnore
+	 * Adds a filter to WPML's wpml_get_home_url filter to ensure we get the unmanipulated home URL.
 	 */
 	public function filter_home_url_before() {
 		add_filter( 'wpml_get_home_url', [ $this, 'wpml_get_home_url' ], 10, 2 );
 	}
 
 	/**
-	 * Removes the wpml_get_home_url filter to return the WPML, language-enrichted home URL.
+	 * Removes the wpml_get_home_url filter to return the WPML, language-enriched home URL.
 	 *
 	 * @param string $home_url The filtered home URL.
 	 *

--- a/src/integrations/compatibility/wpml.php
+++ b/src/integrations/compatibility/wpml.php
@@ -37,15 +37,6 @@ class WPML implements Integration_Interface {
 	 */
 	public function filter_home_url_before() {
 		add_filter( 'wpml_get_home_url', [ $this, 'wpml_get_home_url' ], 10, 2 );
-
-		$home_url = home_url();
-
-		// If the plugin is network activated, use the network home URL.
-		if ( WPSEO_Utils::is_plugin_network_active() ) {
-			$home_url = network_home_url();
-		}
-
-		return $home_url;
 	}
 
 	/**

--- a/src/integrations/compatibility/wpml.php
+++ b/src/integrations/compatibility/wpml.php
@@ -1,11 +1,18 @@
-<?php namespace Yoast\WP\Free\Integrations\Compatibility;
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\YoastSEO\Integrations
+ */
 
-use WPSEO_Utils;
+namespace Yoast\WP\Free\Integrations\Compatibility;
+
 use Yoast\WP\Free\Conditionals\WPML_Conditional;
 use Yoast\WP\Free\Integrations\Integration_Interface;
 
 /**
  * Class WPML
+ *
  * @package Yoast\WP\Free\Integration\Compatibility
  */
 class WPML implements Integration_Interface {
@@ -14,8 +21,8 @@ class WPML implements Integration_Interface {
 	 * @inheritDoc
 	 */
 	public function register_hooks() {
-		add_action( 'wpseo_home_url', 	[ $this, 'filter_home_url_before' ] );
-		add_filter( 'home_url', 		[ $this, 'filter_home_url_after' ], 100 );
+		add_action( 'wpseo_home_url', [ $this, 'filter_home_url_before' ] );
+		add_filter( 'home_url', [ $this, 'filter_home_url_after' ], 100 );
 	}
 
 	/**
@@ -32,8 +39,6 @@ class WPML implements Integration_Interface {
 	 * In case of no multisite setup we return the home_url while overriding the WPML filter.
 	 *
 	 * @codeCoverageIgnore
-	 *
-	 * @return string The home url.
 	 */
 	public function filter_home_url_before() {
 		add_filter( 'wpml_get_home_url', [ $this, 'wpml_get_home_url' ], 10, 2 );
@@ -47,9 +52,9 @@ class WPML implements Integration_Interface {
 	 * @return string The unfiltered home URL.
 	 */
 	public function filter_home_url_after( $home_url ) {
-    	remove_filter( 'wpml_get_home_url', [ $this, 'wpml_get_home_url' ], 10 );
+		remove_filter( 'wpml_get_home_url', [ $this, 'wpml_get_home_url' ], 10 );
 
-    	return $home_url;
+		return $home_url;
 	}
 
 	/**

--- a/src/integrations/compatibility/wpml.php
+++ b/src/integrations/compatibility/wpml.php
@@ -14,8 +14,8 @@ class WPML implements Integration_Interface {
 	 * @inheritDoc
 	 */
 	public function register_hooks() {
-		add_action( 'wpseo_home_url', [ $this, 'filter_home_url_before' ] );
-		add_filter( 'home_url', 	  [ $this, 'filter_home_url_after' ], 100 );
+		add_action( 'wpseo_home_url', 	[ $this, 'filter_home_url_before' ] );
+		add_filter( 'home_url', 		[ $this, 'filter_home_url_after' ], 100 );
 	}
 
 	/**

--- a/src/integrations/compatibility/wpml.php
+++ b/src/integrations/compatibility/wpml.php
@@ -1,0 +1,78 @@
+<?php namespace Yoast\WP\Free\Integrations\Compatibility;
+
+use WPSEO_Utils;
+use Yoast\WP\Free\Conditionals\WPML_Conditional;
+use Yoast\WP\Free\Integrations\Integration_Interface;
+
+/**
+ * Class WPML
+ * @package Yoast\WP\Free\Integration\Compatibility
+ */
+class WPML implements Integration_Interface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		add_action( 'wpseo_home_url', [ $this, 'filter_home_url_before' ] );
+		add_filter( 'home_url', 	  [ $this, 'filter_home_url_after' ], 100 );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ WPML_Conditional::class ];
+	}
+
+	/**
+	 * Returns the home url with the following modifications:
+	 *
+	 * In case of a multisite setup we return the network_home_url.
+	 * In case of no multisite setup we return the home_url while overriding the WPML filter.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return string The home url.
+	 */
+	public function filter_home_url_before() {
+		add_filter( 'wpml_get_home_url', [ $this, 'wpml_get_home_url' ], 10, 2 );
+
+		$home_url = home_url();
+
+		// If the plugin is network activated, use the network home URL.
+		if ( WPSEO_Utils::is_plugin_network_active() ) {
+			$home_url = network_home_url();
+		}
+
+		return $home_url;
+	}
+
+	/**
+	 * Removes the wpml_get_home_url filter to return the WPML, language-enrichted home URL.
+	 *
+	 * @param string $home_url The filtered home URL.
+	 *
+	 * @return string The unfiltered home URL.
+	 */
+	public function filter_home_url_after( $home_url ) {
+    	remove_filter( 'wpml_get_home_url', [ $this, 'wpml_get_home_url' ], 10 );
+
+    	return $home_url;
+	}
+
+	/**
+	 * Returns the original URL instead of the language-enriched URL.
+	 * This method gets automatically triggered by the wpml_get_home_url filter.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $home_url The url altered by WPML. Unused.
+	 * @param string $url      The url that isn't altered by WPML.
+	 *
+	 * @return string The original url.
+	 */
+	public function wpml_get_home_url( $home_url, $url ) {
+		return $url;
+	}
+}


### PR DESCRIPTION
## Summary

Moves the `WPSEO_Utils::get_home_url()` method to an integration, as this method is only necessary if WPML is installed.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the `WPSEO_Utils::get_home_url()` method to an integration.

## Relevant technical choices:

* This is purely a move of some code and doesn't change any of the workings.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Please note: We have a login for WPML in the LastPass shared-licenses vault**

* Ensure that the tests pass.

**Testing the 'moved' filters**
* Ensure you have added `define( 'YOAST_SEO_EXPERIMENTAL_PHP56', true );` to your `wp-config.php`.
* Ensure you have an environment running with WPML and have a primary and secondary language configured.
* First, add the following snippet to your theme's `functions.php`: `var_dump( WPSEO_Utils::get_home_url() );`.
* Refresh a page in your testing environment. Doing so on the front-end makes it easier to spot the output.
* Ensure that the value on your primary language's page equals your 'regular' home URL (i.e. `acceptance.test`).
* Navigate to your secondary language's page (i.e. `acceptance.test/nl`).
* Ensure that the value also equals your 'regular' home URL.
* Checkout this branch, run `composer install` and refresh the page again.
* Ensure that the value on your primary language's page equals your 'regular' home URL (i.e. `acceptance.test`).
* Do the same test again for your secondary language and ensure this still displays the same URL.

**Testing the conditional**
* Navigate to the `src/conditionals/wpml-conditional.php` file and change the `is_met` method to return false.
* Ensure that the value on your primary language's page equals your 'regular' home URL (i.e. `acceptance.test`).
* Ensure that the value on your secondary language's page **does not** equals your 'regular' home URL (i.e. `acceptance.test`) and instead displays the language as well.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
