### PR TITLE
Fix site represents checks in context

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -280,10 +280,10 @@ class Meta_Tags_Context extends Abstract_Presentation {
 
 				/*
 				 * Do not use a company without a logo.
-				 * This is not a false check due to how `get_attachment_id_from_settings` works.
+				 * The logic check is on `< 1` instead of `false` due to how `get_attachment_id_from_settings` works.
 				 */
 				if ( $this->company_logo_id < 1 ) {
-					$this->site_represents = false;
+					return false;
 				}
 
 				return 'company';

--- a/tests/context/meta-tags-context-test.php
+++ b/tests/context/meta-tags-context-test.php
@@ -1,6 +1,6 @@
 <?php
 
-
+use Brain\Monkey\Functions;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -12,6 +12,10 @@ use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Class Meta_Tags_Context_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Context\Meta_Tags_Context
+ *
+ * @group context
  */
 class Meta_Tags_Context_Test extends TestCase {
 
@@ -83,7 +87,7 @@ class Meta_Tags_Context_Test extends TestCase {
 	/**
 	 * Tests whether the page type for author archives is correctly typed as a 'ProfilePage' and a 'WebPage'.
 	 *
-	 * @covers Meta_Tags_Context::generate_schema_page_type
+	 * @covers ::generate_schema_page_type
 	 */
 	public function test_generate_schema_page_type_author_archive() {
 		$this->instance->indexable = (Object) [
@@ -92,7 +96,89 @@ class Meta_Tags_Context_Test extends TestCase {
 
 		$actual = $this->instance->generate_schema_page_type();
 
-		$this->assertContains( 'WebPage' , $actual );
+		$this->assertContains( 'WebPage', $actual );
 		$this->assertContains( 'ProfilePage', $actual );
+	}
+
+	/**
+	 * Tests the generate site represents without representation.
+	 *
+	 * @covers ::generate_site_represents
+	 */
+	public function test_generate_site_represents_without_representation() {
+		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturnFalse();
+
+		$this->assertFalse( $this->instance->generate_site_represents() );
+	}
+
+	/**
+	 * Tests the generate site represents with a company without a name.
+	 *
+	 * @covers ::generate_site_represents
+	 */
+	public function test_generate_site_represents_company_without_name() {
+		$this->instance->company_name = '';
+
+		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
+
+		$this->assertFalse( $this->instance->generate_site_represents() );
+	}
+
+	/**
+	 * Tests the generate site represents with a company without a logo.
+	 *
+	 * @covers ::generate_site_represents
+	 */
+	public function test_generate_site_represents_company_without_logo() {
+		$this->instance->company_name    = 'Company';
+		$this->instance->company_logo_id = 0;
+
+		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
+
+		$this->assertFalse( $this->instance->generate_site_represents() );
+	}
+
+	/**
+	 * Tests the generate site represents with a company with name and logo.
+	 *
+	 * @covers ::generate_site_represents
+	 */
+	public function test_generate_site_represents_company_with_name_and_logo() {
+		$this->instance->company_name    = 'Company';
+		$this->instance->company_logo_id = 12;
+
+		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
+
+		$this->assertEquals( 'company', $this->instance->generate_site_represents() );
+	}
+
+	/**
+	 * Tests the generate site represents with a person without a user id.
+	 *
+	 * @covers ::generate_site_represents
+	 */
+	public function test_generate_site_represents_person_without_user() {
+		$this->instance->site_user_id = 1;
+
+		Functions\expect( 'get_user_by' )->once()->with( 'id', 1 )->andReturn( false );
+
+		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'person' );
+
+		$this->assertFalse( $this->instance->generate_site_represents() );
+	}
+
+	/**
+	 * Tests the generate site represents with a person without a user id.
+	 *
+	 * @covers ::generate_site_represents
+	 */
+	public function test_generate_site_represents_person() {
+		$this->instance->site_user_id = 1;
+
+		Functions\expect( 'get_user_by' )->once()->with( 'id', 1 )->andReturn( true );
+
+		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'person' );
+
+		$this->assertEquals( 'person', $this->instance->generate_site_represents() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a company does not have a logo set, it is not valid schema output.
* With the porting to indexables, a set should've been replaced to a return.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where article and company schema graph would be output when the site had a company without a logo.

## Relevant technical choices:

* Added tests for the touched method.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set Knowledge graph to Organisation, enter a name but DO NOT upload logo.
* Open published post and grab schema.
* When company logo is not uploaded, then it is expected to get only WebSite, WebPage and Person (publisher) nodes (and no Organisation and Article).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14426 
