### PR TITLE
Reintroduce register_wp_assets for backwards compatibility

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -655,4 +655,17 @@ class WPSEO_Admin_Asset_Manager {
 
 		return $this->asset_location->get_url( $asset, $type );
 	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * This function is needed for backwards compatibility with Local SEO 12.5.
+	 *
+	 * @deprecated 12.8
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	public function register_wp_assets() {
+	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reintroduce register_wp_assets for backwards compatibility

## Relevant technical choices:

* In https://github.com/Yoast/wordpress-seo/commit/5a62afe004b8917ce806f90df18727354f07953a we deleted `register_wp_assets ` from the asset manager. Local SEO extends the asset manager class and in 12.5 it calls the `register_wp_assets` method, which was deleted. This resulted in a fatal error if Local SEO was still on 12.5 and Yoast SEO was updated to 12.8. This PR reintroduces `register_wp_assets` as a deprecated function to prevent that fatal error.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install Yoast SEO 12.7 and Local 12.5.
* Checkout tags/12.8-RC2 on Yoast SEO.
* Navigate to Locations and see a fatal error.
* Checkout this branch.
* Navigate to Locations and see no fatal error.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes the fatal error mentioned in step 4 of https://github.com/Yoast/wordpress-seo-local/issues/1927#issue-540951091
