### PR TITLE
Have better BC in WPSEO_Schema_Utils

### DIFF
--- a/deprecated/frontend/schema/class-schema-utils.php
+++ b/deprecated/frontend/schema/class-schema-utils.php
@@ -5,6 +5,10 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Helpers\Post_Helper;
+use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
+use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
+
 /**
  * Schema utility functions.
  *
@@ -26,9 +30,16 @@ class WPSEO_Schema_Utils {
 	 * @return string The user's schema ID.
 	 */
 	public static function get_user_schema_id( $user_id, $context ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\ID_Helper::get_user_schema_id' );
 
-		 return '';
+		/**
+		 * It represents the ID_Helper.
+		 *
+		 * @var ID_Helper $id
+		 */
+		$id = YoastSEO()->classes->get( ID_Helper::class );
+
+		 return $id->get_user_schema_id( $user_id, $context );
 	}
 
 	/**
@@ -42,9 +53,16 @@ class WPSEO_Schema_Utils {
 	 * @return string The post title with fallback to `No title`.
 	 */
 	public static function get_post_title_with_fallback( $post_id = 0 ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', ' Yoast\WP\SEO\Helpers\Post_Helper::get_post_title_with_fallback' );
 
-		return $title;
+		/**
+		 * Represents the Post_Helper.
+		 *
+		 * @var Post_Helper $post
+		 */
+		$post = YoastSEO()->classes->get( Post_Helper::class );
+
+		return $post->get_post_title_with_fallback( $post_id );
 	}
 
 	/**
@@ -62,8 +80,15 @@ class WPSEO_Schema_Utils {
 	 * @return array The Schema piece data with added language property.
 	 */
 	public static function add_piece_language( $data ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Language_Helper::add_piece_language' );
 
-		return $data;
+		/**
+		 * Represents the Language_Helper.
+		 *
+		 * @var Language_Helper $language
+		 */
+		$language = YoastSEO()->classes->get( Language_Helper::class );
+
+		return $language->add_piece_language( $data );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This pull gives a better backwards compatibility experiences by returning actual values instead of empty values.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It does a fallback on the new helpers.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add this somewhere in the code that is executed on your test environment
```php
add_action( 'init', function() {
	$context = (object) [ 'site_url' => get_home_url() ];

	print_r( WPSEO_Schema_Utils::get_user_schema_id( 1, $context ) );

	print_r( WPSEO_Schema_Utils::get_post_title_with_fallback( 1 ) );

	print_r( WPSEO_Schema_Utils::add_piece_language( [] ) );
} );
```
* Verify that there is output. 1. shows an url, 2. will show a post title and 3. will return an array with an inLanguage tag.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14574
