### PR TITLE
Attachment redirects should be a 301

### DIFF
--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -128,7 +128,7 @@ class Redirects implements Integration_Interface {
 			return;
 		}
 
-		$this->redirect->do_redirect( $url );
+		$this->redirect->do_redirect( $url, 301 );
 	}
 
 	/**

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -107,7 +107,7 @@ class Redirects implements Integration_Interface {
 			return;
 		}
 
-		$this->redirect->do_redirect( $redirect );
+		$this->redirect->do_redirect( $redirect, 301 );
 	}
 
 

--- a/tests/integrations/front-end/redirects-test.php
+++ b/tests/integrations/front-end/redirects-test.php
@@ -323,7 +323,7 @@ class Redirects_Test extends TestCase {
 		$this->redirect
 			->expects( 'do_redirect' )
 			->once()
-			->with( 'https://example.org/redirect' );
+			->with( 'https://example.org/redirect', 301 );
 
 		$this->instance->attachment_redirect();
 	}

--- a/tests/integrations/front-end/redirects-test.php
+++ b/tests/integrations/front-end/redirects-test.php
@@ -225,7 +225,7 @@ class Redirects_Test extends TestCase {
 		$this->redirect
 			->expects( 'do_redirect' )
 			->once()
-			->with( 'https://example.org/redirect' );
+			->with( 'https://example.org/redirect', 301 );
 
 		$this->instance->page_redirect();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Attachment redirects should be 301.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* None needed, this was an unintended change.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Attachment URLs should throw a 301 redirect now instead of 302.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/941
