### PR TITLE
Add Good result status to the Paging comments Site Health test.

### DIFF
--- a/inc/health-check-page-comments.php
+++ b/inc/health-check-page-comments.php
@@ -22,10 +22,15 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 	 */
 	public function run() {
 		if ( ! $this->has_page_comments() ) {
+			$this->label          = esc_html__( 'Paging comments is properly disabled', 'wordpress-seo' );
+			$this->status         = self::STATUS_GOOD;
+			$this->badge['color'] = 'blue';
+			$this->description  = esc_html__( 'Paging comments is disabled. As this is not needed in 999 out of 1000 cases, we recommend to keep it disabled.', 'wordpress-seo' );
+
 			return;
 		}
 
-		$this->label          = esc_html__( 'Paging comments enabled', 'wordpress-seo' );
+		$this->label          = esc_html__( 'Paging comments is enabled', 'wordpress-seo' );
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
 

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -27,8 +27,8 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 		$health_check = new \WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
 
-		// We just want to verify that the label attributes hasn't been set.
-		$this->assertAttributeEquals( '', 'label', $health_check );
+		// We just want to verify that the label attribute is the "passed" message.
+		$this->assertAttributeEquals( 'Paging comments is properly disabled', 'label', $health_check );
 	}
 
 	/**
@@ -49,7 +49,7 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 		$health_check = new \WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
 
-		// We just want to verify that the label attributes has been set.
-		$this->assertAttributeEquals( 'Paging comments enabled', 'label', $health_check );
+		// We just want to verify that the label attribute is the "not passed" message.
+		$this->assertAttributeEquals( 'Paging comments is enabled', 'label', $health_check );
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Made sure the Paging comments Site Health test is listed in the Passed tests when it passes.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- repeat the steps from the issue https://github.com/Yoast/bugreports/issues/793
- at the last step, check the Paging comments test is listed within the "Passed tests" section

## Note about the wording
Most of the existing WordPress test labels include a verb, I guess to make the text more human-friendly. For example:
- Your site is set to display errors to site visitors
- You should remove inactive plugins
- Your site does not use HTTPS
- Background updates may not be working properly

For this reason and for consistency I changed "Paging comments enabled" to "Paging comments is enabled". Further improvements to the current wording welcome.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/793
