### PR TITLE
QA: fix namespaces (user facing)

### DIFF
--- a/deprecated/frontend/schema/class-schema-article.php
+++ b/deprecated/frontend/schema/class-schema-article.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\Article;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema Article data.

--- a/deprecated/frontend/schema/class-schema-author.php
+++ b/deprecated/frontend/schema/class-schema-author.php
@@ -7,7 +7,7 @@
 
 use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Generators\Schema\Author;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema Person data.

--- a/deprecated/frontend/schema/class-schema-breadcrumb.php
+++ b/deprecated/frontend/schema/class-schema-breadcrumb.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\Breadcrumb;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema Breadcrumb data.

--- a/deprecated/frontend/schema/class-schema-faq.php
+++ b/deprecated/frontend/schema/class-schema-faq.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\FAQ;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema FAQ data.

--- a/deprecated/frontend/schema/class-schema-howto.php
+++ b/deprecated/frontend/schema/class-schema-howto.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\HowTo;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema FAQ data.

--- a/deprecated/frontend/schema/class-schema-main-image.php
+++ b/deprecated/frontend/schema/class-schema-main-image.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\Main_Image;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns ImageObject schema data.

--- a/deprecated/frontend/schema/class-schema-organization.php
+++ b/deprecated/frontend/schema/class-schema-organization.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\Organization;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema Organization data.

--- a/deprecated/frontend/schema/class-schema-person.php
+++ b/deprecated/frontend/schema/class-schema-person.php
@@ -7,7 +7,7 @@
 
 use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Generators\Schema\Person;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema Person data.

--- a/deprecated/frontend/schema/class-schema-webpage.php
+++ b/deprecated/frontend/schema/class-schema-webpage.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\WebPage;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema WebPage data.

--- a/deprecated/frontend/schema/class-schema-website.php
+++ b/deprecated/frontend/schema/class-schema-website.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Generators\Schema\Website;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Returns schema Website data.

--- a/src/backwards-compatibility/breadcrumbs.php
+++ b/src/backwards-compatibility/breadcrumbs.php
@@ -7,7 +7,7 @@
 
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Initializers\Initializer_Interface;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 

--- a/src/backwards-compatibility/frontend.php
+++ b/src/backwards-compatibility/frontend.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Initializers\Initializer_Interface;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Canonical_Presenter;
 use Yoast\WP\SEO\Presenters\Meta_Description_Presenter;
 use Yoast\WP\SEO\Presenters\Rel_Next_Presenter;

--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -9,7 +9,7 @@ namespace Yoast\WP\SEO\Integrations;
 
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Integrations;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 use Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter;
 use Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter;

--- a/src/main.php
+++ b/src/main.php
@@ -8,7 +8,7 @@
 namespace Yoast\WP\SEO;
 
 use Exception;
-use Yoast\WP\Free\Surfaces\Meta_Surface;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Dependency_Injection\Container_Compiler;
 use Yoast\WP\SEO\Generated\Cached_Container;
 use Yoast\WP\SEO\Surfaces\Classes_Surface;

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -5,7 +5,7 @@
  * @package Yoast\YoastSEO\Memoizers
  */
 
-namespace Yoast\WP\SEO\Memoizer;
+namespace Yoast\WP\SEO\Memoizers;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Blocks_Helper;

--- a/src/memoizers/presentation-memoizer.php
+++ b/src/memoizers/presentation-memoizer.php
@@ -5,7 +5,7 @@
  * @package Yoast\YoastSEO\Memoizers
  */
 
-namespace Yoast\WP\SEO\Memoizer;
+namespace Yoast\WP\SEO\Memoizers;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Models\Indexable;

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -11,7 +11,7 @@ use Exception;
 use Yoast\WP\SEO\Surfaces\Values\Meta;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -5,10 +5,10 @@
  * @package Yoast\YoastSEO\Surfaces
  */
 
-namespace Yoast\WP\Free\Surfaces;
+namespace Yoast\WP\SEO\Surfaces;
 
 use Exception;
-use Yoast\WP\Free\Surfaces\Values\Meta;
+use Yoast\WP\SEO\Surfaces\Values\Meta;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -5,7 +5,7 @@
  * @package Yoast\YoastSEO\Surfaces\Values
  */
 
-namespace Yoast\WP\Free\Surfaces\Values;
+namespace Yoast\WP\SEO\Surfaces\Values;
 
 use Exception;
 use WPSEO_Replace_Vars;

--- a/tests/integrations/breadcrumbs-integration-test.php
+++ b/tests/integrations/breadcrumbs-integration-test.php
@@ -8,7 +8,7 @@ use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Breadcrumbs_Enabled_Conditional;
 use Yoast\WP\SEO\Integrations\Breadcrumbs_Integration;
 use Yoast\WP\SEO\Main;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Title_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\TestCase;

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -6,7 +6,7 @@
  */
 
 use Brain\Monkey;
-use Yoast\WP\Free\Surfaces\Meta_Surface;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -7,7 +7,7 @@
 
 use Brain\Monkey;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
-use Yoast\WP\SEO\Memoizer\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

:warning: **Once this PR is merged, everyone working with the codebase needs to do a `composer dump-autoload` to refresh their Composer autoload classmap!** :warning:

:question: Should this PR be backported to the `14.0` release ? /cc @IreneStr 

### QA: fix incorrect namespace x 2 (memoizer)

Both the classes in the `src/memoizers` folder used `Memoizer` in the namespace, instead of the expected `Memoizers` (note: plural).

Fixed now, including all uses of these.

### QA: fix incorrect namespace x 2 (surfaces)

Both the `Surfaces\Meta_Surface` class as well as the `Surfaces\Values\Meta` class, used the wrong namespace prefix.

Fixed now, including all uses of these.


## Test instructions

This PR can be tested by following these steps:
* Check out this branch and run `composer dump-autoload`.
* Load pages using the Memoizer/Surfaces functionality and see them work as expected, without any fatal errors.