### PR TITLE
Allow Symfony 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"ruckusing/ruckusing-migrations": "^1.1",
 		"psr/log": "^1.0",
 		"league/oauth2-client": "^2.4",
-		"symfony/dependency-injection": "^3.4"
+		"symfony/dependency-injection": "^3.4|^5.0"
 	},
 	"require-dev": {
 		"yoast/php-development-environment": "^1.0",
@@ -41,7 +41,7 @@
 		"brain/monkey": "^2.4",
 		"phpunit/phpunit": "^5.7",
 		"atanamo/php-codeshift": "^1.0",
-		"symfony/config": "^3.4"
+		"symfony/config": "^3.4|^5.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,


### PR DESCRIPTION
Note: I've not tested this or anything (which is why I kept it draft), merely edited on the github website. Just interested if this would be something you would support?

Our use case, we have a setup that also uses symfony DI but are on the latest version and thus unable to install this via composer due to version conflict.

