### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,10 +67,10 @@
 	},
 	"scripts": {
 		"test": [
-			"phpunit -c phpunit.xml.dist"
+			"@php ./vendor/phpunit/phpunit/phpunit"
 		],
 		"integration-test": [
-			"phpunit -c phpunit-integration.xml.dist"
+			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
 		],
 		"config-yoastcs": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp",
@@ -85,9 +85,6 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
-		],
-		"check-cs-errors": [
-			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --error-severity=1 --warning-severity=6"
 		],
 		"check-staged-cs": [
 			"Yoast\\WP\\Free\\Composer\\Actions::check_staged_cs"

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,9 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
 		],
+		"check-cs-errors": [
+			"@check-cs -n"
+		],
 		"check-staged-cs": [
 			"Yoast\\WP\\Free\\Composer\\Actions::check_staged_cs"
 		],


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

The only thing which appears to be needed for this repo is to tweak the `test` scripts for cross-platform compatibility.

I'd also like to propose removing the `check-cs-errors` script. Not sure what that was supposed to do and who ever used it, but whatever the intention was, there are simpler ways to achieve the same without touching the error/warning severity.




## Test instructions

This PR can be tested by following these steps:
* Run the composer test scripts locally on various platforms (Linus, Mac, Windows) and confirm they work on all platforms without problems.
