### PR TITLE
Fix author not being output when site represents organization

### DIFF
--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -69,7 +69,11 @@ class Author extends Person {
 			$this->article->is_article_post_type( $context->indexable->object_sub_type )
 		) {
 			// If the author is the user the site represents, no need for an extra author block.
-			return (int) $context->post->post_author !== $context->site_user_id;
+			if ( parent::is_needed( $context ) ) {
+				return (int) $context->post->post_author !== $context->site_user_id;
+			}
+
+			return true;
 		}
 
 		return false;

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -262,9 +262,40 @@ class Author_Test extends TestCase {
 			'object_sub_type' => $object_sub_type,
 		];
 
-		$this->meta_tags_context->site_user_id = $user_id;
+		$this->meta_tags_context->site_represents = 'person';
+		$this->meta_tags_context->site_user_id    = $user_id;
 
 		$this->assertFalse( $this->instance->is_needed( $this->meta_tags_context ) );
+	}
+
+	/**
+	 * Tests that the author Schema piece is output on a post and the site is represented by an organization.
+	 *
+	 * @covers ::is_needed
+	 */
+	public function test_is_shown_when_on_post_site_organization() {
+		$user_id         = 123;
+		$object_sub_type = 'post';
+
+		$this->article
+			->expects( 'is_article_post_type' )
+			->with( $object_sub_type )
+			->andReturn( true );
+
+		// Set up the context with values.
+		$this->meta_tags_context->post = (Object) [
+			'post_author' => $user_id,
+		];
+
+		$this->meta_tags_context->indexable = (Object) [
+			'object_type'     => 'post',
+			'object_sub_type' => $object_sub_type,
+		];
+
+		$this->meta_tags_context->site_represents = 'organization';
+		$this->meta_tags_context->site_user_id    = $user_id;
+
+		$this->assertTrue( $this->instance->is_needed( $this->meta_tags_context ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The schema author graph piece was output incorrectly when the site represented an Organization. 
* This was because the author schema generator wasn't called, even though it should be. 
* The reason was that a check which was meant to prevent duplicate code when the site represented a Person, was incorrectly applied also when the site represented an Organization.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* There was already a check in place to prevent duplicate graph pieces being output when the site represents a Person, and the post author is the same as the person that the site represents.
* Now, we only call this check when the site is set to represent a Person, and not an Organization.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* To reproduce the problem, see #14534 
* Checkout this branch
* Again follow the steps in #14534, and see that the Author graph piece is correctly output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14534
