### PR TITLE
Fixes empty faq and howto errors

### DIFF
--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -4,24 +4,30 @@
  *
  * @package Yoast\WP\Free\Presentations\Generators\Schema
  */
+
 namespace Yoast\WP\Free\Presentations\Generators\Schema;
+
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Article_Helper;
 use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
+
 /**
  * Returns schema FAQ data.
  *
  * @since 11.3
  */
 class FAQ extends Abstract_Schema_Piece {
+
 	/**
 	 * @var Article_Helper
 	 */
 	private $article_helper;
+
 	/**
 	 * @var HTML_Helper
 	 */
 	private $html_helper;
+
 	/**
 	 * Article constructor.
 	 *
@@ -35,6 +41,7 @@ class FAQ extends Abstract_Schema_Piece {
 		$this->article_helper = $article_helper;
 		$this->html_helper    = $html_helper;
 	}
+
 	/**
 	 * Determines whether or not a piece should be added to the graph.
 	 *
@@ -46,12 +53,15 @@ class FAQ extends Abstract_Schema_Piece {
 		if ( empty( $context->blocks['yoast/faq-block'] ) ) {
 			return false;
 		}
+
 		if ( ! \is_array( $context->schema_page_type ) ) {
 			$context->schema_page_type = [ $context->schema_page_type ];
 		}
 		$context->schema_page_type[] = 'FAQPage';
+
 		return true;
 	}
+
 	/**
 	 * Render a list of questions, referencing them by ID.
 	 *
@@ -64,6 +74,7 @@ class FAQ extends Abstract_Schema_Piece {
 		$graph = [];
 		$number_of_blocks = count( $context->blocks['yoast/faq-block'] );
 		$number_of_items = 0;
+
 		for ( $block_number = 0; $block_number < $number_of_blocks; $block_number++ ) {
 			foreach ( $context->blocks['yoast/faq-block'][ $block_number ]['attrs']['questions'] as $index => $question ) {
 				if ( ! isset( $question['jsonAnswer'] ) || empty( $question['jsonAnswer'] ) ) {
@@ -74,6 +85,7 @@ class FAQ extends Abstract_Schema_Piece {
 				$number_of_items = count( $context->blocks['yoast/faq-block'][ $block_number ]['attrs']['questions'] );
 			}
 		}
+
 		\array_unshift(
 			$graph,
 			[
@@ -83,8 +95,10 @@ class FAQ extends Abstract_Schema_Piece {
 				'itemListElement'  => $ids,
 			]
 		);
+
 		return $graph;
 	}
+
 	/**
 	 * Generate a Question piece.
 	 *

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -134,6 +134,7 @@ class HowTo extends Abstract_Schema_Piece {
 				}
 
 				$schema_step['text'] = '';
+
 				$this->add_step_image( $schema_step, $step, $context );
 
 				// If there is no text and no image, don't output the step.
@@ -149,7 +150,6 @@ class HowTo extends Abstract_Schema_Piece {
 			elseif ( empty( $json_text ) ) {
 				$schema_step['text'] = $json_name;
 			}
-
 			else {
 				$schema_step['name'] = $json_name;
 				$this->add_step_description( $schema_step, $step );

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -4,30 +4,24 @@
  *
  * @package Yoast\WP\Free\Presentations\Generators\Schema
  */
-
 namespace Yoast\WP\Free\Presentations\Generators\Schema;
-
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
 use Yoast\WP\Free\Helpers\Schema\Image_Helper;
-
 /**
  * Returns schema FAQ data.
  *
  * @since 11.5
  */
 class HowTo extends Abstract_Schema_Piece {
-
 	/**
 	 * @var HTML_Helper
 	 */
 	private $html_helper;
-
 	/**
 	 * @var Image_Helper
 	 */
 	private $image_helper;
-
 	/**
 	 * HowTo constructor.
 	 *
@@ -41,7 +35,6 @@ class HowTo extends Abstract_Schema_Piece {
 		$this->html_helper  = $html_helper;
 		$this->image_helper = $image_helper;
 	}
-
 	/**
 	 * Determines whether or not a piece should be added to the graph.
 	 *
@@ -52,7 +45,6 @@ class HowTo extends Abstract_Schema_Piece {
 	public function is_needed( Meta_Tags_Context $context ) {
 		return ! empty( $context->blocks['yoast/how-to-block'] );
 	}
-
 	/**
 	 * Renders a list of questions, referencing them by ID.
 	 *
@@ -62,7 +54,6 @@ class HowTo extends Abstract_Schema_Piece {
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$graph = [];
-
 		foreach ( $context->blocks['yoast/how-to-block'] as $index => $block ) {
 			$data = [
 				'@type'            => 'HowTo',
@@ -71,22 +62,15 @@ class HowTo extends Abstract_Schema_Piece {
 				'mainEntityOfPage' => [ '@id' => $context->main_schema_id ],
 				'description'      => '',
 			];
-
-			$json_description = $this->html_helper->sanitize( $block['attrs']['jsonDescription'] );
-
-			if ( isset( $json_description ) ) {
-				$data['description'] = $json_description;
+			if ( isset( $block['attrs']['jsonDescription'] ) ) {
+				$data['description'] = $this->html_helper->sanitize( $block['attrs']['jsonDescription'] );
 			}
-
 			$this->add_duration( $data, $block['attrs'] );
 			$this->add_steps( $data, $block['attrs']['steps'], $context );
-
 			$graph[] = $data;
 		}
-
 		return $graph;
 	}
-
 	/**
 	 * Adds the duration of the task to the Schema.
 	 *
@@ -94,19 +78,16 @@ class HowTo extends Abstract_Schema_Piece {
 	 * @param array $attributes The block data attributes.
 	 */
 	private function add_duration( &$data, $attributes ) {
-		if ( empty( $attributes['hasDuration'] ) && $attributes['hasDuration'] ) {
+		if ( empty( $attributes['hasDuration'] ) ) {
 			return;
 		}
-
 		$days    = empty( $attributes['days'] ) ? 0 : $attributes['days'];
 		$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];
 		$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
-
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M';
 		}
 	}
-
 	/**
 	 * Adds the steps to our How-To output.
 	 *
@@ -121,43 +102,37 @@ class HowTo extends Abstract_Schema_Piece {
 				'@type' => 'HowToStep',
 				'url'   => $schema_id,
 			];
-
-			$json_text = $this->html_helper->sanitize( $step['jsonText'] );
-			$json_name = \strip_tags( $step['jsonName'] );
-
+			if ( isset( $step['jsonText'] ) ) {
+				$json_text = $this->html_helper->sanitize( $step['jsonText'] );
+			}
+			if ( isset( $step['jsonName'] ) ) {
+				$json_name = \strip_tags( $step['jsonName'] );
+			}
 			if ( empty( $json_name ) ) {
 				if ( empty( $step['text'] ) ) {
 					continue;
 				}
-
 				$schema_step['text'] = '';
-
 				$this->add_step_image( $schema_step, $step, $context );
-
 				// If there is no text and no image, don't output the step.
 				if ( empty( $json_text ) && empty( $schema_step['image'] ) ) {
 					continue;
 				}
-
 				if ( ! empty( $json_text ) ) {
 					$schema_step['text'] = $json_text;
 				}
 			}
-
 			elseif ( empty( $json_text ) ) {
 				$schema_step['text'] = $json_name;
 			}
 			else {
 				$schema_step['name'] = $json_name;
-
 				$this->add_step_description( $schema_step, $step );
 				$this->add_step_image( $schema_step, $step, $context );
 			}
-
 			$data['step'][] = $schema_step;
 		}
 	}
-
 	/**
 	 * Checks if we have a step description, if we do, add it.
 	 *
@@ -166,11 +141,9 @@ class HowTo extends Abstract_Schema_Piece {
 	 */
 	private function add_step_description( &$schema_step, $step ) {
 		$json_text = $this->html_helper->sanitize( $step['jsonText'] );
-
 		if ( empty( $json_text ) ) {
 			return;
 		}
-
 		$schema_step['itemListElement'] = [
 			[
 				'@type' => 'HowToDirection',
@@ -178,7 +151,6 @@ class HowTo extends Abstract_Schema_Piece {
 			],
 		];
 	}
-
 	/**
 	 * Checks if we have a step image, if we do, add it.
 	 *
@@ -193,7 +165,6 @@ class HowTo extends Abstract_Schema_Piece {
 			}
 		}
 	}
-
 	/**
 	 * Generates the image schema from the attachment $url.
 	 *
@@ -206,7 +177,6 @@ class HowTo extends Abstract_Schema_Piece {
 	 */
 	protected function get_image_schema( $url, Meta_Tags_Context $context ) {
 		$schema_id = $context->canonical . '#schema-image-' . \md5( $url );
-
 		return $this->image_helper->generate_from_url( $schema_id, $url );
 	}
 }

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -4,24 +4,30 @@
  *
  * @package Yoast\WP\Free\Presentations\Generators\Schema
  */
+
 namespace Yoast\WP\Free\Presentations\Generators\Schema;
+
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
 use Yoast\WP\Free\Helpers\Schema\Image_Helper;
+
 /**
  * Returns schema FAQ data.
  *
  * @since 11.5
  */
 class HowTo extends Abstract_Schema_Piece {
+
 	/**
 	 * @var HTML_Helper
 	 */
 	private $html_helper;
+
 	/**
 	 * @var Image_Helper
 	 */
 	private $image_helper;
+
 	/**
 	 * HowTo constructor.
 	 *
@@ -35,6 +41,7 @@ class HowTo extends Abstract_Schema_Piece {
 		$this->html_helper  = $html_helper;
 		$this->image_helper = $image_helper;
 	}
+
 	/**
 	 * Determines whether or not a piece should be added to the graph.
 	 *
@@ -45,6 +52,7 @@ class HowTo extends Abstract_Schema_Piece {
 	public function is_needed( Meta_Tags_Context $context ) {
 		return ! empty( $context->blocks['yoast/how-to-block'] );
 	}
+
 	/**
 	 * Renders a list of questions, referencing them by ID.
 	 *
@@ -54,6 +62,7 @@ class HowTo extends Abstract_Schema_Piece {
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$graph = [];
+
 		foreach ( $context->blocks['yoast/how-to-block'] as $index => $block ) {
 			$data = [
 				'@type'            => 'HowTo',
@@ -62,15 +71,20 @@ class HowTo extends Abstract_Schema_Piece {
 				'mainEntityOfPage' => [ '@id' => $context->main_schema_id ],
 				'description'      => '',
 			];
+
 			if ( isset( $block['attrs']['jsonDescription'] ) ) {
 				$data['description'] = $this->html_helper->sanitize( $block['attrs']['jsonDescription'] );
 			}
+
 			$this->add_duration( $data, $block['attrs'] );
 			$this->add_steps( $data, $block['attrs']['steps'], $context );
+
 			$graph[] = $data;
 		}
+
 		return $graph;
 	}
+
 	/**
 	 * Adds the duration of the task to the Schema.
 	 *
@@ -81,13 +95,16 @@ class HowTo extends Abstract_Schema_Piece {
 		if ( empty( $attributes['hasDuration'] ) ) {
 			return;
 		}
+
 		$days    = empty( $attributes['days'] ) ? 0 : $attributes['days'];
 		$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];
 		$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
+
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M';
 		}
 	}
+
 	/**
 	 * Adds the steps to our How-To output.
 	 *
@@ -102,37 +119,47 @@ class HowTo extends Abstract_Schema_Piece {
 				'@type' => 'HowToStep',
 				'url'   => $schema_id,
 			];
+
 			if ( isset( $step['jsonText'] ) ) {
 				$json_text = $this->html_helper->sanitize( $step['jsonText'] );
 			}
+
 			if ( isset( $step['jsonName'] ) ) {
 				$json_name = \strip_tags( $step['jsonName'] );
 			}
+
 			if ( empty( $json_name ) ) {
 				if ( empty( $step['text'] ) ) {
 					continue;
 				}
+
 				$schema_step['text'] = '';
 				$this->add_step_image( $schema_step, $step, $context );
+
 				// If there is no text and no image, don't output the step.
 				if ( empty( $json_text ) && empty( $schema_step['image'] ) ) {
 					continue;
 				}
+
 				if ( ! empty( $json_text ) ) {
 					$schema_step['text'] = $json_text;
 				}
 			}
+
 			elseif ( empty( $json_text ) ) {
 				$schema_step['text'] = $json_name;
 			}
+
 			else {
 				$schema_step['name'] = $json_name;
 				$this->add_step_description( $schema_step, $step );
 				$this->add_step_image( $schema_step, $step, $context );
 			}
+
 			$data['step'][] = $schema_step;
 		}
 	}
+
 	/**
 	 * Checks if we have a step description, if we do, add it.
 	 *
@@ -141,9 +168,11 @@ class HowTo extends Abstract_Schema_Piece {
 	 */
 	private function add_step_description( &$schema_step, $step ) {
 		$json_text = $this->html_helper->sanitize( $step['jsonText'] );
+
 		if ( empty( $json_text ) ) {
 			return;
 		}
+
 		$schema_step['itemListElement'] = [
 			[
 				'@type' => 'HowToDirection',
@@ -151,6 +180,7 @@ class HowTo extends Abstract_Schema_Piece {
 			],
 		];
 	}
+
 	/**
 	 * Checks if we have a step image, if we do, add it.
 	 *
@@ -165,6 +195,7 @@ class HowTo extends Abstract_Schema_Piece {
 			}
 		}
 	}
+
 	/**
 	 * Generates the image schema from the attachment $url.
 	 *
@@ -177,6 +208,7 @@ class HowTo extends Abstract_Schema_Piece {
 	 */
 	protected function get_image_schema( $url, Meta_Tags_Context $context ) {
 		$schema_id = $context->canonical . '#schema-image-' . \md5( $url );
+
 		return $this->image_helper->generate_from_url( $schema_id, $url );
 	}
 }

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -152,6 +152,7 @@ class HowTo extends Abstract_Schema_Piece {
 			}
 			else {
 				$schema_step['name'] = $json_name;
+
 				$this->add_step_description( $schema_step, $step );
 				$this->add_step_image( $schema_step, $step, $context );
 			}


### PR DESCRIPTION
## Summary

I fixed two problems;
- The HowTo block missed some `isset` checks, which caused warnings.
- The Faq block wasn't properly getting the questions, because we didn't check inside the block container.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a notice would be thrown when fields in the FAQ or HowTo blocks were left empty.

## Relevant technical choices:

* For the HowTo block:
    * Added checks to assure all required keys exist. If not, `return`.

* For the Faq block:
We were looking for the `questions` in `$context->blocks['yoast/faq-block']['attrs']['questions']`, while the blocks are put in a block container (by us). So we should be looking in `$context->blocks['yoast/faq-block'][$blockNumber]['attrs']['questions']`. I changed the function, so we now loop through the `blocks['yoast/faq-block']` blocks. 

I also changed the logic in which the`number_of_items` are counted, keeping in mind that there can only be one FAQ block.

Screenshot for clarification. You can see the `array (1) {  [0]=> array(5) {...}` This is the first FAQ block. If there would be more FAQ blocks, it would be `array(2) { [0]=> array(5) {...}, [1]=> array(5) {...} }`
![image](https://user-images.githubusercontent.com/42736463/67690943-112fb900-f99e-11e9-94c8-aee3ac034fbb.png)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new post with an empty Faq block --> Publish.
    * No notices or warnings should be thrown.
    * Fill the Faq block with data, it should output this data and no warnings or notices should be thrown.

* Create a new post with an empty HowTo block --> Publish.
    * No notices or warnings should be thrown.
    * Fill the HowTo block with data, it should output this data and no warnings or notices should be thrown.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13663
