### PR TITLE
Removal of @since where possible

### DIFF
--- a/src/backwards-compatibility/frontend.php
+++ b/src/backwards-compatibility/frontend.php
@@ -219,8 +219,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	/**
 	 * Adds 'prev' and 'next' links to archives.
 	 *
-	 * @link  http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
-	 * @since 1.0.3
+	 * @link http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
 	 */
 	public function adjacent_rel_links() {
 		_deprecated_function( __METHOD__, 'WPSEO xx.x' );

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 
 /**
  * Returns schema Person data.
- *
- * @since 10.2
  */
 class Author extends Person {
 	/**

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -12,8 +12,6 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 
 /**
  * Returns schema Breadcrumb data.
- *
- * @since 10.2
  */
 class Breadcrumb extends Abstract_Schema_Piece {
 

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 
 /**
  * Returns schema FAQ data.
- *
- * @since 11.3
  */
 class FAQ extends Abstract_Schema_Piece {
 

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -15,8 +15,6 @@ use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 
 /**
  * Returns schema FAQ data.
- *
- * @since 11.5
  */
 class HowTo extends Abstract_Schema_Piece {
 

--- a/src/generators/schema/main-image.php
+++ b/src/generators/schema/main-image.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Helpers\Schema;
 
 /**
  * Returns ImageObject schema data.
- *
- * @since 11.5
  */
 class Main_Image extends Abstract_Schema_Piece {
 

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Helpers\Schema\Image_Helper;
 
 /**
  * Returns schema Organization data.
- *
- * @since 10.2
  */
 class Organization extends Abstract_Schema_Piece {
 
@@ -94,8 +92,6 @@ class Organization extends Abstract_Schema_Piece {
 	 * Retrieve the social profiles to display in the organization schema.
 	 *
 	 * @link https://developers.google.com/webmasters/structured-data/customize/social-profiles
-	 *
-	 * @since 1.8
 	 *
 	 * @return array $profiles An array of social profiles.
 	 */

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 
 /**
  * Returns schema Person data.
- *
- * @since 10.2
  */
 class Person extends Abstract_Schema_Piece {
 	/**

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -16,8 +16,6 @@ use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 
 /**
  * Returns schema WebPage data.
- *
- * @since 10.2
  */
 class WebPage extends Abstract_Schema_Piece {
 

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 
 /**
  * Returns schema Website data.
- *
- * @since 10.2
  */
 class Website extends Abstract_Schema_Piece {
 
@@ -74,8 +72,6 @@ class Website extends Abstract_Schema_Piece {
 	 * @param Meta_Tags_Context $context The meta tags context.
 	 *
 	 * @return array Website data blob.
-	 *
-	 * @since 1.5.7
 	 *
 	 * @link https://developers.google.com/structured-data/site-name
 	 */

--- a/src/helpers/schema/id-helper.php
+++ b/src/helpers/schema/id-helper.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Context\Meta_Tags_Context;
 /**
  * Schema utility functions.
  *
- * @since 11.6
- *
  * @property string author_hash
  * @property string author_logo_hash
  * @property string breadcrumb_hash

--- a/src/integrations/front-end/comment-link-fixer.php
+++ b/src/integrations/front-end/comment-link-fixer.php
@@ -13,9 +13,7 @@ use Yoast\WP\SEO\Helpers\Robots_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Class WPSEO_Remove_Reply_To_Com.
- *
- * @since 7.0
+ * Class Comment_Link_Fixer.
  */
 class Comment_Link_Fixer implements Integration_Interface {
 
@@ -96,8 +94,6 @@ class Comment_Link_Fixer implements Integration_Interface {
 
 	/**
 	 * Redirects out the ?replytocom variables.
-	 *
-	 * @since 1.4.13
 	 *
 	 * @return boolean True when redirect has been done.
 	 */

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -69,8 +69,6 @@ class Indexing_Controls implements Integration_Interface {
 	 * Sends a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
 	 * to follow the links in the object at the URL.
 	 *
-	 * @since 1.1.7
-	 *
 	 * @return boolean Boolean indicating whether the noindex header was sent.
 	 */
 	public function noindex_robots() {

--- a/src/integrations/front-end/rss-footer-embed.php
+++ b/src/integrations/front-end/rss-footer-embed.php
@@ -117,8 +117,6 @@ class RSS_Footer_Embed implements Integration_Interface {
 	/**
 	 * Adds the RSS footer and/or header to an RSS feed item.
 	 *
-	 * @since 1.4.14
-	 *
 	 * @param string $content Feed item content.
 	 *
 	 * @return string The content to add.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* `@since` should only used to indicate public api. This means for hooks (actions and filters). 
* Most of the `@since` are copied from the old code and aren't backwards compatible because of the namespaces.
 
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It just removes `@since` annotations.

## Relevant technical choices:

* Kept the `@since` for the hooks.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* It is a code wise change only

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
