### PR TITLE
Use CollectionPage when page_for_posts is the current indexable

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -391,6 +391,9 @@ class Meta_Tags_Context extends Abstract_Presentation {
 				break;
 			default:
 				$type = 'WebPage';
+				if ( (int) \get_option( 'page_for_posts' ) === $this->indexable->object_id ) {
+					$type = 'CollectionPage';
+				}
 		}
 
 		/**

--- a/tests/context/meta-tags-context-test.php
+++ b/tests/context/meta-tags-context-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Context;
 
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_Replace_Vars;
@@ -89,19 +90,123 @@ class Meta_Tags_Context_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether the page type for author archives is correctly typed as a 'ProfilePage' and a 'WebPage'.
+	 * Tests the generation of the schema page type.
+	 *
+	 * @param array        $indexable The indexable data.
+	 * @param string|array $expected  The expected value.
+	 * @param string       $message   Message to show when test fails.
+	 *
+	 * @dataProvider generate_schema_page_type_provider
 	 *
 	 * @covers ::generate_schema_page_type
 	 */
-	public function test_generate_schema_page_type_author_archive() {
-		$this->instance->indexable = (Object) [
-			'object_type' => 'user',
+	public function test_generate_schema_page_type( array $indexable, $expected, $message ) {
+		$this->instance->indexable = (Object) $indexable;
+
+		Filters\expectApplied( 'wpseo_schema_webpage_type' )->with( $expected );
+
+		$this->assertSame( $expected, $this->instance->generate_schema_page_type(), $message );
+	}
+
+	/**
+	 * Provides data for the generate schema page type test.
+	 *
+	 * @return array Test data to use.
+	 */
+	public function generate_schema_page_type_provider() {
+		return [
+			[
+				'indexable' => [
+					'object_type'     => 'system-page',
+					'object_sub_type' => 'search-result',
+				],
+				'expected'  => 'SearchResultsPage',
+				'message'   => 'Tests with an indexable for the search results page.',
+			],
+			[
+				'indexable' => [
+					'object_type'     => 'system-page',
+					'object_sub_type' => '404',
+				],
+				'expected'  => 'WebPage',
+				'message'   => 'Tests with an indexable for the 404 page.',
+			],
+			[
+				'indexable' => [
+					'object_type' => 'user',
+				],
+				'expected'  => [ 'ProfilePage', 'WebPage' ],
+				'message'   => 'Tests with an indexable for the author page.',
+			],
+			[
+				'indexable' => [
+					'object_type' => 'home-page',
+				],
+				'expected'  => 'CollectionPage',
+				'message'   => 'Tests with an indexable for the home page.',
+			],
+			[
+				'indexable' => [
+					'object_type' => 'date-archive',
+				],
+				'expected'  => 'CollectionPage',
+				'message'   => 'Tests with an indexable for a date archive.',
+			],
+			[
+				'indexable' => [
+					'object_type' => 'term',
+				],
+				'expected'  => 'CollectionPage',
+				'message'   => 'Tests with an indexable for a term archive.',
+			],
+			[
+				'indexable' => [
+					'object_type' => 'post-type-archive',
+				],
+				'expected'  => 'CollectionPage',
+				'message'   => 'Tests with an indexable for a post type archive.',
+			],
 		];
+	}
+
+	/**
+	 * Tests the page type for a page set as the post page.
+	 *
+	 * @covers ::generate_schema_page_type
+	 */
+	public function test_generate_schema_page_type_with_page_for_posts() {
+		$this->instance->indexable = (Object) [
+			'object_id'   => 1337,
+			'object_type' => 'post',
+		];
+
+		Functions\expect( 'get_option' )
+			->with( 'page_for_posts' )
+			->andReturn( 1337 );
 
 		$actual = $this->instance->generate_schema_page_type();
 
-		$this->assertContains( 'WebPage', $actual );
-		$this->assertContains( 'ProfilePage', $actual );
+		$this->assertSame( 'CollectionPage', $actual );
+	}
+
+	/**
+	 * Tests the page type for a post.
+	 *
+	 * @covers ::generate_schema_page_type
+	 */
+	public function test_generate_schema_page_for_a_post() {
+		$this->instance->indexable = (Object) [
+			'object_id'   => 1337,
+			'object_type' => 'post',
+		];
+
+		Functions\expect( 'get_option' )
+			->with( 'page_for_posts' )
+			->andReturn( 1338 );
+
+		$actual = $this->instance->generate_schema_page_type();
+
+		$this->assertSame( 'WebPage', $actual );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The page that is set to `page_for_posts` should have the `CollectionPage` as schema page type.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Schema page type was wrong for the page that has been set as posts page.

## Relevant technical choices:

* I also added test in an attempt to have the complete method covered

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set a page as posts for page, view the source and verify that the schema output contains `@type: CollectionPage` data.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14827
