### PR TITLE
Drop og:image:secure_url

### DIFF
--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -52,11 +52,6 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 
 			$return .= '<meta property="og:image" content="' . \esc_url( $image_url ) . '" />';
 
-			// Adds secure URL if detected. Not all services implement this, so the regular one also needs to be rendered.
-			if ( \strpos( $image_url, 'https://' ) === 0 ) {
-				$return .= PHP_EOL . "\t" . '<meta property="og:image:secure_url" content="' . \esc_url( $image_url ) . '" />';
-			}
-
 			foreach ( static::$image_tags as $key => $value ) {
 				if ( empty( $image_meta[ $key ] ) ) {
 					continue;

--- a/tests/presenters/open-graph/image-presenter-test.php
+++ b/tests/presenters/open-graph/image-presenter-test.php
@@ -69,7 +69,7 @@ class Image_Presenter_Test extends TestCase {
 		$this->presentation->open_graph_images = [ $image ];
 
 		$this->assertEquals(
-			'<meta property="og:image" content="https://example.com/image.jpg" />' . PHP_EOL . "\t" . '<meta property="og:image:secure_url" content="https://example.com/image.jpg" />' . PHP_EOL . "\t" . '<meta property="og:image:width" content="100" />' . PHP_EOL . "\t" . '<meta property="og:image:height" content="100" />',
+			'<meta property="og:image" content="https://example.com/image.jpg" />' . PHP_EOL . "\t" . '<meta property="og:image:width" content="100" />' . PHP_EOL . "\t" . '<meta property="og:image:height" content="100" />',
 			$this->instance->present( $this->presentation )
 		);
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* After discussion with Facebook's developer relations team we've decided to drop the `og:image:secure_url` tag. We'd always output next to an `og:image` tag and there's basically no value in doing that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See output for any post with images that is on https, see we no longer have `og:image:secure_url` in our output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14644
Fixes #14635