### PR TITLE
CS: various whitespace fixes

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -338,8 +338,8 @@ class Yoast_Form {
 		'<label class="', $class, '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>',
 		'<input type="checkbox" aria-labelledby="', esc_attr( $var . '-label' ), '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $val, 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>',
 		'<span aria-hidden="true">
-			<span>', esc_html( $off_button ) ,'</span>
-			<span>', esc_html( $on_button ) ,'</span>
+			<span>', esc_html( $off_button ), '</span>
+			<span>', esc_html( $on_button ), '</span>
 			<a></a>
 		 </span>
 		 </label><div class="clear"></div></div>';
@@ -696,7 +696,7 @@ class Yoast_Form {
 			$key_esc = esc_attr( $key );
 			$for     = $var_esc . '-' . $key_esc;
 			echo '<input type="radio" id="' . $for . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $val, $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />',
-			'<label for="', $for, '">', esc_html( $value ), $screen_reader_text_html,'</label>';
+			'<label for="', $for, '">', esc_html( $value ), $screen_reader_text_html, '</label>';
 		}
 
 		echo '<a></a></div></fieldset><div class="clear"></div></div>' . PHP_EOL . PHP_EOL;

--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -54,7 +54,7 @@ if ( $tool_page === '' ) {
 		$attr = ( ! empty( $tool['attr'] ) ) ? $tool['attr'] : '';
 
 		echo '<li>';
-		echo '<strong><a href="', esc_url( $href ), '" ', esc_attr( $attr ) , '>', esc_html( $tool['title'] ), '</a></strong><br/>';
+		echo '<strong><a href="', esc_url( $href ), '" ', esc_attr( $attr ), '>', esc_html( $tool['title'] ), '</a></strong><br/>';
 		echo esc_html( $tool['desc'] );
 		echo '</li>';
 	}

--- a/deprecated/admin/links/class-link-compatibility-notifier.php
+++ b/deprecated/admin/links/class-link-compatibility-notifier.php
@@ -43,7 +43,7 @@ class WPSEO_Link_Compatibility_Notifier {
 	 */
 	protected function get_notification() {
 		_deprecated_function( __METHOD__, 'WPSEO 13.1' );
-		
+
 		return null;
 	}
 }

--- a/deprecated/admin/onpage/class-onpage-option.php
+++ b/deprecated/admin/onpage/class-onpage-option.php
@@ -14,7 +14,7 @@ _deprecated_file( __FILE__, 'WPSEO 13.2' );
  * @deprecated 13.2
  * @codeCoverageIgnore
  */
-class WPSEO_OnPage_Option extends WPSEO_Ryte_Option  {
+class WPSEO_OnPage_Option extends WPSEO_Ryte_Option {
 
 	/**
 	 * Setting the object by setting the properties.

--- a/deprecated/frontend/schema/class-schema-howto.php
+++ b/deprecated/frontend/schema/class-schema-howto.php
@@ -33,7 +33,7 @@ class WPSEO_Schema_HowTo extends HowTo implements WPSEO_Graph_Piece {
 	 * @deprecated 14.0
 	 */
 	public function __construct( $context = null ) {
-		 _deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\HowTo' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\HowTo' );
 
 		$memoizer      = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->context = $memoizer->for_current_page();

--- a/deprecated/frontend/schema/class-schema-main-image.php
+++ b/deprecated/frontend/schema/class-schema-main-image.php
@@ -27,7 +27,7 @@ class WPSEO_Schema_MainImage extends Main_Image implements WPSEO_Graph_Piece {
 	 * @deprecated 14.0
 	 */
 	public function __construct( $context = null ) {
-		 _deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Main_Image' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Main_Image' );
 
 		$memoizer      = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->context = $memoizer->for_current_page();

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -308,7 +308,6 @@ class WPSEO_Utils {
 		 * @param string $filtered The sanitized string.
 		 * @param string $str      The string prior to being sanitized.
 		 */
-
 		return apply_filters( 'sanitize_text_field', $filtered, $value );
 	}
 
@@ -690,7 +689,7 @@ class WPSEO_Utils {
 					$result = bccomp( $number1, $number2, $precision ); // Returns int 0, 1 or -1.
 				}
 				else {
-					$result = ( $number1 == $number2 ) ? 0 : ( ( $number1 > $number2 ) ? 1 : - 1 );
+					$result = ( $number1 == $number2 ) ? 0 : ( ( $number1 > $number2 ) ? 1 : -1 );
 				}
 				break;
 		}

--- a/integration-tests/test-class-wpseo-metabox.php
+++ b/integration-tests/test-class-wpseo-metabox.php
@@ -198,7 +198,7 @@ class WPSEO_Metabox_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @return array The data to use.
 	 */
-	public function save_metabox_field_provider( ) {
+	public function save_metabox_field_provider() {
 		return [
 			[
 				// Related issue for this case: https://github.com/Yoast/wordpress-seo/issues/14476.

--- a/migrations/20171228151840_WpYoastIndexable.php
+++ b/migrations/20171228151840_WpYoastIndexable.php
@@ -99,7 +99,7 @@ class WpYoastIndexable extends Ruckusing_Migration_Base {
 		// Open-Graph.
 		$indexable_table->column( 'open_graph_title', 'string', [ 'null' => true, 'limit' => 191 ] );
 		$indexable_table->column( 'open_graph_description', 'mediumtext', [ 'null' => true ] );
-		$indexable_table->column( 'open_graph_image',  'mediumtext', [ 'null' => true ] );
+		$indexable_table->column( 'open_graph_image', 'mediumtext', [ 'null' => true ] );
 		$indexable_table->column( 'open_graph_image_id', 'string', [ 'null' => true, 'limit' => 191 ] );
 		$indexable_table->column( 'open_graph_image_source', 'string', [ 'null' => true, 'limit' => 191 ] );
 		$indexable_table->column( 'open_graph_image_meta', 'text', [ 'null' => true ] );

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,7 +19,7 @@ use Yoast\WP\SEO\Main;
  * @return Main The main instance.
  */
 function YoastSEO() { // @codingStandardsIgnoreLine
- 	static $main;
+	static $main;
 
 	if ( $main === null ) {
 		$main = new Main();

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -84,7 +84,7 @@ class Post_Helper {
 			return $post_title;
 		}
 
-		return  __( 'No title', 'wordpress-seo' );
+		return __( 'No title', 'wordpress-seo' );
 	}
 
 	/**

--- a/src/integrations/front-end/force-rewrite-title.php
+++ b/src/integrations/front-end/force-rewrite-title.php
@@ -74,7 +74,7 @@ class Force_Rewrite_Title implements Integration_Interface {
 		}
 
 		add_action( 'template_redirect', [ $this, 'force_rewrite_output_buffer' ], 99999 );
-		add_action( 'wp_footer', [ $this, 'flush_cache' ], - 1 );
+		add_action( 'wp_footer', [ $this, 'flush_cache' ], -1 );
 	}
 
 	/**

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -59,7 +59,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 		Post_Type_Helper $post_type,
 		Date_Helper $date,
 		Pagination_Helper $pagination,
-	    Post_Helper $post
+		Post_Helper $post
 	) {
 		$this->post_type  = $post_type;
 		$this->date       = $date;

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -483,13 +483,13 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 */
 	public function generate_twitter_site() {
 		switch ( $this->context->site_represents ) {
-			case 'person' :
+			case 'person':
 				$twitter = $this->user->get_the_author_meta( 'twitter', (int) $this->context->site_user_id );
 				if ( empty( $twitter ) ) {
 					$twitter = $this->options->get( 'twitter_site' );
 				}
 				break;
-			case 'company' :
+			case 'company':
 			default:
 				$twitter = $this->options->get( 'twitter_site' );
 				break;

--- a/src/presenters/open-graph/site-name-presenter.php
+++ b/src/presenters/open-graph/site-name-presenter.php
@@ -35,6 +35,6 @@ class Site_Name_Presenter extends Abstract_Indexable_Tag_Presenter {
 		 *
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		return (string) \trim( \apply_filters( 'wpseo_opengraph_site_name',  $this->presentation->open_graph_site_name, $this->presentation ) );
+		return (string) \trim( \apply_filters( 'wpseo_opengraph_site_name', $this->presentation->open_graph_site_name, $this->presentation ) );
 	}
 }

--- a/src/presenters/robots-presenter.php
+++ b/src/presenters/robots-presenter.php
@@ -67,7 +67,7 @@ class Robots_Presenter extends Abstract_Indexable_Presenter {
 	 */
 	private function remove_defaults( array $robots ) {
 		if ( ! empty( $robots['index'] ) && $robots['index'] === 'index' &&
-		     ! empty( $robots['follow'] ) && $robots['follow'] === 'follow' ) {
+			! empty( $robots['follow'] ) && $robots['follow'] === 'follow' ) {
 			unset( $robots['index'], $robots['follow'] );
 		}
 

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -165,8 +165,8 @@ class Meta {
 			$presenter_namespace .= 'Open_Graph\\';
 			$parts = \array_slice( $parts, 2 );
 		}
-		$presenter_class = $presenter_namespace . implode( '_', array_map( 'ucfirst', $parts ) ) . '_Presenter';
 
+		$presenter_class = $presenter_namespace . implode( '_', array_map( 'ucfirst', $parts ) ) . '_Presenter';
 
 		if ( \class_exists( $presenter_class ) ) {
 			/**

--- a/src/values/images.php
+++ b/src/values/images.php
@@ -128,7 +128,7 @@ class Images {
 			$image = [ 'url' => $image ];
 		}
 
-		if ( ! is_array( $image ) || empty( $image['url'] ) || ! is_string( $image['url'] )  ) {
+		if ( ! is_array( $image ) || empty( $image['url'] ) || ! is_string( $image['url'] ) ) {
 			return;
 		}
 

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -251,7 +251,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 2, 'term' )->andReturn( $parent_indexable );
 
 		$this->post->expects( 'get_post' )->with( 1 )->andReturn(
-			(object) [ 'ID' => 1,'post_parent' => 0, 'post_type' => 'post' ]
+			(object) [ 'ID' => 1, 'post_parent' => 0, 'post_type' => 'post' ]
 		);
 
 		$this->instance->build( $indexable );

--- a/tests/database/migration-status-test.php
+++ b/tests/database/migration-status-test.php
@@ -119,7 +119,7 @@ class Migration_Status_Test extends TestCase {
 
 		$instance = new Migration_Status();
 
-		$this->assertTrue( $instance->is_version( 'test' , '1.0' ) );
+		$this->assertTrue( $instance->is_version( 'test', '1.0' ) );
 	}
 
 	/**
@@ -132,7 +132,7 @@ class Migration_Status_Test extends TestCase {
 
 		$instance = new Migration_Status();
 
-		$this->assertFalse( $instance->is_version( 'test' , '2.0' ) );
+		$this->assertFalse( $instance->is_version( 'test', '2.0' ) );
 	}
 
 	/**
@@ -145,7 +145,7 @@ class Migration_Status_Test extends TestCase {
 
 		$instance = new Migration_Status();
 
-		$this->assertFalse( $instance->is_version( 'test' , '2.0' ) );
+		$this->assertFalse( $instance->is_version( 'test', '2.0' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No space between a unary +/- and the integer.
* No space between  case condition and the colon.
* No space before a comma and exactly one space (or a new line) after.
* For empty parentheses, there should be no space between them.
* One space between the last part of a class declaration and the open brace.
* Exactly one space between a keyword and whatever follows it.
* No superfluous whitespace at the end of lines.
* Use tab indentation, not space.
* Don't use precision alignment.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.