### PR TITLE
Assign jQuery to its $ alias.

### DIFF
--- a/js/src/analysis/classicEditorData.js
+++ b/js/src/analysis/classicEditorData.js
@@ -15,6 +15,8 @@ import {
 } from "../helpers/replacementVariableHelpers";
 import tmceHelper, { tmceId } from "../wp-seo-tinymce";
 
+const $ = jQuery;
+
 /**
  * Represents the classic editor data.
  */


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Fixes jQuery assignment after https://github.com/Yoast/wordpress-seo/pull/13692

## Relevant technical choices:

- There was a missing assignment for the `$` alias, added `const $ = jQuery;`
- With Classic Editor activated this was causing the meta box to not render

## Test instructions
- to reproduce the error on release/12.4: activate the Classic Editor plugin
- edit a post
- see the meta box doesn't render
- console error in Chrome: `classicEditorData.js?7ad1:101 Uncaught TypeError: $ is not a function`
- switch to this branch and build
- edit a post (maybe refresh)
- see the meta box renders correctly
- test setting / removing a featured image and check everything works as expected

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

