### PR TITLE
Remove the functionality regarding Twitter site

### DIFF
--- a/frontend/class-twitter.php
+++ b/frontend/class-twitter.php
@@ -67,8 +67,6 @@ class WPSEO_Twitter {
 	public function twitter() {
 		wp_reset_query();
 
-		$this->site_twitter();
-
 		if ( is_singular() ) {
 			$this->author();
 		}
@@ -102,38 +100,6 @@ class WPSEO_Twitter {
 
 		// Output meta.
 		echo '<meta ', esc_attr( $metatag_key ), '="twitter:', esc_attr( $name ), '" content="', $value, '" />', "\n";
-	}
-
-	/**
-	 * Displays the Twitter account for the site.
-	 */
-	protected function site_twitter() {
-		switch ( WPSEO_Options::get( 'company_or_person', '' ) ) {
-			case 'person':
-				$user_id = (int) WPSEO_Options::get( 'company_or_person_user_id', false );
-				$twitter = get_the_author_meta( 'twitter', $user_id );
-				// For backwards compat reasons, if there is no twitter ID for person, we fall back to site.
-				if ( empty( $twitter ) ) {
-					$twitter = WPSEO_Options::get( 'twitter_site' );
-				}
-				break;
-			case 'company':
-			default:
-				$twitter = WPSEO_Options::get( 'twitter_site' );
-				break;
-		}
-
-		/**
-		 * Filter: 'wpseo_twitter_site' - Allow changing the Twitter site account as output in the Twitter card by Yoast SEO.
-		 *
-		 * @api string $unsigned Twitter site account string.
-		 */
-		$site = apply_filters( 'wpseo_twitter_site', $twitter );
-		$site = $this->get_twitter_id( $site );
-
-		if ( is_string( $site ) && $site !== '' ) {
-			$this->output_metatag( 'site', '@' . $site );
-		}
 	}
 
 	/**

--- a/integration-tests/frontend/test-class-twitter.php
+++ b/integration-tests/frontend/test-class-twitter.php
@@ -54,18 +54,6 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * @covers WPSEO_Twitter::site_twitter
-	 */
-	public function test_site_twitter() {
-		// Test valid option.
-		WPSEO_Options::set( 'twitter_site', 'yoast' );
-		$expected = $this->metatag( 'site', '@yoast' );
-
-		self::$class_instance->site_twitter();
-		$this->expectOutput( $expected );
-	}
-
-	/**
 	 * @covers WPSEO_Twitter::author
 	 */
 	public function test_author_twitter() {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the twitter:site tag is no longer rendered in the frontend.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
