### PR TITLE
Fix devserver assets

### DIFF
--- a/admin/class-admin-asset-dev-server-location.php
+++ b/admin/class-admin-asset-dev-server-location.php
@@ -58,7 +58,7 @@ final class WPSEO_Admin_Asset_Dev_Server_Location implements WPSEO_Admin_Asset_L
 			return $this->get_default_url( $asset, $type );
 		}
 
-		$path = sprintf( '%s%s.js', $asset->get_src(), $asset->get_suffix() );
+		$path = sprintf( 'js/dist/%s%s.js', $asset->get_src(), $asset->get_suffix() );
 
 		return trailingslashit( $this->url ) . $path;
 	}

--- a/integration-tests/admin/test-class-admin-asset-dev-server-location.php
+++ b/integration-tests/admin/test-class-admin-asset-dev-server-location.php
@@ -32,7 +32,7 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 
 		$actual = $dev_server_location->get_url( $asset, WPSEO_Admin_Asset::TYPE_JS );
 
-		$this->assertEquals( 'http://localhost:8080/commons.js', $actual );
+		$this->assertEquals( 'http://localhost:8080/js/dist/commons.js', $actual );
 	}
 
 	/**
@@ -47,7 +47,7 @@ final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestC
 
 		$actual = $dev_server_location->get_url( $asset, WPSEO_Admin_Asset::TYPE_JS );
 
-		$this->assertEquals( 'https://localhost:8081/commons.js', $actual );
+		$this->assertEquals( 'https://localhost:8081/js/dist/commons.js', $actual );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The dev server was broken on trunk. All JS assets gave 404 errors. This PR fixes that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where JS assets returned 404's when running Webpack dev server.

## Relevant technical choices:

* I honestly don't understand how this could have worked before. But it seems that since we added the CSS loader in https://github.com/Yoast/wordpress-seo/pull/14548 the Webpack server is broken and no longer serves assets from the root, but from js/dist. As I think this actually makes more sense, I decided to not try to bring it back in the old condition and simply change the path for dev assets. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Confirm it is broken in trunk.
* Confirm this PR fixes it.

## Quality assurance

* [x] I have tested this code to the best of my abilities
