### PR TITLE
Handle themes that do not support title-tag

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -163,7 +163,7 @@ class Front_End_Integration implements Integration_Interface {
 	public function register_hooks() {
 		add_action( 'wp_head', [ $this, 'call_wpseo_head' ], 1 );
 		// Filter the title for compatibility with other plugins and themes.
-		add_filter( 'wp_title', [ $this, 'filter_title' ] );
+		add_filter( 'wp_title', [ $this, 'filter_title' ], 15 );
 
 		// @todo Walk through AMP post template and unhook all the stuff they don't need to because we do it.
 		add_action( 'amp_post_template_head', [ $this, 'call_wpseo_head' ], 9 );

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
+use Yoast\WP\SEO\Presenters\Title_Presenter;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -38,6 +39,13 @@ class Front_End_Integration implements Integration_Interface {
 	 * @var Options_Helper
 	 */
 	protected $options;
+
+	/**
+	 * The title presenter.
+	 *
+	 * @var Title_Presenter
+	 */
+	protected $title_presenter;
 
 	/**
 	 * The presenters we loop through on each page load.
@@ -133,17 +141,20 @@ class Front_End_Integration implements Integration_Interface {
 	 * @param Meta_Tags_Context_Memoizer $context_memoizer  The meta tags context memoizer.
 	 * @param ContainerInterface         $service_container The DI container.
 	 * @param Options_Helper             $options           The options helper.
+	 * @param Title_Presenter            $title_presenter   The title presenter.
 	 *
 	 * @codeCoverageIgnore It sets dependencies.
 	 */
 	public function __construct(
 		Meta_Tags_Context_Memoizer $context_memoizer,
 		ContainerInterface $service_container,
-		Options_Helper $options
+		Options_Helper $options,
+		Title_Presenter $title_presenter
 	) {
 		$this->container        = $service_container;
 		$this->context_memoizer = $context_memoizer;
 		$this->options          = $options;
+		$this->title_presenter  = $title_presenter;
 	}
 
 	/**
@@ -151,6 +162,8 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		add_action( 'wp_head', [ $this, 'call_wpseo_head' ], 1 );
+		// Filter the title for compatibility with other plugins and themes.
+		add_filter( 'wp_title', [ $this, 'filter_title' ] );
 
 		// @todo Walk through AMP post template and unhook all the stuff they don't need to because we do it.
 		add_action( 'amp_post_template_head', [ $this, 'call_wpseo_head' ], 9 );
@@ -164,6 +177,19 @@ class Front_End_Integration implements Integration_Interface {
 		remove_action( 'wp_head', 'noindex', 1 );
 		remove_action( 'wp_head', '_wp_render_title_tag', 1 );
 		remove_action( 'wp_head', 'gutenberg_render_title_tag', 1 );
+
+		if ( ! get_theme_support( 'title-tag' ) ) {
+			// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
+			$this->base_presenters = array_diff( $this->base_presenters, [ 'Title' ] );
+		}
+	}
+
+	/**
+	 * Filters the title, mainly used for compatibility reasons.
+	 */
+	public function filter_title() {
+		$context = $this->context_memoizer->for_current_page();
+		return $this->title_presenter->present( $context->presentation, false );
 	}
 
 	/**

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -37,17 +37,21 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	 * Returns the document title.
 	 *
 	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 * @param bool                   $output_html  Optional. Whether or not to output HTML. Defaults to true.
 	 *
 	 * @return string The document title tag.
 	 */
-	public function present( Indexable_Presentation $presentation ) {
+	public function present( Indexable_Presentation $presentation, $output_html = true ) {
 		$title = $this->replace_vars( $presentation->title, $presentation );
 		$title = $this->filter( $title, $presentation );
 		$title = $this->string->strip_all_tags( \stripslashes( $title ) );
 		$title = \trim( $title );
 
 		if ( \is_string( $title ) && $title !== '' ) {
-			return '<title>' . \esc_html( $title ) . '</title>';
+			if ( $output_html ) {
+				return '<title>' . \esc_html( $title ) . '</title>';
+			}
+			return \esc_html( $title );
 		}
 
 		return '';

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -36,19 +36,19 @@ class Title_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * Returns the document title.
 	 *
-	 * @param Indexable_Presentation $presentation The presentation of an indexable.
-	 * @param bool                   $output_html  Optional. Whether or not to output HTML. Defaults to true.
+	 * @param Indexable_Presentation $presentation     The presentation of an indexable.
+	 * @param bool                   $output_title_tag Optional. Whether or not to output the title with the title tag (`<title>`) included. Defaults to true.
 	 *
 	 * @return string The document title tag.
 	 */
-	public function present( Indexable_Presentation $presentation, $output_html = true ) {
+	public function present( Indexable_Presentation $presentation, $output_title_tag = true ) {
 		$title = $this->replace_vars( $presentation->title, $presentation );
 		$title = $this->filter( $title, $presentation );
 		$title = $this->string->strip_all_tags( \stripslashes( $title ) );
 		$title = \trim( $title );
 
 		if ( \is_string( $title ) && $title !== '' ) {
-			if ( $output_html ) {
+			if ( $output_title_tag ) {
 				return '<title>' . \esc_html( $title ) . '</title>';
 			}
 			return \esc_html( $title );

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -165,9 +165,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->container
 			->expects( 'get' )
 			->times( 28 )
-			->andReturnUsing( function ( $presenter ) {
-				return $presenter;
-			} );
+			->andReturnArg( 0 );
 
 		$this->options->expects( 'get' )->with( 'opengraph' )->andReturnTrue();
 		$this->options->expects( 'get' )->with( 'twitter' )->andReturnTrue();
@@ -219,9 +217,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->container
 			->expects( 'get' )
 			->times( 7 )
-			->andReturnUsing( function ( $presenter ) {
-				return $presenter;
-			} );
+			->andReturnArg( 0 );
 
 
 		$this->assertEquals(
@@ -249,9 +245,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->container
 			->expects( 'get' )
 			->times( 23 )
-			->andReturnUsing( function ( $presenter ) {
-				return $presenter;
-			} );
+			->andReturnArg( 0 );
 
 		$this->options
 			->expects( 'get' )
@@ -309,9 +303,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->container
 			->expects( 'get' )
 			->times( 6 )
-			->andReturnUsing( function ( $presenter ) {
-				return $presenter;
-			} );
+			->andReturnArg( 0 );
 
 
 		$this->assertEquals(


### PR DESCRIPTION
## Context
Themes that don't support the title-tag and thus always output their own hardcoded title currently conflict with indexables and will result in two title tags being output.

This PR adds compatibility for those themes by removing the Title presenter and additionally always filtering the title to remain as compatible as possible with other themes and plugins.

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions
This PR can be tested by following these steps:

* Requires testing on staging.yoast.com, which means it needs to be merged to the feature branch first.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended