### PR TITLE
Add tests for website schema

### DIFF
--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Generators\Schema;
 
 use Mockery;
+use Brain\Monkey;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
@@ -98,6 +99,7 @@ class Website_Test extends TestCase {
 			->once()
 			->andReturnUsing( function( $data ) {
 				$data['inLanguage'] = 'language';
+
 				return $data;
 			} );
 
@@ -125,5 +127,86 @@ class Website_Test extends TestCase {
 		];
 
 		$this->assertEquals( $expected, $this->instance->generate( $this->meta_tags_context ) );
+	}
+
+	/**
+	 * Tests that no internal search section is added to the schema
+	 * when the `disable_wpseo_json_ld_search` filter disables it.
+	 */
+	public function test_generate_does_not_add_internal_search_when_filter_disables_it() {
+		Monkey\Filters\expectApplied( 'disable_wpseo_json_ld_search' )
+			->with( false )
+			->andReturn( true );
+
+		$this->meta_tags_context->site_url                  = 'https://example.com/';
+		$this->meta_tags_context->site_name                 = 'My site';
+		$this->meta_tags_context->site_represents_reference = 'https://example.com/#publisher';
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->twice()
+			->andReturnArg( 0 );
+
+		$this->language->expects( 'add_piece_language' )
+			->once()
+			->andReturnUsing( function( $data ) {
+				$data['inLanguage'] = 'language';
+
+				return $data;
+			} );
+
+		$this->options->expects( 'get' )
+			->with( 'alternate_website_name', '' )
+			->once()
+			->andReturn( 'Alternate site name' );
+
+		$expected = [
+			'@type'           => 'WebSite',
+			'@id'             => 'https://example.com/#website',
+			'url'             => 'https://example.com/',
+			'name'            => 'My site',
+			'publisher'       => 'https://example.com/#publisher',
+			'alternateName'   => 'Alternate site name',
+			'description'     => 'description',
+			'inLanguage'      => 'language',
+		];
+
+		$this->assertEquals( $expected, $this->instance->generate( $this->meta_tags_context ) );
+	}
+
+	/**
+	 * Tests that the webpage graph piece is always needed.
+	 *
+	 * @covers ::is_needed
+	 */
+	public function test_is_needed() {
+		// The website graph piece is always needed.
+		$this->assertTrue( $this->instance->is_needed( $this->meta_tags_context ) );
+	}
+
+	/**
+	 * Tests that the website schema generator is constructed
+	 * with the right properties.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$instance = new Website( $this->options, $this->html, $this->language );
+
+		$this->assertAttributeInstanceOf(
+			Options_Helper::class,
+			'options',
+			$instance
+		);
+		$this->assertAttributeInstanceOf(
+			HTML_Helper::class,
+			'html',
+			$instance
+		);
+		$this->assertAttributeInstanceOf(
+			Language_Helper::class,
+			'language',
+			$instance
+		);
 	}
 }

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -132,6 +132,10 @@ class Website_Test extends TestCase {
 	/**
 	 * Tests that no internal search section is added to the schema
 	 * when the `disable_wpseo_json_ld_search` filter disables it.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_alternate_name
+	 * @covers ::internal_search_section
 	 */
 	public function test_generate_does_not_add_internal_search_when_filter_disables_it() {
 		Monkey\Filters\expectApplied( 'disable_wpseo_json_ld_search' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the cover all the code paths in the website schema generator to check if they work correctly and keep working correctly in the future.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds unit tests for the website schema generator.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check that Travis passes.
* Run the unit tests, with coverage, locally. Check that the code coverage of `src/generators/schema/website.php` is 100%.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
