### PR TITLE
Remove redundant isset checks for non-static replacement variables.

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -284,11 +284,11 @@ class WPSEO_Replace_Vars {
 		if ( ! empty( $this->args->ID ) ) {
 			$cat = $this->get_terms( $this->args->ID, 'category' );
 			if ( $cat !== '' ) {
-				$replacement = $cat;
+				return $cat;
 			}
 		}
 
-		if ( ( ! isset( $replacement ) || $replacement === '' ) && ( isset( $this->args->cat_name ) && ! empty( $this->args->cat_name ) ) ) {
+		if ( isset( $this->args->cat_name ) && ! empty( $this->args->cat_name ) ) {
 			$replacement = $this->args->cat_name;
 		}
 
@@ -391,7 +391,7 @@ class WPSEO_Replace_Vars {
 	private function retrieve_parent_title() {
 		$replacement = null;
 
-		if ( ! isset( $replacement ) && ( ( is_singular() || is_admin() ) && isset( $GLOBALS['post'] ) ) ) {
+		if ( ( is_singular() || is_admin() ) && isset( $GLOBALS['post'] ) ) {
 			if ( isset( $GLOBALS['post']->post_parent ) && $GLOBALS['post']->post_parent !== 0 ) {
 				$replacement = get_the_title( $GLOBALS['post']->post_parent );
 			}
@@ -408,11 +408,9 @@ class WPSEO_Replace_Vars {
 	private function retrieve_searchphrase() {
 		$replacement = null;
 
-		if ( ! isset( $replacement ) ) {
-			$search = get_query_var( 's' );
-			if ( $search !== '' ) {
-				$replacement = esc_html( $search );
-			}
+		$search = get_query_var( 's' );
+		if ( $search !== '' ) {
+			$replacement = esc_html( $search );
 		}
 
 		return $replacement;
@@ -429,6 +427,9 @@ class WPSEO_Replace_Vars {
 
 	/**
 	 * Retrieve the site's tag line / description for use as replacement string.
+	 *
+	 * The `$replacement` variable is static because it doesn't change depending
+	 * on the context. See https://github.com/Yoast/wordpress-seo/pull/1172#issuecomment-46019482.
 	 *
 	 * @return string|null
 	 */
@@ -447,6 +448,9 @@ class WPSEO_Replace_Vars {
 
 	/**
 	 * Retrieve the site's name for use as replacement string.
+	 *
+	 * The `$replacement` variable is static because it doesn't change depending
+	 * on the context. See https://github.com/Yoast/wordpress-seo/pull/1172#issuecomment-46019482.
 	 *
 	 * @return string|null
 	 */
@@ -766,6 +770,9 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieve the current date for use as replacement string.
 	 *
+	 * The `$replacement` variable is static because it doesn't change depending
+	 * on the context. See https://github.com/Yoast/wordpress-seo/pull/1172#issuecomment-46019482.
+	 *
 	 * @return string The formatted current date.
 	 */
 	private function retrieve_currentdate() {
@@ -780,6 +787,9 @@ class WPSEO_Replace_Vars {
 
 	/**
 	 * Retrieve the current day for use as replacement string.
+	 *
+	 * The `$replacement` variable is static because it doesn't change depending
+	 * on the context. See https://github.com/Yoast/wordpress-seo/pull/1172#issuecomment-46019482.
 	 *
 	 * @return string The current day.
 	 */
@@ -796,6 +806,9 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieve the current month for use as replacement string.
 	 *
+	 * The `$replacement` variable is static because it doesn't change depending
+	 * on the context. See https://github.com/Yoast/wordpress-seo/pull/1172#issuecomment-46019482.
+	 *
 	 * @return string The current month.
 	 */
 	private function retrieve_currentmonth() {
@@ -811,6 +824,9 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieve the current time for use as replacement string.
 	 *
+	 * The `$replacement` variable is static because it doesn't change depending
+	 * on the context. See https://github.com/Yoast/wordpress-seo/pull/1172#issuecomment-46019482.
+	 *
 	 * @return string The formatted current time.
 	 */
 	private function retrieve_currenttime() {
@@ -825,6 +841,9 @@ class WPSEO_Replace_Vars {
 
 	/**
 	 * Retrieve the current year for use as replacement string.
+	 *
+	 * The `$replacement` variable is static because it doesn't change depending
+	 * on the context. See https://github.com/Yoast/wordpress-seo/pull/1172#issuecomment-46019482.
 	 *
 	 * @return string The current year.
 	 */
@@ -1430,7 +1449,7 @@ class WPSEO_Replace_Vars {
 	private function retrieve_term_hierarchy() {
 		$replacement = null;
 
-		if ( ! isset( $replacement ) && isset( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
+		if ( isset( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
 			$hierarchy = $this->get_term_hierarchy();
 
 			if ( $hierarchy !== '' ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Technical debt PR.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Cleans-up code for non-static replacement variables.

## Relevant technical choices:

* See rationale on the issue: https://github.com/Yoast/wordpress-seo/issues/14588#issuecomment-610872050

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- install and activate Classic Editor because it seems some replacement variables don't work in Gutenberg e.g. "Category", see https://github.com/Yoast/bugreports/issues/952
- edit a post
- add the `Category` replacement variable to both the post title and description
- check it works as expected
- edit a Page that is a sub-page of another page
- add the `Parent title` replacement variable to both the post title and description
- check it works as expected
- edit a Category that is a sub-category of another category 
- add the `Term hierarchy` replacement variable to both the post title and description
- check it works as expected
- go to the Front end and do a search
- verify the document title is rendered accordingly to the expected format i.e. the one defined under SEO > Search appearance > Archives > Special pages > Search pages
- the expected default format is: `You searched for %%searchphrase%% %%page%% %%sep%% %%sitename%%`
- Note: `%%page%%` will output something only if there are more than 10 results and you're on a search results page other than the first one 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14588