### PR TITLE
Run migrations when a query throws an exception

### DIFF
--- a/src/config/migration-status.php
+++ b/src/config/migration-status.php
@@ -135,17 +135,21 @@ class Migration_Status {
 	 * @return bool|array The status of the migration, false if no status exists.
 	 */
 	protected function get_migration_status( $name ) {
-		if ( ! isset( $this->migration_options[ $name ] ) ) {
+		$current_blog_id = \get_current_blog_id();
+		if ( ! isset( $this->migration_options[ $current_blog_id ][ $name ] ) ) {
 			$migration_status = \get_option( self::MIGRATION_OPTION_KEY . $name );
 
 			if ( ! is_array( $migration_status ) || ! isset( $migration_status['version'] ) ) {
 				$migration_status = [ 'version' => '0.0' ];
 			}
 
-			$this->migration_options[ $name ] = $migration_status;
+			if ( ! isset( $this->migration_options[ $current_blog_id ] ) ) {
+				$this->migration_options[ $current_blog_id ] = [];
+			}
+			$this->migration_options[ $current_blog_id ][ $name ] = $migration_status;
 		}
 
-		return $this->migration_options[ $name ];
+		return $this->migration_options[ $current_blog_id ][ $name ];
 	}
 
 	/**

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -83,6 +83,7 @@ class Migration_Runner implements Initializer_Interface {
 	 */
 	public function initialize() {
 		$this->run_migrations( 'free', Yoast_Model::get_table_name( 'migrations' ), \WPSEO_PATH . 'migrations' );
+		\add_action( '_yoast_run_migrations', [ $this, 'initialize' ] );
 	}
 
 	/**

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -82,8 +82,20 @@ class Migration_Runner implements Initializer_Interface {
 	 * @return void
 	 */
 	public function initialize() {
+		$this->run_free_migrations();
+		// The below actions is used for when queries fail, this may happen in a multisite environment when switch_to_blog is used.
+		\add_action( '_yoast_run_migrations', [ $this, 'run_free_migrations' ] );
+	}
+
+	/**
+	 * Runs the free migrations.
+	 *
+	 * @throws \Exception When a migration errored.
+	 *
+	 * @return void
+	 */
+	public function run_free_migrations() {
 		$this->run_migrations( 'free', Yoast_Model::get_table_name( 'migrations' ), \WPSEO_PATH . 'migrations' );
-		\add_action( '_yoast_run_migrations', [ $this, 'initialize' ] );
 	}
 
 	/**

--- a/src/orm/yoast-orm-wrapper.php
+++ b/src/orm/yoast-orm-wrapper.php
@@ -217,24 +217,18 @@ class ORMWrapper extends ORM {
 	}
 
 	/**
-	 * Internal helper method for executing statments. Logs queries, and
-	 * stores statement object in ::_last_statment, accessible publicly
-	 * through ::get_last_statement()
-	 *
-	 * @param string $query           The query.
-	 * @param array  $parameters      An array of parameters to be bound in to the query.
-	 * @param string $connection_name Which connection to use.
-	 *
-	 * @return bool Response of PDOStatement::execute().
+	 * Execute the SELECT query that has been built up by chaining methods
+	 * on this class. Return an array of rows as associative arrays.
 	 */
-	protected static function _execute( $query, $parameters = [], $connection_name = self::DEFAULT_CONNECTION ) {
+	protected function _run() {
 		try {
-			return parent::_execute( $query, $parameters, $connection_name );
+			return parent::_run();
 		} catch ( Exception $exception ) {
 			// If the query fails run the migrations and try again.
 			// Action is intentionally undocumented and should not be used by third-parties.
 			\do_action( '_yoast_run_migrations' );
-			return parent::_execute( $query, $parameters, $connection_name );
+			$this->_reset_idiorm_state();
+			return parent::_run();
 		}
 	}
 }

--- a/tests/database/migration-runner-test.php
+++ b/tests/database/migration-runner-test.php
@@ -53,12 +53,15 @@ class Migration_Runner_Test extends TestCase {
 	 * Tests that initialize runs migrations.
 	 *
 	 * @covers ::initialize
+	 * @covers ::run_free_migrations
 	 */
 	public function test_initialize() {
 		$instance = Mockery::mock( Migration_Runner::class )->makePartial();
 		$instance->expects( 'run_migrations' )->once()->with( 'free', Yoast_Model::get_table_name( 'migrations' ), \WPSEO_PATH . 'migrations' );
 
 		$instance->initialize();
+
+		$this->assertTrue( \has_action( '_yoast_run_migrations', [ $instance, 'run_free_migrations' ] ) );
 	}
 
 	/**

--- a/tests/database/migration-status-test.php
+++ b/tests/database/migration-status-test.php
@@ -21,6 +21,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::should_run_migration
 	 */
 	public function test_should_run_migration() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0' ] );
@@ -34,6 +35,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::should_run_migration
 	 */
 	public function test_should_run_migration_without_option() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( false );
@@ -47,6 +49,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::should_run_migration
 	 */
 	public function test_should_run_migration_with_old_lock() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0', 'lock' => strtotime( '-20 minutes' ) ] );
@@ -60,6 +63,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::should_run_migration
 	 */
 	public function test_should_not_run_migration() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => WPSEO_VERSION ] );
@@ -73,6 +77,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::should_run_migration
 	 */
 	public function test_should_not_run_migration_with_lock() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0', 'lock' => strtotime( 'now' ) ] );
@@ -86,6 +91,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::is_version
 	 */
 	public function test_is_version() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0' ] );
@@ -99,6 +105,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::is_version
 	 */
 	public function test_is_version_default() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => WPSEO_VERSION ] );
@@ -112,6 +119,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::is_version
 	 */
 	public function test_is_version_lower() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '2.0' ] );
@@ -125,6 +133,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::is_version
 	 */
 	public function test_is_version_higher() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0' ] );
@@ -138,6 +147,7 @@ class Migration_Status_Test extends TestCase {
 	 * @covers ::is_version
 	 */
 	public function test_is_version_empty() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( false );
@@ -153,26 +163,28 @@ class Migration_Status_Test extends TestCase {
 	public function test_get_error() {
 		$error = [ 'message' => 'Something went wrong', 'time' => strtotime( 'now' ), 'version' => '2.0' ];
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0', 'error' => $error ] );
 
 		$instance = new Migration_Status();
 
-		$this->assertSame( $error, $instance->get_error( 'test'  ) );
+		$this->assertSame( $error, $instance->get_error( 'test' ) );
 	}
 
 	/**
 	 * @covers ::get_error
 	 */
 	public function test_get_error_with_no_error() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0' ] );
 
 		$instance = new Migration_Status();
 
-		$this->assertFalse( $instance->get_error( 'test'  ) );
+		$this->assertFalse( $instance->get_error( 'test' ) );
 	}
 
 	/**
@@ -182,6 +194,7 @@ class Migration_Status_Test extends TestCase {
 		$error_message   = 'Something went wrong';
 		$expected_option = [ 'version' => '1.0', 'error' => [ 'message' => $error_message, 'time' => strtotime( 'now' ), 'version' => WPSEO_VERSION ] ];
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0' ] );
@@ -200,6 +213,7 @@ class Migration_Status_Test extends TestCase {
 	public function test_set_success() {
 		$expected_option = [ 'version' => WPSEO_VERSION ];
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0' ] );
@@ -218,6 +232,7 @@ class Migration_Status_Test extends TestCase {
 	public function test_lock_migration() {
 		$expected_option = [ 'version' => '1.0', 'lock' => strtotime( 'now' ) ];
 
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
 											   ->once()
 											   ->andReturn( [ 'version' => '1.0' ] );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reruns query if they failed after running migrations again. This is mostly relevant in multisite contexts where blog switches happen frequently.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Get a multisite up and running.
* Delete all indexable tables in all sites ( don't use the reset feature in the test helper as that will recreate them ). Plus the migrations table. And then empty the `yoast_migrations_free` field in `wp_options`.
* Write a function that switches to another site, does a query on the indexables and then switches back.
* Call this function making sure the site you're switching to doesn't have any migrations.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended