### PR TITLE
 prefixed CSS properties.

### DIFF
--- a/css/src/yoastcom/0-tools/_mixins.scss
+++ b/css/src/yoastcom/0-tools/_mixins.scss
@@ -1,8 +1,8 @@
 /**
  * Create vendor-prefixed CSS in one go, e.g.
- * 
+ *
    `@include vendor(border-radius, 4px);`
- * 
+ *
  */
 @mixin vendor($property, $value) {
     -webkit-#{$property}: $value;
@@ -10,31 +10,6 @@
         -ms-#{$property}: $value;
          -o-#{$property}: $value;
             #{$property}: $value;
-}
-
-@mixin display-flex {
-	display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
-	display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
-	display: -ms-flexbox;      /* TWEENER - IE 10 */
-	display: -webkit-flex;     /* NEW - Chrome */
-	display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
-	-ms-flex-pack: justify; // for IE10
-
-	.old-ie & {
-		text-align: justify; // for IE9
-
-		&::after {
-			content: '';
-			display: inline-block;
-			width: 100%;
-		}
-
-		> * { // for IE9
-			display: inline-block;
-			text-align: left;
-		}
-	}
-
 }
 
 @mixin rounded--small {

--- a/css/src/yoastcom/_promoblock.scss
+++ b/css/src/yoastcom/_promoblock.scss
@@ -60,10 +60,7 @@
 		margin: 16px auto 32px;
 		margin: 1rem auto 2rem;
 
-		@include display-flex;
-		-webkit-box-pack: center;
-		-ms-flex-line-pack: center;
-		-ms-flex-align: center;
+		display: flex;
 
 		font-size: 16px;
 		font-size: 1rem;


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- Quick PR to continue to work from #13894 / #13962
- removes the `display-flex` mixin that was used only once and uses `display: flex` directly instead
- by doing so, a few `-ms-` prefixed CSS properties are removed as well as hacks for IE9
- also other browser-prefixed properties are removed, as they're no longer necessary

## Test instructions

This PR can be tested by following these steps:

* go to SEO > Premium and check the "promoblock cards" layout is unchanged

<img width="1159" alt="Screenshot 2019-11-29 at 16 09 45" src="https://user-images.githubusercontent.com/1682452/69877544-cc5fb080-12c2-11ea-8caa-e4d03c62b82d.png">


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13978
