### PR TITLE
Fixes private CPT in sitemaps

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -93,7 +93,6 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	public function get_index_links( $max_entries ) {
 		global $wpdb;
 
-		// Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
 		$post_types          = WPSEO_Post_Type::get_accessible_post_types();
 		$post_types          = array_filter( $post_types, array( $this, 'is_valid_post_type' ) );
 		$last_modified_times = WPSEO_Sitemaps::get_last_modified_gmt( $post_types, true );

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -168,7 +168,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$post_type = $type;
 
 		if ( ! $this->is_valid_post_type( $post_type ) ) {
-			return $links;
+			throw new OutOfBoundsException( 'Invalid sitemap page requested' );
 		}
 
 		$steps  = min( 100, $max_entries );

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -489,9 +489,7 @@ class WPSEO_Sitemaps {
 		if ( is_null( $post_type_dates ) ) {
 
 			$post_type_dates = array();
-
-			// Consider using WPSEO_Post_Type::get_accessible_post_types() to filter out any `no-index` post-types.
-			$post_type_names = get_post_types( array( 'public' => true ) );
+			$post_type_names = WPSEO_Post_Type::get_accessible_post_types();
 
 			if ( ! empty( $post_type_names ) ) {
 				$post_statuses = array_map( 'esc_sql', self::get_post_statuses() );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Don't render sub sitemaps if CPT isn't public.

## Relevant technical choices:

* Throw an exception when the sitemap page requested isn't public _post_type_.
* Replace [get_post_types](https://developer.wordpress.org/reference/functions/get_post_types/) with _WPSEO_Post_Type::get_accessible_post_types()_.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the code from issue #13862 to have private custom post type.
* Check sub sitemap - it should return 404.

## UI changes
~~* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13862 
