### PR TITLE
CS: implement using short arrays everywhere

### DIFF
--- a/deprecated/admin/class-metabox-tab-section.php
+++ b/deprecated/admin/class-metabox-tab-section.php
@@ -15,7 +15,7 @@ class WPSEO_Metabox_Tab_Section extends WPSEO_Abstract_Metabox_Tab_With_Sections
 	 *
 	 * @var WPSEO_Metabox_Tab[]
 	 */
-	public $tabs = array();
+	public $tabs = [];
 
 	/**
 	 * Constructor.
@@ -29,13 +29,13 @@ class WPSEO_Metabox_Tab_Section extends WPSEO_Abstract_Metabox_Tab_With_Sections
 	 * @param array  $tabs         The metabox tabs (`WPSEO_Metabox_Tabs[]`) to be included in the section.
 	 * @param array  $options      Optional link attributes.
 	 */
-	public function __construct( $name, $link_content, array $tabs = array(), array $options = array() ) {
+	public function __construct( $name, $link_content, array $tabs = [], array $options = [] ) {
 		_deprecated_function( __METHOD__, 'WPSEO 12.3' );
 
 		parent::__construct( $name, $link_content, $options );
 
 		// Filter out invalid tab instances.
-		$valid_tabs = array_filter( $tabs, array( $this, 'is_valid_tab' ) );
+		$valid_tabs = array_filter( $tabs, [ $this, 'is_valid_tab' ] );
 
 		foreach ( $valid_tabs as $tab ) {
 			$this->add_tab( $tab );

--- a/deprecated/admin/config-ui/components/class-component-connect-google-search-console.php
+++ b/deprecated/admin/config-ui/components/class-component-connect-google-search-console.php
@@ -101,7 +101,7 @@ class WPSEO_Config_Component_Connect_Google_Search_Console implements WPSEO_Conf
 	public function get_data() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -114,6 +114,6 @@ class WPSEO_Config_Component_Connect_Google_Search_Console implements WPSEO_Conf
 	public function set_data( $data ) {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 }

--- a/deprecated/admin/config-ui/fields/class-field-connect-google-search-console.php
+++ b/deprecated/admin/config-ui/fields/class-field-connect-google-search-console.php
@@ -39,6 +39,6 @@ class WPSEO_Config_Field_Connect_Google_Search_Console extends WPSEO_Config_Fiel
 	public function get_data() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 }

--- a/deprecated/admin/google-search-console/class-gsc-category-filters.php
+++ b/deprecated/admin/google-search-console/class-gsc-category-filters.php
@@ -61,6 +61,6 @@ class WPSEO_GSC_Category_Filters {
 	public function as_array() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 }

--- a/deprecated/admin/google-search-console/class-gsc-config.php
+++ b/deprecated/admin/google-search-console/class-gsc-config.php
@@ -23,11 +23,11 @@ class WPSEO_GSC_Config {
 	 *
 	 * @var array
 	 */
-	public static $gsc = array(
+	public static $gsc = [
 		'application_name' => '',
 		'client_id'        => '',
 		'client_secret'    => '',
 		'redirect_uri'     => '',
-		'scopes'           => array(),
-	);
+		'scopes'           => [],
+	];
 }

--- a/deprecated/admin/google-search-console/class-gsc-count.php
+++ b/deprecated/admin/google-search-console/class-gsc-count.php
@@ -55,7 +55,7 @@ class WPSEO_GSC_Count {
 	public function get_platform_counts( $platform ) {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 
 	/**

--- a/deprecated/admin/google-search-console/class-gsc-issue.php
+++ b/deprecated/admin/google-search-console/class-gsc-issue.php
@@ -42,6 +42,6 @@ class WPSEO_GSC_Issue {
 	public function to_array() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 }

--- a/deprecated/admin/google-search-console/class-gsc-issues.php
+++ b/deprecated/admin/google-search-console/class-gsc-issues.php
@@ -41,7 +41,7 @@ class WPSEO_GSC_Issues {
 	public function get_issues() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 
 	/**

--- a/deprecated/admin/google-search-console/class-gsc-modal.php
+++ b/deprecated/admin/google-search-console/class-gsc-modal.php
@@ -25,7 +25,7 @@ class WPSEO_GSC_Modal {
 	 * @param int    $height    The height that the modal will get.
 	 * @param array  $view_vars The attributes to use in the view.
 	 */
-	public function __construct( $view, $height, array $view_vars = array() ) {
+	public function __construct( $view, $height, array $view_vars = [] ) {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 	}
 

--- a/deprecated/admin/google-search-console/class-gsc-service.php
+++ b/deprecated/admin/google-search-console/class-gsc-service.php
@@ -65,7 +65,7 @@ class WPSEO_GSC_Service {
 	public function get_sites() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -80,7 +80,7 @@ class WPSEO_GSC_Service {
 	public function get_crawl_issue_counts() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -117,6 +117,6 @@ class WPSEO_GSC_Service {
 	public function fetch_category_issues( $platform, $category ) {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 }

--- a/deprecated/admin/google-search-console/class-gsc-settings.php
+++ b/deprecated/admin/google-search-console/class-gsc-settings.php
@@ -64,7 +64,7 @@ class WPSEO_GSC_Settings {
 	 */
 	public static function get_profile() {
 		// Get option.
-		$option = get_option( 'wpseo-gsc', array( 'profile' => '' ) );
+		$option = get_option( 'wpseo-gsc', [ 'profile' => '' ] );
 
 		// Set the profile.
 		$profile = '';

--- a/deprecated/admin/google-search-console/class-gsc-table.php
+++ b/deprecated/admin/google-search-console/class-gsc-table.php
@@ -80,6 +80,6 @@ class WPSEO_GSC_Table extends WP_List_Table {
 	public function get_columns() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 
-		return array();
+		return [];
 	}
 }

--- a/deprecated/class-metabox-addon-section.php
+++ b/deprecated/class-metabox-addon-section.php
@@ -24,7 +24,7 @@ class WPSEO_Metabox_Addon_Tab_Section extends WPSEO_Metabox_Tab_Section {
 	 * @param array  $tabs         The metabox tabs (`WPSEO_Metabox_Tabs[]`) to be included in the section.
 	 * @param array  $options      Optional link attributes.
 	 */
-	public function __construct( $name, $link_content, array $tabs = array(), array $options = array() ) {
+	public function __construct( $name, $link_content, array $tabs = [], array $options = [] ) {
 		_deprecated_function( __METHOD__, '11.9' );
 		parent::__construct( $name, $link_content, $tabs, $options );
 	}
@@ -42,12 +42,12 @@ class WPSEO_Metabox_Addon_Tab_Section extends WPSEO_Metabox_Tab_Section {
 				<ul class="wpseo-metabox-tabs">
 					<?php
 					// @deprecated 11.9 This functionality has been replaced by the filter: `yoast_free_additional_metabox_sections`.
-					do_action_deprecated( 'wpseo_tab_header', array(), '11.9' );
+					do_action_deprecated( 'wpseo_tab_header', [], '11.9' );
 					?>
 				</ul>
 				<?php
 				// @deprecated 11.9 This functionality has been replaced by the filter: `yoast_free_additional_metabox_sections`.
-				do_action_deprecated( 'wpseo_tab_content', array(), '11.9' );
+				do_action_deprecated( 'wpseo_tab_content', [], '11.9' );
 				?>
 			</div>
 		</div>

--- a/deprecated/class-recalibration-beta.php
+++ b/deprecated/class-recalibration-beta.php
@@ -57,10 +57,10 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		$values = array(
+		$values = [
 			'on'  => __( 'On', 'wordpress-seo' ),
 			'off' => __( 'Off', 'wordpress-seo' ),
-		);
+		];
 
 		echo '<div class="switch-container">';
 		echo '<fieldset id="', esc_attr( $this->option_name ), '" class="fieldset-switch-toggle">';
@@ -110,7 +110,7 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function register_hooks() {
-		add_action( 'update_option_wpseo', array( $this, 'update_option' ), 10, 2 );
+		add_action( 'update_option_wpseo', [ $this, 'update_option' ], 10, 2 );
 	}
 
 	/**
@@ -195,11 +195,11 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 		try {
 			$this->do_request(
 				'https://my.yoast.com/api/customers/newsletter/recalibration/subscribe',
-				array(
+				[
 					'email'     => get_option( 'admin_email' ),
 					'firstName' => get_option( 'blogname' ),
 					'lastName'  => '',
-				)
+				]
 			);
 
 			$this->set_mailinglist_subscription();
@@ -225,9 +225,9 @@ class WPSEO_Recalibration_Beta implements WPSEO_WordPress_Integration {
 	protected function do_request( $url, $body ) {
 		$response = wp_remote_post(
 			$url,
-			array(
+			[
 				'body' => $body,
-			)
+			]
 		);
 
 		if ( is_wp_error( $response ) ) {

--- a/deprecated/class-wpseo-option-internallinks.php
+++ b/deprecated/class-wpseo-option-internallinks.php
@@ -29,7 +29,7 @@ class WPSEO_Option_InternalLinks {
 	 * @param string $method The method to 'call'.
 	 * @param array  $args   Possibly given arguments.
 	 */
-	public function __call( $method, array $args = array() ) {
+	public function __call( $method, array $args = [] ) {
 		_deprecated_function( $method, 'WPSEO 7.0' );
 	}
 

--- a/deprecated/class-wpseo-option-permalinks.php
+++ b/deprecated/class-wpseo-option-permalinks.php
@@ -28,7 +28,7 @@ class WPSEO_Option_Permalinks {
 	 * @param string $method The method to 'call'.
 	 * @param array  $args   Possibly given arguments.
 	 */
-	public function __call( $method, array $args = array() ) {
+	public function __call( $method, array $args = [] ) {
 		_deprecated_function( $method, 'WPSEO 7.0' );
 	}
 

--- a/deprecated/class-yoast-form-fieldset.php
+++ b/deprecated/class-yoast-form-fieldset.php
@@ -22,9 +22,9 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 	 *
 	 * @var array
 	 */
-	private $attributes = array(
+	private $attributes = [
 		'class' => 'yoast-form-fieldset',
-	);
+	];
 
 	/**
 	 * The grouped form elements for the fieldset.
@@ -38,9 +38,9 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 	 *
 	 * @var array
 	 */
-	private $legend_attributes = array(
+	private $legend_attributes = [
 		'class' => 'yoast-form-legend',
-	);
+	];
 
 	/**
 	 * A translatable string for the fieldset legend content.
@@ -176,7 +176,7 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 		_deprecated_function( __METHOD__, '11.9' );
 
 		$this->legend_attributes = wp_parse_args(
-			array( 'class' => 'screen-reader-text' ),
+			[ 'class' => 'screen-reader-text' ],
 			$this->legend_attributes
 		);
 	}
@@ -190,13 +190,13 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 	 * @return array
 	 */
 	private function get_parts() {
-		return array(
+		return [
 			'id'                => $this->id,
 			'attributes'        => $this->get_attributes_html( $this->attributes ),
 			'legend_content'    => $this->legend_content,
 			'legend_attributes' => $this->get_attributes_html( $this->legend_attributes ),
 			'content'           => $this->content,
-		);
+		];
 	}
 
 	/**
@@ -211,7 +211,7 @@ class Yoast_Form_Fieldset implements Yoast_Form_Element {
 	 */
 	private function get_attributes_html( $attributes ) {
 		if ( ! empty( $attributes ) ) {
-			array_walk( $attributes, array( $this, 'parse_attribute' ) );
+			array_walk( $attributes, [ $this, 'parse_attribute' ] );
 
 			// Use an initial space as `implode()` adds a space only between array elements.
 			return ' ' . implode( ' ', $attributes );

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -241,8 +241,8 @@ abstract class WPSEO_Option {
 	 */
 	public function add_default_filters() {
 		// Don't change, needs to check for false as could return prio 0 which would evaluate to false.
-		if ( has_filter( 'default_option_' . $this->option_name, array( $this, 'get_defaults' ) ) === false ) {
-			add_filter( 'default_option_' . $this->option_name, array( $this, 'get_defaults' ) );
+		if ( has_filter( 'default_option_' . $this->option_name, [ $this, 'get_defaults' ] ) === false ) {
+			add_filter( 'default_option_' . $this->option_name, [ $this, 'get_defaults' ] );
 		}
 	}
 
@@ -441,7 +441,7 @@ abstract class WPSEO_Option {
 	 * @return void
 	 */
 	public function remove_default_filters() {
-		remove_filter( 'default_option_' . $this->option_name, array( $this, 'get_defaults' ) );
+		remove_filter( 'default_option_' . $this->option_name, [ $this, 'get_defaults' ] );
 	}
 
 	/**
@@ -473,8 +473,8 @@ abstract class WPSEO_Option {
 	 */
 	public function add_option_filters() {
 		// Don't change, needs to check for false as could return prio 0 which would evaluate to false.
-		if ( has_filter( 'option_' . $this->option_name, array( $this, 'get_option' ) ) === false ) {
-			add_filter( 'option_' . $this->option_name, array( $this, 'get_option' ) );
+		if ( has_filter( 'option_' . $this->option_name, [ $this, 'get_option' ] ) === false ) {
+			add_filter( 'option_' . $this->option_name, [ $this, 'get_option' ] );
 		}
 	}
 
@@ -485,7 +485,7 @@ abstract class WPSEO_Option {
 	 * @return void
 	 */
 	public function remove_option_filters() {
-		remove_filter( 'option_' . $this->option_name, array( $this, 'get_option' ) );
+		remove_filter( 'option_' . $this->option_name, [ $this, 'get_option' ] );
 	}
 
 	/**
@@ -549,15 +549,15 @@ abstract class WPSEO_Option {
 		$clean = $this->get_defaults();
 
 		/* Return the defaults if the new value is empty. */
-		if ( ! is_array( $option_value ) || $option_value === array() ) {
+		if ( ! is_array( $option_value ) || $option_value === [] ) {
 			return $clean;
 		}
 
-		$option_value = array_map( array( 'WPSEO_Utils', 'trim_recursive' ), $option_value );
+		$option_value = array_map( [ 'WPSEO_Utils', 'trim_recursive' ], $option_value );
 
 		$old = $this->get_original_option();
 		if ( ! is_array( $old ) ) {
-			$old = array();
+			$old = [];
 		}
 		$old = array_merge( $clean, $old );
 
@@ -776,7 +776,7 @@ abstract class WPSEO_Option {
 
 		$defaults = $this->get_defaults();
 
-		if ( ! isset( $options ) || $options === false || $options === array() ) {
+		if ( ! isset( $options ) || $options === false || $options === [] ) {
 			return $defaults;
 		}
 
@@ -837,10 +837,10 @@ abstract class WPSEO_Option {
 	 */
 	protected function get_override_option() {
 		if ( empty( $this->override_option_name ) || $this->multisite_only === true || ! is_multisite() ) {
-			return array();
+			return [];
 		}
 
-		return get_site_option( $this->override_option_name, array() );
+		return get_site_option( $this->override_option_name, [] );
 	}
 
 	/**
@@ -858,7 +858,7 @@ abstract class WPSEO_Option {
 	 * @return array
 	 */
 	protected function retain_variable_keys( $dirty, $clean ) {
-		if ( ( is_array( $this->variable_array_key_patterns ) && $this->variable_array_key_patterns !== array() ) && ( is_array( $dirty ) && $dirty !== array() ) ) {
+		if ( ( is_array( $this->variable_array_key_patterns ) && $this->variable_array_key_patterns !== [] ) && ( is_array( $dirty ) && $dirty !== [] ) ) {
 			foreach ( $dirty as $key => $value ) {
 
 				// Do nothing if already in filtered options.
@@ -890,7 +890,7 @@ abstract class WPSEO_Option {
 	 *                does not have variable array keys.
 	 */
 	protected function get_switch_key( $key ) {
-		if ( ! isset( $this->variable_array_key_patterns ) || ( ! is_array( $this->variable_array_key_patterns ) || $this->variable_array_key_patterns === array() ) ) {
+		if ( ! isset( $this->variable_array_key_patterns ) || ( ! is_array( $this->variable_array_key_patterns ) || $this->variable_array_key_patterns === [] ) ) {
 			return $key;
 		}
 

--- a/integration-tests/admin/import/test-class-import-aioseo.php
+++ b/integration-tests/admin/import/test-class-import-aioseo.php
@@ -124,8 +124,8 @@ class WPSEO_Import_AIOSEO_Test extends WPSEO_UnitTestCase {
 		$original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( 'wpdb' )
-			->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) )
-			->setMethods( array( 'query' ) )
+			->setConstructorArgs( [ DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ] )
+			->setMethods( [ 'query' ] )
 			->getMock();
 		$wpdb->expects( $this->any() )
 			->method( 'query' )
@@ -214,8 +214,8 @@ class WPSEO_Import_AIOSEO_Test extends WPSEO_UnitTestCase {
 		$original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( 'wpdb' )
-			->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) )
-			->setMethods( array( 'query' ) )
+			->setConstructorArgs( [ DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ] )
+			->setMethods( [ 'query' ] )
 			->getMock();
 		$wpdb->expects( $this->any() )
 			->method( 'query' )

--- a/integration-tests/admin/import/test-class-import-detector.php
+++ b/integration-tests/admin/import/test-class-import-detector.php
@@ -19,7 +19,7 @@ class WPSEO_Import_External_Detector_Test extends WPSEO_UnitTestCase {
 		$detector = new WPSEO_Import_Plugins_Detector();
 		$detector->detect();
 
-		$this->assertEquals( array(), $detector->needs_import );
+		$this->assertEquals( [], $detector->needs_import );
 	}
 
 	/**

--- a/integration-tests/admin/import/test-class-import-premium-seo-pack.php
+++ b/integration-tests/admin/import/test-class-import-premium-seo-pack.php
@@ -31,8 +31,8 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 	public function tearDown() {
 		$this->class_instance->run_cleanup();
 
-		add_filter( 'query', array( $this, '_create_temporary_tables' ) );
-		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		add_filter( 'query', [ $this, '_create_temporary_tables' ] );
+		add_filter( 'query', [ $this, '_drop_temporary_tables' ] );
 	}
 
 	/**
@@ -217,8 +217,8 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 		$original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( 'wpdb' )
-			->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) )
-			->setMethods( array( 'query', 'get_var' ) )
+			->setConstructorArgs( [ DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ] )
+			->setMethods( [ 'query', 'get_var' ] )
 			->getMock();
 		$wpdb->expects( $this->any() )
 			->method( 'query' )
@@ -261,7 +261,7 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 
 		$post_id = $this->factory()->post->create();
 		$blob    = $this->build_data_blob(
-			array(
+			[
 				'noindex'     => 0,
 				'nofollow'    => 1,
 				'title'       => 'Test title',
@@ -269,7 +269,7 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 				'og_media'    => 'http://local.wordpress.test/wp-content/uploads/2018/01/actionable-seo.png',
 				'og_title'    => 'OpenGraph AIOSEO title',
 				'cornerstone' => 1,
-			)
+			]
 		);
 		$this->insert_post( $post_id, $blob );
 
@@ -289,9 +289,9 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @return array Complete array
 	 */
-	private function build_data_blob( $data = array() ) {
+	private function build_data_blob( $data = [] ) {
 		return array_merge(
-			array(
+			[
 				'doseo'          => 1,
 				'noindex'        => 0,
 				'nofollow'       => 0,
@@ -313,7 +313,7 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 				'og_media'       => '',
 				'patterns'       => '',
 				'sep'            => '',
-			),
+			],
 			$data
 		);
 	}

--- a/integration-tests/admin/import/test-class-import-rankmath.php
+++ b/integration-tests/admin/import/test-class-import-rankmath.php
@@ -165,7 +165,7 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 		$post_id = $this->factory()->post->create();
 		update_post_meta( $post_id, 'rank_math_title', 'Test title' );
 		update_post_meta( $post_id, 'rank_math_description', 'Test description' );
-		update_post_meta( $post_id, 'rank_math_robots', array( 'noindex', 'nofollow' ) );
+		update_post_meta( $post_id, 'rank_math_robots', [ 'noindex', 'nofollow' ] );
 		update_post_meta( $post_id, 'rank_math_twitter_title', 'Test Twitter title' );
 		update_post_meta( $post_id, 'rank_math_twitter_description', 'Test Twitter description' );
 
@@ -178,11 +178,11 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 	private function setup_options() {
 		update_option(
 			'rank-math-options-titles',
-			array(
+			[
 				'homepage_title'       => 'Test homepage title',
 				'homepage_description' => 'Test homepage description',
 				'pt_post_title'        => 'Test post title template %sep% %sitename%',
-			)
+			]
 		);
 	}
 }

--- a/integration-tests/admin/import/test-class-import-seopressor.php
+++ b/integration-tests/admin/import/test-class-import-seopressor.php
@@ -102,7 +102,7 @@ class WPSEO_Import_SEOPressor_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 1, $robots_noindex );
 		$this->assertEquals( 1, $robots_nofollow );
 		$this->assertEquals( 'Test focus kw', $focus_kw );
-		$this->assertEquals( array( 'Test focus kw 2', 'Test focus kw 3' ), $extra_focus_kw );
+		$this->assertEquals( [ 'Test focus kw 2', 'Test focus kw 3' ], $extra_focus_kw );
 		$this->assertEquals( $this->status( 'import', true ), $result );
 	}
 
@@ -150,11 +150,11 @@ class WPSEO_Import_SEOPressor_Test extends WPSEO_UnitTestCase {
 	 */
 	private function setup_post() {
 		$post_id  = $this->factory()->post->create();
-		$settings = array(
+		$settings = [
 			'meta_title'       => 'Test title',
 			'meta_description' => 'Test description',
 			'meta_rules'       => 'noindex#|#|#nofollow',
-		);
+		];
 		update_post_meta( $post_id, '_seop_settings', $settings );
 		update_post_meta( $post_id, '_seop_kw_1', 'Test focus kw' );
 		update_post_meta( $post_id, '_seop_kw_2', 'Test focus kw 2' );

--- a/integration-tests/admin/import/test-class-import-smartcrawl.php
+++ b/integration-tests/admin/import/test-class-import-smartcrawl.php
@@ -164,8 +164,8 @@ class WPSEO_Import_Smartcrawl_SEO_Test extends WPSEO_UnitTestCase {
 		$original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( 'wpdb' )
-			->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) )
-			->setMethods( array( 'query' ) )
+			->setConstructorArgs( [ DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ] )
+			->setMethods( [ 'query' ] )
 			->getMock();
 		$wpdb->expects( $this->any() )
 			->method( 'query' )
@@ -257,8 +257,8 @@ class WPSEO_Import_Smartcrawl_SEO_Test extends WPSEO_UnitTestCase {
 		$original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( 'wpdb' )
-			->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) )
-			->setMethods( array( 'query' ) )
+			->setConstructorArgs( [ DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ] )
+			->setMethods( [ 'query' ] )
 			->getMock();
 		$wpdb->expects( $this->any() )
 			->method( 'query' )

--- a/integration-tests/admin/import/test-class-import-squirrly.php
+++ b/integration-tests/admin/import/test-class-import-squirrly.php
@@ -31,8 +31,8 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 	public function tearDown() {
 		$this->class_instance->run_cleanup();
 
-		add_filter( 'query', array( $this, '_create_temporary_tables' ) );
-		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		add_filter( 'query', [ $this, '_create_temporary_tables' ] );
+		add_filter( 'query', [ $this, '_drop_temporary_tables' ] );
 	}
 
 	/**
@@ -251,8 +251,8 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 		$original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( 'wpdb' )
-			->setConstructorArgs( array( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) )
-			->setMethods( array( 'query', 'get_var' ) )
+			->setConstructorArgs( [ DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ] )
+			->setMethods( [ 'query', 'get_var' ] )
 			->getMock();
 		$wpdb->expects( $this->any() )
 			->method( 'query' )
@@ -295,7 +295,7 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 
 		$post_id = $this->factory()->post->create();
 		$blob    = $this->build_data_blob(
-			array(
+			[
 				'noindex'     => 0,
 				'nofollow'    => 1,
 				'title'       => 'Test title',
@@ -303,7 +303,7 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 				'og_media'    => 'http://local.wordpress.test/wp-content/uploads/2018/01/actionable-seo.png',
 				'og_title'    => 'OpenGraph AIOSEO title',
 				'cornerstone' => 1,
-			)
+			]
 		);
 		$this->insert_post( $post_id, $blob );
 		update_post_meta( $post_id, '_sq_post_keyword', '{"keyword":"squirrly test","update":1521207189}' );
@@ -324,9 +324,9 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @return array Complete array.
 	 */
-	private function build_data_blob( $data = array() ) {
+	private function build_data_blob( $data = [] ) {
 		return array_merge(
-			array(
+			[
 				'doseo'          => 1,
 				'noindex'        => 0,
 				'nofollow'       => 0,
@@ -348,7 +348,7 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 				'og_media'       => '',
 				'patterns'       => '',
 				'sep'            => '',
-			),
+			],
 			$data
 		);
 	}

--- a/integration-tests/admin/import/test-class-import-wpseo.php
+++ b/integration-tests/admin/import/test-class-import-wpseo.php
@@ -218,10 +218,10 @@ class WPSEO_Import_WPSEO_Test extends WPSEO_UnitTestCase {
 	 */
 	private function create_category_metadata( $name, $desc, $robots ) {
 		$term_id = $this->factory->term->create(
-			array(
+			[
 				'name'     => $name,
 				'taxonomy' => 'category',
-			)
+			]
 		);
 		update_option( 'wpseo_category_' . $term_id, $desc );
 		update_option( 'wpseo_category_' . $term_id . '_robots', $robots );

--- a/integration-tests/admin/links/test-class-link-columns-count.php
+++ b/integration-tests/admin/links/test-class-link-columns-count.php
@@ -45,14 +45,14 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Column_Count $column_count */
 		$column_count = $this
 			->getMockBuilder( 'WPSEO_Link_Column_Count' )
-			->setMethods( array( 'get_results' ) )
+			->setMethods( [ 'get_results' ] )
 			->getMock();
 
 		$column_count
 			->expects( $this->never() )
 			->method( 'get_results' );
 
-		$column_count->set( array() );
+		$column_count->set( [] );
 	}
 
 	/**
@@ -62,7 +62,7 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Column_Count $column_count */
 		$column_count = $this
 			->getMockBuilder( 'WPSEO_Link_Column_Count' )
-			->setMethods( array( 'get_results' ) )
+			->setMethods( [ 'get_results' ] )
 			->getMock();
 
 		$column_count
@@ -70,16 +70,16 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 			->method( 'get_results' )
 			->will(
 				$this->returnValue(
-					array(
-						1 => array(
+					[
+						1 => [
 							'post_id' => 1,
 							'total'   => 10,
-						),
-					)
+						],
+					]
 				)
 			);
 
-		$column_count->set( array( 1 ) );
+		$column_count->set( [ 1 ] );
 	}
 
 	/**
@@ -89,7 +89,7 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Column_Count $column_count */
 		$column_count = $this
 			->getMockBuilder( 'WPSEO_Link_Column_Count' )
-			->setMethods( array( 'get_results' ) )
+			->setMethods( [ 'get_results' ] )
 			->getMock();
 
 		$column_count
@@ -97,16 +97,16 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 			->method( 'get_results' )
 			->will(
 				$this->returnValue(
-					array(
-						1 => array(
+					[
+						1 => [
 							'incoming_link_count' => 0,
 							'internal_link_count' => 10,
-						),
-					)
+						],
+					]
 				)
 			);
 
-		$column_count->set( array( 1 ) );
+		$column_count->set( [ 1 ] );
 
 		$this->assertEquals( 10, $column_count->get( 1 ) );
 	}
@@ -118,7 +118,7 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Column_Count $column_count */
 		$column_count = $this
 			->getMockBuilder( 'WPSEO_Link_Column_Count' )
-			->setMethods( array( 'get_results' ) )
+			->setMethods( [ 'get_results' ] )
 			->getMock();
 
 		$column_count
@@ -126,16 +126,16 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 			->method( 'get_results' )
 			->will(
 				$this->returnValue(
-					array(
-						1 => array(
+					[
+						1 => [
 							'post_id' => 1,
 							'total'   => 10,
-						),
-					)
+						],
+					]
 				)
 			);
 
-		$column_count->set( array( 1 ) );
+		$column_count->set( [ 1 ] );
 
 		$this->assertEquals( 0, $column_count->get( 2 ) );
 	}
@@ -149,7 +149,7 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 
 
 		$column_count = new WPSEO_Link_Column_Count();
-		$column_count->set( array( 100 ) );
+		$column_count->set( [ 100 ] );
 
 		$this->assertEquals( 0, $column_count->get( 100, 'incoming_link_count' ) );
 	}
@@ -159,7 +159,7 @@ class WPSEO_Link_Column_Count_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_results_unfound_posts() {
 		$column_count = new WPSEO_Link_Column_Count();
-		$column_count->set( array( 120 ) );
+		$column_count->set( [ 120 ] );
 
 		$this->assertEquals( 0, $column_count->get( 120, 'internal_link_count' ) );
 	}

--- a/integration-tests/admin/links/test-class-link-columns.php
+++ b/integration-tests/admin/links/test-class-link-columns.php
@@ -55,7 +55,7 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 		$link_columns->register_hooks();
 
 		$this->assertFalse(
-			has_action( 'admin_init', array( $link_columns, 'set_count_objects' ) )
+			has_action( 'admin_init', [ $link_columns, 'set_count_objects' ] )
 		);
 	}
 
@@ -68,8 +68,8 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Columns $link_columns */
 		$link_columns = $this
 			->getMockBuilder( 'WPSEO_Link_Columns' )
-			->setConstructorArgs( array( new WPSEO_Meta_Storage() ) )
-			->setMethods( array( 'set_post_type_hooks' ) )
+			->setConstructorArgs( [ new WPSEO_Meta_Storage() ] )
+			->setMethods( [ 'set_post_type_hooks' ] )
 			->getMock();
 
 		$link_columns
@@ -84,14 +84,14 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_post_columns() {
 		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
-		$expected     = array(
+		$expected     = [
 			'wpseo-links'  => '<span class="yoast-linked-to yoast-column-header-has-tooltip" data-tooltip-text="Number of outgoing internal links in this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text">Outgoing internal links</span></span>',
 			'wpseo-linked' => '<span class="yoast-linked-from yoast-column-header-has-tooltip" data-tooltip-text="Number of internal links linking to this post. See &quot;Yoast Columns&quot; text in the help tab for more info."><span class="screen-reader-text">Received internal links</span></span>',
-		);
+		];
 
 		$this->assertEquals(
 			$expected,
-			$link_columns->add_post_columns( array() )
+			$link_columns->add_post_columns( [] )
 		);
 	}
 
@@ -135,11 +135,11 @@ class WPSEO_Link_Columns_Test extends WPSEO_UnitTestCase {
 		$link_columns = new WPSEO_Link_Columns( new WPSEO_Meta_Storage() );
 
 		$this->assertEquals(
-			array(
+			[
 				'wpseo-links'  => 'wpseo-links',
 				'wpseo-linked' => 'wpseo-linked',
-			),
-			$link_columns->column_sort( array() )
+			],
+			$link_columns->column_sort( [] )
 		);
 	}
 }

--- a/integration-tests/admin/links/test-class-link-content-processor.php
+++ b/integration-tests/admin/links/test-class-link-content-processor.php
@@ -45,7 +45,7 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Storage $storage */
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Link_Storage' )
-			->setMethods( array( 'cleanup', 'save_links' ) )
+			->setMethods( [ 'cleanup', 'save_links' ] )
 			->getMock();
 
 		$storage
@@ -58,7 +58,7 @@ class WPSEO_Link_Content_Processor_Test extends WPSEO_UnitTestCase {
 			->method( 'save_links' )
 			->with(
 				1,
-				array( new WPSEO_Link( 'http://example.org/post', 0, 'internal' ) )
+				[ new WPSEO_Link( 'http://example.org/post', 0, 'internal' ) ]
 			);
 
 		$processor = new WPSEO_Link_Content_Processor( $storage, new WPSEO_Meta_Storage() );

--- a/integration-tests/admin/links/test-class-link-extractor.php
+++ b/integration-tests/admin/links/test-class-link-extractor.php
@@ -16,7 +16,7 @@ class WPSEO_Link_Extractor_Test extends WPSEO_UnitTestCase {
 	public function test_extraction_no_links() {
 		$extractor = new WPSEO_Link_Extractor( 'There are no links.' );
 
-		$this->assertEquals( array(), $extractor->extract() );
+		$this->assertEquals( [], $extractor->extract() );
 	}
 
 	/**
@@ -25,6 +25,6 @@ class WPSEO_Link_Extractor_Test extends WPSEO_UnitTestCase {
 	public function test_extraction_with_links() {
 		$extractor = new WPSEO_Link_Extractor( 'There is one <a href="http://www.test.com">link</a>a> in this test.' );
 
-		$this->assertEquals( array( 'http://www.test.com' ), $extractor->extract() );
+		$this->assertEquals( [ 'http://www.test.com' ], $extractor->extract() );
 	}
 }

--- a/integration-tests/admin/links/test-class-link-factory.php
+++ b/integration-tests/admin/links/test-class-link-factory.php
@@ -25,8 +25,8 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 		$processor = new WPSEO_Link_Factory( $this->getClassifierMock( 'external' ), $populator, $this->getFilterMock( 'page', true ) );
 
 		$this->assertEquals(
-			array( new WPSEO_Link( 'test', 0, 'external' ) ),
-			$processor->build( array( 'test' ) )
+			[ new WPSEO_Link( 'test', 0, 'external' ) ],
+			$processor->build( [ 'test' ] )
 		);
 	}
 
@@ -43,7 +43,7 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_process_internal_link( $classifier, $lookup, $filter, $link_url, $expected ) {
 		$processor = new WPSEO_Link_Factory( $classifier, $lookup, $filter );
-		$actual    = $processor->build( array( $link_url ) );
+		$actual    = $processor->build( [ $link_url ] );
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -55,29 +55,29 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	 */
 	public function link_provider() {
 
-		return array(
-			array(
+		return [
+			[
 				$this->getClassifierMock( 'internal' ),
 				$this->getLookUpMock( 2 ),
 				$this->getFilterMock( 'currentpage', true ),
 				'test',
-				array( new WPSEO_Link( 'test', 2, 'internal' ) ),
-			),
-			array(
+				[ new WPSEO_Link( 'test', 2, 'internal' ) ],
+			],
+			[
 				$this->getClassifierMock( 'internal' ),
 				$this->getLookUpMock( 2 ),
 				$this->getFilterMock( 'test.html', false ),
 				'test.html#hastag',
-				array(),
-			),
-			array(
+				[],
+			],
+			[
 				$this->getClassifierMock( 'internal' ),
 				$this->getLookUpMock( 2 ),
 				$this->getFilterMock( 'test.html', false ),
 				'test.html?foo=bar',
-				array(),
-			),
-		);
+				[],
+			],
+		];
 	}
 
 	/**
@@ -127,7 +127,7 @@ class WPSEO_Link_Factory_Test extends WPSEO_UnitTestCase {
 	protected function getFilterMock( $current_page, $filter_result ) {
 		$filter = $this
 			->getMockBuilder( 'WPSEO_Link_Filter' )
-			->setConstructorArgs( array( $current_page ) )
+			->setConstructorArgs( [ $current_page ] )
 			->getMock();
 
 		$filter

--- a/integration-tests/admin/links/test-class-link-filter.php
+++ b/integration-tests/admin/links/test-class-link-filter.php
@@ -34,62 +34,62 @@ class WPSEO_Link_Filter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function link_provider() {
 
-		return array(
-			array(
+		return [
+			[
 				'page',
 				new WPSEO_Link( 'testpage', 0, 'internal' ),
 				true,
-			),
-			array(
+			],
+			[
 				'testpage',
 				new WPSEO_Link( 'testpage', 0, 'internal' ),
 				false,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( 'page#fragment', 0, 'internal' ),
 				false,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( 'testpage#fragment', 0, 'internal' ),
 				true,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( 'page?param=foo', 0, 'internal' ),
 				false,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( 'testpage?param=foo', 0, 'internal' ),
 				true,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( 'http://extern.al/page?param=foo', 0, 'external' ),
 				true,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( '/', 0, 'internal' ),
 				true,
-			),
-			array(
+			],
+			[
 				'/',
 				new WPSEO_Link( '/', 0, 'internal' ),
 				true,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( '?param=foo', 0, 'internal' ),
 				false,
-			),
-			array(
+			],
+			[
 				'page',
 				new WPSEO_Link( '#fragment', 0, 'internal' ),
 				false,
-			),
-		);
+			],
+		];
 	}
 }

--- a/integration-tests/admin/links/test-class-link-reindex-post-service.php
+++ b/integration-tests/admin/links/test-class-link-reindex-post-service.php
@@ -32,7 +32,7 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 	public function test_reindex_with_inaccessible_tables() {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Link_Reindex_Post_Service' )
-			->setMethods( array( 'is_processable' ) )
+			->setMethods( [ 'is_processable' ] )
 			->getMock();
 
 		$class_instance
@@ -62,11 +62,11 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 
 		$post = $this->factory()
 			->post
-			->create_and_get( array( 'post_content' => 'this is the content' ) );
+			->create_and_get( [ 'post_content' => 'this is the content' ] );
 
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Link_Reindex_Post_Service' )
-			->setMethods( array( 'is_processable', 'get_unprocessed_posts', 'get_content_processor' ) )
+			->setMethods( [ 'is_processable', 'get_unprocessed_posts', 'get_content_processor' ] )
 			->getMock();
 
 		$class_instance
@@ -77,7 +77,7 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 		$class_instance
 			->expects( $this->once() )
 			->method( 'get_unprocessed_posts' )
-			->will( $this->returnValue( array( $post ) ) );
+			->will( $this->returnValue( [ $post ] ) );
 
 		$class_instance
 			->expects( $this->once() )
@@ -103,7 +103,7 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Link_Reindex_Post_Service' )
-			->setMethods( array( 'is_processable', 'get_unprocessed_posts', 'get_content_processor' ) )
+			->setMethods( [ 'is_processable', 'get_unprocessed_posts', 'get_content_processor' ] )
 			->getMock();
 
 		$class_instance
@@ -114,7 +114,7 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 		$class_instance
 			->expects( $this->once() )
 			->method( 'get_unprocessed_posts' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$class_instance
 			->expects( $this->never() )
@@ -134,8 +134,8 @@ class WPSEO_Link_Reindex_Post_Service_Test extends WPSEO_UnitTestCase {
 	private function get_content_processor_mock() {
 		return $this
 			->getMockBuilder( 'WPSEO_Link_Content_Processor' )
-			->setConstructorArgs( array( new WPSEO_Link_Storage(), new WPSEO_Meta_Storage() ) )
-			->setMethods( array( 'process' ) )
+			->setConstructorArgs( [ new WPSEO_Link_Storage(), new WPSEO_Meta_Storage() ] )
+			->setMethods( [ 'process' ] )
 			->getMock();
 	}
 }

--- a/integration-tests/admin/links/test-class-link-storage.php
+++ b/integration-tests/admin/links/test-class-link-storage.php
@@ -45,7 +45,7 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Storage $storage */
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Link_Storage' )
-			->setMethods( array( 'save_link' ) )
+			->setMethods( [ 'save_link' ] )
 			->getMock();
 
 		$storage
@@ -59,9 +59,9 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 
 		$storage->save_links(
 			1,
-			array(
+			[
 				new WPSEO_Link( 'page', 0, 'outbound' ),
-			)
+			]
 		);
 	}
 
@@ -70,7 +70,7 @@ class WPSEO_Link_Storage_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_cleanup() {
 		$storage = new WPSEO_Link_Storage();
-		$storage->save_links( 2, array( new WPSEO_Link( 'page2', 0, 'outbound' ) ) );
+		$storage->save_links( 2, [ new WPSEO_Link( 'page2', 0, 'outbound' ) ] );
 
 		$this->assertEquals( 1, $storage->cleanup( 2 ) );
 	}

--- a/integration-tests/admin/links/test-class-link-type-classifier.php
+++ b/integration-tests/admin/links/test-class-link-type-classifier.php
@@ -49,17 +49,17 @@ class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function provider_urls() {
-		return array(
-			array( 'http://example.com', 'page', 'internal' ),
-			array( 'http://example.com', 'http://example.com/page', 'internal' ),
-			array( 'https://example.com', 'http://example.com/page', 'internal' ),
-			array( 'http://example.com', 'http://test.com/page', 'external' ),
-			array( 'http://example.com', 'http://dev.example.com', 'external' ),
-			array( 'http://example.com/subdirectory', 'http://example.com/subdirectory2/', 'external' ),
-			array( 'http://example.com/subdirectory', 'http://example.com/subdirectory/hi?query=set', 'internal' ),
-			array( 'http://example.com', 'mailto:johndoe@example.com', 'external' ),
-			array( 'http://example.com', 'mailto:example.com', 'external' ),
-		);
+		return [
+			[ 'http://example.com', 'page', 'internal' ],
+			[ 'http://example.com', 'http://example.com/page', 'internal' ],
+			[ 'https://example.com', 'http://example.com/page', 'internal' ],
+			[ 'http://example.com', 'http://test.com/page', 'external' ],
+			[ 'http://example.com', 'http://dev.example.com', 'external' ],
+			[ 'http://example.com/subdirectory', 'http://example.com/subdirectory2/', 'external' ],
+			[ 'http://example.com/subdirectory', 'http://example.com/subdirectory/hi?query=set', 'internal' ],
+			[ 'http://example.com', 'mailto:johndoe@example.com', 'external' ],
+			[ 'http://example.com', 'mailto:example.com', 'external' ],
+		];
 	}
 
 	/**
@@ -71,8 +71,8 @@ class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Type_Classifier $classifier */
 		$classifier = $this
 			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
-			->setConstructorArgs( array( 'http://example.com' ) )
-			->setMethods( array( 'contains_protocol' ) )
+			->setConstructorArgs( [ 'http://example.com' ] )
+			->setMethods( [ 'contains_protocol' ] )
 			->getMock();
 
 		$classifier
@@ -93,8 +93,8 @@ class WPSEO_Link_Type_Classifier_Test extends WPSEO_UnitTestCase {
 		/** @var WPSEO_Link_Type_Classifier $classifier */
 		$classifier = $this
 			->getMockBuilder( 'WPSEO_Link_Type_Classifier' )
-			->setConstructorArgs( array( 'http://example.com' ) )
-			->setMethods( array( 'is_external_link' ) )
+			->setConstructorArgs( [ 'http://example.com' ] )
+			->setMethods( [ 'is_external_link' ] )
 			->getMock();
 
 		$classifier

--- a/integration-tests/admin/links/test-class-link-watcher.php
+++ b/integration-tests/admin/links/test-class-link-watcher.php
@@ -45,10 +45,10 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 
 		$post_parent = $this->factory->post->create_and_get();
 		$post        = $this->factory->post->create_and_get(
-			array(
+			[
 				'post_type'   => 'revision',
 				'post_parent' => $post_parent->ID,
-			)
+			]
 		);
 
 		$processor = $this->get_processor();
@@ -68,9 +68,9 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_skip_trash_posts() {
 
 		$post = self::factory()->post->create(
-			array(
+			[
 				'post_type' => 'post',
-			)
+			]
 		);
 
 		wp_delete_post( $post );
@@ -95,7 +95,7 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_is_processable_draft() {
 
 		$post = $this->factory->post->create_and_get(
-			array( 'post_status' => 'draft' )
+			[ 'post_status' => 'draft' ]
 		);
 
 		$processor = $this->get_processor();
@@ -111,10 +111,10 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	 * Test with a none public posttype.
 	 */
 	public function test_is_processable_none_public_posttype() {
-		register_post_type( 'hidden', array( 'public' => false ) );
+		register_post_type( 'hidden', [ 'public' => false ] );
 
 		$post = $this->factory->post->create_and_get(
-			array( 'post_type' => 'hidden' )
+			[ 'post_type' => 'hidden' ]
 		);
 
 		$processor = $this->get_processor();
@@ -132,9 +132,9 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_is_processable_without_content() {
 
 		$post = $this->factory->post->create_and_get(
-			array(
+			[
 				'post_content' => '',
-			)
+			]
 		);
 
 		$processor = $this->get_processor();
@@ -153,9 +153,9 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_is_processable_with_content() {
 
 		$post = $this->factory->post->create_and_get(
-			array(
+			[
 				'post_content' => 'This is content',
-			)
+			]
 		);
 
 		$processor = $this->get_processor();
@@ -173,15 +173,15 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_delete_post() {
 		$post = $this->factory->post->create_and_get(
-			array(
+			[
 				'post_content' => 'This is content that will be deleted',
-			)
+			]
 		);
 
 		$link_to_save = new WPSEO_Link( 'http://example.com/page', 0, 'external' );
 
 		$storage = new WPSEO_Link_Storage();
-		$storage->save_links( $post->ID, array( $link_to_save ) );
+		$storage->save_links( $post->ID, [ $link_to_save ] );
 
 		$this->assertNotEmpty( $storage->get_links( $post->ID ) );
 
@@ -199,8 +199,8 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	protected function get_processor() {
 		return $this
 			->getMockBuilder( 'WPSEO_Link_Content_Processor' )
-			->setConstructorArgs( array( new WPSEO_Link_Storage(), new WPSEO_Meta_Storage() ) )
-			->setMethods( array( 'process' ) )
+			->setConstructorArgs( [ new WPSEO_Link_Storage(), new WPSEO_Meta_Storage() ] )
+			->setMethods( [ 'process' ] )
 			->getMock();
 	}
 }

--- a/integration-tests/admin/services/test-class-endpoint-indexable.php
+++ b/integration-tests/admin/services/test-class-endpoint-indexable.php
@@ -38,7 +38,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	public function test_get_indexable_for_invalid_object_type() {
 		$request = $this
 			->getMockBuilder( 'WP_REST_Request' )
-			->setMethods( array( 'get_param' ) )
+			->setMethods( [ 'get_param' ] )
 			->getMock();
 
 		$request
@@ -59,17 +59,17 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	public function test_get_indexable_for_valid_post_type_with_a_non_indexable_object() {
 		$provider = $this
 			->getMockBuilder( 'WPSEO_Indexable_Foo_Provider' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$provider
 			->expects( $this->once() )
 			->method( 'get' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$service = $this
 			->getMockBuilder( 'WPSEO_Indexable_Service' )
-			->setMethods( array( 'get_provider' ) )
+			->setMethods( [ 'get_provider' ] )
 			->getMock();
 
 		$service
@@ -79,7 +79,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 
 		$request = $this
 			->getMockBuilder( 'WP_REST_Request' )
-			->setMethods( array( 'get_param' ) )
+			->setMethods( [ 'get_param' ] )
 			->getMock();
 
 		$request
@@ -94,7 +94,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 		 */
 		$response = $service->get_indexable( $request );
 
-		$this->assertEquals( new WP_REST_Response( array(), 200 ), $response );
+		$this->assertEquals( new WP_REST_Response( [], 200 ), $response );
 	}
 
 	/**
@@ -105,7 +105,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 	public function test_get_indexable_for_valid_post_type_with_an_indexable_object() {
 		$provider = $this
 			->getMockBuilder( 'WPSEO_Indexable_Foo_Provider' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$provider
@@ -115,7 +115,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 
 		$service = $this
 			->getMockBuilder( 'WPSEO_Indexable_Service' )
-			->setMethods( array( 'get_provider' ) )
+			->setMethods( [ 'get_provider' ] )
 			->getMock();
 
 		$service
@@ -125,7 +125,7 @@ class WPSEO_Indexable_Service_Test extends WPSEO_UnitTestCase {
 
 		$request = $this
 			->getMockBuilder( 'WP_REST_Request' )
-			->setMethods( array( 'get_param' ) )
+			->setMethods( [ 'get_param' ] )
 			->getMock();
 
 		$request

--- a/integration-tests/admin/services/test-class-file-size.php
+++ b/integration-tests/admin/services/test-class-file-size.php
@@ -21,7 +21,7 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
-			->setMethods( array( 'is_externally_hosted' ) )
+			->setMethods( [ 'is_externally_hosted' ] )
 			->getMock();
 
 		$instance
@@ -43,7 +43,7 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 	public function test_get_with_unknown_failure() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
-			->setMethods( array( 'get_file_url', 'calculate_file_size' ) )
+			->setMethods( [ 'get_file_url', 'calculate_file_size' ] )
 			->getMock();
 
 		$instance
@@ -70,7 +70,7 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 	public function test_get_on_success() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
-			->setMethods( array( 'get_file_url', 'get_file_size' ) )
+			->setMethods( [ 'get_file_url', 'get_file_size' ] )
 			->getMock();
 
 		$instance
@@ -101,7 +101,7 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
-			->setMethods( array( 'is_externally_hosted' ) )
+			->setMethods( [ 'is_externally_hosted' ] )
 			->getMock();
 
 		$instance
@@ -127,7 +127,7 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
-			->setMethods( array( 'is_externally_hosted', 'get_file_size' ) )
+			->setMethods( [ 'is_externally_hosted', 'get_file_size' ] )
 			->getMock();
 
 		$instance

--- a/integration-tests/admin/services/test-class-indexable-post-provider.php
+++ b/integration-tests/admin/services/test-class-indexable-post-provider.php
@@ -102,7 +102,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Indexable_Service_Post_Provider::get
 	 */
 	public function test_get_a_non_indexable_post_with_invalid_object_ids( $object_id, $description ) {
-		$this->assertEquals( array(), $this->provider->get( $object_id ), $description );
+		$this->assertEquals( [], $this->provider->get( $object_id ), $description );
 	}
 
 	/**
@@ -112,8 +112,8 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Indexable_Service_Post_Provider::is_indexable
 	 */
 	public function test_get_a_non_indexable_post() {
-		$this->assertEquals( array(), $this->provider->get( $this->get_revision() ) );
-		$this->assertEquals( array(), $this->provider->get( $this->get_auto_save() ) );
+		$this->assertEquals( [], $this->provider->get( $this->get_revision() ) );
+		$this->assertEquals( [], $this->provider->get( $this->get_auto_save() ) );
 	}
 
 	/**
@@ -142,7 +142,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 		WPSEO_Meta::set_value( 'content_score', '35', $post->ID );
 		WPSEO_Meta::set_value( 'is_cornerstone', '1', $post->ID );
 
-		$expected_array = array(
+		$expected_array = [
 			'object_id'                   => (int) $post->ID,
 			'object_type'                 => 'post',
 			'object_subtype'              => $post->post_type,
@@ -170,7 +170,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 			'incoming_link_count'         => 0,
 			'created_at'                  => null,
 			'updated_at'                  => null,
-		);
+		];
 
 		$provider = new WPSEO_Indexable_Service_Post_Provider();
 
@@ -191,7 +191,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @dataProvider indexable_data_conversion_provider
 	 */
 	public function test_convert_indexable_data( $robot_value, $supplied_value, $expected, $description ) {
-		$data = $this->provider->convert_indexable_data( array( $robot_value => $supplied_value ) );
+		$data = $this->provider->convert_indexable_data( [ $robot_value => $supplied_value ] );
 
 		$this->assertEquals( $expected, $data[ $robot_value ], $description );
 	}
@@ -209,7 +209,7 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @dataProvider advanced_indexable_data_conversion_provider
 	 */
 	public function test_convert_advanced( $robot_value, $supplied_value, $expected, $description ) {
-		$indexable = array( $robot_value => $supplied_value );
+		$indexable = [ $robot_value => $supplied_value ];
 		$data      = $this->provider->convert_advanced( $indexable );
 
 		$this->assertEquals( $expected, $data, $description );
@@ -272,15 +272,15 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function indexable_data_conversion_provider() {
-		return array(
-			array( 'is_robots_nofollow', 'true', '1', 'With is_robots_nofollow value set to nofollow' ),
-			array( 'is_robots_nofollow', false, '0', 'With is_robots_nofollow value set to follow' ),
-			array( 'is_robots_noindex', 'false', '2', 'With is_robots_noindex value set to index' ),
-			array( 'is_robots_noindex', 'true', '1', 'With is_robots_noindex value set to noindex' ),
-			array( 'is_robots_noindex', null, null, 'With is_robots_noindex value set to default' ),
-			array( 'is_cornerstone', 'true', '1', 'With is_cornerstone value set to true' ),
-			array( 'is_cornerstone', false, null, 'With is_cornerstone value set to false' ),
-		);
+		return [
+			[ 'is_robots_nofollow', 'true', '1', 'With is_robots_nofollow value set to nofollow' ],
+			[ 'is_robots_nofollow', false, '0', 'With is_robots_nofollow value set to follow' ],
+			[ 'is_robots_noindex', 'false', '2', 'With is_robots_noindex value set to index' ],
+			[ 'is_robots_noindex', 'true', '1', 'With is_robots_noindex value set to noindex' ],
+			[ 'is_robots_noindex', null, null, 'With is_robots_noindex value set to default' ],
+			[ 'is_cornerstone', 'true', '1', 'With is_cornerstone value set to true' ],
+			[ 'is_cornerstone', false, null, 'With is_cornerstone value set to false' ],
+		];
 	}
 
 	/**
@@ -289,19 +289,19 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function advanced_indexable_data_conversion_provider() {
-		return array(
-			array( 'is_robots_nosnippet', false, '', 'With is_robots_nosnippet value set to false' ),
-			array( 'is_robots_nosnippet', true, 'nosnippet', 'With is_robots_nosnippet value set to true' ),
-			array( 'is_robots_nosnippet', null, '', 'With is_robots_nosnippet value set to null' ),
+		return [
+			[ 'is_robots_nosnippet', false, '', 'With is_robots_nosnippet value set to false' ],
+			[ 'is_robots_nosnippet', true, 'nosnippet', 'With is_robots_nosnippet value set to true' ],
+			[ 'is_robots_nosnippet', null, '', 'With is_robots_nosnippet value set to null' ],
 
-			array( 'is_robots_noarchive', false, '', 'With is_robots_nosnippet value set to false' ),
-			array( 'is_robots_noarchive', true, 'noarchive', 'With is_robots_nosnippet value set to true' ),
-			array( 'is_robots_noarchive', null, '', 'With is_robots_nosnippet value set to null' ),
+			[ 'is_robots_noarchive', false, '', 'With is_robots_nosnippet value set to false' ],
+			[ 'is_robots_noarchive', true, 'noarchive', 'With is_robots_nosnippet value set to true' ],
+			[ 'is_robots_noarchive', null, '', 'With is_robots_nosnippet value set to null' ],
 
-			array( 'is_robots_noimageindex', false, '', 'With is_robots_noimageindex value set to false' ),
-			array( 'is_robots_noimageindex', true, 'noimageindex', 'With is_robots_noimageindex value set to true' ),
-			array( 'is_robots_noimageindex', null, '', 'With is_robots_noimageindex value set to null' ),
-		);
+			[ 'is_robots_noimageindex', false, '', 'With is_robots_noimageindex value set to false' ],
+			[ 'is_robots_noimageindex', true, 'noimageindex', 'With is_robots_noimageindex value set to true' ],
+			[ 'is_robots_noimageindex', null, '', 'With is_robots_noimageindex value set to null' ],
+		];
 	}
 
 	/**
@@ -310,16 +310,16 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function invalid_object_id_provider() {
-		return array(
-			array( false, 'With false as object id' ),
-			array( 'post title', 'With a string as object id' ),
-			array( -1, 'With negative number as object id' ),
-			array( 1000000000, 'With large number as object id' ),
-			array( null, 'With null as object id' ),
-			array( $this->get_revision(), 'With a revision as object id' ),
-			array( $this->get_auto_save(), 'With a revision as object id' ),
+		return [
+			[ false, 'With false as object id' ],
+			[ 'post title', 'With a string as object id' ],
+			[ -1, 'With negative number as object id' ],
+			[ 1000000000, 'With large number as object id' ],
+			[ null, 'With null as object id' ],
+			[ $this->get_revision(), 'With a revision as object id' ],
+			[ $this->get_auto_save(), 'With a revision as object id' ],
 
-		);
+		];
 	}
 
 	/**
@@ -328,13 +328,13 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function cornerstone_conversion_provider() {
-		return array(
-			array( 'true', '1', 'With cornerstone set to string value of true' ),
-			array( 'false', null, 'With cornerstone set to string value of false' ),
-			array( true, null, 'With cornerstone set to boolean value of true' ),
-			array( false, null, 'With cornerstone set to boolean value of false' ),
-			array( '1', null, 'With cornerstone set to string value of 1' ),
-		);
+		return [
+			[ 'true', '1', 'With cornerstone set to string value of true' ],
+			[ 'false', null, 'With cornerstone set to string value of false' ],
+			[ true, null, 'With cornerstone set to boolean value of true' ],
+			[ false, null, 'With cornerstone set to boolean value of false' ],
+			[ '1', null, 'With cornerstone set to string value of 1' ],
+		];
 	}
 
 	/**
@@ -343,15 +343,15 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function nofollow_conversion_provider() {
-		return array(
-			array( 'true', '1', 'With nofollow set to string value of true' ),
-			array( 'false', '0', 'With nofollow set to string value of false' ),
-			array( true, '0', 'With nofollow set to boolean value of true' ),
-			array( false, '0', 'With nofollow set to boolean value of false' ),
-			array( '2', '0', 'With nofollow set to string value of 2' ),
-			array( '1', '0', 'With nofollow set to string value of 1' ),
-			array( '0', '0', 'With nofollow set to string value of 0' ),
-		);
+		return [
+			[ 'true', '1', 'With nofollow set to string value of true' ],
+			[ 'false', '0', 'With nofollow set to string value of false' ],
+			[ true, '0', 'With nofollow set to boolean value of true' ],
+			[ false, '0', 'With nofollow set to boolean value of false' ],
+			[ '2', '0', 'With nofollow set to string value of 2' ],
+			[ '1', '0', 'With nofollow set to string value of 1' ],
+			[ '0', '0', 'With nofollow set to string value of 0' ],
+		];
 	}
 
 	/**
@@ -360,15 +360,15 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function noindex_conversion_provider() {
-		return array(
-			array( 'true', '1', 'With noindex set to string value of true' ),
-			array( 'false', '2', 'With noindex set to string value of false' ),
-			array( true, null, 'With noindex set to boolean value of true' ),
-			array( false, null, 'With noindex set to boolean value of false' ),
-			array( '2', null, 'With noindex set to string value of 2' ),
-			array( '1', null, 'With noindex set to string value of 1' ),
-			array( '0', null, 'With noindex set to string value of 0' ),
-		);
+		return [
+			[ 'true', '1', 'With noindex set to string value of true' ],
+			[ 'false', '2', 'With noindex set to string value of false' ],
+			[ true, null, 'With noindex set to boolean value of true' ],
+			[ false, null, 'With noindex set to boolean value of false' ],
+			[ '2', null, 'With noindex set to string value of 2' ],
+			[ '1', null, 'With noindex set to string value of 1' ],
+			[ '0', null, 'With noindex set to string value of 0' ],
+		];
 	}
 
 	/**
@@ -378,10 +378,10 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 */
 	public function get_revision() {
 		return self::factory()->post->create(
-			array(
+			[
 				'post_type'   => 'revision',
 				'post_parent' => 2,
-			)
+			]
 		);
 	}
 
@@ -392,11 +392,11 @@ class WPSEO_Indexable_Service_Post_Provider_Test extends WPSEO_UnitTestCase {
 	 */
 	public function get_auto_save() {
 		return self::factory()->post->create(
-			array(
+			[
 				'post_type'   => 'revision',
 				'post_name'   => '2-autosave',
 				'post_parent' => 2,
-			)
+			]
 		);
 	}
 }

--- a/integration-tests/admin/services/test-class-indexable-term-provider.php
+++ b/integration-tests/admin/services/test-class-indexable-term-provider.php
@@ -36,10 +36,10 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Indexable_Service_Term_Provider::get
 	 */
 	public function test_get_non_existing_term() {
-		$this->assertEquals( array(), $this->provider->get( false ) );
-		$this->assertEquals( array(), $this->provider->get( 'uncategorized' ) );
-		$this->assertEquals( array(), $this->provider->get( -1 ) );
-		$this->assertEquals( array(), $this->provider->get( 1000000000 ) );
+		$this->assertEquals( [], $this->provider->get( false ) );
+		$this->assertEquals( [], $this->provider->get( 'uncategorized' ) );
+		$this->assertEquals( [], $this->provider->get( -1 ) );
+		$this->assertEquals( [], $this->provider->get( 1000000000 ) );
 	}
 
 	/**
@@ -57,10 +57,10 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 			->factory()
 			->term
 			->create(
-				array(
+				[
 					'name'     => 'test',
 					'taxonomy' => 'category',
-				)
+				]
 			);
 
 		$this->assertTrue( $this->provider->is_indexable( $term ) );
@@ -76,16 +76,16 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 			->factory()
 			->term
 			->create_and_get(
-				array(
+				[
 					'name'     => 'test',
 					'taxonomy' => 'category',
-				)
+				]
 			);
 
 		WPSEO_Taxonomy_Meta::set_values(
 			$term->term_id,
 			$term->taxonomy,
-			array(
+			[
 				'wpseo_canonical'             => 'https://domain.test',
 				'wpseo_title'                 => 'This is the title',
 				'wpseo_desc'                  => 'This is a meta description',
@@ -100,10 +100,10 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 				'wpseo_focuskw'               => 'Focus keyword',
 				'wpseo_linkdex'               => '10',
 				'wpseo_content_score'         => '35',
-			)
+			]
 		);
 
-		$expected = array(
+		$expected = [
 			'object_id'                   => (int) $term->term_id,
 			'object_type'                 => 'term',
 			'object_subtype'              => $term->taxonomy,
@@ -131,7 +131,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 			'incoming_link_count'         => null,
 			'created_at'                  => null,
 			'updated_at'                  => null,
-		);
+		];
 
 		$this->assertEquals( $expected, $this->provider->get( $term->term_id ) );
 		$this->assertInstanceOf( 'WPSEO_Term_Indexable', $this->provider->get( $term->term_id, true ) );
@@ -160,7 +160,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Indexable_Service_Term_Provider::rename_indexable_data
 	 */
 	public function test_rename_indexable_data() {
-		$supplied_values = array(
+		$supplied_values = [
 			'description'                 => '',
 			'breadcrumb_title'            => '',
 			'og_title'                    => '',
@@ -173,9 +173,9 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 			'primary_focus_keyword'       => '',
 			'primary_focus_keyword_score' => '',
 			'readability_score'           => '',
-		);
+		];
 
-		$expected = array(
+		$expected = [
 			'desc'                  => '',
 			'bctitle'               => '',
 			'opengraph-title'       => '',
@@ -188,7 +188,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 			'focuskw'               => '',
 			'linkdex'               => '',
 			'content_score'         => '',
-		);
+		];
 
 		$data = $this->provider->rename_indexable_data( $supplied_values );
 
@@ -204,7 +204,7 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 		$instance = $this
 				->getMockBuilder( 'WPSEO_Indexable_Service_Term_Provider_Double' )
 				->setMethods(
-					array( 'convert_noindex' )
+					[ 'convert_noindex' ]
 				)
 				->getMock();
 
@@ -212,19 +212,19 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 				->method( 'convert_noindex' )
 				->will( $this->returnArgument( 0 ) );
 
-		$supplied_values = array(
+		$supplied_values = [
 			'desc'              => 'I am the test description',
 			'bctitle'           => 'Some breadcrumb title',
 			'opengraph-title'   => 'The OpenGraph title',
 			'is_robots_noindex' => 'index',
-		);
+		];
 
-		$expected = array(
+		$expected = [
 			'desc'              => 'I am the test description',
 			'bctitle'           => 'Some breadcrumb title',
 			'opengraph-title'   => 'The OpenGraph title',
 			'is_robots_noindex' => 'index',
-		);
+		];
 
 		$data = $instance->convert_indexable_data( $supplied_values );
 
@@ -237,14 +237,14 @@ class WPSEO_Indexable_Service_Term_Provider_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function noindex_conversion_provider() {
-		return array(
-			array( 'true', 'noindex', 'With noindex set to string value of true' ),
-			array( 'false', 'index', 'With noindex set to string value of false' ),
-			array( true, 'default', 'With noindex set to boolean value of true' ),
-			array( false, 'default', 'With noindex set to boolean value of false' ),
-			array( '2', 'default', 'With noindex set to string value of 2' ),
-			array( '1', 'default', 'With noindex set to string value of 1' ),
-			array( '0', 'default', 'With noindex set to string value of 0' ),
-		);
+		return [
+			[ 'true', 'noindex', 'With noindex set to string value of true' ],
+			[ 'false', 'index', 'With noindex set to string value of false' ],
+			[ true, 'default', 'With noindex set to boolean value of true' ],
+			[ false, 'default', 'With noindex set to boolean value of false' ],
+			[ '2', 'default', 'With noindex set to string value of 2' ],
+			[ '1', 'default', 'With noindex set to string value of 1' ],
+			[ '0', 'default', 'With noindex set to string value of 0' ],
+		];
 	}
 }

--- a/integration-tests/admin/test-class-admin-asset-dev-server-location.php
+++ b/integration-tests/admin/test-class-admin-asset-dev-server-location.php
@@ -15,10 +15,10 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 	 *
 	 * @var array
 	 */
-	private $asset_defaults = array(
+	private $asset_defaults = [
 		'name' => 'commons',
 		'src'  => 'commons',
-	);
+	];
 
 	/**
 	 * Basic get_url test.

--- a/integration-tests/admin/test-class-admin-asset-seo-location.php
+++ b/integration-tests/admin/test-class-admin-asset-seo-location.php
@@ -16,16 +16,16 @@ final class Test_WPSEO_Admin_Asset_SEO_Location extends PHPUnit_Framework_TestCa
 	 * @covers WPSEO_Admin_Asset_SEO_Location::get_url
 	 */
 	public function test_get_url() {
-		$asset_args = array(
+		$asset_args = [
 			'name'      => 'name',
 			'src'       => 'src',
-			'deps'      => array( 'deps' ),
+			'deps'      => [ 'deps' ],
 			'version'   => 'version',
 			'media'     => 'screen',
 			'in_footer' => false,
 			'suffix'    => '.suffix',
 			'rtl'       => false,
-		);
+		];
 		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
 		$expected_js    = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/src.suffix.js';

--- a/integration-tests/admin/test-class-admin-editor-specific-replace-vars.php
+++ b/integration-tests/admin/test-class-admin-editor-specific-replace-vars.php
@@ -33,12 +33,12 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_for_page_types() {
 		$this->class_instance->add_for_page_types(
-			array( 'post' ),
-			array( 'cf_custom_field' )
+			[ 'post' ],
+			[ 'cf_custom_field' ]
 		);
 
 		$actual   = $this->class_instance->get();
-		$expected = array( 'id', 'term404', 'pt_single', 'pt_plural', 'cf_custom_field' );
+		$expected = [ 'id', 'term404', 'pt_single', 'pt_plural', 'cf_custom_field' ];
 
 		$this->assertEquals( $expected, $actual['post'] );
 	}
@@ -49,10 +49,10 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::add_for_page_types
 	 */
 	public function test_add_for_page_types_with_empty_array() {
-		$this->class_instance->add_for_page_types( array( 'post' ), array() );
+		$this->class_instance->add_for_page_types( [ 'post' ], [] );
 
 		$actual   = $this->class_instance->get();
-		$expected = array( 'id', 'term404', 'pt_single', 'pt_plural' );
+		$expected = [ 'id', 'term404', 'pt_single', 'pt_plural' ];
 
 		$this->assertEquals( $expected, $actual['post'] );
 	}
@@ -66,24 +66,24 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::extract_names
 	 */
 	public function test_get_shared_replace_vars_filters_editor_specific_replace_vars() {
-		$replace_vars_list = array(
-			array(
+		$replace_vars_list = [
+			[
 				'name'  => 'searchphrase',
 				'label' => 'Searchphrase',
 				'value' => '',
-			),
-			array(
+			],
+			[
 				'name'  => 'title',
 				'label' => 'title',
 				'value' => '',
-			),
-			array(
+			],
+			[
 				'no-name' => 'key present',
-			),
-		);
+			],
+		];
 
 		$this->assertEquals(
-			array( 'title' ),
+			[ 'title' ],
 			$this->class_instance->get_generic(
 				$replace_vars_list
 			)
@@ -239,7 +239,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	public function test_determine_for_archive_with_a_existing_archive() {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Admin_Editor_Specific_Replace_Vars' )
-			->setMethods( array( 'has_for_page_type' ) )
+			->setMethods( [ 'has_for_page_type' ] )
 			->getMock();
 
 		$class_instance
@@ -279,9 +279,9 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 */
 	private function create_and_get_with_post_type( $post_type = 'post' ) {
 		return self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => $post_type,
-			)
+			]
 		);
 	}
 
@@ -291,26 +291,26 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Editor_Specific_Replace_Vars::get
 	 */
 	public function test_editor_specific_replacement_variables_filter() {
-		add_filter( 'wpseo_editor_specific_replace_vars', array( $this, 'filter_editor_specific_replacement_variables' ) );
+		add_filter( 'wpseo_editor_specific_replace_vars', [ $this, 'filter_editor_specific_replacement_variables' ] );
 
-		$expected_replacement_variables = array(
-			'page'                     => array( 'pt_single', 'pt_plural', 'parent_title' ),
-			'post'                     => array( 'id', 'term404', 'pt_single', 'pt_plural' ),
-			'custom_post_type'         => array( 'id', 'term404', 'pt_single', 'pt_plural', 'parent_title' ),
-			'category'                 => array( 'term_title', 'term_description', 'category_description', 'parent_title' ),
-			'post_tag'                 => array( 'term_title', 'term_description', 'tag_description' ),
-			'post_format'              => array(),
-			'term-in-custom-taxonomy'  => array( 'term_title', 'term_description', 'category_description', 'parent_title' ),
-			'custom-post-type_archive' => array( 'pt_single', 'pt_plural' ),
-			'search'                   => array( 'searchphrase' ),
-		);
+		$expected_replacement_variables = [
+			'page'                     => [ 'pt_single', 'pt_plural', 'parent_title' ],
+			'post'                     => [ 'id', 'term404', 'pt_single', 'pt_plural' ],
+			'custom_post_type'         => [ 'id', 'term404', 'pt_single', 'pt_plural', 'parent_title' ],
+			'category'                 => [ 'term_title', 'term_description', 'category_description', 'parent_title' ],
+			'post_tag'                 => [ 'term_title', 'term_description', 'tag_description' ],
+			'post_format'              => [],
+			'term-in-custom-taxonomy'  => [ 'term_title', 'term_description', 'category_description', 'parent_title' ],
+			'custom-post-type_archive' => [ 'pt_single', 'pt_plural' ],
+			'search'                   => [ 'searchphrase' ],
+		];
 
 		$this->assertEquals(
 			$expected_replacement_variables,
 			$this->class_instance->get()
 		);
 
-		remove_filter( 'wpseo_editor_specific_replace_vars', array( $this, 'filter_editor_specific_replacement_variables' ) );
+		remove_filter( 'wpseo_editor_specific_replace_vars', [ $this, 'filter_editor_specific_replacement_variables' ] );
 	}
 
 	/**
@@ -321,18 +321,18 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	public function test_editor_specific_replacement_variables_filter_with_wrong_return_value() {
 		add_filter( 'wpseo_editor_specific_replace_vars', '__return_false' );
 
-		$expected_replacement_variables = array(
+		$expected_replacement_variables = [
 			// Posts types.
-			'page'                      => array( 'id', 'pt_single', 'pt_plural', 'parent_title' ),
-			'post'                      => array( 'id', 'term404', 'pt_single', 'pt_plural' ),
-			'custom_post_type'          => array( 'id', 'term404', 'pt_single', 'pt_plural', 'parent_title' ),
-			'category'                  => array( 'term_title', 'term_description', 'category_description', 'parent_title' ),
-			'post_tag'                  => array( 'term_title', 'term_description', 'tag_description' ),
-			'post_format'               => array(),
-			'term-in-custom-taxonomy'   => array( 'term_title', 'term_description', 'category_description', 'parent_title' ),
-			'custom-post-type_archive'  => array( 'pt_single', 'pt_plural' ),
-			'search'                    => array( 'searchphrase' ),
-		);
+			'page'                      => [ 'id', 'pt_single', 'pt_plural', 'parent_title' ],
+			'post'                      => [ 'id', 'term404', 'pt_single', 'pt_plural' ],
+			'custom_post_type'          => [ 'id', 'term404', 'pt_single', 'pt_plural', 'parent_title' ],
+			'category'                  => [ 'term_title', 'term_description', 'category_description', 'parent_title' ],
+			'post_tag'                  => [ 'term_title', 'term_description', 'tag_description' ],
+			'post_format'               => [],
+			'term-in-custom-taxonomy'   => [ 'term_title', 'term_description', 'category_description', 'parent_title' ],
+			'custom-post-type_archive'  => [ 'pt_single', 'pt_plural' ],
+			'search'                    => [ 'searchphrase' ],
+		];
 
 		$this->assertEquals(
 			$expected_replacement_variables,
@@ -349,8 +349,8 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @return array The new editor_specific replacement variables.
 	 */
-	public function filter_editor_specific_replacement_variables( array $replacement_variables = array() ) {
-		$replacement_variables['page'] = array( 'pt_single', 'pt_plural', 'parent_title' );
+	public function filter_editor_specific_replacement_variables( array $replacement_variables = [] ) {
+		$replacement_variables['page'] = [ 'pt_single', 'pt_plural', 'parent_title' ];
 
 		return $replacement_variables;
 	}

--- a/integration-tests/admin/test-class-admin-recommended-replace-vars.php
+++ b/integration-tests/admin/test-class-admin-recommended-replace-vars.php
@@ -24,7 +24,7 @@ class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 		parent::setUp();
 
 		$this->class_instance = new WPSEO_Admin_Recommended_Replace_Vars();
-		add_filter( 'wpseo_recommended_replace_vars', array( $this, 'filter_recommended_replacevars' ) );
+		add_filter( 'wpseo_recommended_replace_vars', [ $this, 'filter_recommended_replacevars' ] );
 	}
 
 	/**
@@ -204,30 +204,30 @@ class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 */
 	public function get_recommended_replacevars_provider() {
 		// This is basically a copy of the $recommended_replace_vars in WPSEO_Admin_Recommended_Replace_Vars.
-		return array(
+		return [
 			// Posts.
-			array( 'page', array( 'sitename', 'title', 'sep', 'primary_category' ) ),
-			array( 'post', array( 'sitename', 'title', 'sep', 'primary_category' ) ),
+			[ 'page', [ 'sitename', 'title', 'sep', 'primary_category' ] ],
+			[ 'post', [ 'sitename', 'title', 'sep', 'primary_category' ] ],
 			// Homepage.
-			array( 'homepage', array( 'sitename', 'sitedesc', 'sep' ) ),
+			[ 'homepage', [ 'sitename', 'sitedesc', 'sep' ] ],
 			// Custom post.
-			array( 'custom_post_type', array( 'sitename', 'title', 'sep' ) ),
+			[ 'custom_post_type', [ 'sitename', 'title', 'sep' ] ],
 
 			// Taxonomies.
-			array( 'category', array( 'sitename', 'term_title', 'sep' ) ),
-			array( 'post_tag', array( 'sitename', 'term_title', 'sep' ) ),
-			array( 'post_format', array( 'sitename', 'term_title', 'sep', 'page' ) ),
+			[ 'category', [ 'sitename', 'term_title', 'sep' ] ],
+			[ 'post_tag', [ 'sitename', 'term_title', 'sep' ] ],
+			[ 'post_format', [ 'sitename', 'term_title', 'sep', 'page' ] ],
 			// Custom taxonomy.
-			array( 'term-in-custom-taxomomy', array( 'sitename', 'term_title', 'sep' ) ),
+			[ 'term-in-custom-taxomomy', [ 'sitename', 'term_title', 'sep' ] ],
 
 			// Settings - archive pages.
-			array( 'author_archive', array( 'sitename', 'title', 'sep', 'page' ) ),
-			array( 'date_archive', array( 'sitename', 'sep', 'date', 'page' ) ),
-			array( 'custom-post-type_archive', array( 'sitename', 'title', 'sep', 'page' ) ),
+			[ 'author_archive', [ 'sitename', 'title', 'sep', 'page' ] ],
+			[ 'date_archive', [ 'sitename', 'sep', 'date', 'page' ] ],
+			[ 'custom-post-type_archive', [ 'sitename', 'title', 'sep', 'page' ] ],
 			// Settings - special pages.
-			array( 'search', array( 'sitename', 'searchphrase', 'sep', 'page' ) ),
-			array( '404', array( 'sitename', 'sep' ) ),
-		);
+			[ 'search', [ 'sitename', 'searchphrase', 'sep', 'page' ] ],
+			[ '404', [ 'sitename', 'sep' ] ],
+		];
 	}
 
 	/**
@@ -236,7 +236,7 @@ class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Recommended_Replace_Vars::get_recommended_replacevars_for
 	 */
 	public function test_get_recommended_replacevars_non_existing() {
-		$this->assertEquals( array(), $this->class_instance->get_recommended_replacevars_for( 'non-existing-replace-var' ) );
+		$this->assertEquals( [], $this->class_instance->get_recommended_replacevars_for( 'non-existing-replace-var' ) );
 	}
 
 	/**
@@ -245,7 +245,7 @@ class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Recommended_Replace_Vars::get_recommended_replacevars_for
 	 */
 	public function test_get_recommended_replacevars_non_array() {
-		$this->assertEquals( array(), $this->class_instance->get_recommended_replacevars_for( 'non-array' ) );
+		$this->assertEquals( [], $this->class_instance->get_recommended_replacevars_for( 'non-array' ) );
 	}
 
 	/**
@@ -255,7 +255,7 @@ class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @return array The new recommended replacement variables.
 	 */
-	public function filter_recommended_replacevars( $replacevars = array() ) {
+	public function filter_recommended_replacevars( $replacevars = [] ) {
 		$replacevars['non-array'] = 'non-array';
 
 		return $replacevars;
@@ -270,9 +270,9 @@ class WPSEO_Admin_Recommended_Replace_Vars_Test extends WPSEO_UnitTestCase {
 	 */
 	private function create_and_get_with_post_type( $post_type = 'post' ) {
 		return self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => $post_type,
-			)
+			]
 		);
 	}
 }

--- a/integration-tests/admin/test-class-database-proxy.php
+++ b/integration-tests/admin/test-class-database-proxy.php
@@ -35,14 +35,14 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		self::$proxy_table_name = 'yoast_seo_test_table';
 		self::$proxy            = new WPSEO_Database_Proxy( $wpdb, self::$proxy_table_name, true );
 		self::$proxy->create_table(
-			array(
+			[
 				'id bigint(20) unsigned NOT NULL AUTO_INCREMENT',
 				'testkey varchar(255) NOT NULL',
 				'testval longtext NOT NULL',
-			),
-			array(
+			],
+			[
 				'PRIMARY KEY (id)',
-			)
+			]
 		);
 
 		$installer = new WPSEO_Link_Installer();
@@ -83,11 +83,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_insert() {
 		$result = self::$proxy->insert(
-			array(
+			[
 				'testkey' => 'key2',
 				'testval' => 'value2',
-			),
-			array( '%s', '%s' )
+			],
+			[ '%s', '%s' ]
 		);
 
 		$this->assertSame( 1, $result );
@@ -100,20 +100,20 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_insert_exists() {
 		self::$proxy->insert(
-			array(
+			[
 				'testkey' => 'key2',
 				'testval' => 'value2',
-			),
-			array( '%s', '%s' )
+			],
+			[ '%s', '%s' ]
 		);
 
 		$result = self::$proxy->insert(
-			array(
+			[
 				'id'      => 1,
 				'testkey' => 'key2',
 				'testval' => 'value2',
-			),
-			array( '%d', '%s', '%s' )
+			],
+			[ '%d', '%s', '%s' ]
 		);
 
 		$this->assertFalse( $result );
@@ -126,10 +126,10 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_insert_invalid() {
 		$result = self::$proxy->insert(
-			array(
+			[
 				'testvalue' => 'value2',
-			),
-			array( '%s' )
+			],
+			[ '%s' ]
 		);
 
 		$this->assertFalse( $result );
@@ -142,22 +142,22 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_update() {
 		self::$proxy->insert(
-			array(
+			[
 				'testkey' => 'key2',
 				'testval' => 'value2',
-			),
-			array( '%s', '%s' )
+			],
+			[ '%s', '%s' ]
 		);
 
 		$result = self::$proxy->update(
-			array(
+			[
 				'testval' => 'value3',
-			),
-			array(
+			],
+			[
 				'testkey' => 'key2',
-			),
-			array( '%s' ),
-			array( '%s' )
+			],
+			[ '%s' ],
+			[ '%s' ]
 		);
 
 		$this->assertSame( 1, $result );
@@ -170,14 +170,14 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_update_not_exists() {
 		$result = self::$proxy->update(
-			array(
+			[
 				'testval' => 'value2',
-			),
-			array(
+			],
+			[
 				'testkey' => 'key2',
-			),
-			array( '%s' ),
-			array( '%s' )
+			],
+			[ '%s' ],
+			[ '%s' ]
 		);
 
 		$this->assertSame( 0, $result );
@@ -190,14 +190,14 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_update_invalid() {
 		$result = self::$proxy->update(
-			array(
+			[
 				'testvalue' => 'value2',
-			),
-			array(
+			],
+			[
 				'testkey' => 'key1',
-			),
-			array( '%s' ),
-			array( '%s' )
+			],
+			[ '%s' ],
+			[ '%s' ]
 		);
 
 		$this->assertFalse( $result );
@@ -210,15 +210,15 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_upsert_new() {
 		$result = self::$proxy->upsert(
-			array(
+			[
 				'id'      => 2,
 				'testkey' => 'key2',
 				'testval' => 'value2',
-			),
-			array(
+			],
+			[
 				'id' => 2,
-			),
-			array( '%d', '%s', '%s' )
+			],
+			[ '%d', '%s', '%s' ]
 		);
 
 		$this->assertSame( 1, $result );
@@ -231,24 +231,24 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_upsert_existing() {
 		self::$proxy->insert(
-			array(
+			[
 				'id'      => 10,
 				'testkey' => 'key10',
 				'testval' => 'value10-1',
-			),
-			array( '%d', '%s', '%s' )
+			],
+			[ '%d', '%s', '%s' ]
 		);
 
 		$result = self::$proxy->upsert(
-			array(
+			[
 				'id'      => 10,
 				'testkey' => 'key10',
 				'testval' => 'value10-2',
-			),
-			array(
+			],
+			[
 				'id' => 10,
-			),
-			array( '%d', '%s', '%s' )
+			],
+			[ '%d', '%s', '%s' ]
 		);
 
 		/*
@@ -266,11 +266,11 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$results    = self::$proxy->get_results( "SELECT * FROM $table_name WHERE testkey = 'key10'" );
 
 		$this->assertEquals(
-			(object) array(
+			(object) [
 				'id'      => 10,
 				'testkey' => 'key10',
 				'testval' => 'value10-2',
-			),
+			],
 			$results[0]
 		);
 	}
@@ -282,18 +282,18 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_delete() {
 		self::$proxy->insert(
-			array(
+			[
 				'testkey' => 'key1',
 				'testval' => 'value',
-			),
-			array( '%s', '%s' )
+			],
+			[ '%s', '%s' ]
 		);
 
 		$result = self::$proxy->delete(
-			array(
+			[
 				'testkey' => 'key1',
-			),
-			array( '%s' )
+			],
+			[ '%s' ]
 		);
 
 		$this->assertSame( 1, $result );
@@ -306,10 +306,10 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_delete_not_exists() {
 		$result = self::$proxy->delete(
-			array(
+			[
 				'testkey' => 'key2',
-			),
-			array( '%s' )
+			],
+			[ '%s' ]
 		);
 
 		$this->assertSame( 0, $result );
@@ -322,10 +322,10 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_delete_invalid() {
 		$result = self::$proxy->delete(
-			array(
+			[
 				'testvalue' => 'key1',
-			),
-			array( '%s' )
+			],
+			[ '%s' ]
 		);
 
 		$this->assertFalse( $result );
@@ -340,22 +340,22 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$table_name = self::$proxy->get_table_name();
 
 		self::$proxy->insert(
-			array(
+			[
 				'testkey' => 'key1',
 				'testval' => 'value',
-			),
-			array( '%s', '%s' )
+			],
+			[ '%s', '%s' ]
 		);
 
 		$result = self::$proxy->get_results( "SELECT * FROM $table_name WHERE testkey = 'key1'" );
 
-		$expected = array(
-			(object) array(
+		$expected = [
+			(object) [
 				'id'      => 1,
 				'testkey' => 'key1',
 				'testval' => 'value',
-			),
-		);
+			],
+		];
 
 		$this->assertEquals( $expected, $result );
 	}
@@ -372,14 +372,14 @@ class WPSEO_Database_Proxy_Test extends WPSEO_UnitTestCase {
 		$proxy            = new WPSEO_Database_Proxy( $wpdb, $proxy_table_name, true );
 
 		$result = $proxy->create_table(
-			array(
+			[
 				'id bigint(20) unsigned NOT NULL AUTO_INCREMENT',
 				'testkey varchar(255) NOT NULL',
 				'testval longtext NOT NULL',
-			),
-			array(
+			],
+			[
 				'PRIMARY KEY (id)',
-			)
+			]
 		);
 
 		$this->assertTrue( $result );

--- a/integration-tests/admin/test-class-extension-manager.php
+++ b/integration-tests/admin/test-class-extension-manager.php
@@ -34,7 +34,7 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 	public function test_has_no_active_extensions_loaded() {
 		$extension_manager = $this
 			->getMockBuilder( 'WPSEO_Extension_Manager' )
-			->setMethods( array( 'get_current_page', 'get_active_extensions', 'set_cached_extensions', 'get_cached_extensions' ) )
+			->setMethods( [ 'get_current_page', 'get_active_extensions', 'set_cached_extensions', 'get_cached_extensions' ] )
 			->getMock();
 
 		$extension_manager
@@ -45,7 +45,7 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 		$extension_manager
 			->expects( $this->once() )
 			->method( 'get_cached_extensions' )
-			->will( $this->returnValue( array( 'wordpress-seo-premium' ) ) );
+			->will( $this->returnValue( [ 'wordpress-seo-premium' ] ) );
 
 		$this->assertTrue( $extension_manager->is_activated( 'wordpress-seo-premium' ) );
 	}
@@ -63,13 +63,13 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 		$extension_manager = $this
 			->getMockBuilder( 'WPSEO_Extension_Manager' )
 			->setMethods(
-				array(
+				[
 					'get_current_page',
 					'get_active_extensions',
 					'set_cached_extensions',
 					'get_cached_extensions',
 					'retrieve_active_extensions',
-				)
+				]
 			)
 			->getMock();
 
@@ -86,12 +86,12 @@ class WPSEO_Extension_Manager_Test extends WPSEO_UnitTestCase {
 		$extension_manager
 			->expects( $this->once() )
 			->method( 'retrieve_active_extensions' )
-			->will( $this->returnValue( array( 'wordpress-seo-premium' ) ) );
+			->will( $this->returnValue( [ 'wordpress-seo-premium' ] ) );
 
 		$extension_manager
 			->expects( $this->once() )
 			->method( 'set_cached_extensions' )
-			->with( $this->identicalTo( array( 'wordpress-seo-premium' ) ) );
+			->with( $this->identicalTo( [ 'wordpress-seo-premium' ] ) );
 
 		$this->assertTrue( $extension_manager->is_activated( 'wordpress-seo-premium' ) );
 	}

--- a/integration-tests/admin/test-class-gutenberg-compatibility.php
+++ b/integration-tests/admin/test-class-gutenberg-compatibility.php
@@ -25,7 +25,7 @@ class WPSEO_Gutenberg_Compatibility_Test extends WPSEO_UnitTestCase {
 
 		$mock = $this
 			->getMockBuilder( 'WPSEO_Gutenberg_Compatibility_Double' )
-			->setMethods( array( 'detect_installed_gutenberg_version', 'get_latest_release', 'get_minimum_supported_version' ) )
+			->setMethods( [ 'detect_installed_gutenberg_version', 'get_latest_release', 'get_minimum_supported_version' ] )
 			->getMock();
 
 		$this->default_mock = $mock;
@@ -39,7 +39,7 @@ class WPSEO_Gutenberg_Compatibility_Test extends WPSEO_UnitTestCase {
 	public function test_gutenberg_is_installed() {
 		$mock = $this
 			->getMockBuilder( 'WPSEO_Gutenberg_Compatibility_Double' )
-			->setMethods( array( 'detect_installed_gutenberg_version' ) )
+			->setMethods( [ 'detect_installed_gutenberg_version' ] )
 			->getMock();
 
 		$mock->set_installed_gutenberg_version( '3.3.0' );
@@ -55,7 +55,7 @@ class WPSEO_Gutenberg_Compatibility_Test extends WPSEO_UnitTestCase {
 	public function test_gutenberg_not_installed() {
 		$mock = $this
 			->getMockBuilder( 'WPSEO_Gutenberg_Compatibility_Double' )
-			->setMethods( array( 'detect_installed_gutenberg_version' ) )
+			->setMethods( [ 'detect_installed_gutenberg_version' ] )
 			->getMock();
 
 		$mock->set_installed_gutenberg_version( '' );

--- a/integration-tests/admin/test-class-my-yoast-route.php
+++ b/integration-tests/admin/test-class-my-yoast-route.php
@@ -20,7 +20,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_register_hooks_on_no_yoast_route() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route' )
-			->setMethods( array( 'is_myyoast_route' ) )
+			->setMethods( [ 'is_myyoast_route' ] )
 			->getMock();
 
 		$instance
@@ -30,8 +30,8 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 
 		$instance->register_hooks();
 
-		$this->assertFalse( has_action( 'admin_menu', array( $instance, 'register_route' ) ) );
-		$this->assertFalse( has_action( 'admin_init', array( $instance, 'handle_route' ) ) );
+		$this->assertFalse( has_action( 'admin_menu', [ $instance, 'register_route' ] ) );
+		$this->assertFalse( has_action( 'admin_init', [ $instance, 'handle_route' ] ) );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_register_hooks_cannot_access_route() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route' )
-			->setMethods( array( 'is_myyoast_route', 'can_access_route' ) )
+			->setMethods( [ 'is_myyoast_route', 'can_access_route' ] )
 			->getMock();
 
 		$instance
@@ -57,8 +57,8 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 
 		$instance->register_hooks();
 
-		$this->assertFalse( has_action( 'admin_menu', array( $instance, 'register_route' ) ) );
-		$this->assertFalse( has_action( 'admin_init', array( $instance, 'handle_route' ) ) );
+		$this->assertFalse( has_action( 'admin_menu', [ $instance, 'register_route' ] ) );
+		$this->assertFalse( has_action( 'admin_init', [ $instance, 'handle_route' ] ) );
 	}
 
 	/**
@@ -69,7 +69,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_register_hooks_with_invalid_route_action() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route' )
-			->setMethods( array( 'is_myyoast_route', 'can_access_route', 'is_valid_action' ) )
+			->setMethods( [ 'is_myyoast_route', 'can_access_route', 'is_valid_action' ] )
 			->getMock();
 
 		$instance
@@ -89,8 +89,8 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 
 		$instance->register_hooks();
 
-		$this->assertFalse( has_action( 'admin_menu', array( $instance, 'register_route' ) ) );
-		$this->assertFalse( has_action( 'admin_init', array( $instance, 'handle_route' ) ) );
+		$this->assertFalse( has_action( 'admin_menu', [ $instance, 'register_route' ] ) );
+		$this->assertFalse( has_action( 'admin_init', [ $instance, 'handle_route' ] ) );
 	}
 
 	/**
@@ -101,7 +101,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_register_hooks() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route' )
-			->setMethods( array( 'is_myyoast_route', 'can_access_route', 'is_valid_action' ) )
+			->setMethods( [ 'is_myyoast_route', 'can_access_route', 'is_valid_action' ] )
 			->getMock();
 
 		$instance
@@ -121,8 +121,8 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 
 		$instance->register_hooks();
 
-		$this->assertNotFalse( has_action( 'admin_menu', array( $instance, 'register_route' ) ) );
-		$this->assertNotFalse( has_action( 'admin_init', array( $instance, 'handle_route' ) ) );
+		$this->assertNotFalse( has_action( 'admin_menu', [ $instance, 'register_route' ] ) );
+		$this->assertNotFalse( has_action( 'admin_init', [ $instance, 'handle_route' ] ) );
 	}
 
 	/**
@@ -133,7 +133,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_handle_route_for_unknown_action() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route' )
-			->setMethods( array( 'get_action' ) )
+			->setMethods( [ 'get_action' ] )
 			->getMock();
 
 		$instance
@@ -152,7 +152,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_handle_route_for_connect() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route' )
-			->setMethods( array( 'get_action', 'connect' ) )
+			->setMethods( [ 'get_action', 'connect' ] )
 			->getMock();
 
 		$instance
@@ -175,7 +175,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_handle_route_for_authorize() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route' )
-			->setMethods( array( 'get_action', 'authorize' ) )
+			->setMethods( [ 'get_action', 'authorize' ] )
 			->getMock();
 
 		$instance
@@ -222,7 +222,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_connect() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route_Double' )
-			->setMethods( array( 'redirect', 'save_client_id', 'generate_uuid', 'get_extensions' ) )
+			->setMethods( [ 'redirect', 'save_client_id', 'generate_uuid', 'get_extensions' ] )
 			->getMock();
 
 		$instance
@@ -238,21 +238,21 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 		$instance
 			->expects( $this->once() )
 			->method( ( 'get_extensions' ) )
-			->will( $this->returnValue( array( 'yoast-seo-extension' ) ) );
+			->will( $this->returnValue( [ 'yoast-seo-extension' ] ) );
 
 		$instance
 			->expects( $this->once() )
 			->method( 'redirect' )
 			->with(
 				'https://my.yoast.com/connect',
-				array(
+				[
 					'url'             => WPSEO_Utils::get_home_url(),
 					'client_id'       => '9740f9cf-608e-4327-8a16-24e3ff6a4c0d',
-					'extensions'      => array( 'yoast-seo-extension' ),
+					'extensions'      => [ 'yoast-seo-extension' ],
 					'redirect_url'    => admin_url( 'admin.php?page=' . WPSEO_MyYoast_Route::PAGE_IDENTIFIER . '&action=complete' ),
 					'credentials_url' => rest_url( 'yoast/v1/myyoast/connect' ),
 					'type'            => 'wordpress',
-				)
+				]
 			);
 
 		/**
@@ -271,12 +271,12 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_authorize_without_having_configuration() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route_Double' )
-			->setMethods( array( 'get_client' ) )
+			->setMethods( [ 'get_client' ] )
 			->getMock();
 
 		$client = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Client' )
-			->setMethods( array( 'has_configuration' ) )
+			->setMethods( [ 'has_configuration' ] )
 			->getMock();
 
 		$client
@@ -305,12 +305,12 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_authorize_with_having_a_configuration() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route_Double' )
-			->setMethods( array( 'get_client', 'redirect' ) )
+			->setMethods( [ 'get_client', 'redirect' ] )
 			->getMock();
 
 		$provider = $this
 			->getMockBuilder( 'Provider' )
-			->setMethods( array( 'getAuthorizationUrl' ) )
+			->setMethods( [ 'getAuthorizationUrl' ] )
 			->getMock();
 
 		$provider
@@ -320,7 +320,7 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 
 		$client = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Client' )
-			->setMethods( array( 'has_configuration', 'get_provider' ) )
+			->setMethods( [ 'has_configuration', 'get_provider' ] )
 			->getMock();
 
 		$client
@@ -359,12 +359,12 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 	public function test_complete_without_having_configuration() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route_Double' )
-			->setMethods( array( 'get_client' ) )
+			->setMethods( [ 'get_client' ] )
 			->getMock();
 
 		$client = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Client' )
-			->setMethods( array( 'has_configuration' ) )
+			->setMethods( [ 'has_configuration' ] )
 			->getMock();
 
 		$client
@@ -394,18 +394,18 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route_Double' )
 			->setMethods(
-				array(
+				[
 					'get_client',
 					'redirect_to_premium_page',
 					'get_authorization_code',
 					'get_current_user_id',
-				)
+				]
 			)
 			->getMock();
 
 		$provider = $this
 			->getMockBuilder( 'Provider' )
-			->setMethods( array( 'getAccessToken' ) )
+			->setMethods( [ 'getAccessToken' ] )
 			->getMock();
 
 		$provider
@@ -413,18 +413,18 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 			->method( 'getAccessToken' )
 			->with(
 				'authorization_code',
-				array( 'code' => 'this-is-the-code' )
+				[ 'code' => 'this-is-the-code' ]
 			)
 			->will( $this->returnValue( 'access-token' ) );
 
 		$client = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Client' )
 			->setMethods(
-				array(
+				[
 					'has_configuration',
 					'get_provider',
 					'save_access_token',
-				)
+				]
 			)
 			->getMock();
 
@@ -479,17 +479,17 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Route_Double' )
 			->setMethods(
-				array(
+				[
 					'get_client',
 					'redirect_to_premium_page',
 					'get_authorization_code',
-				)
+				]
 			)
 			->getMock();
 
 		$provider = $this
 			->getMockBuilder( 'Provider' )
-			->setMethods( array( 'getAccessToken' ) )
+			->setMethods( [ 'getAccessToken' ] )
 			->getMock();
 
 		$provider
@@ -497,18 +497,18 @@ class WPSEO_MyYoast_Route_Test extends WPSEO_UnitTestCase {
 			->method( 'getAccessToken' )
 			->with(
 				'authorization_code',
-				array( 'code' => 'this-is-the-code' )
+				[ 'code' => 'this-is-the-code' ]
 			)
 			->will( $this->throwException( new Exception( 'Something went wrong' ) ) );
 
 		$client = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Client' )
 			->setMethods(
-				array(
+				[
 					'has_configuration',
 					'get_provider',
 					'save_access_token',
-				)
+				]
 			)
 			->getMock();
 

--- a/integration-tests/admin/test-class-option-tab.php
+++ b/integration-tests/admin/test-class-option-tab.php
@@ -38,7 +38,7 @@ class WPSEO_Option_Tab_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Option_Tab::get_opt_group
 	 */
 	public function test_get_opt_group() {
-		$option_tab = new WPSEO_Option_Tab( 'name', 'label', array( 'opt_group' => 'opt_group' ) );
+		$option_tab = new WPSEO_Option_Tab( 'name', 'label', [ 'opt_group' => 'opt_group' ] );
 
 		$this->assertEquals( 'opt_group', $option_tab->get_opt_group() );
 	}
@@ -60,7 +60,7 @@ class WPSEO_Option_Tab_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Option_Tab::has_save_button
 	 */
 	public function test_has_no_save_button() {
-		$option_tab = new WPSEO_Option_Tab( 'name', 'label', array( 'save_button' => false ) );
+		$option_tab = new WPSEO_Option_Tab( 'name', 'label', [ 'save_button' => false ] );
 
 		$this->assertFalse( $option_tab->has_save_button() );
 	}

--- a/integration-tests/admin/test-class-option-tabs.php
+++ b/integration-tests/admin/test-class-option-tabs.php
@@ -45,7 +45,7 @@ class WPSEO_Option_Tabs_Test extends WPSEO_UnitTestCase {
 		$option_tabs = new WPSEO_Option_Tabs( 'base' );
 		$option_tabs->add_tab( $option_tab );
 
-		$this->assertEquals( array( $option_tab ), $option_tabs->get_tabs() );
+		$this->assertEquals( [ $option_tab ], $option_tabs->get_tabs() );
 	}
 
 	/**

--- a/integration-tests/admin/test-class-plugin-availability.php
+++ b/integration-tests/admin/test-class-plugin-availability.php
@@ -33,7 +33,7 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 	 * Tests whether or not a plugin exists.
 	 */
 	public function test_plugin_existence() {
-		$expected = array(
+		$expected = [
 			'url'          => 'http://example.com/',
 			'title'        => 'Test Plugin',
 			'description'  => '',
@@ -41,10 +41,10 @@ class WPSEO_Plugin_Availability_Test extends WPSEO_UnitTestCase {
 			'installed'    => true,
 			'slug'         => 'test-plugin/test-plugin.php',
 			'version_sync' => true,
-		);
+		];
 
 		$this->assertEquals( self::$class_instance->get_plugin( 'test-plugin' ), $expected );
-		$this->assertEquals( self::$class_instance->get_plugin( 'non-exisiting-test-plugin' ), array() );
+		$this->assertEquals( self::$class_instance->get_plugin( 'non-exisiting-test-plugin' ), [] );
 	}
 
 	/**

--- a/integration-tests/admin/test-class-plugin-suggestions.php
+++ b/integration-tests/admin/test-class-plugin-suggestions.php
@@ -33,7 +33,7 @@ class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 		$plugin_availability = new WPSEO_Plugin_Availability_Double();
 
 		$notification_center_mock = $this->getMockBuilder( 'Yoast_Notification_Center_Double' )
-			->setMethods( array( 'add_notification', 'remove_notification' ) )
+			->setMethods( [ 'add_notification', 'remove_notification' ] )
 			->getMock();
 
 		$this->class_instance = new WPSEO_Suggested_Plugins_Double( $plugin_availability, $notification_center_mock );

--- a/integration-tests/admin/test-class-schema-person-upgrade-notification.php
+++ b/integration-tests/admin/test-class-schema-person-upgrade-notification.php
@@ -17,7 +17,7 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_remove_notification_not_person() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
-			->setMethods( array( 'remove_notification' ) )
+			->setMethods( [ 'remove_notification' ] )
 			->getMock();
 
 		WPSEO_Options::set( 'company_or_person', 'company' );
@@ -32,7 +32,7 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_remove_notification_user_id_set() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
-			->setMethods( array( 'remove_notification' ) )
+			->setMethods( [ 'remove_notification' ] )
 			->getMock();
 
 		WPSEO_Options::set( 'company_or_person', 'person' );
@@ -48,7 +48,7 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_notification() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		WPSEO_Options::set( 'company_or_person', 'person' );

--- a/integration-tests/admin/test-class-yoast-form.php
+++ b/integration-tests/admin/test-class-yoast-form.php
@@ -20,7 +20,7 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 		$form->set_option( 'wpseo' );
 
 		$option_instance = WPSEO_Options::get_option_instance( 'wpseo' );
-		$option_keys     = array_keys( get_option( 'wpseo', array() ) );
+		$option_keys     = array_keys( get_option( 'wpseo', [] ) );
 
 		$this->assertSame( 'wpseo', $form->option_name );
 		$this->assertEqualSets( $option_keys, array_keys( $form->options ) );
@@ -33,7 +33,7 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Form::set_option
 	 */
 	public function test_properties_set_with_invalid_option() {
-		$option_keys = array( 'key1', 'key2', 'key3' );
+		$option_keys = [ 'key1', 'key2', 'key3' ];
 		update_option( 'random', array_fill_keys( $option_keys, true ) );
 
 		$form = new Yoast_Form_Double();

--- a/integration-tests/admin/test-class-yoast-input-select.php
+++ b/integration-tests/admin/test-class-yoast-input-select.php
@@ -23,10 +23,10 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		$select = new Yoast_Input_Select(
 			'test-id',
 			'test-field',
-			array(
+			[
 				'foo' => 'bar',
 				'baz' => 'foo',
-			),
+			],
 			false
 		);
 		$html   = $select->get_html();
@@ -46,7 +46,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Input_Select::get_attributes
 	 */
 	public function test_html_without_options() {
-		$select = new Yoast_Input_Select( 'test-id', 'test-field', array(), false );
+		$select = new Yoast_Input_Select( 'test-id', 'test-field', [], false );
 		$html   = $select->get_html();
 
 		$this->assertContains( '<select name="test-field" id="test-id">', $html );
@@ -66,10 +66,10 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		$select = new Yoast_Input_Select(
 			'test-id',
 			'test-field',
-			array(
+			[
 				'foo' => 'bar',
 				'baz' => 'foo',
-			),
+			],
 			'baz'
 		);
 		$html   = $select->get_html();
@@ -89,7 +89,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Input_Select::get_attributes
 	 */
 	public function test_html_with_one_option_without_key() {
-		$select = new Yoast_Input_Select( 'test-id', 'test-field', array( '' => 'bar' ), false );
+		$select = new Yoast_Input_Select( 'test-id', 'test-field', [ '' => 'bar' ], false );
 		$html   = $select->get_html();
 
 		$this->assertContains( '<select name="test-field" id="test-id">', $html );
@@ -106,7 +106,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Input_Select::get_attributes
 	 */
 	public function test_html_with_one_option_without_value() {
-		$select = new Yoast_Input_Select( 'test-id', 'test-field', array( 'foo' => '' ), false );
+		$select = new Yoast_Input_Select( 'test-id', 'test-field', [ 'foo' => '' ], false );
 		$html   = $select->get_html();
 
 		$this->assertContains( '<select name="test-field" id="test-id">', $html );
@@ -122,7 +122,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Input_Select::get_attributes
 	 */
 	public function test_html_printing_the_output() {
-		$select = new Yoast_Input_Select( 'test-id', 'test-field', array(), false );
+		$select = new Yoast_Input_Select( 'test-id', 'test-field', [], false );
 		$select->output_html();
 
 		// Because the output has empty values.
@@ -140,7 +140,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 	 * @covers Yoast_Input_Select::parse_attribute
 	 */
 	public function test_html_with_adding_attribute() {
-		$select = new Yoast_Input_Select( 'test-id', 'test-field', array( 'foo' => '' ), false );
+		$select = new Yoast_Input_Select( 'test-id', 'test-field', [ 'foo' => '' ], false );
 		$select->add_attribute( 'class', 'test' );
 		$html = $select->get_html();
 

--- a/integration-tests/admin/test-class-yoast-network-admin.php
+++ b/integration-tests/admin/test-class-yoast-network-admin.php
@@ -25,7 +25,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 * @return void
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		self::$network_administrator = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$network_administrator = $factory->user->create( [ 'role' => 'administrator' ] );
 		grant_super_admin( self::$network_administrator );
 	}
 
@@ -61,7 +61,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 		$admin = new Yoast_Network_Admin();
 
-		$site_ids = array_map( 'strval', array_merge( array( get_current_blog_id() ), self::factory()->blog->create_many( 5 ) ) );
+		$site_ids = array_map( 'strval', array_merge( [ get_current_blog_id() ], self::factory()->blog->create_many( 5 ) ) );
 
 		$choices = $admin->get_site_choices();
 		$this->assertSame( $site_ids, array_map( 'strval', array_keys( $choices ) ) );
@@ -116,11 +116,11 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 		$admin = new Yoast_Network_Admin();
 
-		$active_states = array(
+		$active_states = [
 			'public' => '1',
 			'mature' => '1',
 			'spam'   => '1',
-		);
+		];
 
 		$site_id = self::factory()->blog->create();
 		update_blog_details( $site_id, $active_states );
@@ -137,7 +137,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	public function test_handle_update_options_request() {
 		$admin = $this
 			->getMockBuilder( 'Yoast_Network_Admin' )
-			->setMethods( array( 'verify_request', 'terminate_request' ) )
+			->setMethods( [ 'verify_request', 'terminate_request' ] )
 			->getMock();
 
 		$admin
@@ -160,7 +160,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	public function test_handle_restore_site_request() {
 		$admin = $this
 			->getMockBuilder( 'Yoast_Network_Admin' )
-			->setMethods( array( 'verify_request', 'terminate_request' ) )
+			->setMethods( [ 'verify_request', 'terminate_request' ] )
 			->getMock();
 
 		$admin
@@ -202,7 +202,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_hooks() {
 		$admin = $this->getMockBuilder( 'Yoast_Network_Admin' )
-			->setMethods( array( 'meets_requirements' ) )
+			->setMethods( [ 'meets_requirements' ] )
 			->getMock();
 
 		$admin
@@ -211,8 +211,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( true ) );
 
 		$admin->register_hooks();
-		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) ) );
-		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) ) );
+		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, [ $admin, 'handle_update_options_request' ] ) );
+		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, [ $admin, 'handle_restore_site_request' ] ) );
 	}
 
 	/**
@@ -224,8 +224,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin = new Yoast_Network_Admin();
 
 		$admin->register_ajax_hooks();
-		$this->assertInternalType( 'int', has_action( 'wp_ajax_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, array( $admin, 'handle_update_options_request' ) ) );
-		$this->assertInternalType( 'int', has_action( 'wp_ajax_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, array( $admin, 'handle_restore_site_request' ) ) );
+		$this->assertInternalType( 'int', has_action( 'wp_ajax_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, [ $admin, 'handle_update_options_request' ] ) );
+		$this->assertInternalType( 'int', has_action( 'wp_ajax_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, [ $admin, 'handle_restore_site_request' ] ) );
 	}
 
 	/**
@@ -307,7 +307,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin = new Yoast_Network_Admin();
 
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'get_wp_die_handler' ] );
 
 		$_REQUEST['_wpnonce'] = '';
 
@@ -324,7 +324,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin = new Yoast_Network_Admin();
 
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'get_wp_die_handler' ] );
 
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'my_action' );
 
@@ -341,7 +341,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin = new Yoast_Network_Admin();
 
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'get_wp_die_handler' ] );
 
 		wp_set_current_user( self::$network_administrator );
 		wp_get_current_user()->add_cap( 'wpseo_manage_network_options' );
@@ -365,7 +365,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 	public function test_terminate_request() {
 		$admin = $this
 			->getMockBuilder( 'Yoast_Network_Admin' )
-			->setMethods( array( 'persist_settings_errors', 'redirect_back' ) )
+			->setMethods( [ 'persist_settings_errors', 'redirect_back' ] )
 			->getMock();
 
 		$admin
@@ -375,7 +375,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin
 			->expects( $this->once() )
 			->method( 'redirect_back' )
-			->with( array( 'settings-updated' => 'true' ) );
+			->with( [ 'settings-updated' => 'true' ] );
 
 		$admin->terminate_request();
 	}
@@ -391,7 +391,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin = new Yoast_Network_Admin();
 
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler' ) );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'get_wp_die_handler' ] );
 
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'my_action' );
 

--- a/integration-tests/admin/test-class-yoast-network-settings-api.php
+++ b/integration-tests/admin/test-class-yoast-network-settings-api.php
@@ -18,14 +18,14 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	public function test_register_setting() {
 		$api = new Yoast_Network_Settings_API();
 
-		$setting_args = array(
+		$setting_args = [
 			'sanitize_callback' => 'absint',
 			'default'           => 1,
-		);
+		];
 		$api->register_setting( 'yst_ms_group', 'yst_ms_option', $setting_args );
 
-		$this->assertInternalType( 'int', has_filter( 'sanitize_option_yst_ms_option', array( $api, 'filter_sanitize_option' ) ) );
-		$this->assertInternalType( 'int', has_filter( 'default_site_option_yst_ms_option', array( $api, 'filter_default_option' ) ) );
+		$this->assertInternalType( 'int', has_filter( 'sanitize_option_yst_ms_option', [ $api, 'filter_sanitize_option' ] ) );
+		$this->assertInternalType( 'int', has_filter( 'default_site_option_yst_ms_option', [ $api, 'filter_default_option' ] ) );
 	}
 
 	/**
@@ -36,16 +36,16 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 	public function test_get_registered_settings() {
 		$group = 'yst_ms_group';
 		$name  = 'yst_ms_option';
-		$args  = array(
+		$args  = [
 			'sanitize_callback' => 'absint',
 			'default'           => 1,
-		);
+		];
 
 		$api = new Yoast_Network_Settings_API();
 		$api->register_setting( $group, $name, $args );
 
-		$args     = array_merge( array( 'group' => $group ), $args );
-		$expected = array( $name => $args );
+		$args     = array_merge( [ 'group' => $group ], $args );
+		$expected = [ $name => $args ];
 
 		$this->assertSame( $expected, $api->get_registered_settings() );
 	}
@@ -59,7 +59,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 		$registered_group   = 'yst_ms_group';
 		$unregistered_group = 'yst_ms_unregistered_group';
 
-		$options = array( 'my_option1', 'my_option2' );
+		$options = [ 'my_option1', 'my_option2' ];
 
 		$api = new Yoast_Network_Settings_API();
 		foreach ( $options as $option ) {
@@ -82,7 +82,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( '2', $api->filter_sanitize_option( '2', 'yst_ms_unregistered_option' ) );
 
 		// Option registered.
-		$api->register_setting( 'yst_ms_group', 'yst_ms_option', array( 'sanitize_callback' => 'absint' ) );
+		$api->register_setting( 'yst_ms_group', 'yst_ms_option', [ 'sanitize_callback' => 'absint' ] );
 		$this->assertSame( 2, $api->filter_sanitize_option( '2', 'yst_ms_option' ) );
 	}
 
@@ -98,7 +98,7 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 		$this->assertSame( false, $api->filter_default_option( false, 'yst_ms_unregistered_option' ) );
 
 		// Option registered.
-		$api->register_setting( 'yst_ms_group', 'yst_ms_option', array( 'default' => 2 ) );
+		$api->register_setting( 'yst_ms_group', 'yst_ms_option', [ 'default' => 2 ] );
 		$this->assertSame( 2, $api->filter_default_option( false, 'yst_ms_option' ) );
 
 		// Option registered, but specific default requested.

--- a/integration-tests/admin/watchers/test-class-slug-change-watcher.php
+++ b/integration-tests/admin/watchers/test-class-slug-change-watcher.php
@@ -46,10 +46,10 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	 * @return void
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		self::$post_id          = $factory->post->create( array( 'post_type' => 'post' ) );
-		self::$nav_menu_item_id = $factory->post->create( array( 'post_type' => 'nav_menu_item' ) );
-		self::$category_id      = $factory->term->create( array( 'taxonomy' => 'category' ) );
-		self::$nav_menu_id      = $factory->term->create( array( 'taxonomy' => 'nav_menu' ) );
+		self::$post_id          = $factory->post->create( [ 'post_type' => 'post' ] );
+		self::$nav_menu_item_id = $factory->post->create( [ 'post_type' => 'nav_menu_item' ] );
+		self::$category_id      = $factory->term->create( [ 'taxonomy' => 'category' ] );
+		self::$nav_menu_id      = $factory->term->create( [ 'taxonomy' => 'nav_menu' ] );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_post_trash() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -92,15 +92,15 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_post_trash_no_visible_post_status() {
 
 		// Make sure we're working with a draft.
-		$post_args = array(
+		$post_args = [
 			'ID'          => self::$post_id,
 			'post_status' => 'draft',
-		);
+		];
 		wp_update_post( $post_args );
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -120,7 +120,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_post_delete() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -140,7 +140,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_post_delete_menu_item() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -159,15 +159,15 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_detect_post_delete_trashed_post() {
 		// Make sure we're working with a trashed post.
-		$post_args = array(
+		$post_args = [
 			'ID'          => self::$post_id,
 			'post_status' => 'trash',
-		);
+		];
 		wp_update_post( $post_args );
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -189,7 +189,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -209,15 +209,15 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_post_delete_when_not_visible() {
 
 		// Make sure we're working with a pending post.
-		$post_args = array(
+		$post_args = [
 			'ID'          => self::$post_id,
 			'post_status' => 'pending',
-		);
+		];
 		wp_update_post( $post_args );
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -237,7 +237,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_term_delete() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -257,7 +257,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_term_delete_when_not_viewable() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance
@@ -277,7 +277,7 @@ class WPSEO_Slug_Change_Watcher_Test extends WPSEO_UnitTestCase {
 	public function test_detect_term_delete_when_not_exists() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Slug_Change_Watcher' )
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$instance

--- a/integration-tests/capabilities/test-class-capability-manager.php
+++ b/integration-tests/capabilities/test-class-capability-manager.php
@@ -21,7 +21,7 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 
 		$this->assertNotContains( 'capability', $instance->get_capabilities() );
 
-		$instance->register( 'capability', array( 'role' ) );
+		$instance->register( 'capability', [ 'role' ] );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
 
@@ -38,8 +38,8 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	public function test_register_overwrite() {
 		$instance = new WPSEO_Capability_Manager_Double();
 
-		$instance->register( 'capability', array( 'role1' ) );
-		$instance->register( 'capability', array( 'role2' ), true );
+		$instance->register( 'capability', [ 'role1' ] );
+		$instance->register( 'capability', [ 'role2' ], true );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
 
@@ -57,8 +57,8 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	public function test_register_add() {
 		$instance = new WPSEO_Capability_Manager_Double();
 
-		$instance->register( 'capability', array( 'role1' ) );
-		$instance->register( 'capability', array( 'role2' ) );
+		$instance->register( 'capability', [ 'role1' ] );
+		$instance->register( 'capability', [ 'role2' ] );
 
 		$this->assertContains( 'capability', $instance->get_capabilities() );
 
@@ -75,19 +75,19 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 	public function test_filter_roles() {
 		$instance = new WPSEO_Capability_Manager_Double();
 
-		add_filter( 'capability_roles', array( $this, 'do_filter_roles' ) );
+		add_filter( 'capability_roles', [ $this, 'do_filter_roles' ] );
 
-		$filtered = $instance->filter_roles( 'capability', array( 'role' ) );
+		$filtered = $instance->filter_roles( 'capability', [ 'role' ] );
 
-		remove_filter( 'capability_roles', array( $this, 'do_filter_roles' ) );
+		remove_filter( 'capability_roles', [ $this, 'do_filter_roles' ] );
 
-		$this->assertEquals( $this->do_filter_roles( array( 'role' ) ), $filtered );
+		$this->assertEquals( $this->do_filter_roles( [ 'role' ] ), $filtered );
 	}
 
 	/**
 	 * Helper function used to filter the roles.
 	 */
 	public function do_filter_roles( $roles ) {
-		return array( 'elor' );
+		return [ 'elor' ];
 	}
 }

--- a/integration-tests/capabilities/test-class-register-capabilities.php
+++ b/integration-tests/capabilities/test-class-register-capabilities.php
@@ -44,7 +44,7 @@ class WPSEO_Register_Capabilities_Tests extends WPSEO_UnitTestCase {
 
 		WPSEO_Options::get_instance();
 
-		$options           = get_site_option( 'wpseo_ms', array() );
+		$options           = get_site_option( 'wpseo_ms', [] );
 		$options['access'] = $access;
 		update_site_option( 'wpseo_ms', $options );
 
@@ -52,14 +52,14 @@ class WPSEO_Register_Capabilities_Tests extends WPSEO_UnitTestCase {
 		$register->register();
 
 		if ( $role === 'network_administrator' ) {
-			$user = self::factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+			$user = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 			grant_super_admin( $user->ID );
 		}
 		else {
-			$user = self::factory()->user->create_and_get( array( 'role' => $role ) );
+			$user = self::factory()->user->create_and_get( [ 'role' => $role ] );
 		}
 
-		$allcaps = $register->filter_user_has_wpseo_manage_options_cap( $user->allcaps, array( 'wpseo_manage_options' ), array(), $user );
+		$allcaps = $register->filter_user_has_wpseo_manage_options_cap( $user->allcaps, [ 'wpseo_manage_options' ], [], $user );
 
 		$this->assertSame( $expected_has_cap, ! empty( $allcaps['wpseo_manage_options'] ) );
 	}
@@ -75,13 +75,13 @@ class WPSEO_Register_Capabilities_Tests extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function data_filter_user_has_wpseo_manage_options_cap() {
-		return array(
-			array( 'wpseo_manager', 'superadmin', true ),
-			array( 'administrator', 'superadmin', false ),
-			array( 'network_administrator', 'superadmin', true ),
-			array( 'wpseo_manager', 'admin', true ),
-			array( 'administrator', 'admin', true ),
-			array( 'network_administrator', 'admin', true ),
-		);
+		return [
+			[ 'wpseo_manager', 'superadmin', true ],
+			[ 'administrator', 'superadmin', false ],
+			[ 'network_administrator', 'superadmin', true ],
+			[ 'wpseo_manager', 'admin', true ],
+			[ 'administrator', 'admin', true ],
+			[ 'network_administrator', 'admin', true ],
+		];
 	}
 }

--- a/integration-tests/config-ui/components/test-class-component-mailchimp-signup.php
+++ b/integration-tests/config-ui/components/test-class-component-mailchimp-signup.php
@@ -41,7 +41,7 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 		$mailchimp_signup = new WPSEO_Config_Component_Mailchimp_Signup();
 
 		$this->assertEquals(
-			array( 'hasSignup' => false ),
+			[ 'hasSignup' => false ],
 			$mailchimp_signup->get_data()
 		);
 	}
@@ -58,8 +58,8 @@ class WPSEO_Config_Component_Mailchimp_Signup_Test extends WPSEO_UnitTestCase {
 		$mailchimp_signup = new WPSEO_Config_Component_Mailchimp_Signup();
 
 		$this->assertEquals(
-			array( 'hasSignup' => true ),
-			$mailchimp_signup->set_data( array( 'hasSignup' => true ) )
+			[ 'hasSignup' => true ],
+			$mailchimp_signup->set_data( [ 'hasSignup' => true ] )
 		);
 	}
 }

--- a/integration-tests/config-ui/components/test-class-factory-post-type.php
+++ b/integration-tests/config-ui/components/test-class-factory-post-type.php
@@ -17,7 +17,7 @@ class WPSEO_Config_Factory_Post_Type_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_get_fields() {
 
-		$post_types = get_post_types( array( 'public' => true ), 'objects' );
+		$post_types = get_post_types( [ 'public' => true ], 'objects' );
 		$post_types = WPSEO_Post_Type::filter_attachment_post_type( $post_types );
 
 		$factory_post_type = new WPSEO_Config_Factory_Post_Type();

--- a/integration-tests/config-ui/fields/test-class-config-field-choice.php
+++ b/integration-tests/config-ui/fields/test-class-config-field-choice.php
@@ -28,7 +28,7 @@ class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_choices_property() {
 		$field = new WPSEO_Config_Field_Choice( 'field' );
-		$this->assertEquals( array( 'choices' => array() ), $field->get_properties() );
+		$this->assertEquals( [ 'choices' => [] ], $field->get_properties() );
 	}
 
 	/**
@@ -41,14 +41,14 @@ class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
 		$label              = 'Yes';
 		$screen_reader_text = 'no';
 
-		$expected = array(
-			'choices' => array(
-				$value => array(
+		$expected = [
+			'choices' => [
+				$value => [
 					'label'            => $label,
 					'screenReaderText' => $screen_reader_text,
-				),
-			),
-		);
+				],
+			],
+		];
 
 		$field = new WPSEO_Config_Field_Choice( 'field' );
 

--- a/integration-tests/config-ui/fields/test-class-config-field.php
+++ b/integration-tests/config-ui/fields/test-class-config-field.php
@@ -44,7 +44,7 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 		$properties = $field->get_properties();
 
 		$this->assertEquals(
-			array( $property => $property_value ),
+			[ $property => $property_value ],
 			$properties
 		);
 	}
@@ -73,10 +73,10 @@ class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
 		$field_b = 'field_b';
 		$value   = 'value';
 
-		$expected = array(
+		$expected = [
 			'field' => $field_b,
 			'value' => $value,
-		);
+		];
 
 		$field = new WPSEO_Config_Field( 'field_a', 'component' );
 		$field->set_requires( $field_b, $value );

--- a/integration-tests/config-ui/test-class-configuration-components.php
+++ b/integration-tests/config-ui/test-class-configuration-components.php
@@ -47,7 +47,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	public function test_set_adapter() {
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->setMethods( array( 'add_custom_lookup' ) )
+			->setMethods( [ 'add_custom_lookup' ] )
 			->getMock();
 
 		$adapter
@@ -56,7 +56,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 
 		$component = $this
 			->getMockBuilder( 'WPSEO_Config_Component' )
-			->setMethods( array( 'get_field', 'get_identifier', 'get_data', 'set_data' ) )
+			->setMethods( [ 'get_field', 'get_identifier', 'get_data', 'set_data' ] )
 			->getMock();
 
 		$field = new WPSEO_Config_Field( 'a', 'b' );
@@ -79,7 +79,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	public function test_set_storage() {
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Configuration_Storage' )
-			->setMethods( array( 'get_adapter' ) )
+			->setMethods( [ 'get_adapter' ] )
 			->getMock();
 
 		$adapter = $this
@@ -103,12 +103,12 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 	public function test_set_storage_on_field() {
 		$component = $this
 			->getMockBuilder( 'WPSEO_Config_Component' )
-			->setMethods( array( 'get_field', 'get_identifier', 'set_data', 'get_data' ) )
+			->setMethods( [ 'get_field', 'get_identifier', 'set_data', 'get_data' ] )
 			->getMock();
 
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setConstructorArgs( array( 'a', 'b' ) )
+			->setConstructorArgs( [ 'a', 'b' ] )
 			->getMock();
 
 		$component
@@ -118,7 +118,7 @@ class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
 
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Configuration_Storage' )
-			->setMethods( array( 'get_adapter', 'add_field' ) )
+			->setMethods( [ 'get_adapter', 'add_field' ] )
 			->getMock();
 
 		$adapter = $this

--- a/integration-tests/config-ui/test-class-configuration-endpoint.php
+++ b/integration-tests/config-ui/test-class-configuration-endpoint.php
@@ -59,7 +59,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Configuration_Endpoint::can_retrieve_data
 	 */
 	public function test_can_retrieve_data_pass() {
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 
 		wp_set_current_user( $user_id );
 
@@ -85,7 +85,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Configuration_Endpoint::can_save_data
 	 */
 	public function test_can_save_data_pass() {
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 
 		wp_set_current_user( $user_id );
 

--- a/integration-tests/config-ui/test-class-configuration-options-adapter.php
+++ b/integration-tests/config-ui/test-class-configuration-options-adapter.php
@@ -36,12 +36,12 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 		$type       = 't';
 		$option     = 'o';
 
-		$expected = array(
-			$class_name => array(
+		$expected = [
+			$class_name => [
 				'type'   => $type,
 				'option' => $option,
-			),
-		);
+			],
+		];
 
 		$this->assertNull( $this->adapter->add_lookup( $class_name, $type, $option ) );
 		$this->assertEquals( $expected, $this->adapter->get_lookups() );
@@ -57,15 +57,15 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 		$callback_set = '__return_true';
 		$callback_get = '__return_false';
 
-		$expected = array(
-			$class_name => array(
+		$expected = [
+			$class_name => [
 				'type'   => WPSEO_Configuration_Options_Adapter::OPTION_TYPE_CUSTOM,
-				'option' => array(
+				'option' => [
 					$callback_set,
 					$callback_get,
-				),
-			),
-		);
+				],
+			],
+		];
 
 		$this->assertNull( $this->adapter->add_custom_lookup( $class_name, $callback_set, $callback_get ) );
 		$this->assertEquals( $expected, $this->adapter->get_lookups() );
@@ -104,12 +104,12 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 		$class_name = 'stdClass';
 		$key        = 'enable_xml_sitemap';
 
-		$expected = array(
-			$class_name => array(
+		$expected = [
+			$class_name => [
 				'type'   => WPSEO_Configuration_Options_Adapter::OPTION_TYPE_YOAST,
 				'option' => $key,
-			),
-		);
+			],
+		];
 
 		$this->assertNull( $this->adapter->add_option_lookup( $class_name, $key ) );
 		$this->assertEquals( $expected, $this->adapter->get_lookups() );
@@ -124,12 +124,12 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 		$class_name = 'stdClass';
 		$option     = 'blogname';
 
-		$expected = array(
-			$class_name => array(
+		$expected = [
+			$class_name => [
 				'type'   => WPSEO_Configuration_Options_Adapter::OPTION_TYPE_WORDPRESS,
 				'option' => $option,
-			),
-		);
+			],
+		];
 
 		$this->assertNull( $this->adapter->add_wordpress_lookup( $class_name, $option ) );
 		$this->assertEquals( $expected, $this->adapter->get_lookups() );
@@ -144,7 +144,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	 * @expectedExceptionMessage WordPress option must be a string.
 	 */
 	public function test_add_wordpress_lookup_option_non_string() {
-		$this->adapter->add_wordpress_lookup( 'stdClass', array() );
+		$this->adapter->add_wordpress_lookup( 'stdClass', [] );
 	}
 
 	/**
@@ -219,7 +219,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	 * @covers WPSEO_Configuration_Options_Adapter::get
 	 */
 	public function test_get_custom_option() {
-		$get = array( $this, 'custom_option_get' );
+		$get = [ $this, 'custom_option_get' ];
 
 		$expected = call_user_func( $get );
 
@@ -243,7 +243,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 
 		$class = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setConstructorArgs( array( $field_name, 'component' ) )
+			->setConstructorArgs( [ $field_name, 'component' ] )
 			->getMock();
 
 		$this->adapter->add_lookup( $field_name, 'some_type', 'some_option' );
@@ -332,7 +332,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 	public function test_set_custom_option() {
 		$catcher = $this
 			->getMockBuilder( 'stdClass' )
-			->setMethods( array( 'set' ) )
+			->setMethods( [ 'set' ] )
 			->getMock();
 
 		$catcher
@@ -345,7 +345,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCas
 		$this->adapter->add_custom_lookup(
 			$field->get_identifier(),
 			'__return_true',
-			array( $catcher, 'set' )
+			[ $catcher, 'set' ]
 		);
 
 		$this->assertTrue( $this->adapter->set( $field, 'value' ) );

--- a/integration-tests/config-ui/test-class-configuration-service.php
+++ b/integration-tests/config-ui/test-class-configuration-service.php
@@ -34,7 +34,7 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 
 		remove_action(
 			'rest_api_init',
-			array( $this->configuration_service, 'initialize' )
+			[ $this->configuration_service, 'initialize' ]
 		);
 	}
 
@@ -116,19 +116,19 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Service::get_configuration
 	 */
 	public function test_get_configuration() {
-		$storage   = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->setMethods( array( 'retrieve' ) )->getMock();
-		$structure = $this->getMockBuilder( 'WPSEO_Configuration_Structure' )->setMethods( array( 'retrieve' ) )->getMock();
+		$storage   = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->setMethods( [ 'retrieve' ] )->getMock();
+		$structure = $this->getMockBuilder( 'WPSEO_Configuration_Structure' )->setMethods( [ 'retrieve' ] )->getMock();
 		$adapter   = new WPSEO_Configuration_Options_Adapter();
 
 		$storage
 			->expects( $this->once() )
 			->method( 'retrieve' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$structure
 			->expects( $this->once() )
 			->method( 'retrieve' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$this->configuration_service->set_storage( $storage );
 		$this->configuration_service->set_options_adapter( $adapter );
@@ -141,11 +141,11 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'array', $result );
 
 		$this->assertEquals(
-			array(
-				'fields'       => array(),
-				'steps'        => array(),
-				'translations' => array(),
-			),
+			[
+				'fields'       => [],
+				'steps'        => [],
+				'translations' => [],
+			],
 			$result
 		);
 	}
@@ -164,9 +164,9 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 		}
 
 
-		$expected = array( 'some_data' );
+		$expected = [ 'some_data' ];
 
-		$storage = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->setMethods( array( 'store' ) )->getMock();
+		$storage = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->setMethods( [ 'store' ] )->getMock();
 
 		$data = new WP_REST_Request();
 		$data->set_header( 'content-type', 'application/json' );
@@ -194,13 +194,13 @@ class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
 		$configuration_service = new WPSEO_Configuration_Service_Mock();
 		$configuration_service->set_default_providers();
 
-		$properties = array(
+		$properties = [
 			'storage',
 			'adapter',
 			'structure',
 			'endpoint',
 			'components',
-		);
+		];
 
 		foreach ( $properties as $property ) {
 			$this->assertNotNull( $configuration_service->get( $property ) );

--- a/integration-tests/config-ui/test-class-configuration-storage.php
+++ b/integration-tests/config-ui/test-class-configuration-storage.php
@@ -34,11 +34,11 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	public function test_add_field() {
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setConstructorArgs( array( 'field', 'component' ) )
+			->setConstructorArgs( [ 'field', 'component' ] )
 			->getMock();
 
 		$this->assertNull( $this->storage->add_field( $field ) );
-		$this->assertEquals( array( $field ), $this->storage->get_fields() );
+		$this->assertEquals( [ $field ], $this->storage->get_fields() );
 	}
 
 	/**
@@ -74,12 +74,12 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setConstructorArgs( array( 'field', 'type' ) )
+			->setConstructorArgs( [ 'field', 'type' ] )
 			->getMock();
 
 		$adapter
@@ -104,12 +104,12 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setConstructorArgs( array( 'field', 'type' ) )
+			->setConstructorArgs( [ 'field', 'type' ] )
 			->getMock();
 
 		$field
@@ -138,12 +138,12 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setConstructorArgs( array( 'field', 'type' ) )
+			->setConstructorArgs( [ 'field', 'type' ] )
 			->getMock();
 
 		$adapter
@@ -163,20 +163,20 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	 * @covers WPSEO_Configuration_Storage::get_field_data
 	 */
 	public function test_get_field_data_array() {
-		$data    = array( 'a' => '1' );
-		$default = array(
+		$data    = [ 'a' => '1' ];
+		$default = [
 			'a' => '2',
 			'b' => '2',
-		);
+		];
 
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setConstructorArgs( array( 'field', 'type' ) )
+			->setConstructorArgs( [ 'field', 'type' ] )
 			->getMock();
 
 		$adapter
@@ -193,10 +193,10 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 		$this->storage->set_adapter( $adapter );
 
 		$this->assertEquals(
-			array(
+			[
 				'a' => '1',
 				'b' => '2',
-			),
+			],
 			$this->storage->get_field_data( $field )
 		);
 	}
@@ -213,20 +213,20 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 		$property_value = 'pv';
 		$data           = 'd';
 
-		$expected = array(
-			$field => array(
+		$expected = [
+			$field => [
 				'componentName' => $component,
-				'properties'    => array(
+				'properties'    => [
 					$property => $property_value,
-				),
+				],
 				'data'          => $data,
-			),
-		);
+			],
+		];
 
 		$config_field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setMethods( array( 'get_identifier', 'get_properties' ) )
-			->setConstructorArgs( array( $field, $component ) )
+			->setMethods( [ 'get_identifier', 'get_properties' ] )
+			->setConstructorArgs( [ $field, $component ] )
 			->getMock();
 
 		$config_field
@@ -237,11 +237,11 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 		$config_field
 			->expects( $this->once() )
 			->method( 'get_properties' )
-			->will( $this->returnValue( array( $property => $property_value ) ) );
+			->will( $this->returnValue( [ $property => $property_value ] ) );
 
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$adapter
@@ -268,13 +268,13 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 	public function test_store() {
 		$field     = 'f';
 		$component = 'c';
-		$data      = array( $field => array( 'data' => 'some_data' ) );
+		$data      = [ $field => [ 'data' => 'some_data' ] ];
 		$return    = 'r';
 
 		$config_field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
-			->setMethods( array( 'get_identifier' ) )
-			->setConstructorArgs( array( $field, $component ) )
+			->setMethods( [ 'get_identifier' ] )
+			->setConstructorArgs( [ $field, $component ] )
 			->getMock();
 
 		$config_field
@@ -284,7 +284,7 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 
 		$adapter = $this
 			->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )
-			->setMethods( array( 'set', 'get' ) )
+			->setMethods( [ 'set', 'get' ] )
 			->getMock();
 
 		$adapter
@@ -302,12 +302,12 @@ class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
 
 		$result = $this->storage->store( $data );
 
-		$expected = array(
-			$field => array(
+		$expected = [
+			$field => [
 				'result' => true,
 				'data'   => $return,
-			),
-		);
+			],
+		];
 
 		$this->assertEquals( $expected, $result );
 	}

--- a/integration-tests/config-ui/test-class-configuration-structure.php
+++ b/integration-tests/config-ui/test-class-configuration-structure.php
@@ -36,7 +36,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 
 		$steps = $this->structure->retrieve();
 
-		$expected = array(
+		$expected = [
 			'environment-type',
 			'site-type',
 			'publishing-entity',
@@ -45,7 +45,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 			'title-template',
 			'newsletter',
 			'success',
-		);
+		];
 
 		$this->assertEquals( $expected, array_keys( $steps ) );
 	}
@@ -80,12 +80,12 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue( isset( $steps[ $identifier ] ) );
 		$this->assertEquals(
-			array(
+			[
 				'title'          => $title,
 				'fields'         => $fields,
 				'hideNavigation' => false,
 				'fullWidth'      => false,
-			),
+			],
 			$steps[ $identifier ]
 		);
 	}

--- a/integration-tests/doubles/class-indexable-double.php
+++ b/integration-tests/doubles/class-indexable-double.php
@@ -15,10 +15,10 @@ class WPSEO_Indexable_Double extends WPSEO_Indexable {
 	 *
 	 * @var array
 	 */
-	protected $updateable_fields = array(
+	protected $updateable_fields = [
 		'title',
 		'description',
-	);
+	];
 
 	/**
 	 * Converts the meta value to a boolean value.

--- a/integration-tests/doubles/class-wpseo-plugin-availability-double.php
+++ b/integration-tests/doubles/class-wpseo-plugin-availability-double.php
@@ -15,7 +15,7 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 	 *
 	 * @var array
 	 */
-	private $available_dependencies = array( 'test-plugin/test-plugin.php' );
+	private $available_dependencies = [ 'test-plugin/test-plugin.php' ];
 
 	/**
 	 * Registers a variety of fake plugins to test against.
@@ -23,8 +23,8 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 	 * @return void
 	 */
 	public function register_yoast_plugins() {
-		$this->plugins = array(
-			'test-plugin' => array(
+		$this->plugins = [
+			'test-plugin' => [
 				'url'          => 'http://example.com/',
 				'title'        => 'Test Plugin',
 				'description'  => '',
@@ -32,63 +32,63 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'installed'    => true,
 				'slug'         => 'test-plugin/test-plugin.php',
 				'version_sync' => true,
-			),
+			],
 
-			'test-plugin-dependency' => array(
+			'test-plugin-dependency' => [
 				'url'           => 'http://example.com/',
 				'title'         => 'Test Plugin With Dependency',
 				'description'   => '',
 				'version'       => '3.3',
 				'installed'     => false,
-				'_dependencies' => array(
-					'test-plugin' => array(
+				'_dependencies' => [
+					'test-plugin' => [
 						'slug' => 'test-plugin/test-plugin.php',
-					),
-				),
+					],
+				],
 				'slug'          => 'test-plugin-with-dependency/test-plugin-with-dependency.php',
-			),
+			],
 
-			'test-plugin-dependency-2' => array(
+			'test-plugin-dependency-2' => [
 				'url'           => 'http://example.com/',
 				'title'         => 'Test Plugin With Dependency Part 2',
 				'description'   => '',
 				'version'       => '3.3',
 				'installed'     => false,
-				'_dependencies' => array(
-					'test-plugin' => array(
+				'_dependencies' => [
+					'test-plugin' => [
 						'slug' => 'test-plugin/test-plugin.php',
-					),
-				),
+					],
+				],
 				'slug'          => 'test-plugin-with-dependency-2/test-plugin-with-dependency-2.php',
-			),
+			],
 
-			'unavailable-test-plugin' => array(
+			'unavailable-test-plugin' => [
 				'url'         => 'http://example.com/',
 				'title'       => 'Unavailable Test Plugin',
 				'description' => '',
 				'version'     => '3.3',
 				'installed'   => false,
 				'slug'        => 'unavailable-test-plugin/unavailable-test-plugin.php',
-			),
+			],
 
-			'unavailable-test-plugin-dependency' => array(
+			'unavailable-test-plugin-dependency' => [
 				'url'         => 'http://example.com/',
 				'title'       => 'Test Plugin Without Dependency',
 				'description' => '',
 				'version'     => '3.3',
 				'installed'   => false,
 				'slug'        => 'test-plugin-without-dependency/test-plugin-without-dependency.php',
-			),
+			],
 
-			'test-plugin-no-version' => array(
+			'test-plugin-no-version' => [
 				'url'         => 'http://example.com/',
 				'title'       => 'Test Plugin With No Version',
 				'description' => '',
 				'installed'   => false,
 				'slug'        => 'test-plugin-with-no-version/test-plugin-with-no-version.php',
-			),
+			],
 
-			'test-plugin-invalid-version' => array(
+			'test-plugin-invalid-version' => [
 				'url'          => 'http://example.com/',
 				'title'        => 'Test Plugin',
 				'description'  => '',
@@ -97,9 +97,9 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'slug'         => 'test-plugin-invalid-version/test-plugin-invalid-version.php',
 				'compatible'   => false,
 				'version_sync' => true,
-			),
+			],
 
-			'test-plugin-non-version-synced' => array(
+			'test-plugin-non-version-synced' => [
 				'url'          => 'http://example.com/',
 				'title'        => 'Test Plugin',
 				'description'  => '',
@@ -107,8 +107,8 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'installed'    => true,
 				'version_sync' => false,
 				'compatible'   => true,
-			),
-			'test-premium-plugin' => array(
+			],
+			'test-premium-plugin' => [
 				'url'          => 'https://example.com/',
 				'title'        => 'Test Plugin',
 				'description'  => '',
@@ -117,8 +117,8 @@ class WPSEO_Plugin_Availability_Double extends WPSEO_Plugin_Availability {
 				'version_sync' => false,
 				'compatible'   => true,
 				'premium'      => true,
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/integration-tests/doubles/wpseo-onpage-request-double.php
+++ b/integration-tests/doubles/wpseo-onpage-request-double.php
@@ -18,11 +18,11 @@ class WPSEO_OnPage_Request_Double extends WPSEO_OnPage_Request {
 	 *
 	 * @return array
 	 */
-	protected function get_remote( $target_url, $parameters = array() ) {
-		$remote_data = array(
+	protected function get_remote( $target_url, $parameters = [] ) {
+		$remote_data = [
 			'is_indexable'    => '0',
 			'passes_juice_to' => '',
-		);
+		];
 
 		switch ( $target_url ) {
 			case home_url():
@@ -30,10 +30,10 @@ class WPSEO_OnPage_Request_Double extends WPSEO_OnPage_Request {
 				break;
 
 			case 'http:://will-be-redirected.wp':
-				$remote_data = array(
+				$remote_data = [
 					'is_indexable'    => '0',
 					'passes_juice_to' => 'http://is-redirected.wp',
-				);
+				];
 				break;
 
 			case 'http://is-redirected.wp':

--- a/integration-tests/doubles/wpseo-primary-term-double.php
+++ b/integration-tests/doubles/wpseo-primary-term-double.php
@@ -16,10 +16,10 @@ class WPSEO_Primary_Term_Double extends WPSEO_Primary_Term {
 	 * @return array
 	 */
 	protected function get_terms() {
-		return array(
-			(object) array(
+		return [
+			(object) [
 				'term_id' => 54,
-			),
-		);
+			],
+		];
 	}
 }

--- a/integration-tests/doubles/wpseo-role-manager-mock.php
+++ b/integration-tests/doubles/wpseo-role-manager-mock.php
@@ -15,14 +15,14 @@ class WPSEO_Role_Manager_Mock extends WPSEO_Abstract_Role_Manager {
 	 *
 	 * @var array
 	 */
-	public $added_roles = array();
+	public $added_roles = [];
 
 	/**
 	 * Removed roles.
 	 *
 	 * @var array
 	 */
-	public $removed_roles = array();
+	public $removed_roles = [];
 
 	/**
 	 * Get registered roles.
@@ -67,12 +67,12 @@ class WPSEO_Role_Manager_Mock extends WPSEO_Abstract_Role_Manager {
 	 *
 	 * @return void
 	 */
-	protected function add_role( $role, $display_name, array $capabilities = array() ) {
-		$this->added_roles[] = array(
+	protected function add_role( $role, $display_name, array $capabilities = [] ) {
+		$this->added_roles[] = [
 			'role'         => $role,
 			'display_name' => $display_name,
 			'capabilities' => $capabilities,
-		);
+		];
 	}
 
 	/**

--- a/integration-tests/doubles/wpseo-taxonomy-fields-double.php
+++ b/integration-tests/doubles/wpseo-taxonomy-fields-double.php
@@ -16,6 +16,6 @@ class WPSEO_Taxonomy_Fields_Double extends WPSEO_Taxonomy_Fields {
 	 * @return array
 	 */
 	public function get() {
-		return array( '1', '2', '3' );
+		return [ '1', '2', '3' ];
 	}
 }

--- a/integration-tests/formatter/test-metabox-formatter.php
+++ b/integration-tests/formatter/test-metabox-formatter.php
@@ -22,7 +22,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		$class_instance = new WPSEO_Metabox_Formatter(
 			new WPSEO_Post_Metabox_Formatter(
 				$this->factory->post->create_and_get(),
-				array(),
+				[],
 				''
 			)
 		);
@@ -50,13 +50,13 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		wp_mkdir_p( plugin_dir_path( WPSEO_FILE ) . 'languages' );
 		file_put_contents(
 			$file_name,
-			WPSEO_Utils::format_json_encode( array( 'key' => 'value' ) )
+			WPSEO_Utils::format_json_encode( [ 'key' => 'value' ] )
 		);
 
 		$class_instance = new WPSEO_Metabox_Formatter(
 			new WPSEO_Post_Metabox_Formatter(
 				$this->factory->post->create_and_get(),
-				array(),
+				[],
 				''
 			)
 		);
@@ -65,12 +65,12 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 
 		$this->assertTrue( array_key_exists( 'translations', $result ) );
 		$this->assertTrue( is_array( $result['translations'] ) );
-		$this->assertEquals( array( 'key' => 'value' ), $result['translations'] );
+		$this->assertEquals( [ 'key' => 'value' ], $result['translations'] );
 
 		unlink( $file_name );
 
 		$result = $class_instance->get_values();
 
-		$this->assertEquals( $result['translations'], array() );
+		$this->assertEquals( $result['translations'], [] );
 	}
 }

--- a/integration-tests/formatter/test-post-metabox-formatter.php
+++ b/integration-tests/formatter/test-post-metabox-formatter.php
@@ -36,7 +36,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Metabox_Formatter::base_url_for_js
 	 */
 	public function test_no_post_with_empty_options() {
-		$instance = new WPSEO_Post_Metabox_Formatter( null, array(), '' );
+		$instance = new WPSEO_Post_Metabox_Formatter( null, [], '' );
 		$result   = $instance->get_values();
 
 		$this->assertEquals( $result['search_url'], admin_url( 'edit.php?seo_kw_filter={keyword}' ) );
@@ -54,14 +54,14 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Metabox_Formatter::get_template
 	 */
 	public function test_post_with_empty_options() {
-		WPSEO_Options::set( 'keyword_usage', array( '' => array() ) );
+		WPSEO_Options::set( 'keyword_usage', [ '' => [] ] );
 		WPSEO_Options::set( 'title-' . $this->post->post_type, '' );
 		WPSEO_Options::set( 'metadesc-' . $this->post->post_type, '' );
 
-		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, array(), '' );
+		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, [], '' );
 		$result   = $instance->get_values();
 
-		$this->assertEquals( array( '' => array() ), $result['keyword_usage'] );
+		$this->assertEquals( [ '' => [] ], $result['keyword_usage'] );
 		$this->assertEquals( '%%title%% %%sep%% %%sitename%%', $result['title_template'] );
 		$this->assertEquals( '', $result['metadesc_template'] );
 	}
@@ -76,7 +76,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'title-post', 'This is the title' );
 		WPSEO_Options::set( 'metadesc-post', 'This is the metadescription' );
 		WPSEO_Options::set( 'showdate-post', true );
-		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, array(), '' );
+		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, [], '' );
 		$result   = $instance->get_values();
 
 		$this->assertEquals( $result['metaDescriptionDate'], date_i18n( 'M j, Y', mysql2date( 'U', $this->post->post_date ) ) );
@@ -94,7 +94,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 
 		$GLOBALS['pagenow'] = 'post-new.php';
 
-		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, array(), '' );
+		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, [], '' );
 		$result   = $instance->get_values();
 
 		$this->assertEquals( $result['base_url'], WPSEO_Utils::home_url() );
@@ -109,7 +109,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Metabox_Formatter::base_url_for_js
 	 */
 	public function test_with_permalink_structure() {
-		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, array(), 'http://example.org/test/%postname%/' );
+		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, [], 'http://example.org/test/%postname%/' );
 		$result   = $instance->get_values();
 
 		$this->assertEquals( $result['base_url'], 'http://example.org/test/' );
@@ -122,7 +122,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Metabox_Formatter::base_url_for_js
 	 */
 	public function test_with_unreplaceble_permalink_structure() {
-		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, array(), '%isnotreplaced%/' );
+		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, [], '%isnotreplaced%/' );
 		$result   = $instance->get_values();
 
 		$this->assertEquals( $result['base_url'], WPSEO_Utils::home_url() );
@@ -138,7 +138,7 @@ class WPSEO_Post_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'title-post', 'This is the title' );
 		WPSEO_Options::set( 'showdate-post', true );
 
-		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, array(), '' );
+		$instance = new WPSEO_Post_Metabox_Formatter( $this->post, [], '' );
 		$result   = $instance->get_values();
 
 		$this->assertEquals( $result['title_template'], 'This is the title' );

--- a/integration-tests/formatter/test-term-metabox-formatter.php
+++ b/integration-tests/formatter/test-term-metabox-formatter.php
@@ -41,7 +41,7 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Term_Metabox_Formatter::get_values
 	 */
 	public function test_no_taxonomy_no_term_and_no_options() {
-		$instance = new WPSEO_Term_Metabox_Formatter( null, null, array() );
+		$instance = new WPSEO_Term_Metabox_Formatter( null, null, [] );
 		$result   = $instance->get_values();
 
 		$this->assertFalse( array_key_exists( 'search_url', $result ) );
@@ -79,7 +79,7 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( $result['post_edit_url'], admin_url( 'edit-tags.php?action=edit&taxonomy=' . $this->term->taxonomy . '&tag_ID={id}' ) );
 
 		$this->assertEquals( trailingslashit( home_url( 'tag' ) ), $result['base_url'] );
-		$this->assertEquals( array( '' => array() ), $result['keyword_usage'] );
+		$this->assertEquals( [ '' => [] ], $result['keyword_usage'] );
 		$this->assertEquals( '%%title%% %%sep%% %%sitename%%', $result['title_template'] );
 		$this->assertEquals( '', $result['metadesc_template'] );
 	}
@@ -92,7 +92,7 @@ class WPSEO_Term_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	public function test_post_edit_url_4_5_and_higher() {
 		global $wp_version;
 
-		$instance = new WPSEO_Term_Metabox_Formatter( $this->taxonomy, $this->term, array() );
+		$instance = new WPSEO_Term_Metabox_Formatter( $this->taxonomy, $this->term, [] );
 
 		$_wp_version = $wp_version;
 		$wp_version  = '4.5.0';

--- a/integration-tests/framework/class-wpseo-unit-test-case.php
+++ b/integration-tests/framework/class-wpseo-unit-test-case.php
@@ -63,7 +63,7 @@ abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 		ob_clean();
 
 		if ( ! is_array( $expected ) ) {
-			$expected = array( $expected );
+			$expected = [ $expected ];
 		}
 
 		foreach ( $expected as $needle ) {

--- a/integration-tests/frontend/test-class-front-end-page-type.php
+++ b/integration-tests/frontend/test-class-front-end-page-type.php
@@ -54,7 +54,7 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 		$current_page_for_posts = get_option( 'page_for_posts' );
 		$current_show_on_front  = get_option( 'show_on_front' );
 
-		$home_page = $this->factory()->post->create_and_get( array( 'post_type' => 'page' ) );
+		$home_page = $this->factory()->post->create_and_get( [ 'post_type' => 'page' ] );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', $home_page->ID );
@@ -85,12 +85,12 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Frontend_Page_Type::get_simple_page_id
 	 */
 	public function test_simple_page_with_a_set_filter_for_the_id() {
-		add_filter( 'wpseo_frontend_page_type_simple_page_id', array( $this, 'simple_page_hook' ) );
+		add_filter( 'wpseo_frontend_page_type_simple_page_id', [ $this, 'simple_page_hook' ] );
 
 		$this->assertTrue( WPSEO_Frontend_Page_Type::is_simple_page() );
 		$this->assertEquals( 100, WPSEO_Frontend_Page_Type::get_simple_page_id() );
 
-		remove_filter( 'wpseo_frontend_page_type_simple_page_id', array( $this, 'simple_page_hook' ) );
+		remove_filter( 'wpseo_frontend_page_type_simple_page_id', [ $this, 'simple_page_hook' ] );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class WPSEO_Frontend_Page_Type_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( WPSEO_Frontend_Page_Type::is_home_static_page() );
 
 		// Create page and set it as front page.
-		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$post_id = $this->factory->post->create( [ 'post_type' => 'page' ] );
 		update_option( 'page_on_front', $post_id );
 		$this->go_to( get_permalink( $post_id ) );
 

--- a/integration-tests/frontend/test-class-opengraph.php
+++ b/integration-tests/frontend/test-class-opengraph.php
@@ -85,7 +85,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 
 		$c      = self::$class_instance;
-		$result = $c->facebook_filter( array() );
+		$result = $c->facebook_filter( [] );
 
 		// Test if values were filtered.
 		$this->assertArrayHasKey( 'http://ogp.me/ns#type', $result );
@@ -109,8 +109,8 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$this->assertFalse( self::$class_instance->article_author_facebook() );
 
 		// Create post with author.
-		$author_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
-		$post_id   = $this->factory->post->create( array( 'post_author' => $author_id ) );
+		$author_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$post_id   = $this->factory->post->create( [ 'post_author' => $author_id ] );
 		$this->go_to( get_permalink( $post_id ) );
 
 		// On post page but facebook meta not set.
@@ -172,10 +172,10 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$expected_title = 'Test title';
 		// Create and go to post.
 		$post_id   = $this->factory->post->create();
-		$post_args = array(
+		$post_args = [
 			'ID'         => $post_id,
 			'post_title' => $expected_title,
-		);
+		];
 		wp_update_post( $post_args );
 		WPSEO_Meta::set_value( 'opengraph-title', '%%title%%', $post_id );
 
@@ -249,7 +249,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$stub =
 			$this
 				->getMockBuilder( 'WPSEO_OpenGraph' )
-				->setMethods( array( 'og_tag' ) )
+				->setMethods( [ 'og_tag' ] )
 				->getMock();
 
 		WPSEO_Options::set( 'og_frontpage_image', get_site_url() . '/wp-content/uploads/2015/01/iphone5_ios7-300x198.jpg' );
@@ -271,7 +271,7 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 		$stub =
 			$this
 				->getMockBuilder( 'WPSEO_OpenGraph' )
-				->setMethods( array( 'og_tag' ) )
+				->setMethods( [ 'og_tag' ] )
 				->getMock();
 
 		$stub
@@ -314,9 +314,9 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_image_IS_SINGULAR_and_HAS_open_graph_image_AND_HAS_content_images() {
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_content' => '<img class="alignnone size-medium wp-image-490" src="' . get_site_url() . '/wp-content/plugins/wordpress-seo/integration-tests/yoast.png" />',
-			)
+			]
 		);
 
 		$image = get_site_url() . '/wp-content/plugins/wordpress-seo/integration-tests/assets/small.png';
@@ -416,10 +416,10 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	public function test_static_front_page() {
 
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title' => 'front-page',
 				'post_type'  => 'page',
-			)
+			]
 		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
@@ -448,19 +448,19 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	public function test_static_posts_page() {
 
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title' => 'front-page',
 				'post_type'  => 'page',
-			)
+			]
 		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
 
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title' => 'blog-page',
 				'post_type'  => 'page',
-			)
+			]
 		);
 		update_option( 'page_for_posts', $post_id );
 		$this->go_to( get_permalink( $post_id ) );
@@ -567,7 +567,7 @@ EXPECTED;
 	public function test_site_name() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_OpenGraph' )
-			->setMethods( array( 'og_tag' ) )
+			->setMethods( [ 'og_tag' ] )
 			->getMock();
 
 		$instance
@@ -589,7 +589,7 @@ EXPECTED;
 	public function test_site_name_with_a_set_name() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_OpenGraph' )
-			->setMethods( array( 'og_tag' ) )
+			->setMethods( [ 'og_tag' ] )
 			->getMock();
 
 		$instance
@@ -612,7 +612,7 @@ EXPECTED;
 	public function test_site_name_with_a_non_string_name() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_OpenGraph' )
-			->setMethods( array( 'og_tag' ) )
+			->setMethods( [ 'og_tag' ] )
 			->getMock();
 
 		$instance
@@ -661,7 +661,7 @@ EXPECTED;
 
 		// Create post in category, go to post.
 		$category_id = wp_create_category( 'Category Name' );
-		$post_id     = $this->factory->post->create( array( 'post_category' => array( $category_id ) ) );
+		$post_id     = $this->factory->post->create( [ 'post_category' => [ $category_id ] ] );
 		$this->go_to( get_permalink( $post_id ) );
 
 		$this->assertTrue( self::$class_instance->category() );
@@ -705,7 +705,7 @@ EXPECTED;
 	 * @covers WPSEO_OpenGraph::opengraph
 	 */
 	public function test_taxonomy_title() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'wpseo_opengraph-title', 'Custom taxonomy open graph title' );
 
@@ -728,7 +728,7 @@ EXPECTED;
 	 * @covers WPSEO_OpenGraph::description
 	 */
 	public function test_taxonomy_description() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-description', 'Custom taxonomy open graph description' );
 
@@ -752,10 +752,10 @@ EXPECTED;
 	 */
 	public function test_taxonomy_description_with_replacevars() {
 		$expected_title = 'Test title';
-		$term_args      = array(
+		$term_args      = [
 			'taxonomy' => 'category',
 			'name'     => $expected_title,
-		);
+		];
 		$term_id        = $this->factory->term->create( $term_args );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-description', '%%term_title%%' );
@@ -781,7 +781,7 @@ EXPECTED;
 	 * @covers WPSEO_OpenGraph::image
 	 */
 	public function test_taxonomy_image() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'wpseo_opengraph-image', home_url( 'custom_twitter_image.png' ) );
 
@@ -826,7 +826,7 @@ EXPECTED;
 	 * @covers WPSEO_OpenGraph::category
 	 */
 	public function test_get_category_with_first_value_removed_by_filter() {
-		add_filter( 'get_the_categories', array( $this, 'remove_first_category' ) );
+		add_filter( 'get_the_categories', [ $this, 'remove_first_category' ] );
 
 		$post_id = $this->create_post_with_categories();
 
@@ -842,7 +842,7 @@ EXPECTED;
 
 		$this->assertContains( '<meta property="article:section" content="category2" />', $output );
 
-		remove_filter( 'get_the_categories', array( $this, 'remove_first_category' ) );
+		remove_filter( 'get_the_categories', [ $this, 'remove_first_category' ] );
 	}
 
 	/**
@@ -855,21 +855,21 @@ EXPECTED;
 		$term1   = self::factory()
 			->term
 			->create(
-				array(
+				[
 					'name'     => 'category1',
 					'taxonomy' => 'category',
-				)
+				]
 			);
 		$term2   = self::factory()
 			->term
 			->create(
-				array(
+				[
 					'name'     => 'category2',
 					'taxonomy' => 'category',
-				)
+				]
 			);
 
-		self::factory()->term->add_post_terms( $post_id, array( $term1, $term2 ), 'category' );
+		self::factory()->term->add_post_terms( $post_id, [ $term1, $term2 ], 'category' );
 
 		return $post_id;
 	}
@@ -902,10 +902,10 @@ EXPECTED;
 
 		copy( $source_image, $featured_image ); // Prevent original from deletion.
 
-		$file_array = array(
+		$file_array = [
 			'name'     => $basename,
 			'tmp_name' => $featured_image,
-		);
+		];
 		$attach_id  = media_handle_sideload( $file_array, $post_id );
 
 		return $attach_id;

--- a/integration-tests/frontend/test-class-primary-category.php
+++ b/integration-tests/frontend/test-class-primary-category.php
@@ -26,7 +26,7 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 		$this->subject =
 			$this
 				->getMockBuilder( 'WPSEO_Frontend_Primary_Category' )
-				->setMethods( array( 'get_category', 'get_primary_category' ) )
+				->setMethods( [ 'get_category', 'get_primary_category' ] )
 				->getMock();
 	}
 
@@ -41,18 +41,18 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 			->method( 'get_primary_category' )
 			->will( $this->returnValue( '54' ) );
 
-		$expect = (object) array(
+		$expect = (object) [
 			'term_id' => 54,
-		);
+		];
 
 		$this->subject
 			->expects( $this->once() )
 			->method( 'get_category' )
 			->will( $this->returnValue( $expect ) );
 
-		$category = (object) array(
+		$category = (object) [
 			'cat_ID' => 52,
-		);
+		];
 
 		$this->assertEquals( $expect, $this->subject->post_link_category( $category ) );
 	}
@@ -72,12 +72,12 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'get_category' );
 
-		$category = (object) array(
+		$category = (object) [
 			'term_id'          => 1,
 			'name'             => 'test',
 			'term_taxonomy_id' => 1,
 			'cat_ID'           => 1,
-		);
+		];
 
 		$this->assertEquals( $category, $this->subject->post_link_category( $category ) );
 	}
@@ -97,12 +97,12 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'get_category' );
 
-		$category = (object) array(
+		$category = (object) [
 			'term_id'          => 1,
 			'name'             => 'test',
 			'term_taxonomy_id' => 1,
 			'cat_ID'           => 1,
-		);
+		];
 
 		$this->assertEquals( $category, $this->subject->post_link_category( $category ) );
 	}
@@ -114,12 +114,12 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_link_category_primary_term_with_post() {
 		$post     = $this->factory->post->create_and_get();
-		$category = (object) array(
+		$category = (object) [
 			'term_id'          => 1,
 			'name'             => 'test',
 			'term_taxonomy_id' => 1,
 			'cat_ID'           => 1,
-		);
+		];
 
 		$this->subject
 			->expects( $this->once() )
@@ -136,12 +136,12 @@ class WPSEO_Frontend_Primary_Category_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_link_category_primary_term_with_invalid_post_ID() {
 		$post     = 99;
-		$category = (object) array(
+		$category = (object) [
 			'term_id'          => 1,
 			'name'             => 'test',
 			'term_taxonomy_id' => 1,
 			'cat_ID'           => 1,
-		);
+		];
 
 		$this->subject
 			->expects( $this->once() )

--- a/integration-tests/frontend/test-class-twitter.php
+++ b/integration-tests/frontend/test-class-twitter.php
@@ -40,7 +40,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		WPSEO_Frontend::get_instance()->reset();
 
 		// Reset shown images.
-		self::$class_instance->shown_images = array();
+		self::$class_instance->shown_images = [];
 	}
 
 	/**
@@ -48,12 +48,12 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_twitter() {
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title'   => 'Twitter Test Post',
 				'post_excerpt' => 'Twitter Test Excerpt',
 				'post_type'    => 'post',
 				'post_status'  => 'publish',
-			)
+			]
 		);
 		$this->go_to( get_permalink( $post_id ) );
 
@@ -115,14 +115,14 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_author_twitter() {
 		// Create user, create post, attach user as author.
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title'  => 'Sample Post',
 				'post_type'   => 'post',
 				'post_status' => 'publish',
 				'post_author' => $user_id,
-			)
+			]
 		);
 
 		// Go to post we just created.
@@ -196,10 +196,10 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	public function test_static_front_page() {
 
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title' => 'front-page',
 				'post_type'  => 'page',
-			)
+			]
 		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
@@ -228,19 +228,19 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	public function test_static_posts_page() {
 
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title' => 'front-page',
 				'post_type'  => 'page',
-			)
+			]
 		);
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $post_id );
 
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title' => 'blog-page',
 				'post_type'  => 'page',
-			)
+			]
 		);
 		update_option( 'page_for_posts', $post_id );
 		$this->go_to( get_permalink( $post_id ) );
@@ -332,7 +332,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		ob_clean();
 
 		// Reset shown_images array.
-		self::$class_instance->shown_images = array();
+		self::$class_instance->shown_images = [];
 
 		return $expected;
 	}
@@ -360,10 +360,10 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	public function test_post_thumbnail_image() {
 		$post_id         = $this->factory->post->create();
 		$filename        = 'post-thumbnail.jpg';
-		$attachment_args = array(
+		$attachment_args = [
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
-		);
+		];
 		$attachment_id   = $this->factory->attachment->create_object( $filename, 0, $attachment_args );
 		update_post_meta( $post_id, '_thumbnail_id', $attachment_id );
 		$this->go_to( get_permalink( $post_id ) );
@@ -379,7 +379,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_post_content_image() {
 		$url     = 'http://example.com/example.jpg';
-		$post_id = $this->factory->post->create( array( 'post_content' => "Bla <img src='$url'/> bla" ) );
+		$post_id = $this->factory->post->create( [ 'post_content' => "Bla <img src='$url'/> bla" ] );
 		$this->go_to( get_permalink( $post_id ) );
 		$expected = $this->metatag( 'image', $url );
 		self::$class_instance->image();
@@ -392,7 +392,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Twitter::title
 	 */
 	public function test_taxonomy_title() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'wpseo_twitter-title', 'Custom taxonomy twitter title' );
 
@@ -409,7 +409,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Twitter::description
 	 */
 	public function test_taxonomy_description() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'wpseo_twitter-description', 'Custom taxonomy twitter description' );
 
@@ -426,7 +426,7 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Twitter::image
 	 */
 	public function test_taxonomy_image() {
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
 
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'wpseo_twitter-image', home_url( 'custom_twitter_image.png' ) );
 
@@ -446,16 +446,16 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 
 		// Insert image into DB so we have something to test against.
 		$filename        = 'image.jpg';
-		$attachment_args = array(
+		$attachment_args = [
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
-		);
+		];
 		$id              = $this->factory->attachment->create_object( $filename, 0, $attachment_args );
 		$expected       .= $this->metatag( 'image', 'http://' . WP_TESTS_DOMAIN . "/wp-content/uploads/$filename" );
 
 		// Create and go to post.
 		$content = '[gallery ids="' . $id . '"]';
-		$post_id = $this->factory->post->create( array( 'post_content' => $content ) );
+		$post_id = $this->factory->post->create( [ 'post_content' => $content ] );
 		$this->go_to( get_permalink( $post_id ) );
 
 		self::$class_instance->type();
@@ -479,10 +479,10 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 		$expected_title = 'Test title';
 		// Create and go to post.
 		$post_id   = $this->factory->post->create();
-		$post_args = array(
+		$post_args = [
 			'ID'         => $post_id,
 			'post_title' => $expected_title,
-		);
+		];
 		wp_update_post( $post_args );
 		WPSEO_Meta::set_value( 'twitter-title', '%%title%%', $post_id );
 
@@ -502,10 +502,10 @@ class WPSEO_Twitter_Test extends WPSEO_UnitTestCase {
 
 		// Create and go to post.
 		$post_id   = $this->factory->post->create();
-		$post_args = array(
+		$post_args = [
 			'ID'         => $post_id,
 			'post_title' => $expected_title,
-		);
+		];
 		wp_update_post( $post_args );
 
 		// Test wpseo meta.

--- a/integration-tests/frontend/test-class-woocommerce-shop-page.php
+++ b/integration-tests/frontend/test-class-woocommerce-shop-page.php
@@ -45,7 +45,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 		 */
 		$woocommerce_shop_page = $this
 			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
-			->setMethods( array( 'is_shop_page', 'get_shop_page_id' ) )
+			->setMethods( [ 'is_shop_page', 'get_shop_page_id' ] )
 			->getMock();
 
 		$woocommerce_shop_page
@@ -73,7 +73,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 		 */
 		$woocommerce_shop_page = $this
 			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
-			->setMethods( array( 'is_shop_page', 'get_shop_page_id' ) )
+			->setMethods( [ 'is_shop_page', 'get_shop_page_id' ] )
 			->getMock();
 
 		$woocommerce_shop_page
@@ -103,7 +103,7 @@ class WPSEO_WooCommerce_Shop_Page_Test extends WPSEO_UnitTestCase {
 		 */
 		$woocommerce_shop_page = $this
 			->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
-			->setMethods( array( 'is_shop_page' ) )
+			->setMethods( [ 'is_shop_page' ] )
 			->getMock();
 
 		$woocommerce_shop_page

--- a/integration-tests/frontend/test-class-wpseo-content-images.php
+++ b/integration-tests/frontend/test-class-wpseo-content-images.php
@@ -35,7 +35,7 @@ class WPSEO_Content_Images_Test extends WPSEO_UnitTestCase {
 		$result = $class_instance->get_images_from_content( $post_content );
 
 		// We expect only the urls of the first two img tags in the array.
-		$expected = array( $external_image, $non_attachment_image );
+		$expected = [ $external_image, $non_attachment_image ];
 		$this->assertEquals( $expected, $result );
 	}
 }

--- a/integration-tests/frontend/test-class-wpseo-frontend-redirects.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-redirects.php
@@ -91,9 +91,9 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 
 		// Create an attachment with parent.
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'   => 'attachment',
-			)
+			]
 		);
 		$this->go_to( get_permalink( $post_id ) );
 
@@ -110,7 +110,7 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 	public function test_attachment_redirect_no_attachment() {
 		WPSEO_Options::set( 'disable-attachment', true );
 
-		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+		$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Should not redirect on regular post pages.
@@ -145,9 +145,9 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 
 		// Create and go to post.
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'   => 'attachment',
-			)
+			]
 		);
 		$this->go_to( get_permalink( $post_id ) );
 
@@ -163,7 +163,7 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 		WPSEO_Options::set( 'disable-attachment', true );
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'do_attachment_redirect' ) )
+			->setMethods( [ 'do_attachment_redirect' ] )
 			->getMock();
 
 
@@ -173,9 +173,9 @@ final class WPSEO_Frontend_Redirects_Test extends WPSEO_UnitTestCase_Frontend {
 
 		// Create an attachment with parent.
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'   => 'attachment',
-			)
+			]
 		);
 		$this->go_to( get_permalink( $post_id ) );
 

--- a/integration-tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-robots.php
@@ -138,7 +138,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_private_post() {
 		// Create and go to post.
-		$post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$post_id = $this->factory->post->create( [ 'post_status' => 'private' ] );
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Test private posts.
@@ -154,7 +154,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		flush_rewrite_rules();
 
 		// Add posts to category.
-		$this->factory->post->create_many( 6, array( 'post_category' => array( $category_id ) ) );
+		$this->factory->post->create_many( 6, [ 'post_category' => [ $category_id ] ] );
 
 		$category_link = get_category_link( $category_id );
 		$this->go_to( $category_link );
@@ -173,7 +173,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		flush_rewrite_rules();
 
 		// Add posts to category.
-		$this->factory->post->create_many( 6, array( 'post_category' => array( $category_id ) ) );
+		$this->factory->post->create_many( 6, [ 'post_category' => [ $category_id ] ] );
 
 		$category_link = get_category_link( $category_id );
 		$this->go_to( $category_link );
@@ -265,11 +265,11 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
 
-		$robots   = array(
+		$robots   = [
 			'index'  => 'index',
 			'follow' => 'follow',
-			'other'  => array(),
-		);
+			'other'  => [],
+		];
 		$expected = $robots;
 
 		// Test noindex.
@@ -284,7 +284,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 
 		// Test meta-robots adv nosnippet.
 		WPSEO_Meta::set_value( 'meta-robots-adv', 'nosnippet', $post_id );
-		$expected['other'] = array( 'nosnippet' );
+		$expected['other'] = [ 'nosnippet' ];
 		$this->assertEquals( $expected, self::$class_instance->robots_for_single_post( $robots, $post_id ) );
 
 		WPSEO_Meta::set_value( 'meta-robots-noindex', '2', $post_id );

--- a/integration-tests/frontend/test-class-wpseo-frontend-title.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-title.php
@@ -75,7 +75,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 		add_user_meta( $user_id, 'wpseo_title', $explicit_title );
 
 		// Test explicit title.
-		$expected_title = wpseo_replace_vars( 'WPSEO Author Title %%sitename%%', array() );
+		$expected_title = wpseo_replace_vars( 'WPSEO Author Title %%sitename%%', [] );
 		$this->assertEquals( $expected_title, self::$class_instance->get_author_title() );
 	}
 
@@ -144,7 +144,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_post_type_archive_title() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_queried_post_type', 'get_title_from_options' ) )
+			->setMethods( [ 'get_queried_post_type', 'get_title_from_options' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -167,7 +167,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_post_type_archive_title_menu_title_fallback() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ) )
+			->setMethods( [ 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -184,9 +184,9 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 			->with( '1', '2', '3' )
 			->will( $this->returnValue( '123' ) );
 
-		$GLOBALS['wp_post_types'] = array(
-			'post_type' => new WP_Post_Type( 'post_type', array( 'labels' => array( 'menu_name' => '3' ) ) ),
-		);
+		$GLOBALS['wp_post_types'] = [
+			'post_type' => new WP_Post_Type( 'post_type', [ 'labels' => [ 'menu_name' => '3' ] ] ),
+		];
 
 		$this->assertEquals( '123', $instance->get_post_type_archive_title( '1', '2' ) );
 	}
@@ -198,7 +198,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_post_type_archive_title_name_fallback() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ) )
+			->setMethods( [ 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -215,9 +215,9 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 			->with( '1', '2', '4' )
 			->will( $this->returnValue( '124' ) );
 
-		$GLOBALS['wp_post_types'] = array(
-			'post_type' => new WP_Post_Type( 'post_type', array( 'labels' => array( 'name' => '4' ) ) ),
-		);
+		$GLOBALS['wp_post_types'] = [
+			'post_type' => new WP_Post_Type( 'post_type', [ 'labels' => [ 'name' => '4' ] ] ),
+		];
 
 		$this->assertEquals( '124', $instance->get_post_type_archive_title( '1', '2' ) );
 	}
@@ -229,7 +229,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_post_type_archive_title_empty_fallback() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ) )
+			->setMethods( [ 'get_queried_post_type', 'get_title_from_options', 'get_default_title' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -246,9 +246,9 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 			->with( '1', '2', 'post_type' )
 			->will( $this->returnValue( '12post_type' ) );
 
-		$GLOBALS['wp_post_types'] = array(
-			'post_type' => new WP_Post_Type( 'post_type', array( 'labels' => array( 'menu_name' => null ) ) ),
-		);
+		$GLOBALS['wp_post_types'] = [
+			'post_type' => new WP_Post_Type( 'post_type', [ 'labels' => [ 'menu_name' => null ] ] ),
+		];
 
 		$this->assertEquals( '12post_type', $instance->get_post_type_archive_title( '1', '2' ) );
 	}
@@ -260,7 +260,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_seo_title_no_valid_object() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_title_from_options' ) )
+			->setMethods( [ 'get_title_from_options' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -278,7 +278,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_seo_title_with_valid_object() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_meta_value', 'replace_vars' ) )
+			->setMethods( [ 'get_seo_meta_value', 'replace_vars' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -289,7 +289,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 		$instance->expects( $this->never() )
 			->method( 'replace_vars' );
 
-		$this->assertEquals( '', $instance->get_seo_title( (object) array( 'ID' => 1 ) ) );
+		$this->assertEquals( '', $instance->get_seo_title( (object) [ 'ID' => 1 ] ) );
 	}
 
 	/**
@@ -299,7 +299,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_seo_title_use_replace_vars() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_meta_value', 'replace_vars' ) )
+			->setMethods( [ 'get_seo_meta_value', 'replace_vars' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -307,7 +307,7 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 			->with( 'title', 1 )
 			->will( $this->returnValue( 'a title' ) );
 
-		$object = (object) array( 'ID' => 1 );
+		$object = (object) [ 'ID' => 1 ];
 
 		$instance->expects( $this->once() )
 			->method( 'replace_vars' )
@@ -324,14 +324,14 @@ final class WPSEO_Frontend_Title_Test extends WPSEO_UnitTestCase_Frontend {
 	 */
 	public function test_get_seo_title_use_queried_object() {
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_meta_value', 'replace_vars' ) )
+			->setMethods( [ 'get_seo_meta_value', 'replace_vars' ] )
 			->getMock();
 
 		$wp_query = $this->getMockBuilder( 'WP_Query' )
-			->setMethods( array( 'get_queried_object' ) )
+			->setMethods( [ 'get_queried_object' ] )
 			->getMock();
 
-		$object = (object) array( 'ID' => 1 );
+		$object = (object) [ 'ID' => 1 ];
 
 		$wp_query->expects( $this->once() )
 			->method( 'get_queried_object' )

--- a/integration-tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-woocommerce-shop.php
@@ -21,7 +21,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 	 */
 	protected function get_woocommerce_shop_page_mock( $post ) {
 		$woocommerce_shop_page = $this->getMockBuilder( 'WPSEO_WooCommerce_Shop_Page_Double' )
-			->setMethods( array( 'is_shop_page', 'get_shop_page_id' ) )
+			->setMethods( [ 'is_shop_page', 'get_shop_page_id' ] )
 			->getMock();
 
 		$woocommerce_shop_page->expects( $this->once() )
@@ -46,7 +46,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 		$woocommerce_shop_page = $this->get_woocommerce_shop_page_mock( $post );
 
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_title' ) )
+			->setMethods( [ 'get_seo_title' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -70,7 +70,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 		$woocommerce_shop_page = $this->get_woocommerce_shop_page_mock( $post );
 
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_title', 'get_post_type_archive_title' ) )
+			->setMethods( [ 'get_seo_title', 'get_post_type_archive_title' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -96,7 +96,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 		$post = self::factory()->post->create_and_get();
 
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ) )
+			->setMethods( [ 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -131,7 +131,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 		$post = self::factory()->post->create_and_get();
 
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ) )
+			->setMethods( [ 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -160,7 +160,7 @@ final class WPSEO_Frontend_WooCommerce_Shop_Test extends WPSEO_UnitTestCase {
 		$post = self::factory()->post->create_and_get();
 
 		$instance = $this->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ) )
+			->setMethods( [ 'get_seo_meta_value', 'get_queried_post_type', 'replace_vars' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )

--- a/integration-tests/frontend/test-class-wpseo-frontend.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend.php
@@ -154,7 +154,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 	public function test_canonical_search() {
 		update_option( 'posts_per_page', 1 );
 
-		$this->factory->post->create_many( 3, array( 'post_title' => 'sample post %d' ) );
+		$this->factory->post->create_many( 3, [ 'post_title' => 'sample post %d' ] );
 
 		// Test search.
 		$search_link = get_search_link( 'sample post' );
@@ -178,13 +178,13 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 
 		register_post_type(
 			'yoast',
-			array(
+			[
 				'public'      => true,
 				'has_archive' => true,
-			)
+			]
 		);
 
-		$this->factory->post->create_many( 3, array( 'post_type' => 'yoast' ) );
+		$this->factory->post->create_many( 3, [ 'post_type' => 'yoast' ] );
 
 		flush_rewrite_rules();
 
@@ -207,9 +207,9 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 	public function test_adjacent_rel_links_canonical_author() {
 		update_option( 'posts_per_page', 1 );
 
-		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
 
-		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
+		$this->factory->post->create_many( 3, [ 'post_author' => $user_id ] );
 
 		$user     = new WP_User( $user_id );
 		$user_url = get_author_posts_url( $user_id, $user->user_nicename );
@@ -253,7 +253,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 
 		// Create a category, add 26 posts to it, go to page 2 of its archives.
 		$category_id = wp_create_category( 'Yoast SEO Plugins' );
-		$this->factory->post->create_many( 3, array( 'post_category' => array( $category_id ) ) );
+		$this->factory->post->create_many( 3, [ 'post_category' => [ $category_id ] ] );
 
 		/*
 		 * This shouldn't be necessary but apparently multisite's rewrites are borked
@@ -282,7 +282,7 @@ class WPSEO_Frontend_Test extends WPSEO_UnitTestCase_Frontend {
 		create_initial_taxonomies();
 
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'    => 'post',
 				'post_content' => '
 Page 1/5
@@ -291,7 +291,7 @@ Page 2/3
 <!--nextpage-->
 Page 3/3
 ',
-			)
+			]
 		);
 
 		$url = get_permalink( $post_id );
@@ -312,7 +312,7 @@ Page 3/3
 	 */
 	public function test_adjacent_rel_links_canonical_split_up_post() {
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'    => 'post',
 				'post_content' => '
 Page 1/5
@@ -321,7 +321,7 @@ Page 2/3
 <!--nextpage-->
 Page 3/3
 ',
-			)
+			]
 		);
 
 		$url = get_permalink( $post_id );
@@ -342,10 +342,10 @@ Page 3/3
 	 */
 	public function test_adjacent_rel_links_non_split_post() {
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_type'    => 'post',
 				'post_content' => 'No nextpage HTML comment present.',
-			)
+			]
 		);
 
 		$url = get_permalink( $post_id );
@@ -371,7 +371,7 @@ Page 3/3
 
 		self::$class_instance->reset();
 		remove_filter( 'wpseo_canonical', '__return_false' );
-		add_filter( 'wpseo_canonical', array( $this, 'filter_canonical_test' ) );
+		add_filter( 'wpseo_canonical', [ $this, 'filter_canonical_test' ] );
 		$this->go_to( home_url() );
 		$this->assertEquals( 'http://canonic.al', self::$class_instance->canonical( false ) );
 	}
@@ -416,8 +416,8 @@ Page 3/3
 		$blog_desc_link = '<a rel="nofollow" href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . get_bloginfo( 'name' ) . ' - ' . get_bloginfo( 'description' ) . '</a>';
 		$expected       = stripslashes( trim( $text ) );
 		$expected       = str_replace(
-			array( '%%AUTHORLINK%%', '%%POSTLINK%%', '%%BLOGLINK%%', '%%BLOGDESCLINK%%' ),
-			array( $author_link, $post_link, $blog_link, $blog_desc_link ),
+			[ '%%AUTHORLINK%%', '%%POSTLINK%%', '%%BLOGLINK%%', '%%BLOGDESCLINK%%' ],
+			[ $author_link, $post_link, $blog_link, $blog_desc_link ],
 			$expected
 		);
 
@@ -513,7 +513,7 @@ Page 3/3
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'show_debug_marker', 'get_debug_mark' ) )
+			->setMethods( [ 'show_debug_marker', 'get_debug_mark' ] )
 			->getMock();
 
 		$frontend
@@ -544,7 +544,7 @@ Page 3/3
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'is_premium' ) )
+			->setMethods( [ 'is_premium' ] )
 			->getMock();
 
 		$frontend
@@ -564,7 +564,7 @@ Page 3/3
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'is_premium' ) )
+			->setMethods( [ 'is_premium' ] )
 			->getMock();
 
 		$frontend
@@ -584,7 +584,7 @@ Page 3/3
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'show_debug_marker', 'get_debug_mark' ) )
+			->setMethods( [ 'show_debug_marker', 'get_debug_mark' ] )
 			->getMock();
 
 		$frontend
@@ -615,7 +615,7 @@ Page 3/3
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'show_debug_marker' ) )
+			->setMethods( [ 'show_debug_marker' ] )
 			->getMock();
 
 		$frontend
@@ -637,7 +637,7 @@ Page 3/3
 		/** @var $frontend WPSEO_Frontend_Double */
 		$frontend = $this
 			->getMockBuilder( 'WPSEO_Frontend_Double' )
-			->setMethods( array( 'show_debug_marker' ) )
+			->setMethods( [ 'show_debug_marker' ] )
 			->getMock();
 
 		$frontend
@@ -797,7 +797,7 @@ Page 3/3
 	public function test_get_queried_post_type() {
 		$wp_query = $this
 			->getMockBuilder( 'WP_Query' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$wp_query
@@ -821,14 +821,14 @@ Page 3/3
 	public function test_get_queried_post_type_array() {
 		$wp_query = $this
 			->getMockBuilder( 'WP_Query' )
-			->setMethods( array( 'get' ) )
+			->setMethods( [ 'get' ] )
 			->getMock();
 
 		$wp_query
 			->expects( $this->once() )
 			->method( 'get' )
 			->with( 'post_type' )
-			->will( $this->returnValue( array( 'my_post_type', 'your_post_type' ) ) );
+			->will( $this->returnValue( [ 'my_post_type', 'your_post_type' ] ) );
 
 		$GLOBALS['wp_query'] = $wp_query;
 

--- a/integration-tests/frontend/test-class-wpseo-handle-404.php
+++ b/integration-tests/frontend/test-class-wpseo-handle-404.php
@@ -106,7 +106,7 @@ class WPSEO_Handle_404_Test extends WPSEO_UnitTestCase {
 	 */
 	private function run_test_on_term_feed( $taxonomy ) {
 		$term = $this->factory->term->create_and_get(
-			array( 'taxonomy' => $taxonomy )
+			[ 'taxonomy' => $taxonomy ]
 		);
 
 		$is_taxonomy = 'is_tax';

--- a/integration-tests/frontend/test-class-wpseo-image-utils.php
+++ b/integration-tests/frontend/test-class-wpseo-image-utils.php
@@ -18,14 +18,14 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 		update_post_meta(
 			$attachment,
 			'_wp_attachment_metadata',
-			array(
+			[
 				'width'  => 1000,
 				'height' => 1000,
-			)
+			]
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				'width'  => 1000,
 				'height' => 1000,
 				'url'    => false,
@@ -35,7 +35,7 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 				'alt'    => '',
 				'pixels' => 1000000,
 				'type'   => '',
-			),
+			],
 			WPSEO_Image_Utils::get_image( $attachment, 'full' )
 		);
 	}
@@ -48,10 +48,10 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 		update_post_meta(
 			$attachment,
 			'_wp_attachment_metadata',
-			array(
+			[
 				'width'  => 1000,
 				'height' => 1000,
-			)
+			]
 		);
 
 		$this->assertFalse( WPSEO_Image_Utils::get_image( $attachment, 'medium' ) );
@@ -95,29 +95,29 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 * @param string  $description Description for the data being tested.
 	 */
 	public function test_get_usable_dimensions( $width, $height, $is_usable, $description = '' ) {
-		$expected = array();
+		$expected = [];
 		if ( $is_usable ) {
-			$expected[] = array(
+			$expected[] = [
 				'width'  => $width,
 				'height' => $height,
-			);
+			];
 		}
 
-		$input = array(
-			array(
+		$input = [
+			[
 				'width'  => $width,
 				'height' => $height,
-			),
-		);
+			],
+		];
 
-		$requirements = array(
+		$requirements = [
 			'min_width'  => 200,
 			'max_width'  => 2000,
 			'min_height' => 200,
 			'max_height' => 2000,
 			'min_ratio'  => 0.333,
 			'max_ratio'  => 3,
-		);
+		];
 
 		$actual = WPSEO_Image_Utils::filter_usable_dimensions( $requirements, $input );
 
@@ -130,19 +130,19 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function data_get_usable_dimensions() {
-		return array(
-			array( 200, 200, true ),
-			array( 200, 199, false ),
-			array( 199, 200, false ),
-			array( 600, 200, true ),
-			array( 601, 200, true ),
-			array( 200, 600, true ),
-			array( 200, 601, true ),
-			array( 2000, 2000, true ),
-			array( 2000, 2001, false ),
-			array( 2001, 2000, false ),
-			array( 1000, 1000, true ),
-		);
+		return [
+			[ 200, 200, true ],
+			[ 200, 199, false ],
+			[ 199, 200, false ],
+			[ 600, 200, true ],
+			[ 601, 200, true ],
+			[ 200, 600, true ],
+			[ 200, 601, true ],
+			[ 2000, 2000, true ],
+			[ 2000, 2001, false ],
+			[ 2001, 2000, false ],
+			[ 1000, 1000, true ],
+		];
 	}
 
 	/**
@@ -168,23 +168,23 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	public function data_get_absolute_path() {
 		$uploads = wp_get_upload_dir();
 
-		return array(
-			array(
+		return [
+			[
 				'/a',
 				$uploads['basedir'] . '/a',
 				'Relative path should receive basedir as prefix.',
-			),
-			array(
+			],
+			[
 				$uploads['basedir'] . '/b',
 				$uploads['basedir'] . '/b',
 				'Absolute path should be returned as is.',
-			),
-			array(
+			],
+			[
 				'/c' . $uploads['basedir'] . '/d',
 				$uploads['basedir'] . '/c' . $uploads['basedir'] . '/d',
 				'Relative path with absolute path inside should be prefixed with basedir.',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -194,105 +194,105 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 */
 	public function get_data_provider() {
 		$attachment_id = self::factory()->attachment->create();
-		return array(
-			array(
+		return [
+			[
 				'image'         => 'This is a string',
 				'expected'      => false,
 				'attachment_id' => $attachment_id,
 				'message'       => 'With a string given as image data',
-			),
-			array(
-				'image'         => array(
+			],
+			[
+				'image'         => [
 					'with' => 'no image',
 					'and'  => 'height keys given',
-				),
+				],
 				'expected'      => false,
 				'attachment_id' => $attachment_id,
 				'message'       => 'An array without the width and height keys',
-			),
-			array(
-				'image'         => array(
+			],
+			[
+				'image'         => [
 					'width'  => '10',
 					'height' => '10',
-				),
-				'expected'      => array(
+				],
+				'expected'      => [
 					'width'  => '10',
 					'height' => '10',
 					'id'     => $attachment_id,
 					'alt'    => '',
 					'pixels' => 100,
 					'type'   => false,
-				),
+				],
 				'attachment_id' => $attachment_id,
 				'message'       => 'With no attachment type given',
-			),
-			array(
-				'image'         => array(
+			],
+			[
+				'image'         => [
 					'width'       => '10',
 					'height'      => '10',
 					'unnecessary' => 'key',
-				),
-				'expected'      => array(
+				],
+				'expected'      => [
 					'width'  => '10',
 					'height' => '10',
 					'id'     => $attachment_id,
 					'alt'    => '',
 					'pixels' => 100,
 					'type'   => false,
-				),
+				],
 				'attachment_id' => $attachment_id,
 				'message'       => 'With unwanted keys being stripped',
-			),
-			array(
-				'image'         => array(
+			],
+			[
+				'image'         => [
 					'width'       => 100,
 					'height'      => 0,
-				),
+				],
 				'expected'      => false,
 				'attachment_id' => $attachment_id,
 				'message'       => 'Empty height should not be parsed as valid image',
-			),
-			array(
-				'image'         => array(
+			],
+			[
+				'image'         => [
 					'width'       => 0,
 					'height'      => 100,
-				),
+				],
 				'expected'      => false,
 				'attachment_id' => $attachment_id,
 				'message'       => 'Empty width should not be parsed as valid image',
-			),
-			array(
-				'image'         => array(
+			],
+			[
+				'image'         => [
 					'width'       => '10',
 					'height'      => '10',
-				),
-				'expected'      => array(
+				],
+				'expected'      => [
 					'width'  => '10',
 					'height' => '10',
 					'id'     => 0,
 					'alt'    => '',
 					'pixels' => 100,
 					'type'   => false,
-				),
+				],
 				'attachment_id' => 0,
 				'message'       => 'With unexisting attachment id',
-			),
-			array(
-				'image'         => array(
+			],
+			[
+				'image'         => [
 					'width'       => 'string',
 					'height'      => 'string',
-				),
-				'expected'      => array(
+				],
+				'expected'      => [
 					'width'  => 'string',
 					'height' => 'string',
 					'id'     => 0,
 					'alt'    => '',
 					'pixels' => 0,
 					'type'   => false,
-				),
+				],
 				'attachment_id' => 0,
 				'message'       => 'With height and width not being an integer',
-			),
-		);
+			],
+		];
 	}
 }

--- a/integration-tests/frontend/test-class-wpseo-opengraph-image.php
+++ b/integration-tests/frontend/test-class-wpseo-opengraph-image.php
@@ -85,7 +85,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	public function test_add_image_relative() {
 		$class_instance = $this->setup_class();
 
-		$class_instance->add_image( array( 'url' => '/test.png' ) );
+		$class_instance->add_image( [ 'url' => '/test.png' ] );
 		$this->assertEquals( $this->sample_array(), $class_instance->get_images() );
 	}
 
@@ -95,8 +95,8 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	public function test_add_image_twice() {
 		$class_instance = $this->setup_class();
 
-		$class_instance->add_image( array( 'url' => 'http://example.org/test.png' ) );
-		$class_instance->add_image( array( 'url' => '/test.png' ) );
+		$class_instance->add_image( [ 'url' => 'http://example.org/test.png' ] );
+		$class_instance->add_image( [ 'url' => '/test.png' ] );
 		$this->assertEquals( $this->sample_array( false ), $class_instance->get_images() );
 	}
 
@@ -156,40 +156,40 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	 * @return array The data.
 	 */
 	public function invalid_image_provider() {
-		return array(
-			array(
-				array( 'url' => 'http://example.org/test.svg' ),
+		return [
+			[
+				[ 'url' => 'http://example.org/test.svg' ],
 				'Adding an SVG as image',
-			),
-			array(
-				array( 'link' => '/test.png' ),
+			],
+			[
+				[ 'link' => '/test.png' ],
 				'With url key missing',
-			),
-			array(
-				array( 'url' => '' ),
+			],
+			[
+				[ 'url' => '' ],
 				'With an empty url given',
-			),
-			array(
-				array( 'url' => null ),
+			],
+			[
+				[ 'url' => null ],
 				'With null given as url',
-			),
-			array(
-				array(),
+			],
+			[
+				[],
 				'With empty array',
-			),
-			array(
+			],
+			[
 				null,
 				'With null given as data',
-			),
-			array(
+			],
+			[
 				false,
 				'With false given as data',
-			),
-			array(
-				(object) array( 'url' => null ),
+			],
+			[
+				(object) [ 'url' => null ],
 				'With object given as data',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -267,10 +267,10 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		copy( $source_image, $full_image_path ); // Prevent original from being deleted.
 
-		$file_array = array(
+		$file_array = [
 			'name'     => $basename,
 			'tmp_name' => $full_image_path,
-		);
+		];
 		$attach_id  = media_handle_sideload( $file_array, $post_id );
 		$filename   = basename( get_attached_file( $attach_id ) );
 
@@ -333,7 +333,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		$class_instance = $this->setup_class();
 
-		$this->assertEquals( array(), $class_instance->get_images() );
+		$this->assertEquals( [], $class_instance->get_images() );
 	}
 
 	/**
@@ -373,16 +373,16 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	public function test_set_taxonomy_image() {
 		$post_id = $this->create_post( 'post' );
 		$term_id = $this->factory()->category->create(
-			array(
+			[
 				'name' => 'Test Category 1',
 				'slug' => 'test1',
-			)
+			]
 		);
 		wp_set_object_terms( $post_id, $term_id, 'category' );
 		WPSEO_Taxonomy_Meta::set_value( $term_id, 'category', 'opengraph-image', '/test.png' );
 
 		$url = add_query_arg(
-			array( 'cat' => $term_id ),
+			[ 'cat' => $term_id ],
 			'/'
 		);
 		$this->go_to( $url );
@@ -413,20 +413,20 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		$featured_image = $upload_dir['path'] . '/' . $basename;
 		copy( $source_image, $featured_image ); // Prevent original from being deleted.
 
-		$file_array = array(
+		$file_array = [
 			'name'     => $basename,
 			'tmp_name' => $featured_image,
-		);
+		];
 		$attach_id  = media_handle_sideload( $file_array, $post_id );
 
 		// Get the image URL so we can add it in the post content.
 		$file           = get_attached_file( $attach_id );
 		$attached_image = $upload_dir['url'] . '/' . basename( $file );
 
-		return array(
+		return [
 			'image' => $attached_image,
 			'id'    => $attach_id,
-		);
+		];
 	}
 
 	/**
@@ -442,24 +442,24 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 		<p>End of post</p>';
 
 		$post_id = self::factory()->post->create(
-			array(
+			[
 				'post_content' => $post_content,
-			)
+			]
 		);
 
 		$opengraph_image = $this
 			->getMockBuilder( 'WPSEO_Opengraph_Image_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'add_image' ) )
+			->setMethods( [ 'add_image' ] )
 			->getMock();
 
 		$opengraph_image
 			->expects( $this->once() )
 			->method( 'add_image' )
 			->with(
-				array(
+				[
 					'url' => $image_url,
-				)
+				]
 			);
 
 		// Run our test.
@@ -505,9 +505,9 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	 */
 	private function create_post( $post_type = 'post' ) {
 		return self::factory()->post->create(
-			array(
+			[
 				'post_type' => $post_type,
-			)
+			]
 		);
 	}
 
@@ -526,21 +526,21 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 
 		copy( $source_image, $featured_image ); // Prevent original from deletion.
 
-		$file_array = array(
+		$file_array = [
 			'name'     => $basename,
 			'tmp_name' => $featured_image,
-		);
+		];
 		$attach_id  = media_handle_sideload( $file_array, $post_id );
 		$file       = get_attached_file( $attach_id );
 		wp_generate_attachment_metadata( $attach_id, $file );
 		update_post_meta( $post_id, '_thumbnail_id', $attach_id );
 
 
-		return array(
+		return [
 			'id'   => $attach_id,
 			'path' => $file,
 			'url'  => $upload_dir['url'] . '/' . basename( $file ),
-		);
+		];
 	}
 
 	/**
@@ -551,11 +551,11 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	private function sample_array( $relative = true ) {
-		return array(
-			'http://example.org/test.png' => array(
+		return [
+			'http://example.org/test.png' => [
 				'url' => ( ( $relative ) ? '/test.png' : 'http://example.org/test.png' ),
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -567,8 +567,8 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 	 * @return array An array for our default file.
 	 */
 	private function sample_full_file_array( $url, $id ) {
-		return array(
-			$url => array(
+		return [
+			$url => [
 				'url'    => $url,
 				'width'  => 500,
 				'height' => 500,
@@ -578,7 +578,7 @@ class WPSEO_OpenGraph_Image_Test extends WPSEO_UnitTestCase {
 				'size'   => 'full',
 				'id'     => $id,
 				'pixels' => 250000,
-			),
-		);
+			],
+		];
 	}
 }

--- a/integration-tests/inc/endpoints/test-class-myyoast-connect.php
+++ b/integration-tests/inc/endpoints/test-class-myyoast-connect.php
@@ -20,7 +20,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 	public function test_get_handle_request_url_mismatch() {
 		$request = $this
 			->getMockBuilder( 'WP_REST_Request' )
-			->setMethods( array( 'get_param' ) )
+			->setMethods( [ 'get_param' ] )
 			->getMock();
 
 		$request
@@ -30,7 +30,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
-			->setMethods( array( 'get_home_url' ) )
+			->setMethods( [ 'get_home_url' ] )
 			->getMock();
 
 		$instance
@@ -55,7 +55,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 	public function test_get_handle_request_client_id_mismatch() {
 		$request = $this
 			->getMockBuilder( 'WP_REST_Request' )
-			->setMethods( array( 'get_param' ) )
+			->setMethods( [ 'get_param' ] )
 			->getMock();
 
 		$request
@@ -70,7 +70,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
-			->setMethods( array( 'get_home_url', 'get_client_id' ) )
+			->setMethods( [ 'get_home_url', 'get_client_id' ] )
 			->getMock();
 
 		$instance
@@ -100,7 +100,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 	public function test_get_handle_request_client_secret_missing() {
 		$request = $this
 			->getMockBuilder( 'WP_REST_Request' )
-			->setMethods( array( 'get_param' ) )
+			->setMethods( [ 'get_param' ] )
 			->getMock();
 
 		$request
@@ -116,7 +116,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
-			->setMethods( array( 'get_home_url', 'get_client_id' ) )
+			->setMethods( [ 'get_home_url', 'get_client_id' ] )
 			->getMock();
 
 		$instance
@@ -146,7 +146,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 	public function test_get_handle_request() {
 		$request = $this
 			->getMockBuilder( 'WP_REST_Request' )
-			->setMethods( array( 'get_param' ) )
+			->setMethods( [ 'get_param' ] )
 			->getMock();
 
 		$request
@@ -162,7 +162,7 @@ class WPSEO_Endpoint_MyYoast_Connect_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Endpoint_MyYoast_Connect' )
-			->setMethods( array( 'get_home_url', 'get_client_id', 'save_secret' ) )
+			->setMethods( [ 'get_home_url', 'get_client_id', 'save_secret' ] )
 			->getMock();
 
 		$instance

--- a/integration-tests/inc/indexables/test-class-indexable.php
+++ b/integration-tests/inc/indexables/test-class-indexable.php
@@ -37,16 +37,16 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Indexable_Double' )
 			->setConstructorArgs(
-				array(
-					array( 'field' => 'value' ),
-				)
+				[
+					[ 'field' => 'value' ],
+				]
 			)
-			->setMethods( array( 'validate_data' ) )
+			->setMethods( [ 'validate_data' ] )
 			->getMock();
 
-		$instance->set_data( array( 'field' => 'value' ) );
+		$instance->set_data( [ 'field' => 'value' ] );
 
-		$this->assertEquals( array( 'field' => 'value' ), $instance->to_array() );
+		$this->assertEquals( [ 'field' => 'value' ], $instance->to_array() );
 	}
 
 	/**
@@ -58,27 +58,27 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Indexable_Double' )
 			->setConstructorArgs(
-				array(
-					array(
+				[
+					[
 						'object_id'   => '1',
 						'description' => '',
 						'title'       => '',
-					),
-				)
+					],
+				]
 			)
-			->setMethods( array( 'validate_data' ) )
+			->setMethods( [ 'validate_data' ] )
 			->getMock();
 
-		$supplied_values = array(
+		$supplied_values = [
 			'object_id'   => '1',
 			'description' => '',
 			'title'       => '',
-		);
+		];
 
-		$expected = array(
+		$expected = [
 			'description' => '',
 			'title'       => '',
-		);
+		];
 
 		$data = $instance->filter_updateable_data( $supplied_values );
 
@@ -91,12 +91,12 @@ class WPSEO_Indexable_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function noindex_conversion_provider() {
-		return array(
-			array( '1', true, 'With noindex set to string value of 1' ),
-			array( '2', false, 'With noindex set to string value of 2' ),
-			array( true, null, 'With noindex set to boolean value of true' ),
-			array( false, null, 'With noindex set to boolean value of false' ),
-			array( null, null, 'With noindex set to value of null' ),
-		);
+		return [
+			[ '1', true, 'With noindex set to string value of 1' ],
+			[ '2', false, 'With noindex set to string value of 2' ],
+			[ true, null, 'With noindex set to boolean value of true' ],
+			[ false, null, 'With noindex set to boolean value of false' ],
+			[ null, null, 'With noindex set to value of null' ],
+		];
 	}
 }

--- a/integration-tests/inc/indexables/test-class-object-type.php
+++ b/integration-tests/inc/indexables/test-class-object-type.php
@@ -27,7 +27,7 @@ class WPSEO_Object_Type_Test extends WPSEO_UnitTestCase {
 
 		$this->class_instance = $this
 			->getMockBuilder( 'WPSEO_Object_Type' )
-			->setConstructorArgs( array( 1, 'post', 'post', 'the-permalink' ) )
+			->setConstructorArgs( [ 1, 'post', 'post', 'the-permalink' ] )
 			->getMockForAbstractClass();
 	}
 

--- a/integration-tests/inc/indexables/test-class-post-indexable.php
+++ b/integration-tests/inc/indexables/test-class-post-indexable.php
@@ -22,10 +22,10 @@ class WPSEO_Post_Indexable_Test extends WPSEO_UnitTestCase {
 			->factory()
 			->post
 			->create_and_get(
-				array(
+				[
 					'title'     => 'test post',
 					'post_type' => 'post',
-				)
+				]
 			);
 
 		$instance = WPSEO_Post_Indexable::from_object( $post->ID );
@@ -52,15 +52,15 @@ class WPSEO_Post_Indexable_Test extends WPSEO_UnitTestCase {
 			->factory()
 			->post
 			->create_and_get(
-				array(
+				[
 					'title'     => 'test post',
 					'post_type' => 'post',
-				)
+				]
 			);
 
 		$instance     = WPSEO_Post_Indexable::from_object( $post->ID );
 		$new_instance = $instance->update(
-			array( 'is_robots_noindex' => true )
+			[ 'is_robots_noindex' => true ]
 		);
 
 		$this->assertInstanceOf( 'WPSEO_Post_Indexable', $new_instance );

--- a/integration-tests/inc/indexables/test-class-term-indexable.php
+++ b/integration-tests/inc/indexables/test-class-term-indexable.php
@@ -39,10 +39,10 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 			->factory()
 			->term
 			->create_and_get(
-				array(
+				[
 					'name'     => 'robot',
 					'taxonomy' => 'category',
-				)
+				]
 			);
 
 		$instance = WPSEO_Term_Indexable_Double::from_object( $term->term_id );
@@ -69,15 +69,15 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 			->factory()
 			->term
 			->create_and_get(
-				array(
+				[
 					'name'     => 'robot',
 					'taxonomy' => 'category',
-				)
+				]
 			);
 
 		$instance     = WPSEO_Term_Indexable_Double::from_object( $term->term_id );
 		$new_instance = $instance->update(
-			array( 'is_robots_noindex' => true )
+			[ 'is_robots_noindex' => true ]
 		);
 
 		$this->assertInstanceOf( 'WPSEO_Term_Indexable', $new_instance );
@@ -93,10 +93,10 @@ class WPSEO_Term_Indexable_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function robots_noindex_provider() {
-		return array(
-			array( 'noindex', true, 'With value set to noindex' ),
-			array( 'index', false, 'With value set to index' ),
-			array( 'default', null, 'With default value' ),
-		);
+		return [
+			[ 'noindex', true, 'With value set to noindex' ],
+			[ 'index', false, 'With value set to index' ],
+			[ 'default', null, 'With default value' ],
+		];
 	}
 }

--- a/integration-tests/inc/options/test-class-wpseo-option-titles.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-titles.php
@@ -20,12 +20,12 @@ class WPSEO_Option_Titles_Test extends WPSEO_UnitTestCase {
 		$wpseo_option_titles = WPSEO_Option_Titles::get_instance();
 
 		// Register all actions again as they will have been removed in previous teardowns.
-		add_action( 'registered_post_type', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'unregistered_post_type', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'registered_taxonomy', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
-		add_action( 'unregistered_taxonomy', array( $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ) );
+		add_action( 'registered_post_type', [ $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ] );
+		add_action( 'unregistered_post_type', [ $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ] );
+		add_action( 'registered_taxonomy', [ $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ] );
+		add_action( 'unregistered_taxonomy', [ $wpseo_option_titles, 'invalidate_enrich_defaults_cache' ] );
 
-		register_post_type( 'custom-post-type', array( 'public' => true ) );
+		register_post_type( 'custom-post-type', [ 'public' => true ] );
 		$this->assertArrayHasKey( 'title-custom-post-type', $wpseo_option_titles->get_defaults() );
 
 		register_taxonomy( 'custom-taxonomy', 'post' );

--- a/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
@@ -15,7 +15,7 @@ class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	protected $feature_vars = array(
+	protected $feature_vars = [
 		'disableadvanced_meta',
 		'onpage_indexability',
 		'content_analysis_active',
@@ -24,7 +24,7 @@ class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 		'enable_cornerstone_content',
 		'enable_xml_sitemap',
 		'enable_text_link_counter',
-	);
+	];
 
 	/**
 	 * Tests that disabled 'wpseo' feature variables return false.

--- a/integration-tests/inc/options/test-class-wpseo-option.php
+++ b/integration-tests/inc/options/test-class-wpseo-option.php
@@ -20,11 +20,11 @@ class WPSEO_Option_Test extends WPSEO_UnitTestCase {
 	public function test_prevent_disabled_options_update() {
 		$this->skipWithoutMultisite();
 
-		$option_vars = array(
+		$option_vars = [
 			'enable_admin_bar_menu',
 			'enable_cornerstone_content',
 			'enable_xml_sitemap',
-		);
+		];
 
 		foreach ( $option_vars as $option_var ) {
 			WPSEO_Options::save_option( 'wpseo', $option_var, true );

--- a/integration-tests/inc/options/test-class-wpseo-options-backfill.php
+++ b/integration-tests/inc/options/test-class-wpseo-options-backfill.php
@@ -15,10 +15,10 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_contents_of_wpseo_rss() {
 		// Setup data to expect.
-		$expected = array(
+		$expected = [
 			'rssbefore' => 'a',
 			'rssafter'  => 'b',
-		);
+		];
 
 		$this->set_options( $expected );
 
@@ -30,21 +30,21 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_contents_of_wpseo_xml() {
 		// Setup data to expect.
-		$expected = array(
+		$expected = [
 			'enablexmlsitemap'       => true,
 			'disable_author_sitemap' => false,
 			'disable_author_noposts' => true,
 			'entries-per-page'       => 1000,
-			'excluded-posts'         => array(),
-		);
+			'excluded-posts'         => [],
+		];
 
-		$option_input = array(
+		$option_input = [
 			'enable_xml_sitemap'     => true, // Note: this is a different key than in $expected!
 			'disable_author_sitemap' => false,
 			'disable_author_noposts' => true,
 			'entries-per-page'       => 1000,
-			'excluded-posts'         => array(),
-		);
+			'excluded-posts'         => [],
+		];
 		$this->set_options( $option_input );
 
 		$this->assertEquals( $expected, get_option( 'wpseo_xml' ) );
@@ -55,7 +55,7 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_contents_of_wpseo_permalinks() {
 		// Setup data to expect.
-		$expected = array(
+		$expected = [
 			'redirectattachment'              => true,
 			'stripcategorybase'               => false,
 
@@ -66,12 +66,12 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 			'cleanreplytocom'                 => false,
 			'cleanslugs'                      => false,
 			'trailingslash'                   => false,
-		);
+		];
 
-		$unexpected = array(
+		$unexpected = [
 			'disable-attachment' => true,
 			'stripcategorybase'  => false,
-		);
+		];
 		$this->set_options( $unexpected );
 
 		$this->assertEquals( $expected, get_option( 'wpseo_permalinks' ) );
@@ -84,7 +84,7 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_contents_of_wpseo_internallinks() {
 		// Setup data to expect.
-		$expected = array(
+		$expected = [
 			'breadcrumbs-404crumb'      => 'a',
 			'breadcrumbs-blog-remove'   => true,
 			'breadcrumbs-boldlast'      => true,
@@ -94,7 +94,7 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 			'breadcrumbs-prefix'        => 'd',
 			'breadcrumbs-searchprefix'  => 'e',
 			'breadcrumbs-sep'           => 'f',
-		);
+		];
 
 		$this->set_options( $expected );
 
@@ -129,14 +129,14 @@ class WPSEO_Options_Backfill_Test extends WPSEO_UnitTestCase {
 	 * Tests the expected fields to be present and filled in the wpseo option.
 	 */
 	public function test_added_fields_to_wpseo() {
-		$expected = array(
+		$expected = [
 			'website_name'           => 'a',
 			'alternate_website_name' => 'b',
 			'company_logo'           => 'http://c',
 			'company_name'           => 'd',
 			'company_or_person'      => 'company',
 			'person_name'            => 'f',
-		);
+		];
 
 		$this->set_options( $expected );
 

--- a/integration-tests/inc/options/test-class-wpseo-options.php
+++ b/integration-tests/inc/options/test-class-wpseo-options.php
@@ -37,7 +37,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_options
 	 */
 	public function test_get_options_IS_EMPTY_with_empty_array() {
-		$result = WPSEO_Options::get_options( array() );
+		$result = WPSEO_Options::get_options( [] );
 		$this->assertEmpty( $result );
 	}
 
@@ -47,7 +47,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_options
 	 */
 	public function test_get_options_IS_EMPTY_with_invalid_option_names() {
-		$result = WPSEO_Options::get_options( array( 'nonexistent_option_one', 'nonexistent_option_two' ) );
+		$result = WPSEO_Options::get_options( [ 'nonexistent_option_one', 'nonexistent_option_two' ] );
 		$this->assertEmpty( $result );
 	}
 
@@ -58,7 +58,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get_options
 	 */
 	public function test_get_options_HAS_VALID_KEYS_with_valid_option_names() {
-		$result = WPSEO_Options::get_options( array( 'wpseo_social', 'wpseo_titles' ) );
+		$result = WPSEO_Options::get_options( [ 'wpseo_social', 'wpseo_titles' ] );
 		$this->assertArrayHasKey( 'opengraph', $result );
 	}
 
@@ -137,8 +137,8 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Options::get
 	 */
 	public function test_get_returns_default_result() {
-		$result = WPSEO_Options::get( 'non_existent_value', array() );
-		$this->assertEquals( array(), $result );
+		$result = WPSEO_Options::get( 'non_existent_value', [] );
+		$this->assertEquals( [], $result );
 	}
 
 	/**
@@ -169,7 +169,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Option::get_option
 	 */
 	public function test_make_sure_keys_are_unique_over_options() {
-		$keys = array();
+		$keys = [];
 
 		// Make sure the backfilling is not being done when determining "real" unique option names.
 		remove_all_actions( 'option_wpseo' );
@@ -179,7 +179,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 			$option_keys = array_keys( WPSEO_Options::get_option( $option_name ) );
 			$intersected = array_intersect( $option_keys, $keys );
 
-			$this->assertEquals( array(), $intersected, 'Option keys must be unique (' . $option_name . ').' );
+			$this->assertEquals( [], $intersected, 'Option keys must be unique (' . $option_name . ').' );
 
 			$keys = array_merge( $keys, $option_keys );
 		}
@@ -196,7 +196,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	public function test_ms_options_included_in_get_in_multisite() {
 		$this->skipWithoutMultisite();
 
-		$ms_option_keys = array(
+		$ms_option_keys = [
 			'access',
 			'defaultblog',
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'disableadvanced_meta',
@@ -207,7 +207,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'enable_cornerstone_content',
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'enable_xml_sitemap',
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'enable_text_link_counter',
-		);
+		];
 
 		foreach ( $ms_option_keys as $key ) {
 			$this->assertNotNull( WPSEO_Options::get( $key ) );
@@ -225,7 +225,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	public function test_ms_options_excluded_in_get_non_multisite() {
 		$this->skipWithMultisite();
 
-		$ms_option_keys = array(
+		$ms_option_keys = [
 			'access',
 			'defaultblog',
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'disableadvanced_meta',
@@ -236,7 +236,7 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'enable_cornerstone_content',
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'enable_xml_sitemap',
 			WPSEO_Option::ALLOW_KEY_PREFIX . 'enable_text_link_counter',
-		);
+		];
 
 		foreach ( $ms_option_keys as $key ) {
 			$this->assertNull( WPSEO_Options::get( $key ) );

--- a/integration-tests/inc/options/test-class-wpseo-taxonomy-meta.php
+++ b/integration-tests/inc/options/test-class-wpseo-taxonomy-meta.php
@@ -28,9 +28,9 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 		$GLOBALS['wp_query']->queried_object = self::factory()
 			->term
 			->create_and_get(
-				array(
+				[
 					'taxonomy' => null,
-				)
+				]
 			);
 
 		$this->assertFalse( WPSEO_Taxonomy_Meta::get_meta_without_term( 'meta_field' ) );
@@ -45,9 +45,9 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 		$GLOBALS['wp_query']->queried_object = self::factory()
 			->term
 			->create_and_get(
-				array(
+				[
 					'taxonomy' => 'category',
-				)
+				]
 			);
 
 		$this->assertEquals( '', WPSEO_Taxonomy_Meta::get_meta_without_term( 'meta_field' ) );
@@ -64,28 +64,28 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 		 * so it should closely resemble what a user could type in the field.
 		 * Normally this is already provided like this through JavaScript.
 		 */
-		$input = array(
+		$input = [
 			'wpseo_noindex'         => 'index',
 			'wpseo_canonical'       => 'https://yoast.com/',
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
 			'wpseo_focuskeywords'   => WPSEO_Utils::format_json_encode(
-				array(
-					array(
+				[
+					[
 						'keyword' => '\"test\"',
 						'score'   => 'good',
-					),
-					array(
+					],
+					[
 						'keyword' => '\\',
 						'score'   => 'bad',
-					),
-				)
+					],
+				]
 			),
-			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( [ '""TESTING""', '""""' ] ),
 			'wpseo_focuskw'         => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_title'           => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_opengraph-title' => '&quotdouble quotes" and \backslashes\.',
-		);
+		];
 		$this->assertEquals( $input, WPSEO_Taxonomy_Meta::validate_term_meta_data( $input, WPSEO_Taxonomy_Meta::$defaults_per_term ) );
 	}
 
@@ -100,51 +100,51 @@ class WPSEO_Taxonomy_Meta_Test extends WPSEO_UnitTestCase {
 		 * so it should closely resemble what a user could type in the field.
 		 * Normally this is already provided like this through JavaScript.
 		 */
-		$expected = array(
+		$expected = [
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
 			'wpseo_canonical'       => 'https://yoast.com/test%20space',
 			'wpseo_focuskeywords'   => WPSEO_Utils::format_json_encode(
-				array(
-					array(
+				[
+					[
 						'keyword' => '\"test\"',
 						'score'   => 'good',
-					),
-					array(
+					],
+					[
 						'keyword' => '\\',
 						'score'   => 'bad',
-					),
-				)
+					],
+				]
 			),
-			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( [ '""TESTING""', '""""' ] ),
 			'wpseo_focuskw'         => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_title'           => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" and \backslashes\.',
 			'wpseo_opengraph-title' => '&quotdouble quotes" and \backslashes\.',
-		);
+		];
 		// With added data that is expected to be removed.
-		$input = array(
+		$input = [
 			'wpseo_noindex'         => 'extra something',
 			'wpseo_canonical'       => 'https://yoast.com/test space',
 			'wpseo_bctitle'         => 'this can contain \backslashes\.',
 			'wpseo_focuskeywords'   => WPSEO_Utils::format_json_encode(
-				array(
-					array(
+				[
+					[
 						'keyword' => '\"test\"',
 						'score'   => 'good',
 						'extra'   => 'will get removed',
-					),
-					array(
+					],
+					[
 						'keyword' => '\\',
 						'score'   => 'bad',
-					),
-				)
+					],
+				]
 			),
-			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( array( '""TESTING""', '""""' ) ),
+			'wpseo_keywordsynonyms' => WPSEO_Utils::format_json_encode( [ '""TESTING""', '""""' ] ),
 			'wpseo_focuskw'         => '  &quotdouble quotes" `>&lt;&gt;&#96<`and \backslashes\.  ',
 			'wpseo_title'           => '&quotdouble quotes"			and \backslashes\.',
 			'wpseo_desc'            => '&quotdouble quotes" <>and<> \backslashes\.',
 			'wpseo_opengraph-title' => '&quotdouble quotes" %aband \backslashes\.',
-		);
+		];
 		$this->assertEquals( $expected, WPSEO_Taxonomy_Meta::validate_term_meta_data( $input, WPSEO_Taxonomy_Meta::$defaults_per_term ) );
 	}
 }

--- a/integration-tests/inc/test-class-myyoast-api-request.php
+++ b/integration-tests/inc/test-class-myyoast-api-request.php
@@ -21,8 +21,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	public function test_fire() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request' )
-			->setMethods( array( 'do_request', 'decode_response' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'do_request', 'decode_response' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
@@ -48,8 +48,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	public function test_fire_with_bad_request_exception_being_thrown() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request' )
-			->setMethods( array( 'do_request', 'decode_response' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'do_request', 'decode_response' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
@@ -78,8 +78,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request' )
-			->setMethods( array( 'do_request', 'decode_response', 'get_access_token' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'do_request', 'decode_response', 'get_access_token' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
@@ -115,8 +115,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request' )
-			->setMethods( array( 'do_request', 'decode_response', 'get_access_token', 'remove_access_token' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'do_request', 'decode_response', 'get_access_token', 'remove_access_token' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
@@ -152,8 +152,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request' )
-			->setMethods( array( 'do_request', 'decode_response', 'get_access_token' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'do_request', 'decode_response', 'get_access_token' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
@@ -186,13 +186,13 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	public function test_decode_response() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request' )
-			->setMethods( array( 'do_request' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'do_request' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
-		$response = array(
+		$response = [
 			'response' => 'okay!',
-		);
+		];
 
 		$instance
 			->expects( $this->once() )
@@ -213,8 +213,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	public function test_decode_response_wrong_output() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request' )
-			->setMethods( array( 'do_request' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'do_request' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
@@ -234,8 +234,8 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	public function test_enrich_request_arguments() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request_Double' )
-			->setMethods( array( 'get_request_body', 'get_installed_addon_versions' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'get_request_body', 'get_installed_addon_versions' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
@@ -243,9 +243,9 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			->method( 'get_request_body' )
 			->will(
 				$this->returnValue(
-					array(
+					[
 						'This is' => 'the request body',
-					)
+					]
 				)
 			);
 
@@ -254,22 +254,22 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			->method( 'get_installed_addon_versions' )
 			->will(
 				$this->returnValue(
-					array(
+					[
 						'yoast-seo-wordpress-premium' => '10.0',
-					)
+					]
 				)
 			);
 
 		$this->assertEquals(
-			array(
-				'body'    => array(
+			[
+				'body'    => [
 					'This is' => 'the request body',
-				),
-				'headers' => array(
+				],
+				'headers' => [
 					'yoast-seo-wordpress-premium-version' => '10.0',
-				),
-			),
-			$instance->enrich_request_arguments( array() )
+				],
+			],
+			$instance->enrich_request_arguments( [] )
 		);
 	}
 
@@ -281,33 +281,33 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	public function test_enrich_request_arguments_with_empty_request_body() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_MyYoast_Api_Request_Double' )
-			->setMethods( array( 'get_request_body', 'get_installed_addon_versions' ) )
-			->setConstructorArgs( array( 'endpoint' ) )
+			->setMethods( [ 'get_request_body', 'get_installed_addon_versions' ] )
+			->setConstructorArgs( [ 'endpoint' ] )
 			->getMock();
 
 		$instance
 			->expects( $this->once() )
 			->method( 'get_request_body' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$instance
 			->expects( $this->once() )
 			->method( 'get_installed_addon_versions' )
 			->will(
 				$this->returnValue(
-					array(
+					[
 						'yoast-seo-wordpress-premium' => '10.0',
-					)
+					]
 				)
 			);
 
 		$this->assertEquals(
-			array(
-				'headers' => array(
+			[
+				'headers' => [
 					'yoast-seo-wordpress-premium-version' => '10.0',
-				),
-			),
-			$instance->enrich_request_arguments( array() )
+				],
+			],
+			$instance->enrich_request_arguments( [] )
 		);
 	}
 
@@ -320,12 +320,12 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	 * @expectedExceptionMessage Error
 	 */
 	public function test_exception_arguments() {
-		add_filter( 'pre_http_request', array( $this, 'return_error_object' ) );
+		add_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
 
-		$instance = new WPSEO_MyYoast_Api_Request_Double( 'some_url', array() );
-		$instance->do_request( 'some_url', array() );
+		$instance = new WPSEO_MyYoast_Api_Request_Double( 'some_url', [] );
+		$instance->do_request( 'some_url', [] );
 
-		remove_filter( 'pre_http_request', array( $this, 'return_error_object' ) );
+		remove_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
 	}
 
 	/**

--- a/integration-tests/inc/test-class-post-type.php
+++ b/integration-tests/inc/test-class-post-type.php
@@ -39,7 +39,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_a_custom_post_type() {
-		register_post_type( 'custom-post-type', array( 'public' => true ) );
+		register_post_type( 'custom-post-type', [ 'public' => true ] );
 
 		$this->assertContains( 'custom-post-type', WPSEO_Post_Type::get_accessible_post_types() );
 	}
@@ -52,10 +52,10 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	public function test_get_accessible_post_types_with_a_custom_post_type_that_is_noy_publicly_queryable() {
 		register_post_type(
 			'hidden-post-type',
-			array(
+			[
 				'public'             => true,
 				'publicly_queryable' => false,
-			)
+			]
 		);
 
 		$this->assertNotContains( 'hidden-post-type', WPSEO_Post_Type::get_accessible_post_types() );
@@ -67,7 +67,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_a_custom_private_post_type() {
-		register_post_type( 'custom-post-type', array( 'public' => false ) );
+		register_post_type( 'custom-post-type', [ 'public' => false ] );
 
 		$this->assertNotContains( 'custom-post-type', WPSEO_Post_Type::get_accessible_post_types() );
 	}
@@ -78,7 +78,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_a_non_indexable_post_type() {
-		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
+		$custom_post_type = register_post_type( 'custom-post-type', [ 'public' => true ] );
 
 		WPSEO_Options::set( 'noindex-' . $custom_post_type->name, true );
 
@@ -92,7 +92,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::get_accessible_post_types
 	 */
 	public function test_get_accessible_post_types_with_an_indexable_post_type() {
-		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
+		$custom_post_type = register_post_type( 'custom-post-type', [ 'public' => true ] );
 
 		WPSEO_Options::set( 'noindex-' . $custom_post_type->name, false );
 
@@ -105,9 +105,9 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	public function test_get_accessible_post_types_with_a_filter_hook() {
 		$this->assertContains( 'attachment', WPSEO_Post_Type::get_accessible_post_types() );
 
-		add_filter( 'wpseo_accessible_post_types', array( $this, 'filter_attachment' ) );
+		add_filter( 'wpseo_accessible_post_types', [ $this, 'filter_attachment' ] );
 		$this->assertNotContains( 'attachment', WPSEO_Post_Type::get_accessible_post_types() );
-		remove_filter( 'wpseo_accessible_post_types', array( $this, 'filter_attachment' ) );
+		remove_filter( 'wpseo_accessible_post_types', [ $this, 'filter_attachment' ] );
 	}
 
 	/**
@@ -116,7 +116,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	public function test_get_accessible_post_types_with_a_filter_hook_that_returns_wrong_type() {
 		add_filter( 'wpseo_accessible_post_types', '__return_true' );
 
-		$this->assertEquals( array(), WPSEO_Post_Type::get_accessible_post_types() );
+		$this->assertEquals( [], WPSEO_Post_Type::get_accessible_post_types() );
 
 		remove_filter( 'wpseo_accessible_post_types', '__return_true' );
 	}
@@ -127,7 +127,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::is_post_type_indexable
 	 */
 	public function test_is_post_type_indexable_with_indexable_post_type() {
-		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
+		$custom_post_type = register_post_type( 'custom-post-type', [ 'public' => true ] );
 
 		WPSEO_Options::set( 'noindex-' . $custom_post_type->name, false );
 
@@ -140,7 +140,7 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type::is_post_type_indexable
 	 */
 	public function test_is_post_type_indexable_with_non_indexable_post_type() {
-		$custom_post_type = register_post_type( 'custom-post-type', array( 'public' => true ) );
+		$custom_post_type = register_post_type( 'custom-post-type', [ 'public' => true ] );
 
 		WPSEO_Options::set( 'noindex-' . $custom_post_type->name, true );
 
@@ -156,10 +156,10 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 		$this->assertNotContains(
 			'attachment',
 			WPSEO_Post_Type::filter_attachment_post_type(
-				array(
+				[
 					'post'       => 'post',
 					'attachment' => 'attachment',
-				)
+				]
 			)
 		);
 	}
@@ -188,14 +188,14 @@ class WPSEO_Post_Type_Test extends WPSEO_UnitTestCase {
 
 		register_post_type(
 			'custom-post-type-api',
-			array(
+			[
 				'public'       => true,
 				'show_in_rest' => true,
-			)
+			]
 		);
 		$this->assertTrue( WPSEO_Post_Type::is_rest_enabled( 'custom-post-type-api' ) );
 
-		register_post_type( 'custom-post-type', array( 'public' => true ) );
+		register_post_type( 'custom-post-type', [ 'public' => true ] );
 		$this->assertFalse( WPSEO_Post_Type::is_rest_enabled( 'custom-post-type' ) );
 	}
 }

--- a/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
+++ b/integration-tests/inc/test-class-wpseo-admin-bar-menu.php
@@ -29,13 +29,13 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	private $mock_wpseo_admin_bar_menu_methods = array(
+	private $mock_wpseo_admin_bar_menu_methods = [
 		'add_root_menu',
 		'add_keyword_research_submenu',
 		'add_analysis_submenu',
 		'add_settings_submenu',
 		'add_network_settings_submenu',
-	);
+	];
 
 	/**
 	 * Sets up user instances to use in tests.
@@ -49,10 +49,10 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
 		}
 
-		self::$wpseo_manager = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$wpseo_manager = $factory->user->create( [ 'role' => 'editor' ] );
 		get_userdata( self::$wpseo_manager )->add_cap( 'wpseo_manage_options' );
 
-		self::$network_administrator = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$network_administrator = $factory->user->create( [ 'role' => 'administrator' ] );
 		grant_super_admin( self::$network_administrator );
 	}
 
@@ -75,7 +75,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	public function test_add_menu_lacking_capabilities() {
 		$admin_bar_menu = $this
 			->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
-			->setConstructorArgs( array( $this->get_asset_manager() ) )
+			->setConstructorArgs( [ $this->get_asset_manager() ] )
 			->setMethods( $this->mock_wpseo_admin_bar_menu_methods )
 			->getMock();
 
@@ -114,7 +114,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 
 		$admin_bar_menu = $this
 			->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
-			->setConstructorArgs( array( $this->get_asset_manager() ) )
+			->setConstructorArgs( [ $this->get_asset_manager() ] )
 			->setMethods( $this->mock_wpseo_admin_bar_menu_methods )
 			->getMock();
 
@@ -153,7 +153,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	public function test_enqueue_assets_without_admin_bar() {
 		add_filter( 'show_admin_bar', '__return_false' );
 
-		$asset_manager = $this->get_asset_manager( array( 'register_assets', 'enqueue_style' ) );
+		$asset_manager = $this->get_asset_manager( [ 'register_assets', 'enqueue_style' ] );
 
 		$asset_manager
 			->expects( $this->never() )
@@ -176,7 +176,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 		add_filter( 'show_admin_bar', '__return_true' );
 		wp_set_current_user( self::$wpseo_manager );
 
-		$asset_manager = $this->get_asset_manager( array( 'register_assets', 'enqueue_style' ) );
+		$asset_manager = $this->get_asset_manager( [ 'register_assets', 'enqueue_style' ] );
 
 		$asset_manager
 			->expects( $this->once() )
@@ -198,8 +198,8 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_hooks() {
 		$admin_bar_menu = $this->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
-			->setConstructorArgs( array( $this->get_asset_manager() ) )
-			->setMethods( array( 'meets_requirements' ) )
+			->setConstructorArgs( [ $this->get_asset_manager() ] )
+			->setMethods( [ 'meets_requirements' ] )
 			->getMock();
 
 		$admin_bar_menu
@@ -208,9 +208,9 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( true ) );
 
 		$admin_bar_menu->register_hooks();
-		$this->assertInternalType( 'int', has_action( 'admin_bar_menu', array( $admin_bar_menu, 'add_menu' ), 95 ) );
-		$this->assertInternalType( 'int', has_action( 'wp_enqueue_scripts', array( $admin_bar_menu, 'enqueue_assets' ) ) );
-		$this->assertInternalType( 'int', has_action( 'admin_enqueue_scripts', array( $admin_bar_menu, 'enqueue_assets' ) ) );
+		$this->assertInternalType( 'int', has_action( 'admin_bar_menu', [ $admin_bar_menu, 'add_menu' ], 95 ) );
+		$this->assertInternalType( 'int', has_action( 'wp_enqueue_scripts', [ $admin_bar_menu, 'enqueue_assets' ] ) );
+		$this->assertInternalType( 'int', has_action( 'admin_enqueue_scripts', [ $admin_bar_menu, 'enqueue_assets' ] ) );
 	}
 
 	/**
@@ -223,12 +223,12 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 
 		WPSEO_Options::get_instance();
 
-		add_filter( 'option_wpseo', array( $this, 'filter_enable_admin_bar_menu_false' ), 9999 );
-		add_filter( 'default_option_wpseo', array( $this, 'filter_enable_admin_bar_menu_false' ), 9999 );
+		add_filter( 'option_wpseo', [ $this, 'filter_enable_admin_bar_menu_false' ], 9999 );
+		add_filter( 'default_option_wpseo', [ $this, 'filter_enable_admin_bar_menu_false' ], 9999 );
 		$first_result = $admin_bar_menu->meets_requirements();
 
-		add_filter( 'option_wpseo', array( $this, 'filter_enable_admin_bar_menu_true' ), 10000 );
-		add_filter( 'default_option_wpseo', array( $this, 'filter_enable_admin_bar_menu_true' ), 10000 );
+		add_filter( 'option_wpseo', [ $this, 'filter_enable_admin_bar_menu_true' ], 10000 );
+		add_filter( 'default_option_wpseo', [ $this, 'filter_enable_admin_bar_menu_true' ], 10000 );
 		$second_result = $admin_bar_menu->meets_requirements();
 
 		$this->assertFalse( $first_result );
@@ -320,14 +320,14 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @return WPSEO_Admin_Asset_Manager Asset manager instance.
 	 */
-	protected function get_asset_manager( array $mock_methods = array() ) {
+	protected function get_asset_manager( array $mock_methods = [] ) {
 		if ( empty( $mock_methods ) ) {
 			return new WPSEO_Admin_Asset_Manager( new WPSEO_Admin_Asset_SEO_Location( WP_PLUGIN_DIR . '/wordpress-seo/wp-seo.php' ) );
 		}
 
 		return $this
 			->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
-			->setConstructorArgs( array( new WPSEO_Admin_Asset_SEO_Location( WP_PLUGIN_DIR . '/wordpress-seo/wp-seo.php' ) ) )
+			->setConstructorArgs( [ new WPSEO_Admin_Asset_SEO_Location( WP_PLUGIN_DIR . '/wordpress-seo/wp-seo.php' ) ] )
 			->setMethods( $mock_methods )
 			->getMock();
 	}

--- a/integration-tests/inc/test-class-wpseo-primary-term.php
+++ b/integration-tests/inc/test-class-wpseo-primary-term.php
@@ -79,7 +79,7 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 		$term_first  = get_term_by( 'name', 'yoast', 'category' );
 		$term_second = get_term_by( 'name', 'seo', 'category' );
 
-		$post_id = $this->factory->post->create( array( 'post_category' => array( $term_first->term_id, $term_second->term_id ) ) );
+		$post_id = $this->factory->post->create( [ 'post_category' => [ $term_first->term_id, $term_second->term_id ] ] );
 
 		$class_instance = new WPSEO_Primary_Term( $this->taxonomy_name, $post_id );
 
@@ -96,6 +96,6 @@ class WPSEO_Primary_Term_Test extends WPSEO_UnitTestCase {
 
 		$class_instance->set_primary_term( $this->primary_term_id );
 
-		$this->assertEquals( array( $this->primary_term_id ), get_post_meta( $this->post_id, '_yoast_wpseo_primary_' . $this->taxonomy_name ) );
+		$this->assertEquals( [ $this->primary_term_id ], get_post_meta( $this->post_id, '_yoast_wpseo_primary_' . $this->taxonomy_name ) );
 	}
 }

--- a/integration-tests/inc/test-class-wpseo-upgrade-history.php
+++ b/integration-tests/inc/test-class-wpseo-upgrade-history.php
@@ -85,7 +85,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 		update_option( 'mock_option_name', 'mock_data' );
 
 		$upgrade_history = $this->get_instance();
-		$upgrade_history->add( '1.0.0', '2.0.0', array( 'mock_option_name' ) );
+		$upgrade_history->add( '1.0.0', '2.0.0', [ 'mock_option_name' ] );
 
 		delete_option( 'mock_option_name' );
 
@@ -106,7 +106,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_no_options() {
 		$upgrade_history = $this->get_instance();
-		$upgrade_history->add( '1.0.0', '2.0.0', array() );
+		$upgrade_history->add( '1.0.0', '2.0.0', [] );
 
 		$history = $upgrade_history->get();
 		$entry   = current( $history );
@@ -125,7 +125,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_empty_option() {
 		$upgrade_history = $this->get_instance();
-		$upgrade_history->add( '1.0.0', '2.0.0', array( 'option_does_not_exist' ) );
+		$upgrade_history->add( '1.0.0', '2.0.0', [ 'option_does_not_exist' ] );
 
 		$history = $upgrade_history->get();
 		$entry   = current( $history );

--- a/integration-tests/inc/test-class-wpseo-upgrade.php
+++ b/integration-tests/inc/test-class-wpseo-upgrade.php
@@ -26,11 +26,11 @@ class WPSEO_Upgrade_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_option_from_database() {
 
-		$content = array(
+		$content = [
 			'a' => 'b',
 			'c' => true,
 			3   => new StdClass(),
-		);
+		];
 
 		$instance = $this->get_instance();
 
@@ -46,22 +46,22 @@ class WPSEO_Upgrade_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_option_from_database_no_filters_applied() {
 		// Tests if the option is fetched from the database.
-		$content = array(
+		$content = [
 			'a' => 'b',
 			'c' => true,
 			3   => new StdClass(),
-		);
+		];
 
 		$instance = $this->get_instance();
 
 		update_option( 'some_option', $content );
 
-		add_filter( 'pre_option_some_option', array( $this, 'return_override' ) );
+		add_filter( 'pre_option_some_option', [ $this, 'return_override' ] );
 
 		$this->assertEquals( $this->return_override(), get_option( 'some_option' ) );
 		$this->assertEquals( $content, $instance->get_option_from_database( 'some_option' ) );
 
-		remove_filter( 'pre_option_some_option', array( $this, 'return_override' ) );
+		remove_filter( 'pre_option_some_option', [ $this, 'return_override' ] );
 	}
 
 	/**
@@ -71,7 +71,7 @@ class WPSEO_Upgrade_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_option_from_database_non_existent() {
 		$instance = $this->get_instance();
-		$this->assertEquals( array(), $instance->get_option_from_database( 'non_existent_option' ) );
+		$this->assertEquals( [], $instance->get_option_from_database( 'non_existent_option' ) );
 	}
 
 	/**
@@ -83,10 +83,10 @@ class WPSEO_Upgrade_Test extends WPSEO_UnitTestCase {
 		// Testing the sanitization of the options framework.
 		$instance = $this->get_instance();
 
-		$original = array(
+		$original = [
 			'invalid_key' => true,
 			'version'     => WPSEO_VERSION,
-		);
+		];
 
 		// Set option with invalid keys in the database.
 		$this->set_option_in_database( 'wpseo', $original );
@@ -121,9 +121,9 @@ class WPSEO_Upgrade_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_save_option_setting() {
 		// Only set the new data if found on the source.
-		$source = array(
+		$source = [
 			'company_name' => 'value1',
-		);
+		];
 
 		$instance = $this->get_instance();
 
@@ -143,9 +143,9 @@ class WPSEO_Upgrade_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_save_option_setting_not_set() {
 		// Only set the new data if found on the source.
-		$source = array(
+		$source = [
 			'key1' => 'value1',
-		);
+		];
 
 		$instance = $this->get_instance();
 
@@ -201,11 +201,11 @@ class WPSEO_Upgrade_Test extends WPSEO_UnitTestCase {
 
 		$wpdb->update(
 			$wpdb->options,
-			array(
+			[
 				'option_name'  => $option_name,
 				'option_value' => serialize( $option_value ),
-			),
-			array( 'option_name' => $option_name )
+			],
+			[ 'option_name' => $option_name ]
 		);
 	}
 }

--- a/integration-tests/notifications/test-class-yoast-notification-center.php
+++ b/integration-tests/notifications/test-class-yoast-notification-center.php
@@ -24,10 +24,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	private $fake_notification_defaults = array(
+	private $fake_notification_defaults = [
 		'id'            => 'some_id',
 		'dismissal_key' => 'notification_dismissal',
-	);
+	];
 
 	/**
 	 * Create user with proper caps.
@@ -75,7 +75,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$subject = $this->get_notification_center();
 		$subject->add_notification( $notification );
 
-		$this->assertEquals( array( $notification ), $subject->get_notifications() );
+		$this->assertEquals( [ $notification ], $subject->get_notifications() );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers ::add_notification
 	 */
 	public function test_add_notification_twice_persistent() {
-		$notification = new Yoast_Notification( 'notification', array( 'id' => 'some_id' ) );
+		$notification = new Yoast_Notification( 'notification', [ 'id' => 'some_id' ] );
 
 		$subject = $this->get_notification_center();
 		$subject->add_notification( $notification );
@@ -121,7 +121,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_is_notification_dismissed() {
 		$notification_dismissal_key = 'notification_dismissal';
-		$notification               = new Yoast_Notification( 'dismiss', array( 'dismissal_key' => $notification_dismissal_key ) );
+		$notification               = new Yoast_Notification( 'dismiss', [ 'dismissal_key' => $notification_dismissal_key ] );
 
 		update_user_meta( $this->user_id, $notification_dismissal_key, '1' );
 
@@ -135,7 +135,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers ::clear_dismissal
 	 */
 	public function test_clear_dismissal() {
-		$notification = new Yoast_Notification( 'notification', array( 'id' => 'some_id' ) );
+		$notification = new Yoast_Notification( 'notification', [ 'id' => 'some_id' ] );
 
 		$subject = $this->get_notification_center();
 
@@ -154,7 +154,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers ::clear_dismissal
 	 */
 	public function test_clear_dismissal_as_string() {
-		$notification = new Yoast_Notification( 'notification', array( 'id' => 'some_id' ) );
+		$notification = new Yoast_Notification( 'notification', [ 'id' => 'some_id' ] );
 
 		$subject = $this->get_notification_center();
 
@@ -185,7 +185,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	public function test_update_storage() {
 
 		$message = 'b';
-		$options = array( 'id' => 'some_id' );
+		$options = [ 'id' => 'some_id' ];
 
 		$notification = new Yoast_Notification(
 			$message,
@@ -199,7 +199,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$stored_notifications = get_user_option( Yoast_Notification_Center::STORAGE_KEY, $this->user_id );
 
-		$test = array( $notification->to_array() );
+		$test = [ $notification->to_array() ];
 
 		$this->assertInternalType( 'array', $stored_notifications );
 		$this->assertEquals( $test, $stored_notifications );
@@ -245,7 +245,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @covers ::remove_storage
 	 */
 	public function test_remove_storage_with_notifications() {
-		$notification = new Yoast_Notification( 'b', array( 'id' => 'fake_id' ) );
+		$notification = new Yoast_Notification( 'b', [ 'id' => 'fake_id' ] );
 
 		$subject = new Yoast_Notification_Center_Double();
 		$subject->setup_current_notifications();
@@ -272,7 +272,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$sorted = $subject->get_sorted_notifications();
 
 		$this->assertInternalType( 'array', $sorted );
-		$this->assertEquals( array( $notification ), $sorted );
+		$this->assertEquals( [ $notification ], $sorted );
 	}
 
 	/**
@@ -286,7 +286,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$sorted = $subject->get_sorted_notifications();
 
 		$this->assertInternalType( 'array', $sorted );
-		$this->assertEquals( array(), $sorted );
+		$this->assertEquals( [], $sorted );
 	}
 
 	/**
@@ -296,10 +296,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_sorted_notifications_by_type() {
 		$message_1 = '1';
-		$options_1 = array( 'type' => 'update' );
+		$options_1 = [ 'type' => 'update' ];
 
 		$message_2 = '2';
-		$options_2 = array( 'type' => 'error' );
+		$options_2 = [ 'type' => 'error' ];
 
 		$notification_1 = new Yoast_Notification( $message_1, $options_1 );
 		$notification_2 = new Yoast_Notification( $message_2, $options_2 );
@@ -310,7 +310,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$sorted = $subject->get_sorted_notifications();
 
-		$this->assertEquals( array( $notification_2, $notification_1 ), $sorted );
+		$this->assertEquals( [ $notification_2, $notification_1 ], $sorted );
 	}
 
 	/**
@@ -320,16 +320,16 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_sorted_notifications_by_priority() {
 		$message_1 = '1';
-		$options_1 = array(
+		$options_1 = [
 			'type'     => 'error',
 			'priority' => 0.5,
-		);
+		];
 
 		$message_2 = '2';
-		$options_2 = array(
+		$options_2 = [
 			'type'     => 'error',
 			'priority' => 1,
-		);
+		];
 
 		$notification_1 = new Yoast_Notification( $message_1, $options_1 );
 		$notification_2 = new Yoast_Notification( $message_2, $options_2 );
@@ -340,7 +340,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$sorted = $subject->get_sorted_notifications();
 
-		$this->assertEquals( array( $notification_2, $notification_1 ), $sorted );
+		$this->assertEquals( [ $notification_2, $notification_1 ], $sorted );
 	}
 
 	/**
@@ -350,12 +350,12 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_notifications() {
 		$message = 'c';
-		$options = array();
+		$options = [];
 
 		$notification = $this
 			->getMockBuilder( 'Yoast_Notification' )
-			->setConstructorArgs( array( $message, $options ) )
-			->setMethods( array( 'display_for_current_user', '__toString' ) )
+			->setConstructorArgs( [ $message, $options ] )
+			->setMethods( [ 'display_for_current_user', '__toString' ] )
 			->getMock();
 
 		$notification
@@ -383,12 +383,12 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_notifications_not_for_current_user() {
 		$message = 'c';
-		$options = array();
+		$options = [];
 
 		$notification = $this
 			->getMockBuilder( 'Yoast_Notification' )
-			->setConstructorArgs( array( $message, $options ) )
-			->setMethods( array( 'display_for_current_user', '__toString' ) )
+			->setConstructorArgs( [ $message, $options ] )
+			->setMethods( [ 'display_for_current_user', '__toString' ] )
 			->getMock();
 
 		$notification
@@ -418,10 +418,10 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_dismissal_key = 'dismissed';
 
 		$message = 'c';
-		$options = array(
+		$options = [
 			'id'            => 'my_id',
 			'dismissal_key' => $notification_dismissal_key,
-		);
+		];
 
 		$notification = new Yoast_Notification( $message, $options );
 
@@ -450,12 +450,12 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$outdated = new Yoast_Notification(
 			'outdated',
-			array(
+			[
 				'nonce' => $old_nonce,
 				'id'    => 'test',
-			)
+			]
 		);
-		$new      = new Yoast_Notification( 'new', array( 'id' => 'test' ) );
+		$new      = new Yoast_Notification( 'new', [ 'id' => 'test' ] );
 
 		$notification_center->add_notification( $outdated );
 		$notification_center->add_notification( $new );
@@ -477,7 +477,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$notification_center = $this->get_notification_center();
 
-		$notification = new Yoast_Notification( 'notification', array( 'id' => $id ) );
+		$notification = new Yoast_Notification( 'notification', [ 'id' => $id ] );
 		$notification_center->add_notification( $notification );
 
 		$new = $notification_center->get_new_notifications();
@@ -509,7 +509,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$a = new Yoast_Notification( 'a' );
 		$this->assertFalse( Yoast_Notification_Center::maybe_dismiss_notification( $a ) );
 
-		$b = new Yoast_Notification( 'b', array( 'id' => uniqid( 'id' ) ) );
+		$b = new Yoast_Notification( 'b', [ 'id' => uniqid( 'id' ) ] );
 		$this->assertFalse( Yoast_Notification_Center::maybe_dismiss_notification( $b ) );
 	}
 
@@ -524,7 +524,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( 0, $notification_center->get_notification_count() );
 
-		$notification_center->add_notification( new Yoast_Notification( 'a', array( 'id' => 'some_id' ) ) );
+		$notification_center->add_notification( new Yoast_Notification( 'a', [ 'id' => 'some_id' ] ) );
 
 		$this->assertEquals( 1, $notification_center->get_notification_count() );
 		$this->assertEquals( 1, $notification_center->get_notification_count( true ) );
@@ -673,8 +673,8 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	public function test_retrieve_notifications_from_storage_strips_nonces() {
 		$notification_center = Yoast_Notification_Center::get();
 
-		$storage_data         = array();
-		$expected             = array();
+		$storage_data         = [];
+		$expected             = [];
 		$sample_notifications = $this->get_sample_notifications();
 		foreach ( $sample_notifications as $sample_notification ) {
 
@@ -706,12 +706,12 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	public function test_update_storage_strips_nonces() {
 		$notification_center = Yoast_Notification_Center::get();
 
-		add_filter( 'yoast_notifications_before_storage', array( $this, 'get_sample_notifications' ) );
+		add_filter( 'yoast_notifications_before_storage', [ $this, 'get_sample_notifications' ] );
 		$notification_center->update_storage();
 
 		$stored_notifications = get_user_option( Yoast_Notification_Center::STORAGE_KEY, get_current_user_id() );
 
-		$expected             = array();
+		$expected             = [];
 		$sample_notifications = $this->get_sample_notifications();
 		foreach ( $sample_notifications as $sample_notification ) {
 			$expected[ $sample_notification->get_id() ] = null;
@@ -729,7 +729,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'remove_notification' ) )
+			->setMethods( [ 'remove_notification' ] )
 			->getMock();
 
 		$notification_center
@@ -748,7 +748,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'remove_notification', 'get_notification_by_id' ) )
+			->setMethods( [ 'remove_notification', 'get_notification_by_id' ] )
 			->getMock();
 
 		$notification_center
@@ -760,7 +760,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 			->method( 'get_notification_by_id' )
 			->will(
 				$this->returnValue(
-					new Yoast_Notification( 'message', array( 'id' => 'this-id-exists' ) )
+					new Yoast_Notification( 'message', [ 'id' => 'this-id-exists' ] )
 				)
 			);
 
@@ -781,7 +781,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	public function test_has_stored_notifications( $stored_notifications, $expected, $message ) {
 		$instance = $this
 			->getMockBuilder( 'Yoast_Notification_Center_Double' )
-			->setMethods( array( 'get_stored_notifications' ) )
+			->setMethods( [ 'get_stored_notifications' ] )
 			->getMock();
 
 		$instance
@@ -800,16 +800,16 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @return array List of notification objects.
 	 */
 	public function get_sample_notifications() {
-		return array(
+		return [
 			new Yoast_Notification(
 				'notification',
-				array( 'id' => 'some_id' )
+				[ 'id' => 'some_id' ]
 			),
 			new Yoast_Notification(
 				'notification',
-				array( 'id' => 'another_id' )
+				[ 'id' => 'another_id' ]
 			),
-		);
+		];
 	}
 
 	/**
@@ -818,23 +818,23 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * @return array The test values.
 	 */
 	public function has_stored_notifications_provider() {
-		return array(
-			array(
+		return [
+			[
 				'stored_notifications' => false,
 				'expected'             => false,
 				'message'              => 'With get_stored_notifications returning false',
-			),
-			array(
-				'stored_notifications' => array(),
+			],
+			[
+				'stored_notifications' => [],
 				'expected'             => false,
 				'message'              => 'With get_stored_notifications returning an empty array',
-			),
-			array(
-				'stored_notifications' => array( 'This is a notification' ),
+			],
+			[
+				'stored_notifications' => [ 'This is a notification' ],
 				'expected'             => true,
 				'message'              => 'With get_stored_notifications returning a notification',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/integration-tests/notifications/test-class-yoast-notification.php
+++ b/integration-tests/notifications/test-class-yoast-notification.php
@@ -15,20 +15,20 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	private $verify_capability_filter_args = array();
+	private $verify_capability_filter_args = [];
 
 	/**
 	 * Test filter capability match.
 	 *
 	 * @var array
 	 */
-	private $verify_capability_match_filter_args = array();
+	private $verify_capability_match_filter_args = [];
 
 	/**
 	 * No ID is not persistent.
 	 */
 	public function test_not_persistent() {
-		$subject = new Yoast_Notification( 'message', array() );
+		$subject = new Yoast_Notification( 'message', [] );
 		$this->assertFalse( $subject->is_persistent() );
 	}
 
@@ -36,21 +36,21 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test defaults.
 	 */
 	public function test_set_defaults() {
-		$subject = new Yoast_Notification( 'message', array() );
+		$subject = new Yoast_Notification( 'message', [] );
 		$test    = $subject->to_array();
 
 		$this->assertEquals(
-			array(
+			[
 				'type'             => 'updated',
 				'id'               => '',
 				'nonce'            => null,
 				'priority'         => 0.5,
-				'data_json'        => array(),
+				'data_json'        => [],
 				'dismissal_key'    => null,
-				'capabilities'     => array( 'wpseo_manage_options' ),
+				'capabilities'     => [ 'wpseo_manage_options' ],
 				'capability_check' => 'all',
 				'yoast_branding'   => false,
-			),
+			],
 			$test['options']
 		);
 	}
@@ -59,9 +59,9 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Verify invalid options.
 	 */
 	public function test_verify_priority_boundary() {
-		$options = array(
+		$options = [
 			'priority' => 2,
-		);
+		];
 
 		$subject = new Yoast_Notification( 'message', $options );
 
@@ -72,7 +72,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test nonce when set.
 	 */
 	public function test_nonce() {
-		$subject = new Yoast_Notification( 'message', array( 'nonce' => 'nonce' ) );
+		$subject = new Yoast_Notification( 'message', [ 'nonce' => 'nonce' ] );
 		$this->assertEquals( 'nonce', $subject->get_nonce() );
 	}
 
@@ -80,7 +80,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test nonce when not set as option.
 	 */
 	public function test_nonce_not_set() {
-		$subject = new Yoast_Notification( 'message', array( 'id' => 'id' ) );
+		$subject = new Yoast_Notification( 'message', [ 'id' => 'id' ] );
 		$nonce   = $subject->get_nonce();
 		$this->assertTrue( wp_verify_nonce( $nonce, 'id' ) !== false );
 	}
@@ -89,7 +89,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test type is set to default and retrievable.
 	 */
 	public function test_type() {
-		$subject = new Yoast_Notification( 'message', array() );
+		$subject = new Yoast_Notification( 'message', [] );
 		$test    = $subject->to_array();
 
 		$this->assertEquals( $test['options']['type'], $subject->get_type() );
@@ -99,7 +99,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test type custom value.
 	 */
 	public function test_type_custom() {
-		$subject = new Yoast_Notification( 'message', array( 'type' => 'bla' ) );
+		$subject = new Yoast_Notification( 'message', [ 'type' => 'bla' ] );
 		$this->assertEquals( 'bla', $subject->get_type() );
 	}
 
@@ -107,12 +107,12 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test setting and retrieving JSON.
 	 */
 	public function test_json() {
-		$data = array( 'bla' );
+		$data = [ 'bla' ];
 
-		$subject = new Yoast_Notification( 'message', array( 'data_json' => $data ) );
+		$subject = new Yoast_Notification( 'message', [ 'data_json' => $data ] );
 		$this->assertEquals( $subject->get_json(), WPSEO_Utils::format_json_encode( $data ) );
 
-		$subject = new Yoast_Notification( 'message', array( 'data_json' => '' ) );
+		$subject = new Yoast_Notification( 'message', [ 'data_json' => '' ] );
 		$this->assertEquals( $subject->get_json(), '' );
 	}
 
@@ -120,7 +120,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test retrieval of dismissal key.
 	 */
 	public function test_get_dismissal_key() {
-		$subject = new Yoast_Notification( 'message', array( 'dismissal_key' => 'dis' ) );
+		$subject = new Yoast_Notification( 'message', [ 'dismissal_key' => 'dis' ] );
 		$this->assertEquals( 'dis', $subject->get_dismissal_key() );
 	}
 
@@ -128,7 +128,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Test retrieval of dismissal key when not set.
 	 */
 	public function test_get_dismissal_key_not_set() {
-		$subject = new Yoast_Notification( 'message', array( 'id' => 'id' ) );
+		$subject = new Yoast_Notification( 'message', [ 'id' => 'id' ] );
 		$this->assertEquals( 'id', $subject->get_dismissal_key() );
 	}
 
@@ -136,11 +136,11 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * Non-persistent Notifications should always be displayed.
 	 */
 	public function test_not_persistent_always_show() {
-		$subject = new Yoast_Notification( 'message', array() );
+		$subject = new Yoast_Notification( 'message', [] );
 		$this->assertFalse( $subject->is_persistent() );
 		$this->assertTrue( $subject->display_for_current_user() );
 
-		$subject = new Yoast_Notification( 'message', array( 'capabilities' => array( 'foooooooo' ) ) );
+		$subject = new Yoast_Notification( 'message', [ 'capabilities' => [ 'foooooooo' ] ] );
 		$this->assertFalse( $subject->is_persistent() );
 		$this->assertTrue( $subject->display_for_current_user() );
 	}
@@ -155,14 +155,14 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 
 		$subject = new Yoast_Notification(
 			'message',
-			array(
+			[
 				'id'               => 'id',
-				'capabilities'     => array(
+				'capabilities'     => [
 					'bla',
 					'foo',
-				),
+				],
 				'capability_check' => 'any',
-			)
+			]
 		);
 
 		$this->assertTrue( $subject->display_for_current_user() );
@@ -180,14 +180,14 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 
 		$subject = new Yoast_Notification(
 			'message',
-			array(
+			[
 				'id'               => 'id',
-				'capabilities'     => array(
+				'capabilities'     => [
 					'bla',
 					'foo',
-				),
+				],
 				'capability_check' => 'any',
-			)
+			]
 		);
 
 		$this->assertFalse( $subject->display_for_current_user() );
@@ -203,14 +203,14 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 
 		$subject = new Yoast_Notification(
 			'message',
-			array(
+			[
 				'id'               => 'id',
-				'capabilities'     => array(
+				'capabilities'     => [
 					'bla',
 					'foo',
-				),
+				],
 				'capability_check' => 'all',
-			)
+			]
 		);
 
 		$this->assertTrue( $subject->display_for_current_user() );
@@ -226,14 +226,14 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 
 		$subject = new Yoast_Notification(
 			'message',
-			array(
+			[
 				'id'               => 'id',
-				'capabilities'     => array(
+				'capabilities'     => [
 					'bla',
 					'foo',
-				),
+				],
 				'capability_check' => 'all',
-			)
+			]
 		);
 
 		$this->add_cap( 'bla' );
@@ -250,7 +250,7 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 * @return mixed
 	 */
 	public function verify_wpseo_notification_capabilities_filter( $capabilities, $notification ) {
-		$test = array( $capabilities, $notification );
+		$test = [ $capabilities, $notification ];
 		$this->assertEquals( $this->verify_capability_filter_args, $test );
 
 		return $capabilities;
@@ -262,10 +262,10 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	public function test_invalid_filter_return_values() {
 		$subject = new Yoast_Notification(
 			'message',
-			array(
+			[
 				'id'           => 'id',
 				'capabilities' => 'not_an_array',
-			)
+			]
 		);
 		$this->assertFalse( $subject->display_for_current_user() );
 	}
@@ -277,8 +277,8 @@ class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function add_wpseo_notification_capabilities( $current_capabilities = array() ) {
-		return array( 'jip', 'janneke' );
+	public function add_wpseo_notification_capabilities( $current_capabilities = [] ) {
+		return [ 'jip', 'janneke' ];
 	}
 
 	/**

--- a/integration-tests/notifiers/test-class-configuration-notifier.php
+++ b/integration-tests/notifiers/test-class-configuration-notifier.php
@@ -42,8 +42,8 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_will_be_shown_and_dismissal_trigger_is_on() {
 		$notifier = $this
 			->getMockBuilder( 'WPSEO_Configuration_Notifier' )
-			->setConstructorArgs( array( 'show_onboarding_notice' => true ) )
-			->setMethods( array( 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ) )
+			->setConstructorArgs( [ 'show_onboarding_notice' => true ] )
+			->setMethods( [ 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ] )
 			->getMock();
 
 		$notifier
@@ -71,8 +71,8 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_is_not_shown() {
 		$notifier = $this
 			->getMockBuilder( 'WPSEO_Configuration_Notifier' )
-			->setConstructorArgs( array( 'show_onboarding_notice' => true ) )
-			->setMethods( array( 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ) )
+			->setConstructorArgs( [ 'show_onboarding_notice' => true ] )
+			->setMethods( [ 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ] )
 			->getMock();
 
 		$notifier
@@ -99,8 +99,8 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_is_show_but_trigger_is_not_on() {
 		$notifier = $this
 			->getMockBuilder( 'WPSEO_Configuration_Notifier' )
-			->setConstructorArgs( array( 'show_onboarding_notice' => true ) )
-			->setMethods( array( 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ) )
+			->setConstructorArgs( [ 'show_onboarding_notice' => true ] )
+			->setMethods( [ 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ] )
 			->getMock();
 
 		$notifier

--- a/integration-tests/notifiers/test-class-dismissible-notification.php
+++ b/integration-tests/notifiers/test-class-dismissible-notification.php
@@ -20,7 +20,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_is_not_dismissed() {
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Dismissible_Notification_Double' )
-			->setMethods( array( 'get_listener_value' ) )
+			->setMethods( [ 'get_listener_value' ] )
 			->getMock();
 
 		$handler
@@ -39,7 +39,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_will_be_dismissed() {
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Dismissible_Notification_Double' )
-			->setMethods( array( 'get_listener_value', 'dismiss' ) )
+			->setMethods( [ 'get_listener_value', 'dismiss' ] )
 			->getMock();
 
 		$handler
@@ -63,7 +63,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'add_notification' ) )
+			->setMethods( [ 'add_notification' ] )
 			->getMock();
 
 		$notification_center
@@ -72,7 +72,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Dismissible_Notification_Double' )
-			->setMethods( array( 'is_applicable' ) )
+			->setMethods( [ 'is_applicable' ] )
 			->getMock();
 
 		$handler
@@ -92,7 +92,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'remove_notification_by_id' ) )
+			->setMethods( [ 'remove_notification_by_id' ] )
 			->getMock();
 
 		$notification_center
@@ -101,7 +101,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Dismissible_Notification_Double' )
-			->setMethods( array( 'is_applicable' ) )
+			->setMethods( [ 'is_applicable' ] )
 			->getMock();
 
 		$handler
@@ -120,7 +120,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	public function test_dismiss() {
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Dismissible_Notification_Double' )
-			->setMethods( array( 'set_dismissal_state', 'redirect_to_dashboard' ) )
+			->setMethods( [ 'set_dismissal_state', 'redirect_to_dashboard' ] )
 			->getMock();
 
 		$handler
@@ -142,7 +142,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	public function test_is_applicable_with_dismissed_notice() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Dismissible_Notification_Double' )
-			->setMethods( array( 'is_notice_dismissed' ) )
+			->setMethods( [ 'is_notice_dismissed' ] )
 			->getMock();
 
 		$instance
@@ -161,7 +161,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	public function test_is_applicable_with_non_dismissed_notice() {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Dismissible_Notification_Double' )
-			->setMethods( array( 'is_notice_dismissed' ) )
+			->setMethods( [ 'is_notice_dismissed' ] )
 			->getMock();
 
 		$instance

--- a/integration-tests/notifiers/test-class-post-type-archive-notifier.php
+++ b/integration-tests/notifiers/test-class-post-type-archive-notifier.php
@@ -20,7 +20,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_is_applicable_notice_dismissed() {
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Post_Type_Archive_Notification_Handler_Double' )
-			->setMethods( array( 'is_notice_dismissed' ) )
+			->setMethods( [ 'is_notice_dismissed' ] )
 			->getMock();
 
 		$handler
@@ -39,7 +39,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_is_applicable_new_install() {
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Post_Type_Archive_Notification_Handler_Double' )
-			->setMethods( array( 'is_notice_dismissed', 'is_new_install' ) )
+			->setMethods( [ 'is_notice_dismissed', 'is_new_install' ] )
 			->getMock();
 
 		$handler
@@ -63,7 +63,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_is_applicable_with_empty_post_types() {
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Post_Type_Archive_Notification_Handler_Double' )
-			->setMethods( array( 'is_notice_dismissed', 'is_new_install', 'get_post_types' ) )
+			->setMethods( [ 'is_notice_dismissed', 'is_new_install', 'get_post_types' ] )
 			->getMock();
 
 		$handler
@@ -79,7 +79,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 		$handler
 			->expects( $this->once() )
 			->method( 'get_post_types' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$this->assertFalse( $handler->is_applicable() );
 	}
@@ -92,7 +92,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_is_applicable_with_post_types() {
 		$handler = $this
 			->getMockBuilder( 'WPSEO_Post_Type_Archive_Notification_Handler_Double' )
-			->setMethods( array( 'is_notice_dismissed', 'is_new_install', 'get_post_types' ) )
+			->setMethods( [ 'is_notice_dismissed', 'is_new_install', 'get_post_types' ] )
 			->getMock();
 
 		$handler
@@ -108,7 +108,7 @@ class WPSEO_Post_Type_Archive_Notifier_Test extends WPSEO_UnitTestCase {
 		$handler
 			->expects( $this->once() )
 			->method( 'get_post_types' )
-			->will( $this->returnValue( array( 123 ) ) );
+			->will( $this->returnValue( [ 123 ] ) );
 
 		$this->assertTrue( $handler->is_applicable() );
 	}

--- a/integration-tests/onpage/test-class-onpage-request.php
+++ b/integration-tests/onpage/test-class-onpage-request.php
@@ -20,10 +20,10 @@ class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals(
 			$request->do_request( home_url() ),
-			array(
+			[
 				'is_indexable'    => '1',
 				'passes_juice_to' => '',
-			)
+			]
 		);
 	}
 
@@ -37,10 +37,10 @@ class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals(
 			$request->do_request( 'http:://will-be-redirected.wp' ),
-			array(
+			[
 				'is_indexable'    => '1',
 				'passes_juice_to' => '',
-			)
+			]
 		);
 	}
 
@@ -54,10 +54,10 @@ class WPSEO_OnPage_Request_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals(
 			$request->do_request( 'http://not_indexable.wp' ),
-			array(
+			[
 				'is_indexable'    => '0',
 				'passes_juice_to' => '',
-			)
+			]
 		);
 	}
 }

--- a/integration-tests/onpage/test-class-onpage.php
+++ b/integration-tests/onpage/test-class-onpage.php
@@ -42,7 +42,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 	public function test_add_weekly_schedule() {
 		$this->class_instance->register_hooks();
 
-		$schedules = $this->class_instance->add_weekly_schedule( array() );
+		$schedules = $this->class_instance->add_weekly_schedule( [] );
 
 		$this->assertTrue( array_key_exists( 'weekly', $schedules ) );
 		$this->assertEquals( $schedules['weekly']['interval'], WEEK_IN_SECONDS );
@@ -132,7 +132,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		$class_instance =
 			$this
 				->getMockBuilder( 'WPSEO_OnPage_Double' )
-				->setMethods( array( 'notify_admins' ) )
+				->setMethods( [ 'notify_admins' ] )
 				->getMock();
 
 		$class_instance
@@ -152,7 +152,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		$instance = new WPSEO_OnPage();
 		$instance->register_hooks();
 
-		$this->assertTrue( has_action( 'admin_init', array( $instance, 'show_notice' ) ) > 0 );
+		$this->assertTrue( has_action( 'admin_init', [ $instance, 'show_notice' ] ) > 0 );
 	}
 
 	/**
@@ -178,7 +178,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		update_option( 'blog_public', 1 );
 
 		$instance = $this->getMockBuilder( 'WPSEO_OnPage_Double' )
-			->setMethods( array( 'get_option' ) )
+			->setMethods( [ 'get_option' ] )
 			->getMock();
 
 		$instance->expects( $this->atLeastOnce() )
@@ -202,7 +202,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		update_option( 'blog_public', 1 );
 
 		$instance = $this->getMockBuilder( 'WPSEO_OnPage_Double' )
-			->setMethods( array( 'get_option' ) )
+			->setMethods( [ 'get_option' ] )
 			->getMock();
 
 		$instance->expects( $this->atLeastOnce() )
@@ -221,7 +221,7 @@ class WPSEO_OnPage_Test extends WPSEO_UnitTestCase {
 		$onpage = new WPSEO_OnPage();
 		$onpage->register_hooks();
 
-		$this->assertNotFalse( has_action( 'admin_init', array( $onpage, 'show_notice' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', [ $onpage, 'show_notice' ] ) );
 	}
 
 	/**

--- a/integration-tests/recalculate/test-class-recalculate-posts.php
+++ b/integration-tests/recalculate/test-class-recalculate-posts.php
@@ -39,12 +39,12 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 
 		$this->instance = new WPSEO_Recalculate_Posts();
 
-		$this->posts = array(
-			1 => $this->factory->post->create( array( 'post_title' => 'Post with focus keyword' ) ),
-			2 => $this->factory->post->create( array( 'post_title' => 'Test Post 2' ) ),
-			3 => $this->factory->post->create( array( 'post_title' => 'Test Post 3' ) ),
-			4 => $this->factory->post->create( array( 'post_title' => 'Test Post 4' ) ),
-		);
+		$this->posts = [
+			1 => $this->factory->post->create( [ 'post_title' => 'Post with focus keyword' ] ),
+			2 => $this->factory->post->create( [ 'post_title' => 'Test Post 2' ] ),
+			3 => $this->factory->post->create( [ 'post_title' => 'Test Post 3' ] ),
+			4 => $this->factory->post->create( [ 'post_title' => 'Test Post 4' ] ),
+		];
 	}
 
 	/**
@@ -57,12 +57,12 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( WPSEO_Meta::get_value( 'linkdex', $this->posts[1] ), 0 );
 
 		$this->instance->save_scores(
-			array(
-				array(
+			[
+				[
 					'item_id' => $this->posts[1],
 					'score'   => 10,
-				),
-			)
+				],
+			]
 		);
 	}
 
@@ -75,10 +75,10 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		$response = $this->instance->get_items_to_recalculate( 1 );
 
 		$this->assertEquals(
-			array(
-				'items'       => array(),
+			[
+				'items'       => [],
 				'total_items' => 0,
-			),
+			],
 			$response
 		);
 	}
@@ -110,11 +110,11 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		$post     = get_post( $this->posts[1] );
 		$expected = $this->add_dummy_content( $post->post_content );
 
-		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content' ), 10, 2 );
+		add_filter( 'wpseo_post_content_for_recalculation', [ $this, 'add_dummy_content' ], 10, 2 );
 
 		$response = $this->instance->get_items_to_recalculate( 1 );
 
-		remove_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content' ) );
+		remove_filter( 'wpseo_post_content_for_recalculation', [ $this, 'add_dummy_content' ] );
 
 		$this->assertEquals( $expected, $response['items'][0]['text'] );
 	}
@@ -130,11 +130,11 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 		$post     = get_post( $this->posts[1] );
 		$expected = do_shortcode( $this->add_dummy_content_with_shortcode( $post->post_content ) );
 
-		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content_with_shortcode' ), 10, 2 );
+		add_filter( 'wpseo_post_content_for_recalculation', [ $this, 'add_dummy_content_with_shortcode' ], 10, 2 );
 
 		$response = $this->instance->get_items_to_recalculate( 1 );
 
-		remove_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_dummy_content_with_shortcode' ) );
+		remove_filter( 'wpseo_post_content_for_recalculation', [ $this, 'add_dummy_content_with_shortcode' ] );
 
 		$this->assertEquals( $expected, $response['items'][0]['text'] );
 	}
@@ -147,8 +147,8 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 	public function test_add_featured_image_to_content() {
 		$test_double = new WPSEO_Recalculate_Posts_Test_Double();
 
-		add_filter( 'get_post_metadata', array( $this, 'mock_post_metadata' ), 10, 3 );
-		add_filter( 'post_thumbnail_html', array( $this, 'mock_thumbnail' ), 10, 3 );
+		add_filter( 'get_post_metadata', [ $this, 'mock_post_metadata' ], 10, 3 );
+		add_filter( 'post_thumbnail_html', [ $this, 'mock_thumbnail' ], 10, 3 );
 
 		$post     = get_post( $this->posts[1] );
 		$expected = $post->post_content . " <img src='' />";
@@ -156,8 +156,8 @@ class WPSEO_Recalculate_Posts_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( $expected, $response['text'] );
 
-		remove_filter( 'get_post_metadata', array( $this, 'mock_post_metadata' ), 10, 3 );
-		remove_filter( 'post_thumbnail_html', array( $this, 'mock_thumbnail' ), 10, 3 );
+		remove_filter( 'get_post_metadata', [ $this, 'mock_post_metadata' ], 10, 3 );
+		remove_filter( 'post_thumbnail_html', [ $this, 'mock_thumbnail' ], 10, 3 );
 
 		$post     = get_post( $this->posts[2] );
 		$expected = $post->post_content;

--- a/integration-tests/recalculate/test-class-recalculate-scores-ajax.php
+++ b/integration-tests/recalculate/test-class-recalculate-scores-ajax.php
@@ -22,7 +22,7 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	private $posts = array();
+	private $posts = [];
 
 	/**
 	 * Setup the class instance and create some posts.
@@ -32,11 +32,11 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 
 		$this->instance = new WPSEO_Recalculate_Scores_Ajax();
 
-		$this->posts = array(
-			1 => $this->factory->post->create( array( 'post_title' => 'Post with focus keyword' ) ),
-			2 => $this->factory->post->create( array( 'post_title' => 'Test Post 2' ) ),
-			3 => $this->factory->post->create( array( 'post_title' => 'Test Post 3' ) ),
-		);
+		$this->posts = [
+			1 => $this->factory->post->create( [ 'post_title' => 'Post with focus keyword' ] ),
+			2 => $this->factory->post->create( [ 'post_title' => 'Test Post 2' ] ),
+			3 => $this->factory->post->create( [ 'post_title' => 'Test Post 3' ] ),
+		];
 	}
 
 	/**
@@ -45,14 +45,14 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Recalculate_Scores_Ajax::get_total
 	 */
 	public function test_get_total() {
-		add_filter( 'wp_die_handler', array( $this, 'set_total_response_no_posts' ) );
+		add_filter( 'wp_die_handler', [ $this, 'set_total_response_no_posts' ] );
 
 		$ajax_nonce        = wp_create_nonce( 'wpseo_recalculate' );
 		$_REQUEST['nonce'] = $ajax_nonce;
 
 		$this->instance->get_total();
 
-		remove_filter( 'wp_die_handler', array( $this, 'set_total_response_no_posts' ) );
+		remove_filter( 'wp_die_handler', [ $this, 'set_total_response_no_posts' ] );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	 * @return array Callable handler for wp_die
 	 */
 	public function set_total_response_no_posts( $response ) {
-		return array( $this, 'get_total_response_no_posts' );
+		return [ $this, 'get_total_response_no_posts' ];
 	}
 
 	/**
@@ -82,7 +82,7 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Recalculate_Scores_Ajax::get_total
 	 */
 	public function test_get_total_with_posts() {
-		add_filter( 'wp_die_handler', array( $this, 'set_total_response_two_posts' ) );
+		add_filter( 'wp_die_handler', [ $this, 'set_total_response_two_posts' ] );
 
 		$ajax_nonce        = wp_create_nonce( 'wpseo_recalculate' );
 		$_REQUEST['nonce'] = $ajax_nonce;
@@ -92,7 +92,7 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 
 		$this->instance->get_total();
 
-		remove_filter( 'wp_die_handler', array( $this, 'set_total_response_two_posts' ) );
+		remove_filter( 'wp_die_handler', [ $this, 'set_total_response_two_posts' ] );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class WPSEO_Recalculate_Scores_Ajax_Test extends WPSEO_UnitTestCase {
 	 * @return array Callable handler for wp_die
 	 */
 	public function set_total_response_two_posts( $response ) {
-		return array( $this, 'get_total_response_two_posts' );
+		return [ $this, 'get_total_response_two_posts' ];
 	}
 
 	/**

--- a/integration-tests/recalculate/test-class-recalculate-terms.php
+++ b/integration-tests/recalculate/test-class-recalculate-terms.php
@@ -32,26 +32,26 @@ class WPSEO_Recalculate_Terms_Test extends WPSEO_UnitTestCase {
 
 		$this->instance = new WPSEO_Recalculate_Terms();
 
-		$this->terms = array(
+		$this->terms = [
 			1 => $this->factory->term->create(
-				array(
+				[
 					'name'     => 'Term with focus keyword',
 					'taxonomy' => 'category',
-				)
+				]
 			),
 			2 => $this->factory->term->create(
-				array(
+				[
 					'name'     => '2nd Term',
 					'taxonomy' => 'category',
-				)
+				]
 			),
 			3 => $this->factory->term->create(
-				array(
+				[
 					'name'     => 'Term 3',
 					'taxonomy' => 'category',
-				)
+				]
 			),
-		);
+		];
 	}
 
 	/**
@@ -64,13 +64,13 @@ class WPSEO_Recalculate_Terms_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( WPSEO_Taxonomy_Meta::get_term_meta( 'linkdex', 'category', $this->terms[1] ), 0 );
 
 		$this->instance->save_scores(
-			array(
-				array(
+			[
+				[
 					'item_id'  => $this->terms[1],
 					'taxonomy' => 'category',
 					'score'    => 10,
-				),
-			)
+				],
+			]
 		);
 	}
 

--- a/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -46,7 +46,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
 
 		// Creates a user, without any posts.
-		$this->factory->user->create( array( 'role' => 'author' ) );
+		$this->factory->user->create( [ 'role' => 'author' ] );
 
 		// Checks which users are in the sitemap, there should be none.
 		self::$class_instance->get_sitemap_links( 'author', 10, 1 );
@@ -62,10 +62,10 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
 
 		// Creates a user, without any posts.
-		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
 
 		// Creates posts.
-		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
+		$this->factory->post->create_many( 3, [ 'post_author' => $user_id ] );
 
 		// Checks which users are in the sitemap.
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
@@ -87,9 +87,9 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
 
 		// Adds three more users (of different types) without posts.
-		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$admin_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
-		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$author_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$admin_id  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
 
 		// Checks which users are in the sitemap.
 		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
@@ -116,8 +116,8 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 */
 	public function test_author_exclusion() {
 		// Creates a user with 3 posts.
-		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$this->factory->post->create_many( 3, array( 'post_author' => $user_id ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$this->factory->post->create_many( 3, [ 'post_author' => $user_id ] );
 
 		// Excludes the user from the sitemaps.
 		update_user_meta( $user_id, 'wpseo_noindex_author', 'on' );
@@ -183,14 +183,14 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 */
 	public function test_throw_no_exception_on_second_sitemap() {
 		// Creates two users, without any posts.
-		$author_id        = $this->factory->user->create( array( 'role' => 'author' ) );
-		$second_author_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$third_author_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_id        = $this->factory->user->create( [ 'role' => 'author' ] );
+		$second_author_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$third_author_id  = $this->factory->user->create( [ 'role' => 'author' ] );
 
 		// Creates posts.
-		$this->factory->post->create_many( 3, array( 'post_author' => $author_id ) );
-		$this->factory->post->create_many( 3, array( 'post_author' => $second_author_id ) );
-		$this->factory->post->create_many( 3, array( 'post_author' => $third_author_id ) );
+		$this->factory->post->create_many( 3, [ 'post_author' => $author_id ] );
+		$this->factory->post->create_many( 3, [ 'post_author' => $second_author_id ] );
+		$this->factory->post->create_many( 3, [ 'post_author' => $third_author_id ] );
 
 		// Collects the author links for the third sitemap.
 		$third_sitemap_links = self::$class_instance->get_sitemap_links( 'author', 1, 3 );

--- a/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/integration-tests/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -24,7 +24,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	private $excluded_posts = array();
+	private $excluded_posts = [];
 
 	/**
 	 * Set up our double class.
@@ -89,11 +89,11 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	public function test_get_index_links_empty_bucket() {
 
 		$this->factory->post->create();
-		$this->excluded_posts = array( $this->factory->post->create() ); // Remove this post.
+		$this->excluded_posts = [ $this->factory->post->create() ]; // Remove this post.
 		$this->factory->post->create();
 
-		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_post' ) );
-		add_filter( 'wpseo_sitemap_entries_per_page', array( $this, 'return_one' ) );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'exclude_post' ] );
+		add_filter( 'wpseo_sitemap_entries_per_page', [ $this, 'return_one' ] );
 
 		// Fetch the global sitemap.
 		set_query_var( 'sitemap', 'post' );
@@ -111,7 +111,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		);
 
 		// Remove the filter.
-		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_post' ) );
+		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'exclude_post' ] );
 	}
 
 	/**
@@ -146,9 +146,9 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$current_page_on_front  = (int) get_option( 'page_on_front' );
 		$current_page_for_posts = (int) get_option( 'page_for_posts' );
 
-		$front_page = $this->factory()->post->create_and_get( array( 'post_type' => 'page' ) );
-		$posts_page = $this->factory()->post->create_and_get( array( 'post_type' => 'page' ) );
-		$post_id    = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+		$front_page = $this->factory()->post->create_and_get( [ 'post_type' => 'page' ] );
+		$posts_page = $this->factory()->post->create_and_get( [ 'post_type' => 'page' ] );
+		$post_id    = $this->factory()->post->create_and_get( [ 'post_type' => 'post' ] );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $front_page->ID );
@@ -197,19 +197,19 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	public function test_get_excluded_posts_with_set_filter() {
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
 
-		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_output' ) );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'filter_with_output' ] );
 
-		$expected = array(
+		$expected = [
 			0 => 5,
 			1 => 600,
 			2 => 23,
 			3 => 0,
 			5 => 3,
-		);
+		];
 
 		$this->assertEquals( $expected, $sitemap_provider->get_excluded_posts( 'post' ) );
 
-		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_output' ) );
+		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'filter_with_output' ] );
 	}
 
 	/**
@@ -220,11 +220,11 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	public function test_get_excluded_posts_with_set_filter_that_has_invalid_return_value() {
 		$sitemap_provider = new WPSEO_Post_Type_Sitemap_Provider_Double();
 
-		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_invalid_output' ) );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'filter_with_invalid_output' ] );
 
-		$this->assertEquals( array(), $sitemap_provider->get_excluded_posts( 'post' ) );
+		$this->assertEquals( [], $sitemap_provider->get_excluded_posts( 'post' ) );
 
-		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_with_invalid_output' ) );
+		remove_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'filter_with_invalid_output' ] );
 	}
 
 	/**
@@ -239,7 +239,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$excluded_post_ids[] = 600;
 		$excluded_post_ids[] = '23books';
 		$excluded_post_ids[] = '';
-		$excluded_post_ids[] = array();
+		$excluded_post_ids[] = [];
 		$excluded_post_ids[] = '    3';
 
 		return $excluded_post_ids;
@@ -301,9 +301,9 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	public function test_password_protected_post() {
 		// Create password protected post.
 		$this->factory->post->create(
-			array(
+			[
 				'post_password' => 'secret',
-			)
+			]
 		);
 
 		// Expect the protected post should not be added.
@@ -325,17 +325,17 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 		// Create non-password-protected post.
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_password' => '',
-			)
+			]
 		);
 
 		$this->factory->post->create(
-			array(
+			[
 				'post_parent' => $post_id,
 				'post_type'   => 'attachment',
 				'post_status' => 'inherit',
-			)
+			]
 		);
 
 		// Expect the attchment to be in the list.
@@ -355,17 +355,17 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 		// Create password protected post.
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_password' => 'secret',
-			)
+			]
 		);
 
 		$this->factory->post->create(
-			array(
+			[
 				'post_parent' => $post_id,
 				'post_type'   => 'attachment',
 				'post_status' => 'inherit',
-			)
+			]
 		);
 
 		// Expect the attachment not to be added to the list.

--- a/integration-tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemap-image-parser.php
@@ -39,7 +39,7 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 		$content_title = 'Content image title.';
 		$content_alt   = 'Content image alt.';
 		$post_id       = $this->factory->post->create(
-			array( 'post_content' => "<img src='{$content_src}' title='{$content_title}' alt='{$content_alt}' />" )
+			[ 'post_content' => "<img src='{$content_src}' title='{$content_title}' alt='{$content_alt}' />" ]
 		);
 
 		$images = self::$class_instance->get_images( get_post( $post_id ) );
@@ -64,19 +64,19 @@ class WPSEO_Sitemap_Image_Parser_Test extends WPSEO_UnitTestCase {
 		 * @var WPSEO_Sitemap_Image_Parser_Double $image_parser
 		 */
 		$image_parser = $this->getMockBuilder( 'WPSEO_Sitemap_Image_Parser_Double' )
-			->setMethods( array( 'get_content_galleries', 'get_gallery_attachments' ) )
+			->setMethods( [ 'get_content_galleries', 'get_gallery_attachments' ] )
 			->getMock();
 
 		$image_parser
 			->expects( $this->once() )
 			->method( 'get_content_galleries' )
-			->will( $this->returnValue( array( array( 'id' => 1 ) ) ) );
+			->will( $this->returnValue( [ [ 'id' => 1 ] ] ) );
 
-		$a = (object) array( 'a', 'b' );
+		$a = (object) [ 'a', 'b' ];
 		$b = (object) 1234;
 		$c = (object) 'some string';
 
-		$attachments = array( $a, $b, $c, $a, $c );
+		$attachments = [ $a, $b, $c, $a, $c ];
 
 		$image_parser
 			->expects( $this->once() )

--- a/integration-tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -46,11 +46,11 @@ class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
 	 */
 	public function test_private_taxonomy_author_overlap() {
 		// Create private taxonomy "author", overlapping the "author" sitemap.
-		register_taxonomy( 'author', array( 'post' ), array( 'public' => false ) );
+		register_taxonomy( 'author', [ 'post' ], [ 'public' => false ] );
 
 		// Create a user with a post.
-		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
 
 		// Fetch the global sitemap.
 		set_query_var( 'sitemap', '1' );
@@ -73,11 +73,11 @@ class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
 	 */
 	public function test_private_taxonomy_author_overlap_author_in_sitemap() {
 		// Create private taxonomy "author", overlapping the "author" sitemap.
-		register_taxonomy( 'author', array( 'post' ), array( 'public' => false ) );
+		register_taxonomy( 'author', [ 'post' ], [ 'public' => false ] );
 
 		// Create a user with a post.
-		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
 
 		// Fetch the global sitemap.
 		set_query_var( 'sitemap', 'author' );

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -19,7 +19,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 		parent::tearDown();
 
-		remove_action( 'update_option', array( 'WPSEO_Sitemaps_Cache', 'clear_on_option_update' ) );
+		remove_action( 'update_option', [ 'WPSEO_Sitemaps_Cache', 'clear_on_option_update' ] );
 	}
 
 	/**
@@ -126,7 +126,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		set_transient( $cache_key, $test_content );
 
 		// Act.
-		WPSEO_Sitemaps_Cache::clear( array( $type ) );
+		WPSEO_Sitemaps_Cache::clear( [ $type ] );
 		WPSEO_Sitemaps_Cache::clear_queued();
 
 		// Get the key again.
@@ -158,7 +158,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		usleep( 10000 );
 
 		// Act.
-		WPSEO_Sitemaps_Cache::clear( array( 'page' ) );
+		WPSEO_Sitemaps_Cache::clear( [ 'page' ] );
 		WPSEO_Sitemaps_Cache::clear_queued();
 
 		// Get the key again.
@@ -190,7 +190,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		set_transient( $type_b_key, $type_b_content );
 
 		// Act.
-		WPSEO_Sitemaps_Cache::clear( array( $type_a ) );
+		WPSEO_Sitemaps_Cache::clear( [ $type_a ] );
 		WPSEO_Sitemaps_Cache::clear_queued();
 
 		// Get the key again.
@@ -212,7 +212,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 		// Hook will be added on default priority.
 		$has_action = has_action(
 			'update_option',
-			array( 'WPSEO_Sitemaps_Cache', 'clear_on_option_update' )
+			[ 'WPSEO_Sitemaps_Cache', 'clear_on_option_update' ]
 		);
 		$this->assertEquals( 10, $has_action );
 	}
@@ -265,7 +265,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_clearing_author_sitemap_by_userid() {
 		$user_id = $this->factory->user->create(
-			array( 'role' => 'administrator' )
+			[ 'role' => 'administrator' ]
 		);
 
 		$this->assertTrue( WPSEO_Sitemaps_Cache::invalidate_author( $user_id ) );
@@ -278,7 +278,7 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_clearing_author_sitemap_by_userid_with_subscriber_role() {
 		$user_id = $this->factory->user->create(
-			array( 'role' => 'subscriber' )
+			[ 'role' => 'subscriber' ]
 		);
 
 		$this->assertFalse( WPSEO_Sitemaps_Cache::invalidate_author( $user_id ) );

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -37,12 +37,12 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 
 		$loc     = 'http://example.com/';
 		$lastmod = date( 'c' );
-		$links   = array(
-			array(
+		$links   = [
+			[
 				'loc'     => $loc,
 				'lastmod' => $lastmod,
-			),
-		);
+			],
+		];
 
 		$index = self::$class_instance->get_index( $links );
 		$this->assertContains( "<loc>{$loc}</loc>", $index );
@@ -61,21 +61,21 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 		$src   = 'http://example.com/image.jpg';
 		$title = 'Image title.';
 		$alt   = 'Image alt.';
-		$links = array(
-			array(
+		$links = [
+			[
 				'loc'    => $loc,
 				'mod'    => $mod,
 				'chf'    => 'daily',
 				'pri'    => 1,
-				'images' => array(
-					array(
+				'images' => [
+					[
 						'src'   => $src,
 						'title' => $title,
 						'alt'   => $alt,
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 
 		$index = self::$class_instance->get_sitemap( $links, 'post', 0 );
 		$this->assertContains( "<loc>{$loc}</loc>", $index );
@@ -100,8 +100,8 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 	public function test_is_home_url_returned_correctly() {
 		$class_instance = new WPSEO_Sitemaps_Renderer_Double();
 
-		add_filter( 'plugins_url', array( $this, 'change_plugin_url' ) );
+		add_filter( 'plugins_url', [ $this, 'change_plugin_url' ] );
 		$this->assertEquals( 'http://example.org/main-sitemap.xsl', $class_instance->get_xsl_url() );
-		remove_filter( 'plugins_url', array( $this, 'change_plugin_url' ) );
+		remove_filter( 'plugins_url', [ $this, 'change_plugin_url' ] );
 	}
 }

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps-router.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps-router.php
@@ -90,9 +90,9 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 		$this->home_url      = $home_url;
 		$GLOBALS['wp_query'] = $wp_query;
 
-		add_filter( 'home_url', array( $this, 'filter_home_url' ), 100, 2 );
+		add_filter( 'home_url', [ $this, 'filter_home_url' ], 100, 2 );
 		$result = self::$class_instance->needs_sitemap_index_redirect();
-		remove_filter( 'home_url', array( $this, 'filter_home_url' ), 100 );
+		remove_filter( 'home_url', [ $this, 'filter_home_url' ], 100 );
 
 		$GLOBALS['wp_query'] = $wp_query_orig;
 		$this->home_url      = '';
@@ -132,48 +132,48 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function data_needs_sitemap_index_redirect() {
-		$server_vars_sets = array(
-			array(
+		$server_vars_sets = [
+			[
 				'SERVER_NAME' => 'testsite.org',
 				'REQUEST_URI' => '/sitemap.xml',
-			),
-			array(
+			],
+			[
 				'HTTP_HOST'   => 'testsite.org',
 				'REQUEST_URI' => '/sitemap.xml',
-			),
-			array(
+			],
+			[
 				'SERVER_NAME' => 'testsite.org',
 				'REQUEST_URI' => '/sitemap_index.xml',
-			),
-			array(
+			],
+			[
 				'HTTP_HOST'   => 'other-testsite.org',
 				'REQUEST_URI' => '/sitemap_index.xml',
-			),
-			array(
+			],
+			[
 				'SERVER_NAME' => 'other-testsite.org',
 				'REQUEST_URI' => '/sitemap.xml',
-			),
-			array(
+			],
+			[
 				'HTTP_HOST'   => 'other-testsite.org',
 				'REQUEST_URI' => '/sitemap.xml',
-			),
-		);
+			],
+		];
 
-		$home_urls = array(
+		$home_urls = [
 			'http://testsite.org',
 			'http://other-testsite.org',
 			'https://testsite.org',
 			'https://other-testsite.org',
-		);
+		];
 
-		$wp_queries            = array(
+		$wp_queries            = [
 			new WP_Query(),
 			new WP_Query(),
-		);
+		];
 		$wp_queries[1]->is_404 = true;
 
 		// Create test data from all possible combinations, plus HTTP vs HTTPS.
-		$testdata = array();
+		$testdata = [];
 		foreach ( $server_vars_sets as $server_vars ) {
 			foreach ( $home_urls as $home_url ) {
 				foreach ( $wp_queries as $wp_query ) {
@@ -181,10 +181,10 @@ class WPSEO_Sitemaps_Router_Test extends WPSEO_UnitTestCase {
 					$path   = $server_vars['REQUEST_URI'];
 
 					$expected   = $home_url === 'http://' . $domain && $path === '/sitemap.xml' && $wp_query->is_404;
-					$testdata[] = array( $server_vars, $home_url, $wp_query, $expected );
+					$testdata[] = [ $server_vars, $home_url, $wp_query, $expected ];
 
 					$expected   = $home_url === 'https://' . $domain && $path === '/sitemap.xml' && $wp_query->is_404;
-					$testdata[] = array( array_merge( $server_vars, array( 'HTTPS' => 'on' ) ), $home_url, $wp_query, $expected );
+					$testdata[] = [ array_merge( $server_vars, [ 'HTTPS' => 'on' ] ), $home_url, $wp_query, $expected ];
 				}
 			}
 		}

--- a/integration-tests/sitemaps/test-class-wpseo-sitemaps.php
+++ b/integration-tests/sitemaps/test-class-wpseo-sitemaps.php
@@ -40,10 +40,10 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
 
-		$expected_contains = array(
+		$expected_contains = [
 			'<?xml',
 			'<urlset ',
-		);
+		];
 		$this->expectOutputContains( $expected_contains );
 	}
 
@@ -67,23 +67,23 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 
 		// Go to the XML sitemap twice, see if transient cache is set.
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
-		$expected_contains = array(
+		$expected_contains = [
 			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
 			'<sitemap>',
 			'<lastmod>',
 			'</sitemapindex>',
-		);
+		];
 		$this->expectOutputContains( $expected_contains );
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
 
-		$expected_contains = array(
+		$expected_contains = [
 			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
 			'<sitemap>',
 			'<lastmod>',
 			'</sitemapindex>',
 			'Served from transient cache',
-		);
+		];
 		$this->expectOutputContains( $expected_contains );
 
 		remove_filter( 'wpseo_enable_xml_sitemap_transient_caching', '__return_true' );
@@ -99,23 +99,23 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 		$older_date  = '2015-01-01 12:00:00';
 		$newest_date = '2016-01-01 12:00:00';
 
-		$post_type_args = array(
+		$post_type_args = [
 			'public'      => true,
 			'has_archive' => true,
-		);
+		];
 		register_post_type( 'yoast', $post_type_args );
 
-		$post_args = array(
+		$post_args = [
 			'post_status' => 'publish',
 			'post_type'   => 'yoast',
 			'post_date'   => $newest_date,
-		);
+		];
 		$this->factory->post->create( $post_args );
 
 		$post_args['post_date'] = $older_date;
 		$this->factory->post->create( $post_args );
 
-		$this->assertEquals( $newest_date, WPSEO_Sitemaps::get_last_modified_gmt( array( 'yoast' ) ) );
+		$this->assertEquals( $newest_date, WPSEO_Sitemaps::get_last_modified_gmt( [ 'yoast' ] ) );
 	}
 
 	/**
@@ -124,6 +124,6 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Sitemaps::get_last_modified_gmt
 	 */
 	public function test_last_modified_with_invalid_post_type() {
-		$this->assertFalse( WPSEO_Sitemaps::get_last_modified_gmt( array( 'invalid_post_type' ) ) );
+		$this->assertFalse( WPSEO_Sitemaps::get_last_modified_gmt( [ 'invalid_post_type' ] ) );
 	}
 }

--- a/integration-tests/statistics/test-class-statistics-service.php
+++ b/integration-tests/statistics/test-class-statistics-service.php
@@ -26,11 +26,11 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_filter_zero_counts() {
 		$statistics = new Statistics_Mock(
-			array(
+			[
 				'ok'  => 10,
 				'na'  => 0,
 				'bad' => 0,
-			)
+			]
 		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );
@@ -48,11 +48,11 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_seo_score_links() {
 		$statistics = new Statistics_Mock(
-			array(
+			[
 				'ok'  => 10,
 				'na'  => 0,
 				'bad' => 0,
-			)
+			]
 		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );
@@ -75,11 +75,11 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 		$user->add_cap( 'edit_others_posts' );
 
 		$statistics = new Statistics_Mock(
-			array(
+			[
 				'ok'  => 10,
 				'na'  => 0,
 				'bad' => 0,
-			)
+			]
 		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );
@@ -101,11 +101,11 @@ class WPSEO_Statistics_Service_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_page_counts() {
 		$statistics = new Statistics_Mock(
-			array(
+			[
 				'ok'  => 10,
 				'na'  => 0,
 				'bad' => 0,
-			)
+			]
 		);
 
 		$class_instance = new WPSEO_Statistics_Service( $statistics );

--- a/integration-tests/taxonomy/test-class-taxonomy-fields.php
+++ b/integration-tests/taxonomy/test-class-taxonomy-fields.php
@@ -16,10 +16,10 @@ class WPSEO_Taxonomy_Fields_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Taxonomy_Fields::get
 	 */
 	public function test_construct() {
-		$class = new WPSEO_Taxonomy_Fields_Double( (object) array( 'term' ) );
+		$class = new WPSEO_Taxonomy_Fields_Double( (object) [ 'term' ] );
 
 		$this->assertEquals(
-			array( '1', '2', '3' ),
+			[ '1', '2', '3' ],
 			$class->get()
 		);
 	}

--- a/integration-tests/taxonomy/test-class-taxonomy-presenter.php
+++ b/integration-tests/taxonomy/test-class-taxonomy-presenter.php
@@ -41,14 +41,14 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => 'test field',
 					'type'        => 'text',
 					'description' => 'this is a test field',
 					'options'     => '',
-				),
-			)
+				],
+			]
 		);
 
 		$expected = '<label for="wpseo_fieldname">test field</label><input name="wpseo_fieldname" id="wpseo_fieldname"  type="text" value="" size="40" aria-describedby="wpseo_fieldname-desc"/><p id="wpseo_fieldname-desc" class="yoast-metabox__description">this is a test field</p>';
@@ -64,14 +64,14 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields_no_label() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => '',
 					'type'        => 'text',
 					'description' => 'this is a test field',
 					'options'     => '',
-				),
-			)
+				],
+			]
 		);
 
 		$expected = '<input name="wpseo_fieldname" id="wpseo_fieldname"  type="text" value="" size="40" aria-describedby="wpseo_fieldname-desc"/><p id="wpseo_fieldname-desc" class="yoast-metabox__description">this is a test field</p>';
@@ -87,14 +87,14 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields_no_description() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => 'test field',
 					'type'        => 'text',
 					'description' => '',
-					'options'     => array(),
-				),
-			)
+					'options'     => [],
+				],
+			]
 		);
 
 		$this->assertEquals( '<label for="wpseo_fieldname">test field</label><input name="wpseo_fieldname" id="wpseo_fieldname"  type="text" value="" size="40"/>', $output );
@@ -107,18 +107,18 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields_select() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => 'test field',
 					'type'        => 'select',
 					'description' => '',
-					'options'     => array(
-						'options' => array(
+					'options'     => [
+						'options' => [
 							'value' => 'option_value',
-						),
-					),
-				),
-			)
+						],
+					],
+				],
+			]
 		);
 
 		$this->assertContains( '<select name="wpseo_fieldname" id="wpseo_fieldname"><option  value="value">option_value</option></select>', $output );
@@ -131,18 +131,18 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields_checkbox() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => 'test field',
 					'type'        => 'checkbox',
 					'description' => '',
-					'options'     => array(
-						'options' => array(
+					'options'     => [
+						'options' => [
 							'value' => 'option_value',
-						),
-					),
-				),
-			)
+						],
+					],
+				],
+			]
 		);
 
 		$this->assertContains( '<input name="wpseo_fieldname" id="wpseo_fieldname" type="checkbox" />', $output );
@@ -155,14 +155,14 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields_hidden() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => 'test field',
 					'type'        => 'hidden',
 					'description' => '',
 					'options'     => '',
-				),
-			)
+				],
+			]
 		);
 
 		$this->assertContains( '<input name="wpseo_fieldname" id="hidden_wpseo_fieldname" type="hidden" value="" />', $output );
@@ -175,14 +175,14 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields_upload() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => 'test field',
 					'type'        => 'upload',
 					'description' => '',
 					'options'     => '',
-				),
-			)
+				],
+			]
 		);
 
 		$this->assertContains( '<input id="wpseo_fieldname" type="text" size="36" name="wpseo_fieldname" value="" readonly="readonly" />', $output );
@@ -199,14 +199,14 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_display_fields_with_description() {
 		$output = $this->class_instance->html(
-			array(
-				'fieldname' => array(
+			[
+				'fieldname' => [
 					'label'       => 'test field',
 					'type'        => 'upload',
 					'description' => 'description for the field',
 					'options'     => '',
-				),
-			)
+				],
+			]
 		);
 
 		$this->assertContains( '<p id="wpseo_fieldname-desc" class="yoast-metabox__description">description for the field</p>', $output );

--- a/integration-tests/test-class-admin-asset-manager.php
+++ b/integration-tests/test-class-admin-asset-manager.php
@@ -36,12 +36,12 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
 			->setMethods(
-				array(
+				[
 					'register_scripts',
 					'register_styles',
 					'scripts_to_be_registered',
 					'styles_to_be_registered',
-				)
+				]
 			)
 			->getMock();
 
@@ -50,7 +50,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 			->method( 'scripts_to_be_registered' )
 			->will(
 				$this->returnValue(
-					array( 'script' )
+					[ 'script' ]
 				)
 			);
 
@@ -59,19 +59,19 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 			->method( 'styles_to_be_registered' )
 			->will(
 				$this->returnValue(
-					array( 'style' )
+					[ 'style' ]
 				)
 			);
 
 		$instance
 			->expects( $this->once() )
 			->method( 'register_scripts' )
-			->with( array( 'script' ) );
+			->with( [ 'script' ] );
 
 		$instance
 			->expects( $this->once() )
 			->method( 'register_styles' )
-			->with( array( 'style' ) );
+			->with( [ 'style' ] );
 
 		$instance->register_assets();
 	}
@@ -121,13 +121,13 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_script
 	 */
 	public function test_register_script() {
-		$asset_args = array(
+		$asset_args = [
 			'name'      => 'handle',
 			'src'       => 'src',
-			'deps'      => array( 'deps' ),
+			'deps'      => [ 'deps' ],
 			'version'   => 'version',
 			'in_footer' => 'in_footer',
-		);
+		];
 		$this->asset_manager->register_script( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2.
@@ -140,9 +140,9 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( WPSEO_Admin_Asset_Manager::PREFIX . 'handle', $result->handle );
 		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/wp-content/plugins/wordpress-seo/js/dist/src' . WPSEO_CSSJS_SUFFIX . '.js', $result->src );
-		$this->assertEquals( array( 'deps' ), $result->deps );
+		$this->assertEquals( [ 'deps' ], $result->deps );
 		$this->assertEquals( 'version', $result->ver );
-		$this->assertEquals( array( 'group' => 1 ), $result->extra );
+		$this->assertEquals( [ 'group' => 1 ], $result->extra );
 	}
 
 	/**
@@ -154,10 +154,10 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 		$prefix        = 'yoast-custom-prefix';
 		$asset_manager = new WPSEO_Admin_Asset_Manager( null, $prefix );
 
-		$asset_args = array(
+		$asset_args = [
 			'name'      => 'handle',
 			'src'       => 'src',
-		);
+		];
 		$asset_manager->register_script( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2.
@@ -173,11 +173,11 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_script
 	 */
 	public function test_register_script_suffix() {
-		$asset_args = array(
+		$asset_args = [
 			'name'   => 'handle2', // Handles have to be unique, isolation YaY ¯\_(ツ)_/¯.
 			'src'    => 'src',
 			'suffix' => '.suffix',
-		);
+		];
 		$this->asset_manager->register_script( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2.
@@ -195,13 +195,13 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_style
 	 */
 	public function test_register_style() {
-		$asset_args = array(
+		$asset_args = [
 			'name'    => 'handle',
 			'src'     => 'src',
-			'deps'    => array( 'deps' ),
+			'deps'    => [ 'deps' ],
 			'version' => 'version',
 			'media'   => 'print',
-		);
+		];
 		$this->asset_manager->register_style( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_style here but we can't because of PHP 5.2.
@@ -214,7 +214,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( WPSEO_Admin_Asset_Manager::PREFIX . 'handle', $result->handle );
 		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/wp-content/plugins/wordpress-seo/css/dist/src.css', $result->src );
-		$this->assertEquals( array( 'deps' ), $result->deps );
+		$this->assertEquals( [ 'deps' ], $result->deps );
 		$this->assertEquals( 'version', $result->ver );
 		$this->assertEquals( 'print', $result->args );
 	}
@@ -228,10 +228,10 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 		$prefix        = 'yoast-custom-prefix';
 		$asset_manager = new WPSEO_Admin_Asset_Manager( null, $prefix );
 
-		$asset_args = array(
+		$asset_args = [
 			'name'      => 'handle',
 			'src'       => 'src',
-		);
+		];
 		$asset_manager->register_style( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2.
@@ -247,11 +247,11 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset_Manager::register_script
 	 */
 	public function test_register_style_suffix() {
-		$asset_args = array(
+		$asset_args = [
 			'name'   => 'handle2', // Handles have to be unique, isolation YaY ¯\_(ツ)_/¯.
 			'src'    => 'src',
 			'suffix' => '.suffix',
-		);
+		];
 		$this->asset_manager->register_style( new WPSEO_Admin_Asset( $asset_args ) );
 
 		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2.
@@ -270,24 +270,24 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_scripts() {
 
-		$asset_args = array(
-			0 => array(
+		$asset_args = [
+			0 => [
 				'name' => 'testfile',
 				'src'  => 'testfile',
-			),
-			1 => array(
+			],
+			1 => [
 				'name'      => 'testfile2',
 				'src'       => 'testfile2',
-				'deps'      => array( 'dep1' ),
+				'deps'      => [ 'dep1' ],
 				'version'   => 'version1',
 				'in_footer' => false,
-			),
-		);
+			],
+		];
 
 		$class_instance =
 			$this
 				->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
-				->setMethods( array( 'register_script' ) )
+				->setMethods( [ 'register_script' ] )
 				->getMock();
 
 		$class_instance
@@ -314,24 +314,24 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_styles() {
 
-		$asset_args = array(
-			0 => array(
+		$asset_args = [
+			0 => [
 				'name' => 'testfile',
 				'src'  => 'testfile',
-			),
-			1 => array(
+			],
+			1 => [
 				'name'    => 'testfile2',
 				'src'     => 'testfile2',
-				'deps'    => array( 'dep1' ),
+				'deps'    => [ 'dep1' ],
 				'version' => 'version1',
 				'media'   => 'screen',
-			),
-		);
+			],
+		];
 
 		$class_instance =
 			$this
 				->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
-				->setMethods( array( 'register_style' ) )
+				->setMethods( [ 'register_style' ] )
 				->getMock();
 
 		$class_instance
@@ -361,7 +361,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 		$class_instance =
 			$this
 				->getMockBuilder( 'WPSEO_Admin_Asset_Manager' )
-				->setMethods( array( 'register_scripts', 'register_styles' ) )
+				->setMethods( [ 'register_scripts', 'register_styles' ] )
 				->getMock();
 
 		$class_instance
@@ -393,13 +393,13 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function flatten_version_provider() {
-		return array(
-			array( '3.0', '300' ),
-			array( '1.4', '140' ),
-			array( '', '' ),
-			array( '3.0.0', '300' ),
-			array( '25.1456.140', '251456140' ),
-			array( '1', '1' ),
-		);
+		return [
+			[ '3.0', '300' ],
+			[ '1.4', '140' ],
+			[ '', '' ],
+			[ '3.0.0', '300' ],
+			[ '25.1456.140', '251456140' ],
+			[ '1', '1' ],
+		];
 	}
 }

--- a/integration-tests/test-class-admin-asset.php
+++ b/integration-tests/test-class-admin-asset.php
@@ -18,7 +18,7 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @expectedException InvalidArgumentException
 	 */
 	public function test_constructor_missing_name() {
-		new WPSEO_Admin_Asset( array() );
+		new WPSEO_Admin_Asset( [] );
 	}
 
 	/**
@@ -29,9 +29,9 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @expectedException InvalidArgumentException
 	 */
 	public function test_constructor_missing_src() {
-		$asset_args = array(
+		$asset_args = [
 			'name' => 'name',
-		);
+		];
 		new WPSEO_Admin_Asset( $asset_args );
 	}
 
@@ -48,15 +48,15 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset::has_rtl
 	 */
 	public function test_constructor_default_values() {
-		$asset_args = array(
+		$asset_args = [
 			'name' => 'name',
 			'src'  => 'src',
-		);
+		];
 		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
 		$this->assertEquals( 'name', $asset->get_name() );
 		$this->assertEquals( 'src', $asset->get_src() );
-		$this->assertEquals( array(), $asset->get_deps() );
+		$this->assertEquals( [], $asset->get_deps() );
 		$this->assertEquals( WPSEO_VERSION, $asset->get_version() );
 		$this->assertEquals( 'all', $asset->get_media() );
 		$this->assertEquals( true, $asset->is_in_footer() );
@@ -75,19 +75,19 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset::has_rtl
 	 */
 	public function test_getters() {
-		$asset_args = array(
+		$asset_args = [
 			'name'      => 'name',
 			'src'       => 'src',
-			'deps'      => array( 'deps' ),
+			'deps'      => [ 'deps' ],
 			'version'   => 'version',
 			'media'     => 'screen',
 			'in_footer' => false,
 			'suffix'    => '.suffix',
 			'rtl'       => false,
-		);
+		];
 		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
-		$this->assertEquals( array( 'deps' ), $asset->get_deps() );
+		$this->assertEquals( [ 'deps' ], $asset->get_deps() );
 		$this->assertEquals( 'version', $asset->get_version() );
 		$this->assertEquals( 'screen', $asset->get_media() );
 		$this->assertEquals( false, $asset->is_in_footer() );
@@ -103,10 +103,10 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @expectedDeprecated WPSEO_Admin_Asset::get_url
 	 */
 	public function test_deprecated_get_url() {
-		$asset_args = array(
+		$asset_args = [
 			'name' => 'name',
 			'src'  => 'src',
-		);
+		];
 		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
 		$default_location = new WPSEO_Admin_Asset_SEO_Location( WPSEO_FILE );

--- a/integration-tests/test-class-primary-term-admin.php
+++ b/integration-tests/test-class-primary-term-admin.php
@@ -26,7 +26,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 		$this->class_instance =
 			$this
 				->getMockBuilder( 'WPSEO_Primary_Term_Admin' )
-				->setMethods( array( 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ) )
+				->setMethods( [ 'get_primary_term_taxonomies', 'include_js_templates', 'save_primary_term', 'get_primary_term' ] )
 				->getMock();
 	}
 
@@ -39,7 +39,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 		$this->class_instance
 			->expects( $this->once() )
 			->method( 'get_primary_term_taxonomies' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$this->class_instance
 			->expects( $this->never() )
@@ -54,9 +54,9 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Primary_Term_Admin::wp_footer
 	 */
 	public function test_wp_footer_INCLUDE_WITH_taxonomies() {
-		$taxonomies = array(
-			'category' => (object) array(),
-		);
+		$taxonomies = [
+			'category' => (object) [],
+		];
 
 		$this->class_instance
 			->expects( $this->once() )
@@ -117,15 +117,15 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 
 		$pagenow = 'post-new.php';
 
-		$taxonomies = array(
-			'category' => (object) array(
-				'labels'    => (object) array(
+		$taxonomies = [
+			'category' => (object) [
+				'labels'    => (object) [
 					'singular_name' => 'Category',
-				),
+				],
 				'name'      => 'category',
 				'rest_base' => 'categories',
-			),
-		);
+			],
+		];
 
 		$this->class_instance
 			->expects( $this->once() )
@@ -144,9 +144,9 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Primary_Term_Admin::save_primary_terms
 	 */
 	public function test_save_primary_terms_CALLS_save_primary_term() {
-		$taxonomies = array(
-			'category' => (object) array(
-				'labels'             => (object) array(
+		$taxonomies = [
+			'category' => (object) [
+				'labels'             => (object) [
 					'name'              => 'Categories',
 					'singular_name'     => 'Category',
 					'search_items'      => 'Search Categories',
@@ -162,7 +162,7 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 					'no_terms'          => 'No categories',
 					'menu_name'         => 'Categories',
 					'name_admin_bar'    => 'category',
-				),
+				],
 				'description'        => '',
 				'public'             => true,
 				'hierarchical'       => true,
@@ -172,28 +172,28 @@ class WPSEO_Primary_Term_Admin_Test extends WPSEO_UnitTestCase {
 				'show_tagcloud'      => true,
 				'show_in_quick_edit' => true,
 				'meta_box_cb'        => 'post_categories_meta_box',
-				'rewrite'            => array(
+				'rewrite'            => [
 					'with_font'    => true,
 					'hierarchical' => true,
 					'ep_mask'      => 512,
 					'slug'         => 'category',
-				),
+				],
 				'query_var'          => 'category_name',
 				'_builtin'           => true,
-				'cap'                => (object) array(
+				'cap'                => (object) [
 					'manage_terms' => 'manage_categories',
 					'edit_terms'   => 'manage_categories',
 					'delete_terms' => 'manage_categories',
 					'assign_terms' => 'edit_posts',
-				),
+				],
 				'name'               => 'category',
-				'object_type'        => array(
+				'object_type'        => [
 					'0' => 'post',
 					'1' => 'movie',
-				),
+				],
 				'label'              => 'categories',
-			),
-		);
+			],
+		];
 
 		$this->class_instance
 			->expects( $this->once() )

--- a/integration-tests/test-class-rewrite.php
+++ b/integration-tests/test-class-rewrite.php
@@ -90,10 +90,10 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Rewrite::query_vars
 	 */
 	public function test_query_vars() {
-		$this->assertEquals( array(), self::$class_instance->query_vars( array() ) );
+		$this->assertEquals( [], self::$class_instance->query_vars( [] ) );
 
 		WPSEO_Options::set( 'stripcategorybase', true );
-		$this->assertEquals( array( 'wpseo_category_redirect' ), self::$class_instance->query_vars( array() ) );
+		$this->assertEquals( [ 'wpseo_category_redirect' ], self::$class_instance->query_vars( [] ) );
 	}
 
 	/**
@@ -105,15 +105,15 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Rewrite' )
-			->setMethods( array( 'redirect' ) )
+			->setMethods( [ 'redirect' ] )
 			->getMock();
 		$instance
 			->expects( $this->never() )
 			->method( 'redirect' );
 
-		$expected = array();
+		$expected = [];
 
-		$this->assertEquals( $expected, $instance->request( array() ) );
+		$this->assertEquals( $expected, $instance->request( [] ) );
 	}
 
 	/**
@@ -125,14 +125,14 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_Rewrite' )
-			->setMethods( array( 'redirect' ) )
+			->setMethods( [ 'redirect' ] )
 			->getMock();
 		$instance
 			->expects( $this->once() )
 			->method( 'redirect' )
 			->with( 'my-category' );
 
-		$instance->request( array( 'wpseo_category_redirect' => 'my-category' ) );
+		$instance->request( [ 'wpseo_category_redirect' => 'my-category' ] );
 	}
 
 	/**
@@ -144,22 +144,22 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 
 		$c = self::$class_instance;
 
-		$categories          = get_categories( array( 'hide_empty' => false ) );
+		$categories          = get_categories( [ 'hide_empty' => false ] );
 		$permalink_structure = get_option( 'permalink_structure' );
 
 		if ( ! ( is_multisite() && 0 === strpos( $permalink_structure, '/blog/' ) ) ) {
-			$expected = array(
+			$expected = [
 				'(uncategorized)/(?:feed/)?(feed|rdf|rss|rss2|atom)/?$' => 'index.php?category_name=$matches[1]&feed=$matches[2]',
 				'(uncategorized)/page/?([0-9]{1,})/?$' => 'index.php?category_name=$matches[1]&paged=$matches[2]',
 				'(uncategorized)/?$'                   => 'index.php?category_name=$matches[1]',
-			);
+			];
 		}
 		else {
-			$expected = array(
+			$expected = [
 				'blog/(uncategorized)/(?:feed/)?(feed|rdf|rss|rss2|atom)/?$' => 'index.php?category_name=$matches[1]&feed=$matches[2]',
 				'blog/(uncategorized)/page/?([0-9]{1,})/?$' => 'index.php?category_name=$matches[1]&paged=$matches[2]',
 				'blog/(uncategorized)/?$'                   => 'index.php?category_name=$matches[1]',
-			);
+			];
 		}
 
 		global $wp_rewrite;

--- a/integration-tests/test-class-wpseo-breadcrumbs.php
+++ b/integration-tests/test-class-wpseo-breadcrumbs.php
@@ -65,7 +65,7 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	public function test_getting_url_of_private_post() {
 		$breadcrumbs = new WPSEO_Breadcrumbs_Double();
 
-		$post = $this->factory()->post->create_and_get( array( 'post_status' => 'private' ) );
+		$post = $this->factory()->post->create_and_get( [ 'post_status' => 'private' ] );
 		$this->assertEquals( '', $breadcrumbs->get_link_url_for_id( $post->ID ) );
 	}
 

--- a/integration-tests/test-class-wpseo-meta-columns.php
+++ b/integration-tests/test-class-wpseo-meta-columns.php
@@ -41,77 +41,77 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @return array The SEO filters dataprovider.
 	 */
 	public function determine_seo_filters_dataprovider() {
-		return array(
-			array(
+		return [
+			[
 				'bad',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'ok',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-						'value'   => array( 41, 70 ),
+						'value'   => [ 41, 70 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'good',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-						'value'   => array( 71, 100 ),
+						'value'   => [ 71, 100 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'na',
-				array(
-					array(
+				[
+					[
 						'key'     => '_yoast_wpseo_meta-robots-noindex',
 						'value'   => 'needs-a-value-anyway',
 						'compare' => 'NOT EXISTS',
-					),
-					array(
+					],
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
 						'value'   => 'needs-a-value-anyway',
 						'compare' => 'NOT EXISTS',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'noindex',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'meta-robots-noindex',
 						'value'   => '1',
 						'compare' => '=',
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 	}
 
 	/**
@@ -120,41 +120,41 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @return array The readability filters dataprovider.
 	 */
 	public function determine_readability_filters_dataprovider() {
-		return array(
-			array(
+		return [
+			[
 				'bad',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'ok',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-						'value'   => array( 41, 70 ),
+						'value'   => [ 41, 70 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'good',
-				array(
-					array(
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-						'value'   => array( 71, 100 ),
+						'value'   => [ 71, 100 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 	}
 
 	/**
@@ -163,116 +163,116 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @return array The Readability filters dataprovider.
 	 */
 	public function build_filter_query_dataprovider() {
-		return array(
-			array(
-				array(),
-				array(
-					array(
+		return [
+			[
+				[],
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-				array(
-					'meta_query' => array(
-						array(
-							array(
+					],
+				],
+				[
+					'meta_query' => [
+						[
+							[
 								'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-								'value'   => array( 1, 40 ),
+								'value'   => [ 1, 40 ],
 								'type'    => 'numeric',
 								'compare' => 'BETWEEN',
-							),
-						),
-					),
-				),
-			),
+							],
+						],
+					],
+				],
+			],
 
-			array(
-				array(),
-				array(
-					array(
+			[
+				[],
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-					array(
+					],
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-				array(
-					'meta_query' => array(
-						array(
+					],
+				],
+				[
+					'meta_query' => [
+						[
 							'relation' => 'AND',
-							array(
+							[
 								'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-								'value'   => array( 1, 40 ),
+								'value'   => [ 1, 40 ],
 								'type'    => 'numeric',
 								'compare' => 'BETWEEN',
-							),
-							array(
+							],
+							[
 								'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-								'value'   => array( 1, 40 ),
+								'value'   => [ 1, 40 ],
 								'type'    => 'numeric',
 								'compare' => 'BETWEEN',
-							),
-						),
-					),
-				),
-			),
+							],
+						],
+					],
+				],
+			],
 
-			array(
-				array(),
-				array(),
-				array(),
-			),
+			[
+				[],
+				[],
+				[],
+			],
 
-			array(
-				array(
+			[
+				[
 					'm'   => 0,
 					'cat' => 0,
-				),
-				array(
-					array(
+				],
+				[
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-					array(
+					],
+					[
 						'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-						'value'   => array( 1, 40 ),
+						'value'   => [ 1, 40 ],
 						'type'    => 'numeric',
 						'compare' => 'BETWEEN',
-					),
-				),
-				array(
+					],
+				],
+				[
 					'm'          => 0,
 					'cat'        => 0,
-					'meta_query' => array(
-						array(
+					'meta_query' => [
+						[
 							'relation' => 'AND',
-							array(
+							[
 								'key'     => WPSEO_Meta::$meta_prefix . 'content_score',
-								'value'   => array( 1, 40 ),
+								'value'   => [ 1, 40 ],
 								'type'    => 'numeric',
 								'compare' => 'BETWEEN',
-							),
-							array(
+							],
+							[
 								'key'     => WPSEO_Meta::$meta_prefix . 'linkdex',
-								'value'   => array( 1, 40 ),
+								'value'   => [ 1, 40 ],
 								'type'    => 'numeric',
 								'compare' => 'BETWEEN',
-							),
-						),
-					),
-				),
-			),
-		);
+							],
+						],
+					],
+				],
+			],
+		];
 	}
 
 	/**
@@ -283,7 +283,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	public function test_column_heading_has_score() {
 		self::$class_instance->set_current_post_type( 'post' );
 
-		$columns = self::$class_instance->column_heading( array() );
+		$columns = self::$class_instance->column_heading( [] );
 		$this->assertArrayHasKey( 'wpseo-score', $columns );
 	}
 
@@ -295,7 +295,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	public function test_column_heading_has_focuskw() {
 		self::$class_instance->set_current_post_type( 'post' );
 
-		$columns = self::$class_instance->column_heading( array() );
+		$columns = self::$class_instance->column_heading( [] );
 		$this->assertArrayHasKey( 'wpseo-focuskw', $columns );
 	}
 
@@ -307,7 +307,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	public function test_column_heading_has_metadesc() {
 		self::$class_instance->set_current_post_type( 'post' );
 
-		$columns = self::$class_instance->column_heading( array() );
+		$columns = self::$class_instance->column_heading( [] );
 		$this->assertArrayHasKey( 'wpseo-metadesc', $columns );
 	}
 
@@ -325,8 +325,8 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 			->method( 'has_prop' )
 			->will( $this->returnValue( false ) );
 
-		$expected = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
-		$received = self::$class_instance->column_hidden( array(), 'option-name', $user );
+		$expected = [ 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' ];
+		$received = self::$class_instance->column_hidden( [], 'option-name', $user );
 
 		$this->assertEquals( $expected, $received );
 	}
@@ -347,7 +347,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 			->method( 'has_prop' )
 			->will( $this->returnValue( true ) );
 
-		$expected = array( 'wpseo-title' );
+		$expected = [ 'wpseo-title' ];
 		$received = self::$class_instance->column_hidden( $expected, 'option-name', $user );
 
 		$this->assertEquals( $expected, $received );
@@ -366,7 +366,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 			->method( 'has_prop' )
 			->will( $this->returnValue( false ) );
 
-		$expected = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' );
+		$expected = [ 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw' ];
 
 		$received = self::$class_instance->column_hidden( false, 'option-name', $user );
 		$this->assertEquals( $expected, $received );
@@ -447,7 +447,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta_Columns::uses_default_indexing
 	 */
 	public function test_is_using_default_indexing() {
-		$post = $this->factory()->post->create_and_get( array() );
+		$post = $this->factory()->post->create_and_get( [] );
 
 		// Set metavalue.
 		WPSEO_Meta::set_value( 'meta-robots-noindex', '0', $post->ID );
@@ -463,7 +463,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta_Columns::uses_default_indexing
 	 */
 	public function test_is_not_using_default_indexing() {
-		$post = $this->factory()->post->create_and_get( array() );
+		$post = $this->factory()->post->create_and_get( [] );
 
 		// Set metavalue.
 		WPSEO_Meta::set_value( 'meta-robots-noindex', '1', $post->ID );
@@ -479,7 +479,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta_Columns::is_indexable
 	 */
 	public function test_is_indexable_when_set_on_post() {
-		$post = $this->factory()->post->create_and_get( array() );
+		$post = $this->factory()->post->create_and_get( [] );
 
 		// Set metavalue.
 		WPSEO_Meta::set_value( 'meta-robots-noindex', '2', $post->ID );
@@ -495,7 +495,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta_Columns::is_indexable
 	 */
 	public function test_is_indexable_when_using_default() {
-		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+		$post = $this->factory()->post->create_and_get( [ 'post_type' => 'post' ] );
 
 		// Set metavalue.
 		WPSEO_Meta::set_value( 'meta-robots-noindex', '0', $post->ID );
@@ -512,7 +512,7 @@ class WPSEO_Meta_Columns_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Meta_Columns::is_indexable
 	 */
 	public function test_is_not_indexable_when_using_default() {
-		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+		$post = $this->factory()->post->create_and_get( [ 'post_type' => 'post' ] );
 
 		// Set metavalue.
 		WPSEO_Meta::set_value( 'meta-robots-noindex', '0', $post->ID );

--- a/integration-tests/test-class-wpseo-meta.php
+++ b/integration-tests/test-class-wpseo-meta.php
@@ -91,7 +91,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 		$key = 'non_registered_key_array';
 
 		// The field exists on the post - because it will be saved.
-		update_post_meta( $post_id, WPSEO_Meta::$meta_prefix . $key, array( 'some_value' ) );
+		update_post_meta( $post_id, WPSEO_Meta::$meta_prefix . $key, [ 'some_value' ] );
 
 		// As the field is not registered, we should ignore the value in the database.
 		$this->assertEquals( '', WPSEO_Meta::get_value( $key ) );
@@ -145,7 +145,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 		$key = 'test_set_value_key_slashed_array';
 		$this->register_meta_key( $key, true );
 
-		$value = array( 'k\"ey' => '""slashed data" \\"' );
+		$value = [ 'k\"ey' => '""slashed data" \\"' ];
 
 		WPSEO_Meta::set_value( $key, $value, $post_id );
 		$this->assertEquals( $value, WPSEO_Meta::get_value( $key, $post_id ) );
@@ -165,7 +165,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 		$key = 'test_set_value_key_slashed_array';
 		$this->register_meta_key( $key, true );
 
-		$array = array( 'ke\\y' => '""slashed data" \\"' );
+		$array = [ 'ke\\y' => '""slashed data" \\"' ];
 		$value = serialize( $array );
 
 		WPSEO_Meta::set_value( $key, $value, $post_id );
@@ -214,7 +214,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 
 		// Default post meta should not be saved.
 		$meta_value = get_post_meta( $post_id, $key );
-		$this->assertEquals( array(), $meta_value );
+		$this->assertEquals( [], $meta_value );
 	}
 
 	/**
@@ -236,17 +236,17 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_array_merge_recursive_distinct() {
 
-		$input_array1 = array(
-			'one' => array(
-				'one-one' => array(),
-			),
-		);
+		$input_array1 = [
+			'one' => [
+				'one-one' => [],
+			],
+		];
 
-		$input_array2 = array(
-			'one' => array(
+		$input_array2 = [
+			'one' => [
 				'one-one' => 'string',
-			),
-		);
+			],
+		];
 
 		$output = WPSEO_Meta::array_merge_recursive_distinct( $input_array1, $input_array2 );
 		$this->assertEquals( $output['one']['one-one'], 'string' );
@@ -266,7 +266,7 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 		);
 		$this->assertEquals(
 			'noarchive,nosnippet',
-			WPSEO_Meta::validate_meta_robots_adv( array( 'noarchive', 'nosnippet' ) )
+			WPSEO_Meta::validate_meta_robots_adv( [ 'noarchive', 'nosnippet' ] )
 		);
 	}
 
@@ -279,16 +279,16 @@ class WPSEO_Meta_Test extends WPSEO_UnitTestCase {
 	 * @return void
 	 */
 	protected function register_meta_key( $key, $serialized = false ) {
-		WPSEO_Meta::$fields_index[ WPSEO_Meta::$meta_prefix . $key ] = array(
+		WPSEO_Meta::$fields_index[ WPSEO_Meta::$meta_prefix . $key ] = [
 			'subset' => 'test',
 			'key'    => $key,
-		);
+		];
 
-		WPSEO_Meta::$meta_fields['test'] = array(
-			$key => array(
+		WPSEO_Meta::$meta_fields['test'] = [
+			$key => [
 				'type'       => 'hidden',
 				'serialized' => $serialized,
-			),
-		);
+			],
+		];
 	}
 }

--- a/integration-tests/test-class-wpseo-metabox.php
+++ b/integration-tests/test-class-wpseo-metabox.php
@@ -74,7 +74,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 
 		$stub = $this
 			->getMockBuilder( 'WPSEO_Metabox' )
-			->setMethods( array( 'is_metabox_hidden' ) )
+			->setMethods( [ 'is_metabox_hidden' ] )
 			->getMock();
 
 		$stub
@@ -112,7 +112,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 		$GLOBALS['wpseo_admin'] = new WPSEO_Admin();
 
 		// Vars.
-		$meta_fields = apply_filters( 'wpseo_save_metaboxes', array() );
+		$meta_fields = apply_filters( 'wpseo_save_metaboxes', [] );
 		$meta_fields = array_merge(
 			$meta_fields,
 			WPSEO_Meta::get_meta_field_defs( 'general', $post->post_type ),

--- a/integration-tests/test-class-wpseo-rank.php
+++ b/integration-tests/test-class-wpseo-rank.php
@@ -51,13 +51,13 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function provider_get_css_class() {
-		return array(
-			array( WPSEO_Rank::BAD, 'bad' ),
-			array( WPSEO_Rank::OK, 'ok' ),
-			array( WPSEO_Rank::GOOD, 'good' ),
-			array( WPSEO_Rank::NO_FOCUS, 'na' ),
-			array( WPSEO_Rank::NO_INDEX, 'noindex' ),
-		);
+		return [
+			[ WPSEO_Rank::BAD, 'bad' ],
+			[ WPSEO_Rank::OK, 'ok' ],
+			[ WPSEO_Rank::GOOD, 'good' ],
+			[ WPSEO_Rank::NO_FOCUS, 'na' ],
+			[ WPSEO_Rank::NO_INDEX, 'noindex' ],
+		];
 	}
 
 	/**
@@ -81,13 +81,13 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function provider_get_label() {
-		return array(
-			array( WPSEO_Rank::NO_FOCUS, 'Not available' ),
-			array( WPSEO_Rank::NO_INDEX, 'No index' ),
-			array( WPSEO_Rank::BAD, 'Needs improvement' ),
-			array( WPSEO_Rank::OK, 'OK' ),
-			array( WPSEO_Rank::GOOD, 'Good' ),
-		);
+		return [
+			[ WPSEO_Rank::NO_FOCUS, 'Not available' ],
+			[ WPSEO_Rank::NO_INDEX, 'No index' ],
+			[ WPSEO_Rank::BAD, 'Needs improvement' ],
+			[ WPSEO_Rank::OK, 'OK' ],
+			[ WPSEO_Rank::GOOD, 'Good' ],
+		];
 	}
 
 	/**
@@ -111,13 +111,13 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function provider_get_drop_down_label() {
-		return array(
-			array( WPSEO_Rank::NO_FOCUS, 'SEO: No Focus Keyphrase' ),
-			array( WPSEO_Rank::BAD, 'SEO: Needs improvement' ),
-			array( WPSEO_Rank::OK, 'SEO: OK' ),
-			array( WPSEO_Rank::GOOD, 'SEO: Good' ),
-			array( WPSEO_Rank::NO_INDEX, 'SEO: Post Noindexed' ),
-		);
+		return [
+			[ WPSEO_Rank::NO_FOCUS, 'SEO: No Focus Keyphrase' ],
+			[ WPSEO_Rank::BAD, 'SEO: Needs improvement' ],
+			[ WPSEO_Rank::OK, 'SEO: OK' ],
+			[ WPSEO_Rank::GOOD, 'SEO: Good' ],
+			[ WPSEO_Rank::NO_INDEX, 'SEO: Post Noindexed' ],
+		];
 	}
 
 	/**
@@ -141,13 +141,13 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function provider_get_starting_score() {
-		return array(
-			array( WPSEO_Rank::NO_INDEX, -1 ),
-			array( WPSEO_Rank::NO_FOCUS, 0 ),
-			array( WPSEO_Rank::BAD, 1 ),
-			array( WPSEO_Rank::OK, 41 ),
-			array( WPSEO_Rank::GOOD, 71 ),
-		);
+		return [
+			[ WPSEO_Rank::NO_INDEX, -1 ],
+			[ WPSEO_Rank::NO_FOCUS, 0 ],
+			[ WPSEO_Rank::BAD, 1 ],
+			[ WPSEO_Rank::OK, 41 ],
+			[ WPSEO_Rank::GOOD, 71 ],
+		];
 	}
 
 	/**
@@ -171,13 +171,13 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function provider_get_end_score() {
-		return array(
-			array( WPSEO_Rank::NO_INDEX, -1 ),
-			array( WPSEO_Rank::NO_FOCUS, 0 ),
-			array( WPSEO_Rank::BAD, 40 ),
-			array( WPSEO_Rank::OK, 70 ),
-			array( WPSEO_Rank::GOOD, 100 ),
-		);
+		return [
+			[ WPSEO_Rank::NO_INDEX, -1 ],
+			[ WPSEO_Rank::NO_FOCUS, 0 ],
+			[ WPSEO_Rank::BAD, 40 ],
+			[ WPSEO_Rank::OK, 70 ],
+			[ WPSEO_Rank::GOOD, 100 ],
+		];
 	}
 
 	/**
@@ -201,18 +201,18 @@ class WPSEO_Rank_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function provider_from_numeric_score() {
-		return array(
-			array( 0, WPSEO_Rank::NO_FOCUS ),
-			array( 1, WPSEO_Rank::BAD ),
-			array( 23, WPSEO_Rank::BAD ),
-			array( 40, WPSEO_Rank::BAD ),
-			array( 41, WPSEO_Rank::OK ),
-			array( 55, WPSEO_Rank::OK ),
-			array( 70, WPSEO_Rank::OK ),
-			array( 71, WPSEO_Rank::GOOD ),
-			array( 83, WPSEO_Rank::GOOD ),
-			array( 100, WPSEO_Rank::GOOD ),
-		);
+		return [
+			[ 0, WPSEO_Rank::NO_FOCUS ],
+			[ 1, WPSEO_Rank::BAD ],
+			[ 23, WPSEO_Rank::BAD ],
+			[ 40, WPSEO_Rank::BAD ],
+			[ 41, WPSEO_Rank::OK ],
+			[ 55, WPSEO_Rank::OK ],
+			[ 70, WPSEO_Rank::OK ],
+			[ 71, WPSEO_Rank::GOOD ],
+			[ 83, WPSEO_Rank::GOOD ],
+			[ 100, WPSEO_Rank::GOOD ],
+		];
 	}
 
 	/**

--- a/integration-tests/test-class-wpseo-statistics.php
+++ b/integration-tests/test-class-wpseo-statistics.php
@@ -22,9 +22,9 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	private $default_post_args = array(
+	private $default_post_args = [
 		'post_status' => 'publish',
-	);
+	];
 
 	/**
 	 * Set up the class which will be tested.
@@ -140,7 +140,7 @@ class WPSEO_Statistics_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Statistics::get_post_count
 	 */
 	public function test_only_published_posts() {
-		$posts = $this->factory->post->create_many( 4, array( 'post_status' => 'draft' ) );
+		$posts = $this->factory->post->create_many( 4, [ 'post_status' => 'draft' ] );
 
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 0 ); // No-focus.
 		add_post_meta( $posts[0], '_yoast_wpseo_linkdex', 1 ); // Bad.

--- a/integration-tests/test-class-wpseo-utils.php
+++ b/integration-tests/test-class-wpseo-utils.php
@@ -23,7 +23,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 		}
 
 		// Admin required by default/option.
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $user_id );
 		$this->assertTrue( WPSEO_Utils::grant_access() );
 
@@ -37,7 +37,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 		$this->assertTrue( WPSEO_Utils::grant_access() );
 
 		// Below admin not allowed.
-		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
 		wp_set_current_user( $user_id );
 		$this->assertFalse( WPSEO_Utils::grant_access() );
 	}
@@ -118,28 +118,28 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 * @return array
 	 */
 	public function translate_score_provider() {
-		return array(
-			array( 0, true, 'na' ),
-			array( 1, true, 'bad' ),
-			array( 23, true, 'bad' ),
-			array( 40, true, 'bad' ),
-			array( 41, true, 'ok' ),
-			array( 55, true, 'ok' ),
-			array( 70, true, 'ok' ),
-			array( 71, true, 'good' ),
-			array( 83, true, 'good' ),
-			array( 100, true, 'good' ),
-			array( 0, false, 'Not available' ),
-			array( 1, false, 'Needs improvement' ),
-			array( 23, false, 'Needs improvement' ),
-			array( 40, false, 'Needs improvement' ),
-			array( 41, false, 'OK' ),
-			array( 55, false, 'OK' ),
-			array( 70, false, 'OK' ),
-			array( 71, false, 'Good' ),
-			array( 83, false, 'Good' ),
-			array( 100, false, 'Good' ),
-		);
+		return [
+			[ 0, true, 'na' ],
+			[ 1, true, 'bad' ],
+			[ 23, true, 'bad' ],
+			[ 40, true, 'bad' ],
+			[ 41, true, 'ok' ],
+			[ 55, true, 'ok' ],
+			[ 70, true, 'ok' ],
+			[ 71, true, 'good' ],
+			[ 83, true, 'good' ],
+			[ 100, true, 'good' ],
+			[ 0, false, 'Not available' ],
+			[ 1, false, 'Needs improvement' ],
+			[ 23, false, 'Needs improvement' ],
+			[ 40, false, 'Needs improvement' ],
+			[ 41, false, 'OK' ],
+			[ 55, false, 'OK' ],
+			[ 70, false, 'OK' ],
+			[ 71, false, 'Good' ],
+			[ 83, false, 'Good' ],
+			[ 100, false, 'Good' ],
+		];
 	}
 
 	/**
@@ -221,11 +221,11 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 		$expected = preg_split( '/,\W*/', YOAST_SEO_ENABLED_FEATURES );
 
 		// Features we expect to be added by the filter.
-		$added_features = array( 'some functionality', 'other things' );
+		$added_features = [ 'some functionality', 'other things' ];
 		// Expected features are the ones in the PHP constant + the features added by the filter.
 		$expected = array_merge( $expected, $added_features );
 
-		add_filter( 'wpseo_enable_feature', array( $this, 'filter_wpseo_enable_feature' ) );
+		add_filter( 'wpseo_enable_feature', [ $this, 'filter_wpseo_enable_feature' ] );
 		$this->assertEquals( $expected, WPSEO_Utils::retrieve_enabled_features() );
 	}
 
@@ -237,10 +237,10 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 * @return array The filtered enabled features.
 	 */
 	public function filter_wpseo_enable_feature( $enabled_features ) {
-		$second_array = array(
+		$second_array = [
 			'some functionality',
 			'other things',
-		);
+		];
 
 		return array_merge( $enabled_features, $second_array );
 	}

--- a/integration-tests/test-wpseo-functions.php
+++ b/integration-tests/test-wpseo-functions.php
@@ -19,21 +19,21 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 
 		// Create author.
 		$user_id = $this->factory->user->create(
-			array(
+			[
 				'user_login'   => 'User_Login',
 				'display_name' => 'User_Nicename',
-			)
+			]
 		);
 
 		// Create post.
 		$post_id = $this->factory->post->create(
-			array(
+			[
 				'post_title'   => 'Post_Title',
 				'post_content' => 'Post_Content',
 				'post_excerpt' => 'Post_Excerpt',
 				'post_author'  => $user_id,
 				'post_date'    => date( 'Y-m-d H:i:s', strtotime( '2000-01-01 2:30:00' ) ),
-			)
+			]
 		);
 
 		// Get post.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Round 2. Follow-up after #13911

The current PHPCS ruleset contain some directory exclusions which prevented the previous run from fixing all long arrays to short.

This should make the change-over complete though.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.