### PR TITLE
Fixing a bug where the needle for strpos

### DIFF
--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -225,7 +225,7 @@ class WPSEO_OpenGraph {
 		 * If the unpaged URL is the same as the normal URL but just with pagination added, use that.
 		 * This makes sure we always use the unpaged URL when we can, but doesn't break for overridden canonicals.
 		 */
-		if ( is_string( $unpaged_url ) && !empty($unpaged_url) && strpos( $url, $unpaged_url ) === 0 ) {
+		if ( ! empty( $unpaged_url ) && is_string( $unpaged_url ) && strpos( $url, $unpaged_url ) === 0 ) {
 			$url = $unpaged_url;
 		}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -225,7 +225,7 @@ class WPSEO_OpenGraph {
 		 * If the unpaged URL is the same as the normal URL but just with pagination added, use that.
 		 * This makes sure we always use the unpaged URL when we can, but doesn't break for overridden canonicals.
 		 */
-		if ( is_string( $unpaged_url ) && strpos( $url, $unpaged_url ) === 0 ) {
+		if ( is_string( $unpaged_url ) && !empty($unpaged_url) && strpos( $url, $unpaged_url ) === 0 ) {
 			$url = $unpaged_url;
 		}
 


### PR DESCRIPTION
Fixes a bug where where the needle in a strpos() check is empty, which causes a PHP Warning.

This commit attempts to fix #13795 by checking that $unpaged_url is not empty before using it as the needle in a `strpos()` check.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a PHP Warning when using an empty string as the needle in a strpos() check. Props [Chris Thompson](https://github.com/ChrisThompsonTLDR).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13795 
