### PR TITLE
Remove front end conditional from breadcrumbs

### DIFF
--- a/src/backwards-compatibility/breadcrumbs.php
+++ b/src/backwards-compatibility/breadcrumbs.php
@@ -5,7 +5,7 @@
  * @package Yoast\YoastSEO\Backwards_Compatibility
  */
 
-use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Initializers\Initializer_Interface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
@@ -17,6 +17,8 @@ use Yoast\WP\SEO\Surfaces\Helpers_Surface;
  * @codeCoverageIgnore Because of deprecation.
  */
 class WPSEO_Breadcrumbs implements Initializer_Interface {
+
+	use No_Conditionals;
 
 	/**
 	 * Instance of this class.
@@ -59,13 +61,6 @@ class WPSEO_Breadcrumbs implements Initializer_Interface {
 	 * @var WPSEO_Replace_Vars
 	 */
 	protected $replace_vars;
-
-	/**
-	 * @inheritDoc
-	 */
-	public static function get_conditionals() {
-		return [ Front_End_Conditional::class ];
-	}
 
 	/**
 	 * WPSEO_Breadcrumbs constructor.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal related to rendering breadcrumbs in the admin.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Render the breadcrumbs using `WPSEO_Breadcrumbs::breadcrumb` while in the admin.
* For example by adding a `var_dump( yoast_breadcrumb( '<p id="breadcrumbs">','</p>' ) )` to an integration you know will be run in the admin.
* It should give valid HTML and not cause any fatals.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://wordpress.org/support/topic/after-update-yoast-14-e_error-breadcrumbs-php-line-107/
