### PR TITLE
Handle the Ryte API response errors

### DIFF
--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -38,14 +38,24 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 		}
 
 		/*
-		 * Fetch the indexability status, set last fetch time, and update the
-		 * Ryte option status. Will run a new fetch only if the last fetch is not
-		 * within the `WPSEO_Ryte_Option::FETCH_LIMIT` time interval.
+		 * Run the request to fetch the indexability status. Set last fetch time.
+		 * Update the Ryte option status. Will run a new request only if the last
+		 * one is not within the `WPSEO_Ryte_Option::FETCH_LIMIT` time interval.
 		 */
 		$wpseo_ryte = new WPSEO_Ryte();
 		$wpseo_ryte->fetch_from_ryte();
 
-		// Get the updated Ryte option.
+		// Get the Ryte API response to properly handle errors.
+		$response = $wpseo_ryte->get_response();
+
+		if ( is_array( $response ) && isset( $response['is_error'] ) ) {
+			$this->response_error( $response );
+			$this->add_yoast_signature();
+
+			return;
+		}
+
+		// The request was successful: get the updated Ryte option.
 		$this->ryte_option = $this->get_ryte_option();
 
 		switch ( $this->ryte_option->get_status() ) {
@@ -97,6 +107,46 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 	 */
 	protected function get_ryte_option() {
 		return new WPSEO_Ryte_Option();
+	}
+
+	/**
+	 * Adds the content for a failed Ryte API request.
+	 *
+	 * @param array $response The error details.
+	 *
+	 * @return void
+	 */
+	protected function response_error( $response ) {
+		$this->label          = esc_html__( 'An error occured while checking whether your site can be found by search engines', 'wordpress-seo' );
+		$this->status         = self::STATUS_RECOMMENDED;
+		$this->badge['color'] = 'red';
+
+		$this->description = sprintf(
+			'%s<br><br>%s',
+			sprintf(
+				/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
+				esc_html( '%1$s offers a free indexability check for %2$s users. The request to %1$s to check whether your site can be found by search engines failed due to an error.', 'wordpress-seo' ),
+				'Ryte',
+				'Yoast SEO'
+			),
+			sprintf(
+				/* translators: 1: The Ryte response raw error code, if any. 2: The error message. 3: The WordPress error code, if any. */
+				__( 'Error details: %1$s %2$s %3$s', 'wordpress-seo' ),
+				$response['raw_error_code'],
+				$response['message'],
+				$response['wp_error_code']
+			)
+		);
+
+		$this->actions = sprintf(
+			/* translators: %1$s: Opening tag of the link to the Yoast knowledge base, %2$s: Link closing tag. */
+			esc_html__( 'If this is a live site, %1$sit is recommended that you figure out why the check failed.%2$s', 'wordpress-seo' ),
+			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/onpagerequestfailed' ) ) . '" target="_blank">',
+			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
+		);
+		$this->actions .= '<br /><br />';
+
+		$this->add_ryte_link();
 	}
 
 	/**

--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -117,7 +117,7 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 	 * @return void
 	 */
 	protected function response_error( $response ) {
-		$this->label          = esc_html__( 'An error occured while checking whether your site can be found by search engines', 'wordpress-seo' );
+		$this->label          = esc_html__( 'An error occurred while checking whether your site can be found by search engines', 'wordpress-seo' );
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
 

--- a/tests/inc/health-check-ryte-test.php
+++ b/tests/inc/health-check-ryte-test.php
@@ -258,7 +258,7 @@ class WPSEO_Health_Check_Ryte_Test extends TestCase {
 		Monkey\Functions\expect( 'update_option' )->andReturn( true );
 
 		$this->health_check->run();
-		$this->assertAttributeEquals( 'An error occured while checking whether your site can be found by search engines', 'label', $this->health_check );
+		$this->assertAttributeEquals( 'An error occurred while checking whether your site can be found by search engines', 'label', $this->health_check );
 		$this->assertAttributeEquals( 'recommended', 'status', $this->health_check );
 	}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds errors handling for the Ryte indexability status request.

## Important notes:
I'd like this PR to be discussed with a senior dev before CR / Acceptance for a couple important things:
1. Seems to me the `CANNOT_FETCH` case now happens only when users try a new request within the 15 seconds `FETCH_LIMIT` item interval. All errors should now be handled. If I'm correct, we could turn this to our advantage and display a proper message in the Site Health page. Right now, there's no feedback for users that the request didn't run because 15 seconds haven't passed yet.
2. To handle errors there's the need to check the actual response. I've implemented part of the logic within the `WPSEO_Ryte` class instead of putting everything into the `WPSEO_Ryte_Request` class to avoid a more substantial refactoring. Please let me know if this is OK.

## Relevant technical choices:
- added logic to check the Ryte response and handle errors
- handles errors that are `WP_Error`s
- handles other HTTP errors with a response code different from `200`
- added one test
- improved documentation and formatting
- `WPSEO_Ryte->request_indexability()` used to return false if the request failed, see https://github.com/Yoast/wordpress-seo/blame/136c1b530996f6e21d432bf30712665d59f53162/admin/onpage/class-onpage.php. This is no longer the case: removed the related check.
- `WPSEO_Ryte_Request->get_remote()` used to throw an Exception on failure. This is no longer the case: removed the `@throws` notation.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

There's the need to manually trigger some error to test the Ryte check in the Site Health page. For example:
- add `define( 'WP_HTTP_BLOCK_EXTERNAL', true );` in your `wp_config.php` file
- go to the Site Health page
- see the Ryte check reports an error
- error label: "An error occurred while checking whether your site can be found by search engines"
- error details; "User has blocked requests through HTTP. (http_request_not_executed)"

**OR:**
- add `$target_url = 'https://nonexisting.yoast.com/';` on the first line of the `WPSEO_Ryte_Request->get_remote()` method
- it's a non existing site, the Ryte API will return an error 500
- go to the Site Health page
- see the Ryte check reports an error
- error label: same as above
- error details: "500 Internal Server Error"

**OR:**
- not 100% reproducible: try to make the Ryte request timeout
- change the `target_url` to a site that is reachable e.g. `$target_url = 'https://yoast.com/';`
- in the `WPSEO_Ryte_Request->get_remote()` method change the line `$response   = wp_remote_get( $url );` to `$response   = wp_remote_get( $url, [ 'timeout', 1 ] );`
- throttle the network via your browser dev tools e.g. on Chrome > Network tab > change "Online" to "Slow3G"
- this will only help to get a timeout
- you actually need that the Ryte response is a bit slower than usual for some reason
- refresh the Site Health page until you get a timeout
- remember you need to wait 15 seconds between each refresh
- with some luck you will get a timeout
- see the error reported
- error label: same as above
- error details: "cURL error 28: Operation timed out after 5001 milliseconds with 0 bytes received (http_request_failed)"

**OR:**
- disconnect from the Internet
- refresh the Site Health page
- see the reported error
- error label: same as above
- error details: "cURL error 6: Could not resolve host: indexability.yoast.onpage.org (http_request_failed)"

**OR:**
- test any other error you may be able to manually trigger

**Test the CANNOT_FETCH case:**
- for any of the instructions above
- refresh the page _within_ the 15 seconds interval
- see that this time the Ryte test reports the CANNOT_FETCH text
- label: "Ryte cannot determine whether your site can be found by search engines"
- description: "Ryte offers a free indexability check for Yoast SEO users and right now it has trouble determining whether search engines can find your site. This could have several (legitimate) reasons and is not a problem in itself. If this is a live site, it is recommended that you figure out why the Ryte check failed."

**Test the indetability status with no errors still works as expected**
- use `$target_url = 'https://yoast.com/';` to test the site is indexable
- on the Site Health page the test will be within the collapsed "Passed tests" section
- use $target_url = 'http://testingwceu2019.altervista.org/'; to test the site is not indexable
- on the Site Health page the test will be within the "critical issues" section


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14254