### PR TITLE
Add aliases for Initializer, Integration and Loadable

### DIFF
--- a/src/initializers/initializer-interface.php
+++ b/src/initializers/initializer-interface.php
@@ -21,3 +21,5 @@ interface Initializer_Interface extends Loadable_Interface {
 	 */
 	public function initialize();
 }
+
+class_alias( '\Yoast\WP\SEO\Initializers\Initializer_Interface', '\Yoast\WP\SEO\WordPress\Initializer' );

--- a/src/integrations/integration-interface.php
+++ b/src/integrations/integration-interface.php
@@ -25,3 +25,5 @@ interface Integration_Interface extends Loadable_Interface {
 	 */
 	public function register_hooks();
 }
+
+class_alias( '\Yoast\WP\SEO\Integrations\Integration_Interface', '\Yoast\WP\SEO\WordPress\Integration' );

--- a/src/loadable-interface.php
+++ b/src/loadable-interface.php
@@ -19,3 +19,5 @@ interface Loadable_Interface {
 	 */
 	public static function get_conditionals();
 }
+
+class_alias( '\Yoast\WP\SEO\Loadable_Interface', '\Yoast\WP\SEO\WordPress\Loadable' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Local SEO uses the old `Initializer`, `Integration` and possibly `Loadable`. Yoast SEO is a dependency of Yoast SEO Local. In order to not throw fatal errors when someone updates Yoast SEO 14.0 when Local SEO is not updated yet, the new classes need an alias.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add class aliases for Initializer, Integration and Loadable

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run this branch together with the Local SEO 12.9 release branch.
* See no fatal errors.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
