### PR TITLE
Removes stripslashes from retrieve_title()

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -532,7 +532,7 @@ class WPSEO_Replace_Vars {
 		$replacement = null;
 
 		if ( is_string( $this->args->post_title ) && $this->args->post_title !== '' ) {
-			$replacement = stripslashes( $this->args->post_title );
+			$replacement = $this->args->post_title;
 		}
 
 		return $replacement;


### PR DESCRIPTION
Props to [jchristopher](https://github.com/jchristopher).

## Context
I wrote a page that documents a `\Namespaced\Class` and that has a Title `\Namespaced\Class` and when viewing the front end the `<title>` ends up as `NamespacedClass` instead of `\Namespaced\Class`

`esc_html()` is fired in `wp_get_document_title()` after this return and a call to `stripslashes()` prevents titles with backslashes e.g. when documenting a namespaced PHP class.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where slashes in titles were removed before they were used as a replacement variable.

## Technical choices

* Removes `stripslashes` from `retrieve_title()`

## Test instructions
1. On `trunk`, enter a title with `\` in it, for example: `\Nice\Namespace`. Save the post.
2. On the front-end, check that the `\` is stripped.
3. Checkout this branch, enter a title with `\` in it, for example: `\Nice\Namespace`. Save the post.
4. On the front-end, check that the `\` is displayed nicely.
