### PR TITLE
Remove hyphen from the beginning of a PHP file.

### DIFF
--- a/admin/views/partial-notifications-errors.php
+++ b/admin/views/partial-notifications-errors.php
@@ -1,4 +1,4 @@
--<?php
+<?php
 /**
  * WPSEO plugin file.
  *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix a typo

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Removes a hyphen introduced in a typo in https://github.com/Yoast/wordpress-seo/commit/d4f539f34f40f282051a8807599d5755870de9f9

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- go to the SEO Dashboard
- see there's a hyphen before the "Problems" heading (refer to the screenshot on the issue)
- switch to this branch
- see the hyphen is gone 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14776
