### PR TITLE
implemented potentialAction array in website schema

### DIFF
--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -197,7 +197,7 @@ class WebPage extends Abstract_Schema_Piece {
 		 *
 		 * @api array $targets The URLs for the WebPage potentialAction target.
 		 */
-		$targets = apply_filters( 'wpseo_schema_webpage_potential_action_target', [ $context->canonical ] );
+		$targets = \apply_filters( 'wpseo_schema_webpage_potential_action_target', [ $context->canonical ] );
 
 		$data['potentialAction'][] = [
 			'@type'  => 'ReadAction',

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -142,15 +142,11 @@ class Website extends Abstract_Schema_Piece {
 		 */
 		$search_url = \apply_filters( 'wpseo_json_ld_search_url', $context->site_url . '?s={search_term_string}' );
 
-		/**
-		 * Array of potentialActions because there can occur more than one
-		 */
-		$data['potentialAction'][] =
-			[
+		$data['potentialAction'][] = [
 			'@type'       => 'SearchAction',
 			'target'      => $search_url,
 			'query-input' => 'required name=search_term_string',
-			];
+		];
 
 		return $data;
 	}

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -142,11 +142,15 @@ class Website extends Abstract_Schema_Piece {
 		 */
 		$search_url = \apply_filters( 'wpseo_json_ld_search_url', $context->site_url . '?s={search_term_string}' );
 
-		$data['potentialAction'] = [
+		/**
+		 * Array of potentialActions because there can occur more than one
+		 */
+		$data['potentialAction'][] =
+			[
 			'@type'       => 'SearchAction',
 			'target'      => $search_url,
 			'query-input' => 'required name=search_term_string',
-		];
+			];
 
 		return $data;
 	}

--- a/tests/generators/schema-generator-test.php
+++ b/tests/generators/schema-generator-test.php
@@ -212,9 +212,11 @@ class Schema_Generator_Test extends TestCase {
 						'name' => '',
 						'description' => 'description',
 						'potentialAction' => [
-							'@type' => 'SearchAction',
-							'target' => '?s={search_term_string}',
-							'query-input' => 'required name=search_term_string',
+							[
+								'@type' => 'SearchAction',
+								'target' => '?s={search_term_string}',
+								'query-input' => 'required name=search_term_string',
+							],
 						],
 						'inLanguage' => 'English',
 					],
@@ -343,9 +345,11 @@ class Schema_Generator_Test extends TestCase {
 						'name'            => '',
 						'description'     => 'description',
 						'potentialAction' => [
-							'@type'       => 'SearchAction',
-							'target'      => '?s={search_term_string}',
-							'query-input' => 'required name=search_term_string',
+							[
+								'@type'       => 'SearchAction',
+								'target'      => '?s={search_term_string}',
+								'query-input' => 'required name=search_term_string',
+							],
 						],
 						'inLanguage'      => 'English',
 					],
@@ -389,9 +393,11 @@ class Schema_Generator_Test extends TestCase {
 					'name'            => '',
 					'description'     => 'description',
 					'potentialAction' => [
-						'@type'       => 'SearchAction',
-						'target'      => '?s={search_term_string}',
-						'query-input' => 'required name=search_term_string',
+						[
+							'@type'       => 'SearchAction',
+							'target'      => '?s={search_term_string}',
+							'query-input' => 'required name=search_term_string',
+						],
 					],
 					'inLanguage'      => 'English',
 				],

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -115,9 +115,11 @@ class Website_Test extends TestCase {
 			'alternateName'   => 'Alternate site name',
 			'description'     => 'description',
 			'potentialAction' => [
-				'@type'       => 'SearchAction',
-				'target'      => 'https://example.com/?s={search_term_string}',
-				'query-input' => 'required name=search_term_string',
+				[
+					'@type'       => 'SearchAction',
+					'target'      => 'https://example.com/?s={search_term_string}',
+					'query-input' => 'required name=search_term_string',
+				],
 			],
 			'inLanguage'      => 'language',
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To create an array of potentialAction elements to be future proof because there may occur more than one potentialAction in the future

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements a potentialAction array instead of a single value, so when more potentialActions are added in the future the website schema is able to adapt to it. 

## Relevant technical choices:

* Created a simple array with adding [] 
* Webpage and article already implement the array the same way, this is the last one to be updated

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a page
* Add a title and some content
* Publish
* Inspect the schema output of website
* Note that the website schema output should have one potentialAction (SearchAction)
* Use the following filter:
```
add_filter( 'wpseo_schema_website', 'add_potential_action_extra' );

function add_potential_action_extra( $data ) { 
  $data['potentialAction'][] = [
				'@type'       => 'ExampleAction',
				'target'      => "ExampleTarget",
				'query-input' => 'Test',
				]; 
  return $data; 
}
```
* Inspect the website schema again
* Note that a potentialAction has been added

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [X] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14446 
