### PR TITLE
Sets the deprecated version to 14.0

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -441,19 +441,19 @@ class WPSEO_Admin_Init {
 				'alternative' => null,
 			],
 			'wpseo_opengraph'                       => [
-				'version'     => 'xx.x',
+				'version'     => '14.0',
 				'alternative' => null,
 			],
 			'wpseo_twitter'                         => [
-				'version'     => 'xx.x',
+				'version'     => '14.0',
 				'alternative' => null,
 			],
 			'wpseo_twitter_taxonomy_image'          => [
-				'version'     => 'xx.x',
+				'version'     => '14.0',
 				'alternative' => null,
 			],
 			'wpseo_twitter_metatag_key'             => [
-				'version'     => 'xx.x',
+				'version'     => '14.0',
 				'alternative' => null,
 			],
 		];

--- a/deprecated/frontend/class-handle-404.php
+++ b/deprecated/frontend/class-handle-404.php
@@ -10,7 +10,7 @@
  *
  * Handles intercepting requests.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  *
  * @since 9.4
  */
@@ -20,26 +20,26 @@ class WPSEO_Handle_404 implements WPSEO_WordPress_Integration {
 	 * Registers all hooks to WordPress.
 	 *
 	 * @codeCoverageIgnore
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 *
 	 * @return void
 	 */
 	public function register_hooks() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Handle the 404 status code.
 	 *
 	 * @codeCoverageIgnore
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 *
 	 * @param bool $handled Whether we've handled the request.
 	 *
 	 * @return bool True if it's 404.
 	 */
 	public function handle_404( $handled ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return $handled;
 	}

--- a/deprecated/frontend/class-opengraph-image.php
+++ b/deprecated/frontend/class-opengraph-image.php
@@ -7,12 +7,12 @@
 
 use Yoast\WP\SEO\Values\Open_Graph\Images;
 
-_deprecated_file( basename( __FILE__ ), 'WPSEO xx.x' );
+_deprecated_file( basename( __FILE__ ), 'WPSEO 14.0' );
 
 /**
  * Class WPSEO_OpenGraph_Image.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  */
 class WPSEO_OpenGraph_Image extends Images {
 
@@ -26,13 +26,13 @@ class WPSEO_OpenGraph_Image extends Images {
 	/**
 	 * Constructor.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @param null|string     $image     Optional. The Image to use.
 	 * @param WPSEO_OpenGraph $opengraph Optional. The OpenGraph object.
 	 */
 	public function __construct( $image = null, WPSEO_OpenGraph $opengraph = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 }

--- a/deprecated/frontend/class-opengraph-oembed.php
+++ b/deprecated/frontend/class-opengraph-oembed.php
@@ -8,7 +8,7 @@
 /**
  * Class WPSEO_OpenGraph_OEmbed.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  */
 class WPSEO_OpenGraph_OEmbed implements WPSEO_WordPress_Integration {
 
@@ -16,10 +16,10 @@ class WPSEO_OpenGraph_OEmbed implements WPSEO_WordPress_Integration {
 	 * @inheritDoc
 	 *
 	 * @codeCoverageIgnore
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 */
 	public function register_hooks() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
@@ -29,7 +29,7 @@ class WPSEO_OpenGraph_OEmbed implements WPSEO_WordPress_Integration {
 	 * if both are present.
 	 *
 	 * @codeCoverageIgnore
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 *
 	 * @param array   $data The oEmbed data.
 	 * @param WP_Post $post The current Post object.
@@ -39,7 +39,7 @@ class WPSEO_OpenGraph_OEmbed implements WPSEO_WordPress_Integration {
 	 * @return array An array of oEmbed data with modified values where appropriate.
 	 */
 	public function set_oembed_data( $data, $post ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return $data;
 	}

--- a/deprecated/frontend/class-opengraph.php
+++ b/deprecated/frontend/class-opengraph.php
@@ -8,7 +8,7 @@
 /**
  * This code adds the OpenGraph output.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  */
 class WPSEO_OpenGraph {
 
@@ -17,27 +17,27 @@ class WPSEO_OpenGraph {
 	/**
 	 * Class constructor.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Main OpenGraph output.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 */
 	public function opengraph() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Internal function to output FB tags. This also adds an output filter to each bit of output based on the property.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @param string $property Property attribute value.
@@ -46,16 +46,16 @@ class WPSEO_OpenGraph {
 	 * @return boolean
 	 */
 	public function og_tag( $property, $content ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		/**
 		 * Filter: 'wpseo_og_' . $og_property - Allow developers to change the content of specific OG meta tags.
 		 *
-		 * @deprecated xx.x
+		 * @deprecated 14.0
 		 *
 		 * @api string $content The content of the property.
 		 */
-		$content = apply_filters_deprecated( 'wpseo_og_' . $og_property, $content, 'WPSEO xx.x');
+		$content = apply_filters_deprecated( 'wpseo_og_' . $og_property, $content, 'WPSEO 14.0');
 
 		return true;
 	}
@@ -92,7 +92,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the canonical URL as OpenGraph URL, which consolidates likes and shares.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
@@ -100,7 +100,7 @@ class WPSEO_OpenGraph {
 	 * @return boolean
 	 */
 	public function url() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return false;
 	}
@@ -108,7 +108,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the SEO title as OpenGraph title.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
@@ -118,7 +118,7 @@ class WPSEO_OpenGraph {
 	 * @return string|boolean
 	 */
 	public function og_title( $echo = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return false;
 	}
@@ -126,7 +126,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the OpenGraph description, specific OG description first, if not, grabs the meta description.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @param bool $echo Whether to echo or return the description.
@@ -134,7 +134,7 @@ class WPSEO_OpenGraph {
 	 * @return string $ogdesc
 	 */
 	public function description( $echo = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return '';
 	}
@@ -142,7 +142,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the author's FB page.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link https://developers.facebook.com/blog/post/2013/06/19/platform-updates--new-open-graph-tags-for-media-publishers-and-more/
@@ -151,7 +151,7 @@ class WPSEO_OpenGraph {
 	 * @return boolean
 	 */
 	public function article_author_facebook() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return false;
 	}
@@ -159,7 +159,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the website's FB page.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link https://developers.facebook.com/blog/post/2013/06/19/platform-updates--new-open-graph-tags-for-media-publishers-and-more/
@@ -168,7 +168,7 @@ class WPSEO_OpenGraph {
 	 * @return boolean
 	 */
 	public function website_facebook() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return false;
 	}
@@ -176,7 +176,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the OpenGraph type.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @param boolean $echo Whether to echo or return the type.
@@ -184,7 +184,7 @@ class WPSEO_OpenGraph {
 	 * @return string $type
 	 */
 	public function type( $echo = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return '';
 	}
@@ -194,7 +194,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * Last update/compare with FB list done on 2015-03-16 by Rarst.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link http://www.facebook.com/translations/FacebookLocales.xml for the list of supported locales.
@@ -205,7 +205,7 @@ class WPSEO_OpenGraph {
 	 * @return string $locale
 	 */
 	public function locale( $echo = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return '';
 	}
@@ -213,7 +213,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Filters the Facebook plugins metadata.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @param array $meta_tags The array to fix.
@@ -221,7 +221,7 @@ class WPSEO_OpenGraph {
 	 * @return array $meta_tags
 	 */
 	public function facebook_filter( $meta_tags ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return array();
 	}
@@ -229,19 +229,19 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the site name straight from the blog info.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */
 	public function site_name() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Outputs the article publish and last modification date.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
@@ -249,7 +249,7 @@ class WPSEO_OpenGraph {
 	 * @return boolean;
 	 */
 	public function publish_date() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return true;
 	}
@@ -257,7 +257,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Creates new WPSEO_OpenGraph_Image class and get the images to set the og:image.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 
 	 * @param string|bool $image Optional. Image URL.
@@ -265,25 +265,25 @@ class WPSEO_OpenGraph {
 	 * @return void
 	 */
 	public function image( $image = false ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Outputs the Facebook app_id.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @return void
 	 */
 	public function app_id() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Outputs the article tags as article:tag tags.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
@@ -291,7 +291,7 @@ class WPSEO_OpenGraph {
 	 * @return boolean
 	 */
 	public function tags() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return false;
 	}
@@ -299,7 +299,7 @@ class WPSEO_OpenGraph {
 	/**
 	 * Outputs the article category as an article:section tag.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @link https://developers.facebook.com/docs/reference/opengraph/object-type/article/
@@ -307,7 +307,7 @@ class WPSEO_OpenGraph {
 	 * @return boolean;
 	 */
 	public function category() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return false;
 	}

--- a/deprecated/frontend/class-primary-category.php
+++ b/deprecated/frontend/class-primary-category.php
@@ -8,7 +8,7 @@
 /**
  * Adds customizations to the front end for the primary category.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  */
 class WPSEO_Frontend_Primary_Category implements WPSEO_WordPress_Integration {
 
@@ -27,12 +27,12 @@ class WPSEO_Frontend_Primary_Category implements WPSEO_WordPress_Integration {
 	 * @param WP_Post  $post       The post in question.
 	 *
 	 * @codeCoverageIgnore
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 *
 	 * @return array|null|object|WP_Error The category we want to use for the post link.
 	 */
 	public function post_link_category( $category, $categories = null, $post = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return $category;
 	}

--- a/deprecated/frontend/class-twitter.php
+++ b/deprecated/frontend/class-twitter.php
@@ -8,7 +8,7 @@
 /**
  * This class handles the Twitter card functionality.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  *
  * @link https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/abouts-cards
  */
@@ -31,33 +31,33 @@ class WPSEO_Twitter {
 	/**
 	 * Class constructor.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Outputs the Twitter Card code on singular pages.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 */
 	public function twitter() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 	}
 
 	/**
 	 * Get the singleton instance of this class.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
 	 * @return object
 	 */
 	public static function get_instance() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return null;
 	}

--- a/frontend/class-woocommerce-shop-page.php
+++ b/frontend/class-woocommerce-shop-page.php
@@ -72,14 +72,14 @@ class WPSEO_WooCommerce_Shop_Page {
 	 * Returns the ID of the WooCommerce shop page when the currently opened page is the shop page.
 	 *
 	 * @codeCoverageIgnore
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 *
 	 * @param int $page_id The page id.
 	 *
 	 * @return int The Page ID of the shop.
 	 */
 	public function get_page_id( $page_id ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return $page_id;
 	}

--- a/inc/wpseo-functions-deprecated.php
+++ b/inc/wpseo-functions-deprecated.php
@@ -39,10 +39,10 @@ if ( ! function_exists( 'initialize_wpseo_front' ) ) {
 	/**
 	 * Wraps frontend class.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 */
 	function initialize_wpseo_front() {
-		_deprecated_function( __FUNCTION__, 'WPSEO xx.x' );
+		_deprecated_function( __FUNCTION__, 'WPSEO 14.0' );
 	}
 }

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -186,13 +186,13 @@ add_filter( 'icl_wpml_config_array', 'wpseo_wpml_config' );
  * Yoast SEO breadcrumb shortcode.
  * [wpseo_breadcrumb]
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  * @codeCoverageIgnore
  *
  * @return string
  */
 function wpseo_shortcode_yoast_breadcrumb() {
-	_deprecated_function( __FUNCTION__, 'WPSEO xx.x' );
+	_deprecated_function( __FUNCTION__, 'WPSEO 14.0' );
 
 	return '';
 }

--- a/src/backwards-compatibility/frontend.php
+++ b/src/backwards-compatibility/frontend.php
@@ -75,7 +75,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @param array  $arguments The given arguments.
 	 */
 	public function __call( $method, $arguments ) {
-		_deprecated_function( $method, 'WPSEO xx.x' );
+		_deprecated_function( $method, 'WPSEO 14.0' );
 
 		$title_methods = [
 			'title',
@@ -114,7 +114,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return string|void
 	 */
 	public function canonical( $echo = true, $un_paged = false, $no_override = false ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$context = $this->context_memoizer->for_current_page();
 		if ( ! $echo ) {
@@ -131,7 +131,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return string
 	 */
 	public function get_robots() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$context = $this->context_memoizer->for_current_page();
 
@@ -142,7 +142,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * Outputs the meta robots value.
 	 */
 	public function robots() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$context   = $this->context_memoizer->for_current_page();
 		$presenter = new Robots_Presenter();
@@ -158,7 +158,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return array
 	 */
 	public function robots_for_single_post( $robots, $post_id = 0 ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$context = $this->context_memoizer->for_current_page();
 
@@ -173,7 +173,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return string The content title.
 	 */
 	private function get_title( $object = null ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$context = $this->context_memoizer->for_current_page();
 		$title   = $context->presentation->title;
@@ -191,7 +191,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return string
 	 */
 	public function add_paging_to_title( $sep, $seplocation, $title ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		return $title;
 	}
@@ -207,7 +207,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return string
 	 */
 	public function add_to_title( $sep, $seplocation, $title, $title_part ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		if ( 'right' === $seplocation ) {
 			return $title . $sep . $title_part;
@@ -222,7 +222,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @link http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
 	 */
 	public function adjacent_rel_links() {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$context = $this->context_memoizer->for_current_page();
 
@@ -241,7 +241,7 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return string
 	 */
 	public function metadesc( $echo = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$context = $this->context_memoizer->for_current_page();
 

--- a/src/integrations/front-end/theme-titles.php
+++ b/src/integrations/front-end/theme-titles.php
@@ -33,7 +33,7 @@ class Theme_Titles implements Integration_Interface {
 	/**
 	 * Filters the title for woo_title and the thematic_doctitle.
 	 *
-	 * @deprecated xx.x
+	 * @deprecated 14.0
 	 *
 	 * @codeCoverageIgnore
 	 *
@@ -44,7 +44,7 @@ class Theme_Titles implements Integration_Interface {
 	public function title( $title ) {
 		_deprecated_function(
 			__METHOD__,
-			'WPSEO xx.x',
+			'WPSEO 14.0',
 			esc_html__(
 				'a theme that has proper title-tag theme support, or adapt your theme to have that support',
 				'wordpress-seo'

--- a/tests/integrations/front-end/theme-titles-test.php
+++ b/tests/integrations/front-end/theme-titles-test.php
@@ -73,7 +73,7 @@ class Theme_Titles_Test extends TestCase {
 			->once()
 			->with(
 				'Yoast\WP\SEO\Integrations\Front_End\Theme_Titles::title',
-				'WPSEO xx.x',
+				'WPSEO 14.0',
 				'a theme that has proper title-tag theme support, or adapt your theme to have that support'
 			);
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -642,19 +642,19 @@ function yoast_free_phpcompat_whitelist( $ignored ) {
 /**
  * Instantiate the different social classes on the frontend.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  * @codeCoverageIgnore
  */
 function wpseo_frontend_head_init() {
-	_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+	_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 }
 
 /**
  * Used to load the required files on the plugins_loaded hook, instead of immediately.
  *
- * @deprecated xx.x
+ * @deprecated 14.0
  * @codeCoverageIgnore
  */
 function wpseo_frontend_init() {
-	_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+	_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We didn't know what the exact version of the indexables release has to be. Therefore we decided to set all version related things (e.g. deprecations) to xx.x. Now we know the version will be 14.0.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A Updates all xx.x versioning to 14.0

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* If the code looks good, just merge.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13814
