### PR TITLE
Fixes the dev server with YoastSEO.js

### DIFF
--- a/js/src/wp-seo-analysis-worker.js
+++ b/js/src/wp-seo-analysis-worker.js
@@ -1,9 +1,11 @@
 // Ensure the global window is set, our dependencies use it.
 self.window = self;
 
+const originalUrl = self.yoastOriginalUrl || self.location.href;
+
 // We only know the URL of the worker script, so base all other files names on that.
-self.importScripts( self.location.href.replace( "wp-seo-analysis-worker", "commons" ) );
-self.importScripts( self.location.href.replace( "wp-seo-analysis-worker", "analysis" ) );
+self.importScripts( originalUrl.replace( "wp-seo-analysis-worker", "commons" ) );
+self.importScripts( originalUrl.replace( "wp-seo-analysis-worker", "analysis" ) );
 
 import "babel-polyfill";
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the dev server

The dev server was broken after the importScripts were introduced.
This was because the web worker would sometimes be loaded in a blob.
When loaded in a blob `self.location.href` is the blob URL and the
URLs of the other URLs cannot be deduced. The `createWorker` method
now adds a global variable `yoastOriginalUrl` so we can use that
instead of `self.location.href`.

## Test instructions

* Make sure the dev server works.

Needs to be tested together with https://github.com/Yoast/javascript/pull/391

Fixes #13367
