### PR TITLE
Undo rename of nofollow_rss_links filter

### DIFF
--- a/src/integrations/front-end/rss-footer-embed.php
+++ b/src/integrations/front-end/rss-footer-embed.php
@@ -180,14 +180,14 @@ class RSS_Footer_Embed implements Integration_Interface {
 	 */
 	protected function get_link_template() {
 		/**
-		 * Filter: 'wpseo_nofollow_rss_links' - Allow the developer to determine whether or not to follow the links in
+		 * Filter: 'nofollow_rss_links' - Allow the developer to determine whether or not to follow the links in
 		 * the bits Yoast SEO adds to the RSS feed, defaults to true.
 		 *
 		 * @api bool $unsigned Whether or not to follow the links in RSS feed, defaults to true.
 		 *
 		 * @since 1.4.20
 		 */
-		if ( apply_filters( 'wpseo_nofollow_rss_links', true ) ) {
+		if ( apply_filters( 'nofollow_rss_links', true ) ) {
 			return '<a rel="nofollow" href="%1$s">%2$s</a>';
 		}
 

--- a/tests/integrations/front-end/rss-footer-embed-test.php
+++ b/tests/integrations/front-end/rss-footer-embed-test.php
@@ -142,7 +142,7 @@ class RSS_Footer_Embed_Test extends TestCase {
 
 		Monkey\Functions\expect( 'get_post' )->andReturn( $post );
 		Monkey\Functions\when( 'wpautop' )->returnArg( 1 );
-		Monkey\Filters\expectApplied( 'wpseo_nofollow_rss_links' )
+		Monkey\Filters\expectApplied( 'nofollow_rss_links' )
 			->with( true )
 			->once()
 			->andReturn( false );
@@ -196,7 +196,7 @@ class RSS_Footer_Embed_Test extends TestCase {
 
 		Monkey\Functions\expect( 'get_post' )->andReturn( $post );
 		Monkey\Functions\when( 'wpautop' )->returnArg( 1 );
-		Monkey\Filters\expectApplied( 'wpseo_nofollow_rss_links' )
+		Monkey\Filters\expectApplied( 'nofollow_rss_links' )
 			->with( true )
 			->once()
 			->andReturn( true );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* `nofollow_rss_links` was renamed to `wpseo_nofollow_rss_links`, but the old one was not deprecated. This could lead to problems for integrators.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Undoes the rename of a filter from `nofollow_rss_links` to `wpseo_nofollow_rss_links`.

## Relevant technical choices:

* For now, we chose for the easiest option. Later, all unprefixed filters will be deprecated and renamed (in a separate CS-project).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
