### PR TITLE
Remove unused indexable indices

### DIFF
--- a/migrations/20171228151840_WpYoastIndexable.php
+++ b/migrations/20171228151840_WpYoastIndexable.php
@@ -138,64 +138,15 @@ class WpYoastIndexable extends Ruckusing_Migration_Base {
 				'object_sub_type',
 			],
 			[
-				'name' => 'indexable',
+				'name' => 'object_type_and_sub_type',
 			]
 		);
 
 		$this->add_index(
 			$indexable_table_name,
+			'permalink_hash',
 			[
-				'primary_focus_keyword_score',
-				'object_type',
-				'object_sub_type',
-			],
-			[
-				'name' => 'primary_focus_keyword_score',
-			]
-		);
-
-		$this->add_index(
-			$indexable_table_name,
-			[
-				'is_cornerstone',
-				'object_type',
-				'object_sub_type',
-			],
-			[
-				'name' => 'cornerstones',
-			]
-		);
-
-		$this->add_index(
-			$indexable_table_name,
-			[
-				'incoming_link_count',
-				'object_type',
-				'object_sub_type',
-			],
-			[
-				'name' => 'orphaned_content',
-			]
-		);
-
-		$this->add_index(
-			$indexable_table_name,
-			[
-				'is_robots_noindex',
-				'object_id',
-				'object_type',
-				'object_sub_type',
-			],
-			[
-				'name' => 'robots_noindex',
-			]
-		);
-
-		$this->add_index(
-			$indexable_table_name,
-			'prominent_words_version',
-			[
-				'name' => 'prominent_words_version',
+				'name' => 'permalink_hash',
 			]
 		);
 	}

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -145,27 +145,6 @@ class Indexable_Repository {
 	/**
 	 * Retrieves all the indexable instances of a certain object subtype.
 	 *
-	 * @param string $object_sub_type The object subtype.
-	 *
-	 * @return Indexable[] The array with all the indexable instances of a certain object subtype.
-	 */
-	public function find_all_with_sub_type( $object_sub_type ) {
-		/**
-		 * The array with all the indexable instances of a certain object subtype.
-		 *
-		 * @var Indexable[] $indexables
-		 */
-		$indexables = $this
-			->query()
-			->where( 'object_sub_type', $object_sub_type )
-			->find_many();
-
-		return $indexables;
-	}
-
-	/**
-	 * Retrieves all the indexable instances of a certain object subtype.
-	 *
 	 * @param string $object_type     The object type.
 	 * @param string $object_sub_type The object subtype.
 	 *


### PR DESCRIPTION
## Context
Removes unused indices from the indexables migration.

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Indices were optimized for the majority if sites. Indices that would only apply to a very small percentage of sites with large amounts of posts were not added.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Remove all indexable-related tables.
* Run the migrations
* You should have all required tables and 3 indices on the indexables table ( one being the primary key index ).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
