### PR TITLE
WPSEO_Metabox::is_internet_explorer(): bug fixes / input handling

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -72,9 +72,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return bool Whether the request comes from an IE 11 browser.
 	 */
 	public static function is_internet_explorer() {
-		$user_agent = $_SERVER['HTTP_USER_AGENT'];
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
 
-		if ( ! stripos( $user_agent, 'Trident/7.0' ) ) {
+		$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+
+		if ( stripos( $user_agent, 'Trident/7.0' ) === false ) {
 			return false;
 		}
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,6 +54,9 @@ abstract class TestCase extends BaseTestCase {
 					return \json_encode( $data, $options, $depth );
 				},
 				'wp_slash'            => null,
+				'wp_unslash'          => function ( $value ) {
+					return \is_string( $value ) ? \stripslashes( $value ) : $value;
+				},
 				'absint'              => function ( $value ) {
 					return \abs( \intval( $value ) );
 				},


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _Improved reliability of checking whether the user uses Internet Explorer_

## Relevant technical choices:

### Bug 1: no input validation

>There is no guarantee that every web server will provide any of these; servers may omit some, or provide others not listed here.

Source: https://www.php.net/manual/en/reserved.variables.server.php

You can never be sure that all "expected" `$_SERVER` variables will be passed along. Always check whether the index exists before accessing it.

### Bug 2: no unslashing/input sanitization

WP slashes all data in superglobals, so for this data to be usable in a comparison, it needs to be unslashed first.

### Bug 3: stripos() can return 0

The `stripos()` function will return an offset - which may be `0` - or false if the string is not found.
By doing a loose comparison using `!`, the _found_ case at position `0` would be incorrectly handled.

Ref: https://www.php.net/manual/en/function.stripos.php


## Test instructions

This PR can be tested by following these steps:

As this is hard to simulate via manual testing, I would recommend adding some dedicated unit tests for this function instead.

As this function was only recently introduced, I'm assigning it to the original author :smiley: 