### PR TITLE
Fix HowTo naming in code documentation / comments

### DIFF
--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Returns schema FAQ data.
+ * Returns schema HowTo data.
  *
  * @since 11.5
  */
@@ -22,7 +22,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	private $is_needed = false;
 
 	/**
-	 * The FAQ blocks count on the current page.
+	 * The HowTo blocks count on the current page.
 	 *
 	 * @var int
 	 */
@@ -43,7 +43,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	private $allowed_json_text_tags = '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><b><strong><i><em>';
 
 	/**
-	 * WPSEO_Schema_FAQ constructor.
+	 * WPSEO_Schema_HowTo constructor.
 	 *
 	 * @param WPSEO_Schema_Context $context A value object with context variables.
 	 *


### PR DESCRIPTION
Multiple instances where HowTo was still displayed as FAQ in the code documentation.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes docs in the Schema HowTo files. Props to [timvaniersel](https://github.com/timvaniersel)

## Relevant technical choices:

*

## Test instructions
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
