### PR TITLE
CS: use (pre-)increment/decrement where appropriate

### DIFF
--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -55,7 +55,7 @@ class Yoast_Input_Validation {
 		foreach ( $errors as $error ) {
 			// For now, filter the admin title only in the Yoast SEO settings pages.
 			if ( self::is_yoast_option_group_name( $error['setting'] ) && $error['code'] !== 'settings_updated' ) {
-				$error_count++;
+				++$error_count;
 			}
 		}
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -424,7 +424,7 @@ class Yoast_Notification_Center {
 		}
 
 		if ( $notification->is_persistent() && $resolve ) {
-			$this->resolved++;
+			++$this->resolved;
 			$this->clear_dismissal( $notification );
 		}
 

--- a/deprecated/frontend/schema/class-schema-howto.php
+++ b/deprecated/frontend/schema/class-schema-howto.php
@@ -68,7 +68,7 @@ class WPSEO_Schema_HowTo extends HowTo implements WPSEO_Graph_Piece {
 	public function render( $graph, $block ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\HowTo::add_how_to' );
 
-		$this->counter++;
+		++$this->counter;
 		$this->add_how_to( $graph, $block, $this->counter );
 
 		return $graph;

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -94,7 +94,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				'lastmod' => ( $user->_yoast_wpseo_profile_updated ) ? $this->date->format_timestamp( $user->_yoast_wpseo_profile_updated ) : null,
 			];
 
-			$page++;
+			++$page;
 		}
 
 		return $index;

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -159,7 +159,7 @@ class Indexable_Hierarchy_Builder {
 		foreach ( $parents as $parent ) {
 			$ancestor = $this->indexable_repository->find_by_id_and_type( $parent->term_id, 'term' );
 			$this->indexable_hierarchy_repository->add_ancestor( $indexable_id, $ancestor->id, $depth );
-			$depth = ( $depth + 1 );
+			++$depth;
 		}
 	}
 

--- a/src/commands/generate-indexables-command.php
+++ b/src/commands/generate-indexables-command.php
@@ -104,7 +104,7 @@ class Generate_Indexables_Command implements Command_Interface {
 				$progress->tick();
 			}
 
-			$page += 1;
+			++$page;
 		}
 
 		$progress->finish();
@@ -132,7 +132,7 @@ class Generate_Indexables_Command implements Command_Interface {
 				$progress->tick();
 			}
 
-			$page += 1;
+			++$page;
 		}
 
 		$progress->finish();

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -47,7 +47,7 @@ class FAQ extends Abstract_Schema_Piece {
 				}
 				$ids[]   = [ '@id' => $this->context->canonical . '#' . esc_attr( $question['id'] ) ];
 				$graph[] = $this->generate_question_block( $question, $index );
-				$number_of_items++;
+				++$number_of_items;
 			}
 		}
 

--- a/src/loggers/database-logger.php
+++ b/src/loggers/database-logger.php
@@ -135,7 +135,7 @@ class Database_Logger implements Integration_Interface {
 		$i = 1;
 		foreach ( $this->query_log as $query ) {
 			echo $i, ': "', $query['query'], '" in ', round( $query['time'], 5 ), PHP_EOL;
-			$i ++;
+			++$i;
 		}
 	}
 
@@ -152,7 +152,7 @@ class Database_Logger implements Integration_Interface {
 			foreach ( $wpdb->queries as $query ) {
 				echo $i, ': "', trim( $query[0] ), '" in ', round( $query[1], 5 ), PHP_EOL;
 				echo '    ', $query[2], PHP_EOL;
-				$i ++;
+				++$i;
 			}
 
 			return;

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -163,7 +163,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			// This is the last element, now close all previous elements.
 			while ( $index > 0 ) {
 				$link .= '</' . $this->get_element() . '>';
-				$index--;
+				--$index;
 			}
 		}
 		else {


### PR DESCRIPTION


## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* When a variable value has to be in/decremented by `1` in a stand-alone statement, the increment/decrement operators should be used.
* And when using increment/decrement operators, pre-in/decrement should be favoured over post-in/decrement.
    Note: there is a difference in behaviour: the "pre" variant increments and returns, the "post" variant returns and increments after. This is a significant difference and the reason why "pre" should be favoured, though for stand-alone statement there is - in effect - no difference.
* Lastly, there should be no whitespace between the increment/decrement operator and the variable it applies to.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.