### PR TITLE
Removed WordPress update notice

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -42,7 +42,6 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_init', array( $this, 'yoast_plugin_suggestions_notification' ), 15 );
 		add_action( 'admin_init', array( $this, 'recalculate_notice' ), 15 );
 		add_action( 'admin_init', array( $this, 'unsupported_php_notice' ), 15 );
-		add_action( 'admin_init', array( $this, 'wordpress_upgrade_notice' ), 15 );
 		add_action( 'admin_init', array( $this->asset_manager, 'register_assets' ) );
 		add_action( 'admin_init', array( $this, 'show_hook_deprecation_warnings' ) );
 		add_action( 'admin_init', array( 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ) );
@@ -379,79 +378,6 @@ class WPSEO_Admin_Init {
 
 		// Strip the patch version and convert to a float.
 		return (float) $wp_version_latest;
-	}
-
-	/**
-	 * Creates a WordPress upgrade notification in the notification center.
-	 *
-	 * @return void
-	 */
-	public function wordpress_upgrade_notice() {
-		global $wp_version;
-
-		$latest_major_wp_version = number_format( $this->get_latest_major_wordpress_version(), 1 );
-		$next_major_wp_version   = number_format( ( $latest_major_wp_version + 0.1 ), 1 );
-
-		$wp_less_than_50             = version_compare( $wp_version, '5.0', '<' );
-		$wp_less_than_latest_version = version_compare( $wp_version, $latest_major_wp_version, '<' );
-
-		$notification_center = Yoast_Notification_Center::get();
-
-		$message = sprintf(
-			/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag, %3$s expands to a html break, %4$s expands to Yoast, %5$s expands to Yoast SEO, %6$s expands to the latest major released WP version, %7$s expands to the next major WP release version */
-			__(
-				'%1$sUpgrade WordPress to the most recent version%2$s%3$sWe’ve noticed that you’re not on the latest WordPress version, which might cause an issue soon. %4$s (for reasons of security and stability) only supports the current and previous version of WordPress. When the next version of WordPress comes out, that means that we will support WordPress %6$s and %7$s. This means you will not get any updates to %5$s until you update your WordPress, so please make sure to upgrade to the latest WordPress version soon!%3$s%3$s',
-				'wordpress-seo'
-			),
-			'<strong>',
-			'</strong>',
-			'<br/>',
-			'Yoast',
-			'Yoast SEO',
-			$latest_major_wp_version,
-			$next_major_wp_version
-		);
-		if ( $wp_less_than_50 ) {
-			$message .= sprintf(
-				/* translators: %1$s expands to Yoast SEO, %2$s expands to 5.0 */
-				__(
-					'If you’ve held off on updating to %2$s and higher because of the new Gutenberg editor, please install the Classic Editor plugin. It will give you the same editing experience you have now, but also the security of newer versions of WordPress and %1$s.',
-					'wordpress-seo'
-				),
-				'Yoast SEO',
-				'5.0'
-			);
-		}
-		$message .= '<br/><br/>';
-		$message .= sprintf(
-			/* translators: %1$s expands to an opening anchor tag, %2$s expands to a closing anchor tag */
-			__(
-				'Read %1$sthis post for more information about why we’re not supporting older versions.%2$s',
-				'wordpress-seo'
-			),
-			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/old-wp-support' ) . '" target="_blank" rel="nofollow">',
-			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
-		);
-
-		$notification = new Yoast_Notification(
-			$message,
-			array(
-				'type' => Yoast_Notification::ERROR,
-				'id'   => 'wpseo-dismiss-wordpress-upgrade',
-			)
-		);
-
-		if ( $wp_less_than_latest_version ) {
-			// If the latest WordPress version is not known, do not initiate the WordPress upgrade notice.
-			if ( $this->get_latest_major_wordpress_version() === 0 ) {
-				$notification_center->remove_notification( $notification );
-				return;
-			}
-
-			$notification_center->add_notification( $notification );
-			return;
-		}
-		$notification_center->remove_notification( $notification );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -145,6 +145,10 @@ class WPSEO_Upgrade {
 			$this->upgrade_124();
 		}
 
+		if ( version_compare( $version, '12.5-RC0', '<' ) ) {
+			$this->upgrade_125();
+		}
+
 		// Since 3.7.
 		$upsell_notice = new WPSEO_Product_Upsell_Notice();
 		$upsell_notice->set_upgrade_notice();
@@ -722,6 +726,17 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_124() {
 		$this->cleanup_option_data( 'wpseo_social' );
+	}
+
+	/**
+	 * Performs the 12.5 upgrade.
+	 *
+	 * Removes the WordPress update notification, because it is no longer necessary when WordPress
+	 * 5.3 is released.
+	 */
+	private function upgrade_125() {
+		$center = Yoast_Notification_Center::get();
+		$center->remove_notification_by_id( 'wpseo-dismiss-wordpress-upgrade' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removed the WordPress update notice, because it is no longer needed after WordPress 5.3 has been released.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out `trunk` and build.
* In `class-admin-init.php` in `wordpress_upgrade_notice` replace `global $wp_version;` by `$wp_version = '4.9'`.
* Go to the SEO dashboard and make sure the notification is present.
* Undo the change.
* Check out `13747-remove-wp-update-notice` (this PR's branch) and build.
* Install the `Yoast test helper`, and trigger the upgrade routine by setting `Yoast SEO` version to 12.3 and saving. 
* Check if the notification is gone in the SEO dashboard.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13747 
