### PR TITLE
Fix schema page type not being able to handle the system pages

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -371,8 +371,14 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 */
 	public function generate_schema_page_type() {
 		switch ( $this->indexable->object_type ) {
-			case 'search-result':
-				$type = 'SearchResultsPage';
+			case 'system-page':
+				switch ( $this->indexable->object_sub_type ) {
+					case 'search-result':
+						$type = 'SearchResultsPage';
+						break;
+					default:
+						$type = 'WebPage';
+				}
 				break;
 			case 'user':
 				$type = [ 'ProfilePage', 'WebPage' ];

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -21,7 +21,7 @@ class WebPage extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
-		return $this->context->indexable->object_type !== 'system-page' && $this->context->indexable->object_sub_type !== '404';
+		return ! ( $this->context->indexable->object_type === 'system-page' && $this->context->indexable->object_sub_type === '404' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A search page should have WebPage schema output of the type `SearchResultsPage`.
* This is the fix for author archives and error pages https://github.com/Yoast/wordpress-seo/pull/14364

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the WebPage schema was not being output on a search page.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Navigate to a Search Page on your website.
* Check Schema for the Search Page.
* Ensure that `@type` is `SearchResultsPage` and the `@id` ends with `#webpage`. Like in the before screenshot of the issue.

### Quick regression check (copied from original PR)
* Go to an author archive page (e.g. http://basic.wordpress.test/author/admin/).
* Check the Schema that is output in the source code.
   * It **should** contain a node with an `@type` property of `[ 'WebPage', 'ProfilePage' ]`.
   * It's `Person` node **should** have a `mainEntityOfPage` property.
      * This property should have an `@id` property referencing the id of the `[ 'WebPage', 'ProfilePage' ]` node.
* Go to a non-existing page (e.g. http://basic.wordpress.test/awgoawgoawbwgo)
  * Check the Schema that is output in the source code.
  * It should **not** have a `WebPage` node.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14764 
