### PR TITLE
Fixes the breadcrumbs shortcode.

### DIFF
--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -55,7 +55,7 @@ class Breadcrumbs_Integration implements Integration_Interface {
 	 * @throws \Exception If something goes wrong generating the DI container.
 	 */
 	public function render() {
-		$indexable_presentation = yoastseo()->get_current_page_presentation();
+		$indexable_presentation = YoastSEO()->current_page->get_presentation();
 
 		return $this->presenter->present( $indexable_presentation );
 	}

--- a/src/surfaces/current-page-surface.php
+++ b/src/surfaces/current-page-surface.php
@@ -71,4 +71,15 @@ class Current_Page_Surface {
 
 		return $meta_tags_context->presentation->robots;
 	}
+
+	/**
+	 * Returns the presentation of the current page.
+	 *
+	 * @return \Yoast\WP\SEO\Presentations\Indexable_Presentation The presentation.
+	 */
+	public function get_presentation() {
+		$meta_tags_context = $this->meta_tags_context_memoizer->for_current_page();
+
+		return $meta_tags_context->presentation;
+	}
 }

--- a/tests/integrations/breadcrumbs-integration-test.php
+++ b/tests/integrations/breadcrumbs-integration-test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Integrations\Breadcrumbs_Integration;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
+use Yoast\WP\SEO\Surfaces\Current_Page_Surface;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -60,14 +61,17 @@ class Breadcrumbs_Integration_Test extends TestCase {
 	 * @covers ::render
 	 */
 	public function test_render() {
-		$indexable_presentation = new Indexable_Presentation();
+		$current_page_surface   = Mockery::mock( Current_Page_Surface::class );
+		$indexable_presentation = Mockery::mock( Indexable_Presentation::class );
 
-		$mock = Mockery::mock( Main::class );
-		$mock
-			->expects( 'get_current_page_presentation' )
+		$current_page_surface
+			->expects( 'get_presentation' )
 			->andReturn( $indexable_presentation );
 
-		Monkey\Functions\expect( 'yoastseo' )->once()->andReturn( $mock );
+		$mock = Mockery::mock( Main::class );
+		$mock->current_page = $current_page_surface;
+
+		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn( $mock );
 
 		$this->presenter
 			->expects( 'present' )


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error was thrown when a breadcrumb shortcode was added to a post or page.

## Relevant technical choices:

* Adds a new `get_presentation` method on the `current_page_surface`.
* Updates the unit tests as well in accordance with the changes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure Breadcrumbs are enabled in _SEO_ > _Search Appearance_.
* Create a new post.
* Add a shortcode (either in a shortcode block in Gutenberg, or using the classic editor).
* Publish the post.
* View the post on the front end.
* The breadcrumbs should be output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14392 
