### PR TITLE
escaped howto and faq IDs

### DIFF
--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -80,7 +80,7 @@ class FAQ extends Abstract_Schema_Piece {
 				if ( ! isset( $question['jsonAnswer'] ) || empty( $question['jsonAnswer'] ) ) {
 					continue;
 				}
-				$ids[]   = [ '@id' => $context->canonical . '#' . $question['id'] ];
+				$ids[]   = [ '@id' => $context->canonical . '#' . esc_attr( $question['id'] ) ];
 				$graph[] = $this->generate_question_block( $question, $index, $context );
 				$number_of_items = count( $context->blocks['yoast/faq-block'][ $block_number ]['attrs']['questions'] );
 			}
@@ -109,11 +109,13 @@ class FAQ extends Abstract_Schema_Piece {
 	 * @return array Schema.org Question piece.
 	 */
 	protected function generate_question_block( $question, $position, Meta_Tags_Context $context ) {
+		$url = $context->canonical . '#' . esc_attr( $question['id'] );
+
 		return [
 			'@type'          => 'Question',
-			'@id'            => $context->canonical . '#' . $question['id'],
+			'@id'            => $url,
 			'position'       => $position,
-			'url'            => $context->canonical . '#' . $question['id'],
+			'url'            => $url,
 			'name'           => \strip_tags( $question['jsonQuestion'] ),
 			'answerCount'    => 1,
 			'acceptedAnswer' => [

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -101,7 +101,7 @@ class HowTo extends Abstract_Schema_Piece {
 		$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
 
 		if ( ( $days + $hours + $minutes ) > 0 ) {
-			$data['totalTime'] = 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M';
+			$data['totalTime'] = esc_attr( 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M' );
 		}
 	}
 
@@ -114,7 +114,7 @@ class HowTo extends Abstract_Schema_Piece {
 	 */
 	private function add_steps( &$data, $steps, Meta_Tags_Context $context ) {
 		foreach ( $steps as $step ) {
-			$schema_id   = $context->canonical . '#' . $step['id'];
+			$schema_id   = $context->canonical . '#' . esc_attr( $step['id'] );
 			$schema_step = [
 				'@type' => 'HowToStep',
 				'url'   => $schema_id,
@@ -192,7 +192,7 @@ class HowTo extends Abstract_Schema_Piece {
 	private function add_step_image( &$schema_step, $step, Meta_Tags_Context $context ) {
 		foreach ( $step['text'] as $line ) {
 			if ( \is_array( $line ) && isset( $line['type'] ) && $line['type'] === 'img' ) {
-				$schema_step['image'] = $this->get_image_schema( $line['props']['src'], $context );
+				$schema_step['image'] = $this->get_image_schema( esc_url( $line['props']['src'] ), $context );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

In #13896 we improved the security of the plugin by adding more output escaping.

As this impacts classes that have been moved in the feature branch this change should be replicated in the feature branch.

all outputs in the feature branch in schema blocks are escaped.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds output escaping to schema blocks.

## Relevant technical choices:

* Addes output escaping to schemas blocks in indexables, just as done in trunk.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if outputs are correct and safely done.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13897
