### PR TITLE
CS/Docs: clean up after merges

### DIFF
--- a/admin/class-admin-asset-seo-location.php
+++ b/admin/class-admin-asset-seo-location.php
@@ -46,9 +46,8 @@ final class WPSEO_Admin_Asset_SEO_Location implements WPSEO_Admin_Asset_Location
 	/**
 	 * Determines the path relative to the plugin folder of an asset.
 	 *
-	 * @param WPSEO_Admin_Asset $asset        The asset to determine the path
-	 *                                        for.
-	 * @param string            $type         The type of asset.
+	 * @param WPSEO_Admin_Asset $asset The asset to determine the path for.
+	 * @param string            $type  The type of asset.
 	 *
 	 * @return string The path to the asset file.
 	 */

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -403,7 +403,7 @@ class Yoast_Notification_Center {
 		$index = false;
 
 		// ID of the user to show the notification for, defaults to current user id.
-		$user_id                = $notification->get_user_id();
+		$user_id       = $notification->get_user_id();
 		$notifications = $this->get_notifications_for_user( $user_id );
 
 		// Match persistent Notifications by ID, non persistent by item in the array.
@@ -589,7 +589,7 @@ class Yoast_Notification_Center {
 			return;
 		}
 
-		array_walk( $notifications , [ $this, 'store_notifications_for_user' ] );
+		array_walk( $notifications, [ $this, 'store_notifications_for_user' ] );
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -735,7 +735,7 @@ class WPSEO_Frontend {
 				if ( WPSEO_Options::get( 'noindex-author-wpseo', false ) ) {
 					$robots['index'] = 'noindex';
 				}
-				$curauth = $wp_query->get_queried_object();
+				$curauth        = $wp_query->get_queried_object();
 				$author_archive = new Author_Archive_Helper();
 				$user_has_posts = ( (int) count_user_posts( $curauth->ID, $author_archive->get_author_archive_post_types(), true ) ) > 0;
 				if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', false ) && ! $user_has_posts ) {

--- a/inc/health-check-page-comments.php
+++ b/inc/health-check-page-comments.php
@@ -33,8 +33,11 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 		$this->label          = esc_html__( 'Paging comments is enabled', 'wordpress-seo' );
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
-		$this->description    = esc_html__( 'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
-								To fix this, uncheck the box in front of "Break comments into pages..." on the Discussion Settings page.', 'wordpress-seo' );
+		$this->description    = esc_html__(
+			'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
+								To fix this, uncheck the box in front of "Break comments into pages..." on the Discussion Settings page.',
+			'wordpress-seo'
+		);
 		$this->actions        = sprintf(
 			/* translators: 1: Opening tag of the link to the discussion settings page, 2: Link closing tag. */
 			esc_html__( '%1$sGo to the Discussion Settings page%2$s', 'wordpress-seo' ),

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -11,6 +11,7 @@
  * Instantiates all the options and offers a number of utility methods to work with the options.
  */
 class WPSEO_Options {
+
 	/**
 	 * The option values.
 	 *
@@ -587,6 +588,7 @@ class WPSEO_Options {
 	 * Fills our option cache.
 	 *
 	 * @deprecated  12.8.1
+	 * @codeCoverageIgnore
 	 */
 	public static function fill_cache() {
 		_deprecated_function( __METHOD__, 'WPSEO 12.8.1', '::clear_cache' );

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -77,7 +77,7 @@ function wpseo_admin_bar_menu() {
 		return;
 	}
 
-	if ( WPSEO_Options::get( 'enable_admin_bar_menu',true ) ) {
+	if ( WPSEO_Options::get( 'enable_admin_bar_menu', true ) ) {
 		return;
 	}
 

--- a/integration-tests/admin/links/test-class-link-internal-lookup.php
+++ b/integration-tests/admin/links/test-class-link-internal-lookup.php
@@ -8,14 +8,14 @@
 /**
  * Unit Test Class.
  *
- * @coversDefaultClass  WPSEO_Link_Internal_Lookup
+ * @coversDefaultClass WPSEO_Link_Internal_Lookup
  */
 class WPSEO_Link_Internal_Lookup_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test with an internal link.
 	 *
-	 * @covers::lookup
+	 * @covers ::lookup
 	 */
 	public function test_lookup_internal() {
 		$post   = $this->factory->post->create_and_get();
@@ -30,7 +30,7 @@ class WPSEO_Link_Internal_Lookup_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test with a relative internal link.
 	 *
-	 * @covers::lookup
+	 * @covers ::lookup
 	 */
 	public function test_lookup_internal_relative() {
 		$post   = $this->factory->post->create_and_get();
@@ -45,7 +45,7 @@ class WPSEO_Link_Internal_Lookup_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test with an external link set a as internal.
 	 *
-	 * @covers::lookup
+	 * @covers ::lookup
 	 */
 	public function test_lookup_external_used_as_internal() {
 		$lookup = new WPSEO_Link_Internal_Lookup();
@@ -59,7 +59,7 @@ class WPSEO_Link_Internal_Lookup_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test with an external link.
 	 *
-	 * @covers::lookup
+	 * @covers ::lookup
 	 */
 	public function test_lookup_external() {
 		$lookup = new WPSEO_Link_Internal_Lookup();

--- a/integration-tests/capabilities/test-class-capability-manager.php
+++ b/integration-tests/capabilities/test-class-capability-manager.php
@@ -86,6 +86,10 @@ class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Helper function used to filter the roles.
+	 *
+	 * @param string[] $roles Original roles.
+	 *
+	 * @return string[]
 	 */
 	public function do_filter_roles( $roles ) {
 		return [ 'elor' ];

--- a/integration-tests/frontend/test-class-opengraph.php
+++ b/integration-tests/frontend/test-class-opengraph.php
@@ -249,11 +249,11 @@ class WPSEO_OpenGraph_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_image_HAS_front_page_image() {
 		$prev_value = WPSEO_Options::get( 'og_frontpage_image' );
-		$stub =
-			$this
-				->getMockBuilder( 'WPSEO_OpenGraph' )
-				->setMethods( [ 'og_tag' ] )
-				->getMock();
+
+		$stub = $this
+			->getMockBuilder( 'WPSEO_OpenGraph' )
+			->setMethods( [ 'og_tag' ] )
+			->getMock();
 
 		WPSEO_Options::set( 'og_frontpage_image', get_site_url() . '/wp-content/uploads/2015/01/iphone5_ios7-300x198.jpg' );
 

--- a/integration-tests/frontend/test-class-wpseo-frontend-robots.php
+++ b/integration-tests/frontend/test-class-wpseo-frontend-robots.php
@@ -196,7 +196,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	public function test_author_archive() {
 		// Go to author page.
 		$user_id = $this->factory->user->create();
-		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
 		$this->go_to( get_author_posts_url( $user_id ) );
 
 		// Test author archive with no special options.
@@ -210,7 +210,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	public function test_author_archive_noindex() {
 		// Go to author page.
 		$user_id = $this->factory->user->create();
-		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
 		$this->go_to( get_author_posts_url( $user_id ) );
 
 		// Test author archive with 'noindex-author-wpseo'.
@@ -230,7 +230,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 	public function test_individual_archive_noindex() {
 		// Go to author page.
 		$user_id = $this->factory->user->create();
-		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
 		update_user_meta( $user_id, 'wpseo_noindex_author', 'on' );
 		$this->go_to( get_author_posts_url( $user_id ) );
 
@@ -239,7 +239,7 @@ final class WPSEO_Frontend_Robots_Test extends WPSEO_UnitTestCase_Frontend {
 
 		// Test that when this is _not_ set, we also do NOT have a noindex.
 		$user_id = $this->factory->user->create();
-		$this->factory->post->create_many( 1, array( 'post_author' => $user_id ) );
+		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
 		$this->go_to( get_author_posts_url( $user_id ) );
 		$expected = 'max-snippet:-1, max-image-preview:large, max-video-preview:-1'; // The default "index,follow" is automatically set to empty string.
 		$this->assertEquals( $expected, self::$class_instance->robots() );

--- a/integration-tests/notifications/test-class-yoast-notification-center.php
+++ b/integration-tests/notifications/test-class-yoast-notification-center.php
@@ -802,32 +802,32 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this->get_notification_center();
 
-		$user_mock_1 = $this->mock_wp_user( 1, array( 'wpseo_manage_options' => true ) );
-		$user_mock_2 = $this->mock_wp_user( 2, array( 'wpseo_manage_options' => true ) );
+		$user_mock_1 = $this->mock_wp_user( 1, [ 'wpseo_manage_options' => true ] );
+		$user_mock_2 = $this->mock_wp_user( 2, [ 'wpseo_manage_options' => true ] );
 
 		$notification_for_user_1 = new Yoast_Notification(
 			'Hello, user 1!',
-			array(
+			[
 				'user'         => $user_mock_1,
-				'capabilities' => array( 'wpseo_manage_options' )
-			)
+				'capabilities' => [ 'wpseo_manage_options' ],
+			]
 		);
 
 		$notification_for_user_2 = new Yoast_Notification(
 			'Hello, user 2!',
-			array(
+			[
 				'user'         => $user_mock_2,
-				'capabilities' => array( 'wpseo_manage_options' )
-			)
+				'capabilities' => [ 'wpseo_manage_options' ],
+			]
 		);
 
 		$instance->add_notification( $notification_for_user_1 );
 		$instance->add_notification( $notification_for_user_2 );
 
-		$expected_for_user_1 = array( $notification_for_user_1 );
+		$expected_for_user_1 = [ $notification_for_user_1 ];
 		$actual_for_user_1   = $instance->get_notifications_for_user( 1 );
 
-		$expected_for_user_2 = array( $notification_for_user_2 );
+		$expected_for_user_2 = [ $notification_for_user_2 ];
 		$actual_for_user_2   = $instance->get_notifications_for_user( 2 );
 
 		$this->assertEquals( $expected_for_user_1, $actual_for_user_1 );
@@ -841,26 +841,25 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$instance = $this->get_notification_center();
 
-		$user_mock = $this->mock_wp_user( 3, array( 'wpseo_manage_options' => true ) );
+		$user_mock = $this->mock_wp_user( 3, [ 'wpseo_manage_options' => true ] );
 
 		$notification = new Yoast_Notification(
 			'Hello, user 3!',
-			array(
+			[
 				'id'           => 'Yoast_Notification_Test',
 				'user'         => $user_mock,
-				'capabilities' => array( 'wpseo_manage_options' )
-			)
+				'capabilities' => [ 'wpseo_manage_options' ],
+			]
 		);
 
 		$instance->add_notification( $notification );
 		$instance->add_notification( $notification );
 
-		$expected = array( $notification );
+		$expected = [ $notification ];
 		$actual   = $instance->get_notifications_for_user( 3 );
 
 		$this->assertEquals( $expected, $actual );
 	}
-
 
 	/**
 	 * Gets some notification objects.
@@ -930,7 +929,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	private function mock_wp_user( $user_id, $role_caps ) {
 		$user_mock = $this
 			->getMockBuilder( 'WP_User' )
-			->setMethods( array( 'get_role_caps' ) )
+			->setMethods( [ 'get_role_caps' ] )
 			->getMock();
 
 		$user_mock

--- a/integration-tests/test-class-admin-asset-manager.php
+++ b/integration-tests/test-class-admin-asset-manager.php
@@ -139,7 +139,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 		$result = $wp_scripts->registered[ WPSEO_Admin_Asset_Manager::PREFIX . 'handle' ];
 
 		$this->assertEquals( WPSEO_Admin_Asset_Manager::PREFIX . 'handle', $result->handle );
-		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/wp-content/plugins/wordpress-seo/js/dist/src' . '.js', $result->src );
+		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/wp-content/plugins/wordpress-seo/js/dist/src.js', $result->src );
 		$this->assertEquals( [ 'deps' ], $result->deps );
 		$this->assertEquals( 'version', $result->ver );
 		$this->assertEquals( [ 'group' => 1 ], $result->extra );

--- a/tests/admin/capabilities/capability-utils-test.php
+++ b/tests/admin/capabilities/capability-utils-test.php
@@ -56,11 +56,13 @@ final class Capabilities_Utils_Test extends TestCase {
 			->expects( 'get_role' )
 			->once()
 			->with( 'administrator' )
-			->andReturn( (object) [
-				'capabilities' => [
-					'wpseo_manage_options' => true,
-				],
-			] );
+			->andReturn(
+				(object) [
+					'capabilities' => [
+						'wpseo_manage_options' => true,
+					],
+				]
+			);
 
 		Monkey\Functions\expect( 'get_users' )
 			->once()
@@ -113,6 +115,7 @@ final class Capabilities_Utils_Test extends TestCase {
 	}
 
 	/**
+	 * Test data provider.
 	 *
 	 * @return array
 	 */

--- a/tests/doubles/inc/options/options-double.php
+++ b/tests/doubles/inc/options/options-double.php
@@ -17,5 +17,4 @@ class Options_Double extends WPSEO_Options {
 	public function __construct() {
 		parent::__construct();
 	}
-
 }

--- a/tests/helpers/author-archive-helper-test.php
+++ b/tests/helpers/author-archive-helper-test.php
@@ -19,10 +19,17 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Author_Archive_Helper_Test extends TestCase {
 
 	/**
-	 * @var Author_Archive_Helper
+	 * Class instance to use for the test.
+	 *
+	 * @var \Yoast\WP\Free\Helpers\Author_Archive_Helper
 	 */
 	private $instance;
 
+	/**
+	 * Set up the class which will be tested.
+	 *
+	 * @return void
+	 */
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/helpers/date-helper-test.php
+++ b/tests/helpers/date-helper-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Helpers
- */
 
 namespace Yoast\WP\SEO\Tests\Helpers;
 
@@ -125,7 +120,6 @@ class Date_Helper_Test extends TestCase {
 		$this->assertEquals( $expected, $this->instance->format_timestamp( $timestamp, $format ), $message );
 	}
 
-
 	/**
 	 * Provides data to the test_format.
 	 *
@@ -170,7 +164,6 @@ class Date_Helper_Test extends TestCase {
 			$this->instance->format_translated( '2020-12-31 13:37:00' )
 		);
 	}
-
 
 	/**
 	 * Test the datetime with a valid date string.

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @group health-check
  */
 class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
+
 	/**
 	 * Tests the run method when page_comments are disabled.
 	 *
@@ -31,6 +32,7 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 		// We just want to verify that the label attribute is the "passed" message.
 		$this->assertAttributeEquals( 'Paging comments is properly disabled', 'label', $health_check );
 	}
+
 	/**
 	 * Tests the run method when page_comments are enabled.
 	 *

--- a/tests/inc/health-check-test.php
+++ b/tests/inc/health-check-test.php
@@ -7,19 +7,26 @@ use Mockery;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
-* Unit Test Class.
-*
-* @group health-check
-*/
+ * Unit Test Class.
+ *
+ * @group health-check
+ */
 class WPSEO_Health_Check_Test extends TestCase {
 
 	/**
+	 * Class instance to use for the test.
+	 *
 	 * @var \Mockery\MockInterface
 	 */
 	protected $instance;
 
+	/**
+	 * Set up the class which will be tested.
+	 *
+	 * @return void
+	 */
 	public function setUp() {
-		$this->instance = Mockery::mock(\WPSEO_Health_Check::class )
+		$this->instance = Mockery::mock( \WPSEO_Health_Check::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 
@@ -71,8 +78,8 @@ class WPSEO_Health_Check_Test extends TestCase {
 				'direct' => [
 					'' => [
 						'test' => [ $this->instance, 'get_test_result' ],
-					]
-				]
+					],
+				],
 			],
 			$this->instance->add_test( [] )
 		);
@@ -89,8 +96,8 @@ class WPSEO_Health_Check_Test extends TestCase {
 				'async' => [
 					'' => [
 						'test' => '',
-					]
-				]
+					],
+				],
 			],
 			$this->instance->add_async_test( [] )
 		);
@@ -110,7 +117,7 @@ class WPSEO_Health_Check_Test extends TestCase {
 				'status'      => '',
 				'badge'       => [
 					'label' => 'SEO',
-					'color' => 'green'
+					'color' => 'green',
 				],
 				'description' => '',
 				'actions'     => '',
@@ -136,7 +143,10 @@ class WPSEO_Health_Check_Test extends TestCase {
 				[
 					'label'       => '',
 					'status'      => '',
-					'badge'       => array( 'label' => 'SEO', 'color' => 'green' ),
+					'badge'       => [
+						'label' => 'SEO',
+						'color' => 'green',
+					],
 					'description' => '',
 					'actions'     => '',
 				]

--- a/tests/inc/options/options-test.php
+++ b/tests/inc/options/options-test.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @group options
  */
 class Options_Test extends TestCase {
+
 	/**
 	 * Tests clearing the cache.
 	 *


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Minor CS fixes:
* Aligning of equal signs.
* Whitespace around commas.
* Multi-line function call formatting.
* Multi-item associative arrays should be multi-line.
* Use short arrays.
* Comma after last array item in a multi-line array.
* Blank lines before/after function declarations.
* No unnecessary string concat.

Minor docs fixes:
* Add some missing docblocks.
* Add some missing property descriptions.
* Add some missing parameter/return tags.
* Docblock tag description alignment.
* Ignoring deprecated methods for code coverage.
* Remove file docblocks for namespaced files.
* Fix some `@covers` tags
* Minor punctuation fixes.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
