### PR TITLE
Improve the Ryte health check "cannot be indexed" copy

### DIFF
--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -127,28 +127,18 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 
 		$this->description  = sprintf(
 			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-			esc_html__( '%1$s offers a free indexability check for %2$s users and it has determined that your site
-			cannot be found by search engines. If this site is live or about to become live, this should be fixed.', 'wordpress-seo' ),
+			esc_html__( '%1$s offers a free indexability check for %2$s users and it has determined that your site cannot be found by search engines. If this site is live or about to become live, this should be fixed.', 'wordpress-seo' ),
 			'Ryte',
 			'Yoast SEO'
 		);
-		$this->description .= '<br /><br />';
-		$this->description .= sprintf(
-			/* translators: %1$s: Opening tag of the link to the reading settings page, %2$s: Link closing tag, %3$s: Strong opening tag, %4$s: Strong closing tag. */
-			esc_html__( 'As a first step, %1$sgo to your site\'s Reading Settings%2$s and make sure the option to
-				discourage search engine visibility is %3$snot enabled%4$s, then re-analyze your site indexability.', 'wordpress-seo' ),
-			'<a href="' . esc_url( admin_url( 'options-reading.php' ) ) . '">',
-			'</a>',
-			'<strong>',
-			'</strong>'
-		);
-		$this->description .= '<br /><br />';
-		$this->description .= sprintf(
+
+		$this->actions  = sprintf(
 			/* translators: %1$s: Opening tag of the link to the Yoast knowledge base, %2$s: Link closing tag. */
-			esc_html__( 'If that did not help, %1$sread more about troubleshooting search engine visibility.%2$s', 'wordpress-seo' ),
+			esc_html__( '%1$sRead more about troubleshooting search engine visibility.%2$s', 'wordpress-seo' ),
 			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/onpageindexerror' ) ) . '" target="_blank">',
 			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
 		);
+		$this->actions .= '<br /><br />';
 
 		$this->add_analyze_site_links();
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the copy for the "cannot be indexed" case of the Ryte indexability Site Health check.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- in the file `admin/ryte/class-ryte-request.php` add `$target_url = 'http://testingwceu2019.altervista.org/';` on the first line of the `get_remote()` method: this site is not indexable
- go to the Site Health page and make sure to fetch the Ryte status by clicking the Re-analyze link or by manually appending the URL query parameter `?wpseo-redo-ryte=1`
- see the test listed in the "critical issues" section and reporting "Your site cannot be found by search engines"

Copy before:

<img width="842" alt="Screenshot 2020-02-05 at 08 54 11" src="https://user-images.githubusercontent.com/1682452/73823484-a4c42180-47f8-11ea-8e13-9673f23edcb2.png">

Copy after:

<img width="841" alt="Screenshot 2020-02-05 at 09 01 17" src="https://user-images.githubusercontent.com/1682452/73823490-abeb2f80-47f8-11ea-8a5a-acf7943b006f.png">

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14253