### PR TITLE
Lazily update indexable hierarchy

### DIFF
--- a/src/integrations/watchers/option-titles-watcher.php
+++ b/src/integrations/watchers/option-titles-watcher.php
@@ -56,7 +56,7 @@ class Option_Titles_Watcher implements Integration_Interface {
 		}
 
 		$relevant_keys = $this->get_relevant_keys();
-		if( empty( $relevant_keys ) ) {
+		if ( empty( $relevant_keys ) ) {
 			return false;
 		}
 

--- a/src/integrations/watchers/option-titles-watcher.php
+++ b/src/integrations/watchers/option-titles-watcher.php
@@ -56,7 +56,11 @@ class Option_Titles_Watcher implements Integration_Interface {
 		}
 
 		$relevant_keys = $this->get_relevant_keys();
-		$post_types    = [];
+		if( empty( $relevant_keys ) ) {
+			return false;
+		}
+
+		$post_types = [];
 
 		foreach ( $relevant_keys as $post_type => $relevant_option ) {
 			// If both values aren't set they haven't changed.
@@ -69,9 +73,7 @@ class Option_Titles_Watcher implements Integration_Interface {
 			}
 		}
 
-		$this->delete_ancestors( $post_types );
-
-		return true;
+		return $this->delete_ancestors( $post_types );
 	}
 
 	/**
@@ -97,10 +99,12 @@ class Option_Titles_Watcher implements Integration_Interface {
 	 * Removes the ancestors for given post types.
 	 *
 	 * @param array $post_types The post types to remove hierarchy for.
+	 *
+	 * @return bool True when ancestors are deleted and false when not.
 	 */
 	protected function delete_ancestors( $post_types ) {
 		if ( empty( $post_types ) ) {
-			return; // There is nothing to do.
+			return false; // There is nothing to do.
 		}
 
 		$wpdb             = Wrapper::get_wpdb();
@@ -110,7 +114,7 @@ class Option_Titles_Watcher implements Integration_Interface {
 		$hierarchy_table  = Yoast_Model::get_table_name( 'Indexable_Hierarchy' );
 		$indexable_table  = Yoast_Model::get_table_name( 'Indexable' );
 
-		$wpdb->query(
+		$result = $wpdb->query(
 			$wpdb->prepare( "
 				DELETE FROM `$hierarchy_table`
 				WHERE indexable_id IN( 
@@ -119,5 +123,11 @@ class Option_Titles_Watcher implements Integration_Interface {
 				$post_types
 			)
 		);
+
+		if ( is_bool( $result ) ) {
+			return $result;
+		}
+
+		return true;
 	}
 }

--- a/src/integrations/watchers/option-titles-watcher.php
+++ b/src/integrations/watchers/option-titles-watcher.php
@@ -43,7 +43,7 @@ class Option_Titles_Watcher implements Integration_Interface {
 	 * @param array $old_value The old value of the option.
 	 * @param array $new_value The new value of the option.
 	 *
-	 * @return bool Whether or not the option has been saved.
+	 * @return bool Whether or not the ancestors are removed.
 	 */
 	public function check_option( $old_value, $new_value ) {
 		// If this is the first time saving the option, thus when value is false.
@@ -100,11 +100,11 @@ class Option_Titles_Watcher implements Integration_Interface {
 	 *
 	 * @param array $post_types The post types to remove hierarchy for.
 	 *
-	 * @return bool True when ancestors are deleted and false when not.
+	 * @return bool True when delete query was successful.
 	 */
 	protected function delete_ancestors( $post_types ) {
 		if ( empty( $post_types ) ) {
-			return false; // There is nothing to do.
+			return false;
 		}
 
 		$wpdb             = Wrapper::get_wpdb();
@@ -124,10 +124,6 @@ class Option_Titles_Watcher implements Integration_Interface {
 			)
 		);
 
-		if ( is_bool( $result ) ) {
-			return $result;
-		}
-
-		return true;
+		return $result !== false;
 	}
 }

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -7,6 +7,9 @@
 
 namespace Yoast\WP\SEO\Repositories;
 
+use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Models\Indexable_Hierarchy;
 use Yoast\WP\SEO\ORM\Yoast_Model;
 
 /**
@@ -15,6 +18,24 @@ use Yoast\WP\SEO\ORM\Yoast_Model;
  * @package Yoast\WP\SEO\ORM\Repositories
  */
 class Indexable_Hierarchy_Repository {
+
+	/**
+	 * Represents the indexable hierarchy builder.
+	 *
+	 * @var Indexable_Hierarchy_Builder
+	 */
+	protected $builder;
+
+	/**
+	 * Sets the hierarchy builder.
+	 *
+	 * @required
+	 *
+	 * @param Indexable_Hierarchy_Builder $builder The indexable hierarchy builder.
+	 */
+	public function set_builder( Indexable_Hierarchy_Builder $builder ) {
+		$this->builder = $builder;
+	}
 
 	/**
 	 * Removes all ancestors for an indexable.
@@ -47,7 +68,35 @@ class Indexable_Hierarchy_Repository {
 	}
 
 	/**
+	 * Retrieves the ancestors. Create them when empty.
+	 *
+	 * @param Indexable $indexable The indexable to get the ancestors for.
+	 *
+	 * @return Indexable_Hierarchy[] The ancestors.
+	 */
+	public function get_ancestors( Indexable $indexable ) {
+		$ancestors = $this->query()
+			->where( 'indexable_id', $indexable->id )
+			->order_by_desc( 'depth' )
+			->find_many();
+
+		if ( ! empty( $ancestors ) ) {
+			return $ancestors;
+		}
+
+		$indexable = $this->builder->build( $indexable );
+		$ancestors = $this->query()
+			->where( 'indexable_id', $indexable->id )
+			->order_by_desc( 'depth' )
+			->find_many();
+
+		return $ancestors;
+	}
+
+	/**
 	 * Starts a query for this repository.
+	 *
+	 * @codeCoverageIgnore Too difficult to test because of static. Needs more research.
 	 *
 	 * @return \Yoast\WP\SEO\ORM\ORMWrapper
 	 */

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -96,8 +96,6 @@ class Indexable_Hierarchy_Repository {
 	/**
 	 * Starts a query for this repository.
 	 *
-	 * @codeCoverageIgnore Too difficult to test because of static. Needs more research.
-	 *
 	 * @return \Yoast\WP\SEO\ORM\ORMWrapper
 	 */
 	public function query() {

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -74,7 +74,7 @@ class Indexable_Hierarchy_Repository {
 	 *
 	 * @return Indexable_Hierarchy[] The ancestors.
 	 */
-	public function get_ancestors( Indexable $indexable ) {
+	public function find_ancestors( Indexable $indexable ) {
 		$ancestors = $this->query()
 			->where( 'indexable_id', $indexable->id )
 			->order_by_desc( 'depth' )

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\SEO\Repositories;
 use Cassandra\Index;
 use Psr\Log\LoggerInterface;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Models\Indexable;
@@ -31,6 +32,13 @@ class Indexable_Repository {
 	private $builder;
 
 	/**
+	 * Represents the hierarchy repository.
+	 *
+	 * @var Indexable_Hierarchy_Repository
+	 */
+	protected $hierarchy_repository;
+
+	/**
 	 * The current page helper.
 	 *
 	 * @var Current_Page_Helper
@@ -47,19 +55,22 @@ class Indexable_Repository {
 	/**
 	 * Returns the instance of this class constructed through the ORM Wrapper.
 	 *
-	 * @param Indexable_Builder   $builder      The indexable builder.
-	 * @param Current_Page_Helper $current_page The current post helper.
-	 * @param Logger              $logger       The logger.
+	 * @param Indexable_Builder              $builder              The indexable builder.
+	 * @param Current_Page_Helper            $current_page         The current post helper.
+	 * @param Logger                         $logger               The logger.
+	 * @param Indexable_Hierarchy_Repository $hierarchy_repository The hierarchy repository.
 	 */
 	public function __construct(
 		Indexable_Builder $builder,
 		Current_Page_Helper $current_page,
-		Logger $logger
-	) {
-		$this->builder      = $builder;
-		$this->current_page = $current_page;
-		$this->logger       = $logger;
+		Logger $logger,
+		Indexable_Hierarchy_Repository $hierarchy_repository
 
+	) {
+		$this->builder              = $builder;
+		$this->current_page         = $current_page;
+		$this->logger               = $logger;
+		$this->hierarchy_repository = $hierarchy_repository;
 	}
 
 	/**
@@ -321,13 +332,23 @@ class Indexable_Repository {
 	 * @return Indexable[] All ancestors of the given indexable.
 	 */
 	public function get_ancestors( Indexable $indexable ) {
-		$hierarchy_table = Yoast_Model::get_table_name( 'Indexable_Hierarchy' );
+		// In the get_ancestors function first do a query purely on the indexable hierarchy table.
+		$ancestors = $this->hierarchy_repository->get_ancestors( $indexable );
+
+		if ( empty( $ancestors ) ) {
+			return [];
+		}
+
+		$indexables = array_column( $ancestors, 'ancestor_id' );
+
+		// If this query returns a single result with an ancestor_id of -1 then return an empty array.
+		if ( $indexables[0] === 0 && count( $indexables ) === 1 ) {
+			return [];
+		}
+
 		return $this->query()
-					->table_alias( 'i' )
-					->select( 'i.*' )
-					->join( $hierarchy_table, 'i.id = ih.ancestor_id', 'ih' )
-					->where( 'ih.indexable_id', $indexable->id )
-					->order_by_desc( 'ih.depth' )
-					->find_many();
+			->where_in( 'id', $indexables )
+			->order_by_expr( 'FIELD(id,' . implode( ',', $indexables ) . ')' )
+			->find_many();
 	}
 }

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -304,13 +304,22 @@ class Indexable_Repository {
 	 * @return Indexable[] An array of indexables.
 	 */
 	public function find_by_multiple_ids_and_type( $object_ids, $object_type, $auto_create = true ) {
+		/**
+		 * Represents an array of indexable objects.
+		 *
+		 * @var Indexable[] $indexables
+		 */
 		$indexables = $this->query()
 						   ->where_in( 'object_id', $object_ids )
 						   ->where( 'object_type', $object_type )
 						   ->find_many();
 
 		if ( $auto_create ) {
-			$indexables_available = \array_column( $indexables, 'object_id' );
+			$indexables_available = [];
+			foreach ( $indexables as $indexable ) {
+				$indexables_available[] = $indexable->object_id;
+			}
+
 			$indexables_to_create = \array_diff( $object_ids, $indexables_available );
 
 			foreach ( $indexables_to_create as $indexable_to_create ) {
@@ -339,7 +348,10 @@ class Indexable_Repository {
 			return [];
 		}
 
-		$indexables = array_column( $ancestors, 'ancestor_id' );
+		$indexables = [];
+		foreach ( $ancestors as $ancestor ) {
+			$indexables[] = $ancestor->ancestor_id;
+		}
 
 		// If this query returns a single result with an ancestor_id of -1 then return an empty array.
 		if ( $indexables[0] === 0 && count( $indexables ) === 1 ) {

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -341,8 +341,7 @@ class Indexable_Repository {
 	 * @return Indexable[] All ancestors of the given indexable.
 	 */
 	public function get_ancestors( Indexable $indexable ) {
-		// In the get_ancestors function first do a query purely on the indexable hierarchy table.
-		$ancestors = $this->hierarchy_repository->get_ancestors( $indexable );
+		$ancestors = $this->hierarchy_repository->find_ancestors( $indexable );
 
 		if ( empty( $ancestors ) ) {
 			return [];
@@ -353,14 +352,13 @@ class Indexable_Repository {
 			$indexables[] = $ancestor->ancestor_id;
 		}
 
-		// If this query returns a single result with an ancestor_id of -1 then return an empty array.
-		if ( $indexables[0] === 0 && count( $indexables ) === 1 ) {
+		if ( $indexables[0] === 0 && \count( $indexables ) === 1 ) {
 			return [];
 		}
 
 		return $this->query()
 			->where_in( 'id', $indexables )
-			->order_by_expr( 'FIELD(id,' . implode( ',', $indexables ) . ')' )
+			->order_by_expr( 'FIELD(id,' . \implode( ',', $indexables ) . ')' )
 			->find_many();
 	}
 }

--- a/tests/integrations/watchers/option-titles-watcher-test.php
+++ b/tests/integrations/watchers/option-titles-watcher-test.php
@@ -131,7 +131,8 @@ class Option_Titles_Watcher_Test extends TestCase {
 		$wpdb = Mockery::mock();
 		$wpdb->prefix = 'wp_';
 
-		$wpdb->expects( 'prepare' )
+		$wpdb
+			->expects( 'prepare' )
 			->once()
 			->with( "
 				DELETE FROM `wp_yoast_indexable_hierarchy`
@@ -146,14 +147,15 @@ class Option_Titles_Watcher_Test extends TestCase {
 					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( 'post' )	
 				)" );
 
-		$wpdb->expects( 'query' )
+		$wpdb
+			->expects( 'query' )
 			->once()
-		     ->with( "
+			->with( "
 				DELETE FROM `wp_yoast_indexable_hierarchy`
 				WHERE indexable_id IN( 
 					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( 'post' )	
 				)"
-		     )
+			)
 			->andReturn( 2 );
 
 		$GLOBALS['wpdb'] = $wpdb;
@@ -162,7 +164,6 @@ class Option_Titles_Watcher_Test extends TestCase {
 			->once()
 			->with( [ 'public' => true ], 'names' )
 			->andReturn( [ 'post' ] );
-
 
 		$this->assertTrue(
 			$this->instance->check_option(
@@ -188,21 +189,23 @@ class Option_Titles_Watcher_Test extends TestCase {
 		$wpdb = Mockery::mock();
 		$wpdb->prefix = 'wp_';
 
-		$wpdb->expects( 'prepare' )
-		     ->once()
-		     ->with( "
+		$wpdb
+			->expects( 'prepare' )
+			->once()
+			->with( "
 				DELETE FROM `wp_yoast_indexable_hierarchy`
 				WHERE indexable_id IN( 
 					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( %s )	
 				)",
-			     [ 'post' ]
-		     )
-		     ->andReturn( 'the query' );
+				[ 'post' ]
+			)
+			->andReturn( 'the query' );
 
-		$wpdb->expects( 'query' )
-		     ->once()
-		     ->with( 'the query' )
-		     ->andReturnFalse();
+		$wpdb
+			->expects( 'query' )
+			->once()
+			->with( 'the query' )
+			->andReturnFalse();
 
 		$GLOBALS['wpdb'] = $wpdb;
 

--- a/tests/integrations/watchers/option-titles-watcher-test.php
+++ b/tests/integrations/watchers/option-titles-watcher-test.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
+
+namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Integrations\Watchers\Option_Titles_Watcher;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Option_Titles_Watcher_Test.
+ *
+ * @group integrations
+ * @group watchers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Option_Titles_Watcher
+ * @covers ::<!public>
+ */
+class Option_Titles_Watcher_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Option_Titles_Watcher
+	 */
+	protected $instance;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new Option_Titles_Watcher();
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Migrations_Conditional::class ],
+			Option_Titles_Watcher::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertTrue( Monkey\Actions\has( 'update_option_wpseo_titles', [ $this->instance, 'check_option' ] ) );
+	}
+
+	/**
+	 * Tests with the old value being false. This is the case when the option is
+	 * saved the first time.
+	 *
+	 * @covers ::check_option
+	 * @covers ::get_relevant_keys
+	 * @covers ::delete_ancestors
+	 */
+	public function test_check_option_with_old_value_being_false() {
+		Monkey\Functions\expect( 'get_post_types' )
+			->once()
+			->with( [ 'public' => true ], 'names' )
+			->andReturn( [ 'post' ] );
+
+		$this->assertFalse( $this->instance->check_option( false, [] ) );
+	}
+
+	/**
+	 * Tests the method with having one argument not being an array.
+	 *
+	 * @covers ::check_option
+	 */
+	public function test_check_option_with_one_value_not_being_an_array() {
+		$this->assertFalse( $this->instance->check_option( 'string', [] ) );
+	}
+
+	/**
+	 * Tests the method with having no public post types.
+	 *
+	 * @covers ::check_option
+	 * @covers ::get_relevant_keys
+	 */
+	public function test_check_option_with_no_public_post_types() {
+		Monkey\Functions\expect( 'get_post_types' )
+			->once()
+			->with( [ 'public' => true ], 'names' )
+			->andReturn( [] );
+
+		$this->assertFalse( $this->instance->check_option( [], [] ) );
+	}
+
+	/**
+	 * Tests the method with having the get_post_types returning null instead of an
+	 * array.
+	 *
+	 * @covers ::check_option
+	 * @covers ::get_relevant_keys
+	 */
+	public function test_check_option_with_get_post_types_return_non_array() {
+		Monkey\Functions\expect( 'get_post_types' )
+			->once()
+			->with( [ 'public' => true ], 'names' )
+			->andReturnNull();
+
+		$this->assertFalse( $this->instance->check_option( [], [] ) );
+	}
+
+	/**
+	 * Tests the method with the ancestors being removed.
+	 *
+	 * @covers ::check_option
+	 * @covers ::get_relevant_keys
+	 * @covers ::delete_ancestors
+	 */
+	public function test_check_option_with_ancestors_being_removed() {
+		$wpdb = Mockery::mock();
+		$wpdb->prefix = 'wp_';
+
+		$wpdb->expects( 'prepare' )
+			->once()
+			->with( "
+				DELETE FROM `wp_yoast_indexable_hierarchy`
+				WHERE indexable_id IN( 
+					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( %s )	
+				)",
+				[ 'post' ]
+			)
+			->andReturn( "
+				DELETE FROM `wp_yoast_indexable_hierarchy`
+				WHERE indexable_id IN( 
+					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( 'post' )	
+				)" );
+
+		$wpdb->expects( 'query' )
+			->once()
+		     ->with( "
+				DELETE FROM `wp_yoast_indexable_hierarchy`
+				WHERE indexable_id IN( 
+					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( 'post' )	
+				)"
+		     )
+			->andReturn( 2 );
+
+		$GLOBALS['wpdb'] = $wpdb;
+
+		Monkey\Functions\expect( 'get_post_types' )
+			->once()
+			->with( [ 'public' => true ], 'names' )
+			->andReturn( [ 'post' ] );
+
+
+		$this->assertTrue(
+			$this->instance->check_option(
+				[
+					'post_types-post-maintax' => 0,
+				],
+				[
+					'post_types-post-maintax' => 1,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Tests the method with having the ancestors not being removed because the
+	 * database object returns false indicating that something went wrong.
+	 *
+	 * @covers ::check_option
+	 * @covers ::get_relevant_keys
+	 * @covers ::delete_ancestors
+	 */
+	public function test_check_option_with_ancestors_not_being_removed() {
+		$wpdb = Mockery::mock();
+		$wpdb->prefix = 'wp_';
+
+		$wpdb->expects( 'prepare' )
+		     ->once()
+		     ->with( "
+				DELETE FROM `wp_yoast_indexable_hierarchy`
+				WHERE indexable_id IN( 
+					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( %s )	
+				)",
+			     [ 'post' ]
+		     )
+		     ->andReturn( 'the query' );
+
+		$wpdb->expects( 'query' )
+		     ->once()
+		     ->with( 'the query' )
+		     ->andReturnFalse();
+
+		$GLOBALS['wpdb'] = $wpdb;
+
+		Monkey\Functions\expect( 'get_post_types' )
+			->once()
+			->with( [ 'public' => true ], 'names' )
+			->andReturn( [ 'post' ] );
+
+		$this->assertFalse(
+			$this->instance->check_option(
+				[
+					'post_types-post-maintax' => 0,
+				],
+				[
+					'post_types-post-maintax' => 1,
+				]
+			)
+		);
+	}
+}

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Presenters
+ */
+
+namespace Yoast\WP\SEO\Tests\Presenters;
+
+use Mockery;
+use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
+use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
+use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Indexable_Hierarchy_Repository_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository
+ *
+ * @group indexables
+ * @group repositories
+ */
+class Indexable_Hierarchy_Repository_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Mockery\Mock|Indexable_Hierarchy_Repository
+	 */
+	protected $instance;
+
+	/**
+	 * Represents the hierarchy builder.
+	 *
+	 * @var Mockery\Mock|Indexable_Hierarchy_Builder
+	 */
+	protected $builder;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = Mockery::mock( Indexable_Hierarchy_Repository::class )->makePartial();
+		$this->builder  = Mockery::mock( Indexable_Hierarchy_Builder::class )->makePartial();
+	}
+
+	/**
+	 * Tests setting the builder object.
+	 *
+	 * @covers ::set_builder
+	 */
+	public function test_set_builder() {
+		$this->instance->set_builder( $this->builder );
+
+		$this->assertAttributeInstanceOf( Indexable_Hierarchy_Builder::class, 'builder', $this->instance );
+	}
+
+	/**
+	 * Tests the retrieval of the get_ancestors when having already results.
+	 *
+	 * @covers ::get_ancestors
+	 */
+	public function test_get_ancestors_having_results() {
+		$indexable     = Mockery::mock( Indexable::class );
+		$indexable->id = 1;
+
+		$ancestors = [
+			(object) [
+				'indexable_id' => 1,
+				'ancestor_id'  => 2,
+				'depth'        => 1,
+			],
+		];
+
+		$orm_object = Mockery::mock()->makePartial();
+		$orm_object
+			->expects( 'where' )
+			->once()
+			->with( 'indexable_id', 1 )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'order_by_desc' )
+			->once()
+			->with( 'depth' )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'find_many' )
+			->once()
+			->andReturn( $ancestors );
+
+		$this->instance
+			->expects( 'query' )
+			->andReturn( $orm_object );
+
+		$this->assertSame( $ancestors, $this->instance->get_ancestors( $indexable ) );
+	}
+
+	/**
+	 * Tests retrieval of the ancestors when having no results the first time we query.
+	 *
+	 * @covers ::get_ancestors
+	 */
+	public function test_get_ancestors_having_no_results_first_time() {
+		$indexable     = Mockery::mock( Indexable::class );
+		$indexable->id = 1;
+
+		$ancestors = [
+			(object) [
+				'indexable_id' => 1,
+				'ancestor_id'  => 2,
+				'depth'        => 1,
+			],
+		];
+
+		$orm_object = Mockery::mock()->makePartial();
+		$orm_object
+			->expects( 'where' )
+			->twice()
+			->with( 'indexable_id', 1 )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'order_by_desc' )
+			->twice()
+			->with( 'depth' )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'find_many' )
+			->twice()
+			->andReturn( [], $ancestors );
+
+		$this->instance->set_builder( $this->builder );
+
+		$this->instance
+			->expects( 'query' )
+			->twice()
+			->andReturn( $orm_object );
+
+		$this->builder
+			->expects( 'build' )
+			->once()
+			->with( $indexable )
+			->andReturn( $indexable );
+
+		$this->assertSame( $ancestors, $this->instance->get_ancestors( $indexable ) );
+	}
+
+	/**
+	 * Tests removing all ancestors for given indexable.
+	 *
+	 * @covers ::clear_ancestors
+	 */
+	public function test_clear_ancestors() {
+		$orm_object = Mockery::mock()->makePartial();
+		$this->instance->expects( 'query' )->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'where' )
+			->once()
+			->with( 'indexable_id', 1 )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'delete_many' )
+			->once();
+
+		$this->instance->clear_ancestors( 1 );
+	}
+
+	/**
+	 * Tests adding an ancestor.
+	 *
+	 * @covers ::add_ancestor
+	 */
+	public function test_add_ancestor() {
+		$hierarchy               = Mockery::mock();
+		$hierarchy->indexable_id = 1;
+		$hierarchy->ancestor_id  = 2;
+		$hierarchy->depth        = 1;
+
+		$hierarchy->expects( 'save' )->once();
+
+		$orm_object = Mockery::mock()->makePartial();
+
+		$orm_object
+			->expects( 'create' )
+			->with( [
+				'indexable_id' => 1,
+				'ancestor_id'  => 2,
+				'depth'        => 1,
+			] )
+			->andReturn( $hierarchy );
+		$this->instance->expects( 'query' )->andReturn( $orm_object );
+
+		$this->assertSame( $hierarchy, $this->instance->add_ancestor( 1, 2, 1 ) );
+	}
+}

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -59,11 +59,11 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the retrieval of the get_ancestors when having already results.
+	 * Tests the retrieval of the find_ancestors when having already results.
 	 *
-	 * @covers ::get_ancestors
+	 * @covers ::find_ancestors
 	 */
-	public function test_get_ancestors_having_results() {
+	public function test_find_ancestors_having_results() {
 		$indexable     = Mockery::mock( Indexable::class );
 		$indexable->id = 1;
 
@@ -97,15 +97,15 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 			->expects( 'query' )
 			->andReturn( $orm_object );
 
-		$this->assertSame( $ancestors, $this->instance->get_ancestors( $indexable ) );
+		$this->assertSame( $ancestors, $this->instance->find_ancestors( $indexable ) );
 	}
 
 	/**
 	 * Tests retrieval of the ancestors when having no results the first time we query.
 	 *
-	 * @covers ::get_ancestors
+	 * @covers ::find_ancestors
 	 */
-	public function test_get_ancestors_having_no_results_first_time() {
+	public function test_find_ancestors_having_no_results_first_time() {
 		$indexable     = Mockery::mock( Indexable::class );
 		$indexable->id = 1;
 
@@ -148,7 +148,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 			->with( $indexable )
 			->andReturn( $indexable );
 
-		$this->assertSame( $ancestors, $this->instance->get_ancestors( $indexable ) );
+		$this->assertSame( $ancestors, $this->instance->find_ancestors( $indexable ) );
 	}
 
 	/**

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Tests\Presenters;
 
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
+use Yoast\WP\SEO\ORM\ORMWrapper;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -199,5 +200,23 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$this->instance->expects( 'query' )->andReturn( $orm_object );
 
 		$this->assertSame( $hierarchy, $this->instance->add_ancestor( 1, 2, 1 ) );
+	}
+
+	/**
+	 * Tests if the query method returns an instance of the ORMWrapper class that
+	 * represents the Indexable_Hierarchy.
+	 *
+	 * @covers ::query
+	 */
+	public function test_query() {
+		$wpdb = Mockery::mock();
+		$wpdb->prefix = 'wp_';
+
+		$GLOBALS['wpdb'] = $wpdb;
+
+		$query = $this->instance->query();
+
+		$this->assertAttributeEquals( '\Yoast\WP\SEO\Models\Indexable_Hierarchy', 'class_name', $query );
+		$this->assertInstanceOf( ORMWrapper::class, $query );
 	}
 }

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Presenters
+ */
+
+namespace Yoast\WP\SEO\Tests\Presenters;
+
+use Mockery;
+use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Loggers\Logger;
+use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Indexable_Repository_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Repositories\Indexable_Repository
+ *
+ * @group indexables
+ * @group repositories
+ */
+class Indexable_Repository_Test extends TestCase {
+
+	/**
+	 * Represents the indexable builder.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Builder
+	 */
+	protected $builder;
+
+	/**
+	 * Represents the current page helper.
+	 *
+	 * @var Mockery\MockInterface|Current_Page_Helper
+	 */
+	protected $current_page;
+
+	/**
+	 * Represents the logger.
+	 *
+	 * @var Mockery\MockInterface|Logger
+	 */
+	protected $logger;
+
+	/**
+	 * Represents the indexable hierarchy repository.
+	 *
+	 * @var Mockery\Mock|Indexable_Hierarchy_Repository
+	 */
+	protected $hierarchy_repository;
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Indexable_Repository
+	 */
+	protected $instance;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->builder              = Mockery::mock( Indexable_Builder::class );
+		$this->current_page         = Mockery::mock( Current_Page_Helper::class );
+		$this->logger               = Mockery::mock( Logger::class );
+		$this->hierarchy_repository = Mockery::mock( Indexable_Hierarchy_Repository::class )->makePartial();
+		$this->instance             = Mockery::mock( Indexable_Repository::class, [
+			$this->builder,
+			$this->current_page,
+			$this->logger,
+			$this->hierarchy_repository,
+		] )->makePartial();
+	}
+
+	/**
+	 * Tests retrieval of ancestors with nothing found.
+	 *
+	 * @covers ::get_ancestors
+	 */
+	public function test_get_ancestors_no_ancestors_found() {
+		$indexable = Mockery::mock( Indexable::class );
+
+		$this->hierarchy_repository
+			->expects( 'get_ancestors' )
+			->once()
+			->with( $indexable )
+			->andReturn( [] );
+
+		$this->assertSame( [], $this->instance->get_ancestors( $indexable ) );
+	}
+
+	/**
+	 * Tests retrieval of ancestors with nothing found.
+	 *
+	 * @covers ::get_ancestors
+	 */
+	public function test_get_ancestors_one_ancestor_that_has_no_ancestor_id_found() {
+		$indexable = Mockery::mock( Indexable::class );
+
+		$this->hierarchy_repository
+			->expects( 'get_ancestors' )
+			->once()
+			->with( $indexable )
+			->andReturn( [
+				(object) [
+					'ancestor_id' => 0,
+				],
+			] );
+
+		$this->assertSame( [], $this->instance->get_ancestors( $indexable ) );
+	}
+
+	/**
+	 * Tests retrieval of ancestors with nothing found.
+	 *
+	 * @covers ::get_ancestors
+	 */
+	public function test_get_ancestors_one_ancestor_that_has_ancestor_id_found() {
+		$indexable = Mockery::mock( Indexable::class );
+
+		$this->hierarchy_repository
+			->expects( 'get_ancestors' )
+			->once()
+			->with( $indexable )
+			->andReturn( [
+				(object) [
+					'ancestor_id' => 1,
+				],
+			] );
+
+		$orm_object = Mockery::mock()->makePartial();
+		$orm_object
+			->expects( 'where_in' )
+			->with( 'id', [ 1 ] )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'order_by_expr' )
+			->with( 'FIELD(id,1)' )
+			->andReturn( $orm_object );
+		$orm_object
+			->expects( 'find_many' )
+			->andReturn( [ $indexable ] );
+
+		$this->instance->expects( 'query' )->andReturn( $orm_object );
+
+		$this->assertSame( [ $indexable ], $this->instance->get_ancestors( $indexable ) );
+	}
+
+	/**
+	 * Tests retrieval of ancestors with nothing found.
+	 *
+	 * @covers ::get_ancestors
+	 */
+	public function test_get_ancestors_with_multple_ancestors() {
+		$indexable = Mockery::mock( Indexable::class );
+
+		$this->hierarchy_repository
+			->expects( 'get_ancestors' )
+			->once()
+			->with( $indexable )
+			->andReturn( [
+				(object) [
+					'ancestor_id' => 1,
+				],
+				(object) [
+					'ancestor_id' => 2,
+				],
+			] );
+
+		$orm_object = Mockery::mock()->makePartial();
+		$orm_object
+			->expects( 'where_in' )
+			->with( 'id', [ 1, 2 ] )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'order_by_expr' )
+			->with( 'FIELD(id,1,2)' )
+			->andReturn( $orm_object );
+		$orm_object
+			->expects( 'find_many' )
+			->andReturn( [ $indexable ] );
+
+		$this->instance->expects( 'query' )->andReturn( $orm_object );
+
+		$this->assertSame( [ $indexable ], $this->instance->get_ancestors( $indexable ) );
+	}
+
+}

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -98,7 +98,7 @@ class Indexable_Repository_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieval of ancestors with nothing found.
+	 * Tests retrieval of ancestors with one ancestor with no ancestor id found.
 	 *
 	 * @covers ::get_ancestors
 	 */
@@ -119,7 +119,7 @@ class Indexable_Repository_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieval of ancestors with nothing found.
+	 * Tests retrieval of ancestors with one found ancestor.
 	 *
 	 * @covers ::get_ancestors
 	 */
@@ -157,7 +157,7 @@ class Indexable_Repository_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieval of ancestors with nothing found.
+	 * Tests retrieval of ancestors with multiple ancestors found.
 	 *
 	 * @covers ::get_ancestors
 	 */

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -11,6 +11,7 @@ use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Loggers\Logger;
+use Yoast\WP\SEO\ORM\ORMWrapper;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
@@ -88,7 +89,7 @@ class Indexable_Repository_Test extends TestCase {
 		$indexable = Mockery::mock( Indexable::class );
 
 		$this->hierarchy_repository
-			->expects( 'get_ancestors' )
+			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
 			->andReturn( [] );
@@ -105,7 +106,7 @@ class Indexable_Repository_Test extends TestCase {
 		$indexable = Mockery::mock( Indexable::class );
 
 		$this->hierarchy_repository
-			->expects( 'get_ancestors' )
+			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
 			->andReturn( [
@@ -126,7 +127,7 @@ class Indexable_Repository_Test extends TestCase {
 		$indexable = Mockery::mock( Indexable::class );
 
 		$this->hierarchy_repository
-			->expects( 'get_ancestors' )
+			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
 			->andReturn( [
@@ -145,6 +146,7 @@ class Indexable_Repository_Test extends TestCase {
 			->expects( 'order_by_expr' )
 			->with( 'FIELD(id,1)' )
 			->andReturn( $orm_object );
+
 		$orm_object
 			->expects( 'find_many' )
 			->andReturn( [ $indexable ] );
@@ -163,7 +165,7 @@ class Indexable_Repository_Test extends TestCase {
 		$indexable = Mockery::mock( Indexable::class );
 
 		$this->hierarchy_repository
-			->expects( 'get_ancestors' )
+			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
 			->andReturn( [
@@ -194,4 +196,21 @@ class Indexable_Repository_Test extends TestCase {
 		$this->assertSame( [ $indexable ], $this->instance->get_ancestors( $indexable ) );
 	}
 
+	/**
+	 * Tests if the query method returns an instance of the ORMWrapper class that
+	 * represents the Indexable.
+	 *
+	 * @covers ::query
+	 */
+	public function test_query() {
+		$wpdb = Mockery::mock();
+		$wpdb->prefix = 'wp_';
+
+		$GLOBALS['wpdb'] = $wpdb;
+
+		$query = $this->instance->query();
+
+		$this->assertAttributeEquals( '\Yoast\WP\SEO\Models\Indexable', 'class_name', $query );
+		$this->assertInstanceOf( ORMWrapper::class, $query );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When we change the taxonomy to show for a certain post type we want to remove the indexable hierarchy records for the belonging indexables. This allows us to recalculate the hierarchy for these posts

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Fixes a bug where wrong breadcrumbs are shown when changing the primary taxonomy to show for the breadcrumbs.

## Relevant technical choices:

* Decided to add extra tests for the hierarchy repository, because I had the context.
* Temporary added `codeCoverageIgnore` for the query method, because testing this one was too complex. In mockery aliasing, overloading doesn't work. Also in combination with `@runInSeperateProcess` won't work. This needs more investigation... (but that is for a later moment)
* The `-1` check for ancestor_id has been changed to `0` because the ancester_id column is unsigned which means that negative integers aren't allowed. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Save a post with multiple categories attached and one selected as the primary.
* Open your database and check which indexable belongs to the post.
* Open your database and view the table `{some_prefix}_indexable_hierarchy` and see some records for the indexable being present.
* Go to the breadcrumbs settings (Yoast SEO -> Search Appearance -> Breadcrumbs and change the `Taxonomy to show in breadcrumbs for content types` for the post from category to tag.
* In the database hierarchy table the records should be gone.
* Visit the post and make sure new records are made again.
* In the source of the post (browser) the breadcrumbs structure should be the right one.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14558 
