### PR TITLE
Fix og:url for static posts pages

### DIFF
--- a/src/presentations/indexable-static-posts-page-presentation.php
+++ b/src/presentations/indexable-static-posts-page-presentation.php
@@ -46,6 +46,6 @@ class Indexable_Static_Posts_Page_Presentation extends Indexable_Post_Type_Prese
 	 * @return string The open graph url.
 	 */
 	public function generate_open_graph_url() {
-		return $this->url->home();
+		return $this->model->permalink;
 	}
 }

--- a/tests/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
+++ b/tests/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
@@ -24,15 +24,13 @@ class Open_Graph_URL_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the canonical is returned.
+	 * Tests the situation where the permalink is returned.
 	 *
 	 * @covers ::generate_open_graph_url
 	 */
-	public function test_generate_open_graph_url_and_return_home_url() {
-		$this->url->expects( 'home' )
-			->once()
-			->andReturn( 'https://example.com/' );
+	public function test_generate_open_graph_url_and_return_permalink() {
+		$this->indexable->permalink = 'https://example.com/static-posts-page';
 
-		$this->assertEquals( 'https://example.com/', $this->instance->generate_open_graph_url() );
+		$this->assertEquals( 'https://example.com/static-posts-page', $this->instance->generate_open_graph_url() );
 	}
 }

--- a/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
@@ -19,8 +19,6 @@ use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 trait Presentation_Instance_Builder {
 	use Presentation_Instance_Dependencies;
 
-
-
 	/**
 	 * Represents the indexable.
 	 *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On static posts pages, the `og:url` meta tag showed the home URL instead of the unpaginated URL of that page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A Fixes a bug where the `og:url` meta tag showed the home URL instead of the unpaginated URL of a static posts page.

## Relevant technical choices:

* I considered whether `generate_open_graph_url()` should have any fallbacks. I looked for other examples. In `indexable-presentation`, `$this->model->permalink` is the final code, and there is no further fallback. In addition, if `$this->model->permalink` is not found in `generate_open_graph_url()`, the presenter will output an empty string. So it seems like the situation is safe enough.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new page
* In `Settings` -> `Reading`, set your homepage to display a static page.
* Set `Homepage` to any random page, and set `Posts page` to the new page you just created.
* On the frontend, navigate to your posts page. Scroll down and click on the next page. 
    * Example url: `http://basic.wordpress.test/page-with-posts/page/2/`. 
    * If you don't have enough posts to have your page divided in multiple pages, you can change the `Blog pages show at most` setting in the reading settings.
* View the source code: `og:url` is set to your homepage. 
    * Example: `http://basic.wordpress.test/`.
* Check out this branch and see that `og:url` is now correctly set to your page, but without pagination. 
    * Example: `http://basic.wordpress.test/page-with-posts/`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14540
