### PR TITLE
Don't output and image object graph piece when the url is empty

### DIFF
--- a/src/generators/schema/main-image.php
+++ b/src/generators/schema/main-image.php
@@ -107,7 +107,7 @@ class Main_Image extends Abstract_Schema_Piece {
 	private function get_first_content_image( $post_id, $image_id ) {
 		$image_url = $this->image_helper->get_post_content_image( $post_id );
 
-		if ( $image_url === null ) {
+		if ( $image_url === '' ) {
 			return null;
 		}
 

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -22,11 +22,8 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Generators\Schema\Article
  * @covers ::<!public>
- *
- * @package Yoast\WP\SEO\Tests\Generators\Schema
  */
 class Article_Test extends TestCase {
-
 
 	/**
 	 * @var Mockery\MockInterface|Article_Helper
@@ -58,6 +55,9 @@ class Article_Test extends TestCase {
 	 */
 	private $html_helper_mock;
 
+	/**
+	 * Setup the test.
+	 */
 	public function setUp() {
 		$this->id_helper_mock                     = Mockery::mock( ID_Helper::class );
 		$this->id_helper_mock->article_hash       = '#article-hash';

--- a/tests/generators/schema/main-image-test.php
+++ b/tests/generators/schema/main-image-test.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Generators\Schema;
+
+use Mockery;
+use Brain\Monkey;
+use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Helpers\Schema;
+use Yoast\WP\SEO\Presentations\Generators\Schema\Main_Image;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Main_Image_Test
+ *
+ * @group generators
+ * @group schema
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presentations\Generators\Schema\Main_Image
+ */
+class Main_Image_Test extends TestCase {
+
+	/**
+	 * @var Main_Image
+	 */
+	private $instance;
+
+	/**
+	 * @var Schema\Image_Helper
+	 */
+	private $schema_image;
+
+	/**
+	 * @var Image_Helper
+	 */
+	private $image;
+
+	/**
+	 * @var Schema\ID_Helper
+	 */
+	private $id;
+
+	/**
+	 * @var Meta_Tags_Context
+	 */
+	private $meta_tags_context;
+
+	/**
+	 * Setup the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->schema_image = Mockery::mock( Schema\Image_Helper::class );
+		$this->image        = Mockery::mock( Image_Helper::class );
+		$this->id           = new Schema\ID_Helper();
+
+		$this->instance = new Main_Image(
+			$this->image,
+			$this->schema_image
+		);
+
+		$this->instance->set_id_helper( $this->id );
+
+		$this->meta_tags_context = new Meta_Tags_Context();
+	}
+
+	/**
+	 * Tests that generate returns null if no image available.
+	 *
+	 * @covers ::generate
+	 * @covers ::get_featured_image
+	 * @covers ::get_first_content_image
+	 */
+	public function test_generate_no_image() {
+		$this->meta_tags_context->canonical = 'https://example.com/canonical';
+		$this->meta_tags_context->id        = 1337;
+
+		Monkey\Functions\expect( 'has_post_thumbnail' )
+			->once()
+			->with( 1337 )
+			->andReturn( false );
+
+		$this->image->expects( 'get_post_content_image' )
+			->once()
+			->with( 1337 )
+			->andReturn( '' );
+
+		$this->assertEquals( false, $this->instance->generate( $this->meta_tags_context ) );
+	}
+}

--- a/tests/generators/schema/main-image-test.php
+++ b/tests/generators/schema/main-image-test.php
@@ -21,26 +21,36 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Main_Image_Test extends TestCase {
 
 	/**
+	 * The instance to test.
+	 *
 	 * @var Main_Image
 	 */
 	private $instance;
 
 	/**
+	 * The schema image helper.
+	 *
 	 * @var Schema\Image_Helper
 	 */
 	private $schema_image;
 
 	/**
+	 * The image helper.
+	 *
 	 * @var Image_Helper
 	 */
 	private $image;
 
 	/**
+	 * The schema id helper.
+	 *
 	 * @var Schema\ID_Helper
 	 */
-	private $id;
+	private $schema_id;
 
 	/**
+	 * The schema context.
+	 *
 	 * @var Meta_Tags_Context
 	 */
 	private $meta_tags_context;
@@ -53,14 +63,14 @@ class Main_Image_Test extends TestCase {
 
 		$this->schema_image = Mockery::mock( Schema\Image_Helper::class );
 		$this->image        = Mockery::mock( Image_Helper::class );
-		$this->id           = new Schema\ID_Helper();
+		$this->schema_id    = new Schema\ID_Helper();
 
 		$this->instance = new Main_Image(
 			$this->image,
 			$this->schema_image
 		);
 
-		$this->instance->set_id_helper( $this->id );
+		$this->instance->set_id_helper( $this->schema_id );
 
 		$this->meta_tags_context = new Meta_Tags_Context();
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Fixes a bug where an image object is output when there is no image URL.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Execute the steps in #14064 
* Make sure no `ImageObject` graph piece is present.
* Make sure the `WebPage` graph piece no longer has a `primaryImageOfPage` property.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14064 
