### PR TITLE
Implement HelpScout consent button

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -330,10 +330,11 @@ class WPSEO_Admin_Asset_Manager {
 
 		return array(
 			array(
-				'name' => 'commons',
+				'name'      => 'commons',
 				// Load webpack-commons for bundle support.
-				'src'  => 'commons-' . $flat_version,
-				'deps' => array(
+				'src'       => 'commons-' . $flat_version,
+				'in_footer' => false,
+				'deps'      => array(
 					'wp-polyfill',
 				),
 			),
@@ -648,6 +649,16 @@ class WPSEO_Admin_Asset_Manager {
 				'src'  => 'styled-components-' . $flat_version,
 				'deps' => array(
 					'wp-element',
+				),
+			),
+			array(
+				'name'      => 'help-scout-beacon',
+				'src'       => 'help-scout-beacon-' . $flat_version,
+				'in_footer' => false,
+				'deps'      => array(
+					self::PREFIX . 'styled-components',
+					'wp-element',
+					'wp-i18n',
 				),
 			),
 		);

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -425,8 +425,8 @@ class WPSEO_Admin {
 	 */
 	private function get_helpscout_beacon() {
 		$helpscout_settings = array(
-			'beacon_id' => '2496aba6-0292-489c-8f5d-1c0fba417c2f',
-			'pages'     => array(
+			'beacon_id'   => '2496aba6-0292-489c-8f5d-1c0fba417c2f',
+			'pages'       => array(
 				'wpseo_dashboard',
 				'wpseo_titles',
 				'wpseo_search_console',
@@ -434,7 +434,8 @@ class WPSEO_Admin {
 				'wpseo_tools',
 				'wpseo_licenses',
 			),
-			'products' => array(),
+			'products'    => array(),
+			'ask_consent' => true,
 		);
 
 		/**
@@ -447,7 +448,8 @@ class WPSEO_Admin {
 		return new WPSEO_HelpScout(
 			$helpscout_settings['beacon_id'],
 			$helpscout_settings['pages'],
-			$helpscout_settings['products']
+			$helpscout_settings['products'],
+			$helpscout_settings['ask_consent']
 		);
 	}
 

--- a/admin/class-helpscout.php
+++ b/admin/class-helpscout.php
@@ -15,58 +15,74 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 *
 	 * @var string
 	 */
-	private $beacon_id;
+	protected $beacon_id;
 
 	/**
 	 * The pages where the beacon is loaded.
 	 *
 	 * @var array
 	 */
-	private $pages;
+	protected $pages;
 
 	/**
 	 * The products the beacon is loaded for.
 	 *
 	 * @var array
 	 */
-	private $products;
+	protected $products;
+
+	/**
+	 * Whether to asks the user's consent before loading in HelpScout.
+	 *
+	 * @var bool
+	 */
+	protected $ask_consent;
 
 	/**
 	 * WPSEO_HelpScout constructor.
 	 *
-	 * @param string $beacon_id The beacon id.
-	 * @param array  $pages     The pages where the beacon is loaded.
-	 * @param array  $products  The products the beacon is loaded for.
+	 * @param string $beacon_id   The beacon id.
+	 * @param array  $pages       The pages where the beacon is loaded.
+	 * @param array  $products    The products the beacon is loaded for.
+	 * @param bool   $ask_consent Optional. Whether to ask for consent before loading in HelpScout.
 	 */
-	public function __construct( $beacon_id, array $pages, array $products ) {
-		$this->beacon_id = $beacon_id;
-		$this->pages     = $pages;
-		$this->products  = $products;
+	public function __construct( $beacon_id, array $pages, array $products, $ask_consent = false ) {
+		$this->beacon_id   = $beacon_id;
+		$this->pages       = $pages;
+		$this->products    = $products;
+		$this->ask_consent = $ask_consent;
 	}
 
 	/**
-	 * Initializes the integration.
-	 *
-	 * This is the place to register hooks and filters.
-	 *
-	 * @return void
+	 * @inheritDoc
 	 */
 	public function register_hooks() {
 		if ( ! $this->is_beacon_page() ) {
 			return;
 		}
 
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_help_scout_script' ) );
 		add_action( 'admin_footer', array( $this, 'output_beacon_js' ) );
 	}
 
 	/**
-	 * Outputs a small piece of javascript for the beacon
+	 * Enqueues the HelpScout script.
+	 */
+	public function enqueue_help_scout_script() {
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		$asset_manager->enqueue_script( 'help-scout-beacon' );
+	}
+
+	/**
+	 * Outputs a small piece of javascript for the beacon.
 	 */
 	public function output_beacon_js() {
-		echo '<script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script>';
-		printf( '<script type="text/javascript">window.Beacon(\'init\', \'%1$s\')</script>', $this->beacon_id );
-		printf( '<script type="text/javascript">window.Beacon(\'session-data\', %1$s )</script>', $this->get_session_data() );
-
+		printf(
+			'<script type="text/javascript">window.%1$s(\'%2$s\', %3$s)</script>',
+			( $this->ask_consent ) ? 'wpseoHelpScoutBeaconConsent' : 'wpseoHelpScoutBeacon',
+			esc_html( $this->beacon_id ),
+			wp_json_encode( $this->get_session_data() )
+		);
 	}
 
 	/**
@@ -82,7 +98,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 * @return string The current page.
 	 */
 	private function get_current_page() {
-		$page      = filter_input( INPUT_GET, 'page' );
+		$page = filter_input( INPUT_GET, 'page' );
 		if ( isset( $page ) && $page !== false ) {
 			return $page;
 		}
@@ -95,7 +111,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	 *
 	 * @return string The data to pass as identifying data.
 	 */
-	private function get_session_data() {
+	protected function get_session_data() {
 		/** @noinspection PhpUnusedLocalVariableInspection */
 		// Do not make these strings translatable! They are for our support agents, the user won't see them!
 		$current_user = wp_get_current_user();
@@ -155,7 +171,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns info about the Yoast SEO plugin version and license.
 	 *
-	 * @param object $product  The product.
+	 * @param object $plugin The plugin.
 	 *
 	 * @return string The product info.
 	 */

--- a/js/src/help-scout-beacon.js
+++ b/js/src/help-scout-beacon.js
@@ -1,0 +1,215 @@
+import { render, useState, Fragment } from "@wordpress/element";
+import styled, { createGlobalStyle } from "styled-components";
+import { __ } from "@wordpress/i18n";
+
+/**
+ * Loads the HelpScout Beacon script.
+ *
+ * @param {string} beaconId    The ID to pass to the HelpScout Beacon.
+ * @param {string} sessionData Optional. JSON encoded session data to pass to the HelpScout Beacon.
+ *
+ * @returns {void}
+ */
+function loadHelpScout( beaconId, sessionData = "" ) {
+	// This IIFE is directly from HelpScout to insert their beacon.
+	( function( window, document ) {
+		let beacon = window.Beacon || function() {};
+
+		/**
+		 * Inserts the HelpScout beacon script.
+		 *
+		 * @returns {void}
+		 */
+		function insertScript() {
+			const domScriptElement = document.getElementsByTagName( "script" )[ 0 ];
+			const scriptElement = document.createElement( "script" );
+
+			scriptElement.type = "text/javascript";
+			scriptElement.async = true;
+			scriptElement.src = "https://beacon-v2.helpscout.net";
+			domScriptElement.parentNode.insertBefore( scriptElement, domScriptElement );
+		}
+
+		if ( window.Beacon = beacon = function( method, options, data ) {
+			window.Beacon.readyQueue.push( { method: method, options: options, data: data } );
+		}, beacon.readyQueue = [], "complete" === document.readyState ) {
+			return insertScript();
+		}
+
+		if ( window.attachEvent ) {
+			window.attachEvent( "onload", insertScript );
+		} else {
+			window.addEventListener( "load", insertScript, false );
+		}
+	}( window, document, window.Beacon || function() {} ) );
+
+	// eslint-disable-next-line new-cap
+	window.Beacon( "init", beaconId );
+	if ( sessionData !== "" ) {
+		// eslint-disable-next-line new-cap
+		window.Beacon( "session-data", JSON.parse( sessionData ) );
+	}
+}
+
+/**
+ * Loads a button that, when clicked, asks the user's consent before possibly loading in the HelpScout beacon.
+ *
+ * @param {string} beaconId    The ID to pass to the HelpScout Beacon.
+ * @param {string} sessionData Optional. JSON encoded session data to pass to the HelpScout Beacon.
+ *
+ * @returns {void}
+ */
+function loadHelpScoutConsent( beaconId, sessionData = null ) {
+	const element = document.createElement( "div" );
+	element.setAttribute( "id", "helpscout-beacon-ask-consent" );
+
+	const BeaconOffset = createGlobalStyle`
+		@media only screen and (min-width: 1024px) {
+			.BeaconFabButtonFrame.BeaconFabButtonFrame {
+				right: 340px;
+			}
+		}
+	`;
+
+	const Frame = styled.div`
+		border-radius: 60px;
+		height: 60px;
+		position: fixed;
+		transform: scale(1);
+		width: 60px;
+		z-index: 1049;
+		bottom: 40px;
+		box-shadow: rgba(0, 0, 0, 0.1) 0 4px 7px;
+		right: 40px;
+		top: auto;
+		border-width: initial;
+		border-style: none;
+		border-color: initial;
+		border-image: initial;
+		transition: box-shadow 250ms ease 0s, opacity 0.4s ease 0s, scale 1000ms ease-in-out 0s, transform 0.2s ease-in-out 0s;
+	`;
+
+	const SvgContainer = styled.span`
+		-webkit-box-align: center;
+		align-items: center;
+		color: white;
+		cursor: pointer;
+		display: flex;
+		height: 100%;
+		-webkit-box-pack: center;
+		justify-content: center;
+		left: 0px;
+		pointer-events: none;
+		position: absolute;
+		text-indent: -99999px;
+		top: 0px;
+		width: 60px;
+		will-change: opacity, transform;
+		opacity: 1 !important;
+		transform: rotate(0deg) scale(1) !important;
+		transition: opacity 80ms linear 0s, transform 160ms linear 0s;
+	`;
+
+	/**
+	 * Initializes the SpeechBubble component.
+	 *
+	 * @constructor
+	 *
+	 * @returns {React.Element} A SpeechBubble element.
+	 */
+	const SpeechBubble = () => {
+		return (
+			<SvgContainer>
+				<svg xmlns="http://www.w3.org/2000/svg" width="52" height="52">
+					{ /* eslint-disable-next-line max-len */ }
+					<path d="M27.031 32h-2.488v-2.046c0-.635.077-1.21.232-1.72.154-.513.366-.972.639-1.381.272-.41.58-.779.923-1.109.345-.328.694-.652 1.049-.97l.995-.854a6.432 6.432 0 0 0 1.475-1.568c.39-.59.585-1.329.585-2.216 0-.635-.117-1.203-.355-1.703a3.7 3.7 0 0 0-.96-1.263 4.305 4.305 0 0 0-1.401-.783A5.324 5.324 0 0 0 26 16.114c-1.28 0-2.316.375-3.11 1.124-.795.75-1.286 1.705-1.475 2.865L19 19.693c.356-1.772 1.166-3.165 2.434-4.176C22.701 14.507 24.26 14 26.107 14c.947 0 1.842.131 2.682.392.84.262 1.57.648 2.185 1.16a5.652 5.652 0 0 1 1.475 1.892c.368.75.551 1.602.551 2.556 0 .728-.083 1.364-.248 1.909a5.315 5.315 0 0 1-.693 1.467 6.276 6.276 0 0 1-1.048 1.176c-.403.351-.83.71-1.28 1.073-.498.387-.918.738-1.26 1.057a4.698 4.698 0 0 0-.836 1.006 3.847 3.847 0 0 0-.462 1.176c-.095.432-.142.955-.142 1.568V32zM26 37a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z" fill="#FFF" />
+				</svg>
+			</SvgContainer>
+		);
+	};
+
+	const Button = styled.button`
+		-webkit-appearance: none;
+		-webkit-box-align: center;
+		align-items: center;
+		bottom: 0px;
+		display: block;
+		height: 60px;
+		-webkit-box-pack: center;
+		justify-content: center;
+		line-height: 60px;
+		position: relative;
+		user-select: none;
+		z-index: 899;
+		background-color: rgb(164, 40, 106);
+		color: white;
+		cursor: pointer;
+		min-width: 60px;
+		-webkit-tap-highlight-color: transparent;
+		border-radius: 200px;
+		margin: 0px;
+		outline: none;
+		padding: 0px;
+		border-width: initial;
+		border-style: none;
+		border-color: initial;
+		border-image: initial;
+		transition: background-color 200ms linear 0s, transform 200ms linear 0s;
+	`;
+
+	/**
+	 * Initializes the HelpScoutBeaconAskConsentButton component.
+	 *
+	 * @constructor
+	 *
+	 * @returns {React.Element} A HelpScoutBeaconAskConsentButton element.
+	 */
+	const HelpScoutBeaconAskConsentButton = () => {
+		const [ show, setShow ] = useState( true );
+		const hasSidebar = !! document.getElementById( "sidebar" );
+
+		/**
+		 * Loads HelpScout beacon and then disables the ask consent button.
+		 *
+		 * @returns {void}
+		 */
+		function onClick() {
+			const askConsentText = __(
+				"When you click OK we will load our HelpScout beacon, which will load data from HelpScout. " +
+				"This beacon can potentially also set cookies.",
+				"wordpress-seo"
+			);
+
+			// eslint-disable-next-line no-alert
+			if ( window.confirm( askConsentText ) ) {
+				// eslint-disable-next-line callback-return
+				loadHelpScout( beaconId, sessionData );
+				// eslint-disable-next-line new-cap
+				window.Beacon( "open" );
+
+				// Hide the consent asking button only after the HelpScout button is visible. There is no callback for that though.
+				window.setTimeout( () => {
+					setShow( false );
+				}, 1000 );
+			}
+		}
+
+		return (
+			<Fragment>
+				{ hasSidebar && <BeaconOffset /> }
+				{ show && <Frame className={ hasSidebar ? "BeaconFabButtonFrame" : "" }>
+					<Button onClick={ onClick }>
+						<SpeechBubble />
+					</Button>
+				</Frame> }
+			</Fragment>
+		);
+	};
+
+	render( <HelpScoutBeaconAskConsentButton />, element );
+
+	document.body.appendChild( element );
+}
+
+window.wpseoHelpScoutBeacon = loadHelpScout;
+window.wpseoHelpScoutBeaconConsent = loadHelpScoutConsent;

--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -8,6 +8,7 @@ const cssDistPath = path.resolve( "css", "dist" );
 // Output filename: Entry file (relative to jsSrcPath)
 const entry = {
 	"configuration-wizard": "./configuration-wizard.js",
+	"help-scout-beacon": "./help-scout-beacon.js",
 	"search-appearance": "./search-appearance.js",
 	"wp-seo-dashboard-widget": "./wp-seo-dashboard-widget.js",
 	"wp-seo-help-center": "./wp-seo-help-center.js",


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduced a HelpScout beacon as a replacement for the Help Center.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the Yoast SEO settings, there should be a help scout beacon button on the bottom right of all the pages.
* Pay some extra attention to the pages with a sidebar, as the button should not be on top of the sidebar.
* When you click the `?` button, you should get a browser confirmation question.
  * When you click cancel, nothing should happen.
  * When you click confirm, the button should be replaced by the actual HelpScout button. The HelpScout beacon should open up too.

Not really implemented in this PR, but might be good to know/test when seeing this:
* When testing with an addon, the addon pages should not have this extra consent step.
* When testing in premium the consent step should not be there (at the time of writing this is not implemented yet).

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13865 
