### PR TITLE
Adds missing `@covers` to unit tests

### DIFF
--- a/integration-tests/inc/options/test-class-wpseo-options.php
+++ b/integration-tests/inc/options/test-class-wpseo-options.php
@@ -165,6 +165,8 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if unique keys are used in all options.
+	 *
+	 * @covers WPSEO_Option::get_option
 	 */
 	public function test_make_sure_keys_are_unique_over_options() {
 		$keys = array();

--- a/integration-tests/notifications/test-class-yoast-notification-center.php
+++ b/integration-tests/notifications/test-class-yoast-notification-center.php
@@ -7,6 +7,8 @@
 
 /**
  * Class Test_Yoast_Notification_Center.
+ *
+ * @coversDefaultClass Yoast_Notification_Center
  */
 class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
@@ -53,6 +55,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test instance.
+	 *
+	 * @covers ::get
 	 */
 	public function test_construct() {
 		$subject = Yoast_Notification_Center::get();
@@ -62,6 +66,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Add notification.
+	 *
+	 * @covers ::add_notification
 	 */
 	public function test_add_notification() {
 		$notification = new Yoast_Notification( 'notification' );
@@ -74,6 +80,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Add wrong notification.
+	 *
+	 * @covers ::add_notification
 	 */
 	public function test_add_notification_twice() {
 		$notification = new Yoast_Notification( 'notification' );
@@ -91,6 +99,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * Add persistent notification twice.
 	 *
 	 * Only one should be in the list.
+	 *
+	 * @covers ::add_notification
 	 */
 	public function test_add_notification_twice_persistent() {
 		$notification = new Yoast_Notification( 'notification', array( 'id' => 'some_id' ) );
@@ -106,6 +116,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test dismissed notification.
+	 *
+	 * @covers ::is_notification_dismissed
 	 */
 	public function test_is_notification_dismissed() {
 		$notification_dismissal_key = 'notification_dismissal';
@@ -119,6 +131,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Clearing dismissal after it was set.
+	 *
+	 * @covers ::clear_dismissal
 	 */
 	public function test_clear_dismissal() {
 		$notification = new Yoast_Notification( 'notification', array( 'id' => 'some_id' ) );
@@ -136,6 +150,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Clearing dismissal after it was set as string.
+	 *
+	 * @covers ::clear_dismissal
 	 */
 	public function test_clear_dismissal_as_string() {
 		$notification = new Yoast_Notification( 'notification', array( 'id' => 'some_id' ) );
@@ -153,6 +169,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Clear dismissal with empty key.
+	 *
+	 * @covers ::clear_dismissal
 	 */
 	public function test_clear_dismissal_empty_key() {
 		$subject = $this->get_notification_center();
@@ -161,6 +179,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Saving notifications to storage.
+	 *
+	 * @covers ::update_storage
 	 */
 	public function test_update_storage() {
 
@@ -187,6 +207,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Not saving non-persistent notifications to storage.
+	 *
+	 * @covers ::update_storage
 	 */
 	public function test_update_storage_non_persistent() {
 		$notification = new Yoast_Notification( 'b' );
@@ -203,6 +225,9 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Not removing notifications from storage when there are no notifications.
+	 *
+	 * @covers ::has_stored_notifications
+	 * @covers ::remove_storage
 	 */
 	public function test_remove_storage_without_notifications() {
 		$subject = new Yoast_Notification_Center_Double();
@@ -215,6 +240,9 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Removing notifications from storage when there are notifications.
+	 *
+	 * @covers ::has_stored_notifications
+	 * @covers ::remove_storage
 	 */
 	public function test_remove_storage_with_notifications() {
 		$notification = new Yoast_Notification( 'b', array( 'id' => 'fake_id' ) );
@@ -232,6 +260,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Sort one notification.
+	 *
+	 * @covers ::get_sorted_notifications
 	 */
 	public function test_get_sorted_notifications() {
 		$notification = new Yoast_Notification( 'c' );
@@ -247,6 +277,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * No notification to sort, still an array.
+	 *
+	 * @covers ::get_sorted_notifications
 	 */
 	public function test_get_sorted_notifications_empty() {
 		$subject = $this->get_notification_center();
@@ -259,6 +291,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Sort by type.
+	 *
+	 * @covers ::get_sorted_notifications
 	 */
 	public function test_get_sorted_notifications_by_type() {
 		$message_1 = '1';
@@ -281,6 +315,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Sort by priority.
+	 *
+	 * @covers ::get_sorted_notifications
 	 */
 	public function test_get_sorted_notifications_by_priority() {
 		$message_1 = '1';

--- a/integration-tests/onpage/test-class-onpage-option.php
+++ b/integration-tests/onpage/test-class-onpage-option.php
@@ -49,7 +49,7 @@ class WPSEO_OnPage_Option_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test without the last fetch time being set.
 	 *
-	 * WPSEO_OnPage_Option::can_fetch
+	 * @covers WPSEO_OnPage_Option::should_be_fetched
 	 */
 	public function test_can_fetch() {
 		$this->assertTrue( $this->class_instance->should_be_fetched() );
@@ -58,7 +58,7 @@ class WPSEO_OnPage_Option_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test with the last fetch time being set to 15 minutes ago.
 	 *
-	 * WPSEO_OnPage_Option::can_fetch
+	 * @covers WPSEO_OnPage_Option::should_be_fetched
 	 */
 	public function test_cannot_fetch() {
 		$this->class_instance->set_last_fetch( strtotime( '-5 seconds' ) );
@@ -68,7 +68,7 @@ class WPSEO_OnPage_Option_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test with the last fetch time being set to 2 hours ago.
 	 *
-	 * WPSEO_OnPage_Option::can_fetch
+	 * @covers WPSEO_OnPage_Option::should_be_fetched
 	 */
 	public function test_cannot_fetch_two_hours_ago() {
 		$this->class_instance->set_last_fetch( strtotime( '-2 hours' ) );

--- a/integration-tests/onpage/test-class-onpage.php
+++ b/integration-tests/onpage/test-class-onpage.php
@@ -214,6 +214,8 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if the notice control is hooked.
+	 *
+	 * @covers WPSEO_OnPage::register_hooks
 	 */
 	public function test_notification_hooks_should_be_hooked() {
 		$onpage = new WPSEO_OnPage();
@@ -224,6 +226,8 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if not active is based on the option.
+	 *
+	 * @covers WPSEO_OnPage::is_active
 	 */
 	public function test_is_not_active() {
 		WPSEO_Options::set( 'onpage_indexability', false );

--- a/integration-tests/onpage/test-class-ryte-service.php
+++ b/integration-tests/onpage/test-class-ryte-service.php
@@ -12,6 +12,8 @@ class WPSEO_Ryte_Service_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests the response data is false when the OnPage is disabled.
+	 *
+	 * @covers WPSEO_Ryte_Service::get_statistics
 	 */
 	public function test_cannot_view_ryte() {
 		$onpage = new OnPage_Option_Mock( false, WPSEO_OnPage_Option::IS_INDEXABLE, true );
@@ -25,6 +27,8 @@ class WPSEO_Ryte_Service_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests the response data is as expected when the OnPage is enabled.
+	 *
+	 * @covers WPSEO_Ryte_Service::get_statistics
 	 */
 	public function test_can_view_ryte() {
 		$user = wp_get_current_user();

--- a/integration-tests/recalculate/test-class-recalculate-posts.php
+++ b/integration-tests/recalculate/test-class-recalculate-posts.php
@@ -141,6 +141,8 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test whether thumbnail images are properly added to the content, if one exists.
+	 *
+	 * @covers WPSEO_Recalculate_Posts::item_to_response
 	 */
 	public function test_add_featured_image_to_content() {
 		$test_double = new WPSEO_Recalculate_Posts_Test_Double();

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -283,6 +283,8 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests a regular post is added to the sitemap.
+	 *
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_regular_post() {
 		$this->factory->post->create();
@@ -293,6 +295,8 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests to make sure password protected posts are not in the sitemap.
+	 *
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_password_protected_post() {
 		// Create password protected post.
@@ -312,6 +316,8 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests to make sure a regular attachment is include in the sitemap.
+	 *
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_regular_attachment() {
 		// Enable attachments in the sitemap.
@@ -338,6 +344,8 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests to make sure attachment is not added when parent is a protected post.
+	 *
+	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_sitemap_links
 	 *
 	 * @link https://github.com/Yoast/wordpress-seo/issues/9194
 	 */

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache-data.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache-data.php
@@ -124,6 +124,8 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test serializing/unserializing.
 	 *
+	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap
+	 *
 	 * Tests if the class is serializable.
 	 */
 	public function test_serialize_unserialize() {

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache-validator.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache-validator.php
@@ -8,12 +8,16 @@
 /**
  * Class WPSEO_Sitemaps_Cache_Validator_Test.
  *
+ * @coversDefaultClass WPSEO_Sitemaps_Cache_Validator
+ *
  * @group sitemaps
  */
 class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test the building of cache keys.
+	 *
+	 * @covers ::get_validator_key
 	 */
 	public function test_get_validator_key_global() {
 
@@ -24,6 +28,8 @@ class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test the building of cache keys.
+	 *
+	 * @covers ::get_validator_key
 	 */
 	public function test_get_validator_key_type() {
 
@@ -37,6 +43,8 @@ class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Normal cache key retrieval.
+	 *
+	 * @covers ::get_storage_key
 	 */
 	public function test_get_storage_key() {
 
@@ -68,6 +76,8 @@ class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 	 *
 	 * This would be 53 if we don't use a timeout, but we can't because all sitemaps would
 	 * be autoloaded every request.
+	 *
+	 * @covers ::get_storage_key
 	 */
 	public function test_get_storage_key_very_long_type() {
 
@@ -84,7 +94,7 @@ class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test base 10 to base 61 converter.
 	 *
-	 * @covers WPSEO_Sitemaps_Cache_Validator::convert_base10_to_base61
+	 * @covers ::convert_base10_to_base61
 	 */
 	public function test_base_10_to_base_61() {
 
@@ -106,6 +116,8 @@ class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 	 * Tests whether an exception is thrown when a non numeric value is passed.
 	 *
 	 * @expectedException InvalidArgumentException
+	 *
+	 * @covers ::convert_base10_to_base61
 	 */
 	public function test_base_10_to_base_61_non_integer() {
 

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -86,6 +86,9 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Clearing all cache.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::clear
+	 * @covers WPSEO_Sitemaps_Cache::clear_queued
 	 */
 	public function test_clear() {
 
@@ -109,6 +112,9 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Clearing specific cache.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::clear
+	 * @covers WPSEO_Sitemaps_Cache::clear_queued
 	 */
 	public function test_clear_type() {
 
@@ -133,6 +139,9 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Clearing specific cache should also clear index.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::clear
+	 * @covers WPSEO_Sitemaps_Cache::clear_queued
 	 */
 	public function test_clear_index_also_cleared() {
 
@@ -162,6 +171,9 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Clearing specific cache should not touch other type.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::clear
+	 * @covers WPSEO_Sitemaps_Cache::clear_queued
 	 */
 	public function test_clear_type_isolation() {
 
@@ -191,6 +203,8 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Make sure the hook is registered on registration.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::__construct
 	 */
 	public function test_register_clear_on_option_update() {
 
@@ -205,6 +219,8 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Option update should clear cache for registered type.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::clear_queued
 	 */
 	public function test_clear_transient_cache() {
 

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -30,6 +30,8 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test the nested sitemap generation.
+	 *
+	 * @covers WPSEO_Sitemaps::redirect
 	 */
 	public function test_post_sitemap() {
 		self::$class_instance->reset();

--- a/integration-tests/statistics/test-class-statistics-service.php
+++ b/integration-tests/statistics/test-class-statistics-service.php
@@ -7,6 +7,8 @@
 
 /**
  * Unit Test Class.
+ *
+ * @coversDefaultClass WPSEO_Statistics_Service
  */
 class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 
@@ -19,6 +21,8 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests filtering the zero counts.
+	 *
+	 * @covers ::get_statisticså
 	 */
 	public function test_filter_zero_counts() {
 		$statistics = new Statistics_Mock(
@@ -39,6 +43,8 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests the rendering of generated link that navigates to an overview with post
 	 * for a specific author.
+	 *
+	 * @covers ::get_statistics
 	 */
 	public function test_seo_score_links() {
 		$statistics = new Statistics_Mock(
@@ -61,6 +67,8 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests the rendering of generated link that navigates to an overview with post of that type.
+	 *
+	 * @covers ::get_statistics
 	 */
 	public function test_admin_seo_score_links() {
 		$user = wp_get_current_user();
@@ -88,6 +96,8 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests the total amount of seo scores.
+	 *
+	 * @covers ::get_statistics
 	 */
 	public function test_page_counts() {
 		$statistics = new Statistics_Mock(

--- a/integration-tests/taxonomy/test-class-taxonomy-content-fields.php
+++ b/integration-tests/taxonomy/test-class-taxonomy-content-fields.php
@@ -7,6 +7,8 @@
 
 /**
  * Unit Test Class.
+ *
+ * @coversDefaultClass WPSEO_Taxonomy_Content_Fields
  */
 class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 
@@ -37,7 +39,7 @@ class WPSEO_Taxonomy_Content_Fields_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test if the array is set properly by picking the first and the last value.
 	 *
-	 * WPSEO_Taxonomy_Content_Fields::get
+	 * @covers ::get
 	 */
 	public function test_get_fields() {
 

--- a/integration-tests/taxonomy/test-class-taxonomy-fields.php
+++ b/integration-tests/taxonomy/test-class-taxonomy-fields.php
@@ -12,6 +12,8 @@ class WPSEO_Taxonomy_Fields_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests if the abstract get method is implemented the right way.
+	 *
+	 * @covers WPSEO_Taxonomy_Fields::get
 	 */
 	public function test_construct() {
 		$class = new WPSEO_Taxonomy_Fields_Double( (object) array( 'term' ) );

--- a/integration-tests/taxonomy/test-class-taxonomy-settings-fields.php
+++ b/integration-tests/taxonomy/test-class-taxonomy-settings-fields.php
@@ -7,6 +7,8 @@
 
 /**
  * Unit Test Class.
+ *
+ * @coversDefaultClass WPSEO_Taxonomy_Settings_Fields
  */
 class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 
@@ -37,7 +39,7 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test if the array is set properly by picking the first and the last value.
 	 *
-	 * WPSEO_Taxonomy_Settings_Fields::get
+	 * @covers ::get
 	 */
 	public function test_get_fields() {
 
@@ -52,7 +54,7 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test if the breadcrumbs title field will be hidden if the option 'breadcrumbs-enable' is set to false.
 	 *
-	 * WPSEO_Taxonomy_Settings_Fields::get
+	 * @covers ::get
 	 */
 	public function test_get_fields_hidden_breadcrumb() {
 		$this->class_instance->set_option( 'breadcrumbs-enable', true );
@@ -65,7 +67,7 @@ class WPSEO_Taxonomy_Settings_Fields_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test the result of get_robot_index.
 	 *
-	 * WPSEO_Taxonomy_Content_Fields::get_robot_index
+	 * @covers ::get_robot_index
 	 */
 	public function test_get_robot_index() {
 		// Setting no index for current taxonomy to true.

--- a/integration-tests/taxonomy/test-class-taxonomy.php
+++ b/integration-tests/taxonomy/test-class-taxonomy.php
@@ -7,11 +7,15 @@
 
 /**
  * Unit Test Class.
+ *
+ * @coversDefaultClass WPSEO_Taxonomy
  */
 class WPSEO_Taxonomy_Test extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Make sure certain pages are marked as term edit.
+	 *
+	 * @covers ::is_term_edit
 	 */
 	public function test_is_term_edit() {
 		$this->assertTrue( WPSEO_Taxonomy::is_term_edit( 'term.php' ) );
@@ -21,6 +25,8 @@ class WPSEO_Taxonomy_Test extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Make sure certain pages are marked as term overview.
+	 *
+	 * @covers ::is_term_overview
 	 */
 	public function test_is_term_overview() {
 		$this->assertFalse( WPSEO_Taxonomy::is_term_overview( 'term.php' ) );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Just adding missing `@covers` to the tests
