### PR TITLE
Add styling for tools page

### DIFF
--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -71,7 +71,7 @@ class WPSEO_Link_Reindex_Dashboard {
 
 		if ( $this->has_unprocessed() ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: `message_start_indexing` is considered a safe method.
-			printf( '<span id="reindexLinks">%s</span>', $this->message_start_indexing() );
+			printf( $this->message_start_indexing() );
 		}
 
 		echo '</li>';
@@ -171,7 +171,7 @@ class WPSEO_Link_Reindex_Dashboard {
 	 * @return string The message to show when everything has been indexed.
 	 */
 	public function message_already_indexed() {
-		return '<span class="wpseo-checkmark-ok-icon"></span>' . esc_html__( 'Good job! All the links in your texts have been counted.', 'wordpress-seo' );
+		return '<span class="yoast-check">' . esc_html__( 'Good job! All the links in your texts have been counted.', 'wordpress-seo' ) . '</span>';
 	}
 
 	/**

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -37,6 +37,8 @@ if ( $tool_page === '' ) {
 		'desc'  => __( 'This tool allows you to quickly change titles and descriptions of your posts and pages without having to go into the editor for each page.', 'wordpress-seo' ),
 	];
 
+	echo '<div class="yoast-break"></div>';
+
 	echo '<p>';
 	printf(
 		/* translators: %1$s expands to Yoast SEO */
@@ -45,7 +47,7 @@ if ( $tool_page === '' ) {
 	);
 	echo '</p>';
 
-	echo '<ul class="ul-disc">';
+	echo '<ul class="yoast-list">';
 
 	$admin_url = admin_url( 'admin.php?page=wpseo_tools' );
 
@@ -54,7 +56,7 @@ if ( $tool_page === '' ) {
 		$attr = ( ! empty( $tool['attr'] ) ) ? $tool['attr'] : '';
 
 		echo '<li>';
-		echo '<strong><a href="', esc_url( $href ), '" ', esc_attr( $attr ) , '>', esc_html( $tool['title'] ), '</a></strong><br/>';
+		echo '<a href="', esc_url( $href ), '" ', esc_attr( $attr ) , '>', esc_html( $tool['title'] ), '</a><br/>';
 		echo esc_html( $tool['desc'] );
 		echo '</li>';
 	}

--- a/css/src/admin/all.css
+++ b/css/src/admin/all.css
@@ -6,3 +6,4 @@
 @import "../components/headings.css";
 @import "../components/card.css";
 @import "../components/paper.css";
+@import "../components/lists.css";

--- a/css/src/components/card.css
+++ b/css/src/components/card.css
@@ -38,26 +38,6 @@
 	padding: 16px;
 }
 
-.yoast-list--usp {
-	margin-top: 0;
-	margin-left: 22px;
-	margin-bottom: 0;
-}
-
-.yoast-list--usp li {
-	position: relative;
-}
-
-.yoast-list--usp li::before {
-	content: '';
-	background: var(--checkmark--green) no-repeat center center;
-	width: 14px;
-	height: 14px;
-	position: absolute;
-	left: -20px;
-	top: 5px;
-}
-
 .yoast-card__footer {
 	padding: 16px;
 }

--- a/css/src/components/headings.css
+++ b/css/src/components/headings.css
@@ -45,6 +45,7 @@ body.yoast {
 
 .yoast p {
 	margin-top: 0;
+	margin-bottom: 16px;
 	font-size: 1em;
 }
 

--- a/css/src/components/lists.css
+++ b/css/src/components/lists.css
@@ -1,0 +1,54 @@
+.yoast-list {
+	margin-left: 22px;
+	max-width: 600px;
+}
+
+.yoast-list li {
+	position: relative;
+	margin-bottom: 16px;
+}
+
+.yoast-list li::before {
+	content: '';
+	background-color: var(--color-default);
+	border-radius: 50%;
+	width: 6px;
+	height: 6px;
+	position: absolute;
+	left: -20px;
+	top: 8px;
+}
+
+.yoast-check {
+	position: relative;
+}
+
+.yoast-check::before {
+	content: '';
+	background: var(--checkmark--green) no-repeat center center;
+	width: 14px;
+	height: 14px;
+	position: absolute;
+	left: -24px;
+	top: 2px;
+}
+
+.yoast-list--usp {
+	margin-top: 0;
+	margin-left: 22px;
+	margin-bottom: 0;
+}
+
+.yoast-list--usp li {
+	position: relative;
+}
+
+.yoast-list--usp li::before {
+	content: '';
+	background: var(--checkmark--green) no-repeat center center;
+	width: 14px;
+	height: 14px;
+	position: absolute;
+	left: -20px;
+	top: 5px;
+}

--- a/css/src/components/tabs.css
+++ b/css/src/components/tabs.css
@@ -12,6 +12,11 @@
 	margin: 30px 0;
 }
 
+.yoast-break {
+	border-bottom: 1px solid var(--color-border);
+	margin-bottom: 32px;
+}
+
 .yoast-tabs {
 	font-size: 16px;
 	overflow: hidden;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add some styling to the tools page

## Relevant technical choices:

* Because of some minor differences in positioning of the default bullet points between Firefox and Chrome, I've decided to create custom bullet points.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14295 
