### PR TITLE
Add tests for the indexable presenters

### DIFF
--- a/src/presenters/abstract-indexable-presenter.php
+++ b/src/presenters/abstract-indexable-presenter.php
@@ -28,6 +28,8 @@ abstract class Abstract_Indexable_Presenter {
 	 * @required
 	 *
 	 * @param \WPSEO_Replace_Vars $replace_vars The replace vars helper.
+	 *
+	 * @codeCoverageIgnore Wrapper method.
 	 */
 	public function set_replace_vars( WPSEO_Replace_Vars $replace_vars ) {
 		$this->replace_vars = $replace_vars;
@@ -38,6 +40,8 @@ abstract class Abstract_Indexable_Presenter {
 	 *
 	 * @param Indexable_Presentation $presentation The presentation to present.
 	 *
+	 * @codeCoverageIgnore There is nothing to test.
+	 *
 	 * @return string The template.
 	 */
 	public abstract function present( Indexable_Presentation $presentation );
@@ -47,6 +51,8 @@ abstract class Abstract_Indexable_Presenter {
 	 *
 	 * @param string                 $meta_description The meta description.
 	 * @param Indexable_Presentation $presentation     The presentation to present.
+	 *
+	 * @codeCoverageIgnore Wrapper method.
 	 *
 	 * @return string The meta description with replacement variables replaced.
 	 */

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -61,6 +61,8 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 * Breadcrumbs_Presenter constructor.
 	 *
 	 * @param Options_Helper $options The options helper.
+	 *
+	 * @codeCoverageIgnore This is a simple constructor.
 	 */
 	public function __construct( Options_Helper $options ) {
 		$this->options = $options;

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -133,10 +133,11 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *                          'url'    => (string) link url.
 	 *                          (optional) 'title'         => (string) link title attribute text.
 	 *                          (optional) 'allow_html'    => (bool) whether to (not) escape html in the link text.
-	 *                          This prevents html stripping from the text strings set in the
-	 *                          WPSEO -> Internal Links options page.
+	 *                          'allow_html' prevents html stripping from the text strings set in the WPSEO -> Internal Links options page.
+	 *                          We never set 'title' or 'allow_html' ourselves but they could be set by users through the
+	 *                          'wpseo_breadcrumb_links' and 'wpseo_breadcrumb_single_link_info' filters.
 	 * @param int   $index      Index for the current breadcrumb.
-	 * @param int   $total      The total amount of breadcrumbs.
+	 * @param int   $total      The total number of breadcrumbs.
 	 *
 	 * @return string The breadcrumb link.
 	 */
@@ -163,7 +164,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			$title_attr = isset( $breadcrumb['title'] ) ? 'title="' . esc_attr( $breadcrumb['title'] ) . '"' : '';
 			$link      .= '<a href="' . esc_url( $breadcrumb['url'] ) . '" ' . $title_attr . ' >' . $text . '</a>';
 		}
-		elseif ( $index === ( $total - 1) ) {
+		elseif ( $index === ( $total - 1 ) ) {
 			// If it's the last element.
 			$inner_elm = 'span';
 			if ( $this->options->get( 'breadcrumbs-boldlast' ) === true ) {

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -161,8 +161,8 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		) {
 			// If it's not the last element and we have a url.
 			$link      .= '<' . $this->get_element() . '>';
-			$title_attr = isset( $breadcrumb['title'] ) ? 'title="' . esc_attr( $breadcrumb['title'] ) . '"' : '';
-			$link      .= '<a href="' . esc_url( $breadcrumb['url'] ) . '" ' . $title_attr . ' >' . $text . '</a>';
+			$title_attr = isset( $breadcrumb['title'] ) ? ' title="' . esc_attr( $breadcrumb['title'] ) . '"' : '';
+			$link      .= '<a href="' . esc_url( $breadcrumb['url'] ) . '"' . $title_attr . '>' . $text . '</a>';
 		}
 		elseif ( $index === ( $total - 1 ) ) {
 			// If it's the last element.

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -204,7 +204,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			 * @api string $unsigned ID to add to the wrapper element.
 			 */
 			$this->id = \apply_filters( 'wpseo_breadcrumb_output_id', '' );
-			if ( \is_string( $this->id ) && '' !== $this->id ) {
+			if ( \is_string( $this->id ) && $this->id !== '' ) {
 				$this->id = ' id="' . \esc_attr( $this->id ) . '"';
 			}
 		}

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -228,7 +228,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			 * @api string $unsigned Class to add to the wrapper element.
 			 */
 			$this->class = \apply_filters( 'wpseo_breadcrumb_output_class', '' );
-			if ( \is_string( $this->class ) && '' !== $this->class ) {
+			if ( \is_string( $this->class ) && $this->class !== '' ) {
 				$this->class = ' class="' . \esc_attr( $this->class ) . '"';
 			}
 		}

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -109,7 +109,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * Filters the output.
 	 *
-	 * @param string                 $output       The output.
+	 * @param string                 $output       The HTML output.
 	 * @param Indexable_Presentation $presentation The presentation of an indexable.
 	 *
 	 * @return string The filtered output.
@@ -118,9 +118,9 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_breadcrumb_output' - Allow changing the HTML output of the Yoast SEO breadcrumbs class.
 		 *
-		 * @api string $unsigned HTML output.
-		 *
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 *
+		 * @api string $output The HTML output.
 		 */
 		return \apply_filters( 'wpseo_breadcrumb_output', $output, $presentation );
 	}
@@ -129,10 +129,10 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 * Create a breadcrumb element string.
 	 *
 	 * @param array $breadcrumb Link info array containing the keys:
-	 *                          'text'    => (string) link text.
-	 *                          'url'    => (string) link url.
-	 *                          (optional) 'title'         => (string) link title attribute text.
-	 *                          (optional) 'allow_html'    => (bool) whether to (not) escape html in the link text.
+	 *                          'text'                  => (string) link text.
+	 *                          'url'                   => (string) link url.
+	 *                          (optional) 'title'      => (string) link title attribute text.
+	 *                          (optional) 'allow_html' => (bool) whether to (not) escape html in the link text.
 	 *                          'allow_html' prevents html stripping from the text strings set in the WPSEO -> Internal Links options page.
 	 *                          We never set 'title' or 'allow_html' ourselves but they could be set by users through the
 	 *                          'wpseo_breadcrumb_links' and 'wpseo_breadcrumb_single_link_info' filters.
@@ -160,9 +160,9 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			! empty( $breadcrumb['url'] )
 		) {
 			// If it's not the last element and we have a url.
-			$link      .= '<' . $this->get_element() . '>';
+			$link       .= '<' . $this->get_element() . '>';
 			$title_attr = isset( $breadcrumb['title'] ) ? ' title="' . esc_attr( $breadcrumb['title'] ) . '"' : '';
-			$link      .= '<a href="' . esc_url( $breadcrumb['url'] ) . '"' . $title_attr . '>' . $text . '</a>';
+			$link       .= '<a href="' . esc_url( $breadcrumb['url'] ) . '"' . $title_attr . '>' . $text . '</a>';
 		}
 		elseif ( $index === ( $total - 1 ) ) {
 			// If it's the last element.
@@ -186,9 +186,9 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_breadcrumb_single_link' - Allow changing of each link being put out by the Yoast SEO breadcrumbs class.
 		 *
-		 * @api string $link_output The output string.
-		 *
 		 * @param array $link The link array.
+		 *
+		 * @api string $link_output The output string.
 		 */
 
 		return \apply_filters( 'wpseo_breadcrumb_single_link', $link, $breadcrumb );

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -114,7 +114,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return string The filtered output.
 	 */
-	private function filter( $output, Indexable_Presentation $presentation ) {
+	protected function filter( $output, Indexable_Presentation $presentation ) {
 		/**
 		 * Filter: 'wpseo_breadcrumb_output' - Allow changing the HTML output of the Yoast SEO breadcrumbs class.
 		 *
@@ -140,7 +140,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return string The breadcrumb link.
 	 */
-	private function crumb_to_link( $breadcrumb, $index, $total ) {
+	protected function crumb_to_link( $breadcrumb, $index, $total ) {
 		$link = '';
 
 		if ( ! isset( $breadcrumb['text'] ) || ! \is_string( $breadcrumb['text'] ) || empty( $breadcrumb['text'] ) ) {
@@ -198,7 +198,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return string The id attribute.
 	 */
-	private function get_id() {
+	protected function get_id() {
 		if ( ! $this->id ) {
 			/**
 			 * Filter: 'wpseo_breadcrumb_output_id' - Allow changing the HTML ID on the Yoast SEO breadcrumbs wrapper element.
@@ -219,7 +219,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return string The class attribute.
 	 */
-	private function get_class() {
+	protected function get_class() {
 		if ( ! $this->class ) {
 			/**
 			 * Filter: 'wpseo_breadcrumb_output_class' - Allow changing the HTML class on the Yoast SEO breadcrumbs wrapper element.
@@ -240,7 +240,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return string The wrapper element name.
 	 */
-	private function get_wrapper() {
+	protected function get_wrapper() {
 		if ( ! $this->wrapper ) {
 			$this->wrapper = \apply_filters( 'wpseo_breadcrumb_output_wrapper', 'span' );
 			$this->wrapper = \tag_escape( $this->wrapper );
@@ -257,7 +257,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return string The separator.
 	 */
-	private function get_separator() {
+	protected function get_separator() {
 		if ( ! $this->separator ) {
 			$this->separator = \apply_filters( 'wpseo_breadcrumb_separator', $this->options->get( 'breadcrumbs-sep' ) );
 			$this->separator = ' ' . $this->separator . ' ';
@@ -271,7 +271,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return string The element to use.
 	 */
-	private function get_element() {
+	protected function get_element() {
 		if ( ! $this->element ) {
 			$this->element = \esc_attr( \apply_filters( 'wpseo_breadcrumb_single_link_wrapper', 'span' ) );
 		}

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -129,12 +129,12 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 * Create a breadcrumb element string.
 	 *
 	 * @param array $breadcrumb Link info array containing the keys:
-	 *                   		'text'    => (string) link text.
-	 *                     		'url'    => (string) link url.
-	 *                    		(optional) 'title'         => (string) link title attribute text.
-	 *                    		(optional) 'allow_html'    => (bool) whether to (not) escape html in the link text.
-	 *                    		This prevents html stripping from the text strings set in the
-	 *                    		WPSEO -> Internal Links options page.
+	 *                          'text'    => (string) link text.
+	 *                          'url'    => (string) link url.
+	 *                          (optional) 'title'         => (string) link title attribute text.
+	 *                          (optional) 'allow_html'    => (bool) whether to (not) escape html in the link text.
+	 *                          This prevents html stripping from the text strings set in the
+	 *                          WPSEO -> Internal Links options page.
 	 * @param int   $index      Index for the current breadcrumb.
 	 * @param int   $total      The total amount of breadcrumbs.
 	 *

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -207,7 +207,11 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			 * @api string $unsigned ID to add to the wrapper element.
 			 */
 			$this->id = \apply_filters( 'wpseo_breadcrumb_output_id', '' );
-			if ( \is_string( $this->id ) && $this->id !== '' ) {
+			if ( ! \is_string( $this->id ) ) {
+				return '';
+			}
+
+			if ( $this->id !== '' ) {
 				$this->id = ' id="' . \esc_attr( $this->id ) . '"';
 			}
 		}
@@ -228,7 +232,11 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			 * @api string $unsigned Class to add to the wrapper element.
 			 */
 			$this->class = \apply_filters( 'wpseo_breadcrumb_output_class', '' );
-			if ( \is_string( $this->class ) && $this->class !== '' ) {
+			if ( ! \is_string( $this->class ) ) {
+				return '';
+			}
+
+			if ( $this->class !== '' ) {
 				$this->class = ' class="' . \esc_attr( $this->class ) . '"';
 			}
 		}

--- a/src/presenters/meta-description-presenter.php
+++ b/src/presenters/meta-description-presenter.php
@@ -26,6 +26,8 @@ class Meta_Description_Presenter extends Abstract_Indexable_Presenter {
 	 * Meta_Description_Presenter constructor.
 	 *
 	 * @param String_Helper $string The string helper.
+	 *
+	 * @codeCoverageIgnore This is a simple constructor.
 	 */
 	public function __construct( String_Helper $string ) {
 		$this->string = $string;

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -67,7 +67,6 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 *
 		 * @api string $title The title.
-		 *
 		 */
 		return (string) \trim( \apply_filters( 'wpseo_opengraph_title', $title, $presentation ) );
 	}

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -27,6 +27,8 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	 * Title_Presenter constructor.
 	 *
 	 * @param String_Helper $string The string helper.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function __construct( String_Helper $string ) {
 		$this->string = $string;
@@ -62,9 +64,10 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_title' - Allow changing the Yoast SEO generated title.
 		 *
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 *
 		 * @api string $title The title.
 		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return (string) \trim( \apply_filters( 'wpseo_opengraph_title', $title, $presentation ) );
 	}

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -26,6 +26,8 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	 * Title_Presenter constructor.
 	 *
 	 * @param String_Helper $string The string helper.
+	 *
+	 * @codeCoverageIgnore This is a simple constructor.
 	 */
 	public function __construct( String_Helper $string ) {
 		$this->string = $string;

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -45,9 +45,10 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_twitter_image' - Allow changing the Twitter Card image.
 		 *
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 *
 		 * @api string $twitter_image Image URL string.
 		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		return (string) \apply_filters( 'wpseo_twitter_image', $twitter_image, $presentation );
 	}

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -48,7 +48,6 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 *
 		 * @api string $twitter_image Image URL string.
-		 *
 		 */
 		return (string) \apply_filters( 'wpseo_twitter_image', $twitter_image, $presentation );
 	}

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\SEO\Presenters\Twitter;
 
-use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 
@@ -15,22 +14,6 @@ use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
  * Class Image_Presenter
  */
 class Image_Presenter extends Abstract_Indexable_Presenter {
-
-	/**
-	 * The URL helper.
-	 *
-	 * @var Url_Helper
-	 */
-	private $url;
-
-	/**
-	 * Sets the url helper as dependency.
-	 *
-	 * @param Url_Helper $url The url helper.
-	 */
-	public function __construct( Url_Helper $url ) {
-		$this->url = $url;
-	}
 
 	/**
 	 * Presents a presentation.

--- a/tests/_mocks/meta-tags-context.php
+++ b/tests/_mocks/meta-tags-context.php
@@ -26,6 +26,7 @@ class Meta_Tags_Context extends \Yoast\WP\SEO\Context\Meta_Tags_Context {
 	public $post;
 
 	/**
+	 *
 	 * @var Indexable_Presentation
 	 */
 	public $presentation;

--- a/tests/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/integrations/watchers/indexable-permalink-watcher-test.php
@@ -13,7 +13,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group indexables
  * @group watchers
- * @group test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Permalink_Watcher
  * @covers ::<!public>

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -463,6 +463,97 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 
 		$this->assertEquals( $link, $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
 	}
+
+	/**
+	 * Tests the retrieval of the HTML ID attribute when the ID is set through the filter.
+	 *
+	 * @covers ::get_id
+	 */
+	public function test_get_id_where_id_is_set_in_filter() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_id' )
+			->once()
+			->with( '' )
+			->andReturn( 'the_id' );
+
+		$id = ' id="the_id"';
+
+		$this->assertEquals( $id, $this->instance->get_id() );
+	}
+
+	/**
+	 * Tests the retrieval of the HTML ID attribute when the ID set through the filter
+	 * is not a string.
+	 *
+	 * @covers ::get_id
+	 */
+	public function test_get_id_not_string() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_id' )
+			->once()
+			->with( '' )
+			->andReturn( 123 );
+
+		$this->assertEmpty( $this->instance->get_id() );
+	}
+
+	/**
+	 * Tests the retrieval of the HTML ID attribute when the ID is not set through the filter.
+	 *
+	 * @covers ::get_id
+	 */
+	public function test_get_id_no_id_set() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_id' )
+			->once()
+			->with( '' )
+			->andReturn( '' );
+
+		$this->assertEmpty( $this->instance->get_id() );
+	}
+
+	/**
+	 * Tests the retrieval of the HTML class attribute when the class is set through the filter.
+	 *
+	 * @covers ::get_class
+	 */
+	public function test_get_class_where_class_is_set_in_filter() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_class' )
+			->once()
+			->with( '' )
+			->andReturn( 'the_class' );
+
+		$class = ' class="the_class"';
+
+		$this->assertEquals( $class, $this->instance->get_class() );
+	}
+
+	/**
+	 * Tests the retrieval of the HTML class attribute when the class set through the filter
+	 * is not a string.
+	 *
+	 * @covers ::get_class
+	 */
+	public function test_get_class_not_string() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_class' )
+			->once()
+			->with( '' )
+			->andReturn( 123 );
+
+		$this->assertEmpty( $this->instance->get_class() );
+	}
+
+	/**
+	 * Tests the retrieval of the HTML class attribute when the class is not set through the filter.
+	 *
+	 * @covers ::get_class
+	 */
+	public function test_get_class_no_class_set() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_class' )
+			->once()
+			->with( '' )
+			->andReturn( '' );
+
+		$this->assertEmpty( $this->instance->get_class() );
+	}
+
 	/**
 	 * Tests the retrieval of the wrapper element name when the wrapper is set through the filter.
 	 *

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ */
+
+namespace Yoast\WP\SEO\Tests\Presenters;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Breadcrumbs_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter
+ *
+ * @group presenters
+ * @group breadcrumbs
+ */
+class Breadcrumbs_Presenter_Test extends TestCase {
+
+	/**
+	 * The options helper mock.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * The breadcrumbs presenter instance.
+	 *
+	 * @var Breadcrumbs_Presenter
+	 */
+	private $instance;
+
+	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	private $presentation;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->options = Mockery::mock( Options_Helper::class );
+
+		$this->instance     = Mockery::mock( Breadcrumbs_Presenter::class, [ $this->options ] )
+		                             ->makePartial()
+		                             ->shouldAllowMockingProtectedMethods();
+		$this->presentation = new Indexable_Presentation();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the presenter of the breadcrumbs when all goes well.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_happy_path() {
+		$breadcrumb_1 = [ 'url' => 'home_url', 'text' => 'home_title' ];
+		$breadcrumb_2 = [ 'url' => 'post_url', 'text' => 'post_title', 'id' => 'post_id' ];
+
+		$this->presentation->breadcrumbs =
+			[
+				$breadcrumb_1,
+				$breadcrumb_2,
+			];
+
+		$this->instance->expects( 'crumb_to_link' )
+		               ->with( $breadcrumb_1, 0, 2 )
+		               ->andReturn( '<a href="home_url">home_title</a>' );
+
+		$this->instance->expects( 'crumb_to_link' )
+		               ->with( $breadcrumb_2, 1, 2 )
+		               ->andReturn( 'post_title' );
+
+		$this->instance->expects( 'get_separator' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( ' » ' );
+
+		$this->instance->expects( 'get_wrapper' )
+		               ->twice()
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$this->instance->expects( 'get_id' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( ' id="example_id"' );
+
+		$this->instance->expects( 'get_class' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( ' class="example_class"' );
+
+		$output_without_prefix = '<span id="example_id" class="example_class"><a href="home_url">home_title</a> » post_title</span>';
+
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output' )
+			->once()
+			->with( $output_without_prefix, $this->presentation )
+			->andReturn( $output_without_prefix );
+
+		$this->options->expects( 'get' )
+		              ->once()
+		              ->with( 'breadcrumbs-prefix' )
+		              ->andReturn( 'example_breadcrumbs_prefix' );
+
+		$output_with_prefix = "\t" . 'example_breadcrumbs_prefix' . "\n" . $output_without_prefix;
+
+		$this->assertEquals(
+			$output_with_prefix,
+			$this->instance->present( $this->presentation ) );
+	}
+}

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -61,6 +61,7 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 	 * Tests the presenter of the breadcrumbs when all goes well.
 	 *
 	 * @covers ::present
+	 * @covers ::filter
 	 */
 	public function test_present_happy_path() {
 		$breadcrumb_1 = [ 'url' => 'home_url', 'text' => 'home_title' ];
@@ -180,6 +181,7 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 	 * Tests the presenter of the breadcrumbs when there is no breadcrumbs prefix.
 	 *
 	 * @covers ::present
+	 * @covers ::filter
 	 */
 	public function test_present_no_breadcrumbs_prefix() {
 		$breadcrumb_1 = [ 'url' => 'home_url', 'text' => 'home_title' ];

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -237,4 +237,230 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			$output_without_prefix,
 			$this->instance->present( $this->presentation ) );
 	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when it's not the last element
+	 * and all goes well.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_not_last_element() {
+		$breadcrumb = [ 'url' => 'home_url', 'text' => 'home_text' ];
+
+		$this->instance->expects( 'get_element' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$link = '<span><a href="home_url"  >home_text</a>';
+
+		$this->assertEquals(
+			$link,
+			$this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests whether the filter is applied when creating a breadcrumb element string.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_filter_applied() {
+		$breadcrumb = [ 'url' => 'home_url', 'text' => 'home_text' ];
+
+		$this->instance->expects( 'get_element' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$link = '<span><a href="home_url"  >home_text</a>';
+
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_single_link' )
+			->once()
+			->with( $link, $breadcrumb )
+			->andReturn( $link );
+
+		$this->assertEquals(
+			$link,
+			$this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when it's not the last element
+	 * and a title is set.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_title_is_set() {
+		$breadcrumb = [ 'url' => 'home_url', 'text' => 'home_text', 'title' => 'home_title' ];
+
+		$this->instance->expects( 'get_element' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$link = '<span><a href="home_url" title="home_title" >home_text</a>';
+
+		$this->assertEquals(
+			$link,
+			$this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when it's the last element
+	 * and the last element should be bolded.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_last_element_bold() {
+		$breadcrumb = [ 'url' => 'page_url', 'text' => 'page_text' ];
+
+		$this->options->expects( 'get' )
+		              ->once()
+		              ->with( 'breadcrumbs-boldlast' )
+		              ->andReturnTrue();
+
+		$link = '<strong class="breadcrumb_last" aria-current="page">page_text</strong>';
+
+		$this->instance->expects( 'get_element' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$link .= '</span>';
+
+		$this->assertEquals(
+			$link,
+			$this->instance->crumb_to_link( $breadcrumb, 1, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when it's the last element
+	 * and the last element should not be bolded.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_last_element_not_bold() {
+		$breadcrumb = [ 'url' => 'page_url', 'text' => 'page_text' ];
+
+		$this->options->expects( 'get' )
+		              ->once()
+		              ->with( 'breadcrumbs-boldlast' )
+		              ->andReturnFalse();
+
+		$link = '<span class="breadcrumb_last" aria-current="page">page_text</span>';
+
+		$this->instance->expects( 'get_element' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$link .= '</span>';
+
+		$this->assertEquals(
+			$link,
+			$this->instance->crumb_to_link( $breadcrumb, 1, 2 ) );
+	}
+
+	/**
+	 * Tests whether enough closing elements are added to the breadcrumb
+	 * when it's the last element.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_add_closing_elements() {
+		$breadcrumb = [ 'url' => 'page_url', 'text' => 'page_text' ];
+
+		$this->options->expects( 'get' )
+		              ->once()
+		              ->with( 'breadcrumbs-boldlast' )
+		              ->andReturnTrue();
+
+		$link = '<strong class="breadcrumb_last" aria-current="page">page_text</strong>';
+
+		$this->instance->expects( 'get_element' )
+		               ->times(3)
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$link .= '</span></span></span>';
+
+		$this->assertEquals(
+			$link,
+			$this->instance->crumb_to_link( $breadcrumb, 3, 4 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when the breadcrumb text is not set.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_with_text_not_set() {
+		$breadcrumb = [ 'url' => 'home_url' ];
+
+		$this->assertEmpty( $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when the breadcrumb text is not a string.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_with_text_not_string() {
+		$breadcrumb = [ 'url' => 'home_url', 'text' => 123 ];
+
+		$this->assertEmpty( $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when the breadcrumb text is empty.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_with_empty_text() {
+		$breadcrumb = [ 'url' => 'home_url', 'text' => '' ];
+
+		$this->assertEmpty( $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when it's the last element
+	 * but the breadcrumb URL is not set.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_with_url_not_set() {
+		$breadcrumb = [ 'text' => 'home_text' ];
+
+		$link = '<span>home_text</span>';
+
+		$this->assertEquals( $link, $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when it's the last element
+	 * but the breadcrumb URL is not a string.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_with_url_not_string() {
+		$breadcrumb = [ 'url' => 123, 'text' => 'home_text' ];
+
+		$link = '<span>home_text</span>';
+
+		$this->assertEquals( $link, $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element string when it's the last element
+	 * but the breadcrumb URL is empty.
+	 *
+	 * @covers ::crumb_to_link
+	 */
+	public function test_crumb_to_link_with_url_empty() {
+		$breadcrumb = [ 'url' => '', 'text' => 'home_text' ];
+
+		$link = '<span>home_text</span>';
+
+		$this->assertEquals( $link, $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
+	}
 }

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -50,8 +50,8 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$this->options = Mockery::mock( Options_Helper::class );
 
 		$this->instance     = Mockery::mock( Breadcrumbs_Presenter::class, [ $this->options ] )
-		                             ->makePartial()
-		                             ->shouldAllowMockingProtectedMethods();
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 		$this->presentation = new Indexable_Presentation();
 
 		return parent::setUp();
@@ -74,32 +74,32 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			];
 
 		$this->instance->expects( 'crumb_to_link' )
-		               ->with( $breadcrumb_1, 0, 2 )
-		               ->andReturn( '<a href="home_url">home_title</a>' );
+			->with( $breadcrumb_1, 0, 2 )
+			->andReturn( '<a href="home_url">home_title</a>' );
 
 		$this->instance->expects( 'crumb_to_link' )
-		               ->with( $breadcrumb_2, 1, 2 )
-		               ->andReturn( 'post_title' );
+			->with( $breadcrumb_2, 1, 2 )
+			->andReturn( 'post_title' );
 
 		$this->instance->expects( 'get_separator' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( ' » ' );
+			->once()
+			->withNoArgs()
+			->andReturn( ' » ' );
 
 		$this->instance->expects( 'get_wrapper' )
-		               ->twice()
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->twice()
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$this->instance->expects( 'get_id' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( ' id="example_id"' );
+			->once()
+			->withNoArgs()
+			->andReturn( ' id="example_id"' );
 
 		$this->instance->expects( 'get_class' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( ' class="example_class"' );
+			->once()
+			->withNoArgs()
+			->andReturn( ' class="example_class"' );
 
 		$output_without_prefix = '<span id="example_id" class="example_class"><a href="home_url">home_title</a> » post_title</span>';
 
@@ -109,9 +109,9 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			->andReturn( $output_without_prefix );
 
 		$this->options->expects( 'get' )
-		              ->once()
-		              ->with( 'breadcrumbs-prefix' )
-		              ->andReturn( 'example_breadcrumbs_prefix' );
+			->once()
+			->with( 'breadcrumbs-prefix' )
+			->andReturn( 'example_breadcrumbs_prefix' );
 
 		$output_with_prefix = "\t" . 'example_breadcrumbs_prefix' . "\n" . $output_without_prefix;
 
@@ -162,17 +162,17 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			];
 
 		$this->instance->expects( 'crumb_to_link' )
-		               ->with( $breadcrumb_1, 0, 2 )
-		               ->andReturn( '' );
+			->with( $breadcrumb_1, 0, 2 )
+			->andReturn( '' );
 
 		$this->instance->expects( 'crumb_to_link' )
-		               ->with( $breadcrumb_2, 1, 2 )
-		               ->andReturn( '' );
+			->with( $breadcrumb_2, 1, 2 )
+			->andReturn( '' );
 
 		$this->instance->expects( 'get_separator' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( ' » ' );
+			->once()
+			->withNoArgs()
+			->andReturn( ' » ' );
 
 		$this->assertEmpty( $this->instance->present( $this->presentation ) );
 	}
@@ -194,32 +194,32 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			];
 
 		$this->instance->expects( 'crumb_to_link' )
-		               ->with( $breadcrumb_1, 0, 2 )
-		               ->andReturn( '<a href="home_url">home_title</a>' );
+			->with( $breadcrumb_1, 0, 2 )
+			->andReturn( '<a href="home_url">home_title</a>' );
 
 		$this->instance->expects( 'crumb_to_link' )
-		               ->with( $breadcrumb_2, 1, 2 )
-		               ->andReturn( 'post_title' );
+			->with( $breadcrumb_2, 1, 2 )
+			->andReturn( 'post_title' );
 
 		$this->instance->expects( 'get_separator' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( ' » ' );
+			->once()
+			->withNoArgs()
+			->andReturn( ' » ' );
 
 		$this->instance->expects( 'get_wrapper' )
-		               ->twice()
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->twice()
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$this->instance->expects( 'get_id' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( ' id="example_id"' );
+			->once()
+			->withNoArgs()
+			->andReturn( ' id="example_id"' );
 
 		$this->instance->expects( 'get_class' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( ' class="example_class"' );
+			->once()
+			->withNoArgs()
+			->andReturn( ' class="example_class"' );
 
 		$output_without_prefix = '<span id="example_id" class="example_class"><a href="home_url">home_title</a> » post_title</span>';
 
@@ -229,9 +229,9 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			->andReturn( $output_without_prefix );
 
 		$this->options->expects( 'get' )
-		              ->once()
-		              ->with( 'breadcrumbs-prefix' )
-		              ->andReturn( '' );
+			->once()
+			->with( 'breadcrumbs-prefix' )
+			->andReturn( '' );
 
 		$this->assertEquals(
 			$output_without_prefix,
@@ -248,9 +248,9 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$breadcrumb = [ 'url' => 'home_url', 'text' => 'home_text' ];
 
 		$this->instance->expects( 'get_element' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->once()
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$link = '<span><a href="home_url">home_text</a>';
 
@@ -268,9 +268,9 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$breadcrumb = [ 'url' => 'home_url', 'text' => 'home_text' ];
 
 		$this->instance->expects( 'get_element' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->once()
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$link = '<span><a href="home_url">home_text</a>';
 
@@ -294,9 +294,9 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$breadcrumb = [ 'url' => 'home_url', 'text' => 'home_text', 'title' => 'home_title' ];
 
 		$this->instance->expects( 'get_element' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->once()
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$link = '<span><a href="home_url" title="home_title">home_text</a>';
 
@@ -315,16 +315,16 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$breadcrumb = [ 'url' => 'page_url', 'text' => 'page_text' ];
 
 		$this->options->expects( 'get' )
-		              ->once()
-		              ->with( 'breadcrumbs-boldlast' )
-		              ->andReturnTrue();
+			->once()
+			->with( 'breadcrumbs-boldlast' )
+			->andReturnTrue();
 
 		$link = '<strong class="breadcrumb_last" aria-current="page">page_text</strong>';
 
 		$this->instance->expects( 'get_element' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->once()
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$link .= '</span>';
 
@@ -343,16 +343,16 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$breadcrumb = [ 'url' => 'page_url', 'text' => 'page_text' ];
 
 		$this->options->expects( 'get' )
-		              ->once()
-		              ->with( 'breadcrumbs-boldlast' )
-		              ->andReturnFalse();
+			->once()
+			->with( 'breadcrumbs-boldlast' )
+			->andReturnFalse();
 
 		$link = '<span class="breadcrumb_last" aria-current="page">page_text</span>';
 
 		$this->instance->expects( 'get_element' )
-		               ->once()
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->once()
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$link .= '</span>';
 
@@ -371,16 +371,16 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$breadcrumb = [ 'url' => 'page_url', 'text' => 'page_text' ];
 
 		$this->options->expects( 'get' )
-		              ->once()
-		              ->with( 'breadcrumbs-boldlast' )
-		              ->andReturnTrue();
+			->once()
+			->with( 'breadcrumbs-boldlast' )
+			->andReturnTrue();
 
 		$link = '<strong class="breadcrumb_last" aria-current="page">page_text</strong>';
 
 		$this->instance->expects( 'get_element' )
-		               ->times(3)
-		               ->withNoArgs()
-		               ->andReturn( 'span' );
+			->times( 3 )
+			->withNoArgs()
+			->andReturn( 'span' );
 
 		$link .= '</span></span></span>';
 
@@ -620,9 +620,9 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 	 */
 	public function test_get_separator() {
 		$this->options->expects( 'get' )
-		              ->once()
-		              ->with( 'breadcrumbs-sep' )
-		              ->andReturn( 'the_separator' );
+			->once()
+			->with( 'breadcrumbs-sep' )
+			->andReturn( 'the_separator' );
 
 		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_separator' )
 			->once()

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -252,7 +252,7 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		               ->withNoArgs()
 		               ->andReturn( 'span' );
 
-		$link = '<span><a href="home_url"  >home_text</a>';
+		$link = '<span><a href="home_url">home_text</a>';
 
 		$this->assertEquals(
 			$link,
@@ -272,7 +272,7 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		               ->withNoArgs()
 		               ->andReturn( 'span' );
 
-		$link = '<span><a href="home_url"  >home_text</a>';
+		$link = '<span><a href="home_url">home_text</a>';
 
 		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_single_link' )
 			->once()
@@ -298,7 +298,7 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		               ->withNoArgs()
 		               ->andReturn( 'span' );
 
-		$link = '<span><a href="home_url" title="home_title" >home_text</a>';
+		$link = '<span><a href="home_url" title="home_title">home_text</a>';
 
 		$this->assertEquals(
 			$link,

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -478,6 +478,8 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$id = ' id="the_id"';
 
 		$this->assertEquals( $id, $this->instance->get_id() );
+		// Call it again to test that the ID is not built again.
+		$this->assertEquals( $id, $this->instance->get_id() );
 	}
 
 	/**
@@ -523,6 +525,8 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$class = ' class="the_class"';
 
 		$this->assertEquals( $class, $this->instance->get_class() );
+		// Call it again to test that the class is not built again.
+		$this->assertEquals( $class, $this->instance->get_class() );
 	}
 
 	/**
@@ -559,7 +563,7 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 	 *
 	 * @covers ::get_wrapper
 	 */
-	public function test_get_wrapper_where_wrapper_set_in_filter() {
+	public function test_get_wrapper_where_wrapper_is_set_in_filter() {
 		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_wrapper' )
 			->once()
 			->with( 'span' )
@@ -570,6 +574,8 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			->with( 'span' )
 			->andReturn( 'span' );
 
+		$this->assertEquals( 'span', $this->instance->get_wrapper() );
+		// Call it again to test that the wrapper is not built again.
 		$this->assertEquals( 'span', $this->instance->get_wrapper() );
 	}
 
@@ -632,6 +638,8 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 		$separator = ' the_separator ';
 
 		$this->assertEquals( $separator, $this->instance->get_separator() );
+		// Call it again to test that the separator is not built again.
+		$this->assertEquals( $separator, $this->instance->get_separator() );
 	}
 
 	/**
@@ -645,6 +653,8 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			->with( 'span' )
 			->andReturn( 'span' );
 
+		$this->assertEquals( 'span', $this->instance->get_element() );
+		// Call it again to test that the element is not built again.
 		$this->assertEquals( 'span', $this->instance->get_element() );
 	}
 

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -463,4 +463,62 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 
 		$this->assertEquals( $link, $this->instance->crumb_to_link( $breadcrumb, 0, 2 ) );
 	}
+	/**
+	 * Tests the retrieval of the wrapper element name when the wrapper is set through the filter.
+	 *
+	 * @covers ::get_wrapper
+	 */
+	public function test_get_wrapper_where_wrapper_set_in_filter() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_wrapper' )
+			->once()
+			->with( 'span' )
+			->andReturn( 'span' );
+
+		Monkey\Functions\expect( 'tag_escape' )
+			->once()
+			->with( 'span' )
+			->andReturn( 'span' );
+
+		$this->assertEquals( 'span', $this->instance->get_wrapper() );
+	}
+
+	/**
+	 * Tests the retrieval of the wrapper element name
+	 * when the wrapper that is set through the filter, is not a string.
+	 *
+	 * @covers ::get_wrapper
+	 */
+	public function test_get_wrapper_where_wrapper_not_a_string() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_wrapper' )
+			->once()
+			->with( 'span' )
+			->andReturn( 123 );
+
+		Monkey\Functions\expect( 'tag_escape' )
+			->once()
+			->with( 123 )
+			->andReturn( 123 );
+
+		$this->assertEquals( 'span', $this->instance->get_wrapper() );
+	}
+
+	/**
+	 * Tests the retrieval of the wrapper element name
+	 * when the wrapper that is set through the filter, is empty.
+	 *
+	 * @covers ::get_wrapper
+	 */
+	public function test_get_wrapper_where_wrapper_empty() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output_wrapper' )
+			->once()
+			->with( 'span' )
+			->andReturn( '' );
+
+		Monkey\Functions\expect( 'tag_escape' )
+			->once()
+			->with( '' )
+			->andReturn( '' );
+
+		$this->assertEquals( 'span', $this->instance->get_wrapper() );
+	}
 }

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -118,4 +118,121 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 			$output_with_prefix,
 			$this->instance->present( $this->presentation ) );
 	}
+
+	/**
+	 * Tests the presenter of the breadcrumbs when the breadcrumbs are not in array format.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_breadcrumbs_not_array() {
+		$breadcrumb = 'breadcrumb_string';
+
+		$this->presentation->breadcrumbs = $breadcrumb;
+
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
+	}
+
+	/**
+	 * Tests the presenter of the breadcrumbs when the breadcrumbs are empty.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_breadcrumbs_empty() {
+		$breadcrumb = '';
+
+		$this->presentation->breadcrumbs = $breadcrumb;
+
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
+	}
+
+	/**
+	 * Tests the presenter of the breadcrumbs when the output is empty.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_empty_output() {
+		$breadcrumb_1 = [];
+		$breadcrumb_2 = [];
+
+		$this->presentation->breadcrumbs =
+			[
+				$breadcrumb_1,
+				$breadcrumb_2,
+			];
+
+		$this->instance->expects( 'crumb_to_link' )
+		               ->with( $breadcrumb_1, 0, 2 )
+		               ->andReturn( '' );
+
+		$this->instance->expects( 'crumb_to_link' )
+		               ->with( $breadcrumb_2, 1, 2 )
+		               ->andReturn( '' );
+
+		$this->instance->expects( 'get_separator' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( ' » ' );
+
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
+	}
+
+	/**
+	 * Tests the presenter of the breadcrumbs when there is no breadcrumbs prefix.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_no_breadcrumbs_prefix() {
+		$breadcrumb_1 = [ 'url' => 'home_url', 'text' => 'home_title' ];
+		$breadcrumb_2 = [ 'url' => 'post_url', 'text' => 'post_title', 'id' => 'post_id' ];
+
+		$this->presentation->breadcrumbs =
+			[
+				$breadcrumb_1,
+				$breadcrumb_2,
+			];
+
+		$this->instance->expects( 'crumb_to_link' )
+		               ->with( $breadcrumb_1, 0, 2 )
+		               ->andReturn( '<a href="home_url">home_title</a>' );
+
+		$this->instance->expects( 'crumb_to_link' )
+		               ->with( $breadcrumb_2, 1, 2 )
+		               ->andReturn( 'post_title' );
+
+		$this->instance->expects( 'get_separator' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( ' » ' );
+
+		$this->instance->expects( 'get_wrapper' )
+		               ->twice()
+		               ->withNoArgs()
+		               ->andReturn( 'span' );
+
+		$this->instance->expects( 'get_id' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( ' id="example_id"' );
+
+		$this->instance->expects( 'get_class' )
+		               ->once()
+		               ->withNoArgs()
+		               ->andReturn( ' class="example_class"' );
+
+		$output_without_prefix = '<span id="example_id" class="example_class"><a href="home_url">home_title</a> » post_title</span>';
+
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_output' )
+			->once()
+			->with( $output_without_prefix, $this->presentation )
+			->andReturn( $output_without_prefix );
+
+		$this->options->expects( 'get' )
+		              ->once()
+		              ->with( 'breadcrumbs-prefix' )
+		              ->andReturn( '' );
+
+		$this->assertEquals(
+			$output_without_prefix,
+			$this->instance->present( $this->presentation ) );
+	}
 }

--- a/tests/presenters/breadcrumbs-presenter-test.php
+++ b/tests/presenters/breadcrumbs-presenter-test.php
@@ -612,4 +612,40 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 
 		$this->assertEquals( 'span', $this->instance->get_wrapper() );
 	}
+
+	/**
+	 * Tests the retrieval of the separator.
+	 *
+	 * @covers ::get_separator
+	 */
+	public function test_get_separator() {
+		$this->options->expects( 'get' )
+		              ->once()
+		              ->with( 'breadcrumbs-sep' )
+		              ->andReturn( 'the_separator' );
+
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_separator' )
+			->once()
+			->with( 'the_separator' )
+			->andReturn( 'the_separator' );
+
+		$separator = ' the_separator ';
+
+		$this->assertEquals( $separator, $this->instance->get_separator() );
+	}
+
+	/**
+	 * Tests the retrieval of the crumb element name.
+	 *
+	 * @covers ::get_element
+	 */
+	public function test_get_element() {
+		Monkey\Filters\expectApplied( 'wpseo_breadcrumb_single_link_wrapper' )
+			->once()
+			->with( 'span' )
+			->andReturn( 'span' );
+
+		$this->assertEquals( 'span', $this->instance->get_element() );
+	}
+
 }

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -20,6 +20,8 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Googlebot_Presenter_Test extends TestCase {
 
 	/**
+	 * The Googlebot presenter instance.
+	 *
 	 * @var Googlebot_Presenter
 	 */
 	private $instance;

--- a/tests/presenters/meta-description-presenter-test.php
+++ b/tests/presenters/meta-description-presenter-test.php
@@ -76,13 +76,13 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->once()
-			->andReturnUsing( function ( $string ) {
+			->andReturnUsing( function( $string ) {
 				return $string;
 			} );
 
 		Monkey\Filters\expectApplied( 'wpseo_metadesc' )
 			->once()
-			->with( 'the_meta_description', $this->indexable_presentation)
+			->with( 'the_meta_description', $this->indexable_presentation )
 			->andReturn( 'the_meta_description' );
 
 		$this->string
@@ -107,7 +107,7 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->once()
-			->andReturnUsing( function ( $string ) {
+			->andReturnUsing( function( $string ) {
 				return $string;
 			} );
 
@@ -137,7 +137,7 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->once()
-			->andReturnUsing( function ( $string ) {
+			->andReturnUsing( function( $string ) {
 				return $string;
 			} );
 

--- a/tests/presenters/meta-description-presenter-test.php
+++ b/tests/presenters/meta-description-presenter-test.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Presenters;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\String_Helper;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Meta_Description_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Meta_Description_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Meta_Description_Presenter
+ *
+ * @group presenters
+ * @group twitter
+ * @group twitter-description
+ */
+class Meta_Description_Presenter_Test extends TestCase {
+
+	/**
+	 * The WPSEO Replace Vars object.
+	 *
+	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 */
+	protected $replace_vars;
+
+	/**
+	 * The string helper mock.
+	 *
+	 * @var Mockery\MockInterface|String_Helper
+	 */
+	protected $string;
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var Meta_Description_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	protected $indexable_presentation;
+
+	/**
+	 * Setup of the tests.
+	 */
+	public function setUp() {
+		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->string       = Mockery::mock( String_Helper::class );
+
+		$this->instance = new Meta_Description_Presenter( $this->string );
+		$this->instance->set_replace_vars( $this->replace_vars );
+
+		$this->indexable_presentation         = new Indexable_Presentation();
+		$this->indexable_presentation->source = [];
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests the presenter of the meta description.
+	 *
+	 * @covers ::present
+	 * @covers ::filter
+	 */
+	public function test_present_and_filter_happy_path() {
+		$this->indexable_presentation->meta_description = 'the_meta_description';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->once()
+			->andReturnUsing( function ( $string ) {
+				return $string;
+			} );
+
+		Monkey\Filters\expectApplied( 'wpseo_metadesc' )
+			->once()
+			->with( 'the_meta_description', $this->indexable_presentation)
+			->andReturn( 'the_meta_description' );
+
+		$this->string
+			->expects( 'strip_all_tags' )
+			->once()
+			->with( 'the_meta_description' )
+			->andReturn( 'the_meta_description' );
+
+		$output = '<meta name="description" content="the_meta_description" />';
+
+		$this->assertEquals( $output, $this->instance->present( $this->indexable_presentation ) );
+	}
+
+	/**
+	 * Tests the presenter of the meta description when the meta description is empty.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_meta_description_not_string() {
+		$this->indexable_presentation->meta_description = '';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->once()
+			->andReturnUsing( function ( $string ) {
+				return $string;
+			} );
+
+		$this->string
+			->expects( 'strip_all_tags' )
+			->once()
+			->with( '' )
+			->andReturn( '' );
+
+		Monkey\Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'wpseo_manage_options' )
+			->andReturn( false );
+
+		$this->assertEmpty( $this->instance->present( $this->indexable_presentation ) );
+	}
+
+	/**
+	 * Tests the presenter of the meta description when the meta description is empty
+	 * and the current user can manage the options.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_meta_description_not_string_show_notice() {
+		$this->indexable_presentation->meta_description = '';
+
+		$this->replace_vars
+			->expects( 'replace' )
+			->once()
+			->andReturnUsing( function ( $string ) {
+				return $string;
+			} );
+
+		$this->string
+			->expects( 'strip_all_tags' )
+			->once()
+			->with( '' )
+			->andReturn( '' );
+
+		Monkey\Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'wpseo_manage_options' )
+			->andReturn( true );
+
+		$notice = '<!-- Admin only notice: this page does not show a meta description because it does not have one, either write it for this page specifically or go into the [SEO - Search Appearance] menu and set up a template. -->';
+
+		$this->assertEquals( $notice, $this->instance->present( $this->indexable_presentation ) );
+	}
+}

--- a/tests/presenters/open-graph/article-author-presenter-test.php
+++ b/tests/presenters/open-graph/article-author-presenter-test.php
@@ -18,11 +18,15 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Article_Author_Presenter_Test extends TestCase {
 
 	/**
+	 * The article author presenter instance.
+	 *
 	 * @var Article_Author_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;

--- a/tests/presenters/open-graph/article-author-presenter-test.php
+++ b/tests/presenters/open-graph/article-author-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;

--- a/tests/presenters/open-graph/article-modified-time-presenter-test.php
+++ b/tests/presenters/open-graph/article-modified-time-presenter-test.php
@@ -17,11 +17,15 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Article_Modified_Time_Presenter_Test extends TestCase {
 
 	/**
+	 * The article modified time presenter instance.
+	 *
 	 * @var Article_Modified_Time_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;

--- a/tests/presenters/open-graph/article-modified-time-presenter-test.php
+++ b/tests/presenters/open-graph/article-modified-time-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Article_Modified_Time_Presenter;

--- a/tests/presenters/open-graph/article-published-time-presenter-test.php
+++ b/tests/presenters/open-graph/article-published-time-presenter-test.php
@@ -17,11 +17,15 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Article_Published_Time_Presenter_Test extends TestCase {
 
 	/**
+	 * The article published time presenter instance.
+	 *
 	 * @var Article_Published_Time_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;

--- a/tests/presenters/open-graph/article-published-time-presenter-test.php
+++ b/tests/presenters/open-graph/article-published-time-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Article_Published_Time_Presenter;

--- a/tests/presenters/open-graph/article-publisher-presenter-test.php
+++ b/tests/presenters/open-graph/article-publisher-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;

--- a/tests/presenters/open-graph/article-publisher-presenter-test.php
+++ b/tests/presenters/open-graph/article-publisher-presenter-test.php
@@ -18,11 +18,15 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Article_Publisher_Presenter_Test extends TestCase {
 
 	/**
+	 * The article publisher presenter test.
+	 *
 	 * @var Article_Publisher_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;

--- a/tests/presenters/open-graph/description-presenter-test.php
+++ b/tests/presenters/open-graph/description-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Mockery;

--- a/tests/presenters/open-graph/description-presenter-test.php
+++ b/tests/presenters/open-graph/description-presenter-test.php
@@ -19,16 +19,22 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Description_Presenter_Test extends TestCase {
 
 	/**
+	 * The description presenter instance.
+	 *
 	 * @var \Yoast\WP\SEO\Presenters\Open_Graph\Description_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;
 
 	/**
+	 * The WPSEO Replace Vars object.
+	 *
 	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;

--- a/tests/presenters/open-graph/fb-app-id-presenter-test.php
+++ b/tests/presenters/open-graph/fb-app-id-presenter-test.php
@@ -17,11 +17,15 @@ use Yoast\WP\SEO\Tests\TestCase;
 class FB_App_ID_Presenter_Test extends TestCase {
 
 	/**
+	 * The FB app ID presenter instance.
+	 *
 	 * @var FB_App_ID_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;

--- a/tests/presenters/open-graph/fb-app-id-presenter-test.php
+++ b/tests/presenters/open-graph/fb-app-id-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\FB_App_ID_Presenter;

--- a/tests/presenters/open-graph/image-presenter-test.php
+++ b/tests/presenters/open-graph/image-presenter-test.php
@@ -20,11 +20,15 @@ use Brain\Monkey;
 class Image_Presenter_Test extends TestCase {
 
 	/**
+	 * The image presenter instance.
+	 *
 	 * @var Image_Presenter|Mockery\MockInterface
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;

--- a/tests/presenters/open-graph/locale-presenter-test.php
+++ b/tests/presenters/open-graph/locale-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;

--- a/tests/presenters/open-graph/locale-presenter-test.php
+++ b/tests/presenters/open-graph/locale-presenter-test.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Presenters;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Locale_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter
+ *
+ * @group presenters
+ * @group open-graph
+ */
+class Locale_Presenter_Test extends TestCase {
+
+	/**
+	 * The locale presenter instance.
+	 *
+	 * @var Locale_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	protected $presentation;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->instance     = new Locale_Presenter();
+		$this->presentation = new Indexable_Presentation();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct locale.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$this->presentation->open_graph_locale = 'nl_BE';
+
+		$expected = '<meta property="og:locale" content="nl_BE" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct locale, when the `wpseo_og_locale` filter is applied.
+	 *
+	 * @covers ::present
+	 * @covers ::filter
+	 */
+	public function test_present_filter() {
+		$this->presentation->open_graph_locale = 'nl_BE';
+
+		Monkey\Filters\expectApplied( 'wpseo_og_locale' )
+			->once()
+			->with( 'nl_BE', $this->presentation )
+			->andReturn( 'nl_BE' );
+
+		$expected = '<meta property="og:locale" content="nl_BE" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/tests/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/presenters/open-graph/site-name-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;

--- a/tests/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/presenters/open-graph/site-name-presenter-test.php
@@ -18,11 +18,15 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Site_Name_Presenter_Test extends TestCase {
 
 	/**
+	 * The site name presenter instance.
+	 *
 	 * @var Site_Name_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $presentation;

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -18,23 +18,32 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @group open-graph
  */
 class Title_Presenter_Test extends TestCase {
+
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $indexable_presentation;
 
 	/**
+	 * The title presenter instance.
+	 *
 	 * @var Title_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The WPSEO Replace Vars object.
+	 *
 	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 
 	/**
-	 * @var Mockery\MockInterface
+	 * The string helper.
+	 *
+	 * @var String_Helper|Mockery\MockInterface
 	 */
 	protected $string;
 

--- a/tests/presenters/open-graph/type-presenter-test.php
+++ b/tests/presenters/open-graph/type-presenter-test.php
@@ -19,11 +19,15 @@ use Yoast\WP\SEO\Tests\TestCase;
  */
 class Type_Presenter_Test extends TestCase {
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $indexable_presentation;
 
 	/**
+	 * The type presenter instance.
+	 *
 	 * @var Type_Presenter
 	 */
 	protected $instance;

--- a/tests/presenters/open-graph/url-presenter-test.php
+++ b/tests/presenters/open-graph/url-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;

--- a/tests/presenters/open-graph/url-presenter-test.php
+++ b/tests/presenters/open-graph/url-presenter-test.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Presenters;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Open_Graph\Url_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Url_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Open_Graph\Url_Presenter
+ *
+ * @group presenters
+ * @group open-graph
+ */
+class Url_Presenter_Test extends TestCase {
+
+	/**
+	 * The URL presenter instance.
+	 *
+	 * @var Url_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	protected $presentation;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->instance     = new Url_Presenter();
+		$this->presentation = new Indexable_Presentation();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct URL.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$this->presentation->open_graph_url = 'www.example.com';
+
+		$expected = '<meta property="og:url" content="www.example.com" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests the presenter with an empty URL.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_empty_url() {
+		$this->presentation->open_graph_url = '';
+
+		$actual = $this->instance->present( $this->presentation );
+
+		$this->assertEmpty( $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct URL, when the `wpseo_opengraph_url` filter is applied.
+	 *
+	 * @covers ::present
+	 * @covers ::filter
+	 */
+	public function test_present_filter() {
+		$this->presentation->open_graph_url = 'www.example.com';
+
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_url' )
+			->once()
+			->with( 'www.example.com', $this->presentation )
+			->andReturn( 'www.example.com' );
+
+		$expected = '<meta property="og:url" content="www.example.com" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/tests/presenters/open-graph/url-presenter-test.php
+++ b/tests/presenters/open-graph/url-presenter-test.php
@@ -63,9 +63,7 @@ class Url_Presenter_Test extends TestCase {
 	public function test_present_empty_url() {
 		$this->presentation->open_graph_url = '';
 
-		$actual = $this->instance->present( $this->presentation );
-
-		$this->assertEmpty( $actual );
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
 	}
 
 	/**

--- a/tests/presenters/rel-next-presenter-test.php
+++ b/tests/presenters/rel-next-presenter-test.php
@@ -22,12 +22,14 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Rel_Next_Presenter_Test extends TestCase {
 
 	/**
+	 * The rel next presenter instance.
+	 *
 	 * @var Rel_Next_Presenter|Mockery\MockInterface
 	 */
 	private $instance;
 
 	/**
-	 * Set up.
+	 * Sets up the test class.
 	 */
 	public function setUp() {
 		parent::setUp();

--- a/tests/presenters/rel-next-presenter-test.php
+++ b/tests/presenters/rel-next-presenter-test.php
@@ -12,11 +12,11 @@ use Yoast\WP\SEO\Presenters\Rel_Next_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Rel_Next_Presenter_Test.
+ * Class Rel_Next_Presenter_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Rel_Next_Presenter
  *
- * @group presentations
+ * @group presenters
  * @group rel-next
  */
 class Rel_Next_Presenter_Test extends TestCase {

--- a/tests/presenters/rel-prev-presenter-test.php
+++ b/tests/presenters/rel-prev-presenter-test.php
@@ -22,12 +22,14 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Rel_Prev_Presenter_Test extends TestCase {
 
 	/**
+	 * The rel prev presenter instance.
+	 *
 	 * @var Rel_Prev_Presenter|Mockery\MockInterface
 	 */
 	private $instance;
 
 	/**
-	 * Set up.
+	 * Sets up the test class.
 	 */
 	public function setUp() {
 		parent::setUp();

--- a/tests/presenters/rel-prev-presenter-test.php
+++ b/tests/presenters/rel-prev-presenter-test.php
@@ -12,11 +12,11 @@ use Yoast\WP\SEO\Presenters\Rel_Prev_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Rel_Prev_Presenter_Test.
+ * Class Rel_Prev_Presenter_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Rel_Prev_Presenter
  *
- * @group presentations
+ * @group presenters
  * @group rel-prev
  */
 class Rel_Prev_Presenter_Test extends TestCase {

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -20,6 +20,8 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Robots_Presenter_Test extends TestCase {
 
 	/**
+	 * The robots presenter instance.
+	 *
 	 * @var Robots_Presenter
 	 */
 	private $instance;

--- a/tests/presenters/schema-presenter-test.php
+++ b/tests/presenters/schema-presenter-test.php
@@ -37,7 +37,7 @@ class Schema_Presenter_Test extends TestCase {
 	 */
 	public function setUp() {
 		$this->instance     = Mockery::mock( Schema_Presenter::class )
-		                             ->makePartial();
+			->makePartial();
 		$this->presentation = new Indexable_Presentation();
 
 		return parent::setUp();
@@ -58,7 +58,7 @@ class Schema_Presenter_Test extends TestCase {
 		Monkey\Actions\expectDone( 'wpseo_json_ld' )
 			->once();
 
-		$output  = '<script type="application/ld+json" class="yoast-schema-graph">[' . PHP_EOL;
+		$output = '<script type="application/ld+json" class="yoast-schema-graph">[' . PHP_EOL;
 		$output .= "\t    \"the_schema\"" . PHP_EOL;
 		$output .= "\t]</script>";
 

--- a/tests/presenters/schema-presenter-test.php
+++ b/tests/presenters/schema-presenter-test.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Presenters;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Schema_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Schema_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Schema_Presenter
+ *
+ * @group presenters
+ * @group schema
+ */
+class Schema_Presenter_Test extends TestCase {
+
+	/**
+	 * The Schema presenter instance.
+	 *
+	 * @var Schema_Presenter
+	 */
+	private $instance;
+
+	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	private $presentation;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		$this->instance     = Mockery::mock( Schema_Presenter::class )
+		                             ->makePartial();
+		$this->presentation = new Indexable_Presentation();
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tests presenting the Schema meta tag.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_happy_path() {
+		$this->presentation->schema = [ 'the_schema' ];
+
+		Monkey\Filters\expectApplied( 'wpseo_json_ld_output' )
+			->once()
+			->andReturn( '' );
+
+		Monkey\Actions\expectDone( 'wpseo_json_ld' )
+			->once();
+
+		$output  = '<script type="application/ld+json" class="yoast-schema-graph">[' . PHP_EOL;
+		$output .= "\t    \"the_schema\"" . PHP_EOL;
+		$output .= "\t]</script>";
+
+		$this->assertEquals( $output, $this->instance->present( $this->presentation ) );
+	}
+
+	/**
+	 * Tests presenting the Schema meta tag when the filter returns an empty array.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_filter_returns_empty_array() {
+		$this->presentation->schema = [ 'the_schema' ];
+
+		Monkey\Filters\expectApplied( 'wpseo_json_ld_output' )
+			->once()
+			->andReturn( [] );
+
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
+	}
+
+	/**
+	 * Tests presenting the Schema meta tag when the filter returns false.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_filter_returns_false() {
+		$this->presentation->schema = [ 'the_schema' ];
+
+		Monkey\Filters\expectApplied( 'wpseo_json_ld_output' )
+			->once()
+			->andReturn( false );
+
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
+	}
+
+	/**
+	 * Tests presenting the Schema meta tag when the Schema is not an array.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_schema_not_an_array() {
+		$this->presentation->schema = 'the_schema';
+
+		Monkey\Filters\expectApplied( 'wpseo_json_ld_output' )
+			->once()
+			->andReturn( '' );
+
+		Monkey\Actions\expectDone( 'wpseo_json_ld' )
+			->once();
+
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
+	}
+}

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -127,9 +127,9 @@ class Title_Presenter_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_title' )
 			->once()
 			->with( 'example_title', Mockery::type( Indexable_Presentation::class ) )
-			->andReturn( 'exampletitle' );
+			->andReturn( 'example_title' );
 
-		$expected = '<title>exampletitle</title>';
+		$expected = '<title>example_title</title>';
 		$actual   = $this->instance->present( $this->indexable_presentation );
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -19,22 +19,30 @@ use Yoast\WP\SEO\Tests\TestCase;
  */
 class Title_Presenter_Test extends TestCase {
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $indexable_presentation;
 
 	/**
+	 * The title presenter instance.
+	 *
 	 * @var Title_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The WPSEO Replace Vars object.
+	 *
 	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 
 	/**
-	 * @var Mockery\MockInterface
+	 * The string helper.
+	 *
+	 * @var String_Helper|Mockery\MockInterface
 	 */
 	protected $string;
 

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -19,6 +19,8 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Description_Presenter_Test extends TestCase {
 
 	/**
+	 * The WPSEO Replace Vars object.
+	 *
 	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -43,7 +43,7 @@ class Description_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the presentation for a set twitter description.
+	 * Tests the presenter for a set twitter description.
 	 *
 	 * @covers ::present
 	 * @covers ::filter
@@ -64,7 +64,7 @@ class Description_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the presentation of an empty description.
+	 * Tests the presenter of an empty description.
 	 *
 	 * @covers ::present
 	 * @covers ::filter

--- a/tests/presenters/twitter/image-presenter-test.php
+++ b/tests/presenters/twitter/image-presenter-test.php
@@ -2,33 +2,42 @@
 
 namespace Yoast\WP\SEO\Tests\Presenters\Twitter;
 
-use Mockery;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Twitter\Image_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
 
 /**
- * Class Image_Presenter_Test.
+ * Class Image_Presenter_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Twitter\Image_Presenter
  *
- * @group presentations
+ * @group presenters
  * @group twitter
  * @group twitter-image
  */
 class Image_Presenter_Test extends TestCase {
 
 	/**
+	 * The image presenter instance.
+	 *
 	 * @var Image_Presenter
 	 */
 	private $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	protected $presentation;
+
+	/**
 	 * Sets up the test class.
 	 */
 	public function setUp() {
-		$this->instance   = new Image_Presenter();
+		$this->instance     = new Image_Presenter();
+		$this->presentation = new Indexable_Presentation();
 
 		parent::setUp();
 
@@ -36,18 +45,48 @@ class Image_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the presentation of a relative image.
+	 * Tests whether the presenter returns the correct image.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		$this->presentation->twitter_image = 'relative_image.jpg';
+
+		$expected = '<meta name="twitter:image" content="relative_image.jpg" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests the presenter with an empty image.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_empty_image() {
+		$this->presentation->twitter_image = '';
+
+		$this->assertEmpty( $this->instance->present( $this->presentation ) );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct image,
+	 * when the `wpseo_twitter_image` filter is applied.
 	 *
 	 * @covers ::present
 	 * @covers ::filter
 	 */
-	public function test_present() {
-		$presentation = new Indexable_Presentation();
-		$presentation->twitter_image = 'relative_image.jpg';
+	public function test_present_filter() {
+		$this->presentation->twitter_image = 'relative_image.jpg';
 
-		$this->assertEquals(
-			'<meta name="twitter:image" content="relative_image.jpg" />',
-			$this->instance->present( $presentation )
-		);
+		Monkey\Filters\expectApplied( 'wpseo_twitter_image' )
+			->once()
+			->with( 'relative_image.jpg', $this->presentation )
+			->andReturn( 'relative_image.jpg' );
+
+		$expected = '<meta name="twitter:image" content="relative_image.jpg" />';
+		$actual   = $this->instance->present( $this->presentation );
+
+		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/tests/presenters/twitter/image-presenter-test.php
+++ b/tests/presenters/twitter/image-presenter-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Presenters\Twitter;
 
 use Mockery;
-use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Twitter\Image_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -21,21 +20,15 @@ use Brain\Monkey;
 class Image_Presenter_Test extends TestCase {
 
 	/**
-	 * @var Url_Helper|Mockery\MockInterface
-	 */
-	private $url;
-
-	/**
 	 * @var Image_Presenter
 	 */
 	private $instance;
 
 	/**
-	 * Sets an instance with the mocked url helper.
+	 * Sets up the test class.
 	 */
 	public function setUp() {
-		$this->url = Mockery::mock( Url_Helper::class )->makePartial();
-		$this->instance   = new Image_Presenter( $this->url );
+		$this->instance   = new Image_Presenter();
 
 		parent::setUp();
 

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Twitter\Presenters;
+namespace Yoast\WP\SEO\Tests\Presenters\Twitter;
 
 use Brain\Monkey;
 use Mockery;

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -18,16 +18,22 @@ use Yoast\WP\SEO\Tests\TestCase;
  */
 class Title_Presenter_Test extends TestCase {
 	/**
+	 * The indexable presentation.
+	 *
 	 * @var Indexable_Presentation
 	 */
 	protected $indexable_presentation;
 
 	/**
+	 * The title presenter instance.
+	 *
 	 * @var Title_Presenter
 	 */
 	protected $instance;
 
 	/**
+	 * The WPSEO Replace Vars object.
+	 *
 	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to have full coverage of the code in `src/presenters`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A Adds tests for the presenters.

## Relevant technical choices:

* ~~For `get_id()` in the `breadcrumbs_presenter`, I didn't test the scenario where the ID is already set, because currently the ID doesn't get set in the `breadcrumbs_presenter`, and it's hard to set up this scenario because `id` is a private variable.~~
    * ~~The same applies to `get_class()`, `get_wrapper()`, `get_separator()` and `get_element()`.~~
* 👆This is fixed in the last [commit](https://github.com/Yoast/wordpress-seo/pull/14488/commits/0d258fa5bb91618639f70ea7fac97bfb2d3edcde): we now call the tests twice to test caching. If the caching doesn't work correctly, the tests will fail since the filters are expected to be called only `once`.
* For `present()` in the `meta_description_presenter`, I didn't test the scenario where the meta description is not a string, because the `trim()` function always returns a string.
* I added missing documentation in various places.
* I removed the URL helper from `twitter/image-presenter` because it wasn't used.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See all the unit tests pass.
* See the code coverage in `src/presenters` is at 100%.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
