### PR TITLE
Improve paging comments health check

### DIFF
--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -609,7 +609,7 @@ body.folded {
 	}
 
 	&__signature-icon,
-		// needs higher specificity
+	// needs higher specificity
 	&__inline-button.fetch-status {
 		margin-right: 8px;
 	}

--- a/css/src/admin-global.scss
+++ b/css/src/admin-global.scss
@@ -596,4 +596,21 @@ body.folded {
 		color: #674E00;
 		background: #FFF3CD;
 	}
+
+}
+
+.yoast-site-health {
+	&__signature {
+		display: flex;
+		font-size: 12px;
+		line-height: 20px; // same as the icon height
+		margin-top: 2em;
+		color: #707070;
+	}
+
+	&__signature-icon,
+		// needs higher specificity
+	&__inline-button.fetch-status {
+		margin-right: 8px;
+	}
 }

--- a/inc/health-check-page-comments.php
+++ b/inc/health-check-page-comments.php
@@ -22,13 +22,16 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 	 */
 	public function run() {
 		if ( ! $this->has_page_comments() ) {
+			$this->label          = esc_html__( 'Paging comments is properly disabled', 'wordpress-seo' );
+			$this->status         = self::STATUS_GOOD;
+			$this->badge['color'] = 'blue';
+			$this->description    = esc_html__( 'Paging comments is disabled. As this is not needed in 999 out of 1000 cases, we recommend to keep it disabled.', 'wordpress-seo' );
+			$this->add_yoast_signature();
 			return;
 		}
-
 		$this->label          = esc_html__( 'Paging comments is enabled', 'wordpress-seo' );
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
-
 		$this->description  = esc_html__( 'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
 								To fix this, uncheck the comment settings box in front of "Break comments into pages..." on the Discussion Settings page.', 'wordpress-seo' );
 		$this->actions = sprintf(
@@ -38,7 +41,6 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 			'</a>'
 		);
 		$this->add_yoast_signature();
-
 	}
 
 	/**

--- a/inc/health-check-page-comments.php
+++ b/inc/health-check-page-comments.php
@@ -25,22 +25,20 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 			return;
 		}
 
-		$this->label          = esc_html__( 'Paging comments enabled', 'wordpress-seo' );
+		$this->label          = esc_html__( 'Paging comments is enabled', 'wordpress-seo' );
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
 
-		$this->description  = esc_html__( 'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.', 'wordpress-seo' );
-		$this->description .= '<br />';
-		$this->description .= sprintf(
-			/* translators: %1$s resolves to the opening tag of the link to the comment setting page, %2$s resolves to the closing tag of the link */
-			esc_html__( 'To fix this, uncheck the box in front of the "Break comments into pages..." on the %1$sComment settings page%2$s.', 'wordpress-seo' ),
+		$this->description  = esc_html__( 'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
+								To fix this, uncheck the comment settings box in front of "Break comments into pages..." on the Discussion Settings page.', 'wordpress-seo' );
+		$this->actions = sprintf(
+		/* translators:  */
+			esc_html__( '%1$sGo to the Discussion Settings page%2$s', 'wordpress-seo' ),
 			'<a href="' . esc_url( admin_url( 'options-discussion.php' ) ) . '">',
 			'</a>'
 		);
+		$this->add_yoast_signature();
 
-		$this->actions  = '<a href="' . esc_url( admin_url( 'options-discussion.php' ) ) . '">';
-		$this->actions .= esc_html__( 'Go to the comment settings page', 'wordpress-seo' );
-		$this->actions .= '</a>';
 	}
 
 	/**

--- a/inc/health-check-page-comments.php
+++ b/inc/health-check-page-comments.php
@@ -29,12 +29,13 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 			$this->add_yoast_signature();
 			return;
 		}
+
 		$this->label          = esc_html__( 'Paging comments is enabled', 'wordpress-seo' );
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
-		$this->description  = esc_html__( 'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
-								To fix this, uncheck the comment settings box in front of "Break comments into pages..." on the Discussion Settings page.', 'wordpress-seo' );
-		$this->actions = sprintf(
+		$this->description    = esc_html__( 'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
+								To fix this, uncheck the box in front of "Break comments into pages..." on the Discussion Settings page.', 'wordpress-seo' );
+		$this->actions        = sprintf(
 			/* translators: 1: Opening tag of the link to the discussion settings page, 2: Link closing tag. */
 			esc_html__( '%1$sGo to the Discussion Settings page%2$s', 'wordpress-seo' ),
 			'<a href="' . esc_url( admin_url( 'options-discussion.php' ) ) . '">',

--- a/inc/health-check-page-comments.php
+++ b/inc/health-check-page-comments.php
@@ -35,7 +35,7 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 		$this->description  = esc_html__( 'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
 								To fix this, uncheck the comment settings box in front of "Break comments into pages..." on the Discussion Settings page.', 'wordpress-seo' );
 		$this->actions = sprintf(
-		/* translators:  */
+			/* translators: 1: Opening tag of the link to the discussion settings page, 2: Link closing tag. */
 			esc_html__( '%1$sGo to the Discussion Settings page%2$s', 'wordpress-seo' ),
 			'<a href="' . esc_url( admin_url( 'options-discussion.php' ) ) . '">',
 			'</a>'

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -147,6 +147,7 @@ abstract class WPSEO_Health_Check {
 			'badge'       => $this->get_badge(),
 			'description' => $this->description,
 			'actions'     => $this->actions,
+			'test'        => $this->test,
 		];
 	}
 

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -197,4 +197,17 @@ abstract class WPSEO_Health_Check {
 	protected function is_async() {
 		return ! empty( $this->async );
 	}
+
+	/**
+	 * Adds a text to the bottom of the Site Health check to indicate it is a Yoast SEO Site Health Check.
+	 */
+	protected function add_yoast_signature() {
+		$this->actions .= sprintf(
+		/* translators: %1$s: Start of a paragraph beginning with the Yoast icon, %2$s: Expands to 'Yoast SEO', %3$s: Paragraph closing tag. */
+			esc_html__( '%1$sThis was reported by the %2$s plugin%3$s', 'wordpress-seo' ),
+			'<p class="yoast-site-health__signature"><img src="' . esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/Yoast_SEO_Icon.svg' ) . '" height="20" width="20" class="yoast-site-health__signature-icon">',
+			'Yoast SEO',
+			'</p>'
+		);
+	}
 }

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -203,9 +203,9 @@ abstract class WPSEO_Health_Check {
 	 */
 	protected function add_yoast_signature() {
 		$this->actions .= sprintf(
-		/* translators: %1$s: Start of a paragraph beginning with the Yoast icon, %2$s: Expands to 'Yoast SEO', %3$s: Paragraph closing tag. */
+			/* translators: 1: Start of a paragraph beginning with the Yoast icon, 2: Expands to 'Yoast SEO', 3: Paragraph closing tag. */
 			esc_html__( '%1$sThis was reported by the %2$s plugin%3$s', 'wordpress-seo' ),
-			'<p class="yoast-site-health__signature"><img src="' . esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/Yoast_SEO_Icon.svg' ) . '" height="20" width="20" class="yoast-site-health__signature-icon">',
+			'<p class="yoast-site-health__signature"><img src="' . esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/Yoast_SEO_Icon.svg' ) . '" alt="" height="20" width="20" class="yoast-site-health__signature-icon">',
 			'Yoast SEO',
 			'</p>'
 		);

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -11,7 +11,6 @@ use Yoast\WP\Free\Tests\TestCase;
  * @group health-check
  */
 class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
-
 	/**
 	 * Tests the run method when page_comments are disabled.
 	 *
@@ -23,14 +22,11 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 			->once()
 			->with( 'page_comments' )
 			->andReturn( '0' );
-
 		$health_check = new \WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
-
-		// We just want to verify that the label attributes hasn't been set.
-		$this->assertAttributeEquals( '', 'label', $health_check );
+		// We just want to verify that the label attribute is the "passed" message.
+		$this->assertAttributeEquals( 'Paging comments is properly disabled', 'label', $health_check );
 	}
-
 	/**
 	 * Tests the run method when page_comments are enabled.
 	 *
@@ -42,14 +38,11 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 			->once()
 			->with( 'page_comments' )
 			->andReturn( '1' );
-
 		Monkey\Functions\expect( 'esc_url' )->andReturn( '' );
 		Monkey\Functions\expect( 'admin_url' )->andReturn( '' );
-
 		$health_check = new \WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
-
-		// We just want to verify that the label attributes has been set.
-		$this->assertAttributeEquals( 'Paging comments enabled', 'label', $health_check );
+		// We just want to verify that the label attribute is the "not passed" message.
+		$this->assertAttributeEquals( 'Paging comments is enabled', 'label', $health_check );
 	}
 }

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -22,8 +22,12 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 			->once()
 			->with( 'page_comments' )
 			->andReturn( '0' );
+
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
 		$health_check = new \WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
+		
 		// We just want to verify that the label attribute is the "passed" message.
 		$this->assertAttributeEquals( 'Paging comments is properly disabled', 'label', $health_check );
 	}
@@ -40,8 +44,11 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 			->andReturn( '1' );
 		Monkey\Functions\expect( 'esc_url' )->andReturn( '' );
 		Monkey\Functions\expect( 'admin_url' )->andReturn( '' );
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
 		$health_check = new \WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
+
 		// We just want to verify that the label attribute is the "not passed" message.
 		$this->assertAttributeEquals( 'Paging comments is enabled', 'label', $health_check );
 	}

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -27,7 +27,7 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 
 		$health_check = new \WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
-		
+
 		// We just want to verify that the label attribute is the "passed" message.
 		$this->assertAttributeEquals( 'Paging comments is properly disabled', 'label', $health_check );
 	}
@@ -42,6 +42,7 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 			->once()
 			->with( 'page_comments' )
 			->andReturn( '1' );
+
 		Monkey\Functions\expect( 'esc_url' )->andReturn( '' );
 		Monkey\Functions\expect( 'admin_url' )->andReturn( '' );
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );

--- a/tests/inc/health-check-test.php
+++ b/tests/inc/health-check-test.php
@@ -114,6 +114,7 @@ class WPSEO_Health_Check_Test extends TestCase {
 				],
 				'description' => '',
 				'actions'     => '',
+				'test'        => '',
 			],
 			$this->instance->get_test_result()
 		);


### PR DESCRIPTION
## Summary

Improves copy of the paging comments health check, adds the Yoast signature for health checks and adds the scenario for a 'good' result, where the check is moved to `Passed tests`. 

This PR should be merged to `trunk` and not `feature/site-health`. 

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*  "Comment Settings page" was changed to "Discussion Settings page", since the page is found at `Settings` > `Discussion` and then there is a subheading called `Other comment settings` (see image below).

![image](https://user-images.githubusercontent.com/43582255/72080032-50fb1100-32fc-11ea-8962-90aa4aac6a08.png)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See whether everything is still working as desired : look at #14102 and #13522 and the screenshots below

`Recommended`:
![Screenshot 2020-01-10 at 12 57 24](https://user-images.githubusercontent.com/43582255/72151853-a2150e80-33a9-11ea-85ec-11e2080ad0ff.png)

`Passed tests`:
![Screenshot 2020-01-10 at 13 04 47](https://user-images.githubusercontent.com/43582255/72151915-cbce3580-33a9-11ea-8542-542453b26ca9.png)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14178
