### PR TITLE
Only send tracking info on the main site of a multi site install

### DIFF
--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -91,6 +91,11 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 			return false;
 		}
 
+		// Only send tracking on the main site of a multi-site instance. This returns true on non-multisite installs.
+		if ( ! is_main_site() ) {
+			return false;
+		}
+
 		// Because we don't want to possibly block plugin actions with our routines.
 		if ( in_array( $pagenow, array( 'plugins.php', 'plugin-install.php', 'plugin-editor.php' ), true ) ) {
 			return false;


### PR DESCRIPTION
## Summary
We currently send tracking info for every site in a multisite instance, that's a bit nonsense.

This PR can be summarized in the following changelog entry:

* None needed.

## Relevant technical choices:

* Used `is_main_site` which returns true on single site all the time.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
