### PR TITLE
Add safety check around filter author schema

### DIFF
--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -127,7 +127,13 @@ class Author extends Person {
 		 *
 		 * @api int|bool $user_id The user ID currently determined.
 		 */
-		return apply_filters( 'wpseo_schema_person_user_id', $user_id );
+		$user_id = \apply_filters( 'wpseo_schema_person_user_id', $user_id );
+
+		if ( \is_int( $user_id ) && $user_id > 0 ) {
+			return $user_id;
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -190,6 +190,43 @@ class Author_Test extends TestCase {
 		$this->assertSame( $this->person_data, $actual );
 	}
 
+
+	/**
+	 * Tests that the author Schema piece is not output
+	 * on non-user archives and non-posts.
+	 *
+	 * @covers ::generate
+	 * @covers ::is_needed
+	 */
+	public function test_is_not_shown_when_filter_does_not_output_valid_user_id() {
+		$user_id = 123;
+
+		$this->instance->expects( 'build_person_data' )
+			->never();
+
+		$this->id->webpage_hash = '#webpage';
+
+		// Set up the context with values.
+		$this->meta_tags_context->post = (Object) [
+			'post_author' => $user_id,
+		];
+
+		$this->meta_tags_context->indexable = (Object) [
+			'object_type' => 'post',
+			'object_id'   => 1234,
+		];
+
+		$this->meta_tags_context->canonical = 'http://basic.wordpress.test/author/admin/';
+
+		Brain\Monkey\Filters\expectApplied( 'wpseo_schema_person_user_id' )
+			->with( $user_id )
+			->andReturn( 'not_a_valid_user_id' );
+
+		$actual = $this->instance->generate( $this->meta_tags_context );
+
+		$this->assertFalse( $actual );
+	}
+
 	/**
 	 * Tests that the author is not output when no user id could be determined.
 	 *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to short-circuit the output of author schema when no valid user ID is given out of the application of the `wpseo_schema_person_user_id` filter.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* We now check if the result of applying the `wpseo_schema_person_user_id` filter in the author schema outputs a valid user ID. If it is invalid, no author schema is output.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Invalid user ID.
* Add this code somewhere in the code, for example in `wp-seo.php`:
  ```php
  add_filter( 'wpseo_schema_person_user_id', function( $user_id ) {
	  return 'invalid_user_id';
  } );
  ```
* Go to a post on the frontend.
* Check the schema. It should **not** contain a `Person` graph piece.

### Valid user ID.
* Replace the above code with this code:
  ```php
  add_filter( 'wpseo_schema_person_user_id', function( $user_id ) {
	  return 2;
  } );
  ```
* Go to a post on the frontend.
* Check the schema. It **should** contain a `Person` graph piece representing the user with ID 2.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14615 
