### PR TITLE
Breadcrumb fixes

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -66,7 +66,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$static_ancestors = [];
-		if ( $this->options->get( 'breadcrumbs-home' ) !== '' ) {
+		$breadcrumbs_home = $this->options->get( 'breadcrumbs-home' );
+		if ( $breadcrumbs_home !== '' ) {
 			$front_page_id = $this->current_page->get_front_page_id();
 			if ( $front_page_id === 0 ) {
 				$static_ancestors[] = $this->repository->find_for_home_page();
@@ -78,6 +79,13 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		$page_for_posts = \get_option( 'page_for_posts' );
 		if ( $this->should_have_blog_crumb( $page_for_posts ) ) {
 			$static_ancestors[] = $this->repository->find_by_id_and_type( $page_for_posts, 'post' );
+		}
+		if (
+			$context->indexable->object_type === 'post' &&
+			$context->indexable->object_sub_type !== 'post' &&
+			$context->indexable->object_sub_type !== 'page'
+		) {
+			$static_ancestors[] = $this->repository->find_for_post_type_archive( $context->indexable->object_sub_type );
 		}
 
 		// Get all ancestors of the indexable and append itself to get all indexables in the full crumb.
@@ -102,6 +110,10 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			}
 			return $crumb;
 		}, $indexables );
+
+		if ( $breadcrumbs_home !== '' ) {
+			$crumbs[0]['text'] = $breadcrumbs_home;
+		}
 
 		/**
 		 * Filter: 'wpseo_breadcrumb_links' - Allow the developer to filter the Yoast SEO breadcrumb links, add to them, change order, etc.

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -141,6 +141,14 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				->andReturn( $this->indexable );
 		}
 
+		if ( $scenario === 'show-custom-post-type' ) {
+			$this->repository
+				->expects( 'find_for_post_type_archive' )
+				->once()
+				->with( 'custom' )
+				->andReturn( $this->indexable );
+		}
+
 		$this->repository
 			->expects( 'get_ancestors' )
 			->once()
@@ -235,6 +243,13 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				'front_page_id'    => 2,
 				'message'          => 'Tests with current request being a singular post page and a front page being set',
 			],
+			[
+				'scenario'         => 'show-custom-post-type',
+				'page_for_posts'   => 1,
+				'breadcrumb_home'  => 'home',
+				'front_page_id'    => 2,
+				'message'          => 'Tests with current request being a singular custom post page',
+			],
 		];
 	}
 
@@ -265,6 +280,10 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				->andReturn( 'posts' );
 
 			return;
+		}
+
+		if ( $scenario === 'show-custom-post-type' ) {
+			$this->indexable->object_sub_type = 'custom';
 		}
 
 		Monkey\Functions\expect( 'get_option' )

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -83,6 +83,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 		$this->indexable                   = Mockery::mock( Indexable::class );
 		$this->indexable->object_id        = 1;
 		$this->indexable->object_type      = 'post';
+		$this->indexable->object_sub_type  = 'post';
 		$this->indexable->permalink        = 'https://example.com/post';
 		$this->indexable->breadcrumb_title = 'post';
 		$this->context                     = Mockery::mock( Meta_Tags_Context::class );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes issues with the breadcrumbs where the home crumb wasn't using the correct text and post type archives of custom post types weren't being added.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Enable our breadcrumbs
* Make sure you have a custom post type.
* Visit a post of that post type.
* You should see the custom post type archive in the breadcrumbs.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14679
Fixes #14658 
