### PR TITLE
Fix rest endpoint for sites with a path in their site_url

### DIFF
--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -235,12 +235,13 @@ class Meta_Surface {
 	 * @return Meta|false The meta values. False if none could be found.
 	 */
 	public function for_url( $url ) {
-		$url_parts = \wp_parse_url( $url );
-		$site_host = \wp_parse_url( \site_url(), PHP_URL_HOST );
-		if ( $url_parts['host'] !== $site_host ) {
+		$url_parts  = \wp_parse_url( $url );
+		$site_parts = \wp_parse_url( \site_url() );
+		if ( $url_parts['host'] !== $site_parts['host'] ) {
 			return false;
 		}
-		$url = \site_url( $url_parts['path'] );
+		// Ensure the scheme is consistent with values in the DB.
+		$url = $site_parts['scheme'] . '://' . $url_parts['host'] . $url_parts['path'];
 
 		if ( $this->is_date_archive_url( $url ) ) {
 			$indexable = $this->repository->find_for_date_archive();

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -396,10 +396,10 @@ class Meta_Surface_Test extends TestCase {
 	public function test_for_url( $object_type, $object_sub_type, $object_id, $page_type, $front_page_id, $page_for_posts_id ) {
 		$wp_rewrite = Mockery::mock( 'WP_Rewrite' );
 
-		Monkey\Functions\expect( 'wp_parse_url' )->once()->with( 'url' )->andReturn( [ 'host' => 'host', 'path' => 'path' ] );
-		Monkey\Functions\expect( 'wp_parse_url' )->once()->with( 'https://www.example.org', PHP_URL_HOST )->andReturn( 'host' );
+		Monkey\Functions\expect( 'wp_parse_url' )->once()->with( 'url' )->andReturn( [ 'host' => 'host', 'path' => '/path' ] );
+		Monkey\Functions\expect( 'wp_parse_url' )->once()->with( 'https://www.example.org' )->andReturn( [ 'scheme' => 'scheme', 'host' => 'host' ] );
 		$this->container->expects( 'get' )->times( 3 )->andReturn( null );
-		$this->repository->expects( 'find_by_permalink' )->once()->with( 'https://www.example.org' )->andReturn( $this->indexable );
+		$this->repository->expects( 'find_by_permalink' )->once()->with( 'scheme://host/path' )->andReturn( $this->indexable );
 		$this->wp_rewrite_wrapper->expects( 'get' )->once()->andReturn( $wp_rewrite );
 		$wp_rewrite->expects( 'get_date_permastruct' )->once()->andReturn( 'date_permastruct' );
 		$wp_rewrite->expects( 'generate_rewrite_rules' )->once()->with( 'date_permastruct', EP_DATE )->andReturn( [] );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures the new `get_head` endpoint works as expected on sites with a path in their site name.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Note: this has already been tested on staging.
* Have a site with a path in the `site_url` ( for example: `https://developer.yoast.com/blog/` ).
* Visit the get_head route with a valid url you just visited ( this ensures the indexable exists )
* It should have a `status` of 200.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intende
