### PR TITLE
CS/I18n: fix missing text domain in gettext call

### DIFF
--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -150,7 +150,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 			foreach ( $terms as $term ) {
 				// We are checking against the WordPress internal translation.
 				// @codingStandardsIgnoreLine
-				if ( $term->name !== __( 'Uncategorized' ) ) {
+				if ( $term->name !== __( 'Uncategorized', 'default' ) ) {
 					$keywords[] = $term->name;
 				}
 			}


### PR DESCRIPTION

## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Plugins/themes should use their own text domain. however, in some cases, using the WP Core translation for a string is warranted, like in this case.

The WP Core text-domain is `default` and while all gettext function call have a default value of `default` for the `$domain` parameter, explicitly setting the `$domain` in a gettext function call to `default` documents that the intention for this function call was to use the WP Core translation.

For CS purposes, the line still has to be ignored (for now) as it doesn't use the WPSEO text domain. Once WPSEO upgrades to a more recent version of WordPressCS, the ignore comment can be removed as since WPCS 0.11.0, a plugin can indicate that it uses more than one text-domain.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.