### PR TITLE
Our own title tag is only removed is force rewriting of the title is disabled.

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -247,7 +247,7 @@ class Front_End_Integration implements Integration_Interface {
 	private function get_needed_presenters( $page_type ) {
 		$presenters = $this->get_presenters_for_page_type( $page_type );
 
-		if ( ! get_theme_support( 'title-tag' ) ) {
+		if ( ! get_theme_support( 'title-tag' ) && ! $this->options->get( 'forcerewritetitle', false ) ) {
 			// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
 			$presenters = array_diff( $presenters, [ 'Title' ] );
 		}

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -292,15 +292,21 @@ class Front_End_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieval of the presents for a theme without title tag.
+	 * Tests retrieval of the presents for a theme without title tag
+	 * and with force rewrite titles disabled.
 	 *
 	 * @covers ::get_presenters
 	 * @covers ::get_needed_presenters
 	 * @covers ::get_presenters_for_page_type
 	 * @covers ::get_all_presenters
 	 */
-	public function test_get_presenters_for_theme_without_title_tag() {
+	public function test_get_presenters_for_theme_without_title_tag_and_force_rewrite_titles_disabled() {
 		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( false );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'forcerewritetitle', false )
+			->andReturn( false );
 
 		$this->container
 			->expects( 'get' )
@@ -311,6 +317,43 @@ class Front_End_Integration_Test extends TestCase {
 		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
+				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+				'Yoast\WP\SEO\Presenters\Robots_Presenter',
+				'Yoast\WP\SEO\Presenters\Googlebot_Presenter',
+				'Yoast\WP\SEO\Presenters\Schema_Presenter',
+				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
+			],
+			array_values( $this->instance->get_presenters( 'Error_Page' ) )
+		);
+	}
+
+	/**
+	 * Tests retrieval of the presents for a theme without title tag
+	 * and with force rewrite titles enabled.
+	 *
+	 * @covers ::get_presenters
+	 * @covers ::get_needed_presenters
+	 * @covers ::get_presenters_for_page_type
+	 * @covers ::get_all_presenters
+	 */
+	public function test_get_presenters_for_theme_without_title_tag_and_force_rewrite_titles_enabled() {
+		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( false );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'forcerewritetitle', false )
+			->andReturn( true );
+
+		$this->container
+			->expects( 'get' )
+			->times( 7 )
+			->andReturnArg( 0 );
+
+
+		$this->assertEquals(
+			[
+				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
+				'Yoast\WP\SEO\Presenters\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
 				'Yoast\WP\SEO\Presenters\Robots_Presenter',
 				'Yoast\WP\SEO\Presenters\Googlebot_Presenter',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a theme does not explicitly support WordPress handling the title tags and force rewriting of the title is enabled, we remove the pre-existing title-tags from the webpage. However, since https://github.com/Yoast/wordpress-seo/pull/14555 removed our own title tag when a theme does not have support, we ended up without any title at all if force rewriting was enabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where no `title` tag was output when force rewriting titles is enabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have a theme that has a hardcoded `<title><?php wp_title(); ?></title>` in the `header.php`.
  * The simplest way is to add it manually to your activated theme.
* Make sure the theme does not register support for title-tag.
  * To do this, remove the `add_theme_support( 'title-tag' );` line from your theme's `functions.php` file.
* Turn on the force rewrite titles option.
  * In _SEO_ > _Search Appearance_ in your wp-admin.
* Go to a webpage on the frontend. You should see a single title tag, located between the `This site is optimized with the Yoast SEO plugin` tags.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14628
