### PR TITLE
Enqueue monorepo styles on admin pages

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -56,7 +56,7 @@ class WPSEO_Admin_Pages {
 		wp_enqueue_style( 'global' );
 		wp_enqueue_style( 'wp-admin' );
 		$this->asset_manager->enqueue_style( 'select2' );
-
+		$this->asset_manager->enqueue_style( 'monorepo');
 		$this->asset_manager->enqueue_style( 'admin-all' );
 	}
 

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -109,6 +109,7 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 		$yoast_components_l10n->localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'dashboard-widget' );
 		$this->asset_manager->enqueue_script( 'dashboard-widget' );
 		$this->asset_manager->enqueue_style( 'wp-dashboard' );
+		$this->asset_manager->enqueue_style( 'monorepo' );
 	}
 
 	/**

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -87,6 +87,7 @@ class WPSEO_Configuration_Page {
 		$asset_manager->register_assets();
 		$asset_manager->enqueue_script( 'configuration-wizard' );
 		$asset_manager->enqueue_style( 'configuration-wizard' );
+		$asset_manager->enqueue_style( 'monorepo' );
 
 		$config = $this->get_config();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the Javascript monorepo styles to be available on the wordpress-seo admin pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Adds Javascript monorepo stylesheets to admin pages.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout branch, have monorepo linked to a recent branch (preferably develop) with `yarn link-monorepo`.
* Build everything.
* Verify that the stylesheets are present on the expected pages by searching for `monorepo` in the inspector of your browser.
* Visually inspect the admin pages.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14580 
