### PR TITLE
Use browserlist instead of babel targets directly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,5 @@
 {
-  "presets": [ [ "env", {
-    "targets": {
-      "browsers": [
-        "last 2 versions",
-        "ie >= 9"
-      ]
-    }
-  } ] ],
+  "presets": [ [ "env" ] ],
   "plugins": [
     [
       "transform-react-jsx",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,9 @@
     "yoast-components": "^4.39.0-rc.0",
     "yoastseo": "^1.66.0-rc.0"
   },
+  "browserslist": [
+    "extends @yoast/browserslist-config"
+  ],
   "yoast": {
     "pluginVersion": "12.7.1"
   }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Switches to `babel-preset-env` using `@yoast/browserslist-config` (dropping IE11 support).

## Relevant technical choices:

* See issue

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- See no errors when running `grunt build`
- Create a post, make sure the language analysis doesn't throw errors in the console.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Partially fixes #13954 
