### PR TITLE
Tests: remove incorrect `@covers` tags

### DIFF
--- a/tests/admin/admin-asset-analysis-worker-location-test.php
+++ b/tests/admin/admin-asset-analysis-worker-location-test.php
@@ -11,7 +11,6 @@ use Yoast\WP\Free\Tests\TestCase;
  * Tests WPSEO_Admin_Asset.
  *
  * @coversDefaultClass WPSEO_Admin_Asset_Analysis_Worker_Location
- * @covers <!public>
  */
 final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -16,7 +16,6 @@ use Yoast\WP\Free\Tests\TestCase;
  * @package Yoast\Tests\Admin
  *
  * @coversDefaultClass WPSEO_Admin
- * @covers <!public>
  */
 class Admin_Features_Test extends TestCase {
 

--- a/tests/admin/metabox/metabox-test.php
+++ b/tests/admin/metabox/metabox-test.php
@@ -13,7 +13,6 @@ use Yoast\WP\Free\Tests\TestCase;
  * @group Metabox
  *
  * @coversDefaultClass \WPSEO_Metabox
- * @covers <!public>
  */
 class Metabox_Test extends TestCase {
 

--- a/tests/admin/myyoast-proxy-test.php
+++ b/tests/admin/myyoast-proxy-test.php
@@ -14,7 +14,6 @@ use Yoast\WP\Free\Tests\TestCase;
  * @group MyYoast
  *
  * @coversDefaultClass WPSEO_MyYoast_Proxy
- * @covers <!public>
  */
 class MyYoast_Proxy_Test extends TestCase {
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

`@covers ClassName::<!public>` means that a test covers the methods in a class that are _not_ public.

Most of these tests are actually testing `public` methods, so the indicator is incorrect. Aside from that that, `<!public>` without class or `::` is incorrect as an annotation and PHPUnit has been complaining about this for a while (see detailed Travis output).



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
