### PR TITLE
Disables the forcerewritetitle option

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -146,6 +146,7 @@ class WPSEO_Upgrade {
 		}
 
 		if ( version_compare( $version, '12.5-RC0', '<' ) ) {
+			// We have to run this by hook, because otherwise the theme support check isn't available.
 			add_action( 'init', array( $this, 'upgrade_125' ) );
 		}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -146,7 +146,7 @@ class WPSEO_Upgrade {
 		}
 
 		if ( version_compare( $version, '12.5-RC0', '<' ) ) {
-			$this->upgrade_125();
+			add_action( 'init', array( $this, 'upgrade_125' ) );
 		}
 
 		// Since 3.7.
@@ -732,7 +732,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Performs the 12.5 upgrade.
 	 */
-	private function upgrade_125() {
+	public function upgrade_125() {
 		if ( WPSEO_Options::get( 'forcerewritetitle', false ) && current_theme_supports( 'title-tag' ) ) {
 			WPSEO_Options::set( 'forcerewritetitle', false );
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -145,6 +145,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_124();
 		}
 
+		if ( version_compare( $version, '12.5-RC0', '<' ) ) {
+			$this->upgrade_125();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -723,6 +727,15 @@ class WPSEO_Upgrade {
 	private function upgrade_124() {
 		$this->cleanup_option_data( 'wpseo_social', 'google_plus_url' );
 		$this->cleanup_option_data( 'wpseo_social', 'plus-publisher' );
+	}
+
+	/**
+	 * Performs the 12.5 upgrade.
+	 */
+	private function upgrade_125() {
+		if ( WPSEO_Options::get( 'forcerewritetitle', false ) && current_theme_supports( 'title-tag' ) ) {
+			WPSEO_Options::set( 'forcerewritetitle', false );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* When theme has `title-tag` support and the forcerewritetitle option is enabled, we should disable it.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Put the next line of code somewhere in your WordPress installation:
```php
add_action( 'init', function() {
WPSEO_Options::set( 'forcerewritetitle', true );
} ); 
```
* Check in your database if the option is set correctly (table `wp_options` where the `option_name` is `wpseo_titles`).
* Remove the code you added above.
* Run the upgrade routine
* Check the option value for `forcerewritetitle` is set to false.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
