### PR TITLE
Add support to automatically cast all int columns of yoast models

### DIFF
--- a/src/models/indexable-hierarchy.php
+++ b/src/models/indexable-hierarchy.php
@@ -17,4 +17,15 @@ use Yoast\WP\SEO\ORM\Yoast_Model;
  * @property int $depth        The depth of the ancestry. 1 being a parent, 2 being a grandparent etc.
  */
 class Indexable_Hierarchy extends Yoast_Model {
+
+	/**
+	 * Which columns contain int values.
+	 *
+	 * @var array
+	 */
+	protected $int_columns = [
+		'indexable_id',
+		'ancestor_id',
+		'depth',
+	];
 }

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -97,6 +97,25 @@ class Indexable extends Yoast_Model {
 	];
 
 	/**
+	 * Which columns contain int values.
+	 *
+	 * @var array
+	 */
+	protected $int_columns = [
+		'id',
+		'object_id',
+		'author_id',
+		'post_parent',
+		'content_score',
+		'primary_focus_keyword_score',
+		'readability_score',
+		'link_count',
+		'incoming_link_count',
+		'number_of_pages',
+		'prominent_words_version',
+	];
+
+	/**
 	 * The loaded indexable extensions.
 	 *
 	 * @var \Yoast\WP\SEO\Models\Indexable_Extension[]

--- a/src/models/primary-term.php
+++ b/src/models/primary-term.php
@@ -28,4 +28,15 @@ class Primary_Term extends Yoast_Model {
 	 * @var bool
 	 */
 	protected $uses_timestamps = true;
+
+	/**
+	 * Which columns contain int values.
+	 *
+	 * @var array
+	 */
+	protected $int_columns = [
+		'id',
+		'post_id',
+		'term_id',
+	];
 }

--- a/src/models/seo-links.php
+++ b/src/models/seo-links.php
@@ -19,4 +19,15 @@ use Yoast\WP\SEO\ORM\Yoast_Model;
  * @property string $type
  */
 class SEO_Links extends Yoast_Model {
+
+	/**
+	 * Which columns contain int values.
+	 *
+	 * @var array
+	 */
+	protected $int_columns = [
+		'id',
+		'post_id',
+		'target_post_id',
+	];
 }

--- a/src/models/seo-meta.php
+++ b/src/models/seo-meta.php
@@ -24,4 +24,15 @@ class SEO_Meta extends Yoast_Model {
 	 * @var string
 	 */
 	public static $id_column = 'object_id';
+
+	/**
+	 * Which columns contain int values.
+	 *
+	 * @var array
+	 */
+	protected $int_columns = [
+		'object_id',
+		'internal_link_count',
+		'incoming_link_count',
+	];
 }

--- a/src/orm/yoast-model.php
+++ b/src/orm/yoast-model.php
@@ -104,6 +104,13 @@ class Yoast_Model {
 	protected $boolean_columns = [];
 
 	/**
+	 * Which columns contain int values.
+	 *
+	 * @var array
+	 */
+	protected $int_columns = [];
+
+	/**
 	 * Hacks around the Model to provide WordPress prefix to tables.
 	 *
 	 * @param string $class_name   Type of Model to load.
@@ -521,6 +528,9 @@ class Yoast_Model {
 		if ( $value !== null && \in_array( $property, $this->boolean_columns, true ) ) {
 			return (bool) $value;
 		}
+		if ( $value !== null && \in_array( $property, $this->int_columns, true ) ) {
+			return (int) $value;
+		}
 
 		return $value;
 	}
@@ -536,6 +546,9 @@ class Yoast_Model {
 	public function __set( $property, $value ) {
 		if ( $value !== null && \in_array( $property, $this->boolean_columns, true ) ) {
 			$value = ( $value ) ? '1' : '0';
+		}
+		if ( $value !== null && \in_array( $property, $this->int_columns, true ) ) {
+			$value = (string) $value;
 		}
 
 		$this->orm->set( $property, $value );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Automatically casts all int values to ints instead of them being strings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Uses the same implementation already used for booleans.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* All properties in int_columns should be ints.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
