### PR TITLE
Remove yoast class from wrapper div

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -66,7 +66,7 @@ class Yoast_Form {
 			$option_long_name = WPSEO_Options::get_group_name( $option );
 		}
 		?>
-		<div class="wrap wpseo-admin-page <?php echo esc_attr( 'page-' . $option ); ?>">
+		<div class="wrap <?php echo esc_attr( 'yoast-' . $option ); ?>">
 		<?php
 		/**
 		 * Display the updated/error messages.

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -66,7 +66,7 @@ class Yoast_Form {
 			$option_long_name = WPSEO_Options::get_group_name( $option );
 		}
 		?>
-		<div class="wrap yoast wpseo-admin-page <?php echo esc_attr( 'page-' . $option ); ?>">
+		<div class="wrap wpseo-admin-page <?php echo esc_attr( 'page-' . $option ); ?>">
 		<?php
 		/**
 		 * Display the updated/error messages.

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -28,7 +28,7 @@ if ( isset( $_GET['allow_tracking'] ) && check_admin_referer( 'wpseo_activate_tr
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true, 'wpseo' );
+$yform->admin_header( true, 'general' );
 
 do_action( 'wpseo_all_admin_notices' );
 

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true, 'wpseo_titles' );
+$yform->admin_header( true, 'search-appearance' );
 
 $tabs = new WPSEO_Option_Tabs( 'metas' );
 $tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );

--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( true, 'wpseo_social' );
+$yform->admin_header( true, 'social' );
 
 $tabs = new WPSEO_Option_Tabs( 'social' );
 $tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ) ) );

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $tool_page = (string) filter_input( INPUT_GET, 'tool' );
 
 $yform = Yoast_Form::get_instance();
-$yform->admin_header( false );
+$yform->admin_header( false, 'tools' );
 
 if ( $tool_page === '' ) {
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -113,7 +113,7 @@ $new_tab_message         = sprintf(
 
 ?>
 
-<div class="wrap yoast wpseo_table_page">
+<div class="wrap yoast-premium">
 
 	<h1 id="wpseo-title" class="yoast-h1"><?php echo esc_html( $wpseo_extensions_header ); ?></h1>
 


### PR DESCRIPTION
## Summary

Remove `yoast` class from wrapper div. Can also remove / change more classes if needed, or the entire wrapping `div` it's not needed at all.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* None needed.
