### PR TITLE
Schema: strip tags on text fields

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -75,7 +75,7 @@ class Article extends Abstract_Schema_Piece {
 			'@id'              => $context->canonical . $this->id_helper->article_hash,
 			'isPartOf'         => [ '@id' => $context->canonical . $this->id_helper->webpage_hash ],
 			'author'           => [ '@id' => $this->id_helper->get_user_schema_id( $context->post->post_author, $context ) ],
-			'headline'         => $context->title,
+			'headline'         => \wp_strip_all_tags( $context->title ),
 			'datePublished'    => $this->date_helper->format( $context->post->post_date_gmt ),
 			'dateModified'     => $this->date_helper->format( $context->post->post_modified_gmt ),
 			'commentCount'     => $comment_count['approved'],

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\Free\Presentations\Generators\Schema;
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Article_Helper;
 use Yoast\WP\Free\Helpers\Date_Helper;
+use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
 
 /**
  * Returns schema Article data.
@@ -27,14 +28,21 @@ class Article extends Abstract_Schema_Piece {
 	private $date_helper;
 
 	/**
+	 * @var HTML_Helper
+	 */
+	private $html_helper;
+
+	/**
 	 * Article constructor.
 	 *
 	 * @param Article_Helper $article_helper The article helper.
 	 * @param Date_Helper    $date_helper    The date helper.
+	 * @param HTML_Helper    $html_helper    The HTML helper.
 	 */
-	public function __construct( Article_Helper $article_helper, Date_Helper $date_helper ) {
+	public function __construct( Article_Helper $article_helper, Date_Helper $date_helper, HTML_Helper $html_helper ) {
 		$this->article_helper = $article_helper;
 		$this->date_helper    = $date_helper;
+		$this->html_helper    = $html_helper;
 	}
 
 	/**
@@ -55,6 +63,7 @@ class Article extends Abstract_Schema_Piece {
 
 		if ( $this->article_helper->is_article_post_type( $context->indexable->object_sub_type ) ) {
 			$context->main_schema_id = $context->canonical . $this->id_helper->article_hash;
+
 			return true;
 		}
 
@@ -75,7 +84,7 @@ class Article extends Abstract_Schema_Piece {
 			'@id'              => $context->canonical . $this->id_helper->article_hash,
 			'isPartOf'         => [ '@id' => $context->canonical . $this->id_helper->webpage_hash ],
 			'author'           => [ '@id' => $this->id_helper->get_user_schema_id( $context->post->post_author, $context ) ],
-			'headline'         => \wp_strip_all_tags( $context->title ),
+			'headline'         => $this->html_helper->smart_strip_tags( $context->title ),
 			'datePublished'    => $this->date_helper->format( $context->post->post_date_gmt ),
 			'dateModified'     => $this->date_helper->format( $context->post->post_modified_gmt ),
 			'commentCount'     => $comment_count['approved'],

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -36,13 +36,15 @@ class Author extends Person {
 	 * @param Article_Helper      $article_helper      The article helper.
 	 * @param Image_Helper        $image_helper        The image helper.
 	 * @param Schema\Image_Helper $schema_image_helper The schema image helper.
+	 * @param Schema\HTML_Helper  $html_helper         The HTML helper.
 	 */
 	public function __construct(
 		Article_Helper $article_helper,
 		Image_Helper $image_helper,
-		Schema\Image_Helper $schema_image_helper
+		Schema\Image_Helper $schema_image_helper,
+		Schema\HTML_Helper $html_helper
 	) {
-		parent::__construct( $image_helper, $schema_image_helper );
+		parent::__construct( $image_helper, $schema_image_helper, $html_helper );
 		$this->article_helper = $article_helper;
 	}
 

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -116,7 +116,7 @@ class FAQ extends Abstract_Schema_Piece {
 			'@id'            => $url,
 			'position'       => $position,
 			'url'            => $url,
-			'name'           => \strip_tags( $question['jsonQuestion'] ),
+			'name'           => \wp_strip_all_tags( $question['jsonQuestion'] ),
 			'answerCount'    => 1,
 			'acceptedAnswer' => [
 				'@type' => 'Answer',

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -116,7 +116,7 @@ class FAQ extends Abstract_Schema_Piece {
 			'@id'            => $url,
 			'position'       => $position,
 			'url'            => $url,
-			'name'           => \wp_strip_all_tags( $question['jsonQuestion'] ),
+			'name'           => $this->html_helper->smart_strip_tags( $question['jsonQuestion'] ),
 			'answerCount'    => 1,
 			'acceptedAnswer' => [
 				'@type' => 'Answer',

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -67,7 +67,7 @@ class HowTo extends Abstract_Schema_Piece {
 			$data = [
 				'@type'            => 'HowTo',
 				'@id'              => $context->canonical . '#howto-' . $index,
-				'name'             => \wp_strip_all_tags( $context->title ),
+				'name'             => $this->html_helper->smart_strip_tags( $context->title ),
 				'mainEntityOfPage' => [ '@id' => $context->main_schema_id ],
 				'description'      => '',
 			];
@@ -125,7 +125,7 @@ class HowTo extends Abstract_Schema_Piece {
 			}
 
 			if ( isset( $step['jsonName'] ) ) {
-				$json_name = \wp_strip_all_tags( $step['jsonName'] );
+				$json_name = $this->html_helper->smart_strip_tags( $step['jsonName'] );
 			}
 
 			if ( empty( $json_name ) ) {

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -67,7 +67,7 @@ class HowTo extends Abstract_Schema_Piece {
 			$data = [
 				'@type'            => 'HowTo',
 				'@id'              => $context->canonical . '#howto-' . $index,
-				'name'             => $context->title,
+				'name'             => \wp_strip_all_tags( $context->title ),
 				'mainEntityOfPage' => [ '@id' => $context->main_schema_id ],
 				'description'      => '',
 			];
@@ -125,7 +125,7 @@ class HowTo extends Abstract_Schema_Piece {
 			}
 
 			if ( isset( $step['jsonName'] ) ) {
-				$json_name = \strip_tags( $step['jsonName'] );
+				$json_name = \wp_strip_all_tags( $step['jsonName'] );
 			}
 
 			if ( empty( $json_name ) ) {

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\Free\Presentations\Generators\Schema;
 
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
 use Yoast\WP\Free\Helpers\Schema\Image_Helper;
 
 /**
@@ -22,23 +23,32 @@ class Organization extends Abstract_Schema_Piece {
 	 * @var Image_Helper
 	 */
 	private $image_helper;
+
 	/**
 	 * @var Options_Helper
 	 */
 	private $options_helper;
 
 	/**
+	 * @var HTML_Helper
+	 */
+	private $html_helper;
+
+	/**
 	 * Organization constructor.
 	 *
 	 * @param Image_Helper   $image_helper   The image helper.
 	 * @param Options_Helper $options_helper The options helper.
+	 * @param HTML_Helper    $html_helper    The HTML helper.
 	 */
 	public function __construct(
 		Image_Helper $image_helper,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		HTML_Helper $html_helper
 	) {
 		$this->image_helper   = $image_helper;
 		$this->options_helper = $options_helper;
+		$this->html_helper    = $html_helper;
 	}
 
 	/**
@@ -64,7 +74,7 @@ class Organization extends Abstract_Schema_Piece {
 		$data      = [
 			'@type'  => 'Organization',
 			'@id'    => $context->site_url . $this->id_helper->organization_hash,
-			'name'   => \wp_strip_all_tags( $context->company_name ),
+			'name'   => $this->html_helper->smart_strip_tags( $context->company_name ),
 			'url'    => $context->site_url,
 			'sameAs' => $this->fetch_social_profiles(),
 			'logo'   => $this->image_helper->generate_from_attachment_id( $schema_id, $context->company_logo_id, $context->company_name ),
@@ -77,11 +87,11 @@ class Organization extends Abstract_Schema_Piece {
 	/**
 	 * Retrieve the social profiles to display in the organization schema.
 	 *
-	 * @since 1.8
-	 *
+	 * @return array $profiles An array of social profiles.
 	 * @link  https://developers.google.com/webmasters/structured-data/customize/social-profiles
 	 *
-	 * @return array $profiles An array of social profiles.
+	 * @since 1.8
+	 *
 	 */
 	private function fetch_social_profiles() {
 		$profiles        = [];

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -64,7 +64,7 @@ class Organization extends Abstract_Schema_Piece {
 		$data      = [
 			'@type'  => 'Organization',
 			'@id'    => $context->site_url . $this->id_helper->organization_hash,
-			'name'   => $context->company_name,
+			'name'   => \wp_strip_all_tags( $context->company_name ),
 			'url'    => $context->site_url,
 			'sameAs' => $this->fetch_social_profiles(),
 			'logo'   => $this->image_helper->generate_from_attachment_id( $schema_id, $context->company_logo_id, $context->company_name ),

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -87,11 +87,11 @@ class Organization extends Abstract_Schema_Piece {
 	/**
 	 * Retrieve the social profiles to display in the organization schema.
 	 *
-	 * @return array $profiles An array of social profiles.
 	 * @link  https://developers.google.com/webmasters/structured-data/customize/social-profiles
 	 *
 	 * @since 1.8
 	 *
+	 * @return array $profiles An array of social profiles.
 	 */
 	private function fetch_social_profiles() {
 		$profiles        = [];

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -150,13 +150,13 @@ class Person extends Abstract_Schema_Piece {
 		$data      = [
 			'@type' => $this->type,
 			'@id'   => $this->id_helper->get_user_schema_id( $user_id, $context ),
-			'name'  => $user_data->display_name,
+			'name'  => \wp_strip_all_tags( $user_data->display_name ),
 		];
 
 		$data = $this->add_image( $data, $user_data, $context );
 
 		if ( ! empty( $user_data->description ) ) {
-			$data['description'] = $user_data->description;
+			$data['description'] = \wp_strip_all_tags( $user_data->description );
 		}
 
 		$social_profiles = $this->get_social_profiles( $user_id );

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\Free\Presentations\Generators\Schema;
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Image_Helper;
 use Yoast\WP\Free\Helpers\Schema;
+use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
 
 /**
  * Returns schema Person data.
@@ -53,17 +54,25 @@ class Person extends Abstract_Schema_Piece {
 	private $schema_image_helper;
 
 	/**
+	 * @var HTML_Helper
+	 */
+	private $html_helper;
+
+	/**
 	 * Main_Image constructor.
 	 *
 	 * @param Image_Helper        $image_helper        The image helper.
 	 * @param Schema\Image_Helper $schema_image_helper The schema image helper.
+	 * @param HTML_Helper         $html_helper         The HTML helper.
 	 */
 	public function __construct(
 		Image_Helper $image_helper,
-		Schema\Image_Helper $schema_image_helper
+		Schema\Image_Helper $schema_image_helper,
+		HTML_Helper $html_helper
 	) {
 		$this->image_helper        = $image_helper;
 		$this->schema_image_helper = $schema_image_helper;
+		$this->html_helper         = $html_helper;
 	}
 
 	/**
@@ -150,13 +159,13 @@ class Person extends Abstract_Schema_Piece {
 		$data      = [
 			'@type' => $this->type,
 			'@id'   => $this->id_helper->get_user_schema_id( $user_id, $context ),
-			'name'  => \wp_strip_all_tags( $user_data->display_name ),
+			'name'  => $this->html_helper->smart_strip_tags( $user_data->display_name ),
 		];
 
 		$data = $this->add_image( $data, $user_data, $context );
 
 		if ( ! empty( $user_data->description ) ) {
-			$data['description'] = \wp_strip_all_tags( $user_data->description );
+			$data['description'] = $this->html_helper->smart_strip_tags( $user_data->description );
 		}
 
 		$social_profiles = $this->get_social_profiles( $user_id );

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Free\Presentations\Generators\Schema;
 
-use WP_Post;
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Date_Helper;
@@ -26,30 +25,30 @@ class WebPage extends Abstract_Schema_Piece {
 	private $current_page;
 
 	/**
-	 * @var HTML_Helper
-	 */
-	private $html_helper;
-
-	/**
 	 * @var Date_Helper
 	 */
 	private $date_helper;
 
 	/**
+	 * @var HTML_Helper
+	 */
+	private $html_helper;
+
+	/**
 	 * WebPage constructor.
 	 *
 	 * @param Current_Page_Helper $current_page_helper The current page helper.
-	 * @param HTML_Helper         $html_helper         The HTML helper.
 	 * @param Date_Helper         $date_helper         The date helper.
+	 * @param HTML_Helper         $html_helper         The HTML helper.
 	 */
 	public function __construct(
 		Current_Page_Helper $current_page_helper,
-		HTML_Helper $html_helper,
-		Date_Helper $date_helper
+		Date_Helper $date_helper,
+		HTML_Helper $html_helper
 	) {
 		$this->current_page = $current_page_helper;
-		$this->html_helper  = $html_helper;
 		$this->date_helper  = $date_helper;
+		$this->html_helper  = $html_helper;
 	}
 
 	/**
@@ -76,7 +75,7 @@ class WebPage extends Abstract_Schema_Piece {
 			'@id'        => $context->canonical . $this->id_helper->webpage_hash,
 			'url'        => $context->canonical,
 			'inLanguage' => \get_bloginfo( 'language' ),
-			'name'       => \wp_strip_all_tags( $context->title ),
+			'name'       => $this->html_helper->smart_strip_tags( $context->title ),
 			'isPartOf'   => [
 				'@id' => $context->site_url . $this->id_helper->website_hash,
 			],
@@ -100,7 +99,7 @@ class WebPage extends Abstract_Schema_Piece {
 		}
 
 		if ( ! empty( $context->description ) ) {
-			$data['description'] = $this->html_helper->sanitize( $context->description );
+			$data['description'] = $this->html_helper->smart_strip_tags( $context->description );
 		}
 
 		if ( $this->add_breadcrumbs( $context ) ) {

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -76,7 +76,7 @@ class WebPage extends Abstract_Schema_Piece {
 			'@id'        => $context->canonical . $this->id_helper->webpage_hash,
 			'url'        => $context->canonical,
 			'inLanguage' => \get_bloginfo( 'language' ),
-			'name'       => $context->title,
+			'name'       => \wp_strip_all_tags( $context->title ),
 			'isPartOf'   => [
 				'@id' => $context->site_url . $this->id_helper->website_hash,
 			],
@@ -116,7 +116,7 @@ class WebPage extends Abstract_Schema_Piece {
 	 * Adds an author property to the $data if the WebPage is not represented.
 	 *
 	 * @param array             $data    The WebPage schema.
-	 * @param WP_Post           $post    The post the context is representing.
+	 * @param \WP_Post          $post    The post the context is representing.
 	 * @param Meta_Tags_Context $context The meta tags context.
 	 *
 	 * @return array The WebPage schema.

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Free\Presentations\Generators\Schema;
 
+use WP_Post;
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Current_Page_Helper;
 use Yoast\WP\Free\Helpers\Date_Helper;
@@ -25,26 +26,26 @@ class WebPage extends Abstract_Schema_Piece {
 	private $current_page;
 
 	/**
-	 * @var Date_Helper
-	 */
-	private $date_helper;
-
-	/**
 	 * @var HTML_Helper
 	 */
 	private $html_helper;
 
 	/**
+	 * @var Date_Helper
+	 */
+	private $date_helper;
+
+	/**
 	 * WebPage constructor.
 	 *
 	 * @param Current_Page_Helper $current_page_helper The current page helper.
-	 * @param Date_Helper         $date_helper         The date helper.
 	 * @param HTML_Helper         $html_helper         The HTML helper.
+	 * @param Date_Helper         $date_helper         The date helper.
 	 */
 	public function __construct(
 		Current_Page_Helper $current_page_helper,
-		Date_Helper $date_helper,
-		HTML_Helper $html_helper
+		HTML_Helper $html_helper,
+		Date_Helper $date_helper
 	) {
 		$this->current_page = $current_page_helper;
 		$this->date_helper  = $date_helper;
@@ -115,7 +116,7 @@ class WebPage extends Abstract_Schema_Piece {
 	 * Adds an author property to the $data if the WebPage is not represented.
 	 *
 	 * @param array             $data    The WebPage schema.
-	 * @param \WP_Post          $post    The post the context is representing.
+	 * @param WP_Post           $post    The post the context is representing.
 	 * @param Meta_Tags_Context $context The meta tags context.
 	 *
 	 * @return array The WebPage schema.

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -57,7 +57,7 @@ class Website extends Abstract_Schema_Piece {
 			'@type'     => 'WebSite',
 			'@id'       => $context->site_url . $this->id_helper->website_hash,
 			'url'       => $context->site_url,
-			'name'      => $context->site_name,
+			'name'      => wp_strip_all_tags( $context->site_name ),
 		];
 
 		if ( $context->site_represents_reference ) {
@@ -80,7 +80,7 @@ class Website extends Abstract_Schema_Piece {
 	private function add_alternate_name( $data ) {
 		$alternate_name = $this->options_helper->get( 'alternate_website_name', '' );
 		if ( $alternate_name !== '' ) {
-			$data['alternateName'] = $alternate_name;
+			$data['alternateName'] = \wp_strip_all_tags( $alternate_name );
 		}
 
 		return $data;

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\Free\Presentations\Generators\Schema;
 
 use Yoast\WP\Free\Context\Meta_Tags_Context;
 use Yoast\WP\Free\Helpers\Options_Helper;
+use Yoast\WP\Free\Helpers\Schema\HTML_Helper;
 
 /**
  * Returns schema Website data.
@@ -23,11 +24,18 @@ class Website extends Abstract_Schema_Piece {
 	private $options_helper;
 
 	/**
+	 * @var HTML_Helper
+	 */
+	private $html_helper;
+
+	/**
 	 * Website constructor.
 	 *
 	 * @param Options_Helper $options_helper The options helper.
+	 * @param HTML_Helper    $html_helper    The HTML helper.
 	 */
-	public function __construct( Options_Helper $options_helper ) {
+	public function __construct( Options_Helper $options_helper, HTML_Helper $html_helper ) {
+		$this->html_helper    = $html_helper;
 		$this->options_helper = $options_helper;
 	}
 
@@ -54,10 +62,10 @@ class Website extends Abstract_Schema_Piece {
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$data = [
-			'@type'     => 'WebSite',
-			'@id'       => $context->site_url . $this->id_helper->website_hash,
-			'url'       => $context->site_url,
-			'name'      => wp_strip_all_tags( $context->site_name ),
+			'@type' => 'WebSite',
+			'@id'   => $context->site_url . $this->id_helper->website_hash,
+			'url'   => $context->site_url,
+			'name'  => $this->html_helper->smart_strip_tags( $context->site_name ),
 		];
 
 		if ( $context->site_represents_reference ) {
@@ -80,7 +88,7 @@ class Website extends Abstract_Schema_Piece {
 	private function add_alternate_name( $data ) {
 		$alternate_name = $this->options_helper->get( 'alternate_website_name', '' );
 		if ( $alternate_name !== '' ) {
-			$data['alternateName'] = \wp_strip_all_tags( $alternate_name );
+			$data['alternateName'] = $this->html_helper->smart_strip_tags( $alternate_name );
 		}
 
 		return $data;

--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -38,14 +38,17 @@ class HTML_Helper {
 		$html = preg_replace( '/<br(\s*)?\/?>/i', ' ', $html );
 
 		// Replace closing </p> and other tags with the same tag with a space after it, so we don't end up connecting words when we remove them later.
-		$html = preg_replace( '/<\/(p|li|div|h\d)>/i', '</$1> ', $html );
+		$html = preg_replace( '/<\/(p|div|h\d)>/i', '</$1> ', $html );
 
 		// Replace list items with list identifiers so it still looks natural.
-		$html = preg_replace( '/<li([^>]+)>/i', '&#149; ', $html );
+		$html = preg_replace( '/(<li[^>]*>)/i', '$1• ', $html );
+
+		// Strip tags.
+		$html = \wp_strip_all_tags( $html );
 
 		// Replace multiple spaces with one space.
-		$html = preg_replace( '/\s+/', ' ', $html );
+		$html = preg_replace( '!\s+!', ' ', $html );
 
-		return trim( \wp_strip_all_tags( $html ) );
+		return trim( $html );
 	}
 }

--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -32,10 +32,10 @@ class HTML_Helper {
 	 */
 	public function smart_strip_tags( $html ) {
 		// Replace all new lines with spaces.
-		$html = preg_replace('/(\r|\n)/', " ", $html );
+		$html = preg_replace( '/(\r|\n)/', " ", $html );
 
 		// Replace <br> tags with spaces.
-		$html = preg_replace('/<br(\s*)?\/?>/i', " ", $html );
+		$html = preg_replace( '/<br(\s*)?\/?>/i', " ", $html );
 
 		// Replace closing </p> and other tags with the same tag with a space after it, so we don't end up connecting words when we remove them later.
 		$html = preg_replace( '/<\/(p|li|div|h\d)>/i', '</$1> ', $html );

--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -24,4 +24,28 @@ class HTML_Helper {
 	public function sanitize( $html ) {
 		return \strip_tags( $html, '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><b><strong><i><em>' );
 	}
+
+	/**
+	 * @param string $html The original HTML.
+	 *
+	 * @return string The sanitized HTML.
+	 */
+	public function smart_strip_tags( $html ) {
+		// Replace all new lines with spaces.
+		$html = preg_replace('/(\r|\n)/i', " ", $html );
+
+		// Replace <br> tags with spaces.
+		$html = preg_replace('/<br(\s*)?\/?>/i', " ", $html );
+
+		// Replace closing </p> and other tags with the same tag with a space after it, so we don't end up connecting words when we remove them later.
+		$html = preg_replace( '/<\/(p|li|div|h\d)>/', '</$1> ', $html );
+
+		// Replace list items with list identifiers so it still looks natural.
+		$html = preg_replace( '/<li([^>]+)>/', '&#149; ', $html );
+
+		// Replace multiple spaces with one space.
+		$html = preg_replace( '/\s+/', ' ', $html );
+
+		return trim( \wp_strip_all_tags( $html ) );
+	}
 }

--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -32,16 +32,16 @@ class HTML_Helper {
 	 */
 	public function smart_strip_tags( $html ) {
 		// Replace all new lines with spaces.
-		$html = preg_replace('/(\r|\n)/i', " ", $html );
+		$html = preg_replace('/(\r|\n)/', " ", $html );
 
 		// Replace <br> tags with spaces.
 		$html = preg_replace('/<br(\s*)?\/?>/i', " ", $html );
 
 		// Replace closing </p> and other tags with the same tag with a space after it, so we don't end up connecting words when we remove them later.
-		$html = preg_replace( '/<\/(p|li|div|h\d)>/', '</$1> ', $html );
+		$html = preg_replace( '/<\/(p|li|div|h\d)>/i', '</$1> ', $html );
 
 		// Replace list items with list identifiers so it still looks natural.
-		$html = preg_replace( '/<li([^>]+)>/', '&#149; ', $html );
+		$html = preg_replace( '/<li([^>]+)>/i', '&#149; ', $html );
 
 		// Replace multiple spaces with one space.
 		$html = preg_replace( '/\s+/', ' ', $html );

--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -32,10 +32,10 @@ class HTML_Helper {
 	 */
 	public function smart_strip_tags( $html ) {
 		// Replace all new lines with spaces.
-		$html = preg_replace( '/(\r|\n)/', " ", $html );
+		$html = preg_replace( '/(\r|\n)/', ' ', $html );
 
 		// Replace <br> tags with spaces.
-		$html = preg_replace( '/<br(\s*)?\/?>/i', " ", $html );
+		$html = preg_replace( '/<br(\s*)?\/?>/i', ' ', $html );
 
 		// Replace closing </p> and other tags with the same tag with a space after it, so we don't end up connecting words when we remove them later.
 		$html = preg_replace( '/<\/(p|li|div|h\d)>/i', '</$1> ', $html );

--- a/src/helpers/schema/id-helper.php
+++ b/src/helpers/schema/id-helper.php
@@ -93,8 +93,11 @@ class ID_Helper {
 	 */
 	public function get_user_schema_id( $user_id, $context ) {
 		$user = get_userdata( $user_id );
+		if ( is_a( $user, 'WP_User' ) ) {
+			return $context->site_url . $this->person_hash . wp_hash( $user->user_login . $user_id );
+		}
 
-		return $context->site_url . $this->person_hash . wp_hash( $user->user_login . $user_id );
+		return '';
 	}
 
 	/**

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -66,7 +66,7 @@ class Image_Helper {
 		$data['url'] = $url;
 
 		if ( ! empty( $caption ) ) {
-			$data['caption'] = $caption;
+			$data['caption'] = \wp_strip_all_tags( $caption );
 		}
 
 		return $data;
@@ -90,14 +90,14 @@ class Image_Helper {
 
 		$caption = \wp_get_attachment_caption( $attachment_id );
 		if ( ! empty( $caption ) ) {
-			$data['caption'] = $caption;
+			$data['caption'] = \wp_strip_all_tags( $caption );
 
 			return $data;
 		}
 
 		$caption = \get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 		if ( ! empty( $caption ) ) {
-			$data['caption'] = $caption;
+			$data['caption'] = \wp_strip_all_tags( $caption );
 		}
 
 		return $data;

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -21,7 +21,7 @@ class Image_Helper {
 	/**
 	 * Image_Helper constructor.
 	 *
-	 * @param HTML_Helper $html_helper
+	 * @param HTML_Helper $html_helper The HTML helper.
 	 */
 	public function __construct( HTML_Helper $html_helper ) {
 		$this->html_helper = $html_helper;

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -13,6 +13,19 @@ namespace Yoast\WP\Free\Helpers\Schema;
  * @package Yoast\WP\Free\Helpers\Schema
  */
 class Image_Helper {
+	/**
+	 * @var HTML_Helper
+	 */
+	private $html_helper;
+
+	/**
+	 * Image_Helper constructor.
+	 *
+	 * @param HTML_Helper $html_helper
+	 */
+	public function __construct( HTML_Helper $html_helper ) {
+		$this->html_helper = $html_helper;
+	}
 
 	/**
 	 * Find an image based on its URL and generate a Schema object for it.
@@ -66,7 +79,7 @@ class Image_Helper {
 		$data['url'] = $url;
 
 		if ( ! empty( $caption ) ) {
-			$data['caption'] = \wp_strip_all_tags( $caption );
+			$data['caption'] = $this->html_helper->smart_strip_tags( $caption );
 		}
 
 		return $data;
@@ -90,14 +103,14 @@ class Image_Helper {
 
 		$caption = \wp_get_attachment_caption( $attachment_id );
 		if ( ! empty( $caption ) ) {
-			$data['caption'] = \wp_strip_all_tags( $caption );
+			$data['caption'] = $this->html_helper->smart_strip_tags( $caption );
 
 			return $data;
 		}
 
 		$caption = \get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 		if ( ! empty( $caption ) ) {
-			$data['caption'] = \wp_strip_all_tags( $caption );
+			$data['caption'] = $this->html_helper->smart_strip_tags( $caption );
 		}
 
 		return $data;

--- a/tests/helpers/schema/html-helper-test.php
+++ b/tests/helpers/schema/html-helper-test.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Helpers;
+
+use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @group helpers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Schema\HTML_Helper
+ */
+class HTML_Helper_Test extends TestCase {
+
+	/**
+	 * @var HTML_Helper_Test
+	 */
+	private $instance;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new HTML_Helper();
+	}
+
+	/**
+	 * Test whether sanitize sanitizes properly.
+	 *
+	 * @covers ::sanitize
+	 */
+	public function test_sanitize() {
+		// Test whether sanitize properly removes script tags.
+		$input    = 'Test <script>alert(0)</script> bla';
+		$expected = 'Test alert(0) bla';
+		$this->assertEquals( $expected, $this->instance->sanitize( $input ) );
+
+		// Test whether sanitize leaves allowed <p> tags intact.
+		$input    = 'Test <p>Paragraph</p> bla';
+		$expected = 'Test <p>Paragraph</p> bla';
+		$this->assertEquals( $expected, $this->instance->sanitize( $input ) );
+	}
+
+	/**
+	 * Test whether smart strips tags strips tags in a smart way.
+	 *
+	 * @covers ::smart_strip_tags
+	 */
+	public function test_smart_strip_tags() {
+		// Test removing script tags.
+		$input    = 'Test </script>bla';
+		$expected = 'Test bla';
+		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
+
+		// Test removing script tags.
+		$input    = 'Test </script ><script>alert(0)</script><script>';
+		$expected = 'Test';
+		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
+
+		// Test replacing `<br>` tags with spaces.
+		$input    = 'Test<br>word';
+		$expected = 'Test word';
+		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
+
+		// Test replacing closing heading tags with spaces.
+		$input    = '<h1>Heading</h1>
+First words';
+		$expected = 'Heading First words';
+		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
+
+		// Test replacing tags li with • and new lines with spaces.
+		$input    = 'I am:
+<ul>
+<li>smart</li>
+<li>beautiful</li>
+</ul>';
+		$expected = 'I am: • smart • beautiful';
+		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
+	}
+
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Security fix: strip tags on the output of text fields in Schema.

@moorscode does this need attribution in the changelog?

## Relevant technical choices:

* Uses a new method that does some smart replaces before applying `wp_strip_all_tags` everywhere we output text nodes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See steps in https://github.com/Yoast/bugreports/issues/776, although might be easier to do this with a post's title.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/776
Fixes https://github.com/Yoast/bugreports/issues/572
Fixes #12939
