### PR TITLE
Make sure indexation actually stops if someone clicks stop indexation

### DIFF
--- a/src/presenters/admin/indexation-modal-presenter.php
+++ b/src/presenters/admin/indexation-modal-presenter.php
@@ -63,7 +63,7 @@ class Indexation_Modal_Presenter extends Abstract_Presenter {
 		);
 
 		return \sprintf(
-			'<div id="yoast-indexation-wrapper" class="hidden">%s<button onclick="tb_remove();" type="button" class="button">%s</button></div>',
+			'<div id="yoast-indexation-wrapper" class="hidden">%s<button id="yoast-indexation-stop" type="button" class="button">%s</button></div>',
 			\implode( '<hr />', $blocks ),
 			\esc_html( 'Stop indexation', 'wordpress-seo' )
 		);


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes sure indexation actually stops when someone stops indexation.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open your requests tab in your browser inspector.
* Start the indexation ( reset your indexable tables if they're already filled ).
* Click stop indexation.
* There should be no more requests being made to the indexation endpoint ( note: the page does refresh immediately after so there will be requests, just none should match `/wp-json/yoast/v1/indexation/*` ).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
