### PR TITLE
Add indexable columns

### DIFF
--- a/migrations/20200420073606_AddColumnsToIndexables.php
+++ b/migrations/20200420073606_AddColumnsToIndexables.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\SEO\ORM\Yoast_Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * Class AddColumnsToIndexables.
+ */
+class AddColumnsToIndexables extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$tables = $this->get_tables();
+
+		$blog_id = \get_current_blog_id();
+		foreach ( $tables as $table ) {
+			$this->add_column( $table, 'blog_id', 'biginteger', [
+				'null'  => false,
+				'limit' => 20,
+			] );
+
+			$this->query( 'UPDATE ' . $table . ' SET blog_id = ' . $blog_id );
+		}
+
+		$this->add_column( $tables[0], 'language', 'string', [ 'null' => true, 'limit' => 32 ] );
+		$this->add_column( $tables[0], 'region', 'string', [ 'null' => true, 'limit' => 32 ] );
+		$this->add_column( $tables[0], 'schema_page_type', 'string', [ 'null' => true, 'limit' => 64 ] );
+		$this->add_column( $tables[0], 'schema_article_type', 'string', [ 'null' => true, 'limit' => 64 ] );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		$tables = $this->get_tables();
+
+		foreach ( $tables as $table ) {
+			$this->remove_column( $table, 'blog_id' );
+		}
+
+		$this->remove_column( $tables[0], 'language' );
+		$this->remove_column( $tables[0], 'region' );
+		$this->remove_column( $tables[0], 'schema_page_type' );
+		$this->remove_column( $tables[0], 'schema_article_type' );
+	}
+
+	/**
+	 * Retrieves the tables to use.
+	 *
+	 * @return string[] The tables to use.
+	 */
+	protected function get_tables() {
+		return [
+			Yoast_Model::get_table_name( 'Indexable' ),
+			Yoast_Model::get_table_name( 'Indexable_Hierarchy' ),
+			Yoast_Model::get_table_name( 'Primary_Term' ),
+		];
+	}
+}

--- a/migrations/20200420073606_AddColumnsToIndexables.php
+++ b/migrations/20200420073606_AddColumnsToIndexables.php
@@ -17,22 +17,21 @@ class AddColumnsToIndexables extends Ruckusing_Migration_Base {
 	 * Migration up.
 	 */
 	public function up() {
-		$tables = $this->get_tables();
-
+		$tables  = $this->get_tables();
 		$blog_id = \get_current_blog_id();
 		foreach ( $tables as $table ) {
 			$this->add_column( $table, 'blog_id', 'biginteger', [
-				'null'  => false,
-				'limit' => 20,
+				'null'    => false,
+				'limit'   => 20,
+				'default' => $blog_id,
 			] );
-
-			$this->query( 'UPDATE ' . $table . ' SET blog_id = ' . $blog_id );
 		}
 
-		$this->add_column( $tables[0], 'language', 'string', [ 'null' => true, 'limit' => 32 ] );
-		$this->add_column( $tables[0], 'region', 'string', [ 'null' => true, 'limit' => 32 ] );
-		$this->add_column( $tables[0], 'schema_page_type', 'string', [ 'null' => true, 'limit' => 64 ] );
-		$this->add_column( $tables[0], 'schema_article_type', 'string', [ 'null' => true, 'limit' => 64 ] );
+		$indexable_table = $this->get_indexable_table();
+		$this->add_column( $indexable_table, 'language', 'string', [ 'null' => true, 'limit' => 32 ] );
+		$this->add_column( $indexable_table, 'region', 'string', [ 'null' => true, 'limit' => 32 ] );
+		$this->add_column( $indexable_table, 'schema_page_type', 'string', [ 'null' => true, 'limit' => 64 ] );
+		$this->add_column( $indexable_table, 'schema_article_type', 'string', [ 'null' => true, 'limit' => 64 ] );
 	}
 
 	/**
@@ -40,25 +39,34 @@ class AddColumnsToIndexables extends Ruckusing_Migration_Base {
 	 */
 	public function down() {
 		$tables = $this->get_tables();
-
 		foreach ( $tables as $table ) {
 			$this->remove_column( $table, 'blog_id' );
 		}
 
-		$this->remove_column( $tables[0], 'language' );
-		$this->remove_column( $tables[0], 'region' );
-		$this->remove_column( $tables[0], 'schema_page_type' );
-		$this->remove_column( $tables[0], 'schema_article_type' );
+		$indexable_table = $this->get_indexable_table();
+		$this->remove_column( $indexable_table, 'language' );
+		$this->remove_column( $indexable_table, 'region' );
+		$this->remove_column( $indexable_table, 'schema_page_type' );
+		$this->remove_column( $indexable_table, 'schema_article_type' );
 	}
 
 	/**
-	 * Retrieves the tables to use.
+	 * Retrieves the Indexable table.
 	 *
-	 * @return string[] The tables to use.
+	 * @return string The Indexable table name.
+	 */
+	protected function get_indexable_table() {
+		return Yoast_Model::get_table_name( 'Indexable' );
+	}
+
+	/**
+	 * Retrieves the table names to use.
+	 *
+	 * @return string[] The table names to use.
 	 */
 	protected function get_tables() {
 		return [
-			Yoast_Model::get_table_name( 'Indexable' ),
+			$this->get_indexable_table(),
 			Yoast_Model::get_table_name( 'Indexable_Hierarchy' ),
 			Yoast_Model::get_table_name( 'Primary_Term' ),
 		];

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -56,6 +56,7 @@ class Indexable_Author_Builder {
 		$indexable->is_robots_nosnippet    = null;
 		$indexable->is_public              = ( $indexable->is_robots_noindex ) ? false : null;
 		$indexable->has_public_posts       = $this->author_archive->author_has_public_posts( $user_id );
+		$indexable->blog_id                = \get_current_blog_id();
 
 		$this->reset_social_images( $indexable );
 		$this->handle_social_images( $indexable );

--- a/src/builders/indexable-date-archive-builder.php
+++ b/src/builders/indexable-date-archive-builder.php
@@ -47,6 +47,7 @@ class Indexable_Date_Archive_Builder {
 		$indexable->description       = $this->options->get( 'metadesc-archive-wpseo' );
 		$indexable->is_robots_noindex = $this->options->get( 'noindex-archive-wpseo' );
 		$indexable->is_public         = ( (int) $indexable->is_robots_noindex !== 1 );
+		$indexable->blog_id           = \get_current_blog_id();
 
 		return $indexable;
 	}

--- a/src/builders/indexable-home-page-builder.php
+++ b/src/builders/indexable-home-page-builder.php
@@ -56,6 +56,7 @@ class Indexable_Home_Page_Builder {
 		$indexable->title            = $this->options->get( 'title-home-wpseo' );
 		$indexable->breadcrumb_title = $this->options->get( 'breadcrumbs-home' );
 		$indexable->permalink        = $this->url->home();
+		$indexable->blog_id          = \get_current_blog_id();
 		$indexable->description      = $this->options->get( 'metadesc-home-wpseo' );
 		if ( empty( $indexable->description ) ) {
 			$indexable->description = \get_bloginfo( 'description' );

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -128,6 +128,7 @@ class Indexable_Post_Builder {
 		$indexable->is_protected     = $post->post_password !== '';
 		$indexable->is_public        = $this->is_public( $indexable );
 		$indexable->has_public_posts = $this->has_public_posts( $indexable );
+		$indexable->blog_id         = \get_current_blog_id();
 
 		return $indexable;
 	}

--- a/src/builders/indexable-post-type-archive-builder.php
+++ b/src/builders/indexable-post-type-archive-builder.php
@@ -50,6 +50,7 @@ class Indexable_Post_Type_Archive_Builder {
 		$indexable->permalink         = \get_post_type_archive_link( $post_type );
 		$indexable->is_robots_noindex = $this->options->get( 'noindex-ptarchive-' . $post_type );
 		$indexable->is_public         = ( (int) $indexable->is_robots_noindex !== 1 );
+		$indexable->blog_id           = \get_current_blog_id();
 
 		return $indexable;
 	}

--- a/src/builders/indexable-system-page-builder.php
+++ b/src/builders/indexable-system-page-builder.php
@@ -54,6 +54,7 @@ class Indexable_System_Page_Builder {
 		$indexable->object_sub_type   = $object_sub_type;
 		$indexable->title             = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ] );
 		$indexable->is_robots_noindex = true;
+		$indexable->blog_id           = \get_current_blog_id();
 
 		return $indexable;
 	}

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -65,6 +65,7 @@ class Indexable_Term_Builder {
 		$indexable->object_type     = 'term';
 		$indexable->object_sub_type = $term->taxonomy;
 		$indexable->permalink       = $term_link;
+		$indexable->blog_id         = \get_current_blog_id();
 
 		$indexable->primary_focus_keyword_score = $this->get_keyword_score(
 			$this->get_meta_value( 'wpseo_focuskw', $term_meta ),
@@ -72,7 +73,7 @@ class Indexable_Term_Builder {
 		);
 
 		$indexable->is_robots_noindex = $this->get_noindex_value( $this->get_meta_value( 'wpseo_noindex', $term_meta ) );
-		$indexable->is_public = ( $indexable->is_robots_noindex === null ) ? null : ! $indexable->is_robots_noindex;
+		$indexable->is_public         = ( $indexable->is_robots_noindex === null ) ? null : ! $indexable->is_robots_noindex;
 
 		$this->reset_social_images( $indexable );
 

--- a/src/builders/primary-term-builder.php
+++ b/src/builders/primary-term-builder.php
@@ -9,7 +9,6 @@ namespace Yoast\WP\SEO\Builders;
 
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
-use Yoast\WP\SEO\Models\Primary_Term;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 
 /**
@@ -95,6 +94,7 @@ class Primary_Term_Builder {
 		$primary_term->term_id  = $term_id;
 		$primary_term->post_id  = $post_id;
 		$primary_term->taxonomy = $taxonomy;
+		$primary_term->blog_id  = \get_current_blog_id();
 		$primary_term->save();
 	}
 }

--- a/src/models/indexable-hierarchy.php
+++ b/src/models/indexable-hierarchy.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\ORM\Yoast_Model;
  * @property int $indexable_id The ID of the indexable.
  * @property int $ancestor_id  The ID of the indexable's ancestor.
  * @property int $depth        The depth of the ancestry. 1 being a parent, 2 being a grandparent etc.
+ * @property int $blog_id      Blog ID.
  */
 class Indexable_Hierarchy extends Yoast_Model {
 
@@ -27,5 +28,6 @@ class Indexable_Hierarchy extends Yoast_Model {
 		'indexable_id',
 		'ancestor_id',
 		'depth',
+		'blog_id',
 	];
 }

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -69,6 +69,14 @@ use Yoast\WP\SEO\ORM\Yoast_Model;
  * @property boolean $is_protected
  * @property string  $post_status
  * @property boolean $has_public_posts
+ *
+ * @property int     $blog_id
+ *
+ * @property string  $language
+ * @property string  $region
+ *
+ * @property string  $schema_page_type
+ * @property string  $schema_article_type
  */
 class Indexable extends Yoast_Model {
 
@@ -113,6 +121,7 @@ class Indexable extends Yoast_Model {
 		'incoming_link_count',
 		'number_of_pages',
 		'prominent_words_version',
+		'blog_id',
 	];
 
 	/**

--- a/src/models/primary-term.php
+++ b/src/models/primary-term.php
@@ -16,6 +16,7 @@ use Yoast\WP\SEO\ORM\Yoast_Model;
  * @property int    $post_id  Post ID.
  * @property int    $term_id  Term ID.
  * @property string $taxonomy Taxonomy.
+ * @property int    $blog_id  Blog ID.
  *
  * @property string $created_at
  * @property string $updated_at
@@ -38,5 +39,6 @@ class Primary_Term extends Yoast_Model {
 		'id',
 		'post_id',
 		'term_id',
+		'blog_id',
 	];
 }

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -62,8 +62,10 @@ class Indexable_Hierarchy_Repository {
 			'indexable_id' => $indexable_id,
 			'ancestor_id'  => $ancestor_id,
 			'depth'        => $depth,
+			'blog_id'      => \get_current_blog_id(),
 		] );
 		$hierarchy->save();
+
 		return $hierarchy;
 	}
 

--- a/tests/builders/indexable-author-builder-test.php
+++ b/tests/builders/indexable-author-builder-test.php
@@ -74,6 +74,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 
 		$indexable_mock->orm->expects( 'get' )->with( 'is_robots_noindex' )->andReturn( 0 );
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+
 		Monkey\Functions\expect( 'get_avatar_url' )
 			->once()
 			->andReturn( 'avatar_image.jpg' );
@@ -135,6 +138,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'has_public_posts', true );
 
 		$indexable_mock->orm->expects( 'get' )->with( 'is_robots_noindex' )->andReturn( 0 );
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
 
 		Monkey\Functions\expect( 'get_avatar_url' )
 			->once()

--- a/tests/builders/indexable-date-archive-builder-test.php
+++ b/tests/builders/indexable-date-archive-builder-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Builders;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Date_Archive_Builder;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -43,6 +44,9 @@ class Indexable_Date_Archive_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'is_public', true );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', false );
 		$indexable_mock->orm->expects( 'get' )->with( 'is_robots_noindex' )->andReturn( 0 );
+
+		Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
 
 		$builder = new Indexable_Date_Archive_Builder( $options_mock );
 		$builder->build( $indexable_mock );

--- a/tests/builders/indexable-home-page-builder-test.php
+++ b/tests/builders/indexable-home-page-builder-test.php
@@ -155,6 +155,9 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 
 		$this->indexable_mock->orm->expects( 'set' )->with( 'description', 'home_meta_description' );
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+
 		$builder = new Indexable_Home_Page_Builder( $this->options_mock, $this->url_mock );
 		$builder->set_social_image_helpers( $this->image_mock, $this->open_graph_image_mock, $this->twitter_image_mock );
 		$builder->build( $this->indexable_mock );
@@ -176,6 +179,9 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 		// We expect the description to be `false` in the ORM layer.
 		$this->indexable_mock->orm->expects( 'set' )->with( 'description', false );
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+
 		$builder = new Indexable_Home_Page_Builder( $this->options_mock, $this->url_mock );
 		$builder->set_social_image_helpers( $this->image_mock, $this->open_graph_image_mock, $this->twitter_image_mock );
 		$builder->build( $this->indexable_mock );
@@ -195,6 +201,9 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_meta', $image_meta_mock_json );
 		// We expect image meta data to be retrieved from the open graph image helper.
 		$this->open_graph_image_mock->expects( 'get_image_by_id' )->with( 1337 )->andReturn( $this->image_meta_mock );
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
 
 		$builder = new Indexable_Home_Page_Builder( $this->options_mock, $this->url_mock );
 		$builder->set_social_image_helpers( $this->image_mock, $this->open_graph_image_mock, $this->twitter_image_mock );

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -211,6 +211,9 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->orm->expects( 'offsetExists' )->once()->with( 'breadcrumb_title' )->andReturnTrue();
 		$this->indexable->orm->expects( 'get' )->once()->with( 'breadcrumb_title' )->andReturnTrue();
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$this->indexable->orm->expects( 'set' )->with( 'blog_id', 1 );
+
 		$this->seo_meta_repository->expects( 'find_by_post_id' )->once()->with( 1 )->andReturn(
 			(object) [
 				'internal_link_count' => 5,

--- a/tests/builders/indexable-post-type-archive-builder-test.php
+++ b/tests/builders/indexable-post-type-archive-builder-test.php
@@ -6,7 +6,6 @@ use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Post_Type_Archive_Builder;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\ORM\ORMWrapper;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -48,6 +47,9 @@ class Indexable_Post_Type_Archive_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', false );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_public', true );
 		$indexable_mock->orm->expects( 'get' )->with( 'is_robots_noindex' )->andReturnFalse();
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
 
 		$builder = new Indexable_Post_Type_Archive_Builder( $options_mock );
 		$builder->build( 'my-post-type', $indexable_mock );

--- a/tests/builders/indexable-system-page-builder-test.php
+++ b/tests/builders/indexable-system-page-builder-test.php
@@ -39,6 +39,9 @@ class Indexable_System_Page_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'title', 'search_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', true );
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+
 		$builder = new Indexable_System_Page_Builder( $options_mock );
 		$builder->build( 'search-result', $indexable_mock );
 	}

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -94,6 +94,9 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'get' )->twice()->with( 'is_robots_noindex' )->andReturn( true );
 		$indexable_mock->orm->expects( 'set' )->once()->with( 'is_public', false );
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+
 		$image            = Mockery::mock( Image_Helper::class );
 		$open_graph_image = Mockery::mock( \Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper::class );
 		$twitter_image    = Mockery::mock( \Yoast\WP\SEO\Helpers\Twitter\Image_Helper::class );

--- a/tests/builders/primary-term-builder-test.php
+++ b/tests/builders/primary-term-builder-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Builders;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
@@ -159,6 +160,8 @@ class Primary_Term_Builder_Test extends TestCase {
 		$primary_term = Mockery::mock( Primary_Term::class );
 		$primary_term->expects( 'save' )->once();
 
+		Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+
 		$this->repository
 			->expects( 'find_by_post_id_and_taxonomy' )
 			->once()
@@ -175,6 +178,7 @@ class Primary_Term_Builder_Test extends TestCase {
 		$this->assertEquals( 1337, $primary_term->term_id );
 		$this->assertEquals( 1, $primary_term->post_id );
 		$this->assertEquals( 'category', $primary_term->taxonomy );
+		$this->assertEquals( 1, $primary_term->blog_id );
 	}
 
 	/**

--- a/tests/mocks/primary-term.php
+++ b/tests/mocks/primary-term.php
@@ -12,4 +12,5 @@ class Primary_Term extends \Yoast\WP\SEO\Models\Primary_Term {
 	public $post_id;
 	public $term_id;
 	public $taxonomy;
+	public $blog_id;
 }

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Tests\Repositories;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\ORM\ORMWrapper;
@@ -184,6 +185,9 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$hierarchy->indexable_id = 1;
 		$hierarchy->ancestor_id  = 2;
 		$hierarchy->depth        = 1;
+		$hierarchy->blog_id      = 1;
+
+		Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 
 		$hierarchy->expects( 'save' )->once();
 
@@ -195,6 +199,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 				'indexable_id' => 1,
 				'ancestor_id'  => 2,
 				'depth'        => 1,
+				'blog_id'      => 1,
 			] )
 			->andReturn( $hierarchy );
 		$this->instance->expects( 'query' )->andReturn( $orm_object );
@@ -209,7 +214,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	 * @covers ::query
 	 */
 	public function test_query() {
-		$wpdb = Mockery::mock();
+		$wpdb         = Mockery::mock();
 		$wpdb->prefix = 'wp_';
 
 		$GLOBALS['wpdb'] = $wpdb;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `blog_id` is to start keeping track of which blog the "indexable" row belongs too. While seemingly pointless now, this might become handy in a future where we only have 1 indexable table.
* Adding 4 more fields to the Indexable table, also to prepare for future things.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `blog_id` field to the Indexable, Indexable Hierarchy and Primary Term tables.
* Adds `language`, `region`, `schema_page_type` and `schema_article_type` fields to the Indexable table.

## Relevant technical choices:

* `blog_id` has the same type and length as `wp_blogs`'s `blog_id`.
* `language` and `region` have a length of 32 to not be so large we can not use them in a merged index later. But should still be large enough to hold the largest values. Larger than the suggestion on  https://tools.ietf.org/html/rfc5646#section-4.4.1
* `schema_page_type` and `schema_article_type` have a length of 64. Same as above but more of a "guestimate".

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Please test on single AND multisite.

### Setup
* Switch to before this branch (either `release/14.0` or RC5). Important to keep this this way before ever switching to this branch because of the migration. Otherwise reset the migrations (can be done via the Yoast Test Helper 1.6).
* Ensure you have entries in your indexable tables by:
  * Running the indexation from the Yoast Dashboard. If the notification is not there you're up-to-date.
  * Add at least 1 post with a primary key so that you have a row in the `wp_yoast_primary_term` table.
  * Fill the parent of at least 1 term so that you have a row in the `wp_yoast_indexable_hierarchy` table.

### Migration
* Switch to this branch
* Reset the migration option manually by emptying the value of `yoast_migrations_free` in the `wp_options` table. Note that on multisite each site has their own options table that should be updated too.
* Visit an admin page, this should trigger the new migration.
* Check the database to see if it now has the new fields. Again on multisite each site should have the changes too.
  * `wp_yoast_indexable` -> `blog_id`, `language`, `region`, `schema_page_type`
  * `wp_yoast_indexable_hierarchy` -> `blog_id`
  * `wp_yoast_primary_term` -> `blog_id`
* Check that `blog_id` always has the `blog_id` of that blog. So on multisite this is `1` for the `wp_yoast_indexable` and `2` for the `wp_2_yoast_indexable`, etc. See the `wp_blogs` table for the possibilities on your site.

### New indexables
* Create a new category and select a parent category. This should create a new entry in the `wp_yoast_indexable_hierarchy` and `wp_yoast_indexable` tables.
* Create a new post and select multiple terms, make one primary. This should create a new entry in the `wp_yoast_primary_term` and `wp_yoast_indexable` tables.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14837 
