### PR TITLE
Add a migration for prominent word indexable column

### DIFF
--- a/migrations/20191029111111_WpYoastProminentWordIndexableColumn.php
+++ b/migrations/20191029111111_WpYoastProminentWordIndexableColumn.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\Free\ORM\Yoast_Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * Class WpYoastProminentWordIndexableColumn
+ */
+class WpYoastProminentWordIndexableColumn extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$table_name = $this->get_table_name();
+
+		$this->add_column( $table_name, 'prominent_words_version', 'integer', [
+			'null'     => true,
+			'limit'    => 11,
+			'unsigned' => true,
+			'default'  => null,
+		] );
+
+		$this->add_index(
+			$table_name,
+			'prominent_words_version',
+			[
+				'name' => 'prominent_words_version',
+			]
+		);
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		$table_name = $this->get_table_name();
+
+		$this->remove_column( $table_name, 'prominent_words_version' );
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Yoast_Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -59,6 +59,8 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  * @property string  $twitter_image_id
  * @property string  $twitter_image_source
  * @property string  $twitter_card
+ *
+ * @property int     $prominent_words_version
  */
 class Indexable extends Yoast_Model {
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a migration for the `prominent_word_version` column on `indexable`

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Replication
* Remove the columns `prominent_word_version` and `prominent_word_vector_length` from the `wp-yoast-indexable` table of the database of your local WP site [if you have those].
* Remove the migration `20190813111111` from the list in `wp_yoast_migrations`[if you have it].
* Check out the `feature/indexables-frontend` branch.
* Build the plugin.
* Open any page in your local environment (e.g., Post Editor).
* Verify that there is no column `prominent_word_version` in the `wp-yoast-indexable` table of the database.

### Testing
* Remove the columns `prominent_word_version` and `prominent_word_vector_length` from the `wp-yoast-indexable` table of the database of your local WP site [if you have those].
* Remove the migration `20190813111111` from the list in `wp_yoast_migrations`[if you have it].
* Check out the `13701-add-migration-for-prominent-word-indexable-column` branch.
* Build the plugin.
* Open any page in your local environment.
* Verify that the column `prominent_word_version` appeared in the `wp-yoast-indexable` table of the database and a migration `20191029111111` appeared in the list of migrations in `wp-yoast-migrations`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13701 
