### PR TITLE
14407 create redux store images

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -48,6 +48,7 @@ class WPSEO_Metabox_Formatter {
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 
 		return [
+			'sidewide_social_image'     => WPSEO_Options::get( 'og_default_image' ),
 			'language'                  => WPSEO_Language_Utils::get_site_language_name(),
 			'settings_link'             => $this->get_settings_link(),
 			'search_url'                => '',

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -33,6 +33,7 @@ const PinnedPluginIcon = styled( PluginIcon )`
 	height: 20px;
 `;
 
+/** Class representing edit functions. */
 class Edit {
 	/**
 	 * @param {Object}   args                                 Edit initialize arguments.
@@ -63,6 +64,11 @@ class Edit {
 		);
 	}
 
+	/**
+	 * Initializes the settings store.
+	 *
+	 * @returns {void} .
+	 */
 	_init() {
 		this._store = this._registerStoreInGutenberg();
 
@@ -71,6 +77,9 @@ class Edit {
 		this._data = this._initializeData();
 
 		this._store.dispatch( setSettings( {
+			socialPreviews: {
+				sidewideImage: this._localizedData.sidewide_social_image,
+			},
 			snippetEditor: {
 				baseUrl: this._args.snippetEditorBaseUrl,
 				date: this._args.snippetEditorDate,
@@ -114,6 +123,11 @@ class Edit {
 			isRtl: this._localizedData.isRtl,
 		};
 
+		/**
+		 * Renders the yoast sidebar
+		 *
+	 	 * @returns {Component} The yoast sidebar component.
+	 	 */
 		const YoastSidebar = () => (
 			<Fragment>
 				<PluginSidebarMoreMenuItem

--- a/js/src/redux/actions/settings.js
+++ b/js/src/redux/actions/settings.js
@@ -13,4 +13,3 @@ export const setSettings = function( settings ) {
 		settings,
 	};
 };
-

--- a/js/src/redux/actions/settings.js
+++ b/js/src/redux/actions/settings.js
@@ -13,3 +13,4 @@ export const setSettings = function( settings ) {
 		settings,
 	};
 };
+

--- a/js/src/redux/reducers/settings.js
+++ b/js/src/redux/reducers/settings.js
@@ -9,9 +9,10 @@ import { SET_SETTINGS } from "../actions/settings";
  * @returns {Object} The state.
  */
 export default function settingsReducer( state = {}, action ) {
-	if ( action.type === SET_SETTINGS ) {
-		return action.settings;
+	switch ( action.type ) {
+		case SET_SETTINGS:
+			return { ...state, ...action.settings };
+		default:
+			return state;
 	}
-
-	return state;
 }

--- a/js/tests/redux/actions/settings.test.js
+++ b/js/tests/redux/actions/settings.test.js
@@ -1,0 +1,19 @@
+import { setSettings, SET_SETTINGS } from "../../../src/redux/actions/settings";
+
+
+describe( setSettings, () => {
+	it( "Returns an object with the set settings", () => {
+		const settings = {
+			thisSetting: true,
+		};
+
+		const expected = {
+			type: SET_SETTINGS,
+			settings: { ...settings },
+
+		};
+		const actual = setSettings( settings );
+
+		expect( actual ).toEqual( expected );
+	} );
+} );

--- a/js/tests/redux/reducers/settings.test.js
+++ b/js/tests/redux/reducers/settings.test.js
@@ -1,0 +1,24 @@
+import settingsReducer from "../../../src/redux/reducers/settings";
+import { SET_SETTINGS } from "../../../src/redux/actions/settings";
+
+describe( settingsReducer, () => {
+	it( "Returns the state with the settings when action.type is SET_SETTINGS", () => {
+		const state = {};
+
+		const action = { type: SET_SETTINGS, settings: { test: "test" } };
+		const expected = { test: "test" };
+		const actual = settingsReducer( state, action );
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "Returns an empty object when the action.type is NOT SET_SETTINGS", () => {
+		const state = {};
+		const SET_NOTHING = "SET_NOTHING";
+		const action = { type: SET_NOTHING, settings: { test: "test" } };
+		const expected = {};
+		const actual = settingsReducer( state, action );
+
+		expect( actual ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* add siteWideImage to the redux store. 
* add action to do so.
* add tests.

## Relevant technical choices:

* Add sitewide_social_image to get_defaults function. So the variable is set on the window object. 
* Add a social previews object to the settings with the `sideWideImage` key.  The data for sidewide image is scraped from the window. 
* Add JS-doc in edit.js
* Add tests for the reducer and action.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the tests resolve.
* Check if `sideWideImage` is available in the yoast-seo/editor redux store.
* If in the Admin-social-settings the default url is set, see if the yoast-seo/editor redux store reflects this.
* Make sure this works in classic and gutenberg.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14407 
