### PR TITLE
Restore wp_query logic that used to be present in the plugin

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -173,19 +173,12 @@ class Front_End_Integration implements Integration_Interface {
 	public function call_wpseo_head() {
 		global $wp_query;
 
-		$old_wp_query = null;
-
-		if ( ! $wp_query->is_main_query() ) {
-			$old_wp_query = $wp_query;
-			wp_reset_query();
-		}
+		$old_wp_query = $wp_query;
+		wp_reset_query();
 
 		do_action( 'wpseo_head' );
 
-		if ( ! empty( $old_wp_query ) ) {
-			$GLOBALS['wp_query'] = $old_wp_query;
-			unset( $old_wp_query );
-		}
+		$GLOBALS['wp_query'] = $old_wp_query;
 	}
 
 	/**

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -171,7 +171,21 @@ class Front_End_Integration implements Integration_Interface {
 	 * @codeCoverageIgnore It just calls a WordPress function.
 	 */
 	public function call_wpseo_head() {
+		global $wp_query;
+
+		$old_wp_query = null;
+
+		if ( ! $wp_query->is_main_query() ) {
+			$old_wp_query = $wp_query;
+			wp_reset_query();
+		}
+
 		do_action( 'wpseo_head' );
+
+		if ( ! empty( $old_wp_query ) ) {
+			$GLOBALS['wp_query'] = $old_wp_query;
+			unset( $old_wp_query );
+		}
 	}
 
 	/**

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -100,30 +100,10 @@ class Front_End_Integration_Test extends TestCase {
 	 *
 	 * @covers ::call_wpseo_head
 	 */
-	public function test_call_wpseo_head_with_query() {
-		global $wp_query;
-
-		$wp_query = Mockery::mock( 'WP_Query' );
-		$wp_query->expects( 'is_main_query' )->once()->andReturn( true );
-
-		Monkey\Functions\expect( 'wp_reset_query' )->never();
-
-		$this->instance->call_wpseo_head();
-
-		$this->assertSame( 1, did_action( 'wpseo_head' ) );
-	}
-
-	/**
-	 * Tests calling wpseo_head and it's interaction with wp_query.
-	 *
-	 * @covers ::call_wpseo_head
-	 */
-	public function test_call_wpseo_head_without_query() {
+	public function test_call_wpseo_head() {
 		global $wp_query;
 
 		$wp_query = $initial_wp_query = Mockery::mock( 'WP_Query' );
-		$wp_query->expects( 'is_main_query' )->once()->andReturn( false );
-
 		Monkey\Functions\expect( 'wp_reset_query' )->once();
 
 		$this->instance->call_wpseo_head();

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -96,6 +96,43 @@ class Front_End_Integration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests calling wpseo_head and it's interaction with wp_query.
+	 *
+	 * @covers ::call_wpseo_head
+	 */
+	public function test_call_wpseo_head_with_query() {
+		global $wp_query;
+
+		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query->expects( 'is_main_query' )->once()->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_reset_query' )->never();
+
+		$this->instance->call_wpseo_head();
+
+		$this->assertSame( 1, did_action( 'wpseo_head' ) );
+	}
+
+	/**
+	 * Tests calling wpseo_head and it's interaction with wp_query.
+	 *
+	 * @covers ::call_wpseo_head
+	 */
+	public function test_call_wpseo_head_without_query() {
+		global $wp_query;
+
+		$wp_query = $initial_wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query->expects( 'is_main_query' )->once()->andReturn( false );
+
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
+
+		$this->instance->call_wpseo_head();
+
+		$this->assertSame( 1, did_action( 'wpseo_head' ) );
+		$this->assertSame( $initial_wp_query, $GLOBALS['wp_query'] );
+	}
+
+	/**
 	 * Tests the present_head.
 	 *
 	 * @covers ::present_head


### PR DESCRIPTION
## Context
Restores logic that used to be present in the plugin which sites, such as yoast.com, implicitly rely upon.

## Summary
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Logic was returned from the initial class-frontend. This logic was also present, although without checks, in class-opengraph and class-twitter.

## Test instructions
This PR can be tested by following these steps:

* Deploy it to staging.yoast.com
* Posts should have content.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
