### PR TITLE
Changes cURL Health Check status from recommended to critical

### DIFF
--- a/inc/health-check-curl-version.php
+++ b/inc/health-check-curl-version.php
@@ -33,7 +33,7 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 				esc_html__( 'Your site can not connect to %1$s', 'wordpress-seo' ),
 				'my.yoast.com'
 			);
-			$this->status         = self::STATUS_RECOMMENDED;
+			$this->status         = self::STATUS_CRITICAL;
 			$this->badge['color'] = 'red';
 			$this->description    = sprintf(
 				/* translators: %1$s Emphasis open tag, %2$s: Emphasis close tag, %3$s Link start tag to the Yoast knowledge base, %4$s Link closing tag. */

--- a/tests/inc/health-check-curl-version-test.php
+++ b/tests/inc/health-check-curl-version-test.php
@@ -75,10 +75,10 @@ class WPSEO_Health_Check_Curl_Version_Test extends TestCase {
 
 		$this->instance->run();
 
-		// We want to verify that the label attribute is the "passed" message.
+		// We want to verify that the label attribute is the "not passed" message.
 		$this->assertAttributeEquals( 'Your site can not connect to my.yoast.com', 'label', $this->instance );
-		// We want to verify that the status attribute is "recommended".
-		$this->assertAttributeEquals( 'recommended', 'status', $this->instance );
+		// We want to verify that the status attribute is "critical".
+		$this->assertAttributeEquals( 'critical', 'status', $this->instance );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Changes status of the cURL Health Check from recommended to critical (#14149).

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes cURL Health Check to `critical` instead of `recommended`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* uninstall any premium plugin (just move out the plugins from the WP plugins directory) and keep just Yoast SEO Free
* go to the Site Health page: Tools > Site Health
* verify the test doesn't run

**Can connect case:**
* bring back at least one of the premium plugins e.g. Video (no need to activate it)
* go to the Site Health page
* the test should run and pass: expand the "Passed tests" section and verify the copy: 
  - label: "Your site can connect to my.yoast.com"
  - description: "Great! You can activate your premium plugin(s) and receive updates." 

**Cannot connect, cURL is fine case:**
* disconnect from the Internet
* go to the Site Health page
* the test should not pass and should appear within the "critical issues" section
* verify the copy:
  - label: "Your site can not connect to my.yoast.com"
  - description: "You can _not_ activate your premium plugin(s) and receive updates. A common cause for not being able to connect is an out-of-date version of cURL, software used to connect to other servers. However, your cURL version seems fine. Please talk to your host and, if needed, the Yoast support team to figure out what is broken. Read more about cURL in our knowledge base"

**Cannot connect, cURL is outdated case:**
* stay disconnected from the Internet
* In the`is_recent_curl_version()` function (in `health-check-curl-version.php`), change 
`version_compare( $curl_version, '7.34.0', '>=' )` to 
`version_compare( $curl_version, '7.90.0', '>=' )`
* go to the Site Health page
* the test should not pass and should appear within the "critical issues" section
* verify the copy:
  - label: "Your site can not connect to my.yoast.com"
  - description: "You can _not_ activate your premium plugin(s) and receive updates. The cause for this error is probably that the cURL software on your server is too old. Please contact your host and ask them to update it to at least version 7.34. Read more about cURL in our knowledge base."

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
