### PR TITLE
Move and adapt the site represents current author to person from author

### DIFF
--- a/deprecated/frontend/schema/class-schema-author.php
+++ b/deprecated/frontend/schema/class-schema-author.php
@@ -26,6 +26,13 @@ class WPSEO_Schema_Author extends Author implements WPSEO_Graph_Piece {
 	protected $image_hash = Schema_IDs::AUTHOR_LOGO_HASH;
 
 	/**
+	 * The Schema type we use for this class.
+	 *
+	 * @var string[]
+	 */
+	protected $type = [ 'Person' ];
+
+	/**
 	 * WPSEO_Schema_Author constructor.
 	 *
 	 * @param null $context The context. No longer used but present for BC.

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -47,8 +47,9 @@ class Author extends Person {
 
 		$data = $this->build_person_data( $user_id );
 
-		if ( ! $this->site_represents_current_author() ) {
+		if ( $this->site_represents_current_author() === false ) {
 			$data['@type'] = [ 'Person' ];
+			unset( $data['logo'] );
 		}
 
 		// If this is an author page, the Person object is the main object, so we set it as such here.

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -15,13 +15,6 @@ use Yoast\WP\SEO\Config\Schema_IDs;
 class Author extends Person {
 
 	/**
-	 * The Schema type we use for this class.
-	 *
-	 * @var string[]
-	 */
-	protected $type = [ 'Person' ];
-
-	/**
 	 * Determine whether we should return Person schema.
 	 *
 	 * @return bool
@@ -35,11 +28,6 @@ class Author extends Person {
 			$this->context->indexable->object_type === 'post' &&
 			$this->helpers->schema->article->is_article_post_type( $this->context->indexable->object_sub_type )
 		) {
-			// If the author is the user the site represents, no need for an extra author block.
-			if ( parent::is_needed() ) {
-				return (int) $this->context->post->post_author !== $this->context->site_user_id;
-			}
-
 			return true;
 		}
 
@@ -58,6 +46,10 @@ class Author extends Person {
 		}
 
 		$data = $this->build_person_data( $user_id );
+
+		if ( ! $this->site_represents_current_author() ) {
+			$data['@type'] = [ 'Person' ];
+		}
 
 		// If this is an author page, the Person object is the main object, so we set it as such here.
 		if ( $this->context->indexable->object_type === 'user' ) {
@@ -105,11 +97,13 @@ class Author extends Person {
 	 * @param array  $data      The Person schema.
 	 * @param string $schema_id The string used in the `@id` for the schema.
 	 *
-	 * @codeCoverageIgnore Wrapper method, only returns `$data` argument.
-	 *
 	 * @return array The Person schema.
 	 */
 	protected function set_image_from_options( $data, $schema_id ) {
+		if ( $this->site_represents_current_author() ) {
+			return parent::set_image_from_options( $data, $schema_id );
+		}
+
 		return $data;
 	}
 }

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -44,6 +44,11 @@ class Person extends Abstract_Schema_Piece {
 	 * @return bool
 	 */
 	public function is_needed() {
+		// Using an author piece instead.
+		if ( $this->site_represents_current_author() ) {
+			return false;
+		}
+
 		return $this->context->site_represents === 'person' || $this->context->indexable->object_type === 'user';
 	}
 
@@ -241,5 +246,28 @@ class Person extends Abstract_Schema_Piece {
 		}
 
 		return $url;
+	}
+
+	/**
+	 * Checks the site is represented by the same person as this indexable.
+	 *
+	 * @return bool True when the site is represented by the same person as this indexable.
+	 */
+	protected function site_represents_current_author() {
+		// Can only be the case when the site represents a user.
+		if ( $this->context->site_represents !== 'person' ) {
+			return false;
+		}
+
+		// Article post from the same user as the site represents.
+		if (
+			$this->context->indexable->object_type === 'post' &&
+			$this->helpers->schema->article->is_article_post_type( $this->context->indexable->object_sub_type )
+		) {
+			return $this->context->site_user_id === $this->context->indexable->author_id;
+		}
+
+		// Author archive from the same user as the site represents.
+		return $this->context->indexable->object_type === 'user' && $this->context->site_user_id === $this->context->indexable->object_id;
 	}
 }

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -6,7 +6,6 @@ use Brain\Monkey\Expectation\Exception\ExpectationArgsRequired;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
-use PhpParser\Node\Expr\Cast\Object_;
 use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
@@ -210,7 +209,7 @@ class Author_Test extends TestCase {
 		$object_id       = 1234;
 		$user_data       = (object) [
 			'display_name' => $this->person_data['name'],
-			'user_email'   => 'bla@example.org'
+			'user_email'   => 'bla@example.org',
 		];
 
 		$this->instance->context->site_represents = 'person';
@@ -249,7 +248,7 @@ class Author_Test extends TestCase {
 			[
 				'facebook'  => 'https://facebook.example.org/admin',
 				'instagram' => 'https://instagram.example.org/admin',
-				'linkedin'  => 'https://linkedin.example.org/admin'
+				'linkedin'  => 'https://linkedin.example.org/admin',
 			]
 		);
 

--- a/tests/generators/schema/person-test.php
+++ b/tests/generators/schema/person-test.php
@@ -13,6 +13,7 @@ use Mockery;
 use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Generators\Schema\Person;
 use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper as Schema_Image_Helper;
@@ -67,9 +68,10 @@ class Person_Test extends TestCase {
 		$this->instance->helpers            = (object) [
 			'image'  => Mockery::mock( Image_Helper::class ),
 			'schema' => (object) [
-				'id'    => Mockery::mock( ID_Helper::class ),
-				'image' => Mockery::mock( Schema_Image_Helper::class ),
-				'html'  => Mockery::mock( HTML_Helper::class ),
+				'article' => Mockery::mock( Article_Helper::class ),
+				'id'      => Mockery::mock( ID_Helper::class ),
+				'image'   => Mockery::mock( Schema_Image_Helper::class ),
+				'html'    => Mockery::mock( HTML_Helper::class ),
 			],
 		];
 	}
@@ -387,6 +389,7 @@ class Person_Test extends TestCase {
 	 * Tests whether the person Schema piece is shown when the site represents a person.
 	 *
 	 * @covers ::is_needed
+	 * @covers ::site_represents_current_author
 	 */
 	public function test_is_shown_when_site_represents_person() {
 		$this->instance->context->site_represents = 'person';
@@ -398,6 +401,7 @@ class Person_Test extends TestCase {
 	 * Tests whether the person Schema piece is shown on author archive pages.
 	 *
 	 * @covers ::is_needed
+	 * @covers ::site_represents_current_author
 	 */
 	public function test_is_shown_on_author_archive_pages() {
 		$this->instance->context->indexable = (Object) [
@@ -408,15 +412,37 @@ class Person_Test extends TestCase {
 	}
 
 	/**
-	 * Tests is not needed.
+	 * Tests is not needed when the site represents an organization.
 	 *
 	 * @covers ::is_needed
+	 * @covers ::site_represents_current_author
 	 */
-	public function test_is_not_needed() {
+	public function test_is_not_needed_site_represents_organization() {
 		$this->instance->context->site_represents        = 'organization';
 		$this->instance->context->indexable->object_type = 'post';
 
-		$this->assertFalse( $this->instance->is_needed( $this->instance->context ) );
+		$this->assertFalse( $this->instance->is_needed() );
+	}
+
+	/**
+	 * Tests is not needed on a post with the same author as the site represents.
+	 *
+	 * @covers ::is_needed
+	 * @covers ::site_represents_current_author
+	 */
+	public function test_is_not_needed_post_with_same_author_as_site_represents() {
+		$this->instance->context->site_represents            = 'person';
+		$this->instance->context->site_user_id               = 1;
+		$this->instance->context->indexable->author_id       = 1;
+		$this->instance->context->indexable->object_type     = 'post';
+		$this->instance->context->indexable->object_sub_type = 'post';
+
+		$this->instance->helpers->schema->article
+			->expects( 'is_article_post_type' )
+			->with( $this->instance->context->indexable->object_sub_type )
+			->andReturn( true );
+
+		$this->assertFalse( $this->instance->is_needed() );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

### Before
We output a `person` piece because the site represents a `person`.
  * This has the extra type `Organization`.
  * This has the `logo` property, which can be changed on the site.
  * This has the social profiles `sameAs`.
We output another `person` piece (through Author) because the author archive is from that `person`.
  * This is the holder of the `mainEntitiyOfPage` pointing to the `WebPage`.
  * This is a WP user and can only have Gravatar logo, which is why the images are different in this issue.
### After on author archive page where the site represents that author
We output a `person` piece because the site represents a `person`.
  * This has the extra type `Organization`.
  * This has the `logo` property, which can be changed on the site.
  * This has the social profiles `sameAs`.
  * This is the holder of the `mainEntitiyOfPage` pointing to the `WebPage`.
  * This has the `image` property, which can be changed on the site.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an almost duplicate person schema piece was output when on an author archive page on a site that represents that author. 

## Relevant technical choices:

* Also changed the duplicate prevention of the author for posts. And removing the type declaration in author. This was needed to be able to still generate the original person schema data.
* **Note** Google's Structured Data Testing Tool shows the graph different than before due to the order change in the array. Before the (site represents) Person piece was on top, now it is at the bottom. This was discussed with Jono and found to be acceptable. The schema itself is okay.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set Knowledge graph to Person and upload logo:
<img width="614" alt="Screenshot 2020-04-07 at 09 49 36" src="https://user-images.githubusercontent.com/19681708/78643789-1b42d580-78b5-11ea-82b4-47e4b6cb8cdb.png">

* Under `Users` --> `Your profile`, set some social media URLs.

### Test the author archives from the site represent author
* Browse to author archive `/author/admin/` and grab schema.
* There should no longer be two `@type` `Person` entries in the graph, only one and it should have:
  * ...the extra type `Organization`.
  * ... the `logo` property, which can be changed on the site.
  * ...the social profiles `sameAs`.
  * ...the `mainEntitiyOfPage` pointing to the `WebPage`.
  * ...the `image` property, which can be changed on the site.
<details><summary>It should look something like this</summary>

```json
{
  "@type": [
    "Person",
    "Organization"
  ],
  "@id": "http://basic.wordpress.test/#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21",
  "name": "admin",
  "image": {
    "@type": "ImageObject",
    "@id": "http://basic.wordpress.test/#personlogo",
    "inLanguage": "en-US",
    "url": "http://basic.wordpress.test/wp-content/uploads/2020/02/cookie-monster.jpg",
    "width": 400,
    "height": 400,
    "caption": "admin"
  },
  "logo": {
    "@id": "http://basic.wordpress.test/#personlogo"
  },
  "sameAs": [
    "http://basic.wordpress.text/kn\u00e4ckebr\u00f6d"
  ],
  "mainEntityOfPage": {
    "@id": "http://basic.wordpress.test/author/admin/#webpage"
  }
}
```
</details>

### Regression tests
#### Test a post by the site represents author
* Browse to a post from the admin and grab the schema.
* The only difference should be that the person piece moved down in the graph array. It should look the same as above.
#### Test the author archives from an author that does not represent the site
* Browse to author archive `/author/someauthor/` and grab the schema.
* There should be no difference in schema output caused by this PR.
#### Test a post by an author that does not represent the site
* Browse to a post from that author and grab the schema.
* There should be no difference in schema output caused by this PR.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14762
