### PR TITLE
Use strcasecmp to compare encoded URLs

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -328,8 +328,8 @@ class WPSEO_Utils {
 	public static function sanitize_url( $value, $allowed_protocols = [ 'http', 'https' ] ) {
 		$stripped_value = preg_replace( '/[:\/@?#\[\]&\+=]/', '', $value );
 
-		$test_value = rawurlencode( sanitize_text_field( rawurldecode( $stripped_value ) ) );
-		if ( strcasecmp( $test_value, $stripped_value ) === 0 ) {
+		$sanitized_value = rawurlencode( sanitize_text_field( rawurldecode( $stripped_value ) ) );
+		if ( strcasecmp( $sanitized_value, $stripped_value ) === 0 ) {
 			return esc_url_raw( $value, $allowed_protocols );
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -328,7 +328,8 @@ class WPSEO_Utils {
 	public static function sanitize_url( $value, $allowed_protocols = [ 'http', 'https' ] ) {
 		$stripped_value = preg_replace( '/[:\/@?#\[\]&\+=]/', '', $value );
 
-		if ( rawurlencode( sanitize_text_field( rawurldecode( $stripped_value ) ) ) === $stripped_value ) {
+		$test_value = rawurlencode( sanitize_text_field( rawurldecode( $stripped_value ) ) );
+		if ( strcasecmp( $test_value, $stripped_value ) === 0 ) {
 			return esc_url_raw( $value, $allowed_protocols );
 		}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Compare URL percent-encoding as case insensitive

## Relevant technical choices:

* According to [RFC 3986](https://tools.ietf.org/html/rfc3986#section-2.1) we should use [strcasecmp](https://www.php.net/manual/en/function.strcasecmp.php) to compare percent-encoded characters:
> The uppercase hexadecimal digits 'A' through 'F' are equivalent to the lowercase digits 'a' through 'f', respectively. If two URIs differ only in the case of hexadecimal digits used in percent-encoded octets, they are equivalent.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Try to save URLs (canonical or social account.) with lower-case and upper-case percent-encoded URLs

## UI changes
~~* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Partially fixes #14476.
