### PR TITLE
Change the order in which the functions are executed

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -882,7 +882,7 @@ class WPSEO_Frontend {
 		}
 
 		if ( is_string( $canonical ) && '' !== $canonical ) {
-			echo '<link rel="canonical" href="' . urldecode( esc_url( $canonical, null, 'other' ) ) . '" />' . "\n";
+			echo '<link rel="canonical" href="' . esc_url( urldecode( $canonical ), null, 'other' ) . '" />' . "\n";
 		}
 	}
 


### PR DESCRIPTION
This makes sure that someone can no longer escape from the href field in the frontend.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
Before, it was possible to escape the `href` field in the `<link>` tag by entering something like this as the canonical URL: `" onafterprint="console.log(0)`.

We circumvent this problem if we first decode the URL and then use `esc_url`.

Now, entering `" onafterprint="console.log(0)` is still allowed but creates the following link tag:
```
<link rel="canonical" href="http://%20onafterprint=console.log(0)" />
```
Which is fine™️.

**Note: we might still benefit from extra validation on the URL but that is something that can be picked up later.**

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where entering `"` in the canonical URL would lead to HTML injection in the canonical URL.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. Check out the release branch `release/13.3`.
2. Enter `" onafterprint="console.log(0)` as the canonical URL of a post.
3. Verify that the output is in the front-end (view source):
```
<link rel="canonical" href="http://" onafterprint="console.log(0)" />
```
4. Check out this branch.
5. Refresh the page. The canonical URL should now be:
```
<link rel="canonical" href="http://%20onafterprint=console.log(0)" />
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
