### PR TITLE
Add missing multisite checks for the actions

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -130,6 +130,11 @@ class WPSEO_Admin {
 	 * Schedules a rewrite flush to happen at shutdown.
 	 */
 	public function schedule_rewrite_flush() {
+		// Bail if this is a multisite installation and the site has been switched.
+		if ( is_multisite() && ms_is_switched() ) {
+			return;
+		}
+
 		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 

--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -45,6 +45,11 @@ class WPSEO_Link_Watcher {
 	 * @return void
 	 */
 	public function save_post( $post_id, WP_Post $post ) {
+		// Bail if this is a multisite installation and the site has been switched.
+		if ( is_multisite() && ms_is_switched() ) {
+			return;
+		}
+
 		/**
 		 * Filter: 'wpseo_should_index_links' - Allows disabling of Yoast's links indexation.
 		 *

--- a/admin/statistics/class-statistics-integration.php
+++ b/admin/statistics/class-statistics-integration.php
@@ -26,6 +26,11 @@ class WPSEO_Statistic_Integration implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function clear_cache() {
+		// Bail if this is a multisite installation and the site has been switched.
+		if ( is_multisite() && ms_is_switched() ) {
+			return;
+		}
+
 		delete_transient( WPSEO_Statistics_Service::CACHE_TRANSIENT_KEY );
 	}
 }

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -166,6 +166,7 @@ class WPSEO_Taxonomy {
 	 * @param string $taxonomy The taxonomy the term belongs to.
 	 */
 	public function update_term( $term_id, $tt_id, $taxonomy ) {
+		// Bail if this is a multisite installation and the site has been switched.
 		if ( is_multisite() && ms_is_switched() ) {
 			return;
 		}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `create` and `update` actions would be done twice on multisite environments in combination with MultilingualPress.

## Relevant technical choices:

* The deletions are not covered: for some reason I don't fully understand, the deletions are not affected by multisite like the saves/updates are. If someone knows, please enlighten me.
* The rewrite is already covered for the full class. It is not loaded in on multisite.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

These are kind of hard to test. The idea is that the code could get called twice when on multisite.
Therefore, some debugging is needed to verify this. [See this Wiki page to learn how](https://github.com/Yoast/Wiki/wiki/PHPStorm-debugging).

*Note: To acquire a copy of MultilingualPress, login to LastPass -> Shared-licenses vault. There's a login there for MultilingualPress so you can download the latest version.*

Setup your multisite with MLP:
* Ensure you have a multisite environment with MultilingualPress and Yoast SEO installed.
* Configure at least two languages in MultilingualPress.

Test the `class-admin` > `schedule_rewrite_flush`:
* Remove the categories prefix: `SEO` > `Taxonomies` > `Category URLs`.
* Create a new category and ensure you set it to sync with the secondary language in the MLP metabox (`Create a new term, and use it as translation in <language>.`).
* Set a breakpoint in `wordpress-seo/admin/class-admin.php` in the method `schedule_rewrite_flush` on lines 135 (the new `return`) and 138 (the `add_action`).
* Save the category.
* You should see both debug lines executed now. So where before the `add_action` would be run twice, now one bails out due to the new multisite check.
* You could reset the categories prefix you removed on the first step.

Test the `class-taxonomy` > `update_term`:
**Note by Andrea:** as far as I see, this was already fixed in https://github.com/Yoast/wordpress-seo/pull/13676 and https://github.com/Yoast/wordpress-seo/pull/13697

* Create a new category and ensure you set it to sync with the secondary language in the MLP metabox (`Create a new term, and use it as translation in <language>.`).
* Go to the edit page of the category you just created.
* Set a breakpoint in `admin/taxonomy/class-taxonomy.phpp` in the method `update_term` on lines 171 (the new `return`) and 175 (the `$new_meta_data` / first code after).
* Update the category.
* You should see both debug lines executed now.
* If you change some meta data on this should not influence the term on the other site. Unlike before.

Test the `class-link-watcher` > `save_post`:
* Create a new post and ensure you set it to sync with the secondary language in the MLP metabox) and publish it.
* Set a breakpoint in `admin/links/class-link-watcher.php` in the method `save_post` on lines 50 (the new `return`) and 58 (the first statement after the new `return`).
* Update the post. 
* You should see both debug lines executed now. Both are called twice, one of these is the actual post, the other is the revision.

Test the `class-statistics-integration` > `clear_cache`:
* Set a breakpoint in `admin/statistics/class-statistics-integration.php` in the method `clear_cache` on lines 31 (the new `return`) and 34 (the first statement after the new `return`).
* *Note* You will see a stop on the 2nd breakpoint because of the WP draft that gets saved, just continue.
* Create a new post and ensure you set it to sync with the secondary language in the MLP metabox) and publish it.
* You should see both debug lines executed now. Both are called twice, one of these is the actual post, the other is the revision.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Related https://github.com/Yoast/wordpress-seo/issues/13765
