### PR TITLE
Import from @yoast/components root

### DIFF
--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -1,8 +1,8 @@
 import Collapsible from "./SidebarCollapsible";
 import { __, sprintf } from "@wordpress/i18n";
-import { MultiSelect, Select } from "@yoast/components/src/select/Select";
-import RadioButtonGroup from "@yoast/components/src/radiobutton/RadioButtonGroup";
-import TextInput from "@yoast/components/src/inputs/TextInput";
+import { MultiSelect, Select } from "@yoast/components";
+import { RadioButtonGroup } from "@yoast/components";
+import { TextInput } from "@yoast/components";
 import { curryUpdateToHiddenInput, getValueFromHiddenInput } from "@yoast/helpers";
 import { Component } from "@wordpress/element";
 import { Fragment } from "react";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Trunk production build is failing: 
<details>
  <summary>Click to see error</summary>
  
  ```
 ERROR in ./js/src/components/AdvancedSettings.js
    Module not found: Error: Can't resolve '@yoast/components/src/inputs/TextInput' in '/home/travis/build/Yoast/wordpress-seo/js/src/components'
     @ ./js/src/components/AdvancedSettings.js 21:17-66
     @ ./js/src/components/Metabox.js
     @ ./js/src/containers/Metabox.js
     @ ./js/src/components/MetaboxPortal.js
     @ ./js/src/edit.js
     @ ./js/src/wp-seo-post-scraper.js
    
    ERROR in ./js/src/components/AdvancedSettings.js
    Module not found: Error: Can't resolve '@yoast/components/src/radiobutton/RadioButtonGroup' in '/home/travis/build/Yoast/wordpress-seo/js/src/components'
     @ ./js/src/components/AdvancedSettings.js 17:24-85
     @ ./js/src/components/Metabox.js
     @ ./js/src/containers/Metabox.js
     @ ./js/src/components/MetaboxPortal.js
     @ ./js/src/edit.js
     @ ./js/src/wp-seo-post-scraper.js
    
    ERROR in ./js/src/components/AdvancedSettings.js
    Module not found: Error: Can't resolve '@yoast/components/src/select/Select' in '/home/travis/build/Yoast/wordpress-seo/js/src/components'
     @ ./js/src/components/AdvancedSettings.js 15:14-60
     @ ./js/src/components/Metabox.js
     @ ./js/src/containers/Metabox.js
     @ ./js/src/components/MetaboxPortal.js
     @ ./js/src/edit.js
     @ ./js/src/wp-seo-post-scraper.js
```
</details>


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixed failing production build on trunk.

## Relevant technical choices:

* Added imports from the root of @yoast/components, because relative imports did not work.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* `yarn link-monorepo` with https://github.com/Yoast/javascript/pull/643
* Build everything. Then run `grunt webpack:buildProd`. Should not have errors.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
