### PR TITLE
Breadcrumb title and indexable hierarchy reset migration

### DIFF
--- a/migrations/20200428123747_BreadcrumbTitleAndHierarchyReset.php
+++ b/migrations/20200428123747_BreadcrumbTitleAndHierarchyReset.php
@@ -12,31 +12,36 @@ use YoastSEO_Vendor\Ruckusing_Migration_Base;
  * BreadcrumbTitleAndHierarchyReset
  */
 class BreadcrumbTitleAndHierarchyReset extends Ruckusing_Migration_Base {
-    /**
+	/**
 	 * Migration up.
 	 */
 	public function up() {
-        $this->change_column( $this->get_indexable_table_name(), 'breadcrumb_title', 'text', [ 'null' => true ] );
-        $this->query( 'DELETE FROM ' . $this->get_indexable_hierarchy_table_name() );
-    }
+		$this->change_column( $this->get_indexable_table_name(), 'breadcrumb_title', 'text', [ 'null' => true ] );
+		$this->query( 'DELETE FROM ' . $this->get_indexable_hierarchy_table_name() );
+	}
 
-    /**
+	/**
 	 * Migration down.
 	 */
 	public function down() {
-        $this->change_column( $this->get_indexable_table_name(), 'breadcrumb_title', 'string', [ 'null' => true, 'limit' => 191 ] );
-    }
+		$this->change_column(
+			$this->get_indexable_table_name(),
+			'breadcrumb_title',
+			'string',
+			[ 'null' => true, 'limit' => 191 ]
+		);
+	}
 
-    /**
+	/**
 	 * Retrieves the table name to use for storing indexables.
 	 *
 	 * @return string The table name to use.
 	 */
 	protected function get_indexable_table_name() {
 		return Yoast_Model::get_table_name( 'Indexable' );
-    }
+	}
 
-    /**
+	/**
 	 * Retrieves the table name to use.
 	 *
 	 * @return string The table name to use.

--- a/migrations/20200428123747_BreadcrumbTitleAndHierarchyReset.php
+++ b/migrations/20200428123747_BreadcrumbTitleAndHierarchyReset.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\SEO\ORM\Yoast_Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * BreadcrumbTitleAndHierarchyReset
+ */
+class BreadcrumbTitleAndHierarchyReset extends Ruckusing_Migration_Base {
+    /**
+	 * Migration up.
+	 */
+	public function up() {
+        $this->change_column( $this->get_indexable_table_name(), 'breadcrumb_title', 'text', [ 'null' => true ] );
+        $this->query( 'DELETE FROM ' . $this->get_indexable_hierarchy_table_name() );
+    }
+
+    /**
+	 * Migration down.
+	 */
+	public function down() {
+        $this->change_column( $this->get_indexable_table_name(), 'breadcrumb_title', 'string', [ 'null' => true, 'limit' => 191 ] );
+    }
+
+    /**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_indexable_table_name() {
+		return Yoast_Model::get_table_name( 'Indexable' );
+    }
+
+    /**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_indexable_hierarchy_table_name() {
+		return Yoast_Model::get_table_name( 'Indexable_Hierarchy' );
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Removes all indexable hierarchy entries to account for https://github.com/Yoast/wordpress-seo/pull/14942
* Fixes a fatal error when breadcrumb titles were too long.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Delete the `yoast_migrations_free` option or change the plugin version to 14.0.1.
* Load any page.
* Your indexable hierarchy table should be ( almost ) empty, it may contain entries for the current page.
* The breadcrumb title should be of type text in the indexable table.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
