### PR TITLE
QA: fix import `use` statements

### DIFF
--- a/tests/integrations/breadcrumbs-integration-test.php
+++ b/tests/integrations/breadcrumbs-integration-test.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Integrations;
 
-use \Mockery;
+use Mockery;
 use Brain\Monkey;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Integrations;
 
-use \Mockery;
+use Mockery;
 use Brain\Monkey;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

Import `use` statements MUST always be fully qualified. For that reason no leading backslash should be used.

> Note that for namespaced names (fully qualified namespace names containing namespace separator, such as Foo\Bar as opposed to global names that do not, such as FooBar), the leading backslash is unnecessary and **not recommended**, as import names must be fully qualified, and are not processed relative to the current namespace.

Ref: https://www.php.net/manual/en/language.namespaces.importing.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.