### PR TITLE
Ensure ICL_LANGUAGE_CODE constant is populated

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -559,7 +559,7 @@ class WPSEO_Frontend {
 			$title = $this->get_default_title( $separator, $separator_location, $title_part );
 		}
 
-		if ( defined( 'ICL_LANGUAGE_CODE' ) && false !== strpos( $title, ICL_LANGUAGE_CODE ) ) {
+		if ( defined( 'ICL_LANGUAGE_CODE' ) && !empty(ICL_LANGUAGE_CODE) && false !== strpos( $title, ICL_LANGUAGE_CODE ) ) {
 			$title = str_replace( ' @' . ICL_LANGUAGE_CODE, '', $title );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Yoast/wordpress-seo/issues/14597

If `ICL_LANGUAGE_CODE`, defined by 'WPML' plugin, is `null` (if for example, you have installed WPML but not yet set it up), a deprecation error is thrown:

`Deprecated: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in /var/www/html/assets/plugins/wordpress-seo/frontend/class-frontend.php`

This commit adds a check to ensure that `ICL_LANGUAGE_CODE` is not only defined but is also not `null` (or just not empty) to prevent this error.
