### PR TITLE
Remove the "get headers" item from the adminbar

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -319,11 +319,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				'href'   => '//webcache.googleusercontent.com/search?strip=1&q=cache:' . $encoded_url,
 			],
 			[
-				'id'     => 'wpseo-header',
-				'title'  => __( 'Check Headers', 'wordpress-seo' ),
-				'href'   => '//quixapp.com/headers/?r=' . urlencode( $url ),
-			],
-			[
 				'id'     => 'wpseo-structureddata',
 				'title'  => __( 'Google Structured Data Test', 'wordpress-seo' ),
 				'href'   => 'https://search.google.com/structured-data/testing-tool#url=' . $encoded_url,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the "Get Headers" from the page analysis, as it is no longer available.

## Relevant technical choices:

* The quixapp was discontinued so the item was simply redirecting to the Yoast homepage.

## Test instructions
This PR can be tested by following these steps:

1.  Install Yoast.
2. Visit a page, go to the admin bar Yoast icon and check the items under "Analyze this page".
3. No "Check Headers" should be visible.
4. All other items in the menu should still work as expected.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/893
