### PR TITLE
Fixes method get_gallery_image

### DIFF
--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -112,7 +112,7 @@ class Image_Helper {
 	 */
 	public function get_gallery_image( $post_id ) {
 		$post = \get_post( $post_id );
-		if ( \strpos( $post->post_content, '[gallery' ) !== false ) {
+		if ( \strpos( $post->post_content, '[gallery' ) === false ) {
 			return '';
 		}
 

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -112,11 +112,11 @@ class Image_Helper {
 	 */
 	public function get_gallery_image( $post_id ) {
 		$post = \get_post( $post_id );
-		if ( ! \has_shortcode( $post->post_content, 'gallery' ) ) {
+		if ( \strpos( $post->post_content, '[gallery' ) !== false ) {
 			return '';
 		}
 
-		$images = \get_post_gallery_images();
+		$images = \get_post_gallery_images( $post );
 		if ( empty( $images ) ) {
 			return '';
 		}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Pass correct $post object to function [get_post_galleries](https://developer.wordpress.org/reference/functions/get_post_galleries/).

## Relevant technical choices:

* Function [has_shortcode](has_shortcode) is already called from function [get_post_galleries](https://developer.wordpress.org/reference/functions/get_post_galleries/). Replace it with faster way - [strpos](https://www.php.net/manual/en/function.strpos.php).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* ~~[ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
