### PR TITLE
Add siteUrl selector and connect containers

### DIFF
--- a/js/src/containers/Facebook.js
+++ b/js/src/containers/Facebook.js
@@ -62,7 +62,7 @@ export default compose( [
 			getImageFallback,
 			getRecommendedReplaceVars,
 			getReplaceVars,
-			getSiteName,
+			getSiteUrl,
 			getAuthorName,
 		} = select( "yoast-seo/editor" );
 
@@ -78,8 +78,7 @@ export default compose( [
 			title: getFacebookTitle(),
 			imageWarnings: data.warnings,
 			authorName: getAuthorName(),
-			siteName: getSiteName(),
-			alt: data.alt,
+			siteUrl: getSiteUrl(),
 		};
 	} ),
 

--- a/js/src/containers/Twitter.js
+++ b/js/src/containers/Twitter.js
@@ -62,7 +62,7 @@ export default compose( [
 			getImageFallback,
 			getRecommendedReplaceVars,
 			getReplaceVars,
-			getSiteName,
+			getSiteUrl,
 			getAuthorName,
 		} = select( "yoast-seo/editor" );
 
@@ -78,8 +78,7 @@ export default compose( [
 			title: getTwitterTitle(),
 			imageWarnings: data.warnings,
 			authorName: getAuthorName(),
-			siteName: getSiteName(),
-			alt: data.alt,
+			siteUrl: getSiteUrl(),
 		};
 	} ),
 

--- a/js/src/redux/selectors/social.js
+++ b/js/src/redux/selectors/social.js
@@ -21,6 +21,15 @@ const getTitleFallback = state => state.analysisData.snippet.title;
 const getDescriptionFallback = state => state.analysisData.snippet.description;
 
 /**
+ * Gets the site base URL from the analysisdata state. Then cuts it after the first "/".
+ *
+ * @param {Object} state The state object.
+ *
+ * @returns {string} The authorName
+ */
+export const getSiteUrl = state => state.analysisData.snippet.url.split( "/" )[ 0 ];
+
+/**
  * Gets the fallback image from:
  * state.settings.socialPreviews.sitewideImage
  * or
@@ -37,4 +46,5 @@ export default {
 	getTitleFallback,
 	getImageFallback,
 	getDescriptionFallback,
+	getSiteUrl,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* All context and test instructions are in https://github.com/Yoast/wordpress-seo-premium/pull/2744

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Add siteUrl selector and let Facebook and Twitter containers use the selector to connect the props.


Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2734
