### PR TITLE
Add migration failed notification

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -280,7 +280,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	protected function add_analysis_submenu( WP_Admin_Bar $wp_admin_bar ) {
-		$url           = YoastSEO()->meta->for_current_page()->canonical;
+		try {
+			$url = YoastSEO()->meta->for_current_page()->canonical;
+		} catch ( Exception $e ) {
+			// This is not the type of error we can handle here.
+			return;
+		}
+
 		$focus_keyword = '';
 
 		if ( ! $url ) {

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Initializers;
 
+use Exception;
 use Yoast\WP\SEO\Config\Ruckusing_Framework;
 use Yoast\WP\SEO\Config\Migration_Status;
 use Yoast\WP\SEO\Loggers\Logger;
@@ -146,7 +147,7 @@ class Migration_Runner implements Initializer_Interface {
 			// determine the actual directory if the plugin is installed with composer.
 			$task_manager = $this->framework->get_framework_task_manager( $adapter, $migrations_table_name, $migrations_directory );
 			$task_manager->execute( $framework_runner, 'db:migrate', [] );
-		} catch ( \Exception $exception ) {
+		} catch ( Exception $exception ) {
 			$this->logger->error( $exception->getMessage() );
 
 			// Something went wrong...

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -30,7 +31,11 @@ class Indexation_Integration implements Integration_Interface {
 	 * @inheritDoc
 	 */
 	public static function get_conditionals() {
-		return [ Admin_Conditional::class, Yoast_Admin_And_Dashboard_Conditional::class ];
+		return [
+			Admin_Conditional::class,
+			Yoast_Admin_And_Dashboard_Conditional::class,
+			Migrations_Conditional::class,
+		];
 	}
 
 	/**

--- a/src/integrations/admin/migration-error-integration.php
+++ b/src/integrations/admin/migration-error-integration.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\SEO\Integrations\Admin
+ */
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Config\Migration_Status;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
+
+/**
+ * Migration_Error_Integration class
+ */
+class Migration_Error_Integration implements Integration_Interface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * The migration status object.
+	 *
+	 * @var Migration_Status
+	 */
+	protected $migration_status;
+
+	/**
+	 * Migration_Error_Integration constructor.
+	 *
+	 * @param Migration_Status $migration_status The migration status object.
+	 */
+	public function __construct( Migration_Status $migration_status ) {
+		$this->migration_status = $migration_status;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		if ( $this->migration_status->get_error( 'free' ) === false ) {
+			return;
+		}
+
+		\add_action( 'admin_notices', [ $this, 'render_migration_error' ] );
+	}
+
+	/**
+	 * Renders the migration error.
+	 *
+	 * @return void
+	 */
+	public function render_migration_error() {
+		echo new Migration_Error_Presenter();
+	}
+}

--- a/src/presenters/admin/migration-error-presenter.php
+++ b/src/presenters/admin/migration-error-presenter.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Presenter class for the indexation warning.
+ *
+ * @package Yoast\YoastSEO\Presenters\Admin
+ */
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Migration_Error_Presenter class.
+ */
+class Migration_Error_Presenter extends Abstract_Presenter {
+
+	/**
+	 * Presents the warning that your site's content is not fully indexed.
+	 *
+	 * @return string The warning HTML.
+	 */
+	public function present() {
+		$message = \sprintf(
+			/* translators: %s: Yoast SEO. */
+			\esc_html__( '%s was unable to create the database tables required and as such will not function correctly.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
+		$support = \sprintf(
+			/* translators: %1$s: link to knowledge base article about solving table issue. %2$s: is anchor closing. */
+			esc_html__( 'Please read the following %1$sknowledge base article%2$s to find out how to resolve this problem.', 'wordpress-seo' ),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15o' ) . '">',
+			'</a>'
+		);
+
+		return \sprintf(
+			'<div class="notice notice-error">' .
+				'<p>%1$s</p>' .
+				'<p>%2$s</p>' .
+			'</div>',
+			$message,
+			$support
+		);
+	}
+}

--- a/src/presenters/admin/migration-error-presenter.php
+++ b/src/presenters/admin/migration-error-presenter.php
@@ -27,9 +27,9 @@ class Migration_Error_Presenter extends Abstract_Presenter {
 			'Yoast SEO'
 		);
 		$support = \sprintf(
-			/* translators: %1$s: link to knowledge base article about solving table issue. %2$s: is anchor closing. */
-			esc_html__( 'Please read the following %1$sknowledge base article%2$s to find out how to resolve this problem.', 'wordpress-seo' ),
-			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/15o' ) . '">',
+			/* translators: %1$s: link to help article about solving table issue. %2$s: is anchor closing. */
+			esc_html__( 'Please read %1$sthis help article%2$s to find out how to resolve this problem.', 'wordpress-seo' ),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">',
 			'</a>'
 		);
 

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -24,8 +24,8 @@ use Yoast\WP\SEO\Tests\TestCase;
 /**
  * Class Indexation_Integration_Test
  *
- * @group actions
- * @group indexables
+ * @group integrations
+ * @group indexation
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Indexation_Integration
  */

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Indexation_Integration;
@@ -113,6 +114,7 @@ class Indexation_Integration_Test extends TestCase {
 		$this->assertEquals( [
 			Admin_Conditional::class,
 			Yoast_Admin_And_Dashboard_Conditional::class,
+			Migrations_Conditional::class,
 		], $conditionals );
 	}
 

--- a/tests/integrations/admin/migration-error-integration-test.php
+++ b/tests/integrations/admin/migration-error-integration-test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Admin
+ */
+
+namespace Yoast\WP\SEO\Tests\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Config\Migration_Status;
+use Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Indexation_Integration_Test
+ *
+ * @group integrations
+ * @group migrations
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration
+ */
+class Migration_Error_Integration_Test extends TestCase {
+
+	/**
+	 * Represents the migration status class.
+	 *
+	 * @var Mockery\MockInterface|Migration_Status
+	 */
+	protected $migration_status;
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Migration_Error_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->migration_status = Mockery::mock( Migration_Status::class );
+		$this->instance         = new Migration_Error_Integration( $this->migration_status );
+	}
+
+	/**
+	 * Tests if the dependency is set right.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertAttributeInstanceOf( Migration_Status::class, 'migration_status', $this->instance );
+	}
+
+	/**
+	 * Tests if the expected conditionals are given.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [ Admin_Conditional::class ], Migration_Error_Integration::get_conditionals() );
+	}
+
+	/**
+	 * Tests the registratation of the hooks with having no error set.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks_with_no_error_set() {
+		$this->migration_status
+			->expects( 'get_error' )
+			->with( 'free' )
+			->andReturnFalse();
+
+		$this->instance->register_hooks();
+
+		$this->assertFalse( has_action( 'Migration_Error_Integration', [ $this->instance, 'render_migration_error' ] ) );
+	}
+
+	/**
+	 * Tests the registratation of the hooks with having no error set.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks_with_error_set() {
+		$this->migration_status
+			->expects( 'get_error' )
+			->with( 'free' )
+			->andReturnTrue();
+
+		$this->instance->register_hooks();
+
+		$this->assertTrue( has_action( 'Migration_Error_Integration', [ $this->instance, 'render_migration_error' ] ) );
+	}
+
+	/**
+	 * Tests the rendering of the migration error.
+	 *
+	 * @covers ::render_migration_error
+	 */
+	public function test_render_migration_error() {
+		Monkey\Functions\expect( 'add_query_arg' )
+			->andReturn( 'https://yoa.st/3-6' );
+
+		$expected  = '<div class="notice notice-error">';
+		$expected .= '<p>Yoast SEO was unable to create the database tables required and as such will not function correctly.</p>';
+		$expected .= '<p>Please read <a href="' . \WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">this help article</a> to find out how to resolve this problem.</p>';
+		$expected .= '</div>';
+
+		$this->instance->render_migration_error();
+
+		$this->expectOutput( $expected );
+	}
+
+}

--- a/tests/integrations/admin/migration-error-integration-test.php
+++ b/tests/integrations/admin/migration-error-integration-test.php
@@ -79,7 +79,7 @@ class Migration_Error_Integration_Test extends TestCase {
 
 		$this->instance->register_hooks();
 
-		$this->assertFalse( has_action( 'Migration_Error_Integration', [ $this->instance, 'render_migration_error' ] ) );
+		$this->assertFalse( has_action( 'admin_notices', [ $this->instance, 'render_migration_error' ] ) );
 	}
 
 	/**
@@ -95,7 +95,7 @@ class Migration_Error_Integration_Test extends TestCase {
 
 		$this->instance->register_hooks();
 
-		$this->assertTrue( has_action( 'Migration_Error_Integration', [ $this->instance, 'render_migration_error' ] ) );
+		$this->assertTrue( has_action( 'admin_notices', [ $this->instance, 'render_migration_error' ] ) );
 	}
 
 	/**

--- a/tests/integrations/admin/migration-error-integration-test.php
+++ b/tests/integrations/admin/migration-error-integration-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Migration_Error_Presenter_Test
+ * Class Migration_Error_Integration_Test
  *
  * @group integrations
  * @group migrations

--- a/tests/integrations/admin/migration-error-integration-test.php
+++ b/tests/integrations/admin/migration-error-integration-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Indexation_Integration_Test
+ * Class Migration_Error_Presenter_Test
  *
  * @group integrations
  * @group migrations

--- a/tests/integrations/watchers/indexable-post-meta-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-meta-watcher-test.php
@@ -21,7 +21,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @group integrations
  * @group watchers
  *
- * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Meta_Watcher_Test
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Meta_Watcher
  *
  * @package Yoast\Tests\Watchers
  */

--- a/tests/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/presenters/admin/indexation-warning-presenter-test.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Presenters\Admin
  */
 
 namespace Yoast\WP\SEO\Tests\Presenters\Admin;
@@ -16,7 +18,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group presenters
  * @group indexation
- * @group test
  */
 class Indexation_Warning_Presenter_Test extends TestCase {
 

--- a/tests/presenters/admin/migration-error-presenter-test.php
+++ b/tests/presenters/admin/migration-error-presenter-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Indexation_Warning_Presenter_Test
+ * Class Migration_Error_Presenter_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter
  *

--- a/tests/presenters/admin/migration-error-presenter-test.php
+++ b/tests/presenters/admin/migration-error-presenter-test.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Presenters\Admin
+ */
+
+namespace Yoast\WP\SEO\Tests\Presenters\Admin;
+
+use Brain\Monkey;
+use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Indexation_Warning_Presenter_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter
+ *
+ * @group presenters
+ */
+class Migration_Error_Presenter_Test extends TestCase {
+
+	/**
+	 * Tests the present method.
+	 *
+	 * @covers ::present
+	 */
+	public function test_present() {
+		Monkey\Functions\expect( 'add_query_arg' )
+			->andReturn( 'https://yoa.st/3-6' );
+
+		$expected  = '<div class="notice notice-error">';
+		$expected .= '<p>Yoast SEO was unable to create the database tables required and as such will not function correctly.</p>';
+		$expected .= '<p>Please read <a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">this help article</a> to find out how to resolve this problem.</p>';
+		$expected .= '</div>';
+
+		$instance = new Migration_Error_Presenter();
+
+		$this->assertSame( $expected, $instance->present() );
+
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a notification to the admin in case migrations fail for whatever reason.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the following to the `up` method of any migration: `throw new \Exception( 'Migration failed!' );`
* Reset your tables in the yoast test helper plugin.
* You should see a notification in the admin that migrations have failed.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
