### PR TITLE
Improve backwards compatibility for basic schema classes

### DIFF
--- a/deprecated/frontend/schema/class-schema-article.php
+++ b/deprecated/frontend/schema/class-schema-article.php
@@ -41,11 +41,15 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 
 		$yoast = YoastSEO();
 		/**
+		 * Holds a memoizer for the meta tag context.
+		 *
 		 * @var Meta_Tags_Context_Memoizer
 		 */
 		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
 		$context  = $memoizer->for_current_page();
 		/**
+		 * Holds the article schema.
+		 *
 		 * @var Article
 		 */
 		$piece = $yoast->classes->get( Article::class );

--- a/deprecated/frontend/schema/class-schema-article.php
+++ b/deprecated/frontend/schema/class-schema-article.php
@@ -19,13 +19,30 @@ use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the article schema generator.
+	 *
+	 * @var Article
+	 */
+	private $article;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_Article constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::__construct' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->article  = YoastSEO()->classes->get( Article::class );
 	}
 
 	/**
@@ -39,22 +56,9 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	public function is_needed() {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::is_needed' );
 
-		$yoast = YoastSEO();
-		/**
-		 * Holds a memoizer for the meta tag context.
-		 *
-		 * @var Meta_Tags_Context_Memoizer
-		 */
-		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
-		$context  = $memoizer->for_current_page();
-		/**
-		 * Holds the article schema.
-		 *
-		 * @var Article
-		 */
-		$piece = $yoast->classes->get( Article::class );
+		$context = $this->memoizer->for_current_page();
 
-		return $piece->is_needed( $context );
+		return $this->article->is_needed( $context );
 	}
 
 	/**
@@ -68,22 +72,9 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	public function generate() {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::generate' );
 
-		$yoast = YoastSEO();
-		/**
-		 * Holds a memoizer for the meta tag context.
-		 *
-		 * @var Meta_Tags_Context_Memoizer
-		 */
-		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
-		$context  = $memoizer->for_current_page();
-		/**
-		 * Holds the article schema.
-		 *
-		 * @var Article
-		 */
-		$piece = $yoast->classes->get( Article::class );
+		$context = $this->memoizer->for_current_page();
 
-		return $piece->generate( $context );
+		return $this->article->generate( $context );
 	}
 
 	/**

--- a/deprecated/frontend/schema/class-schema-article.php
+++ b/deprecated/frontend/schema/class-schema-article.php
@@ -5,6 +5,10 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\Article;
+use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema Article data.
  *
@@ -21,7 +25,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::__construct' );
 	}
 
 	/**
@@ -33,9 +37,20 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::is_needed' );
 
-		return false;
+		$yoast = YoastSEO();
+		/**
+		 * @var Meta_Tags_Context_Memoizer
+		 */
+		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
+		$context  = $memoizer->for_current_page();
+		/**
+		 * @var Article
+		 */
+		$piece = $yoast->classes->get( Article::class );
+
+		return $piece->is_needed( $context );
 	}
 
 	/**
@@ -47,9 +62,24 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @return array $data Article data.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::generate' );
 
-		return array();
+		$yoast = YoastSEO();
+		/**
+		 * Holds a memoizer for the meta tag context.
+		 *
+		 * @var Meta_Tags_Context_Memoizer
+		 */
+		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
+		$context  = $memoizer->for_current_page();
+		/**
+		 * Holds the article schema.
+		 *
+		 * @var Article
+		 */
+		$piece = $yoast->classes->get( Article::class );
+
+		return $piece->generate( $context );
 	}
 
 	/**
@@ -63,8 +93,15 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @return bool True if it has article schema, false if not.
 	 */
 	public static function is_article_post_type( $post_type = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Article_Helper::is_article_post_type' );
 
-		return false;
+		/**
+		 * Holds the article schema helper.
+		 *
+		 * @var Article_Helper
+		 */
+		$article = YoastSEO()->classes->get( Article_Helper::class );
+
+		return $article->is_article_post_type( $post_type );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-author.php
+++ b/deprecated/frontend/schema/class-schema-author.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\Author;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema Person data.
  *
@@ -21,7 +24,7 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::__construct' );
 	}
 
 	/**
@@ -33,9 +36,24 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::is_needed' );
 
-		return false;
+		$yoast = YoastSEO();
+		/**
+		 * Holds a memoizer for the meta tag context.
+		 *
+		 * @var Meta_Tags_Context_Memoizer
+		 */
+		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
+		$context  = $memoizer->for_current_page();
+		/**
+		 * Holds the author schema.
+		 *
+		 * @var Author
+		 */
+		$piece = $yoast->classes->get( Author::class );
+
+		return $piece->is_needed( $context );
 	}
 
 	/**
@@ -44,9 +62,24 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	 * @return bool|array Person data on success, false on failure.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::generate' );
 
-		return array();
+		$yoast = YoastSEO();
+		/**
+		 * Holds a memoizer for the meta tag context.
+		 *
+		 * @var Meta_Tags_Context_Memoizer
+		 */
+		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
+		$context  = $memoizer->for_current_page();
+		/**
+		 * Holds the author schema.
+		 *
+		 * @var Author
+		 */
+		$piece = $yoast->classes->get( Author::class );
+
+		return $piece->generate( $context );
 	}
 
 	/**

--- a/deprecated/frontend/schema/class-schema-author.php
+++ b/deprecated/frontend/schema/class-schema-author.php
@@ -18,13 +18,30 @@ use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the author schema generator.
+	 *
+	 * @var Author
+	 */
+	private $author;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_Author constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::__construct' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->author   = YoastSEO()->classes->get( Author::class );
 	}
 
 	/**
@@ -38,52 +55,32 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	public function is_needed() {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::is_needed' );
 
-		$yoast = YoastSEO();
-		/**
-		 * Holds a memoizer for the meta tag context.
-		 *
-		 * @var Meta_Tags_Context_Memoizer
-		 */
-		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
-		$context  = $memoizer->for_current_page();
-		/**
-		 * Holds the author schema.
-		 *
-		 * @var Author
-		 */
-		$piece = $yoast->classes->get( Author::class );
+		$context = $this->memoizer->for_current_page();
 
-		return $piece->is_needed( $context );
+		return $this->author->is_needed( $context );
 	}
 
 	/**
 	 * Returns Person Schema data.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated xx.x
 	 *
 	 * @return bool|array Person data on success, false on failure.
 	 */
 	public function generate() {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::generate' );
 
-		$yoast = YoastSEO();
-		/**
-		 * Holds a memoizer for the meta tag context.
-		 *
-		 * @var Meta_Tags_Context_Memoizer
-		 */
-		$memoizer = $yoast->classes->get( Meta_Tags_Context_Memoizer::class );
-		$context  = $memoizer->for_current_page();
-		/**
-		 * Holds the author schema.
-		 *
-		 * @var Author
-		 */
-		$piece = $yoast->classes->get( Author::class );
+		$context = $this->memoizer->for_current_page();
 
-		return $piece->generate( $context );
+		return $this->author->generate( $context );
 	}
 
 	/**
 	 * Gets the Schema type we use for this class.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated xx.x
 	 *
 	 * @return string[] The schema type.
 	 */

--- a/deprecated/frontend/schema/class-schema-author.php
+++ b/deprecated/frontend/schema/class-schema-author.php
@@ -87,6 +87,6 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	public static function get_type() {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
 
-		return array();
+		return [ 'Person' ];
 	}
 }

--- a/deprecated/frontend/schema/class-schema-faq.php
+++ b/deprecated/frontend/schema/class-schema-faq.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\FAQ;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema FAQ data.
  *
@@ -15,13 +18,30 @@
 class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the FAQ schema generator.
+	 *
+	 * @var FAQ
+	 */
+	private $faq;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_FAQ constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->faq      = YoastSEO()->classes->get( FAQ::class );
 	}
 
 	/**
@@ -61,9 +81,11 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @return array $data Our Schema graph.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ::generate' );
 
-		return array();
+		$context = $this->memoizer->for_current_page();
+
+		return $this->faq->generate( $context );
 	}
 
 	/**
@@ -93,8 +115,10 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ::is_needed' );
 
-		return false;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->faq->is_needed( $context );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-howto.php
+++ b/deprecated/frontend/schema/class-schema-howto.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\HowTo;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema FAQ data.
  *
@@ -15,13 +18,30 @@
 class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the HowTo schema generator.
+	 *
+	 * @var HowTo
+	 */
+	private $how_to;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_FAQ constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->how_to   = YoastSEO()->classes->get( HowTo::class );
 	}
 
 	/**
@@ -33,9 +53,11 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * @return array $data Our Schema graph.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo::generate' );
 
-		return array();
+		$context = $this->memoizer->for_current_page();
+
+		return $this->how_to->generate( $context );
 	}
 
 	/**
@@ -64,8 +86,10 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo::is_needed' );
 
-		return false;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->how_to->is_needed( $context );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-main-image.php
+++ b/deprecated/frontend/schema/class-schema-main-image.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\Main_Image;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns ImageObject schema data.
  *
@@ -16,13 +19,30 @@
 class WPSEO_Schema_MainImage implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the Main_Image schema generator.
+	 *
+	 * @var Main_Image
+	 */
+	private $main_image;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_WebPage constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image' );
+
+		$this->memoizer     = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->main_image   = YoastSEO()->classes->get( Main_Image::class );
 	}
 
 	/**
@@ -34,9 +54,11 @@ class WPSEO_Schema_MainImage implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image::is_needed' );
 
-		return false;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->main_image->is_needed( $context );
 	}
 
 	/**
@@ -50,8 +72,10 @@ class WPSEO_Schema_MainImage implements WPSEO_Graph_Piece {
 	 * @return false|array $data Image Schema.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image::generate' );
 
-		return array();
+		$context = $this->memoizer->for_current_page();
+
+		return $this->main_image->generate( $context );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-organization.php
+++ b/deprecated/frontend/schema/class-schema-organization.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\Organization;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema Organization data.
  *
@@ -15,13 +18,30 @@
 class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the Organization schema generator.
+	 *
+	 * @var Organization
+	 */
+	private $organization;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_Organization constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->organization = YoastSEO()->classes->get( Organization::class );
 	}
 
 	/**
@@ -33,9 +53,11 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization::is_needed' );
 
-		return false;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->organization->is_needed( $context );
 	}
 
 	/**
@@ -47,8 +69,10 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @return array $data The Organization schema.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization::generate' );
 
-		return array();
+		$context = $this->memoizer->for_current_page();
+
+		return $this->organization->generate( $context );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-organization.php
+++ b/deprecated/frontend/schema/class-schema-organization.php
@@ -40,7 +40,7 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	public function __construct() {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization' );
 
-		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->memoizer     = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->organization = YoastSEO()->classes->get( Organization::class );
 	}
 

--- a/deprecated/frontend/schema/class-schema-person.php
+++ b/deprecated/frontend/schema/class-schema-person.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\Person;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema Person data.
  *
@@ -15,13 +18,30 @@
 class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the Person schema generator.
+	 *
+	 * @var Person
+	 */
+	private $person;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_Person constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->person = YoastSEO()->classes->get( Person::class );
 	}
 
 	/**
@@ -33,9 +53,11 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person::is_needed' );
 
-		return false;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->person->is_needed( $context );
 	}
 
 	/**
@@ -47,8 +69,10 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 * @return bool|array Person data on success, false on failure.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person::generate' );
 
-		return array();
+		$context = $this->memoizer->for_current_page();
+
+		return $this->person->generate( $context );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-webpage.php
+++ b/deprecated/frontend/schema/class-schema-webpage.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\WebPage;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema WebPage data.
  *
@@ -15,13 +18,30 @@
 class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the WebPage schema generator.
+	 *
+	 * @var WebPage
+	 */
+	private $web_page;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_WebPage constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->web_page = YoastSEO()->classes->get( WebPage::class );
 	}
 
 	/**
@@ -33,9 +53,11 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::is_needed' );
 
-		return false;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->web_page->is_needed( $context );
 	}
 
 	/**
@@ -47,9 +69,11 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @return array WebPage schema data.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::generate' );
 
-		return array();
+		$context = $this->memoizer->for_current_page();
+
+		return $this->web_page->generate( $context );
 	}
 
 	/**
@@ -64,9 +88,11 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @return array The WebPage schema.
 	 */
 	public function add_author( $data, $post ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::add_author' );
 
-		return $data;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->web_page->add_author( $data, $post, $context );
 	}
 
 	/**
@@ -78,6 +104,10 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @param array $data WebPage schema data.
 	 */
 	public function add_image( &$data ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::add_image' );
+
+		$context = $this->memoizer->for_current_page();
+
+		$this->web_page->add_image( $data, $context );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-website.php
+++ b/deprecated/frontend/schema/class-schema-website.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\Website;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema Website data.
  *
@@ -15,13 +18,30 @@
 class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 
 	/**
+	 * Holds the Website schema generator.
+	 *
+	 * @var Website
+	 */
+	private $website;
+
+	/**
+	 * Holds a memoizer for the meta tag context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_Website constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website' );
+
+		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->website  = YoastSEO()->classes->get( Website::class );
 	}
 
 	/**
@@ -33,9 +53,11 @@ class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website::is_needed' );
 
-		return false;
+		$context = $this->memoizer->for_current_page();
+
+		return $this->website->is_needed( $context );
 	}
 
 	/**
@@ -51,8 +73,10 @@ class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 	 * @return array Website data blob.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website::generate' );
 
-		return array();
+		$context = $this->memoizer->for_current_page();
+
+		return $this->website->generate( $context );
 	}
 }

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -112,7 +112,12 @@ class Author extends Person {
 	 * @return bool|int User ID or false upon return.
 	 */
 	protected function determine_user_id( Meta_Tags_Context $context ) {
-		$user_id = (int) $context->post->post_author;
+		$user_id = 0;
+
+		if ( $context->indexable->object_type === 'post' ) {
+			$user_id = (int) $context->post->post_author;
+		}
+
 		if ( $context->indexable->object_type === 'user' ) {
 			$user_id = $context->indexable->object_id;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This pull request makes sure that the 'deprecated' schema classes are returning actual values instead of empty arrays.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves backwards compatibility for basic schema classes.
* Fixes a bug where the author schema output could generate a notice when not on a post.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### WPSEO_Schema_Article
* Add this code somewhere in a theme or in the `wp-seo.php` file. This is a hacky way of testing. Using the `wp_footer` hook to make sure the normal schema context is already filled. Which should be done as well when the normal implementation is used.
```php
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_Article();
	$is_needed = $schema->is_needed();
	$post_type = \get_post_type();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	echo 'post_type: ', $post_type, '<br/>';
	echo 'is_article_post_type: ', ( $schema->is_article_post_type( $post_type ) ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Navigate to a post on the frontend.
* Verify that the `is_needed` output is `true`.
* Verify that the `post_type` is `post`.
* Verify that the `is_article_post_type` is `true`.
* Verify that there is schema output for the article. You can compare it with the output in the normal schema output, it should be the same (maybe you have to disable your Yoast Test Helper domain override for that to happen).
* Navigate to a custom post type on the frontend, a book for example.
* Verify that the `is_needed` output is `false`.
* Verify that the `post_type` is `book` (depending on what custom post type you went to of course).
* Verify that the `is_article_post_type` is `false`.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### WPSEO_Schema_Author
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```php
add_action( 'wp_footer', function () {
	$schema    = new \WPSEO_Schema_Author();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Navigate to a post on the frontend.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the article. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### Author schema notice bugfix
* Ensure you have author archives enabled: SEO --> Search Appearance --> Archives.
* Go to an author archive page that has at least one entry.
* Verify you have no PHP Error like `Notice: Trying to get property 'post_author' of non-object in /srv/www/local/public_html/wp-content/plugins/wordpress-seo/src/generators/schema/author.php on line 109`.
* Compare to before (`feature/indexables-frontend` branch) where you would have it.
* Related issue: steps to reproduce are similar https://github.com/Yoast/wordpress-seo/issues/14423

### WPSEO_Schema_FAQ
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_FAQ();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Navigate to the frontend of a post _without an FAQ block_.
* Verify that the `is_needed` output is `false`.
* Navigate to the frontend of a post _with an FAQ block_.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the FAQ. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### WPSEO_Schema_HowTo
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_HowTo();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Navigate to the frontend of a post _without an HowTo block_.
* Verify that the `is_needed` output is `false`.
* Navigate to the frontend of a post _with an HowTo block_.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the HowTo. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### WPSEO_Schema_MainImage
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_MainImage();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Navigate to the frontend of a category.
* Verify that the `is_needed` output is `false`.
* Navigate to the frontend of a post.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the MainImage. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### WPSEO_Schema_Organization
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_Organization();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Set your site to represent a person: SEO --> Search Appearance --> General --> Knowledge Graph & Schema.org.
* Verify that the `is_needed` output is `false`.
* Navigate to the frontend of a post.
* Set your site to represent an organization with name & logo: SEO --> Search Appearance --> General --> Knowledge Graph & Schema.org.
* Navigate to the frontend of a post.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the Organization. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### WPSEO_Schema_Person
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_Person();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Set your site to represent an organization with name & logo: SEO --> Search Appearance --> General --> Knowledge Graph & Schema.org.
* Verify that the `is_needed` output is `false`.
* Navigate to the frontend of a post.
* Set your site to represent a person: SEO --> Search Appearance --> General --> Knowledge Graph & Schema.org.
* Navigate to the frontend of a post.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the Person. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### WPSEO_Schema_WebPage
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_WebPage();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$encode   = ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT );
		$generate = \wp_json_encode( $schema->generate(), $encode );
		$author   = \wp_json_encode( $schema->add_author( [], \get_post() ), $encode );
		$image    = [];
		$schema->add_image( $image );
		$image = \wp_json_encode( $image, $encode );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ',', $author, ',', $image, ']}</script>';
	}
} );
```
* Navigate to the frontend of a non-existing page (search for some random thing like `dfjdlkfjdslkfhsd`).
* Verify that the `is_needed` output is `false`.
* Set your site to represent not really represent an organization by removing the logo: SEO --> Search Appearance --> General --> Knowledge Graph & Schema.org.
* Add a featured image to a post.
* Navigate to the frontend of that post.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the WebPage. You can compare it with the output in the normal schema output, it should be the same.
* Verify that there is an extra graph piece with `author` that is the same as in the `WebPage` output. This is the output of the `add_author` method (and is already called through generate).
* Verify that there is an extra graph piece with `primaryImageOfPage` that is the same as in the `WebPage` output. This is the output of the `add_image` method (and is already called through generate).
* You could reinstate your site represents and verify the `author` part is empty now (or not there in the base).
* You could remove the featured image of the post and verify the `primaryImageOfPage` is empty now (or not there in the base).
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

### WPSEO_Schema_Website
* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_Website();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Navigate to the frontend of a post.
* Verify that the `is_needed` output is `true`. Since this is always true, there is no `false` check here.
* Verify that there is schema output for the Website. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14571 
