### PR TITLE
Simpler copy for the paginated comments Site Health test.

### DIFF
--- a/inc/health-check-page-comments.php
+++ b/inc/health-check-page-comments.php
@@ -22,22 +22,18 @@ class WPSEO_Health_Check_Page_Comments extends WPSEO_Health_Check {
 	 */
 	public function run() {
 		if ( ! $this->has_page_comments() ) {
-			$this->label          = esc_html__( 'Paging comments is properly disabled', 'wordpress-seo' );
+			$this->label          = esc_html__( 'Comments are displayed on a single page', 'wordpress-seo' );
 			$this->status         = self::STATUS_GOOD;
 			$this->badge['color'] = 'blue';
-			$this->description    = esc_html__( 'Paging comments is disabled. As this is not needed in 999 out of 1000 cases, we recommend to keep it disabled.', 'wordpress-seo' );
+			$this->description    = esc_html__( 'Comments on your posts are displayed on a single page. Breaking comments into multiple pages is not needed in 999 out of 1000 cases. We recommend to display all comments on the same page.', 'wordpress-seo' );
 			$this->add_yoast_signature();
 			return;
 		}
 
-		$this->label          = esc_html__( 'Paging comments is enabled', 'wordpress-seo' );
+		$this->label          = esc_html__( 'Comments break into multiple pages', 'wordpress-seo' );
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
-		$this->description    = esc_html__(
-			'Paging comments is enabled. As this is not needed in 999 out of 1000 cases, we recommend you disable it.
-								To fix this, uncheck the box in front of "Break comments into pages..." on the Discussion Settings page.',
-			'wordpress-seo'
-		);
+		$this->description    = esc_html__( 'Comments on your posts break into multiple pages. As this is not needed in 999 out of 1000 cases, we recommend you disable it. To fix this, uncheck "Break comments into pages..." on the Discussion Settings page.', 'wordpress-seo' );
 		$this->actions        = sprintf(
 			/* translators: 1: Opening tag of the link to the discussion settings page, 2: Link closing tag. */
 			esc_html__( '%1$sGo to the Discussion Settings page%2$s', 'wordpress-seo' ),

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -30,7 +30,7 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'Paging comments is properly disabled', 'label', $health_check );
+		$this->assertAttributeEquals( 'Comments are displayed on a single page', 'label', $health_check );
 	}
 
 	/**
@@ -53,6 +53,6 @@ class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "not passed" message.
-		$this->assertAttributeEquals( 'Paging comments is enabled', 'label', $health_check );
+		$this->assertAttributeEquals( 'Comments break into multiple pages', 'label', $health_check );
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improved the copy for the paginated comments Site Health check.

## Relevant technical choices:

**New copy for the "not passed" case:**

> Comments break into multiple pages
> Comments on your posts break into multiple pages. As this is not needed in 999 out of 1000 cases, we recommend you disable it. To fix this, uncheck "Break comments into pages..." on the Discussion Settings page. 

I removed also "the box in front" as it was not needed and potentially confusing (which "box"?). Also confusing for translators.

Screenshot:

<img width="836" alt="Screenshot 2020-01-22 at 11 05 39" src="https://user-images.githubusercontent.com/1682452/72886331-e4bfda80-3d09-11ea-8786-9f7431447b28.png">

**New copy for the "passed" case:**

> Comments are displayed on a single page
> Comments on your posts are displayed on a single page. Breaking comments into multiple pages is not needed in 999 out of 1000 cases. We recommend to display all comments on the same page.

Screenshot:

<img width="836" alt="Screenshot 2020-01-22 at 11 19 29" src="https://user-images.githubusercontent.com/1682452/72886431-1afd5a00-3d0a-11ea-94a9-6e4be78e870c.png">

Suggestions for further improvements welcome!

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- go to the WordPress Discussion Settings, check "Break comments into pages..." and save
- go to the Site Health page
- see the test copy
- go to the WordPress Discussion Settings, uncheck "Break comments into pages..." and save
- go to the Site Health page
- see the test copy (it's in the collapsed "Passed tests" section)


## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14211
