### PR TITLE
Implements BC for WPSEO_Schema_Breadcrumb.

### DIFF
--- a/deprecated/frontend/schema/class-schema-breadcrumb.php
+++ b/deprecated/frontend/schema/class-schema-breadcrumb.php
@@ -47,6 +47,9 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	/**
 	 * Determine if we should add a breadcrumb attribute.
 	 *
+	 * @codeCoverageIgnore
+	 * @deprecated xx.x
+	 *
 	 * @return bool
 	 */
 	public function is_needed() {
@@ -59,6 +62,9 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	 * Returns Schema breadcrumb data to allow recognition of page's position in the site hierarchy.
 	 *
 	 * @link https://developers.google.com/search/docs/data-types/breadcrumb
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated xx.x
 	 *
 	 * @return bool|array Array on success, false on failure.
 	 */

--- a/deprecated/frontend/schema/class-schema-breadcrumb.php
+++ b/deprecated/frontend/schema/class-schema-breadcrumb.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Generators\Schema\Breadcrumb;
+use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+
 /**
  * Returns schema Breadcrumb data.
  *
@@ -15,13 +18,30 @@
 class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 
 	/**
+	 * The new breadcrumb schema generator.
+	 *
+	 * @var Breadcrumb
+	 */
+	private $breadcrumb;
+
+	/**
+	 * The meta tags context memoizer.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
+
+	/**
 	 * WPSEO_Schema_Breadcrumb constructor.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb' );
+
+		$this->breadcrumb = YoastSEO()->classes->get( Breadcrumb::class );
+		$this->memoizer   = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 	}
 
 	/**
@@ -30,9 +50,9 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
-		return false;
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb::is_needed' );
+		$context = $this->memoizer->for_current_page();
+		return $this->breadcrumb->is_needed( $context );
 	}
 
 	/**
@@ -43,8 +63,8 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	 * @return bool|array Array on success, false on failure.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
-		return array();
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb::generate' );
+		$context = $this->memoizer->for_current_page();
+		return $this->breadcrumb->generate( $context );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This pull gives a better backwards compatibility experiences by returning actual values instead of empty values.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The deprecated `WPSEO_Schema_Breadcrumb` class now falls back to the new `Yoast\WP\SEO\Generators\Schema\Breadcrumb` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add this to `wpseo.php` in your test environment
```php
add_action( 'wp_head', static function() {
	$breadcrumbs = new WPSEO_Schema_Breadcrumb();
	// Should output '1'.
	print_r( $breadcrumbs->is_needed() );
	// Should output a breadcrumb list Schema piece.
	print_r( $breadcrumbs->generate() );
} );
```
* Open a post on the frontend of your website.
* Open the browser's console.
* Just below the `<body>` tag, you should see two things:
   * The number 1, indicating that breadcrumb Schema is indeed needed for this page.
   * A PHP array containing the breadcrumb Schema.
      * Check that the Schema is correct and reflects your breadcrumb settings.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
