### PR TITLE
Filter test: fix @covers tag

### DIFF
--- a/integration-tests/test-filters.php
+++ b/integration-tests/test-filters.php
@@ -31,7 +31,7 @@ class Filters_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests global wp_filter.
 	 *
-	 * phpcs:disable Yoast.Commenting.TestsHaveCoversTag -- There is no actual function being tested here.
+	 * @coversNothing
 	 */
 	public function test_wp_head() {
 		$wp_head = $this->wp_filter['wp_head'];
@@ -44,5 +44,4 @@ class Filters_Test extends WPSEO_UnitTestCase {
 		$this->assertArrayNotHasKey( 'jetpack_og_tags', $wp_head[10] );
 		$this->assertArrayNotHasKey( 'wp_no_robots', $wp_head[10] );
 	}
-	// phpcs:enable Yoast.Commenting.TestsHaveCoversTag -- Because with `phpcs:ignore` it fights with the docblock sniff.
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

If a test should not cause code coverage to be recorded, you can use the PHPUnit `@coversNothing` annotation.

Ref: https://phpunit.de/manual/5.7/en/appendixes.annotations.html#appendixes.annotations.coversNothing

@igorschoester If the build passes, this can be merged straight away. I would merge it myself, but figured it may be useful for you to know how to handle this situation for the future.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.