### PR TITLE
13825 generate replace vars object renaming

### DIFF
--- a/src/backwards-compatibility/frontend.php
+++ b/src/backwards-compatibility/frontend.php
@@ -174,7 +174,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 		$context = $this->context_memoizer->for_current_page();
 		$title   = $context->presentation->title;
 
-		return $this->replace_vars->replace( $title, $context->presentation->replace_vars_object );
+		return $this->replace_vars->replace( $title, $context->presentation->source );
 	}
 
 	/**

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -140,7 +140,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @return string the title
 	 */
 	public function generate_title() {
-		return $this->replace_vars_helper->replace( $this->presentation->title, $this->presentation->replace_vars_object );
+		return $this->replace_vars_helper->replace( $this->presentation->title, $this->presentation->source );
 	}
 
 	/**
@@ -149,7 +149,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @return string the description
 	 */
 	public function generate_description() {
-		return $this->replace_vars_helper->replace( $this->presentation->meta_description, $this->presentation->replace_vars_object );
+		return $this->replace_vars_helper->replace( $this->presentation->meta_description, $this->presentation->source );
 	}
 
 	/**

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -240,12 +240,12 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			 *
 			 * @api bool Whether or not to show publish date.
 			 */
-			if ( ! apply_filters( 'wpseo_opengraph_show_publish_date', false, $this->post_type->get_post_type( $this->context->post ) ) ) {
+			if ( ! apply_filters( 'wpseo_opengraph_show_publish_date', false, $this->post_type->get_post_type( $this->source ) ) ) {
 				return '';
 			}
 		}
 
-		return $this->date->format( $this->context->post->post_date_gmt );
+		return $this->date->format( $this->source->post_date_gmt );
 	}
 
 	/**
@@ -254,8 +254,8 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 * @return string The open graph article modified time.
 	 */
 	public function generate_og_article_modified_time() {
-		if ( $this->context->post->post_modified_gmt !== $this->context->post->post_date_gmt ) {
-			return $this->date->format( $this->context->post->post_modified_gmt );
+		if ( $this->source->post_modified_gmt !== $this->source->post_date_gmt ) {
+			return $this->date->format( $this->source->post_modified_gmt );
 		}
 
 		return '';
@@ -327,7 +327,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_twitter_creator() {
-		$twitter_creator = \ltrim( \trim( \get_the_author_meta( 'twitter', $this->context->post->post_author ) ), '@' );
+		$twitter_creator = \ltrim( \trim( \get_the_author_meta( 'twitter', $this->source->post_author ) ), '@' );
 
 		/**
 		 * Filter: 'wpseo_twitter_creator_account' - Allow changing the Twitter account as output in the Twitter card by Yoast SEO.

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -200,7 +200,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 * @return string The open graph article author.
 	 */
 	public function generate_og_article_author() {
-		$post = $this->replace_vars_object;
+		$post = $this->source;
 
 		$og_article_author = $this->user->get_the_author_meta( 'facebook', $post->post_author );
 
@@ -264,7 +264,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	/**
 	 * @inheritDoc
 	 */
-	public function generate_replace_vars_object() {
+	public function generate_source() {
 		return \get_post( $this->model->object_id );
 	}
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -49,7 +49,7 @@ use Yoast\WP\SEO\Presentations\Generators\Schema_Generator;
  * @property string twitter_image
  * @property string twitter_creator
  * @property string twitter_site
- * @property array  replace_vars_object
+ * @property array  source
  * @property array  breadcrumbs
  */
 class Indexable_Presentation extends Abstract_Presentation {
@@ -475,11 +475,11 @@ class Indexable_Presentation extends Abstract_Presentation {
 	}
 
 	/**
-	 * Generates the replace vars object.
+	 * Generates the source.
 	 *
-	 * @return array The replace vars object.
+	 * @return array The source.
 	 */
-	public function generate_replace_vars_object() {
+	public function generate_source() {
 		return [];
 	}
 

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 /**
  * Class Indexable_Presentation
  *
- * @property \WP_Term $replace_vars_object
+ * @property \WP_Term $source
  */
 class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	use Archive_Adjacent;
@@ -86,7 +86,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	/**
 	 * @inheritDoc
 	 */
-	public function generate_replace_vars_object() {
+	public function generate_source() {
 		return \get_term( $this->model->object_id, $this->model->object_sub_type );
 	}
 
@@ -137,7 +137,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		 * First we get the no index option for this taxonomy, because it can be overwritten the indexable value for
 		 * this specific term.
 		 */
-		if ( ! $this->taxonomy->is_indexable( $this->replace_vars_object->taxonomy ) ) {
+		if ( ! $this->taxonomy->is_indexable( $this->source->taxonomy ) ) {
 			$robots['index'] = 'noindex';
 		}
 
@@ -160,13 +160,13 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		}
 
 		// Get the SEO title as entered in Search Appearance.
-		$title = $this->options_helper->get( 'title-tax-' . $this->replace_vars_object->taxonomy );
+		$title = $this->options_helper->get( 'title-tax-' . $this->source->taxonomy );
 		if ( $title ) {
 			return $title;
 		}
 
 		// Get the installation default title.
-		$title = $this->options_helper->get_title_default( 'title-tax-' . $this->replace_vars_object->taxonomy );
+		$title = $this->options_helper->get_title_default( 'title-tax-' . $this->source->taxonomy );
 
 		return $title;
 	}
@@ -179,10 +179,10 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	protected function is_multiple_terms_query() {
 		$queried_terms = $this->wp_query_wrapper->get_query()->tax_query->queried_terms;
 
-		if ( empty( $queried_terms[ $this->replace_vars_object->taxonomy ]['terms'] ) ) {
+		if ( empty( $queried_terms[ $this->source->taxonomy ]['terms'] ) ) {
 			return false;
 		}
 
-		return \count( $queried_terms[ $this->replace_vars_object->taxonomy ]['terms'] ) > 1;
+		return \count( $queried_terms[ $this->source->taxonomy ]['terms'] ) > 1;
 	}
 }

--- a/src/presenters/abstract-indexable-presenter.php
+++ b/src/presenters/abstract-indexable-presenter.php
@@ -49,6 +49,6 @@ abstract class Abstract_Indexable_Presenter {
 	 * @return string The meta description with replacement variables replaced.
 	 */
 	protected function replace_vars( $meta_description, Indexable_Presentation $presentation ) {
-		return $this->replace_vars_helper->replace( $meta_description, $presentation->replace_vars_object );
+		return $this->replace_vars_helper->replace( $meta_description, $presentation->source );
 	}
 }

--- a/tests/presentations/indexable-post-type-presentation/og-article-author-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-article-author-test.php
@@ -32,7 +32,7 @@ class OG_Article_Author_Test extends TestCase {
 	 */
 	public function test_generate_og_article_author() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [ 'post_author' => 2 ] );
 
@@ -52,7 +52,7 @@ class OG_Article_Author_Test extends TestCase {
 	 */
 	public function test_generate_og_article_author_no_author() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [ 'post_author' => 2 ] );
 

--- a/tests/presentations/indexable-post-type-presentation/og-article-modified-time-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-article-modified-time-test.php
@@ -30,10 +30,12 @@ class OG_Article_Modified_Time_Test extends TestCase {
 	 * @covers ::generate_og_article_modified_time
 	 */
 	public function test_generate_og_article_modified_time_same_as_published_time() {
-		$this->context->post = (object) [
+		$source = (object) [
 			'post_date_gmt'     => '2019-10-08T12:26:31+00:00',
 			'post_modified_gmt' => '2019-10-08T12:26:31+00:00',
 		];
+		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
+
 		$actual = $this->instance->generate_og_article_modified_time();
 		$this->assertEmpty( $actual );
 	}
@@ -44,10 +46,12 @@ class OG_Article_Modified_Time_Test extends TestCase {
 	 * @covers ::generate_og_article_modified_time
 	 */
 	public function test_generate_og_article_modified_time_differs_from_published_time() {
-		$this->context->post              = (object) [
+		$source = (object) [
 			'post_date_gmt'     => '2019-10-08T12:26:31+00:00',
 			'post_modified_gmt' => '2019-11-09T12:34:56+00:00',
 		];
+
+		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
 
 		$this->date_helper
 			->expects( 'format' )

--- a/tests/presentations/indexable-post-type-presentation/og-article-published-time-test.php
+++ b/tests/presentations/indexable-post-type-presentation/og-article-published-time-test.php
@@ -32,7 +32,9 @@ class OG_Article_Published_Time_Test extends TestCase {
 	 */
 	public function test_generate_og_article_published_time_post() {
 		$this->indexable->object_sub_type = 'post';
-		$this->context->post = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
+
+		$source = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
+		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
 
 		$this->date_helper
 			->expects( 'format' )
@@ -54,6 +56,8 @@ class OG_Article_Published_Time_Test extends TestCase {
 	public function test_generate_og_article_published_time_page() {
 		$this->indexable->object_sub_type = 'page';
 
+		$this->instance->expects( 'generate_source' )->andReturn( (object) [] );
+
 		$this->post_type_helper
 			->expects( 'get_post_type' )
 			->once()
@@ -69,8 +73,10 @@ class OG_Article_Published_Time_Test extends TestCase {
 	 * @covers ::generate_og_article_published_time
 	 */
 	public function test_generate_og_article_published_time_page_enabled() {
-		$this->context->post = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
 		$this->indexable->object_sub_type = 'page';
+
+		$source = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
+		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
 
 		$this->date_helper
 			->expects( 'format' )

--- a/tests/presentations/indexable-post-type-presentation/replace-vars-object-test.php
+++ b/tests/presentations/indexable-post-type-presentation/replace-vars-object-test.php
@@ -6,13 +6,13 @@ use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
 
 /**
- * Class Replace_Vars_Object_Test
+ * Class Generate_Source_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation
  *
  * @group presentations
  */
-class Replace_Vars_Object_Test extends TestCase {
+class Generate_Source_Test extends TestCase {
 	use Presentation_Instance_Builder;
 
 	/**
@@ -28,15 +28,15 @@ class Replace_Vars_Object_Test extends TestCase {
 	/**
 	 * Tests whether the term is returned.
 	 *
-	 * @covers ::generate_replace_vars_object
+	 * @covers ::generate_source
 	 */
-	public function test_generate_replace_vars_object() {
+	public function test_generate_source() {
 		Monkey\Functions\expect( 'get_post' )
 			->with( 11 )
 			->once()
 			->andReturn( 'Example post' );
 
-		$this->assertEquals( 'Example post', $this->instance->generate_replace_vars_object() );
+		$this->assertEquals( 'Example post', $this->instance->generate_source() );
 	}
 }
 

--- a/tests/presentations/indexable-post-type-presentation/twitter-creator-test.php
+++ b/tests/presentations/indexable-post-type-presentation/twitter-creator-test.php
@@ -23,7 +23,8 @@ class Twitter_Creator_Test extends TestCase {
 	public function setUp() {
 		$this->set_instance();
 
-		$this->context->post = (object) [ 'post_author' => 1337 ];
+		$source = (object) [ 'post_author' => 1337 ];
+		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
 
 		parent::setUp();
 	}

--- a/tests/presentations/indexable-presentation/replace-vars-object-test.php
+++ b/tests/presentations/indexable-presentation/replace-vars-object-test.php
@@ -5,13 +5,13 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Replace_Vars_Object_Test
+ * Class Generate_Source_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Presentation
  *
  * @group presentations
  */
-class Replace_Vars_Object_Test extends TestCase {
+class Generate_Source_Test extends TestCase {
 	use Presentation_Instance_Builder;
 
 	/**
@@ -26,9 +26,9 @@ class Replace_Vars_Object_Test extends TestCase {
 	/**
 	 * Tests whether an empty array is returned.
 	 *
-	 * @covers ::generate_replace_vars_object
+	 * @covers ::generate_source
 	 */
-	public function test_generate_replace_vars_object() {
-		$this->assertEquals( [], $this->instance->generate_replace_vars_object() );
+	public function test_generate_source() {
+		$this->assertEquals( [], $this->instance->generate_source() );
 	}
 }

--- a/tests/presentations/indexable-term-archive-presentation/canonical-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/canonical-test.php
@@ -113,7 +113,7 @@ class Canonical_Test extends TestCase {
 	 * @param bool $is_multiple Optional. Determines if the WP query contains multiple terms or not.
 	 */
 	private function setup_multiple_terms_query( $is_multiple = false ) {
-		$this->instance->replace_vars_object = (object) [ 'taxonomy' => 'my-taxonomy' ];
+		$this->instance->source = (object) [ 'taxonomy' => 'my-taxonomy' ];
 
 		$terms = [];
 		if ( $is_multiple ) {

--- a/tests/presentations/indexable-term-archive-presentation/replace-vars-object-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/replace-vars-object-test.php
@@ -6,13 +6,13 @@ use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
 
 /**
- * Class Replace_Vars_Object_Test
+ * Class Generate_Source_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation
  *
  * @group presentations
  */
-class Replace_Vars_Object_Test extends TestCase {
+class Generate_Source_Test extends TestCase {
 	use Presentation_Instance_Builder;
 
 	/**
@@ -29,15 +29,15 @@ class Replace_Vars_Object_Test extends TestCase {
 	/**
 	 * Tests whether the term is returned.
 	 *
-	 * @covers ::generate_replace_vars_object
+	 * @covers ::generate_source
 	 */
-	public function test_generate_replace_vars_object() {
+	public function test_generate_source() {
 		Monkey\Functions\expect( 'get_term' )
 			->with( 11, 'Object subtype' )
 			->once()
 			->andReturn( 'Example term' );
 
-		$this->assertEquals( 'Example term', $this->instance->generate_replace_vars_object() );
+		$this->assertEquals( 'Example term', $this->instance->generate_source() );
 	}
 }
 

--- a/tests/presentations/indexable-term-archive-presentation/robots-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/robots-test.php
@@ -32,7 +32,7 @@ class Robots_Test extends TestCase {
 	 */
 	public function test_generate_robots() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [
 				'taxonomy' => 'category',
@@ -64,7 +64,7 @@ class Robots_Test extends TestCase {
 	 */
 	public function test_generate_robots_taxonomy_not_indexable() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [
 				'taxonomy' => 'category',
@@ -97,7 +97,7 @@ class Robots_Test extends TestCase {
 	 */
 	public function test_generate_robots_taxonomy_not_indexable_term_indexable() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [
 				'taxonomy' => 'category',
@@ -132,7 +132,7 @@ class Robots_Test extends TestCase {
 	 */
 	public function test_generate_robots_taxonomy_indexable_term_not_indexable() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [
 				'taxonomy' => 'category',

--- a/tests/presentations/indexable-term-archive-presentation/title-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/title-test.php
@@ -43,7 +43,7 @@ class Title_Test extends TestCase {
 	 */
 	public function test_with_general_category_seo_title() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [
 				'taxonomy' => 'category',
@@ -67,7 +67,7 @@ class Title_Test extends TestCase {
 	 */
 	public function test_with_default_fallback() {
 		$this->instance
-			->expects( 'generate_replace_vars_object' )
+			->expects( 'generate_source' )
 			->once()
 			->andReturn( (object) [
 				'taxonomy' => 'category',

--- a/tests/presenters/open-graph/description-presenter-test.php
+++ b/tests/presenters/open-graph/description-presenter-test.php
@@ -44,7 +44,7 @@ class Description_Presenter_Test extends TestCase {
 		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
 
 		$this->instance->set_replace_vars_helper( $this->replace_vars );
-		$this->presentation->replace_vars_object = [];
+		$this->presentation->source = [];
 
 		$this->replace_vars
 			->expects( 'replace' )

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -50,8 +50,8 @@ class Title_Presenter_Test extends TestCase {
 		$this->instance = new Title_Presenter( $this->string );
 		$this->instance->set_replace_vars_helper( $this->replace_vars );
 
-		$this->indexable_presentation                      = new Indexable_Presentation();
-		$this->indexable_presentation->replace_vars_object = [];
+		$this->indexable_presentation         = new Indexable_Presentation();
+		$this->indexable_presentation->source = [];
 
 		$this->string
 			->expects( 'strip_all_tags' )

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -50,8 +50,8 @@ class Title_Presenter_Test extends TestCase {
 		$this->instance = new Title_Presenter( $this->string );
 		$this->instance->set_replace_vars_helper( $this->replace_vars );
 
-		$this->indexable_presentation                      = new Indexable_Presentation();
-		$this->indexable_presentation->replace_vars_object = [];
+		$this->indexable_presentation         = new Indexable_Presentation();
+		$this->indexable_presentation->source = [];
 
 		$this->string
 			->expects( 'strip_all_tags' )

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -47,8 +47,8 @@ class Description_Presenter_Test extends TestCase {
 	 * @covers ::filter
 	 */
 	public function test_present() {
-		$presentation = new Indexable_Presentation();
-		$presentation->replace_vars_object = [];
+		$presentation                      = new Indexable_Presentation();
+		$presentation->source              = [];
 		$presentation->twitter_description = 'This is the twitter description';
 
 		$this->replace_vars
@@ -68,8 +68,8 @@ class Description_Presenter_Test extends TestCase {
 	 * @covers ::filter
 	 */
 	public function test_present_with_empty_twitter_description() {
-		$presentation = new Indexable_Presentation();
-		$presentation->replace_vars_object = [];
+		$presentation                      = new Indexable_Presentation();
+		$presentation->source              = [];
 		$presentation->twitter_description = '';
 
 		$this->replace_vars

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -40,7 +40,7 @@ class Title_Presenter_Test extends TestCase {
 		$this->indexable_presentation = new Indexable_Presentation();
 		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
 		$this->instance->set_replace_vars_helper( $this->replace_vars );
-		$this->indexable_presentation->replace_vars_object = [];
+		$this->indexable_presentation->source = [];
 
 		return parent::setUp();
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Renames `replace_vars` property of `Indexable_Presentation` class to `source`.
* `source` property is now used instead of the `context` property to retrieve the source of the indexable (post, archive, page etc.)

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Do a smoke test on posts, pages, terms, custom post types, custom taxonomies, archives. See no PHP errors in query monitor or anywhere else.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #13825
