### PR TITLE
Move applyReplaceUsingPlugin to the replacementVariableHelpers

### DIFF
--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -1,14 +1,8 @@
 import React from "react";
 import { connect } from "react-redux";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
-import {
-	get,
-	identity,
-} from "lodash-es";
 import { __ } from "@wordpress/i18n";
 import { dispatch as wpDataDispatch } from "@wordpress/data";
-import analysis from "yoastseo";
-const { stripHTMLTags: stripFullTags } = analysis.string;
 
 import {
 	switchMode,
@@ -16,52 +10,7 @@ import {
 } from "../redux/actions/snippetEditor";
 import { updateAnalysisData } from "../redux/actions/analysisData";
 import SnippetPreviewSection from "../components/SnippetPreviewSection";
-
-/**
- * Runs the legacy replaceVariables function on the data in the snippet preview.
- *
- * @param {Object} data             The snippet preview data object.
- * @param {string} data.title       The snippet preview title.
- * @param {string} data.url         The snippet preview url: baseUrl with the slug.
- * @param {string} data.description The snippet preview description.
- *
- * @returns {Object} Returns the data object in which the placeholders have been replaced.
- */
-const legacyReplaceUsingPlugin = function( data ) {
-	const replaceVariables = get( window, [ "YoastSEO", "wp", "replaceVarsPlugin", "replaceVariables" ], identity );
-
-	return {
-		url: data.url,
-		title: stripFullTags( replaceVariables( data.title ) ),
-		description: stripFullTags( replaceVariables( data.description ) ),
-	};
-};
-
-/**
- * Apply replaceVariables function on the data in the snippet preview.
- *
- * @param {Object} data             The snippet preview data object.
- * @param {string} data.title       The snippet preview title.
- * @param {string} data.url         The snippet preview url: baseUrl with the slug.
- * @param {string} data.description The snippet preview description.
- *
- * @returns {Object} Returns the data object in which the placeholders have been replaced.
- */
-const applyReplaceUsingPlugin = function( data ) {
-	// If we do not have pluggable loaded, apply just our own replace variables.
-	const pluggable = get( window, [ "YoastSEO", "app", "pluggable" ], false );
-	if ( ! pluggable || ! get( window, [ "YoastSEO", "app", "pluggable", "loaded" ], false ) ) {
-		return legacyReplaceUsingPlugin( data );
-	}
-
-	const applyModifications = pluggable._applyModifications.bind( pluggable );
-
-	return {
-		url: data.url,
-		title: stripFullTags( applyModifications( "data_page_title", data.title ) ),
-		description: stripFullTags( applyModifications( "data_meta_desc", data.description ) ),
-	};
-};
+import { applyReplaceUsingPlugin } from "../helpers/replacementVariableHelpers";
 
 /**
  * Process the snippet editor form data before it's being displayed in the snippet preview.

--- a/js/src/helpers/replacementVariableHelpers.js
+++ b/js/src/helpers/replacementVariableHelpers.js
@@ -4,11 +4,16 @@
 import {
 	forEach,
 	omit,
+	get,
+	identity,
 } from "lodash-es";
 
 /* Internal dependencies */
 import { updateReplacementVariable } from "../redux/actions/snippetEditor";
 import { firstToUpperCase } from "./stringHelpers";
+
+import analysis from "yoastseo";
+const { stripHTMLTags: stripFullTags } = analysis.string;
 
 export const nonReplaceVars = [ "slug", "content" ];
 
@@ -227,3 +232,49 @@ export function excerptFromContent( content, limit = 156 ) {
 	// Caps to the last space to have a full last word.
 	return content.substring( 0, content.lastIndexOf( " " ) );
 }
+
+/**
+ * Runs the legacy replaceVariables function on the data in the snippet preview.
+ *
+ * @param {Object} data             The snippet preview data object.
+ * @param {string} data.title       The snippet preview title.
+ * @param {string} data.url         The snippet preview url: baseUrl with the slug.
+ * @param {string} data.description The snippet preview description.
+ *
+ * @returns {Object} Returns the data object in which the placeholders have been replaced.
+ */
+const legacyReplaceUsingPlugin = function( data ) {
+	const replaceVariables = get( window, [ "YoastSEO", "wp", "replaceVarsPlugin", "replaceVariables" ], identity );
+
+	return {
+		url: data.url,
+		title: stripFullTags( replaceVariables( data.title ) ),
+		description: stripFullTags( replaceVariables( data.description ) ),
+	};
+};
+
+/**
+ * Apply replaceVariables function on the data in the snippet preview.
+ *
+ * @param {Object} data             The snippet preview data object.
+ * @param {string} data.title       The snippet preview title.
+ * @param {string} data.url         The snippet preview url: baseUrl with the slug.
+ * @param {string} data.description The snippet preview description.
+ *
+ * @returns {Object} Returns the data object in which the placeholders have been replaced.
+ */
+export const applyReplaceUsingPlugin = function( data ) {
+	// If we do not have pluggable loaded, apply just our own replace variables.
+	const pluggable = get( window, [ "YoastSEO", "app", "pluggable" ], false );
+	if ( ! pluggable || ! get( window, [ "YoastSEO", "app", "pluggable", "loaded" ], false ) ) {
+		return legacyReplaceUsingPlugin( data );
+	}
+
+	const applyModifications = pluggable._applyModifications.bind( pluggable );
+
+	return {
+		url: data.url,
+		title: stripFullTags( applyModifications( "data_page_title", data.title ) ),
+		description: stripFullTags( applyModifications( "data_meta_desc", data.description ) ),
+	};
+};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* We want to make the replacement variables work in the Social Previews.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Move applyReplaceUsingPlugin to the replacementVariableHelpers file.

## Needs PRs
https://github.com/Yoast/wordpress-seo/pull/14930
https://github.com/Yoast/wordpress-seo-premium/pull/2753
https://github.com/Yoast/javascript/pull/648

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Checkout `14592-make-replacevars-work` on the monorepo and Premium.
* Merge `free/14592-make-replacevars-work` into premium using `git merge free/14592-make-replacevars-work --no-commit`
* Link the monorepo in the root and premium folder of wordpress-seo-premium.
* Build everything 👷 
* Checkout the Social Previews
* Enter a replacement variable in the input field
* Check that it is nicely replaced in the Preview 👍 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14592 
