### PR TITLE
Improve backwards compatibility of deprecated methods.

### DIFF
--- a/deprecated/frontend/schema/class-schema-image.php
+++ b/deprecated/frontend/schema/class-schema-image.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Helpers\Schema\Image_Helper;
+
 /**
  * Returns schema image data.
  *
@@ -19,6 +21,19 @@
 class WPSEO_Schema_Image {
 
 	/**
+	 * The image helper.
+	 *
+	 * @var Image_Helper
+	 */
+	private $image;
+
+	/**
+	 * Value to use as the image id.
+	 * @var string
+	 */
+	private $schema_id;
+
+	/**
 	 * WPSEO_Schema_Image constructor.
 	 *
 	 * @codeCoverageIgnore
@@ -27,7 +42,10 @@ class WPSEO_Schema_Image {
 	 * @param string $schema_id The string to use in an image's `@id`.
 	 */
 	public function __construct( $schema_id ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper' );
+
+		$this->schema_id = $schema_id;
+		$this->image     = YoastSEO()->classes->get( Image_Helper::class );
 	}
 
 	/**
@@ -42,9 +60,9 @@ class WPSEO_Schema_Image {
 	 * @return array Schema ImageObject array.
 	 */
 	public function generate_from_url( $url, $caption = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::generate_from_url' );
 
-		return array();
+		return $this->image->generate_from_url( $this->schema_id, $url, $caption );
 	}
 
 	/**
@@ -59,9 +77,9 @@ class WPSEO_Schema_Image {
 	 * @return array Schema ImageObject array.
 	 */
 	public function generate_from_attachment_id( $attachment_id, $caption = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::generate_from_attachment_id' );
 
-		return array();
+		return $this->image->generate_from_attachment_id( $this->schema_id, $attachment_id, $caption );
 	}
 
 	/**
@@ -76,8 +94,8 @@ class WPSEO_Schema_Image {
 	 * @return array $data Schema ImageObject array.
 	 */
 	public function simple_image_object( $url, $caption = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::simple_image_object' );
 
-		return array();
+		return $this->image->simple_image_object( $this->schema_id, $url, $caption );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-image.php
+++ b/deprecated/frontend/schema/class-schema-image.php
@@ -29,6 +29,7 @@ class WPSEO_Schema_Image {
 
 	/**
 	 * Value to use as the image id.
+	 *
 	 * @var string
 	 */
 	private $schema_id;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This pull request makes sure that the 'deprecated' schema classes are returning actual values instead empty arrays.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It brings back a better backwards compatibility for `WPSEO_Schema_Image`

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add this code somewhere in a theme or in the wp-seo.php file. 
```php
add_action( 'init', function() {
	$image_helper = new WPSEO_Schema_Image( 'foo' );

	print_r( $image_helper->generate_from_url( 'https://example.org/image.jpg', 'This is a caption' ) );

        // I've used 12 as attachment id. You might have to check for on in your database.
	print_r( $image_helper->generate_from_attachment_id( 12, 'This is a caption' ) );

	print_r( $image_helper->simple_image_object( 'https://example.org/image.jpg', 'This is a caption' ) );
} );
```
* Navigate to the homepage or an other page on the frontend
* Verify that there is schema like output.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14573 
