### PR TITLE
Add novalidate to our forms as we don't use native validation.

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -93,7 +93,12 @@ class Yoast_Form {
 				$hidden_fields_cb = 'settings_fields';
 			}
 
-			echo '<form action="' . esc_url( $action_url ) . '" method="post" id="wpseo-conf"' . $enctype . ' accept-charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
+			echo '<form action="' .
+				esc_url( $action_url ) .
+				'" method="post" id="wpseo-conf"' .
+				$enctype . ' accept-charset="' .
+				esc_attr( get_bloginfo( 'charset' ) ) .
+				'" novalidate="novalidate">';
 			call_user_func( $hidden_fields_cb, $option_long_name );
 		}
 		$this->set_option( $option );

--- a/js/tests/components/__snapshots__/CompanyInfoMissing.test.js.snap
+++ b/js/tests/components/__snapshots__/CompanyInfoMissing.test.js.snap
@@ -6,7 +6,7 @@ exports[`CompanyInfoMissing matches the snapshot 1`] = `
 >
   <svg
     aria-hidden={true}
-    className="yoast-svg-icon yoast-svg-icon-alert-warning Alert__AlertIcon-sc-13lb81i-2 camkTq createSvgIconComponent__StyledSvg-f1towz-0 dzRRs"
+    className="yoast-svg-icon yoast-svg-icon-alert-warning Alert__AlertIcon-sc-13lb81i-2 camkTq createSvgIconComponent__StyledSvg-sc-1h4gl3a-0 cPnaHk"
     fill="#674e00"
     focusable="false"
     role="img"

--- a/js/tests/components/__snapshots__/LocalSEOUpsell.test.js.snap
+++ b/js/tests/components/__snapshots__/LocalSEOUpsell.test.js.snap
@@ -84,7 +84,7 @@ exports[`LocalSEOUpsell matches the snapshot 1`] = `
     >
       Get the Local SEO plugin now
       <span
-        className="A11yNotice-u1v0gg-0 dWDZbM"
+        className="A11yNotice-sc-1feyioo-0 gHCoqL"
       >
         (Opens in a new browser tab)
       </span>
@@ -180,7 +180,7 @@ exports[`LocalSEOUpsell matches the snapshot in right to left mode 1`] = `
     >
       Get the Local SEO plugin now
       <span
-        className="A11yNotice-u1v0gg-0 dWDZbM"
+        className="A11yNotice-sc-1feyioo-0 gHCoqL"
       >
         (Opens in a new browser tab)
       </span>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where form fields were validated inconsistently

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where form fields were validated inconsistently.

## Relevant technical choices:

* Just put novalidate on the form.
* Decided to let the other forms in the plugin alone where we don't run into this problem.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Try to reproduce https://github.com/Yoast/bugreports/issues/930, see it's fixed.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/bugreports/issues/930
