### PR TITLE
Bug fix: make text string translatable

### DIFF
--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -114,7 +114,7 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 			'%s<br><br>%s',
 			sprintf(
 				/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-				esc_html( '%1$s offers a free indexability check for %2$s users. The request to %1$s to check whether your site can be found by search engines failed due to an error.', 'wordpress-seo' ),
+				esc_html__( '%1$s offers a free indexability check for %2$s users. The request to %1$s to check whether your site can be found by search engines failed due to an error.', 'wordpress-seo' ),
 				'Ryte',
 				'Yoast SEO'
 			),


### PR DESCRIPTION
## Context

* Translatable string was not being translated.

## Summary

This PR can be summarized in the following changelog entry:

* Improved translatability.

## Relevant technical choices:

The function call was already set up for a translatable string, just using the wrong function.
`esc_html()` only escapes. `esc_html__()` escapes and tranlates.

/cc @IreneStr Should this one be backported to `14.0` ?

## Test instructions

This PR can be tested by following these steps:
* Using the `trunk` branch, switch to another language and see this text string still in English.
* Switch to this branch, make sure there is a translation available and see the text string in the chosen language.
* (or use the Pig Latin plugin to see that the text string is picked up as translatable)