### PR TITLE
Limit targets for force rewrite titles option to title tags in head tag

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1572,23 +1572,26 @@ class WPSEO_Frontend {
 			return false;
 		}
 
-		$content = ob_get_clean();
+		$content  = ob_get_clean();
+		$head_end = stripos( $content, '/head>' );
 
 		$old_wp_query = $wp_query;
 
 		wp_reset_query();
 
 		// Only replace the debug marker when it is hooked.
-		if ( $this->show_debug_marker() ) {
+		if ( $head_end && $this->show_debug_marker() ) {
 			$title      = $this->title( '' );
 			$debug_mark = $this->get_debug_mark();
 
 			/*
-			 * Find all titles, strip them out and add the new one in within the debug marker,
+			 * Find all titles in the head, strip them out and add the new one in within the debug marker,
 			 * so it's easily identified whether a site uses force rewrite.
 			 */
-			$content = preg_replace( '/<title.*?\/title>/i', '', $content );
-			$content = str_replace( $debug_mark, $debug_mark . "\n" . '<title>' . esc_html( $title ) . '</title>', $content );
+			$head = preg_replace( '/<title.*?\/title>/si', '', substr( $content, 0, $head_end ) );
+			$head = str_replace( $debug_mark, $debug_mark . PHP_EOL . '<title>' . esc_html( $title ) . '</title>', $head );
+
+			$content = $head . substr( $content, $head_end );
 		}
 
 		$GLOBALS['wp_query'] = $old_wp_query;

--- a/integration-tests/frontend/test-class-wpseo-frontend.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend.php
@@ -528,6 +528,9 @@ Page 3/3
 		// Enables the output buffering.
 		$frontend->force_rewrite_output_buffer();
 
+		// Output title
+		echo '<head><title>Test</title></head>'
+
 		// Run function.
 		$result = $frontend->flush_cache();
 
@@ -598,6 +601,9 @@ Page 3/3
 
 		// Enables the output buffering.
 		$frontend->force_rewrite_output_buffer();
+
+		// Output title
+		echo '<head><title>Test</title></head>'
 
 		// Run function.
 		$result = $frontend->flush_cache();

--- a/integration-tests/frontend/test-class-wpseo-frontend.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend.php
@@ -529,7 +529,7 @@ Page 3/3
 		$frontend->force_rewrite_output_buffer();
 
 		// Output title
-		echo '<head><title>Test</title></head>'
+		echo '<head><title>Test</title></head>';
 
 		// Run function.
 		$result = $frontend->flush_cache();
@@ -603,7 +603,7 @@ Page 3/3
 		$frontend->force_rewrite_output_buffer();
 
 		// Output title
-		echo '<head><title>Test</title></head>'
+		echo '<head><title>Test</title></head>';
 
 		// Run function.
 		$result = $frontend->flush_cache();


### PR DESCRIPTION
## Summary

Replaces #13430
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the "force rewrite titles" option would removes title tag in svg tags. Props @dsktschy

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Remove support for 'title-tag' in the theme. You could use following code:
```php
add_action( 'after_setup_theme', function() {
	remove_theme_support( 'title-tag' );
}, 9999 );
```
* Enable Force rewrite titles in SEO - Search Appearance under the General tab.
* Add SVG by the instructions in #6770 or #13430
* Check title tags in HTML source.

## UI changes
~~* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Documentation
~~* [ ] I have written documentation for this change.~~

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #6770
