### PR TITLE
QA: test `setUp()` should not return

### DIFF
--- a/tests/inc/health-check-test.php
+++ b/tests/inc/health-check-test.php
@@ -23,7 +23,7 @@ class WPSEO_Health_Check_Test extends TestCase {
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 
-		return parent::setUp();
+		parent::setUp();
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

The return type of the PHPUnit `setUp()` method is explicitly `void`, so the method should not contain a `return` statement.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.