### PR TITLE
Adjust migrations to have max column lengths matching WordPress

### DIFF
--- a/migrations/20171228151840_WpYoastIndexable.php
+++ b/migrations/20171228151840_WpYoastIndexable.php
@@ -45,8 +45,8 @@ class WpYoastIndexable extends Ruckusing_Migration_Base {
 
 		// Object information.
 		$indexable_table->column( 'object_id', 'integer', [ 'unsigned' => true, 'null' => true, 'limit' => 11 ] );
-		$indexable_table->column( 'object_type', 'string', [ 'null' => false, 'limit' => 191 ] );
-		$indexable_table->column( 'object_sub_type', 'string', [ 'null' => true, 'limit' => 191 ] );
+		$indexable_table->column( 'object_type', 'string', [ 'null' => false, 'limit' => 32 ] );
+		$indexable_table->column( 'object_sub_type', 'string', [ 'null' => true, 'limit' => 32 ] );
 
 		// Ownership.
 		$indexable_table->column( 'author_id', 'integer', [ 'unsigned' => true, 'null' => true, 'limit' => 11 ] );

--- a/migrations/20171228151841_WpYoastPrimaryTerm.php
+++ b/migrations/20171228151841_WpYoastPrimaryTerm.php
@@ -46,7 +46,7 @@ class WpYoastPrimaryTerm extends Ruckusing_Migration_Base {
 			'string',
 			[
 				'null'  => false,
-				'limit' => 191,
+				'limit' => 32,
 			]
 		);
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adjusts the max column lengths in the migrations so they do not fail on our Windows testing setup and better match the values used in WordPress.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Has already been tested by @sannevndrmeulen and me.
* For future testers:
  - Use the yoast test helper to reset the indexable tables.
  - Visit a post on the front-end.
  - It shouldn't crash.
  - Note, that it only used to crash if your MySQL server was configured with a limit on composite indexes of 1000.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14846 
