### PR TITLE
Introduce date format helper

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -25,6 +25,13 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	private $permalink;
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WP_Post|array $post      Post object.
@@ -34,6 +41,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	public function __construct( $post, array $options, $structure ) {
 		$this->post      = $post;
 		$this->permalink = $structure;
+		$this->date      = new Date_Helper();
 	}
 
 	/**
@@ -222,7 +230,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		$date = '';
 
 		if ( $this->is_show_date_enabled() ) {
-			$date = date_i18n( 'M j, Y', mysql2date( 'U', $this->post->post_date ) );
+			$date = $this->date->format_translated( $this->post->post_date, 'M j, Y' );
 		}
 
 		return $date;

--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -32,6 +32,13 @@ class WPSEO_Breadcrumbs {
 	public static $after = '';
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * Blog's show on front setting, 'page' or 'posts'.
 	 *
 	 * @var string
@@ -122,6 +129,7 @@ class WPSEO_Breadcrumbs {
 		$this->show_on_front         = get_option( 'show_on_front' );
 		$this->page_for_posts        = get_option( 'page_for_posts' );
 		$this->woocommerce_shop_page = new WPSEO_WooCommerce_Shop_Page();
+		$this->date                  = new Date_Helper();
 
 		$this->filter_element();
 		$this->filter_separator();
@@ -728,17 +736,9 @@ class WPSEO_Breadcrumbs {
 
 	/**
 	 * Add (non-link) date crumb to crumbs property.
-	 *
-	 * @param string $date Optional date string, defaults to post's date.
 	 */
-	private function add_date_crumb( $date = null ) {
-		if ( is_null( $date ) ) {
-			$date = get_the_date();
-		}
-		else {
-			$date = mysql2date( get_option( 'date_format' ), $date, true );
-			$date = apply_filters( 'get_the_date', $date, '' );
-		}
+	private function add_date_crumb() {
+		$date = get_the_date();
 
 		$this->add_predefined_crumb(
 			WPSEO_Options::get( 'breadcrumbs-archiveprefix' ) . ' ' . esc_html( $date ),

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -21,7 +21,7 @@ class WPSEO_OpenGraph {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->date = Date_Helper();
+		$this->date = new Date_Helper();
 
 		if ( isset( $GLOBALS['fb_ver'] ) || class_exists( 'Facebook_Loader', false ) ) {
 			add_filter( 'fb_meta_tags', array( $this, 'facebook_filter' ), 10, 1 );

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -11,9 +11,18 @@
 class WPSEO_OpenGraph {
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
+		$this->date = Date_Helper();
+
 		if ( isset( $GLOBALS['fb_ver'] ) || class_exists( 'Facebook_Loader', false ) ) {
 			add_filter( 'fb_meta_tags', array( $this, 'facebook_filter' ), 10, 1 );
 		}
@@ -701,10 +710,10 @@ class WPSEO_OpenGraph {
 
 		$post = get_post();
 
-		$pub = mysql2date( DATE_W3C, $post->post_date, false );
+		$pub = $this->date->format( $post->post_date_gmt );
 		$this->og_tag( 'article:published_time', $pub );
 
-		$mod = mysql2date( DATE_W3C, $post->post_modified, false );
+		$mod = $this->date->format( $post->post_modified_gmt );
 		if ( $mod !== $pub ) {
 			$this->og_tag( 'article:modified_time', $mod );
 			$this->og_tag( 'og:updated_time', $mod );

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -13,6 +13,13 @@
 class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * A value object with context variables.
 	 *
 	 * @var WPSEO_Schema_Context
@@ -26,6 +33,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 */
 	public function __construct( WPSEO_Schema_Context $context ) {
 		$this->context = $context;
+		$this->date    = new Date_Helper();
 	}
 
 	/**
@@ -59,8 +67,8 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 			'isPartOf'         => array( '@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH ),
 			'author'           => array( '@id' => WPSEO_Schema_Utils::get_user_schema_id( $post->post_author, $this->context ) ),
 			'headline'         => get_the_title(),
-			'datePublished'    => mysql2date( DATE_W3C, $post->post_date, false ),
-			'dateModified'     => mysql2date( DATE_W3C, $post->post_modified, false ),
+			'datePublished'    => $this->date->format( $post->post_date_gmt ),
+			'dateModified'     => $this->date->format( $post->post_modified_gmt ),
 			'commentCount'     => $comment_count['approved'],
 			'mainEntityOfPage' => array( '@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH ),
 		);

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -13,6 +13,13 @@
 class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * A value object with context variables.
 	 *
 	 * @var WPSEO_Schema_Context
@@ -26,6 +33,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 */
 	public function __construct( WPSEO_Schema_Context $context ) {
 		$this->context = $context;
+		$this->date    = new Date_Helper();
 	}
 
 	/**
@@ -68,8 +76,8 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			$this->add_image( $data );
 
 			$post                  = get_post( $this->context->id );
-			$data['datePublished'] = mysql2date( DATE_W3C, $post->post_date, false );
-			$data['dateModified']  = mysql2date( DATE_W3C, $post->post_modified, false );
+			$data['datePublished'] = $this->date->format( $post->post_date_gmt );
+			$data['dateModified']  = $this->date->format( $post->post_modified_gmt );
 
 			if ( get_post_type( $post ) === 'post' ) {
 				$data = $this->add_author( $data, $post );

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -48,6 +48,13 @@ class WPSEO_Replace_Vars {
 	protected $args;
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * Help texts for use in WPSEO -> Search appearance tabs.
 	 *
 	 * @var array
@@ -67,6 +74,7 @@ class WPSEO_Replace_Vars {
 	 * @return \WPSEO_Replace_Vars
 	 */
 	public function __construct() {
+		$this->date = new Date_Helper();
 	}
 
 	/**
@@ -307,7 +315,7 @@ class WPSEO_Replace_Vars {
 		$replacement = null;
 
 		if ( $this->args->post_date !== '' ) {
-			$replacement = mysql2date( get_option( 'date_format' ), $this->args->post_date, true );
+			$replacement = $this->date->format_translated( $this->args->post_date, get_option( 'date_format' ) );
 		}
 		else {
 			if ( get_query_var( 'day' ) && get_query_var( 'day' ) !== '' ) {
@@ -883,7 +891,7 @@ class WPSEO_Replace_Vars {
 		$replacement = null;
 
 		if ( ! empty( $this->args->post_modified ) ) {
-			$replacement = mysql2date( get_option( 'date_format' ), $this->args->post_modified, true );
+			$replacement = $this->date->format_translated( $this->args->post_modified, get_option( 'date_format' ) );
 		}
 
 		return $replacement;

--- a/inc/date-helper.php
+++ b/inc/date-helper.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Date helper class.
+ *
+ * @package WPSEO\Internals
+ */
+
+/**
+ * Class Date_Helper
+ *
+ * Note: Move this class with namespace to the src/helpers directory and add a class_alias for BC.
+ */
+class Date_Helper {
+
+	/**
+	 * Formats a given date in UTC TimeZone format.
+	 *
+	 * @param string $date   String representing the date / time.
+	 * @param string $format The format that the passed date should be in.
+	 *
+	 * @return string The formatted date.
+	 */
+	public function format( $date, $format = DATE_W3C ) {
+		$immutable_date = date_create_immutable_from_format( 'Y-m-d h:i:s', $date, new DateTimeZone( 'UTC' ) );
+
+		return $immutable_date->format( $format );
+	}
+}

--- a/inc/date-helper.php
+++ b/inc/date-helper.php
@@ -21,8 +21,20 @@ class Date_Helper {
 	 * @return string The formatted date.
 	 */
 	public function format( $date, $format = DATE_W3C ) {
-		$immutable_date = date_create_immutable_from_format( 'Y-m-d h:i:s', $date, new DateTimeZone( 'UTC' ) );
+		$immutable_date = date_create_immutable_from_format( 'Y-m-d H:i:s', $date, new DateTimeZone( 'UTC' ) );
 
 		return $immutable_date->format( $format );
+	}
+
+	/**
+	 * Formats a given date in UTC TimeZone format and translate it to the set language.
+	 *
+	 * @param string $date   String representing the date / time.
+	 * @param string $format The format that the passed date should be in.
+	 *
+	 * @return string The formatted and translated date.
+	 */
+	public function format_translated( $date, $format = DATE_W3C ) {
+		return date_i18n( $format, $this->format( $date, 'U' ) );
 	}
 }

--- a/tests/frontend/schema/schema-webpage-test.php
+++ b/tests/frontend/schema/schema-webpage-test.php
@@ -135,8 +135,8 @@ class Schema_WebPage_Test extends TestCase {
 		$this->context->site_represents = false;
 
 		$post                    = Mockery::mock( 'WP_Post' );
-		$post->post_date_gmt     = '';
-		$post->post_modified_gmt = '';
+		$post->post_date_gmt     = '0000-00-00 00:00:00';
+		$post->post_modified_gmt = '0000-00-00 00:00:00';
 
 		Monkey\Functions\expect( 'get_post' )
 			->andReturn( $post );
@@ -165,8 +165,8 @@ class Schema_WebPage_Test extends TestCase {
 		$this->context->site_represents = false;
 
 		$post                    = Mockery::mock( 'WP_Post' );
-		$post->post_date_gmt     = '';
-		$post->post_modified_gmt = '';
+		$post->post_date_gmt     = '0000-00-00 00:00:00';
+		$post->post_modified_gmt = '0000-00-00 00:00:00';
 		$post->post_author       = 'author';
 
 		Monkey\Functions\expect( 'get_post' )

--- a/tests/frontend/schema/schema-webpage-test.php
+++ b/tests/frontend/schema/schema-webpage-test.php
@@ -135,9 +135,7 @@ class Schema_WebPage_Test extends TestCase {
 		$this->context->site_represents = false;
 
 		$post                    = Mockery::mock( 'WP_Post' );
-		$post->post_date         = '';
 		$post->post_date_gmt     = '';
-		$post->post_modified     = '';
 		$post->post_modified_gmt = '';
 
 		Monkey\Functions\expect( 'get_post' )
@@ -167,9 +165,7 @@ class Schema_WebPage_Test extends TestCase {
 		$this->context->site_represents = false;
 
 		$post                    = Mockery::mock( 'WP_Post' );
-		$post->post_date         = '';
 		$post->post_date_gmt     = '';
-		$post->post_modified     = '';
 		$post->post_modified_gmt = '';
 		$post->post_author       = 'author';
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the time in the `article:published_time` and `article:modified_time` meta tag output and in the `datePublished` and `dateModified` schema output was incorrect when in WordPress 5.2.

## Relevant technical choices:

* For all the user-facing dates we still use the non-GMT date from WP.
* The date format helper presumes the same format as the WP database column.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Setup
* Change your timezone: `Settings` > `General` > `Timezone` to somewhere where the date is different than where you are now. E.g. Sydney or Honolulu.
* In the same spot, ensure you have the `Date Format` to something that includes the date.
* Ensure you have the date prefix for the snippet preview: `Yoast SEO` > `Search Appearance` > `Content Types` > `Date in Snippet Preview` set to `Show`.

### Test both in WP 5.2 & WP 5.3:

#### Snippet preview / replace vars
* Create a new post.
* Verify that the date in the snippet preview is the date that represents the current date in the timezone you entered.
* Enter %%date%% in the meta description (or title).
* Verify that the same date (as above) is displayed in the snippet preview.

#### Breadcrumbs
* Add a breadcrumb shortcode to a post: `[wpseo_breadcrumb]` and save the post.
* Go to a date archive of the date you expect, for example: `http://local.wordpress.test/2019/11/26/`
* Verify there is a breadcrumb with the correct date.
* Verify your post is there.

#### OpenGraph output
* View the source of the post you created earlier.
* Verify the `article_published_time`, `article:modified_time`, and `og:updated_time` have the UTC / GMT time with `+00:00` included.

#### Schema WebPage & Article
* View the source of the post you created earlier.
* Search the schema output WebPage piece.
* Verify the `datePublished` and `dateModified`  have the UTC / GMT time with `+00:00` included.
* Search the schema output Article piece (make sure you do not have News activated, News overrides this).
* Verify the `datePublished` and `dateModified`  have the UTC / GMT time with `+00:00` included.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13906 
