### PR TITLE
Fill cache properly when option is registered.

### DIFF
--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -108,6 +108,8 @@ class WPSEO_Options {
 		}
 
 		self::$option_instances[ $option_name ] = $option_instance;
+
+		self::fill_cache();
 	}
 
 	/**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -85,9 +85,6 @@ abstract class TestCase extends BaseTestCase {
 			]
 		);
 
-		// This is required to ensure backfill and other statics are set.
-		WPSEO_Options::get_instance();
-
 		Monkey\Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
 			->with( \call_user_func_array( 'Mockery::anyOf', $this->mocked_options ) )
@@ -97,6 +94,9 @@ abstract class TestCase extends BaseTestCase {
 			->zeroOrMoreTimes()
 			->with( \call_user_func_array( 'Mockery::anyOf', $this->mocked_options ) )
 			->andReturn( [] );
+
+		// This is required to ensure backfill and other statics are set.
+		WPSEO_Options::get_instance();
 	}
 
 	/**


### PR DESCRIPTION
Make sure that when a new option is registered we fill the cache properly

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* None needed.

## Relevant technical choices:

* Call `fill_cache()` at the end of `register_option()`.

## Test instructions
This PR can be tested by following these steps:

* Use this with Local trunk and make sure it works.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


