### PR TITLE
Add @covers to WPSEO_Schema_Person_Upgrade_Notification_Test

### DIFF
--- a/integration-tests/admin/test-class-schema-person-upgrade-notification.php
+++ b/integration-tests/admin/test-class-schema-person-upgrade-notification.php
@@ -14,6 +14,8 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Remove the notification when Person is not selected.
+	 *
+	 * @covers WPSEO_Schema_Person_Upgrade_Notification::handle_notification
 	 */
 	public function test_remove_notification_not_person() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
@@ -29,6 +31,8 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Remove the notification if a person is selected.
+	 *
+	 * @covers WPSEO_Schema_Person_Upgrade_Notification::handle_notification
 	 */
 	public function test_remove_notification_user_id_set() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )
@@ -45,6 +49,8 @@ class WPSEO_Schema_Person_Upgrade_Notification_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Add a notification when Person is selected, but no person is selected.
+	 *
+	 * @covers WPSEO_Schema_Person_Upgrade_Notification::handle_notification
 	 */
 	public function test_add_notification() {
 		$instance = $this->getMockBuilder( 'WPSEO_Schema_Person_Upgrade_Notification' )


### PR DESCRIPTION
## Summary
Fixes 
```
FILE: integration-tests\admin\test-class-schema-person-upgrade-notification.php
--
----------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------------------------------------
18 \| ERROR \| Each test function should have at least one @covers tag annotating which
\|       \| class/method/function is being tested. Tag missing for function
\|       \| test_remove_notification_not_person()
33 \| ERROR \| Each test function should have at least one @covers tag annotating which
\|       \| class/method/function is being tested. Tag missing for function
\|       \| test_remove_notification_user_id_set()
49 \| ERROR \| Each test function should have at least one @covers tag annotating which
\|       \| class/method/function is being tested. Tag missing for function
\|       \| test_add_notification()
```

