### PR TITLE
Improve Ryte site health checks usability

### DIFF
--- a/admin/ryte/class-ryte-option.php
+++ b/admin/ryte/class-ryte-option.php
@@ -117,6 +117,10 @@ class WPSEO_Ryte_Option {
 	 * @return bool
 	 */
 	public function should_be_fetched() {
+		if ( ! isset( $this->ryte_option[ self::LAST_FETCH ] ) ) {
+			return true;
+		}
+
 		return ( ( time() - $this->ryte_option[ self::LAST_FETCH ] ) > self::FETCH_LIMIT );
 	}
 

--- a/admin/ryte/class-ryte-option.php
+++ b/admin/ryte/class-ryte-option.php
@@ -112,9 +112,13 @@ class WPSEO_Ryte_Option {
 	}
 
 	/**
-	 * Check if the last fetch is within the time of 15 seconds.
+	 * Determines whether the indexability status should be fetched.
 	 *
-	 * @return bool
+	 * If LAST_FETCH isn't set, we assume the indexability status hasn't been fetched
+	 * yet and return true. Then, we check whether the last fetch is within the
+	 * FETCH_LIMIT time interval (15 seconds) to avoid too many consecutive API calls.
+	 *
+	 * @return bool Whether the indexability status should be fetched.
 	 */
 	public function should_be_fetched() {
 		if ( ! isset( $this->ryte_option[ self::LAST_FETCH ] ) ) {

--- a/admin/ryte/class-ryte.php
+++ b/admin/ryte/class-ryte.php
@@ -22,7 +22,6 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 */
 	public function __construct() {
 		$this->maybe_add_weekly_schedule();
-		$this->catch_redo_listener();
 	}
 
 	/**
@@ -189,23 +188,6 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 		}
 
 		wp_clear_scheduled_hook( 'wpseo_ryte_fetch' );
-	}
-
-	/**
-	 * Redo the fetch request for Ryte.
-	 *
-	 * @return void
-	 */
-	private function catch_redo_listener() {
-		if ( ! self::is_active() ) {
-			return;
-		}
-
-		if ( filter_input( INPUT_GET, 'wpseo-redo-ryte' ) === '1' ) {
-			$this->is_manual_request = true;
-
-			add_action( 'admin_init', [ $this, 'fetch_from_ryte' ] );
-		}
 	}
 
 	/**

--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -134,7 +134,7 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
 		);
 
-		$this->add_ryte_link());
+		$this->add_ryte_link();
 	}
 
 	/**

--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -37,16 +37,25 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 			return;
 		}
 
+		/*
+		 * Fetch the indexability status, set last fetch time, and update the
+		 * Ryte option status. Will run a new fetch only if the last fetch is not
+		 * within the `WPSEO_Ryte_Option::FETCH_LIMIT` time interval.
+		 */
+		$wpseo_ryte = new WPSEO_Ryte();
+		$wpseo_ryte->fetch_from_ryte();
+
+		// Get the updated Ryte option.
+		$this->ryte_option = $this->get_ryte_option();
+
 		switch ( $this->ryte_option->get_status() ) {
-			case WPSEO_Ryte_Option::NOT_FETCHED:
-				$this->is_not_fetched_yet();
-				break;
 			case WPSEO_Ryte_Option::IS_NOT_INDEXABLE:
 				$this->is_not_indexable_response();
 				break;
 			case WPSEO_Ryte_Option::IS_INDEXABLE:
 				$this->is_indexable_response();
 				break;
+			case WPSEO_Ryte_Option::NOT_FETCHED:
 			default: // WPSEO_Ryte_Option::CANNOT_FETCH.
 				$this->unknown_indexability_response();
 				break;
@@ -88,31 +97,6 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 	 */
 	protected function get_ryte_option() {
 		return new WPSEO_Ryte_Option();
-	}
-
-	/**
-	 * Adds the content for the "Not fetched yet" case.
-	 *
-	 * @return void
-	 */
-	protected function is_not_fetched_yet() {
-		$this->label          = sprintf(
-			/* translators: %1$s: expands to Yoast SEO, %2$s: expands to Ryte. */
-			esc_html__( '%1$s has not checked your site indexability status yet from %2$s', 'wordpress-seo' ),
-			'Yoast SEO',
-			'Ryte'
-		);
-		$this->status         = self::STATUS_RECOMMENDED;
-		$this->badge['color'] = 'red';
-
-		$this->description = sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-			esc_html__( '%1$s offers a free indexability check for %2$s users. If this site is live or about to become live, it is recommended that you check the indexability status now.', 'wordpress-seo' ),
-			'Ryte',
-			'Yoast SEO'
-		);
-
-		$this->add_check_current_status_link();
 	}
 
 	/**
@@ -206,35 +190,12 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 	 * @return void
 	 */
 	protected function add_analyze_site_links() {
-		if ( $this->ryte_option->should_be_fetched() ) {
-			$this->actions .= sprintf(
-				/* translators: %1$s: Opening link tag to fetch current Ryte indexability status, %2$s: Link closing tag. */
-				esc_html__( '%1$sRe-analyze site indexability%2$s', 'wordpress-seo' ),
-				'<a class="fetch-status button yoast-site-health__inline-button" href="' . esc_url( add_query_arg( 'wpseo-redo-ryte', '1', admin_url( 'site-health.php' ) ) ) . '">',
-				'</a>'
-			);
-		}
-
 		$this->actions .= sprintf(
 			/* translators: %1$s: Opening tag of the link to the Yoast Ryte website, %2$s: Expands to 'Ryte', %3$s: Link closing tag. */
 			esc_html__( '%1$sGo to %2$s to analyze your entire site%3$s', 'wordpress-seo' ),
 			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/rytelp' ) ) . '" target="_blank">',
 			'Ryte',
 			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
-		);
-	}
-
-	/**
-	 * Adds the "Check indexability status" link styled like a button.
-	 *
-	 * @return void
-	 */
-	protected function add_check_current_status_link() {
-		$this->actions .= sprintf(
-			/* translators: %1$s: Opening link tag to fetch Ryte indexability status, %2$s: Link closing tag. */
-			esc_html__( '%1$sCheck the indexability status%2$s', 'wordpress-seo' ),
-			'<a class="fetch-status button yoast-site-health__inline-button" href="' . esc_url( add_query_arg( 'wpseo-redo-ryte', '1', admin_url( 'site-health.php' ) ) ) . '">',
-			'</a>'
 		);
 	}
 }

--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -134,7 +134,7 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
 		);
 
-		$this->add_analyze_site_links();
+		$this->add_ryte_link());
 	}
 
 	/**
@@ -162,7 +162,7 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
 		);
 
-		$this->add_analyze_site_links();
+		$this->add_ryte_link();
 	}
 
 	/**
@@ -185,11 +185,11 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 	}
 
 	/**
-	 * Adds the "Re-analyze site indexability" link styled like a button and the link to the Ryte site to the actions.
+	 * Adds the link to the Ryte site to the actions.
 	 *
 	 * @return void
 	 */
-	protected function add_analyze_site_links() {
+	protected function add_ryte_link() {
 		$this->actions .= sprintf(
 			/* translators: %1$s: Opening tag of the link to the Yoast Ryte website, %2$s: Expands to 'Ryte', %3$s: Link closing tag. */
 			esc_html__( '%1$sGo to %2$s to analyze your entire site%3$s', 'wordpress-seo' ),

--- a/tests/inc/health-check-ryte-test.php
+++ b/tests/inc/health-check-ryte-test.php
@@ -16,12 +16,12 @@ use WPSEO_Utils;
 class WPSEO_Health_Check_Ryte_Test extends TestCase {
 
 	/**
-	 * @var \Mockery\Mock WPSEO_Ryte_Option
+	 * @var \Mockery\Mock|\WPSEO_Ryte_Option
 	 */
 	private $ryte_option;
 
 	/**
-	 * @var \Mockery\Mock WPSEO_Health_Check_Ryte
+	 * @var \Mockery\Mock|\WPSEO_Health_Check_Ryte
 	 */
 	private $health_check;
 
@@ -130,12 +130,8 @@ class WPSEO_Health_Check_Ryte_Test extends TestCase {
 		Monkey\Functions\stubs(
 			[
 				'wp_remote_get'                    => null,
-				'wp_remote_retrieve_response_code' => function () {
-					return 200;
-				},
-				'wp_remote_retrieve_body'          => function () {
-					return WPSEO_Utils::format_json_encode( [] );
-				},
+				'wp_remote_retrieve_response_code' => 200,
+				'wp_remote_retrieve_body'          => WPSEO_Utils::format_json_encode( [] ),
 			]
 		);
 
@@ -172,12 +168,8 @@ class WPSEO_Health_Check_Ryte_Test extends TestCase {
 		Monkey\Functions\stubs(
 			[
 				'wp_remote_get'                    => null,
-				'wp_remote_retrieve_response_code' => function () {
-					return 500;
-				},
-				'wp_remote_retrieve_body'          => function () {
-					return null;
-				},
+				'wp_remote_retrieve_response_code' => 500,
+				'wp_remote_retrieve_body'          => null,
 			]
 		);
 
@@ -212,12 +204,8 @@ class WPSEO_Health_Check_Ryte_Test extends TestCase {
 		Monkey\Functions\stubs(
 			[
 				'wp_remote_get'                    => null,
-				'wp_remote_retrieve_response_code' => function () {
-					return 200;
-				},
-				'wp_remote_retrieve_body'          => function () {
-					return WPSEO_Utils::format_json_encode( [] );
-				},
+				'wp_remote_retrieve_response_code' => 200,
+				'wp_remote_retrieve_body'          => WPSEO_Utils::format_json_encode( [] ),
 			]
 		);
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the usability of the Ryte indexability Site Health check.

## Relevant technical choices:

- The check now fetches the Ryte indexability status on page load instead of requiring action from users.
- Keeps the 15 seconds interval set by `FETCH_LIMIT`: new fetches can only happen after 15 seconds from the previous one. Thinking it is good to keep this, can be removed if desired.
- The "not fetched yet" case is now pointless, as the test always runs and fetches on page load. Removed.
- Removed the "Check the indexability status" button that was initially displayed when the Ryte indexability wasn't fetched yet.
- Removed the "Re-analyze site indexability" button as no user action should be required.
- Adjusted the tests: please double check this part as I'm not that familiar with monkeys 🐵 
- Please note that when passing a non-reachable site URL, the Ryte API returns an error 500 and the body response is `null` e.g. `https://indexability.yoast.onpage.org/?url=http://my-non-reachable-awesome-site.org`. One test reflects this scenario. Should be updated if / when any change happens on the API side.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Make sure at least 15 seconds have passed between an indexbility status fetch and the following one.

- delete the `wpseo_ryte` option, or the `wpseo_onpage` if you still have the old one, from the options table in your database
- switch to this branch and build
- go to the Site Health page: Tools > Site Health
- the indexability status is fetched for the first time
- on a local environment the initial status should be "cannot determine..."
- see the test appears in the "recommended improvements" section
- see the test label is "Ryte cannot determine whether your site can be found by search engines"

**Is indexable case:**
- navigate away from the Site Health page
- in the file `admin/ryte/class-ryte-request.php` add `$target_url = 'https://yoast.com/';` on the first line of the `get_remote()` method
- go to the Site Health page
- see the test is now displayed within the "Passed tests" section
- see the test label is "Your site can be found by search engines"

**Is not indexable case:**
- navigate away from the Site Health page
- in the file `admin/ryte/class-ryte-request.php` add `$target_url = 'http://testingwceu2019.altervista.org/';` on the first line of the `get_remote()` method: this site disallow search engines in its robots.txt file thus is not indexable
- go to the Site Health page
- see the test is now displayed within the "critical issues" section
- see the test label is "Your site cannot be found by search engines"

**Cannot fetch case:**
- navigate away from the Site Health page
- in the file `admin/ryte/class-ryte-request.php` add `$target_url = 'http://my-non-reachable-awesome-site.org/';` on the first line of the `get_remote()` method: this site doesn't exist thus it's not reachable
- go to the Site Health page
- see the test is now displayed within the "recommended improvements" section
- see the test label is "Ryte cannot determine whether your site can be found by search engines"

**Really test the status is fetched immediately on page load:**
- stay on the Site Health page
- change the `$target_url` value to one of the other example sites
- refresh the page and, assuming 15 seconds have passed from the previous fetch, the test result should change immediately
- change back and forth the `$target_url` value to a different site
- refresh again the Site Health page _within_ 15 seconds
- no change should happen
- keep refreshing
- after 15 seconds have passed, the test result should change

## Important note
This PR is a first step to make this test run synchronously on page load. It's a first important step so that we can test the new flow and the new feedback given to users.

Later on, this test should be made asynchronous to not slow down the Site Health page loading. Right now, there's a noticeable delay of 1-2 seconds at best. Depending on network conditions and the API response readiness, the delay may be even longer,

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14245