### PR TITLE
Add inlanguage property to the schema CreativeWork pieces

### DIFF
--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -64,7 +64,6 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		$data          = [
 			'@type'            => 'Article',
 			'@id'              => $this->context->canonical . WPSEO_Schema_IDs::ARTICLE_HASH,
-			'inLanguage'       => WPSEO_Schema_Utils::get_schema_piece_language(),
 			'isPartOf'         => [ '@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH ],
 			'author'           => [ '@id' => WPSEO_Schema_Utils::get_user_schema_id( $post->post_author, $this->context ) ],
 			'headline'         => get_the_title(),
@@ -81,6 +80,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		$data = $this->add_image( $data );
 		$data = $this->add_keywords( $data );
 		$data = $this->add_sections( $data );
+		$data = WPSEO_Schema_Utils::add_piece_language( $data );
 
 		return $data;
 	}

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -64,6 +64,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		$data          = [
 			'@type'            => 'Article',
 			'@id'              => $this->context->canonical . WPSEO_Schema_IDs::ARTICLE_HASH,
+			'inLanguage'       => WPSEO_Schema_Utils::get_schema_piece_language(),
 			'isPartOf'         => [ '@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH ],
 			'author'           => [ '@id' => WPSEO_Schema_Utils::get_user_schema_id( $post->post_author, $this->context ) ],
 			'headline'         => get_the_title(),

--- a/frontend/schema/class-schema-faq-questions.php
+++ b/frontend/schema/class-schema-faq-questions.php
@@ -53,9 +53,9 @@ class WPSEO_Schema_FAQ_Questions {
 	}
 
 	/**
-	 * Find an image based on its URL and generate a Schema object for it.
+	 * Returns the Question and Answers schema data.
 	 *
-	 * @return array The Schema with Questions added.
+	 * @return array The Schema with Questions and Answers added.
 	 */
 	public function generate() {
 		foreach ( $this->block['attrs']['questions'] as $question ) {
@@ -68,7 +68,7 @@ class WPSEO_Schema_FAQ_Questions {
 	}
 
 	/**
-	 * Generate a Question piece.
+	 * Generates a Question and Answer piece.
 	 *
 	 * @param array $question The question to generate schema for.
 	 *
@@ -77,17 +77,36 @@ class WPSEO_Schema_FAQ_Questions {
 	protected function generate_question_block( $question ) {
 		$url = $this->context->canonical . '#' . esc_attr( $question['id'] );
 
-		return [
+		$data = [
 			'@type'          => 'Question',
 			'@id'            => $url,
 			'position'       => $this->position ++,
 			'url'            => $url,
 			'name'           => wp_strip_all_tags( $question['jsonQuestion'] ),
 			'answerCount'    => 1,
-			'acceptedAnswer' => [
-				'@type' => 'Answer',
-				'text'  => strip_tags( $question['jsonAnswer'], '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><b><strong><i><em>' ),
-			],
+			'acceptedAnswer' => $this->add_accepted_answer_property( $question ),
 		];
+
+		$data = WPSEO_Schema_Utils::add_piece_language( $data );
+
+		return $data;
+	}
+
+	/**
+	 * Adds the Questions `acceptedAnswer` property.
+	 *
+	 * @param array $question The question to add the acceptedAnswer to.
+	 *
+	 * @return array Schema.org Question piece.
+	 */
+	protected function add_accepted_answer_property( $question ) {
+		$data = [
+			'@type' => 'Answer',
+			'text'  => strip_tags( $question['jsonAnswer'], '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><b><strong><i><em>' ),
+		];
+
+		$data = WPSEO_Schema_Utils::add_piece_language( $data );
+
+		return $data;
 	}
 }

--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -79,6 +79,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 			'@type'            => 'HowTo',
 			'@id'              => $this->context->canonical . '#howto-' . $this->counter,
 			'name'             => $this->context->title,
+			'inLanguage'       => WPSEO_Schema_Utils::get_schema_piece_language(),
 			'mainEntityOfPage' => [ '@id' => $this->get_main_schema_id() ],
 			'description'      => '',
 		];

--- a/frontend/schema/class-schema-howto.php
+++ b/frontend/schema/class-schema-howto.php
@@ -79,7 +79,6 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 			'@type'            => 'HowTo',
 			'@id'              => $this->context->canonical . '#howto-' . $this->counter,
 			'name'             => $this->context->title,
-			'inLanguage'       => WPSEO_Schema_Utils::get_schema_piece_language(),
 			'mainEntityOfPage' => [ '@id' => $this->get_main_schema_id() ],
 			'description'      => '',
 		];
@@ -92,6 +91,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 
 		$this->add_duration( $data, $block['attrs'] );
 		$this->add_steps( $data, $block['attrs']['steps'] );
+		$data = WPSEO_Schema_Utils::add_piece_language( $data );
 
 		$graph[] = $data;
 

--- a/frontend/schema/class-schema-image.php
+++ b/frontend/schema/class-schema-image.php
@@ -133,10 +133,11 @@ class WPSEO_Schema_Image {
 	 */
 	private function generate_object() {
 		$this->data = [
-			'@type'      => 'ImageObject',
-			'@id'        => $this->schema_id,
-			'inLanguage' => WPSEO_Schema_Utils::get_schema_piece_language(),
+			'@type' => 'ImageObject',
+			'@id'   => $this->schema_id,
 		];
+
+		$this->data = WPSEO_Schema_Utils::add_piece_language( $this->data );
 	}
 
 	/**

--- a/frontend/schema/class-schema-image.php
+++ b/frontend/schema/class-schema-image.php
@@ -133,8 +133,9 @@ class WPSEO_Schema_Image {
 	 */
 	private function generate_object() {
 		$this->data = [
-			'@type' => 'ImageObject',
-			'@id'   => $this->schema_id,
+			'@type'      => 'ImageObject',
+			'@id'        => $this->schema_id,
+			'inLanguage' => WPSEO_Schema_Utils::get_schema_piece_language(),
 		];
 	}
 

--- a/frontend/schema/class-schema-utils.php
+++ b/frontend/schema/class-schema-utils.php
@@ -30,20 +30,24 @@ class WPSEO_Schema_Utils {
 	}
 
 	/**
-	 * Retrieves the language for the Schema pieces.
+	 * Adds the `inLanguage` property to a Schema piece.
 	 *
 	 * Must use one of the language codes from the IETF BCP 47 standard. The
 	 * language tag syntax is made of one or more subtags separated by a hyphen
 	 * e.g. "en", "en-US", "zh-Hant-CN".
 	 *
-	 * @return string The Schema pieces language.
+	 * @param array $data The Schema piece data.
+	 *
+	 * @return string The Schema piece language.
 	 */
-	public static function get_schema_piece_language() {
+	public static function add_piece_language( $data ) {
 		/**
-		 * Filter: 'wpseo_schema_piece_language' - Allow changing the Schema pieces language.
+		 * Filter: 'wpseo_schema_piece_language' - Allow changing the Schema piece language.
 		 *
-		 * @api string $type The Schema pieces language.
+		 * @api string $type The Schema piece language.
 		 */
-		return apply_filters( 'wpseo_schema_piece_language', get_bloginfo( 'language' ) );
+		$data['inLanguage'] = apply_filters( 'wpseo_schema_piece_language', get_bloginfo( 'language' ), $data );
+
+		return $data;
 	}
 }

--- a/frontend/schema/class-schema-utils.php
+++ b/frontend/schema/class-schema-utils.php
@@ -13,7 +13,7 @@
 class WPSEO_Schema_Utils {
 
 	/**
-	 * Retrieve a users Schema ID.
+	 * Retrieves a user's Schema ID.
 	 *
 	 * @param int                  $user_id The ID of the User you need a Schema ID for.
 	 * @param WPSEO_Schema_Context $context A value object with context variables.
@@ -27,5 +27,23 @@ class WPSEO_Schema_Utils {
 			return $context->site_url . WPSEO_Schema_IDs::PERSON_HASH . wp_hash( $user->user_login . $user_id );
 		}
 		return $context->site_url . WPSEO_Schema_IDs::PERSON_HASH;
+	}
+
+	/**
+	 * Retrieves the language for the Schema pieces.
+	 *
+	 * Must use one of the language codes from the IETF BCP 47 standard. The
+	 * language tag syntax is made of one or more subtags separated by a hyphen
+	 * e.g. "en", "en-US", "zh-Hant-CN".
+	 *
+	 * @return string The Schema pieces language.
+	 */
+	public static function get_schema_piece_language() {
+		/**
+		 * Filter: 'wpseo_schema_piece_language' - Allow changing the Schema pieces language.
+		 *
+		 * @api string $type The Schema pieces language.
+		 */
+		return apply_filters( 'wpseo_schema_piece_language', get_bloginfo( 'language' ) );
 	}
 }

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -59,7 +59,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			'@type'      => $this->determine_page_type(),
 			'@id'        => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
 			'url'        => $this->context->canonical,
-			'inLanguage' => get_bloginfo( 'language' ),
+			'inLanguage' => WPSEO_Schema_Utils::get_schema_piece_language(),
 			'name'       => $this->context->title,
 			'isPartOf'   => [
 				'@id' => $this->context->site_url . WPSEO_Schema_IDs::WEBSITE_HASH,

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -56,15 +56,16 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 */
 	public function generate() {
 		$data = [
-			'@type'      => $this->determine_page_type(),
-			'@id'        => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
-			'url'        => $this->context->canonical,
-			'inLanguage' => WPSEO_Schema_Utils::get_schema_piece_language(),
-			'name'       => $this->context->title,
-			'isPartOf'   => [
+			'@type'    => $this->determine_page_type(),
+			'@id'      => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
+			'url'      => $this->context->canonical,
+			'name'     => $this->context->title,
+			'isPartOf' => [
 				'@id' => $this->context->site_url . WPSEO_Schema_IDs::WEBSITE_HASH,
 			],
 		];
+
+		$data = WPSEO_Schema_Utils::add_piece_language( $data );
 
 		if ( is_front_page() ) {
 			if ( $this->context->site_represents_reference ) {

--- a/frontend/schema/class-schema-website.php
+++ b/frontend/schema/class-schema-website.php
@@ -48,10 +48,11 @@ class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 	 */
 	public function generate() {
 		$data = [
-			'@type'     => 'WebSite',
-			'@id'       => $this->context->site_url . WPSEO_Schema_IDs::WEBSITE_HASH,
-			'url'       => $this->context->site_url,
-			'name'      => $this->context->site_name,
+			'@type'      => 'WebSite',
+			'@id'        => $this->context->site_url . WPSEO_Schema_IDs::WEBSITE_HASH,
+			'url'        => $this->context->site_url,
+			'inLanguage' => WPSEO_Schema_Utils::get_schema_piece_language(),
+			'name'       => $this->context->site_name,
 		];
 
 		if ( $this->context->site_description ) {

--- a/frontend/schema/class-schema-website.php
+++ b/frontend/schema/class-schema-website.php
@@ -48,12 +48,13 @@ class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 	 */
 	public function generate() {
 		$data = [
-			'@type'      => 'WebSite',
-			'@id'        => $this->context->site_url . WPSEO_Schema_IDs::WEBSITE_HASH,
-			'url'        => $this->context->site_url,
-			'inLanguage' => WPSEO_Schema_Utils::get_schema_piece_language(),
-			'name'       => $this->context->site_name,
+			'@type' => 'WebSite',
+			'@id'   => $this->context->site_url . WPSEO_Schema_IDs::WEBSITE_HASH,
+			'url'   => $this->context->site_url,
+			'name'  => $this->context->site_name,
 		];
+
+		$data = WPSEO_Schema_Utils::add_piece_language( $data );
 
 		if ( $this->context->site_description ) {
 			$data['description'] = $this->context->site_description;

--- a/tests/frontend/schema/schema-faq-questions-test.php
+++ b/tests/frontend/schema/schema-faq-questions-test.php
@@ -50,9 +50,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => 'This is an answer',
+				'@type'      => 'Answer',
+				'text'       => 'This is an answer',
+				'inLanguage' => 'language',
 			],
 		];
 
@@ -80,9 +82,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => '',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => 'This is an answer',
+				'@type'      => 'Answer',
+				'text'       => 'This is an answer',
+				'inLanguage' => 'language',
 			],
 		];
 
@@ -110,9 +114,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => '',
+				'@type'      => 'Answer',
+				'text'       => '',
+				'inLanguage' => 'language',
 			],
 		];
 
@@ -140,9 +146,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => '',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => '',
+				'@type'      => 'Answer',
+				'text'       => '',
+				'inLanguage' => 'language',
 			],
 		];
 
@@ -172,9 +180,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => '<h1>This is an answer<h1>',
+				'@type'      => 'Answer',
+				'text'       => '<h1>This is an answer<h1>',
+				'inLanguage' => 'language',
 			],
 		];
 
@@ -204,9 +214,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => 'This is an answer',
+				'@type'      => 'Answer',
+				'text'       => 'This is an answer',
+				'inLanguage' => 'language',
 			],
 		];
 
@@ -236,9 +248,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => '<h1>This is an answer</h1>',
+				'@type'      => 'Answer',
+				'text'       => '<h1>This is an answer</h1>',
+				'inLanguage' => 'language',
 			],
 		];
 
@@ -268,9 +282,11 @@ class Schema_FAQ_Questions_Test extends TestCase {
 			'url'              => 'example.com/#question-1',
 			'name'             => 'Is this a question?',
 			'answerCount'      => 1,
+			'inLanguage'       => 'language',
 			'acceptedAnswer'   => [
-				'@type' => 'Answer',
-				'text'  => 'This is an answer',
+				'@type'      => 'Answer',
+				'text'       => 'This is an answer',
+				'inLanguage' => 'language',
 			],
 		];
 

--- a/tests/frontend/schema/schema-how-to-test.php
+++ b/tests/frontend/schema/schema-how-to-test.php
@@ -98,6 +98,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 			],
@@ -143,6 +144,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 			],
@@ -188,6 +190,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -259,6 +262,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -319,6 +323,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -376,6 +381,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -440,6 +446,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -492,6 +499,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 			],
@@ -544,6 +552,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'totalTime'        => 'P1DT12H30M',
@@ -604,6 +613,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -663,6 +673,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -722,6 +733,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -781,6 +793,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -840,6 +853,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => '<h1>description</h1>',
 				'step'             => [
@@ -899,6 +913,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => 'description',
 				'step'             => [
@@ -958,6 +973,7 @@ class Schema_HowTo_Test extends TestCase {
 				'@type'            => 'HowTo',
 				'@id'              => 'example.com/#howto-1',
 				'name'             => 'title',
+				'inLanguage'       => 'language',
 				'mainEntityOfPage' => [ '@id' => 'example.com/#article' ],
 				'description'      => '<h1>description</h1>',
 				'step'             => [

--- a/tests/frontend/schema/schema-image-test.php
+++ b/tests/frontend/schema/schema-image-test.php
@@ -73,10 +73,11 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->generate_from_url( 'https://www.example.com/media/image-200x200.jpg' );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.example.com/media/image.png',
-			'caption' => 'image caption',
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.example.com/media/image.png',
+			'caption'    => 'image caption',
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );
@@ -105,12 +106,13 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->generate_from_url( 'https://www.example.com/media/image-200x200.jpg' );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.example.com/media/image.png',
-			'caption' => 'image caption',
-			'height'  => 120,
-			'width'   => 100,
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.example.com/media/image.png',
+			'caption'    => 'image caption',
+			'height'     => 120,
+			'width'      => 100,
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );
@@ -135,9 +137,10 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->generate_from_url( 'https://www.external.com/media/image-200x200.png' );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.external.com/media/image-200x200.png',
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.external.com/media/image-200x200.png',
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );
@@ -160,10 +163,11 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->generate_from_attachment_id( 123 );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.example.com/media/image.png',
-			'caption' => 'image caption',
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.example.com/media/image.png',
+			'caption'    => 'image caption',
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );
@@ -194,10 +198,11 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->generate_from_attachment_id( 123 );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.example.com/media/image.png',
-			'caption' => 'Image alt caption',
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.example.com/media/image.png',
+			'caption'    => 'Image alt caption',
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );
@@ -226,12 +231,13 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->generate_from_attachment_id( 123, 'Different caption' );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.example.com/media/image.png',
-			'caption' => 'Different caption',
-			'height'  => 120,
-			'width'   => 100,
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.example.com/media/image.png',
+			'caption'    => 'Different caption',
+			'height'     => 120,
+			'width'      => 100,
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );
@@ -260,12 +266,13 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->generate_from_attachment_id( 123 );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.example.com/media/image.png',
-			'caption' => 'image caption',
-			'height'  => 120,
-			'width'   => 100,
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.example.com/media/image.png',
+			'caption'    => 'image caption',
+			'height'     => 120,
+			'width'      => 100,
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );
@@ -282,10 +289,11 @@ class Schema_Image_Test extends TestCase {
 		$image_schema = $this->instance->simple_image_object( 'https://www.example.com/media/image.png', 'Different caption' );
 
 		$expected = [
-			'@id'     => self::IMAGE_ID,
-			'@type'   => 'ImageObject',
-			'url'     => 'https://www.example.com/media/image.png',
-			'caption' => 'Different caption',
+			'@id'        => self::IMAGE_ID,
+			'@type'      => 'ImageObject',
+			'url'        => 'https://www.example.com/media/image.png',
+			'caption'    => 'Different caption',
+			'inLanguage' => 'language',
 		];
 
 		$this->assertEquals( $expected, $image_schema );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added `inLanguage` property to the schema CreativeWork pieces

## Relevant technical choices:

- introduces `WPSEO_Schema_Utils::add_piece_language()`
- introduces a `wpseo_schema_piece_language` filter 
- the filter is passed the schema piece `$data` array so that it can be used for some logic, for example to change the language of a specific piece type
- adjusts the tests 
Note:
Regarding this requirement from the issue:
> When the language of the content of a specific piece isn't explicitly set/known, we should fall back to ...

I don't see cases where a specific piece may have its own language setting. For example: it's not possible to set a language on a `HowTo` within the post content. Same for `Question`, `ImageObject`, `VideoObject`,  etc. 

I might be missing something, if there's any way to set a language on a specific piece of content within the post content please do let me know.

For now, I think we can only add `'inLanguage' => get_bloginfo( 'language' )`, or better a wrapper utility method, to all the schema pieces that need it.


## Test instructions

- create a post with some content, an image, a How-to block, and publish
- inspect the schema output on the front end 
- check the following pieces have an `inLanguage` property with a correct value e.g. `en-US` or `nl-NL` etc.
  - `Article`
  - `HowTo`
  - `ImageObject`
  - `WebPage`
  - `WebSite`
- activate Yoast SEO News and set the `post` posts type to be news 
- refresh the page of your published post and inspect the schema output 
- `Article` is now changed to `NewsArticle`: check it has its `inLanguage` property
- activate Yoast SEO Video 
- switch Yoast SEO Video to the `13750-schema-creativework-pieces-inlanguage` branch
- create a post with a video 
- inspect the schema output on the front end 
- check the `VideoObject` piece has its `inLanguage` property
- create a post with a FAQ block and add a couple Q/A
- inspect the schema output on the front end 
- check the `Question` pieces have their `inLanguage` property
- check the `Answer` pieces nested under Question > acceptedAnswer have their `inLanguage` property. I'd like this to be checked by @jono-alderson as the `Answer` isn't actually a "top-level" piece

**Testing the filter:**
- to check the filter works as expected put this example in your theme's `functions.php`

```
add_filter( 'wpseo_schema_piece_language', 'how_to_block_custom_language', 10, 2 );

function how_to_block_custom_language( $language, $data ) {
	if ( $data['@type'] === 'HowTo' ) {
		return 'it-IT';
	}

	return $language;
}
```

- inspect the schema output and check that only the `HowTo` piece has its `inLanguage` set to Italian while all the other pieces get the site language 


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13750
