### PR TITLE
Add wp_seo_get_bc_ancestors to the list of deprecated filters

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -456,6 +456,10 @@ class WPSEO_Admin_Init {
 				'version'     => '14.0',
 				'alternative' => null,
 			],
+			'wp_seo_get_bc_ancestors'               => [
+				'version'     => '14.0',
+				'alternative' => 'wpseo_breadcrumb_links',
+			],
 		];
 
 		// Determine which filters have been registered.

--- a/readme.txt
+++ b/readme.txt
@@ -240,6 +240,7 @@ Enhancements:
 Other:
 
 * Deprecates the `wpseo_twitter_taxonomy_image` and `wpseo_twitter_metatag_key` filters.
+* Deprecates the `wp_seo_get_bc_ancestors` filter. Developers should use the `wpseo_breadcrumb_links` filter instead to add and/or replace breadcrumbs.
 * Deprecates the `wpseo_opengraph` and `wpseo_twitter` actions.
 * Adds the following filters:
      * `wpseo_debug_markers`, which allows users to disable the debug markers.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Deprecates the wp_seo_get_bc_ancestors filter. Developers should use the wpseo_breadcrumb_links filter instead to add and/or replace breadcrumbs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add a filter to the wp_seo_get_bc_ancestors filter in, for example, your theme's functions.php:
```php
add_filter( 'wp_seo_get_bc_ancestors', function ( $post_ids ) {
  return $post_ids;
} );
```
* Visit the admin.
* You should get a deprecation warning ( provided you're showing warnings ).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14894
