### PR TITLE
Sets article as og:type for the searchpage

### DIFF
--- a/src/presentations/indexable-search-result-page-presentation.php
+++ b/src/presentations/indexable-search-result-page-presentation.php
@@ -56,4 +56,13 @@ class Indexable_Search_Result_Page_Presentation extends Indexable_Presentation {
 
 		return '';
 	}
+
+	/**
+	 * Generates the Open Graph type.
+	 *
+	 * @return string The Open Graph type.
+	 */
+	public function generate_open_graph_type() {
+		return 'article';
+	}
 }

--- a/tests/presentations/indexable-search-result-page-presentation/open-graph-type-test.php
+++ b/tests/presentations/indexable-search-result-page-presentation/open-graph-type-test.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Search_Result_Page_Presentation;
+
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Open_Graph_Type_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Search_Result_Page_Presentation
+ *
+ * @group presentations
+ * @group open-graph
+ */
+class Open_Graph_Type_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->set_instance();
+	}
+
+	/**
+	 * Tests the situation where the Open Graph type is given.
+	 *
+	 * @covers ::generate_open_graph_type
+	 */
+	public function test_generate_open_graph_type() {
+		$this->assertEquals( 'article', $this->instance->generate_open_graph_type() );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The OG type was wrong and should have the value article

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the `og:type` for a search result page

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout the release branch
* Search on the frontend and view the source of the results page
* See that the og:type is website
* Checkout this branch
* The type is `article` now


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14819 
