### PR TITLE
CS: comma after each array item in multi-line arrays

### DIFF
--- a/tests/generators/schema-generator-test.php
+++ b/tests/generators/schema-generator-test.php
@@ -196,7 +196,7 @@ class Schema_Generator_Test extends TestCase {
 						[
 							'@type' => 'ReadAction',
 							'target' => [
-								null
+								null,
 							],
 						],
 					],
@@ -318,7 +318,7 @@ class Schema_Generator_Test extends TestCase {
 							[
 								'@type'  => 'ReadAction',
 								'target' => [
-									null
+									null,
 								],
 							],
 						],
@@ -327,7 +327,7 @@ class Schema_Generator_Test extends TestCase {
 						'@type'            => 'ItemList',
 						'mainEntityOfPage' => [ '@id' => null ],
 						'numberOfItems'    => 1,
-						'itemListElement'  => [ [ '@id' => '#id-1' ] ]
+						'itemListElement'  => [ [ '@id' => '#id-1' ] ],
 					],
 					[
 						'@type'          => 'Question',
@@ -342,7 +342,7 @@ class Schema_Generator_Test extends TestCase {
 							'inLanguage' => 'English',
 						],
 						'inLanguage' => 'English',
-					]
+					],
 				],
 			],
 			$this->instance->generate( $this->context )
@@ -386,7 +386,7 @@ class Schema_Generator_Test extends TestCase {
 						[
 							'@type'  => 'ReadAction',
 							'target' => [
-								null
+								null,
 							],
 						],
 					],

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -111,7 +111,7 @@ class Article_Test extends TestCase {
 				'id'       => $this->id,
 				'html'     => $this->html,
 				'language' => $this->language,
-			]
+			],
 		];
 
 		return parent::setUp();

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -115,7 +115,7 @@ class Author_Test extends TestCase {
 				'id'      => $this->id,
 				'image'   => $this->schema_image,
 				'html'    => $this->html,
-			]
+			],
 		];
 	}
 

--- a/tests/generators/schema/breadcrumb-test.php
+++ b/tests/generators/schema/breadcrumb-test.php
@@ -70,7 +70,7 @@ class Breadcrumb_Test extends TestCase {
 			'current_page' => $this->current_page,
 			'schema'       => (object) [
 				'id' => $this->id,
-			]
+			],
 		];
 	}
 

--- a/tests/generators/schema/faq-test.php
+++ b/tests/generators/schema/faq-test.php
@@ -52,7 +52,7 @@ class FAQ_Test extends TestCase {
 			'schema' => (object) [
 				'language' => $this->language,
 				'html'     => $this->html,
-			]
+			],
 		];
 		parent::setUp();
 	}

--- a/tests/generators/schema/organization-test.php
+++ b/tests/generators/schema/organization-test.php
@@ -94,7 +94,7 @@ class Organization_Test extends TestCase {
 				'id'      => $this->id,
 				'image'   => $this->image,
 				'html'    => $this->html,
-			]
+			],
 		];
 	}
 

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -78,7 +78,7 @@ class Website_Test extends TestCase {
 				'id'       => new ID_Helper(),
 				'language' => $this->language,
 				'html'     => $this->html,
-			]
+			],
 		];
 	}
 

--- a/tests/helpers/blocks-helper-test.php
+++ b/tests/helpers/blocks-helper-test.php
@@ -136,8 +136,8 @@ class Blocks_Helper_Test extends TestCase {
 					[
 						'blockName'        => 'InnerBlock',
 						'blockDescription' => 'This is a inner block',
-					]
-				]
+					],
+				],
 			],
 			$this->instance->get_all_blocks_from_content( 'post content' ) );
 	}

--- a/tests/helpers/home-url-helper-test.php
+++ b/tests/helpers/home-url-helper-test.php
@@ -68,14 +68,14 @@ class Home_Url_Helper_Test extends TestCase {
 			->andReturn(
 				[
 					'scheme' => 'https',
-					'host'   => 'example.com'
+					'host'   => 'example.com',
 				]
 			);
 
 		$this->assertEquals(
 			[
 				'scheme' => 'https',
-				'host'   => 'example.com'
+				'host'   => 'example.com',
 			],
 			$this->instance->get_parsed() );
 	}
@@ -92,7 +92,7 @@ class Home_Url_Helper_Test extends TestCase {
 		$this->assertEquals(
 			[
 				'scheme' => 'https',
-				'host'   => 'example.com'
+				'host'   => 'example.com',
 			],
 			$this->instance->get_parsed() );
 	}

--- a/tests/helpers/options-helper-test.php
+++ b/tests/helpers/options-helper-test.php
@@ -44,7 +44,7 @@ class Options_Helper_Test extends TestCase {
 			->once()
 			->andReturn(
 				[
-					'my-title' => 'This is a title'
+					'my-title' => 'This is a title',
 				]
 			);
 

--- a/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
@@ -87,7 +87,7 @@ trait Presentation_Instance_Builder {
 				$this->post_type,
 				$this->date,
 				$this->pagination,
-				$this->post
+				$this->post,
 			]
 		)
 			->shouldAllowMockingProtectedMethods()


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Use a comma after each array item, including after the last item.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.