### PR TITLE
CS: fix chained method call indentation

### DIFF
--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -100,7 +100,7 @@ class Custom_Loader extends PhpFileLoader {
 		foreach ( $interfaces as $interface ) {
 			if ( ! empty( $singly_implemented[ $interface ] ) ) {
 				$this->container->setAlias( $interface, $singly_implemented[ $interface ] )
-								->setPublic( false );
+					->setPublic( false );
 			}
 		}
 	}

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -127,9 +127,9 @@ class Indexable_Repository {
 
 		// Find by both permalink_hash and permalink, permalink_hash is indexed so will be used first by the DB to optimize the query.
 		return $this->query()
-					->where( 'permalink_hash', $permalink_hash )
-					->where( 'permalink', $permalink )
-					->find_one();
+			->where( 'permalink_hash', $permalink_hash )
+			->where( 'permalink', $permalink )
+			->find_one();
 	}
 
 	/**
@@ -235,9 +235,9 @@ class Indexable_Repository {
 		 * @var Indexable $indexable
 		 */
 		$indexable = $this->query()
-						  ->where( 'object_type', 'post-type-archive' )
-						  ->where( 'object_sub_type', $post_type )
-						  ->find_one();
+			->where( 'object_type', 'post-type-archive' )
+			->where( 'object_sub_type', $post_type )
+			->find_one();
 
 		if ( $auto_create && ! $indexable ) {
 			$indexable = $this->builder->build_for_post_type_archive( $post_type );
@@ -261,9 +261,9 @@ class Indexable_Repository {
 		 * @var Indexable $indexable
 		 */
 		$indexable = $this->query()
-						  ->where( 'object_type', 'system-page' )
-						  ->where( 'object_sub_type', $object_sub_type )
-						  ->find_one();
+			->where( 'object_type', 'system-page' )
+			->where( 'object_sub_type', $object_sub_type )
+			->find_one();
 
 		if ( $auto_create && ! $indexable ) {
 			$indexable = $this->builder->build_for_system_page( $object_sub_type );
@@ -283,9 +283,9 @@ class Indexable_Repository {
 	 */
 	public function find_by_id_and_type( $object_id, $object_type, $auto_create = true ) {
 		$indexable = $this->query()
-						  ->where( 'object_id', $object_id )
-						  ->where( 'object_type', $object_type )
-						  ->find_one();
+			->where( 'object_id', $object_id )
+			->where( 'object_type', $object_type )
+			->find_one();
 
 		if ( $auto_create && ! $indexable ) {
 			$indexable = $this->builder->build_for_id_and_type( $object_id, $object_type );
@@ -310,9 +310,9 @@ class Indexable_Repository {
 		 * @var Indexable[] $indexables
 		 */
 		$indexables = $this->query()
-						   ->where_in( 'object_id', $object_ids )
-						   ->where( 'object_type', $object_type )
-						   ->find_many();
+			->where_in( 'object_id', $object_ids )
+			->where( 'object_type', $object_type )
+			->find_many();
 
 		if ( $auto_create ) {
 			$indexables_available = [];

--- a/src/repositories/primary-term-repository.php
+++ b/src/repositories/primary-term-repository.php
@@ -39,9 +39,9 @@ class Primary_Term_Repository {
 	public function find_by_post_id_and_taxonomy( $post_id, $taxonomy, $auto_create = true ) {
 		/** @var Primary_Term $primary_term */
 		$primary_term = $this->query()
-							 ->where( 'post_id', $post_id )
-							 ->where( 'taxonomy', $taxonomy )
-							 ->find_one();
+			->where( 'post_id', $post_id )
+			->where( 'taxonomy', $taxonomy )
+			->find_one();
 
 		if ( $auto_create && ! $primary_term ) {
 			$primary_term = $this->query()->create();

--- a/src/repositories/seo-meta-repository.php
+++ b/src/repositories/seo-meta-repository.php
@@ -35,7 +35,7 @@ class SEO_Meta_Repository {
 	 */
 	public function find_by_post_id( $post_id ) {
 		return $this->query()
-					->where( 'object_id', $post_id )
-					->find_one();
+			->where( 'object_id', $post_id )
+			->find_one();
 	}
 }

--- a/tests/database/migration-status-test.php
+++ b/tests/database/migration-status-test.php
@@ -23,8 +23,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_should_run_migration() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0' ] );
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
 
 		$instance = new Migration_Status();
 
@@ -36,8 +36,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_should_run_migration_without_option() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( false );
+			->once()
+			->andReturn( false );
 
 		$instance = new Migration_Status();
 
@@ -49,8 +49,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_should_run_migration_with_old_lock() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0', 'lock' => strtotime( '-20 minutes' ) ] );
+			->once()
+			->andReturn( [ 'version' => '1.0', 'lock' => strtotime( '-20 minutes' ) ] );
 
 		$instance = new Migration_Status();
 
@@ -62,8 +62,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_should_not_run_migration() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => WPSEO_VERSION ] );
+			->once()
+			->andReturn( [ 'version' => WPSEO_VERSION ] );
 
 		$instance = new Migration_Status();
 
@@ -75,8 +75,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_should_not_run_migration_with_lock() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0', 'lock' => strtotime( 'now' ) ] );
+			->once()
+			->andReturn( [ 'version' => '1.0', 'lock' => strtotime( 'now' ) ] );
 
 		$instance = new Migration_Status();
 
@@ -88,8 +88,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_is_version() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0' ] );
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
 
 		$instance = new Migration_Status();
 
@@ -101,8 +101,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_is_version_default() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => WPSEO_VERSION ] );
+			->once()
+			->andReturn( [ 'version' => WPSEO_VERSION ] );
 
 		$instance = new Migration_Status();
 
@@ -114,8 +114,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_is_version_lower() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '2.0' ] );
+			->once()
+			->andReturn( [ 'version' => '2.0' ] );
 
 		$instance = new Migration_Status();
 
@@ -127,8 +127,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_is_version_higher() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0' ] );
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
 
 		$instance = new Migration_Status();
 
@@ -140,8 +140,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_is_version_empty() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( false );
+			->once()
+			->andReturn( false );
 
 		$instance = new Migration_Status();
 
@@ -155,8 +155,8 @@ class Migration_Status_Test extends TestCase {
 		$error = [ 'message' => 'Something went wrong', 'time' => strtotime( 'now' ), 'version' => '2.0' ];
 
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0', 'error' => $error ] );
+			->once()
+			->andReturn( [ 'version' => '1.0', 'error' => $error ] );
 
 		$instance = new Migration_Status();
 
@@ -168,8 +168,8 @@ class Migration_Status_Test extends TestCase {
 	 */
 	public function test_get_error_with_no_error() {
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0' ] );
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
 
 		$instance = new Migration_Status();
 
@@ -184,11 +184,11 @@ class Migration_Status_Test extends TestCase {
 		$expected_option = [ 'version' => '1.0', 'error' => [ 'message' => $error_message, 'time' => strtotime( 'now' ), 'version' => WPSEO_VERSION ] ];
 
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0' ] );
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
 		Monkey\Functions\expect( 'update_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test', $expected_option )
-												  ->once()
-												  ->andReturn( true );
+			->once()
+			->andReturn( true );
 
 		$instance = new Migration_Status();
 
@@ -202,11 +202,11 @@ class Migration_Status_Test extends TestCase {
 		$expected_option = [ 'version' => WPSEO_VERSION ];
 
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0' ] );
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
 		Monkey\Functions\expect( 'update_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test', $expected_option )
-												  ->once()
-												  ->andReturn( true );
+			->once()
+			->andReturn( true );
 
 		$instance = new Migration_Status();
 
@@ -220,11 +220,11 @@ class Migration_Status_Test extends TestCase {
 		$expected_option = [ 'version' => '1.0', 'lock' => strtotime( 'now' ) ];
 
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
-											   ->once()
-											   ->andReturn( [ 'version' => '1.0' ] );
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
 		Monkey\Functions\expect( 'update_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test', $expected_option )
-												  ->once()
-												  ->andReturn( true );
+			->once()
+			->andReturn( true );
 
 		$instance = new Migration_Status();
 

--- a/tests/presentations/abstract_presentation_test.php
+++ b/tests/presentations/abstract_presentation_test.php
@@ -88,7 +88,7 @@ class Abstract_Presentation_Test extends TestCase {
 	 */
 	public function test_get_throws_exception_when_accessing_property_on_prototype() {
 		$this->instance->expects( 'is_prototype' )
-					   ->andReturnFalse();
+			->andReturnFalse();
 
 		$this->instance->non_existing_property;
 	}

--- a/tests/presentations/indexable-post-type-presentation/robots-test.php
+++ b/tests/presentations/indexable-post-type-presentation/robots-test.php
@@ -43,9 +43,9 @@ class Robots_Test extends TestCase {
 			->andReturn( 'published' );
 
 		$this->post_type->expects( 'is_indexable' )
-							   ->once()
-							   ->with( 'post' )
-							   ->andReturn( true );
+			->once()
+			->with( 'post' )
+			->andReturn( true );
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [


### PR DESCRIPTION

## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Chained method calls should be indented one tab in from the start of the chain, with each line being allowed one tab (more/less) difference, if so desired, with the minimum staying at one tab in from the start of the chain.

Precision alignment for the indentation is not allowed.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.