### PR TITLE
Extends the OG image class with the one that replaces it

### DIFF
--- a/deprecated/frontend/class-opengraph-image.php
+++ b/deprecated/frontend/class-opengraph-image.php
@@ -5,12 +5,16 @@
  * @package WPSEO\Frontend
  */
 
+use Yoast\WP\Free\Values\Open_Graph\Images;
+
+_deprecated_file( basename( __FILE__ ), 'WPSEO xx.x' );
+
 /**
  * Class WPSEO_OpenGraph_Image.
  *
  * @deprecated xx.x
  */
-class WPSEO_OpenGraph_Image {
+class WPSEO_OpenGraph_Image extends Images {
 
 	/**
 	 * The image ID used when the image is external.
@@ -29,91 +33,6 @@ class WPSEO_OpenGraph_Image {
 	 * @param WPSEO_OpenGraph $opengraph Optional. The OpenGraph object.
 	 */
 	public function __construct( $image = null, WPSEO_OpenGraph $opengraph = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-	}
-
-	/**
-	 * Outputs the images.
-	 *
-	 * @deprecated xx.x
-	 * @codeCoverageIgnore
-	 *
-	 * @return void
-	 */
-	public function show() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-	}
-
-	/**
-	 * Returns the images array.
-	 *
-	 * @deprecated xx.x
-	 * @codeCoverageIgnore
-	 *
-	 * @return array The images.
-	 */
-	public function get_images() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
-		return array();
-	}
-
-	/**
-	 * Checks whether we have images or not.
-	 *
-	 * @deprecated xx.x
-	 * @codeCoverageIgnore
-	 *
-	 * @return bool True if we have images, false if we don't.
-	 */
-	public function has_images() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
-		return false;
-	}
-
-	/**
-	 * Displays an OpenGraph image tag.
-	 *
-	 * @deprecated xx.x
-	 * @codeCoverageIgnore
-	 *
-	 * @param string|array $attachment Attachment array.
-	 *
-	 * @return void
-	 */
-	public function add_image( $attachment ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-	}
-
-	/**
-	 * Adds an image based on a given URL, and attempts to be smart about it.
-	 *
-	 * @deprecated xx.x
-	 * @codeCoverageIgnore
-	 *
-	 * @param string $url The given URL.
-	 *
-	 * @return null|number Returns the found attachment ID if it exists. Otherwise -1.
-	 *                     If the URL is empty we return null.
-	 */
-	public function add_image_by_url( $url ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
-		return -1;
-	}
-
-	/**
-	 * Adds an image to the list by attachment ID.
-	 *
-	 * @deprecated xx.x
-	 * @codeCoverageIgnore
-	 *
-	 * @param int $attachment_id The attachment ID to add.
-	 *
-	 * @return void
-	 */
-	public function add_image_by_id( $attachment_id ) {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It just deprecates the OpenGraph Image class gracefully.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add this to `wp-seo.php`
```php
add_action( 'init', function() {
	$haha = new WPSEO_OpenGraph_Image();
} );
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13939
