### PR TITLE
Remove the readfile try - go straight into the wp_remote_get

### DIFF
--- a/admin/class-my-yoast-proxy.php
+++ b/admin/class-my-yoast-proxy.php
@@ -88,16 +88,6 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 		$this->set_header( 'Content-Type: ' . $proxy_options['content_type'] );
 		$this->set_header( 'Cache-Control: max-age=' . self::CACHE_CONTROL_MAX_AGE );
 
-		if ( $this->should_load_url_directly() ) {
-			/*
-			 * If an error occurred, fallback to the next proxy method (`wp_remote_get`).
-			 * Otherwise, we are done here.
-			 */
-			if ( $this->load_url( $proxy_options['url'] ) ) {
-				return;
-			}
-		}
-
 		try {
 			echo $this->get_remote_url_body( $proxy_options['url'] );
 		}
@@ -142,21 +132,6 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * Tries to load the given url.
-	 *
-	 * @link https://php.net/manual/en/function.readfile.php
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @param string $url The url to load.
-	 *
-	 * @return bool False if an error occurred.
-	 */
-	protected function load_url( $url ) {
-		return readfile( $url ) !== false;
-	}
-
-	/**
 	 * Determines the proxy options based on the file and plugin version arguments.
 	 *
 	 * When the file is known it returns an array like this:
@@ -178,19 +153,6 @@ class WPSEO_MyYoast_Proxy implements WPSEO_WordPress_Integration {
 		}
 
 		return [];
-	}
-
-	/**
-	 * Checks the PHP configuration of allow_url_fopen.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @link https://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen
-	 *
-	 * @return bool True when the PHP configuration allows for url loading via readfile.
-	 */
-	protected function should_load_url_directly() {
-		return ! ! ini_get( 'allow_url_fopen' );
 	}
 
 	/**

--- a/tests/admin/myyoast-proxy-test.php
+++ b/tests/admin/myyoast-proxy-test.php
@@ -94,7 +94,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		 */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'set_header', 'get_remote_url_body' ] )
 			->getMock();
 
 		$instance
@@ -119,13 +119,8 @@ class MyYoast_Proxy_Test extends TestCase {
 
 		$instance
 			->expects( $this->once() )
-			->method( 'should_load_url_directly' )
-			->will( $this->returnValue( true ) );
-
-		$instance
-			->expects( $this->once() )
-			->method( 'load_url' )
-			->will( $this->returnValue( true ) );
+			->method( 'get_remote_url_body' )
+			->with( 'https://my.yoast.com/api/downloads/file/analysis-worker?plugin_version=1.0' );
 
 		$instance->render_proxy_page();
 
@@ -155,7 +150,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		 */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
+			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'set_header' ] )
 			->getMock();
 
 		$instance
@@ -179,148 +174,19 @@ class MyYoast_Proxy_Test extends TestCase {
 			->with( 'Cache-Control: max-age=' . WPSEO_MyYoast_Proxy::CACHE_CONTROL_MAX_AGE );
 
 		$instance
-			->expects( $this->once() )
-			->method( 'should_load_url_directly' )
-			->will( $this->returnValue( true ) );
-
-		$instance
-			->expects( $this->once() )
-			->method( 'load_url' )
-			->will( $this->returnValue( false ) );
-
-		$instance
-			->expects( $this->at( 6 ) )
+			->expects( $this->at( 4 ) )
 			->method( 'set_header' )
 			->with( 'Content-Type: text/plain' );
-
-		$instance
-			->expects( $this->at( 7 ) )
-			->method( 'set_header' )
-			->with( 'Cache-Control: max-age=0' );
-
-		$instance
-			->expects( $this->at( 8 ) )
-			->method( 'set_header' )
-			->with( 'HTTP/1.0 500 Received unexpected response from MyYoast' );
-
-		$instance->render_proxy_page();
-
-		$this->expectOutput( '', 'wp_remote_get failed, no output expected' );
-	}
-
-	/**
-	 * Tests rendering the proxy page that went via WordPress.
-	 *
-	 * @covers ::render_proxy_page
-	 */
-	public function test_render_proxy_page_via_wordpress() {
-		Monkey\Functions\expect( 'wp_remote_get' )
-			->times( 1 )
-			->with( 'https://my.yoast.com/api/downloads/file/analysis-worker?plugin_version=1.0' )
-			->andReturn( 'response' );
-
-		Monkey\Functions\expect( 'wp_remote_retrieve_response_code' )
-			->times( 1 )
-			->with( 'response' )
-			->andReturn( 200 );
-
-		Monkey\Functions\expect( 'wp_remote_retrieve_body' )
-			->times( 1 )
-			->with( 'response' )
-			->andReturn( 'success' );
-
-		/**
-		 * Holds the instance of the class being tested.
-		 *
-		 * @var \WPSEO_MyYoast_Proxy $instance
-		 */
-		$instance = $this
-			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
-			->getMock();
-
-		$instance
-			->expects( $this->once() )
-			->method( 'get_proxy_file' )
-			->will( $this->returnValue( 'research-webworker' ) );
-
-		$instance
-			->expects( $this->once() )
-			->method( 'get_plugin_version' )
-			->will( $this->returnValue( '1.0' ) );
-
-		$instance
-			->expects( $this->once() )
-			->method( 'should_load_url_directly' )
-			->will( $this->returnValue( false ) );
-
-		$instance->render_proxy_page();
-
-		$this->expectOutput( 'success', 'Load URL succeeded, success expected' );
-	}
-
-	/**
-	 * Tests rendering of the proxy page where WordPress remote get throws an error.
-	 *
-	 * @covers ::render_proxy_page
-	 */
-	public function test_render_proxy_page_via_wordpress_errored() {
-		$wp_error_mock = Mockery::mock( '\WP_Error' );
-
-		Monkey\Functions\expect( 'wp_remote_get' )
-			->times( 1 )
-			->with( 'https://my.yoast.com/api/downloads/file/analysis-worker?plugin_version=1.0' )
-			->andReturn( $wp_error_mock );
-
-		/**
-		 * It acts like an instance of WPSEO_MyYoast_Proxy.
-		 *
-		 * @var \WPSEO_MyYoast_Proxy $instance
-		 */
-		$instance = $this
-			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
-			->setMethods( [ 'get_proxy_file', 'get_plugin_version', 'should_load_url_directly', 'set_header', 'load_url' ] )
-			->getMock();
-
-		$instance
-			->expects( $this->once() )
-			->method( 'get_proxy_file' )
-			->will( $this->returnValue( 'research-webworker' ) );
-
-		$instance
-			->expects( $this->once() )
-			->method( 'get_plugin_version' )
-			->will( $this->returnValue( '1.0' ) );
-
-		$instance
-			->expects( $this->at( 2 ) )
-			->method( 'set_header' )
-			->with( 'Content-Type: text/javascript; charset=UTF-8' );
-
-		$instance
-			->expects( $this->at( 3 ) )
-			->method( 'set_header' )
-			->with( 'Cache-Control: max-age=' . WPSEO_MyYoast_Proxy::CACHE_CONTROL_MAX_AGE );
-
-		$instance
-			->expects( $this->once() )
-			->method( 'should_load_url_directly' )
-			->will( $this->returnValue( false ) );
 
 		$instance
 			->expects( $this->at( 5 ) )
 			->method( 'set_header' )
-			->with( 'Content-Type: text/plain' );
+			->with( 'Cache-Control: max-age=0' );
 
 		$instance
 			->expects( $this->at( 6 ) )
 			->method( 'set_header' )
-			->with( 'Cache-Control: max-age=0' );
-
-		$instance
-			->expects( $this->at( 7 ) )
-			->method( 'set_header' )
-			->with( $this->equalTo( 'HTTP/1.0 500 Unable to retrieve file from MyYoast' ) );
+			->with( 'HTTP/1.0 500 Received unexpected response from MyYoast' );
 
 		$instance->render_proxy_page();
 


### PR DESCRIPTION
This is part of the Yoast CS sniff: `WordPress.WP.AlternativeFunctions.file_system_read_readfile`
Preventing the file system readfile.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the `readfile` flow in the Yoast Proxy (used for the analysis-worker).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
