### PR TITLE
Move deprecated method

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -205,18 +205,6 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Shows a notice to the user if they have Google Analytics for WordPress 5.4.3 installed because it causes an error
-	 * on the google search console page.
-	 *
-	 * @deprecated 12.5
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public function ga_compatibility_notice() {
-		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
-	}
-
-	/**
 	 * Determines whether a suggested plugins notification needs to be displayed.
 	 *
 	 * @return void
@@ -595,6 +583,18 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	public function wordpress_upgrade_notice() {
+		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
+	}
+
+	/**
+	 * Shows a notice to the user if they have Google Analytics for WordPress 5.4.3 installed because it causes an error
+	 * on the google search console page.
+	 *
+	 * @deprecated 12.5
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function ga_compatibility_notice() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.5' );
 	}
 


### PR DESCRIPTION
## Summary

The GA compatibility notice had already been deprecated in a [previous commit](https://github.com/Yoast/wordpress-seo/pull/13632/commits/7f17ffc20abea30f32ce60890e74582457dcd904). This PR only moves the method to the bottom of the class, with the other deprecated methods.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #12901
