### PR TITLE
Indexables: fix per-post robots setting

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -282,11 +282,14 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			]
 		);
 
-		$private           = \get_post_status( $this->model->object_id ) === 'private';
-		$post_type_noindex = ! $this->post_type->is_indexable( $this->model->object_sub_type );
+		// When the post specific index is not set, look to the post status and default of the post type.
+		if ( $this->model->is_robots_noindex === null ) {
+			$post_status_private = \get_post_status( $this->model->object_id ) === 'private';
+			$post_type_noindex   = ! $this->post_type->is_indexable( $this->model->object_sub_type );
 
-		if ( $private || $post_type_noindex ) {
-			$robots['index'] = 'noindex';
+			if ( $post_status_private || $post_type_noindex ) {
+				$robots['index'] = 'noindex';
+			}
 		}
 
 		return $robots;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the per post robot override was not being honored.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

The following can be done with all post types (post, page, custom posts). I will use posts only for the test instructions.

### Check with the default set to `noindex`
* Set the indexing of a post type to `false`: SEO > Search Appearance > Content Types > Show Posts in search results? > No
* Set the indexing of an individual post to `true`: Metabox > SEO > Advanced > Allow search engines to show this Post in search results? > Yes
* Check the source of the frontend.
  * No robots tag or with `index`: `<meta name="robots" content="index"/>`
  * A canonical: `<link rel="canonical" href=""/>`
  * A rel next/prev when applicable: `<link rel="next" href=""/>`
* Set the indexing of an individual post to `false`: Metabox > SEO > Advanced > Allow search engines to show this Post in search results? > No
* Check the source of the frontend.
  * A robots tag with `noindex`: `<meta name="robots" content="noindex"/>`
  * No canonical tag: `<link rel="canonical" href=""/>`
  * No rel next/prev: `<link rel="next" href=""/>`
* Set the indexing of an individual post to `default`: Metabox > SEO > Advanced > Allow search engines to show this Post in search results? > Default for Posts
* Check the source of the frontend.
  * A robots tag with `noindex`: `<meta name="robots" content="noindex"/>`
  * No canonical tag: `<link rel="canonical" href=""/>`
  * No rel next/prev: `<link rel="next" href=""/>`

### Check with the default set to `index`
* Set the indexing of a post type to `true`: SEO > Search Appearance > Content Types > Show Posts in search results? > Yes
* Set the indexing of an individual post to `default`: Metabox > SEO > Advanced > Allow search engines to show this Post in search results? > Default for Posts
* Check the source of the frontend.
  * No robots tag or with `index`: `<meta name="robots" content="index"/>`
  * A canonical: `<link rel="canonical" href=""/>`
  * A rel next/prev when applicable: `<link rel="next" href=""/>`
* Set the indexing of an individual post to `true`: Metabox > SEO > Advanced > Allow search engines to show this Post in search results? > Yes
* Check the source of the frontend.
  * No robots tag or with `index`: `<meta name="robots" content="index"/>`
  * A canonical: `<link rel="canonical" href=""/>`
  * A rel next/prev when applicable: `<link rel="next" href=""/>`
* Set the indexing of an individual post to `false`: Metabox > SEO > Advanced > Allow search engines to show this Post in search results? > No
* Check the source of the frontend.
  * A robots tag with `noindex`: `<meta name="robots" content="noindex"/>`
  * No canonical tag: `<link rel="canonical" href=""/>`
  * No rel next/prev: `<link rel="next" href=""/>`


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13997
