### PR TITLE
Add pdo_mysql extension to tracking and remove modXml as it doesn't exist

### DIFF
--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -74,12 +74,12 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 	 */
 	protected function get_php_extensions() {
 		return [
-			'imagick' => extension_loaded( 'imagick' ),
-			'filter'  => extension_loaded( 'filter' ),
-			'bcmath'  => extension_loaded( 'bcmath' ),
-			'modXml'  => extension_loaded( 'modXml' ),
-			'pcre'    => extension_loaded( 'pcre' ),
-			'xml'     => extension_loaded( 'xml' ),
+			'imagick'   => extension_loaded( 'imagick' ),
+			'filter'    => extension_loaded( 'filter' ),
+			'bcmath'    => extension_loaded( 'bcmath' ),
+			'pcre'      => extension_loaded( 'pcre' ),
+			'xml'       => extension_loaded( 'xml' ),
+			'pdo_mysql' => extension_loaded( 'pdo_mysql' ),
 		];
 	}
 }


### PR DESCRIPTION
## Summary

Adds the `pdo_mysql` extension to tracking and removes the `modXml` extension ( there's no such extension ).

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* The `pdo_mysql` extension is required for idiorm to function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use `wp shell`.
* Create an instance of `WPSEO_Tracking_Server_Data`.
* Call `get`.
* You should see whether or not `pdo_mysql` is enabled in the results.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14047 
