### PR TITLE
Restore the CSS fixed table layout on the settings pages.

### DIFF
--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -4,6 +4,7 @@
 .wpseo_content_wrapper {
 	display: table;
 	width: 100%;
+	table-layout: fixed;
 }
 
 .wpseo_content_cell {


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Restored the CSS fixed table layout on the settings pages after #13962 


## Relevant technical choices:

* The fixed table layout algorithm was removed in https://github.com/Yoast/wordpress-seo/commit/0f6adc633b216e6e775e7165ab4a6e0773305be3#diff-a66b2fe73151a449fa79a2e7676283a2 as the inline comment was a bit misleading
* Looks like it's still needed by modern browsers. Difference between the two algorithms:
  - normal (default): adapts the columns width based on the table cells content: the CSS widths are only a "hint"
  - fixed: sets the columns width based on the specified CSS values _before even attempting_ to adapt to the cells content width

## Test instructions
This PR can be tested by following these steps:

-  go in the settings pages
- see the two main layout columns render correctly

Before:

<img width="1279" alt="before" src="https://user-images.githubusercontent.com/1682452/69946665-62c2ea80-14ec-11ea-8805-64bdfe5dbc32.png">

After:

<img width="1280" alt="after" src="https://user-images.githubusercontent.com/1682452/69946682-68b8cb80-14ec-11ea-8d0e-60f19258c4f2.png">


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


