### PR TITLE
Add tests for integrations/watchers

### DIFF
--- a/src/integrations/watchers/indexable-post-type-archive-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-archive-watcher.php
@@ -67,10 +67,6 @@ class Indexable_Post_Type_Archive_Watcher implements Integration_Interface {
 	public function check_option( $old_value, $new_value ) {
 		$relevant_keys = [ 'title-ptarchive-', 'metadesc-ptarchive-', 'bctitle-ptarchive-', 'noindex-ptarchive-' ];
 
-		if ( ! is_array( $old_value ) || ! is_array( $new_value ) ) {
-			return;
-		}
-
 		$keys               = array_unique( array_merge( array_keys( $old_value ), array_keys( $new_value ) ) );
 		$post_types_rebuild = [];
 

--- a/src/integrations/watchers/indexable-post-type-archive-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-archive-watcher.php
@@ -62,10 +62,19 @@ class Indexable_Post_Type_Archive_Watcher implements Integration_Interface {
 	 * @param array $old_value The old value of the option.
 	 * @param array $new_value The new value of the option.
 	 *
-	 * @return void
+	 * @return bool Whether or not the option has been saved.
 	 */
 	public function check_option( $old_value, $new_value ) {
 		$relevant_keys = [ 'title-ptarchive-', 'metadesc-ptarchive-', 'bctitle-ptarchive-', 'noindex-ptarchive-' ];
+
+		// If this is the first time saving the option, thus when value is false.
+		if ( $old_value === false ) {
+			$old_value = [];
+		}
+
+		if ( ! is_array( $old_value ) || ! is_array( $new_value ) ) {
+			return false;
+		}
 
 		$keys               = array_unique( array_merge( array_keys( $old_value ), array_keys( $new_value ) ) );
 		$post_types_rebuild = [];
@@ -98,6 +107,8 @@ class Indexable_Post_Type_Archive_Watcher implements Integration_Interface {
 				$post_types_rebuild[] = $post_type;
 			}
 		}
+
+		return true;
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-term-watcher.php
+++ b/src/integrations/watchers/indexable-term-watcher.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
@@ -39,14 +40,23 @@ class Indexable_Term_Watcher implements Integration_Interface {
 	protected $builder;
 
 	/**
+	 * Represents the site helper.
+	 *
+	 * @var Site_Helper
+	 */
+	protected $site;
+
+	/**
 	 * Indexable_Term_Watcher constructor.
 	 *
 	 * @param Indexable_Repository $repository The repository to use.
 	 * @param Indexable_Builder    $builder    The post builder to use.
+	 * @param Site_Helper          $site       The site helper.
 	 */
-	public function __construct( Indexable_Repository $repository, Indexable_Builder $builder ) {
+	public function __construct( Indexable_Repository $repository, Indexable_Builder $builder, Site_Helper $site ) {
 		$this->repository = $repository;
 		$this->builder    = $builder;
+		$this->site       = $site;
 	}
 
 	/**
@@ -87,7 +97,7 @@ class Indexable_Term_Watcher implements Integration_Interface {
 	 */
 	public function build_indexable( $term_id ) {
 		// Bail if this is a multisite installation and the site has been switched.
-		if ( is_multisite() && ms_is_switched() ) {
+		if ( $this->site->is_multisite_and_switched() ) {
 			return;
 		}
 

--- a/tests/integrations/watchers/indexable-author-watcher-test.php
+++ b/tests/integrations/watchers/indexable-author-watcher-test.php
@@ -1,9 +1,13 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
 use Mockery;
-use Yoast\WP\SEO\Builders\Indexable_Author_Builder;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Models\Indexable;
@@ -26,26 +30,35 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexable_Author_Watcher_Test extends TestCase {
 
 	/**
+	 * Represents the indexable repository.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Repository
 	 */
-	private $repository_mock;
+	private $repository;
 
 	/**
+	 * Represents the indexable builder.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Builder
 	 */
-	private $builder_mock;
+	private $builder;
 
 	/**
+	 * Represents the instance to test.
+	 *
 	 * @var Indexable_Author_Watcher
 	 */
 	private $instance;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp() {
-		$this->repository_mock = Mockery::mock( Indexable_Repository::class );
-		$this->builder_mock    = Mockery::mock( Indexable_Builder::class );
-		$this->instance        = new Indexable_Author_Watcher( $this->repository_mock, $this->builder_mock );
+		parent::setUp();
 
-		return parent::setUp();
+		$this->repository = Mockery::mock( Indexable_Repository::class );
+		$this->builder    = Mockery::mock( Indexable_Builder::class );
+		$this->instance   = new Indexable_Author_Watcher( $this->repository, $this->builder );
 	}
 
 	/**
@@ -84,7 +97,11 @@ class Indexable_Author_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'delete' )->once();
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'user', false )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( $id, 'user', false )
+			->andReturn( $indexable_mock );
 
 		$this->instance->delete_indexable( $id );
 	}
@@ -97,7 +114,11 @@ class Indexable_Author_Watcher_Test extends TestCase {
 	public function test_delete_indexable_not_found() {
 		$id = 1;
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'user', false )->andReturn( false );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( $id, 'user', false )
+			->andReturn( false );
 
 		$this->instance->delete_indexable( $id );
 	}
@@ -112,8 +133,17 @@ class Indexable_Author_Watcher_Test extends TestCase {
 
 		$indexable_mock = Mockery::mock( Indexable::class );
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'user', false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_id_and_type' )->once()->with( $id, 'user', $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( $id, 'user', false )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_id_and_type' )
+			->once()
+			->with( $id, 'user', $indexable_mock )
+			->andReturn( $indexable_mock );
 
 		$this->instance->build_indexable( $id );
 	}
@@ -128,8 +158,17 @@ class Indexable_Author_Watcher_Test extends TestCase {
 
 		$indexable_mock = Mockery::mock( Indexable::class );
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'user', false )->andReturn( false );
-		$this->builder_mock->expects( 'build_for_id_and_type' )->once()->with( $id, 'user', false )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( $id, 'user', false )
+			->andReturn( false );
+
+		$this->builder
+			->expects( 'build_for_id_and_type' )
+			->once()
+			->with( $id, 'user', false )
+			->andReturn( $indexable_mock );
 
 		$this->instance->build_indexable( $id );
 	}

--- a/tests/integrations/watchers/indexable-date-archive-watcher-test.php
+++ b/tests/integrations/watchers/indexable-date-archive-watcher-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
@@ -25,26 +30,33 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexable_Date_Archive_Watcher_Test extends TestCase {
 
 	/**
+	 * Represents the indexable repository.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Repository
 	 */
-	private $repository_mock;
+	private $repository;
 
 	/**
+	 * Represents the indexable builder.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Builder
 	 */
-	private $builder_mock;
+	private $builder;
 
 	/**
 	 * @var Indexable_Date_Archive_Watcher
 	 */
 	private $instance;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp() {
-		$this->repository_mock = Mockery::mock( Indexable_Repository::class );
-		$this->builder_mock    = Mockery::mock( Indexable_Builder::class );
-		$this->instance        = new Indexable_Date_Archive_Watcher( $this->repository_mock, $this->builder_mock );
+		parent::setUp();
 
-		return parent::setUp();
+		$this->repository = Mockery::mock( Indexable_Repository::class );
+		$this->builder    = Mockery::mock( Indexable_Builder::class );
+		$this->instance   = new Indexable_Date_Archive_Watcher( $this->repository, $this->builder );
 	}
 
 	/**
@@ -81,8 +93,8 @@ class Indexable_Date_Archive_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_date_archive' )->once()->with( false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_date_archive' )->once()->with( $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository->expects( 'find_for_date_archive' )->once()->with( false )->andReturn( $indexable_mock );
+		$this->builder->expects( 'build_for_date_archive' )->once()->with( $indexable_mock )->andReturn( $indexable_mock );
 
 		$this->instance->check_option( [ 'title-archive-wpseo' => 'bar' ], [ 'title-archive-wpseo' => 'baz' ] );
 	}
@@ -121,8 +133,8 @@ class Indexable_Date_Archive_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_date_archive' )->once()->with( false )->andReturn( false );
-		$this->builder_mock->expects( 'build_for_date_archive' )->once()->with( false )->andReturn( $indexable_mock );
+		$this->repository->expects( 'find_for_date_archive' )->once()->with( false )->andReturn( false );
+		$this->builder->expects( 'build_for_date_archive' )->once()->with( false )->andReturn( $indexable_mock );
 
 		$this->instance->build_indexable();
 	}

--- a/tests/integrations/watchers/indexable-home-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-home-page-watcher-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
@@ -25,27 +30,35 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexable_Home_Page_Watcher_Test extends TestCase {
 
 	/**
+	 * Represents the indexable repository.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Repository
 	 */
-	private $repository_mock;
+	private $repository;
 
 	/**
+	 * Represents the indexable builder.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Builder
 	 */
-	private $builder_mock;
+	private $builder;
 
 	/**
+	 * Represents the instance to test.
+	 *
 	 * @var Indexable_Home_Page_Watcher
 	 */
 	private $instance;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp() {
-		$this->repository_mock = Mockery::mock( Indexable_Repository::class );
-		$this->builder_mock    = Mockery::mock( Indexable_Builder::class );
+		parent::setUp();
 
-		$this->instance = new Indexable_Home_Page_Watcher( $this->repository_mock, $this->builder_mock );
-
-		return parent::setUp();
+		$this->repository = Mockery::mock( Indexable_Repository::class );
+		$this->builder    = Mockery::mock( Indexable_Builder::class );
+		$this->instance   = new Indexable_Home_Page_Watcher( $this->repository, $this->builder );
 	}
 
 	/**
@@ -87,8 +100,17 @@ class Indexable_Home_Page_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_home_page' )->once()->with( false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_home_page' )->once()->with( $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_home_page' )
+			->once()
+			->with( false )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_home_page' )
+			->once()
+			->with( $indexable_mock )
+			->andReturn( $indexable_mock );
 
 		$this->instance->check_option( [ 'title-home-wpseo' => 'bar' ], [ 'title-home-wpseo' => 'baz' ], 'wpseo_titles' );
 	}
@@ -116,8 +138,17 @@ class Indexable_Home_Page_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_home_page' )->once()->with( false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_home_page' )->once()->with( $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_home_page' )
+			->once()
+			->with( false )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_home_page' )
+			->once()
+			->with( $indexable_mock )
+			->andReturn( $indexable_mock );
 
 		$this->instance->check_option( [ 'og_frontpage_desc' => 'bar' ], [ 'og_frontpage_desc' => 'baz' ], 'wpseo_social' );
 	}
@@ -144,8 +175,17 @@ class Indexable_Home_Page_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_home_page' )->once()->with( false )->andReturn( false );
-		$this->builder_mock->expects( 'build_for_home_page' )->once()->with( false )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_home_page' )
+			->once()
+			->with( false )
+			->andReturn( false );
+
+		$this->builder
+			->expects( 'build_for_home_page' )
+			->once()
+			->with( false )
+			->andReturn( $indexable_mock );
 
 		$this->instance->build_indexable();
 	}

--- a/tests/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/integrations/watchers/indexable-permalink-watcher-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
@@ -24,11 +29,15 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexable_Permalink_Watcher_Test extends TestCase {
 
 	/**
+	 * Represents the instance to test.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Permalink_Watcher
 	 */
 	protected $instance;
 
 	/**
+	 * Represents the post type helper.
+	 *
 	 * @var Mockery\MockInterface|Post_Type_Helper
 	 */
 	protected $post_type;
@@ -66,8 +75,8 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 		$this->instance->register_hooks();
 
 		$this->assertTrue( Monkey\Actions\has( 'update_option_permalink_structure', [ $this->instance, 'reset_permalinks' ] ) );
-		$this->assertTrue( Monkey\Actions\has(  'update_option_category_base', [ $this->instance, 'reset_permalinks_term' ] ) );
-		$this->assertTrue( Monkey\Actions\has(  'update_option_tag_base', [ $this->instance, 'reset_permalinks_term' ] ) );
+		$this->assertTrue( Monkey\Actions\has( 'update_option_category_base', [ $this->instance, 'reset_permalinks_term' ] ) );
+		$this->assertTrue( Monkey\Actions\has( 'update_option_tag_base', [ $this->instance, 'reset_permalinks_term' ] ) );
 	}
 
 	/**

--- a/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
@@ -25,26 +30,35 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 
 	/**
+	 * Represents the indexable repository.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Repository
 	 */
-	private $repository_mock;
+	private $repository;
 
 	/**
+	 * Represents the indexable builder.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Builder
 	 */
-	private $builder_mock;
+	private $builder;
 
 	/**
+	 * Represents the instance to test.
+	 *
 	 * @var Indexable_Post_Type_Archive_Watcher
 	 */
 	private $instance;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp() {
-		$this->repository_mock = Mockery::mock( Indexable_Repository::class );
-		$this->builder_mock    = Mockery::mock( Indexable_Builder::class );
-		$this->instance        = new Indexable_Post_Type_Archive_Watcher( $this->repository_mock, $this->builder_mock );
+		parent::setUp();
 
-		return parent::setUp();
+		$this->repository = Mockery::mock( Indexable_Repository::class );
+		$this->builder    = Mockery::mock( Indexable_Builder::class );
+		$this->instance   = new Indexable_Post_Type_Archive_Watcher( $this->repository, $this->builder );
 	}
 
 	/**
@@ -81,8 +95,17 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_post_type_archive' )->once()->with( 'my-post-type', false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_post_type_archive' )->once()->with( 'my-post-type', $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', false )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', $indexable_mock )
+			->andReturn( $indexable_mock );
 
 		$this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'bar' ], [ 'title-ptarchive-my-post-type' => 'baz' ] );
 	}
@@ -98,8 +121,17 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_post_type_archive' )->once()->with( 'my-post-type', false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_post_type_archive' )->once()->with( 'my-post-type', $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', false )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', $indexable_mock )
+			->andReturn( $indexable_mock );
 
 		$this->instance->check_option( [], [ 'title-ptarchive-my-post-type' => 'baz' ] );
 	}
@@ -118,11 +150,29 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 		$other_indexable_mock = Mockery::mock( Indexable::class );
 		$other_indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_post_type_archive' )->once()->with( 'my-post-type', false )->andReturn( $indexable_mock );
-		$this->repository_mock->expects( 'find_for_post_type_archive' )->once()->with( 'other-post-type', false )->andReturn( $other_indexable_mock );
+		$this->repository
+			->expects( 'find_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', false )
+			->andReturn( $indexable_mock );
 
-		$this->builder_mock->expects( 'build_for_post_type_archive' )->once()->with( 'my-post-type', $indexable_mock )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_post_type_archive' )->once()->with( 'other-post-type', $other_indexable_mock )->andReturn( $other_indexable_mock );
+		$this->repository
+			->expects( 'find_for_post_type_archive' )
+			->once()
+			->with( 'other-post-type', false )
+			->andReturn( $other_indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', $indexable_mock )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_post_type_archive' )
+			->once()
+			->with( 'other-post-type', $other_indexable_mock )
+			->andReturn( $other_indexable_mock );
 
 		$this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'baz' ], [ 'title-ptarchive-other-post-type' => 'baz' ] );
 	}
@@ -161,8 +211,17 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_post_type_archive' )->once()->with( 'my-post-type', false )->andReturn( false );
-		$this->builder_mock->expects( 'build_for_post_type_archive' )->once()->with( 'my-post-type', false )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', false )
+			->andReturn( false );
+
+		$this->builder
+			->expects( 'build_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', false )
+			->andReturn( $indexable_mock );
 
 		$this->instance->build_indexable( 'my-post-type' );
 	}

--- a/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
@@ -85,6 +85,41 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	}
 
 	/**
+	 * Tests check option with false given as old_value. This happens when the value is updated
+	 * the first time.
+	 *
+	 * @covers ::check_option
+	 */
+	public function test_check_option_first_time_save() {
+		$indexable_mock = Mockery::mock( Indexable::class );
+		$indexable_mock->expects( 'save' )->once();
+
+		$this->repository
+			->expects( 'find_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', false )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_post_type_archive' )
+			->once()
+			->with( 'my-post-type', $indexable_mock )
+			->andReturn( $indexable_mock );
+
+		$this->assertTrue( $this->instance->check_option( false, [ 'title-ptarchive-my-post-type' => 'baz' ] ) );
+	}
+
+	/**
+	 * Tests check option with two strings given as input. This should be considered as faulty, because we only
+	 * want to accept arrays.
+	 *
+	 * @covers ::check_option
+	 */
+	public function test_check_option_wrong_input_given() {
+		$this->assertFalse( $this->instance->check_option( 'string', 'string' ) );
+	}
+
+	/**
 	 * Tests if updating titles works as expected.
 	 *
 	 * @covers ::__construct
@@ -107,7 +142,7 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 			->with( 'my-post-type', $indexable_mock )
 			->andReturn( $indexable_mock );
 
-		$this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'bar' ], [ 'title-ptarchive-my-post-type' => 'baz' ] );
+		$this->assertTrue( $this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'bar' ], [ 'title-ptarchive-my-post-type' => 'baz' ] ) );
 	}
 
 	/**
@@ -133,7 +168,7 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 			->with( 'my-post-type', $indexable_mock )
 			->andReturn( $indexable_mock );
 
-		$this->instance->check_option( [], [ 'title-ptarchive-my-post-type' => 'baz' ] );
+		$this->assertTrue( $this->instance->check_option( [], [ 'title-ptarchive-my-post-type' => 'baz' ] ) );
 	}
 
 	/**
@@ -174,7 +209,7 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 			->with( 'other-post-type', $other_indexable_mock )
 			->andReturn( $other_indexable_mock );
 
-		$this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'baz' ], [ 'title-ptarchive-other-post-type' => 'baz' ] );
+		$this->assertTrue( $this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'baz' ], [ 'title-ptarchive-other-post-type' => 'baz' ] ) );
 	}
 
 	/**
@@ -186,7 +221,7 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value_same_value() {
 		// No assertions made so this will fail if any method is called on our mocks.
-		$this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'bar' ], [ 'title-ptarchive-my-post-type' => 'bar' ] );
+		$this->assertTrue( $this->instance->check_option( [ 'title-ptarchive-my-post-type' => 'bar' ], [ 'title-ptarchive-my-post-type' => 'bar' ] ) );
 	}
 
 	/**
@@ -198,7 +233,7 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value_without_change() {
 		// No assertions made so this will fail if any method is called on our mocks.
-		$this->instance->check_option( [ 'other_key' => 'bar' ], [ 'other_key' => 'baz' ] );
+		$this->assertTrue( $this->instance->check_option( [ 'other_key' => 'bar' ], [ 'other_key' => 'baz' ] ) );
 	}
 
 	/**

--- a/tests/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-watcher-test.php
@@ -1,10 +1,16 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
 use Brain\Monkey;
 use Exception;
 use Mockery;
+use Symfony\Component\DependencyInjection\Tests\Compiler\I;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
@@ -300,8 +306,8 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'update_relations' )
 			->never();
 
-		$old_indexable     = Mockery::mock();
-		$updated_indexable = Mockery::mock();
+		$old_indexable     = Mockery::mock( Indexable::class );
+		$updated_indexable = Mockery::mock( Indexable::class );
 		$updated_indexable->object_type = 'term';
 
 		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
@@ -317,10 +323,10 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'update_relations' )
 			->never();
 
-		$old_indexable            = Mockery::mock();
+		$old_indexable            = Mockery::mock( Indexable::class );
 		$old_indexable->is_public = false;
 
-		$updated_indexable              = Mockery::mock();
+		$updated_indexable              = Mockery::mock( Indexable::class );
 		$updated_indexable->object_type = 'post';
 		$updated_indexable->is_public   = false;
 
@@ -343,15 +349,16 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( [] )
 			->once();
 
-		$old_indexable            = Mockery::mock();
+		$old_indexable            = Mockery::mock( Indexable::class );
 		$old_indexable->is_public = true;
 
-		$updated_indexable              = Mockery::mock();
+		$updated_indexable              = Mockery::mock( Indexable::class );
 		$updated_indexable->object_type = 'post';
 		$updated_indexable->is_public   = false;
 		$updated_indexable->object_id   = 1;
 
-		$this->post->expects( 'get_post' )
+		$this->post
+			->expects( 'get_post' )
 			->once()
 			->with( 1 )->andReturn( [] );
 
@@ -375,11 +382,20 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		$post_indexable->author_id       = 1;
 		$post_indexable->is_public       = null;
 
-		$author_indexable            = Mockery::mock();
+		$author_indexable            = Mockery::mock( Indexable::class );
 		$author_indexable->object_id = 11;
 
-		$this->repository->expects( 'find_by_id_and_type' )->with( 1, 'user' )->once()->andReturn( $author_indexable );
-		$this->author_archive->expects( 'author_has_public_posts' )->with( 11 )->once()->andReturn( true );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->with( 1, 'user' )
+			->once()
+			->andReturn( $author_indexable );
+
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( 11 )
+			->once()
+			->andReturn( true );
 		$author_indexable->expects( 'save' )->once();
 
 		$this->post->expects( 'update_has_public_posts_on_attachments' )->once()->with( 33, null )->andReturnTrue();
@@ -454,7 +470,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'get_related_indexables' )
 			->once()
 			->with( $post )
-			->andReturn( [ $indexable ] ) ;
+			->andReturn( [ $indexable ] );
 
 		$this->instance->update_relations( $post );
 	}
@@ -475,7 +491,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'get_related_indexables' )
 			->once()
 			->with( $post )
-			->andReturn( [] ) ;
+			->andReturn( [] );
 
 		$this->instance->update_relations( $post );
 	}
@@ -498,7 +514,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->andReturn(
 				[
 					'taxonomy',
-					'another-taxonomy'
+					'another-taxonomy',
 				]
 			);
 

--- a/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
@@ -29,7 +34,7 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 	 *
 	 * @var Mockery\MockInterface|Indexable_Repository
 	 */
-	private $repository_mock;
+	private $repository;
 
 	/**
 	 * The class instance.
@@ -44,8 +49,8 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->repository_mock = Mockery::mock( Indexable_Repository::class );
-		$this->instance        = new Indexable_Static_Home_Page_Watcher( $this->repository_mock );
+		$this->repository = Mockery::mock( Indexable_Repository::class );
+		$this->instance   = new Indexable_Static_Home_Page_Watcher( $this->repository );
 	}
 
 	/**
@@ -96,12 +101,14 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 		$indexable_new->permalink      = 'https://example.com/old-permalink';
 		$indexable_new->permalink_hash = 'https://example.com/old-permalink';
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )
+		$this->repository
+			->expects( 'find_by_id_and_type' )
 			->with( 1, 'post', false )
 			->once()
 			->andReturn( $indexable_old );
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )
+		$this->repository
+			->expects( 'find_by_id_and_type' )
 			->with( 2, 'post', false )
 			->once()
 			->andReturn( $indexable_new );
@@ -114,7 +121,7 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 			->expects( 'save' )
 			->once();
 
-		$this->instance->update_static_homepage_permalink( "1", 2 );
+		$this->instance->update_static_homepage_permalink( '1', 2 );
 
 		$this->assertEquals( 'https://example.com/', $indexable_new->permalink );
 		$this->assertEquals( 'https://example.com/permalink/', $indexable_old->permalink );
@@ -136,7 +143,8 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 		$indexable_old->permalink      = 'https://example.com/';
 		$indexable_old->permalink_hash = 'https://example.com/';
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )
+		$this->repository
+			->expects( 'find_by_id_and_type' )
 			->with( 1, 'post', false )
 			->once()
 			->andReturn( $indexable_old );
@@ -145,8 +153,36 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 			->expects( 'save' )
 			->once();
 
-		$this->instance->update_static_homepage_permalink( "1", 0 );
+		$this->instance->update_static_homepage_permalink( '1', 0 );
 
 		$this->assertEquals( 'https://example.com/permalink/', $indexable_old->permalink );
+	}
+
+	/**
+	 * Tests the routine with having the same value for the old and the new value.
+	 *
+	 * @covers ::update_static_homepage_permalink
+	 */
+	public function test_update_page_on_front_no_value_change() {
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->never();
+
+		$this->instance->update_static_homepage_permalink( '1', 1 );
+	}
+
+	/**
+	 * Tests the routine with having the same value for the old and the new value.
+	 *
+	 * @covers ::update_static_homepage_permalink
+	 */
+	public function test_update_page_on_front_with_no_indexable_found() {
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->with( 1, 'post', false )
+			->once()
+			->andReturnFalse();
+
+		$this->instance->update_static_homepage_permalink( '1', 0 );
 	}
 }

--- a/tests/integrations/watchers/indexable-system-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-system-page-watcher-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
@@ -25,26 +30,35 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexable_System_Page_Watcher_Test extends TestCase {
 
 	/**
+	 * Represents the indexable repository.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Repository
 	 */
-	private $repository_mock;
+	private $repository;
 
 	/**
+	 * Represents the indexable builder.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Builder
 	 */
-	private $builder_mock;
+	private $builder;
 
 	/**
+	 * Represents the instance we want to test.
+	 *
 	 * @var Indexable_System_Page_Watcher
 	 */
 	private $instance;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp() {
-		$this->repository_mock = Mockery::mock( Indexable_Repository::class );
-		$this->builder_mock    = Mockery::mock( Indexable_Builder::class );
-		$this->instance        = new Indexable_System_Page_Watcher( $this->repository_mock, $this->builder_mock );
+		parent::setUp();
 
-		return parent::setUp();
+		$this->repository = Mockery::mock( Indexable_Repository::class );
+		$this->builder    = Mockery::mock( Indexable_Builder::class );
+		$this->instance   = new Indexable_System_Page_Watcher( $this->repository, $this->builder );
 	}
 
 	/**
@@ -81,8 +95,17 @@ class Indexable_System_Page_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_system_page' )->once()->with( 'search-result', false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_system_page' )->once()->with( 'search-result', $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_system_page' )
+			->once()
+			->with( 'search-result', false )
+			->andReturn( $indexable_mock );
+
+		$this->builder
+			->expects( 'build_for_system_page' )
+			->once()
+			->with( 'search-result', $indexable_mock )
+			->andReturn( $indexable_mock );
 
 		$this->instance->check_option( [ 'title-search-wpseo' => 'bar' ], [ 'title-search-wpseo' => 'baz' ] );
 	}
@@ -96,7 +119,18 @@ class Indexable_System_Page_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value_without_change() {
 		// No assertions made so this will fail if any method is called on our mocks.
-		$this->instance->check_option( [ 'other_key' => 'bar' ], [ 'other_key' => 'baz' ] );
+		$this->instance->check_option(
+			[
+				'other_key'          => 'bar',
+				'title-search-wpseo' => 'baz',
+				'title-404-wpseo'    => 'baz',
+			],
+			[
+				'other_key'          => 'baz',
+				'title-search-wpseo' => 'baz',
+				'title-404-wpseo'    => 'baz',
+			]
+		);
 	}
 
 	/**
@@ -109,8 +143,17 @@ class Indexable_System_Page_Watcher_Test extends TestCase {
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'save' )->once();
 
-		$this->repository_mock->expects( 'find_for_system_page' )->once()->with( '404-page', false )->andReturn( false );
-		$this->builder_mock->expects( 'build_for_system_page' )->once()->with( '404-page', false )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_for_system_page' )
+			->once()
+			->with( '404-page', false )
+			->andReturn( false );
+
+		$this->builder
+			->expects( 'build_for_system_page' )
+			->once()
+			->with( '404-page', false )
+			->andReturn( $indexable_mock );
 
 		$this->instance->build_indexable( '404-page' );
 	}

--- a/tests/integrations/watchers/indexable-term-watcher-test.php
+++ b/tests/integrations/watchers/indexable-term-watcher-test.php
@@ -1,10 +1,17 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
+use Exception;
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Term_Watcher;
@@ -25,26 +32,43 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexable_Term_Watcher_Test extends TestCase {
 
 	/**
+	 * Represents the indexable repository.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Repository
 	 */
-	private $repository_mock;
+	private $repository;
 
 	/**
+	 * Represents the indexable builder.
+	 *
 	 * @var Mockery\MockInterface|Indexable_Builder
 	 */
-	private $builder_mock;
+	private $builder;
 
 	/**
+	 * Represents the site helper.
+	 *
+	 * @var Mockery\MockInterface|Site_Helper
+	 */
+	private $site;
+
+	/**
+	 * Represents the instance we are testing.
+	 *
 	 * @var Indexable_Term_Watcher
 	 */
 	private $instance;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp() {
-		$this->repository_mock  = Mockery::mock( Indexable_Repository::class );
-		$this->builder_mock     = Mockery::mock( Indexable_Builder::class );
-		$this->instance         = new Indexable_Term_Watcher( $this->repository_mock, $this->builder_mock );
+		parent::setUp();
 
-		return parent::setUp();
+		$this->repository = Mockery::mock( Indexable_Repository::class );
+		$this->builder    = Mockery::mock( Indexable_Builder::class );
+		$this->site       = Mockery::mock( Site_Helper::class );
+		$this->instance   = new Indexable_Term_Watcher( $this->repository, $this->builder, $this->site );
 	}
 
 	/**
@@ -78,13 +102,16 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	 * @covers ::delete_indexable
 	 */
 	public function test_delete_indexable() {
-		$id = 1;
-
 		$indexable_mock = Mockery::mock( Indexable::class );
 		$indexable_mock->expects( 'delete' )->once();
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'term', false )->andReturn( $indexable_mock );
-		$this->instance->delete_indexable( $id );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( 1, 'term', false )
+			->andReturn( $indexable_mock );
+
+		$this->instance->delete_indexable( 1 );
 	}
 
 	/**
@@ -93,9 +120,13 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	 * @covers ::delete_indexable
 	 */
 	public function test_delete_indexable_does_not_exist() {
-		$id = 1;
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'term', false )->andReturn( false );
-		$this->instance->delete_indexable( $id );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( 1, 'term', false )
+			->andReturn( false );
+
+		$this->instance->delete_indexable( 1 );
 	}
 
 	/**
@@ -104,15 +135,45 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	 * @covers ::build_indexable
 	 */
 	public function test_build_indexable() {
-		$id = 1;
+		$indexable = Mockery::mock( Indexable::class );
+		$indexable->expects( 'save' )->once();
 
-		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
+		$this->site
+			->expects( 'is_multisite_and_switched' )
+			->andReturnFalse();
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'term', false )->andReturn( $indexable_mock );
-		$this->builder_mock->expects( 'build_for_id_and_type' )->once()->with( $id, 'term', $indexable_mock )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( 1, 'term', false )
+			->andReturn( $indexable );
 
-		$this->instance->build_indexable( $id );
+		$this->builder
+			->expects( 'build_for_id_and_type' )
+			->once()
+			->with( 1, 'term', $indexable )
+			->andReturn( $indexable );
+
+		$this->instance->build_indexable( 1 );
+	}
+
+
+	/**
+	 * Tests the build indexable function on a multisite with a switch between the sites.
+	 *
+	 * @covers ::build_indexable
+	 */
+	public function test_build_indexable_on_multisite_with_a_site_switch() {
+		$this->site
+			->expects( 'is_multisite_and_switched' )
+			->andReturnTrue();
+
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->never()
+			->with( 1, 'term', false );
+
+		$this->instance->build_indexable( 1 );
 	}
 
 	/**
@@ -121,14 +182,50 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	 * @covers ::build_indexable
 	 */
 	public function test_build_does_not_exist() {
-		$id = 1;
+		$indexable = Mockery::mock( Indexable::class );
+		$indexable->expects( 'save' )->once();
 
-		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
+		$this->site
+			->expects( 'is_multisite_and_switched' )
+			->andReturnFalse();
 
-		$this->repository_mock->expects( 'find_by_id_and_type' )->once()->with( $id, 'term', false )->andReturn( false );
-		$this->builder_mock->expects( 'build_for_id_and_type' )->once()->with( $id, 'term', false )->andReturn( $indexable_mock );
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( 1, 'term', false )
+			->andReturn( false );
 
-		$this->instance->build_indexable( $id );
+		$this->builder
+			->expects( 'build_for_id_and_type' )
+			->once()
+			->with( 1, 'term', false )
+			->andReturn( $indexable );
+
+		$this->instance->build_indexable( 1 );
+	}
+
+	/**
+	 * Tests the build indexable functionality with an exception being thrown.
+	 *
+	 * @covers ::build_indexable
+	 */
+	public function test_build_with_an_exception_thrown() {
+		$this->site
+			->expects( 'is_multisite_and_switched' )
+			->andReturnFalse();
+
+		$this->repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( 1, 'term', false )
+			->andReturn( false );
+
+		$this->builder
+			->expects( 'build_for_id_and_type' )
+			->once()
+			->with( 1, 'term', false )
+			->andThrow( Exception::class );
+
+		$this->instance->build_indexable( 1 );
 	}
 }

--- a/tests/integrations/watchers/primary-term-watcher-test.php
+++ b/tests/integrations/watchers/primary-term-watcher-test.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* It improves testcoverage for the integrations/watchers.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It just adds tests

## Relevant technical choices:

* I removed a `if ( ! is_array( $old_value ) || ! is_array( $new_value ) ) {` because it is not testable and the filter is called by WordPress. If the type is wrong, someone is hacking this makes me believe won't be our problem.
* I also formatted some expectation changes over more lines to make it more readable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* If Travis is happy, merge!

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
