### PR TITLE
Use the post title for the HowTo schema name.

### DIFF
--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -78,7 +78,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 		$data = [
 			'@type'            => 'HowTo',
 			'@id'              => $this->context->canonical . '#howto-' . $this->counter,
-			'name'             => $this->context->title,
+			'name'             => $this->get_post_title(),
 			'mainEntityOfPage' => [ '@id' => $this->get_main_schema_id() ],
 			'description'      => '',
 		];
@@ -239,5 +239,19 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 		$image = new WPSEO_Schema_Image( $this->context->canonical . '#schema-image-' . md5( $url ) );
 
 		return $image->generate_from_url( $url );
+	}
+
+	/**
+	 * Gets the post title.
+	 *
+	 * @return string $post_title The post title.
+	 */
+	protected function get_post_title() {
+		$post_title = wp_strip_all_tags( trim( get_the_title() ) );
+		if ( empty( $post_title ) ) {
+			$post_title = __( 'No title', 'wordpress-seo' );
+		}
+
+		return $post_title;
 	}
 }

--- a/tests/frontend/schema/schema-how-to-test.php
+++ b/tests/frontend/schema/schema-how-to-test.php
@@ -48,15 +48,15 @@ class Schema_HowTo_Test extends TestCase {
 
 		$this->context = Mockery::mock( WPSEO_Schema_Context::class )->makePartial();
 
-		$this->context->title     = 'title';
 		$this->context->canonical = 'example.com/';
 
 		$this->instance = $this->getMockBuilder( Schema_HowTo_Double::class )
-			->setMethods( [ 'get_image_schema' ] )
+			->setMethods( [ 'get_image_schema', 'get_post_title' ] )
 			->setConstructorArgs( [ $this->context ] )
 			->getMock();
 
 		$this->instance->method( 'get_image_schema' )->willReturn( 'https://example.com/image.png' );
+		$this->instance->method( 'get_post_title' )->willReturn( 'title' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Fixes a bug where the HowTo schema name was incorrectly set to the page title.

## Relevant technical choices:

- it now uses the post title
- fallbacks to `No title`
- pending reply to the questions on the issue starting from https://github.com/Yoast/wordpress-seo/issues/13259#issuecomment-577124486

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- make sure your SEO title setting is using the post title plus something else e.g.: `%%title%% %%sep%% %%sitename%%`
- create a post
- set the post title
- add a How-to block
- publish the post
- view the front end and inspect the source to see the schema
- search for the `"@type":"HowTo"` entry
- see its name contains only the post title: no separator and no site name
- edit the post title to add some HTML tags and quotes e.g.: `Post title with <strong>tags</strong>, single ' quote, and " double quote`
- update the post
- refresh the frontend page and inspect the source to see the schema
- check the `"@type":"HowTo"` name doesn't contain HTML tags and the quotes are encoded e.g.: `"name":"Post title with tags, single &#8216; quote, and &#8221; double quote"`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13259