### PR TITLE
Use WPSEO_Options::get where we can

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -29,14 +29,6 @@ class Yoast_Form {
 	public $option_name;
 
 	/**
-	 * Option values for the WPSEO_Options.
-	 *
-	 * @var array
-	 * @since 2.0
-	 */
-	public $options = [];
-
-	/**
 	 * Option instance.
 	 *
 	 * @since 8.4
@@ -117,29 +109,9 @@ class Yoast_Form {
 	public function set_option( $option_name ) {
 		$this->option_name = $option_name;
 
-		$this->options = WPSEO_Options::get_option( $option_name );
-		if ( $this->options === null ) {
-			$this->options = (array) get_option( $option_name, [] );
-		}
-
 		$this->option_instance = WPSEO_Options::get_option_instance( $option_name );
 		if ( ! $this->option_instance ) {
 			$this->option_instance = null;
-		}
-	}
-
-	/**
-	 * Sets a value in the options.
-	 *
-	 * @since 5.4
-	 *
-	 * @param string $key       The key of the option to set.
-	 * @param mixed  $value     The value to set the option to.
-	 * @param bool   $overwrite Whether to overwrite existing options. Default is false.
-	 */
-	public function set_options_value( $key, $value, $overwrite = false ) {
-		if ( $overwrite || ! array_key_exists( $key, $this->options ) ) {
-			$this->options[ $key ] = $value;
 		}
 	}
 
@@ -269,12 +241,10 @@ class Yoast_Form {
 	 * @param bool   $label_left Whether the label should be left (true) or right (false).
 	 */
 	public function checkbox( $var, $label, $label_left = false ) {
-		if ( ! isset( $this->options[ $var ] ) ) {
-			$this->options[ $var ] = false;
-		}
+		$val = WPSEO_Options::get( $var, false );
 
-		if ( $this->options[ $var ] === true ) {
-			$this->options[ $var ] = 'on';
+		if ( $val === true ) {
+			$val = 'on';
 		}
 
 		$class = '';
@@ -285,7 +255,7 @@ class Yoast_Form {
 			$class = 'double';
 		}
 
-		echo '<input class="checkbox ', esc_attr( $class ), '" type="checkbox" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $this->options[ $var ], 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>';
+		echo '<input class="checkbox ', esc_attr( $class ), '" type="checkbox" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $val, 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>';
 
 		if ( ! empty( $label ) ) {
 			$this->label( $label, [ 'for' => $var ] );
@@ -307,13 +277,10 @@ class Yoast_Form {
 	 * @param bool   $strong  Whether the visual label is displayed in strong text. Default is false.
 	 */
 	public function light_switch( $var, $label, $buttons = [], $reverse = true, $help = '', $strong = false ) {
+		$val = WPSEO_Options::get( $var, false );
 
-		if ( ! isset( $this->options[ $var ] ) ) {
-			$this->options[ $var ] = false;
-		}
-
-		if ( $this->options[ $var ] === true ) {
-			$this->options[ $var ] = 'on';
+		if ( $val === true ) {
+			$val = 'on';
 		}
 
 		$class = 'switch-light switch-candy switch-yoast-seo';
@@ -328,9 +295,6 @@ class Yoast_Form {
 
 		list( $off_button, $on_button ) = $buttons;
 
-		$help_class               = '';
-		$screen_reader_text_class = '';
-
 		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
 
 		$strong_class = ( $strong ) ? ' switch-light-visual-label__strong' : '';
@@ -338,7 +302,7 @@ class Yoast_Form {
 		echo '<div class="switch-container', $help_class, '">',
 		'<span class="switch-light-visual-label' . $strong_class . '" id="', esc_attr( $var . '-label' ), '">', esc_html( $label ), '</span>' . $help,
 		'<label class="', $class, '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>',
-		'<input type="checkbox" aria-labelledby="', esc_attr( $var . '-label' ), '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $this->options[ $var ], 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>',
+		'<input type="checkbox" aria-labelledby="', esc_attr( $var . '-label' ), '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $val, 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>',
 		'<span aria-hidden="true">
 			<span>', esc_html( $off_button ) ,'</span>
 			<span>', esc_html( $on_button ) ,'</span>
@@ -370,7 +334,7 @@ class Yoast_Form {
 			'class'       => '',
 		];
 		$attr       = wp_parse_args( $attr, $defaults );
-		$val        = isset( $this->options[ $var ] ) ? $this->options[ $var ] : '';
+		$val        = WPSEO_Options::get( $var, '' );
 		$attributes = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';
 		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
 			$attributes .= ' disabled';
@@ -416,7 +380,7 @@ class Yoast_Form {
 			'class' => '',
 		];
 		$attr     = wp_parse_args( $attr, $defaults );
-		$val      = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		$val      = WPSEO_Options::get( $var, '' );
 
 		$this->label(
 			$label,
@@ -437,7 +401,7 @@ class Yoast_Form {
 	 * @param string $id  The ID of the element.
 	 */
 	public function hidden( $var, $id = '' ) {
-		$val = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		$val = WPSEO_Options::get( $var, '' );
 		if ( is_bool( $val ) ) {
 			$val = ( $val === true ) ? 'true' : 'false';
 		}
@@ -478,7 +442,7 @@ class Yoast_Form {
 		}
 
 		$select_name       = esc_attr( $this->option_name ) . '[' . esc_attr( $var ) . ']';
-		$active_option     = ( isset( $this->options[ $var ] ) ) ? $this->options[ $var ] : '';
+		$active_option     = WPSEO_Options::get( $var, '' );
 		$wrapper_start_tag = '';
 		$wrapper_end_tag   = '';
 
@@ -511,9 +475,9 @@ class Yoast_Form {
 	 * @param string $label The label to show for the variable.
 	 */
 	public function file_upload( $var, $label ) {
-		$val = '';
-		if ( isset( $this->options[ $var ] ) && is_array( $this->options[ $var ] ) ) {
-			$val = $this->options[ $var ]['url'];
+		$val = WPSEO_Options::get( $var, '' );
+		if ( is_array( $val ) ) {
+			$val = $val['url'];
 		}
 
 		$var_esc = esc_attr( $var );
@@ -527,7 +491,7 @@ class Yoast_Form {
 		echo '<input type="file" value="' . esc_attr( $val ) . '" class="textinput" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" id="' . $var_esc . '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>';
 
 		// Need to save separate array items in hidden inputs, because empty file inputs type will be deleted by settings API.
-		if ( ! empty( $this->options[ $var ] ) ) {
+		if ( ! empty( $val ) ) {
 			$this->hidden( 'file', $this->option_name . '_file' );
 			$this->hidden( 'url', $this->option_name . '_url' );
 			$this->hidden( 'type', $this->option_name . '_type' );
@@ -544,15 +508,8 @@ class Yoast_Form {
 	 * @param string $label Label message.
 	 */
 	public function media_input( $var, $label ) {
-		$val = '';
-		if ( isset( $this->options[ $var ] ) ) {
-			$val = $this->options[ $var ];
-		}
-
-		$id_value = '';
-		if ( isset( $this->options[ $var . '_id' ] ) ) {
-			$id_value = $this->options[ $var . '_id' ];
-		}
+		$val      = WPSEO_Options::get( $var, '' );
+		$id_value = WPSEO_Options::get( $var . '_id', '' );
 
 		$var_esc = esc_attr( $var );
 
@@ -613,9 +570,7 @@ class Yoast_Form {
 		if ( ! is_array( $values ) || $values === [] ) {
 			return;
 		}
-		if ( ! isset( $this->options[ $var ] ) ) {
-			$this->options[ $var ] = false;
-		}
+		$val = WPSEO_Options::get( $var, false );
 
 		$var_esc = esc_attr( $var );
 
@@ -643,7 +598,7 @@ class Yoast_Form {
 			}
 
 			$key_esc = esc_attr( $key );
-			echo '<input type="radio" class="radio" id="' . $var_esc . '-' . $key_esc . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $this->options[ $var ], $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />';
+			echo '<input type="radio" class="radio" id="' . $var_esc . '-' . $key_esc . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $val, $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />';
 			$this->label(
 				$label,
 				[
@@ -672,14 +627,12 @@ class Yoast_Form {
 		if ( ! is_array( $values ) || $values === [] ) {
 			return;
 		}
-		if ( ! isset( $this->options[ $var ] ) ) {
-			$this->options[ $var ] = false;
+		$val = WPSEO_Options::get( $var, false );
+		if ( $val === true ) {
+			$val = 'on';
 		}
-		if ( $this->options[ $var ] === true ) {
-			$this->options[ $var ] = 'on';
-		}
-		if ( $this->options[ $var ] === false ) {
-			$this->options[ $var ] = 'off';
+		if ( $val === false ) {
+			$val = 'off';
 		}
 
 		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
@@ -703,7 +656,7 @@ class Yoast_Form {
 
 			$key_esc = esc_attr( $key );
 			$for     = $var_esc . '-' . $key_esc;
-			echo '<input type="radio" id="' . $for . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $this->options[ $var ], $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />',
+			echo '<input type="radio" id="' . $for . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $val, $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />',
 			'<label for="', $for, '">', esc_html( $value ), $screen_reader_text_html,'</label>';
 		}
 

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -77,9 +77,7 @@ function wpseo_admin_bar_menu() {
 		return;
 	}
 
-	$options = WPSEO_Options::get_options( [ 'wpseo', 'wpseo_ms' ] );
-
-	if ( $options['enable_admin_bar_menu'] !== true ) {
+	if ( WPSEO_Options::get( 'enable_admin_bar_menu',true ) ) {
 		return;
 	}
 

--- a/integration-tests/admin/test-class-yoast-form.php
+++ b/integration-tests/admin/test-class-yoast-form.php
@@ -20,10 +20,8 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 		$form->set_option( 'wpseo' );
 
 		$option_instance = WPSEO_Options::get_option_instance( 'wpseo' );
-		$option_keys     = array_keys( get_option( 'wpseo', [] ) );
 
 		$this->assertSame( 'wpseo', $form->option_name );
-		$this->assertEqualSets( $option_keys, array_keys( $form->options ) );
 		$this->assertSame( $option_instance, $form->get_option_instance() );
 	}
 
@@ -40,7 +38,6 @@ class Yoast_Form_Test extends WPSEO_UnitTestCase {
 		$form->set_option( 'random' );
 
 		$this->assertSame( 'random', $form->option_name );
-		$this->assertEqualSets( $option_keys, array_keys( $form->options ) );
 		$this->assertNull( $form->get_option_instance() );
 	}
 


### PR DESCRIPTION
## Summary
This uses `WPSEO_Options::get` where we can instead of a local `$this->options` everywhere.

This PR can be summarized in the following changelog entry:

* Optimized option retrieval on admin pages.

## Relevant technical choices:

* See Summary.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See Yoast SEO admin pages, make sure all forms still work as intended.
* Make sure you can still disable the admin bar.
* Do a quick check with the site-wide settings on multisite 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
