### PR TITLE
Indexation notification presenter test

### DIFF
--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -24,15 +24,19 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 			'<div id="yoast-indexation-warning" class="notice notice-warning"><p>%s</p></div>',
 			\sprintf(
 				/* translators: 1: Strong start tag, 2: Strong closing tag, 3: Button start tag to open the indexation modal, 4: Button closing tag, 5: Button start tag to dismiss the warning, 6: Button closing tag. */
-				\esc_html__( '%1$sNEW:%2$s Yoast SEO can speed up your website! Please %3$sclick here%4$s to run our indexing process. Or %5$sdismiss this warning%6$s.', 'wordpress-seo' ),
+				\esc_html__( '%1$sNEW:%2$s %3$s can speed up your website! Please %4$sclick here%5$s to run our indexing process. Or %6$sdismiss this warning%7$s.', 'wordpress-seo' ),
 				'<strong>',
 				'</strong>',
+				'Yoast SEO',
 				\sprintf(
 					'<button type="button" id="yoast-open-indexation" class="button-link" data-title="%s">',
-					\__( 'Your content is being indexed', 'wordpress-seo' )
+					\esc_attr__( 'Your content is being indexed', 'wordpress-seo' )
 				),
 				'</button>',
-				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="' . \esc_js( wp_create_nonce( 'wpseo-ignore' ) ) . '">',
+				\sprintf(
+					'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
+					\esc_js( wp_create_nonce( 'wpseo-ignore' ) )
+				),
 				'</button>'
 			)
 		);

--- a/tests/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/presenters/admin/indexation-warning-presenter-test.php
@@ -20,7 +20,7 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Indexation_Warning_Presenter_Test extends TestCase {
 
 	/**
-	 * Tests the presentation of the warning.
+	 * Tests the presenter of the warning.
 	 *
 	 * @covers ::present
 	 */

--- a/tests/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/presenters/admin/indexation-warning-presenter-test.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ */
+
+namespace Yoast\WP\SEO\Tests\Presenters\Admin;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Indexation_Warning_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter
+ *
+ * @group presenters
+ * @group indexation
+ */
+class Indexation_Warning_Presenter_Test extends TestCase {
+
+	/**
+	 * Tests the presentation of the warning.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		Monkey\Functions\expect( 'esc_js' )
+			->with( '123456789' )
+			->andReturnFirstArg();
+
+		Monkey\Functions\expect( 'wp_create_nonce' )
+			->with( 'wpseo-ignore' )
+			->andReturn( 123456789 );
+
+		Monkey\Functions\expect( 'esc_attr__' )
+			->with( 'Your content is being indexed', 'wordpress-seo' )
+			->andReturnFirstArg();
+
+		$presenter = new Indexation_Warning_Presenter();
+
+		$expected  = '<div id="yoast-indexation-warning" class="notice notice-warning"><p>';
+		$expected .= '<strong>NEW:</strong> Yoast SEO can speed up your website! Please ';
+		$expected .= '<button type="button" id="yoast-open-indexation" class="button-link" data-title="Your content is being indexed">click here</button> ';
+		$expected .= 'to run our indexing process. Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="123456789">';
+		$expected .= 'dismiss this warning</button>.</p></div>';
+
+		$this->assertEquals( $expected, $presenter->present() );
+	}
+
+
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to have full test coverage 💪 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds unit tests for the indexation warning presenter.

## Relevant technical choices:

* I also changed the way we build the warning

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* I've change the presenter a little bit. Trigger the warning (it is shown on the admin pages) by removing all indexables. 
* If the test passed, just merge it.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

