### PR TITLE
Add content-type header to request

### DIFF
--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -105,9 +105,16 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 			return;
 		}
 
+		// Set a 'content-type' header of 'application/json'.
+		$tracking_request_args = [
+			'headers' => [
+				'content-type:' => 'application/json',
+			],
+		];
+
 		$collector = $this->get_collector();
 
-		$request = new WPSEO_Remote_Request( $this->endpoint );
+		$request = new WPSEO_Remote_Request( $this->endpoint, $tracking_request_args );
 		$request->set_body( $collector->get_as_json() );
 		$request->send();
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Non-user-facing: adds the `content-type: application/json` header to the tracking request.

## Relevant technical choices:

* The tracking application now forces all requests as json, even when they may be not valid json. This fix will let the request set this value so that error handling will be clearer.

## Test instructions
This PR can be tested by following these steps:

Once this pull is active, every tracking request should have a HTTP header with the value `content-type: application/json`. This is not easily tracked and will need cooperation from DevOps.

1. Install Yoast premium (this code only activates in premium at the moment).
2. Clear all site transients (just to make sure).
3. Visit the SEO dashboard page.
You will see nothing happen, but the site should now have sent a tracking request to our tracking server with the correct header.
4. To make sure this has happened, contact DevOps and schedule a short moment to enable request logging on our servers. Once logging is enabled, repeat steps 2 and 3 and have DevOps check the logs for the correct headers.

**Please note that I have already tested and verified these steps with @noud-github while developing this PR.**

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2705
