### PR TITLE
Show FAQPage as page type in schema output

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -153,7 +153,7 @@ class Schema_Generator implements Generator_Interface {
 		foreach ( $context->blocks as $block_type => $blocks ) {
 			foreach ( $blocks as $block ) {
 				/**
-				 * Filter: 'wpseo_schema_block_<block-type>' - Allows filtering graph output per block. 
+				 * Filter: 'wpseo_schema_block_<block-type>' - Allows filtering graph output per block.
 				 *
 				 * @param WP_Block_Parser_Block $block   The block.
 				 * @param Meta_Tags_Context     $context A value object with context variables.

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -105,8 +105,8 @@ class Schema_Generator implements Generator_Interface {
 			\do_action( 'wpseo_pre_schema_block_type_' . $block_type, $context->blocks[ $block_type ], $context );
 		}
 
+		$pieces_to_generate = [];
 		foreach ( $pieces as $piece ) {
-
 			$identifier = \strtolower( \str_replace( 'Yoast\WP\SEO\Presentations\Generators\Schema\\', '', \get_class( $piece ) ) );
 			if ( property_exists( $piece, 'identifier' ) ) {
 				$identifier = $piece->identifier;
@@ -122,6 +122,10 @@ class Schema_Generator implements Generator_Interface {
 				continue;
 			}
 
+			$pieces_to_generate[ $identifier ] = $piece;
+		}
+
+		foreach ( $pieces_to_generate as $identifier => $piece ) {
 			$graph_pieces = $piece->generate( $context );
 			// If only a single graph piece was returned.
 			if ( isset( $graph_pieces['@type'] ) ) {
@@ -149,7 +153,7 @@ class Schema_Generator implements Generator_Interface {
 		foreach ( $context->blocks as $block_type => $blocks ) {
 			foreach ( $blocks as $block ) {
 				/**
-				 * Filter: 'wpseo_schema_block_<block-type>' - Allows filtering graph output per block.
+				 * Filter: 'wpseo_schema_block_<block-type>' - Allows filtering graph output per block. 
 				 *
 				 * @param WP_Block_Parser_Block $block   The block.
 				 * @param Meta_Tags_Context     $context A value object with context variables.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Fixes a bug where FAQ page was missing in the page type

## Relevant technical choices:

* Altering the pagetype was done in the same loop as the generating was done. Because of this the `schema_page_type` was already set. I've solved this by splitting the logic. 
* In this case the `is_needed` method for the FAQblock was altering the schema_page_type. Unfortunately the `generate` method of the WebPage part was already executed. This causes the `schema_page_type` already been set and altering was not possible.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Adds a FAQ block to a page and verify the JSON-LD has the right output for page type.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14283
