### PR TITLE
Add yoast signature

### DIFF
--- a/inc/health-check-default-tagline.php
+++ b/inc/health-check-default-tagline.php
@@ -26,6 +26,7 @@ class WPSEO_Health_Check_Default_Tagline extends WPSEO_Health_Check {
 			$this->status         = self::STATUS_GOOD;
 			$this->badge['color'] = 'blue';
 			$this->description    = esc_html__( 'You are using a custom tagline or an empty one.', 'wordpress-seo' );
+			$this->add_yoast_signature();
 
 			return;
 		}
@@ -47,6 +48,8 @@ class WPSEO_Health_Check_Default_Tagline extends WPSEO_Health_Check {
 			'<a href="' . esc_attr( $customize_url ) . '">',
 			'</a>'
 		);
+
+		$this->add_yoast_signature();
 	}
 
 	/**

--- a/inc/health-check-postname-permalink.php
+++ b/inc/health-check-postname-permalink.php
@@ -26,6 +26,7 @@ class WPSEO_Health_Check_Postname_Permalink extends WPSEO_Health_Check {
 			$this->status         = self::STATUS_GOOD;
 			$this->badge['color'] = 'blue';
 			$this->description    = esc_html__( 'You do have your postname in the URL of your posts and pages.', 'wordpress-seo' );
+			$this->add_yoast_signature();
 
 			return;
 		}
@@ -46,6 +47,8 @@ class WPSEO_Health_Check_Postname_Permalink extends WPSEO_Health_Check {
 			'<a href="' . admin_url( 'options-permalink.php' ) . '">',
 			'</a>'
 		);
+
+		$this->add_yoast_signature();
 	}
 
 	/**

--- a/tests/inc/health-check-default-tagline-test.php
+++ b/tests/inc/health-check-default-tagline-test.php
@@ -32,6 +32,8 @@ class WPSEO_Health_Check_Default_Tagline_Test extends TestCase {
 			->once()
 			->andReturn( 'http://example.org/wp-admin/customize.php?autofocus[control]=blogdescription' );
 
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
 		$health_check = new \WPSEO_Health_Check_Default_Tagline();
 		$health_check->run();
 
@@ -51,6 +53,8 @@ class WPSEO_Health_Check_Default_Tagline_Test extends TestCase {
 			->with( 'blogdescription' )
 			->andReturn( '' );
 
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
 		$health_check = new \WPSEO_Health_Check_Default_Tagline();
 		$health_check->run();
 
@@ -69,6 +73,8 @@ class WPSEO_Health_Check_Default_Tagline_Test extends TestCase {
 			->once()
 			->with( 'blogdescription' )
 			->andReturn( 'My custom site tagline' );
+
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
 
 		$health_check = new \WPSEO_Health_Check_Default_Tagline();
 		$health_check->run();

--- a/tests/inc/health-check-postname-permalink-test.php
+++ b/tests/inc/health-check-postname-permalink-test.php
@@ -24,6 +24,8 @@ class WPSEO_Health_Check_Postname_Permalink_Test extends TestCase {
 			->with( 'permalink_structure' )
 			->andReturn( '/%postname%/' );
 
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
 		$health_check = new \WPSEO_Health_Check_Postname_Permalink();
 		$health_check->run();
 
@@ -42,6 +44,8 @@ class WPSEO_Health_Check_Postname_Permalink_Test extends TestCase {
 			->once()
 			->with( 'permalink_structure' )
 			->andReturn( '/%category%/%postname%/' );
+
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
 
 		$health_check = new \WPSEO_Health_Check_Postname_Permalink();
 		$health_check->run();
@@ -63,6 +67,7 @@ class WPSEO_Health_Check_Postname_Permalink_Test extends TestCase {
 			->andReturn( '' );
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( '' );
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
 
 		$health_check = new \WPSEO_Health_Check_Postname_Permalink();
 		$health_check->run();


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added the "Yoast signature" at the bottom of the Site Health checks

## Relevant technical choices:

* This PR add the "Yoast signature" to the "default tagline" and "post name in permalink" tests. The other tests already have the signature.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- switch to this branch, run composer install and build
- go to the Site Health page
- whether the "default tagline" and "post name in permalink" tests pass or not, they should display the "Yoast signature" e.g.:

<img width="846" alt="Screenshot 2020-01-15 at 14 02 45" src="https://user-images.githubusercontent.com/1682452/72436017-c1dc7600-379f-11ea-8d27-a7eb923dbae7.png">


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14183
