### PR TITLE
Don't enqueue the monorepo CSS

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -631,11 +631,14 @@ class WPSEO_Admin_Asset_Manager {
 				'name' => 'search-appearance',
 				'src'  => 'search-appearance-' . $flat_version,
 			],
-			// Temporarily commented out to prevent unwanted monorepo styles seeping through.
-//			[
-//				'name' => 'monorepo',
-//				'src'  => 'monorepo-' . $flat_version,
-//			],
+
+			/*
+			 * Temporarily commented out to prevent unwanted monorepo styles seeping through.
+			 * [
+			 * 	'name' => 'monorepo',
+			 * 	'src'  => 'monorepo-' . $flat_version,
+			 * ],
+			 */
 			[
 				'name' => 'structured-data-blocks',
 				'src'  => 'structured-data-blocks-' . $flat_version,

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -631,10 +631,11 @@ class WPSEO_Admin_Asset_Manager {
 				'name' => 'search-appearance',
 				'src'  => 'search-appearance-' . $flat_version,
 			],
-			[
-				'name' => 'monorepo',
-				'src'  => 'monorepo-' . $flat_version,
-			],
+			// Temporarily commented out to prevent unwanted monorepo styles seeping through.
+//			[
+//				'name' => 'monorepo',
+//				'src'  => 'monorepo-' . $flat_version,
+//			],
 			[
 				'name' => 'structured-data-blocks',
 				'src'  => 'structured-data-blocks-' . $flat_version,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/commit/2b2b4975d790d5c388dcba6a6ec35949cacc98b1#diff-dc369be3d1812b2810483ec8bdf3c377 we started enqueuing styles from the monorepo. However, those styles had unwanted consequences in the metabox of Free, Premium, News, and Local (see issues below). Those styles are needed in the upcoming reactifications, but not in the indexables release. @JoseeWouters will make sure those unwanted consequences will seize to exist, but in order to make the indexables release as risk-free as possible, this PR makes sure the monorepo styles are no longer enqueued. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where styles from the monorepo were seeping through in the 14.0. 

## Relevant technical choices:

* I didn't remove the following lines to make reverting this change easier: https://github.com/Yoast/wordpress-seo/commit/2b2b4975d790d5c388dcba6a6ec35949cacc98b1#diff-dc369be3d1812b2810483ec8bdf3c377R847 and https://github.com/Yoast/wordpress-seo/commit/2b2b4975d790d5c388dcba6a6ec35949cacc98b1#diff-bbf8c8bcaa1d28e2943b02f43f392098R138.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use this branch in combination with Local `release/13.0` and News `master` (current release).
* See that the following issues have been solved:
   *  https://github.com/Yoast/wordpress-seo/issues/14687
   * https://github.com/Yoast/wordpress-seo-local/issues/2032
   * https://github.com/Yoast/wpseo-news/issues/624
   * https://github.com/Yoast/wordpress-seo/issues/14629
* Enable WP_DEBUG and Query monitor.
* Visit the post metabox and category metabox, and see no errors/warnings/notices in the Query monitor related to the enqueuing of styles. It's important to check this, because I didn't remove these lines: https://github.com/Yoast/wordpress-seo/commit/2b2b4975d790d5c388dcba6a6ec35949cacc98b1#diff-dc369be3d1812b2810483ec8bdf3c377R847 and https://github.com/Yoast/wordpress-seo/commit/2b2b4975d790d5c388dcba6a6ec35949cacc98b1#diff-bbf8c8bcaa1d28e2943b02f43f392098R138.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14687
Fixes https://github.com/Yoast/wordpress-seo-local/issues/2032
Fixes https://github.com/Yoast/wpseo-news/issues/624
Fixes https://github.com/Yoast/wordpress-seo/issues/14629