### PR TITLE
Merge pull request #14269 from Yoast/code-cleanup-free-docs-maarten

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -566,6 +566,8 @@ class Yoast_Notification_Center {
 		$notifications = $this->notifications;
 
 		/**
+		 * One array of Yoast_Notifications, merged from multiple arrays.
+		 *
 		 * @var Yoast_Notification[] $merged_notifications
 		 */
 		$merged_notifications = [];

--- a/integration-tests/admin/test-class-yoast-network-admin.php
+++ b/integration-tests/admin/test-class-yoast-network-admin.php
@@ -283,6 +283,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		try {
 			$admin->verify_request( 'my_action' );
 		} catch ( WPDieException $e ) {
+			// WP_die has been called in the verify request function.
 		}
 
 		$this->assertNull( $e );
@@ -342,6 +343,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		try {
 			$admin->verify_request( 'my_action' );
 		} catch ( WPDieException $e ) {
+			// WP_die has been called in the verify request function.
 		}
 
 		$this->assertNull( $e );

--- a/integration-tests/doubles/class-dismissible-notification-double.php
+++ b/integration-tests/doubles/class-dismissible-notification-double.php
@@ -11,14 +11,18 @@
 class WPSEO_Dismissible_Notification_Double extends WPSEO_Dismissible_Notification {
 
 	/**
-	 * @inheritdoc
+	 * Test double. Listens to an argument in the request URL and triggers an action.
+	 *
+	 * @return void
 	 */
 	public function dismiss() {
 		parent::dismiss();
 	}
 
 	/**
-	 * @inheritdoc
+	 * Test double. Checks if a notice is applicable.
+	 *
+	 * @return bool Whether a notice should be shown or not.
 	 */
 	public function is_applicable() {
 		return parent::is_applicable();

--- a/integration-tests/doubles/class-upgrade-double.php
+++ b/integration-tests/doubles/class-upgrade-double.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * WPSEO plugin test file.
+ *
  * @package WPSEO\Tests\Doubles
  */
 
@@ -27,7 +29,7 @@ class WPSEO_Upgrade_Double extends WPSEO_Upgrade {
 	}
 
 	/**
-	 * Retrieves the option value directly from the database.
+	 * Test double. Retrieves the option value directly from the database.
 	 *
 	 * @param string $option_name Option to retrieve.
 	 *
@@ -38,7 +40,7 @@ class WPSEO_Upgrade_Double extends WPSEO_Upgrade {
 	}
 
 	/**
-	 * Saves an option setting to where it should be stored.
+	 * Test double. Saves an option setting to where it should be stored.
 	 *
 	 * @param array       $source_data    The option containing the value to be migrated.
 	 * @param string      $source_setting Name of the key in the "from" option.
@@ -51,7 +53,7 @@ class WPSEO_Upgrade_Double extends WPSEO_Upgrade {
 	}
 
 	/**
-	 * Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
+	 * Test double. Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
 	 */
 	public function finish_up() {
 		parent::finish_up();

--- a/integration-tests/doubles/frontend-double.php
+++ b/integration-tests/doubles/frontend-double.php
@@ -35,6 +35,8 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	}
 
 	/**
+	 * Sets the WooCommerce shop page.
+	 *
 	 * @param WPSEO_WooCommerce_Shop_Page $woocommerce_shop_page Shop page object.
 	 */
 	public function set_woocommerce_shop_page( WPSEO_WooCommerce_Shop_Page $woocommerce_shop_page ) {
@@ -52,21 +54,28 @@ class WPSEO_Frontend_Double extends WPSEO_Frontend {
 	}
 
 	/**
-	 * @inheritdoc
+	 * Intentionally left empty to remove actual redirection code to be able to test it.
 	 */
 	public function do_attachment_redirect( $attachment_url ) {
 		// Intentionally left empty to remove actual redirection code to be able to test it.
 	}
 
 	/**
-	 * @inheritdoc
+	 * Test double. Retrieves the queried post type.
+	 *
+	 * @return string The queried post type.
 	 */
 	public function get_queried_post_type() {
 		return parent::get_queried_post_type();
 	}
 
 	/**
-	 * @inheritdoc
+	 * Test double. Builds the title for a post type archive.
+	 *
+	 * @param string $separator          The title separator.
+	 * @param string $separator_location The location of the title separator.
+	 *
+	 * @return string The title to use on a post type archive.
 	 */
 	public function get_post_type_archive_title( $separator, $separator_location ) {
 		return parent::get_post_type_archive_title( $separator, $separator_location );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

N/A - Fixed Free doc issues.

Code style improvements:

```
FILE: admin\class-yoast-notification-center.php
--
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
568 \| WARNING \| Missing short description in doc comment
----------------------------------------------------------------------


FILE: integration-tests\admin\test-class-yoast-network-admin.php
--
-----------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
-----------------------------------------------------------------------------------------------------
285 \| ERROR \| Empty CATCH statement must have a comment to explain why the exception is not handled
344 \| ERROR \| Empty CATCH statement must have a comment to explain why the exception is not handled
-----------------------------------------------------------------------------------------------------


FILE: integration-tests\doubles\class-dismissible-notification-double.php
--
-------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
-------------------------------------------------------------------------
13 \| WARNING \| Missing short description in doc comment
20 \| WARNING \| Missing short description in doc comment
-------------------------------------------------------------------------
 
 
FILE: integration-tests\doubles\class-upgrade-double.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
2 \| WARNING \| Missing short description in doc comment
----------------------------------------------------------------------
 
 
FILE: integration-tests\doubles\frontend-double.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 4 WARNINGS AFFECTING 4 LINES
----------------------------------------------------------------------
37 \| WARNING \| Missing short description in doc comment
54 \| WARNING \| Missing short description in doc comment
61 \| WARNING \| Missing short description in doc comment
68 \| WARNING \| Missing short description in doc comment
----------------------------------------------------------------------
```
