### PR TITLE
An indexable is built for a term when it is created.

### DIFF
--- a/src/integrations/watchers/indexable-term-watcher.php
+++ b/src/integrations/watchers/indexable-term-watcher.php
@@ -63,6 +63,7 @@ class Indexable_Term_Watcher implements Integration_Interface {
 	 * @inheritDoc
 	 */
 	public function register_hooks() {
+		\add_action( 'created_term', [ $this, 'build_indexable' ], \PHP_INT_MAX );
 		\add_action( 'edited_term', [ $this, 'build_indexable' ], \PHP_INT_MAX );
 		\add_action( 'delete_term', [ $this, 'delete_indexable' ], \PHP_INT_MAX );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Because of performance reasons, we want indexables to be built when posts, terms, pages etc. are created, instead of lazily building them when they are being output on the frontend. This PR introduces this behavior for terms.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* An indexable for a term will be built when a term is created.

## Relevant technical choices:

* I looked at the hooks that build the home page and static home page indexables. It hooks into all the applicable hooks as far as I can tell.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new category or tag.
* Look in the `wp_yoast_indexable` table. There should be a row representing the newly created indexable.
  * E.g. with `object_type` 'term' and `object_id` being the ID of the respective term.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14516 
