### PR TITLE
14063 add description to website

### DIFF
--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -62,10 +62,11 @@ class Website extends Abstract_Schema_Piece {
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$data = [
-			'@type' => 'WebSite',
-			'@id'   => $context->site_url . $this->id_helper->website_hash,
-			'url'   => $context->site_url,
-			'name'  => $this->html_helper->smart_strip_tags( $context->site_name ),
+			'@type'       => 'WebSite',
+			'@id'         => $context->site_url . $this->id_helper->website_hash,
+			'url'         => $context->site_url,
+			'name'        => $this->html_helper->smart_strip_tags( $context->site_name ),
+			'description' => \get_bloginfo( 'description' ),
 		];
 
 		if ( $context->site_represents_reference ) {

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -42,13 +42,6 @@ class Website_Test extends TestCase {
 	private $html;
 
 	/**
-	 * The ID helper.
-	 *
-	 * @var ID_Helper|Mockery\MockInterface
-	 */
-	private $id;
-
-	/**
 	 * The meta tags context object.
 	 *
 	 * @var Meta_Tags_Context
@@ -63,14 +56,13 @@ class Website_Test extends TestCase {
 
 		$this->options = Mockery::mock( Options_Helper::class );
 		$this->html    = Mockery::mock( HTML_Helper::class );
-		$this->id      = new ID_Helper();
 
 		$this->instance = new Website(
 			$this->options,
 			$this->html
 		);
 
-		$this->instance->set_id_helper( $this->id );
+		$this->instance->set_id_helper( new ID_Helper() );
 
 		$this->meta_tags_context = new Meta_Tags_Context();
 	}

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Generators\Schema;
+
+use Mockery;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
+use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
+use Yoast\WP\SEO\Presentations\Generators\Schema\Website;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Website_Test
+ *
+ * @group generators
+ * @group schema
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presentations\Generators\Schema\Website
+ */
+class Website_Test extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Website
+	 */
+	private $instance;
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper|Mockery\MockInterface
+	 */
+	private $options;
+
+	/**
+	 * The HTML helper.
+	 *
+	 * @var HTML_Helper|Mockery\MockInterface
+	 */
+	private $html;
+
+	/**
+	 * The ID helper.
+	 *
+	 * @var ID_Helper|Mockery\MockInterface
+	 */
+	private $id;
+
+	/**
+	 * The meta tags context object.
+	 *
+	 * @var Meta_Tags_Context
+	 */
+	private $meta_tags_context;
+
+	/**
+	 * Sets up the tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->options = Mockery::mock( Options_Helper::class );
+		$this->html    = Mockery::mock( HTML_Helper::class );
+		$this->id      = new ID_Helper();
+
+		$this->instance = new Website(
+			$this->options,
+			$this->html
+		);
+
+		$this->instance->set_id_helper( $this->id );
+
+		$this->meta_tags_context = new Meta_Tags_Context();
+	}
+
+	/**
+	 * Tests the generate function.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_alternate_name
+	 * @covers ::internal_search_section
+	 */
+	public function test_generate() {
+		$this->meta_tags_context->site_url                  = 'https://example.com/';
+		$this->meta_tags_context->site_name                 = 'My site';
+		$this->meta_tags_context->site_represents_reference = 'https://example.com/#publisher';
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->twice()
+			->andReturnArg( 0 );
+
+		$this->options->expects( 'get' )
+			->with( 'alternate_website_name', '' )
+			->once()
+			->andReturn( 'Alternate site name' );
+
+		$expected = [
+			'@type'           => 'WebSite',
+			'@id'             => 'https://example.com/#website',
+			'url'             => 'https://example.com/',
+			'name'            => 'My site',
+			'publisher'       => 'https://example.com/#publisher',
+			'alternateName'   => 'Alternate site name',
+			'description'     => 'description',
+			'potentialAction' => [
+				'@type'       => 'SearchAction',
+				'target'      => 'https://example.com/?s={search_term_string}',
+				'query-input' => 'required name=search_term_string',
+			],
+		];
+
+		$this->assertEquals( $expected, $this->instance->generate( $this->meta_tags_context ) );
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Adds site description to webpage graph piece.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See steps in #14063

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14063 
