### PR TITLE
Change backward compatibility of person schema to include protected functionality

### DIFF
--- a/deprecated/frontend/schema/class-schema-person.php
+++ b/deprecated/frontend/schema/class-schema-person.php
@@ -5,7 +5,7 @@
  * @package WPSEO\Frontend\Schema
  */
 
-use Yoast\WP\SEO\Config\Schema_Ids;
+use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Generators\Schema\Person;
 use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 
@@ -33,7 +33,7 @@ class WPSEO_Schema_Person extends Person implements WPSEO_Graph_Piece {
 	 */
 	public function __construct() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person' );
-		$this->image_hash = Schema_Ids::PERSON_LOGO_HASH;
+		$this->image_hash = Schema_IDs::PERSON_LOGO_HASH;
 		$memoizer         = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->context    = $memoizer->for_current_page();
 		$this->helpers    = YoastSEO()->helpers;

--- a/deprecated/frontend/schema/class-schema-person.php
+++ b/deprecated/frontend/schema/class-schema-person.php
@@ -5,6 +5,7 @@
  * @package WPSEO\Frontend\Schema
  */
 
+use Yoast\WP\SEO\Config\Schema_Ids;
 use Yoast\WP\SEO\Generators\Schema\Person;
 use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 
@@ -15,14 +16,14 @@ use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
  *
  * @since 10.2
  */
-class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
+class WPSEO_Schema_Person extends Person implements WPSEO_Graph_Piece {
 
 	/**
-	 * Holds a memoizer for the meta tag context.
+	 * The hash used for images.
 	 *
-	 * @var Meta_Tags_Context_Memoizer
+	 * @var string
 	 */
-	private $memoizer;
+	protected $image_hash;
 
 	/**
 	 * WPSEO_Schema_Person constructor.
@@ -32,7 +33,10 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 */
 	public function __construct() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person' );
-		$this->memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->image_hash = Schema_Ids::PERSON_LOGO_HASH;
+		$memoizer         = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->context    = $memoizer->for_current_page();
+		$this->helpers    = YoastSEO()->helpers;
 	}
 
 	/**
@@ -45,11 +49,8 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 */
 	public function is_needed() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::is_needed' );
-		$person = new Person();
-		$person->context = $this->memoizer->for_current_page();
-		$person->helpers = YoastSEO()->helpers;
 
-		return $person->is_needed();
+		return parent::is_needed();
 	}
 
 	/**
@@ -62,10 +63,87 @@ class WPSEO_Schema_Person implements WPSEO_Graph_Piece {
 	 */
 	public function generate() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::generate' );
-		$person = new Person();
-		$person->context = $this->memoizer->for_current_page();
-		$person->helpers = YoastSEO()->helpers;
 
-		return $person->generate();
+		return parent::generate();
+	}
+
+	/**
+	 * Determines a User ID for the Person data.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 14.0
+	 *
+	 * @return bool|int User ID or false upon return.
+	 */
+	protected function determine_user_id() {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::determine_user_id' );
+
+		return parent::determine_user_id();
+	}
+
+	/**
+	 * Retrieve a list of social profile URLs for Person.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 14.0
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return string[] $output A list of social profiles.
+	 */
+	protected function get_social_profiles( $user_id ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::get_social_profiles' );
+
+		return parent::get_social_profiles( $user_id );
+	}
+
+	/**
+	 * Builds our array of Schema Person data for a given user ID.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 14.0
+	 *
+	 * @param int $user_id The user ID to use.
+	 *
+	 * @return array An array of Schema Person data.
+	 */
+	protected function build_person_data( $user_id ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::build_person_data' );
+
+		return parent::build_person_data( $user_id );
+	}
+
+	/**
+	 * Returns an ImageObject for the persons avatar.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 14.0
+	 *
+	 * @param array    $data      The Person schema.
+	 * @param \WP_User $user_data User data.
+	 *
+	 * @return array $data The Person schema.
+	 */
+	protected function add_image( $data, $user_data ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::add_image' );
+
+		return parent::add_image( $data, $user_data );
+	}
+
+	/**
+	 * Returns an author's social site URL.
+	 *
+	 * @codeCoverageIgnore
+	 * @deprecated 14.0
+	 *
+	 * @param string $social_site The social site to retrieve the URL for.
+	 * @param mixed  $user_id     The user ID to use function outside of the loop.
+	 *
+	 * @return string
+	 */
+	protected function url_social_site( $social_site, $user_id = false ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::url_social_site' );
+
+		return parent::url_social_site( $social_site, $user_id );
 	}
 }

--- a/deprecated/frontend/schema/class-schema-person.php
+++ b/deprecated/frontend/schema/class-schema-person.php
@@ -23,7 +23,7 @@ class WPSEO_Schema_Person extends Person implements WPSEO_Graph_Piece {
 	 *
 	 * @var string
 	 */
-	protected $image_hash;
+	protected $image_hash = Schema_IDs::PERSON_LOGO_HASH;
 
 	/**
 	 * WPSEO_Schema_Person constructor.
@@ -33,7 +33,6 @@ class WPSEO_Schema_Person extends Person implements WPSEO_Graph_Piece {
 	 */
 	public function __construct() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person' );
-		$this->image_hash = Schema_IDs::PERSON_LOGO_HASH;
 		$memoizer         = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->context    = $memoizer->for_current_page();
 		$this->helpers    = YoastSEO()->helpers;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The BC should include protected functionality for class extensions.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds person schema backward compatibility for the protected functionality.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Compare [old code](https://github.com/Yoast/wordpress-seo/blob/3c927425518c3529125b91a04e57e6bcde465a98/frontend/schema/class-schema-person.php) to the current and see that I did not skip any `public` or `protected` methods or properties.

Not really testing the protected functionality here. As this would require writing your own implementation. The following covers testing of the same tests as done before in https://github.com/Yoast/wordpress-seo/pull/14583:

* Add this code somewhere in a theme or in the `wp-seo.php` file.
```
add_action( 'wp_head', function () {
	$schema    = new \WPSEO_Schema_Person();
	$is_needed = $schema->is_needed();

	echo 'is_needed: ', ( $is_needed ) ? 'true' : 'false', '<br/>';
	if ( $is_needed ) {
		$generate = \wp_json_encode( $schema->generate(), ( JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) );
		echo '<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[', $generate, ']}</script>';
	}
} );
```
* Set your site to represent an organization with name & logo: SEO --> Search Appearance --> General --> Knowledge Graph & Schema.org.
* Verify that the `is_needed` output is `false`.
* Navigate to the frontend of a post.
* Set your site to represent a person: SEO --> Search Appearance --> General --> Knowledge Graph & Schema.org.
* Navigate to the frontend of a post.
* Verify that the `is_needed` output is `true`.
* Verify that there is schema output for the Person. You can compare it with the output in the normal schema output, it should be the same.
* Change the action hook to `init`, instead of `wp_head` in the code snippet.
* Verify that deprecated notices are given. You can do this by using Query Monitor.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14638 
