### PR TITLE
Add MySQLi default socket to config

### DIFF
--- a/src/initializers/database-setup.php
+++ b/src/initializers/database-setup.php
@@ -81,6 +81,9 @@ class Database_Setup implements Initializer_Interface {
 		if ( empty( $port ) ) {
 			$port = 3306;
 		}
+		if ( empty( $socket ) ) {
+			$socket = ini_get( 'mysqli.default_socket' );
+		}
 
 		return [
 			'host'   => $host,


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the `mysqli.default_socket` setting to the database config in order to support database that make connection using defaults rather than explicit config.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* @Djennez can test this.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14791 
