### PR TITLE
Fix robots noindex on static homepage

### DIFF
--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -30,6 +30,7 @@ class Robots_Helper {
 
 		$new_robots          = $presentation->robots;
 		$new_robots['index'] = 'noindex';
+		$new_robots          = \array_filter( $new_robots );
 
 		return implode( ',', $new_robots );
 	}

--- a/tests/admin/capabilities/capability-utils-test.php
+++ b/tests/admin/capabilities/capability-utils-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\Free\Tests\Admin\Capabilities;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_Capability_Utils;
-use Yoast\WP\Free\Tests\TestCase;
+use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Tests WPSEO_Admin_Asset.

--- a/tests/helpers/robots-helper-test.php
+++ b/tests/helpers/robots-helper-test.php
@@ -2,10 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Helpers;
 
-use Brain\Monkey;
 use Yoast\WP\SEO\Helpers\Robots_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -32,7 +30,7 @@ class Robots_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Tests setting the robots to no index when having robots value already.
+	 * Tests setting 'index' to 'noindex' when 'index' is already set to 'noindex'.
 	 *
 	 * @covers ::set_robots_no_index
 	 */
@@ -47,13 +45,28 @@ class Robots_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Tests setting the robots to no index.
+	 * Tests setting 'index' to 'noindex' when 'index' is set to 'index'.
 	 *
 	 * @covers ::set_robots_no_index
 	 */
-	public function test_set_robots_no_index_with() {
+	public function test_set_robots_no_index_when_already_set() {
 		$presentation         = new Indexable_Presentation();
 		$presentation->robots = [ 'index' => 'index', 'follow' => 'follow' ];
+
+		$this->assertEquals(
+			'noindex,follow',
+			$this->instance->set_robots_no_index( 'index,follow', $presentation )
+		);
+	}
+
+	/**
+	 * Tests setting 'index' to 'noindex' when the array contains empty values.
+	 *
+	 * @covers ::set_robots_no_index
+	 */
+	public function test_set_robots_no_index_with_empty_value() {
+		$presentation         = new Indexable_Presentation();
+		$presentation->robots = [ 'index' => 'index', 'follow' => 'follow', '' => '', '' => '' ];
 
 		$this->assertEquals(
 			'noindex,follow',

--- a/tests/inc/options/options-test.php
+++ b/tests/inc/options/options-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\Free\Tests\Inc\Options;
 use Brain\Monkey;
 use WPSEO_Options;
 use Yoast\WP\Free\Tests\Doubles\Inc\Options\Options_Double;
-use Yoast\WP\Free\Tests\TestCase;
+use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Unit Test Class.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Filter the array to remove empty values.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* To reproduce the issue, see [here](https://github.com/Yoast/wordpress-seo/issues/14090).
* Check out this branch, build, and follow the same steps as above.
* See that the meta tag output has changed to `meta name="robots" content="noindex,follow"`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14090