### PR TITLE
Hide googlebot when robots noindex

### DIFF
--- a/src/presenters/googlebot-presenter.php
+++ b/src/presenters/googlebot-presenter.php
@@ -20,7 +20,7 @@ class Googlebot_Presenter extends Abstract_Indexable_Presenter {
 	 * @return string The googlebot output tag.
 	 */
 	public function present() {
-		if ( $this->presentation->model->is_robots_noindex === true ) {
+		if ( \in_array( 'noindex', $this->presentation->robots, true ) ) {
 			return '';
 		}
 

--- a/src/presenters/googlebot-presenter.php
+++ b/src/presenters/googlebot-presenter.php
@@ -20,6 +20,10 @@ class Googlebot_Presenter extends Abstract_Indexable_Presenter {
 	 * @return string The googlebot output tag.
 	 */
 	public function present() {
+		if ( $this->presentation->model->is_robots_noindex === true ) {
+			return '';
+		}
+
 		$googlebot = \implode( ', ', $this->get() );
 		$googlebot = $this->filter( $googlebot );
 

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -73,7 +73,7 @@ class Googlebot_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the presenter returns the correct meta tag.
+	 * Tests whether the presenter returns an empty string because of robots no index.
 	 *
 	 * @covers ::present
 	 */

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -6,6 +6,7 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Googlebot_Presenter;
+use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -18,6 +19,20 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @package Yoast\WP\SEO\Tests\Presenters
  */
 class Googlebot_Presenter_Test extends TestCase {
+
+	/**
+	 * Represents the indexable.
+	 *
+	 * @var Indexable
+	 */
+	protected $indexable;
+
+	/**
+	 * Represents the indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	protected $presentation;
 
 	/**
 	 * The Googlebot presenter instance.
@@ -35,6 +50,12 @@ class Googlebot_Presenter_Test extends TestCase {
 		$this->instance = Mockery::mock( Googlebot_Presenter::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
+
+		$this->indexable           = new Indexable();
+		$this->presentation        = Mockery::mock( Indexable_Presentation::class );
+		$this->presentation->model = $this->indexable;
+
+		$this->instance->presentation = $this->presentation;
 	}
 
 	/**
@@ -43,13 +64,23 @@ class Googlebot_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
-		$indexable_presentation = $this->instance->presentation = new Indexable_Presentation();
-		$indexable_presentation->googlebot = [ 'one', 'two', 'three' ];
+		$this->presentation->googlebot = [ 'one', 'two', 'three' ];
 
-		$actual = $this->instance->present();
+		$actual   = $this->instance->present();
 		$expected = '<meta name="googlebot" content="one, two, three" />';
 
-		$this->assertEquals( $actual, $expected );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the presenter returns the correct meta tag.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present_with_robots_set_to_no_index() {
+		$this->indexable->is_robots_noindex = true;
+
+		$this->assertEquals( '', $this->instance->present() );
 	}
 
 	/**
@@ -59,18 +90,17 @@ class Googlebot_Presenter_Test extends TestCase {
 	 * @covers ::filter
 	 */
 	public function test_present_filter() {
-		$indexable_presentation = $this->instance->presentation = new Indexable_Presentation();
-		$indexable_presentation->googlebot = [ 'one', 'two', 'three' ];
+		$this->presentation->googlebot = [ 'one', 'two', 'three' ];
 
 		Monkey\Filters\expectApplied( 'wpseo_googlebot' )
 			->once()
-			->with( 'one, two, three', $indexable_presentation )
+			->with( 'one, two, three', $this->presentation )
 			->andReturn( 'one, two' );
 
 		$actual = $this->instance->present();
 		$expected = '<meta name="googlebot" content="one, two" />';
 
-		$this->assertEquals( $actual, $expected );
+		$this->assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -79,8 +109,7 @@ class Googlebot_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present_empty() {
-		$indexable_presentation = $this->instance->presentation = new Indexable_Presentation();
-		$indexable_presentation->googlebot = [];
+		$this->presentation->googlebot = [];
 
 		$this->assertEmpty( $this->instance->present() );
 	}

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -64,14 +64,14 @@ class Googlebot_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the presenter returns an empty string because of robots no index.
+	 * Tests whether the presenter returns an empty string because of robots noindex.
 	 *
 	 * @covers ::present
 	 */
 	public function test_present_with_robots_set_to_no_index() {
 		$this->presentation->robots = [ 'index' => 'noindex' ];
 
-		$this->assertEquals( '', $this->instance->present() );
+		$this->assertEmpty( $this->instance->present() );
 	}
 
 	/**
@@ -108,7 +108,7 @@ class Googlebot_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieval the raw value.
+	 * Tests retrieval of the raw value.
 	 *
 	 * @covers ::get
 	 */

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -21,13 +21,6 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Googlebot_Presenter_Test extends TestCase {
 
 	/**
-	 * Represents the indexable.
-	 *
-	 * @var Indexable
-	 */
-	protected $indexable;
-
-	/**
 	 * Represents the indexable presentation.
 	 *
 	 * @var Indexable_Presentation
@@ -51,10 +44,7 @@ class Googlebot_Presenter_Test extends TestCase {
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 
-		$this->indexable           = new Indexable();
-		$this->presentation        = Mockery::mock( Indexable_Presentation::class );
-		$this->presentation->model = $this->indexable;
-
+		$this->presentation           = Mockery::mock();
 		$this->instance->presentation = $this->presentation;
 	}
 
@@ -65,6 +55,7 @@ class Googlebot_Presenter_Test extends TestCase {
 	 */
 	public function test_present() {
 		$this->presentation->googlebot = [ 'one', 'two', 'three' ];
+		$this->presentation->robots    = [ 'index' => 'index' ];
 
 		$actual   = $this->instance->present();
 		$expected = '<meta name="googlebot" content="one, two, three" />';
@@ -78,7 +69,7 @@ class Googlebot_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present_with_robots_set_to_no_index() {
-		$this->indexable->is_robots_noindex = true;
+		$this->presentation->robots = [ 'index' => 'noindex' ];
 
 		$this->assertEquals( '', $this->instance->present() );
 	}
@@ -91,6 +82,7 @@ class Googlebot_Presenter_Test extends TestCase {
 	 */
 	public function test_present_filter() {
 		$this->presentation->googlebot = [ 'one', 'two', 'three' ];
+		$this->presentation->robots    = [];
 
 		Monkey\Filters\expectApplied( 'wpseo_googlebot' )
 			->once()
@@ -110,7 +102,19 @@ class Googlebot_Presenter_Test extends TestCase {
 	 */
 	public function test_present_empty() {
 		$this->presentation->googlebot = [];
+		$this->presentation->robots    = [];
 
 		$this->assertEmpty( $this->instance->present() );
+	}
+
+	/**
+	 * Tests retrieval the raw value.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$this->presentation->googlebot = [ 'one', 'two', 'three' ];
+
+		$this->assertEquals( [ 'one', 'two', 'three' ], $this->instance->get() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When robots no index is true we should hide the google bot tag.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides the Google bot metatag when the current page is set to robots `noindex`.

## Relevant technical choices:

* Restructured the unit tests a little bit:
   * Flipped the `actual` and `$expected`, this are given in the wrong sequence.
   * Removed an assignment in an assigment (`$variable = $variable2 = 123`)
   * Set the instances to use for testing in the `setUp` method

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On release branch: Set a post to robots no index
* The googlebot meta tag is rendered
* Checkout this branch
* The metatag is gone!

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14804
