### PR TITLE
Make current page surface use a magic getter

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -280,7 +280,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	protected function add_analysis_submenu( WP_Admin_Bar $wp_admin_bar ) {
-		$url           = YoastSEO()->current_page->get_canonical();
+		$url           = YoastSEO()->current_page->canonical;
 		$focus_keyword = '';
 
 		if ( ! $url ) {

--- a/src/surfaces/current-page-surface.php
+++ b/src/surfaces/current-page-surface.php
@@ -11,6 +11,51 @@ use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 
 /**
  * Class Current_Page_Surface
+ *
+ * @property string      $canonical
+ * @property string      $description
+ * @property string      $title
+ * @property string      $id
+ * @property string      $site_name
+ * @property string      $wordpress_site_name
+ * @property string      $site_url
+ * @property string      $company_name
+ * @property int         $company_logo_id
+ * @property int         $site_user_id
+ * @property string      $site_represents
+ * @property array|false $site_represents_reference
+ * @property bool        $breadcrumbs_enabled
+ * @property string      $schema_page_type
+ * @property string      $main_schema_id
+ * @property string      $page_type
+ * @property string      $meta_description
+ * @property array       $robots
+ * @property array       $googlebot
+ * @property string      $rel_next
+ * @property string      $rel_prev
+ * @property bool        $open_graph_enabled
+ * @property string      $open_graph_publisher
+ * @property string      $open_graph_type
+ * @property string      $open_graph_title
+ * @property string      $open_graph_description
+ * @property array       $open_graph_images
+ * @property string      $open_graph_url
+ * @property string      $open_graph_site_name
+ * @property string      $open_graph_article_publisher
+ * @property string      $open_graph_article_author
+ * @property string      $open_graph_article_published_time
+ * @property string      $open_graph_article_modified_time
+ * @property string      $open_graph_locale
+ * @property string      $open_graph_fb_app_id
+ * @property array       $schema
+ * @property string      $twitter_card
+ * @property string      $twitter_title
+ * @property string      $twitter_description
+ * @property string      $twitter_image
+ * @property string      $twitter_creator
+ * @property string      $twitter_site
+ * @property array       $source
+ * @property array       $breadcrumbs
  */
 class Current_Page_Surface {
 
@@ -31,47 +76,24 @@ class Current_Page_Surface {
 	}
 
 	/**
-	 * Returns the title of the current page.
+	 * Magic getter to retrieve variables from either meta tags context or presentation.
 	 *
-	 * @return string The title.
+	 * @param string $key The variable to retrieve.
+	 *
+	 * @return mixed|null
 	 */
-	public function get_title() {
+	public function __get( $key ) {
 		$meta_tags_context = $this->meta_tags_context_memoizer->for_current_page();
 
-		return $meta_tags_context->title;
-	}
+		if ( isset( $meta_tags_context->$key ) ) {
+			return $meta_tags_context->$key;
+		}
 
-	/**
-	 * Returns the meta description of the current page.
-	 *
-	 * @return string The meta description.
-	 */
-	public function get_description() {
-		$meta_tags_context = $this->meta_tags_context_memoizer->for_current_page();
+		if ( isset( $meta_tags_context->presentation->$key ) ) {
+			return $meta_tags_context->presentation->$key;
+		}
 
-		return $meta_tags_context->description;
-	}
-
-	/**
-	 * Returns the canonical of the current page.
-	 *
-	 * @return string The canonical.
-	 */
-	public function get_canonical() {
-		$meta_tags_context = $this->meta_tags_context_memoizer->for_current_page();
-
-		return $meta_tags_context->canonical;
-	}
-
-	/**
-	 * Returns the robots of the current page.
-	 *
-	 * @return string[] The robots.
-	 */
-	public function get_robots() {
-		$meta_tags_context = $this->meta_tags_context_memoizer->for_current_page();
-
-		return $meta_tags_context->presentation->robots;
+		return null;
 	}
 
 	/**

--- a/src/surfaces/current-page-surface.php
+++ b/src/surfaces/current-page-surface.php
@@ -12,50 +12,50 @@ use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 /**
  * Class Current_Page_Surface
  *
- * @property string      $canonical
- * @property string      $description
- * @property string      $title
- * @property string      $id
- * @property string      $site_name
- * @property string      $wordpress_site_name
- * @property string      $site_url
- * @property string      $company_name
- * @property int         $company_logo_id
- * @property int         $site_user_id
- * @property string      $site_represents
- * @property array|false $site_represents_reference
- * @property bool        $breadcrumbs_enabled
- * @property string      $schema_page_type
- * @property string      $main_schema_id
- * @property string      $page_type
- * @property string      $meta_description
- * @property array       $robots
- * @property array       $googlebot
- * @property string      $rel_next
- * @property string      $rel_prev
- * @property bool        $open_graph_enabled
- * @property string      $open_graph_publisher
- * @property string      $open_graph_type
- * @property string      $open_graph_title
- * @property string      $open_graph_description
- * @property array       $open_graph_images
- * @property string      $open_graph_url
- * @property string      $open_graph_site_name
- * @property string      $open_graph_article_publisher
- * @property string      $open_graph_article_author
- * @property string      $open_graph_article_published_time
- * @property string      $open_graph_article_modified_time
- * @property string      $open_graph_locale
- * @property string      $open_graph_fb_app_id
- * @property array       $schema
- * @property string      $twitter_card
- * @property string      $twitter_title
- * @property string      $twitter_description
- * @property string      $twitter_image
- * @property string      $twitter_creator
- * @property string      $twitter_site
- * @property array       $source
- * @property array       $breadcrumbs
+ * @property string      $canonical                         The canonical URL for the current page.
+ * @property string      $description                       The meta description for the current page, if set.
+ * @property string      $title                             The SEO title for the current page.
+ * @property string      $id                                The requested object ID.
+ * @property string      $site_name                         The site name from the Yoast SEO settings.
+ * @property string      $wordpress_site_name               The site name from the WordPress settings.
+ * @property string      $site_url                          The site's main URL.
+ * @property string      $company_name                      The company name from the Knowledge graph settings.
+ * @property int         $company_logo_id                   The attachment ID for the company logo.
+ * @property int         $site_user_id                      If the site represents a 'person', this is the ID of the accompanying user profile.
+ * @property string      $site_represents                   Whether the site represents a 'person' or a 'company'.
+ * @property array|false $site_represents_reference         The schema reference ID for what this site represents.
+ * @property bool        $breadcrumbs_enabled               Whether breadcrumbs are enabled or not.
+ * @property string      $schema_page_type                  The Schema page type.
+ * @property string      $main_schema_id                    Schema ID that points to the main Schema thing on the page, usually the webpage or article Schema piece.
+ * @property string      $page_type                         The Schema page type.
+ * @property string      $meta_description                  The meta description for the current page, if set.
+ * @property array       $robots                            An array of the robots values set for the current page.
+ * @property array       $googlebot                         The meta robots values we specifically output for Googlebot on this page.
+ * @property string      $rel_next                          The next page in the series, if any.
+ * @property string      $rel_prev                          The previous page in the series, if any.
+ * @property bool        $open_graph_enabled                Whether OpenGraph is enabled on this site.
+ * @property string      $open_graph_publisher              The OpenGraph publisher reference.
+ * @property string      $open_graph_type                   The og:type.
+ * @property string      $open_graph_title                  The og:title.
+ * @property string      $open_graph_description            The og:description.
+ * @property array       $open_graph_images                 The array of images we have for this page.
+ * @property string      $open_graph_url                    The og:url.
+ * @property string      $open_graph_site_name              The og:site_name.
+ * @property string      $open_graph_article_publisher      The article:publisher value.
+ * @property string      $open_graph_article_author         The article:author value.
+ * @property string      $open_graph_article_published_time The article:published_time value.
+ * @property string      $open_graph_article_modified_time  The article:modified_time value.
+ * @property string      $open_graph_locale                 The og:locale for the current page.
+ * @property string      $open_graph_fb_app_id              The Facebook App ID.
+ * @property array       $schema                            The entire Schema array for the current page.
+ * @property string      $twitter_card                      The Twitter card type for the current page.
+ * @property string      $twitter_title                     The Twitter card title for the current page.
+ * @property string      $twitter_description               The Twitter card description for the current page.
+ * @property string      $twitter_image                     The Twitter card image for the current page.
+ * @property string      $twitter_creator                   The Twitter card author for the current page.
+ * @property string      $twitter_site                      The Twitter card site reference for the current page.
+ * @property array       $source                            The source object for most of this page's data.
+ * @property array       $breadcrumbs                       The breadcrumbs array for the current page.
  */
 class Current_Page_Surface {
 

--- a/src/surfaces/current-page-surface.php
+++ b/src/surfaces/current-page-surface.php
@@ -12,50 +12,48 @@ use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 /**
  * Class Current_Page_Surface
  *
+ * @property array       $breadcrumbs                       The breadcrumbs array for the current page.
+ * @property bool        $breadcrumbs_enabled               Whether breadcrumbs are enabled or not.
  * @property string      $canonical                         The canonical URL for the current page.
- * @property string      $description                       The meta description for the current page, if set.
- * @property string      $title                             The SEO title for the current page.
- * @property string      $id                                The requested object ID.
- * @property string      $site_name                         The site name from the Yoast SEO settings.
- * @property string      $wordpress_site_name               The site name from the WordPress settings.
- * @property string      $site_url                          The site's main URL.
  * @property string      $company_name                      The company name from the Knowledge graph settings.
  * @property int         $company_logo_id                   The attachment ID for the company logo.
- * @property int         $site_user_id                      If the site represents a 'person', this is the ID of the accompanying user profile.
- * @property string      $site_represents                   Whether the site represents a 'person' or a 'company'.
- * @property array|false $site_represents_reference         The schema reference ID for what this site represents.
- * @property bool        $breadcrumbs_enabled               Whether breadcrumbs are enabled or not.
- * @property string      $schema_page_type                  The Schema page type.
- * @property string      $main_schema_id                    Schema ID that points to the main Schema thing on the page, usually the webpage or article Schema piece.
- * @property string      $page_type                         The Schema page type.
- * @property string      $meta_description                  The meta description for the current page, if set.
- * @property array       $robots                            An array of the robots values set for the current page.
+ * @property string      $description                       The meta description for the current page, if set.
  * @property array       $googlebot                         The meta robots values we specifically output for Googlebot on this page.
+ * @property string      $main_schema_id                    Schema ID that points to the main Schema thing on the page, usually the webpage or article Schema piece.
+ * @property string      $meta_description                  The meta description for the current page, if set.
+ * @property string      $open_graph_article_author         The article:author value.
+ * @property string      $open_graph_article_modified_time  The article:modified_time value.
+ * @property string      $open_graph_article_published_time The article:published_time value.
+ * @property string      $open_graph_article_publisher      The article:publisher value.
+ * @property string      $open_graph_description            The og:description.
+ * @property bool        $open_graph_enabled                Whether OpenGraph is enabled on this site.
+ * @property string      $open_graph_fb_app_id              The Facebook App ID.
+ * @property array       $open_graph_images                 The array of images we have for this page.
+ * @property string      $open_graph_locale                 The og:locale for the current page.
+ * @property string      $open_graph_publisher              The OpenGraph publisher reference.
+ * @property string      $open_graph_site_name              The og:site_name.
+ * @property string      $open_graph_title                  The og:title.
+ * @property string      $open_graph_type                   The og:type.
+ * @property string      $open_graph_url                    The og:url.
+ * @property string      $page_type                         The Schema page type.
+ * @property array       $robots                            An array of the robots values set for the current page.
  * @property string      $rel_next                          The next page in the series, if any.
  * @property string      $rel_prev                          The previous page in the series, if any.
- * @property bool        $open_graph_enabled                Whether OpenGraph is enabled on this site.
- * @property string      $open_graph_publisher              The OpenGraph publisher reference.
- * @property string      $open_graph_type                   The og:type.
- * @property string      $open_graph_title                  The og:title.
- * @property string      $open_graph_description            The og:description.
- * @property array       $open_graph_images                 The array of images we have for this page.
- * @property string      $open_graph_url                    The og:url.
- * @property string      $open_graph_site_name              The og:site_name.
- * @property string      $open_graph_article_publisher      The article:publisher value.
- * @property string      $open_graph_article_author         The article:author value.
- * @property string      $open_graph_article_published_time The article:published_time value.
- * @property string      $open_graph_article_modified_time  The article:modified_time value.
- * @property string      $open_graph_locale                 The og:locale for the current page.
- * @property string      $open_graph_fb_app_id              The Facebook App ID.
  * @property array       $schema                            The entire Schema array for the current page.
+ * @property string      $schema_page_type                  The Schema page type.
+ * @property string      $site_name                         The site name from the Yoast SEO settings.
+ * @property string      $site_represents                   Whether the site represents a 'person' or a 'company'.
+ * @property array|false $site_represents_reference         The schema reference ID for what this site represents.
+ * @property string      $site_url                          The site's main URL.
+ * @property int         $site_user_id                      If the site represents a 'person', this is the ID of the accompanying user profile.
+ * @property string      $title                             The SEO title for the current page.
  * @property string      $twitter_card                      The Twitter card type for the current page.
- * @property string      $twitter_title                     The Twitter card title for the current page.
+ * @property string      $twitter_creator                   The Twitter card author for the current page.
  * @property string      $twitter_description               The Twitter card description for the current page.
  * @property string      $twitter_image                     The Twitter card image for the current page.
- * @property string      $twitter_creator                   The Twitter card author for the current page.
  * @property string      $twitter_site                      The Twitter card site reference for the current page.
- * @property array       $source                            The source object for most of this page's data.
- * @property array       $breadcrumbs                       The breadcrumbs array for the current page.
+ * @property string      $twitter_title                     The Twitter card title for the current page.
+ * @property string      $wordpress_site_name               The site name from the WordPress settings.
  */
 class Current_Page_Surface {
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Make the `current_page` surface use a magic getter instead of only having a few get functions.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduce a magical getter for SEO & social meta data, dev blog post about this.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test `YoastSEO()->current_page->canonical` returns a canonical URL string, for instance, and some other values.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
