### PR TITLE
Make all shortlinker calls secure

### DIFF
--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -45,7 +45,7 @@ $wpseo_contributors_phrase = sprintf(
 	<h3><?php esc_html_e( 'Credits', 'wordpress-seo' ); ?></h3>
 	<p>
 		<span class="dashicons dashicons-groups"></span>
-		<a href="<?php WPSEO_Shortlinker::show( 'http://yoa.st/yoast-seo-credits' ); ?>"><?php echo esc_html( $wpseo_contributors_phrase ); ?></a>
+		<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/yoast-seo-credits' ); ?>"><?php echo esc_html( $wpseo_contributors_phrase ); ?></a>
 	</p>
 </div>
 

--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -105,7 +105,7 @@ unset( $taxonomies, $post_types );
 	printf(
 		/* translators: %1$s / %2$s: links to the breadcrumbs implementation page on the Yoast knowledgebase */
 		esc_html__( 'Usage of this breadcrumbs feature is explained in %1$sour knowledge-base article on breadcrumbs implementation%2$s.', 'wordpress-seo' ),
-		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'http://yoa.st/breadcrumbs' ) ) . '" target="_blank">',
+		'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/breadcrumbs' ) ) . '" target="_blank">',
 		'</a>'
 	);
 	?>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* "Improve speed and efficiency" by making 2 yoa.st shortlinker calls secure.

## Test instructions
This PR can be tested by following these steps:

Make sure that the following 2 links show, are clickable and point to the "https" protocol:
- On `SEO -> General` at the `Credits` heading: "See who contributed to Yoast SEO."
- On `SEO -> Search Apprearance -> Tab:Breadcrumbs` scroll down to the bottom at the `How to insert breadcrumbs in your theme` header: "our knowledge-base article on breadcrumbs implementation"

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/806
