### PR TITLE
Remove unused code for the recalculate SEO scores notification.

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -37,7 +37,6 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_dismissible' ] );
 		add_action( 'admin_init', [ $this, 'blog_public_notice' ], 15 );
 		add_action( 'admin_init', [ $this, 'yoast_plugin_suggestions_notification' ], 15 );
-		add_action( 'admin_init', [ $this, 'recalculate_notice' ], 15 );
 		add_action( 'admin_init', [ $this, 'unsupported_php_notice' ], 15 );
 		add_action( 'admin_init', [ $this->asset_manager, 'register_assets' ] );
 		add_action( 'admin_init', [ $this, 'show_hook_deprecation_warnings' ] );
@@ -189,44 +188,6 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Shows the notice for recalculating the post. the Notice will only be shown if the user hasn't dismissed it before.
-	 */
-	public function recalculate_notice() {
-		// Just a return, because we want to temporary disable this notice (#3998 and #4532).
-		return;
-
-		if ( filter_input( INPUT_GET, 'recalculate' ) === '1' ) {
-			update_option( 'wpseo_dismiss_recalculate', '1' );
-
-			return;
-		}
-
-		if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
-			return;
-		}
-
-		if ( $this->is_site_notice_dismissed( 'wpseo_dismiss_recalculate' ) ) {
-			return;
-		}
-
-		Yoast_Notification_Center::get()->add_notification(
-			new Yoast_Notification(
-				sprintf(
-					/* translators: 1: is a link to 'admin_url / admin.php?page=wpseo_tools&recalculate=1' 2: closing link tag */
-					__( 'We\'ve updated our SEO score algorithm. %1$sRecalculate the SEO scores%2$s for all posts and pages.', 'wordpress-seo' ),
-					'<a href="' . admin_url( 'admin.php?page=wpseo_tools&recalculate=1' ) . '">',
-					'</a>'
-				),
-				[
-					'type'  => 'updated yoast-dismissible',
-					'id'    => 'wpseo-dismiss-recalculate',
-					'nonce' => wp_create_nonce( 'wpseo-dismiss-recalculate' ),
-				]
-			)
-		);
-	}
-
-	/**
 	 * Creates an unsupported PHP version notification in the notification center.
 	 *
 	 * @return void
@@ -257,17 +218,6 @@ class WPSEO_Admin_Init {
 
 		// Strip the patch version and convert to a float.
 		return (float) $wp_version_latest;
-	}
-
-	/**
-	 * Check if the user has dismissed the given notice (by $notice_name).
-	 *
-	 * @param string $notice_name The name of the notice that might be dismissed.
-	 *
-	 * @return bool
-	 */
-	private function is_site_notice_dismissed( $notice_name ) {
-		return get_option( $notice_name, true ) === '1';
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -53,6 +53,7 @@ class WPSEO_Upgrade {
 			'12.4-RC0'  => 'upgrade_124',
 			'12.8-RC0'  => 'upgrade_128',
 			'13.2-RC0'  => 'upgrade_132',
+			'14.1-RC0'  => 'upgrade_141',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -726,6 +727,13 @@ class WPSEO_Upgrade {
 		 */
 		do_action( 'wpseo_register_capabilities' );
 		WPSEO_Capability_Manager_Factory::get()->add();
+	}
+
+	/**
+	 * Performs the 14.1 upgrade.
+	 */
+	private function upgrade_141() {
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-recalculate' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove unused code.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the code related to the "Recalculate the SEO scores" notification.

## Relevant technical choices:

- removes the notification code, see `WPSEO_Admin_Init->recalculate_notice()`
- note: this was "temporarily" disabled more than 4 years ago in https://github.com/Yoast/wordpress-seo/pull/4001/files#diff-107adb4228cae05d2fd2293a098f17d4R204
- it's a public method and I'm removing it entirely because it doesn't do anything since 4 years
- if a deprecation is preferred, please do let me know
- removes private method `is_site_notice_dismissed()` that was only used here
- adds an upgrade routine to remove the notification from the notification center in the remote chance it's still there after 4 years for some users

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- the notification was already disabled so there's nothing to test

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/14495