### PR TITLE
Optimize parsing gallery shortcode in sitemaps

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -103,7 +103,7 @@ class WPSEO_Sitemap_Image_Parser {
 			$images[] = $this->get_image_item( $post, $image['src'], $image['title'], $image['alt'] );
 		}
 
-		foreach ( $this->parse_galleries( $post->post_content, $post->ID ) as $attachment ) {
+		foreach ( $this->parse_galleries( $content, $post->ID ) as $attachment ) {
 
 			$src = $this->get_absolute_url( $this->image_url( $attachment->ID ) );
 			$alt = WPSEO_Image_Utils::get_alt_tag( $attachment->ID );
@@ -256,7 +256,6 @@ class WPSEO_Sitemap_Image_Parser {
 
 			$gallery_attachments = $this->get_gallery_attachments( $id, $gallery );
 
-
 			$attachments = array_merge( $attachments, $gallery_attachments );
 		}
 
@@ -279,27 +278,21 @@ class WPSEO_Sitemap_Image_Parser {
 	 */
 	protected function get_content_galleries( $content ) {
 
-		if ( ! has_shortcode( $content, 'gallery' ) ) {
-			return array();
-		}
-
 		$galleries = array();
 
-		if ( ! preg_match_all( '/' . get_shortcode_regex() . '/s', $content, $matches, PREG_SET_ORDER ) ) {
+		if ( ! preg_match_all( '/' . get_shortcode_regex( array( 'gallery' ) ) . '/s', $content, $matches, PREG_SET_ORDER ) ) {
 			return $galleries;
 		}
 
 		foreach ( $matches as $shortcode ) {
-			if ( 'gallery' === $shortcode[2] ) {
 
-				$attributes = shortcode_parse_atts( $shortcode[3] );
+			$attributes = shortcode_parse_atts( $shortcode[3] );
 
-				if ( '' === $attributes ) { // Valid shortcode without any attributes. R.
-					$attributes = array();
-				}
-
-				$galleries[] = $attributes;
+			if ( '' === $attributes ) { // Valid shortcode without any attributes. R.
+				$attributes = array();
 			}
+
+			$galleries[] = $attributes;
 		}
 
 		return $galleries;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Optimize parsing gallery's shortcode with "lighter" regular expression. This solution is faster and it supports a case if gallery's shortcode is nested in other shortcodes. Use same "content" for parsing HTML images and gallery's shortcode.

## Relevant technical choices:

* Since WP 4.4, _$tagnames_ is added as the parameter to the function [_get_shortcode_regex_](https://developer.wordpress.org/reference/functions/get_shortcode_regex/).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create simple shortcode (add following code into functions.php) which is simulation of  a "page builder":
```php
add_shortcode( 'my_content', function( $atts, $content = null ) {
        return '<div class="my_content">' . do_shortcode( $content ) . '</div>';
}
);
```
* Create simple page where "gallery shortcode" is nested inside "my_content shortcode":
`[my_content][gallery ids="image_id1,image_id2,..."][/my_content]`
* Check page sitemap.

## UI changes
* ~~[ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13829 
Partially fixes #13794
