### PR TITLE
Reduce the number of newlines below our debug marker

### DIFF
--- a/src/presenters/debug/marker-close-presenter.php
+++ b/src/presenters/debug/marker-close-presenter.php
@@ -30,7 +30,7 @@ final class Marker_Close_Presenter extends Abstract_Indexable_Presenter {
 		}
 
 		return \sprintf(
-			'<!-- / %s. -->' . PHP_EOL . PHP_EOL,
+			'<!-- / %s. -->',
 			\esc_html( $this->helpers->product->get_name() )
 		);
 	}

--- a/tests/presenters/debug/marker-close-presenter-test.php
+++ b/tests/presenters/debug/marker-close-presenter-test.php
@@ -40,7 +40,7 @@ class Marker_Close_Presenter_Test extends TestCase {
 		];
 
 		$this->assertEquals(
-			'<!-- / Yoast SEO plugin. -->' . PHP_EOL . PHP_EOL,
+			'<!-- / Yoast SEO plugin. -->',
 			$instance->present()
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove the number of newlines after our meta block. There are already 2 `PHP_EOL`'s in `front-end-integration.php` after our presenters, we don't need any in the debug marker itself.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* None needed

Fixes #14716
