### PR TITLE
Add potentialAction to webpage and article Schema

### DIFF
--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -81,7 +81,8 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		$data = $this->add_keywords( $data );
 		$data = $this->add_sections( $data );
 		$data = WPSEO_Schema_Utils::add_piece_language( $data );
-		if ( $comment_count['approved'] > 0 ) {
+
+		if ( post_type_supports( $post->post_type, 'comments' ) && $post->comment_status === 'open' ) {
 			$data = $this->add_potential_action( $data );
 		}
 

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -81,6 +81,9 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		$data = $this->add_keywords( $data );
 		$data = $this->add_sections( $data );
 		$data = WPSEO_Schema_Utils::add_piece_language( $data );
+		if ( $comment_count['approved'] > 0 ) {
+			$data = $this->add_potential_action( $data );
+		}
 
 		return $data;
 	}
@@ -182,6 +185,30 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 				'@id' => $this->context->canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
 			];
 		}
+
+		return $data;
+	}
+
+	/**
+	 * Adds the potential action JSON LD code to an Article Schema piece.
+	 *
+	 * @param array $data The Article data array.
+	 *
+	 * @return array $data
+	 */
+	private function add_potential_action( $data ) {
+		/**
+		 * Filter: 'wpseo_schema_article_potential_action_target' - Allows filtering of the schema Article potentialAction target.
+		 *
+		 * @api array $targets The URLs for the Article potentialAction target.
+		 */
+		$targets = apply_filters( 'wpseo_schema_article_potential_action_target', [ $this->context->canonical . '#comments' ] );
+
+		$data['potentialAction'][] = [
+			'@type'  => 'CommentAction',
+			'name'   => 'Comment',
+			'target' => $targets,
+		];
 
 		return $data;
 	}

--- a/frontend/schema/class-schema-article.php
+++ b/frontend/schema/class-schema-article.php
@@ -203,7 +203,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 		 *
 		 * @api array $targets The URLs for the Article potentialAction target.
 		 */
-		$targets = apply_filters( 'wpseo_schema_article_potential_action_target', [ $this->context->canonical . '#comments' ] );
+		$targets = apply_filters( 'wpseo_schema_article_potential_action_target', [ $this->context->canonical . '#respond' ] );
 
 		$data['potentialAction'][] = [
 			'@type'  => 'CommentAction',

--- a/frontend/schema/class-schema-webpage.php
+++ b/frontend/schema/class-schema-webpage.php
@@ -95,6 +95,8 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 			];
 		}
 
+		$data = $this->add_potential_action( $data );
+
 		return $data;
 	}
 
@@ -169,5 +171,32 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 		 * @api string $type The WebPage type.
 		 */
 		return apply_filters( 'wpseo_schema_webpage_type', $type );
+	}
+
+	/**
+	 * Adds the potential action JSON LD code to a WebPage Schema piece.
+	 *
+	 * @param array $data The WebPage data array.
+	 *
+	 * @return array $data
+	 */
+	private function add_potential_action( $data ) {
+		if ( $this->determine_page_type() !== 'WebPage' ) {
+			return $data;
+		}
+
+		/**
+		 * Filter: 'wpseo_schema_webpage_potential_action_target' - Allows filtering of the schema WebPage potentialAction target.
+		 *
+		 * @api array $targets The URLs for the WebPage potentialAction target.
+		 */
+		$targets = apply_filters( 'wpseo_schema_webpage_potential_action_target', [ $this->context->canonical ] );
+
+		$data['potentialAction'][] = [
+			'@type'  => 'ReadAction',
+			'target' => $targets,
+		];
+
+		return $data;
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `potentialAction` entity to the `WebPage` and `Article` Schema pieces.

## Relevant technical choices:
Introduces two new filters to extend the action targets.

> When a page contains a valid Article piece, and comments are _enabled_ for the page ...

I made it in a way that `potentialAction` is output only when there are _approved_ comments regardless whether comments are enabled. For example, a post might have comments initially enabled and get some comments. Later on, the admin might decide to disallow comments. Also, we need to take into consideration the WordPress setting `Automatically close comments on posts older than nn days` could be on.

> We assume that {{URL}}#comment ...

Note that the URL fragment identifier that WordPress uses by default is `#comments` with a trailing `s`.



## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**WebPage:**
- in the front end, go to a post or a page that is _not_:
  -  home
  - the blog page
  - an archive page
  - a search page
  - an author page
- inspect the Schema output
- verify the `WebPage` piece has a `potentialAction`
- example output:
```
        {
            "@type": "WebPage",
            "@id": "http://local.wordpress.test/sample-page/#webpage",
            "url": "http://local.wordpress.test/sample-page/",
            "name": "Sample Page - WordPress stable",
            "isPartOf": {
                "@id": "http://local.wordpress.test/#website"
            },
            "inLanguage": "en-US",
            "datePublished": "2018-06-05T14:48:19+00:00",
            "dateModified": "2018-06-05T14:48:19+00:00",
            "breadcrumb": {
                "@id": "http://local.wordpress.test/sample-page/#breadcrumb"
            },
            "potentialAction": [
                {
                    "@type": "ReadAction",
                    "target": [
                        "http://local.wordpress.test/sample-page/"
                    ]
                }
            ]
        },
```
- test the filter `wpseo_schema_webpage_potential_action_target`
- example usage:
```
add_filter( 'wpseo_schema_webpage_potential_action_target', 'one_more_target_read_action_target' );
function one_more_target_read_action_target( $targets ) {
	$targets[] = 'http://onemorereadaction.org';

	return $targets;
}
```

**Article:**
- verify that the `potentialAction` is output in the `Article` piece only when comments are allowed
- allowing comments can be changed in several ways in WordPress but it always ends up in the value of the `$post->comment_status` property to be `open` or `closed`
- For example, go to the Discussion Settings and change the settings:
	- Allow people to submit comments on new posts (affects only _new_ posts)
	- Automatically close comments on posts older than `nn` days  (affects only posts older than nn days)
- Or on a per-post basis, change the specific post setting (this can be quickly changed via the WordPress Quick Edit form)

<img width="1271" alt="Screenshot 2020-02-07 at 11 59 59" src="https://user-images.githubusercontent.com/1682452/74028400-7d14bb00-49aa-11ea-9768-76731d3fbb25.png">


- in the front end, go to a post (of type `post`) and inspect the Schema output
- verify the Article potentialAction is output only when comments are open
- example output:
```
        {
            "@type": "Article",
            "@id": "http://local.wordpress.test/template-comments/#article",
            "isPartOf": {
                "@id": "http://local.wordpress.test/template-comments/#webpage"
            },
            "author": {
                "@id": "http://local.wordpress.test/#/schema/person/320b0a2fd0a9bd645dac1e59a6c9e7e8"
            },
            "headline": "Template: Comments",
            "datePublished": "2012-01-03T17:11:37+00:00",
            "dateModified": "2012-01-03T17:11:37+00:00",
            "commentCount": "18",
            "mainEntityOfPage": {
                "@id": "http://local.wordpress.test/template-comments/#webpage"
            },
            "publisher": {
                "@id": "http://local.wordpress.test/#/schema/person/04e5e504da5906ca87c05b0a4d6ecbef"
            },
            "keywords": "comments,template",
            "articleSection": "Template",
            "inLanguage": "en-US",
            "potentialAction": [
                {
                    "@type": "CommentAction",
                    "name": "Comment",
                    "target": [
                        "http://local.wordpress.test/template-comments/#comments"
                    ]
                }
            ]
        },
```
- test the filter `wpseo_schema_article_potential_action_target`
- example usage:
```
add_filter( 'wpseo_schema_article_potential_action_target', 'one_more_comment_action_target' );
function one_more_comment_action_target( $targets ) {
	$targets[] = 'http://onemorecommentaction.org';

	return $targets;
}
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14012