### PR TITLE
Add primary key to migrations table

### DIFF
--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -137,7 +137,7 @@ class Migration_Runner implements Initializer_Interface {
 			// Create our own migrations table with a 191 string limit to support older versions of MySQL.
 			// Run this before calling the framework runner so it doesn't create it's own.
 			if ( ! $adapter->has_table( $migrations_table_name ) ) {
-				$table = $adapter->create_table( $migrations_table_name, [ 'id' => false ] );
+				$table = $adapter->create_table( $migrations_table_name );
 				$table->column( 'version', 'string', [ 'limit' => 191 ] );
 				$table->finish();
 				$adapter->add_index( $migrations_table_name, 'version', [ 'unique' => true ] );

--- a/tests/database/migration-runner-test.php
+++ b/tests/database/migration-runner-test.php
@@ -115,7 +115,7 @@ class Migration_Runner_Test extends TestCase {
 		$framework_mock->expects( 'get_framework_task_manager' )->once()->with( $adapter_mock, 'table', 'dir' )->andReturn( $task_manager_mock );
 		$runner_mock->expects( 'get_adapter' )->once()->andReturn( $adapter_mock );
 		$adapter_mock->expects( 'has_table' )->once()->with( 'table' )->andReturn( false );
-		$adapter_mock->expects( 'create_table' )->once()->with( 'table', [ 'id' => false ] )->andReturn( $table_mock );
+		$adapter_mock->expects( 'create_table' )->once()->with( 'table' )->andReturn( $table_mock );
 		$adapter_mock->expects( 'add_index' )->once()->with( 'table', 'version', [ 'unique' => true ] );
 		$table_mock->expects( 'column' )->once()->with( 'version', 'string', [ 'limit' => 191 ] );
 		$table_mock->expects( 'finish' )->once();


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal error related to the Yoast migrations table not having a primary key.

## Relevant technical choices:

* Adds the primary key.
* For anyone where the migrations have already been done it won't matter that their table doesn't have a primary key.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset your indexable migrations.
* Your migrations table should have a primary key.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://wordpress.org/support/topic/unable-to-create-database-tables-after-update-to-v14/page/2/#post-12743891
