### PR TITLE
Hide facebook options when facebook is disabled

### DIFF
--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -24,6 +24,7 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 		?>
 	</p>
 
+<div id="wpseo-facebook-settings" style="display: none;">
 <?php
 
 $yform->textinput( 'fbadminapp', __( 'Facebook App ID', 'wordpress-seo' ) );
@@ -76,7 +77,7 @@ $yform->media_input( 'og_default_image', __( 'Image URL', 'wordpress-seo' ) );
 	<p class="desc label">
 		<?php esc_html_e( 'This image is used if the post/page being shared does not contain any images.', 'wordpress-seo' ); ?>
 	</p>
-
+</div>
 <?php
 
 do_action( 'wpseo_admin_opengraph_section' );

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -24,7 +24,7 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 		?>
 	</p>
 
-<div id="wpseo-facebook-settings" style="display: none;">
+<div id="wpseo-opengraph-settings" style="display: none;">
 <?php
 
 $yform->textinput( 'fbadminapp', __( 'Facebook App ID', 'wordpress-seo' ) );

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -372,12 +372,12 @@ import { debounce } from "lodash-es";
 		} );
 
 		const opengraphToggle = jQuery( "#opengraph" );
-		const facebookSettingsContainer = jQuery( "#wpseo-facebook-settings" );
+		const facebookSettingsContainer = jQuery( "#wpseo-opengraph-settings" );
 		if ( opengraphToggle.length && facebookSettingsContainer.length ) {
 			facebookSettingsContainer.toggle( opengraphToggle[ 0 ].checked );
 
 			opengraphToggle.change( ( event ) => {
-				jQuery( "#wpseo-facebook-settings" ).toggle( event.target.checked );
+				facebookSettingsContainer.toggle( event.target.checked );
 			} );
 		}
 

--- a/js/src/wp-seo-admin.js
+++ b/js/src/wp-seo-admin.js
@@ -371,6 +371,16 @@ import { debounce } from "lodash-es";
 				.find( "span" ).toggleClass( "dashicons-arrow-up-alt2 dashicons-arrow-down-alt2" );
 		} );
 
+		const opengraphToggle = jQuery( "#opengraph" );
+		const facebookSettingsContainer = jQuery( "#wpseo-facebook-settings" );
+		if ( opengraphToggle.length && facebookSettingsContainer.length ) {
+			facebookSettingsContainer.toggle( opengraphToggle[ 0 ].checked );
+
+			opengraphToggle.change( ( event ) => {
+				jQuery( "#wpseo-facebook-settings" ).toggle( event.target.checked );
+			} );
+		}
+
 		wpseoCopyHomeMeta();
 		setInitialActiveTab();
 		initSelect2();


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hide facebook settings when Open Graph is disabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to `SEO` > `Social` > `Facebook`.
* Disable `Add Open Graph meta data` and make sure the other facebook settings disappear.
* Save the settings.
* Disable `Add Open Graph meta data` and make sure the other facebook settings appear.
* Save the settings.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14111 
