### PR TITLE
Return the indexation button to the tools page

### DIFF
--- a/js/src/wp-seo-indexation.js
+++ b/js/src/wp-seo-indexation.js
@@ -67,7 +67,7 @@ const settings = yoastIndexationData;
 	}
 
 	$( () => {
-		$( "#yoast-open-indexation" ).on( "click", function() {
+		$( ".yoast-open-indexation" ).on( "click", function() {
 			// WordPress overwrites the tb_position function if the media library is loaded to ignore custom height and width arguments.
 			// So we temporarily revert that change as we do want to have custom height and width.
 			// Eslint is disabled as these have to use the correct names.
@@ -102,6 +102,7 @@ const settings = yoastIndexationData;
 						.html( "<p>" + settings.message.indexingCompleted + "</p>" )
 						.addClass( "notice-success" )
 						.removeClass( "notice-warning" );
+					$( "#yoast-indexation" ).html( settings.message.indexingCompleted );
 
 					tb_remove();
 					indexationInProgress = false;
@@ -112,6 +113,7 @@ const settings = yoastIndexationData;
 						.html( "<p>" + settings.message.indexingFailed + "</p>" )
 						.addClass( "notice-error" )
 						.removeClass( "notice-warning" );
+					$( "#yoast-indexation" ).html( settings.message.indexingFailed );
 
 					tb_remove();
 				} );

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -16,6 +16,7 @@ use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Indexation_List_Item_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_Modal_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter;
 use Yoast\WP\SEO\Routes\Indexable_Indexation_Route;
@@ -111,10 +112,7 @@ class Indexation_Integration implements Integration_Interface {
 	 * @inheritDoc
 	 */
 	public function register_hooks() {
-		if ( $this->options_helper->get( 'ignore_indexation_warning', false ) !== false ) {
-			return;
-		}
-
+		\add_action( 'wpseo_tools_overview_list_items', [ $this, 'render_indexation_list_item' ], 10 );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ], 10 );
 	}
 
@@ -131,7 +129,9 @@ class Indexation_Integration implements Integration_Interface {
 		}
 
 		\add_action( 'admin_footer', [ $this, 'render_indexation_modal' ], 20 );
-		\add_action( 'admin_notices', [ $this, 'render_indexation_warning' ], 10 );
+		if ( $this->options_helper->get( 'ignore_indexation_warning', false ) === false ) {
+			\add_action( 'admin_notices', [ $this, 'render_indexation_warning' ], 10 );
+		}
 
 		$this->asset_manager->enqueue_script( 'indexation' );
 		$this->asset_manager->enqueue_style( 'admin-css' );
@@ -167,7 +167,7 @@ class Indexation_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Renders the indexation list item.
+	 * Renders the indexation warning.
 	 *
 	 * @return void
 	 */
@@ -184,6 +184,15 @@ class Indexation_Integration implements Integration_Interface {
 		\add_thickbox();
 
 		echo new Indexation_Modal_Presenter( $this->get_total_unindexed() );
+	}
+
+	/**
+	 * Renders the indexation list item.
+	 *
+	 * @return void
+	 */
+	public function render_indexation_list_item() {
+		echo new Indexation_List_Item_Presenter( $this->get_total_unindexed() );
 	}
 
 	/**

--- a/src/presenters/admin/indexation-list-item-presenter.php
+++ b/src/presenters/admin/indexation-list-item-presenter.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Presenter class for the indexation modal.
+ *
+ * @package Yoast\YoastSEO\Presenters\Admin
+ */
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Indexation_List_Item_Presenter class.
+ */
+class Indexation_List_Item_Presenter extends Abstract_Presenter {
+
+	/**
+	 * The number of objects that need to be reindexed.
+	 *
+	 * @var int
+	 */
+	protected $total_unindexed;
+
+	/**
+	 * Indexation_List_Item_Presenter constructor.
+	 *
+	 * @param int $total_unindexed The number of objects that need to be indexed.
+	 */
+	public function __construct( $total_unindexed ) {
+		$this->total_unindexed = $total_unindexed;
+	}
+
+	/**
+	 * Presents the list item for the tools menu.
+	 *
+	 * @return string The list item HTML.
+	 */
+	public function present() {
+		$output = \sprintf( '<li><strong>%s</strong><br/>', \esc_html__( 'Content indexation', 'wordpress-seo' ) );
+
+		if ( $this->total_unindexed === 0 ) {
+			$output .= '<span class="wpseo-checkmark-ok-icon"></span>' . \esc_html__( 'Good job! All your site\'s content has been indexed.', 'wordpress-seo' );
+		}
+		else {
+			$output .= \sprintf(
+				'<span id="yoast-indexation">' .
+					'<button type="button" class="button yoast-open-indexation">' .
+						'%1$s' .
+					'</button>' .
+				'</span>',
+				\esc_html__( 'Index your content', 'wordpress-seo' )
+			);
+		}
+
+		$output .= '</li>';
+
+		return $output;
+	}
+}

--- a/src/presenters/admin/indexation-list-item-presenter.php
+++ b/src/presenters/admin/indexation-list-item-presenter.php
@@ -44,10 +44,11 @@ class Indexation_List_Item_Presenter extends Abstract_Presenter {
 		else {
 			$output .= \sprintf(
 				'<span id="yoast-indexation">' .
-					'<button type="button" class="button yoast-open-indexation">' .
-						'%1$s' .
+					'<button type="button" class="button yoast-open-indexation" data-title="%1$s">' .
+						'%2$s' .
 					'</button>' .
 				'</span>',
+				\esc_attr__( 'Your content is being indexed', 'wordpress-seo' ),
 				\esc_html__( 'Index your content', 'wordpress-seo' )
 			);
 		}

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -29,7 +29,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 				'</strong>',
 				'Yoast SEO',
 				\sprintf(
-					'<button type="button" id="yoast-open-indexation" class="button-link" data-title="%s">',
+					'<button type="button" class="button-link yoast-open-indexation" data-title="%s">',
 					\esc_attr__( 'Your content is being indexed', 'wordpress-seo' )
 				),
 				'</button>',

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -314,7 +314,7 @@ class Indexation_Integration_Test extends TestCase {
 			]
 		);
 
-		$this->expectOutputString( '<li><strong>Content indexation</strong><br/><span id="yoast-indexation"><button type="button" class="button yoast-open-indexation">Index your content</button></span></li>' );
+		$this->expectOutputString( '<li><strong>Content indexation</strong><br/><span id="yoast-indexation"><button type="button" class="button yoast-open-indexation" data-title="Your content is being indexed">Index your content</button></span></li>' );
 
 		$this->instance->render_indexation_list_item();
 	}

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -117,37 +117,13 @@ class Indexation_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the right hooks are registered when the indexation
-	 * warning is not ignored.
+	 * Tests the register hooks function.
 	 *
 	 * @covers ::register_hooks
 	 */
-	public function test_register_hooks_when_warning_is_not_ignored() {
-		// Warning is not ignored.
-		$this->options
-			->expects( 'get' )
-			->with( 'ignore_indexation_warning', false )
-			->andReturn( false );
-
-		// The admin_enqueue_scripts should be hooked into.
+	public function test_register_hooks() {
 		Monkey\Actions\expectAdded( 'admin_enqueue_scripts' );
-
-		$this->instance->register_hooks();
-	}
-
-	/**
-	 * Tests that no hooks are registered when the warning is ignored.
-	 *
-	 * @covers ::register_hooks
-	 */
-	public function test_register_hooks_when_warning_is_ignored() {
-		// Warning is ignored.
-		$this->options->expects( 'get' )
-			->with( 'ignore_indexation_warning', false )
-			->andReturn( true );
-
-		// The scripts and/or styles should not be enqueued.
-		Monkey\Actions\expectAdded( 'admin_enqueue_scripts' )->never();
+		Monkey\Actions\expectAdded( 'wpseo_tools_overview_list_items' );
 
 		$this->instance->register_hooks();
 	}
@@ -157,8 +133,10 @@ class Indexation_Integration_Test extends TestCase {
 	 * is rendered when there is something to index.
 	 *
 	 * @covers ::enqueue_scripts
+	 *
+	 * @dataProvider ignore_warning_provider
 	 */
-	public function test_enqueue_scripts() {
+	public function test_enqueue_scripts( $ignore_warning ) {
 		// Mock that 40 indexables should be indexed.
 		$this->set_total_unindexed_expectations(
 			[
@@ -168,6 +146,15 @@ class Indexation_Integration_Test extends TestCase {
 				'term'              => 10,
 			]
 		);
+
+		$this->options
+			->expects( 'get' )
+			->with( 'ignore_indexation_warning', false )
+			->andReturn( $ignore_warning );
+
+		if ( ! $ignore_warning ) {
+			Monkey\Actions\expectAdded( 'admin_notices' );
+		}
 
 		// Expect that the script and style for the modal is enqueued.
 		$this->asset_manager
@@ -182,7 +169,6 @@ class Indexation_Integration_Test extends TestCase {
 
 		// We should hook into the admin footer and admin notices hook.
 		Monkey\Actions\expectAdded( 'admin_footer' );
-		Monkey\Actions\expectAdded( 'admin_notices' );
 
 		// Mock retrieval of the REST URL.
 		Monkey\Functions\expect( 'rest_url' )
@@ -234,6 +220,18 @@ class Indexation_Integration_Test extends TestCase {
 	}
 
 	/**
+	 * Returns whether or not the warning is ignored.
+	 *
+	 * @return array The possible values.
+	 */
+	public function ignore_warning_provider() {
+		return [
+			[ true ],
+			[ false ],
+		];
+	}
+
+	/**
 	 * Tests that scripts and styles are not enqueued when there is
 	 * nothing to index.
 	 *
@@ -272,7 +270,7 @@ class Indexation_Integration_Test extends TestCase {
 			->once()
 			->andReturn( 'nonce' );
 
-		$this->expectOutputString( '<div id="yoast-indexation-warning" class="notice notice-warning"><p><strong>NEW:</strong> Yoast SEO can speed up your website! Please <button type="button" id="yoast-open-indexation" class="button-link" data-title="Your content is being indexed">click here</button> to run our indexing process. Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="nonce">dismiss this warning</button>.</p></div>' );
+		$this->expectOutputString( '<div id="yoast-indexation-warning" class="notice notice-warning"><p><strong>NEW:</strong> Yoast SEO can speed up your website! Please <button type="button" class="button-link yoast-open-indexation" data-title="Your content is being indexed">click here</button> to run our indexing process. Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="nonce">dismiss this warning</button>.</p></div>' );
 
 		$this->instance->render_indexation_warning();
 	}
@@ -299,6 +297,26 @@ class Indexation_Integration_Test extends TestCase {
 		$this->expectOutputString( '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><div id="yoast-indexation-progress-bar" class="wpseo-progressbar"></div><p>Object <span id="yoast-indexation-current-count">0</span> of <strong id="yoast-indexation-total-count">40</strong> processed.</p></div><button id="yoast-indexation-stop" type="button" class="button">Stop indexation</button></div>' );
 
 		$this->instance->render_indexation_modal();
+	}
+
+	/**
+	 * Tests that the indexation list item is shown when its respective method is called.
+	 *
+	 * @covers ::render_indexation_list_item
+	 */
+	public function test_render_indexation_list_item() {
+		$this->set_total_unindexed_expectations(
+			[
+				'post_type_archive' => 5,
+				'general'           => 10,
+				'post'              => 15,
+				'term'              => 10,
+			]
+		);
+
+		$this->expectOutputString( '<li><strong>Content indexation</strong><br/><span id="yoast-indexation"><button type="button" class="button yoast-open-indexation">Index your content</button></span></li>' );
+
+		$this->instance->render_indexation_list_item();
 	}
 
 	/**

--- a/tests/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/presenters/admin/indexation-warning-presenter-test.php
@@ -34,7 +34,7 @@ class Indexation_Warning_Presenter_Test extends TestCase {
 
 		$expected  = '<div id="yoast-indexation-warning" class="notice notice-warning"><p>';
 		$expected .= '<strong>NEW:</strong> Yoast SEO can speed up your website! Please ';
-		$expected .= '<button type="button" id="yoast-open-indexation" class="button-link" data-title="Your content is being indexed">click here</button> ';
+		$expected .= '<button type="button" class="button-link yoast-open-indexation" data-title="Your content is being indexed">click here</button> ';
 		$expected .= 'to run our indexing process. Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="123456789">';
 		$expected .= 'dismiss this warning</button>.</p></div>';
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Returns the indexation button back to the tools page, even if you have dismissed the warning.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Remove all your indexables.
* Dismiss the warning.
* Go to the SEO -> tools page.
* You should still be able to index your content.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
