### PR TITLE
Introduces a filter to add presenter instances

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -50,7 +50,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The presenters we loop through on each page load.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $base_presenters = [
 		'Debug\Marker_Open',
@@ -63,7 +63,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The presenters we loop through on each page load.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $indexing_directive_presenters = [
 		'Canonical',
@@ -74,7 +74,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The Open Graph specific presenters.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $open_graph_presenters = [
 		'Open_Graph\Locale',
@@ -94,7 +94,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The Twitter card specific presenters.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $twitter_card_presenters = [
 		'Twitter\Card',
@@ -108,7 +108,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Presenters that are only needed on singular pages.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $singular_presenters = [
 		'Open_Graph\Article_Author',
@@ -121,7 +121,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The presenters we want to be last in our output.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $closing_presenters = [
 		'Schema',
@@ -227,14 +227,21 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
 	public function get_presenters( $page_type ) {
-		$needed_presenters = $this->get_needed_presenters( $page_type );
-		$invalid_behaviour = $this->invalid_behaviour();
+			$needed_presenters = $this->get_needed_presenters( $page_type );
+			$invalid_behaviour = $this->invalid_behaviour();
 
-		return array_filter(
+		$presenters = array_filter(
 			array_map( function( $presenter ) use ( $page_type, $invalid_behaviour ) {
 				return $this->container->get( "Yoast\WP\SEO\Presenters\\{$presenter}_Presenter", $invalid_behaviour );
 			}, $needed_presenters )
 		);
+
+		/**
+		 * Filter 'wpseo_frontend_presenters' - Allow filtering the presenter instances in or out of the request.
+		 *
+		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
+		 */
+		return apply_filters( 'wpseo_frontend_presenters', $presenters );
 	}
 
 	/**
@@ -242,7 +249,7 @@ class Front_End_Integration implements Integration_Interface {
 	 *
 	 * @param string $page_type The page type we're retrieving presenters for.
 	 *
-	 * @return Abstract_Indexable_Presenter[] The presenters.
+	 * @return string[] The presenters.
 	 */
 	private function get_needed_presenters( $page_type ) {
 		$presenters = $this->get_presenters_for_page_type( $page_type );
@@ -253,11 +260,11 @@ class Front_End_Integration implements Integration_Interface {
 		}
 
 		/**
-		 * Filter 'wpseo_frontend_presenters' - Allow filtering presenters in or out of the request.
+		 * Filter 'wpseo_frontend_presenter_classes' - Allow filtering presenters in or out of the request.
 		 *
 		 * @api array List of presenters.
 		 */
-		$presenters = apply_filters( 'wpseo_frontend_presenters', $presenters );
+		$presenters = apply_filters( 'wpseo_frontend_presenter_classes', $presenters );
 
 		return $presenters;
 	}
@@ -267,7 +274,7 @@ class Front_End_Integration implements Integration_Interface {
 	 *
 	 * @param string $page_type The page type.
 	 *
-	 * @return Abstract_Indexable_Presenter[] The presenters.
+	 * @return string[] The presenters.
 	 */
 	private function get_presenters_for_page_type( $page_type ) {
 		if ( $page_type === 'Error_Page' ) {
@@ -286,7 +293,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Returns a list of all available presenters based on settings.
 	 *
-	 * @return Abstract_Indexable_Presenter[] The presenters.
+	 * @return string[] The presenters.
 	 */
 	private function get_all_presenters() {
 		$presenters = array_merge( $this->base_presenters, $this->indexing_directive_presenters );

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -227,8 +227,8 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
 	public function get_presenters( $page_type ) {
-			$needed_presenters = $this->get_needed_presenters( $page_type );
-			$invalid_behaviour = $this->invalid_behaviour();
+		$needed_presenters = $this->get_needed_presenters( $page_type );
+		$invalid_behaviour = $this->invalid_behaviour();
 
 		$presenters = array_filter(
 			array_map( function( $presenter ) use ( $page_type, $invalid_behaviour ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need an extra filter to add additional presenters to the frontend integration. This allows our plugins to add extra meta tags. For example: https://github.com/Yoast/wpseo-news/pull/625

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Introduces an extra filter for adding presenter instances.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* It only introduces a filter, it's best to test this together with https://github.com/Yoast/wpseo-news/pull/625

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Needed for https://github.com/Yoast/wpseo-news/pull/625