### PR TITLE
Consider static homepages to be a singular page

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -230,7 +230,7 @@ class Front_End_Integration implements Integration_Interface {
 
 		$presenters = $this->get_all_presenters();
 		// Filter out the presenters only needed for singular pages on non-singular pages.
-		if ( $page_type !== 'Post_Type' ) {
+		if ( ! in_array( $page_type, [ 'Post_Type', 'Static_Home_Page' ], true ) ) {
 			$presenters = array_diff( $presenters, $this->singular_presenters );
 		}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A Fixes a bug where the `twitter:creator` tag was not shown on static homepages.

## Relevant technical choices:

* Static homepages show the content of a single page, and therefore they should be considered as a singular page when it comes to meta tag output. I added the `Static_Home_Page` page type to a conditional, so that the singular page presenters will not be excluded for this page type.
* I didn't write unit tests because the whole `front-end-integration` class is not yet covered.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See the issue #14375 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14375
