### PR TITLE
Optimize the cache fill

### DIFF
--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -160,6 +160,9 @@ abstract class WPSEO_Option {
 			add_action( 'add_option', [ $this, 'add_default_filters' ] ); // Adding back after INSERT.
 
 			add_action( 'update_option', [ $this, 'add_default_filters' ] );
+
+			// Refills the cache when the option has been updated.
+			add_action( 'update_option_' . $this->option_name, [ 'WPSEO_Options', 'fill_cache' ], 10 );
 		}
 		elseif ( is_multisite() ) {
 			/*
@@ -173,6 +176,8 @@ abstract class WPSEO_Option {
 			add_action( 'add_site_option_' . $this->option_name, [ $this, 'add_default_filters' ] );
 			add_action( 'update_site_option_' . $this->option_name, [ $this, 'add_default_filters' ] );
 
+			// Refills the cache when the option has been updated.
+			add_action( 'update_site_option_' . $this->option_name, [ 'WPSEO_Options', 'fill_cache' ], 1, 0 );
 		}
 
 

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -70,6 +70,8 @@ class WPSEO_Options {
 		foreach ( self::$options as $option_name => $option_class ) {
 			self::register_option( call_user_func( [ $option_class, 'get_instance' ] ) );
 		}
+
+		self::fill_cache();
 	}
 
 	/**
@@ -99,7 +101,8 @@ class WPSEO_Options {
 			return;
 		}
 
-		if ( ! array_key_exists( $option_name, self::$options ) ) {
+		$is_already_registered = array_key_exists( $option_name, self::$options );
+		if ( ! $is_already_registered ) {
 			self::$options[ $option_name ] = get_class( $option_instance );
 		}
 
@@ -109,7 +112,9 @@ class WPSEO_Options {
 
 		self::$option_instances[ $option_name ] = $option_instance;
 
-		self::fill_cache();
+		if ( ! $is_already_registered ) {
+			self::fill_cache();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Fixes a bug where the option cache is refreshed after saving the options.

## Relevant technical choices:

* When relying on option values when the option has been updated it will return the cached value. This has been fixed by refreshing the cache after option save.

## Alert!!!
Please merge trunk into the indexables feature branch when you have merged this one!!!!

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure options are still saved correctly.
* Follow the steps in #14056 and make sure this pull solves it 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14056 - Merge trunk into the indexables feature branch
