### PR TITLE
Travis: don't allow builds against PHP 7.4 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ jobs:
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
     - php: "7.4snapshot"
-      env: WP_VERSION=master PHPUNIT=1
+      env: WP_VERSION=latest PHPUNIT=1
+    - php: "nightly"
+      env: PHPLINT=1
     - stage: 🚀 deployment
       name: "Deploy to S3"
       if: branch = deploy # Only build when on the `deploy` branch, this functionality is not used yet and is taking a long time to complete.
@@ -91,8 +93,7 @@ jobs:
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
-      env: WP_VERSION=master PHPUNIT=1
+    - php: "nightly"
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"yoast/yoastcs": "~0.4.3",
 		"phpcompatibility/phpcompatibility-wp": "^2.0.0",
 		"humbug/php-scoper": "^0.12.0",
-		"brain/monkey": "^2.2",
+		"brain/monkey": "^2.4",
 		"phpunit/phpunit": "^5.7",
 		"atanamo/php-codeshift": "^1.0",
 		"symfony/config": "^3.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "772e8a868261705aa5b446d2736982d5",
+    "content-hash": "87311d753c245fc3baee7f2ab3a69e39",
     "packages": [
         {
             "name": "composer/installers",
@@ -939,20 +939,23 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.8",
+            "version": "2.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "3bb81ace3914c220aa273d1c0603d5e1b454c0d7"
+                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/3bb81ace3914c220aa273d1c0603d5e1b454c0d7",
-                "reference": "3bb81ace3914c220aa273d1c0603d5e1b454c0d7",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
+                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -976,7 +979,7 @@
                 "runkit",
                 "testing"
             ],
-            "time": "2018-02-19T18:52:50+00:00"
+            "time": "2019-10-26T07:10:56+00:00"
         },
         {
             "name": "atanamo/php-codeshift",
@@ -1027,16 +1030,16 @@
         },
         {
             "name": "brain/monkey",
-            "version": "2.2.1",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "326a537bf518edd61bc57ab275e8b075ebb8a1a9"
+                "reference": "b3ce8b619c26db6abd01b9dcfd6a2c0254060956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/326a537bf518edd61bc57ab275e8b075ebb8a1a9",
-                "reference": "326a537bf518edd61bc57ab275e8b075ebb8a1a9",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/b3ce8b619c26db6abd01b9dcfd6a2c0254060956",
+                "reference": "b3ce8b619c26db6abd01b9dcfd6a2c0254060956",
                 "shasum": ""
             },
             "require": {
@@ -1045,7 +1048,9 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5.7.9"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
@@ -1087,7 +1092,7 @@
                 "test",
                 "testing"
             ],
-            "time": "2019-03-15T13:42:24+00:00"
+            "time": "2019-11-24T16:03:21+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1312,22 +1317,23 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.2.2",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2"
+                "reference": "5571962a4f733fbb57bede39778f71647fae8e66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2",
-                "reference": "0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/5571962a4f733fbb57bede39778f71647fae8e66",
+                "reference": "5571962a4f733fbb57bede39778f71647fae8e66",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "~2.0",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.6.0"
+                "php": ">=5.6.0",
+                "sebastian/comparator": "^1.2.4|^3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
@@ -1335,7 +1341,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1373,7 +1379,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-02-13T09:37:52+00:00"
+            "time": "2019-11-24T07:54:50+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/integration-tests/admin/links/test-class-link-content-processor.php
+++ b/integration-tests/admin/links/test-class-link-content-processor.php
@@ -42,6 +42,9 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 	 * Test link storage.
 	 */
 	public function test_store_links() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		/** @var WPSEO_Link_Storage $storage */
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Link_Storage' )

--- a/integration-tests/admin/links/test-class-link-storage.php
+++ b/integration-tests/admin/links/test-class-link-storage.php
@@ -42,6 +42,9 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 	 * Tests the saving of a link.
 	 */
 	public function test_save_link() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		/** @var WPSEO_Link_Storage $storage */
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Link_Storage' )

--- a/integration-tests/admin/links/test-class-link-type-classifier.php
+++ b/integration-tests/admin/links/test-class-link-type-classifier.php
@@ -68,6 +68,9 @@ class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Link_Type_Classifier::classify
 	 */
 	public function test_contains_protocol() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		/** @var WPSEO_Link_Type_Classifier $classifier */
 		$classifier = $this
 			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
@@ -90,6 +93,9 @@ class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Link_Type_Classifier::classify
 	 */
 	public function test_is_external_link() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		/** @var WPSEO_Link_Type_Classifier $classifier */
 		$classifier = $this
 			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )

--- a/integration-tests/admin/services/test-class-file-size.php
+++ b/integration-tests/admin/services/test-class-file-size.php
@@ -41,6 +41,9 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_File_Size_Service::get
 	 */
 	public function test_get_with_unknown_failure() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
 			->setMethods( [ 'get_file_url', 'calculate_file_size' ] )
@@ -68,6 +71,9 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_File_Size_Service::get
 	 */
 	public function test_get_on_success() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
 			->setMethods( [ 'get_file_url', 'get_file_size' ] )

--- a/integration-tests/admin/test-class-plugin-suggestions.php
+++ b/integration-tests/admin/test-class-plugin-suggestions.php
@@ -32,7 +32,11 @@ class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 
 		$plugin_availability = new WPSEO_Plugin_Availability_Double();
 
-		$notification_center_mock = $this->getMockBuilder( 'Yoast_Notification_Center_Double' )
+		/*
+		 * Silencing errors for PHP 7.4 in combination with the Mock Builder.
+		 * See WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() for context.
+		 */
+		@$notification_center_mock = $this->getMockBuilder( 'Yoast_Notification_Center_Double' )
 			->setMethods( [ 'add_notification', 'remove_notification' ] )
 			->getMock();
 

--- a/integration-tests/config-ui/test-class-configuration-components.php
+++ b/integration-tests/config-ui/test-class-configuration-components.php
@@ -77,6 +77,9 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Components::set_storage
 	 */
 	public function test_set_storage() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Configuration_Storage' )
 			->setMethods( [ 'get_adapter' ] )
@@ -101,6 +104,9 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Components::set_storage
 	 */
 	public function test_set_storage_on_field() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$component = $this
 			->getMockBuilder( 'WPSEO_Config_Component' )
 			->setMethods( [ 'get_field', 'get_identifier', 'set_data', 'get_data' ] )
@@ -137,5 +143,20 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 
 		$this->components->add_component( $component );
 		$this->components->set_storage( $storage );
+	}
+
+	/**
+	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
+	 * in select circumstances.
+	 *
+	 * @see WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() For full explanation.
+	 *
+	 * @return void
+	 */
+	protected function bypass_php74_mockbuilder_deprecation_warning() {
+		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
+			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
+			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
+		}
 	}
 }

--- a/integration-tests/config-ui/test-class-configuration-endpoint.php
+++ b/integration-tests/config-ui/test-class-configuration-endpoint.php
@@ -34,6 +34,9 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Configuration_Endpoint::set_service
 	 */
 	public function test_set_service() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$service = $this->getMockBuilder( 'WPSEO_Configuration_Service' )->getMock();
 
 		$this->assertNull( $this->endpoint->set_service( $service ) );

--- a/integration-tests/config-ui/test-class-configuration-options-adapter.php
+++ b/integration-tests/config-ui/test-class-configuration-options-adapter.php
@@ -239,6 +239,12 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	 */
 	public function test_get_unknown_type() {
 
+		// See WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() for context.
+		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
+			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
+			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
+		}
+
 		$field_name = 'field';
 
 		$class = $this

--- a/integration-tests/config-ui/test-class-configuration-service.php
+++ b/integration-tests/config-ui/test-class-configuration-service.php
@@ -51,6 +51,9 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Service::set_storage
 	 */
 	public function test_set_storage() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$service = new WPSEO_Configuration_Service_Mock();
 		$storage = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->getMock();
 
@@ -64,6 +67,9 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Service::set_endpoint
 	 */
 	public function test_set_endpoint() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$service  = new WPSEO_Configuration_Service_Mock();
 		$endpoint = $this->getMockBuilder( 'WPSEO_Configuration_Endpoint' )->getMock();
 
@@ -77,6 +83,9 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Service::set_options_adapter
 	 */
 	public function test_set_options_adapter() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$service = new WPSEO_Configuration_Service_Mock();
 		$adapter = $this->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )->getMock();
 
@@ -90,6 +99,9 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Service::set_components
 	 */
 	public function test_set_components() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$service    = new WPSEO_Configuration_Service_Mock();
 		$components = $this->getMockBuilder( 'WPSEO_Configuration_Components' )->getMock();
 
@@ -204,6 +216,21 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 
 		foreach ( $properties as $property ) {
 			$this->assertNotNull( $configuration_service->get( $property ) );
+		}
+	}
+
+	/**
+	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
+	 * in select circumstances.
+	 *
+	 * @see WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() For full explanation.
+	 *
+	 * @return void
+	 */
+	protected function bypass_php74_mockbuilder_deprecation_warning() {
+		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
+			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
+			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
 		}
 	}
 }

--- a/integration-tests/config-ui/test-class-configuration-storage.php
+++ b/integration-tests/config-ui/test-class-configuration-storage.php
@@ -32,6 +32,9 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::add_field
 	 */
 	public function test_add_field() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
 			->setConstructorArgs( [ 'field', 'component' ] )
@@ -70,6 +73,9 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_null() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$data = null;
 
 		$adapter = $this
@@ -99,6 +105,9 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_field_default() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$data    = null;
 		$default = 'default';
 
@@ -134,6 +143,9 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_string() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$data = 'data';
 
 		$adapter = $this
@@ -163,6 +175,9 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_array() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$data    = [ 'a' => '1' ];
 		$default = [
 			'a' => '2',
@@ -310,5 +325,20 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 		];
 
 		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
+	 * in select circumstances.
+	 *
+	 * @see WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() For full explanation.
+	 *
+	 * @return void
+	 */
+	protected function bypass_php74_mockbuilder_deprecation_warning() {
+		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
+			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
+			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
+		}
 	}
 }

--- a/integration-tests/config-ui/test-class-configuration-storage.php
+++ b/integration-tests/config-ui/test-class-configuration-storage.php
@@ -222,6 +222,11 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::retrieve
 	 */
 	public function test_retrieve() {
+
+		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
+			$this->markTestSkipped( 'Skipping on PHP 7.4 due to issues with the MockBuilder dependency' );
+		}
+
 		$field          = 'f';
 		$component      = 'c';
 		$property       = 'p';
@@ -281,6 +286,11 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::store
 	 */
 	public function test_store() {
+
+		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
+			$this->markTestSkipped( 'Skipping on PHP 7.4 due to issues with the MockBuilder dependency' );
+		}
+
 		$field     = 'f';
 		$component = 'c';
 		$data      = [ $field => [ 'data' => 'some_data' ] ];

--- a/integration-tests/framework/class-wpseo-unit-test-case.php
+++ b/integration-tests/framework/class-wpseo-unit-test-case.php
@@ -71,4 +71,29 @@ abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 			$this->assertTrue( $found !== false, sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
 		}
 	}
+
+	/**
+	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
+	 * in select circumstances.
+	 *
+	 * In PHP 7.4+ a deprecation warning may be thrown about functionality in the PHPUnit mock builder.
+	 * Setting an expectation for this will allow the test to run on PHP 7.4 and report proper
+	 * results without the test failing on the deprecation warning.
+	 *
+	 * For tests which error out on PHP 7.4 because of this, a call to this function should be added
+	 * at the top of the test method.
+	 * Use selectively and with care !
+	 *
+	 * {@internal Note: The below way to set the expected exception in only supported in PHPUnit 5+.
+	 *            As this functionality will only be used with PHP 7.4, this is fine as that means that
+	 *            PHPUnit 5+ will be used anyway.}
+	 *
+	 * @return void
+	 */
+	protected function bypass_php74_mockbuilder_deprecation_warning() {
+		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
+			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
+			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
+		}
+	}
 }

--- a/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -73,6 +73,9 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Bar_Menu::add_menu
 	 */
 	public function test_add_menu_lacking_capabilities() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$admin_bar_menu = $this
 			->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
 			->setConstructorArgs( [ $this->get_asset_manager() ] )
@@ -108,6 +111,9 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Bar_Menu::add_menu
 	 */
 	public function test_add_menu() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		wp_set_current_user( self::$wpseo_manager );
 
 		$wp_admin_bar = new WP_Admin_Bar();

--- a/integration-tests/notifications/test-class-yoast-notification-center.php
+++ b/integration-tests/notifications/test-class-yoast-notification-center.php
@@ -725,6 +725,9 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::remove_notification_by_id
 	 */
 	public function test_remove_notification_by_id_when_no_notification_is_found() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
 			->disableOriginalConstructor()
@@ -744,6 +747,9 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Notification_Center::remove_notification_by_id
 	 */
 	public function test_remove_notification_by_id_when_notification_is_found() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
 			->disableOriginalConstructor()

--- a/integration-tests/notifiers/test-class-dismissible-notification.php
+++ b/integration-tests/notifiers/test-class-dismissible-notification.php
@@ -60,6 +60,9 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Dismissible_Notification::handle
 	 */
 	public function test_handle_where_situation_is_applicable() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
 			->disableOriginalConstructor()

--- a/integration-tests/test-class-admin-asset-manager.php
+++ b/integration-tests/test-class-admin-asset-manager.php
@@ -270,6 +270,8 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_scripts() {
 
+		$this->bypass_php74_mockbuilder_deprecation_warning();
+
 		$asset_args = [
 			0 => [
 				'name' => 'testfile',
@@ -313,6 +315,8 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_styles
 	 */
 	public function test_register_styles() {
+
+		$this->bypass_php74_mockbuilder_deprecation_warning();
 
 		$asset_args = [
 			0 => [


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:


### Travis: don't allow builds against PHP 7.4 to fail

Includes:
* Adjusting the Travis matrix now WP 5.3 has been released
* Removing the build against PHP 7.4 from `allowed failures`.
* Adding (back) a build against PHP `nightly` (PHP 8) and adding it to  `allowed_failures`.
    For now, this build will only lint the code. Unit testing is not yet possible with  the current setup.
* Updating BrainMonkey to `^2.4.0` which is the first release which supports PHP 7.4.
    Note: the BrainMonkey dependencies have been updated as well, but _nothing else_.
    Ref: https://github.com/Brain-WP/BrainMonkey/releases/tag/2.4.0

---

### After this the Travis build would still fail.

This has been discussed in depth with @herregroen and @IreneStr.

The short summary is:
* The `ReflectionType::__toString()` method has been deprecated since PHP 7.1 and as of PHP 7.4, deprecation warnings are thrown about it.
* The PHPUnit Mock Builder package, however, uses this functionality and as the package is abandoned, aside from it also being locked at a very old version, there is no way this will be fixed anymore.
* This causes some of the unit tests in the _integration tests_ test suite which use a particular feature of the PHPUnit Mock Builder package to error out, causing the unit test task to fail the Travis build.

To solve this, I have added instructions for PHPUnit to expect a PHP deprecation warning for most of these tests when run on PHP 7.4.

This allows them to still be run and report errors properly, while ignoring the (expected) deprecation warning.

There are only two tests for which that wasn't enough and which need to be skipped completely on PHP 7.4 (for now).

### Commit messages for the related commits to bypass the deprecation warnings:

#### Integration tests: add new `bypass_php74_mockbuilder_deprecation_warning()` method

To allow the unit tests to run without errors on PHP 7.4, the new `WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning()` method is being introduced, which can be used to tell PHPUnit to expect that specific deprecation warning on PHP 7.4.

By doing so, PHPUnit will ignore the deprecation warning and will run the test properly, allowing the functionality being tested to also be tested on PHP 7.4.
This is in contrast to, for instance, using something like `@requires PHP < 7.4` which would skip the test completely on PHP 7.4 instead.

This method should be used selectively, only where needed.

Additional notes:
The setting of the expected exception is done in a manner only supported in PHPUnit 5+ for two reasons:
- Using the `@expectedException` annotation way of setting the expected exception would not allow to _only_ expect the exception on PHP 7.4 and not on older PHP versions.
- Using the function call way of setting the expected exception allowed for abstracting this code out to its own method.

As this functionality will only be used with PHP 7.4, the fact that this code does not allow for PHPUnit 4 is fine as PHPUnit 5+ is needed to run the tests on PHP 7.4 anyway.

#### Integration tests: implement use of `bypass_php74_mockbuilder_deprecation_warning()`

... in the test classes containing tests affected by the issue and which extend the `WPSEO_UnitTestCase` class.

#### Integration tests: add `bypass_php74_mockbuilder_deprecation_warning()` and implement

... in the test classes containing tests affected by the issue and which extend the `PHPUnit_Framework_TestCase` class.

#### Integration tests: skip two tests on PHP 7.4 which will fail

These failures are more than likely related to the PHPUnit MockBuilder, not to the code under test itself, though this hasn't been exhaustively investigated.

For now, skipping these tests will allow the unit test suite to pass on PHP 7.4. Further investigation and/or moving of these tests to the BrainMonkey framework is recommended.

#### Integration tests: silence the PHP 7.4 mockbuilder deprecation warning in a setUp() method

... as no expected exceptions can be set for the `setUp()`.





## Test instructions

This PR can be tested by following these steps:
* Check the detailed output of the Travis run against PHP 7.4 and take note of the tests passing.