### PR TITLE
Modernize: use nowdoc instead of heredoc

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -982,7 +982,7 @@ class WPSEO_Utils {
 	 * @return string
 	 */
 	public static function traffic_light_svg() {
-		return <<<SVG
+		return <<<'SVG'
 <svg class="yst-traffic-light init" version="1.1" xmlns="http://www.w3.org/2000/svg"
 	 role="img" aria-hidden="true" focusable="false"
 	 x="0px" y="0px" viewBox="0 0 30 47" enable-background="new 0 0 30 47" xml:space="preserve">

--- a/integration-tests/admin/import/test-class-import-settings.php
+++ b/integration-tests/admin/import/test-class-import-settings.php
@@ -55,7 +55,7 @@ class WPSEO_Import_Settings_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( true, WPSEO_Options::get( 'enable_admin_bar_menu' ) );
 
-		$settings = <<<EO_DATA
+		$settings = <<<'EO_DATA'
 ; These are settings for the Yoast SEO plugin by Yoast.com
 
 [wpseo]
@@ -79,7 +79,7 @@ EO_DATA;
 			$this->markTestSkipped( 'Not possible in PHP 5.2' );
 		}
 
-		$settings = <<<EO_DATA
+		$settings = <<<'EO_DATA'
 Not a valid INI file format...
 EO_DATA;
 


### PR DESCRIPTION
## Context

* Code modernization

## Summary

This PR can be summarized in the following changelog entry:

* Code modernization

## Relevant technical choices:

* No functional changes.

Nowdocs are to heredocs as double quoted strings are to single quoted strings.
In other words: the engine to find & interpolate variables won't kick in when a nowdoc is used, while it will for heredocs.

Nowdocs are available since PHP 5.3.

Ref: https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.nowdoc

@IreneStr Nothing too exiting about this PR, but if I remember correctly, this is the first PR of this kind, so felt like something to leave for review.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.