### PR TITLE
Better checking authority/host parts in URL

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -332,10 +332,18 @@ class WPSEO_Utils {
 			$url = $parts['scheme'] . '://';
 
 			if ( isset( $parts['user'] ) ) {
-				$url .= $parts['user'] . ( isset( $parts['pass'] ) ? ':' . $parts['pass'] : '' ) . '@';
+				$url .= rawurlencode ( $parts['user'] );
+				$url .= isset( $parts['pass'] ) ? ':' . rawurlencode( $parts['pass'] ) : '';
+				$url .= '@';
 			}
 
-			$url .= $parts['host'] . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' );
+			$parts['host'] = preg_replace(
+				'`[^a-z0-9-.:\[\]\\x80-\\xff]`',
+				'',
+				strtolower( $parts['host'] )
+			);
+
+			$url .= $parts['host'] . ( isset( $parts['port'] ) ? ':' . intval( $parts['port'] ) : '' );
 		}
 
 		if ( isset( $parts['path'] ) && strpos( $parts['path'], '/' ) === 0 ) {

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -332,7 +332,7 @@ class WPSEO_Utils {
 			$url = $parts['scheme'] . '://';
 
 			if ( isset( $parts['user'] ) ) {
-				$url .= rawurlencode ( $parts['user'] );
+				$url .= rawurlencode( $parts['user'] );
 				$url .= isset( $parts['pass'] ) ? ':' . rawurlencode( $parts['pass'] ) : '';
 				$url .= '@';
 			}

--- a/integration-tests/test-class-wpseo-utils.php
+++ b/integration-tests/test-class-wpseo-utils.php
@@ -287,6 +287,10 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 				'expected'        => 'https://user:pass@[fc00::1]:8443/subdir/test1/?query=test2#fragment',
 				'url_to_sanitize' => 'https://user:pass@[fc00::1]:8443/subdir/test1/?query=test2#fragment',
 			],
+			'html_injection'                 => [
+				'expected'        => 'https://onafterprintconsole.log0',
+				'url_to_sanitize' => 'https://" onafterprint="console.log(0)',
+			],
 		];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Related PR #14502

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes reserved characters from host component.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Steps performed by @andizer:
* I've test this by navigating to the social fields and there I have given `https://" onafterprint="console.log(0)` as value for the facebook url.
* I also added the value as canonical in the metabox. 

## UI changes
~~* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
