### PR TITLE
Fix the height of select2 inputs when zooming in in WP 5.3

### DIFF
--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -58,6 +58,19 @@
 	min-height: 0;
 }
 
+/* Turn off select2 fixed height */
+.wpseo-admin-page {
+	.select2-container {
+		.select2-selection--single {
+			height: auto;
+
+			.select2-selection__arrow {
+				height: 100%;
+			}
+		}
+	}
+}
+
 .yoast-label-strong {
 	font-weight: 600;
 }

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -59,6 +59,7 @@
 }
 
 /* Turn off select2 fixed height */
+.wpseo-metabox,
 .wpseo-admin-page {
 	.select2-container {
 		.select2-selection--single {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the size of select2 input boxes would not increase in WordPress 5.3 when zooming in in Firefox.

## Relevant technical choices:

* This CSS ensures that the 28px height of select2 inputs is only overwritten on wordpress-seo and wpseo-local admin pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See #13722 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13722 

In case of questions, please ask @rubsel. I merely put his code in this PR.
