### PR TITLE
Bump monorepo packages for 12.6 RC2

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@yoast/components": "^0.11.0-rc.0",
     "@yoast/configuration-wizard": "^1.10.0-rc.0",
     "@yoast/helpers": "^0.9.0-rc.0",
-    "@yoast/search-metadata-previews": "^1.13.0-rc.0",
+    "@yoast/search-metadata-previews": "^1.13.0-rc.1",
     "@yoast/style-guide": "^0.9.0-rc.0",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
@@ -132,7 +132,7 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^4.2.0",
-    "yoast-components": "^4.37.0-rc.0",
+    "yoast-components": "^4.37.0-rc.1",
     "yoastseo": "^1.64.0-rc.0"
   },
   "yoast": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,10 +758,10 @@
     styled-components "^2.4.1"
     whatwg-fetch "1.1.1"
 
-"@yoast/search-metadata-previews@^1.13.0-rc.0":
-  version "1.13.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.13.0-rc.0.tgz#d774c322020fbb72f399b5ed0bcce26da07280f2"
-  integrity sha512-cXrI7o/VF+XR8btXDx/+9fhuu6OGiAOdzjnJNtJO2v9EpOB7DS6kH39Z6VHdvemXw0n9oGJXgCymZavtKDIg8w==
+"@yoast/search-metadata-previews@^1.13.0-rc.1":
+  version "1.13.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-1.13.0-rc.1.tgz#b21e0ad336ada27082e99eb941854e910aff0620"
+  integrity sha512-lgEZC6+Wn9WRURqzxzz8lq0qVV/EHhnRZAwIPMcs9Py0cw6lJLTuDpdX2hQ31C6/aTHFcqhesZche2QtbsqYfg==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -13110,10 +13110,10 @@ yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yoast-components@^4.37.0-rc.0:
-  version "4.37.0-rc.0"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.37.0-rc.0.tgz#329236b05efdc1b80fd86697cf4605dcaaf11342"
-  integrity sha512-tdDUr2YnF4JyOwtu/C1rgDOaeITqFaQ5cK4uOy9a8Hs5oN1CIfL+PjvlcBraWnpJuqnWSE57igevFtalBZyiOw==
+yoast-components@^4.37.0-rc.1:
+  version "4.37.0-rc.1"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-4.37.0-rc.1.tgz#8e6bc7cc59e3543b79ae5dfa553b724ea269f2b5"
+  integrity sha512-8UX0JCBU62Wox2/y9pT5JJ/CyOR/jT8wd1CNnE3+mZvoEG0NhXV/7GPijwVuCXoqRM3mO2HtE6QZvT3WJ1Za0Q==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -13122,7 +13122,7 @@ yoast-components@^4.37.0-rc.0:
     "@yoast/components" "^0.11.0-rc.0"
     "@yoast/configuration-wizard" "^1.10.0-rc.0"
     "@yoast/helpers" "^0.9.0-rc.0"
-    "@yoast/search-metadata-previews" "^1.13.0-rc.0"
+    "@yoast/search-metadata-previews" "^1.13.0-rc.1"
     "@yoast/style-guide" "^0.9.0-rc.0"
     algoliasearch "^3.22.3"
     clipboard "^1.5.15"


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Bumps the `search-metadata-previews` and `yoast-components` packages for 12.6-RC2

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
