### PR TITLE
WP 5.4: Fix category_link deprecated warning

### DIFF
--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -57,14 +57,14 @@ class WPSEO_Rewrite {
 	/**
 	 * Override the category link to remove the category base.
 	 *
-	 * @param string  $link     Unused, overridden by the function.
+	 * @param string  $link     Term link, overridden by the function for categories.
 	 * @param WP_Term $term     Unused, term object.
 	 * @param string  $taxonomy Taxonomy slug.
 	 *
 	 * @return string
 	 */
 	public function no_category_base( $link, $term, $taxonomy ) {
-		if ( 'category' !== $taxonomy ) {
+		if ( $taxonomy !== 'category' ) {
 			return $link;
 		}
 

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -15,7 +15,7 @@ class WPSEO_Rewrite {
 	 */
 	public function __construct() {
 		add_filter( 'query_vars', [ $this, 'query_vars' ] );
-		add_filter( 'category_link', [ $this, 'no_category_base' ] );
+		add_filter( 'term_link', [ $this, 'no_category_base' ], 10, 3 );
 		add_filter( 'request', [ $this, 'request' ] );
 		add_filter( 'category_rewrite_rules', [ $this, 'category_rewrite_rules' ] );
 
@@ -57,11 +57,17 @@ class WPSEO_Rewrite {
 	/**
 	 * Override the category link to remove the category base.
 	 *
-	 * @param string $link Unused, overridden by the function.
+	 * @param string  $link     Unused, overridden by the function.
+	 * @param WP_Term $term     Unused, term object.
+	 * @param string  $taxonomy Taxonomy slug.
 	 *
 	 * @return string
 	 */
-	public function no_category_base( $link ) {
+	public function no_category_base( $link, $term, $taxonomy ) {
+		if ( 'category' !== $taxonomy ) {
+			return $link;
+		}
+
 		$category_base = get_option( 'category_base' );
 
 		if ( empty( $category_base ) ) {

--- a/integration-tests/test-class-rewrite.php
+++ b/integration-tests/test-class-rewrite.php
@@ -81,7 +81,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 		$category_base .= '/';
 
 		$expected = preg_replace( '`' . preg_quote( $category_base, '`' ) . '`u', '', $input, 1 );
-		$this->assertEquals( $expected, self::$class_instance->no_category_base( $input ) );
+		$this->assertEquals( $expected, self::$class_instance->no_category_base( $input, null, 'category' ) ); // Passing null as 2nd parameter as it is not used.
 	}
 
 	/**


### PR DESCRIPTION
## Context
The filter `category_link` is deprecated since WordPress 2.5. WordPress 5.4 will start displaying a warning. See https://github.com/WordPress/WordPress/blob/641c632b0c9fde4e094b217f50749984ca43a2fa/wp-includes/taxonomy.php#L4259-L4268

## Summary
This PR replaces the use of the `category_link` filter by `term_link` as suggested by the warning.
