### PR TITLE
Remove BlackFriday option

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -51,17 +51,18 @@ class WPSEO_Upgrade {
 			'12.1-RC0'  => 'clean_all_notifications',
 			'12.3-RC0'  => 'upgrade_123',
 			'12.4-RC0'  => 'upgrade_124',
+			'12.5-RC0'  => 'upgrade_125',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
 
-		if ( version_compare( $version, '12.5-RC0', '<' ) ) {
+		if ( version_compare( $version, '12.7-RC0', '<' ) ) {
 			/*
 			 * We have to run this by hook, because otherwise:
 			 * - the theme support check isn't available.
 			 * - the notification center notifications are not filled yet.
 			 */
-			add_action( 'init', [ $this, 'upgrade_125' ] );
+			add_action( 'init', [ $this, 'upgrade_127' ] );
 		}
 
 		// Since 3.7.
@@ -677,6 +678,14 @@ class WPSEO_Upgrade {
 		// Removes the WordPress update notification, because it is no longer necessary when WordPress 5.3 is released.
 		$center = Yoast_Notification_Center::get();
 		$center->remove_notification_by_id( 'wpseo-dismiss-wordpress-upgrade' );
+	}
+
+	/**
+	 * Performs the 12.7 upgrade.
+	 */
+	public function upgrade_127() {
+		// Re-save wpseo to make sure bf_banner_2019_dismissed key is gone.
+		$this->cleanup_option_data( 'wpseo' );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -52,7 +52,6 @@ class WPSEO_Upgrade {
 			'12.3-RC0'  => 'upgrade_123',
 			'12.4-RC0'  => 'upgrade_124',
 			'12.7-RC0'  => 'upgrade_127',
-
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -51,18 +51,19 @@ class WPSEO_Upgrade {
 			'12.1-RC0'  => 'clean_all_notifications',
 			'12.3-RC0'  => 'upgrade_123',
 			'12.4-RC0'  => 'upgrade_124',
-			'12.5-RC0'  => 'upgrade_125',
+			'12.7-RC0'  => 'upgrade_127',
+
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
 
-		if ( version_compare( $version, '12.7-RC0', '<' ) ) {
+		if ( version_compare( $version, '12.5-RC0', '<' ) ) {
 			/*
 			 * We have to run this by hook, because otherwise:
 			 * - the theme support check isn't available.
 			 * - the notification center notifications are not filled yet.
 			 */
-			add_action( 'init', [ $this, 'upgrade_127' ] );
+			add_action( 'init', [ $this, 'upgrade_125' ] );
 		}
 
 		// Since 3.7.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* None needed

## Relevant technical choices:

* Re-saved the `wpseo` option, which makes the validation run and thus removes the no longer valid keys.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure you have a database where `bf_banner_2019_dismissed` is stored, probably with value `true` in the `wpseo` option.
* In Yoast Test Helper, set the version to 12.6, see that the upgrade routine runs and the `bf_banner_2019_dismissed` key is removed from the `wpseo` option.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13965
