### PR TITLE
Adjust input fields heights after WordPress 5.3 CSS changes.

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -554,7 +554,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					' name="' . $esc_form_key . '"' .
 					' value="' . esc_attr( $meta_value ) . '"' . $aria_describedby .
 					' readonly="readonly"' .
-					' />';
+					' /> ';
 				$content .= '<input' .
 					' id="' . esc_attr( $esc_form_key ) . '_button"' .
 					' class="wpseo_image_upload_button button"' .

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -287,6 +287,36 @@ td.column-wpseo-linked {
 	word-wrap: normal;
 }
 
+// Temporary adjustments for form controls styling changed in WordPress 5.3.
+.yoast {
+	// Reset 1px margin inherited from WordPress.
+	input {
+		margin: 0;
+	}
+
+	// Make inputs same height as buttons and selects.
+	input[type="text"],
+	input[type="password"],
+	input[type="date"],
+	input[type="datetime"],
+	input[type="datetime-local"],
+	input[type="email"],
+	input[type="month"],
+	input[type="number"],
+	input[type="search"],
+	input[type="tel"],
+	input[type="time"],
+	input[type="url"],
+	input[type="week"] {
+		padding: 0 8px;
+		vertical-align: top;
+		/* inherits font size 14px */
+		line-height: 1.85714285; /* 26px vs. 28px from core */
+		/* Only necessary for IE11 */
+		min-height: 28px; /* 28px vs. 30px from core */
+	}
+}
+
 @media screen and ( max-width: 782px ) {
 	.yoast-settings {
 		padding-left: 0;
@@ -317,6 +347,31 @@ td.column-wpseo-linked {
 	.yoast-settings__group--checkbox .yoast-settings__checkbox + label,
 	.yoast-settings__group--radio .yoast-settings__radio + label {
 		padding-top: 4px;
+	}
+
+	// Temporary adjustments for form controls styling changed in WordPress 5.3.
+	.yoast {
+		// Make inputs same height as buttons and selects.
+		input[type="text"],
+		input[type="password"],
+		input[type="date"],
+		input[type="datetime"],
+		input[type="datetime-local"],
+		input[type="email"],
+		input[type="month"],
+		input[type="number"],
+		input[type="search"],
+		input[type="tel"],
+		input[type="time"],
+		input[type="url"],
+		input[type="week"] {
+			padding: 0 10px;
+			vertical-align: top;
+			/* inherits font size 16px */
+			line-height: 1.875; /* 30px */
+			/* Only necessary for IE11 */
+			min-height: 32px;
+		}
 	}
 
 	.yoast-settings input[type="text"],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improved form controls alignments after CSS changes in WordPress 5.3.

## Relevant technical choices:
- on large screens:
  - input fields have a 28 pixels height vs. the 30 pixels height from core
  - this way they have the same height of buttons and selects
- on small screens:
  - input fields have a 32 pixels height vs. the 40 pixels height from core
  - this way, they have the same height of buttons and selects
- I also added a missing space between an image input field and its upload image button

## Test instructions
- build the CSS
- enable Yoast SEO and Yoast SEO: Video
- check input fields and buttons alignments look OK, for example:
- metabox > social > Facebook > Facebook Image
- metabox > video > Video Thumbnail
- SEO > Social > Facebook > Frontpage settings > Image URL
- SEO > Social > Facebook > Default settings > Image URL
- all the settings pages for example: SEO > General > Webmaster tools
- note: under Users > Your Profile, there are no changes for the input fields added by Yoast SEO
- **test also in the responsive view for small screens**

You can also refer to the screenshot on the related issue

Note: this PR doesn't introduce UI changes _per se_. The CSS changes from WordPress 5.3 do introduce UI changes of course.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/686