### PR TITLE
Add is_wp_error check

### DIFF
--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -179,8 +179,11 @@ class Indexable_Hierarchy_Builder {
 
 		$primary_term = $this->primary_term_repository->find_by_post_id_and_taxonomy( $post->ID, $main_taxonomy, false );
 
-		if ( $primary_term && \get_term( $primary_term->term_id ) ) {
-			return $primary_term->term_id;
+		if ( $primary_term ) {
+			$term = \get_term( $primary_term->term_id );
+			if ( $term !== null && ! \is_wp_error( $term ) ) {
+				return $primary_term->term_id;
+			}
 		}
 
 		$terms = \get_the_terms( $post->ID, $main_taxonomy );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In pull request #14652 an `is_wp_error` check was missing. I've added this.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Extra safety check.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* This is an extension for #14652 and it adds an extra sanity check and therefore its hard to test.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
