### PR TITLE
Temporary disable the deprecation notices for schema.

### DIFF
--- a/deprecated/frontend/schema/class-schema-article.php
+++ b/deprecated/frontend/schema/class-schema-article.php
@@ -39,7 +39,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article' );
+		//_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article' );
 
 		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->article  = YoastSEO()->classes->get( Article::class );
@@ -54,8 +54,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->article->is_needed( $context );
@@ -70,8 +69,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @return array $data Article data.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Article::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->article->generate( $context );
@@ -88,8 +86,7 @@ class WPSEO_Schema_Article implements WPSEO_Graph_Piece {
 	 * @return bool True if it has article schema, false if not.
 	 */
 	public static function is_article_post_type( $post_type = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Article_Helper::is_article_post_type' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Article_Helper::is_article_post_type' );
 		/**
 		 * Holds the article schema helper.
 		 *

--- a/deprecated/frontend/schema/class-schema-author.php
+++ b/deprecated/frontend/schema/class-schema-author.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author' );
 		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->author   = YoastSEO()->classes->get( Author::class );
 	}
@@ -53,8 +52,7 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->author->is_needed( $context );
@@ -69,8 +67,7 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	 * @return bool|array Person data on success, false on failure.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Author::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->author->generate( $context );
@@ -85,8 +82,7 @@ class WPSEO_Schema_Author implements WPSEO_Graph_Piece {
 	 * @return string[] The schema type.
 	 */
 	public static function get_type() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 		return [ 'Person' ];
 	}
 }

--- a/deprecated/frontend/schema/class-schema-breadcrumb.php
+++ b/deprecated/frontend/schema/class-schema-breadcrumb.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb' );
 		$this->breadcrumb = YoastSEO()->classes->get( Breadcrumb::class );
 		$this->memoizer   = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 	}
@@ -53,7 +52,7 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb::is_needed' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb::is_needed' );
 		$context = $this->memoizer->for_current_page();
 		return $this->breadcrumb->is_needed( $context );
 	}
@@ -69,7 +68,7 @@ class WPSEO_Schema_Breadcrumb implements WPSEO_Graph_Piece {
 	 * @return bool|array Array on success, false on failure.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb::generate' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Breadcrumb::generate' );
 		$context = $this->memoizer->for_current_page();
 		return $this->breadcrumb->generate( $context );
 	}

--- a/deprecated/frontend/schema/class-schema-faq-question-list.php
+++ b/deprecated/frontend/schema/class-schema-faq-question-list.php
@@ -24,7 +24,7 @@ class WPSEO_Schema_FAQ_Question_List {
 	 * @param WPSEO_Schema_Context    $context A value object with context variables.
 	 */
 	public function __construct( $blocks, $context ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 	}
 
 	/**
@@ -36,8 +36,7 @@ class WPSEO_Schema_FAQ_Question_List {
 	 * @return array The Schema with a question list added.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 		return array();
 	}
 }

--- a/deprecated/frontend/schema/class-schema-faq-questions.php
+++ b/deprecated/frontend/schema/class-schema-faq-questions.php
@@ -25,7 +25,7 @@ class WPSEO_Schema_FAQ_Questions {
 	 * @param WPSEO_Schema_Context  $context A value object with context variables.
 	 */
 	public function __construct( $data, $block, $context ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 	}
 
 	/**
@@ -37,8 +37,7 @@ class WPSEO_Schema_FAQ_Questions {
 	 * @return array The Schema with Questions added.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 		return array();
 	}
 }

--- a/deprecated/frontend/schema/class-schema-faq.php
+++ b/deprecated/frontend/schema/class-schema-faq.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ' );
 		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->faq      = YoastSEO()->classes->get( FAQ::class );
 	}
@@ -53,7 +52,7 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @param array $blocks The blocks of this type on the current page.
 	 */
 	public function prepare_schema( $blocks ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 	}
 
 	/**
@@ -67,8 +66,7 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @return array $page_type The page type that's now an array.
 	 */
 	public function change_schema_page_type( $page_type ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 		return array();
 	}
 
@@ -81,8 +79,7 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @return array $data Our Schema graph.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->faq->generate( $context );
@@ -101,8 +98,7 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @return array $data Our Schema graph.
 	 */
 	public function render_schema_questions( $graph, $block, $context ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 		return array();
 	}
 

--- a/deprecated/frontend/schema/class-schema-faq.php
+++ b/deprecated/frontend/schema/class-schema-faq.php
@@ -111,8 +111,7 @@ class WPSEO_Schema_FAQ implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\FAQ::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->faq->is_needed( $context );

--- a/deprecated/frontend/schema/class-schema-howto.php
+++ b/deprecated/frontend/schema/class-schema-howto.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo' );
 		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->how_to   = YoastSEO()->classes->get( HowTo::class );
 	}
@@ -53,8 +52,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * @return array $data Our Schema graph.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->how_to->generate( $context );
@@ -72,8 +70,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * @return mixed
 	 */
 	public function render( $graph, $block ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 		return array();
 	}
 
@@ -86,8 +83,7 @@ class WPSEO_Schema_HowTo implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\HowTo::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->how_to->is_needed( $context );

--- a/deprecated/frontend/schema/class-schema-image.php
+++ b/deprecated/frontend/schema/class-schema-image.php
@@ -43,8 +43,7 @@ class WPSEO_Schema_Image {
 	 * @param string $schema_id The string to use in an image's `@id`.
 	 */
 	public function __construct( $schema_id ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper' );
 		$this->schema_id = $schema_id;
 		$this->image     = YoastSEO()->classes->get( Image_Helper::class );
 	}
@@ -61,8 +60,7 @@ class WPSEO_Schema_Image {
 	 * @return array Schema ImageObject array.
 	 */
 	public function generate_from_url( $url, $caption = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::generate_from_url' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::generate_from_url' );
 		return $this->image->generate_from_url( $this->schema_id, $url, $caption );
 	}
 
@@ -78,8 +76,7 @@ class WPSEO_Schema_Image {
 	 * @return array Schema ImageObject array.
 	 */
 	public function generate_from_attachment_id( $attachment_id, $caption = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::generate_from_attachment_id' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::generate_from_attachment_id' );
 		return $this->image->generate_from_attachment_id( $this->schema_id, $attachment_id, $caption );
 	}
 
@@ -95,8 +92,7 @@ class WPSEO_Schema_Image {
 	 * @return array $data Schema ImageObject array.
 	 */
 	public function simple_image_object( $url, $caption = '' ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::simple_image_object' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Image_Helper::simple_image_object' );
 		return $this->image->simple_image_object( $this->schema_id, $url, $caption );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-main-image.php
+++ b/deprecated/frontend/schema/class-schema-main-image.php
@@ -39,8 +39,7 @@ class WPSEO_Schema_MainImage implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image' );
 		$this->memoizer     = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->main_image   = YoastSEO()->classes->get( Main_Image::class );
 	}
@@ -54,8 +53,7 @@ class WPSEO_Schema_MainImage implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->main_image->is_needed( $context );
@@ -72,8 +70,7 @@ class WPSEO_Schema_MainImage implements WPSEO_Graph_Piece {
 	 * @return false|array $data Image Schema.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Main_Image::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->main_image->generate( $context );

--- a/deprecated/frontend/schema/class-schema-organization.php
+++ b/deprecated/frontend/schema/class-schema-organization.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization' );
 		$this->memoizer     = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->organization = YoastSEO()->classes->get( Organization::class );
 	}
@@ -53,8 +52,7 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->organization->is_needed( $context );
@@ -69,8 +67,7 @@ class WPSEO_Schema_Organization implements WPSEO_Graph_Piece {
 	 * @return array $data The Organization schema.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Organization::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->organization->generate( $context );

--- a/deprecated/frontend/schema/class-schema-person.php
+++ b/deprecated/frontend/schema/class-schema-person.php
@@ -53,8 +53,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->person->is_needed( $context );
@@ -69,8 +68,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 * @return bool|array Person data on success, false on failure.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->person->generate( $context );

--- a/deprecated/frontend/schema/class-schema-person.php
+++ b/deprecated/frontend/schema/class-schema-person.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Person' );
 		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->person = YoastSEO()->classes->get( Person::class );
 	}

--- a/deprecated/frontend/schema/class-schema-utils.php
+++ b/deprecated/frontend/schema/class-schema-utils.php
@@ -30,8 +30,7 @@ class WPSEO_Schema_Utils {
 	 * @return string The user's schema ID.
 	 */
 	public static function get_user_schema_id( $user_id, $context ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\ID_Helper::get_user_schema_id' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\ID_Helper::get_user_schema_id' );
 		/**
 		 * It represents the ID_Helper.
 		 *
@@ -39,7 +38,7 @@ class WPSEO_Schema_Utils {
 		 */
 		$id = YoastSEO()->classes->get( ID_Helper::class );
 
-		 return $id->get_user_schema_id( $user_id, $context );
+		return $id->get_user_schema_id( $user_id, $context );
 	}
 
 	/**
@@ -53,8 +52,7 @@ class WPSEO_Schema_Utils {
 	 * @return string The post title with fallback to `No title`.
 	 */
 	public static function get_post_title_with_fallback( $post_id = 0 ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', ' Yoast\WP\SEO\Helpers\Post_Helper::get_post_title_with_fallback' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', ' Yoast\WP\SEO\Helpers\Post_Helper::get_post_title_with_fallback' );
 		/**
 		 * Represents the Post_Helper.
 		 *
@@ -80,8 +78,7 @@ class WPSEO_Schema_Utils {
 	 * @return array The Schema piece data with added language property.
 	 */
 	public static function add_piece_language( $data ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Language_Helper::add_piece_language' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Helpers\Schema\Language_Helper::add_piece_language' );
 		/**
 		 * Represents the Language_Helper.
 		 *

--- a/deprecated/frontend/schema/class-schema-webpage.php
+++ b/deprecated/frontend/schema/class-schema-webpage.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage' );
 		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->web_page = YoastSEO()->classes->get( WebPage::class );
 	}
@@ -53,8 +52,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->web_page->is_needed( $context );
@@ -69,8 +67,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @return array WebPage schema data.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->web_page->generate( $context );
@@ -88,8 +85,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @return array The WebPage schema.
 	 */
 	public function add_author( $data, $post ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::add_author' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::add_author' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->web_page->add_author( $data, $post, $context );
@@ -104,8 +100,7 @@ class WPSEO_Schema_WebPage implements WPSEO_Graph_Piece {
 	 * @param array $data WebPage schema data.
 	 */
 	public function add_image( &$data ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::add_image' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\WebPage::add_image' );
 		$context = $this->memoizer->for_current_page();
 
 		$this->web_page->add_image( $data, $context );

--- a/deprecated/frontend/schema/class-schema-website.php
+++ b/deprecated/frontend/schema/class-schema-website.php
@@ -38,8 +38,7 @@ class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 	 * @deprecated xx.x
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website' );
 		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->website  = YoastSEO()->classes->get( Website::class );
 	}
@@ -53,8 +52,7 @@ class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website::is_needed' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website::is_needed' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->website->is_needed( $context );
@@ -73,8 +71,7 @@ class WPSEO_Schema_Website implements WPSEO_Graph_Piece {
 	 * @return array Website data blob.
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website::generate' );
-
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x', 'Yoast\WP\SEO\Generators\Schema\Website::generate' );
 		$context = $this->memoizer->for_current_page();
 
 		return $this->website->generate( $context );

--- a/deprecated/frontend/schema/class-schema.php
+++ b/deprecated/frontend/schema/class-schema.php
@@ -23,7 +23,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 * @deprecated xx.x
 	 */
 	public function register_hooks() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 	}
 
 	/**
@@ -35,7 +35,7 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 * @since 1.8
 	 */
 	public function json_ld() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 	}
 
 	/**
@@ -49,6 +49,6 @@ class WPSEO_Schema implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	public function generate() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		// _deprecated_function( __METHOD__, 'WPSEO xx.x' );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Till we have a surface for easily accessing helper methods we shouldn't show any deprecation notices on the schema classes. We only do the Schema classes because we have publicly communicates its api.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - I've commented out all `_deprecate_function` calls.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Nothing should break. Only deprecation notices shouldn't pop up.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
