### PR TITLE
Try catch opengraph image filters

### DIFF
--- a/src/generators/open-graph-image-generator.php
+++ b/src/generators/open-graph-image-generator.php
@@ -74,28 +74,41 @@ class Open_Graph_Image_Generator implements Generator_Interface {
 	/**
 	 * Retrieves the images for an indexable.
 	 *
+	 * For legacy reasons some plugins might expect we filter a WPSEO_Opengraph_Image object. That might cause
+	 * type errors. This is why we try/catch our filters.
+	 *
 	 * @param Meta_Tags_Context $context The context.
 	 *
 	 * @return array The images.
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$image_container = $this->get_image_container();
+		$backup_image_container = $this->get_image_container();
 
-		/**
-		 * Filter: wpseo_add_opengraph_images - Allow developers to add images to the Open Graph tags.
-		 *
-		 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
-		 */
-		do_action( 'wpseo_add_opengraph_images', $image_container );
+		try {
+			/**
+			 * Filter: wpseo_add_opengraph_images - Allow developers to add images to the Open Graph tags.
+			 *
+			 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
+			 */
+			apply_filters( 'wpseo_add_opengraph_images', $image_container );
+		} catch ( \Error $error ) {
+			$image_container = $backup_image_container;
+		}
 
 		$this->add_from_indexable( $context->indexable, $image_container );
+		$backup_image_container = $image_container;
 
-		/**
-		 * Filter: wpseo_add_opengraph_additional_images - Allows to add additional images to the Open Graph tags.
-		 *
-		 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
-		 */
-		do_action( 'wpseo_add_opengraph_additional_images', $image_container );
+		try {
+			/**
+			 * Filter: wpseo_add_opengraph_additional_images - Allows to add additional images to the Open Graph tags.
+			 *
+			 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
+			 */
+			apply_filters( 'wpseo_add_opengraph_additional_images', $image_container );
+		} catch ( \Error $error ) {
+			$image_container = $backup_image_container;
+		}
 
 		$this->add_from_default( $image_container );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We changed the type of the images container that we filter for opengraph images. This could cause type errors with integrators who typehint their filter callbacks. In order to prevent fatals from occurring, we ignore the filter if a filter like that breaks.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents integrations relying on the deprecated WPSEO_OpenGraph_Image class from creating Type Errors with the latest version of Yoast SEO.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Follow the steps in the issue. See the fatal is solved.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #14689
