### PR TITLE
Fixed webpack dev server after hackaton branch was merged

### DIFF
--- a/grunt/config/webpack.js
+++ b/grunt/config/webpack.js
@@ -1,9 +1,12 @@
 /* global require */
 const webpackConfig = require( "../../webpack/webpack.config" );
+const get = require( "lodash" ).get;
 
 module.exports = ( grunt ) => {
+	const pluginVersion = get( grunt, "config.data.pluginVersion", null );
+
 	return {
-		buildDev: () => webpackConfig( grunt, { environment: "development" } ),
-		buildProd: () => webpackConfig( grunt ),
+		buildDev: () => webpackConfig( { environment: "development", pluginVersion } ),
+		buildProd: () => webpackConfig( { environment: "production", pluginVersion } ),
 	};
 };

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -116,10 +116,15 @@ function addBundleAnalyzer( plugins ) {
 	return plugins;
 }
 
-module.exports = function( grunt, env = { environment: "production" } ) {
+module.exports = function( env ) {
 	const mode = env.environment || process.env.NODE_ENV || "production";
 
-	const pluginVersionSlug = paths.flattenVersionForFile( grunt.config.data.pluginVersion );
+	if ( ! env.pluginVersion ) {
+		// eslint-disable-next-line global-require
+		env.pluginVersion = require( "../package" ).yoast.pluginVersion;
+	}
+
+	const pluginVersionSlug = paths.flattenVersionForFile( env.pluginVersion );
 
 	// Allowed hosts is space separated string. Example usage: ALLOWED_HOSTS="first.allowed.host second.allowed.host"
 	let allowedHosts = ( process.env.ALLOWED_HOSTS || "" ).split( " " );

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -121,7 +121,7 @@ module.exports = function( env ) {
 
 	if ( ! env.pluginVersion ) {
 		// eslint-disable-next-line global-require
-		env.pluginVersion = require( "../package" ).yoast.pluginVersion;
+		env.pluginVersion = require( "../package.json" ).yoast.pluginVersion;
 	}
 
 	const pluginVersionSlug = paths.flattenVersionForFile( env.pluginVersion );


### PR DESCRIPTION
## Summary

When the hackathon branch was merged (for the automated RC creation) we broke the webpack dev server, because the plugin version required to generate the file names was no longer injected in the webpack config. In this PR I fixed that by checking if the plugin version is available and if not it is extracted from the `package.json` file. 

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Fixed webpack dev server after hackaton branch was merged

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `grunt webpack:buildProd`
* Run `grunt webpack:buildDev`
* Run `yarn start`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
