### PR TITLE
Catch second exception in the query and show migration error

### DIFF
--- a/src/orm/yoast-orm-wrapper.php
+++ b/src/orm/yoast-orm-wrapper.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\ORM;
 use Exception;
 use PDO;
 use Yoast\WP\Polyfills\PDO\PDO_MySQLi_Polyfill;
-use Yoast\WP\SEO\Initializers\Migration_Runner;
+use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
 use YoastSEO_Vendor\ORM;
 
 /**
@@ -228,7 +228,25 @@ class ORMWrapper extends ORM {
 			// Action is intentionally undocumented and should not be used by third-parties.
 			\do_action( '_yoast_run_migrations' );
 			$this->_reset_idiorm_state();
-			return parent::_run();
+
+			try {
+				return parent::_run();
+			} catch ( Exception $another_exception ) {
+				// If the query fails again, show the migration error.
+				$this->show_migration_error_once();
+			}
+		}
+	}
+
+	/**
+	 * Shows the migration error once and only once.
+	 */
+	protected function show_migration_error_once() {
+		static $already_shown = false;
+
+		if ( ! $already_shown ) {
+			$already_shown = true;
+			echo new Migration_Error_Presenter();
 		}
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prevent fatal errors best we can.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Catches exception after migration has been tried to resolve it and show the migration error.

## Relevant technical choices:

* There are multiple queries in each request so there is a static variable to ensure the error is only output once.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the site works as expected. Observe the table `wp_yoast_indexable` in the database exists.
* Delete this table
* Navigate to the plugins-page, front-end or SEO page from your website, all will throw the following error:
```
Uncaught Exception: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'wordpress.wp_yoast_indexable' doesn't exist in /var/www/html/wp-content/plugins/wordpress-seo/vendor_prefixed/j4mie/idiorm/idiorm.php on line 464
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14918 
