### PR TITLE
Adds tests for the author Schema generator

### DIFF
--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -39,6 +39,8 @@ class Author extends Person {
 	 * @param Image_Helper        $image        The image helper.
 	 * @param Schema\Image_Helper $schema_image The schema image helper.
 	 * @param Schema\HTML_Helper  $html         The HTML helper.
+	 *
+	 * @codeCoverageIgnore Constructor method.
 	 */
 	public function __construct(
 		Article_Helper $article,
@@ -125,6 +127,8 @@ class Author extends Person {
 	 * @param array             $data      The Person schema.
 	 * @param string            $schema_id The string used in the `@id` for the schema.
 	 * @param Meta_Tags_Context $context   The meta tags context.
+	 *
+	 * @codeCoverageIgnore Wrapper method, only returns `$data` argument.
 	 *
 	 * @return array The Person schema.
 	 */

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -18,39 +18,77 @@ use Yoast\WP\SEO\Tests\Mocks\Author;
  */
 class Author_Test extends TestCase {
 	/**
+	 * Holds the Schema ID helper.
+	 *
 	 * @var Schema\ID_Helper
 	 */
 	private $id;
 
 	/**
+	 * Holds the article helper.
+	 *
 	 * @var Article_Helper
 	 */
 	private $article;
 
 	/**
+	 * Holds the image helper.
+	 *
 	 * @var Image_Helper
 	 */
 	private $image;
 
 	/**
+	 * Holds the Schema image helper.
+	 *
 	 * @var Schema\Image_Helper
 	 */
 	private $schema_image;
 
 	/**
+	 * Holds the HTML helper.
+	 *
 	 * @var Schema\HTML_Helper
 	 */
 	private $html;
 
 	/**
+	 * Holds the meta tags context.
+	 *
 	 * @var Meta_Tags_Context
 	 */
 	private $meta_tags_context;
 
 	/**
+	 * Holds the author schema generator under test.
+	 *
 	 * @var Author
 	 */
 	private $instance;
+
+	/**
+	 * Mock Person schema piece.
+	 *
+	 * @var array
+	 */
+	private $person_data = [
+		'@type' => [
+			'Person',
+		],
+		'@id'   => 'http://basic.wordpress.test/#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21',
+		'name'  => 'Ad Minnie',
+		'image' => [
+			'@type' => 'ImageObject',
+			'@id'   => 'http://basic.wordpress.test/#personlogo',
+			'url'   => 'http://2.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=96&d=mm&r=g',
+			'caption' => 'Ad Minnie',
+		],
+		'sameAs' => [
+			'https://facebook.example.org/admin',
+			'https://instagram.example.org/admin',
+			'https://linkedin.example.org/admin',
+		],
+	];
 
 	/**
 	 * Sets up the test.
@@ -87,31 +125,13 @@ class Author_Test extends TestCase {
 	 * @covers ::generate
 	 * @covers ::determine_user_id
 	 */
-	public function test_generate() {
+	public function test_generate_on_author_pages() {
 		$user_id = 123;
-		$person_data = [
-			'@type' => [
-				'Person',
-			],
-			'@id'   => 'http://basic.wordpress.test/#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21',
-			'name'  => 'Ad Minnie',
-			'image' => [
-				'@type' => 'ImageObject',
-				'@id'   => 'http://basic.wordpress.test/#personlogo',
-				'url'   => 'http://2.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=96&d=mm&r=g',
-				'caption' => 'Ad Minnie',
-			],
-			'sameAs' => [
-				'https://facebook.example.org/admin',
-				'https://instagram.example.org/admin',
-				'https://linkedin.example.org/admin',
-			],
-		];
 
 		$this->instance->expects( 'build_person_data' )
 					   ->once()
 					   ->with( $user_id, $this->meta_tags_context )
-			           ->andReturn( $person_data );
+			           ->andReturn( $this->person_data );
 
 		$this->id->webpage_hash = '#webpage';
 
@@ -127,6 +147,8 @@ class Author_Test extends TestCase {
 
 		$this->meta_tags_context->canonical = 'http://basic.wordpress.test/author/admin/';
 
+		Brain\Monkey\Filters\expectApplied( 'wpseo_schema_person_user_id' );
+
 		$actual = $this->instance->generate( $this->meta_tags_context );
 
 		$this->assertArrayHasKey( 'mainEntityOfPage', $actual );
@@ -134,22 +156,71 @@ class Author_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the author gets a 'mainEntityOfPage' property pointing to the webpage Schema piece on the same page.
+	 *
+	 * @covers ::generate
+	 * @covers ::determine_user_id
+	 */
+	public function test_generate_on_posts() {
+		$user_id = 123;
+
+		$this->instance->expects( 'build_person_data' )
+					   ->once()
+					   ->with( $user_id, $this->meta_tags_context )
+					   ->andReturn( $this->person_data );
+
+		$this->id->webpage_hash = '#webpage';
+
+		// Set up the context with values.
+		$this->meta_tags_context->post = (Object) [
+			'post_author' => $user_id,
+		];
+
+		$this->meta_tags_context->indexable = (Object) [
+			'object_type' => 'post',
+			'object_id'   => 1234,
+		];
+
+		$this->meta_tags_context->canonical = 'http://basic.wordpress.test/author/admin/';
+
+		Brain\Monkey\Filters\expectApplied( 'wpseo_schema_person_user_id' );
+
+		$actual = $this->instance->generate( $this->meta_tags_context );
+
+		$this->assertSame( $this->person_data, $actual );
+	}
+
+	/**
 	 * Tests that the author is not output when no user id could be determined.
 	 *
-	 * @covers Yoast\WP\SEO\Presentations\Generators\Schema\Author::generate
+	 * @covers ::generate
 	 */
 	public function test_not_generate_when_user_id_cannot_be_defined() {
-		$this->instance
-			->expects( 'determine_user_id' )
-			->andReturn( false );
+		$this->id->webpage_hash = '#webpage';
 
-		$this->assertFalse( $this->instance->generate( $this->meta_tags_context ) );
+		// Set up the context with values.
+		$this->meta_tags_context->post = (Object) [
+			'post_author' => false,
+		];
+
+		$this->meta_tags_context->indexable = (Object) [
+			'object_type' => 'post',
+			'object_id'   => 1234,
+		];
+
+		$this->meta_tags_context->canonical = 'http://basic.wordpress.test/author/admin/';
+
+		Brain\Monkey\Filters\expectApplied( 'wpseo_schema_person_user_id' );
+
+		$actual = $this->instance->generate( $this->meta_tags_context );
+
+		$this->assertFalse( $actual );
 	}
 
 	/**
 	 * Tests that the author Schema piece is output when the page is a author archive page.
 	 *
-	 * @covers Yoast\WP\SEO\Presentations\Generators\Schema\Author::is_needed
+	 * @covers ::is_needed
 	 */
 	public function test_is_shown_when_on_author_page() {
 		$user_id = 123;
@@ -170,7 +241,7 @@ class Author_Test extends TestCase {
 	 * Tests that the author Schema piece is not output on a post
 	 * authored by the person the website represents.
 	 *
-	 * @covers Yoast\WP\SEO\Presentations\Generators\Schema\Author::is_needed
+	 * @covers ::is_needed
 	 */
 	public function test_is_not_shown_when_on_post_and_site_represents_author() {
 		$user_id         = 123;
@@ -197,41 +268,10 @@ class Author_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the author Schema piece is output on a post
-	 * not authored by the person the website represents.
+	 * Tests that the author Schema piece is not output
+	 * on non-user archives and non-posts.
 	 *
-	 * @covers Yoast\WP\SEO\Presentations\Generators\Schema\Author::is_needed
-	 */
-	public function test_is_shown_when_on_post_and_site_does_not_represent_author() {
-		$user_id         = 123;
-		$other_user_id   = 404;
-		$object_sub_type = 'recipe';
-
-		$this->article
-			->expects( 'is_article_post_type' )
-			->with( $object_sub_type )
-			->andReturn( true );
-
-		// Set up the context with values.
-		$this->meta_tags_context->post = (Object) [
-			'post_author' => $user_id,
-		];
-
-		$this->meta_tags_context->indexable = (Object) [
-			'object_type'     => 'post',
-			'object_sub_type' => $object_sub_type,
-		];
-
-		$this->meta_tags_context->site_user_id = $other_user_id;
-
-		$this->assertTrue( $this->instance->is_needed( $this->meta_tags_context ) );
-	}
-
-	/**
-	 * Tests that the author Schema piece is output on a post
-	 * not authored by the person the website represents.
-	 *
-	 * @covers Yoast\WP\SEO\Presentations\Generators\Schema\Author::is_needed
+	 * @covers ::is_needed
 	 */
 	public function test_is_not_shown_when_not_a_user_or_post_type() {
 		$user_id         = 123;

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -72,15 +72,15 @@ class Author_Test extends TestCase {
 	 * @var array
 	 */
 	private $person_data = [
-		'@type' => [
+		'@type'  => [
 			'Person',
 		],
-		'@id'   => 'http://basic.wordpress.test/#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21',
-		'name'  => 'Ad Minnie',
-		'image' => [
-			'@type' => 'ImageObject',
-			'@id'   => 'http://basic.wordpress.test/#personlogo',
-			'url'   => 'http://2.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=96&d=mm&r=g',
+		'@id'    => 'http://basic.wordpress.test/#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21',
+		'name'   => 'Ad Minnie',
+		'image'  => [
+			'@type'   => 'ImageObject',
+			'@id'     => 'http://basic.wordpress.test/#personlogo',
+			'url'     => 'http://2.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=96&d=mm&r=g',
 			'caption' => 'Ad Minnie',
 		],
 		'sameAs' => [
@@ -109,8 +109,8 @@ class Author_Test extends TestCase {
 		];
 
 		$this->instance = Mockery::mock( Author::class, $constructor_args )
-								 ->shouldAllowMockingProtectedMethods()
-								 ->makePartial();
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
 
 		$this->id = Mockery::mock( Schema\ID_Helper::class );
 
@@ -129,9 +129,9 @@ class Author_Test extends TestCase {
 		$user_id = 123;
 
 		$this->instance->expects( 'build_person_data' )
-					   ->once()
-					   ->with( $user_id, $this->meta_tags_context )
-			           ->andReturn( $this->person_data );
+			->once()
+			->with( $user_id, $this->meta_tags_context )
+			->andReturn( $this->person_data );
 
 		$this->id->webpage_hash = '#webpage';
 
@@ -165,9 +165,9 @@ class Author_Test extends TestCase {
 		$user_id = 123;
 
 		$this->instance->expects( 'build_person_data' )
-					   ->once()
-					   ->with( $user_id, $this->meta_tags_context )
-					   ->andReturn( $this->person_data );
+			->once()
+			->with( $user_id, $this->meta_tags_context )
+			->andReturn( $this->person_data );
 
 		$this->id->webpage_hash = '#webpage';
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to take the code coverage of the indexables code to 100%.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Takes the code coverage of the author Schema generator to 100%.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check that travis passes.
* Run the unit tests in `tests/generators/schema/author-test.php` with code coverage.
* Check that `generators/schema/author.php` has a coverage of 100%.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
