### PR TITLE
No longer use .min as a suffix anywhere

### DIFF
--- a/admin/class-admin-asset-dev-server-location.php
+++ b/admin/class-admin-asset-dev-server-location.php
@@ -58,7 +58,7 @@ final class WPSEO_Admin_Asset_Dev_Server_Location implements WPSEO_Admin_Asset_L
 			return $this->get_default_url( $asset, $type );
 		}
 
-		$path = sprintf( '%s%s.js', $asset->get_src(), $asset->get_suffix() );
+		$path = sprintf( '%s.js', $asset->get_src() );
 
 		return trailingslashit( $this->url ) . $path;
 	}

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -397,8 +397,7 @@ class WPSEO_Admin_Asset_Manager {
 			],
 			[
 				'name'    => 'select2',
-				'src'     => 'select2/select2.full',
-				'suffix'  => '.min',
+				'src'     => 'select2/select2.full.min',
 				'deps'    => [
 					'jquery',
 				],
@@ -412,7 +411,6 @@ class WPSEO_Admin_Asset_Manager {
 					self::PREFIX . 'select2',
 				],
 				'version' => '4.0.3',
-				'suffix'  => '',
 			],
 			[
 				'name' => 'configuration-wizard',
@@ -606,8 +604,7 @@ class WPSEO_Admin_Asset_Manager {
 			],
 			[
 				'name'    => 'select2',
-				'src'     => 'select2/select2',
-				'suffix'  => '.min',
+				'src'     => 'select2/select2.min',
 				'version' => '4.0.1',
 				'rtl'     => false,
 			],

--- a/admin/class-admin-asset-seo-location.php
+++ b/admin/class-admin-asset-seo-location.php
@@ -40,26 +40,6 @@ final class WPSEO_Admin_Asset_SEO_Location implements WPSEO_Admin_Asset_Location
 			return '';
 		}
 
-		if ( YOAST_ENVIRONMENT !== 'development' && ! $asset->get_suffix() ) {
-			$plugin_path = plugin_dir_path( $this->plugin_file );
-			if ( ! file_exists( $plugin_path . $path ) ) {
-
-				// Give a notice to the user in the console (only once).
-				WPSEO_Utils::javascript_console_notification(
-					'Development Files',
-					sprintf(
-						/* translators: %1$s resolves to https://github.com/Yoast/wordpress-seo */
-						__( 'You are trying to load non-minified files. These are only available in our development package. Check out %1$s to see all the source files.', 'wordpress-seo' ),
-						'https://github.com/Yoast/wordpress-seo'
-					),
-					true
-				);
-
-				// Just load the .min file.
-				$path = $this->get_path( $asset, $type, '.min' );
-			}
-		}
-
 		return plugins_url( $path, $this->plugin_file );
 	}
 
@@ -69,20 +49,16 @@ final class WPSEO_Admin_Asset_SEO_Location implements WPSEO_Admin_Asset_Location
 	 * @param WPSEO_Admin_Asset $asset        The asset to determine the path
 	 *                                        for.
 	 * @param string            $type         The type of asset.
-	 * @param string|null       $force_suffix The suffix to force, or null when
-	 *                                        to use the default suffix.
 	 *
 	 * @return string The path to the asset file.
 	 */
-	protected function get_path( WPSEO_Admin_Asset $asset, $type, $force_suffix = null ) {
+	protected function get_path( WPSEO_Admin_Asset $asset, $type ) {
 		$relative_path = '';
 		$rtl_suffix    = '';
 
-		$suffix = ( $force_suffix === null ) ? $asset->get_suffix() : $force_suffix;
-
 		switch ( $type ) {
 			case WPSEO_Admin_Asset::TYPE_JS:
-				$relative_path = 'js/dist/' . $asset->get_src() . $suffix . '.js';
+				$relative_path = 'js/dist/' . $asset->get_src() . '.js';
 				break;
 
 			case WPSEO_Admin_Asset::TYPE_CSS:
@@ -90,7 +66,7 @@ final class WPSEO_Admin_Asset_SEO_Location implements WPSEO_Admin_Asset_Location
 				if ( function_exists( 'is_rtl' ) && is_rtl() && $asset->has_rtl() ) {
 					$rtl_suffix = '-rtl';
 				}
-				$relative_path = 'css/dist/' . $asset->get_src() . $rtl_suffix . $suffix . '.css';
+				$relative_path = 'css/dist/' . $asset->get_src() . $rtl_suffix . '.css';
 				break;
 		}
 

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -146,7 +146,6 @@ class WPSEO_Admin_Asset {
 		'in_footer' => true,
 		'rtl'       => true,
 		'media'     => 'all',
-		'suffix'    => WPSEO_CSSJS_SUFFIX,
 	];
 
 	/**
@@ -174,7 +173,7 @@ class WPSEO_Admin_Asset {
 		$this->media     = $args['media'];
 		$this->in_footer = $args['in_footer'];
 		$this->rtl       = $args['rtl'];
-		$this->suffix    = $args['suffix'];
+		$this->suffix    = isset( $args['suffix'] ) ? $args['suffix'] : '';
 	}
 
 	/**

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -129,13 +129,6 @@ class WPSEO_Admin_Asset {
 	protected $rtl;
 
 	/**
-	 * File suffix.
-	 *
-	 * @var string
-	 */
-	protected $suffix;
-
-	/**
 	 * Default asset arguments.
 	 *
 	 * @var array
@@ -173,7 +166,6 @@ class WPSEO_Admin_Asset {
 		$this->media     = $args['media'];
 		$this->in_footer = $args['in_footer'];
 		$this->rtl       = $args['rtl'];
-		$this->suffix    = isset( $args['suffix'] ) ? $args['suffix'] : '';
 	}
 
 	/**
@@ -242,10 +234,14 @@ class WPSEO_Admin_Asset {
 	/**
 	 * Returns the file suffix.
 	 *
+	 * @deprecated 12.9
+	 * @codeCoverageIgnore
+	 *
 	 * @return string
 	 */
 	public function get_suffix() {
-		return $this->suffix;
+		_deprecated_function( __CLASS__ . '::get_suffix', '12.9', false );
+		return '';
 	}
 
 	/**

--- a/integration-tests/admin/test-class-admin-asset-dev-server-location.php
+++ b/integration-tests/admin/test-class-admin-asset-dev-server-location.php
@@ -32,7 +32,7 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 
 		$actual = $dev_server_location->get_url( $asset, WPSEO_Admin_Asset::TYPE_JS );
 
-		$this->assertEquals( 'http://localhost:8080/commons' . WPSEO_CSSJS_SUFFIX . '.js', $actual );
+		$this->assertEquals( 'http://localhost:8080/commons.js', $actual );
 	}
 
 	/**
@@ -47,7 +47,7 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 
 		$actual = $dev_server_location->get_url( $asset, WPSEO_Admin_Asset::TYPE_JS );
 
-		$this->assertEquals( 'https://localhost:8081/commons' . WPSEO_CSSJS_SUFFIX . '.js', $actual );
+		$this->assertEquals( 'https://localhost:8081/commons.js', $actual );
 	}
 
 	/**

--- a/integration-tests/admin/test-class-admin-asset-seo-location.php
+++ b/integration-tests/admin/test-class-admin-asset-seo-location.php
@@ -23,13 +23,12 @@ final class Test_WPSEO_Admin_Asset_SEO_Location extends PHPUnit_Framework_TestCa
 			'version'   => 'version',
 			'media'     => 'screen',
 			'in_footer' => false,
-			'suffix'    => '.suffix',
 			'rtl'       => false,
 		];
 		$asset      = new WPSEO_Admin_Asset( $asset_args );
 
-		$expected_js    = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/src.suffix.js';
-		$expected_css   = home_url() . '/wp-content/plugins/wordpress-seo/css/dist/src.suffix.css';
+		$expected_js    = home_url() . '/wp-content/plugins/wordpress-seo/js/dist/src.js';
+		$expected_css   = home_url() . '/wp-content/plugins/wordpress-seo/css/dist/src.css';
 		$expected_empty = '';
 
 		$location = new WPSEO_Admin_Asset_SEO_Location( WPSEO_FILE );

--- a/integration-tests/test-class-admin-asset-manager.php
+++ b/integration-tests/test-class-admin-asset-manager.php
@@ -139,7 +139,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 		$result = $wp_scripts->registered[ WPSEO_Admin_Asset_Manager::PREFIX . 'handle' ];
 
 		$this->assertEquals( WPSEO_Admin_Asset_Manager::PREFIX . 'handle', $result->handle );
-		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/wp-content/plugins/wordpress-seo/js/dist/src' . WPSEO_CSSJS_SUFFIX . '.js', $result->src );
+		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/wp-content/plugins/wordpress-seo/js/dist/src' . '.js', $result->src );
 		$this->assertEquals( [ 'deps' ], $result->deps );
 		$this->assertEquals( 'version', $result->ver );
 		$this->assertEquals( [ 'group' => 1 ], $result->extra );

--- a/integration-tests/test-class-admin-asset-manager.php
+++ b/integration-tests/test-class-admin-asset-manager.php
@@ -168,28 +168,6 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether the registers_script function applies the suffix correctly.
-	 *
-	 * @covers WPSEO_Admin_Asset_Manager::register_script
-	 */
-	public function test_register_script_suffix() {
-		$asset_args = [
-			'name'   => 'handle2', // Handles have to be unique, isolation YaY ¯\_(ツ)_/¯.
-			'src'    => 'src',
-			'suffix' => '.suffix',
-		];
-		$this->asset_manager->register_script( new WPSEO_Admin_Asset( $asset_args ) );
-
-		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2.
-		// Use the WordPress internals to assert instead.
-		global $wp_scripts;
-
-		$result = $wp_scripts->registered[ WPSEO_Admin_Asset_Manager::PREFIX . 'handle2' ];
-
-		$this->assertEquals( 'http://example.org/wp-content/plugins/wordpress-seo/js/dist/src.suffix.js', $result->src );
-	}
-
-	/**
 	 * Tests whether the register_style registers the included style.
 	 *
 	 * @covers WPSEO_Admin_Asset_Manager::register_style
@@ -239,28 +217,6 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 		global $wp_scripts;
 
 		$this->assertTrue( isset( $wp_scripts->registered[ $prefix . 'handle' ] ) );
-	}
-
-	/**
-	 * Tests whether the register_style applies the suffix correctly.
-	 *
-	 * @covers WPSEO_Admin_Asset_Manager::register_script
-	 */
-	public function test_register_style_suffix() {
-		$asset_args = [
-			'name'   => 'handle2', // Handles have to be unique, isolation YaY ¯\_(ツ)_/¯.
-			'src'    => 'src',
-			'suffix' => '.suffix',
-		];
-		$this->asset_manager->register_style( new WPSEO_Admin_Asset( $asset_args ) );
-
-		// We really want to mock wp_enqueue_script here but we can't because of PHP 5.2.
-		// Use the WordPress internals to assert instead.
-		global $wp_styles;
-
-		$result = $wp_styles->registered[ WPSEO_Admin_Asset_Manager::PREFIX . 'handle2' ];
-
-		$this->assertEquals( 'http://example.org/wp-content/plugins/wordpress-seo/css/dist/src.suffix.css', $result->src );
 	}
 
 	/**

--- a/integration-tests/test-class-admin-asset.php
+++ b/integration-tests/test-class-admin-asset.php
@@ -60,7 +60,6 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( WPSEO_VERSION, $asset->get_version() );
 		$this->assertEquals( 'all', $asset->get_media() );
 		$this->assertEquals( true, $asset->is_in_footer() );
-		$this->assertEquals( WPSEO_CSSJS_SUFFIX, $asset->get_suffix() );
 		$this->assertEquals( true, $asset->has_rtl() );
 	}
 

--- a/integration-tests/test-class-admin-asset.php
+++ b/integration-tests/test-class-admin-asset.php
@@ -44,7 +44,6 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset::get_version
 	 * @covers WPSEO_Admin_Asset::get_media
 	 * @covers WPSEO_Admin_Asset::is_in_footer
-	 * @covers WPSEO_Admin_Asset::get_suffix
 	 * @covers WPSEO_Admin_Asset::has_rtl
 	 */
 	public function test_constructor_default_values() {
@@ -70,7 +69,6 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset::get_version
 	 * @covers WPSEO_Admin_Asset::get_media
 	 * @covers WPSEO_Admin_Asset::is_in_footer
-	 * @covers WPSEO_Admin_Asset::get_suffix
 	 * @covers WPSEO_Admin_Asset::has_rtl
 	 */
 	public function test_getters() {

--- a/integration-tests/test-class-admin-asset.php
+++ b/integration-tests/test-class-admin-asset.php
@@ -81,7 +81,6 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 			'version'   => 'version',
 			'media'     => 'screen',
 			'in_footer' => false,
-			'suffix'    => '.suffix',
 			'rtl'       => false,
 		];
 		$asset      = new WPSEO_Admin_Asset( $asset_args );
@@ -90,7 +89,6 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 'version', $asset->get_version() );
 		$this->assertEquals( 'screen', $asset->get_media() );
 		$this->assertEquals( false, $asset->is_in_footer() );
-		$this->assertEquals( '.suffix', $asset->get_suffix() );
 		$this->assertEquals( false, $asset->has_rtl() );
 	}
 

--- a/tests/admin/admin-asset-analysis-worker-location-test.php
+++ b/tests/admin/admin-asset-analysis-worker-location-test.php
@@ -22,7 +22,6 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 	public function test_get_url() {
 		$version  = 'test-version';
 		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $version );
-		$suffix   = ( \YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->once()
@@ -31,7 +30,7 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 
 		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'js/dist/wp-seo-analysis-worker-' . $version . $suffix . '.js', \realpath( __DIR__ . '/../../wp-seo.php' ) )
+			->with( 'js/dist/wp-seo-analysis-worker-' . $version . '.js', \realpath( __DIR__ . '/../../wp-seo.php' ) )
 			->andReturn( 'asset_location' );
 
 		$actual = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );
@@ -48,7 +47,6 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 		$version          = 'test-version';
 
 		$location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $version, $custom_file_name );
-		$suffix   = ( \YOAST_ENVIRONMENT === 'development' ) ? '' : '.min';
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->once()
@@ -57,7 +55,7 @@ final class Admin_Asset_Analysis_Worker_Location_Test extends TestCase {
 
 		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'js/dist/wp-seo-' . $custom_file_name . '-' . $version . $suffix . '.js', \realpath( __DIR__ . '/../../wp-seo.php' ) )
+			->with( 'js/dist/wp-seo-' . $custom_file_name . '-' . $version . '.js', \realpath( __DIR__ . '/../../wp-seo.php' ) )
 			->andReturn( 'asset_location' );
 
 		$actual = $location->get_url( $location->get_asset(), WPSEO_Admin_Asset::TYPE_JS );

--- a/tests/admin/metabox/metabox-editor-test.php
+++ b/tests/admin/metabox/metabox-editor-test.php
@@ -48,7 +48,7 @@ class Metabox_Editor_Test extends TestCase {
 	public function test_add_css_inside_editor_empty() {
 		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . '/../../../wp-seo.php' ) )
+			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . '.css', \realpath( __DIR__ . '/../../../wp-seo.php' ) )
 			->andReturn( 'example.org' );
 
 		$actual   = $this->subject->add_css_inside_editor( '' );
@@ -65,7 +65,7 @@ class Metabox_Editor_Test extends TestCase {
 	public function test_add_css_inside_editor_preexisting() {
 		Monkey\Functions\expect( 'plugins_url' )
 			->once()
-			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . \WPSEO_CSSJS_SUFFIX . '.css', \realpath( __DIR__ . '/../../../wp-seo.php' ) )
+			->with( 'css/dist/inside-editor-' . $this->get_flat_version() . '.css', \realpath( __DIR__ . '/../../../wp-seo.php' ) )
 			->andReturn( 'example.org' );
 
 

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -129,10 +129,7 @@ module.exports = function( env = { environment: "production" } ) {
 	// Prepend the default allowed hosts.
 	allowedHosts = defaultAllowedHosts.concat( allowedHosts );
 
-	const outputFilenameMinified = "[name]-" + pluginVersionSlug + ".min.js";
-	const outputFilenameUnminified = "[name]-" + pluginVersionSlug + ".js";
-
-	const outputFilename = mode === "development" ? outputFilenameUnminified : outputFilenameMinified;
+	const outputFilename = "[name]-" + pluginVersionSlug + ".js";
 
 	const plugins = [
 		new CaseSensitivePathsPlugin(),
@@ -231,7 +228,7 @@ module.exports = function( env = { environment: "production" } ) {
 			...base,
 			output: {
 				path: paths.jsDist,
-				filename: outputFilenameMinified,
+				filename: "[name]-" + pluginVersionSlug + ".js",
 				jsonpFunction: "yoastWebpackJsonp",
 			},
 			entry: {

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -89,13 +89,6 @@ if ( ! defined( 'YOAST_ENVIRONMENT' ) ) {
 	define( 'YOAST_ENVIRONMENT', 'production' );
 }
 
-/**
- * Only use minified assets when we are in a production environment.
- */
-if ( ! defined( 'WPSEO_CSSJS_SUFFIX' ) ) {
-	define( 'WPSEO_CSSJS_SUFFIX', ( YOAST_ENVIRONMENT !== 'development' ) ? '.min' : '' );
-}
-
 /* ***************************** PLUGIN (DE-)ACTIVATION *************************** */
 
 /**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* No longer use `.min` in _all_ our asset URLs, so there's no longer a difference in URLs between development and non-development setups.

## Relevant technical choices:

* Completely remove the suffix code.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

For both free and Premium:
* The plugin should still work on all its pages and on edit-post etc, not ever throwing 404s for CSS and JS files.
* Create zips with create_beta.sh + check if they're working correctly (see previous item).

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14186
