### PR TITLE
Add upgrade routine to remove WordPress upgrade notice

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -688,6 +688,7 @@ class WPSEO_Upgrade {
 		$this->cleanup_option_data( 'wpseo' );
 
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-page_comments-notice' );
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-wordpress-upgrade' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the "Upgrade WordPress to the most recent version" notification.

## Relevant technical choices:

* The function that adds or removes this notification was removed in 12.5 with no upgrade routine to clean up the database. This made this a persistent message until dismissed or the plugin was deactivated and reactivated.
* Added a notification removal to the 12.8 upgrade routine.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

This test is for the RC only. Testing this as a branch requires altering the version number in-code.
1. Install this RC and the Yoast Test Helper
2. Add the following database entry to the `wp_usermeta` table:
- `umeta_id`: the next one
- `user_id`: 1 (assuming you are the admin user)
- `meta_key`: wp_yoast_notifications
- `meta_value`: 
```
a:1:{i:0;a:2:{s:7:"message";s:817:"<strong>Upgrade WordPress to the most recent version</strong><br/>We’ve noticed that you’re not on the latest WordPress version, which might cause an issue soon. Yoast (for reasons of security and stability) only supports the current and previous version of WordPress. When the next version of WordPress comes out, that means that we will support WordPress 5.2 and 5.3. This means you will not get any updates to Yoast SEO until you update your WordPress, so please make sure to upgrade to the latest WordPress version soon!<br/><br/><br/><br/>Read <a href="https://yoa.st/old-wp-support?php_version=7.3&platform=wordpress&platform_version=5.2.4&software=free&software_version=11.4&days_active=0-1" target="_blank" rel="nofollow">this post for more information about why we’re not supporting older versions.</a>";s:7:"options";a:9:{s:4:"type";s:5:"error";s:2:"id";s:31:"wpseo-dismiss-wordpress-upgrade";s:5:"nonce";N;s:8:"priority";d:0.5;s:9:"data_json";a:0:{}s:13:"dismissal_key";N;s:12:"capabilities";a:1:{i:0;s:20:"wpseo_manage_options";}s:16:"capability_check";s:3:"all";s:14:"yoast_branding";b:0;}}}
```
3. Confirm you are seeing the WordPress-upgrade notice in the notification center.
4. In the Yoast Test Helper set the version to 12.7 so that the upgrade routine from 12.7 to 12.8 runs
5. Observe that the notification is gone.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13861
