### PR TITLE
Remove featured image alt attribute fallback to image title.

### DIFF
--- a/js/src/wp-seo-featured-image.js
+++ b/js/src/wp-seo-featured-image.js
@@ -145,12 +145,7 @@ import { isGutenbergDataAvailable } from "./helpers/isGutenbergAvailable";
 
 			selectedImage = featuredImage.state().get( "selection" ).first();
 
-			// WordPress falls back to the title for the alt attribute if no alt is present.
 			alt = selectedImage.get( "alt" );
-
-			if ( "" === alt ) {
-				alt = selectedImage.get( "title" );
-			}
 
 			selectedImageHTML = "<img" +
 				' src="' + selectedImage.get( "url" ) + '"' +


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Fixes a bug where the images alt attribute SEO assessment in the Classic Editor was wrong when the image had not alt attribute and did have a title attribute

## Relevant technical choices:

* Since WordPress 4.7 the image alt attribute doesn't fallback to the image title attribute any longer. Yoast SEO still used the old fallback, which is now removed.

## Test instructions

**To reproduce the bug on trunk:**
- use the Classic Editor 
- create a post
- set a featured image with no alt attribute
- see the analysis says the image does have an alt attribute
- set a test keyphrase `mykeyphrase`
- edit the featured image and set its title attribute to `mykeyphrase`
- see the analysis says: Image alt attributes: Good job!
- however, the image has no alt attribute so the assessment feedback is misleading

**Switch to this branch and build the plugin:**
- repeat the steps above
- see the result assessment is correct 
- try different combinations of empty/filled alt and title attributes . matching or not matching the SEO keyphrase
- the assessment should always be based exclusively on the alt attribute 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/6277