### PR TITLE
CS: clean up after merges / namespaced files

### DIFF
--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -106,11 +106,11 @@ class Actions {
 	 * @return void
 	 */
 	private static function check_cs_for_changed_files( $compare ) {
-		\exec( 'git diff --name-only --diff-filter=d ' . escapeshellarg( $compare ), $files );
-		$files = array_filter(
+		\exec( 'git diff --name-only --diff-filter=d ' . \escapeshellarg( $compare ), $files );
+		$files = \array_filter(
 			$files,
 			function ( $file ) {
-				return substr( $file, -4 ) === '.php';
+				return \substr( $file, -4 ) === '.php';
 			}
 		);
 
@@ -119,6 +119,6 @@ class Actions {
 			return;
 		}
 
-		\system( 'composer check-cs -- ' . implode( ' ', array_map( 'escapeshellarg', $files ) ) );
+		\system( 'composer check-cs -- ' . \implode( ' ', \array_map( 'escapeshellarg', $files ) ) );
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,14 +63,14 @@ abstract class TestCase extends BaseTestCase {
 					return \array_merge( $defaults, $settings );
 				},
 				'wp_strip_all_tags'   => function ( $string, $remove_breaks = false ) {
-					$string = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
-					$string = strip_tags( $string );
+					$string = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
+					$string = \strip_tags( $string );
 
 					if ( $remove_breaks ) {
-						$string = preg_replace( '/[\r\n\t ]+/', ' ', $string );
+						$string = \preg_replace( '/[\r\n\t ]+/', ' ', $string );
 					}
 
-					return trim( $string );
+					return \trim( $string );
 				},
 				'get_bloginfo'        => function ( $show ) {
 					switch ( $show ) {

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -22,7 +22,7 @@ class Admin_Features_Test extends TestCase {
 	/**
 	 * Returns an instance with set expectations for the dependencies.
 	 *
-	 * @return WPSEO_Admin Instance to test against.
+	 * @return \WPSEO_Admin Instance to test against.
 	 */
 	private function get_admin_with_expectations() {
 		$shortlinker = new Shortlinker();

--- a/tests/admin/myyoast-proxy-test.php
+++ b/tests/admin/myyoast-proxy-test.php
@@ -255,7 +255,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/**
 		 * It acts like an instance of WPSEO_MyYoast_Proxy.
 		 *
-		 * @var WPSEO_MyYoast_Proxy $instance
+		 * @var \WPSEO_MyYoast_Proxy $instance
 		 */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )

--- a/tests/doubles/inc/addon-manager-double.php
+++ b/tests/doubles/inc/addon-manager-double.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package WPSEO\Tests\Doubles
- */
 
 namespace Yoast\WP\Free\Tests\Doubles\Inc;
 
@@ -37,9 +32,9 @@ class Addon_Manager_Double extends \WPSEO_Addon_Manager {
 	/**
 	 * Converts a subscription to plugin based format.
 	 *
-	 * @param stdClass $subscription The subscription to convert.
+	 * @param \stdClass $subscription The subscription to convert.
 	 *
-	 * @return stdClass The converted subscription.
+	 * @return \stdClass The converted subscription.
 	 */
 	public function convert_subscription_to_plugin( $subscription ) {
 		return parent::convert_subscription_to_plugin( $subscription );
@@ -66,7 +61,7 @@ class Addon_Manager_Double extends \WPSEO_Addon_Manager {
 	/**
 	 * Checks whether a plugin expiry date has been passed.
 	 *
-	 * @param stdClass $subscription Plugin subscription.
+	 * @param \stdClass $subscription Plugin subscription.
 	 *
 	 * @return bool Has the plugin expired.
 	 */

--- a/tests/inc/addon-manager-test.php
+++ b/tests/inc/addon-manager-test.php
@@ -1,14 +1,8 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\Free\Tests\Inc
- */
 
 namespace Yoast\WP\Free\Tests\Inc;
 
 use Mockery;
-use WPSEO_Addon_Manager;
 use WPSEO_Utils;
 use Yoast\WP\Free\Tests\Doubles\Inc\Addon_Manager_Double;
 use Yoast\WP\Free\Tests\TestCase;
@@ -39,7 +33,7 @@ class Addon_Manager_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var Mockery\Mock|Addon_Manager_Double
+	 * @var \Mockery\Mock|\Yoast\WP\Free\Tests\Doubles\Inc\Addon_Manager_Double
 	 */
 	protected $instance;
 
@@ -703,7 +697,7 @@ class Addon_Manager_Test extends TestCase {
 	 * @return \stdClass Subscriptions.
 	 */
 	protected function get_subscriptions() {
-		return json_decode(
+		return \json_decode(
 			WPSEO_Utils::format_json_encode(
 				[
 					'wp-seo-premium.php' => [
@@ -743,7 +737,7 @@ class Addon_Manager_Test extends TestCase {
 	 */
 	protected function get_future_date() {
 		if ( $this->future_date === null ) {
-			$this->future_date = gmdate( 'Y-m-d\TH:i:s\Z', ( time() + DAY_IN_SECONDS ) );
+			$this->future_date = \gmdate( 'Y-m-d\TH:i:s\Z', ( \time() + \DAY_IN_SECONDS ) );
 		}
 
 		return $this->future_date;
@@ -756,7 +750,7 @@ class Addon_Manager_Test extends TestCase {
 	 */
 	protected function get_past_date() {
 		if ( $this->past_date === null ) {
-			$this->past_date = gmdate( 'Y-m-d\TH:i:s\Z', ( time() - DAY_IN_SECONDS ) );
+			$this->past_date = \gmdate( 'Y-m-d\TH:i:s\Z', ( \time() - \DAY_IN_SECONDS ) );
 		}
 		return $this->past_date;
 	}


### PR DESCRIPTION


## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.

Code style compliance:
* Use FQCN in docblocks.
* Remove unused `use` statement.
* Namespaced files in Yoast repos do not need a file docblock.
* Use fully qualified functions in namespaced files.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.