### PR TITLE
Added a dash to max-age in caching headers of .xsl files

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -432,7 +432,7 @@ class WPSEO_Sitemaps {
 		// Make the browser cache this file properly.
 		$expires = YEAR_IN_SECONDS;
 		header( 'Pragma: public' );
-		header( 'Cache-Control: maxage=' . $expires );
+		header( 'Cache-Control: max-age=' . $expires );
 		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
 
 		readfile( WPSEO_PATH . 'css/main-sitemap.xsl' );


### PR DESCRIPTION
## Context
* We set the `Cache-Control` header of `.xsl` files with the intent to cache this file for a year. The current directive is written wrong (without a dash) so it's not working as intended.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the cache control header of `.xsl` files to cache for a year.

## Relevant technical choices:

Small performance improvement by having `.xsl` files cached for longer. The functional effect varies per browser / server / CDN, since this value can get overridden or ignored. But to make it work without any interference, `max-age` [should be written with a dash](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Cache_request_directives).

## Test instructions
This PR can be tested by following these steps:

From a theoretical perspective, these are steps to verify that the header directive has changed:

1. Install Yoast on a testsite and set it up so that you can use the sitemap.
2. Visit the sitemap with the `Network` tab in the developer tools open.
3. Locate the call to `main-sitemap.xsl` and check the headers.
4. Verify the `Cache-Control` header has `max-age` set, and not `maxage`

From a functional perspective I do not have a valid way of verifying that this file is indeed getting cached differently. I'm going by documentation here.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes: https://wordpress.org/support/topic/http-header-cache-control/