### PR TITLE
Don't output breadcrumb schema on error pages

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -41,7 +41,7 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed( Meta_Tags_Context $context ) {
-		if ( $context->indexable->object_type === 'error-page' ) {
+		if ( $context->indexable->object_type === 'system-page' && $context->indexable->object_sub_type === '404' ) {
 			return false;
 		}
 

--- a/tests/generators/schema/breadcrumb-test.php
+++ b/tests/generators/schema/breadcrumb-test.php
@@ -1,12 +1,12 @@
 <?php
 
 
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
+use Yoast\WP\SEO\Presentations\Generators\Schema\Breadcrumb;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
-use Yoast\WP\SEO\Helpers\Current_Page_Helper;
-use Yoast\WP\SEO\Presentations\Generators\Schema\Breadcrumb;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -400,7 +400,8 @@ class Breadcrumb_Test extends TestCase {
 	 * @covers ::is_needed
 	 */
 	public function test_is_not_needed_on_error_page() {
-		$this->meta_tags_context->indexable->object_type = 'error-page';
+		$this->meta_tags_context->indexable->object_type     = 'system-page';
+		$this->meta_tags_context->indexable->object_sub_type = '404';
 		$this->assertFalse( $this->instance->is_needed( $this->meta_tags_context ) );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want breadcrumbs on error pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the breadcrumbs schema would be output on error pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure Breadcrumbs are enabled in Search Appearance - Yoast SEO.
* Browse to non-existing post.
* Check that you get 404 RC and grab schema. There should not be a `"@type":"BreadcrumbList"` graph included. See issue for what it was.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14420
