### PR TITLE
Implement date helper

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -76,8 +76,8 @@ class Article extends Abstract_Schema_Piece {
 			'isPartOf'         => [ '@id' => $context->canonical . $this->id_helper->webpage_hash ],
 			'author'           => [ '@id' => $this->id_helper->get_user_schema_id( $context->post->post_author, $context ) ],
 			'headline'         => $context->title,
-			'datePublished'    => $this->date_helper->mysql_date_to_w3c_format( $context->post->post_date_gmt ),
-			'dateModified'     => $this->date_helper->mysql_date_to_w3c_format( $context->post->post_modified_gmt ),
+			'datePublished'    => $this->date_helper->format( $context->post->post_date_gmt ),
+			'dateModified'     => $this->date_helper->format( $context->post->post_modified_gmt ),
 			'commentCount'     => $comment_count['approved'],
 			'mainEntityOfPage' => [ '@id' => $context->canonical . $this->id_helper->webpage_hash ],
 		];

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -91,8 +91,8 @@ class WebPage extends Abstract_Schema_Piece {
 		if ( $context->indexable->object_type === 'post' ) {
 			$this->add_image( $data, $context );
 
-			$data['datePublished'] = $this->date_helper->mysql_date_to_w3c_format( $context->post->post_date_gmt );
-			$data['dateModified']  = $this->date_helper->mysql_date_to_w3c_format( $context->post->post_modified_gmt );
+			$data['datePublished'] = $this->date_helper->format( $context->post->post_date_gmt );
+			$data['dateModified']  = $this->date_helper->format( $context->post->post_modified_gmt );
 
 			if ( $context->indexable->object_sub_type === 'post' ) {
 				$data = $this->add_author( $data, $context->post, $context );

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -12,6 +12,21 @@ namespace Yoast\WP\Free\Helpers;
  * Class Date_Helper
  */
 class Date_Helper {
+
+	/**
+	 * The date helper.
+	 *
+	 * @var \WPSEO_Date_Helper
+	 */
+	protected $date;
+
+	/**
+	 * Date_Helper constructor.
+	 */
+	public function __construct() {
+		$this->date = new \WPSEO_Date_Helper();
+	}
+
 	/**
 	 * Convert given date string to the W3C format.
 	 *
@@ -25,5 +40,17 @@ class Date_Helper {
 	 */
 	public function mysql_date_to_w3c_format( $date, $translate = false ) {
 		return \mysql2date( DATE_W3C, $date, $translate );
+	}
+
+	/**
+	 * Formats a given date in UTC TimeZone format.
+	 *
+	 * @param string $date   String representing the date / time.
+	 * @param string $format The format that the passed date should be in.
+	 *
+	 * @return string The formatted date.
+	 */
+	public function format( $date, $format = DATE_W3C ) {
+		return $this->date->format( $date, $format );
 	}
 }

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -243,7 +243,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			}
 		}
 
-		return $this->date->mysql_date_to_w3c_format( $this->context->post->post_date_gmt );
+		return $this->date->format( $this->context->post->post_date_gmt );
 	}
 
 	/**
@@ -253,7 +253,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 */
 	public function generate_og_article_modified_time() {
 		if ( $this->context->post->post_modified_gmt !== $this->context->post->post_date_gmt ) {
-			return $this->date->mysql_date_to_w3c_format( $this->context->post->post_modified_gmt );
+			return $this->date->format( $this->context->post->post_modified_gmt );
 		}
 
 		return '';

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -176,13 +176,13 @@ class Article_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_list_pluck' )->once()->with( $categories, 'name' )->andReturn( [ 'Category1' ] );
 
 		$this->date_helper_mock
-			->expects( 'mysql_date_to_w3c_format' )
+			->expects( 'format' )
 			->once()
 			->with( '2345-12-12 12:12:12' )
 			->andReturn( '2345-12-12 12:12:12' );
 
 		$this->date_helper_mock
-			->expects( 'mysql_date_to_w3c_format' )
+			->expects( 'format' )
 			->once()
 			->with( '2345-12-12 23:23:23' )
 			->andReturn( '2345-12-12 23:23:23' );

--- a/tests/presentations/indexable-post-type-presentation/og-article-modified-time-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-article-modified-time-test.php
@@ -50,7 +50,7 @@ class OG_Article_Modified_Time_Test extends TestCase {
 		];
 
 		$this->date_helper
-			->expects( 'mysql_date_to_w3c_format' )
+			->expects( 'format' )
 			->with( '2019-11-09T12:34:56+00:00' )
 			->once()
 			->andReturn( '2019-11-09T12:34:56+00:00' );

--- a/tests/presentations/indexable-post-type-presentation/og-article-published-time-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-article-published-time-test.php
@@ -35,7 +35,7 @@ class OG_Article_Published_Time_Test extends TestCase {
 		$this->context->post = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
 
 		$this->date_helper
-			->expects( 'mysql_date_to_w3c_format' )
+			->expects( 'format' )
 			->with( '2019-10-08T12:26:31+00:00' )
 			->once()
 			->andReturn( '2019-10-08T12:26:31+00:00' );
@@ -73,7 +73,7 @@ class OG_Article_Published_Time_Test extends TestCase {
 		$this->indexable->object_sub_type = 'page';
 
 		$this->date_helper
-			->expects( 'mysql_date_to_w3c_format' )
+			->expects( 'format' )
 			->with( '2019-10-08T12:26:31+00:00' )
 			->once()
 			->andReturn( '2019-10-08T12:26:31+00:00' );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A Implements the datehelper for formatting the date UTC+0.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Change the timezone in `Settings` --> `General` to a city.
* Create a post and view the page source.
* Make sure the schema outputs the right `datePublished` fields.
* Edit the post and view the page source.
* Make sure the schema outputs the right `dateModified` fields.
* Change the timezone in `Settings` --> `General` to a manual offset.
* Repeat the above steps to check the schema output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes: #13907  
