### PR TITLE
Add new endpoint for getting the head by URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ local.properties
 *.launch
 .cproject
 .buildpath
+.vscode
 nbproject/
 node_modules/
 bower_components/

--- a/src/actions/indexables/indexable-head-action.php
+++ b/src/actions/indexables/indexable-head-action.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Get ehad action for indexables.
+ *
+ * @package Yoast\WP\SEO\Actions\Indexables
+ */
+
+namespace Yoast\WP\SEO\Actions\Indexables;
+
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
+
+/**
+ * Indexable_Head_Action class
+ */
+class Indexable_Head_Action {
+
+	/**
+	 * The meta surface.
+	 *
+	 * @var Meta_Surface
+	 */
+	private $meta_surface;
+
+	/**
+	 * Indexable_Indexation_Route constructor.
+	 *
+	 * @param Meta_Surface $meta_surface The meta surface.
+	 */
+	public function __construct( Meta_Surface $meta_surface ) {
+		$this->meta_surface = $meta_surface;
+	}
+
+	/**
+	 * Retrieves the head for a url.
+	 *
+	 * @param string $url The url to get the head for.
+	 *
+	 * @return object Object with head and found properties.
+	 */
+	public function for_url( $url ) {
+		$meta = $this->meta_surface->for_url( $url );
+
+		if ( $meta === false ) {
+			$meta = $this->meta_surface->for_404();
+			return (object) [ 'head' => $meta->get_head(), 'status' => 404 ];
+		}
+
+		return (object) [ 'head' => $meta->get_head(), 'status' => 200 ];
+	}
+}

--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -25,7 +25,7 @@ class Indexables_Head_Route implements Route_Interface {
 	 *
 	 * @var string
 	 */
-	const HEAD_FOR_URL_ROUTE = 'indexables/get_head_for_url';
+	const HEAD_FOR_URL_ROUTE = 'get_head';
 
 	/**
 	 * The full posts route constant.
@@ -56,21 +56,41 @@ class Indexables_Head_Route implements Route_Interface {
 	public function register_routes() {
 		\register_rest_route( Main::API_V1_NAMESPACE, self::HEAD_FOR_URL_ROUTE, [
 			'methods'  => 'GET',
-			'callback' => [ $this, 'get_head_for_url' ],
+			'callback' => [ $this, 'get_head' ],
+			'args'     => [
+				'url' => [
+					'validate_callback' => [ $this, 'is_valid_url' ],
+					'required'          => true,
+				],
+			],
 		] );
 	}
 
 	/**
 	 * Gets the head of a page for a given URL.
 	 *
-	 * @param WP_REST_Request $request The request.
+	 * @param WP_REST_Request $request The request. This request should have a url param set.
 	 *
 	 * @return WP_REST_Response The response.
 	 */
-	public function get_head_for_url( WP_REST_Request $request ) {
+	public function get_head( WP_REST_Request $request ) {
 		$url  = \esc_url_raw( $request['url'] );
 		$data = $this->head_action->for_url( $url );
 
 		return new WP_REST_Response( $data, $data->status );
+	}
+
+	/**
+	 * Checks if a url is a valid url.
+	 *
+	 * @param string $url The url to check.
+	 *
+	 * @return boolean Whether or not the url is valid.
+	 */
+	public function is_valid_url( $url ) {
+		if ( \filter_var( $url, FILTER_VALIDATE_URL ) === false ) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Reindexation route for indexables.
+ *
+ * @package Yoast\WP\SEO\Routes\Routes
+ */
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
+
+/**
+ * Indexable_Reindexing_Route class.
+ */
+class Indexables_Head_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * The posts route constant.
+	 *
+	 * @var string
+	 */
+	const HEAD_FOR_URL_ROUTE = 'indexables/get_head_for_url';
+
+	/**
+	 * The full posts route constant.
+	 *
+	 * @var string
+	 */
+	const FULL_HEAD_FOR_URL_ROUTE = Main::API_V1_NAMESPACE . '/' . self::HEAD_FOR_URL_ROUTE;
+
+	/**
+	 * The meta surface.
+	 *
+	 * @var Meta_Surface
+	 */
+	private $meta_surface;
+
+	/**
+	 * Indexable_Indexation_Route constructor.
+	 *
+	 * @param Meta_Surface $meta_surface The meta surface.
+	 */
+	public function __construct( Meta_Surface $meta_surface ) {
+		$this->meta_surface = $meta_surface;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_routes() {
+		\register_rest_route( Main::API_V1_NAMESPACE, self::HEAD_FOR_URL_ROUTE, [
+			'methods'             => 'GET',
+			'callback'            => [ $this, 'get_head_for_url' ],
+		] );
+	}
+
+	/**
+	 * Gets the head of a page for a given URL.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response.
+	 */
+	public function get_head_for_url( WP_REST_Request $request ) {
+		$url  = \esc_url_raw( $request['url'] );
+		$meta = $this->meta_surface->for_url( $url );
+
+		if ( $meta === false ) {
+			$meta = $this->meta_surface->for_404();
+			return new WP_REST_Response( [ 'head' => $meta->get_head(), 'found' => false ], 404 );
+		}
+
+		return new WP_REST_Response( [ 'head' => $meta->get_head(), 'found' => true ] );
+	}
+}

--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -9,9 +9,9 @@ namespace Yoast\WP\SEO\Routes;
 
 use WP_REST_Request;
 use WP_REST_Response;
+use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
-use Yoast\WP\SEO\Surfaces\Meta_Surface;
 
 /**
  * Indexable_Reindexing_Route class.
@@ -35,19 +35,19 @@ class Indexables_Head_Route implements Route_Interface {
 	const FULL_HEAD_FOR_URL_ROUTE = Main::API_V1_NAMESPACE . '/' . self::HEAD_FOR_URL_ROUTE;
 
 	/**
-	 * The meta surface.
+	 * The head action.
 	 *
-	 * @var Meta_Surface
+	 * @var Indexable_Head_Action
 	 */
-	private $meta_surface;
+	private $head_action;
 
 	/**
 	 * Indexable_Indexation_Route constructor.
 	 *
-	 * @param Meta_Surface $meta_surface The meta surface.
+	 * @param Indexable_Head_Action $head_action The head action.
 	 */
-	public function __construct( Meta_Surface $meta_surface ) {
-		$this->meta_surface = $meta_surface;
+	public function __construct( Indexable_Head_Action $head_action ) {
+		$this->head_action = $head_action;
 	}
 
 	/**
@@ -55,8 +55,8 @@ class Indexables_Head_Route implements Route_Interface {
 	 */
 	public function register_routes() {
 		\register_rest_route( Main::API_V1_NAMESPACE, self::HEAD_FOR_URL_ROUTE, [
-			'methods'             => 'GET',
-			'callback'            => [ $this, 'get_head_for_url' ],
+			'methods'  => 'GET',
+			'callback' => [ $this, 'get_head_for_url' ],
 		] );
 	}
 
@@ -69,13 +69,8 @@ class Indexables_Head_Route implements Route_Interface {
 	 */
 	public function get_head_for_url( WP_REST_Request $request ) {
 		$url  = \esc_url_raw( $request['url'] );
-		$meta = $this->meta_surface->for_url( $url );
+		$data = $this->head_action->for_url( $url );
 
-		if ( $meta === false ) {
-			$meta = $this->meta_surface->for_404();
-			return new WP_REST_Response( [ 'head' => $meta->get_head(), 'found' => false ], 404 );
-		}
-
-		return new WP_REST_Response( [ 'head' => $meta->get_head(), 'found' => true ] );
+		return new WP_REST_Response( $data, $data->status );
 	}
 }

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -7,12 +7,11 @@
 
 namespace Yoast\WP\SEO\Surfaces;
 
-use Exception;
 use Yoast\WP\SEO\Surfaces\Values\Meta;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
-use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -36,20 +35,29 @@ class Meta_Surface {
 	private $repository;
 
 	/**
+	 * @var WP_Rewrite_Wrapper
+	 */
+	private $wp_rewrite_wrapper;
+
+
+	/**
 	 * Meta_Surface constructor.
 	 *
 	 * @param ContainerInterface         $container            The DI container.
 	 * @param Meta_Tags_Context_Memoizer $context_memoizer     The meta tags context memoizer.
 	 * @param Indexable_Repository       $indexable_repository The indexable repository.
+	 * @param WP_Rewrite_Wrapper         $wp_rewrite_wrapper   The WP rewrite wrapper.
 	 */
 	public function __construct(
 		ContainerInterface $container,
 		Meta_Tags_Context_Memoizer $context_memoizer,
-		Indexable_Repository $indexable_repository
+		Indexable_Repository $indexable_repository,
+		WP_Rewrite_Wrapper $wp_rewrite_wrapper
 	) {
-		$this->container        = $container;
-		$this->context_memoizer = $context_memoizer;
-		$this->repository       = $indexable_repository;
+		$this->container          = $container;
+		$this->context_memoizer   = $context_memoizer;
+		$this->repository         = $indexable_repository;
+		$this->wp_rewrite_wrapper = $wp_rewrite_wrapper;
 	}
 
 	/**
@@ -303,8 +311,7 @@ class Meta_Surface {
 		$path = \wp_parse_url( $url, PHP_URL_PATH );
 		$path = \ltrim( $path, '/' );
 
-		global $wp_rewrite;
-
+		$wp_rewrite   = $this->wp_rewrite_wrapper->get();
 		$date_rewrite = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->get_date_permastruct(), EP_DATE );
 		$date_rewrite = \apply_filters( 'date_rewrite_rules', $date_rewrite );
 

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -12,6 +12,8 @@ use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
+use Yoast\WP\SEO\Presenters\Rel_Next_Presenter;
+use Yoast\WP\SEO\Presenters\Rel_Prev_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -122,6 +124,12 @@ class Meta {
 	 */
 	public function get_head() {
 		$presenters = $this->front_end->get_presenters( $this->context->page_type );
+
+		if ( $this->context->page_type === 'Date_Archive' ) {
+			$presenters = \array_filter( $presenters, function ( $presenter ) {
+				return ! \is_a( $presenter, Rel_Next_Presenter::class ) && ! \is_a( $presenter, Rel_Prev_Presenter::class );
+			} );
+		}
 
 		$output = '';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,8 @@ define( 'DB_NAME', 'none' );
 define( 'DB_USER', 'nobody' );
 define( 'DB_PASSWORD', 'nothing' );
 
+define( 'EP_DATE', 1 );
+
 if ( function_exists( 'opcache_reset' ) ) {
 	opcache_reset();
 }

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
 use Yoast\WP\SEO\Tests\TestCase;
+use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -63,6 +64,11 @@ class Meta_Surface_Test extends TestCase {
 	protected $indexable;
 
 	/**
+	 * @var WP_Rewrite_Wrapper
+	 */
+	private $wp_rewrite_wrapper;
+
+	/**
 	 * The instance
 	 *
 	 * @var Meta_Surface
@@ -79,12 +85,14 @@ class Meta_Surface_Test extends TestCase {
 		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->context = Mockery::mock( Meta_Tags_Context::class );
+		$this->wp_rewrite_wrapper = Mockery::mock( WP_Rewrite_Wrapper::class );
 		$this->indexable = Mockery::mock( Indexable::class );
 
 		$this->instance = new Meta_Surface(
 			$this->container,
 			$this->context_memoizer,
-			$this->repository
+			$this->repository,
+			$this->wp_rewrite_wrapper
 		);
 
 		$this->context->presentation = (object) [ 'test' => 'succeeds' ];
@@ -386,10 +394,15 @@ class Meta_Surface_Test extends TestCase {
 	 * @dataProvider for_url_provider
 	 */
 	public function test_for_url( $object_type, $object_sub_type, $object_id, $page_type, $front_page_id, $page_for_posts_id ) {
+		$wp_rewrite = Mockery::mock( 'WP_Rewrite' );
+
 		Monkey\Functions\expect( 'wp_parse_url' )->once()->with( 'url' )->andReturn( [ 'host' => 'host', 'path' => 'path' ] );
 		Monkey\Functions\expect( 'wp_parse_url' )->once()->with( 'https://www.example.org', PHP_URL_HOST )->andReturn( 'host' );
 		$this->container->expects( 'get' )->times( 3 )->andReturn( null );
 		$this->repository->expects( 'find_by_permalink' )->once()->with( 'https://www.example.org' )->andReturn( $this->indexable );
+		$this->wp_rewrite_wrapper->expects( 'get' )->once()->andReturn( $wp_rewrite );
+		$wp_rewrite->expects( 'get_date_permastruct' )->once()->andReturn( 'date_permastruct' );
+		$wp_rewrite->expects( 'generate_rewrite_rules' )->once()->with( 'date_permastruct', EP_DATE )->andReturn( [] );
 		$this->indexable->object_type     = $object_type;
 		$this->indexable->object_id       = $object_id;
 		$this->indexable->object_sub_type = $object_sub_type;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [Developer only feature] Adds the `/wp-json/yoast/v1/get_head` endpoint to get the our head for an url. This endpoint takes a single paramter, `url` which should be the absolute url of the page to get the head for.

## Relevant technical choices:

* Date archives have their rel-next and rel-prev stripped as it's complicated to retrieve these when not in the full WordPress request and they add little value.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Visit `/wp-json/yoast/v1/get_head?url=${some_url}` with a variety of URLs.
* You should always get an object that has a `head` and a `status` property.
* If you call it with a URL that has an indexable then the `head` should match what's seen in the head of that page ( excluding the exception described above for date archives ) and `status` should be `200`.
* If there is no indexable for that url then `status` should be `404` and the `head` should match what's returned on a `404` page.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
