### PR TITLE
Add indexing controls integration

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -68,11 +68,6 @@ class WPSEO_Frontend {
 
 		add_action( 'wp', array( $this, 'page_redirect' ), 99 );
 
-		add_action( 'template_redirect', array( $this, 'noindex_robots' ) );
-
-		add_filter( 'loginout', array( $this, 'nofollow_link' ) );
-		add_filter( 'register', array( $this, 'nofollow_link' ) );
-
 		// Add support for shortcodes to category descriptions.
 		add_filter( 'category_description', array( $this, 'custom_category_descriptions_add_shortcode_support' ) );
 
@@ -194,35 +189,6 @@ class WPSEO_Frontend {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Send a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
-	 * to follow the links in the object at the URL.
-	 *
-	 * @since 1.1.7
-	 * @return boolean Boolean indicating whether the noindex header was sent.
-	 */
-	public function noindex_robots() {
-
-		if ( ( is_robots() ) && headers_sent() === false ) {
-			header( 'X-Robots-Tag: noindex, follow', true );
-
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Adds rel="nofollow" to a link, only used for login / registration links.
-	 *
-	 * @param string $input The link element as a string.
-	 *
-	 * @return string
-	 */
-	public function nofollow_link( $input ) {
-		return str_replace( '<a ', '<a rel="nofollow" ', $input );
 	}
 
 	/**
@@ -960,6 +926,39 @@ class WPSEO_Frontend {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
 
 		return $content;
+	}
+
+	/**
+	 * Send a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
+	 * to follow the links in the object at the URL.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @deprecated xx.x
+	 *
+	 * @since 1.1.7
+	 * @return boolean Boolean indicating whether the noindex header was sent.
+	 */
+	public function noindex_robots() {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+
+		return false;
+	}
+	/**
+	 * Adds rel="nofollow" to a link, only used for login / registration links.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @deprecated xx.x
+	 *
+	 * @param string $input The link element as a string.
+	 *
+	 * @return string
+	 */
+	public function nofollow_link( $input ) {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+
+		return '';
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -929,7 +929,7 @@ class WPSEO_Frontend {
 	}
 
 	/**
-	 * Send a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
+	 * Sends a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
 	 * to follow the links in the object at the URL.
 	 *
 	 * @codeCoverageIgnore

--- a/integration-tests/frontend/test-class-wpseo-frontend.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend.php
@@ -45,14 +45,6 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 		update_option( 'posts_per_page', 10 );
 	}
 
-	/**
-	 * @covers WPSEO_Frontend::nofollow_link
-	 */
-	public function test_nofollow_link() {
-		$input    = '<a href="#">A link</a>';
-		$expected = str_replace( '<a ', '<a rel="nofollow" ', $input );
-		$this->assertEquals( $expected, self::$class_instance->nofollow_link( $input ) );
-	}
 
 
 	/**

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\Free\Integrations\Front_End
+ */
+
+namespace Yoast\WP\Free\Integrations\Front_End;
+
+use Yoast\WP\Free\Conditionals\Front_End_Conditional;
+use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Integrations\Integration_Interface;
+
+/**
+ * Class Indexing_Controls
+ */
+class Indexing_Controls implements Integration_Interface {
+
+	/**
+	 * @codeCoverageIgnore
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Front_End_Conditional::class ];
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		\add_action( 'template_redirect', [ $this, 'noindex_robots' ] );
+		\add_filter( 'loginout', [ $this, 'nofollow_link' ] );
+		\add_filter( 'register', [ $this, 'nofollow_link' ] );
+	}
+
+	/**
+	 * Send a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
+	 * to follow the links in the object at the URL.
+	 *
+	 * @since 1.1.7
+	 *
+	 * @return boolean Boolean indicating whether the noindex header was sent.
+	 */
+	public function noindex_robots() {
+		if ( ! is_robots() ) {
+			return false;
+		}
+
+		return $this->set_robots_header();
+	}
+
+	/**
+	 * Adds rel="nofollow" to a link, only used for login / registration links.
+	 *
+	 * @param string $input The link element as a string.
+	 *
+	 * @return string
+	 */
+	public function nofollow_link( $input ) {
+		return str_replace( '<a ', '<a rel="nofollow" ', $input );
+	}
+
+	/**
+	 * Sets the x-robots-tag to noindex follow.
+	 *
+	 * @codeCoverageIgnore To difficult to test.
+	 */
+	protected function set_robots_header() {
+		if ( headers_sent() === false ) {
+			header( 'X-Robots-Tag: noindex, follow', true );
+
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -35,7 +35,7 @@ class Indexing_Controls implements Integration_Interface {
 	}
 
 	/**
-	 * Send a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
+	 * Sends a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
 	 * to follow the links in the object at the URL.
 	 *
 	 * @since 1.1.7
@@ -64,7 +64,7 @@ class Indexing_Controls implements Integration_Interface {
 	/**
 	 * Sets the x-robots-tag to noindex follow.
 	 *
-	 * @codeCoverageIgnore To difficult to test.
+	 * @codeCoverageIgnore Too difficult to test.
 	 */
 	protected function set_robots_header() {
 		if ( headers_sent() === false ) {

--- a/tests/integrations/front-end/indexing-controls-test.php
+++ b/tests/integrations/front-end/indexing-controls-test.php
@@ -68,7 +68,7 @@ class Indexing_Controls_Test extends TestCase {
 	}
 
 	/**
-	 * Tests if the link is converted to a no follow one.
+	 * Tests if the link is converted to a no-follow one.
 	 *
 	 * @covers ::nofollow_link
 	 */

--- a/tests/integrations/front-end/indexing-controls-test.php
+++ b/tests/integrations/front-end/indexing-controls-test.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ */
+
+namespace Yoast\WP\Free\Tests\Integrations\Front_End;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\Free\Integrations\Front_End\Indexing_Controls;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @coversDefaultClass \Yoast\WP\Free\Integrations\Front_End\Indexing_Controls
+ * @covers ::<!public>
+ *
+ * @group integrations
+ * @group front-end
+ */
+class Indexing_Controls_Test extends TestCase {
+
+	/**
+	 * The test instance.
+	 *
+	 * @var Indexing_Controls|Mockery\MockInterface
+	 */
+	private $instance;
+
+	/**
+	 * Sets an instance for test purposes.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = Mockery::mock( Indexing_Controls::class )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+	/**
+	 * Tests the situation where the request is performed by a robot.
+	 *
+	 * @covers ::noindex_robots
+	 */
+	public function test_no_index_robots() {
+		Monkey\Functions\expect( 'is_robots' )
+			->once()
+			->andReturn( true );
+
+		$this->instance
+			->shouldReceive( 'set_robots_header' )
+			->once()
+			->andReturnTrue();
+
+		$this->assertTrue( $this->instance->noindex_robots() );
+	}
+
+	/**
+	 * Tests the situation where the request isn't performed by a robot.
+	 *
+	 * @covers ::noindex_robots
+	 */
+	public function test_no_index_and_is_no_robots() {
+		Monkey\Functions\expect( 'is_robots' )->once()->andReturn( false );
+
+		$this->instance->shouldNotReceive( 'set_robots_header' );
+
+		$this->assertFalse( $this->instance->noindex_robots() );
+	}
+
+	/**
+	 * Tests if the link is converted to a no follow one.
+	 *
+	 * @covers ::nofollow_link
+	 */
+	public function test_nofollow_link() {
+		$this->assertEquals(
+			'<a rel="nofollow" href="#">A link</a>',
+			$this->instance->nofollow_link( '<a href="#">A link</a>' )
+		);
+	}
+
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the frontpage of your installation and in the meta widget you should have a login or logout link. Verify this one has the `rel="nofollow"` attribute.
* The other one is tricky, you have to be a robot to test this. Are you 3CPO? Maybe you can ask Bassie and Adriaan to help you.
* I would test this by reversing the if-statement in the code. Go to the line that says `! is_robot()` and change it to `is_robot()` and check if you have the header. This can be done by checking the network tab in the webmaster tools.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

