### PR TITLE
Add an ID to the FAQ sections output

### DIFF
--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -4,8 +4,18 @@ import { __ } from "@wordpress/i18n";
 
 /* Internal dependencies */
 import Faq from "./components/FAQ";
+import legacy from "./legacy";
 
 const { registerBlockType } = window.wp.blocks;
+
+const attributes = {
+	questions: {
+		type: "array",
+	},
+	additionalListCssClasses: {
+		type: "string",
+	},
+};
 
 export default () => {
 	registerBlockType( "yoast/faq-block", {
@@ -23,14 +33,7 @@ export default () => {
 			multiple: false,
 		},
 		// Block attributes - decides what to save and how to parse it from and to HTML.
-		attributes: {
-			questions: {
-				type: "array",
-			},
-			additionalListCssClasses: {
-				type: "string",
-			},
-		},
+		attributes,
 
 		/**
 		 * The edit function describes the structure of your block in the context of the editor.
@@ -50,6 +53,7 @@ export default () => {
 			return <Faq { ...{ attributes, setAttributes, className } } />;
 		},
 
+		/* eslint-disable react/display-name */
 		/**
 		 * The save function defines the way in which the different attributes should be combined
 		 * into the final markup, which is then serialized by Gutenberg into post_content.
@@ -59,9 +63,16 @@ export default () => {
 		 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
 		 * @returns {Component} The display component.
 		 */
-		// eslint-disable-next-line react/display-name
 		save: function( { attributes } ) {
 			return <Faq.Content { ...attributes } />;
 		},
+		/* eslint-enable react/display-name */
+
+		deprecated: [
+			{
+				attributes,
+				save: legacy.v13_1,
+			},
+		],
 	} );
 };

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -308,7 +308,7 @@ export default class Question extends Component {
 	 */
 	static Content( question ) {
 		return (
-			<div className={ "schema-faq-section" } key={ question.id }>
+			<div className={ "schema-faq-section" } id={ question.id } key={ question.id }>
 				<RichTextWithAppendedSpace
 					tagName="strong"
 					className="schema-faq-question"

--- a/js/src/structured-data-blocks/faq/legacy/13.1.js
+++ b/js/src/structured-data-blocks/faq/legacy/13.1.js
@@ -1,0 +1,73 @@
+/* External dependencies */
+import PropTypes from "prop-types";
+
+const { RichText } = window.wp.editor;
+
+/* Internal dependencies */
+import appendSpace from "../../../components/higherorder/appendSpace";
+
+/**
+ * This migration is necessary because the HTML markup changed, because in 13.1
+ *  an id attribute was added to the FAQ section.
+ *
+ * See https://github.com/Yoast/wordpress-seo/issues/13166.
+ */
+
+/**
+ * Returns the component of the given question and answer to be rendered in a WordPress post
+ * (e.g. not in the editor).
+ *
+ * @param {object} question The question and its answer.
+ *
+ * @returns {Component} The component to be rendered.
+ */
+function LegacyQuestion( question ) {
+	const RichTextWithAppendedSpace = appendSpace( RichText.Content );
+
+	return (
+		<div className={ "schema-faq-section" } key={ question.id }>
+			<RichTextWithAppendedSpace
+				tagName="strong"
+				className="schema-faq-question"
+				key={ question.id + "-question" }
+				value={ question.question }
+			/>
+			<RichTextWithAppendedSpace
+				tagName="p"
+				className="schema-faq-answer"
+				key={ question.id + "-answer" }
+				value={ question.answer }
+			/>
+		</div>
+	);
+}
+
+/**
+ * Returns the component to be used to render
+ * the FAQ block on Wordpress (e.g. not in the editor).
+ *
+ * @param {object} props The props with attributes of the FAQ block.
+ *
+ * @returns {Component} The component representing a FAQ block.
+ */
+export default function LegacyFaq( props ) {
+	const { questions, className } = props.attributes;
+
+	const QuestionContentWithAppendedSpace = appendSpace( LegacyQuestion );
+
+	const questionList = questions ? questions.map( ( question, index ) =>
+		<QuestionContentWithAppendedSpace key={ index } { ...question } />
+	) : null;
+
+	const classNames = [ "schema-faq", className ].filter( ( i ) => i ).join( " " );
+
+	return (
+		<div className={ classNames }>
+			{ questionList }
+		</div>
+	);
+}
+
+LegacyFaq.propTypes = {
+	attributes: PropTypes.object.isRequired,
+};

--- a/js/src/structured-data-blocks/faq/legacy/index.js
+++ b/js/src/structured-data-blocks/faq/legacy/index.js
@@ -1,0 +1,6 @@
+/* eslint-disable camelcase */
+import v13_1 from "./13.1";
+
+export default {
+	v13_1,
+};

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -81,6 +81,7 @@ export default () => {
 			return <HowTo { ...{ attributes, setAttributes, className } } />;
 		},
 
+		/* eslint-disable react/display-name */
 		/**
 		 * The save function defines the way in which the different attributes should be combined
 		 * into the final markup, which is then serialized by Gutenberg into post_content.
@@ -90,10 +91,10 @@ export default () => {
 		 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
 		 * @returns {Component} The display component.
 		 */
-		// eslint-disable-next-line react/display-name
 		save: function( { attributes } ) {
 			return <HowTo.Content { ...attributes } />;
 		},
+		/* eslint-enable react/display-name */
 
 		deprecated: [
 			{


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an ID to the FAQ sections in the front end output.

## Relevant technical choices:

- added an ID to the `Content` output
- added a block transform: please someone familiar with transforms double check this part: first time trying to code a block transform and it could be totally wrong 🙂 
- fixed a couple ESLint warnings to keep their amount under the current `max-warnings`

**Note:**
I'm not sure how a block transform is supposed to work. For me, the actual output is updated only after the post is updated. I was expecting the transform to be saved automatically. As it works now, it actually requires users to go through all the posts with a FAQ block and update all of them.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
**For QA:**
- Install YoastSEO 13.1
- create a post with a FAQ block and add a couple Q/A
- publish the post
- inspect the source in the front end
- see the FAQ sections don't have an ID, for example:

```
<div class="schema-faq wp-block-yoast-faq-block">
	<div class="schema-faq-section"> <--
	...
	<div class="schema-faq-section"> <--
	...

```
- see the How-to questions do have an ID
- Install the 13.2 RC.
- Reload or open the editor for the created post again.
- in your browser console you should see messages like:
  - `Block successfully updated for `yoast/faq-block``
  - `New content generated by `save` function: ...`
  - `Content retrieved from post body: ...`
- Update the post.
- inspect the source in the front end
- check the FAQ sections now have an ID e.g. ` id="faq-question-1580821876913"`
- check the IDs match the ones used in the Schema output

**For Development:**
- on trunk
- create a post with a FAQ block and add a couple Q/A
- add also a How-to block
- publish the post
- inspect the source in the front end
- see the FAQ sections don't have an ID, for example:

```
<div class="schema-faq wp-block-yoast-faq-block">
	<div class="schema-faq-section"> <--
	...
	<div class="schema-faq-section"> <--
	...

```
- see the How-to questions do have an ID
- switch to this branch and build
- update the post in the admin
- in your browser console you should see messages like:
  - `Block successfully updated for `yoast/faq-block``
  - `New content generated by `save` function: ...`
  - `Content retrieved from post body: ...`
- inspect the source in the front end
- check the FAQ sections now have an ID e.g. ` id="faq-question-1580821876913"`
- check the IDs match the ones used in the Schema output

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13166