### PR TITLE
Remove all IE11-specific scss

### DIFF
--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -311,6 +311,7 @@ td.column-wpseo-linked {
 		vertical-align: top;
 		/* inherits font size 14px */
 		line-height: 1.85714285; /* 26px vs. 28px from core */
+		min-height: 28px; /* 28px vs. 30px from core */
 	}
 }
 
@@ -366,6 +367,7 @@ td.column-wpseo-linked {
 			vertical-align: top;
 			/* inherits font size 16px */
 			line-height: 1.875; /* 30px */
+			min-height: 32px;
 		}
 	}
 
@@ -436,7 +438,6 @@ td.column-wpseo-linked {
 }
 
 .yoast_help.yoast-help-button {
-	overflow: visible;
 	position: relative;
 	width: 20px;
 	height: 20px;
@@ -448,6 +449,7 @@ td.column-wpseo-linked {
 	background: transparent;
 	box-shadow: none;
 	vertical-align: top;
+	cursor: pointer;
 }
 
 .yoast-section .yoast_help.yoast-help-button {

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -311,8 +311,6 @@ td.column-wpseo-linked {
 		vertical-align: top;
 		/* inherits font size 14px */
 		line-height: 1.85714285; /* 26px vs. 28px from core */
-		/* Only necessary for IE11 */
-		min-height: 28px; /* 28px vs. 30px from core */
 	}
 }
 
@@ -368,8 +366,6 @@ td.column-wpseo-linked {
 			vertical-align: top;
 			/* inherits font size 16px */
 			line-height: 1.875; /* 30px */
-			/* Only necessary for IE11 */
-			min-height: 32px;
 		}
 	}
 
@@ -452,8 +448,6 @@ td.column-wpseo-linked {
 	background: transparent;
 	box-shadow: none;
 	vertical-align: top;
-	/* IE 11 */
-	cursor: pointer;
 }
 
 .yoast-section .yoast_help.yoast-help-button {

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -553,15 +553,6 @@ td.column-wpseo-linked {
 		filter: none;
 	}
 
-	// Only needed for IE 10+. Don't add spaces within brackets for this to work.
-	@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-		&::after {
-			display: inline-block;
-			content: "";
-			min-height: 32px;
-		}
-	}
-
 	&#wpseo-premium-button {
 		color: $color-black;
 	}

--- a/css/src/alerts.scss
+++ b/css/src/alerts.scss
@@ -46,8 +46,6 @@ $yoast-alerts-active-margin: 20px;
 }
 
 .yoast-container .yoast-alert-holder {
-	display: -ms-flexbox;
-	display: -webkit-flex;
 	display: flex;
 	position: relative;
 }

--- a/css/src/extensions.scss
+++ b/css/src/extensions.scss
@@ -117,6 +117,8 @@
 	}
 
 	&-promo-extension {
+		// This is already a flex item of the container yoast-promo-extensions.
+		max-width: 340px;
 		// Then we style it as flex container to layout its content in a vertical flexbox.
 		display: flex;
 		flex-direction: column;

--- a/css/src/extensions.scss
+++ b/css/src/extensions.scss
@@ -117,10 +117,6 @@
 	}
 
 	&-promo-extension {
-		// This is already a flex item of the container yoast-promo-extensions.
-		// First we style it as flex item to include fixes for IE11.
-		flex: 0 1 340px;
-		max-width: 340px;
 		// Then we style it as flex container to layout its content in a vertical flexbox.
 		display: flex;
 		flex-direction: column;

--- a/css/src/extensions.scss
+++ b/css/src/extensions.scss
@@ -117,11 +117,9 @@
 	}
 
 	&-promo-extension {
-		// This is already a flex item of the container yoast-promo-extensions.
-		max-width: 340px;
-		// Then we style it as flex container to layout its content in a vertical flexbox.
 		display: flex;
 		flex-direction: column;
+		max-width: 340px;
 		background-color: #fff;
 		margin-left: $gutter;
 

--- a/css/src/toggle-switch.scss
+++ b/css/src/toggle-switch.scss
@@ -415,7 +415,7 @@
 	}
 
 	.switch-yoast-seo .switch-yoast-seo-jaws-a11y {
-		/* IE11 and JAWS 17.0 need this hack. */
+		/* JAWS 17.0 need this hack. */
 		display: block;
 		overflow: hidden;
 		height: 1px;

--- a/css/src/toggle-switch.scss
+++ b/css/src/toggle-switch.scss
@@ -415,7 +415,7 @@
 	}
 
 	.switch-yoast-seo .switch-yoast-seo-jaws-a11y {
-		/* JAWS 17.0 need this hack. */
+		/* JAWS 17.0 needs this hack. */
 		display: block;
 		overflow: hidden;
 		height: 1px;

--- a/css/src/wpseo-dismissible.scss
+++ b/css/src/wpseo-dismissible.scss
@@ -43,10 +43,6 @@
 	box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);
 }
 
-.ie8 .yoast-notice-dismiss:focus {
-	outline: 1px solid #5b9dd9;
-}
-
 .yoast-notice.is-dismissible {
 	position: relative;
 }

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -184,10 +184,6 @@
 	&--choice {
 		& > .yoast-wizard--rows {
 			height: 100%;
-			// Only needed for IE 10+. Don't add spaces within brackets for this to work.
-			@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-				width: 100%;
-			}
 		}
 
 		& div {
@@ -239,10 +235,6 @@
 
 			& > div {
 				margin-left: 0;
-				// Only needed for IE 10+. Don't add spaces within brackets for this to work.
-				@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-					width: 95.5%;
-				}
 			}
 
 			& > .yoast-wizard--column__push_ {

--- a/css/src/yoast-components.scss
+++ b/css/src/yoast-components.scss
@@ -298,7 +298,3 @@
 	}
 
 }
-
-.ie9 .yoast-wizard--stepper {
-	display: none;
-}

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -309,7 +309,6 @@ tr.yst_row.even {
 		width: 100%;
 		padding: 0;
 		text-align: left;
-		overflow: visible; // IE11 clips the icon focus style
 	}
 
 	.toggleable-container-icon {
@@ -823,10 +822,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 			opacity: .75;
 		}
 
-		/* Remove background focus style from IE11 while keeping focus style available on option elements. */
-		&::-ms-value {
-			background: transparent;
-		}
 		/* Remove the default down arrow in IE/Edge. */
 		&::-ms-expand {
 			display: none;

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -4,8 +4,6 @@
 .wpseo_content_wrapper {
 	display: table;
 	width: 100%;
-	// Edge needs this for the Help Center responsiveness.
-	table-layout: fixed;
 }
 
 .wpseo_content_cell {

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -4,7 +4,7 @@
 .wpseo_content_wrapper {
 	display: table;
 	width: 100%;
-	// IE11 and Edge need this for the Help Center responsiveness.
+	// Edge needs this for the Help Center responsiveness.
 	table-layout: fixed;
 }
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test in browsers other than IE11.
* `Social` : input fields and buttons should be same height (28px). 
* When hoovering over question marks (e.g. at `Social` > `Accounts`) the cursor should be a pointer.
* `Premium`: the extensions should be correctly formatted (see below).

<img width="1126" alt="Screenshot 2019-11-28 at 12 10 00" src="https://user-images.githubusercontent.com/43582255/69801699-20da3180-11d8-11ea-9875-fd0ac9527180.png">

* When clicking on a collapsable header (e.g. see `Social` for a specific post) a blue focus bar should appear around the header.

<img width="974" alt="Screenshot 2019-11-28 at 11 50 55" src="https://user-images.githubusercontent.com/43582255/69803832-7a912a80-11dd-11ea-9be0-4871b1de5fc3.png">

* Look at styled select element ( `SEO` > `Search Appearance` > `General` > `Knowledge Graph & Schema.org` ), see image below.

<img width="452" alt="Screenshot 2019-11-28 at 12 55 14" src="https://user-images.githubusercontent.com/43582255/69804314-8df0c580-11de-11ea-975b-13494d70e76e.png">


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13894 
