### PR TITLE
Fix missing modal title in 14.0 indexing window

### DIFF
--- a/js/src/wp-seo-indexation.js
+++ b/js/src/wp-seo-indexation.js
@@ -33,7 +33,7 @@ const settings = yoastIndexationData;
 	}
 
 	/**
-	 * Does the indexation of a given endpoint
+	 * Does the indexation of a given endpoint.
 	 *
 	 * @param {string}      endpoint    The endpoint.
 	 * @param {ProgressBar} progressBar The progress bar.

--- a/src/presenters/admin/indexation-modal-presenter.php
+++ b/src/presenters/admin/indexation-modal-presenter.php
@@ -41,7 +41,7 @@ class Indexation_Modal_Presenter extends Abstract_Presenter {
 		if ( $this->total_unindexed === 0 ) {
 			$inner_text = \sprintf(
 				'<p>%s</p>',
-				\esc_html__( 'All your content is already indexed, there is no need to index them again.', 'wordpress-seo' )
+				\esc_html__( 'All your content is already indexed, there is no need to index it again.', 'wordpress-seo' )
 			);
 		}
 		else {

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -32,7 +32,8 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 			\sprintf(
 				/* translators: 1: Button start tag to open the indexation modal, 2: Button closing tag. */
 				\esc_html__( '%1$sClick here to speed up your site now%2$s', 'wordpress-seo' ),
-				'<button type="button" class="button yoast-open-indexation">',
+				\sprintf( '<button type="button" class="button yoast-open-indexation" data-title="%s">',
+					\esc_html__( "Yoast indexation status", 'wordpress_seo' ) ),
 				'</button>'
 			),
 			\sprintf(

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -33,7 +33,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 				/* translators: 1: Button start tag to open the indexation modal, 2: Button closing tag. */
 				\esc_html__( '%1$sClick here to speed up your site now%2$s', 'wordpress-seo' ),
 				\sprintf( '<button type="button" class="button yoast-open-indexation" data-title="%s">',
-					\esc_html__( "Yoast indexation status", 'wordpress_seo' ) ),
+					\esc_html__( 'Yoast indexation status', 'wordpress-seo' ) ),
 				'</button>'
 			),
 			\sprintf(

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -274,7 +274,7 @@ class Indexation_Integration_Test extends TestCase {
 
 		$expected  = '<div id="yoast-indexation-warning" class="notice notice-success"><p>';
 		$expected .= '<strong>NEW:</strong> Yoast SEO can now store your site’s SEO data in a smarter way!</p>';
-		$expected .= '<button type="button" class="button yoast-open-indexation">Click here to speed up your site now</button>';
+		$expected .= '<button type="button" class="button yoast-open-indexation" data-title="Yoast indexation status">Click here to speed up your site now</button>';
 		$expected .= '<p>Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="nonce">hide this notice</button> ';
 		$expected .= '(everything will continue to function as normal).</p></div>';
 

--- a/tests/presenters/admin/indexation-modal-presenter-test.php
+++ b/tests/presenters/admin/indexation-modal-presenter-test.php
@@ -37,7 +37,7 @@ class Indexation_Modal_Presenter_Test extends TestCase {
 	 */
 	public function test_present_without_unindexed() {
 		$instance = new Indexation_Modal_Presenter( 0 );
-		$expected = '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><p>All your content is already indexed, there is no need to index them again.</p></div><button id="yoast-indexation-stop" type="button" class="button">Stop indexation</button></div>';
+		$expected = '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><p>All your content is already indexed, there is no need to index it again.</p></div><button id="yoast-indexation-stop" type="button" class="button">Stop indexation</button></div>';
 
 		$this->assertSame( $expected, $instance->present() );
 	}

--- a/tests/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/presenters/admin/indexation-warning-presenter-test.php
@@ -35,7 +35,7 @@ class Indexation_Warning_Presenter_Test extends TestCase {
 
 		$expected  = '<div id="yoast-indexation-warning" class="notice notice-success"><p>';
 		$expected .= '<strong>NEW:</strong> Yoast SEO can now store your site’s SEO data in a smarter way!</p>';
-		$expected .= '<button type="button" class="button yoast-open-indexation">Click here to speed up your site now</button>';
+		$expected .= '<button type="button" class="button yoast-open-indexation" data-title="Yoast indexation status">Click here to speed up your site now</button>';
 		$expected .= '<p>Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="123456789">hide this notice</button> ';
 		$expected .= '(everything will continue to function as normal).</p></div>';
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Modals should have a title.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where no title was shown on the modal that you see when you click to speed up your site.

## Relevant technical choices:

* I set the `data-title` attribute, so that `$( this ).data( "title" )` will no longer be `undefined`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use the Yoast Test Helper to `Reset Indexables tables & migrations`.
* On the admin dashboard, click on the button that says `Click here to speed up your site now`.
* See that the title is `Yoast indexation status`.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/983
