### PR TITLE
Do not build post hierarchy for post parents that do not exist

### DIFF
--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -125,7 +125,7 @@ class Indexable_Hierarchy_Builder {
 			return;
 		}
 
-		if ( $post->post_parent !== 0 ) {
+		if ( $post->post_parent !== 0 && $this->post->get_post( $post->post_parent ) !== null ) {
 			$ancestor = $this->indexable_repository->find_by_id_and_type( $post->post_parent, 'post' );
 			$this->indexable_hierarchy_repository->add_ancestor( $indexable_id, $ancestor->id, $depth );
 			$this->add_ancestors_for_post( $indexable_id, $ancestor->object_id, ( $depth + 1 ) );

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -134,8 +134,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 2, 'post' )->andReturn( $parent_indexable );
 
 		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( (object) [ 'post_parent' => 2, 'post_type' => 'post' ] );
-		$this->post->expects( 'get_post' )->once()->with( 2 )->andReturn( (object) [ 'post_parent' => 0, 'post_type' => 'post' ] );
-
+		$this->post->expects( 'get_post' )->twice()->with( 2 )->andReturn( (object) [ 'post_parent' => 0, 'post_type' => 'post' ] );
 		$this->instance->build( $indexable );
 	}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a crash in the indexation when indexing a post with a post_parent that does not exist.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post.
* In the database set that post's `post_parent` field to an ID that does not exist.
* Delete all indexables.
* Run the indexation, it should complete without issue.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
