### PR TITLE
Fix title interaction with themes

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -177,11 +177,6 @@ class Front_End_Integration implements Integration_Interface {
 		remove_action( 'wp_head', 'noindex', 1 );
 		remove_action( 'wp_head', '_wp_render_title_tag', 1 );
 		remove_action( 'wp_head', 'gutenberg_render_title_tag', 1 );
-
-		if ( ! get_theme_support( 'title-tag' ) ) {
-			// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
-			$this->base_presenters = array_diff( $this->base_presenters, [ 'Title' ] );
-		}
 	}
 
 	/**
@@ -251,6 +246,11 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	private function get_needed_presenters( $page_type ) {
 		$presenters = $this->get_presenters_for_page_type( $page_type );
+
+		if ( ! get_theme_support( 'title-tag' ) ) {
+			// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
+			$presenters = array_diff( $presenters, [ 'Title' ] );
+		}
 
 		/**
 		 * Filter 'wpseo_frontend_presenters' - Allow filtering presenters in or out of the request.

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -91,8 +91,6 @@ class Front_End_Integration_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
-		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( true );
-
 		$this->instance->register_hooks();
 
 		$this->assertTrue( has_action( 'wp_head', [ $this->instance, 'call_wpseo_head' ] ), 'Does not have expected wp_head action' );
@@ -162,6 +160,8 @@ class Front_End_Integration_Test extends TestCase {
 	 * @covers ::get_all_presenters
 	 */
 	public function test_get_presenters_for_singular_page() {
+		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( true );
+
 		$this->container
 			->expects( 'get' )
 			->times( 28 )
@@ -214,6 +214,8 @@ class Front_End_Integration_Test extends TestCase {
 	 * @covers ::get_all_presenters
 	 */
 	public function test_get_presenters_for_error_page() {
+		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( true );
+
 		$this->container
 			->expects( 'get' )
 			->times( 7 )
@@ -242,6 +244,8 @@ class Front_End_Integration_Test extends TestCase {
 	 * @covers ::get_all_presenters
 	 */
 	public function test_get_presenters_for_non_singular_page() {
+		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( true );
+
 		$this->container
 			->expects( 'get' )
 			->times( 23 )
@@ -298,8 +302,6 @@ class Front_End_Integration_Test extends TestCase {
 	public function test_get_presenters_for_theme_without_title_tag() {
 		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( false );
 
-		$this->instance->register_hooks();
-
 		$this->container
 			->expects( 'get' )
 			->times( 6 )
@@ -315,7 +317,7 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
-			$this->instance->get_presenters( 'Error_Page' )
+			array_values( $this->instance->get_presenters( 'Error_Page' ) )
 		);
 	}
 }


### PR DESCRIPTION
## Context
Themes differ in when they register their support for various features. During register_hooks `title-tag` support may not yet be registered. This delays the check so even if themes register support slightly later they will still get picked up.

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Visit any page with twentytwenty active. You should see a title.
  * error pages
  * homepage
  * search page
  * custom post type
  * custom taxonomy
  * any other page you want to check, like normal post

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14561
Fixes https://github.com/Yoast/wordpress-seo/issues/14562
Fixes https://github.com/Yoast/wordpress-seo/issues/14563
Fixes https://github.com/Yoast/wordpress-seo/issues/14564