### PR TITLE
Remove dismiss tagline notice remnants

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -67,23 +67,6 @@ function wpseo_set_ignore() {
 add_action( 'wp_ajax_wpseo_set_ignore', 'wpseo_set_ignore' );
 
 /**
- * Hides the default tagline notice for a specific user.
- */
-function wpseo_dismiss_tagline_notice() {
-	if ( ! current_user_can( 'manage_options' ) ) {
-		die( '-1' );
-	}
-
-	check_ajax_referer( 'wpseo-dismiss-tagline-notice' );
-
-	update_user_meta( get_current_user_id(), 'wpseo_seen_tagline_notice', 'seen' );
-
-	die( '1' );
-}
-
-add_action( 'wp_ajax_wpseo_dismiss_tagline_notice', 'wpseo_dismiss_tagline_notice' );
-
-/**
  * Save an individual SEO title from the Bulk Editor.
  */
 function wpseo_save_title() {

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -315,7 +315,6 @@ class WPSEO_Admin {
 				'HelpScout beacon'
 			),
 			'dismiss_about_url'       => $this->get_dismiss_url( 'wpseo-dismiss-about' ),
-			'dismiss_tagline_url'     => $this->get_dismiss_url( 'wpseo-dismiss-tagline-notice' ),
 			/* translators: %s: expends to Yoast SEO */
 			'help_video_iframe_title' => sprintf( __( '%s video tutorial', 'wordpress-seo' ), 'Yoast SEO' ),
 			'scrollable_table_hint'   => __( 'Scroll to see the table content.', 'wordpress-seo' ),

--- a/js/src/wp-seo-admin-global.js
+++ b/js/src/wp-seo-admin-global.js
@@ -26,21 +26,6 @@
 	jQuery( document ).ready( displayConsoleNotifications );
 
 	/**
-	 * Used to dismiss the tagline notice for a specific user.
-	 *
-	 * @param {string} nonce Nonce for verification.
-	 *
-	 * @returns {void}
-	 */
-	function wpseoDismissTaglineNotice( nonce ) {
-		jQuery.post( ajaxurl, {
-			action: "wpseo_dismiss_tagline_notice",
-			_wpnonce: nonce,
-		}
-		);
-	}
-
-	/**
 	 * Used to remove the admin notices for several purposes, dies on exit.
 	 *
 	 * @param {string} option The option to ignore.
@@ -121,7 +106,7 @@
 			} );
 		} );
 	} );
-	window.wpseoDismissTaglineNotice = wpseoDismissTaglineNotice;
+
 	window.wpseoSetIgnore = wpseoSetIgnore;
 	window.wpseoDismissLink = wpseoDismissLink;
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes remnants of the tagline notice for hte Notification Center.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- build
- under WordPress > General Settings make sure to have the default WordPress tagline `Just another WordPress site`
- go to the SEO Dashboard 
- verify there are no PHP or JS errors

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14352