### PR TITLE
Fix breadcrumbs home when indexables do not yet exist

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -70,7 +70,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			$front_page_id = $this->current_page->get_front_page_id();
 			if ( $front_page_id === 0 ) {
 				$static_ancestors[] = $this->repository->find_for_home_page();
-			} else {
+			}
+			else {
 				$static_ancestors[] = $this->repository->find_by_id_and_type( $front_page_id, 'post' );
 			}
 		}

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Generators;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Generators\Generator_Interface;
@@ -33,17 +34,27 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	private $options;
 
 	/**
+	 * The current page helper
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $current_page;
+
+	/**
 	 * Breadcrumbs_Generator constructor.
 	 *
-	 * @param Indexable_Repository $repository The repository.
-	 * @param Options_Helper       $options    The options helper.
+	 * @param Indexable_Repository $repository   The repository.
+	 * @param Options_Helper       $options      The options helper.
+	 * @param Current_Page_Helper  $current_page The current page helper.
 	 */
 	public function __construct(
 		Indexable_Repository $repository,
-		Options_Helper $options
+		Options_Helper $options,
+		Current_Page_Helper $current_page
 	) {
-		$this->repository = $repository;
-		$this->options    = $options;
+		$this->repository   = $repository;
+		$this->options      = $options;
+		$this->current_page = $current_page;
 	}
 
 	/**
@@ -56,16 +67,22 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	public function generate( Meta_Tags_Context $context ) {
 		$static_ancestors = [];
 		if ( $this->options->get( 'breadcrumbs-home' ) !== '' ) {
-			$static_ancestors[] = [ 'object_type' => 'home-page' ];
+			$front_page_id = $this->current_page->get_front_page_id();
+			if ( $front_page_id === 0 ) {
+				$static_ancestors[] = $this->repository->find_for_home_page();
+			} else {
+				$static_ancestors[] = $this->repository->find_by_id_and_type( $front_page_id, 'post' );
+			}
 		}
 		$page_for_posts = \get_option( 'page_for_posts' );
 		if ( $this->should_have_blog_crumb( $page_for_posts ) ) {
-			$static_ancestors[] = [ 'object_type' => 'post', 'object_id' => $page_for_posts ];
+			$static_ancestors[] = $this->repository->find_by_id_and_type( $page_for_posts, 'post' );
 		}
 
 		// Get all ancestors of the indexable and append itself to get all indexables in the full crumb.
-		$indexables   = $this->repository->get_ancestors( $context->indexable, $static_ancestors );
+		$indexables   = $this->repository->get_ancestors( $context->indexable );
 		$indexables[] = $context->indexable;
+		array_unshift( $indexables, ...$static_ancestors );
 
 		$crumbs = array_map( function ( Indexable $ancestor ) {
 			$crumb = [

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -314,37 +314,20 @@ class Indexable_Repository {
 	}
 
 	/**
-	 * Returns all ancestors of a given indexable. Optionally prepending a set of static ancestors.
+	 * Returns all ancestors of a given indexable.
 	 *
-	 * @param Indexable $indexable              The indexable to find the ancestors of.
-	 * @param array     $static_ancestor_wheres Optional. The where conditions by which to find static ancestors.
-	 *                                          Should be an array of arrays with the inner arrays containing find
-	 *                                          conditions.
+	 * @param Indexable $indexable The indexable to find the ancestors of.
 	 *
 	 * @return Indexable[] All ancestors of the given indexable.
 	 */
-	public function get_ancestors( Indexable $indexable, $static_ancestor_wheres = [] ) {
+	public function get_ancestors( Indexable $indexable ) {
 		$hierarchy_table = Yoast_Model::get_table_name( 'Indexable_Hierarchy' );
-		$ancestor_query  = $this->query()
-								->table_alias( 'i' )
-								->select( 'i.*' )
-								->join( $hierarchy_table, 'i.id = ih.ancestor_id', 'ih' )
-								->where( 'ih.indexable_id', $indexable->id )
-								->order_by_desc( 'ih.depth' );
-
-		$ancestor_queries = [];
-		if ( ! empty( $static_ancestor_wheres ) ) {
-			$ancestor_queries = array_map( function ( $where ) {
-				return $this->query()->where( $where )->limit( 1 )->find_many();
-			}, $static_ancestor_wheres );
-		}
-
-		$ancestor_queries[] = $ancestor_query->find_many();
-
-		if ( empty( $ancestor_queries ) ) {
-			return [];
-		}
-
-		return array_merge( ...$ancestor_queries );
+		return $this->query()
+					->table_alias( 'i' )
+					->select( 'i.*' )
+					->join( $hierarchy_table, 'i.id = ih.ancestor_id', 'ih' )
+					->where( 'ih.indexable_id', $indexable->id )
+					->order_by_desc( 'ih.depth' )
+					->find_many();
 	}
 }

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -124,14 +124,15 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				->once()
 				->with( $front_page_id, 'post' )
 				->andReturn( $this->indexable );
-		} else {
+		}
+		else {
 			$this->repository
 				->expects( 'find_for_home_page' )
 				->once()
 				->andReturn( $this->indexable );
 		}
 
-		if ( substr( $scenario, 0, 21 ) === 'on-singular-post-page' ) {
+		if ( strpos( $scenario, 'on-singular-post-page' ) === 0 ) {
 			$this->repository
 				->expects( 'find_by_id_and_type' )
 				->once()
@@ -265,7 +266,6 @@ class Breadcrumbs_Generator_Test extends TestCase {
 			return;
 		}
 
-
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'show_on_front' )
@@ -273,7 +273,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 
 		$is_home     = ( $scenario === 'on-home-page' );
 		$is_search   = ( $scenario === 'on-search-page' );
-		$is_singular = ( substr( $scenario, 0, 21 ) === 'on-singular-post-page' );
+		$is_singular = ( strpos( $scenario, 'on-singular-post-page' ) === 0 );
 
 		Monkey\Functions\expect( 'is_home' )
 			->andReturn( $is_home );

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\SEO\Tests\Generators;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Generators\Breadcrumbs_Generator;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
@@ -41,6 +42,13 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	private $repository;
 
 	/**
+	 * Represents the current page helper.
+	 *
+	 * @var Mockery\MockInterface|Current_Page_Helper
+	 */
+	private $current_page;
+
+	/**
 	 * Represents the options helper.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper
@@ -67,9 +75,10 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->repository = Mockery::mock( Indexable_Repository::class );
-		$this->options    = Mockery::mock( Options_Helper::class );
-		$this->instance   = new Breadcrumbs_Generator( $this->repository, $this->options );
+		$this->repository   = Mockery::mock( Indexable_Repository::class );
+		$this->options      = Mockery::mock( Options_Helper::class );
+		$this->current_page = Mockery::mock( Current_Page_Helper::class );
+		$this->instance     = new Breadcrumbs_Generator( $this->repository, $this->options, $this->current_page );
 
 		$this->indexable                   = Mockery::mock( Indexable::class );
 		$this->indexable->object_id        = 1;
@@ -89,13 +98,13 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	 *
 	 * @dataProvider generate_provider
 	 *
-	 * @param string $scenario         The scenario to test.
-	 * @param int    $page_for_posts   ID for page for posts option.
-	 * @param bool   $breadcrumb_home  Show the home breadcrumbs.
-	 * @param array  $static_ancestors The ancestors.
-	 * @param string $message          Message to show when test fails.
+	 * @param string $scenario           The scenario to test.
+	 * @param int    $page_for_posts     ID for page for posts option.
+	 * @param bool   $breadcrumb_home    Show the home breadcrumbs.
+	 * @param int    $front_page_id      The front page ID.
+	 * @param string $message            Message to show when test fails.
 	 */
-	public function test_generate( $scenario, $page_for_posts, $breadcrumb_home, $static_ancestors, $message ) {
+	public function test_generate( $scenario, $page_for_posts, $breadcrumb_home, $front_page_id, $message ) {
 		$this->set_scenario( $scenario );
 
 		Monkey\Functions\expect( 'get_option' )
@@ -109,11 +118,37 @@ class Breadcrumbs_Generator_Test extends TestCase {
 			->with( 'breadcrumbs-home' )
 			->andReturn( $breadcrumb_home );
 
+		if ( $front_page_id !== 0 ) {
+			$this->repository
+				->expects( 'find_by_id_and_type' )
+				->once()
+				->with( $front_page_id, 'post' )
+				->andReturn( $this->indexable );
+		} else {
+			$this->repository
+				->expects( 'find_for_home_page' )
+				->once()
+				->andReturn( $this->indexable );
+		}
+
+		if ( substr( $scenario, 0, 21 ) === 'on-singular-post-page' ) {
+			$this->repository
+				->expects( 'find_by_id_and_type' )
+				->once()
+				->with( $page_for_posts, 'post' )
+				->andReturn( $this->indexable );
+		}
+
 		$this->repository
 			->expects( 'get_ancestors' )
 			->once()
-			->with( $this->indexable, $static_ancestors )
+			->with( $this->indexable )
 			->andReturn( $this->get_ancestors() );
+
+		$this->current_page
+			->expects( 'get_front_page_id' )
+			->once()
+			->andReturn( $front_page_id );
 
 		$expected = [
 			[
@@ -130,7 +165,8 @@ class Breadcrumbs_Generator_Test extends TestCase {
 
 		$this->assertEquals(
 			$expected,
-			$this->instance->generate( $this->context )
+			array_slice( $this->instance->generate( $this->context ), -2 ),
+			$message
 		);
 	}
 
@@ -145,82 +181,57 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				'scenario'         => 'hide-blog-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
-				'static_ancestors' => [
-					[
-						'object_type' => 'home-page',
-					],
-				],
+				'front_page_id'    => 0,
 				'message'          => 'Tests with the display blog page option disabled.',
 			],
 			[
 				'scenario'         => 'show_posts_on_front',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
-				'static_ancestors' => [
-					[
-						'object_type' => 'home-page',
-					],
-				],
+				'front_page_id'    => 0,
 				'message'          => 'Tests with the posts being shown on front',
 			],
 			[
 				'scenario'         => 'show_page_on_front',
 				'page_for_posts'   => 0,
 				'breadcrumb_home'  => 'home',
-				'static_ancestors' => [
-					[
-						'object_type' => 'home-page',
-					],
-				],
+				'front_page_id'    => 0,
 				'message'          => 'Tests with the page being shown on front, but no page being set',
 			],
 			[
 				'scenario'         => 'on-home-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
-				'static_ancestors' => [
-					[
-						'object_type' => 'home-page',
-					],
-				],
+				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being the home page',
 			],
 			[
 				'scenario'         => 'on-search-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
-				'static_ancestors' => [
-					[
-						'object_type' => 'home-page',
-					],
-				],
+				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being the search page',
 			],
 			[
 				'scenario'         => 'on-singular-post-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
-				'static_ancestors' => [
-					[
-						'object_type' => 'home-page',
-					],
-					[
-						'object_type' => 'post',
-						'object_id'   => 1,
-					],
-				],
+				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being a singular post page',
 			],
 			[
 				'scenario'         => 'not-on-home-search-or-singular-post-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
-				'static_ancestors' => [
-					[
-						'object_type' => 'home-page',
-					],
-				],
+				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being not the home, search or a singular post page',
+			],
+			[
+				'scenario'         => 'on-singular-post-page-with-front-page-id',
+				'page_for_posts'   => 1,
+				'breadcrumb_home'  => 'home',
+				'front_page_id'    => 2,
+				'message'          => 'Tests with current request being a singular post page and a front page being set',
 			],
 		];
 	}
@@ -254,6 +265,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 			return;
 		}
 
+
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'show_on_front' )
@@ -261,7 +273,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 
 		$is_home     = ( $scenario === 'on-home-page' );
 		$is_search   = ( $scenario === 'on-search-page' );
-		$is_singular = ( $scenario === 'on-singular-post-page' );
+		$is_singular = ( substr( $scenario, 0, 21 ) === 'on-singular-post-page' );
 
 		Monkey\Functions\expect( 'is_home' )
 			->andReturn( $is_home );


### PR DESCRIPTION
## Context
This gathers the home page and page for posts indexables in the breadcrumbs using existing methods rather than custom queries so they are created automatically if they are missing.

## Summary
This PR can be summarized in the following changelog entry:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Delete all indexables and all indexable hierarchies.
* Visit a random post that's not your homepage.
* Your homepage should be present in the schema output of that page.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14545
