### PR TITLE
Add indexation for terms

### DIFF
--- a/src/actions/indexation/indexable-term-indexation-action.php
+++ b/src/actions/indexation/indexable-term-indexation-action.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Reindexation action for indexables.
+ *
+ * @package Yoast\WP\SEO\Actions\Indexation
+ */
+
+namespace Yoast\WP\SEO\Actions\Indexation;
+
+use wpdb;
+use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\ORM\Yoast_Model;
+
+/**
+ * Indexable_Term_Indexation_Action class.
+ */
+class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
+
+	/**
+	 * The post type helper.
+	 *
+	 * @var Taxonomy_Helper
+	 */
+	protected $taxonomy;
+
+	/**
+	 * The indexable builder.
+	 *
+	 * @var Indexable_Builder
+	 */
+	protected $builder;
+
+	/**
+	 * The WordPress database instance.
+	 *
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * Indexable_Term_Indexation_Action constructor
+	 *
+	 * @param Taxonomy_Helper   $taxonomy The taxonomy helper.
+	 * @param Indexable_Builder $builder  The indexable builder.
+	 * @param wpdb              $wpdb     The WordPress database instance.
+	 */
+	public function __construct( Taxonomy_Helper $taxonomy, Indexable_Builder $builder, wpdb $wpdb ) {
+		$this->taxonomy = $taxonomy;
+		$this->builder  = $builder;
+		$this->wpdb     = $wpdb;
+	}
+
+	/**
+	 * The total number of unindexed terms.
+	 *
+	 * @return int|false The amount of unindexed terms. False if the query fails.
+	 */
+	public function get_total_unindexed() {
+		$query = $this->get_query( true );
+
+		$result = $this->wpdb->get_var( $query );
+
+		if ( \is_null( $result ) ) {
+			return false;
+		}
+
+		return (int) $result;
+	}
+
+	/**
+	 * Creates indexables for unindexed terms.
+	 *
+	 * @return Indexable[] The created indexables.
+	 */
+	public function index() {
+		/**
+		 * Filter 'wpseo_term_indexing_limit' - Allow filtering the amount of terms indexed during each indexing pass.
+		 *
+		 * @api int The maximum number of terms indexed.
+		 */
+		$limit = \apply_filters( 'wpseo_term_indexation_limit', 25 );
+
+		if ( ! \is_int( $limit ) || $limit < 1 ) {
+			$limit = 25;
+		}
+
+		$query    = $this->get_query( false, $limit );
+		$term_ids = $this->wpdb->get_col( $query );
+
+		$indexables = [];
+		foreach ( $term_ids as $term_id ) {
+			$indexables[] = $this->builder->build_for_id_and_type( (int) $term_id, 'term' );
+		}
+
+		return $indexables;
+	}
+
+	/**
+	 * Queries the database for unindexed term IDs.
+	 *
+	 * @param bool $count Whether or not it should be a count query.
+	 * @param int  $limit The maximum amount of term IDs to return.
+	 *
+	 * @return string The query.
+	 */
+	protected function get_query( $count, $limit = 1 ) {
+		$public_taxonomies = $this->taxonomy->get_public_taxonomies();
+		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
+		$indexable_table   = Yoast_Model::get_table_name( 'Indexable' );
+		$replacements      = $public_taxonomies;
+
+		$select = 'term_id';
+		if ( $count ) {
+			$select = 'COUNT(term_id)';
+		}
+		$limit_query = '';
+		if ( ! $count ) {
+			$limit_query    = 'LIMIT %d';
+			$replacements[] = $limit;
+		}
+
+		return $this->wpdb->prepare( "
+			SELECT $select
+			FROM {$this->wpdb->term_taxonomy}
+			WHERE term_id NOT IN (SELECT object_id FROM $indexable_table WHERE object_type = 'term') AND taxonomy IN ($placeholders)
+			$limit_query
+		", $replacements );
+	}
+}

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -51,6 +51,18 @@ class Taxonomy_Helper {
 	}
 
 	/**
+	 * Returns an array with the public taxonomies.
+	 *
+	 * @param string $output The output type to use.
+	 *
+	 * @return string[]|\WP_Taxonomy[] Array with all the public taxonomies.
+	 *                                 The type depends on the specified output variable.
+	 */
+	public function get_public_taxonomies( $output = 'names' ) {
+		return \get_taxonomies( [ 'public' => true ], $output );
+	}
+
+	/**
 	 * Retrieves the term description (without tags).
 	 *
 	 * @param int $term_id Term ID.

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Dashboard_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -36,6 +37,13 @@ class Indexation_Integration implements Integration_Interface {
 	protected $post_indexation;
 
 	/**
+	 * The term indexation action.
+	 *
+	 * @var Indexable_Term_Indexation_Action
+	 */
+	protected $term_indexation;
+
+	/**
 	 * The total amount of unindexed objects.
 	 *
 	 * @var int
@@ -46,9 +54,11 @@ class Indexation_Integration implements Integration_Interface {
 	 * Indexation_Integration constructor.
 	 *
 	 * @param Indexable_Post_Indexation_Action $post_indexation The post indexation action.
+	 * @param Indexable_Term_Indexation_Action $term_indexation The term indexation action.
 	 */
-	public function __construct( Indexable_Post_Indexation_Action $post_indexation ) {
+	public function __construct( Indexable_Post_Indexation_Action $post_indexation, Indexable_Term_Indexation_Action $term_indexation ) {
 		$this->post_indexation = $post_indexation;
+		$this->term_indexation = $term_indexation;
 	}
 
 	/**
@@ -79,6 +89,7 @@ class Indexation_Integration implements Integration_Interface {
 				'root'      => \esc_url_raw( \rest_url() ),
 				'endpoints' => [
 					'posts' => Indexable_Indexation_Route::FULL_POSTS_ROUTE,
+					'terms' => Indexable_Indexation_Route::FULL_TERMS_ROUTE,
 				],
 				'nonce'     => \wp_create_nonce( 'wp_rest' ),
 			],
@@ -124,6 +135,7 @@ class Indexation_Integration implements Integration_Interface {
 	protected function get_total_unindexed() {
 		if ( \is_null( $this->total_unindexed ) ) {
 			$this->total_unindexed = $this->post_indexation->get_total_unindexed();
+			$this->total_unindexed += $this->term_indexation->get_total_unindexed();
 		}
 
 		return $this->total_unindexed;

--- a/tests/actions/indexation/indexable-term-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-term-indexation-action-test.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Actions\Indexation;
+
+use Mockery;
+use Brain\Monkey\Filters;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
+use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Indexable_Term_Indexation_Action_Test class
+ *
+ * @group actions
+ * @group indexation
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action
+ */
+class Indexable_Term_Indexation_Action_Test extends TestCase {
+
+	/**
+	 * The post type helper mock.
+	 *
+	 * @var Taxonomy_Helper|Mockery\MockInterface
+	 */
+	protected $taxonomy;
+
+	/**
+	 * The builder mock.
+	 *
+	 * @var Indexable_Builder|Mockery\MockInterface
+	 */
+	protected $builder;
+
+	/**
+	 * The wpdb mock.
+	 *
+	 * @var \wpdb|Mockery\MockInterface
+	 */
+	protected $wpdb;
+
+	/**
+	 * The instance.
+	 *
+	 * @var Indexable_Term_Indexation_Action
+	 */
+	protected $instance;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		global $wpdb;
+		$wpdb = (object) [ 'prefix' => 'wp_' ];
+
+		$this->taxonomy            = Mockery::mock( Taxonomy_Helper::class );
+		$this->builder             = Mockery::mock( Indexable_Builder::class );
+		$this->wpdb                = Mockery::mock( 'wpdb' );
+		$this->wpdb->term_taxonomy = 'wp_term_taxonomy';
+
+		$this->instance = new Indexable_Term_Indexation_Action(
+			$this->taxonomy,
+			$this->builder,
+			$this->wpdb
+		);
+	}
+
+	/**
+	 * Tests the get total unindexed method.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_total_unindexed
+	 * @covers ::get_query
+	 */
+	public function test_get_total_unindexed() {
+		$limit_placeholder = '';
+		$expected_query    = "
+			SELECT COUNT(term_id)
+			FROM wp_term_taxonomy
+			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = 'term') AND taxonomy IN (%s)
+			$limit_placeholder
+		";
+
+		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
+		$this->wpdb->expects( 'prepare' )
+			->once()
+			->with( $expected_query, [ 'public_taxonomy' ] )
+			->andReturn( 'query' );
+		$this->wpdb->expects( 'get_var' )->once()->with( 'query' )->andReturn( '10' );
+
+		$this->assertEquals( 10, $this->instance->get_total_unindexed() );
+	}
+
+	/**
+	 * Tests the get total unindexed method when the query fails.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_total_unindexed
+	 */
+	public function test_get_total_unindexed_failed_query() {
+		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
+		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
+		$this->wpdb->expects( 'get_var' )->once()->with( 'query' )->andReturn( null );
+
+		$this->assertFalse( $this->instance->get_total_unindexed() );
+	}
+
+	/**
+	 * Tests the index method.
+	 *
+	 * @covers ::__construct
+	 * @covers ::index
+	 * @covers ::get_query
+	 */
+	public function test_index() {
+		$expected_query = '
+			SELECT term_id
+			FROM wp_term_taxonomy
+			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = \'term\') AND taxonomy IN (%s)
+			LIMIT %d
+		';
+
+		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 25 );
+
+		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
+		$this->wpdb->expects( 'prepare' )
+			->once()
+			->with( $expected_query, [ 'public_taxonomy', 25 ] )
+			->andReturn( 'query' );
+		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
+
+		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 1, 'term' );
+		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 3, 'term' );
+		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 8, 'term' );
+
+		$this->instance->index();
+	}
+
+	/**
+	 * Tests the filter fallback when not returning an integer.
+	 *
+	 * @covers ::index
+	 */
+	public function test_index_with_limit_filter_no_int() {
+		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 'not an integer' );
+
+		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
+		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
+		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
+
+		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 1, 'term' );
+		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 3, 'term' );
+		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 8, 'term' );
+
+		$this->instance->index();
+	}
+}

--- a/tests/helpers/taxonomy-helper-test.php
+++ b/tests/helpers/taxonomy-helper-test.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Helpers;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\String_Helper;
@@ -79,12 +79,40 @@ class Taxonomy_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the WordPress function is called with the expected parameters.
+	 *
+	 * @covers ::get_public_taxonomies
+	 */
+	public function test_get_public_taxonomies() {
+		Functions\expect( 'get_taxonomies' )
+			->once()
+			->with( [ 'public' => true ], 'names' )
+			->andReturn( [] );
+
+		$this->instance->get_public_taxonomies();
+	}
+
+	/**
+	 * Tests that the WordPress function is called with the expected parameters.
+	 *
+	 * @covers ::get_public_taxonomies
+	 */
+	public function test_get_public_taxonomies_with_objects() {
+		Functions\expect( 'get_taxonomies' )
+			->once()
+			->with( [ 'public' => true ], 'objects' )
+			->andReturn( [] );
+
+		$this->instance->get_public_taxonomies( 'objects' );
+	}
+
+	/**
 	 * Tests the retrieval of the term description
 	 *
 	 * @covers ::get_term_description
 	 */
 	public function test_get_term_description() {
-		Monkey\Functions\expect( 'term_description' )
+		Functions\expect( 'term_description' )
 			->once()
 			->with( 1337 )
 			->andReturn( 'Term description' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* See https://github.com/Yoast/wordpress-seo/pull/14797

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds term indexation to the indexation framework.

## Relevant technical choices:

* Queried the term_taxonomy table because the term id and taxonomy names are there.
* Also added some coverage tests for the post.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `TRUNCATE TABLE wp_yoast_indexable` to delete all your indexables.
* Go to SEO -> Tools and click on the button to index your content.
* You should have indexables again for every public term.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Partially Fixes #14824 
