### PR TITLE
Move the tagline notification to a site health test

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -101,34 +101,6 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Notify about the default tagline if the user hasn't changed it.
-	 */
-	public function tagline_notice() {
-		$query_args    = [
-			'autofocus[control]' => 'blogdescription',
-		];
-		$customize_url = add_query_arg( $query_args, wp_customize_url() );
-
-		$info_message = sprintf(
-			/* translators: 1: link open tag; 2: link close tag. */
-			__( 'You still have the default WordPress tagline, even an empty one is probably better. %1$sYou can fix this in the customizer%2$s.', 'wordpress-seo' ),
-			'<a href="' . esc_attr( $customize_url ) . '">',
-			'</a>'
-		);
-
-		$notification_options = [
-			'type'         => Yoast_Notification::ERROR,
-			'id'           => 'wpseo-dismiss-tagline-notice',
-			'capabilities' => 'wpseo_manage_options',
-		];
-
-		$tagline_notification = new Yoast_Notification( $info_message, $notification_options );
-
-		$notification_center = Yoast_Notification_Center::get();
-		$notification_center->remove_notification( $tagline_notification );
-	}
-
-	/**
 	 * Add an alert if the blog is not publicly visible.
 	 */
 	public function blog_public_notice() {
@@ -607,5 +579,36 @@ class WPSEO_Admin_Init {
 		_deprecated_function( __METHOD__, 'WPSEO 12.8' );
 
 		return '1' === get_option( 'page_comments' );
+	}
+
+	/**
+	 * Notify about the default tagline if the user hasn't changed it.
+	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
+	 */
+	public function tagline_notice() {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+	}
+
+	/**
+	 * Returns whether or not the site has the default tagline.
+	 *
+	 * @deprecated xx.x
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool
+	 */
+	public function has_default_tagline() {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+
+		$blog_description         = get_bloginfo( 'description' );
+		$default_blog_description = 'Just another WordPress site';
+
+		// We are checking against the WordPress internal translation.
+		// @codingStandardsIgnoreLine
+		$translated_blog_description = __( 'Just another WordPress site', 'default' );
+
+		return $translated_blog_description === $blog_description || $default_blog_description === $blog_description;
 	}
 }

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -50,6 +50,9 @@ class WPSEO_Admin_Init {
 		$page_comments = new WPSEO_Health_Check_Page_Comments();
 		$page_comments->register_test();
 
+		$default_tagline = new WPSEO_Health_Check_Default_Tagline();
+		$default_tagline->register_test();
+
 		$listeners   = [];
 		$listeners[] = new WPSEO_Post_Type_Archive_Notification_Handler();
 
@@ -154,22 +157,6 @@ class WPSEO_Admin_Init {
 		else {
 			$notification_center->remove_notification( $notification );
 		}
-	}
-
-	/**
-	 * Returns whether or not the site has the default tagline.
-	 *
-	 * @return bool
-	 */
-	public function has_default_tagline() {
-		$blog_description         = get_bloginfo( 'description' );
-		$default_blog_description = 'Just another WordPress site';
-
-		// We are checking against the WordPress internal translation.
-		// @codingStandardsIgnoreLine
-		$translated_blog_description = __( 'Just another WordPress site', 'default' );
-
-		return $translated_blog_description === $blog_description || $default_blog_description === $blog_description;
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -35,7 +35,6 @@ class WPSEO_Admin_Init {
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_dismissible' ] );
-		add_action( 'admin_init', [ $this, 'tagline_notice' ], 15 );
 		add_action( 'admin_init', [ $this, 'blog_public_notice' ], 15 );
 		add_action( 'admin_init', [ $this, 'permalink_notice' ], 15 );
 		add_action( 'admin_init', [ $this, 'yoast_plugin_suggestions_notification' ], 15 );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -52,6 +52,7 @@ class WPSEO_Upgrade {
 			'12.3-RC0'  => 'upgrade_123',
 			'12.4-RC0'  => 'upgrade_124',
 			'12.8-RC0'  => 'upgrade_128',
+			'xx.x-RC0'  => 'upgrade_xxx',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -689,6 +690,13 @@ class WPSEO_Upgrade {
 
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-page_comments-notice' );
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-wordpress-upgrade' );
+	}
+
+	/**
+	 * Performs the xx.x upgrade.
+	 */
+	private function upgrade_xxx() {
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-tagline-notice' );
 	}
 
 	/**

--- a/inc/health-check-default-tagline.php
+++ b/inc/health-check-default-tagline.php
@@ -49,7 +49,6 @@ class WPSEO_Health_Check_Default_Tagline extends WPSEO_Health_Check {
 		);
 	}
 
-
 	/**
 	 * Returns whether or not the site has the default tagline.
 	 *

--- a/inc/health-check-tagline.php
+++ b/inc/health-check-tagline.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Internals
+ */
+
+/**
+ * Represents the health check for the default tagline.
+ */
+class WPSEO_Health_Check_Default_Tagline extends WPSEO_Health_Check {
+
+	/**
+	 * The name of the test.
+	 *
+	 * @var string
+	 */
+	protected $test = 'yoast-health-check-default-tagline';
+
+	/**
+	 * Runs the test.
+	 */
+	public function run() {
+		if ( ! $this->has_default_tagline() ) {
+			$this->label          = esc_html__( 'You changed the default WordPress tagline', 'wordpress-seo' );
+			$this->status         = self::STATUS_GOOD;
+			$this->badge['color'] = 'blue';
+			$this->description    = esc_html__( 'You are using a custom tagline or an empty one.', 'wordpress-seo' );
+
+			return;
+		}
+
+		$this->label          = esc_html__( 'You should change the default WordPress tagline', 'wordpress-seo' );
+		$this->status         = self::STATUS_RECOMMENDED;
+		$this->badge['color'] = 'red';
+
+		$this->description = esc_html__( 'You still have the default WordPress tagline. Even an empty one is probably better.', 'wordpress-seo' );
+
+		$query_args    = [
+			'autofocus[control]' => 'blogdescription',
+		];
+		$customize_url = add_query_arg( $query_args, wp_customize_url() );
+
+		$this->actions = sprintf(
+			/* translators: 1: link open tag; 2: link close tag. */
+			esc_html__( '%1$sYou can change the tagline in the customizer%2$s.', 'wordpress-seo' ),
+			'<a href="' . esc_attr( $customize_url ) . '">',
+			'</a>'
+		);
+	}
+
+
+	/**
+	 * Returns whether or not the site has the default tagline.
+	 *
+	 * @return bool
+	 */
+	public function has_default_tagline() {
+		$blog_description         = get_bloginfo( 'description' );
+		$default_blog_description = 'Just another WordPress site';
+
+		// We are checking against the WordPress internal translation.
+		// @codingStandardsIgnoreLine
+		$translated_blog_description = __( 'Just another WordPress site', 'default' );
+
+		return $translated_blog_description === $blog_description || $default_blog_description === $blog_description;
+	}
+}

--- a/inc/health-check-tagline.php
+++ b/inc/health-check-tagline.php
@@ -56,7 +56,7 @@ class WPSEO_Health_Check_Default_Tagline extends WPSEO_Health_Check {
 	 * @return bool
 	 */
 	public function has_default_tagline() {
-		$blog_description         = get_bloginfo( 'description' );
+		$blog_description         = get_option( 'blogdescription' );
 		$default_blog_description = 'Just another WordPress site';
 
 		// We are checking against the WordPress internal translation.

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -147,6 +147,7 @@ abstract class WPSEO_Health_Check {
 			'badge'       => $this->get_badge(),
 			'description' => $this->description,
 			'actions'     => $this->actions,
+			'test'        => $this->test,
 		];
 	}
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -82,15 +82,6 @@ abstract class TestCase extends BaseTestCase {
 					}
 					return $show;
 				},
-				'add_query_arg'       => function() {
-					return \Mockery::mock( '\add_query_arg' );
-				},
-				'admin_url'           => function() {
-					return \Mockery::mock( '\admin_url' );
-				},
-				'wp_customize_url'    => function() {
-					return esc_url( admin_url( 'customize.php' ) );
-				},
 			]
 		);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -82,6 +82,15 @@ abstract class TestCase extends BaseTestCase {
 					}
 					return $show;
 				},
+				'add_query_arg'       => function() {
+					return \Mockery::mock( '\add_query_arg' );
+				},
+				'admin_url'           => function() {
+					return \Mockery::mock( '\admin_url' );
+				},
+				'wp_customize_url'    => function() {
+					return esc_url( admin_url( 'customize.php' ) );
+				},
 			]
 		);
 

--- a/tests/inc/health-check-default-tagline-test.php
+++ b/tests/inc/health-check-default-tagline-test.php
@@ -24,6 +24,14 @@ class WPSEO_Health_Check_Default_Tagline_Test extends TestCase {
 			->with( 'blogdescription' )
 			->andReturn( 'Just another WordPress site' );
 
+		Monkey\Functions\expect( 'wp_customize_url' )
+			->once()
+			->andReturn( 'http://example.org/wp-admin/customize.php' );
+
+		Monkey\Functions\expect( 'add_query_arg' )
+			->once()
+			->andReturn( 'http://example.org/wp-admin/customize.php?autofocus[control]=blogdescription' );
+
 		$health_check = new \WPSEO_Health_Check_Default_Tagline();
 		$health_check->run();
 

--- a/tests/inc/health-check-default-tagline-test.php
+++ b/tests/inc/health-check-default-tagline-test.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Yoast\WP\Free\Tests\Inc;
+
+use Brain\Monkey;
+use Yoast\WP\Free\Tests\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @group health-check
+ */
+class WPSEO_Health_Check_Default_Tagline_Test extends TestCase {
+
+	/**
+	 * Tests the run method when the WordPress tagline is the default one.
+	 *
+	 * @covers WPSEO_Health_Check_Default_Tagline::run
+	 * @covers WPSEO_Health_Check_Default_Tagline::has_default_tagline
+	 */
+	public function test_run_with_default_tagline() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'blogdescription' )
+			->andReturn( 'Just another WordPress site' );
+
+		$health_check = new \WPSEO_Health_Check_Default_Tagline();
+		$health_check->run();
+
+		// We just want to verify that the label attribute is the "not passed" message.
+		$this->assertAttributeEquals( 'You should change the default WordPress tagline', 'label', $health_check );
+	}
+
+	/**
+	 * Tests the run method when the WordPress tagline is empty.
+	 *
+	 * @covers WPSEO_Health_Check_Default_Tagline::run
+	 * @covers WPSEO_Health_Check_Default_Tagline::has_default_tagline
+	 */
+	public function test_run_with_empty_tagline() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'blogdescription' )
+			->andReturn( '' );
+
+		$health_check = new \WPSEO_Health_Check_Default_Tagline();
+		$health_check->run();
+
+		// We just want to verify that the label attribute is the "passed" message.
+		$this->assertAttributeEquals( 'You changed the default WordPress tagline', 'label', $health_check );
+	}
+
+	/**
+	 * Tests the run method when the WordPress tagline is a custom one.
+	 *
+	 * @covers WPSEO_Health_Check_Default_Tagline::run
+	 * @covers WPSEO_Health_Check_Default_Tagline::has_default_tagline
+	 */
+	public function test_run_with_custom_tagline() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'blogdescription' )
+			->andReturn( 'My custom site tagline' );
+
+		$health_check = new \WPSEO_Health_Check_Default_Tagline();
+		$health_check->run();
+
+		// We just want to verify that the label attribute is the "passed" message.
+		$this->assertAttributeEquals( 'You changed the default WordPress tagline', 'label', $health_check );
+	}
+}

--- a/tests/inc/health-check-test.php
+++ b/tests/inc/health-check-test.php
@@ -114,6 +114,7 @@ class WPSEO_Health_Check_Test extends TestCase {
 				],
 				'description' => '',
 				'actions'     => '',
+				'test'        => '',
 			],
 			$this->instance->get_test_result()
 		);


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moved the Default Tagline notice from the SEO Dashboard to WordPress' Health Check

## Relevant technical choices:

- Worth noting `WPSEO_Health_Check->get_test_result()` omitted to pass `$test` which represents the name of the test. Without this, multiple Site Health accordions won't work because they will have the same (incomplete) ID: `health-check-accordion-block-` produced by `health-check-accordion-block-{{ data.test }}`. This is fixed in this PR.
- Added two deprecations and one upgrade routine using a temporary `xx.x` for the plugin version. This should be updated when merging into trunk once the actual milestone will be determined.
- Better wording for the non-passed / passed test welcome.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- Go to Settings > General and make sure you have the default WordPress tagline `Just another WordPress site`
- Save
- Go to the Site Health page: Tools > Site Health and see a check being presented:
<img width="841" alt="Screenshot 2019-12-27 at 11 58 28" src="https://user-images.githubusercontent.com/1682452/71514885-e3cd9180-28a0-11ea-9d5d-e00345c59212.png">
- Change the default WordPress tagline `Just another WordPress site` to something else and save
- Go to the Site Health page and see the check is within to the "Passed tests" section:
<img width="827" alt="Screenshot 2019-12-27 at 11 59 17" src="https://user-images.githubusercontent.com/1682452/71514922-08c20480-28a1-11ea-84cb-fcbe4babe924.png">
- Empty the tagline field and save
- Go to the Site Health page and see the check is within the "Passed tests" section:

<img width="827" alt="Screenshot 2019-12-27 at 11 59 17" src="https://user-images.githubusercontent.com/1682452/71579489-17a4f300-2afd-11ea-8928-7ba77eaeddf0.png">

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12899