### PR TITLE
14695 restore og content image

### DIFF
--- a/src/generators/open-graph-image-generator.php
+++ b/src/generators/open-graph-image-generator.php
@@ -89,6 +89,7 @@ class Open_Graph_Image_Generator implements Generator_Interface {
 		do_action( 'wpseo_add_opengraph_images', $image_container );
 
 		$this->add_from_indexable( $context->indexable, $image_container );
+		$this->add_for_object_type( $context->indexable, $image_container );
 
 		/**
 		 * Filter: wpseo_add_opengraph_additional_images - Allows to add additional images to the Open Graph tags.
@@ -129,6 +130,65 @@ class Open_Graph_Image_Generator implements Generator_Interface {
 
 		if ( $indexable->open_graph_image_id ) {
 			$image_container->add_image_by_id( $indexable->open_graph_image_id );
+		}
+	}
+
+	/**
+	 * Adds the images for the indexable object type.
+	 *
+	 * @param Indexable $indexable       The indexable.
+	 * @param Images    $image_container The image container.
+	 */
+	protected function add_for_object_type( Indexable $indexable, Images $image_container ) {
+		if ( $image_container->has_images() ) {
+			return;
+		}
+
+		switch ( $indexable->object_type ) {
+			case 'post' :
+				if ( $indexable->object_sub_type === 'attachment' ) {
+					$this->add_for_attachment( $indexable->object_id, $image_container );
+
+					return;
+				}
+
+				$this->add_for_post_type( $indexable, $image_container );
+
+				break;
+		}
+	}
+
+	/**
+	 * Adds the image for an attachment.
+	 *
+	 * @param int    $attachment_id   The attachment id.
+	 * @param Images $image_container The image container.
+	 */
+	protected function add_for_attachment( $attachment_id, Images $image_container ) {
+		if ( ! \wp_attachment_is_image( $attachment_id ) ) {
+			return;
+		}
+
+		$image_container->add_image_by_id( $attachment_id );
+	}
+
+	/**
+	 * Adds the images for a post type.
+	 *
+	 * @param Indexable $indexable       The indexable.
+	 * @param Images    $image_container The image container.
+	 */
+	protected function add_for_post_type( Indexable $indexable, Images $image_container ) {
+		$featured_image_id = $this->image->get_featured_image_id( $indexable->object_id );
+		if ( $featured_image_id ) {
+			$image_container->add_image_by_id( $featured_image_id );
+
+			return;
+		}
+
+		$content_image = $this->image->get_post_content_image( $indexable->object_id );
+		if ( $content_image ) {
+			$image_container->add_image_by_url( $content_image );
 		}
 	}
 

--- a/tests/generators/open-graph-image-generator-test.php
+++ b/tests/generators/open-graph-image-generator-test.php
@@ -162,6 +162,168 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	}
 
 	/**
+	 * Tests getting the image for a specific object type which isn't unknown to us.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_for_object_type
+	 */
+	public function test_generate_for_object_type_for_unknown_type() {
+		$this->indexable->object_type = 'unknown';
+
+		$this->instance->expects( 'add_from_indexable' )->andReturnNull();
+		$this->instance->expects( 'add_from_default' )->andReturnNull();
+
+		$this->image_container
+			->expects( 'has_images' )
+			->once()
+			->andReturnTrue();
+
+		$this->instance->generate( $this->context );
+	}
+
+	/**
+	 * Tests getting the image for a specific object in the case we already have found images.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_for_object_type
+	 */
+	public function test_generate_for_object_type_when_having_images_already() {
+		$this->indexable->object_type = 'post';
+
+		$this->instance->expects( 'add_from_indexable' )->andReturnNull();
+		$this->instance->expects( 'add_from_default' )->andReturnNull();
+
+		$this->image_container
+			->expects( 'has_images' )
+			->once()
+			->andReturnTrue();
+
+		$this->instance->generate( $this->context );
+	}
+
+	/**
+	 * Tests getting the attachment image for an attachment that isn't one.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_for_object_type
+	 * @covers ::add_for_attachment
+	 */
+	public function test_generate_with_attachment_no_being_an_attachment() {
+		$this->indexable->object_type     = 'post';
+		$this->indexable->object_sub_type = 'attachment';
+
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( false );
+
+		$this->instance->expects( 'add_from_indexable' )->andReturnNull();
+		$this->instance->expects( 'add_from_default' )->andReturnNull();
+
+		$this->image_container
+			->expects( 'has_images' )
+			->once()
+			->andReturnFalse();
+
+		$this->instance->generate( $this->context );
+	}
+
+	/**
+	 * Test getting the attachment image.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_for_object_type
+	 * @covers ::add_for_attachment
+	 */
+	public function test_generate_with_attachment() {
+		$this->indexable->object_type     = 'post';
+		$this->indexable->object_sub_type = 'attachment';
+		$this->indexable->object_id       = 1337;
+
+		\Brain\Monkey\Functions\expect( 'wp_attachment_is_image' )
+			->once()
+			->andReturn( true );
+
+		$this->instance->expects( 'add_from_indexable' )->andReturnNull();
+		$this->instance->expects( 'add_from_default' )->andReturnNull();
+
+		$this->image_container
+			->expects( 'add_image_by_id' )
+			->once()
+			->with( 1337 );
+
+		$this->image_container
+			->expects( 'has_images' )
+			->once()
+			->andReturnFalse();
+
+		$this->instance->generate( $this->context );
+	}
+
+	/**
+	 * Tests getting the featured image id for a post.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_for_object_type
+	 * @covers ::add_for_post_type
+	 */
+	public function test_with_featured_image_id() {
+		$this->indexable->object_type = 'post';
+		$this->indexable->object_id   = 1337;
+
+		$this->instance->expects( 'add_from_indexable' )->andReturnNull();
+		$this->instance->expects( 'add_from_default' )->andReturnNull();
+
+		$this->image
+			->expects( 'get_featured_image_id' )
+			->once()
+			->with( 1337 )
+			->andReturn( 1 );
+
+		$this->image_container
+			->expects( 'add_image_by_id' )
+			->once()
+			->with( 1 )
+			->andReturnNull();
+
+		$this->instance->generate( $this->context );
+	}
+
+	/**
+	 * Tests the situation where the content image is used.
+	 *
+	 * @covers ::generate
+	 * @covers ::add_for_object_type
+	 * @covers ::add_for_post_type
+	 */
+	public function test_with_content_image() {
+		$this->indexable->object_type = 'post';
+		$this->indexable->object_id   = 1337;
+
+		$this->instance->expects( 'add_from_indexable' )->andReturnNull();
+		$this->instance->expects( 'add_from_default' )->andReturnNull();
+
+		$this->image
+			->expects( 'get_featured_image_id' )
+			->once()
+			->with( 1337 )
+			->andReturnFalse();
+
+		$this->image
+			->expects( 'get_post_content_image' )
+			->once()
+			->with( 1337 )
+			->andReturn( 'image.jpg' );
+
+		$this->image_container
+			->expects( 'add_image_by_url' )
+			->with( 'image.jpg' )
+			->andReturnNull();
+
+
+		$this->instance->generate( $this->context );
+	}
+
+	/**
 	 * Tests the situation where the default Open Graph image id is given.
 	 *
 	 * @covers ::generate
@@ -172,7 +334,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 
 		$this->image_container
 			->expects( 'has_images' )
-			->once()
+			->times( 2 )
 			->andReturnFalse();
 
 		$this->options
@@ -200,7 +362,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 
 		$this->image_container
 			->expects( 'has_images' )
-			->once()
+			->times( 2 )
 			->andReturnFalse();
 
 		$this->options
@@ -234,7 +396,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 
 		$this->image_container
 			->expects( 'has_images' )
-			->once()
+			->times( 2 )
 			->andReturnTrue();
 
 		$this->instance->generate( $this->context );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Restores using the first content image if no open graph image or featured image has been set.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* This does not use gallery images. The current code on master does not use them either and to keep things simple and consistent with previous behavior I've elected to not use them here either.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post that does have images it in it but no featured image or open graph image set.
* The first image from the content should be in the open graph tags.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14695
