### PR TITLE
Fix AMP meta output by adding new AMP integration

### DIFF
--- a/src/integrations/third-party/amp.php
+++ b/src/integrations/third-party/amp.php
@@ -19,7 +19,7 @@ class AMP implements Integration_Interface {
 	/**
 	 * The front end integration.
 	 *
-	 * @return Front_End_Integration
+	 * @var Front_End_Integration
 	 */
 	protected $front_end;
 

--- a/src/integrations/third-party/amp.php
+++ b/src/integrations/third-party/amp.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\SEO\Integrations\Third_Party
+ */
+
+namespace Yoast\WP\SEO\Integrations\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Integrations\Front_End_Integration;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * AMP integration
+ */
+class AMP implements Integration_Interface {
+
+	/**
+	 * The front end integration.
+	 *
+	 * @return Front_End_Integration
+	 */
+	protected $front_end;
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Front_End_Conditional::class ];
+	}
+
+	/**
+	 * Constructs the AMP integration
+	 *
+	 * @param Front_End_Integration $front_end The front end integration.
+	 */
+	public function __construct( Front_End_Integration $front_end ) {
+		$this->front_end = $front_end;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		\add_action( 'amp_post_template_head', [ $this, 'remove_amp_meta_output' ], 0 );
+		\add_action( 'amp_post_template_head', [ $this->front_end, 'call_wpseo_head' ], 9 );
+	}
+
+	/**
+	 * Removes amp meta output.
+	 *
+	 * @return void
+	 */
+	public function remove_amp_meta_output() {
+		\remove_action( 'amp_post_template_head', 'amp_post_template_add_title' );
+		\remove_action( 'amp_post_template_head', 'amp_post_template_add_canonical' );
+		\remove_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
+	}
+}

--- a/tests/integrations/third-party/amp-test.php
+++ b/tests/integrations/third-party/amp-test.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Third_Party
+ */
+
+namespace Yoast\WP\SEO\Tests\Integrations\Third_Party;
+
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Integrations\Front_End_Integration;
+use Yoast\WP\SEO\Integrations\Third_Party\AMP;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * AMP integration test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\AMP
+ * @covers ::<!public>
+ *
+ * @group integrations
+ * @group third-party
+ */
+class AMP_Test extends TestCase {
+
+	/**
+	 * The AMP integration
+	 *
+	 * @var AMP
+	 */
+	protected $instance;
+
+	/**
+	 * The front end integration
+	 *
+	 * @var Front_End_Integration
+	 */
+	protected $front_end;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->front_end = Mockery::mock( Front_End_Integration::class );
+		$this->instance  = new AMP( $this->front_end );
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Front_End_Conditional::class ],
+			AMP::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests register hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertTrue( \has_action( 'amp_post_template_head', [ $this->instance, 'remove_amp_meta_output' ] ), 'The remove AMP meta output function is registered.' );
+		$this->assertTrue( \has_action( 'amp_post_template_head', [ $this->front_end, 'call_wpseo_head' ] ), 'The wpseo head action is registered.' );
+	}
+
+	/**
+	 * Tests remove amp meta output.
+	 *
+	 * @covers ::remove_amp_meta_output
+	 */
+	public function test_remove_amp_meta_output() {
+		\add_action( 'amp_post_template_head', 'amp_post_template_add_title' );
+		\add_action( 'amp_post_template_head', 'amp_post_template_add_canonical' );
+		\add_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
+
+		$this->instance->remove_amp_meta_output();
+
+		$this->assertFalse( \has_action( 'amp_post_template_head', 'amp_post_template_add_title' ), 'The AMP title action is not registered' );
+		$this->assertFalse( \has_action( 'amp_post_template_head', 'amp_post_template_add_canonical' ), 'The AMP canonical action is not registered' );
+		$this->assertFalse( \has_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' ), 'The AMP schema action is not registered' );
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures no duplicate tags are output on AMP pages with the official AMP plugin.

## Relevant technical choices:

* A new integration has been added to keep things separated.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Activate the official AMP plugin.
* Visit the AMP version of any post ( add `/amp/` to the URL ).
* There should be no duplicate title, schema or canonicals output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14713
