### PR TITLE
Add is_public to indexables table

### DIFF
--- a/migrations/20191211144248_WpYoastIndexablesAddIsPublicField.php
+++ b/migrations/20191211144248_WpYoastIndexablesAddIsPublicField.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\Free\ORM\Yoast_Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * Class WpYoastIndexablesAddPostStatusField
+ */
+class WpYoastIndexablesAddIsPublicField extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$table_name = $this->get_table_name();
+		$this->add_column( $table_name, 'is_public', 'boolean', [ 'default' => true ] );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		$table_name = $this->get_table_name();
+		$this->remove_column( $table_name, 'is_public' );
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Yoast_Model::get_table_name( 'Indexable' );
+	}
+}

--- a/migrations/20191211144248_WpYoastIndexablesAddIsPublicField.php
+++ b/migrations/20191211144248_WpYoastIndexablesAddIsPublicField.php
@@ -9,7 +9,7 @@ use Yoast\WP\Free\ORM\Yoast_Model;
 use YoastSEO_Vendor\Ruckusing_Migration_Base;
 
 /**
- * Class WpYoastIndexablesAddPostStatusField
+ * Class WpYoastIndexablesAddIsPublicField
  */
 class WpYoastIndexablesAddIsPublicField extends Ruckusing_Migration_Base {
 

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -40,9 +40,11 @@ class Indexable_Post_Builder {
 	 * @return \Yoast\WP\Free\Models\Indexable The extended indexable.
 	 */
 	public function build( $post_id, $indexable ) {
+		$post = \get_post( $post_id );
+
 		$indexable->object_id       = $post_id;
 		$indexable->object_type     = 'post';
-		$indexable->object_sub_type = \get_post_type( $post_id );
+		$indexable->object_sub_type = $post->post_type;
 		$indexable->permalink       = \get_permalink( $post_id );
 
 		$indexable->primary_focus_keyword_score = $this->get_keyword_score(
@@ -80,6 +82,10 @@ class Indexable_Post_Builder {
 		$indexable = $this->set_link_count( $post_id, $indexable );
 
 		$indexable->number_of_pages = $this->get_number_of_pages_for_post( $post_id );
+
+		if ( $post->post_status !== 'publish' || $post->post_password !== '' ) {
+			$indexable->is_public = false;
+		}
 
 		return $indexable;
 	}

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -82,10 +82,7 @@ class Indexable_Post_Builder {
 		$indexable = $this->set_link_count( $post_id, $indexable );
 
 		$indexable->number_of_pages = $this->get_number_of_pages_for_post( $post_id );
-
-		if ( $post->post_status !== 'publish' || $post->post_password !== '' ) {
-			$indexable->is_public = false;
-		}
+		$indexable->is_public       = ( $post->post_status === 'publish' && $post->post_password === '' );
 
 		return $indexable;
 	}

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -81,7 +81,7 @@ class Indexable_Post_Builder {
 
 		$indexable = $this->set_link_count( $post_id, $indexable );
 
-		$indexable->number_of_pages = $this->get_number_of_pages_for_post( $post_id );
+		$indexable->number_of_pages = $this->get_number_of_pages_for_post( $post );
 		$indexable->is_public       = ( $post->post_status === 'publish' && $post->post_password === '' );
 
 		return $indexable;
@@ -280,13 +280,11 @@ class Indexable_Post_Builder {
 	/**
 	 * Gets the number of pages for a post.
 	 *
-	 * @param int $post_id The post id.
+	 * @param object $post The post object.
 	 *
 	 * @return int|null The number of pages or null if the post isn't paginated.
 	 */
-	protected function get_number_of_pages_for_post( $post_id ) {
-		$post = \get_post( $post_id );
-
+	protected function get_number_of_pages_for_post( $post ) {
 		$number_of_pages = ( \substr_count( $post->post_content, '<!--nextpage-->' ) + 1 );
 
 		if ( $number_of_pages <= 1 ) {

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -82,9 +82,23 @@ class Indexable_Post_Builder {
 		$indexable = $this->set_link_count( $post_id, $indexable );
 
 		$indexable->number_of_pages = $this->get_number_of_pages_for_post( $post );
-		$indexable->is_public       = ( $post->post_status === 'publish' && $post->post_password === '' );
+		$indexable->is_public       = ( \in_array( $post->post_status, $this->is_public_post_status(), true ) && $post->post_password === '' );
 
 		return $indexable;
+	}
+
+	/**
+	 * Retrieves the list of public posts statuses.
+	 *
+	 * @return array The public post statuses.
+	 */
+	protected function is_public_post_status() {
+		/**
+		 * Filter: 'wpseo_public_post_statuses' - List of public post statuses.
+		 *
+		 * @apo array $post_statuses Post status list, defaults to array( 'publish' ).
+		 */
+		return \apply_filters( 'wpseo_public_post_statuses', [ 'publish' ] );
 	}
 
 	/**

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -61,6 +61,8 @@ use Yoast\WP\Free\ORM\Yoast_Model;
  * @property string  $twitter_card
  *
  * @property int     $prominent_words_version
+ *
+ * @property boolean $is_public
  */
 class Indexable extends Yoast_Model {
 

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -32,11 +32,13 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 */
 	public function test_build() {
 		Monkey\Functions\expect( 'get_post' )->once()->with( 1 )->andReturn( (object) [
-			'post_content' => 'The content of the post',
+			'post_content'  => 'The content of the post',
+			'post_type'     => 'post',
+			'post_status'   => 'publish',
+			'post_password' => '',
 		] );
 
 		Monkey\Functions\expect( 'get_permalink' )->once()->with( 1 )->andReturn( 'https://permalink' );
-		Monkey\Functions\expect( 'get_post_type' )->once()->with( 1 )->andReturn( 'post' );
 		Monkey\Functions\expect( 'get_post_custom' )->with( 1 )->andReturn(
 			[
 				'_yoast_wpseo_focuskw'               => [ 'focuskeyword' ],
@@ -104,6 +106,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'link_count', 5 );
 		$indexable_mock->orm->expects( 'set' )->with( 'incoming_link_count', 2 );
 		$indexable_mock->orm->expects( 'set' )->with( 'number_of_pages', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_public', true );
 
 		$indexable_mock->orm->expects( 'get' )->once()->with( 'og_image' );
 		$indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'og_image_id' );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `is_public` field to the indexables table.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set a password for a post
* Check in the post table that the is_public value is set to 0
* Remove the password
* The value should be 1
* Make the post a draft -> The value should be 0
* Publish it again -> It should be 1.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13973
