### PR TITLE
13996 send list of blocks to analysis

### DIFF
--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -19,7 +19,16 @@ function filterBlockData( block ) {
 	const filteredBlock = {};
 
 	// Main data of the block (content, but also heading level etc.)
-	filteredBlock.attributes = Object.assign( {}, block.attributes );
+	filteredBlock.attributes = {};
+
+	// Heading level, HTML-content and image alt text.
+	const attributeNames = [ "level", "content", "alt" ];
+	attributeNames.forEach( name => {
+		if ( block.attributes[ name ] ) {
+			filteredBlock.attributes[ name ] = block.attributes[ name ];
+		}
+	} );
+
 	// Type of block, e.g. "core/paragraph"
 	filteredBlock.name = block.name;
 	filteredBlock.clientId = block.clientId;

--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -6,8 +6,6 @@ import getContentLocale from "./getContentLocale";
 
 import { Paper } from "yoastseo";
 
-/* global wp */
-
 /**
  * Filters the WordPress block editor block data to use for the analysis.
  *

--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -50,21 +50,23 @@ function filterBlockData( block ) {
  * 3. Pluggable modifications.
  * 4. The WordPress block-editor Redux store.
  *
- * @param {Edit}               edit               The edit instance.
- * @param {Object}             store              The redux store.
- * @param {CustomAnalysisData} customAnalysisData The custom analysis data.
- * @param {Pluggable}          pluggable          The Pluggable.
+ * @param {Edit}               edit                   The edit instance.
+ * @param {Object}             store                  The redux store.
+ * @param {CustomAnalysisData} customAnalysisData     The custom analysis data.
+ * @param {Pluggable}          pluggable              The Pluggable.
+ * @param {Object}            [blockEditorDataModule] The WordPress block editor data module. E.g. `window.wp.data.select("core/block-editor")`
  *
  * @returns {Paper} The paper data used for the analyses.
  */
-export default function collectAnalysisData( edit, store, customAnalysisData, pluggable ) {
+export default function collectAnalysisData( edit, store, customAnalysisData, pluggable, blockEditorDataModule ) {
 	const storeData = cloneDeep( store.getState() );
 	merge( storeData, customAnalysisData.getData() );
 	const editData = edit.getData().getData();
 
 	// Retrieve the block editor blocks from WordPress and filter on useful information.
-	let blocks = wp.data.select( "core/block-editor" ).getBlocks();
-	if ( blocks ) {
+	let blocks = null;
+	if ( blockEditorDataModule ) {
+		blocks = blockEditorDataModule.getBlocks();
 		blocks = blocks.map( block => filterBlockData( block ) );
 	}
 

--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -6,6 +6,8 @@ import getContentLocale from "./getContentLocale";
 
 import { Paper } from "yoastseo";
 
+/* global wp */
+
 /**
  * Retrieves the data needed for the analyses.
  *
@@ -26,6 +28,8 @@ export default function collectAnalysisData( edit, store, customAnalysisData, pl
 	merge( storeData, customAnalysisData.getData() );
 	const editData = edit.getData().getData();
 
+	const blocks = wp.data.select( "core/block-editor" ).getBlocks();
+
 	// Make a data structure for the paper data.
 	const data = {
 		text: editData.content,
@@ -40,6 +44,7 @@ export default function collectAnalysisData( edit, store, customAnalysisData, pl
 		title: storeData.analysisData.snippet.title || storeData.snippetEditor.data.title,
 		url: storeData.snippetEditor.data.slug,
 		permalink: storeData.settings.snippetEditor.baseUrl + storeData.snippetEditor.data.slug,
+		wpBlocks: blocks,
 	};
 
 	// Modify the data through pluggable.

--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -82,6 +82,7 @@ export default function collectAnalysisData( edit, store, customAnalysisData, pl
 		data.title = pluggable._applyModifications( "title", data.title );
 		data.description = pluggable._applyModifications( "data_meta_desc", data.description );
 		data.text = pluggable._applyModifications( "content", data.text );
+		data.wpBlocks = pluggable._applyModifications( "wpBlocks", data.wpBlocks );
 	}
 
 	data.titleWidth = measureTextWidth( data.title );

--- a/js/src/analysis/collectAnalysisData.js
+++ b/js/src/analysis/collectAnalysisData.js
@@ -32,9 +32,7 @@ function filterBlockData( block ) {
 	filteredBlock.clientId = block.clientId;
 
 	// Recurse on inner blocks.
-	if ( block.innerBlocks ) {
-		filteredBlock.innerBlocks = block.innerBlocks.map( innerBlock => filterBlockData( innerBlock ) );
-	}
+	filteredBlock.innerBlocks = block.innerBlocks.map( innerBlock => filterBlockData( innerBlock ) );
 
 	return filteredBlock;
 }

--- a/js/src/wp-seo-post-scraper.js
+++ b/js/src/wp-seo-post-scraper.js
@@ -421,6 +421,8 @@ setWordPressSeoL10n();
 		editStore =  edit.getStore();
 		const data = edit.getData();
 
+		const blockEditorDataModule = window.wp.data.select( "core/block-editor" );
+
 		metaboxContainer = $( "#wpseo_meta" );
 
 		tinyMCEHelper.setStore( editStore );
@@ -446,7 +448,13 @@ setWordPressSeoL10n();
 		window.YoastSEO.store = editStore;
 		window.YoastSEO.analysis = {};
 		window.YoastSEO.analysis.worker = createAnalysisWorker();
-		window.YoastSEO.analysis.collectData = () => collectAnalysisData( edit, YoastSEO.store, customAnalysisData, YoastSEO.app.pluggable );
+		window.YoastSEO.analysis.collectData = () => collectAnalysisData(
+			edit,
+			YoastSEO.store,
+			customAnalysisData,
+			YoastSEO.app.pluggable,
+			blockEditorDataModule
+		);
 		window.YoastSEO.analysis.applyMarks = ( paper, marks ) => getApplyMarks( YoastSEO.store )( paper, marks );
 
 		// YoastSEO.app overwrites.

--- a/js/tests/__test-data__/blocksForAnalysisTestData.json
+++ b/js/tests/__test-data__/blocksForAnalysisTestData.json
@@ -1,0 +1,97 @@
+[
+  {
+    "attributes": {
+      "content": "<strong>Over the years, we’ve written&nbsp;quite a few articles about&nbsp;</strong><a href=\"https://yoast.com/tag/branding/\">branding</a><strong>. Branding is about getting people to relate to your company and products. It’s also about trying to make your brand synonymous with a certain product or service. This can be a lengthy and hard project. It can potentially cost you all of your revenue. It’s no wonder that branding is often associated with investing lots of money in marketing and promotion. However, for a lot of small business owners, the investment in branding will have to&nbsp;be made with a&nbsp;relatively small budget.&nbsp;</strong>"
+    },
+    "name": "core/paragraph",
+    "clientId": "6860403c-0b36-43b2-96fa-2d30c10cb44c",
+    "innerBlocks": []
+  },
+  {
+    "attributes": {
+      "content": "You might be a local bakery with 10 employees, or a local industrial company employing up to 500 people. These all can be qualified as ‘small business’. All have the same main goal when they start: the need to establish a name in their field of expertise. There are multiple ways to do this, without a huge budget. In this post, I’ll share my thoughts on how to go about your own low-budget branding."
+    },
+    "name": "core/paragraph",
+    "clientId": "65be5146-3395-4845-8c7c-4a79fd6e3611",
+    "innerBlocks": []
+  },
+  {
+    "attributes": {
+      "level": 2,
+      "content": "Define and communicate brand values"
+    },
+    "name": "core/heading",
+    "clientId": "b8e62d35-b3af-45ec-9889-139ef0a9baaa",
+    "innerBlocks": []
+  },
+  {
+    "attributes": {
+      "content": "Branding with a limited budget&nbsp;starts with defining your company’s and your brand’s values. You need to&nbsp;think about what you, as a brand, want to communicate to the world. Doing this yourself won’t cost you, provided you are capable of doing this yourself. In fact, it’s a pretty hard task, when you think of it. It’s about your&nbsp;<a href=\"https://yoast.com/whats-your-mission/\">mission</a>, the things that make your brand into your brand. Brand values relate to Cialdini’s&nbsp;<a href=\"https://en.wikipedia.org/wiki/Robert_Cialdini#The_Seventh_Principle_of_Influence\">seventh</a>&nbsp;principle, Unity."
+    },
+    "name": "core/paragraph",
+    "clientId": "87b446e4-79f4-4b62-8717-a95ca2c4500f",
+    "innerBlocks": []
+  },
+  {
+    "attributes": {
+      "content": "My favorite example illustrating unity: outdoor brands like Patagonia and The North Face, which make you feel&nbsp;<em>included</em>&nbsp;in their business ‘family’. “We are all alike, share the same values.” By being able to relate to these brands and their values, we are more enticed to buy their products. It’s a brand for&nbsp;<em>us, outdoor people</em>."
+    },
+    "name": "core/paragraph",
+    "clientId": "ddf97007-bf9f-4a82-be15-28a4b43a76f6",
+    "innerBlocks": []
+  },
+  {
+    "attributes": {
+      "content": "Take some time to define your brand values. That way, you’re able to communicate your main message in a clear and consistent way. It makes your marketing all the easier. You’ll be able to create&nbsp;<a href=\"https://yoast.com/online-customer-brand-ambassador/\">brand ambassadors</a>, even on a&nbsp;budget."
+    },
+    "name": "core/paragraph",
+    "clientId": "e5e10851-4c05-4048-a2bb-e380466d1028",
+    "innerBlocks": []
+  },
+  {
+    "attributes": {
+      "alt": "Alt text."
+    },
+    "name": "core/image",
+    "clientId": "3e1b6401-b328-4bb1-8e2d-b26e52fe8f17",
+    "innerBlocks": []
+  },
+  {
+    "attributes": {},
+    "name": "core/columns",
+    "clientId": "f6b74183-d7b0-4174-ac8e-282076aba9e2",
+    "innerBlocks": [
+      {
+        "attributes": {},
+        "name": "core/column",
+        "clientId": "008f4a5f-837a-44bd-82a8-76495ebba53e",
+        "innerBlocks": [
+          {
+            "attributes": {
+              "content": "Hello World!"
+            },
+            "name": "core/paragraph",
+            "clientId": "e25fb873-d061-41d2-8ab3-b094cb846a53",
+            "innerBlocks": []
+          }
+        ]
+      },
+      {
+        "attributes": {},
+        "name": "core/column",
+        "clientId": "f83a4294-9041-4d2f-b8f7-cf52c5aac17f",
+        "innerBlocks": [
+          {
+            "attributes": {
+              "content": "How are you doing?"
+            },
+            "name": "core/paragraph",
+            "clientId": "a391e8d3-3efc-4136-b6d9-7bc3a27a8e99",
+            "innerBlocks": []
+          }
+        ]
+      }
+    ]
+  }
+]
+

--- a/js/tests/__test-data__/gutenbergBlocksTestData.json
+++ b/js/tests/__test-data__/gutenbergBlocksTestData.json
@@ -1,0 +1,134 @@
+[
+  {
+    "clientId": "6860403c-0b36-43b2-96fa-2d30c10cb44c",
+    "name": "core/paragraph",
+    "isValid": true,
+    "validationIssues": [],
+    "originalContent": "<p><strong>Over the years, we’ve written&nbsp;quite a few articles about&nbsp;</strong><a href=\"https://yoast.com/tag/branding/\">branding</a><strong>. Branding is about getting people to relate to your company and products. It’s also about trying to make your brand synonymous with a certain product or service. This can be a lengthy and hard project. It can potentially cost you all of your revenue. It’s no wonder that branding is often associated with investing lots of money in marketing and promotion. However, for a lot of small business owners, the investment in branding will have to&nbsp;be made with a&nbsp;relatively small budget.&nbsp;</strong></p>",
+    "attributes": {
+      "content": "<strong>Over the years, we’ve written&nbsp;quite a few articles about&nbsp;</strong><a href=\"https://yoast.com/tag/branding/\">branding</a><strong>. Branding is about getting people to relate to your company and products. It’s also about trying to make your brand synonymous with a certain product or service. This can be a lengthy and hard project. It can potentially cost you all of your revenue. It’s no wonder that branding is often associated with investing lots of money in marketing and promotion. However, for a lot of small business owners, the investment in branding will have to&nbsp;be made with a&nbsp;relatively small budget.&nbsp;</strong>",
+      "dropCap": false
+    },
+    "innerBlocks": []
+  },
+  {
+    "clientId": "65be5146-3395-4845-8c7c-4a79fd6e3611",
+    "name": "core/paragraph",
+    "isValid": true,
+    "validationIssues": [],
+    "originalContent": "<p>You might be a local bakery with 10 employees, or a local industrial company employing up to 500 people. These all can be qualified as ‘small business’. All have the same main goal when they start: the need to establish a name in their field of expertise. There are multiple ways to do this, without a huge budget. In this post, I’ll share my thoughts on how to go about your own low-budget branding.</p>",
+    "attributes": {
+      "content": "You might be a local bakery with 10 employees, or a local industrial company employing up to 500 people. These all can be qualified as ‘small business’. All have the same main goal when they start: the need to establish a name in their field of expertise. There are multiple ways to do this, without a huge budget. In this post, I’ll share my thoughts on how to go about your own low-budget branding.",
+      "dropCap": false
+    },
+    "innerBlocks": []
+  },
+  {
+    "clientId": "b8e62d35-b3af-45ec-9889-139ef0a9baaa",
+    "name": "core/heading",
+    "isValid": true,
+    "validationIssues": [],
+    "originalContent": "<h2>Define and communicate brand values</h2>",
+    "attributes": {
+      "content": "Define and communicate brand values",
+      "level": 2
+    },
+    "innerBlocks": []
+  },
+  {
+    "clientId": "87b446e4-79f4-4b62-8717-a95ca2c4500f",
+    "name": "core/paragraph",
+    "isValid": true,
+    "validationIssues": [],
+    "originalContent": "<p>Branding with a limited budget&nbsp;starts with defining your company’s and your brand’s values. You need to&nbsp;think about what you, as a brand, want to communicate to the world. Doing this yourself won’t cost you, provided you are capable of doing this yourself. In fact, it’s a pretty hard task, when you think of it. It’s about your&nbsp;<a href=\"https://yoast.com/whats-your-mission/\">mission</a>, the things that make your brand into your brand. Brand values relate to Cialdini’s&nbsp;<a href=\"https://en.wikipedia.org/wiki/Robert_Cialdini#The_Seventh_Principle_of_Influence\">seventh</a>&nbsp;principle, Unity.</p>",
+    "attributes": {
+      "content": "Branding with a limited budget&nbsp;starts with defining your company’s and your brand’s values. You need to&nbsp;think about what you, as a brand, want to communicate to the world. Doing this yourself won’t cost you, provided you are capable of doing this yourself. In fact, it’s a pretty hard task, when you think of it. It’s about your&nbsp;<a href=\"https://yoast.com/whats-your-mission/\">mission</a>, the things that make your brand into your brand. Brand values relate to Cialdini’s&nbsp;<a href=\"https://en.wikipedia.org/wiki/Robert_Cialdini#The_Seventh_Principle_of_Influence\">seventh</a>&nbsp;principle, Unity.",
+      "dropCap": false
+    },
+    "innerBlocks": []
+  },
+  {
+    "clientId": "ddf97007-bf9f-4a82-be15-28a4b43a76f6",
+    "name": "core/paragraph",
+    "isValid": true,
+    "validationIssues": [],
+    "originalContent": "<p>My favorite example illustrating unity: outdoor brands like Patagonia and The North Face, which make you feel&nbsp;<em>included</em>&nbsp;in their business ‘family’. “We are all alike, share the same values.” By being able to relate to these brands and their values, we are more enticed to buy their products. It’s a brand for&nbsp;<em>us, outdoor people</em>.</p>",
+    "attributes": {
+      "content": "My favorite example illustrating unity: outdoor brands like Patagonia and The North Face, which make you feel&nbsp;<em>included</em>&nbsp;in their business ‘family’. “We are all alike, share the same values.” By being able to relate to these brands and their values, we are more enticed to buy their products. It’s a brand for&nbsp;<em>us, outdoor people</em>.",
+      "dropCap": false
+    },
+    "innerBlocks": []
+  },
+  {
+    "clientId": "e5e10851-4c05-4048-a2bb-e380466d1028",
+    "name": "core/paragraph",
+    "isValid": true,
+    "validationIssues": [],
+    "originalContent": "<p>Take some time to define your brand values. That way, you’re able to communicate your main message in a clear and consistent way. It makes your marketing all the easier. You’ll be able to create <a href=\"https://yoast.com/online-customer-brand-ambassador/\">brand ambassadors</a>, even on a budget.</p>",
+    "attributes": {
+      "content": "Take some time to define your brand values. That way, you’re able to communicate your main message in a clear and consistent way. It makes your marketing all the easier. You’ll be able to create&nbsp;<a href=\"https://yoast.com/online-customer-brand-ambassador/\">brand ambassadors</a>, even on a&nbsp;budget.",
+      "dropCap": false
+    },
+    "innerBlocks": []
+  },
+  {
+    "clientId": "3e1b6401-b328-4bb1-8e2d-b26e52fe8f17",
+    "name": "core/image",
+    "isValid": true,
+    "validationIssues": [],
+    "originalContent": "<figure class=\"wp-block-image size-large\"><img src=\"http://local.wordpress.test/wp-content/uploads/2019/07/1729a430-2c59-3f53-b508-c90a8ce08906-1024x647.jpg\" alt=\"Alt text.\" class=\"wp-image-749\"/><figcaption>A caption.</figcaption></figure>",
+    "attributes": {
+      "url": "http://local.wordpress.test/wp-content/uploads/2019/07/1729a430-2c59-3f53-b508-c90a8ce08906-1024x647.jpg",
+      "alt": "Alt text.",
+      "caption": "A caption.",
+      "id": 749,
+      "sizeSlug": "large",
+      "linkDestination": "none"
+    },
+    "innerBlocks": []
+  },
+  {
+    "clientId": "f6b74183-d7b0-4174-ac8e-282076aba9e2",
+    "name": "core/columns",
+    "isValid": true,
+    "attributes": {},
+    "innerBlocks": [
+      {
+        "clientId": "008f4a5f-837a-44bd-82a8-76495ebba53e",
+        "name": "core/column",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [
+          {
+            "clientId": "e25fb873-d061-41d2-8ab3-b094cb846a53",
+            "name": "core/paragraph",
+            "isValid": true,
+            "attributes": {
+              "content": "Hello World!",
+              "dropCap": false
+            },
+            "innerBlocks": []
+          }
+        ]
+      },
+      {
+        "clientId": "f83a4294-9041-4d2f-b8f7-cf52c5aac17f",
+        "name": "core/column",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [
+          {
+            "clientId": "a391e8d3-3efc-4136-b6d9-7bc3a27a8e99",
+            "name": "core/paragraph",
+            "isValid": true,
+            "attributes": {
+              "content": "How are you doing?",
+              "dropCap": false
+            },
+            "innerBlocks": []
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/js/tests/collectAnalysisData.test.js
+++ b/js/tests/collectAnalysisData.test.js
@@ -1,0 +1,92 @@
+import collectAnalysisData from "../src/analysis/collectAnalysisData";
+import gutenbergBlocks from "./__test-data__/gutenbergBlocksTestData";
+
+describe( "filterBlockData", () => {
+	const storeData = {
+		focusKeyword: "focus keyword",
+		synonyms: [],
+		analysisData: {
+			snippet: {
+				description: "A meta description",
+				title: "A meta title",
+			},
+		},
+		snippetEditor: {
+			data: {
+				slug: "a-slug",
+			},
+		},
+		settings: {
+			snippetEditor: {
+				baseUrl: "https://example.org/",
+			},
+		},
+	};
+
+	/**
+	 * Mocks an edit store.
+	 *
+	 * @param {string} content The editors content.
+	 *
+	 * @returns {Edit} The mocked edit store.
+	 */
+	function mockEdit( content ) {
+		return {
+			getData: () => ( {
+				getData: () => ( { content } ),
+			} ),
+		};
+	}
+
+	/**
+	 * Mocks the Pluggable.
+	 *
+	 * @returns {Pluggable} The mocked Pluggable.
+	 */
+	function mockPluggable() {
+		return {
+			_applyModifications: ( modification, content ) => content,
+		};
+	}
+
+	/**
+	 * Mocks the Yoast SEO metabox Redux store.
+	 *
+	 * @param {Object} data The data stored in the store.
+	 *
+	 * @returns {{getState: (function(): *)}} The mocked store.
+	 */
+	function mockStore( data ) {
+		return { getState: () => data };
+	}
+
+	/**
+	 * Mocks customAnalysisData.
+	 *
+	 * @returns {CustomAnalysisData} The mocked custom analysis data.
+	 */
+	function mockCustomAnalysisData() {
+		return { getData: () => {} };
+	}
+
+	/**
+	 * Mocks the WordPress block editor data module.
+	 *
+	 * @param {Object[]} blocks The blocks that the data module should return.
+	 *
+	 * @returns {{getBlocks: (function(): *)}} The mocked data module.
+	 */
+	function mockBlockEditorDataModule( blocks ) {
+		return { getBlocks: () => blocks };
+	}
+
+	it( "filters the content from blocks", () => {
+		const edit = mockEdit( "<p>some content</p>" );
+		const store = mockStore( storeData );
+		const customData = mockCustomAnalysisData();
+		const pluggable = mockPluggable();
+		const blockEditorDataModule = mockBlockEditorDataModule( gutenbergBlocks );
+
+		const results = collectAnalysisData( edit, store, customData, pluggable, blockEditorDataModule );
+	} );
+} );

--- a/js/tests/collectAnalysisData.test.js
+++ b/js/tests/collectAnalysisData.test.js
@@ -1,5 +1,6 @@
 import collectAnalysisData from "../src/analysis/collectAnalysisData";
 import gutenbergBlocks from "./__test-data__/gutenbergBlocksTestData";
+import expectedBlocks from "./__test-data__/blocksForAnalysisTestData";
 
 describe( "filterBlockData", () => {
 	const storeData = {
@@ -88,5 +89,8 @@ describe( "filterBlockData", () => {
 		const blockEditorDataModule = mockBlockEditorDataModule( gutenbergBlocks );
 
 		const results = collectAnalysisData( edit, store, customData, pluggable, blockEditorDataModule );
+
+		expect( results ).toHaveProperty( "_attributes.wpBlocks" );
+		expect( results._attributes.wpBlocks ).toEqual( expectedBlocks );
 	} );
 } );

--- a/js/tests/collectAnalysisData.test.js
+++ b/js/tests/collectAnalysisData.test.js
@@ -2,7 +2,7 @@ import collectAnalysisData from "../src/analysis/collectAnalysisData";
 import gutenbergBlocks from "./__test-data__/gutenbergBlocksTestData";
 import expectedBlocks from "./__test-data__/blocksForAnalysisTestData";
 
-describe( "filterBlockData", () => {
+describe( "collectAnalysisData", () => {
 	const storeData = {
 		focusKeyword: "focus keyword",
 		synonyms: [],
@@ -42,10 +42,13 @@ describe( "filterBlockData", () => {
 	/**
 	 * Mocks the Pluggable.
 	 *
+	 * @param {boolean} loaded If the pluggable is loaded.
+	 *
 	 * @returns {Pluggable} The mocked Pluggable.
 	 */
-	function mockPluggable() {
+	function mockPluggable( loaded = true ) {
 		return {
+			loaded: loaded,
 			_applyModifications: ( modification, content ) => content,
 		};
 	}
@@ -92,5 +95,31 @@ describe( "filterBlockData", () => {
 
 		expect( results ).toHaveProperty( "_attributes.wpBlocks" );
 		expect( results._attributes.wpBlocks ).toEqual( expectedBlocks );
+	} );
+
+	it( "does not add wpBlocks if no blockEditorDataModule is added", () => {
+		const edit = mockEdit( "<p>some content</p>" );
+		const store = mockStore( storeData );
+		const customData = mockCustomAnalysisData();
+		const pluggable = mockPluggable();
+
+		const results = collectAnalysisData( edit, store, customData, pluggable );
+
+		expect( results ).toHaveProperty( "_attributes.wpBlocks" );
+		expect( results._attributes.wpBlocks ).toBeNull();
+	} );
+
+	it( "does not modify the data through the pluggable if the pluggable is not loaded.", () => {
+		const edit = mockEdit( "<p>some content</p>" );
+		const store = mockStore( storeData );
+		const customData = mockCustomAnalysisData();
+		const pluggable = mockPluggable( false );
+
+		// To be able to test whether the method is called.
+		pluggable._applyModifications = jest.fn();
+
+		collectAnalysisData( edit, store, customData, pluggable );
+
+		expect( pluggable._applyModifications ).not.toBeCalled();
 	} );
 } );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Gutenberg blocks are now sent to the SEO- and Readability analysis web worker, so we can use its structure in the analysis.

## Relevant technical choices:

* I chose to send this data for analysis:
   * `attributes`: 
      * `content`: The main HTML-content of the block (e.g. paragraph, heading content).
      * `level`: Heading level, used in single-H1-assessment.
      * `alt`: Alt text of images, used in keyword-in-alt-text-assessment.
   * `clientId`: locally unique block identifier, used for e.g. markings.
   * `name`: Type of block, e.g. `core/paragraph` for Gutenberg paragraphs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Note**: This PR needs to be tested in parallel with this PR on the JavaScript monorepo: 

* Open an existing post in the block editor.
* Open the developer console of your browser.
* Wait until an `analyze` request is made to the analysis web worker.
   * E.g. a console log statement like this:
     ```
     AnalysisWebWorker incoming: analyze 6 {paper: Paper}
     ```
* Check the `paper` object sent in the request.
  * It should have an attribute called `wpBlocks`, which contains a list of blocks,
  * Each block should have the data described in **Relevant technical choices**, where appropriate.
    * E.g. image blocks should have the alt text attribute, paragraphs and headings the content attribute, headings the level attribute.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/wordpress-seo/issues/13996
