### PR TITLE
Allow HTML in breadcrumbs settings

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -102,7 +102,7 @@ class Breadcrumb extends Abstract_Schema_Piece {
 				'@type' => 'WebPage',
 				'@id'   => $breadcrumb['url'],
 				'url'   => $breadcrumb['url'], // For future proofing, we're trying to change the standard for this.
-				'name'  => $breadcrumb['text'],
+				'name'  => $this->helpers->schema->html->smart_strip_tags( $breadcrumb['text'] ),
 			],
 		];
 	}

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -76,7 +76,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		}
 
 		$output = '<' . $this->get_wrapper() . $this->get_id() . $this->get_class() . '>' . $output . '</' . $this->get_wrapper() . '>';
-		$output = $this->filter( $output, $this->presentation );
+		$output = $this->filter( $output );
 
 		$prefix = $this->helpers->options->get( 'breadcrumbs-prefix' );
 		if ( $prefix !== '' ) {
@@ -120,10 +120,6 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 	 *                          'text'                  => (string) link text.
 	 *                          'url'                   => (string) link url.
 	 *                          (optional) 'title'      => (string) link title attribute text.
-	 *                          (optional) 'allow_html' => (bool) whether to (not) escape html in the link text.
-	 *                          'allow_html' prevents html stripping from the text strings set in the WPSEO -> Internal Links options page.
-	 *                          We never set 'title' or 'allow_html' ourselves but they could be set by users through the
-	 *                          'wpseo_breadcrumb_links' and 'wpseo_breadcrumb_single_link_info' filters.
 	 * @param int   $index      Index for the current breadcrumb.
 	 * @param int   $total      The total number of breadcrumbs.
 	 *
@@ -137,9 +133,6 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		}
 
 		$text = \trim( $breadcrumb['text'] );
-		if ( ! isset( $breadcrumb['allow_html'] ) || $breadcrumb['allow_html'] !== true ) {
-			$text = \esc_html( $text );
-		}
 
 		if (
 			$index < ( $total - 1 ) &&


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows HTML in Breadcrumbs settings.

## Relevant technical choices:

* Stripped the tags in Schema output. Note that this _can_ cause the schema output to be empty.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set `<i class=”fa fa-home”></i>` as your "Anchor text for the homepage" in the breadcrumbs settings.
* See that it renders on the frontend.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14940 
