### PR TITLE
Adds the `yoast` body class yoast SEO admin pages

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -76,6 +76,7 @@ class WPSEO_Admin {
 
 		if ( WPSEO_Utils::is_yoast_seo_page() ) {
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+			add_filter( 'admin_body_class', [ $this, 'set_yoast_body_class' ] );
 		}
 
 		if ( WPSEO_Utils::is_api_available() ) {
@@ -124,6 +125,17 @@ class WPSEO_Admin {
 		foreach ( $integrations as $integration ) {
 			$integration->register_hooks();
 		}
+	}
+
+	/**
+	 * Adds `yoast` to the admin page body class.
+	 *
+	 * @param string $body_class Space-separated list of CSS classes.
+	 *
+	 * @return string Space-separated list of CSS classes with `yoast` added.
+	 */
+	public function set_yoast_body_class( $body_class ) {
+		return $body_class . ' yoast';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added the `yoast` body class to Yoast SEO admin pages for easier CSS targeting.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See `yoast` as a body class on Yoast admin pages with this pull on Yoast SEO admin pages.
* See `yoast` _not_ as a body class on other admin pages.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14286
