### PR TITLE
Uses content instead of value

### DIFF
--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -50,11 +50,11 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		foreach ( $images as $image_index => $image_meta ) {
 			$image_url = $image_meta['url'];
 
-			$return .= '<meta property="og:image" value="' . \esc_url( $image_url ) . '"/>';
+			$return .= '<meta property="og:image" content="' . \esc_url( $image_url ) . '"/>';
 
 			// Adds secure URL if detected. Not all services implement this, so the regular one also needs to be rendered.
 			if ( \strpos( $image_url, 'https://' ) === 0 ) {
-				$return .= PHP_EOL . '<meta property="og:image:secure_url" value="' . \esc_url( $image_url ) . '"/>';
+				$return .= PHP_EOL . '<meta property="og:image:secure_url" content="' . \esc_url( $image_url ) . '"/>';
 			}
 
 			foreach ( static::$image_tags as $key => $value ) {
@@ -62,7 +62,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 					continue;
 				}
 
-				$return .= PHP_EOL . '<meta property="og:image:' . \esc_attr( $key ) . '" value="' . $image_meta[ $key ] . '"/>';
+				$return .= PHP_EOL . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . $image_meta[ $key ] . '"/>';
 			}
 		}
 

--- a/src/presenters/open-graph/type-presenter.php
+++ b/src/presenters/open-graph/type-presenter.php
@@ -26,7 +26,7 @@ class Type_Presenter extends Abstract_Indexable_Presenter {
 		$og_type = $this->filter( $presentation->og_type, $presentation );
 
 		if ( \is_string( $og_type ) && $og_type !== '' ) {
-			return '<meta property="og:type" value="' . \esc_attr( $og_type ) . '"/>';
+			return '<meta property="og:type" content="' . \esc_attr( $og_type ) . '"/>';
 		}
 
 		return '';

--- a/tests/presenters/open-graph/image-presenter-test.php
+++ b/tests/presenters/open-graph/image-presenter-test.php
@@ -65,7 +65,7 @@ class Image_Presenter_Test extends TestCase {
 		$this->presentation->og_images = [ $image ];
 
 		$this->assertEquals(
-			'<meta property="og:image" value="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:secure_url" value="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:width" value="100"/>' . PHP_EOL . '<meta property="og:image:height" value="100"/>',
+			'<meta property="og:image" content="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:secure_url" content="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:width" content="100"/>' . PHP_EOL . '<meta property="og:image:height" content="100"/>',
 			$this->instance->present( $this->presentation )
 		);
 	}

--- a/tests/presenters/open-graph/type-presenter-test.php
+++ b/tests/presenters/open-graph/type-presenter-test.php
@@ -45,7 +45,7 @@ class Type_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->indexable_presentation->og_type = 'article';
 
-		$expected = '<meta property="og:type" value="article"/>';
+		$expected = '<meta property="og:type" content="article"/>';
 		$actual = $this->instance->present( $this->indexable_presentation );
 
 		$this->assertEquals( $expected, $actual );
@@ -79,7 +79,7 @@ class Type_Presenter_Test extends TestCase {
 			->with( 'website', $this->indexable_presentation )
 			->andReturn( 'article' );
 
-		$expected = '<meta property="og:type" value="article"/>';
+		$expected = '<meta property="og:type" content="article"/>';
 		$actual = $this->instance->present( $this->indexable_presentation );
 
 		$this->assertEquals( $expected, $actual );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - The `value` property has been changed into `content`

## Relevant technical choices:

* I also changed it for the images, where value was used as property.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have a OG type and have an OG image.
* Verify that the property for `og:type` and `og:image` is `content` now.  

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14055
