### PR TITLE
Fix open graph output on 404 pages

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -92,6 +92,17 @@ class Front_End_Integration implements Integration_Interface {
 	];
 
 	/**
+	 * The Open Graph specific presenters that should be output on error pages.
+	 *
+	 * @var array
+	 */
+	protected $open_graph_error_presenters = [
+		'Open_Graph\Locale',
+		'Open_Graph\Title',
+		'Open_Graph\Site_Name',
+	];
+
+	/**
 	 * The Twitter card specific presenters.
 	 *
 	 * @var array
@@ -271,7 +282,11 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	private function get_presenters_for_page_type( $page_type ) {
 		if ( $page_type === 'Error_Page' ) {
-			return array_merge( $this->base_presenters, $this->closing_presenters );
+			$presenters = $this->base_presenters;
+			if ( $this->options->get( 'opengraph' ) === true ) {
+				$presenters = array_merge( $presenters, $this->open_graph_error_presenters );
+			}
+			return array_merge( $presenters, $this->closing_presenters );
 		}
 
 		$presenters = $this->get_all_presenters();

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -68,7 +68,7 @@ class Front_End_Integration_Test extends TestCase {
 				$this->context_memoizer,
 				$this->container,
 				$this->options,
-				$this->title_presenter
+				$this->title_presenter,
 			]
 		)->makePartial();
 	}
@@ -216,9 +216,14 @@ class Front_End_Integration_Test extends TestCase {
 	public function test_get_presenters_for_error_page() {
 		Monkey\Functions\expect( 'get_theme_support' )->once()->with( 'title-tag' )->andReturn( true );
 
+		$this->options
+			->expects( 'get' )
+			->with( 'opengraph' )
+			->andReturnTrue();
+
 		$this->container
 			->expects( 'get' )
-			->times( 7 )
+			->times( 10 )
 			->andReturnArg( 0 );
 
 
@@ -229,6 +234,9 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
 				'Yoast\WP\SEO\Presenters\Robots_Presenter',
 				'Yoast\WP\SEO\Presenters\Googlebot_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
@@ -238,6 +246,7 @@ class Front_End_Integration_Test extends TestCase {
 
 	/**
 	 * Tests the retrieval of the presenters for a non singular page.
+	 *
 	 * @covers ::get_presenters
 	 * @covers ::get_needed_presenters
 	 * @covers ::get_presenters_for_page_type
@@ -308,9 +317,14 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'forcerewritetitle', false )
 			->andReturn( false );
 
+		$this->options
+			->expects( 'get' )
+			->with( 'opengraph' )
+			->andReturnTrue();
+
 		$this->container
 			->expects( 'get' )
-			->times( 6 )
+			->times( 9 )
 			->andReturnArg( 0 );
 
 
@@ -320,6 +334,9 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
 				'Yoast\WP\SEO\Presenters\Robots_Presenter',
 				'Yoast\WP\SEO\Presenters\Googlebot_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
@@ -344,9 +361,14 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'forcerewritetitle', false )
 			->andReturn( true );
 
+		$this->options
+			->expects( 'get' )
+			->with( 'opengraph' )
+			->andReturnTrue();
+
 		$this->container
 			->expects( 'get' )
-			->times( 7 )
+			->times( 10 )
 			->andReturnArg( 0 );
 
 
@@ -357,6 +379,9 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
 				'Yoast\WP\SEO\Presenters\Robots_Presenter',
 				'Yoast\WP\SEO\Presenters\Googlebot_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds required open graph output to 404 pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Adds a separate array of open graph error presenters as to preserve the order of open graph presenters on other pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Visit a 404 page. You should see open graph locale, title and site name tags.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14654
