### PR TITLE
Tests: fix incorrect `@covers` tags

### DIFF
--- a/tests/inc/options/option-social-test.php
+++ b/tests/inc/options/option-social-test.php
@@ -162,7 +162,7 @@ class Option_Social_Test extends TestCase {
 	/**
 	 * Tests the Facebook App ID validation method with an invalid ID.
 	 *
-	 * @covers Yoast_Input_Validation::validate_facebook_app_id
+	 * @covers WPSEO_Option_Social::validate_facebook_app_id
 	 */
 	public function test_facebook_app_id_is_invalid() {
 		Monkey\Functions\stubs(
@@ -221,7 +221,7 @@ class Option_Social_Test extends TestCase {
 	/**
 	 * Tests the Facebook App ID validation method with a valid ID.
 	 *
-	 * @covers Yoast_Input_Validation::validate_facebook_app_id
+	 * @covers WPSEO_Option_Social::validate_facebook_app_id
 	 */
 	public function test_facebook_app_id_is_valid() {
 		$GLOBALS['wp_settings_errors'] = [];


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

The tags were referring to a class which didn't contain the method being tested.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.