### PR TITLE
CS: fix placement PHP open/close tags for embedded PHP

### DIFF
--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -135,10 +135,12 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				?>
 			</p>
 			<p>
-				<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/3t6' ); ?>" target="_blank"><?php
+				<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/3t6' ); ?>" target="_blank">
+					<?php
 					/* translators: %1$s expands to Yoast SEO academy */
 					printf( esc_html__( 'Check out %1$s', 'wordpress-seo' ), 'Yoast SEO academy' );
-					?></a>
+					?>
+				</a>
 			</p>
 		</div>
 		<div class="yoast-sidebar__section">


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.



## Test instructions

As this is an inline (non-block) HTML tag, a quick visual check should be done to make sure this change doesn't affect the rendered layout of the sidebar.
    If it does, there is another way this can be solved, but let's try this first.

This PR can be tested by following these steps:
* Check out `trunk`, view the admin sidebar and take note of the layout for the Yoast SEO Academy block.
* Check out this branch and make sure the rendered layout has not changed.