### PR TITLE
Removal of the manual set x-redirect-header

### DIFF
--- a/src/helpers/redirect-helper.php
+++ b/src/helpers/redirect-helper.php
@@ -19,7 +19,19 @@ class Redirect_Helper {
 	 * @param int    $status   Status code to use.
 	 */
 	public function do_redirect( $location, $status = 302 ) {
-		header( 'X-Redirect-By: Yoast SEO' );
+		\wp_redirect( $location, $status, 'Yoast SEO' );
+		exit;
+	}
+
+	/**
+	 * Wraps wp_safe_redirect to allow testing for redirects.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $location The path to redirect to.
+	 * @param int    $status   Status code to use.
+	 */
+	public function do_safe_redirect( $location, $status = 302 ) {
 		\wp_safe_redirect( $location, $status, 'Yoast SEO' );
 		exit;
 	}

--- a/src/helpers/redirect-helper.php
+++ b/src/helpers/redirect-helper.php
@@ -13,10 +13,12 @@ namespace Yoast\WP\Free\Helpers;
 class Redirect_Helper {
 
 	/**
-	 * Wraps wp_safe_redirect to allow testing for redirects.
+	 * Wraps wp_redirect to allow testing for redirects.
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @param string $location The path to redirect to.
-	 * @param int    $status   Status code to use.
+	 * @param int    $status   The status code to use.
 	 */
 	public function do_redirect( $location, $status = 302 ) {
 		\wp_redirect( $location, $status, 'Yoast SEO' );
@@ -24,12 +26,12 @@ class Redirect_Helper {
 	}
 
 	/**
-	 * Wraps wp_safe_redirect to allow testing for redirects.
+	 * Wraps wp_safe_redirect to allow testing for safe redirects.
 	 *
 	 * @codeCoverageIgnore
 	 *
 	 * @param string $location The path to redirect to.
-	 * @param int    $status   Status code to use.
+	 * @param int    $status   The status code to use.
 	 */
 	public function do_safe_redirect( $location, $status = 302 ) {
 		\wp_safe_redirect( $location, $status, 'Yoast SEO' );

--- a/src/integrations/front-end/comment-link-fixer.php
+++ b/src/integrations/front-end/comment-link-fixer.php
@@ -103,7 +103,7 @@ class Comment_Link_Fixer implements Integration_Interface {
 			}
 			$url .= '#comment-' . $hash;
 
-			$this->redirect_helper->do_redirect( $url, 301 );
+			$this->redirect_helper->do_safe_redirect( $url, 301 );
 
 			return true;
 		}

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -11,6 +11,7 @@ use Yoast\WP\Free\Conditionals\Front_End_Conditional;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Meta_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Redirect_Helper;
 use Yoast\WP\Free\Integrations\Integration_Interface;
 
 /**
@@ -34,6 +35,13 @@ class Redirects implements Integration_Interface {
 	protected $current_page;
 
 	/**
+	 * The redirect helper.
+	 *
+	 * @var Redirect_Helper
+	 */
+	private $redirect;
+
+	/**
 	 * Sets the helpers.
 	 *
 	 * @codeCoverageIgnore
@@ -41,11 +49,13 @@ class Redirects implements Integration_Interface {
 	 * @param Options_Helper      $options      Options helper.
 	 * @param Meta_Helper         $meta         Meta helper.
 	 * @param Current_Page_Helper $current_page The current page helper.
+	 * @param Redirect_Helper     $redirect     The redirect helper.
 	 */
-	public function __construct( Options_Helper $options, Meta_Helper $meta, Current_Page_Helper $current_page ) {
+	public function __construct( Options_Helper $options, Meta_Helper $meta, Current_Page_Helper $current_page, Redirect_Helper $redirect ) {
 		$this->options      = $options;
 		$this->meta         = $meta;
 		$this->current_page = $current_page;
+		$this->redirect     = $redirect;
 	}
 
 	/**
@@ -71,7 +81,7 @@ class Redirects implements Integration_Interface {
 	 */
 	public function archive_redirect() {
 		if ( $this->need_archive_redirect() ) {
-			$this->do_safe_redirect( get_bloginfo( 'url' ), 301 );
+			$this->redirect->do_safe_redirect( get_bloginfo( 'url' ), 301 );
 		}
 	}
 
@@ -93,7 +103,7 @@ class Redirects implements Integration_Interface {
 			return;
 		}
 
-		$this->do_redirect( $redirect );
+		$this->redirect->do_redirect( $redirect );
 	}
 
 
@@ -114,37 +124,7 @@ class Redirects implements Integration_Interface {
 			return;
 		}
 
-		$this->do_redirect( $url );
-	}
-
-	/**
-	 * Wraps wp_safe_redirect to allow testing for redirects.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @param string $location The path to redirect to.
-	 * @param int    $status   Status code to use.
-	 */
-	protected function do_safe_redirect( $location, $status = 302 ) {
-		\header( 'X-Redirect-By: Yoast SEO' );
-		\wp_safe_redirect( $location, $status, 'Yoast SEO' );
-		exit;
-	}
-
-	/**
-	 * Wraps safe_redirect to allow testing for redirects.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @param string $location The path to redirect to.
-	 * @param int    $status   Status code to use.
-	 *
-	 * @return void
-	 */
-	protected function do_redirect( $location, $status = 301 ) {
-		\header( 'X-Redirect-By: Yoast SEO' );
-		\wp_redirect( $location, $status, 'Yoast SEO' );
-		exit;
+		$this->redirect->do_redirect( $url );
 	}
 
 	/**

--- a/tests/integrations/front-end/comment-link-fixer-test.php
+++ b/tests/integrations/front-end/comment-link-fixer-test.php
@@ -89,7 +89,7 @@ class Comment_link_Fixer_Test extends TestCase {
 	 * @covers ::replytocom_redirect
 	 */
 	public function test_replytocom_redirect() {
-		$this->redirect->expects( 'do_redirect' )->once()->with( 'https://permalink#comment-unique_hash', 301 )->andReturn( true );
+		$this->redirect->expects( 'do_safe_redirect' )->once()->with( 'https://permalink#comment-unique_hash', 301 )->andReturn( true );
 
 		$_GET['replytocom'] = 'unique_hash';
 		Monkey\Functions\expect( 'is_singular' )->once()->andReturn( true );
@@ -105,7 +105,7 @@ class Comment_link_Fixer_Test extends TestCase {
 	 * @covers ::replytocom_redirect
 	 */
 	public function test_replytocom_redirect_with_query_string() {
-		$this->redirect->expects( 'do_redirect' )->once()->with( 'https://permalink?param=foo#comment-unique_hash', 301 )->andReturn( true );
+		$this->redirect->expects( 'do_safe_redirect' )->once()->with( 'https://permalink?param=foo#comment-unique_hash', 301 )->andReturn( true );
 
 		$_GET['replytocom'] = 'unique_hash';
 		Monkey\Functions\expect( 'is_singular' )->once()->andReturn( true );

--- a/tests/integrations/front-end/redirects-test.php
+++ b/tests/integrations/front-end/redirects-test.php
@@ -12,6 +12,7 @@ use Mockery;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Meta_Helper;
 use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Redirect_Helper;
 use Yoast\WP\Free\Integrations\Front_End\Redirects;
 use Yoast\WP\Free\Tests\TestCase;
 
@@ -55,6 +56,13 @@ class Redirects_Test extends TestCase {
 	private $current_page;
 
 	/**
+	 * The redirect helper mock.
+	 *
+	 * @var Mockery\MockInterface|Redirect_Helper
+	 */
+	private $redirect;
+
+	/**
 	 * Sets an instance for test purposes.
 	 */
 	public function setUp() {
@@ -63,7 +71,8 @@ class Redirects_Test extends TestCase {
 		$this->options      = Mockery::mock( Options_Helper::class );
 		$this->meta         = Mockery::mock( Meta_Helper::class );
 		$this->current_page = Mockery::mock( Current_Page_Helper::class );
-		$this->instance     = Mockery::mock( Redirects::class, [ $this->options, $this->meta, $this->current_page ] )
+		$this->redirect     = Mockery::mock( Redirect_Helper::class );
+		$this->instance     = Mockery::mock( Redirects::class, [ $this->options, $this->meta, $this->current_page, $this->redirect ] )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 	}
@@ -79,7 +88,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->instance
+		$this->redirect
 			->shouldNotReceive( 'do_safe_redirect' )
 			->with( 'https://example.org', 301 );
 
@@ -97,7 +106,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->instance
+		$this->redirect
 			->expects( 'do_safe_redirect' )
 			->once()
 			->with( 'url', 301 );
@@ -116,7 +125,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->instance
+		$this->redirect
 			->shouldNotReceive( 'do_redirect' );
 
 		$this->instance->page_redirect();
@@ -135,7 +144,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->instance
+		$this->redirect
 			->shouldNotReceive( 'do_redirect' );
 
 		$this->instance->page_redirect();
@@ -161,7 +170,7 @@ class Redirects_Test extends TestCase {
 			->with( 'redirect', 1337 )
 			->andReturn( '' );
 
-		$this->instance
+		$this->redirect
 			->shouldNotReceive( 'do_redirect' );
 
 		$this->instance->page_redirect();
@@ -187,7 +196,7 @@ class Redirects_Test extends TestCase {
 			->with( 'redirect', 1337 )
 			->andReturn( 'https://example.org/redirect' );
 
-		$this->instance
+		$this->redirect
 			->expects( 'do_redirect' )
 			->once()
 			->with( 'https://example.org/redirect' );
@@ -206,7 +215,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->instance
+		$this->redirect
 			->shouldNotReceive( 'do_redirect' );
 
 		$this->instance->attachment_redirect();
@@ -229,7 +238,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->instance
+		$this->redirect
 			->shouldNotReceive( 'do_redirect' );
 
 		$this->instance->attachment_redirect();
@@ -257,7 +266,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturn( '' );
 
-		$this->instance
+		$this->redirect
 			->shouldNotReceive( 'do_redirect' );
 
 		$this->instance->attachment_redirect();
@@ -285,7 +294,7 @@ class Redirects_Test extends TestCase {
 			->once()
 			->andReturn( 'https://example.org/redirect' );
 
-		$this->instance
+		$this->redirect
 			->expects( 'do_redirect' )
 			->once()
 			->with( 'https://example.org/redirect' );


### PR DESCRIPTION
Also moved two methods that performs a redirect to the redirect helper.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It removes the manual set x-redirect header

## Relevant technical choices:

* I also used the redirect helper instead of defining two redirect methods in the class where I needed them. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Navigate to a comment (the oldstyle: `?replytocom={comment-id}`) and make sure you get redirected. The redirect should contain our x-redirect-by: Yoast header.
* Disable the date archive or the author archive. Navigate to the author / date archive and make sure the redirect contains x-redirect-by: Yoast.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have ~added~ edited unittests to verify the code works as intended

Fixes #
