### PR TITLE
Fixed overlapping of help scout beacon on pages iwth ads

### DIFF
--- a/js/src/help-scout-beacon.js
+++ b/js/src/help-scout-beacon.js
@@ -2,6 +2,39 @@ import { render, useState, Fragment } from "@wordpress/element";
 import styled, { createGlobalStyle } from "styled-components";
 import { __ } from "@wordpress/i18n";
 
+const BeaconOffset = createGlobalStyle`
+	@media only screen and (min-width: 1024px) {
+		.BeaconFabButtonFrame.BeaconFabButtonFrame {
+			right: 340px;
+		}
+	}
+`;
+
+/**
+ * Render a component in a newly created div.
+ *
+ * @param {React.Component} Component The component to render.
+ *
+ * @returns {void}
+ */
+function renderComponent( Component ) {
+	const element = document.createElement( "div" );
+	element.setAttribute( "id", "yoast-helpscout-beacon" );
+
+	render( <Component />, element );
+
+	document.body.appendChild( element );
+}
+
+/**
+ * Checks whether the current page contains upsells.
+ *
+ * @returns {boolean} Whether the current page contains upsells.
+ */
+function pageHasUpsells() {
+	return !! document.getElementById( "sidebar" );
+}
+
 /**
  * Loads the HelpScout Beacon script.
  *
@@ -49,6 +82,10 @@ function loadHelpScout( beaconId, sessionData = "" ) {
 		// eslint-disable-next-line new-cap
 		window.Beacon( "session-data", JSON.parse( sessionData ) );
 	}
+
+	if ( pageHasUpsells() ) {
+		renderComponent( BeaconOffset );
+	}
 }
 
 /**
@@ -60,17 +97,6 @@ function loadHelpScout( beaconId, sessionData = "" ) {
  * @returns {void}
  */
 function loadHelpScoutConsent( beaconId, sessionData = null ) {
-	const element = document.createElement( "div" );
-	element.setAttribute( "id", "helpscout-beacon-ask-consent" );
-
-	const BeaconOffset = createGlobalStyle`
-		@media only screen and (min-width: 1024px) {
-			.BeaconFabButtonFrame.BeaconFabButtonFrame {
-				right: 340px;
-			}
-		}
-	`;
-
 	const Frame = styled.div`
 		border-radius: 60px;
 		height: 60px;
@@ -98,11 +124,11 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 		height: 100%;
 		-webkit-box-pack: center;
 		justify-content: center;
-		left: 0px;
+		left: 0;
 		pointer-events: none;
 		position: absolute;
 		text-indent: -99999px;
-		top: 0px;
+		top: 0;
 		width: 60px;
 		will-change: opacity, transform;
 		opacity: 1 !important;
@@ -132,7 +158,7 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 		-webkit-appearance: none;
 		-webkit-box-align: center;
 		align-items: center;
-		bottom: 0px;
+		bottom: 0;
 		display: block;
 		height: 60px;
 		-webkit-box-pack: center;
@@ -147,9 +173,9 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 		min-width: 60px;
 		-webkit-tap-highlight-color: transparent;
 		border-radius: 200px;
-		margin: 0px;
+		margin: 0;
 		outline: none;
-		padding: 0px;
+		padding: 0;
 		border-width: initial;
 		border-style: none;
 		border-color: initial;
@@ -166,7 +192,7 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 	 */
 	const HelpScoutBeaconAskConsentButton = () => {
 		const [ show, setShow ] = useState( true );
-		const hasSidebar = !! document.getElementById( "sidebar" );
+		const hasUpsells = pageHasUpsells();
 
 		/**
 		 * Loads HelpScout beacon and then disables the ask consent button.
@@ -196,8 +222,8 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 
 		return (
 			<Fragment>
-				{ hasSidebar && <BeaconOffset /> }
-				{ show && <Frame className={ hasSidebar ? "BeaconFabButtonFrame" : "" }>
+				{ hasUpsells && <BeaconOffset /> }
+				{ show && <Frame className={ hasUpsells ? "BeaconFabButtonFrame" : "" }>
 					<Button onClick={ onClick }>
 						<SpeechBubble />
 					</Button>
@@ -206,9 +232,7 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 		);
 	};
 
-	render( <HelpScoutBeaconAskConsentButton />, element );
-
-	document.body.appendChild( element );
+	renderComponent( HelpScoutBeaconAskConsentButton );
 }
 
 window.wpseoHelpScoutBeacon = loadHelpScout;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* For developers:
  * Merge this branch in `wordpress-seo-premium` `release/12.6` branch.
  * Make sure ads are shown by disabling the subscription check in `class-yoast-form.php` on line 209.
* Go to the SEO dashboard, make sure the help scout button doesn't overlap the ads.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/wordpress-seo-premium#2619
