### PR TITLE
Revert "Adjust input fields heights after WordPress 5.3 CSS changes."

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -616,7 +616,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					' name="' . $esc_form_key . '"' .
 					' value="' . esc_attr( $meta_value ) . '"' . $aria_describedby .
 					' readonly="readonly"' .
-					' /> ';
+					' />';
 				$content .= '<input' .
 					' id="' . esc_attr( $esc_form_key ) . '_button"' .
 					' class="wpseo_image_upload_button button"' .

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -616,7 +616,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					' name="' . $esc_form_key . '"' .
 					' value="' . esc_attr( $meta_value ) . '"' . $aria_describedby .
 					' readonly="readonly"' .
-					' />';
+					' /> ';
 				$content .= '<input' .
 					' id="' . esc_attr( $esc_form_key ) . '_button"' .
 					' class="wpseo_image_upload_button button"' .

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -286,36 +286,6 @@ td.column-wpseo-linked {
 	word-wrap: normal;
 }
 
-// Temporary adjustments for form controls styling changed in WordPress 5.3.
-.yoast {
-	// Reset 1px margin inherited from WordPress.
-	input {
-		margin: 0;
-	}
-
-	// Make inputs same height as buttons and selects.
-	input[type="text"],
-	input[type="password"],
-	input[type="date"],
-	input[type="datetime"],
-	input[type="datetime-local"],
-	input[type="email"],
-	input[type="month"],
-	input[type="number"],
-	input[type="search"],
-	input[type="tel"],
-	input[type="time"],
-	input[type="url"],
-	input[type="week"] {
-		padding: 0 8px;
-		vertical-align: top;
-		/* inherits font size 14px */
-		line-height: 1.85714285; /* 26px vs. 28px from core */
-		/* Only necessary for IE11 */
-		min-height: 28px; /* 28px vs. 30px from core */
-	}
-}
-
 @media screen and ( max-width: 782px ) {
 	.yoast-settings {
 		padding-left: 0;
@@ -346,31 +316,6 @@ td.column-wpseo-linked {
 	.yoast-settings__group--checkbox .yoast-settings__checkbox + label,
 	.yoast-settings__group--radio .yoast-settings__radio + label {
 		padding-top: 4px;
-	}
-
-	// Temporary adjustments for form controls styling changed in WordPress 5.3.
-	.yoast {
-		// Make inputs same height as buttons and selects.
-		input[type="text"],
-		input[type="password"],
-		input[type="date"],
-		input[type="datetime"],
-		input[type="datetime-local"],
-		input[type="email"],
-		input[type="month"],
-		input[type="number"],
-		input[type="search"],
-		input[type="tel"],
-		input[type="time"],
-		input[type="url"],
-		input[type="week"] {
-			padding: 0 10px;
-			vertical-align: top;
-			/* inherits font size 16px */
-			line-height: 1.875; /* 30px */
-			/* Only necessary for IE11 */
-			min-height: 32px;
-		}
 	}
 
 	.yoast-settings input[type="text"],


### PR DESCRIPTION
This reverts commit 556e583f8bb4af0856dc5bd2f5034b3b572d12e4.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts the 5.3-specific CSS changes that are no longer needed when 5.3.1 has been released.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* A round of testing with the desktop and responsive views wherever we use form controls would be recommended. Don’t forget the configuration wizard.
* Test in WP 5.2.x and 5.3.1 (RC). See that the styling is correct.
* NB: In 5.3.0, the styling will be off as shown in https://github.com/Yoast/bugreports/issues/686.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/768