### PR TITLE
Move class aliasses

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -28,7 +28,3 @@ function YoastSEO() { // @codingStandardsIgnoreLine
 
 	return $main;
 }
-
-class_alias( '\Yoast\WP\SEO\Initializers\Initializer_Interface', '\Yoast\WP\SEO\WordPress\Initializer' );
-class_alias( '\Yoast\WP\SEO\Loadable_Interface', '\Yoast\WP\SEO\WordPress\Loadable' );
-class_alias( '\Yoast\WP\SEO\Integrations\Integration_Interface', '\Yoast\WP\SEO\WordPress\Integration' );

--- a/src/functions.php
+++ b/src/functions.php
@@ -29,3 +29,6 @@ function YoastSEO() { // @codingStandardsIgnoreLine
 	return $main;
 }
 
+class_alias( '\Yoast\WP\SEO\Initializers\Initializer_Interface', '\Yoast\WP\SEO\WordPress\Initializer' );
+class_alias( '\Yoast\WP\SEO\Loadable_Interface', '\Yoast\WP\SEO\WordPress\Loadable' );
+class_alias( '\Yoast\WP\SEO\Integrations\Integration_Interface', '\Yoast\WP\SEO\WordPress\Integration' );

--- a/src/initializers/initializer-interface.php
+++ b/src/initializers/initializer-interface.php
@@ -21,5 +21,3 @@ interface Initializer_Interface extends Loadable_Interface {
 	 */
 	public function initialize();
 }
-
-class_alias( '\Yoast\WP\SEO\Initializers\Initializer_Interface', '\Yoast\WP\SEO\WordPress\Initializer' );

--- a/src/integrations/integration-interface.php
+++ b/src/integrations/integration-interface.php
@@ -25,5 +25,3 @@ interface Integration_Interface extends Loadable_Interface {
 	 */
 	public function register_hooks();
 }
-
-class_alias( '\Yoast\WP\SEO\Integrations\Integration_Interface', '\Yoast\WP\SEO\WordPress\Integration' );

--- a/src/loadable-interface.php
+++ b/src/loadable-interface.php
@@ -19,5 +19,3 @@ interface Loadable_Interface {
 	 */
 	public static function get_conditionals();
 }
-
-class_alias( '\Yoast\WP\SEO\Loadable_Interface', '\Yoast\WP\SEO\WordPress\Loadable' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -658,3 +658,10 @@ function wpseo_frontend_head_init() {
 function wpseo_frontend_init() {
 	_deprecated_function( __METHOD__, 'WPSEO xx.x' );
 }
+
+/**
+ * Aliasses added in order to keep compatibility with Yoast SEO: Local.
+ */
+class_alias( '\Yoast\WP\SEO\Initializers\Initializer_Interface', '\Yoast\WP\SEO\WordPress\Initializer' );
+class_alias( '\Yoast\WP\SEO\Loadable_Interface', '\Yoast\WP\SEO\WordPress\Loadable' );
+class_alias( '\Yoast\WP\SEO\Integrations\Integration_Interface', '\Yoast\WP\SEO\WordPress\Integration' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Class aliasses were added to maintain compatibilty between Yoast SEO and Yoast SEO: Local. These were added by @IreneStr . However it turns out that the aliasses were called in a too late stadium resulting in fatal errors in Local. We have moved the aliasses to `/src/fuctions.php` to make sure they are called in time.

## Summary
This PR can be summarized in the following changelog entry:
* Fixes issue where class aliasses are called too late, resulting in fatal erros in Local SEO

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Run this branch together with the Local SEO trunk branch and a .zip from Local SEO trunk
* See no fatal errors.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
