### PR TITLE
Allow the SEO Manager role to view the Site Health checks.

### DIFF
--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -35,10 +35,11 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		$manager->register( 'wpseo_edit_advanced_metadata', [ 'wpseo_editor', 'wpseo_manager' ] );
 
 		$manager->register( 'wpseo_manage_options', [ 'administrator', 'wpseo_manager' ] );
+		$manager->register( 'view_site_health_checks', [ 'wpseo_manager' ] );
 	}
 
 	/**
-	 * Revokes the 'wpseo_manage_options' capability from administrator users if it should only
+	 * Revokes the 'wpseo_manage_options' capability from administrator users if it should
 	 * only be granted to network administrators.
 	 *
 	 * @param array   $allcaps An array of all the user's capabilities.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -698,6 +698,13 @@ class WPSEO_Upgrade {
 	private function upgrade_xxx() {
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-tagline-notice' );
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-permalink-notice' );
+
+		/*
+		 * Re-register capabilities to add the new `view_site_health_checks`
+		 * capability to the SEO Manager role.
+		 */
+		do_action( 'wpseo_register_capabilities' );
+		WPSEO_Capability_Manager_Factory::get()->add();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added capability to view Site Health to the SEO Manager role.

## Relevant technical choices:

- adds the `view_site_health_checks` capability to the `wpseo_manager` role
- since capabilities are registered by default only on plugin activation / deactivation, adds the new capability in the upgrade routine for the Site Health feature (it's temporarily marked as `xx.x-RC0`
 version)
- fixes an "only only" dittography

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- on the `feature/site-health` branch:
- set the SEO Manager role to one of your users
- log in with that user
- go to WordPress > Tools
- see there's a blank page with no sub-items in the menu: no access to Site Health
- switch to this branch
- deactivate and re-activate Yoast SEO 
- go to WordPress > Tools
- see there are now sub-items in the admin menu under "Tools"
- click on "Site Health"
- see your SEO Manager user has now access to Site Health

**To test the upgrade routine:**
- remove the `view_site_health_checks` capability from the SEO Manager role either via code or by using a Roles Editor plugin e.g. "User Role Editor by Members"
- alter the code in `inc/class-upgrade.php` and change `'xx.x-RC0'  => 'upgrade_xxx',` to, for example, `'13.1-RC0'  => 'upgrade_xxx',`
- log in as admin
- install and activate the Yoast Test Helper plugin
- go to Tools > Yoast Test, and set the Yoast SEO DB version to one that is older than your real version e.g.: real version is `12.9-RC2`? Set it to `12.8`
- this will trigger the upgrade routine
- log out and log in as SEO Manager
- go to WordPress > Tools
- see there are now sub-items in the admin menu under "Tools" and you have access to Site Health


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14250
