### PR TITLE
Update post relations on update

### DIFF
--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -204,7 +204,7 @@ class Indexable_Builder {
 	 *
 	 * @param Indexable|false $indexable The indexable.
 	 *
-	 * @return Indexable The indexable;
+	 * @return Indexable The indexable.
 	 */
 	private function ensure_indexable( $indexable ) {
 		if ( ! $indexable ) {
@@ -216,7 +216,8 @@ class Indexable_Builder {
 	/**
 	 * Saves and returns an indexable.
 	 *
-	 * @param Indexable $indexable The indexable.
+	 * @param Indexable      $indexable        The indexable.
+	 * @param Indexable|null $indexable_before The indexable before possible changes.
 	 *
 	 * @return Indexable The indexable.
 	 */

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -106,16 +106,17 @@ class Indexable_Builder {
 	/**
 	 * Creates an indexable by its ID and type.
 	 *
-	 * @param int       $object_id   The indexable object ID.
-	 * @param string    $object_type The indexable object type.
-	 * @param Indexable $indexable   Optional. An existing indexable to overwrite.
+	 * @param int            $object_id   The indexable object ID.
+	 * @param string         $object_type The indexable object type.
+	 * @param Indexable|bool $indexable   Optional. An existing indexable to overwrite.
 	 *
 	 * @return bool|Indexable Instance of indexable.
 	 *
 	 * @throws \Exception If the object_id could not be found.
 	 */
 	public function build_for_id_and_type( $object_id, $object_type, $indexable = false ) {
-		$indexable = $this->ensure_indexable( $indexable );
+		$indexable        = $this->ensure_indexable( $indexable );
+		$indexable_before = $indexable;
 
 		switch ( $object_type ) {
 			case 'post':
@@ -131,7 +132,7 @@ class Indexable_Builder {
 				return $indexable;
 		}
 
-		$indexable->save();
+		$this->save_indexable( $indexable, $indexable_before );
 
 		if ( in_array( $object_type, [ 'post', 'term' ], true ) ) {
 			$this->hierarchy_builder->build( $indexable );
@@ -143,21 +144,21 @@ class Indexable_Builder {
 	/**
 	 * Creates an indexable for the homepage.
 	 *
-	 * @param Indexable $indexable Optional. An existing indexable to overwrite.
+	 * @param Indexable|bool $indexable Optional. An existing indexable to overwrite.
 	 *
 	 * @return Indexable The home page indexable.
 	 */
 	public function build_for_home_page( $indexable = false ) {
-		$indexable = $this->ensure_indexable( $indexable );
-		$indexable = $this->home_page_builder->build( $indexable );
+		$indexable_before = $this->ensure_indexable( $indexable );
+		$indexable        = $this->home_page_builder->build( $indexable_before );
 
-		return $this->save_indexable( $indexable );
+		return $this->save_indexable( $indexable, $indexable_before );
 	}
 
 	/**
 	 * Creates an indexable for the date archive.
 	 *
-	 * @param Indexable $indexable Optional. An existing indexable to overwrite.
+	 * @param Indexable|bool $indexable Optional. An existing indexable to overwrite.
 	 *
 	 * @return Indexable The date archive indexable.
 	 */
@@ -171,31 +172,31 @@ class Indexable_Builder {
 	/**
 	 * Creates an indexable for a post type archive.
 	 *
-	 * @param string    $post_type The post type.
-	 * @param Indexable $indexable Optional. An existing indexable to overwrite.
+	 * @param string         $post_type The post type.
+	 * @param Indexable|bool $indexable Optional. An existing indexable to overwrite.
 	 *
 	 * @return Indexable The post type archive indexable.
 	 */
 	public function build_for_post_type_archive( $post_type, $indexable = false ) {
-		$indexable = $this->ensure_indexable( $indexable );
-		$indexable = $this->post_type_archive_builder->build( $post_type, $indexable );
+		$indexable_before = $this->ensure_indexable( $indexable );
+		$indexable        = $this->post_type_archive_builder->build( $post_type, $indexable_before );
 
-		return $this->save_indexable( $indexable );
+		return $this->save_indexable( $indexable, $indexable_before );
 	}
 
 	/**
 	 * Creates an indexable for a system page.
 	 *
-	 * @param string    $object_sub_type The type of system page.
-	 * @param Indexable $indexable       Optional. An existing indexable to overwrite.
+	 * @param string         $object_sub_type The type of system page.
+	 * @param Indexable|bool $indexable       Optional. An existing indexable to overwrite.
 	 *
 	 * @return Indexable The search result indexable.
 	 */
 	public function build_for_system_page( $object_sub_type, $indexable = false ) {
-		$indexable = $this->ensure_indexable( $indexable );
-		$indexable = $this->system_page_builder->build( $object_sub_type, $indexable );
+		$indexable_before = $this->ensure_indexable( $indexable );
+		$indexable        = $this->system_page_builder->build( $object_sub_type, $indexable_before );
 
-		return $this->save_indexable( $indexable );
+		return $this->save_indexable( $indexable, $indexable_before );
 	}
 
 	/**
@@ -219,8 +220,20 @@ class Indexable_Builder {
 	 *
 	 * @return Indexable The indexable.
 	 */
-	private function save_indexable( $indexable ) {
+	private function save_indexable( $indexable, $indexable_before = null ) {
+		if ( $indexable_before ) {
+			/**
+			 * Action: 'wpseo_save_indexable' - Allow developers to perform an action
+			 * when the indexable is udated.
+			 *
+			 * @api   Indexable The saved indexable.
+			 * @param Indexable The indexable before saving.
+			 */
+			do_action( 'wpseo_save_indexable', $indexable, $indexable_before );
+		}
+
 		$indexable->save();
+
 		return $indexable;
 	}
 }

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -9,7 +9,9 @@ namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Generators\Related_Indexables_Generator;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
@@ -63,6 +65,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'wp_insert_post', [ $this, 'build_indexable' ], \PHP_INT_MAX );
 		\add_action( 'delete_post', [ $this, 'delete_indexable' ] );
+		\add_action( 'transition_post_status', [ $this, 'status_transition' ], \PHP_INT_MAX, 3 );
 
 		\add_action( 'edit_attachment',[ $this, 'build_indexable' ], \PHP_INT_MAX );
 		\add_action( 'add_attachment', [ $this, 'build_indexable' ], \PHP_INT_MAX );
@@ -81,6 +84,10 @@ class Indexable_Post_Watcher implements Integration_Interface {
 
 		if ( ! $indexable ) {
 			return;
+		}
+
+		if ( $indexable->is_public ) {
+			$this->update_relations( get_post( $post_id ) );
 		}
 
 		$this->hierarchy_repository->clear_ancestors( $indexable->id );
@@ -107,6 +114,10 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		$indexable = $this->repository->find_by_id_and_type( $post_id, 'post', false );
 		$indexable = $this->builder->build_for_id_and_type( $post_id, 'post', $indexable );
 
+		if ( $indexable->is_public ) {
+			$this->update_relations( get_post( $post_id ) );
+		}
+
 		$indexable->save();
 	}
 
@@ -127,5 +138,59 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if the relations should be updated on status transition.
+	 *
+	 * @param string   $new_status The new status.
+	 * @param string   $old_status The old status.
+	 * @param \WP_Post $post       The post object.
+	 */
+	public function status_transition( $new_status, $old_status, $post ) {
+		/**
+		 * Filter: 'wpseo_public_post_statuses' - List of public post statuses.
+		 *
+		 * @apo array $post_statuses Post status list, defaults to array( 'publish' ).
+		 */
+		$public_statuses = \apply_filters( 'wpseo_public_post_statuses', [ 'publish' ] );
+
+		if ( in_array( $new_status, $public_statuses, true ) || in_array( $old_status, $public_statuses, true ) ) {
+			$this->update_relations( $post );
+		}
+	}
+
+	/**
+	 * Updates the relations on post save or post status change.
+	 *
+	 * @param \WP_Post $post The post that has been updated.
+	 */
+	protected function update_relations( $post ) {
+		/**
+		 * The related indexables.
+		 *
+		 * @var Indexable[] $related_indexables.
+		 */
+		$related_indexables   = [];
+		$related_indexables[] = $this->repository->find_by_id_and_type( $post->post_author, 'user', false );
+		$related_indexables[] = $this->repository->find_for_post_type_archive( $post->post_type, false );
+		$related_indexables[] = $this->repository->find_for_home_page( false );
+
+		$taxonomies = get_post_taxonomies( $post->ID );
+		$taxonomies = array_filter( $taxonomies, 'is_taxonomy_viewable' );
+		foreach ( $taxonomies as $taxonomy ) {
+			$terms = get_the_terms( $post->ID, $taxonomy );
+			foreach( $terms as $term ) {
+				$related_indexables[] = $this->repository->find_by_id_and_type( $term->term_id, 'term', false );
+			}
+		}
+
+		$related_indexables = \array_filter( $related_indexables );
+
+		$updated_at = \gmdate( 'Y-m-d H:i:s' );
+		foreach ( $related_indexables as $indexable ) {
+			$indexable->updated_at = $updated_at;
+			$indexable->save();
+		}
 	}
 }

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -172,7 +172,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		$taxonomies = array_filter( $taxonomies, 'is_taxonomy_viewable' );
 		foreach ( $taxonomies as $taxonomy ) {
 			$terms = get_the_terms( $post->ID, $taxonomy );
-			foreach( $terms as $term ) {
+			foreach ( $terms as $term ) {
 				$related_indexables[] = $this->repository->find_by_id_and_type( $term->term_id, 'term', false );
 			}
 		}

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -189,6 +189,10 @@ class Indexable_Post_Watcher implements Integration_Interface {
 
 		$updated_at = \gmdate( 'Y-m-d H:i:s' );
 		foreach ( $related_indexables as $indexable ) {
+			if ( ! $indexable->is_public ) {
+				continue;
+			}
+
 			$indexable->updated_at = $updated_at;
 			$indexable->save();
 		}

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -172,6 +172,11 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		$taxonomies = array_filter( $taxonomies, 'is_taxonomy_viewable' );
 		foreach ( $taxonomies as $taxonomy ) {
 			$terms = get_the_terms( $post->ID, $taxonomy );
+
+			if ( empty( $terms ) ) {
+				continue;
+			}
+
 			foreach ( $terms as $term ) {
 				$related_indexables[] = $this->repository->find_by_id_and_type( $term->term_id, 'term', false );
 			}

--- a/tests/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-watcher-test.php
@@ -49,7 +49,16 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		$this->repository_mock           = Mockery::mock( Indexable_Repository::class );
 		$this->builder_mock              = Mockery::mock( Indexable_Builder::class );
 		$this->hierarchy_repository_mock = Mockery::mock( Indexable_Hierarchy_Repository::class );
-		$this->instance                  = new Indexable_Post_Watcher( $this->repository_mock, $this->builder_mock, $this->hierarchy_repository_mock );
+		$this->instance                  = Mockery::mock(
+			Indexable_Post_Watcher::class,
+			[
+				$this->repository_mock,
+				$this->builder_mock,
+				$this->hierarchy_repository_mock
+			]
+		)
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
 		return parent::setUp();
 	}
@@ -85,14 +94,27 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * @covers ::delete_indexable
 	 */
 	public function test_delete_indexable() {
-		$id = 1;
+		$id   = 1;
+		$post = (object) [
+			'post_author' => 0,
+			'post_type'   => 'post',
+			'ID'          => 0
+		];
 
-		$indexable_mock = Mockery::mock( Indexable::class );
+		$indexable_mock = Mockery::mock();
 		$indexable_mock->id = 1;
+		$indexable_mock->is_public = true;
 		$indexable_mock->expects( 'delete' )->once();
 
 		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'post', false )->andReturn( $indexable_mock );
 		$this->hierarchy_repository_mock->expects( 'clear_ancestors' )->once()->with( $id )->andReturn( true );
+
+		Monkey\Functions\expect( 'get_post' )->once()->with( $id )->andReturn( $post );
+
+		$this->instance
+			->expects( 'update_relations' )
+			->with( $post )
+			->once();
 
 		$this->instance->delete_indexable( $id );
 	}
@@ -114,6 +136,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * Tests the save meta functionality.
 	 *
 	 * @covers ::build_indexable
+	 * @covers ::is_post_indexable
 	 */
 	public function test_build_indexable() {
 		$id = 1;
@@ -176,5 +199,68 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		$this->builder_mock->expects( 'build_for_id_and_type' )->once()->with( $id, 'post', false )->andReturn( $indexable_mock );
 
 		$this->instance->build_indexable( $id );
+	}
+
+	/**
+	 * Tests the updated where the indexable isn't for a post.
+	 *
+	 * @covers ::updated_indexable
+	 */
+	public function test_updated_indexable_non_post( ) {
+		$this->instance
+			->expects( 'update_relations' )
+			->never();
+
+		$old_indexable     = Mockery::mock();
+		$updated_indexable = Mockery::mock();
+		$updated_indexable->object_type = 'term';
+
+		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
+	}
+
+	/**
+	 * Tests the updated indexable method with no transition in status.
+	 *
+	 * @covers ::updated_indexable
+	 */
+	public function test_updated_indexable_not_public_and_no_transition() {
+		$this->instance
+			->expects( 'update_relations' )
+			->never();
+
+		$old_indexable            = Mockery::mock();
+		$old_indexable->is_public = false;
+
+		$updated_indexable              = Mockery::mock();
+		$updated_indexable->object_type = 'post';
+		$updated_indexable->is_public   = false;
+
+		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
+	}
+
+	/**
+	 * Tests the updated indexable method with a transition in status.
+	 *
+	 * @covers ::updated_indexable
+	 */
+	public function test_updated_indexable_public_transition() {
+		$this->instance
+			->expects( 'update_relations' )
+			->with( [] )
+			->once();
+
+		$old_indexable            = Mockery::mock();
+		$old_indexable->is_public = true;
+
+		$updated_indexable              = Mockery::mock();
+		$updated_indexable->object_type = 'post';
+		$updated_indexable->is_public   = false;
+		$updated_indexable->object_id   = 1;
+
+		Monkey\Functions\expect( 'get_post' )
+			->once()
+			->with( 1 )->andReturn( [] );
+
+		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Update related indexables when the post is saved.

## Relevant technical choices:

* I introduced an action names `wpseo_save_indexable` that is triggered when the indexable is saved. It received the updated and the old indexable.
* Decided to not introduce any helper methods, because it is only used a couple of times between the same class.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post and attach some terms like categories and tags to it.
* Save it
* Make a change and save it again
* Open the indexables table in the database and verify the related indexables have a new date for the `updated_at` field. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14079
