### PR TITLE
14710 fix breadcrumbs shortcode

### DIFF
--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -7,8 +7,10 @@
 
 namespace Yoast\WP\SEO\Integrations;
 
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 
 /**
  * Adds customizations to the front end for breadcrumbs.
@@ -23,14 +25,18 @@ class Breadcrumbs_Integration implements Integration_Interface {
 	private $presenter;
 
 	/**
-	 * Breadcrumbs_Integration constructor.
+	 * Breadcrumbs integration constructor.
 	 *
-	 * @param Breadcrumbs_Presenter $presenter The breadcrumbs presenter.
-	 *
-	 * @codeCoverageIgnore
+	 * @param Helpers_Surface    $helpers      The helpers.
+	 * @param WPSEO_Replace_Vars $replace_vars The replace vars.
 	 */
-	public function __construct( Breadcrumbs_Presenter $presenter ) {
-		$this->presenter = $presenter;
+	public function __construct(
+		Helpers_Surface $helpers,
+		WPSEO_Replace_Vars $replace_vars
+	) {
+		$this->presenter = new Breadcrumbs_Presenter();
+		$this->presenter->helpers      = $helpers;
+		$this->presenter->replace_vars = $replace_vars;
 	}
 
 	/**
@@ -52,11 +58,10 @@ class Breadcrumbs_Integration implements Integration_Interface {
 	 * Renders the breadcrumbs.
 	 *
 	 * @return string The rendered breadcrumbs.
-	 * @throws \Exception If something goes wrong generating the DI container.
 	 */
 	public function render() {
-		$indexable_presentation = YoastSEO()->current_page->get_presentation();
+		$this->presenter->presentation = YoastSEO()->current_page->get_presentation();
 
-		return $this->presenter->present( $indexable_presentation );
+		return $this->presenter->present();
 	}
 }

--- a/tests/integrations/breadcrumbs-integration-test.php
+++ b/tests/integrations/breadcrumbs-integration-test.php
@@ -4,12 +4,14 @@ namespace Yoast\WP\SEO\Tests\Integrations;
 
 use \Mockery;
 use Brain\Monkey;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
 use Yoast\WP\SEO\Integrations\Breadcrumbs_Integration;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Surfaces\Current_Page_Surface;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -41,9 +43,7 @@ class Breadcrumbs_Integration_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->presenter = Mockery::mock( Breadcrumbs_Presenter::class );
-
-		$this->instance = new Breadcrumbs_Integration( $this->presenter );
+		$this->instance = new Breadcrumbs_Integration( Mockery::mock( Helpers_Surface::class ), Mockery::mock( WPSEO_Replace_Vars::class ) );
 	}
 
 	/**
@@ -63,6 +63,7 @@ class Breadcrumbs_Integration_Test extends TestCase {
 	public function test_render() {
 		$current_page_surface   = Mockery::mock( Current_Page_Surface::class );
 		$indexable_presentation = Mockery::mock( Indexable_Presentation::class );
+		$indexable_presentation->breadcrumbs = [];
 
 		$current_page_surface
 			->expects( 'get_presentation' )
@@ -73,12 +74,6 @@ class Breadcrumbs_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'YoastSEO' )->once()->andReturn( $mock );
 
-		$this->presenter
-			->expects( 'present' )
-			->once()
-			->with( $indexable_presentation )
-			->andReturn( 'breadcrumbs html' );
-
-		$this->assertEquals( 'breadcrumbs html', $this->instance->render() );
+		$this->assertEquals( '', $this->instance->render() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the breadcrumbs shortcode not being output

## Relevant technical choices:

* Fix is also included in #14569 and was taken from there.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add `[wpseo_breadcrumb]` shortcode to any post.
* It should be output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14710
