### PR TITLE
Add safety check for when the PHP date format would return false

### DIFF
--- a/inc/date-helper.php
+++ b/inc/date-helper.php
@@ -23,6 +23,10 @@ class WPSEO_Date_Helper {
 	public function format( $date, $format = DATE_W3C ) {
 		$immutable_date = date_create_immutable_from_format( 'Y-m-d H:i:s', $date, new DateTimeZone( 'UTC' ) );
 
+		if ( ! $immutable_date ) {
+			return $date;
+		}
+
 		return $immutable_date->format( $format );
 	}
 


### PR DESCRIPTION
This fixes a fatal when you pass an empty date string for example.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal would occur when an empty string would be passed to the `WPSEO_Date_Helper->format` method. Props to [@mpolek](https://github.com/mpolek).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the following to your `function.php` of your theme:
```
$date = new WPSEO_Date_Helper();
$date->format( '' );
```
* Verify that it produces a fatal without this PR.
* Verify that is no longer produces a fatal with this PR.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13948 
