### PR TITLE
Set @wordpress packages as externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "@wordpress/i18n": "^3.3.0",
     "@wordpress/is-shallow-equal": "^1.2.0",
     "@wordpress/rich-text": "^3.2.2",
-    "@wordpress/url": "^2.5.0",
     "@yoast/analysis-report": "^0.11.0-rc.1",
     "@yoast/components": "^0.11.0-rc.1",
     "@yoast/configuration-wizard": "^1.10.0-rc.1",

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -40,6 +40,8 @@ const wordpressExternals = {
 	"@wordpress/api-fetch": "window.wp.apiFetch",
 	"@wordpress/rich-text": "window.wp.richText",
 	"@wordpress/compose": "window.wp.compose",
+	"@wordpress/autop": "window.wp.autop",
+	"@wordpress/url": "window.wp.url",
 };
 
 // Make sure all these packages are exposed in `./js/src/components.js`.


### PR DESCRIPTION
## Summary

Sets `@wordpress/autop` and `@wordpress/url` as externals so we don't include them in our packages. Saves about 50KB.

This PR can be summarized in the following changelog entry:

* Optimize JavaScript package size by removing `@wordpress/autop` and `@wordpress/url` from our packages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Get this branch, build the JS.
* The editor and all Yoast SEO functionality in it should remain working.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13974
