### PR TITLE
Consistent spacing in our tags

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -166,10 +166,6 @@ class Front_End_Integration implements Integration_Interface {
 		$presenters = $this->get_presenters( $context->page_type );
 		echo PHP_EOL;
 		foreach ( $presenters as $presenter ) {
-			if ( \defined( 'WPSEO_DEBUG' ) && WPSEO_DEBUG === true ) {
-				echo '<!-- ' . get_class( $presenter ) . ' -->';
-			}
-
 			$output = $presenter->present( $context->presentation );
 			if ( ! empty( $output ) ) {
 				echo "\t" . $output . PHP_EOL;

--- a/src/integrations/front-end/webmaster-tools-meta.php
+++ b/src/integrations/front-end/webmaster-tools-meta.php
@@ -114,7 +114,7 @@ class Webmaster_Tools_Meta implements Integration_Interface {
 	 */
 	private function render_meta_tag( array $webmaster_tool ) {
 		printf(
-			'<meta name="%1$s" content="%2$s" />' . PHP_EOL,
+			"\t" . '<meta name="%1$s" content="%2$s" />' . PHP_EOL,
 			esc_attr( $webmaster_tool['tag_name'] ),
 			esc_attr( $webmaster_tool['tag_value'] )
 		);

--- a/src/presenters/googlebot-presenter.php
+++ b/src/presenters/googlebot-presenter.php
@@ -26,7 +26,7 @@ class Googlebot_Presenter extends Abstract_Indexable_Presenter {
 		$googlebot = $this->filter( $googlebot, $presentation );
 
 		if ( \is_string( $googlebot ) && $googlebot !== '' ) {
-			return \sprintf( '<meta name="googlebot" content="%s"/>', \esc_attr( $googlebot ) );
+			return \sprintf( '<meta name="googlebot" content="%s" />', \esc_attr( $googlebot ) );
 		}
 
 		return '';

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -50,11 +50,11 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		foreach ( $images as $image_index => $image_meta ) {
 			$image_url = $image_meta['url'];
 
-			$return .= '<meta property="og:image" content="' . \esc_url( $image_url ) . '"/>';
+			$return .= '<meta property="og:image" content="' . \esc_url( $image_url ) . '" />';
 
 			// Adds secure URL if detected. Not all services implement this, so the regular one also needs to be rendered.
 			if ( \strpos( $image_url, 'https://' ) === 0 ) {
-				$return .= PHP_EOL . '<meta property="og:image:secure_url" content="' . \esc_url( $image_url ) . '"/>';
+				$return .= PHP_EOL . "\t" . '<meta property="og:image:secure_url" content="' . \esc_url( $image_url ) . '" />';
 			}
 
 			foreach ( static::$image_tags as $key => $value ) {
@@ -62,7 +62,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 					continue;
 				}
 
-				$return .= PHP_EOL . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . $image_meta[ $key ] . '"/>';
+				$return .= PHP_EOL . "\t" . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . $image_meta[ $key ] . '" />';
 			}
 		}
 

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -42,7 +42,7 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		$title = $this->string->strip_all_tags( \stripslashes( $title ) );
 
 		if ( \is_string( $title ) && $title !== '' ) {
-			return '<meta property="og:title" content="' . \esc_attr( $title ) . '"/>';
+			return '<meta property="og:title" content="' . \esc_attr( $title ) . '" />';
 		}
 
 		return '';

--- a/src/presenters/open-graph/type-presenter.php
+++ b/src/presenters/open-graph/type-presenter.php
@@ -26,7 +26,7 @@ class Type_Presenter extends Abstract_Indexable_Presenter {
 		$og_type = $this->filter( $presentation->og_type, $presentation );
 
 		if ( \is_string( $og_type ) && $og_type !== '' ) {
-			return '<meta property="og:type" content="' . \esc_attr( $og_type ) . '"/>';
+			return '<meta property="og:type" content="' . \esc_attr( $og_type ) . '" />';
 		}
 
 		return '';

--- a/src/presenters/open-graph/url-presenter.php
+++ b/src/presenters/open-graph/url-presenter.php
@@ -26,7 +26,7 @@ class Url_Presenter extends Abstract_Indexable_Presenter {
 		$og_url = $this->filter( $presentation->og_url, $presentation );
 
 		if ( \is_string( $og_url ) && $og_url !== '' ) {
-			return '<meta property="og:url" content="' . \esc_url( $og_url ) . '"/>';
+			return '<meta property="og:url" content="' . \esc_url( $og_url ) . '" />';
 		}
 
 		return '';

--- a/src/presenters/robots-presenter.php
+++ b/src/presenters/robots-presenter.php
@@ -28,7 +28,7 @@ class Robots_Presenter extends Abstract_Indexable_Presenter {
 		$robots = $this->filter( $robots, $presentation );
 
 		if ( \is_string( $robots ) && $robots !== '' ) {
-			return \sprintf( '<meta name="robots" content="%s"/>', \esc_attr( $robots ) );
+			return \sprintf( '<meta name="robots" content="%s" />', \esc_attr( $robots ) );
 		}
 
 		return '';

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -45,7 +45,7 @@ class Googlebot_Presenter_Test extends TestCase {
 		$indexable_presentation->googlebot = [ 'one', 'two', 'three' ];
 
 		$actual = $this->instance->present( $indexable_presentation );
-		$expected = '<meta name="googlebot" content="one, two, three"/>';
+		$expected = '<meta name="googlebot" content="one, two, three" />';
 
 		$this->assertEquals( $actual, $expected );
 	}
@@ -66,7 +66,7 @@ class Googlebot_Presenter_Test extends TestCase {
 			->andReturn( 'one, two' );
 
 		$actual = $this->instance->present( $indexable_presentation );
-		$expected = '<meta name="googlebot" content="one, two"/>';
+		$expected = '<meta name="googlebot" content="one, two" />';
 
 		$this->assertEquals( $actual, $expected );
 	}

--- a/tests/presenters/open-graph/image-presenter-test.php
+++ b/tests/presenters/open-graph/image-presenter-test.php
@@ -65,7 +65,7 @@ class Image_Presenter_Test extends TestCase {
 		$this->presentation->og_images = [ $image ];
 
 		$this->assertEquals(
-			'<meta property="og:image" content="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:secure_url" content="https://example.com/image.jpg"/>' . PHP_EOL . '<meta property="og:image:width" content="100"/>' . PHP_EOL . '<meta property="og:image:height" content="100"/>',
+			'<meta property="og:image" content="https://example.com/image.jpg" />' . PHP_EOL . "\t" . '<meta property="og:image:secure_url" content="https://example.com/image.jpg" />' . PHP_EOL . "\t" . '<meta property="og:image:width" content="100" />' . PHP_EOL . "\t" . '<meta property="og:image:height" content="100" />',
 			$this->instance->present( $this->presentation )
 		);
 	}

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -76,7 +76,7 @@ class Title_Presenter_Test extends TestCase {
 				return $str;
 			} );
 
-		$expected = '<meta property="og:title" content="example_title"/>';
+		$expected = '<meta property="og:title" content="example_title" />';
 		$actual   = $this->instance->present( $this->indexable_presentation );
 
 		$this->assertEquals( $expected, $actual );
@@ -121,7 +121,7 @@ class Title_Presenter_Test extends TestCase {
 			->with( 'example_title', $this->indexable_presentation )
 			->andReturn( 'exampletitle' );
 
-		$expected = '<meta property="og:title" content="exampletitle"/>';
+		$expected = '<meta property="og:title" content="exampletitle" />';
 		$actual   = $this->instance->present( $this->indexable_presentation );
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/presenters/open-graph/type-presenter-test.php
+++ b/tests/presenters/open-graph/type-presenter-test.php
@@ -45,7 +45,7 @@ class Type_Presenter_Test extends TestCase {
 	public function test_present() {
 		$this->indexable_presentation->og_type = 'article';
 
-		$expected = '<meta property="og:type" content="article"/>';
+		$expected = '<meta property="og:type" content="article" />';
 		$actual = $this->instance->present( $this->indexable_presentation );
 
 		$this->assertEquals( $expected, $actual );
@@ -79,7 +79,7 @@ class Type_Presenter_Test extends TestCase {
 			->with( 'website', $this->indexable_presentation )
 			->andReturn( 'article' );
 
-		$expected = '<meta property="og:type" content="article"/>';
+		$expected = '<meta property="og:type" content="article" />';
 		$actual = $this->instance->present( $this->indexable_presentation );
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -48,7 +48,7 @@ class Robots_Presenter_Test extends TestCase {
 		];
 
 		$actual   = $this->instance->present( $indexable_presentation );
-		$expected = '<meta name="robots" content="index,nofollow"/>';
+		$expected = '<meta name="robots" content="index,nofollow" />';
 
 		$this->assertEquals( $actual, $expected );
 	}
@@ -72,7 +72,7 @@ class Robots_Presenter_Test extends TestCase {
 			->andReturn( 'noindex' );
 
 		$actual   = $this->instance->present( $indexable_presentation );
-		$expected = '<meta name="robots" content="noindex"/>';
+		$expected = '<meta name="robots" content="noindex" />';
 
 		$this->assertEquals( $actual, $expected );
 	}
@@ -106,7 +106,7 @@ class Robots_Presenter_Test extends TestCase {
 		];
 
 		$actual   = $this->instance->present( $indexable_presentation );
-		$expected = '<meta name="robots" content="noimageindex"/>';
+		$expected = '<meta name="robots" content="noimageindex" />';
 
 		$this->assertEquals( $actual, $expected );
 	}


### PR DESCRIPTION
## Summary

Quite nit picky, but this pull makes sure we always:

* Close our tags like this `content" />`, instead of varying between that and `content"/>`.
* Properly add tabs to indent every element.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* None needed.

## Relevant technical choices:

* Removed the `WPSEO_DEBUG` presenter comment for every presenter so you can actually see all this a bit more easily.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See that all output has `" />`.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
