### PR TITLE
Change text reference to Open Graph checkbox.

### DIFF
--- a/admin/views/tabs/social/pinterest.php
+++ b/admin/views/tabs/social/pinterest.php
@@ -17,7 +17,7 @@ echo '<h2>' . esc_html__( 'Pinterest settings', 'wordpress-seo' ) . '</h2>';
 
 printf(
 	'<p>%s</p>',
-	esc_html__( 'Pinterest uses Open Graph metadata just like Facebook, so be sure to keep the Open Graph checkbox on the Facebook tab checked if you want to optimize your site for Pinterest.', 'wordpress-seo' )
+	esc_html__( 'Pinterest uses Open Graph metadata just like Facebook, so be sure to keep the "Add Open Graph meta data" setting on the Facebook tab enabled if you want to optimize your site for Pinterest.', 'wordpress-seo' )
 );
 printf(
 	'<p>%s</p>',

--- a/admin/views/tabs/social/twitterbox.php
+++ b/admin/views/tabs/social/twitterbox.php
@@ -18,7 +18,7 @@ echo '<h2>' . esc_html__( 'Twitter settings', 'wordpress-seo' ) . '</h2>';
 
 printf(
 	'<p>%s</p>',
-	esc_html__( 'Twitter uses Open Graph metadata just like Facebook, so be sure to keep the Open Graph checkbox on the Facebook tab checked if you want to optimize your site for Twitter.', 'wordpress-seo' )
+	esc_html__( 'Twitter uses Open Graph metadata just like Facebook, so be sure to keep the "Add Open Graph meta data" setting on the Facebook tab enabled if you want to optimize your site for Twitter.', 'wordpress-seo' )
 );
 
 $yform->light_switch( 'twitter', __( 'Add Twitter card meta data', 'wordpress-seo' ), [], true, '', true );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updated text reference to Open Graph checkbox.

## Relevant technical choices:

* This quick PR fixes the last pending part of https://github.com/Yoast/bugreports/issues/404
* A couple text strings on the SEO > Social > Twitter and SEO > Social > Pinterest still referenced an "Open Graph checkbox" on the Facebook tab that doesn't exist any longer
* Updated two text strings to reference the "Add Open Graph meta data setting"

## Test instructions

This PR can be tested by following these steps:

* on trunk:
* go to the SEO > Social > Twitter and SEO > Social > Pinterest
* see the text referencing a "checkbox":

<img width="658" alt="Screenshot 2019-12-03 at 10 03 20" src="https://user-images.githubusercontent.com/1682452/70037093-4b503400-15b6-11ea-86a8-3403bb759df7.png">

* go to the Facebook tab
* see there's no checkbox, instead there's a "switch toggle" control:

<img width="329" alt="Screenshot 2019-12-03 at 10 02 31" src="https://user-images.githubusercontent.com/1682452/70037145-5efb9a80-15b6-11ea-9f12-3b37eb36d4b9.png">

* switch to this branch
* go to the SEO > Social > Twitter and SEO > Social > Pinterest
* see the new text referencing an "Add Open Graph meta data" setting to be enabled:

<img width="632" alt="Screenshot 2019-12-03 at 10 20 16" src="https://user-images.githubusercontent.com/1682452/70037244-8a7e8500-15b6-11ea-9416-9cd1516a78e0.png">

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/404
