### PR TITLE
Fix notification center buttons style.

### DIFF
--- a/css/src/alerts.scss
+++ b/css/src/alerts.scss
@@ -105,6 +105,12 @@ $yoast-alerts-active-margin: 20px;
 	}
 }
 
+// Get started dismiss button focus style position.
+.yoast-alerts .button.dismiss.yoast-container__configuration-wizard--dismiss::before {
+	top: 0;
+	transform: translate(-50%,6px);
+}
+
 .yoast-container .separator {
 	margin-top: 1em;
 	margin-bottom: 1em;
@@ -287,7 +293,7 @@ $yoast-alerts-active-margin: 20px;
 
 				.dashicons {
 					text-decoration: none;
-					margin-top: 11px;
+					margin-top: 12px;
 				}
 			}
 		}

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,13 +3,13 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 151,
+			maxWarnings: 143,
 		},
 	},
 	tests: {
 		src: [ "<%= files.jsTests %>" ],
 		options: {
-			maxWarnings: 4,
+			maxWarnings: 3,
 		},
 	},
 	grunt: {

--- a/js/src/wp-seo-admin-global.js
+++ b/js/src/wp-seo-admin-global.js
@@ -223,8 +223,6 @@
 			var $container = $this.closest( ".yoast-container" );
 			$container.append( '<div class="yoast-container-disabled"/>' );
 
-			$this.find( "span" ).removeClass( "dashicons-no-alt" ).addClass( "dashicons-randomize" );
-
 			$.post(
 				ajaxurl,
 				{
@@ -244,8 +242,6 @@
 
 			var $container = $this.closest( ".yoast-container" );
 			$container.append( '<div class="yoast-container-disabled"/>' );
-
-			$this.find( "span" ).removeClass( "dashicons-arrow-up" ).addClass( "dashicons-randomize" );
 
 			$.post(
 				ajaxurl,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed a bug where clicking the notification center buttons would display a wrong icon and a misplaced focus style for the dismiss and restore buttons.

## Relevant technical choices:

* Removed leftover code from the old implementation of the notification center, see https://github.com/Yoast/wordpress-seo/pull/4621
* Updated the ESLint max-warnings

## Test instructions
This PR can be tested by following these steps:

* Go to SEO > General and observe the notification center
- make sure you have the "Get started" notification displayed: for testing purposes I temporarily altered the code to make it appear, not sure if there are better methods
- using the keyboard, tab through the interface and verify the "Get started" notification button focus style is displayed correctly

Previously it was misplaced:

![Screenshot (74)](https://user-images.githubusercontent.com/1682452/68854851-367e3000-06dd-11ea-9f7c-0dd0caeb67a4.png)

- dismiss one of the notifications by clicking on its dismiss button
- verify the `dashicons-randomize` doesn't appear any longer after the click (see screenshot on the issue)
- restore one of the dismissed notifications: 
- verify the `dashicons-randomize` doesn't appear any longer after the click 


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/733