### PR TITLE
Add debug markers later

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -59,7 +59,7 @@ class Front_End_Integration implements Integration_Interface {
 	protected $helpers;
 
 	/**
-	 * The replace vars helper
+	 * The replace vars helper.
 	 *
 	 * @var WPSEO_Replace_Vars
 	 */
@@ -281,11 +281,11 @@ class Front_End_Integration implements Integration_Interface {
 		 */
 		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters );
 
-		if ( ! is_array( $presenter_instances ) ) {
+		if ( ! \is_array( $presenter_instances ) ) {
 			return $presenters;
 		}
 
-		return array_merge(
+		return \array_merge(
 			[ new Marker_Open_Presenter() ], $presenter_instances, [ new Marker_Close_Presenter() ]
 		);
 	}

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -12,6 +12,8 @@ use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
+use Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter;
+use Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter;
 use Yoast\WP\SEO\Presenters\Title_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
@@ -69,7 +71,6 @@ class Front_End_Integration implements Integration_Interface {
 	 * @var string[]
 	 */
 	protected $base_presenters = [
-		'Debug\Marker_Open',
 		'Title',
 		'Meta_Description',
 		'Robots',
@@ -152,7 +153,6 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	protected $closing_presenters = [
 		'Schema',
-		'Debug\Marker_Close',
 	];
 
 	/**
@@ -279,7 +279,15 @@ class Front_End_Integration implements Integration_Interface {
 		 *
 		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
 		 */
-		return \apply_filters( 'wpseo_frontend_presenters', $presenters );
+		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters );
+
+		if ( ! is_array( $presenter_instances ) ) {
+			return $presenters;
+		}
+
+		return array_merge(
+			[ new Marker_Open_Presenter() ], $presenter_instances, [ new Marker_Close_Presenter() ]
+		);
 	}
 
 	/**

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -285,6 +285,10 @@ class Front_End_Integration implements Integration_Interface {
 			return $presenters;
 		}
 
+		$presenter_instances = \array_filter( $presenter_instances, function ( $presenter_instance ) {
+			return $presenter_instance instanceof Abstract_Indexable_Presenter;
+		} );
+
 		return \array_merge(
 			[ new Marker_Open_Presenter() ], $presenter_instances, [ new Marker_Close_Presenter() ]
 		);

--- a/src/presenters/debug/marker-close-presenter.php
+++ b/src/presenters/debug/marker-close-presenter.php
@@ -20,6 +20,15 @@ final class Marker_Close_Presenter extends Abstract_Indexable_Presenter {
 	 * @return string The debug close marker.
 	 */
 	public function present() {
+		/**
+		 * Filter: 'wpseo_debug_markers' - Allow disabling the debug markers.
+		 *
+		 * @api bool $show_markers True when the debug markers should be shown.
+		 */
+		if ( ! \apply_filters( 'wpseo_debug_markers', true ) ) {
+			return '';
+		}
+
 		return \sprintf(
 			'<!-- / %s. -->' . PHP_EOL . PHP_EOL,
 			\esc_html( $this->helpers->product->get_name() )

--- a/src/presenters/debug/marker-open-presenter.php
+++ b/src/presenters/debug/marker-open-presenter.php
@@ -20,6 +20,15 @@ final class Marker_Open_Presenter extends Abstract_Indexable_Presenter {
 	 * @return string The debug close marker.
 	 */
 	public function present() {
+		/**
+		 * Filter: 'wpseo_debug_markers' - Allow disabling the debug markers.
+		 *
+		 * @api bool $show_markers True when the debug markers should be shown.
+		 */
+		if ( ! \apply_filters( 'wpseo_debug_markers', true ) ) {
+			return '';
+		}
+
 		return \sprintf(
 			'<!-- This site is optimized with the %1$s %2$s - https://yoast.com/wordpress/plugins/seo/ -->',
 			\esc_html( $this->helpers->product->get_name() ),

--- a/tests/presenters/debug/marker-close-presenter-test.php
+++ b/tests/presenters/debug/marker-close-presenter-test.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Presenters
  */
 
 namespace Yoast\WP\SEO\Tests\Presenters;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter;
 use Yoast\WP\SEO\Helpers\Product_Helper;
@@ -23,12 +26,13 @@ class Marker_Close_Presenter_Test extends TestCase {
 	/**
 	 * Tests the presentation of the close debug marker.
 	 *
-	 * @covers ::__construct
 	 * @covers ::present
 	 */
 	public function test_present() {
 		$product = Mockery::mock( Product_Helper::class );
 		$product->expects( 'get_name' )->andReturn( 'Yoast SEO plugin' );
+
+		Monkey\Filters\expectApplied( 'wpseo_debug_markers' )->andReturn( true );
 
 		$instance = new Marker_Close_Presenter();
 		$instance->helpers = (object) [
@@ -41,4 +45,25 @@ class Marker_Close_Presenter_Test extends TestCase {
 		);
 	}
 
+	/**
+	 * Tests the presentation of the close debug marker.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_disabled_by_filter() {
+		$product = Mockery::mock( Product_Helper::class );
+		$product->expects( 'get_name' )->never();
+
+		Monkey\Filters\expectApplied( 'wpseo_debug_markers' )->andReturn( false );
+
+		$instance = new Marker_Close_Presenter();
+		$instance->helpers = (object) [
+			'product' => $product,
+		];
+
+		$this->assertEquals(
+			'',
+			$instance->present()
+		);
+	}
 }

--- a/tests/presenters/debug/marker-open-presenter-test.php
+++ b/tests/presenters/debug/marker-open-presenter-test.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Presenters
  */
 
 namespace Yoast\WP\SEO\Tests\Presenters;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter;
 use Yoast\WP\SEO\Helpers\Product_Helper;
@@ -23,7 +26,6 @@ class Marker_Open_Presenter_Test extends TestCase {
 	/**
 	 * Tests the presentation of the open debug marker.
 	 *
-	 * @covers ::__construct
 	 * @covers ::present
 	 */
 	public function test_present() {
@@ -37,6 +39,30 @@ class Marker_Open_Presenter_Test extends TestCase {
 
 		$this->assertEquals(
 			'<!-- This site is optimized with the Yoast SEO plugin v' . \WPSEO_VERSION . ' - https://yoast.com/wordpress/plugins/seo/ -->',
+			$instance->present()
+		);
+	}
+
+
+
+	/**
+	 * Tests the presentation of the close debug marker.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_disabled_by_filter() {
+		$product_mock = Mockery::mock( Product_Helper::class );
+		$product_mock->expects( 'get_name' )->never();
+
+		Monkey\Filters\expectApplied( 'wpseo_debug_markers' )->andReturn( false );
+
+		$instance = new Marker_Open_Presenter();
+		$instance->helpers = (object) [
+			'product' => $product_mock,
+		];
+
+		$this->assertEquals(
+			'',
 			$instance->present()
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The debug markers are misplaces when adding new presenters using the filter.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  N/A - 

## Relevant technical choices:

* Add an `is_array` check and show original presenters when the outcome is false.
* Introduced a filter to disable the debug markers.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Verify the output of the meta tags, especially the debug markers, is still the same compared to the release branch
* Add the following filter and verify that the debug markers are gone:
```
add_filter( 'wpseo_debug_markers', '__return_false' ); 
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Needs #14706