### PR TITLE
Human readable url output

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -351,6 +351,7 @@ class Yoast_Form {
 	 * @param array|string $attr  Extra attributes to add to the input field. Can be class, disabled, autocomplete.
 	 */
 	public function textinput( $var, $label, $attr = [] ) {
+		$type = 'text';
 		if ( ! is_array( $attr ) ) {
 			$attr = [
 				'class'    => $attr,
@@ -366,6 +367,7 @@ class Yoast_Form {
 		$val        = $this->get_field_value( $var, '' );
 		if ( isset( $attr[ 'type' ] ) && $attr[ 'type' ] === 'url' ) {
 			$val = urldecode( $val );
+			$type = 'url';
 		}
 		$attributes = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';
 		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
@@ -386,7 +388,7 @@ class Yoast_Form {
 		Yoast_Input_Validation::set_error_descriptions();
 		$aria_attributes .= Yoast_Input_Validation::get_the_aria_describedby_attribute( $var );
 
-		echo '<input' . $attributes . $aria_attributes . ' class="textinput ' . esc_attr( $attr['class'] ) . '" placeholder="' . esc_attr( $attr['placeholder'] ) . '" type="text" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '<br class="clear" />';
+		echo '<input' . $attributes . $aria_attributes . ' class="textinput ' . esc_attr( $attr['class'] ) . '" placeholder="' . esc_attr( $attr['placeholder'] ) . '" type="' . $type . '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '<br class="clear" />';
 		echo Yoast_Input_Validation::get_the_error_description( $var );
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -365,8 +365,8 @@ class Yoast_Form {
 		];
 		$attr       = wp_parse_args( $attr, $defaults );
 		$val        = $this->get_field_value( $var, '' );
-		if ( isset( $attr[ 'type' ] ) && $attr[ 'type' ] === 'url' ) {
-			$val = urldecode( $val );
+		if ( isset( $attr['type'] ) && $attr['type'] === 'url' ) {
+			$val  = urldecode( $val );
 			$type = 'url';
 		}
 		$attributes = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -364,6 +364,9 @@ class Yoast_Form {
 		];
 		$attr       = wp_parse_args( $attr, $defaults );
 		$val        = $this->get_field_value( $var, '' );
+		if ( isset( $attr[ 'type' ] ) && $attr[ 'type' ] === 'url' ) {
+			$val = urldecode( $val );
+		}
 		$attributes = isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '';
 		if ( isset( $attr['disabled'] ) && $attr['disabled'] ) {
 			$attributes .= ' disabled';

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -512,6 +512,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$esc_form_key = esc_attr( WPSEO_Meta::$form_prefix . $key );
 		$meta_value   = WPSEO_Meta::get_value( $key, $this->get_metabox_post()->ID );
 
+		if ( $key === 'canonical' ) {
+			$meta_value = urldecode( $meta_value );
+		}
+
 		$class = '';
 		if ( isset( $meta_field_def['class'] ) && $meta_field_def['class'] !== '' ) {
 			$class = ' ' . $meta_field_def['class'];

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -545,7 +545,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				if ( $placeholder !== '' ) {
 					$placeholder = ' placeholder="' . esc_attr( $placeholder ) . '"';
 				}
-				$content .= '<input type="url"' . $placeholder . ' id="' . $esc_form_key . '" ' . 'name="' . $esc_form_key . '" value="' . esc_attr( urldecode( $meta_value ) ) . '" class="large-text' . $class . '"' . $aria_describedby . '/>';
+				$content .= '<input type="url"' . $placeholder . ' id="' . $esc_form_key . '" name="' . $esc_form_key . '" value="' . esc_attr( urldecode( $meta_value ) ) . '" class="large-text' . $class . '"' . $aria_describedby . '/>';
 				break;
 
 			case 'textarea':

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -512,10 +512,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$esc_form_key = esc_attr( WPSEO_Meta::$form_prefix . $key );
 		$meta_value   = WPSEO_Meta::get_value( $key, $this->get_metabox_post()->ID );
 
-		if ( $key === 'canonical' ) {
-			$meta_value = urldecode( $meta_value );
-		}
-
 		$class = '';
 		if ( isset( $meta_field_def['class'] ) && $meta_field_def['class'] !== '' ) {
 			$class = ' ' . $meta_field_def['class'];
@@ -543,6 +539,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					$placeholder = ' placeholder="' . esc_attr( $placeholder ) . '"';
 				}
 				$content .= '<input type="text"' . $placeholder . ' id="' . $esc_form_key . '" ' . $ac . 'name="' . $esc_form_key . '" value="' . esc_attr( $meta_value ) . '" class="large-text' . $class . '"' . $aria_describedby . '/>';
+				break;
+
+			case 'url':
+				if ( $placeholder !== '' ) {
+					$placeholder = ' placeholder="' . esc_attr( $placeholder ) . '"';
+				}
+				$content .= '<input type="url"' . $placeholder . ' id="' . $esc_form_key . '" ' . 'name="' . $esc_form_key . '" value="' . esc_attr( urldecode( $meta_value ) ) . '" class="large-text' . $class . '"' . $aria_describedby . '/>';
 				break;
 
 			case 'textarea':

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -85,6 +85,10 @@ class WPSEO_Taxonomy_Fields_Presenter {
 			$description      = '<p id="' . $field_name . '-desc" class="yoast-metabox__description">' . $options['description'] . '</p>';
 		}
 
+		if ( $field_name === 'wpseo_canonical' ) {
+			$field_value = urldecode( $field_value );
+		}
+
 		switch ( $field_type ) {
 			case 'div':
 				$field .= '<div id="' . $field_name . '"></div>';

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -90,7 +90,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 				$field .= '<div id="' . $field_name . '"></div>';
 				break;
 			case 'url':
-				$field .= '<input name="' . $field_name . '" id="' . $field_name . '" ' . $class . ' type="url" value="' . esc_attr( urldecode( $field_value ) ). '" size="40"' . $aria_describedby . '/>';
+				$field .= '<input name="' . $field_name . '" id="' . $field_name . '" ' . $class . ' type="url" value="' . esc_attr( urldecode( $field_value ) ) . '" size="40"' . $aria_describedby . '/>';
 				break;
 			case 'text':
 				$field .= '<input name="' . $field_name . '" id="' . $field_name . '" ' . $class . ' type="text" value="' . esc_attr( $field_value ) . '" size="40"' . $aria_describedby . '/>';

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -85,15 +85,13 @@ class WPSEO_Taxonomy_Fields_Presenter {
 			$description      = '<p id="' . $field_name . '-desc" class="yoast-metabox__description">' . $options['description'] . '</p>';
 		}
 
-		if ( $field_name === 'wpseo_canonical' ) {
-			$field_value = urldecode( $field_value );
-		}
-
 		switch ( $field_type ) {
 			case 'div':
 				$field .= '<div id="' . $field_name . '"></div>';
 				break;
-
+			case 'url':
+				$field .= '<input name="' . $field_name . '" id="' . $field_name . '" ' . $class . ' type="url" value="' . esc_attr( urldecode( $field_value ) ). '" size="40"' . $aria_describedby . '/>';
+				break;
 			case 'text':
 				$field .= '<input name="' . $field_name . '" id="' . $field_name . '" ' . $class . ' type="text" value="' . esc_attr( $field_value ) . '" size="40"' . $aria_describedby . '/>';
 				break;

--- a/admin/taxonomy/class-taxonomy-settings-fields.php
+++ b/admin/taxonomy/class-taxonomy-settings-fields.php
@@ -51,7 +51,8 @@ class WPSEO_Taxonomy_Settings_Fields extends WPSEO_Taxonomy_Fields {
 			),
 			'canonical' => $this->get_field_config(
 				__( 'Canonical URL', 'wordpress-seo' ),
-				esc_html__( 'The canonical link is shown on the archive page for this term.', 'wordpress-seo' )
+				esc_html__( 'The canonical link is shown on the archive page for this term.', 'wordpress-seo' ),
+				'url'
 			),
 		];
 

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -94,7 +94,7 @@ if ( $company_or_person === 'company' ) {
 	echo $social_profiles_help->get_panel_html();
 
 	foreach ( $organization_social_fields as $organization ) {
-		$yform->textinput( $organization['id'], $organization['label'] );
+		$yform->textinput( $organization['id'], $organization['label'], [ 'type' => 'url' ] );
 	}
 }
 

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -25,36 +25,44 @@ $company_or_person = WPSEO_Options::get( 'company_or_person', '' );
 
 $organization_social_fields = [
 	[
-		'id'    => 'facebook_site',
-		'label' => __( 'Facebook Page URL', 'wordpress-seo' ),
+		'id'         => 'facebook_site',
+		'label'      => __( 'Facebook Page URL', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'url' ],
 	],
 	[
-		'id'    => 'twitter_site',
-		'label' => __( 'Twitter Username', 'wordpress-seo' ),
+		'id'         => 'twitter_site',
+		'label'      => __( 'Twitter Username', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'text' ],
 	],
 	[
-		'id'    => 'instagram_url',
-		'label' => __( 'Instagram URL', 'wordpress-seo' ),
+		'id'         => 'instagram_url',
+		'label'      => __( 'Instagram URL', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'url' ],
 	],
 	[
-		'id'    => 'linkedin_url',
-		'label' => __( 'LinkedIn URL', 'wordpress-seo' ),
+		'id'         => 'linkedin_url',
+		'label'      => __( 'LinkedIn URL', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'url' ],
 	],
 	[
-		'id'    => 'myspace_url',
-		'label' => __( 'MySpace URL', 'wordpress-seo' ),
+		'id'         => 'myspace_url',
+		'label'      => __( 'MySpace URL', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'url' ],
 	],
 	[
-		'id'    => 'pinterest_url',
-		'label' => __( 'Pinterest URL', 'wordpress-seo' ),
+		'id'         => 'pinterest_url',
+		'label'      => __( 'Pinterest URL', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'url' ],
 	],
 	[
-		'id'    => 'youtube_url',
-		'label' => __( 'YouTube URL', 'wordpress-seo' ),
+		'id'         => 'youtube_url',
+		'label'      => __( 'YouTube URL', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'url' ],
 	],
 	[
-		'id'    => 'wikipedia_url',
-		'label' => __( 'Wikipedia URL', 'wordpress-seo' ),
+		'id'         => 'wikipedia_url',
+		'label'      => __( 'Wikipedia URL', 'wordpress-seo' ),
+		'attributes' => [ 'type' => 'url' ],
 	],
 ];
 
@@ -94,7 +102,7 @@ if ( $company_or_person === 'company' ) {
 	echo $social_profiles_help->get_panel_html();
 
 	foreach ( $organization_social_fields as $organization ) {
-		$yform->textinput( $organization['id'], $organization['label'], [ 'type' => 'url' ] );
+		$yform->textinput( $organization['id'], $organization['label'], $organization['attributes'] );
 	}
 }
 

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -882,7 +882,7 @@ class WPSEO_Frontend {
 		}
 
 		if ( is_string( $canonical ) && '' !== $canonical ) {
-			echo '<link rel="canonical" href="' . esc_url( $canonical, null, 'other' ) . '" />' . "\n";
+			echo '<link rel="canonical" href="' . urldecode( esc_url( $canonical, null, 'other' ) ) . '" />' . "\n";
 		}
 	}
 

--- a/frontend/class-opengraph.php
+++ b/frontend/class-opengraph.php
@@ -243,7 +243,7 @@ class WPSEO_OpenGraph {
 		 *
 		 * @api string $unsigned Canonical URL.
 		 */
-		$url = apply_filters( 'wpseo_opengraph_url', $url );
+		$url = urldecode( apply_filters( 'wpseo_opengraph_url', $url ) );
 
 		if ( is_string( $url ) && $url !== '' ) {
 			$this->og_tag( 'og:url', esc_url( $url ) );

--- a/frontend/schema/class-schema-organization.php
+++ b/frontend/schema/class-schema-organization.php
@@ -93,7 +93,7 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 		];
 		foreach ( $social_profiles as $profile ) {
 			if ( WPSEO_Options::get( $profile, '' ) !== '' ) {
-				$profiles[] = WPSEO_Options::get( $profile );
+				$profiles[] = urldecode( WPSEO_Options::get( $profile ) );
 			}
 		}
 

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -178,13 +178,13 @@ class WPSEO_Meta {
 				'description'   => '', // Translation added later.
 			],
 			'canonical'            => [
-				'type'          => 'text',
+				'type'          => 'url',
 				'title'         => '', // Translation added later.
 				'default_value' => '',
 				'description'   => '', // Translation added later.
 			],
 			'redirect'             => [
-				'type'          => 'text',
+				'type'          => 'url',
 				'title'         => '', // Translation added later.
 				'default_value' => '',
 				'description'   => '', // Translation added later.
@@ -416,8 +416,7 @@ class WPSEO_Meta {
 				break;
 
 
-			case ( $field_def['type'] === 'text' && $meta_key === self::$meta_prefix . 'canonical' ):
-			case ( $field_def['type'] === 'text' && $meta_key === self::$meta_prefix . 'redirect' ):
+			case ( $field_def['type'] === 'url' ):
 				// Validate as url(-part).
 				$url = WPSEO_Utils::sanitize_url( $meta_value );
 				if ( $url !== '' ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want urls to be human readable, both in our forms and in the metadata we output on the frontend.

## Summary

When you input a url containing letters from a non-roman alphabet. The url will be escaped and encoded before it is stored.
It is also possible to submit a url in which these letters are already encoded.

In any case, these urls will now be shown unencoded the next time the users loads the form, and they will appear unencoded in the metadata on the frontend.

Only in the schema will they still remain encoded, but this is because the schema is a JSON string and the Array containing the string is JSON encoded.

This logic has been applied to:
- canonical field on posts and terms
- canonicals on the frontend
- OG urls on the frontend
- Social profiles fields for organization in the Yoast SEO social settings
- Social profiles fields for authors in the WordPress user profile for unencoded urls.
- SameAs properties for both authors and organizations. These still get JSON encoded. But when you JSON decode, the search engine gets the unencoded urls.

Wontfix:
- When I paste in an encoded url to social profiles fields for authors in the WordPress user profile, the encoded entities are stripped. If I write the unencoded string, it works fine. This is WordPress functionality so wontfix and works pretty much as expected.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes sure encoded urls are human readable in forms and output.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Canonical & Open Graph URL for posts & terms
* Edit a post.
* Edit the canonical URL to something that includes encoding, e.g. `http://basic.wordpress.text/kn%c3%a4ckebr%c3%b6d`.
* Save the post (refresh the page when on posts).
* Verify that the canonical URL got decoded and is now showing the decoded value, e.g. `http://basic.wordpress.text/knäckebröd`
* Go to the frontend.
* Verify that the canonical meta tag is `<link rel="canonical" href="http://basic.wordpress.text/knäckebröd">` instead of `<link rel="canonical" href="http://basic.wordpress.text/kn%c3%a4ckebr%c3%b6d">`.
* Verify that the og:url meta tag is `<meta property="og:url" content="http://basic.wordpress.text/knäckebröd">` instead of `<meta property="og:url" content="http://basic.wordpress.text/kn%c3%a4ckebr%c3%b6d">`.
* Repeat the above steps for a term.

### Social profiles
* Ensure your site is set to an Organization. Search appearance --> General --> Knowledge Graph. And be sure to set a name and logo for the organization.
* Edit the social URLs on your profile, e.g. `http://basic.wordpress.text/kn%c3%a4ckebr%c3%b6d`. Users --> Your profile.
* Edit the social URLs to something that includes encoding, e.g. `http://basic.wordpress.text/kn%c3%a4ckebr%c3%b6d`. Social --> Accounts.
* Note that the Twitter is a username that is not included in this PR.
* Save the changes.
* Verify the values are now showing as decoded.
* Go to the frontend of a post that you created and verify the structured data output to be encoded (possibly differently).
  * The WordPress user profile is the author data.
  * The Yoast social profile data is the organization data.
* Enter the structured data in the [SDTT](https://search.google.com/structured-data/testing-tool) and verify that Google decodes it properly (the Organization sameAs attributes).

### Possible unhappy path tests
#### Textinput changes
* General --> Webmaster tools
* Search appearance --> Breadcrumbs
* Search appearance --> Content types
* Search appearance --> General --> Knowledge graph
* Network --> General
* Network --> Restore site
* Social --> Accounts
* Social --> Facebook
* Social --> Pinterest
#### Metabox changes
* Tab content, the new URL inputs.
#### Taxonomy metabox
Same as above.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
