### PR TITLE
Rename snippet preview to Google preview in search appearance

### DIFF
--- a/admin/views/class-view-utils.php
+++ b/admin/views/class-view-utils.php
@@ -88,7 +88,7 @@ class Yoast_View_Utils {
 
 		$this->form->show_hide_switch(
 			'showdate-' . $post_type->name,
-			__( 'Date in Snippet Preview', 'wordpress-seo' )
+			__( 'Date in Google Preview', 'wordpress-seo' )
 		);
 
 		$this->form->show_hide_switch(

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -23,7 +23,7 @@ $yform->index_switch(
 
 $yform->show_hide_switch(
 	'showdate-' . $wpseo_post_type->name,
-	__( 'Date in Snippet Preview', 'wordpress-seo' )
+	__( 'Date in Google Preview', 'wordpress-seo' )
 );
 
 $yform->show_hide_switch(


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Renames 
I've added the non-user-facing label, because the change is already covered by the changelog item `Renames the 'Snippet preview' to 'Google preview'`.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See https://github.com/Yoast/bugreports/issues/675

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/675
