### PR TITLE
Move the robots filter to the generator

### DIFF
--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -91,11 +91,12 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_robots() {
-		$robots = parent::generate_robots();
+		$robots = $this->get_base_robots();
 
 		// Global option: "Show author archives in search results".
 		if ( $this->options->get( 'noindex-author-wpseo', false ) ) {
 			$robots['index'] = 'noindex';
+			return $this->filter_robots( $robots );
 		}
 
 		$current_author = \get_userdata( $this->model->object_id );
@@ -103,6 +104,7 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 		// Safety check. The call to `get_user_data` could return false (called in `get_queried_object`).
 		if ( $current_author === false ) {
 			$robots['index'] = 'noindex';
+			return $this->filter_robots( $robots );
 		}
 
 		$public_post_types = $this->post_type->get_public_post_types();
@@ -110,11 +112,13 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 		// Global option: "Show archives for authors without posts in search results".
 		if ( $this->options->get( 'noindex-author-noposts-wpseo', false ) && $this->user->count_posts( $current_author->ID, $public_post_types ) === 0 ) {
 			$robots['index'] = 'noindex';
+			return $this->filter_robots( $robots );
 		}
 
 		// User option: "Do not allow search engines to show this author's archives in search results".
 		if ( $this->user->get_meta( $current_author->ID, 'wpseo_noindex_author', true ) === 'on' ) {
 			$robots['index'] = 'noindex';
+			return $this->filter_robots( $robots );
 		}
 
 		return $this->filter_robots( $robots );

--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -96,8 +96,6 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 		// Global option: "Show author archives in search results".
 		if ( $this->options->get( 'noindex-author-wpseo', false ) ) {
 			$robots['index'] = 'noindex';
-
-			return $robots;
 		}
 
 		$current_author = \get_userdata( $this->model->object_id );
@@ -105,8 +103,6 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 		// Safety check. The call to `get_user_data` could return false (called in `get_queried_object`).
 		if ( $current_author === false ) {
 			$robots['index'] = 'noindex';
-
-			return $robots;
 		}
 
 		$public_post_types = $this->post_type->get_public_post_types();
@@ -114,18 +110,14 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 		// Global option: "Show archives for authors without posts in search results".
 		if ( $this->options->get( 'noindex-author-noposts-wpseo', false ) && $this->user->count_posts( $current_author->ID, $public_post_types ) === 0 ) {
 			$robots['index'] = 'noindex';
-
-			return $robots;
 		}
 
 		// User option: "Do not allow search engines to show this author's archives in search results".
 		if ( $this->user->get_meta( $current_author->ID, 'wpseo_noindex_author', true ) === 'on' ) {
 			$robots['index'] = 'noindex';
-
-			return $robots;
 		}
 
-		return \array_filter( $robots );
+		return $this->filter_robots( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-date-archive-presentation.php
+++ b/src/presentations/indexable-date-archive-presentation.php
@@ -54,7 +54,7 @@ class Indexable_Date_Archive_Presentation extends Indexable_Presentation {
 			$robots['index'] = 'noindex';
 		}
 
-		return $robots;
+		return $this->filter_robots( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-date-archive-presentation.php
+++ b/src/presentations/indexable-date-archive-presentation.php
@@ -48,7 +48,7 @@ class Indexable_Date_Archive_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_robots() {
-		$robots = parent::generate_robots();
+		$robots = $this->get_base_robots();
 
 		if ( $this->options->get( 'noindex-archive-wpseo', false ) ) {
 			$robots['index'] = 'noindex';

--- a/src/presentations/indexable-error-page-presentation.php
+++ b/src/presentations/indexable-error-page-presentation.php
@@ -16,7 +16,7 @@ class Indexable_Error_Page_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_robots() {
-		$robots = parent::generate_robots();
+		$robots = $this->get_base_robots();
 
 		$robots['index'] = 'noindex';
 

--- a/src/presentations/indexable-error-page-presentation.php
+++ b/src/presentations/indexable-error-page-presentation.php
@@ -20,7 +20,7 @@ class Indexable_Error_Page_Presentation extends Indexable_Presentation {
 
 		$robots['index'] = 'noindex';
 
-		return $robots;
+		return $this->filter_robots( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -39,7 +39,7 @@ class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 			$robots['index'] = 'noindex';
 		}
 
-		return $robots;
+		return $this->filter_robots( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -33,7 +33,7 @@ class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_robots() {
-		$robots = parent::generate_robots();
+		$robots = $this->get_base_robots();
 
 		if ( $this->options->get( 'noindex-ptarchive-' . $this->model->object_sub_type, false ) ) {
 			$robots['index'] = 'noindex';

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -283,7 +283,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_robots() {
-		$robots = parent::generate_robots();
+		$robots = $this->get_base_robots();
 		$robots = array_merge(
 			$robots,
 			[

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -303,7 +303,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			}
 		}
 
-		return \array_filter( $robots );
+		return $this->filter_robots( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -221,12 +221,21 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @return array The robots value.
 	 */
 	public function generate_robots() {
-		$robots = [
+		$robots = $this->get_base_robots();
+
+		return $this->filter_robots( $robots );
+	}
+
+	/**
+	 * Gets the base robots value.
+	 *
+	 * @return array The base robots value.
+	 */
+	protected function get_base_robots() {
+		return [
 			'index'  => ( $this->model->is_robots_noindex === true ) ? 'noindex' : 'index',
 			'follow' => ( $this->model->is_robots_nofollow === true ) ? 'nofollow' : 'follow',
 		];
-
-		return $this->filter_robots( $robots );
 	}
 
 	/**
@@ -248,7 +257,18 @@ class Indexable_Presentation extends Abstract_Presentation {
 		$robots_filtered = \apply_filters( 'wpseo_robots', $robots_string, $this );
 
 		if ( is_string( $robots_filtered ) ) {
-			return \array_filter( explode( ', ', $robots_filtered ) );
+			$robots_values = \explode( ', ', $robots_filtered );
+			$robots_new    = [];
+
+			foreach( $robots_values as $value ) {
+				$key = $value;
+				if ( \strpos( $key, 'no' ) === 0 ) {
+					$key = \substr( $value, 2 );
+				}
+				$robots_new[ $key ] = $value;
+			}
+
+			return \array_filter( $robots_new );
 		}
 
 		if ( ! $robots_filtered ) {

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -237,7 +237,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @return array The filtered meta robots values.
 	 */
 	protected function filter_robots( $robots ) {
-		$robots_str = \implode( ', ', $robots );
+		$robots_string = \implode( ', ', $robots );
 		/**
 		 * Filter: 'wpseo_robots' - Allows filtering of the meta robots output of Yoast SEO.
 		 *
@@ -245,14 +245,16 @@ class Indexable_Presentation extends Abstract_Presentation {
 		 *
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		$robots_filtered = \apply_filters( 'wpseo_robots', $robots_str, $this->presentation );
+		$robots_filtered = \apply_filters( 'wpseo_robots', $robots_string, $this );
 
 		if ( is_string( $robots_filtered ) ) {
 			return \array_filter( explode( ', ', $robots_filtered ) );
 		}
+
 		if ( ! $robots_filtered ) {
 			return [];
 		}
+
 		return \array_filter( $robots );
 	}
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -261,7 +261,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 			$robots_values = \explode( ', ', $robots_filtered );
 			$robots_new    = [];
 
-			foreach( $robots_values as $value ) {
+			foreach ( $robots_values as $value ) {
 				$key = $value;
 				if ( \strpos( $key, 'no' ) === 0 ) {
 					$key = \substr( $value, 2 );

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -221,10 +221,39 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @return array The robots value.
 	 */
 	public function generate_robots() {
-		return [
+		$robots = [
 			'index'  => ( $this->model->is_robots_noindex === true ) ? 'noindex' : 'index',
 			'follow' => ( $this->model->is_robots_nofollow === true ) ? 'nofollow' : 'follow',
 		];
+
+		return $this->filter_robots( $robots );
+	}
+
+	/**
+	 * Run the robots output content through the `wpseo_robots` filter.
+	 *
+	 * @param array $robots The meta robots values to filter.
+	 *
+	 * @return array The filtered meta robots values.
+	 */
+	protected function filter_robots( $robots ) {
+		$robots_str = \implode( ', ', $robots );
+		/**
+		 * Filter: 'wpseo_robots' - Allows filtering of the meta robots output of Yoast SEO.
+		 *
+		 * @api string $robots The meta robots directives to be echoed.
+		 *
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 */
+		$robots_filtered = \apply_filters( 'wpseo_robots', $robots_str, $this->presentation );
+
+		if ( is_string( $robots_filtered ) ) {
+			return \array_filter( explode( ', ', $robots_filtered ) );
+		}
+		if ( ! $robots_filtered ) {
+			return [];
+		}
+		return \array_filter( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-search-result-page-presentation.php
+++ b/src/presentations/indexable-search-result-page-presentation.php
@@ -16,7 +16,7 @@ class Indexable_Search_Result_Page_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_robots() {
-		$robots = parent::generate_robots();
+		$robots = $this->get_base_robots();
 
 		$robots['index'] = 'noindex';
 

--- a/src/presentations/indexable-search-result-page-presentation.php
+++ b/src/presentations/indexable-search-result-page-presentation.php
@@ -20,7 +20,7 @@ class Indexable_Search_Result_Page_Presentation extends Indexable_Presentation {
 
 		$robots['index'] = 'noindex';
 
-		return $robots;
+		return $this->filter_robots( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -130,7 +130,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 		if ( $this->current_page->is_multiple_terms_page() ) {
 			$robots['index'] = 'noindex';
 
-			return $robots;
+			return $this->filter_robots( $robots );
 		}
 
 		/**
@@ -148,7 +148,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 			$robots['index'] = ( $this->model->is_robots_noindex ) ? 'noindex' : 'index';
 		}
 
-		return $robots;
+		return $this->filter_robots( $robots );
 	}
 
 	/**

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -122,7 +122,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	 * @inheritDoc
 	 */
 	public function generate_robots() {
-		$robots = parent::generate_robots();
+		$robots = $this->get_base_robots();
 
 		/**
 		 * If its a multiple terms archive page return a noindex.

--- a/src/presenters/robots-presenter.php
+++ b/src/presenters/robots-presenter.php
@@ -21,7 +21,6 @@ class Robots_Presenter extends Abstract_Indexable_Presenter {
 	 */
 	public function present() {
 		$robots = \implode( ', ', $this->get() );
-		$robots = $this->filter( $robots );
 
 		if ( \is_string( $robots ) && $robots !== '' ) {
 			return \sprintf( '<meta name="robots" content="%s" />', \esc_attr( $robots ) );
@@ -39,21 +38,4 @@ class Robots_Presenter extends Abstract_Indexable_Presenter {
 		return $this->presentation->robots;
 	}
 
-	/**
-	 * Run the robots output content through the `wpseo_robots` filter.
-	 *
-	 * @param string $robots The meta robots output to filter.
-	 *
-	 * @return string The filtered meta robots output.
-	 */
-	private function filter( $robots ) {
-		/**
-		 * Filter: 'wpseo_robots' - Allows filtering of the meta robots output of Yoast SEO.
-		 *
-		 * @api string $robots The meta robots directives to be echoed.
-		 *
-		 * @param Indexable_Presentation $presentation The presentation of an indexable.
-		 */
-		return (string) \apply_filters( 'wpseo_robots', $robots, $this->presentation );
-	}
 }

--- a/tests/presentations/indexable-post-type-presentation/robots-test.php
+++ b/tests/presentations/indexable-post-type-presentation/robots-test.php
@@ -49,11 +49,11 @@ class Robots_Test extends TestCase {
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'        => 'index',
-			'follow'       => 'follow',
-			'nosnippet'    => 'nosnippet',
-			'noarchive'    => 'noarchive',
-			'noimageindex' => 'noimageindex',
+			'index'      => 'index',
+			'follow'     => 'follow',
+			'snippet'    => 'nosnippet',
+			'archive'    => 'noarchive',
+			'imageindex' => 'noimageindex',
 		];
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -27,6 +27,13 @@ class Robots_Presenter_Test extends TestCase {
 	private $instance;
 
 	/**
+	 * The indexable presentation.
+	 *
+	 * @var Indexable_Presentation
+	 */
+	private $presentation;
+
+	/**
 	 * Sets up the test class.
 	 */
 	public function setUp() {
@@ -35,6 +42,9 @@ class Robots_Presenter_Test extends TestCase {
 		$this->instance = Mockery::mock( Robots_Presenter::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
+
+		$this->presentation           = new Indexable_Presentation();
+		$this->instance->presentation = $this->presentation;
 	}
 
 	/**
@@ -43,8 +53,7 @@ class Robots_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
-		$indexable_presentation = $this->instance->presentation = new Indexable_Presentation();
-		$indexable_presentation->robots = [
+		$this->presentation->robots = [
 			'index'  => 'index',
 			'follow' => 'nofollow',
 		];
@@ -55,29 +64,6 @@ class Robots_Presenter_Test extends TestCase {
 		$this->assertEquals( $actual, $expected );
 	}
 
-	/**
-	 * Tests whether the presenter returns the correct meta tag, when the `wpseo_robots` filter is applied.
-	 *
-	 * @covers ::present
-	 * @covers ::filter
-	 */
-	public function test_present_filter() {
-		$indexable_presentation = $this->instance->presentation = new Indexable_Presentation();
-		$indexable_presentation->robots = [
-			'index'  => 'index',
-			'follow' => 'nofollow',
-		];
-
-		Monkey\Filters\expectApplied( 'wpseo_robots' )
-			->once()
-			->with( 'index, nofollow', $indexable_presentation )
-			->andReturn( 'noindex' );
-
-		$actual   = $this->instance->present();
-		$expected = '<meta name="robots" content="noindex" />';
-
-		$this->assertEquals( $expected, $actual );
-	}
 
 	/**
 	 * Tests the situation where the presentation is empty.
@@ -85,8 +71,7 @@ class Robots_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present_empty() {
-		$indexable_presentation = $this->instance->presentation = new Indexable_Presentation();
-		$indexable_presentation->robots = [];
+		$this->presentation->robots = [];
 
 		$this->assertEmpty( $this->instance->present() );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Because the `wpseo_robots` filter runs on the presenter, the `googlebot` and `bingbot` presenter don't get the filtered value. This patch fixes that + the fact that REST API output would differ from frontend.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Made sure changes through the `wpseo_robots` filter are shown in the `googlebot` and `bingbot` meta tag output too.

