### PR TITLE
Restore open graph and twitter actions

### DIFF
--- a/src/integrations/front-end/backwards-compatiblity.php
+++ b/src/integrations/front-end/backwards-compatiblity.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\SEO\Integrations\Front_End
+ */
+
+namespace Yoast\WP\SEO\Integrations\Front_End;
+
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Adds actions that were previously called and are now deprecated.
+ */
+class Backwards_Compatibility implements Integration_Interface {
+
+	/**
+	 * Represents the options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	protected $options;
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Front_End_Conditional::class ];
+	}
+
+	/**
+	 * Backwards_Compatibility constructor
+	 *
+	 * @param Options_Helper $options The options helper.
+	 */
+	public function __construct( Options_Helper $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		if ( $this->options->get( 'opengraph' ) === true ) {
+			add_action( 'wpseo_head', [ $this, 'call_wpseo_opengraph' ], 30 );
+		}
+		if ( $this->options->get( 'twitter' ) === true && apply_filters( 'wpseo_output_twitter_card', true ) !== false ) {
+			add_action( 'wpseo_head', [ $this, 'call_wpseo_twitter' ], 40 );
+		}
+	}
+
+	/**
+	 * Calls the old wpseo_opengraph action.
+	 *
+	 * @return void
+	 */
+	public function call_wpseo_opengraph() {
+		do_action_deprecated( 'wpseo_opengraph', [], '14.0', 'wpseo_frontend_presenters' );
+	}
+
+	/**
+	 * Calls the old wpseo_twitter action.
+	 *
+	 * @return void
+	 */
+	public function call_wpseo_twitter() {
+		do_action_deprecated( 'wpseo_twitter', [], '14.0', 'wpseo_frontend_presenters' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Ensures we're still calling the `wpseo_opengraph` and `wpseo_twitter` actions as we did previously.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Actions are called exactly as they were. This does mean that anything output during this time will no longer be between our debug markers.
* This also means we don't have to use output buffering to ensure we don't lose performance or memory over this.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add your own output to the `wpseo_opengraph` and `wpseo_twitter` actions.
* You should see your output.
* You should see deprecation warnings.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
