### PR TITLE
Fix edit post breadcrumbs shortcode

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -186,13 +186,16 @@ add_filter( 'icl_wpml_config_array', 'wpseo_wpml_config' );
  * Yoast SEO breadcrumb shortcode.
  * [wpseo_breadcrumb]
  *
+ * @deprecated xx.x
+ * @codeCoverageIgnore
+ *
  * @return string
  */
 function wpseo_shortcode_yoast_breadcrumb() {
-	return yoast_breadcrumb( '', '', false );
-}
+	_deprecated_function( __FUNCTION__, 'WPSEO xx.x' );
 
-add_shortcode( 'wpseo_breadcrumb', 'wpseo_shortcode_yoast_breadcrumb' );
+	return '';
+}
 
 if ( ! extension_loaded( 'ctype' ) || ! function_exists( 'ctype_digit' ) ) {
 	/**

--- a/src/conditionals/breadcrumbs-enabled-conditional.php
+++ b/src/conditionals/breadcrumbs-enabled-conditional.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\SEO\Conditionals;
 
-use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 
 /**
@@ -26,6 +25,8 @@ class Breadcrumbs_Enabled_Conditional implements Conditional {
 	 * Breadcrumbs_Enabled_Conditional constructor.
 	 *
 	 * @param Options_Helper $options The options helper.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function __construct( Options_Helper $options ) {
 		$this->options = $options;

--- a/src/conditionals/breadcrumbs-enabled-conditional.php
+++ b/src/conditionals/breadcrumbs-enabled-conditional.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Yoast SEO plugin file.
+ *
+ * @package Yoast\YoastSEO\Conditionals
+ */
+
+namespace Yoast\WP\SEO\Conditionals;
+
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
+/**
+ * Conditional that is only met when breadcrumbs are enabled.
+ */
+class Breadcrumbs_Enabled_Conditional implements Conditional {
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * Breadcrumbs_Enabled_Conditional constructor.
+	 *
+	 * @param Options_Helper $options The options helper.
+	 */
+	public function __construct( Options_Helper $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function is_met() {
+		return $this->options->get( 'breadcrumbs-enable' );
+	}
+}

--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -16,6 +16,8 @@ use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 class Breadcrumbs_Integration implements Integration_Interface {
 
 	/**
+	 * The breadcrumbs presenter.
+	 *
 	 * @var Breadcrumbs_Presenter
 	 */
 	private $presenter;

--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\SEO\Integrations;
 
 use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 
 /**
@@ -17,21 +16,24 @@ use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 class Breadcrumbs_Integration implements Integration_Interface {
 
 	/**
-	 * @var Options_Helper
-	 */
-	private $options;
-
-	/**
 	 * @var Breadcrumbs_Presenter
 	 */
 	private $presenter;
 
+	/**
+	 * Breadcrumbs_Integration constructor.
+	 *
+	 * @param Breadcrumbs_Presenter $presenter The breadcrumbs presenter.
+	 *
+	 * @codeCoverageIgnore
+	 */
 	public function __construct( Breadcrumbs_Presenter $presenter ) {
 		$this->presenter = $presenter;
 	}
 
 	/**
-	 * @codeCoverageIgnore
+	 * Returns the conditionals.
+	 *
 	 * @inheritDoc
 	 */
 	public static function get_conditionals() {
@@ -39,6 +41,8 @@ class Breadcrumbs_Integration implements Integration_Interface {
 	}
 
 	/**
+	 * Registers the required hooks.
+	 *
 	 * @codeCoverageIgnore
 	 * @inheritDoc
 	 */
@@ -46,6 +50,12 @@ class Breadcrumbs_Integration implements Integration_Interface {
 		add_shortcode( 'wpseo_breadcrumb', [ $this, 'render' ] );
 	}
 
+	/**
+	 * Renders the breadcrumbs.
+	 *
+	 * @return string The rendered breadcrumbs.
+	 * @throws \Exception If something goes wrong generating the DI container.
+	 */
 	public function render() {
 		$indexable_presentation = yoastseo()->get_current_page_presentation();
 

--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 
 /**
- * Adds customizations to the front end for the primary category.
+ * Adds customizations to the front end for breadcrumbs.
  */
 class Breadcrumbs_Integration implements Integration_Interface {
 
@@ -34,8 +34,6 @@ class Breadcrumbs_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Returns the conditionals.
-	 *
 	 * @inheritDoc
 	 */
 	public static function get_conditionals() {
@@ -43,8 +41,6 @@ class Breadcrumbs_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Registers the required hooks.
-	 *
 	 * @codeCoverageIgnore
 	 * @inheritDoc
 	 */

--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\SEO\Integrations\Front_End
+ */
+
+namespace Yoast\WP\SEO\Integrations;
+
+use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
+
+/**
+ * Adds customizations to the front end for the primary category.
+ */
+class Breadcrumbs_Integration implements Integration_Interface {
+
+	/**
+	 * @var Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * @var Breadcrumbs_Presenter
+	 */
+	private $presenter;
+
+	public function __construct( Breadcrumbs_Presenter $presenter ) {
+		$this->presenter = $presenter;
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Breadcrumbs_Enabled_Conditional::class ];
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		add_shortcode( 'wpseo_breadcrumb', [ $this, 'render' ] );
+	}
+
+	public function render() {
+		$indexable_presentation = yoastseo()->get_current_page_presentation();
+
+		return $this->presenter->present( $indexable_presentation );
+	}
+}

--- a/tests/conditionals/breadcrumbs-enabled-conditional-test.php
+++ b/tests/conditionals/breadcrumbs-enabled-conditional-test.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Conditionals;
+
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Breadcrumbs_Enabled_Conditional_Test.
+ *
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional
+ */
+class Breadcrumbs_Enabled_Conditional_Test extends TestCase {
+	/**
+	 * The breadcrumbs enabled conditional.
+	 *
+	 * @var Breadcrumbs_Enabled_Conditional
+	 */
+	private $instance;
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->options = Mockery::mock( Options_Helper::class );
+
+		$this->instance = new Breadcrumbs_Enabled_Conditional( $this->options );
+	}
+
+	/**
+	 * Tests that the conditional returns the correct option value.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_breadcrumbs_enabled_option() {
+		$this->options
+			->expects( 'get' )
+			->once()
+			->with( 'breadcrumbs-enable' )
+			->andReturn( true );
+
+		$this->assertEquals( true, $this->instance->is_met() );
+	}
+}

--- a/tests/integrations/breadcrumbs-integration-test.php
+++ b/tests/integrations/breadcrumbs-integration-test.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Integrations;
+
+use \Mockery;
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
+use Yoast\WP\SEO\Integrations\Breadcrumbs_Integration;
+use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Breadcrumbs_Integration
+ *
+ * @group integrations
+ */
+class Breadcrumbs_Integration_Test extends TestCase {
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var Breadcrumbs_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * The breadcrumbs presenter;
+	 *
+	 * @var Breadcrumbs_Presenter
+	 */
+	protected $presenter;
+
+	/**
+	 * Set up the class which will be tested.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->presenter = Mockery::mock( Breadcrumbs_Presenter::class );
+
+		$this->instance = new Breadcrumbs_Integration( $this->presenter );
+	}
+
+	/**
+	 * Tests the get_conditionals functions.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [ Breadcrumbs_Enabled_Conditional::class ], Breadcrumbs_Integration::get_conditionals() );
+	}
+
+	/**
+	 * Tests the render function.
+	 *
+	 * @covers ::render
+	 */
+	public function test_render() {
+		$indexable_presentation = new Indexable_Presentation();
+
+		$mock = Mockery::mock( Main::class );
+		$mock
+			->expects( 'get_current_page_presentation' )
+			->andReturn( $indexable_presentation );
+
+		Monkey\Functions\expect( 'yoastseo' )->once()->andReturn( $mock );
+
+		$this->presenter
+			->expects( 'present' )
+			->once()
+			->with( $indexable_presentation )
+			->andReturn( 'breadcrumbs html' );
+
+		$this->assertEquals( 'breadcrumbs html', $this->instance->render() );
+	}
+}

--- a/tests/integrations/breadcrumbs-integration-test.php
+++ b/tests/integrations/breadcrumbs-integration-test.php
@@ -28,7 +28,7 @@ class Breadcrumbs_Integration_Test extends TestCase {
 	protected $instance;
 
 	/**
-	 * The breadcrumbs presenter;
+	 * The breadcrumbs presenter.
 	 *
 	 * @var Breadcrumbs_Presenter
 	 */


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Fixed editor when yoast breadcrumbs are enabled and used.

## Relevant technical choices:

* Created a breadcrumbs integration.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Repeat the steps in #14101 .

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14101 
