### PR TITLE
Fix ORDER BY for get_last_modified_gmt function

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -500,7 +500,7 @@ class WPSEO_Sitemaps {
 					WHERE post_status IN ('" . implode( "','", $post_statuses ) . "')
 						AND post_type IN ('" . implode( "','", $post_type_names ) . "')
 					GROUP BY post_type
-					ORDER BY MAX(post_modified_gmt) DESC
+					ORDER BY date DESC
 				";
 
 				foreach ( $wpdb->get_results( $sql ) as $obj ) {

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -500,7 +500,7 @@ class WPSEO_Sitemaps {
 					WHERE post_status IN ('" . implode( "','", $post_statuses ) . "')
 						AND post_type IN ('" . implode( "','", $post_type_names ) . "')
 					GROUP BY post_type
-					ORDER BY post_modified_gmt DESC
+					ORDER BY MAX(post_modified_gmt) DESC
 				";
 
 				foreach ( $wpdb->get_results( $sql ) as $obj ) {


### PR DESCRIPTION
## Context

* Fix `ORDER BY` clause.

## Summary

This PR can be summarized in the following changelog entry:

* Improve ORDER BY clause to match SQL standards. Props to [rafaelbernard](https://github.com/rafaelbernard).

## Relevant technical choices:

* This is a non-brake change. I use Postgres as RDBMS. This is compatible with standard MySQL/MariaDB installations and as also "non-supported" as PG. :-)

## Test instructions

This PR can be tested by following these steps:

* N/A - this is a code-only change and should have no effect on the functionality.

## UI changes
~~* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~~

## Documentation
~~* [ ] I have written documentation for this change.~~

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
