### PR TITLE
Adds two fields to the indexables table

### DIFF
--- a/migrations/20200121154000_WpYoastIndexablesAddFields.php
+++ b/migrations/20200121154000_WpYoastIndexablesAddFields.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\SEO\ORM\Yoast_Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * Class WpYoastIndexablesAddFields
+ */
+class WpYoastIndexablesAddFields extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$table_name = $this->get_table_name();
+
+		$this->add_column( $table_name, 'post_status', 'string', [ 'null' => true, 'limit' => 191 ] );
+		$this->add_column( $table_name, 'is_protected', 'boolean', [ 'default' => false ] );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		$table_name = $this->get_table_name();
+
+		$this->remove_column( $table_name, 'post_status' );
+		$this->remove_column( $table_name, 'is_protected' );
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Yoast_Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -83,6 +83,8 @@ class Indexable_Post_Builder {
 
 		$indexable->number_of_pages = $this->get_number_of_pages_for_post( $post );
 		$indexable->is_public       = ( \in_array( $post->post_status, $this->is_public_post_status(), true ) && $post->post_password === '' );
+		$indexable->post_status     = $post->post_status;
+		$indexable->is_protected    = $post->post_password !== '';
 
 		return $indexable;
 	}

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -63,6 +63,8 @@ use Yoast\WP\SEO\ORM\Yoast_Model;
  * @property int     $prominent_words_version
  *
  * @property boolean $is_public
+ * @property boolean $is_protected
+ * @property string  $post_status
  */
 class Indexable extends Yoast_Model {
 

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -107,6 +107,8 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'incoming_link_count', 2 );
 		$indexable_mock->orm->expects( 'set' )->with( 'number_of_pages', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_public', true );
+		$indexable_mock->orm->expects( 'set' )->with( 'post_status', 'publish' );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_protected', false );
 
 		$indexable_mock->orm->expects( 'get' )->once()->with( 'og_image' );
 		$indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'og_image_id' );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Adds the `is_protected` and `post_status` fields to the indexables table

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the migrations are run. I've returned true in the`Migrations_Conditional::is_met`
* Add a password to the post and publish the post
* Verify that in the database the `is_protected` value is set to 1 for the indexable. The `post_status` should be set to `publish`
* Remove the password - `is_protected` should be 0 now
* Unpublish the post by making it a draft - the `post_status` should be `draft` now

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14072
