### PR TITLE
Support %%cf_<custom-field-name>%% for taxonomy terms

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -705,6 +705,12 @@ class WPSEO_Replace_Vars {
 				if ( $name !== '' ) {
 					$replacement = $name;
 				}
+			} elseif ( is_category() || is_tag() || is_tax() ) {
+				$term = $GLOBALS['wp_query']->get_queried_object();
+				$name = get_term_meta( $term->term_id, $field, true );
+				if ( $name !== '' ) {
+					$replacement = $name;
+				}
 			}
 		}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -705,7 +705,8 @@ class WPSEO_Replace_Vars {
 				if ( $name !== '' ) {
 					$replacement = $name;
 				}
-			} elseif ( is_category() || is_tag() || is_tax() ) {
+			}
+			elseif ( is_category() || is_tag() || is_tax() ) {
 				$term = $GLOBALS['wp_query']->get_queried_object();
 				$name = get_term_meta( $term->term_id, $field, true );
 				if ( $name !== '' ) {


### PR DESCRIPTION


## Context
* Add term meta support to variables

## Summary

WordPress supports term meta for a long time now, so this PR adds support for term meta with the same %%cf_<custom-field-name>%% syntax used for posts.

## Test instructions

This PR can be tested by following these steps:

* Add term meta to a taxonomy, with ACF or any other plugin
* Add a snippet variable to the taxonomy SEO Title or Meta Description in the %%cf_<custom-field-name>%% format

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended