### PR TITLE
Check whether all OG and Twitter filters are correct

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -517,7 +517,11 @@ class WPSEO_Admin_Init {
 				'version'     => 'xx.x',
 				'alternative' => null,
 			],
-			'wpseo_twitter_taxonomy_image'         => [
+			'wpseo_twitter_taxonomy_image'          => [
+				'version'     => 'xx.x',
+				'alternative' => null,
+			],
+			'wpseo_twitter_metatag_key'             => [
 				'version'     => 'xx.x',
 				'alternative' => null,
 			],

--- a/src/conditionals/jetpack-conditional.php
+++ b/src/conditionals/jetpack-conditional.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Yoast SEO plugin file.
+ *
+ * @package Yoast\YoastSEO\Conditionals
+ */
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Conditional that is only met when Jetpack exists.
+ */
+class Jetpack_Conditional implements Conditional {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function is_met() {
+		return class_exists( 'Jetpack' );
+	}
+}

--- a/src/integrations/third-party/jetpack.php
+++ b/src/integrations/third-party/jetpack.php
@@ -8,7 +8,7 @@
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
-use Yoast\WP\SEO\Conditionals\JetPack_Conditional;
+use Yoast\WP\SEO\Conditionals\Jetpack_Conditional;
 use Yoast\WP\SEO\Conditionals\OpenGraph_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
@@ -22,7 +22,7 @@ class Jetpack implements Integration_Interface {
 	 * @inheritDoc
 	 */
 	public static function get_conditionals() {
-		return [ Front_End_Conditional::class, JetPack_Conditional::class, OpenGraph_Conditional::class ];
+		return [ Front_End_Conditional::class, Jetpack_Conditional::class, OpenGraph_Conditional::class ];
 	}
 
 	/**

--- a/src/integrations/third-party/jetpack.php
+++ b/src/integrations/third-party/jetpack.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\SEO\Integrations\Third_Party
+ */
+
+namespace Yoast\WP\SEO\Integrations\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Conditionals\JetPack_Conditional;
+use Yoast\WP\SEO\Conditionals\OpenGraph_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Class Jetpack
+ */
+class Jetpack implements Integration_Interface {
+
+	/**
+	 * @codeCoverageIgnore
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Front_End_Conditional::class, JetPack_Conditional::class, OpenGraph_Conditional::class ];
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		\add_filter( 'jetpack_enable_open_graph', '__return_false' );
+	}
+}

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -49,7 +49,7 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	}
 
 	/**
-	 * Run the title content through the `wpseo_title` filter.
+	 * Run the title content through the `wpseo_opengraph_title` filter.
 	 *
 	 * @param string                 $title        The title to filter.
 	 * @param Indexable_Presentation $presentation The presentation of an indexable.
@@ -58,12 +58,12 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	 */
 	private function filter( $title, Indexable_Presentation $presentation ) {
 		/**
-		 * Filter: 'wpseo_og_title' - Allow changing the Yoast SEO generated title.
+		 * Filter: 'wpseo_opengraph_title' - Allow changing the Yoast SEO generated title.
 		 *
 		 * @api string $title The title.
 		 *
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		return (string) \trim( \apply_filters( 'wpseo_og_title', $title, $presentation ) );
+		return (string) \trim( \apply_filters( 'wpseo_opengraph_title', $title, $presentation ) );
 	}
 }

--- a/tests/conditionals/jetpack-conditional-test.php
+++ b/tests/conditionals/jetpack-conditional-test.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Conditionals;
+
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Jetpack_Conditional;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Jetpack_Conditional_Test.
+ *
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Jetpack_Conditional
+ */
+class Jetpack_Conditional_Test extends TestCase {
+	/**
+	 * The breadcrumbs enabled conditional.
+	 *
+	 * @var Jetpack_Conditional
+	 */
+	private $instance;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new Jetpack_Conditional();
+	}
+
+	/**
+	 * Tests that the conditional is not met when the Jetpack class does not exist.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_not_met() {
+		$this->assertEquals( false, $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests that the conditional is met when the Jetpack class exists.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met() {
+		Mockery::mock( 'Jetpack' );
+
+		$this->assertEquals( true, $this->instance->is_met() );
+	}
+}

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -102,7 +102,7 @@ class Title_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the presenter returns the correct title, when the `wpseo_title` filter is applied.
+	 * Tests whether the presenter returns the correct title, when the `wpseo_opengraph_title` filter is applied.
 	 *
 	 * @covers ::present
 	 * @covers ::filter
@@ -116,7 +116,7 @@ class Title_Presenter_Test extends TestCase {
 				return $str;
 			} );
 
-		Monkey\Filters\expectApplied( 'wpseo_og_title' )
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_title' )
 			->once()
 			->with( 'example_title', $this->indexable_presentation )
 			->andReturn( 'exampletitle' );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Deprecates the `wpseo_twitter_metatag_key` filter.
* Renames the `wpseo_og_title` filter to `wpseo_opengraph_title`.
* Adds a Jetpack integration to disable Open Graph when ours is enabled.

## Relevant technical choices:

* The deprecation of the metatag keys was missing. We no longer support the changing of the keys themselves in the indexables branch. Andy told me this has been discussed and decided upon by product.
* About `wpseo_opengraph_title`. All the filters are named `opengraph`. We had a `wpseo_og_*` way, which is already deprecated. For title this produced `wpseo_og_og_title`, which is obviously wrong. So instead of creating the `wpseo_og_title`, we use the already existing `wpseo_opengraph_title`.
* While searching for the OG filters I found that we did not port the Jetpack OG disable apply filter call. Implemented an integration after confirming with product that we still want that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Metatag keys filter deprecation
* Add `add_filter( 'wpseo_twitter_metatag_key', function() { return 'hi'; } );` somewhere in code that gets executed (like in the `functions.php` of your theme). 
* Check the backend of a page, it should have a deprecation warning like: `Notice: wpseo_twitter_metatag_key is deprecated since version WPSEO xx.x with no alternative available.`.

### OG title filter rename
* Add `add_filter( 'wpseo_opengraph_title', function() { return 'hi'; } );` somewhere in code that gets executed (like in the `functions.php` of your theme).
* Check on a frontend of a page that the metatag `og:title` now has the content that you return (`hi` in the above example).

### Jetpack integration
I tried to get this to show up in Jetpack in development mode, but have not succeeded. So going the hacky route:
* Enable the Jetpack plugin.
* Add something that creates a syntax error in the `src/integrations/third-party/jetpack.php` in the `register_hooks` function, like: `rlkhewlewhrewkj`.
* Go to a frontend page.
* You should get a fatal error. This shows that it got to that code path and thus checks if the integration is actually loaded and running.
* Disable the Jetpack plugin.
* Go to a frontend page.
* It should work fine.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #13824 
