### PR TITLE
Sets the type for term archives to article

### DIFF
--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -172,6 +172,13 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	public function generate_open_graph_type() {
+		return 'article';
+	}
+
+	/**
 	 * Checks if term archive query is for multiple terms (/term-1,term-2/ or /term-1+term-2/).
 	 *
 	 * @return bool Whether the query contains multiple terms.

--- a/tests/presentations/indexable-term-archive-presentation/open-graph-type-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/open-graph-type-test.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Term_Archive_Presentation;
+
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Open_Graph_Description_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation
+ *
+ * @group presentations
+ * @group open-graph
+ */
+class Open_Graph_Type_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->set_instance();
+	}
+
+	/**
+	 * Tests the situation where the Open Graph type is given.
+	 *
+	 * @covers ::generate_open_graph_type
+	 */
+	public function test_generate_open_graph_type() {
+		$this->assertEquals( 'article', $this->instance->generate_open_graph_type() );
+	}
+}

--- a/tests/presentations/indexable-term-archive-presentation/open-graph-type-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/open-graph-type-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Term_Archive_Presentation;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Open_Graph_Description_Test
+ * Class Open_Graph_Type_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation
  *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The OG:type for a term archive has to be `article`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Fixes a 'bug' that the wrong OG:type is rendered.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Visit a term archive and see in the source that the `og:type` is set to `article`. On the release branch it is `website`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14774 
