### PR TITLE
Premium: Update to YoastCS 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,9 +80,7 @@
 		],
 		"premium-check-cs": [
 			"@before-premium-cs",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/premium/cli/,*/tests/load/wp-seo-premium.php,*/tests/premium/ --runtime-set ignore_warnings_on_exit 1",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./premium/cli/ --runtime-set testVersion 5.3- --runtime-set ignore_warnings_on_exit 1",
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/load/wp-seo-premium.php ./tests/premium/ --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1",
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
 		],
 		"check-cs-errors": [
@@ -103,7 +101,7 @@
 			"@after-premium-cs"
 		],
 		"before-premium-cs": [
-			"composer require --dev yoast/yoastcs:~1.3.0 --update-with-dependencies --no-suggest --no-interaction"
+			"composer require --dev yoast/yoastcs:~2.0.0 --update-with-dependencies --no-suggest --no-interaction"
 		],
 		"after-premium-cs": [
 			"composer require --dev yoast/yoastcs:~0.4.3 --update-with-dependencies --no-suggest --no-interaction",


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This updates the Composer script used to run the PHPCS check for Premium to YoastCS 2.0.0.

Includes:
* Removing the tweaks to the Composer `premium-check-cs` script to allow for different PHP requirements in different directories.
    PHP 5.6 is now the minimum PHP version everywhere.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0


## Test instructions

This PR can be tested by following these steps:
* This change in itself can't be tested in the Free repo. It needs the ruleset changes as pulled in PR https://github.com/Yoast/wordpress-seo-premium/pull/2649 and a merge-back for Free to Premium before this can be tested.