### PR TITLE
Stop forcing WP_Post object

### DIFF
--- a/admin/links/class-link-watcher.php
+++ b/admin/links/class-link-watcher.php
@@ -44,7 +44,11 @@ class WPSEO_Link_Watcher {
 	 *
 	 * @return void
 	 */
-	public function save_post( $post_id, WP_Post $post ) {
+	public function save_post( $post_id, $post ) {
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
 		// Bail if this is a multisite installation and the site has been switched.
 		if ( is_multisite() && ms_is_switched() ) {
 			return;

--- a/integration-tests/admin/links/test-class-link-watcher.php
+++ b/integration-tests/admin/links/test-class-link-watcher.php
@@ -41,6 +41,23 @@ class WPSEO_Link_Watcher_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Test whether the given argument isn't a WP_Post.
+	 *
+	 * @see https://github.com/Yoast/wordpress-seo/issues/14616
+	 *
+	 * @covers ::save_post
+	 */
+	public function test_is_wrong_post_type() {
+		$processor = $this->get_processor();
+		$processor
+			->expects( $this->never() )
+			->method( 'process' );
+
+		$watcher = new WPSEO_Link_Watcher( $processor );
+		$watcher->save_post( 1, null );
+	}
+
+	/**
 	 * Test whether a post revision is correctly recognized as processable.
 	 *
 	 * @covers ::save_post


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In some case the second argument given to the method which is executed by a hook isn't an instance of `WP_Post` resulting in fatal errors. By removing the type hint we can prevent these failures. These means we have to check the instance of given argument in the method itself and return early when the type is not a WP_Post

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug when a fatal error is given when saving a post.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have error reporting enabled
* On trunk: Add this to your code and visit an admin page
```php
add_action( 'admin_init', function() {
	$watcher = new WPSEO_Link_Watcher(
		new WPSEO_Link_Content_Processor(
			new WPSEO_Link_Storage(), new WPSEO_Meta_Storage()
		)
	);
	$watcher->save_post( 12, null );
} );
```
* A fatal error should be given
* Switch to this branch and execute the same code again. 
* No error should given.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14616
