### PR TITLE
Docs: various fixes

### DIFF
--- a/admin/ryte/class-ryte.php
+++ b/admin/ryte/class-ryte.php
@@ -13,7 +13,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	/**
 	 * Is the request started by pressing the fetch button.
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	private $is_manual_request = false;
 

--- a/deprecated/frontend/class-opengraph.php
+++ b/deprecated/frontend/class-opengraph.php
@@ -259,7 +259,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @deprecated 14.0
 	 * @codeCoverageIgnore
-
+	 *
 	 * @param string|bool $image Optional. Image URL.
 	 *
 	 * @return void

--- a/integration-tests/frontend/test-class-wpseo-image-utils.php
+++ b/integration-tests/frontend/test-class-wpseo-image-utils.php
@@ -75,12 +75,12 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @dataProvider get_data_provider
 	 *
+	 * @covers \WPSEO_Image_Utils::get_data
+	 *
 	 * @param mixed   $image         The image data.
 	 * @param mixed   $expected      Expected value.
 	 * @param integer $attachment_id The attachment id.
 	 * @param string  $message       Message to show when test fails.
-	 *
-	 * @covers WPSEO_Image_Utils::get_data
 	 */
 	public function test_get_data( $image, $expected, $attachment_id, $message ) {
 		$this->assertEquals(
@@ -156,13 +156,13 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests if the absolute path is working as expected.
 	 *
+	 * @dataProvider data_get_absolute_path
+	 *
 	 * @covers \WPSEO_Image_Utils::get_absolute_path
 	 *
 	 * @param string $input    Data to use in execution.
 	 * @param string $expected Expected result.
 	 * @param string $message  Description of the tested data.
-	 *
-	 * @dataProvider data_get_absolute_path
 	 */
 	public function test_absolute_path( $input, $expected, $message = '' ) {
 		$result = WPSEO_Image_Utils::get_absolute_path( $input );

--- a/integration-tests/test-class-wpseo-utils.php
+++ b/integration-tests/test-class-wpseo-utils.php
@@ -233,6 +233,9 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	 * @dataProvider sanitize_url_provider
 	 *
 	 * @covers WPSEO_Utils::sanitize_url
+	 *
+	 * @param string $expected        Expected function outcome.
+	 * @param string $url_to_sanitize Input to pass to the function under test.
 	 */
 	public function test_sanitize_url( $expected, $url_to_sanitize ) {
 		$this->assertEquals( $expected, WPSEO_Utils::sanitize_url( $url_to_sanitize ) );

--- a/integration-tests/test-class-wpseo-utils.php
+++ b/integration-tests/test-class-wpseo-utils.php
@@ -257,7 +257,7 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 				'expected'        => 'https://example.com/%da%af%d8%b1%d9%88%d9%87-%d8%aa%d9%84%da%af%d8%b1%d8%a7%d9%85-%d8%b3%d8%a6%d9%88',
 				'url_to_sanitize' => 'https://example.com/گروه-تلگرام-سئو',
 			],
-			// https://github.com/Yoast/wordpress-seo/issues/7664.
+			// Related issue: https://github.com/Yoast/wordpress-seo/issues/7664.
 			'invalid_url'                    => [
 				'expected'        => '',
 				'url_to_sanitize' => 'WordPress',

--- a/src/builders/indexable-social-image-trait.php
+++ b/src/builders/indexable-social-image-trait.php
@@ -43,7 +43,7 @@ trait Indexable_Social_Image_Trait {
 	 *
 	 * @required
 	 *
-	 * @param Image_Helper            $image     The image helper.
+	 * @param Image_Helper            $image            The image helper.
 	 * @param Open_Graph_Image_Helper $open_graph_image The Open Graph image helper.
 	 * @param Twitter_Image_Helper    $twitter_image    The Twitter image helper.
 	 */

--- a/src/helpers/user-helper.php
+++ b/src/helpers/user-helper.php
@@ -30,9 +30,9 @@ class User_Helper {
 	/**
 	 * Counts the number of posts the user has written in this post type.
 	 *
-	 * @param int          $user_id     User ID.
-	 * @param array|string $post_type   Optional. Single post type or array of post types to count the number of posts
-	 *                                  for. Default 'post'.
+	 * @param int          $user_id   User ID.
+	 * @param array|string $post_type Optional. Single post type or array of post types to count the number of posts
+	 *                                for. Default 'post'.
 	 *
 	 * @codeCoverageIgnore It only wraps a WordPress function.
 	 *
@@ -45,7 +45,7 @@ class User_Helper {
 	/**
 	 * Retrieves the requested data of the author.
 	 *
-	 * @param string    $field  The user field to retrieve.
+	 * @param string    $field   The user field to retrieve.
 	 * @param int|false $user_id User ID.
 	 *
 	 * @codeCoverageIgnore It only wraps a WordPress function.

--- a/src/integrations/front-end/comment-link-fixer.php
+++ b/src/integrations/front-end/comment-link-fixer.php
@@ -44,7 +44,7 @@ class Comment_Link_Fixer implements Integration_Interface {
 	 * @codeCoverageIgnore It only sets depedencies.
 	 *
 	 * @param Redirect_Helper $redirect The redirect helper.
-	 * @param Robots_Helper   $robots The robots helper.
+	 * @param Robots_Helper   $robots   The robots helper.
 	 */
 	public function __construct(
 		Redirect_Helper $redirect, Robots_Helper $robots

--- a/src/integrations/front-end/force-rewrite-title.php
+++ b/src/integrations/front-end/force-rewrite-title.php
@@ -27,7 +27,7 @@ class Force_Rewrite_Title implements Integration_Interface {
 	/**
 	 * Toggle indicating whether output buffering has been started.
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	private $ob_started = false;
 

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -99,11 +99,11 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	 *
 	 * @dataProvider generate_provider
 	 *
-	 * @param string $scenario           The scenario to test.
-	 * @param int    $page_for_posts     ID for page for posts option.
-	 * @param bool   $breadcrumb_home    Show the home breadcrumbs.
-	 * @param int    $front_page_id      The front page ID.
-	 * @param string $message            Message to show when test fails.
+	 * @param string $scenario        The scenario to test.
+	 * @param int    $page_for_posts  ID for page for posts option.
+	 * @param bool   $breadcrumb_home Show the home breadcrumbs.
+	 * @param int    $front_page_id   The front page ID.
+	 * @param string $message         Message to show when test fails.
 	 */
 	public function test_generate( $scenario, $page_for_posts, $breadcrumb_home, $front_page_id, $message ) {
 		$this->set_scenario( $scenario );

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -276,8 +276,6 @@ class Article_Test extends TestCase {
 	/**
 	 * Tests adding terms to the data array when the terms are a non-empty array.
 	 *
-	 * @param array $terms The terms.
-	 *
 	 * @covers ::add_terms
 	 */
 	public function test_add_terms_happy_path() {
@@ -305,8 +303,6 @@ class Article_Test extends TestCase {
 	/**
 	 * Tests adding terms to the data array when the terms are not an array.
 	 *
-	 * @param array $terms The terms.
-	 *
 	 * @covers ::add_terms
 	 */
 	public function test_add_terms_not_array() {
@@ -324,8 +320,6 @@ class Article_Test extends TestCase {
 
 	/**
 	 * Tests adding terms to the data array when the terms are an empty array.
-	 *
-	 * @param array $terms The terms.
 	 *
 	 * @covers ::add_terms
 	 */

--- a/tests/helpers/schema/image-helper-test.php
+++ b/tests/helpers/schema/image-helper-test.php
@@ -24,7 +24,6 @@ class Image_Helper_Test extends TestCase {
 	 * The instance to test.
 	 *
 	 * @var Image_Helper|Mockery\MockInterface
-	 * @var Image_Helper|Mockery\MockInterface
 	 */
 	private $instance;
 


### PR DESCRIPTION
## Context

* Improve documentation

## Summary

This PR can be summarized in the following changelog entry:

* Improve documentation

## Relevant technical choices:

* Docs: fix tag order
* Docs: use short form types
    `bool` instead of `boolean`, `int` instead of `integer`.
* Docs: docblock format fix
* Docs: add missing parameter tags
* Docs: minor tweaks
* Docs: fix tag alignment
* Docs: remove duplicate `@var` tag
* Docs: remove superfluous `@param` tags
    These methods don't take parameters.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.