### PR TITLE
Stop explicit support for PHP < 5.6 /  WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: xenial
-sudo: false
 
 services:
   - mysql
@@ -25,17 +24,13 @@ jobs:
   fast_finish: true
   include:
     - php: 7.2
-      env: WP_VERSION=latest PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION="10.16" AUTO_CHECKOUT_MONOREPO_BRANCH=1
+      env: PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION="10.16" AUTO_CHECKOUT_MONOREPO_BRANCH=1
     - php: 7.3
       env: WP_VERSION=latest PHPLINT=1 WP_MULTISITE=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=latest PHPUNIT=1
+      env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
-    - php: 5.2
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPLINT=1
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
     - php: "7.4snapshot"
@@ -100,6 +95,7 @@ jobs:
       env: WP_VERSION=master PHPUNIT=1
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
+
 cache:
   yarn: true
   directories:
@@ -119,7 +115,7 @@ before_install:
 
 install:
 - |
-  if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then
+  if [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" || "$TRAVIS_BUILD_STAGE_NAME" == "🚀 deployment" ]]; then
     # The prefix-dependencies task only works on PHP 7.1 and we need to prefix our dependencies to accurately test them.
     # So we temporarily switch PHP versions, do a full install and then remove the package.
     # Then switch back to the PHP version we want to test and delete the vendor directory.
@@ -138,10 +134,14 @@ install:
     composer require phpunit/phpcov ^3.1
   fi
 - |
-  if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then
+  if [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$COVERAGE" == "1" ]]; then
     # Run composer update as we have dev dependencies locked at PHP ^7.0 versions.
     composer update
     composer install --no-scripts --no-interaction
+    composer du
+  elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "🚀 deployment" ]]; then
+    composer update
+    composer install --no-dev --no-interaction
     composer du
   fi
 - |
@@ -158,7 +158,7 @@ install:
 before_script:
 # Careful: The HTTPS version of the following URL is different, therefore we need to use HTTP.
 - |
-  if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then
+  if [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" ]]; then
     if [[ "$WP_VERSION" == "latest" ]]; then
       curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
       WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
@@ -232,14 +232,7 @@ script:
 - |
   if [[ "$PHPLINT" == "1" ]]; then
     travis_fold start "PHP.check" && travis_time_start
-    if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then
-      SKIP_CLI="-o -path ./cli -prune"
-    fi
-    if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then
-      find -L . -path ./vendor -prune -o -path ./node_modules -prune $SKIP_CLI -o -path ./migrations -prune -o -path ./src -prune -o -path ./tests -prune -o -path ./config -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    else
-      find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    fi
+    find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     travis_time_finish && travis_fold end "PHP.check"
   fi
 # PHP CS
@@ -266,8 +259,6 @@ script:
     vendor/bin/phpunit
     travis_time_finish && travis_fold end "PHP.tests"
   fi;
-# Coverage environment variable is only set on the PHP 7 build, so we can safely
-# assume that PHPUnit is in the vendor directory.
 - |
   if [[ "$COVERAGE" == "1" ]]; then
     travis_fold start "PHP.coverage" && travis_time_start
@@ -280,10 +271,6 @@ script:
     vendor/bin/phpunit --coverage-php /tmp/coverage/tests.cov
     travis_time_finish && travis_fold end "PHP.coverage"
   fi
-- |
-  if [[ "$COVERAGE" == "1" ]]; then
-    ./vendor/bin/phpcov merge /tmp/coverage --clover build/logs/clover.xml
-  fi
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
 - if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
@@ -292,6 +279,10 @@ script:
 - if [[ "$SECURITY" == "1" ]]; then php $SECURITYCHECK_DIR/security-checker.phar -n security:check $(pwd)/composer.lock;fi
 
 after_script:
+- |
+  if [[ "$COVERAGE" == "1" ]]; then
+    ./vendor/bin/phpcov merge /tmp/coverage --clover build/logs/clover.xml
+  fi
 - if [[ "$COVERAGE" == "1" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -141,6 +141,9 @@
 			"rm -f ./src/generated/container.php.meta",
 			"composer du",
 			"Yoast\\WP\\Free\\Composer\\Actions::compile_dependency_injection_container"
+		],
+		"post-install-cmd": [
+			"Yoast\\WP\\Free\\Composer\\Actions::prefix_dependencies"
 		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,10 @@
 		"source": "https://github.com/Yoast/wordpress-seo"
 	},
 	"require": {
-		"php": "^5.6.0||^7.0",
+		"php": "^5.6.20||^7.0",
 		"composer/installers": "~1.0",
 		"yoast/license-manager": "1.6.0",
 		"yoast/i18n-module": "^3.1.1",
-		"xrstf/composer-php52": "^1.0.20",
 		"j4mie/idiorm": "^1.5",
 		"pimple/pimple": "^3.2",
 		"ruckusing/ruckusing-migrations": "^1.1",
@@ -142,16 +141,6 @@
 			"rm -f ./src/generated/container.php.meta",
 			"composer du",
 			"Yoast\\WP\\Free\\Composer\\Actions::compile_dependency_injection_container"
-		],
-		"post-install-cmd": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd",
-			"Yoast\\WP\\Free\\Composer\\Actions::prefix_dependencies"
-		],
-		"post-update-cmd": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
-		],
-		"post-autoload-dump": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
 		]
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c25b5d30473627d687ee840f7520ef2",
+    "content-hash": "772e8a868261705aa5b446d2736982d5",
     "packages": [
         {
             "name": "composer/installers",
@@ -844,37 +844,6 @@
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
             "time": "2019-05-19T14:11:39+00:00"
-        },
-        {
-            "name": "xrstf/composer-php52",
-            "version": "v1.0.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer-php52/composer-php52.git",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-default": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "xrstf\\Composer52": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "time": "2016-04-16T21:52:24+00:00"
         },
         {
             "name": "yoast/i18n-module",
@@ -3722,7 +3691,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6.0||^7.0"
+        "php": "^5.6.20||^7.0"
     },
     "platform-dev": []
 }

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -35,12 +35,7 @@ define( 'YOAST_VENDOR_DEFINE_PREFIX', 'YOASTSEO_VENDOR__' );
 define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
 if ( ! defined( 'WPSEO_NAMESPACES' ) ) {
-	if ( version_compare( phpversion(), '5.3', '>=' ) ) {
-		define( 'WPSEO_NAMESPACES', true );
-	}
-	else {
-		define( 'WPSEO_NAMESPACES', false );
-	}
+	define( 'WPSEO_NAMESPACES', true );
 }
 
 
@@ -70,10 +65,7 @@ function wpseo_auto_load( $class ) {
 	}
 }
 
-$yoast_autoload_file = WPSEO_PATH . 'vendor/autoload_52.php';
-if ( version_compare( phpversion(), '5.6', '>=' ) ) {
-	$yoast_autoload_file = WPSEO_PATH . 'vendor/autoload.php';
-}
+$yoast_autoload_file = WPSEO_PATH . 'vendor/autoload.php';
 
 if ( is_readable( $yoast_autoload_file ) ) {
 	require $yoast_autoload_file;


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Includes:
* Removing builds against PHP < 5.6.
* Adjusting the Travis matrix for dropped support of WP < 5.2.
* Adjusting the conditions for setting up the test environment to be environment variable based instead of PHP version based.
* Using the composer scripts to run various tasks.
* Removing the `xrstf/composer-php52` dependency and references to the  `vendor/autoload_52.php` file.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.
* And removing the `WP_VERSION` environment variable from the PHP 7.2 build.
    This build doesn't need the WP environment as it doesn't run the PHP unit tests.

Related to https://github.com/Yoast/wordpress-seo/issues/13758

## Test instructions

This PR can be tested by following these steps:
* Check the detailed output of the Travis scripts to verify that all is working as expected.

**_Please be extra critical reviewing this PR for any changes which may impact the `deploy` stage as those won't show up during the PR build._**